### PR TITLE
vim-patch:9.0.{0017,0021,0022}: invalid memory access

### DIFF
--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -699,6 +699,21 @@ func Test_spellsuggest_too_deep()
   bwipe!
 endfunc
 
+func Test_spell_good_word_invalid()
+  " This was adding a word with a 0x02 byte, which causes havoc.
+  enew
+  norm o0
+  sil! norm rzzWs00/
+  2
+  sil! norm VzGprzzW
+  sil! norm z=
+
+  bwipe!
+  " clear the internal word list
+  " set enc=latin1
+  set enc=utf-8
+endfunc
+
 func LoadAffAndDic(aff_contents, dic_contents)
   throw 'skipped: Nvim does not support enc=latin1'
   set enc=latin1

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -780,7 +780,12 @@ func Test_no_crash_with_weird_text()
       
   END
   call setline(1, lines)
-  exe "%norm \<C-v>ez=>\<C-v>wzG"
+  try
+    exe "%norm \<C-v>ez=>\<C-v>wzG"
+  catch /E1280:/
+    let caught = 'yes'
+  endtry
+  call assert_equal('yes', caught)
 
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1431,5 +1431,17 @@ func Test_visual_paste_clipboard()
   bwipe!
 endfunc
 
+func Test_visual_area_adjusted_when_hiding()
+  " The Visual area ended after the end of the line after :hide
+  call setline(1, 'xxx')
+  vsplit Xfile
+  call setline(1, 'xxxxxxxx')
+  norm! $o
+  hid
+  norm! zW
+  bwipe!
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2741,6 +2741,8 @@ int win_close(win_T *win, bool free_buf, bool force)
      * to be the last one left, return now.
      */
     if (wp->w_buffer != curbuf) {
+      reset_VIsual_and_resel();  // stop Visual mode
+
       other_buffer = true;
       win->w_closing = true;
       apply_autocmds(EVENT_BUFLEAVE, NULL, NULL, false, curbuf);


### PR DESCRIPTION
#### vim-patch:9.0.0017: accessing memory beyond the end of the line

Problem:    Accessing memory beyond the end of the line.
Solution:   Stop Visual mode when closing a window.
https://github.com/vim/vim/commit/3d51ce18ab1be4f9f6061568a4e7fabf00b21794


#### vim-patch:9.0.0021: invalid memory access when adding word to spell word list

Problem:    Invalid memory access when adding word with a control character to
            the internal spell word list.
Solution:   Disallow adding a word with control characters or a trailing
            slash.
https://github.com/vim/vim/commit/5e59ea54c0c37c2f84770f068d95280069828774


#### vim-patch:9.0.0022: spell test fails

Problem:    Spell test fails.
Solution:   Expect new error is given.
https://github.com/vim/vim/commit/95afae6d1760b2efcc4968dbd3784799d24e9fdf