### PR TITLE
vim-patch:8.2.{1470,1493,1522,1523,1770,5072,5074}: spell patches

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2327,11 +2327,11 @@ char *did_set_spelllang(win_T *wp)
       }
     }
   }
+  redraw_later(wp, NOT_VALID);
 
 theend:
   xfree(spl_copy);
   recursive = false;
-  redraw_later(wp, NOT_VALID);
   return ret_msg;
 }
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1469,7 +1469,9 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
     }
 
     // Copy the line into "buf" and append the start of the next line if
-    // possible.
+    // possible.  Note: this ml_get_buf() may make "line" invalid, check
+    // for empty line first.
+    bool empty_line = *skipwhite((const char *)line) == NUL;
     STRCPY(buf, line);
     if (lnum < wp->w_buffer->b_ml.ml_line_count) {
       spell_cat_line(buf + STRLEN(buf),
@@ -1613,7 +1615,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
       --capcol;
 
       // But after empty line check first word in next line
-      if (*skipwhite((char *)line) == NUL) {
+      if (empty_line) {
         capcol = 0;
       }
     }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2379,7 +2379,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
               || cur_aff->ah_flag == aff->af_needcomp
               || cur_aff->ah_flag == aff->af_comproot) {
             smsg(_("Affix also used for "
-                   "BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST"
+                   "BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST "
                    "in %s line %d: %s"),
                  fname, lnum, items[1]);
           }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -733,7 +733,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
       if (lp->sl_syllable == NULL) {
         goto endFAIL;
       }
-      if (init_syl_tab(lp) == FAIL) {
+      if (init_syl_tab(lp) != OK) {
         goto endFAIL;
       }
       break;

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -131,6 +131,30 @@ foobar/?
   set spell&
 endfunc
 
+func Test_spell_file_missing()
+  let s:spell_file_missing = 0
+  augroup TestSpellFileMissing
+    autocmd! SpellFileMissing * let s:spell_file_missing += 1
+  augroup END
+
+  set spell spelllang=ab_cd
+  let messages = GetMessages()
+  " This message is not shown in Nvim because of #3027
+  " call assert_equal('Warning: Cannot find word list "ab.utf-8.spl" or "ab.ascii.spl"', messages[-1])
+  call assert_equal(1, s:spell_file_missing)
+
+  new XTestSpellFileMissing
+  augroup TestSpellFileMissing
+    autocmd! SpellFileMissing * bwipe
+  augroup END
+  call assert_fails('set spell spelllang=ab_cd', 'E797:')
+
+  augroup! TestSpellFileMissing
+  unlet s:spell_file_missing
+  set spell& spelllang&
+  %bwipe!
+endfunc
+
 func Test_spelllang_inv_region()
   set spell spelllang=en_xx
   let messages = GetMessages()

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -808,5 +808,20 @@ func Test_word_index()
   call delete('Xtmpfile')
 endfunc
 
+func Test_check_empty_line()
+  " This was using freed memory
+  enew
+  spellgood! ﬂ
+  norm z=
+  norm yy
+  sil! norm P]svc
+  norm P]s
+
+  " set 'encoding' to clear the wordt list
+  set enc=latin1
+  set enc=utf-8
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -817,9 +817,7 @@ func Test_check_empty_line()
   sil! norm P]svc
   norm P]s
 
-  " set 'encoding' to clear the wordt list
-  set enc=latin1
-  set enc=utf-8
+  " TODO: should we clear the word list?
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_spellfile.vim
+++ b/src/nvim/testdir/test_spellfile.vim
@@ -510,6 +510,207 @@ func Test_mkspell()
   call assert_fails('mkspell en en_US abc_xyz', 'E755:')
 endfunc
 
+" Tests for :mkspell with a .dic and .aff file
+func Test_aff_file_format_error()
+  " No word count in .dic file
+  call writefile([], 'Xtest.dic')
+  call writefile([], 'Xtest.aff')
+  call assert_fails('mkspell! Xtest.spl Xtest', 'E760:')
+
+  " Invalid encoding in .aff file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['# comment', 'SET Xinvalidencoding'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Conversion in Xtest.aff not supported: from xinvalidencoding', output)
+
+  " Invalid flag in .aff file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['FLAG xxx'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Invalid value for FLAG in Xtest.aff line 1: xxx', output)
+
+  " set FLAGS after using flag for an affix
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['SFX L Y 1', 'SFX L 0 re [^x]', 'FLAG long'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('FLAG after using flags in Xtest.aff line 3: long', output)
+
+  " INFO in affix file
+  let save_encoding = &encoding
+  call mkdir('Xrtp/spell', 'p')
+  call writefile(['1', 'work'], 'Xrtp/spell/Xtest.dic')
+  call writefile(['NAME klingon', 'VERSION 1.4', 'AUTHOR Spock'],
+        \ 'Xrtp/spell/Xtest.aff')
+  silent mkspell! Xrtp/spell/Xtest.utf-8.spl Xrtp/spell/Xtest
+  let save_rtp = &rtp
+  set runtimepath=./Xrtp
+  set spelllang=Xtest
+  set spell
+  let output = split(execute('spellinfo'), "\n")
+  call assert_equal("NAME klingon", output[1])
+  call assert_equal("VERSION 1.4", output[2])
+  call assert_equal("AUTHOR Spock", output[3])
+  let &rtp = save_rtp
+  call delete('Xrtp', 'rf')
+  set spell& spelllang& spellfile&
+  %bw!
+  " 'encoding' must be set again to clear the spell file in memory
+  let &encoding = save_encoding
+
+  " COMPOUNDFORBIDFLAG flag after PFX in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L 0 re x', 'COMPOUNDFLAG c', 'COMPOUNDFORBIDFLAG x'],
+        \ 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in Xtest.aff line 4', output)
+
+  " COMPOUNDPERMITFLAG flag after PFX in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L 0 re x', 'COMPOUNDPERMITFLAG c'],
+        \ 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in Xtest.aff line 3', output)
+
+  " Wrong COMPOUNDRULES flag value in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['COMPOUNDRULES a'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Wrong COMPOUNDRULES value in Xtest.aff line 1: a', output)
+
+  " Wrong COMPOUNDWORDMAX flag value in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['COMPOUNDWORDMAX 0'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Wrong COMPOUNDWORDMAX value in Xtest.aff line 1: 0', output)
+
+  " Wrong COMPOUNDMIN flag value in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['COMPOUNDMIN 0'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Wrong COMPOUNDMIN value in Xtest.aff line 1: 0', output)
+
+  " Wrong COMPOUNDSYLMAX flag value in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['COMPOUNDSYLMAX 0'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Wrong COMPOUNDSYLMAX value in Xtest.aff line 1: 0', output)
+
+  " Wrong CHECKCOMPOUNDPATTERN flag value in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['CHECKCOMPOUNDPATTERN 0'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Wrong CHECKCOMPOUNDPATTERN value in Xtest.aff line 1: 0', output)
+
+  " Duplicate affix entry in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L 0 re x', 'PFX L Y 1', 'PFX L 0 re x'],
+        \ 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Duplicate affix in Xtest.aff line 3: L', output)
+
+  " Duplicate affix entry in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L Y 1'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Unrecognized or duplicate item in Xtest.aff line 2: PFX', output)
+
+  " Different combining flags in an affix file
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L 0 re x', 'PFX L N 1'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Different combining flag in continued affix block in Xtest.aff line 3', output)
+
+  " Try to reuse a affix used for BAD flag
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['BAD x', 'PFX x Y 1', 'PFX x 0 re x'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in Xtest.aff line 2: x', output)
+
+  " Trailing characters in an affix entry
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1 Test', 'PFX L 0 re x'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Trailing text in Xtest.aff line 1: Test', output)
+
+  " Trailing characters in an affix entry
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L Y 1', 'PFX L 0 re x Test'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Trailing text in Xtest.aff line 2: Test', output)
+
+  " Incorrect combine flag in an affix entry
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['PFX L X 1', 'PFX L 0 re x'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Expected Y or N in Xtest.aff line 1: X', output)
+
+  " Invalid count for REP item
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['REP a'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Expected REP(SAL) count in Xtest.aff line 1', output)
+
+  " Trailing characters in REP item
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['REP 1', 'REP f ph test'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Trailing text in Xtest.aff line 2: test', output)
+
+  " Invalid count for MAP item
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['MAP a'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Expected MAP count in Xtest.aff line 1', output)
+
+  " Duplicate character in a MAP item
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['MAP 2', 'MAP xx', 'MAP yy'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Duplicate character in MAP in Xtest.aff line 2', output)
+
+  " Use COMPOUNDSYLMAX without SYLLABLE
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['COMPOUNDSYLMAX 2'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('COMPOUNDSYLMAX used without SYLLABLE', output)
+
+  " Missing SOFOTO
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['SOFOFROM abcdef'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Missing SOFOTO line in Xtest.aff', output)
+
+  " FIXME: The following test causes a heap overflow with the ASAN build
+  " " Both SAL and SOFOFROM/SOFOTO items
+  " call writefile(['1', 'work'], 'Xtest.dic')
+  " call writefile(['SOFOFROM abcd', 'SOFOTO ABCD', 'SAL CIA X'], 'Xtest.aff')
+  " let output = execute('mkspell! Xtest.spl Xtest')
+  " call assert_match('Both SAL and SOFO lines in Xtest.aff', output)
+
+  " use an alphabet flag when FLAG is num
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['FLAG num', 'SFX L Y 1', 'SFX L 0 re [^x]'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Flag is not a number in Xtest.aff line 2: L', output)
+
+  " use number and alphabet flag when FLAG is num
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['FLAG num', 'SFX 4f Y 1', 'SFX 4f 0 re [^x]'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Affix name too long in Xtest.aff line 2: 4f', output)
+
+  " use a single character flag when FLAG is long
+  call writefile(['1', 'work'], 'Xtest.dic')
+  call writefile(['FLAG long', 'SFX L Y 1', 'SFX L 0 re [^x]'], 'Xtest.aff')
+  let output = execute('mkspell! Xtest.spl Xtest')
+  call assert_match('Illegal flag in Xtest.aff line 2: L', output)
+
+  call delete('Xtest.dic')
+  call delete('Xtest.aff')
+  call delete('Xtest.spl')
+  call delete('Xtest.sug')
+endfunc
+
 func Test_spell_add_word()
   set spellfile=
   call assert_fails('spellgood abc', 'E764:')
@@ -521,6 +722,28 @@ func Test_spell_add_word()
   call setline(1, 'sample')
   call assert_fails('spellgood abc', 'E139:')
   set spellfile&
+  %bw!
+endfunc
+
+" When 'spellfile' is not set, adding a new good word will automatically set
+" the 'spellfile'
+func Test_init_spellfile()
+  let save_rtp = &rtp
+  let save_encoding = &encoding
+  call mkdir('Xrtp/spell', 'p')
+  call writefile(['vim'], 'Xrtp/spell/Xtest.dic')
+  silent mkspell Xrtp/spell/Xtest.utf-8.spl Xrtp/spell/Xtest.dic
+  set runtimepath=./Xrtp
+  set spelllang=Xtest
+  set spell
+  silent spellgood abc
+  call assert_equal('./Xrtp/spell/Xtest.utf-8.add', &spellfile)
+  call assert_equal(['abc'], readfile('Xrtp/spell/Xtest.utf-8.add'))
+  call assert_true(filereadable('Xrtp/spell/Xtest.utf-8.spl'))
+  set spell& spelllang& spellfile&
+  call delete('Xrtp', 'rf')
+  let &encoding = save_encoding
+  let &rtp = save_rtp
   %bw!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.1470: errors in spell file not tested

Problem:    Errors in spell file not tested.
Solution:   Add test for spell file errors. (Yegappan Lakshmanan,
            closes vim/vim#6721)
https://github.com/vim/vim/commit/c0f8823ee4ca629db5446ba0a935f68d4a4fb193


#### vim-patch:8.2.1493: not enough test coverage for the spell file handling

Problem:    Not enough test coverage for the spell file handling.
Solution:   Add spell file tests. (Yegappan Lakshmanan, closes vim/vim#6728)
https://github.com/vim/vim/commit/fc2a47ffc425777704b329c9edbe21163bedf63c


#### vim-patch:8.2.1522: not enough test coverage for the spell file handling

Problem:    Not enough test coverage for the spell file handling.
Solution:   Add spell file tests. (Yegappan Lakshmanan, closes vim/vim#6763)
https://github.com/vim/vim/commit/c8ec5fe56fc30201c889ca577bf1e69823fadb2a

Add missing whitespace in message.


#### vim-patch:8.2.1523: still not enough test coverage for the spell file handling

Problem:    Still not enough test coverage for the spell file handling.
Solution:   Add spell file tests. (Yegappan Lakshmanan, closes vim/vim#6790)
https://github.com/vim/vim/commit/b9fc192f928b484c8809fb985ef334d7a2bb5a09


#### vim-patch:8.2.1770: invalid memory use when using SpellFileMissing autocmd

Problem:    Invalid memory use when using SpellFileMissing autocmd.
Solution:   Add test case. (Dominique Pellé)  Fix using a window
            that was closed.
https://github.com/vim/vim/commit/d569a9e74684cd17f9cea63e804281388728e513

Skip an assert because of #3027.


#### vim-patch:8.2.5072: using uninitialized value and freed memory in spell command

Problem:    Using uninitialized value and freed memory in spell command.
Solution:   Initialize "attr".  Check for empty line early.
https://github.com/vim/vim/commit/2813f38e021c6e6581c0c88fcf107e41788bc835


#### vim-patch:8.2.5074: spell test fails on MS-Windows

Problem:    Spell test fails on MS-Windows.
Solution:   Do not change 'encoding'
https://github.com/vim/vim/commit/ad73cc2ff2a8b5397ed20598757b702a4e686256