### PR TITLE
fix(lua): make it possible to cancel vim.wait() with Ctrl-C

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -416,9 +416,9 @@ static int nlua_wait(lua_State *lstate)
   LOOP_PROCESS_EVENTS_UNTIL(&main_loop,
                             loop_events,
                             (int)timeout,
-                            is_function ? nlua_wait_condition(lstate,
-                                                              &pcall_status,
-                                                              &callback_result) : false || got_int);
+                            got_int || (is_function ? nlua_wait_condition(lstate,
+                                                                          &pcall_status,
+                                                                          &callback_result) : false));
 
   // Stop dummy timer
   time_watcher_stop(tw);


### PR DESCRIPTION
If I run the following ex command (but note that it happens generally for any `vim.wait` invocations):

`lua vim.wait(4096, function() end, 100)`

It's not possible to cancel `vim.wait` before its timeout by inputting `Ctrl-C`. This patch fixes that.