### PR TITLE
vim-patch:9.0.0015: with EXITFREE defined terminal menus are not cleared

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -687,6 +687,7 @@ void free_all_mem(void)
 
   // Clear menus.
   do_cmdline_cmd("aunmenu *");
+  do_cmdline_cmd("tlunmenu *");
   do_cmdline_cmd("menutranslate clear");
 
   // Clear mappings, abbreviations, breakpoints.

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1496,11 +1496,10 @@ void execute_menu(const exarg_T *eap, vimmenu_T *menu, int mode_idx)
     }
   }
 
-  if (idx == -1 || eap == NULL) {
+  if (idx == MENU_INDEX_INVALID || eap == NULL) {
     idx = MENU_INDEX_NORMAL;
   }
 
-  assert(idx != MENU_INDEX_INVALID);
   if (menu->strings[idx] != NULL && (menu->modes & (1 << idx))) {
     // When executing a script or function execute the commands right now.
     // Also for the window toolbar


### PR DESCRIPTION
#### vim-patch:9.0.0015: with EXITFREE defined terminal menus are not cleared

Problem:    With EXITFREE defined terminal menus are not cleared.
Solution:   Also clear terminal menus. Remove condition that is always true.
            (closes vim/vim#10641)
https://github.com/vim/vim/commit/79ae152697ed0dfa578cfac305d05021dec2a6bc