### PR TITLE
vim-patch:8.0.1562: the terminal debugger can't set a breakpoint with the mouse

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -472,6 +472,20 @@ any window, using the TermDebugSendCommand() function.  Example: >
 The argument is the gdb command.
 
 
+Popup menu ~
+							*termdebug_popup*
+
+By default the Termdebug plugin sets 'mousemodel' to "popup_setpos" and adds
+these entries to the popup menu:
+	Set breakpoint		`:Break`
+	Clear breakpoint	`:Clear`
+	Evaluate		`:Evaluate`
+If you don't want this then disable it with: >
+	let g:termdebug_config['popup'] = 0
+or if there is no g:termdebug_config: >
+	let g:termdebug_popup = 0
+
+
 Vim window width ~
 							*termdebug_wide*
 

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -37,7 +37,7 @@
 "
 " For neovim compatibility, the vim specific calls were replaced with neovim
 " specific calls:
-"   term_start -> term_open
+"   term_start -> termopen
 "   term_sendkeys -> chansend
 "   term_getline -> getbufline
 "   job_info && term_getjob -> using linux command ps to get the tty
@@ -902,6 +902,26 @@ func s:InstallCommands()
     nnoremap K :Evaluate<CR>
   endif
 
+  if has('menu') && &mouse != ''
+    call s:InstallWinbar()
+
+    let popup = 1
+    if exists('g:termdebug_config')
+      let popup = get(g:termdebug_config, 'popup', 1)
+    elseif exists('g:termdebug_popup')
+      let popup = g:termdebug_popup
+    endif
+    if popup
+      let s:saved_mousemodel = &mousemodel
+      let &mousemodel = 'popup_setpos'
+      an 1.200 PopUp.-SEP3-	<Nop>
+      an 1.210 PopUp.Set\ breakpoint	:Break<CR>
+      an 1.220 PopUp.Clear\ breakpoint	:Clear<CR>
+      an 1.230 PopUp.Run\ until		:Until<CR>
+      an 1.240 PopUp.Evaluate		:Evaluate<CR>
+    endif
+  endif
+
   let &cpo = save_cpo
 endfunc
 
@@ -954,6 +974,33 @@ func s:DeleteCommands()
         \ })
     endif
     unlet s:k_map_saved
+  endif
+
+  if has('menu')
+    " Remove the WinBar entries from all windows where it was added.
+    " let curwinid = win_getid(winnr())
+    " for winid in s:winbar_winids
+    "   if win_gotoid(winid)
+    "     aunmenu WinBar.Step
+    "     aunmenu WinBar.Next
+    "     aunmenu WinBar.Finish
+    "     aunmenu WinBar.Cont
+    "     aunmenu WinBar.Stop
+    "     aunmenu WinBar.Eval
+    "   endif
+    " endfor
+    " call win_gotoid(curwinid)
+    " let s:winbar_winids = []
+
+    if exists('s:saved_mousemodel')
+      let &mousemodel = s:saved_mousemodel
+      unlet s:saved_mousemodel
+      aunmenu PopUp.-SEP3-
+      aunmenu PopUp.Set\ breakpoint
+      aunmenu PopUp.Clear\ breakpoint
+      aunmenu PopUp.Run\ until
+      aunmenu PopUp.Evaluate
+    endif
   endif
 
   call sign_unplace('TermDebug')


### PR DESCRIPTION
#### vim-patch:8.0.1562: the terminal debugger can't set a breakpoint with the mouse

Problem:    The terminal debugger can't set a breakpoint with the mouse.
Solution:   Add popup menu entries.
https://github.com/vim/vim/commit/71137fed4d77e985d49ca32c79f030512767b8ce

This ports missing popup menu code to termdebug plugin.
Despite the commit message, the code is copied from latest Vim.
WinBar code is commented out and WinBar docs is not ported.