### PR TITLE
vim-patch:8.2.5162: reading before the start of the line with BS in Replace mode

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -8373,7 +8373,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
       }
 
       // delete characters until we are at or before want_vcol
-      while (vcol > want_vcol
+      while (vcol > want_vcol && curwin->w_cursor.col > 0
              && (cc = *(get_cursor_pos_ptr() - 1), ascii_iswhite(cc))) {
         ins_bs_one(&vcol);
       }


### PR DESCRIPTION
#### vim-patch:8.2.5162: reading before the start of the line with BS in Replace mode

Problem:    Reading before the start of the line with BS in Replace mode.
Solution:   Check the cursor column is more than zero.
https://github.com/vim/vim/commit/0971c7a4e537ea120a6bb2195960be8d0815e97b