### PR TITLE
fix(mark): do not try to restore the view of a mark without a view

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -607,6 +607,8 @@ void mark_view_restore(fmark_T *fm)
 {
   if (fm != NULL && fm->view.topline_offset >= 0) {
     linenr_T topline = fm->mark.lnum - fm->view.topline_offset;
+    // If the mark does not have a view, topline_offset is MAXLNUM,
+    // and this check can prevent restoring mark view in that case.
     if (topline >= 1) {
       set_topline(curwin, topline);
     }

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -64,9 +64,10 @@ typedef enum {
 /// Represents view in which the mark was created
 typedef struct fmarkv {
   linenr_T topline_offset;  ///< Amount of lines from the mark lnum to the top of the window.
+                            ///< Use MAXLNUM to indicate that the mark does not have a view.
 } fmarkv_T;
 
-#define INIT_FMARKV { 0 }
+#define INIT_FMARKV { MAXLNUM }
 
 /// Structure defining single local mark
 typedef struct filemark {

--- a/test/functional/editor/jump_spec.lua
+++ b/test/functional/editor/jump_spec.lua
@@ -251,4 +251,32 @@ describe("jumpoptions=view", function()
                 |
     ]])
   end)
+
+  it('falls back to standard behavior for a mark without a view', function()
+    local screen = Screen.new(5, 8)
+    screen:attach()
+    command('edit ' .. file1)
+    feed('10ggzzvwy')
+    screen:expect([[
+      7 line      |
+      8 line      |
+      9 line      |
+      ^10 line     |
+      11 line     |
+      12 line     |
+      13 line     |
+                  |
+    ]])
+    feed('`]')
+    screen:expect([[
+      7 line      |
+      8 line      |
+      9 line      |
+      10 ^line     |
+      11 line     |
+      12 line     |
+      13 line     |
+                  |
+    ]])
+  end)
 end)


### PR DESCRIPTION
For a local mark without a view, currently trying to restore its view
will put the cursor at topline, which is not the correct behavior.
Initialize `topline_offset` to `MAXLNUM` instead to fix this.