### PR TITLE
ci(release): force working `libintl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,8 +107,9 @@ jobs:
         run: |
           export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
           OSX_FLAGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES=arm64\;x86_64"
+          # TODO(carlocab): fix `FindLibIntl` so that the test for `libintl` works when linking statically.
           make CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
-               CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH= $OSX_FLAGS" \
+               CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH= -DHAVE_WORKING_LIBINTL:BOOLEAN=TRUE $OSX_FLAGS" \
                DEPS_CMAKE_FLAGS="$OSX_FLAGS"
           make DESTDIR="$GITHUB_WORKSPACE/build/release/nvim-macos" install
       - name: Create package


### PR DESCRIPTION
The test for `HAVE_WORKING_LIBINTL` does not work correctly when linking
statically to `libintl`, since the test requires explicit linkage with
libiconv and the CoreFoundation framework.

I haven't worked out how to fix that test yet. In the meantime, this fix
works. I'll find the time to fix this properly in the next couple of days.
Or, if this is too much of a hack, we can just hold off on merging this until
we have a proper fix.

Closes #19127.

@clason
