### PR TITLE
vim-patch:8.1.{0342,0425}: can_unload_buffer()

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -391,6 +391,7 @@ static bool can_unload_buffer(buf_T *buf)
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer == buf) {
         can_unload = false;
+        break;
       }
     }
   }
@@ -1568,6 +1569,9 @@ void enter_buffer(buf_T *buf)
 
   // mark cursor position as being invalid
   curwin->w_valid = 0;
+
+  buflist_setfpos(curbuf, curwin, curbuf->b_last_cursor.mark.lnum, curbuf->b_last_cursor.mark.col,
+                  true);
 
   // Make sure the buffer is loaded.
   if (curbuf->b_ml.ml_mfp == NULL) {    // need to load the file

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -93,6 +93,33 @@ func Test_appendbufline()
   exe "bwipe! " . b
 endfunc
 
+func Test_appendbufline_no_E315()
+  let after = [
+    \ 'set stl=%f ls=2',
+    \ 'new',
+    \ 'let buf = bufnr("%")',
+    \ 'quit',
+    \ 'vsp',
+    \ 'exec "buffer" buf',
+    \ 'wincmd w',
+    \ 'call appendbufline(buf, 0, "abc")',
+    \ 'redraw',
+    \ 'while getbufline(buf, 1)[0] =~ "^\\s*$"',
+    \ '  sleep 10m',
+    \ 'endwhile',
+    \ 'au VimLeavePre * call writefile([v:errmsg], "Xerror")',
+    \ 'au VimLeavePre * call writefile(["done"], "Xdone")',
+    \ 'qall!',
+    \ ]
+  if !RunVim([], after, '--clean')
+    return
+  endif
+  call assert_notmatch("^E315:", readfile("Xerror")[0])
+  call assert_equal("done", readfile("Xdone")[0])
+  call delete("Xerror")
+  call delete("Xdone")
+endfunc
+
 func Test_deletebufline()
   new
   let b = bufnr('%')


### PR DESCRIPTION
#### vim-patch:8.1.0342: crash when a callback deletes a window that is being used

Problem:    Crash when a callback deletes a window that is being used.
Solution:   Do not unload a buffer that is being displayed while redrawing the
            screen. Also avoid invoking callbacks while redrawing.
            (closes vim/vim#2107)
https://github.com/vim/vim/commit/94f01956a583223dafe24135489d0ab1100ab0ad

Omit parse_queued_messages(): N/A


#### vim-patch:8.1.0425: ml_get error and crash with appendbufline()

Problem:    ml_get error and crash with appendbufline(). (Masashi Iizuka)
Solution:   Set per-window buffer info. (Hirohito Higashi, closes vim/vim#3455)
https://github.com/vim/vim/commit/9cea87c5775948a35098f3602746c20ecf95dbcd