### PR TITLE
fix: emoji "Regional Indicator Symbols" handling

### DIFF
--- a/src/nvim/generators/gen_unicode_tables.lua
+++ b/src/nvim/generators/gen_unicode_tables.lua
@@ -250,9 +250,12 @@ local build_emoji_table = function(ut_fp, emojiprops, doublewidth, ambiwidth)
         table.insert(emoji, { n, n_last })
       end
 
-      -- Characters below 1F000 may be considered single width traditionally,
-      -- making them double width causes problems.
-      if n >= 0x1f000 then
+      -- Special cases:
+      --   * Below 1F000 is considered single-width traditionally.
+      --   * Regional Indicator Symbols 0x1F1E6-0X1F1FF are almost always used
+      --     in pairs to represent a country flag, so special-case as
+      --     single-width to avoid 4 virtual columns. #16447
+      if (n >= 0x1f000 and n < 0x1f1e6) or n > 0x1f1ff then
         -- exclude characters that are in the ambiguous/doublewidth table
         for _, ambi in ipairs(ambiwidth) do
           if n >= ambi[1] and n <= ambi[2] then


### PR DESCRIPTION
The regional indicator symbol characters 0x1F1E6 to 0x1F1FF (as
given in www.unicode.org/charts/PDF/U1F100.pdf) are by themselves
double width characters.  And as such, currently are allocated
two virtual columns when displayed.

However, in actuality these characters are almost always used in
pairs that represent a country flag.  Within a terminal window,
the flag is displayed as a double width character.  But we
incorrectly allocate 4 virtual columns for the displayed flag,
(two combining-characters multiplied by two virtual columns each).

Unfortunately, there is no good way within the code to indicate
that these characters should be handled differently when combined
in sequence.

On balance, editing is much easier if we properly handle the usual
case where they appear as combined characters, and thus accept the
minor visual glitch when they appear as lone characters.

While not ideal, special case these unicode regional indicator
emoji symbols as single width.

Neovim issues #19258 #16447