### PR TITLE
[Backport release-0.7] build(cmake): fix static `libintl` test on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,7 @@ jobs:
           brew uninstall $(brew uses --installed --recursive gettext)
           brew unlink gettext
           ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/bin"/* /usr/local/bin/
+          ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/include"/* /usr/local/include/
           rm -f "$GETTEXT_PREFIX"
       - name: Build release
         run: |

--- a/cmake/FindLibIntl.cmake
+++ b/cmake/FindLibIntl.cmake
@@ -41,6 +41,16 @@ endif()
 if (MSVC)
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARY})
 endif()
+
+# On macOS, if libintl is a static library then we also need
+# to link libiconv and CoreFoundation.
+get_filename_component(LibIntl_EXT "${LibIntl_LIBRARY}" EXT)
+if (APPLE AND (LibIntl_EXT STREQUAL ".a"))
+  set(LibIntl_STATIC TRUE)
+  find_library(CoreFoundation_FRAMEWORK CoreFoundation)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${ICONV_LIBRARY}" "${CoreFoundation_FRAMEWORK}")
+endif()
+
 check_c_source_compiles("
 #include <libintl.h>
 
@@ -53,6 +63,9 @@ int main(int argc, char** argv) {
 }" HAVE_WORKING_LIBINTL)
 if (MSVC)
   list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARY})
+endif()
+if (LibIntl_STATIC)
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES  "${ICONV_LIBRARY}" "${CoreFoundation_FRAMEWORK}")
 endif()
 if (LibIntl_INCLUDE_DIR)
   list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${LibIntl_INCLUDE_DIR}")


### PR DESCRIPTION
Backport of #19139 to to `release-0.7`.
