### PR TITLE
vim-patch:8.2.5063: error for a command may go over the end of IObuff

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2904,9 +2904,16 @@ int checkforcmd(char **pp, char *cmd, int len)
 /// invisible otherwise.
 static void append_command(char *cmd)
 {
+  size_t len = STRLEN(IObuff);
   char *s = cmd;
   char *d;
 
+  if (len > IOSIZE - 100) {
+    // Not enough space, truncate and put in "...".
+    d = (char *)IObuff + IOSIZE - 100;
+    d -= utf_head_off(IObuff, (const char_u *)d);
+    STRCPY(d, "...");
+  }
   STRCAT(IObuff, ": ");
   d = (char *)IObuff + STRLEN(IObuff);
   while (*s != NUL && (char_u *)d - IObuff + 5 < IOSIZE) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1361,4 +1361,9 @@ func Test_recursive_register()
   call assert_equal('yes', caught)
 endfunc
 
+func Test_long_error_message()
+  " the error should be truncated, not overrun IObuff
+  silent! norm Q00000000000000     000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000                                                                                                                                                                                                                        
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5063: error for a command may go over the end of IObuff

Problem:    Error for a command may go over the end of IObuff.
Solution:   Truncate the message.
https://github.com/vim/vim/commit/44a3f3353e0407e9fffee138125a6927d1c9e7e5