### PR TITLE
vim-patch:8.2.{2904,3644.3980,3990}: three Normal mode fixes

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2494,20 +2494,29 @@ static void prep_redo_cmd(cmdarg_T *cap)
 /// Note that only the last argument can be a multi-byte char.
 void prep_redo(int regname, long num, int cmd1, int cmd2, int cmd3, int cmd4, int cmd5)
 {
+  prep_redo_num2(regname, num, cmd1, cmd2, 0L, cmd3, cmd4, cmd5);
+}
+
+/// Prepare for redo of any command with extra count after "cmd2".
+void prep_redo_num2(int regname, long num1, int cmd1, int cmd2, long num2, int cmd3, int cmd4,
+                    int cmd5)
+{
   ResetRedobuff();
   if (regname != 0) {   // yank from specified buffer
     AppendCharToRedobuff('"');
     AppendCharToRedobuff(regname);
   }
-  if (num) {
-    AppendNumberToRedobuff(num);
+  if (num1 != 0) {
+    AppendNumberToRedobuff(num1);
   }
-
   if (cmd1 != NUL) {
     AppendCharToRedobuff(cmd1);
   }
   if (cmd2 != NUL) {
     AppendCharToRedobuff(cmd2);
+  }
+  if (num2 != 0) {
+    AppendNumberToRedobuff(num2);
   }
   if (cmd3 != NUL) {
     AppendCharToRedobuff(cmd3);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6157,6 +6157,16 @@ static void nv_g_cmd(cmdarg_T *cap)
       i = curwin->w_leftcol + curwin->w_width_inner - col_off - 1;
       coladvance((colnr_T)i);
 
+      // if the character doesn't fit move one back
+      if (curwin->w_cursor.col > 0 && utf_ptr2cells((const char *)get_cursor_pos_ptr()) > 1) {
+        colnr_T vcol;
+
+        getvvcol(curwin, &curwin->w_cursor, NULL, NULL, &vcol);
+        if (vcol >= curwin->w_leftcol + curwin->w_width - col_off) {
+          curwin->w_cursor.col--;
+        }
+      }
+
       // Make sure we stick in this column.
       validate_virtcol();
       curwin->w_curswant = curwin->w_virtcol;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -6485,6 +6485,8 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
                     get_op_char(oap->op_type), get_extra_op_char(oap->op_type),
                     oap->motion_force, cap->cmdchar, cap->nchar);
         } else if (cap->cmdchar != ':' && cap->cmdchar != K_COMMAND) {
+          int opchar = get_op_char(oap->op_type);
+          int extra_opchar = get_extra_op_char(oap->op_type);
           int nchar = oap->op_type == OP_REPLACE ? cap->nchar : NUL;
 
           // reverse what nv_replace() did
@@ -6493,8 +6495,13 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
           } else if (nchar == REPLACE_NL_NCHAR) {
             nchar = NL;
           }
-          prep_redo(oap->regname, 0L, NUL, 'v', get_op_char(oap->op_type),
-                    get_extra_op_char(oap->op_type), nchar);
+
+          if (opchar == 'g' && extra_opchar == '@') {
+            // also repeat the count for 'operatorfunc'
+            prep_redo_num2(oap->regname, 0L, NUL, 'v', cap->count0, opchar, extra_opchar, nchar);
+          } else {
+            prep_redo(oap->regname, 0L, NUL, 'v', opchar, extra_opchar, nchar);
+          }
         }
         if (!redo_VIsual_busy) {
           redo_VIsual_mode = resel_VIsual_mode;

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -406,6 +406,10 @@ func OperatorfuncRedo(_)
   let g:opfunc_count = v:count
 endfunc
 
+func Underscorize(_)
+  normal! '[V']r_
+endfunc
+
 func Test_normal09c_operatorfunc()
   " Test redoing operatorfunc
   new
@@ -419,6 +423,16 @@ func Test_normal09c_operatorfunc()
 
   bw!
   unlet g:opfunc_count
+
+  " Test redoing Visual mode
+  set operatorfunc=Underscorize
+  new
+  call setline(1, ['first', 'first', 'third', 'third', 'second'])
+  normal! 1GVjr_
+  normal! 5G.
+  normal! 3G.
+  call assert_equal(['_____', '_____', '_____', '_____', '______'], getline(1, '$'))
+  bwipe!
   set operatorfunc=
 endfunc
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1784,9 +1784,9 @@ fun! Test_normal33_g_cmd2()
   %d
   15vsp
   set wrap listchars= sbr=
-  let lineA='abcdefghijklmnopqrstuvwxyz'
-  let lineB='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-  let lineC='0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567890123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  let lineA = 'abcdefghijklmnopqrstuvwxyz'
+  let lineB = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  let lineC = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567890123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
   $put =lineA
   $put =lineB
 
@@ -1820,6 +1820,28 @@ fun! Test_normal33_g_cmd2()
   call assert_equal(15, col('.'))
   call assert_equal('l', getreg(0))
   call assert_beeps('normal 5g$')
+
+  " Test for g$ with double-width character half displayed
+  vsplit
+  9wincmd |
+  setlocal nowrap nonumber
+  call setline(2, 'asdfasdfヨ')
+  2
+  normal 0g$
+  call assert_equal(8, col('.'))
+  10wincmd |
+  normal 0g$
+  call assert_equal(9, col('.'))
+
+  setlocal signcolumn=yes
+  11wincmd |
+  normal 0g$
+  call assert_equal(8, col('.'))
+  12wincmd |
+  normal 0g$
+  call assert_equal(9, col('.'))
+
+  close
 
   " Test for g_
   call assert_beeps('normal! 100g_')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -345,7 +345,7 @@ func Test_normal08_fold()
   bw!
 endfunc
 
-func Test_normal09_operatorfunc()
+func Test_normal09a_operatorfunc()
   " Test operatorfunc
   call Setup_NewWindow()
   " Add some spaces for counting
@@ -375,7 +375,7 @@ func Test_normal09_operatorfunc()
   bw!
 endfunc
 
-func Test_normal09a_operatorfunc()
+func Test_normal09b_operatorfunc()
   " Test operatorfunc
   call Setup_NewWindow()
   " Add some spaces for counting
@@ -397,8 +397,29 @@ func Test_normal09a_operatorfunc()
   " clean up
   unmap <buffer> ,,
   set opfunc=
+  call assert_fails('normal Vg@', 'E774:')
   bw!
   unlet! g:opt
+endfunc
+
+func OperatorfuncRedo(_)
+  let g:opfunc_count = v:count
+endfunc
+
+func Test_normal09c_operatorfunc()
+  " Test redoing operatorfunc
+  new
+  call setline(1, 'some text')
+  set operatorfunc=OperatorfuncRedo
+  normal v3g@
+  call assert_equal(3, g:opfunc_count)
+  let g:opfunc_count = 0
+  normal .
+  call assert_equal(3, g:opfunc_count)
+
+  bw!
+  unlet g:opfunc_count
+  set operatorfunc=
 endfunc
 
 func Test_normal10_expand()

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -428,7 +428,7 @@ func Test_normal09c_operatorfunc()
   set operatorfunc=Underscorize
   new
   call setline(1, ['first', 'first', 'third', 'third', 'second'])
-  normal! 1GVjr_
+  normal! 1GVjg@
   normal! 5G.
   normal! 3G.
   call assert_equal(['_____', '_____', '_____', '_____', '______'], getline(1, '$'))


### PR DESCRIPTION
#### vim-patch:8.2.2904: "g$" causes scroll if half a double width char is visible

Problem:    "g$" causes scroll if half a double width char is visible.
Solution:   Advance to the last fully visible character.
https://github.com/vim/vim/commit/74ede80aeb272ac81d41a256057c4f250372dd00


#### vim-patch:8.2.3644: count for 'operatorfunc' in Visual mode is not redone

Problem:    Count for 'operatorfunc' in Visual mode is not redone.
Solution:   Add the count to the redo buffer.
https://github.com/vim/vim/commit/2228cd72cf7c6f326e4e41179e88d37595ca4abc

Cherry-pick a line from patch 8.2.0522.


#### vim-patch:8.2.3980: if 'operatorfunc' invokes an operator Visual mode is changed

Problem:    If 'operatorfunc' invokes an operator the remembered Visual mode
            may be changed. (Naohiro Ono)
Solution:   Save and restore the information for redoing the Visual area.
https://github.com/vim/vim/commit/b3bd1d39e68e2d697c014b9f85482c2c12a3f909


#### vim-patch:8.2.3990: testing wrong operator

Problem:    Testing wrong operator.
Solution:   Test "g@" instead of "r_". (Naohiro Ono, closes vim/vim#9463)
https://github.com/vim/vim/commit/5c75eed758fbeb39825834d51f3ee4e08f137af3