### PR TITLE
vim-patch:8.2.{3674,4399}: problems after ml_get error

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1834,6 +1834,7 @@ char_u *ml_get_buf(buf_T *buf, linenr_T lnum, bool will_change)
   DATA_BL *dp;
   char_u *ptr;
   static int recursive = 0;
+  static char_u questions[4];
 
   if (lnum > buf->b_ml.ml_line_count) {  // invalid line number
     if (recursive == 0) {
@@ -1844,8 +1845,8 @@ char_u *ml_get_buf(buf_T *buf, linenr_T lnum, bool will_change)
       recursive--;
     }
 errorret:
-    STRCPY(IObuff, "???");
-    return IObuff;
+    STRCPY(questions, "???");
+    return questions;
   }
   if (lnum <= 0) {                      // pretend line 0 is line 1
     lnum = 1;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1844,8 +1844,11 @@ char_u *ml_get_buf(buf_T *buf, linenr_T lnum, bool will_change)
       siemsg(_("E315: ml_get: invalid lnum: %" PRId64), (int64_t)lnum);
       recursive--;
     }
+    ml_flush_line(buf);
+    buf->b_ml.ml_flags &= ~ML_LINE_DIRTY;
 errorret:
     STRCPY(questions, "???");
+    buf->b_ml.ml_line_lnum = lnum;
     return questions;
   }
   if (lnum <= 0) {                      // pretend line 0 is line 1


### PR DESCRIPTION
#### vim-patch:8.2.3674: when ml_get_buf() fails it messes up IObuff

Problem:    When ml_get_buf() fails it messes up IObuff.
Solution:   Return a local pointer.
https://github.com/vim/vim/commit/96e7a5928e1e7a350cd6c6d0b9376305190046e7


#### vim-patch:8.2.4399: crash after ml_get error

Problem:    Crash after ml_get error.
Solution:   When returning "???" flush the line and set ml_line_lnum.
https://github.com/vim/vim/commit/f9435e49ef8032e80d38e31e950e4a9b75387533