### PR TITLE
vim-patch:8.2.{0261,0316}: insufficient test coverage

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6293,7 +6293,7 @@ static int calc_hist_idx(int histype, int num)
         wrapped = TRUE;
       }
     }
-    if (hist[i].hisnum == num && hist[i].hisstr != NULL) {
+    if (i >= 0 && hist[i].hisnum == num && hist[i].hisstr != NULL) {
       return i;
     }
   } else if (-num <= hislen) {

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -2,6 +2,160 @@
 
 source check.vim
 
+" Test for the :bunload command with an offset
+func Test_bunload_with_offset()
+  %bwipe!
+  call writefile(['B1'], 'b1')
+  call writefile(['B2'], 'b2')
+  call writefile(['B3'], 'b3')
+  call writefile(['B4'], 'b4')
+
+  " Load four buffers. Unload the second and third buffers and then
+  " execute .+3bunload to unload the last buffer.
+  edit b1
+  new b2
+  new b3
+  new b4
+
+  bunload b2
+  bunload b3
+  exe bufwinnr('b1') . 'wincmd w'
+  .+3bunload
+  call assert_equal(0, getbufinfo('b4')[0].loaded)
+  call assert_equal('b1',
+        \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
+
+  " Load four buffers. Unload the third and fourth buffers. Execute .+3bunload
+  " and check whether the second buffer is unloaded.
+  ball
+  bunload b3
+  bunload b4
+  exe bufwinnr('b1') . 'wincmd w'
+  .+3bunload
+  call assert_equal(0, getbufinfo('b2')[0].loaded)
+  call assert_equal('b1',
+        \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
+
+  " Load four buffers. Unload the second and third buffers and from the last
+  " buffer execute .-3bunload to unload the first buffer.
+  ball
+  bunload b2
+  bunload b3
+  exe bufwinnr('b4') . 'wincmd w'
+  .-3bunload
+  call assert_equal(0, getbufinfo('b1')[0].loaded)
+  call assert_equal('b4',
+        \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
+
+  " Load four buffers. Unload the first and second buffers. Execute .-3bunload
+  " from the last buffer and check whether the third buffer is unloaded.
+  ball
+  bunload b1
+  bunload b2
+  exe bufwinnr('b4') . 'wincmd w'
+  .-3bunload
+  call assert_equal(0, getbufinfo('b3')[0].loaded)
+  call assert_equal('b4',
+        \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
+
+  %bwipe!
+  call delete('b1')
+  call delete('b2')
+  call delete('b3')
+  call delete('b4')
+
+  call assert_fails('1,4bunload', 'E16:')
+  call assert_fails(',100bunload', 'E16:')
+
+  " Use a try-catch for this test. When assert_fails() is used for this
+  " test, the command fails with E515: instead of E90:
+  let caught_E90 = 0
+  try
+    $bunload
+  catch /E90:/
+    let caught_E90 = 1
+  endtry
+  call assert_equal(1, caught_E90)
+  call assert_fails('$bunload', 'E515:')
+endfunc
+
+" Test for :buffer, :bnext, :bprevious, :brewind, :blast and :bmodified
+" commands
+func Test_buflist_browse()
+  %bwipe!
+  call assert_fails('buffer 1000', 'E86:')
+
+  call writefile(['foo1', 'foo2', 'foo3', 'foo4'], 'Xfile1')
+  call writefile(['bar1', 'bar2', 'bar3', 'bar4'], 'Xfile2')
+  call writefile(['baz1', 'baz2', 'baz3', 'baz4'], 'Xfile3')
+  edit Xfile1
+  let b1 = bufnr()
+  edit Xfile2
+  let b2 = bufnr()
+  edit +/baz4 Xfile3
+  let b3 = bufnr()
+
+  call assert_fails('buffer ' .. b1 .. ' abc', 'E488:')
+  call assert_equal(b3, bufnr())
+  call assert_equal(4, line('.'))
+  exe 'buffer +/bar2 ' .. b2
+  call assert_equal(b2, bufnr())
+  call assert_equal(2, line('.'))
+  exe 'buffer +/bar1'
+  call assert_equal(b2, bufnr())
+  call assert_equal(1, line('.'))
+
+  brewind +/foo3
+  call assert_equal(b1, bufnr())
+  call assert_equal(3, line('.'))
+
+  blast +/baz2
+  call assert_equal(b3, bufnr())
+  call assert_equal(2, line('.'))
+
+  bprevious +/bar4
+  call assert_equal(b2, bufnr())
+  call assert_equal(4, line('.'))
+
+  bnext +/baz3
+  call assert_equal(b3, bufnr())
+  call assert_equal(3, line('.'))
+
+  call assert_fails('bmodified', 'E84:')
+  call setbufvar(b2, '&modified', 1)
+  exe 'bmodified +/bar3'
+  call assert_equal(b2, bufnr())
+  call assert_equal(3, line('.'))
+
+  " With no listed buffers in the list, :bnext and :bprev should fail
+  %bwipe!
+  set nobuflisted
+  call assert_fails('bnext', 'E85:')
+  call assert_fails('bprev', 'E85:')
+  set buflisted
+
+  call assert_fails('sandbox bnext', 'E48:')
+
+  call delete('Xfile1')
+  call delete('Xfile2')
+  call delete('Xfile3')
+  %bwipe!
+endfunc
+
+" Test for :bdelete
+func Test_bdelete_cmd()
+  %bwipe!
+  call assert_fails('bdelete 5', 'E516:')
+
+  " Deleting a unlisted and unloaded buffer
+  edit Xfile1
+  let bnr = bufnr()
+  set nobuflisted
+  enew
+  call assert_fails('bdelete ' .. bnr, 'E516:')
+  %bwipe!
+endfunc
+
 func Test_buffer_error()
   new foo1
   new foo2

--- a/src/nvim/testdir/test_exists.vim
+++ b/src/nvim/testdir/test_exists.vim
@@ -94,8 +94,12 @@ func Test_exists()
   call assert_equal(0, exists(':edit/a'))
   " Valid internal command (partial match)
   call assert_equal(1, exists(':q'))
+  " Valid internal command with a digit
+  call assert_equal(2, exists(':2match'))
   " Non-existing internal command
   call assert_equal(0, exists(':invalidcmd'))
+  " Internal command with a count
+  call assert_equal(0, exists(':3buffer'))
 
   " User defined command (full match)
   command! MyCmd :echo 'My command'

--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -245,3 +245,19 @@ func Test_file_changed_dialog()
   bwipe!
   call delete('Xchanged_d')
 endfunc
+
+" Test for editing a new buffer from a FileChangedShell autocmd
+func Test_FileChangedShell_newbuf()
+  call writefile(['one', 'two'], 'Xfile')
+  new Xfile
+  augroup testnewbuf
+    autocmd FileChangedShell * enew
+  augroup END
+  sleep 10m  " make the test less flaky in Nvim
+  call writefile(['red'], 'Xfile')
+  call assert_fails('checktime', 'E811:')
+  au! testnewbuf
+  call delete('Xfile')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -31,6 +31,7 @@ func Test_abclear()
 
    abclear
    call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
+   call assert_fails('%abclear', 'E481:')
 endfunc
 
 func Test_abclear_buffer()

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -232,6 +232,15 @@ func Test_lockmarks_with_put()
   bwipe!
 endfunc
 
+" Test for :k command to set a mark
+func Test_marks_k_cmd()
+  new
+  call setline(1, ['foo', 'bar', 'baz', 'qux'])
+  1,3kr
+  call assert_equal([0, 3, 1, 0], getpos("'r"))
+  close!
+endfunc
+
 " Test for the getmarklist() function
 func Test_getmarklist()
   new

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -89,3 +89,39 @@ func Test_menu_commands()
 
   unlet g:did_menu
 endfun
+
+" Test for menu item completion in command line
+func Test_menu_expand()
+  " Create the menu itmes for test
+  for i in range(1, 4)
+    let m = 'menu Xmenu.A' .. i .. '.A' .. i
+    for j in range(1, 4)
+      exe m .. 'B' .. j .. ' :echo "A' .. i .. 'B' .. j .. '"' .. "<CR>"
+    endfor
+  endfor
+  set wildmenu
+
+  " Test for <CR> selecting a submenu
+  call feedkeys(":emenu Xmenu.A\<Tab>\<CR>\<Right>x\<BS>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"emenu Xmenu.A1.A1B2', @:)
+
+  " Test for <Down> selecting a submenu
+  call feedkeys(":emenu Xmenu.A\<Tab>\<Right>\<Right>\<Down>" ..
+        \ "\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"emenu Xmenu.A3.A3B1 A3B2 A3B3 A3B4', @:)
+
+  " Test for <Up> to go up a submenu
+  call feedkeys(":emenu Xmenu.A\<Tab>\<Down>\<Up>\<Right>\<Right>" ..
+        \ "\<Left>\<Down>\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"emenu Xmenu.A2.A2B1 A2B2 A2B3 A2B4', @:)
+
+  " Test for <Up> to go up a menu
+  call feedkeys(":emenu Xmenu.A\<Tab>\<Down>\<Up>\<Up>\<Up>" ..
+        \ "\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"emenu Buffers. Xmenu.', @:)
+
+  set wildmenu&
+  unmenu Xmenu
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2748,6 +2748,23 @@ func Test_normal_gk()
   set cpoptions& number& numberwidth&
 endfunc
 
+" Test for cursor movement with '-' in 'cpoptions'
+func Test_normal_cpo_minus()
+  throw 'Skipped: Nvim does not support cpoptions flag "-"'
+  new
+  call setline(1, ['foo', 'bar', 'baz'])
+  let save_cpo = &cpo
+  set cpo+=-
+  call assert_beeps('normal 10j')
+  call assert_equal(1, line('.'))
+  normal G
+  call assert_beeps('normal 10k')
+  call assert_equal(3, line('.'))
+  call assert_fails(10, 'E16:')
+  let &cpo = save_cpo
+  close!
+endfunc
+
 " Some commands like yy, cc, dd, >>, << and !! accept a count after
 " typing the first letter of the command.
 func Test_normal_count_after_operator()

--- a/src/nvim/testdir/test_plus_arg_edit.vim
+++ b/src/nvim/testdir/test_plus_arg_edit.vim
@@ -32,3 +32,16 @@ func Test_edit_bad()
   bw!
   call delete('Xfile')
 endfunc
+
+" Test for ++bin and ++nobin arguments
+func Test_binary_arg()
+  new
+  edit ++bin Xfile1
+  call assert_equal(1, &binary)
+  edit ++nobin Xfile2
+  call assert_equal(0, &binary)
+  call assert_fails('edit ++binabc Xfile3', 'E474:')
+  close!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -553,6 +553,15 @@ func Xtest_browse(cchar)
   10Xcc
   call assert_equal(11, line('.'))
   call assert_equal('Xqftestfile2', bufname('%'))
+  Xopen
+  call cursor(2, 1)
+  if a:cchar == 'c'
+    .cc
+  else
+    .ll
+  endif
+  call assert_equal(6, line('.'))
+  call assert_equal('Xqftestfile1', bufname('%'))
 
   " Jumping to an error from the error window (when only the error window is
   " present)


### PR DESCRIPTION
#### vim-patch:8.2.0261: some code not covered by tests

Problem:    Some code not covered by tests.
Solution:   Add test cases. (Yegappan Lakshmanan, closes vim/vim#5645)
https://github.com/vim/vim/commit/f0cee1971f5258ce61f8a4e6a04d35c1e625bb01

Cherry-pick Test_bunload_with_offset() from patch 8.2.0243


#### vim-patch:8.2.0316: ex_getln.c code has insufficient test coverage

Problem:    ex_getln.c code has insufficient test coverage.
Solution:   Add more tests. Fix a problem. (Yegappan Lakshmanan, closes vim/vim#5693)
https://github.com/vim/vim/commit/8d588ccee57390aa01c2395fc599bbe6506ee13a