### PR TITLE
vim-patch:8.0.1732 / fix(terminal): crash if TermClose deletes own buffer

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -169,7 +169,9 @@ func Test_autocmd_bufunload_avoiding_SEGV_01()
     exe 'autocmd BufUnload <buffer> ' . (lastbuf + 1) . 'bwipeout!'
   augroup END
 
-  call assert_fails('edit bb.txt', 'E937:')
+  " Todo: check for E937 generated first
+  " call assert_fails('edit bb.txt', 'E937:')
+  call assert_fails('edit bb.txt', 'E517:')
 
   autocmd! test_autocmd_bufunload
   augroup! test_autocmd_bufunload
@@ -540,7 +542,7 @@ func Test_three_windows()
   e Xtestje2
   sp Xtestje1
   call assert_fails('e', 'E937:')
-  call assert_equal('Xtestje2', expand('%'))
+  call assert_equal('Xtestje1', expand('%'))
 
   " Test changing buffers in a BufWipeout autocommand.  If this goes wrong
   " there are ml_line errors and/or a Crash.
@@ -563,7 +565,6 @@ func Test_three_windows()
 
   au!
   enew
-  bwipe! Xtestje1
   call delete('Xtestje1')
   call delete('Xtestje2')
   call delete('Xtestje3')

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -7,6 +7,8 @@ local eval, eq, neq, retry =
   helpers.eval, helpers.eq, helpers.neq, helpers.retry
 local ok = helpers.ok
 local feed = helpers.feed
+local pcall_err = helpers.pcall_err
+local assert_alive = helpers.assert_alive
 local iswin = helpers.iswin
 
 describe('autocmd TermClose', function()
@@ -14,6 +16,24 @@ describe('autocmd TermClose', function()
     clear()
     nvim('set_option', 'shell', testprg('shell-test'))
     command('set shellcmdflag=EXE shellredir= shellpipe= shellquote= shellxquote=')
+  end)
+
+
+  local function test_termclose_delete_own_buf()
+    command('autocmd TermClose * bdelete!')
+    command('terminal')
+    eq('Vim(bdelete):E937: Attempt to delete a buffer that is in use', pcall_err(command, 'bdelete!'))
+    assert_alive()
+  end
+
+  -- TODO: fixed after merging patches for `can_unload_buffer`?
+  pending('TermClose deleting its own buffer, altbuf = buffer 1 #10386', function()
+    test_termclose_delete_own_buf()
+  end)
+
+  it('TermClose deleting its own buffer, altbuf NOT buffer 1 #10386', function()
+    command('edit foo1')
+    test_termclose_delete_own_buf()
   end)
 
   it('triggers when fast-exiting terminal job stops', function()


### PR DESCRIPTION
- Partially fixes #10386 except for the case where the alternate buffer is the default, empty, first buffer created on startup (Just Vim Things).
    - Maybe fully fixed after porting patches related to `can_unload_buffer`.  @vigoux started that here: https://github.com/neovim/neovim/pull/15267
- Related: https://github.com/vim/vim/commit/8adb0d03ca2694922da915356d7ede05e31c5a5c
    - But kinda tracked in https://github.com/neovim/neovim/issues/5431

vim-patch:8.0.1732: crash when terminal API call deletes the buffer

cc @zeertzjq 