### PR TITLE
feat(lsp): allow passing custom list handler to LSP functions that return lists

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -427,9 +427,8 @@ This table can be used with vim.fn.setqflist or vim.fn.setloclist. E.g.:
     vim.api.nvim_command('cfirst')
   end
 
-  local bufopts = { noremap=true, silent=true, buffer=bufnr }
-  vim.keymap.set('n', '<leader>d', function() vim.lsp.buf.definition{on_list=on_list} end, bufopts)
-  vim.keymap.set('n', '<leader>af', function() vim.lsp.buf.references(nil, {on_list=on_list}) end, bufopts)
+  vim.lsp.buf.definition{on_list=on_list}
+  vim.lsp.buf.references(nil, {on_list=on_list})
 
 If you prefer loclist do something like this:
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -414,8 +414,13 @@ For the format of the notification message, see:
 
                                                                 *on-list-handler*
 
-on_list handler accepts single parameter options which can be passed directly
-to vim.fn.setqflist or vim.fn.setloclist. E.g.:
+`on_list` receives a table with:
+
+ - `items` table[], structured like |setqflist-what|
+ - `title` string, title for the list.
+ - `context` table|nil. `ctx` from |lsp-handler|
+
+This table can be used with vim.fn.setqflist or vim.fn.setloclist. E.g.:
 
   local function on_list(options)
     vim.fn.setqflist({}, ' ', options)

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1114,6 +1114,7 @@ declaration({options})                             *vim.lsp.buf.declaration()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
+                               • on_list: (function) handler for list results
 
 definition({options})                               *vim.lsp.buf.definition()*
                 Jumps to the definition of the symbol under the cursor.
@@ -1122,6 +1123,7 @@ definition({options})                               *vim.lsp.buf.definition()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
+                               • on_list: (function) handler for list results
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
                 Send request to the server to resolve document highlights for
@@ -1139,9 +1141,13 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
                 to see the actual highlights. |LspReferenceText|
                 |LspReferenceRead| |LspReferenceWrite|
 
-document_symbol()                              *vim.lsp.buf.document_symbol()*
+document_symbol({options})                     *vim.lsp.buf.document_symbol()*
                 Lists all symbols in the current buffer in the quickfix
                 window.
+
+                Parameters: ~
+                    {options}  (table|nil) additional options
+                               • on_list: (function) handler for list results
 
 execute_command({command_params})              *vim.lsp.buf.execute_command()*
                 Executes an LSP server command.
@@ -1251,9 +1257,13 @@ hover()                                                  *vim.lsp.buf.hover()*
                 in a floating window. Calling the function twice will jump
                 into the floating window.
 
-implementation()                                *vim.lsp.buf.implementation()*
+implementation({options})                       *vim.lsp.buf.implementation()*
                 Lists all the implementations for the symbol under the cursor
                 in the quickfix window.
+
+                Parameters: ~
+                    {options}  (table|nil) additional options
+                               • on_list: (function) handler for list results
 
 incoming_calls()                                *vim.lsp.buf.incoming_calls()*
                 Lists all the call sites of the symbol under the cursor in the
@@ -1300,12 +1310,14 @@ range_formatting({options}, {start_pos}, {end_pos})
                                  position. Defaults to the end of the last
                                  visual selection.
 
-references({context})                               *vim.lsp.buf.references()*
+references({context}, {options})                    *vim.lsp.buf.references()*
                 Lists all the references to the symbol under the cursor in the
                 quickfix window.
 
                 Parameters: ~
                     {context}  (table) Context for the request
+                    {options}  (table|nil) additional options
+                               • on_list: (function) handler for list results
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -1351,8 +1363,9 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
+                               • on_list: (function) handler for list results
 
-workspace_symbol({query})                     *vim.lsp.buf.workspace_symbol()*
+workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
                 Lists all symbols in the current workspace in the quickfix
                 window.
 
@@ -1362,7 +1375,9 @@ workspace_symbol({query})                     *vim.lsp.buf.workspace_symbol()*
                 done.
 
                 Parameters: ~
-                    {query}  (string, optional)
+                    {query}    (string, optional)
+                    {options}  (table|nil) additional options
+                               • on_list: (function) handler for list results
 
 
 ==============================================================================

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -438,8 +438,6 @@ If you prefer loclist do something like this:
     vim.api.nvim_command('lopen')
   end
 
-options parameter is table that has title, list and optionally context.
-
 ================================================================================
 LSP HIGHLIGHT                                                    *lsp-highlight*
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -412,6 +412,29 @@ For the format of the response message, see:
 For the format of the notification message, see:
     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
 
+                                                                *on-list-handler*
+
+on_list handler accepts single parameter options which can be passed directly
+to vim.fn.setqflist or vim.fn.setloclist. E.g.:
+
+  local function on_list(options)
+    vim.fn.setqflist({}, ' ', options)
+    vim.api.nvim_command('cfirst')
+  end
+
+  local bufopts = { noremap=true, silent=true, buffer=bufnr }
+  vim.keymap.set('n', '<leader>d', function() vim.lsp.buf.definition{on_list=on_list} end, bufopts)
+  vim.keymap.set('n', '<leader>af', function() vim.lsp.buf.references(nil, {on_list=on_list}) end, bufopts)
+
+If you prefer loclist do something like this:
+
+  local function on_list(options)
+    vim.fn.setloclist(0, {}, ' ', options)
+    vim.api.nvim_command('lopen')
+  end
+
+options parameter is table that has title, list and optionally context.
+
 ================================================================================
 LSP HIGHLIGHT                                                    *lsp-highlight*
 
@@ -1114,7 +1137,8 @@ declaration({options})                             *vim.lsp.buf.declaration()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 definition({options})                               *vim.lsp.buf.definition()*
                 Jumps to the definition of the symbol under the cursor.
@@ -1123,7 +1147,8 @@ definition({options})                               *vim.lsp.buf.definition()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
                 Send request to the server to resolve document highlights for
@@ -1147,7 +1172,8 @@ document_symbol({options})                     *vim.lsp.buf.document_symbol()*
 
                 Parameters: ~
                     {options}  (table|nil) additional options
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 execute_command({command_params})              *vim.lsp.buf.execute_command()*
                 Executes an LSP server command.
@@ -1263,7 +1289,8 @@ implementation({options})                       *vim.lsp.buf.implementation()*
 
                 Parameters: ~
                     {options}  (table|nil) additional options
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 incoming_calls()                                *vim.lsp.buf.incoming_calls()*
                 Lists all the call sites of the symbol under the cursor in the
@@ -1317,7 +1344,8 @@ references({context}, {options})                    *vim.lsp.buf.references()*
                 Parameters: ~
                     {context}  (table) Context for the request
                     {options}  (table|nil) additional options
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -1363,7 +1391,8 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
                     {options}  (table|nil) additional options
                                • reuse_win: (boolean) Jump to existing window
                                  if buffer is already open.
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
                 Lists all symbols in the current workspace in the quickfix
@@ -1377,7 +1406,8 @@ workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
                 Parameters: ~
                     {query}    (string, optional)
                     {options}  (table|nil) additional options
-                               • on_list: (function) handler for list results
+                               • on_list: (function) handler for list results.
+                                 See |on-list-handler|
 
 
 ==============================================================================

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -61,6 +61,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
+---     - on_list: (function) handler for list results
 function M.declaration(options)
   local params = util.make_position_params()
   request_with_options('textDocument/declaration', params, options)
@@ -70,6 +71,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
+---     - on_list: (function) handler for list results
 function M.definition(options)
   local params = util.make_position_params()
   request_with_options('textDocument/definition', params, options)
@@ -79,6 +81,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
+---     - on_list: (function) handler for list results
 function M.type_definition(options)
   local params = util.make_position_params()
   request_with_options('textDocument/typeDefinition', params, options)
@@ -86,9 +89,12 @@ end
 
 --- Lists all the implementations for the symbol under the cursor in the
 --- quickfix window.
-function M.implementation()
+---
+---@param options table|nil additional options
+---     - on_list: (function) handler for list results
+function M.implementation(options)
   local params = util.make_position_params()
-  request('textDocument/implementation', params)
+  request_with_options('textDocument/implementation', params, options)
 end
 
 --- Displays signature information about the symbol under the cursor in a
@@ -496,20 +502,24 @@ end
 ---
 ---@param context (table) Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
-function M.references(context)
+---@param options table|nil additional options
+---     - on_list: (function) handler for list results
+function M.references(context, options)
   validate({ context = { context, 't', true } })
   local params = util.make_position_params()
   params.context = context or {
     includeDeclaration = true,
   }
-  request('textDocument/references', params)
+  request_with_options('textDocument/references', params, options)
 end
 
 --- Lists all symbols in the current buffer in the quickfix window.
 ---
-function M.document_symbol()
+---@param options table|nil additional options
+---     - on_list: (function) handler for list results
+function M.document_symbol(options)
   local params = { textDocument = util.make_text_document_params() }
-  request('textDocument/documentSymbol', params)
+  request_with_options('textDocument/documentSymbol', params, options)
 end
 
 ---@private
@@ -648,13 +658,15 @@ end
 --- string means no filtering is done.
 ---
 ---@param query (string, optional)
-function M.workspace_symbol(query)
+---@param options table|nil additional options
+---     - on_list: (function) handler for list results
+function M.workspace_symbol(query, options)
   query = query or npcall(vim.fn.input, 'Query: ')
   if query == nil then
     return
   end
   local params = { query = query }
-  request('workspace/symbol', params)
+  request_with_options('workspace/symbol', params, options)
 end
 
 --- Send request to the server to resolve document highlights for the current

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -61,7 +61,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.declaration(options)
   local params = util.make_position_params()
   request_with_options('textDocument/declaration', params, options)
@@ -71,7 +71,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.definition(options)
   local params = util.make_position_params()
   request_with_options('textDocument/definition', params, options)
@@ -81,7 +81,7 @@ end
 ---
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.type_definition(options)
   local params = util.make_position_params()
   request_with_options('textDocument/typeDefinition', params, options)
@@ -91,7 +91,7 @@ end
 --- quickfix window.
 ---
 ---@param options table|nil additional options
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.implementation(options)
   local params = util.make_position_params()
   request_with_options('textDocument/implementation', params, options)
@@ -503,7 +503,7 @@ end
 ---@param context (table) Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 ---@param options table|nil additional options
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.references(context, options)
   validate({ context = { context, 't', true } })
   local params = util.make_position_params()
@@ -516,7 +516,7 @@ end
 --- Lists all symbols in the current buffer in the quickfix window.
 ---
 ---@param options table|nil additional options
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.document_symbol(options)
   local params = { textDocument = util.make_text_document_params() }
   request_with_options('textDocument/documentSymbol', params, options)
@@ -659,7 +659,7 @@ end
 ---
 ---@param query (string, optional)
 ---@param options table|nil additional options
----     - on_list: (function) handler for list results
+---     - on_list: (function) handler for list results. See |on-list-handler|
 function M.workspace_symbol(query, options)
   query = query or npcall(vim.fn.input, 'Query: ')
   if query == nil then

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -193,11 +193,6 @@ M['textDocument/references'] = function(_, result, ctx, config)
     local items = util.locations_to_items(result, client.offset_encoding)
 
     if config.loclist then
-      vim.notify_once(
-        '[LSP] config.loclist is deprecated. '
-          .. 'Update your plugins or configuration to use options.on_list.',
-        vim.log.levels.WARN
-      )
       vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
       api.nvim_command('lopen')
     elseif config.on_list then
@@ -231,11 +226,6 @@ local function response_to_list(map_result, entity, title_fn)
       local items = map_result(result, ctx.bufnr)
 
       if config.loclist then
-        vim.notify_once(
-          '[LSP] config.loclist is deprecated. '
-            .. 'Update your plugins or configuration to use options.on_list.',
-          vim.log.levels.WARN
-        )
         vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
         api.nvim_command('lopen')
       elseif config.on_list then

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -189,19 +189,22 @@ M['textDocument/references'] = function(_, result, ctx, config)
   else
     local client = vim.lsp.get_client_by_id(ctx.client_id)
     config = config or {}
+    local title = 'References'
+    local items = util.locations_to_items(result, client.offset_encoding)
+
     if config.loclist then
-      vim.fn.setloclist(0, {}, ' ', {
-        title = 'References',
-        items = util.locations_to_items(result, client.offset_encoding),
-        context = ctx,
-      })
+      vim.notify_once(
+        '[LSP] config.loclist is deprecated. '
+          .. 'Update your plugins or configuration to use options.on_list.',
+        vim.log.levels.WARN
+      )
+      vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
       api.nvim_command('lopen')
+    elseif config.on_list then
+      assert(type(config.on_list) == 'function', 'on_list is not a function')
+      config.on_list({ title = title, items = items, context = ctx })
     else
-      vim.fn.setqflist({}, ' ', {
-        title = 'References',
-        items = util.locations_to_items(result, client.offset_encoding),
-        context = ctx,
-      })
+      vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
       api.nvim_command('botright copen')
     end
   end
@@ -224,19 +227,22 @@ local function response_to_list(map_result, entity, title_fn)
       vim.notify('No ' .. entity .. ' found')
     else
       config = config or {}
+      local title = title_fn(ctx)
+      local items = map_result(result, ctx.bufnr)
+
       if config.loclist then
-        vim.fn.setloclist(0, {}, ' ', {
-          title = title_fn(ctx),
-          items = map_result(result, ctx.bufnr),
-          context = ctx,
-        })
+        vim.notify_once(
+          '[LSP] config.loclist is deprecated. '
+            .. 'Update your plugins or configuration to use options.on_list.',
+          vim.log.levels.WARN
+        )
+        vim.fn.setloclist(0, {}, ' ', { title = title, items = items, context = ctx })
         api.nvim_command('lopen')
+      elseif config.on_list then
+        assert(type(config.on_list) == 'function', 'on_list is not a function')
+        config.on_list({ title = title, items = items, context = ctx })
       else
-        vim.fn.setqflist({}, ' ', {
-          title = title_fn(ctx),
-          items = map_result(result, ctx.bufnr),
-          context = ctx,
-        })
+        vim.fn.setqflist({}, ' ', { title = title, items = items, context = ctx })
         api.nvim_command('botright copen')
       end
     end
@@ -354,11 +360,16 @@ local function location_handler(_, result, ctx, config)
     util.jump_to_location(result[1], client.offset_encoding, config.reuse_win)
 
     if #result > 1 then
-      vim.fn.setqflist({}, ' ', {
-        title = 'LSP locations',
-        items = util.locations_to_items(result, client.offset_encoding),
-      })
-      api.nvim_command('botright copen')
+      local title = 'LSP locations'
+      local items = util.locations_to_items(result, client.offset_encoding)
+
+      if config.on_list then
+        assert(type(config.on_list) == 'function', 'on_list is not a function')
+        config.on_list({ title = title, items = items })
+      else
+        vim.fn.setqflist({}, ' ', { title = title, items = items })
+        api.nvim_command('botright copen')
+      end
     end
   else
     util.jump_to_location(result, client.offset_encoding, config.reuse_win)


### PR DESCRIPTION
Currently LSP allows only using loclist or quickfix list window. I
normally prefer to review all quickfix items without opening quickfix
window. This fix allows passing `on_list` option which allows full
control what to do with list.

Here is example how to use it with quick fix list:

```lua
local function on_list(options)
  vim.fn.setqflist({}, ' ', options)
  vim.api.nvim_command('cfirst')
end

local bufopts = { noremap=true, silent=true, buffer=bufnr }
vim.keymap.set('n', '<leader>ad', function() vim.lsp.buf.declaration{on_list=on_list} end, bufopts)
vim.keymap.set('n', '<leader>d', function() vim.lsp.buf.definition{on_list=on_list} end, bufopts)
vim.keymap.set('n', '<leader>ai', function() vim.lsp.buf.implementation{on_list=on_list} end, bufopts)
vim.keymap.set('n', '<leader>at', function() vim.lsp.buf.type_definition{on_list=on_list} end, bufopts)
vim.keymap.set('n', '<leader>af', function() vim.lsp.buf.references(nil, {on_list=on_list}) end, bufopts)
```

If you prefer loclist do something like this:

```lua
local function on_list(options)
  vim.fn.setloclist(0, {}, ' ', options)
  vim.api.nvim_command('lopen')
end
```

close https://github.com/neovim/neovim/issues/19182