### PR TITLE
fix(coverity): 353827 unnecessary null check

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -280,7 +280,7 @@ fmark_T *get_jumplist(win_T *win, int count)
     }
     break;
   }
-  return jmp != NULL ? &jmp->fmark : NULL;
+  return &jmp->fmark;
 }
 
 /// Get mark in "count" position in the |changelist| relative to the current index.


### PR DESCRIPTION
Previous checks make sure the index is not out of bounds. Therefore jmp
is never NULL.

```
*** CID 353827:  Null pointer dereferences  (REVERSE_INULL)
/src/nvim/mark.c: 283 in get_jumplist()
277             count += count < 0 ? -1 : 1;
278             continue;
279           }
280         }
281         break;
282       }
>>>     CID 353827:  Null pointer dereferences  (REVERSE_INULL)
>>>     Null-checking "jmp" suggests that it may be null, but it has already been dereferenced on all paths leading to the check.
283       return jmp != NULL ? &jmp->fmark : NULL;
284     }
285     
286     /// Get mark in "count" position in the |changelist| relative to the current index.
287     ///
288     /// @note  Changes the win->w_changelistidx.
```