### PR TITLE
vim-patch:8.2.{1808,5098},9.0.0034

### DIFF
--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -16,6 +16,8 @@ func TearDown()
   call delete('Xtest.latin1.add.spl')
   call delete('Xtest.latin1.spl')
   call delete('Xtest.latin1.sug')
+  " set 'encoding' to clear the word list
+  set encoding=utf-8
 endfunc
 
 func Test_wrap_search()
@@ -726,6 +728,10 @@ func Test_zz_sal_and_addition()
   set spl=Xtest_ca.latin1.spl
   call assert_equal("elequint", FirstSpellWord())
   call assert_equal("elekwint", SecondSpellWord())
+
+  bwipe!
+  set spellfile=
+  set spl&
 endfunc
 
 func Test_spellfile_value()
@@ -809,9 +815,6 @@ func Test_spell_good_word_invalid()
   sil! norm z=
 
   bwipe!
-  " clear the internal word list
-  " set enc=latin1
-  set enc=utf-8
 endfunc
 
 func LoadAffAndDic(aff_contents, dic_contents)

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -155,6 +155,44 @@ func Test_spell_file_missing()
   %bwipe!
 endfunc
 
+func Test_spelldump()
+  set spell spelllang=en
+  spellrare! emacs
+
+  spelldump
+
+  " Check assumption about region: 1: us, 2: au, 3: ca, 4: gb, 5: nz.
+  call assert_equal('/regions=usaucagbnz', getline(1))
+  call assert_notequal(0, search('^theater/1$'))    " US English only.
+  call assert_notequal(0, search('^theatre/2345$')) " AU, CA, GB or NZ English.
+
+  call assert_notequal(0, search('^emacs/?$'))      " ? for a rare word.
+  call assert_notequal(0, search('^the the/!$'))    " ! for a wrong word.
+
+  bwipe
+  set spell&
+endfunc
+
+func Test_spelldump_bang()
+  new
+  call setline(1, 'This is a sample sentence.')
+  redraw
+  set spell
+  redraw
+  spelldump!
+
+  " :spelldump! includes the number of times a word was found while updating
+  " the screen.
+  " Common word count starts at 10, regular word count starts at 0.
+  call assert_notequal(0, search("^is\t11$"))    " common word found once.
+  call assert_notequal(0, search("^the\t10$"))   " common word never found.
+  call assert_notequal(0, search("^sample\t1$")) " regular word found once.
+  call assert_equal(0, search("^screen\t"))      " regular word never found.
+
+  %bwipe!
+  set spell&
+endfunc
+
 func Test_spelllang_inv_region()
   set spell spelllang=en_xx
   let messages = GetMessages()

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -13,6 +13,8 @@ func TearDown()
   call delete('Xtest.utf-8.add.spl')
   call delete('Xtest.utf-8.spl')
   call delete('Xtest.utf-8.sug')
+  " set 'encoding' to clear the word list
+  set encoding=utf-8
 endfunc
 
 let g:test_data_aff1 = [
@@ -484,7 +486,6 @@ let g:test_data_aff_sal = [
       \ ]
 
 func LoadAffAndDic(aff_contents, dic_contents)
-  set enc=utf-8
   set spellfile=
   call writefile(a:aff_contents, "Xtest.aff")
   call writefile(a:dic_contents, "Xtest.dic")
@@ -760,6 +761,7 @@ func Test_spell_sal_and_addition()
   call assert_equal("elequint", FirstSpellWord())
   call assert_equal("elekwint", SecondSpellWord())
 
+  bwipe!
   set spellfile=
   set spl&
 endfunc
@@ -803,8 +805,6 @@ func Test_word_index()
   sil norm z=
 
   bwipe!
-  " clear the word list
-  set enc=utf-8
   call delete('Xtmpfile')
 endfunc
 
@@ -817,7 +817,6 @@ func Test_check_empty_line()
   sil! norm P]svc
   norm P]s
 
-  " TODO: should we clear the word list?
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.1808: no test coverage for ":spelldump!"

Problem:    No test coverage for ":spelldump!".
Solution:   Add a test. (Dominique Pellé, closes vim/vim#7089)
https://github.com/vim/vim/commit/f12f0022e6698831681f0931a4e7e5298f6ef0d8


#### vim-patch:8.2.5098: spelldump test sometimes hangs

Problem:    Spelldump test sometimes hangs.
Solution:   Catch the problem of the spell file not being found to avoid
            hanging in the download dialog.
https://github.com/vim/vim/commit/fc9f0fd6d18c03d6420f84ebb374a373c830fbad


#### vim-patch:9.0.0034: spell tests do not always clear the word list

Problem:    Spell tests do not always clear the word list.
Solution:   Clear the word list in TearDown(). (closes vim/vim#10659)
https://github.com/vim/vim/commit/288ed23e3929ff55a8ae30db0ba3f57b6f119dc8