### PR TITLE
build: move lint target to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -653,6 +653,15 @@ add_glob_targets(
   TOUCH_STRATEGY SINGLE
   )
 
+add_custom_target(lintcommit
+  COMMAND ${PROJECT_BINARY_DIR}/bin/nvim -u NONE -es -c [[lua require('scripts.lintcommit').main({trace=false})]]
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  VERBATIM)
+add_dependencies(lintcommit nvim)
+
+add_custom_target(lint)
+add_dependencies(lint check-single-includes lintc lintlua lintpy lintsh lintcommit lintuncrustify)
+
 install_helper(
   FILES ${CMAKE_SOURCE_DIR}/src/man/nvim.1
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
@@ -775,3 +784,4 @@ add_custom_target(uninstall
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   add_subdirectory(cmake.packaging)
 endif()
+

--- a/Makefile
+++ b/Makefile
@@ -137,15 +137,8 @@ helphtml: | nvim build/runtime/doc/tags
 functionaltest functionaltest-lua unittest benchmark: | nvim
 	$(BUILD_TOOL) -C build $@
 
-lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources: | build/.ran-cmake
+lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources lintcommit lint: | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@
-
-commitlint: | nvim
-	$(NVIM_PRG) -u NONE -es +"lua require('scripts.lintcommit').main({trace=false})"
-
-_opt_commitlint:
-	@test -x build/bin/nvim && { $(MAKE) commitlint; exit $$?; } \
-		|| echo "SKIP: commitlint (build/bin/nvim not found)"
 
 test: functionaltest unittest
 
@@ -171,8 +164,6 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-lint: check-single-includes lintc lintlua lintpy lintsh _opt_commitlint lintuncrustify
-
 # Generic pattern rules, allowing for `make build/bin/nvim` etc.
 # Does not work with "Unix Makefiles".
 ifeq ($(CMAKE_GENERATOR),Ninja)
@@ -183,4 +174,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix commitlint
+.PHONY: test lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix lintcommit


### PR DESCRIPTION
This will ensure less verbose output and faster linting.
