### PR TITLE
cmdheight=0: fix bugs part2

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2899,6 +2899,11 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
   no_mapping--;
   allow_keys--;
 
+  if (!ui_has_messages()) {
+    // redraw the screen after getchar()
+    update_screen(CLEAR);
+  }
+
   set_vim_var_nr(VV_MOUSE_WIN, 0);
   set_vim_var_nr(VV_MOUSE_WINID, 0);
   set_vim_var_nr(VV_MOUSE_LNUM, 0);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3669,7 +3669,7 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
     }
   }
 
-  bool cmdheight0 = p_ch < 1 && !ui_has(kUIMessages);
+  bool cmdheight0 = !ui_has_messages();
   if (cmdheight0) {
     // If cmdheight is 0, cmdheight must be set to 1 when we enter command line.
     set_option_value("ch", 1L, NULL, 0);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -689,7 +689,7 @@ static void finish_incsearch_highlighting(int gotesc, incsearch_state_T *s, bool
 /// @param init_ccline  clear ccline first
 static uint8_t *command_line_enter(int firstc, long count, int indent, bool init_ccline)
 {
-  bool cmdheight0 = p_ch < 1 && !ui_has(kUIMessages);
+  bool cmdheight0 = !ui_has_messages();
 
   if (cmdheight0) {
     // If cmdheight is 0, cmdheight must be set to 1 when we enter command line.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -490,7 +490,14 @@ int smsg(const char *s, ...)
 {
   if (!ui_has_messages()) {
     // Use emsg() instead.  Because msg() does not work if no command line area
-    return semsg(s);
+    bool ret;
+    va_list arglist;
+
+    va_start(arglist, s);
+    ret = semsgv(s, arglist);
+    va_end(arglist);
+
+    return ret;
   } else {
     va_list arglist;
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -488,16 +488,16 @@ void trunc_string(char *s, char *buf, int room_in, int buflen)
 int smsg(const char *s, ...)
   FUNC_ATTR_PRINTF(1, 2)
 {
-  va_list arglist;
-
-  va_start(arglist, s);
-  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
-  va_end(arglist);
-
   if (!ui_has_messages()) {
     // Use emsg() instead.  Because msg() does not work if no command line area
-    return semsg((char *)IObuff);
+    return semsg(s);
   } else {
+    va_list arglist;
+
+    va_start(arglist, s);
+    vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
+    va_end(arglist);
+
     return msg((char *)IObuff);
   }
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1389,7 +1389,7 @@ void msg_start(void)
     need_fileinfo = false;
   }
 
-  bool no_msg_area = !ui_has(kUIMessages) && p_ch < 1;
+  bool no_msg_area = !ui_has_messages();
 
   if (need_clr_eos || (no_msg_area && redrawing_cmdline)) {
     // Halfway an ":echo" command and getting an (error) message: clear
@@ -3112,7 +3112,7 @@ void msg_clr_eos_force(void)
     msg_row = msg_grid_pos;
   }
 
-  if (p_ch > 0) {
+  if (ui_has_messages()) {
     grid_fill(&msg_grid_adj, msg_row, msg_row + 1, msg_startcol, msg_endcol,
               ' ', ' ', HL_ATTR(HLF_MSG));
     grid_fill(&msg_grid_adj, msg_row + 1, Rows, 0, Columns,

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -488,25 +488,13 @@ void trunc_string(char *s, char *buf, int room_in, int buflen)
 int smsg(const char *s, ...)
   FUNC_ATTR_PRINTF(1, 2)
 {
-  if (!ui_has_messages()) {
-    // Use emsg() instead.  Because msg() does not work if no command line area
-    bool ret;
-    va_list arglist;
+  va_list arglist;
 
-    va_start(arglist, s);
-    ret = semsgv(s, arglist);
-    va_end(arglist);
+  va_start(arglist, s);
+  vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
+  va_end(arglist);
 
-    return ret;
-  } else {
-    va_list arglist;
-
-    va_start(arglist, s);
-    vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
-    va_end(arglist);
-
-    return msg((char *)IObuff);
-  }
+  return msg((char *)IObuff);
 }
 
 int smsg_attr(int attr, const char *s, ...)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -493,7 +493,13 @@ int smsg(const char *s, ...)
   va_start(arglist, s);
   vim_vsnprintf((char *)IObuff, IOSIZE, s, arglist);
   va_end(arglist);
-  return msg((char *)IObuff);
+
+  if (!ui_has_messages()) {
+    // Use emsg() instead.  Because msg() does not work if no command line area
+    return semsg((char *)IObuff);
+  } else {
+    return msg((char *)IObuff);
+  }
 }
 
 int smsg_attr(int attr, const char *s, ...)

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2810,7 +2810,7 @@ void pop_showcmd(void)
 
 static void display_showcmd(void)
 {
-  if (p_ch < 1 && !ui_has(kUIMessages)) {
+  if (!ui_has_messages()) {
     return;
   }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -687,8 +687,7 @@ void op_reindent(oparg_T *oap, Indenter how)
     redraw_curbuf_later(INVERTED);
   }
 
-  // TODO(Shougo): Use ext_messages instead
-  if (oap->line_count > p_report && ui_has_messages()) {
+  if (oap->line_count > p_report) {
     i = oap->line_count - (i + 1);
     smsg(NGETTEXT("%" PRId64 " line indented ",
                   "%" PRId64 " lines indented ", i),
@@ -2807,8 +2806,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     xfree(reg->y_array);
   }
 
-  // TODO(Shougo): Use ext_messages instead
-  if (message && ui_has_messages()) {  // Display message about yank?
+  if (message) {  // Display message about yank?
     if (yank_type == kMTCharWise && yanklines == 1) {
       yanklines = 0;
     }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -687,7 +687,7 @@ void op_reindent(oparg_T *oap, Indenter how)
     redraw_curbuf_later(INVERTED);
   }
 
-  // TODO: Use ext_messages instead
+  // TODO(Shougo): Use ext_messages instead
   if (oap->line_count > p_report && ui_has_messages()) {
     i = oap->line_count - (i + 1);
     smsg(NGETTEXT("%" PRId64 " line indented ",
@@ -2790,7 +2790,7 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     xfree(reg->y_array);
   }
 
-  // TODO: Use ext_messages instead
+  // TODO(Shougo): Use ext_messages instead
   if (message && ui_has_messages()) {  // Display message about yank?
     if (yank_type == kMTCharWise && yanklines == 1) {
       yanklines = 0;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -687,7 +687,8 @@ void op_reindent(oparg_T *oap, Indenter how)
     redraw_curbuf_later(INVERTED);
   }
 
-  if (oap->line_count > p_report) {
+  // TODO: Use ext_messages instead
+  if (oap->line_count > p_report && ui_has_messages()) {
     i = oap->line_count - (i + 1);
     smsg(NGETTEXT("%" PRId64 " line indented ",
                   "%" PRId64 " lines indented ", i),
@@ -2789,7 +2790,8 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
     xfree(reg->y_array);
   }
 
-  if (message && (p_ch > 0 || ui_has(kUIMessages))) {  // Display message about yank?
+  // TODO: Use ext_messages instead
+  if (message && ui_has_messages()) {  // Display message about yank?
     if (yank_type == kMTCharWise && yanklines == 1) {
       yanklines = 0;
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6143,7 +6143,7 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
-  // TODO: Use ext_messages instead
+  // TODO(Shougo): Use ext_messages instead
   if (!ui_has_messages()) {
     return;
   }
@@ -6165,7 +6165,7 @@ void clearmode(void)
 
 static void recording_mode(int attr)
 {
-  // TODO: Use ext_messages instead
+  // TODO(Shougo): Use ext_messages instead
   if (!ui_has_messages()) {
     return;
   }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6143,7 +6143,8 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
-  if (p_ch <= 0 && !ui_has(kUIMessages)) {
+  // TODO: Use ext_messages instead
+  if (!ui_has_messages()) {
     return;
   }
 
@@ -6164,7 +6165,8 @@ void clearmode(void)
 
 static void recording_mode(int attr)
 {
-  if (p_ch <= 0 && !ui_has(kUIMessages)) {
+  // TODO: Use ext_messages instead
+  if (!ui_has_messages()) {
     return;
   }
 
@@ -6472,8 +6474,7 @@ int redrawing(void)
  */
 int messaging(void)
 {
-  return !(p_lz && char_avail() && !KeyTyped)
-         && (p_ch > 0 || ui_has(kUIMessages));
+  return !(p_lz && char_avail() && !KeyTyped) && ui_has_messages();
 }
 
 /// Show current status info in ruler and various other places
@@ -6587,7 +6588,7 @@ static void win_redr_ruler(win_T *wp, bool always)
       off = 0;
     }
 
-    if (!part_of_status && p_ch < 1 && !ui_has(kUIMessages)) {
+    if (!part_of_status && !ui_has_messages()) {
       return;
     }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6143,11 +6143,6 @@ void unshowmode(bool force)
 // Clear the mode message.
 void clearmode(void)
 {
-  // TODO(Shougo): Use ext_messages instead
-  if (!ui_has_messages()) {
-    return;
-  }
-
   const int save_msg_row = msg_row;
   const int save_msg_col = msg_col;
 
@@ -6165,11 +6160,6 @@ void clearmode(void)
 
 static void recording_mode(int attr)
 {
-  // TODO(Shougo): Use ext_messages instead
-  if (!ui_has_messages()) {
-    return;
-  }
-
   msg_puts_attr(_("recording"), attr);
   if (!shortmess(SHM_RECORDING)) {
     char s[4];

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -5558,6 +5558,7 @@ func Test_locationlist_open_in_newtab()
   call delete('Xqftestfile3')
   set switchbuf&vim
 
+  set cmdheight=1
   %bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -5558,7 +5558,6 @@ func Test_locationlist_open_in_newtab()
   call delete('Xqftestfile3')
   set switchbuf&vim
 
-  set cmdheight=1
   %bwipe!
 endfunc
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -612,6 +612,13 @@ bool ui_has(UIExtension ext)
   return ui_ext[ext];
 }
 
+
+/// Returns true if the UI has messages area.
+bool ui_has_messages(void)
+{
+  return p_ch > 0 || ui_has(kUIMessages);
+}
+
 Array ui_array(void)
 {
   Array all_uis = ARRAY_DICT_INIT;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -612,7 +612,6 @@ bool ui_has(UIExtension ext)
   return ui_ext[ext];
 }
 
-
 /// Returns true if the UI has messages area.
 bool ui_has_messages(void)
 {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5877,7 +5877,7 @@ void win_setminheight(void)
   // loop until there is a 'winminheight' that is possible
   while (p_wmh > 0) {
     const int room = Rows - (int)p_ch;
-    const int needed = min_rows() - 1;  // 1 was added for the cmdline
+    const int needed = min_rows();
     if (room >= needed) {
       break;
     }
@@ -6830,7 +6830,9 @@ int min_rows(void)
     }
   }
   total += tabline_height() + global_stl_height();
-  total += 1;           // count the room for the command line
+  if (p_ch > 0) {
+    total += 1;           // count the room for the command line
+  }
   return total;
 }
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1103,7 +1103,7 @@ describe('cmdheight=0', function()
       ~                        |
       ~                        |
       ~                        |
-      ~                        |
+      recording @q             |
     ]], showmode={}}
     feed('q')
     screen:expect{grid=[[


### PR DESCRIPTION
Continue of https://github.com/neovim/neovim/pull/16251 https://github.com/neovim/neovim/pull/18961

Fix #19184
Fix #19193

Note:  I don't recommend for you to use `rhysd/accelerated-jk` plugin with `cmdheight=0` because of https://github.com/neovim/neovim/issues/18953

Note: It is the feature that `If you enter the cmdline while the cursor is in the lower half of the window, the entire buffer content will shift one line up while the cmdline is open`.  Because of https://github.com/neovim/neovim/issues/19112