### PR TITLE
vim-patch:8.2.{5023,5043,5044}: substitute textlock fixes

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1963,11 +1963,7 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
     return OK;
   }
 
-  if (text_locked()) {
-    text_locked_msg();
-    return FAIL;
-  }
-  if (curbuf_locked()) {
+  if (text_or_buf_locked()) {
     return FAIL;
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2726,6 +2726,17 @@ char *get_text_locked_msg(void)
   }
 }
 
+/// Check for text, window or buffer locked.
+/// Give an error message and return true if something is locked.
+bool text_or_buf_locked(void)
+{
+  if (text_locked()) {
+    text_locked_msg();
+    return true;
+  }
+  return curbuf_locked();
+}
+
 /// Check if "curbuf->b_ro_locked" or "allbuf_lock" is set and
 /// return true when it is and give an error message.
 bool curbuf_locked(void)
@@ -6599,6 +6610,11 @@ static int open_cmdwin(void)
   int save_State = State;
   bool save_exmode = exmode_active;
   int save_cmdmsg_rl = cmdmsg_rl;
+
+  // Can't do this when text or buffer is locked.
+  if (text_or_buf_locked()) {
+    return K_IGNORE;
+  }
 
   // Can't do this recursively.  Can't do it when typing a password.
   if (cmdwin_type != 0

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -6612,13 +6612,8 @@ static int open_cmdwin(void)
   int save_cmdmsg_rl = cmdmsg_rl;
 
   // Can't do this when text or buffer is locked.
-  if (text_or_buf_locked()) {
-    return K_IGNORE;
-  }
-
   // Can't do this recursively.  Can't do it when typing a password.
-  if (cmdwin_type != 0
-      || cmdline_star > 0) {
+  if (text_or_buf_locked() || cmdwin_type != 0 || cmdline_star > 0) {
     beep_flush();
     return K_IGNORE;
   }

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -1,5 +1,7 @@
 " Tests for the substitute (:s) command
 
+source shared.vim
+
 func Test_multiline_subst()
   enew!
   call append(0, ["1 aa",
@@ -871,6 +873,31 @@ func Test_sub_undo_change()
   call Do_Test_sub_undo_change()
 
   delfunc Repl
+endfunc
+
+" This was opening a command line window from the expression
+func Test_sub_open_cmdline_win()
+  " the error only happens in a very specific setup, run a new Vim instance to
+  " get a clean starting point.
+  let lines =<< trim [SCRIPT]
+    norm o0000000000000000000000000000000000000000000000000000
+    func Replace()
+      norm q/
+    endfunc
+    s/\%')/\=Replace()
+    redir >Xresult
+    messages
+    redir END
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '-u NONE -S Xscript')
+    let messages = readfile('Xresult')
+    call assert_match('E565: Not allowed to change text or change window', messages[3])
+  endif
+
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 " Test for the 2-letter and 3-letter :substitute commands

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -880,6 +880,7 @@ func Test_sub_open_cmdline_win()
   " the error only happens in a very specific setup, run a new Vim instance to
   " get a clean starting point.
   let lines =<< trim [SCRIPT]
+    set vb t_vb=
     norm o0000000000000000000000000000000000000000000000000000
     func Replace()
       norm q/
@@ -892,8 +893,8 @@ func Test_sub_open_cmdline_win()
   [SCRIPT]
   call writefile(lines, 'Xscript')
   if RunVim([], [], '-u NONE -S Xscript')
-    let messages = readfile('Xresult')
-    call assert_match('E565: Not allowed to change text or change window', messages[3])
+    call assert_match('E565: Not allowed to change text or change window',
+          \ readfile('Xresult')->join('XX'))
   endif
 
   call delete('Xscript')

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -851,6 +851,28 @@ func Test_sub_change_window()
   delfunc Repl
 endfunc
 
+" This was undoign a change in between computing the length and using it.
+func Do_Test_sub_undo_change()
+  new
+  norm o0000000000000000000000000000000000000000000000000000
+  silent! s/\%')/\=Repl()
+  bwipe!
+endfunc
+
+func Test_sub_undo_change()
+  func Repl()
+    silent! norm g-
+  endfunc
+  call Do_Test_sub_undo_change()
+
+  func! Repl()
+    silent earlier
+  endfunc
+  call Do_Test_sub_undo_change()
+
+  delfunc Repl
+endfunc
+
 " Test for the 2-letter and 3-letter :substitute commands
 func Test_substitute_short_cmd()
   new

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -89,6 +89,7 @@
 #include "nvim/change.h"
 #include "nvim/cursor.h"
 #include "nvim/edit.h"
+#include "nvim/ex_getln.h"
 #include "nvim/extmark.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
@@ -1953,6 +1954,11 @@ void undo_time(long step, bool sec, bool file, bool absolute)
   bool dofile = file;
   bool above = false;
   bool did_undo = true;
+
+  if (text_locked()) {
+    text_locked_msg();
+    return;
+  }
 
   // First make sure the current undoable change is synced.
   if (curbuf->b_u_synced == false) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4571,12 +4571,8 @@ void win_goto(win_T *wp)
 {
   win_T *owp = curwin;
 
-  if (text_locked()) {
+  if (text_or_buf_locked()) {
     beep_flush();
-    text_locked_msg();
-    return;
-  }
-  if (curbuf_locked()) {
     return;
   }
 


### PR DESCRIPTION
#### vim-patch:8.2.5023: substitute overwrites allocated buffer

Problem:    Substitute overwrites allocated buffer.
Solution:   Disallow undo when in a substitute command.
https://github.com/vim/vim/commit/338f1fc0ee3ca929387448fe464579d6113fa76a


#### vim-patch:8.2.5043: can open a cmdline window from a substitute expression

Problem:    Can open a cmdline window from a substitute expression.
Solution:   Disallow opening a command line window when text or buffer is
            locked.
https://github.com/vim/vim/commit/71223e2db87c2bf3b09aecb46266b56cda26191d


#### vim-patch:8.2.5044: command line test fails

Problem:    Command line test fails.
Solution:   Also beep when cmdline win can't be opened because of locks.
            Make the test not beep.  Make the test pass on MS-Windows.
https://github.com/vim/vim/commit/be99042b03edf7b8156c9adbc23516bfcf2cec0f