### PR TITLE
vim-patch:9.0.0011: reading beyond the end of the line with put command

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3344,7 +3344,6 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
 
       totlen = (size_t)(count * (yanklen + spaces)
                         + bd.startspaces + bd.endspaces);
-      int addcount = (int)totlen + lines_appended;
       newp = (char_u *)xmalloc(totlen + oldlen + 1);
 
       // copy part up to cursor to new line
@@ -3366,7 +3365,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
           memset(ptr, ' ', (size_t)spaces);
           ptr += spaces;
         } else {
-          addcount -= spaces;
+          totlen -= (size_t)spaces;  // didn't use these spaces
         }
       }
 
@@ -3380,7 +3379,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
       memmove(ptr, oldp + bd.textcol + delcount, (size_t)columns);
       ml_replace(curwin->w_cursor.lnum, (char *)newp, false);
       extmark_splice_cols(curbuf, (int)curwin->w_cursor.lnum - 1, bd.textcol,
-                          delcount, addcount, kExtmarkUndo);
+                          delcount, (int)totlen + lines_appended, kExtmarkUndo);
 
       ++curwin->w_cursor.lnum;
       if (i == 0) {

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -213,5 +213,17 @@ func Test_put_empty_register()
   bwipe!
 endfunc
 
+" this was putting the end mark after the end of the line
+func Test_put_visual_mode()
+  edit! SomeNewBuffer
+  set selection=exclusive
+  exe "norm o\t"
+  m0
+  sil! norm pp
+
+  bwipe!
+  set selection&
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0011: reading beyond the end of the line with put command

Problem:    Reading beyond the end of the line with put command.
Solution:   Adjust the end mark position.
https://github.com/vim/vim/commit/d25f003342aca9889067f2e839963dfeccf1fe05