### PR TITLE
build(cmake): fix static `libintl` test on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
           brew uninstall $(brew uses --installed --recursive gettext)
           brew unlink gettext
           ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/bin"/* /usr/local/bin/
+          ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/include"/* /usr/local/include/
           rm -f "$GETTEXT_PREFIX"
       - name: Build release
         run: |

--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -41,6 +41,16 @@ endif()
 if (MSVC)
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARY})
 endif()
+
+# On macOS, if libintl is a static library then we also need
+# to link libiconv and CoreFoundation.
+get_filename_component(LibIntl_EXT "${LibIntl_LIBRARY}" EXT)
+if (APPLE AND (LibIntl_EXT STREQUAL ".a"))
+  set(LibIntl_STATIC TRUE)
+  find_library(CoreFoundation_FRAMEWORK CoreFoundation)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${ICONV_LIBRARY}" "${CoreFoundation_FRAMEWORK}")
+endif()
+
 check_c_source_compiles("
 #include <libintl.h>
 
@@ -53,6 +63,9 @@ int main(int argc, char** argv) {
 }" HAVE_WORKING_LIBINTL)
 if (MSVC)
   list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARY})
+endif()
+if (LibIntl_STATIC)
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES  "${ICONV_LIBRARY}" "${CoreFoundation_FRAMEWORK}")
 endif()
 if (LibIntl_INCLUDE_DIR)
   list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${LibIntl_INCLUDE_DIR}")


### PR DESCRIPTION
If `libintl` is a static library on macOS, we also need to explicitly
link with `libiconv` and the `CoreFoundation` framework. Otherwise, our
`HAVE_WORKING_LIBINTL` test erroneously fails.

We also need to link Gettext's include directory into `/usr/local` so that
its headers can be found.

Closes #19127
Closes #19138
