### PR TITLE
vim-patch:9.0.{0024,0030}

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1804,7 +1804,8 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   bool is_plug_map = false;
 
   // If typehead starts with <Plug> then remap, even for a "noremap" mapping.
-  if (typebuf.tb_buf[typebuf.tb_off] == K_SPECIAL
+  if (typebuf.tb_len >= 3
+      && typebuf.tb_buf[typebuf.tb_off] == K_SPECIAL
       && typebuf.tb_buf[typebuf.tb_off + 1] == KS_EXTRA
       && typebuf.tb_buf[typebuf.tb_off + 2] == KE_PLUG) {
     is_plug_map = true;

--- a/src/nvim/testdir/test_matchfuzzy.vim
+++ b/src/nvim/testdir/test_matchfuzzy.vim
@@ -59,7 +59,7 @@ func Test_matchfuzzy()
 
   %bw!
   eval ['somebuf', 'anotherone', 'needle', 'yetanotherone']->map({_, v -> bufadd(v) + bufload(v)})
-  let l = getbufinfo()->map({_, v -> v.name})->matchfuzzy('ndl')
+  let l = getbufinfo()->map({_, v -> fnamemodify(v.name, ':t')})->matchfuzzy('ndl')
   call assert_equal(1, len(l))
   call assert_match('needle', l[0])
 


### PR DESCRIPTION
#### vim-patch:9.0.0024: may access part of typeahead buf that isn't filled

Problem:    May access part of typeahead buf that isn't filled.
Solution:   Check length of typeahead.
https://github.com/vim/vim/commit/af043e12d9e5869c597de40b9a2517ae97ac72e7


#### vim-patch:9.0.0030: matchfuzzy test depends on path of current directory

Problem:    Matchfuzzy test depends on path of current directory.
Solution:   Use fnamemodify() to remove the path. (Robin Becker)
https://github.com/vim/vim/commit/22e7e867e224596bd758260e4278ce6239c35ba5