### PR TITLE
vim-patch:8.2.4378: incsearch HL broken when calling searchcount in 'tabLine'

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -286,6 +286,8 @@ static struct spat saved_last_search_spat;
 static int did_save_last_search_spat = 0;
 static int saved_last_idx = 0;
 static bool saved_no_hlsearch = false;
+static colnr_T saved_search_match_endcol;
+static linenr_T saved_search_match_lines;
 
 /// Save and restore the search pattern for incremental highlight search
 /// feature.
@@ -326,6 +328,21 @@ void restore_last_search_pattern(void)
   set_vv_searchforward();
   last_idx = saved_last_idx;
   set_no_hlsearch(saved_no_hlsearch);
+}
+
+/// Save and restore the incsearch highlighting variables.
+/// This is required so that calling searchcount() at does not invalidate the
+/// incsearch highlighting.
+static void save_incsearch_state(void)
+{
+  saved_search_match_endcol = search_match_endcol;
+  saved_search_match_lines  = search_match_lines;
+}
+
+static void restore_incsearch_state(void)
+{
+  search_match_endcol = saved_search_match_endcol;
+  search_match_lines  = saved_search_match_lines;
 }
 
 char_u *last_search_pattern(void)
@@ -4717,6 +4734,7 @@ void f_searchcount(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   save_last_search_pattern();
+  save_incsearch_state();
   if (pattern != NULL) {
     if (*pattern == NUL) {
       goto the_end;
@@ -4738,6 +4756,7 @@ void f_searchcount(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
 the_end:
   restore_last_search_pattern();
+  restore_incsearch_state();
 }
 
 /// Fuzzy string matching

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -370,6 +370,48 @@ func Test_search_stat_then_gd()
   call delete('Xsearchstatgd')
 endfunc
 
+func Test_search_stat_and_incsearch()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['abc--c', '--------abc', '--abc'])
+    set hlsearch
+    set incsearch
+    set bg=dark
+    set showtabline=2
+
+    function MyTabLine()
+    try
+      let a=searchcount(#{recompute: 1, maxcount: -1})
+      return a.current .. '/' .. a.total
+    catch
+      return ''
+    endtry
+    endfunction
+
+    set tabline=%!MyTabLine()
+  END
+  call writefile(lines, 'Xsearchstat_inc')
+
+  let buf = RunVimInTerminal('-S Xsearchstat_inc', #{rows: 10})
+  call term_sendkeys(buf, "/abc")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_inc_1', {})
+
+  call term_sendkeys(buf, "\<c-g>")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_inc_2', {})
+
+  call term_sendkeys(buf, "\<c-g>")
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_searchstat_inc_3', {})
+
+  call term_sendkeys(buf, "\<esc>:qa\<cr>")
+  call TermWait(buf)
+
+  call StopVimInTerminal(buf)
+  call delete('Xsearchstat_inc')
+endfunc
 
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -12,6 +12,7 @@ describe('search stat', function()
       [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
       [2] = {background = Screen.colors.Yellow},  -- Search
       [3] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGrey},  -- Folded
+      [4] = {reverse = true},  -- IncSearch, TabLineFill
     })
     screen:attach()
   end)
@@ -116,6 +117,68 @@ describe('search stat', function()
       {1:~                             }|
       {1:~                             }|
                                     |
+    ]])
+  end)
+
+  it('is not broken by calling searchcount() in tabline vim-patch:8.2.4378', function()
+    exec([[
+      call setline(1, ['abc--c', '--------abc', '--abc'])
+      set hlsearch
+      set incsearch
+      set showtabline=2
+
+      function MyTabLine()
+      try
+        let a=searchcount(#{recompute: 1, maxcount: -1})
+        return a.current .. '/' .. a.total
+      catch
+        return ''
+      endtry
+      endfunction
+
+      set tabline=%!MyTabLine()
+    ]])
+
+    feed('/abc')
+    screen:expect([[
+      {4:                              }|
+      {2:abc}--c                        |
+      --------{4:abc}                   |
+      --{2:abc}                         |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /abc^                          |
+    ]])
+
+    feed('<C-G>')
+    screen:expect([[
+      {4:3/3                           }|
+      {2:abc}--c                        |
+      --------{2:abc}                   |
+      --{4:abc}                         |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /abc^                          |
+    ]])
+
+    feed('<C-G>')
+    screen:expect([[
+      {4:1/3                           }|
+      {4:abc}--c                        |
+      --------{2:abc}                   |
+      --{2:abc}                         |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /abc^                          |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.4378: incsearch HL broken when calling searchcount in 'tabLine'

Problem:    Incsearch highlight broken when calling searchcount() in 'tabLine'
            function. (Mirko Palmer)
Solution:   Save and restore the incsearch state. (Christian Brabandt,
            closes vim/vim#9763)
https://github.com/vim/vim/commit/6dd7424c7e6ab81998c29ca3526c41b75cfde5a1