### PR TITLE
vim-patch:9.0.0012: signature files not detected properly

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -459,7 +459,7 @@ func dist#ft#FTmm()
   setf nroff
 endfunc
 
-" Returns true if file content looks like LambdaProlog
+" Returns true if file content looks like LambdaProlog module
 func IsLProlog()
   " skip apparent comments and blank lines, what looks like 
   " LambdaProlog comment may be RAPID header
@@ -845,6 +845,27 @@ func dist#ft#FTperl()
     return 1
   endif
   return 0
+endfunc
+
+" LambdaProlog and Standard ML signature files
+func dist#ft#FTsig()
+  if exists("g:filetype_sig")
+    exe "setf " .. g:filetype_sig
+    return
+  endif
+
+  let lprolog_comment = '^\s*\%(/\*\|%\)'
+  let lprolog_keyword = '^\s*sig\s\+\a'
+  let sml_comment = '^\s*(\*'
+  let sml_keyword = '^\s*\%(signature\|structure\)\s\+\a'
+
+  let line = getline(nextnonblank(1))
+
+  if line =~ lprolog_comment || line =~# lprolog_keyword
+    setf lprolog
+  elseif line =~ sml_comment || line =~# sml_keyword
+    setf sml
+  endif
 endfunc
 
 func dist#ft#FTsys()

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -155,6 +155,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.pp		g:filetype_pp	|ft-pascal-syntax|
 	*.prg		g:filetype_prg
 	*.r		g:filetype_r
+	*.sig		g:filetype_sig
 	*.sql		g:filetype_sql	|ft-sql-syntax|
 	*.src		g:filetype_src
 	*.sys		g:filetype_sys

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -993,8 +993,8 @@ au BufNewFile,BufRead *.latte,*.lte		setf latte
 " Limits
 au BufNewFile,BufRead */etc/limits,*/etc/*limits.conf,*/etc/*limits.d/*.conf	setf limits
 
-" LambdaProlog (see dist#ft#FTmod for *.mod)
-au BufNewFile,BufRead *.sig			setf lprolog
+" LambdaProlog or SML (see dist#ft#FTmod for *.mod)
+au BufNewFile,BufRead *.sig			call dist#ft#FTsig()
 
 " LDAP LDIF
 au BufNewFile,BufRead *.ldif			setf ldif

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -586,7 +586,6 @@ local extension = {
   c = function(path, bufnr)
     return require('vim.filetype.detect').lpc(bufnr)
   end,
-  sig = 'lprolog',
   lsl = 'lsl',
   lss = 'lss',
   nse = 'lua',
@@ -867,6 +866,9 @@ local extension = {
   end,
   sieve = 'sieve',
   siv = 'sieve',
+  sig = function(path, bufnr)
+    return require('vim.filetype.detect').sig(bufnr)
+  end,
   sil = 'sil',
   sim = 'simula',
   ['s85'] = 'sinda',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -922,6 +922,23 @@ function M.rules(path)
   end
 end
 
+-- LambdaProlog and Standard ML signature files
+function M.sig(bufnr)
+  if vim.g.filetype_sig then
+    return vim.g.filetype_sig
+  end
+
+  local line = nextnonblank(bufnr, 1)
+
+  -- LambdaProlog comment or keyword
+  if findany(line, { '^%s*/%*', '^%s*%%', '^%s*sig%s+%a' }) then
+    return 'lprolog'
+    -- SML comment or keyword
+  elseif findany(line, { '^%s*%(%*', '^%s*signature%s+%a', '^%s*structure%s+%a' }) then
+    return 'sml'
+  end
+end
+
 -- This function checks the first 25 lines of file extension "sc" to resolve
 -- detection between scala and SuperCollider
 function M.sc(bufnr)

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -313,7 +313,6 @@ let s:filename_checks = {
     \ 'lotos': ['file.lot', 'file.lotos'],
     \ 'lout': ['file.lou', 'file.lout'],
     \ 'lpc': ['file.lpc', 'file.ulpc'],
-    \ 'lprolog': ['file.sig'],
     \ 'lsl': ['file.lsl'],
     \ 'lss': ['file.lss'],
     \ 'lua': ['file.lua', 'file.rockspec', 'file.nse'],
@@ -1732,5 +1731,60 @@ func Test_cls_file()
   call delete('Xfile.cls')
   filetype off
 endfunc
+
+func Test_sig_file()
+  filetype on
+
+  call writefile(['this is neither Lambda Prolog nor SML'], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('', &filetype)
+  bwipe!
+
+  " Test dist#ft#FTsig()
+
+  let g:filetype_sig = 'sml'
+  split Xfile.sig
+  call assert_equal('sml', &filetype)
+  bwipe!
+  unlet g:filetype_sig
+
+  " Lambda Prolog
+
+  call writefile(['sig foo.'], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
+  call writefile(['/* ... */'], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
+  call writefile(['% ...'], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('lprolog', &filetype)
+  bwipe!
+
+  " SML signature file
+
+  call writefile(['signature FOO ='], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('sml', &filetype)
+  bwipe!
+
+  call writefile(['structure FOO ='], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('sml', &filetype)
+  bwipe!
+
+  call writefile(['(* ... *)'], 'Xfile.sig')
+  split Xfile.sig
+  call assert_equal('sml', &filetype)
+  bwipe!
+
+  call delete('Xfile.sig')
+  filetype off
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Signature files not detected properly.
Solution:   Add a function to better detect signature files. (Doug Kearns)
https://github.com/vim/vim/commit/cdbfc6dbab1d63aa56af316d6b13e37939e7f7a8