### PR TITLE
vim-patch:8.2.0049: command line completion not fully tested

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5019,7 +5019,15 @@ static int help_compare(const void *s1, const void *s2)
 
   p1 = *(char **)s1 + strlen(*(char **)s1) + 1;
   p2 = *(char **)s2 + strlen(*(char **)s2) + 1;
-  return strcmp(p1, p2);
+
+  // Compare by help heuristic number first.
+  int cmp = strcmp(p1, p2);
+  if (cmp != 0) {
+    return cmp;
+  }
+
+  // Compare by strings as tie-breaker when same heuristic number.
+  return strcmp(*(char **)s1, *(char **)s2);
 }
 
 /// Find all help tags matching "arg", sort them and return in matches[], with

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -225,6 +225,21 @@ func Test_cd_from_non_existing_dir()
   call assert_equal(saveddir, getcwd())
 endfunc
 
+func Test_cd_completion()
+  call mkdir('XComplDir1', 'p')
+  call mkdir('XComplDir2', 'p')
+  call writefile([], 'XComplFile')
+
+  for cmd in ['cd', 'chdir', 'lcd', 'lchdir', 'tcd', 'tchdir']
+    call feedkeys(':' .. cmd .. " XCompl\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"' .. cmd .. ' XComplDir1/ XComplDir2/', @:)
+  endfor
+
+  call delete('XComplDir1', 'd')
+  call delete('XComplDir2', 'd')
+  call delete('XComplFile')
+endfunc
+
 func Test_cd_unknown_dir()
   call mkdir('Xa')
   cd Xa

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -757,6 +757,15 @@ funct Test_cmdline_complete_languages()
   endif
 endfunc
 
+func Test_cmdline_complete_env_variable()
+  let $X_VIM_TEST_COMPLETE_ENV = 'foo'
+
+  call feedkeys(":edit $X_VIM_TEST_COMPLETE_E\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('"edit $X_VIM_TEST_COMPLETE_ENV', @:)
+
+  unlet $X_VIM_TEST_COMPLETE_ENV
+endfunc
+
 func Test_cmdline_complete_expression()
   let g:SomeVar = 'blah'
   for cmd in ['exe', 'echo', 'echon', 'echomsg']

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -902,22 +902,6 @@ func Test_getcmdwin_autocmd()
   augroup END
 endfunc
 
-" Test error: "E135: *Filter* Autocommands must not change current buffer"
-func Test_cmd_bang_E135()
-  new
-  call setline(1, ['a', 'b', 'c', 'd'])
-  augroup test_cmd_filter_E135
-    au!
-    autocmd FilterReadPost * help
-  augroup END
-  call assert_fails('2,3!echo "x"', 'E135:')
-
-  augroup test_cmd_filter_E135
-    au!
-  augroup END
-  %bwipe!
-endfunc
-
 func Test_verbosefile()
   set verbosefile=Xlog
   echomsg 'foo'
@@ -998,34 +982,6 @@ func Test_cmdline_overstrike()
   let &encoding = encoding_save
 endfunc
 
-func Test_cmdwin_feedkeys()
-  " This should not generate E488
-  call feedkeys("q:\<CR>", 'x')
-endfunc
-
-" Tests for the issues fixed in 7.4.441.
-" When 'cedit' is set to Ctrl-C, opening the command window hangs Vim
-func Test_cmdwin_cedit()
-  exe "set cedit=\<C-c>"
-  normal! :
-  call assert_equal(1, winnr('$'))
-
-  let g:cmd_wintype = ''
-  func CmdWinType()
-      let g:cmd_wintype = getcmdwintype()
-      let g:wintype = win_gettype()
-      return ''
-  endfunc
-
-  call feedkeys("\<C-c>a\<C-R>=CmdWinType()\<CR>\<CR>")
-  echo input('')
-  call assert_equal('@', g:cmd_wintype)
-  call assert_equal('command', g:wintype)
-
-  set cedit&vim
-  delfunc CmdWinType
-endfunc
-
 func Test_cmdwin_restore()
   CheckScreendump
 
@@ -1102,6 +1058,34 @@ func Test_buffers_lastused()
   bwipeout bufc
 endfunc
 
+func Test_cmdwin_feedkeys()
+  " This should not generate E488
+  call feedkeys("q:\<CR>", 'x')
+endfunc
+
+" Tests for the issues fixed in 7.4.441.
+" When 'cedit' is set to Ctrl-C, opening the command window hangs Vim
+func Test_cmdwin_cedit()
+  exe "set cedit=\<C-c>"
+  normal! :
+  call assert_equal(1, winnr('$'))
+
+  let g:cmd_wintype = ''
+  func CmdWinType()
+      let g:cmd_wintype = getcmdwintype()
+      let g:wintype = win_gettype()
+      return ''
+  endfunc
+
+  call feedkeys("\<C-c>a\<C-R>=CmdWinType()\<CR>\<CR>")
+  echo input('')
+  call assert_equal('@', g:cmd_wintype)
+  call assert_equal('command', g:wintype)
+
+  set cedit&vim
+  delfunc CmdWinType
+endfunc
+
 " Test for CmdwinEnter autocmd
 func Test_cmdwin_autocmd()
   CheckFeature cmdwin
@@ -1150,6 +1134,22 @@ func Test_cmdwin_tabpage()
   call assert_fails("silent norm q/g	", 'E11:')
   call assert_fails("silent norm q/g	:I\<Esc>", 'E492:')
   tabclose!
+endfunc
+
+" Test error: "E135: *Filter* Autocommands must not change current buffer"
+func Test_cmd_bang_E135()
+  new
+  call setline(1, ['a', 'b', 'c', 'd'])
+  augroup test_cmd_filter_E135
+    au!
+    autocmd FilterReadPost * help
+  augroup END
+  call assert_fails('2,3!echo "x"', 'E135:')
+
+  augroup test_cmd_filter_E135
+    au!
+  augroup END
+  %bwipe!
 endfunc
 
 " test that ";" works to find a match at the start of the first line

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -92,6 +92,11 @@ func Test_help_local_additions()
   let &rtp = rtp_save
 endfunc
 
+func Test_help_completion()
+  call feedkeys(":help :undo\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"help :undo :undoj :undol :undojoin :undolist', @:)
+endfunc
+
 " Test for the :helptags command
 func Test_helptag_cmd()
   call mkdir('Xdir/a/doc', 'p')

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -46,6 +46,10 @@ func Test_menu_commands()
   imenu 2 Test.FooBar :let g:did_menu = 'insert'<CR>
   cmenu 2 Test.FooBar :let g:did_menu = 'cmdline'<CR>
   emenu n Test.FooBar
+
+  call feedkeys(":menu Test.FooB\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"menu Test.FooBar', @:)
+
   call assert_equal('normal', g:did_menu)
   emenu v Test.FooBar
   call assert_equal('visual', g:did_menu)

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -238,6 +238,12 @@ func Test_set_completion()
   call feedkeys(":set di\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set dictionary diff diffexpr diffopt digraph directory display', @:)
 
+  call feedkeys(":setlocal di\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"setlocal dictionary diff diffexpr diffopt digraph directory display', @:)
+
+  call feedkeys(":setglobal di\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"setglobal dictionary diff diffexpr diffopt digraph directory display', @:)
+
   " Expand boolan options. When doing :set no<Tab>
   " vim displays the options names without "no" but completion uses "no...".
   call feedkeys(":set nodi\<C-A>\<C-B>\"\<CR>", 'tx')
@@ -268,6 +274,7 @@ func Test_set_completion()
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
+
   set tags&
 
   " Expand values for 'filetype'

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -197,6 +197,12 @@ func Test_syntax_completion()
   call assert_match('^"syn match Boolean Character ', @:)
 endfunc
 
+func Test_echohl_completion()
+  call feedkeys(":echohl no\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"echohl NonText Normal none', @:)
+  call assert_equal('"echohl NonText Normal NormalFloat NormalNC none', @:)
+endfunc
+
 func Test_syntax_arg_skipped()
   syn clear
   syntax case ignore


### PR DESCRIPTION
#### vim-patch:8.2.0049: command line completion not fully tested

Problem:    Command line completion not fully tested.
Solution:   Add more test cases.  Make help sorting stable. (Dominique Pelle,
            closes vim/vim#5402)
https://github.com/vim/vim/commit/297610ba4b110c918ffe60c45eb4a1d6ea2daae5