### PR TITLE
vim-patch:8.2.{3615,3754,5122}: indent fixes

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7330,7 +7330,7 @@ static void replace_do_bs(int limit_col)
 }
 
 /// Check that C-indenting is on.
-static bool cindent_on(void)
+bool cindent_on(void)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return !p_paste && (curbuf->b_p_cin || *curbuf->b_p_inde != NUL);

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -656,6 +656,9 @@ int get_lisp_indent(void)
               }
             }
           }
+          if (*that == NUL) {
+            break;
+          }
         }
         if ((*that == '(') || (*that == '[')) {
           parencount++;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4547,9 +4547,20 @@ void format_lines(linenr_T line_count, int avoid_fex)
        */
       if (is_end_par || force_format) {
         if (need_set_indent) {
+          int indent = 0;  // amount of indent needed
+
           // replace indent in first line with minimal number of
           // tabs and spaces, according to current options
-          (void)set_indent(get_indent(), SIN_CHANGED);
+          if (curbuf->b_p_lisp) {
+            indent = get_lisp_indent();
+          } else {
+            if (cindent_on()) {
+              indent = *curbuf->b_p_inde != NUL ? get_expr_indent() : get_c_indent();
+            } else {
+              indent = get_indent();
+            }
+          }
+          (void)set_indent(indent, SIN_CHANGED);
         }
 
         // put cursor on last non-space

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4421,6 +4421,7 @@ void format_lines(linenr_T line_count, int avoid_fex)
   int smd_save;
   long count;
   bool need_set_indent = true;      // set indent of next paragraph
+  linenr_T first_line = curwin->w_cursor.lnum;
   bool force_format = false;
   const int old_State = State;
 
@@ -4549,9 +4550,13 @@ void format_lines(linenr_T line_count, int avoid_fex)
         if (need_set_indent) {
           int indent = 0;  // amount of indent needed
 
-          // replace indent in first line with minimal number of
-          // tabs and spaces, according to current options
-          if (curbuf->b_p_lisp) {
+          // Replace indent in first line of a paragraph with minimal
+          // number of tabs and spaces, according to current options.
+          // For the very first formatted line keep the current
+          // indent.
+          if (curwin->w_cursor.lnum == first_line) {
+            indent = get_indent();
+          } else if (curbuf->b_p_lisp) {
             indent = get_lisp_indent();
           } else {
             if (cindent_on()) {

--- a/src/nvim/testdir/test_indent.vim
+++ b/src/nvim/testdir/test_indent.vim
@@ -144,6 +144,16 @@ func Test_lisp_indent()
   close!
 endfunc
 
+func Test_lisp_indent_quoted()
+  " This was going past the end of the line
+  new
+  setlocal lisp autoindent
+  call setline(1, ['"[', '='])
+  normal Gvk=
+
+  bwipe!
+endfunc
+
 " Test for setting the 'indentexpr' from a modeline
 func Test_modeline_indent_expr()
   let modeline = &modeline

--- a/src/nvim/testdir/test_indent.vim
+++ b/src/nvim/testdir/test_indent.vim
@@ -165,4 +165,79 @@ func Test_modeline_indent_expr()
   call delete('Xfile.txt')
 endfunc
 
+func Test_indent_func_with_gq()
+  
+  function GetTeXIndent()
+    " Sample indent expression for TeX files
+    let lnum = prevnonblank(v:lnum - 1)
+    " At the start of the file use zero indent.
+    if lnum == 0
+      return 0
+    endif
+    let line = getline(lnum)
+    let ind = indent(lnum)
+    " Add a 'shiftwidth' after beginning of environments.
+    if line =~ '\\begin{center}' 
+      let ind = ind + shiftwidth()
+    endif
+    return ind
+  endfunction
+
+  new
+  setl et sw=2 sts=2 ts=2 tw=50 indentexpr=GetTeXIndent()
+  put =[  '\documentclass{article}', '', '\begin{document}', '',
+        \ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce ut enim non',
+        \ 'libero efficitur aliquet. Maecenas metus justo, facilisis convallis blandit',
+        \ 'non, semper eu urna. Suspendisse diam diam, iaculis faucibus lorem eu,',
+        \ 'fringilla condimentum lectus. Quisque euismod diam at convallis vulputate.',
+        \ 'Pellentesque laoreet tortor sit amet mauris euismod ornare. Sed varius',
+        \ 'bibendum orci vel vehicula. Pellentesque tempor, ipsum et auctor accumsan,',
+        \ 'metus lectus ultrices odio, sed elementum mi ante at arcu.', '', '\begin{center}', '',
+        \ 'Proin nec risus consequat nunc dapibus consectetur. Mauris lacinia est a augue',
+        \ 'tristique accumsan. Morbi pretium, felis molestie eleifend condimentum, arcu',
+        \ 'ipsum congue nisl, quis euismod purus libero in ante. Donec id semper purus.',
+        \ 'Suspendisse eget aliquam nunc. Maecenas fringilla mauris vitae maximus',
+        \ 'condimentum. Cras a quam in mi dictum eleifend at a lorem. Sed convallis',
+        \ 'ante a commodo facilisis. Nam suscipit vulputate odio, vel dapibus nisl',
+        \ 'dignissim facilisis. Vestibulum ante ipsum primis in faucibus orci luctus et',
+        \ 'ultrices posuere cubilia curae;', '', '']
+  1d_
+  call cursor(5, 1)
+  ka
+  call cursor(15, 1)
+  kb
+  norm! 'agqap
+  norm! 'bgqap
+  let expected = [ '\documentclass{article}', '', '\begin{document}', '',
+        \ 'Lorem ipsum dolor sit amet, consectetur adipiscing',
+        \ 'elit. Fusce ut enim non libero efficitur aliquet.',
+        \ 'Maecenas metus justo, facilisis convallis blandit',
+        \ 'non, semper eu urna. Suspendisse diam diam,',
+        \ 'iaculis faucibus lorem eu, fringilla condimentum',
+        \ 'lectus. Quisque euismod diam at convallis',
+        \ 'vulputate.  Pellentesque laoreet tortor sit amet',
+        \ 'mauris euismod ornare. Sed varius bibendum orci',
+        \ 'vel vehicula. Pellentesque tempor, ipsum et auctor',
+        \ 'accumsan, metus lectus ultrices odio, sed',
+        \ 'elementum mi ante at arcu.', '', '\begin{center}', '',
+        \ '  Proin nec risus consequat nunc dapibus',
+        \ '  consectetur. Mauris lacinia est a augue',
+        \ '  tristique accumsan. Morbi pretium, felis',
+        \ '  molestie eleifend condimentum, arcu ipsum congue',
+        \ '  nisl, quis euismod purus libero in ante. Donec',
+        \ '  id semper purus.  Suspendisse eget aliquam nunc.',
+        \ '  Maecenas fringilla mauris vitae maximus',
+        \ '  condimentum. Cras a quam in mi dictum eleifend',
+        \ '  at a lorem. Sed convallis ante a commodo',
+        \ '  facilisis. Nam suscipit vulputate odio, vel',
+        \ '  dapibus nisl dignissim facilisis. Vestibulum',
+        \ '  ante ipsum primis in faucibus orci luctus et',
+        \ '  ultrices posuere cubilia curae;', '', '']
+  call assert_equal(expected, getline(1, '$'))
+
+  bwipe!
+  delmark ab
+  delfunction GetTeXIndent 
+endfu
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_indent.vim
+++ b/src/nvim/testdir/test_indent.vim
@@ -195,7 +195,8 @@ func Test_indent_func_with_gq()
         \ 'metus lectus ultrices odio, sed elementum mi ante at arcu.', '', '\begin{center}', '',
         \ 'Proin nec risus consequat nunc dapibus consectetur. Mauris lacinia est a augue',
         \ 'tristique accumsan. Morbi pretium, felis molestie eleifend condimentum, arcu',
-        \ 'ipsum congue nisl, quis euismod purus libero in ante. Donec id semper purus.',
+        \ 'ipsum congue nisl, quis euismod purus libero in ante.', '',
+        \ 'Donec id semper purus.',
         \ 'Suspendisse eget aliquam nunc. Maecenas fringilla mauris vitae maximus',
         \ 'condimentum. Cras a quam in mi dictum eleifend at a lorem. Sed convallis',
         \ 'ante a commodo facilisis. Nam suscipit vulputate odio, vel dapibus nisl',
@@ -204,10 +205,10 @@ func Test_indent_func_with_gq()
   1d_
   call cursor(5, 1)
   ka
-  call cursor(15, 1)
+  call cursor(14, 1)
   kb
   norm! 'agqap
-  norm! 'bgqap
+  norm! 'bgqG
   let expected = [ '\documentclass{article}', '', '\begin{document}', '',
         \ 'Lorem ipsum dolor sit amet, consectetur adipiscing',
         \ 'elit. Fusce ut enim non libero efficitur aliquet.',
@@ -224,9 +225,10 @@ func Test_indent_func_with_gq()
         \ '  consectetur. Mauris lacinia est a augue',
         \ '  tristique accumsan. Morbi pretium, felis',
         \ '  molestie eleifend condimentum, arcu ipsum congue',
-        \ '  nisl, quis euismod purus libero in ante. Donec',
-        \ '  id semper purus.  Suspendisse eget aliquam nunc.',
-        \ '  Maecenas fringilla mauris vitae maximus',
+        \ '  nisl, quis euismod purus libero in ante.',
+        \ '',
+        \ '  Donec id semper purus.  Suspendisse eget aliquam',
+        \ '  nunc. Maecenas fringilla mauris vitae maximus',
         \ '  condimentum. Cras a quam in mi dictum eleifend',
         \ '  at a lorem. Sed convallis ante a commodo',
         \ '  facilisis. Nam suscipit vulputate odio, vel',
@@ -239,5 +241,29 @@ func Test_indent_func_with_gq()
   delmark ab
   delfunction GetTeXIndent 
 endfu
+
+func Test_formatting_keeps_first_line_indent()
+  let lines =<< trim END
+      foo()
+      {
+          int x;         // manually positioned
+                         // more text that will be formatted
+                         // but not reindented
+  END
+  new
+  call setline(1, lines)
+  setlocal sw=4 cindent tw=45 et
+  normal! 4Ggqj
+  let expected =<< trim END
+      foo()
+      {
+          int x;         // manually positioned
+                         // more text that will be
+                         // formatted but not
+                         // reindented
+  END
+  call assert_equal(expected, getline(1, '$'))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3615: wrong indent in first line if re-formatting with indent expr

Problem:    When re-formatting with an indent expression the first line of a
            paragraph may get the wrong indent. (Martin F. Krafft)
Solution:   Apply the correct indenting function for the first line.
            (Christian Brabandt, closes vim/vim#9150)
https://github.com/vim/vim/commit/818ff25cd1aabf60b9cd239da2f1328a959954f7


#### vim-patch:8.2.3754: undesired changing of the indent of the first formatted line

Problem:    Undesired changing of the indent of the first formatted line.
Solution:   Do not indent the first formatted line.
https://github.com/vim/vim/commit/ecabb511074b3f56cdd5067553c947a291d04e17


#### vim-patch:8.2.5122: lisp indenting my run over the end of the line

Problem:    Lisp indenting my run over the end of the line.
Solution:   Check for NUL earlier.
https://github.com/vim/vim/commit/0e8e938d497260dd57be67b4966cb27a5f72376f