### PR TITLE
vim-patch:9.0.0031: <mods> of user command does not have correct verbose value

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1605,10 +1605,10 @@ The valid escape sequences are
 		nothing. Supported modifiers are |:aboveleft|, |:belowright|,
 		|:botright|, |:browse|, |:confirm|, |:hide|, |:keepalt|,
 		|:keepjumps|, |:keepmarks|, |:keeppatterns|, |:leftabove|,
-		|:lockmarks|, |:noswapfile| |:rightbelow|, |:silent|, |:tab|,
-		|:topleft|, |:verbose|, and |:vertical|.
-		Note that these are not yet supported: |:noautocmd|,
-		|:sandbox| and |:unsilent|.
+		|:lockmarks|, |:noautocmd|, |:noswapfile| |:rightbelow|,
+		|:sandbox|, |:silent|, |:tab|, |:topleft|, |:unsilent|,
+		|:verbose|, and |:vertical|.
+		Note that |:filter| is not supported.
 		Examples: >
 		    command! -nargs=+ -complete=file MyEdit
 				\ for f in expand(<q-args>, 0, 1) |

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6567,20 +6567,27 @@ size_t uc_mods(char *buf, const cmdmod_T *cmod, bool quote)
 
   // the modifiers that are simple flags
   for (size_t i = 0; i < ARRAY_SIZE(mod_entries); i++) {
-    if (cmdmod.cmod_flags & mod_entries[i].flag) {
+    if (cmod->cmod_flags & mod_entries[i].flag) {
       result += add_cmd_modifier(buf, mod_entries[i].name, &multi_mods);
     }
   }
 
   // :silent
-  if (msg_silent > 0) {
+  if (cmod->cmod_flags & CMOD_SILENT) {
     result += add_cmd_modifier(buf,
                                (cmod->cmod_flags & CMOD_ERRSILENT) ? "silent!" : "silent",
                                &multi_mods);
   }
   // :verbose
-  if (p_verbose > 0) {
-    result += add_cmd_modifier(buf, "verbose", &multi_mods);
+  if (cmod->cmod_verbose > 0) {
+    int verbose_value = cmod->cmod_verbose - 1;
+    if (verbose_value == 1) {
+      result += add_cmd_modifier(buf, "verbose", &multi_mods);
+    } else {
+      char verbose_buf[NUMBUFLEN];
+      snprintf(verbose_buf, NUMBUFLEN, "%dverbose", verbose_value);
+      result += add_cmd_modifier(buf, verbose_buf, &multi_mods);
+    }
   }
   // flags from cmod->cmod_split
   result += add_win_cmd_modifers(buf, cmod, &multi_mods);

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -56,7 +56,10 @@ function Test_cmdmods()
   call assert_equal('lockmarks', g:mods)
   loc MyCmd
   call assert_equal('lockmarks', g:mods)
-  " noautocmd MyCmd
+  noautocmd MyCmd
+  call assert_equal('noautocmd', g:mods)
+  noa MyCmd
+  call assert_equal('noautocmd', g:mods)
   noswapfile MyCmd
   call assert_equal('noswapfile', g:mods)
   nos MyCmd
@@ -70,29 +73,43 @@ function Test_cmdmods()
   call assert_equal('silent', g:mods)
   sil MyCmd
   call assert_equal('silent', g:mods)
+  silent! MyCmd
+  call assert_equal('silent!', g:mods)
+  sil! MyCmd
+  call assert_equal('silent!', g:mods)
   tab MyCmd
   call assert_equal('tab', g:mods)
   topleft MyCmd
   call assert_equal('topleft', g:mods)
   to MyCmd
   call assert_equal('topleft', g:mods)
-  " unsilent MyCmd
+  unsilent MyCmd
+  call assert_equal('unsilent', g:mods)
+  uns MyCmd
+  call assert_equal('unsilent', g:mods)
   verbose MyCmd
   call assert_equal('verbose', g:mods)
   verb MyCmd
   call assert_equal('verbose', g:mods)
+  0verbose MyCmd
+  call assert_equal('0verbose', g:mods)
+  3verbose MyCmd
+  call assert_equal('3verbose', g:mods)
+  999verbose MyCmd
+  call assert_equal('999verbose', g:mods)
   vertical MyCmd
   call assert_equal('vertical', g:mods)
   vert MyCmd
   call assert_equal('vertical', g:mods)
 
   aboveleft belowright botright browse confirm hide keepalt keepjumps
-	      \ keepmarks keeppatterns lockmarks noswapfile silent tab
-	      \ topleft verbose vertical MyCmd
+	      \ keepmarks keeppatterns lockmarks noautocmd noswapfile silent
+	      \ tab topleft unsilent verbose vertical MyCmd
 
   call assert_equal('browse confirm hide keepalt keepjumps ' .
-      \ 'keepmarks keeppatterns lockmarks noswapfile silent ' .
-      \ 'verbose aboveleft belowright botright tab topleft vertical', g:mods)
+      \ 'keepmarks keeppatterns lockmarks noswapfile unsilent noautocmd ' .
+      \ 'silent verbose aboveleft belowright botright tab topleft vertical',
+      \ g:mods)
 
   let g:mods = ''
   command! -nargs=* MyQCmd let g:mods .= '<q-mods> '


### PR DESCRIPTION
#### vim-patch:9.0.0031: \<mods\> of user command does not have correct verbose value

Problem:    \<mods\> of user command does not have correct verbose value.
Solution:   Use the value from the command modifier. (closes vim/vim#10651)
https://github.com/vim/vim/commit/9359e8a6d99fe2abfcbb9603339f1740d8870cc6