### PR TITLE
refactor: remove unnecessary volatile

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -503,8 +503,7 @@ EXTERN int stdout_isatty INIT(= true);
 EXTERN int stdin_fd INIT(= -1);
 
 // true when doing full-screen output, otherwise only writing some messages.
-// volatile because it is used in a signal handler.
-EXTERN volatile int full_screen INIT(= false);
+EXTERN int full_screen INIT(= false);
 
 /// Non-zero when only "safe" commands are allowed, e.g. when sourcing .exrc or
 /// .vimrc in current directory.
@@ -724,7 +723,8 @@ EXTERN bool need_highlight_changed INIT(= true);
 
 EXTERN FILE *scriptout INIT(= NULL);  ///< Stream to write script to.
 
-// volatile because it is used in a signal handler.
+// Note that even when handling SIGINT, volatile is not necessary because the
+// callback is not called directly from the signal handlers.
 EXTERN bool got_int INIT(= false);          // set to true when interrupt signal occurred
 EXTERN bool bangredo INIT(= false);         // set to true with ! command
 EXTERN int searchcmdlen;                    // length of previous search cmd

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -165,8 +165,7 @@ static char *signal_name(int signum)
 // This function handles deadly signals.
 // It tries to preserve any swap files and exit properly.
 // (partly from Elvis).
-// NOTE: Avoid unsafe functions, such as allocating memory, they can result in
-// a deadlock.
+// NOTE: this is scheduled on the event loop, not called directly from a signal handler.
 static void deadly_signal(int signum)
   FUNC_ATTR_NORETURN
 {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -137,7 +137,7 @@ struct TUIData {
   char *space_buf;
 };
 
-static bool volatile got_winch = false;
+static bool got_winch = false;
 static bool did_user_set_dimensions = false;
 static bool cursor_style_enabled = false;
 


### PR DESCRIPTION
libuv does not call callback functions(`uv_signal_cb`) directly from signal handlers. Therefore, there is no need to use `volatile`.

Ref. https://github.com/libuv/libuv/blob/1a91b51976a1adc6972081faa78b6b70022254d3/src/unix/signal.c#L183