### PR TITLE
vim-patch:9.0.0035: spell dump may go beyond end of an array

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -7023,8 +7023,9 @@ void spell_dump_compl(char_u *pat, int ic, Direction *dir, int dumpflags_arg)
           n = arridx[depth] + curi[depth];
           ++curi[depth];
           c = byts[n];
-          if (c == 0) {
-            // End of word, deal with the word.
+          if (c == 0 || depth >= MAXWLEN - 1) {
+            // End of word or reached maximum length, deal with the
+            // word.
             // Don't use keep-case words in the fold-case tree,
             // they will appear in the keep-case tree.
             // Only use the word when the region matches.

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -287,6 +287,18 @@ func Test_spellreall()
   bwipe!
 endfunc
 
+func Test_spell_dump_word_length()
+  " this was running over MAXWLEN
+  new
+  noremap 0 0a0zW0000000
+  sil! norm 0z=0
+  sil norm 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  sil! norm 0z=0
+
+  bwipe!
+  nunmap 0
+endfunc
+
 " Test spellsuggest({word} [, {max} [, {capital}]])
 func Test_spellsuggest()
   " Verify suggestions are given even when spell checking is not enabled.


### PR DESCRIPTION
#### vim-patch:9.0.0035: spell dump may go beyond end of an array

Problem:    Spell dump may go beyond end of an array.
Solution:   Limit the word length.
https://github.com/vim/vim/commit/54e5fed6d27b747ff152cdb6edfb72ff60e70939