### PR TITLE
vim-patch:9.0.0002: map functionality outside of map.c

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -815,8 +815,8 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
   uc_clear(&buf->b_ucmds);               // clear local user commands
   buf_delete_signs(buf, (char_u *)"*");  // delete any signs
   extmark_free_all(buf);                 // delete any extmarks
-  map_clear_int(buf, MAP_ALL_MODES, true, false);    // clear local mappings
-  map_clear_int(buf, MAP_ALL_MODES, true, true);     // clear local abbrevs
+  map_clear_mode(buf, MAP_ALL_MODES, true, false);  // clear local mappings
+  map_clear_mode(buf, MAP_ALL_MODES, true, true);   // clear local abbrevs
   XFREE_CLEAR(buf->b_start_fenc);
 
   buf_updates_unload(buf, false);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4474,29 +4474,6 @@ static void f_haslocaldir(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 }
 
-/// "hasmapto()" function
-static void f_hasmapto(typval_T *argvars, typval_T *rettv, FunPtr fptr)
-{
-  const char *mode;
-  const char *const name = tv_get_string(&argvars[0]);
-  bool abbr = false;
-  char buf[NUMBUFLEN];
-  if (argvars[1].v_type == VAR_UNKNOWN) {
-    mode = "nvo";
-  } else {
-    mode = tv_get_string_buf(&argvars[1], buf);
-    if (argvars[2].v_type != VAR_UNKNOWN) {
-      abbr = tv_get_number(&argvars[2]);
-    }
-  }
-
-  if (map_to_exists(name, mode, abbr)) {
-    rettv->vval.v_number = true;
-  } else {
-    rettv->vval.v_number = false;
-  }
-}
-
 /// "histadd()" function
 static void f_histadd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -939,8 +939,8 @@ static int get_map_mode(char **cmdp, bool forceit)
   return mode;
 }
 
-/// Clear all mappings or abbreviations.
-/// 'abbr' should be false for mappings, true for abbreviations.
+/// Clear all mappings (":mapclear") or abbreviations (":abclear").
+/// "abbr" should be false for mappings, true for abbreviations.
 /// This function used to be called map_clear().
 static void do_mapclear(char_u *cmdp, char_u *arg, int forceit, int abbr)
 {
@@ -954,7 +954,7 @@ static void do_mapclear(char_u *cmdp, char_u *arg, int forceit, int abbr)
   }
 
   mode = get_map_mode((char **)&cmdp, forceit);
-  map_clear_int(curbuf, mode, local, abbr);
+  map_clear_mode(curbuf, mode, local, abbr);
 }
 
 /// Clear all mappings in "mode".
@@ -963,7 +963,7 @@ static void do_mapclear(char_u *cmdp, char_u *arg, int forceit, int abbr)
 /// @param mode  mode in which to delete
 /// @param local  true for buffer-local mappings
 /// @param abbr  true for abbreviations
-void map_clear_int(buf_T *buf, int mode, bool local, bool abbr)
+void map_clear_mode(buf_T *buf, int mode, bool local, bool abbr)
 {
   mapblock_T *mp, **mpp;
   int hash;
@@ -1942,6 +1942,29 @@ char_u *check_map(char_u *keys, int mode, int exact, int ign_mod, int abbr, mapb
   }
 
   return NULL;
+}
+
+/// "hasmapto()" function
+void f_hasmapto(typval_T *argvars, typval_T *rettv, FunPtr fptr)
+{
+  const char *mode;
+  const char *const name = tv_get_string(&argvars[0]);
+  bool abbr = false;
+  char buf[NUMBUFLEN];
+  if (argvars[1].v_type == VAR_UNKNOWN) {
+    mode = "nvo";
+  } else {
+    mode = tv_get_string_buf(&argvars[1], buf);
+    if (argvars[2].v_type != VAR_UNKNOWN) {
+      abbr = tv_get_number(&argvars[2]);
+    }
+  }
+
+  if (map_to_exists(name, mode, abbr)) {
+    rettv->vval.v_number = true;
+  } else {
+    rettv->vval.v_number = false;
+  }
 }
 
 /// Fill a dictionary with all applicable maparg() like dictionaries

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -691,8 +691,8 @@ void free_all_mem(void)
 
   // Clear mappings, abbreviations, breakpoints.
   // NB: curbuf not used with local=false arg
-  map_clear_int(curbuf, MAP_ALL_MODES, false, false);
-  map_clear_int(curbuf, MAP_ALL_MODES, false, true);
+  map_clear_mode(curbuf, MAP_ALL_MODES, false, false);
+  map_clear_mode(curbuf, MAP_ALL_MODES, false, true);
   do_cmdline_cmd("breakdel *");
   do_cmdline_cmd("profdel *");
   do_cmdline_cmd("set keymap=");


### PR DESCRIPTION
#### vim-patch:9.0.0002: map functionality outside of map.c

Problem:    Map functionality outside of map.c.
Solution:   Move f_hasmapto() to map.c.  Rename a function. (closes vim/vim#10611)
https://github.com/vim/vim/commit/c207fd2535717030d78f9b92839e5f2ac004cc78