### PR TITLE
ci: verify that system-managed dependencies work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,12 @@ jobs:
             ~/.ccache
           key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!cmake.deps/**CMakeLists.txt') }}-${{ github.base_ref }}
 
-      - name: Build third-party deps
-        run: ./ci/before_script.sh
+      - name: prepare-ccache
+        run: |
+          echo "ccache stats will be cleared"
+          ccache -s
+          # Reset ccache stats for real results in before_cache.
+          ccache --zero-stats
 
       - name: Build nvim
         run: ./ci/run_tests.sh build_nvim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,20 @@ jobs:
             lua-filesystem \
             lua-inspect \
             lua-lpeg \
-            lua-luv-dev \
             lua-nvim \
             luajit \
             ninja-build \
             pkg-config
 
+      # LIBLUV 1.43.0+ is required, which isn't available on apt
+      - name: Install luv
+        run: |
+          git clone https://github.com/luvit/luv.git
+          sudo make -C luv \
+            WITH_SHARED_LIBUV=ON \
+            LUA_BUILD_TYPE=System \
+            BUILD_DIR=build-luv \
+            install
 
       - name: Cache uncrustify
         id: cache-uncrustify


### PR DESCRIPTION
Actually skip using third-party when verifying downloading dependencies with the system's package manager.

Simply removing the install deps actually [broke cmake's configuration](https://github.com/neovim/neovim/runs/7211684631?check_suite_focus=true), since the required version libluv is not available on Ubuntu
https://github.com/neovim/neovim/blob/f47d1e0390581fc0061a60a3faaacf9171ba2b2b/CMakeLists.txt#L418-L418

#### Solutions
- use `luarocks` to install a new version of luv
- build luv from source
- use third-party to only build luv