### PR TITLE
vim-patch:7.4.212,8.2.{4165,4221}: some functions in normal.c are too long

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -7935,13 +7935,8 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
    * Don't do it for CTRL-O, unless past the end of the line.
    */
   if (!nomove
-      && (curwin->w_cursor.col != 0
-          || curwin->w_cursor.coladd > 0
-          )
-      && (restart_edit == NUL
-          || (gchar_cursor() == NUL
-              && !VIsual_active
-              ))
+      && (curwin->w_cursor.col != 0 || curwin->w_cursor.coladd > 0)
+      && (restart_edit == NUL || (gchar_cursor() == NUL && !VIsual_active))
       && !revins_on) {
     if (curwin->w_cursor.coladd > 0 || get_ve_flags() == VE_ALL) {
       oneleft();

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2078,8 +2078,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
   } else if ((mod_mask & MOD_MASK_SHIFT)) {
     // Shift-Mouse click searches for the next occurrence of the word under
     // the mouse pointer
-    if (State & MODE_INSERT
-        || (VIsual_active && VIsual_select)) {
+    if (State & MODE_INSERT || (VIsual_active && VIsual_select)) {
       stuffcharReadbuff(Ctrl_O);
     }
     if (which_button == MOUSE_LEFT) {
@@ -2546,8 +2545,7 @@ static bool checkclearop(oparg_T *oap)
 /// @return  true if operator or Visual was active.
 static bool checkclearopq(oparg_T *oap)
 {
-  if (oap->op_type == OP_NOP
-      && !VIsual_active) {
+  if (oap->op_type == OP_NOP && !VIsual_active) {
     return false;
   }
   clearopbeep(oap);
@@ -4472,7 +4470,6 @@ static void nv_scroll(cmdarg_T *cap)
 static void nv_right(cmdarg_T *cap)
 {
   long n;
-  int PAST_LINE;
 
   if (mod_mask & (MOD_MASK_SHIFT | MOD_MASK_CTRL)) {
     // <C-Right> and <S-Right> move a word or WORD right
@@ -4485,18 +4482,17 @@ static void nv_right(cmdarg_T *cap)
 
   cap->oap->motion_type = kMTCharWise;
   cap->oap->inclusive = false;
-  PAST_LINE = (VIsual_active && *p_sel != 'o');
+  bool past_line = (VIsual_active && *p_sel != 'o');
 
-  // In virtual mode, there's no such thing as "PAST_LINE", as lines are
-  // (theoretically) infinitely long.
+  // In virtual edit mode, there's no such thing as "past_line", as lines
+  // are (theoretically) infinitely long.
   if (virtual_active()) {
-    PAST_LINE = 0;
+    past_line = false;
   }
 
   for (n = cap->count1; n > 0; n--) {
-    if ((!PAST_LINE && oneright() == false)
-        || (PAST_LINE
-            && *get_cursor_pos_ptr() == NUL)) {
+    if ((!past_line && oneright() == false)
+        || (past_line && *get_cursor_pos_ptr() == NUL)) {
       //          <Space> wraps to next line if 'whichwrap' has 's'.
       //              'l' wraps to next line if 'whichwrap' has 'l'.
       // CURS_RIGHT wraps to next line if 'whichwrap' has '>'.
@@ -4531,7 +4527,7 @@ static void nv_right(cmdarg_T *cap)
         }
       }
       break;
-    } else if (PAST_LINE) {
+    } else if (past_line) {
       curwin->w_set_curswant = true;
       if (virtual_active()) {
         oneright();
@@ -6472,8 +6468,7 @@ static void nv_redo_or_register(cmdarg_T *cap)
 static void nv_Undo(cmdarg_T *cap)
 {
   // In Visual mode and typing "gUU" triggers an operator
-  if (cap->oap->op_type == OP_UPPER
-      || VIsual_active) {
+  if (cap->oap->op_type == OP_UPPER || VIsual_active) {
     // translate "gUU" to "gUgU"
     cap->cmdchar = 'g';
     cap->nchar = 'U';
@@ -6488,9 +6483,7 @@ static void nv_Undo(cmdarg_T *cap)
 /// single character.
 static void nv_tilde(cmdarg_T *cap)
 {
-  if (!p_to
-      && !VIsual_active
-      && cap->oap->op_type != OP_TILDE) {
+  if (!p_to && !VIsual_active && cap->oap->op_type != OP_TILDE) {
     if (bt_prompt(curbuf) && !prompt_curpos_editable()) {
       clearopbeep(cap->oap);
       return;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -6627,9 +6627,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     switch (oap->op_type) {
     case OP_LSHIFT:
     case OP_RSHIFT:
-      op_shift(oap, true,
-               oap->is_VIsual ? (int)cap->count1 :
-               1);
+      op_shift(oap, true, oap->is_VIsual ? (int)cap->count1 : 1);
       auto_format(false, true);
       break;
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -514,7 +514,7 @@ void last_pat_prog(regmmatch_T *regmatch)
   --emsg_off;
 }
 
-/// lowest level search function.
+/// Lowest level search function.
 /// Search for 'count'th occurrence of pattern "pat" in direction "dir".
 /// Start at position "pos" and return the found position in "pos".
 ///
@@ -3991,8 +3991,7 @@ static int find_prev_quote(char_u *line, int col_start, int quotechar, char_u *e
     }
     if (n & 1) {
       col_start -= n;           // uneven number of escape chars, skip it
-    } else if (line[col_start] ==
-               quotechar) {
+    } else if (line[col_start] == quotechar) {
       break;
     }
   }
@@ -4115,8 +4114,7 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
         col_end = curwin->w_cursor.col;
       }
     }
-  } else if (line[col_start] == quotechar
-             || !vis_empty) {
+  } else if (line[col_start] == quotechar || !vis_empty) {
     int first_col = col_start;
 
     if (!vis_empty) {
@@ -4185,9 +4183,8 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
 
   // Set start position.  After vi" another i" must include the ".
   // For v2i" include the quotes.
-  if (!include && count < 2
-      && (vis_empty || !inside_quotes)) {
-    ++col_start;
+  if (!include && count < 2 && (vis_empty || !inside_quotes)) {
+    col_start++;
   }
   curwin->w_cursor.col = col_start;
   if (VIsual_active) {

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1422,9 +1422,16 @@ func Test_normal27_bracket()
   call assert_equal(5, line('.'))
   call assert_equal(3, col('.'))
 
-  " No mark after line 21, cursor moves to first non blank on current line
+  " No mark before line 1, cursor moves to first non-blank on current line
+  1
+  norm! 5|['
+  call assert_equal('  1   b', getline('.'))
+  call assert_equal(1, line('.'))
+  call assert_equal(3, col('.'))
+
+  " No mark after line 21, cursor moves to first non-blank on current line
   21
-  norm! $]'
+  norm! 5|]'
   call assert_equal('  21   b', getline('.'))
   call assert_equal(21, line('.'))
   call assert_equal(3, col('.'))
@@ -1441,12 +1448,40 @@ func Test_normal27_bracket()
   call assert_equal(20, line('.'))
   call assert_equal(8, col('.'))
 
+  " No mark before line 1, cursor does not move
+  1
+  norm! 5|[`
+  call assert_equal('  1   b', getline('.'))
+  call assert_equal(1, line('.'))
+  call assert_equal(5, col('.'))
+
+  " No mark after line 21, cursor does not move
+  21
+  norm! 5|]`
+  call assert_equal('  21   b', getline('.'))
+  call assert_equal(21, line('.'))
+  call assert_equal(5, col('.'))
+
+  " Count too large for [`
+  " cursor moves to first lowercase mark
+  norm! 99[`
+  call assert_equal('  1   b', getline('.'))
+  call assert_equal(1, line('.'))
+  call assert_equal(7, col('.'))
+
+  " Count too large for ]`
+  " cursor moves to last lowercase mark
+  norm! 99]`
+  call assert_equal('  20   b', getline('.'))
+  call assert_equal(20, line('.'))
+  call assert_equal(8, col('.'))
+
   " clean up
   bw!
 endfunc
 
+" Test for ( and ) sentence movements
 func Test_normal28_parenthesis()
-  " basic testing for ( and )
   new
   call append(0, ['This is a test. With some sentences!', '', 'Even with a question? And one more. And no sentence here'])
 


### PR DESCRIPTION
#### vim-patch:7.4.212

Problem:    Now that the +visual feature is always enabled the #ifdefs for it
            are not useful.
Solution:   Remove the checks for FEAT_VISUAL.
https://github.com/vim/vim/commit/f7ff6e85e8a4e84cff023f5db4b66ef85986605a


#### vim-patch:8.2.4165: the nv_g_cmd() function is too long

Problem:    The nv_g_cmd() function is too long.
Solution:   Move code to separate functions. (Yegappan Lakshmanan,
            closes vim/vim#9576)
https://github.com/vim/vim/commit/05386ca1d4823e5c98c24b8cd038af49aee62577


#### vim-patch:8.2.4221: some functions in normal.c are very long

Problem:    Some functions in normal.c are very long.
Solution:   Move code to separate functions. (Yegappan Lakshmanan,
            closes vim/vim#9628)
https://github.com/vim/vim/commit/a827bf3ea8fe465aa456ef7a7a37d6afe6a47628