### PR TITLE
build: add basic cmake-presets integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ tags
 
 # vim patches
 /vim-*.patch
+
+/CMakeUserPresets.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,7 +3,6 @@
   "configurePresets": [
     {
       "name": "base",
-      "displayName": "base preset",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
       "cacheVariables": {
@@ -15,28 +14,7 @@
       "hidden": true
     },
     {
-      "name": "clang",
-      "environment": {
-        "CC": "clang"
-      },
-      "inherits": [
-        "base"
-      ],
-      "hidden": true
-    },
-    {
-      "name": "release",
-      "displayName": "Release",
-      "description": "Same as RelWithDebInfo, but disables debug information",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release"
-      },
-      "inherits": [
-        "base"
-      ]
-    },
-    {
-      "name": "relwithdebinfo",
+      "name": "default",
       "displayName": "RelWithDebInfo",
       "description": "Enables optimizations (-Og or -O2) with debug information",
       "cacheVariables": {
@@ -58,54 +36,50 @@
       ]
     },
     {
-      "name": "asan",
-      "displayName": "Debug (with AddressSanitizer and UndefinedBehaviorSanitizer)",
+      "name": "release",
+      "displayName": "Release",
+      "description": "Same as RelWithDebInfo, but disables debug information",
       "cacheVariables": {
-        "CLANG_ASAN_UBSAN": "ON"
+        "CMAKE_BUILD_TYPE": "Release"
       },
       "inherits": [
-        "clang",
-        "debug"
+        "base"
       ]
     },
     {
-      "name": "tsan",
-      "displayName": "Debug (with ThreadSanitizer)",
-      "cacheVariables": {
-        "CLANG_TSAN": "ON"
-      },
-      "inherits": [
-        "clang",
-        "debug"
-      ]
-    },
-    {
-      "name": "msan",
-      "displayName": "Debug (with MemorySanitizer)",
-      "cacheVariables": {
-        "CLANG_MSAN": "ON"
-      },
-      "inherits": [
-        "clang",
-        "debug"
-      ]
-    },
-    {
-      "name": "msvc-vs2022",
-      "displayName": "Windows MSVC x64 (with VS2022)",
-      "generator": "Visual Studio 17 2022",
+      "name": "windows-default",
+      "displayName": "Windows x64 RelWithDebInfo",
+      "description": "Sets Ninja generator, enables optimizations with debug information for x64",
+      "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },
-      "inherits": "base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": [
+            "Windows"
+          ]
+        }
+      },
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
-      }
+      },
+      "inherits": [
+        "base"
+      ]
     }
   ],
   "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
     {
       "name": "debug",
       "configurePreset": "debug"
@@ -115,29 +89,13 @@
       "configurePreset": "release"
     },
     {
-      "name": "asan",
-      "configurePreset": "asan"
-    },
-    {
-      "name": "tsan",
-      "configurePreset": "tsan"
-    },
-    {
-      "name": "msan",
-      "configurePreset": "msan"
-    },
-    {
-      "name": "msvc-vs2022",
-      "configurePreset": "msvc-vs2022",
-      "nativeToolOptions": [
-        "/verbosity:normal",
-        "/m"
-      ],
+      "name": "windows-default",
+      "configurePreset": "windows-default",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       }
     }
-  ],
+  ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,12 +5,6 @@
       "name": "base",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build",
-      "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": true
-      },
-      "environment": {
-        "LOG_DIR": "${sourceDir}/build/logs"
-      },
       "hidden": true
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,143 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "displayName": "base preset",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_EXPORT_COMPILE_COMMANDS": true
+      },
+      "environment": {
+        "LOG_DIR": "${sourceDir}/build/logs"
+      },
+      "hidden": true
+    },
+    {
+      "name": "clang",
+      "environment": {
+        "CC": "clang"
+      },
+      "inherits": [
+        "base"
+      ],
+      "hidden": true
+    },
+    {
+      "name": "release",
+      "displayName": "Release",
+      "description": "Same as RelWithDebInfo, but disables debug information",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "relwithdebinfo",
+      "displayName": "RelWithDebInfo",
+      "description": "Enables optimizations (-Og or -O2) with debug information",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "debug",
+      "displayName": "Debug",
+      "description": "Disables optimizations (-O0), enables debug information",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "inherits": [
+        "base"
+      ]
+    },
+    {
+      "name": "asan",
+      "displayName": "Debug (with AddressSanitizer and UndefinedBehaviorSanitizer)",
+      "cacheVariables": {
+        "CLANG_ASAN_UBSAN": "ON"
+      },
+      "inherits": [
+        "clang",
+        "debug"
+      ]
+    },
+    {
+      "name": "tsan",
+      "displayName": "Debug (with ThreadSanitizer)",
+      "cacheVariables": {
+        "CLANG_TSAN": "ON"
+      },
+      "inherits": [
+        "clang",
+        "debug"
+      ]
+    },
+    {
+      "name": "msan",
+      "displayName": "Debug (with MemorySanitizer)",
+      "cacheVariables": {
+        "CLANG_MSAN": "ON"
+      },
+      "inherits": [
+        "clang",
+        "debug"
+      ]
+    },
+    {
+      "name": "msvc-vs2022",
+      "displayName": "Windows MSVC x64 (with VS2022)",
+      "generator": "Visual Studio 17 2022",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      },
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "asan",
+      "configurePreset": "asan"
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan"
+    },
+    {
+      "name": "msan",
+      "configurePreset": "msan"
+    },
+    {
+      "name": "msvc-vs2022",
+      "configurePreset": "msvc-vs2022",
+      "nativeToolOptions": [
+        "/verbosity:normal",
+        "/m"
+      ],
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    }
+  ],
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,15 +176,21 @@ master build. To view the defects, just request access; you will be approved.
 
   ASAN/UBSAN can be used to detect memory errors and other common forms of undefined behavior at runtime in debug builds.
 
-- To build Neovim with sanitizers enabled, use
+- Using CMake 3.21+ is recommended to take advantage of the predefined presets in `CMakePresets.json`
   ```
-  rm -rf build && CMAKE_EXTRA_FLAGS="-DCMAKE_C_COMPILER=clang -DCLANG_ASAN_UBSAN=1" make
+  # configure cmake for ASAN
+  cmake -S . --preset=asan
+
+  # build it
+  cmake --build --preset=asan
   ```
 - When running Neovim, use
   ```
   UBSAN_OPTIONS=print_stacktrace=1 ASAN_OPTIONS=log_path=/tmp/nvim_asan nvim args...
   ```
 - If Neovim exits unexpectedly, check `/tmp/nvim_asan.{PID}` (or your preferred `log_path`) for log files with error messages.
+
+For more details, check [build with asan][build-with-asan].
 
 
 Coding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,21 +176,15 @@ master build. To view the defects, just request access; you will be approved.
 
   ASAN/UBSAN can be used to detect memory errors and other common forms of undefined behavior at runtime in debug builds.
 
-- Using CMake 3.21+ is recommended to take advantage of the predefined presets in `CMakePresets.json`
+- To build Neovim with sanitizers enabled, use
   ```
-  # configure cmake for ASAN
-  cmake -S . --preset=asan
-
-  # build it
-  cmake --build --preset=asan
+  rm -rf build && CMAKE_EXTRA_FLAGS="-DCMAKE_C_COMPILER=clang -DCLANG_ASAN_UBSAN=1" make
   ```
 - When running Neovim, use
   ```
   UBSAN_OPTIONS=print_stacktrace=1 ASAN_OPTIONS=log_path=/tmp/nvim_asan nvim args...
   ```
 - If Neovim exits unexpectedly, check `/tmp/nvim_asan.{PID}` (or your preferred `log_path`) for log files with error messages.
-
-For more details, check [build with asan][build-with-asan].
 
 
 Coding


### PR DESCRIPTION
Add template for using [`CMakePresets.json`](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)

> One problem that `CMake` users often face is sharing settings with other people for common ways to configure a project. This may be done to support CI builds,  or for users who frequently use the same build. `CMake` supports two main files, `CMakePresets.json` and `CMakeUserPresets.json`, that allow users to specify common configure options and share them with others. `CMake` also supports files included with the include field.

--- 

#### Example usage

```bash
# get a list of pre-configured presets
cmake --list-presets

# configure a preset
cmake . --preset=default

# build it
cmake --build --preset=default

# you can also use ninja directly
ninja -C build/<presetName>
```

#### Custom presets

Create your own `CMakeUserPresets.json`

<details>
<summary>custom presets</summary>

```json
{
  "version": 3,
  "configurePresets": [
    {
      "name": "user",
      "displayName": "custom cmake debug preset",
      "description": "Sets clang by default with a custom build dir",
      "binaryDir": "${sourceDir}/build/custom",
      "environment": {
        "CC": "clang",
        "CXX": "clang++"
      },
      "cacheVariables": {
        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
        "LANGUAGES":"en_GB",
        "ENABLE_COMPILER_SUGGESTIONS": true,
        "DEPS_PREFIX": "${sourceDir}/.deps/usr",
        "PREFER_LUA": false,
        "COMPILE_LUA": true,
        "ENABLE_LTO": false
      },
      "inherits": [
        "debug"
      ]
    }
  ],
  "buildPresets": [
    {
      "name": "user",
      "configurePreset": "user"
    }
  ]
}
```
</details>

---

### Overview
#### cons
- requires cmake v3.21+ to use 

#### pros
- works on all platforms (no need to bother with bash/powershell/whatever)
- provides _short-hand_ commands for different build configurations
- provides a quick overview of all available targets/configurations along with suggestions (presets) in an [extremely easy to read json manifest](https://github.com/kylo252/neovim/blob/507ea19edb5b1c5fe535a178e4cca36ee60190c0/contrib/CMakePresets.json#L46-L57)
- provides a quick overview of suggested environment variables
- allows inheriting all of the above from a custom preset in `CMakeUsersPresets.json`, that can have on-the-fly tweaks
 ```console
 :split term://cmake . --preset=myDebugPreset
 ```
- we're not really adding any extra functionality to the current cmake, it's more akin to using [policies](https://cmake.org/cmake/help/latest/command/cmake_policy.html)
  ```cmake
  if(POLICY ...)
  	# cmake_policy(...)
  endif()
  ```
 - last but not least, enables easier tracking of configurations along with all the other benefits of [configuration-as-code](https://www.perforce.com/blog/vcs/configuration-as-code#:~:text=Configuration%20as%20code%20is%20the,control%20for%20your%20entire%20product.)
 
 ---
 
 TODO
 - [x] decide if `build/${presetName}` is okay, will not work with scripts hard-coding `./build`
 - [x] ~~consider adding a separate presets file for third-party~~ [out of scope]
 - [x] consider adding a `contrib/CMakeUserPresets.json.example` (how does it affect `local.mk`?)