### PR TITLE
feat(runtime)!: enable filetype.lua by default

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -177,7 +177,9 @@ This means that the contents of compressed files are not inspected.
 If a file type that you want to use is not detected yet, there are a few ways
 to add it.  In any way, it's better not to modify the $VIMRUNTIME/filetype.lua
 or $VIMRUNTIME/filetype.vim files.  They will be overwritten when installing a
-new version of Nvim.
+new version of Nvim. The following explains the legacy Vim mechanism (enabled
+if |do_legacy_filetype| is set). For Nvim's default mechanism, see
+|vim.filetype.add()|.
 
 A. If you want to overrule all default file type checks.
    This works by writing one file for each filetype.  The disadvantage is that
@@ -236,39 +238,8 @@ C. If your file type can be detected by the file name or extension.
       Write this file as "filetype.vim" in your user runtime directory.  For
       example, for Unix: >
 	:w ~/.config/nvim/filetype.vim
-<
-      Alternatively, create a file called "filetype.lua" that adds new
-      filetypes.
-      Example: >
-	vim.filetype.add({
-	  extension = {
-	    foo = "fooscript",
-	  },
-	  filename = {
-	    [".foorc"] = "foorc",
-	  },
-	  pattern = {
-	    [".*/etc/foo/.*%.conf"] = "foorc",
-	  },
-	})
-<
-      See |vim.filetype.add()|.
-						     *g:do_filetype_lua*
-      For now, Lua filetype detection is opt-in. You can enable it by adding
-      the following to your |init.vim|: >
-        let g:do_filetype_lua = 1
-<						     *g:did_load_filetypes*
-      In either case, the builtin filetype detection provided by Nvim can be
-      disabled by setting the did_load_filetypes global variable. If this
-      variable exists, $VIMRUNTIME/filetype.vim will not run.
-      Example: >
-	" Disable filetype.vim (but still load filetype.lua if enabled)
-	let g:did_load_filetypes = 0
 
-	" Disable filetype.vim and filetype.lua
-	let g:did_load_filetypes = 1
-
-<  3. To use the new filetype detection you must restart Vim.
+<   3. To use the new filetype detection you must restart Vim.
 
    Your filetype.vim will be sourced before the default FileType autocommands
    have been installed.  Your autocommands will match first, and the
@@ -314,6 +285,16 @@ scripts.vim files in a runtime directory that is used for everybody.  Check
 the 'runtimepath' for a directory to use.  If there isn't one, set
 'runtimepath' in the |system-vimrc|.  Be careful to keep the default
 directories!
+
+						     *g:do_legacy_filetype*
+To disable Nvim's default filetype detection and revert to Vim's legacy
+filetype detection, add the following to your |init.vim|: >
+  let g:do_legacy_filetype = 1
+<						     *g:did_load_filetypes*
+The builtin filetype detection provided by Nvim can be disabled by setting
+the `did_load_filetypes` global variable. If this variable exists, neither
+the default `$VIMRUNTIME/filetype.lua` nor the legacy `$VIMRUNTIME/filetype.vim`
+will run.
 
 							*plugin-details*
 The "plugin" directory can be in any of the directories in the 'runtimepath'

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2022,8 +2022,8 @@ add({filetypes})                                          *vim.filetype.add()*
 
                 See $VIMRUNTIME/lua/vim/filetype.lua for more examples.
 
-                Note that Lua filetype detection is only enabled when
-                |g:do_filetype_lua| is set to 1.
+                Note that Lua filetype detection is disabled when
+                |g:do_legacy_filetype| is set.
 
                 Example: >
 

--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -1,11 +1,8 @@
-if vim.g.did_load_filetypes and vim.g.did_load_filetypes ~= 0 then
+-- Skip if legacy filetype is enabled or filetype detection is disabled
+if vim.g.do_legacy_filetype or vim.g.did_load_filetypes then
   return
 end
-
--- For now, make this opt-in with a global variable
-if vim.g.do_filetype_lua ~= 1 then
-  return
-end
+vim.g.did_load_filetypes = 1
 
 vim.api.nvim_create_augroup('filetypedetect', { clear = false })
 
@@ -38,21 +35,16 @@ if not vim.g.did_load_ftdetect then
   ]])
 end
 
--- Set a marker so that the ftdetect scripts are not sourced a second time by filetype.vim
-vim.g.did_load_ftdetect = 1
+-- Set up the autocmd for user scripts.vim
+vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+  group = 'filetypedetect',
+  command = "if !did_filetype() && expand('<amatch>') !~ g:ft_ignore_pat | runtime! scripts.vim | endif",
+})
 
--- If filetype.vim is disabled, set up the autocmd to use scripts.vim
-if vim.g.did_load_filetypes then
-  vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
-    group = 'filetypedetect',
-    command = "if !did_filetype() && expand('<amatch>') !~ g:ft_ignore_pat | runtime! scripts.vim | endif",
-  })
-
-  vim.api.nvim_create_autocmd('StdinReadPost', {
-    group = 'filetypedetect',
-    command = 'if !did_filetype() | runtime! scripts.vim | endif',
-  })
-end
+vim.api.nvim_create_autocmd('StdinReadPost', {
+  group = 'filetypedetect',
+  command = 'if !did_filetype() | runtime! scripts.vim | endif',
+})
 
 if not vim.g.ft_ignore_pat then
   vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -3,6 +3,11 @@
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
 " Last Change:	2022 Jun 03
 
+" Only run this if enabled
+if !exists("do_legacy_filetype")
+  finish
+endif
+
 " Listen very carefully, I will say this only once
 if exists("did_load_filetypes")
   finish

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2223,8 +2223,7 @@ end
 ---
 --- See $VIMRUNTIME/lua/vim/filetype.lua for more examples.
 ---
---- Note that Lua filetype detection is only enabled when |g:do_filetype_lua| is
---- set to 1.
+--- Note that Lua filetype detection is disabled when |g:do_legacy_filetype| is set.
 ---
 --- Example:
 --- <pre>

--- a/runtime/scripts.vim
+++ b/runtime/scripts.vim
@@ -11,9 +11,13 @@
 " 'ignorecase' option making a difference.  Where case is to be ignored use
 " =~? instead.  Do not use =~ anywhere.
 
-" Only do the rest when not using Lua filetype detection
-" and the FileType autocommand has not been triggered yet.
-if exists("g:do_filetype_lua") && g:do_filetype_lua || did_filetype()
+" Only run when using legacy filetype
+if !exists('g:do_legacy_filetype')
+  finish
+endif
+
+" Only do the rest when the FileType autocommand has not been triggered yet.
+if did_filetype()
   finish
 endif
 

--- a/src/nvim/testdir/test_filetype_lua.vim
+++ b/src/nvim/testdir/test_filetype_lua.vim
@@ -1,3 +1,0 @@
-let g:do_filetype_lua = 1
-let g:did_load_filetypes = 0
-source test_filetype.vim

--- a/src/nvim/testdir/test_legacy_filetype.vim
+++ b/src/nvim/testdir/test_legacy_filetype.vim
@@ -1,0 +1,4 @@
+let g:do_legacy_filetype = 1
+filetype on
+
+source test_filetype.vim


### PR DESCRIPTION
* revert to filetype.vim by setting `g:do_legacy_filetype`
* skip either filetype.lua or filetype.vim via `g:did_load_filetypes`

(Running both is no longer required and therefore no longer supported.)

**NOTE:** Still not sure how to revert to filetype.vim for the corresponding oldtest, since the guard variables 
are set too late in the test to affect the filetype detection. One option is to only run the tests on `filetype.lua` and trust Vim for the legacy codepath. @gpanders 

Feedback on documentation changes and variable names welcome. 