### PR TITLE
vim-patch:9.0.0006: not all Visual Basic files are recognized

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -78,22 +78,30 @@ func dist#ft#FTbas()
 
   " most frequent FreeBASIC-specific keywords in distro files
   let fb_keywords = '\c^\s*\%(extern\|var\|enum\|private\|scope\|union\|byref\|operator\|constructor\|delete\|namespace\|public\|property\|with\|destructor\|using\)\>\%(\s*[:=(]\)\@!'
-  let fb_preproc  = '\c^\s*\%(#\a\+\|option\s\+\%(byval\|dynamic\|escape\|\%(no\)\=gosub\|nokeyword\|private\|static\)\>\)'
+  let fb_preproc  = '\c^\s*\%(' ..
+        \ '#\s*\a\+\|' ..
+        \ 'option\s\+\%(byval\|dynamic\|escape\|\%(no\)\=gosub\|nokeyword\|private\|static\)\>\|' ..
+        \ '\%(''\|rem\)\s*\$lang\>\|' ..
+        \ 'def\%(byte\|longint\|short\|ubyte\|uint\|ulongint\|ushort\)\>' ..
+        \ '\)'
   let fb_comment  = "^\\s*/'"
   " OPTION EXPLICIT, without the leading underscore, is common to many dialects
   let qb64_preproc = '\c^\s*\%($\a\+\|option\s\+\%(_explicit\|_\=explicitarray\)\>\)'
 
-  let lines = getline(1, min([line("$"), 100]))
-
-  if match(lines, fb_preproc) > -1 || match(lines, fb_comment) > -1 || match(lines, fb_keywords) > -1
-    setf freebasic
-  elseif match(lines, qb64_preproc) > -1
-    setf qb64
-  elseif match(lines, s:ft_visual_basic_content) > -1
-    setf vb
-  else
-    setf basic
-  endif
+  for lnum in range(1, min([line("$"), 100]))
+    let line = getline(lnum)
+    if line =~ s:ft_visual_basic_content
+      setf vb
+      return
+    elseif line =~ fb_preproc || line =~ fb_comment || line =~ fb_keywords
+      setf freebasic
+      return
+    elseif line =~ qb64_preproc
+      setf qb64
+      return
+    endif
+  endfor
+  setf basic
 endfunc
 
 func dist#ft#FTbtm()
@@ -128,6 +136,23 @@ func dist#ft#FTcfg()
     setf rapid
   else
     setf cfg
+  endif
+endfunc
+
+func dist#ft#FTcls()
+  if exists("g:filetype_cls")
+    exe "setf " .. g:filetype_cls
+    return
+  endif
+
+  if getline(1) =~ '^%'
+    setf tex
+  elseif getline(1)[0] == '#' && getline(1) =~ 'rexx'
+    setf rexx
+  elseif getline(1) == 'VERSION 1.0 CLASS'
+    setf vb
+  else
+    setf st
   endif
 endfunc
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -141,6 +141,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.asp		g:filetype_asp	|ft-aspvbs-syntax| |ft-aspperl-syntax|
 	*.bas		g:filetype_bas	|ft-basic-syntax|
 	*.cfg		g:filetype_cfg
+	*.cls		g:filetype_cls
 	*.csh		g:filetype_csh	|ft-csh-syntax|
 	*.dat		g:filetype_dat
 	*.frm		g:filetype_frm	|ft-form-syntax|

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1791,16 +1791,11 @@ au BufNewFile,BufRead *.il,*.ils,*.cdf		setf skill
 au BufNewFile,BufRead .slrnrc			setf slrnrc
 au BufNewFile,BufRead *.score			setf slrnsc
 
-" Smalltalk (and TeX)
+" Smalltalk
 au BufNewFile,BufRead *.st			setf st
-au BufNewFile,BufRead *.cls
-	\ if getline(1) =~ '^%' |
-	\  setf tex |
-	\ elseif getline(1)[0] == '#' && getline(1) =~ 'rexx' |
-	\  setf rexx |
-	\ else |
-	\  setf st |
-	\ endif
+
+" Smalltalk (and Rexx, TeX, and Visual Basic)
+au BufNewFile,BufRead *.cls                     call dist#ft#FTcls()
 
 " Smarty templates
 au BufNewFile,BufRead *.tpl			setf smarty

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -83,19 +83,19 @@ function M.bas(bufnr)
   local fb_keywords =
     [[\c^\s*\%(extern\|var\|enum\|private\|scope\|union\|byref\|operator\|constructor\|delete\|namespace\|public\|property\|with\|destructor\|using\)\>\%(\s*[:=(]\)\@!]]
   local fb_preproc =
-    [[\c^\s*\%(#\a\+\|option\s\+\%(byval\|dynamic\|escape\|\%(no\)\=gosub\|nokeyword\|private\|static\)\>\)]]
+    [[\c^\s*\%(#\s*\a\+\|option\s\+\%(byval\|dynamic\|escape\|\%(no\)\=gosub\|nokeyword\|private\|static\)\>\|\%(''\|rem\)\s*\$lang\>\|def\%(byte\|longint\|short\|ubyte\|uint\|ulongint\|ushort\)\>\)]]
 
   local fb_comment = "^%s*/'"
   -- OPTION EXPLICIT, without the leading underscore, is common to many dialects
   local qb64_preproc = [[\c^\s*\%($\a\+\|option\s\+\%(_explicit\|_\=explicitarray\)\>\)]]
 
   for _, line in ipairs(getlines(bufnr, 1, 100)) do
-    if line:find(fb_comment) or matchregex(line, fb_preproc) or matchregex(line, fb_keywords) then
+    if findany(line:lower(), visual_basic_content) then
+      return 'vb'
+    elseif line:find(fb_comment) or matchregex(line, fb_preproc) or matchregex(line, fb_keywords) then
       return 'freebasic'
     elseif matchregex(line, qb64_preproc) then
       return 'qb64'
-    elseif findany(line:lower(), visual_basic_content) then
-      return 'vb'
     end
   end
   return 'basic'
@@ -172,11 +172,16 @@ function M.class(bufnr)
 end
 
 function M.cls(bufnr)
+  if vim.g.filetype_cls then
+    return vim.g.filetype_cls
+  end
   local line = getlines(bufnr, 1)
   if line:find('^%%') then
     return 'tex'
   elseif line:find('^#') and line:lower():find('rexx') then
     return 'rexx'
+  elseif line == 'VERSION 1.0 CLASS' then
+    return 'vb'
   else
     return 'st'
   end

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -811,7 +811,7 @@ func Test_bas_file()
 
   " Visual Basic
 
-  call writefile(['Attribute VB_NAME = "Testing"'], 'Xfile.bas')
+  call writefile(['Attribute VB_NAME = "Testing"', 'Enum Foo', 'End Enum'], 'Xfile.bas')
   split Xfile.bas
   call assert_equal('vb', &filetype)
   bwipe!
@@ -1691,5 +1691,45 @@ func Test_xpm_file()
   filetype off
 endfunc
 
+func Test_cls_file()
+  filetype on
+
+  call writefile(['looks like Smalltalk'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('st', &filetype)
+  bwipe!
+
+  " Test dist#ft#FTcls()
+
+  let g:filetype_cls = 'vb'
+  split Xfile.cls
+  call assert_equal('vb', &filetype)
+  bwipe!
+  unlet g:filetype_cls
+
+  " TeX
+
+  call writefile(['%'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('tex', &filetype)
+  bwipe!
+
+  " Rexx
+
+  call writefile(['# rexx'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  " Visual Basic
+
+  call writefile(['VERSION 1.0 CLASS'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('vb', &filetype)
+  bwipe!
+
+  call delete('Xfile.cls')
+  filetype off
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Not all Visual Basic files are recognized.
Solution:   Change detection of *.cls files. (Doug Kearns)
https://github.com/vim/vim/commit/8b5901e2f9466eb6f38f5b251e871f609f65e252