### PR TITLE
feat(api): add nvim_win_get_folds

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2984,6 +2984,17 @@ nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
                 Return: ~
                     (row, col) tuple
 
+nvim_win_get_folds({window}, {opts})                    *nvim_win_get_folds()*
+                Get fold for the current window
+
+                Parameters: ~
+                    {window}  Window handle, or 0 for current window
+                    {opts}    Optional parameters. Reserved for future use.
+
+                Return: ~
+                    Array of 2-integer tuples representing start and end of
+                    the fold (0-indexed, inclusive).
+
 nvim_win_get_height({window})                          *nvim_win_get_height()*
                 Gets the window height
 

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -41,26 +41,7 @@
 
 // local declarations. {{{1
 // typedef fold_T {{{2
-/*
- * The toplevel folds for each window are stored in the w_folds growarray.
- * Each toplevel fold can contain an array of second level folds in the
- * fd_nested growarray.
- * The info stored in both growarrays is the same: An array of fold_T.
- */
-typedef struct {
-  linenr_T fd_top;              // first line of fold; for nested fold
-                                // relative to parent
-  linenr_T fd_len;              // number of lines in the fold
-  garray_T fd_nested;           // array of nested folds
-  char fd_flags;                // see below
-  TriState fd_small;            // kTrue, kFalse, or kNone: fold smaller than
-                                // 'foldminlines'; kNone applies to nested
-                                // folds too
-} fold_T;
 
-#define FD_OPEN         0       // fold is open (nested ones can be closed)
-#define FD_CLOSED       1       // fold is closed
-#define FD_LEVEL        2       // depends on 'foldlevel' (nested folds too)
 
 #define MAX_LEVEL       20      // maximum fold depth
 
@@ -1522,7 +1503,7 @@ static int getDeepestNestingRecurse(garray_T *gap)
 /// @param[out] maybe_smallp true: outer this had fd_small == kNone
 /// @param lnum_off line number offset for fp->fd_top
 /// @return true if fold is closed
-static bool check_closed(win_T *const wp, fold_T *const fp, bool *const use_levelp, const int level,
+bool check_closed(win_T *const wp, fold_T *const fp, bool *const use_levelp, const int level,
                          bool *const maybe_smallp, const linenr_T lnum_off)
 {
   bool closed = false;

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -21,6 +21,28 @@ typedef struct foldinfo {
   long fi_lines;
 } foldinfo_T;
 
+// local declarations. {{{1
+// typedef fold_T {{{2
+//
+// The toplevel folds for each window are stored in the w_folds growarray.
+// Each toplevel fold can contain an array of second level folds in the
+// fd_nested growarray.
+// The info stored in both growarrays is the same: An array of fold_T.
+typedef struct {
+  linenr_T fd_top;              // first line of fold; for nested fold
+                                // relative to parent
+  linenr_T fd_len;              // number of lines in the fold
+  garray_T fd_nested;           // array of nested folds
+  char fd_flags;                // see below
+  TriState fd_small;            // kTrue, kFalse, or kNone: fold smaller than
+                                // 'foldminlines'; kNone applies to nested
+                                // folds too
+} fold_T;
+
+#define FD_OPEN         0       // fold is open (nested ones can be closed)
+#define FD_CLOSED       1       // fold is closed
+#define FD_LEVEL        2       // depends on 'foldlevel' (nested folds too)
+
 #define FOLDINFO_INIT { 0, 0, 0, 0 }
 
 EXTERN int disable_fold_update INIT(= 0);


### PR DESCRIPTION
```
nvim_win_get_folds({ns_id}, {window}, {opts})                    *nvim_win_get_folds()*
                 Get fold for the current window

                 Parameters: ~
                     {ns_id}   Namespace id from |nvim_create_namespace()|. Use `0` to 
                               retrieve non-extmark folds.
                     {window}  Window handle, or 0 for current window
                     {opts}    Optional parameters. Reserved for future use.

                 Return: ~
                     Array of 2-integer tuples representing start and end of
                     the fold (0-indexed, inclusive).
```