### PR TITLE
vim-patch:9.0.0005: hare files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -785,6 +785,9 @@ au BufNewFile,BufRead *.hsm			setf hamster
 " Handlebars
 au BufNewFile,BufRead *.hbs			setf handlebars
 
+" Hare
+au BufNewFile,BufRead *.ha			setf hare
+
 " Haskell
 au BufNewFile,BufRead *.hs,*.hsc,*.hs-boot,*.hsig setf haskell
 au BufNewFile,BufRead *.lhs			setf lhaskell

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -435,6 +435,7 @@ local extension = {
   haml = 'haml',
   hsm = 'hamster',
   hbs = 'handlebars',
+  ha = 'hare',
   ['hs-boot'] = 'haskell',
   hsig = 'haskell',
   hsc = 'haskell',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -234,6 +234,7 @@ let s:filename_checks = {
     \ 'haml': ['file.haml'],
     \ 'hamster': ['file.hsm'],
     \ 'handlebars': ['file.hbs'],
+    \ 'hare': ['file.ha'],
     \ 'haskell': ['file.hs', 'file.hsc', 'file.hs-boot', 'file.hsig'],
     \ 'haste': ['file.ht'],
     \ 'hastepreproc': ['file.htpp'],


### PR DESCRIPTION
Problem:    Hare files are not recognized.
Solution:   Add a filetype pattern. (Hugo Osvaldo Barrera, closes vim/vim#10630)
https://github.com/vim/vim/commit/040674129f3382822eeb7b590380efa5228124a8