### PR TITLE
vim-patch:8.1.{1524,1544}: tests are silently skipped

### DIFF
--- a/src/nvim/testdir/test_arabic.vim
+++ b/src/nvim/testdir/test_arabic.vim
@@ -2,9 +2,8 @@
 " NOTE: This just checks if the code works. If you know Arabic please add
 " functional tests that check the shaping works with real text.
 
-if !has('arabic')
-  throw 'Skipped: arabic feature missing'
-endif
+source check.vim
+CheckFeature arabic
 
 source view_util.vim
 

--- a/src/nvim/testdir/test_assert.vim
+++ b/src/nvim/testdir/test_assert.vim
@@ -257,6 +257,26 @@ func Test_assert_with_msg()
   call remove(v:errors, 0)
 endfunc
 
+func Test_mouse_position()
+  throw 'Skipped: Nvim does not have test_setmouse()'
+  let save_mouse = &mouse
+  set mouse=a
+  new
+  call setline(1, ['line one', 'line two'])
+  call assert_equal([0, 1, 1, 0], getpos('.'))
+  call test_setmouse(1, 5)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 5, 0], getpos('.'))
+  call test_setmouse(2, 20)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 8, 0], getpos('.'))
+  call test_setmouse(5, 1)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 2, 1, 0], getpos('.'))
+  bwipe!
+  let &mouse = save_mouse
+endfunc
+
 " Must be last.
 func Test_zz_quit_detected()
   " Verify that if a test function ends Vim the test script detects this.

--- a/src/nvim/testdir/test_cscope.vim
+++ b/src/nvim/testdir/test_cscope.vim
@@ -1,7 +1,11 @@
 " Test for cscope commands.
 
-if !has('cscope') || !executable('cscope') || !has('quickfix')
-  finish
+source check.vim
+CheckFeature cscope
+CheckFeature quickfix
+
+if !executable('cscope')
+  throw 'Skipped: cscope program missing'
 endif
 
 func CscopeSetupOrClean(setup)

--- a/src/nvim/testdir/test_float_func.vim
+++ b/src/nvim/testdir/test_float_func.vim
@@ -1,8 +1,7 @@
 " test float functions
 
-if !has('float')
-  finish
-end
+source check.vim
+CheckFeature float
 
 func Test_abs()
   call assert_equal('1.23', string(abs(1.23)))

--- a/src/nvim/testdir/test_history.vim
+++ b/src/nvim/testdir/test_history.vim
@@ -1,8 +1,7 @@
 " Tests for the history functions
 
-if !has('cmdline_hist')
-  finish
-endif
+source check.vim
+CheckFeature cmdline_hist
 
 set history=7
 

--- a/src/nvim/testdir/test_langmap.vim
+++ b/src/nvim/testdir/test_langmap.vim
@@ -1,5 +1,8 @@
 " tests for 'langmap'
 
+source check.vim
+CheckFeature langmap
+
 func Test_langmap()
   new
   set langmap=}l,^x,%v

--- a/src/nvim/testdir/test_listlbr.vim
+++ b/src/nvim/testdir/test_listlbr.vim
@@ -2,9 +2,9 @@
 
 scriptencoding latin1
 
-if !exists("+linebreak") || !has("conceal")
-  finish
-endif
+source check.vim
+CheckOption linebreak
+CheckFeature conceal
 
 source view_util.vim
 

--- a/src/nvim/testdir/test_listlbr_utf8.vim
+++ b/src/nvim/testdir/test_listlbr_utf8.vim
@@ -3,9 +3,10 @@
 set encoding=utf-8
 scriptencoding utf-8
 
-if !exists("+linebreak") || !has("conceal") || !has("signs")
-  finish
-endif
+source check.vim
+CheckOption linebreak
+CheckFeature conceal
+CheckFeature signs
 
 source view_util.vim
 

--- a/src/nvim/testdir/test_makeencoding.vim
+++ b/src/nvim/testdir/test_makeencoding.vim
@@ -4,8 +4,7 @@ source shared.vim
 
 let s:python = PythonProg()
 if s:python == ''
-  " Can't run this test.
-  finish
+  throw 'Skipped: python program missing'
 endif
 
 let s:script = 'test_makeencoding.py'

--- a/src/nvim/testdir/test_matchadd_conceal_utf8.vim
+++ b/src/nvim/testdir/test_matchadd_conceal_utf8.vim
@@ -1,7 +1,7 @@
 " Test for matchadd() and conceal feature using utf-8.
-if !has('conceal')
-  finish
-endif
+
+source check.vim
+CheckFeature conceal
 
 func s:screenline(lnum) abort
   let line = []

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -1,8 +1,7 @@
 " Test that the system menu can be loaded.
 
-if !has('menu')
-  finish
-endif
+source check.vim
+CheckFeature menu
 
 func Test_load_menu()
   try

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -2,9 +2,8 @@
 
 scriptencoding latin1
 
-if !has('mksession')
-  finish
-endif
+source check.vim
+CheckFeature mksession
 
 source shared.vim
 source term_util.vim
@@ -43,9 +42,9 @@ func Test_mksession()
     \   '    four leadinG spaces',
     \   'two		consecutive tabs',
     \   'two	tabs	in one line',
-    \   'one Ã¤ multibyteCharacter',
-    \   'aÃ¤ Ã„  two multiByte characters',
-    \   'AÃ¤Ã¶Ã¼  three mulTibyte characters',
+    \   'one ä multibyteCharacter',
+    \   'aä Ä  two multiByte characters',
+    \   'Aäöü  three mulTibyte characters',
     \   'short line',
     \ ])
   let tmpfile = 'Xtemp'

--- a/src/nvim/testdir/test_mksession_utf8.vim
+++ b/src/nvim/testdir/test_mksession_utf8.vim
@@ -3,9 +3,8 @@
 set encoding=utf-8
 scriptencoding utf-8
 
-if !has('mksession')
-  finish
-endif
+source check.vim
+CheckFeature mksession
 
 func Test_mksession_utf8()
   tabnew

--- a/src/nvim/testdir/test_perl.vim
+++ b/src/nvim/testdir/test_perl.vim
@@ -1,8 +1,8 @@
 " Tests for Perl interface
 
-if !has('perl') || has('win32')
-  finish
-endif
+source check.vim
+CheckFeature perl
+CheckNotMSWindows
 
 " FIXME: RunTest don't see any error when Perl abort...
 perl $SIG{__WARN__} = sub { die "Unexpected warnings from perl: @_" };

--- a/src/nvim/testdir/test_python2.vim
+++ b/src/nvim/testdir/test_python2.vim
@@ -1,9 +1,8 @@
 " Test for python 2 commands.
 " TODO: move tests from test86.in here.
 
-if !has('python')
-  finish
-endif
+source check.vim
+CheckFeature python
 
 func Test_pydo()
   " Check deleting lines does not trigger ml_get error.

--- a/src/nvim/testdir/test_python3.vim
+++ b/src/nvim/testdir/test_python3.vim
@@ -1,9 +1,8 @@
 " Test for python 3 commands.
 " TODO: move tests from test87.in here.
 
-if !has('python3')
-  finish
-endif
+source check.vim
+CheckFeature python3
 
 func Test_py3do()
   " Check deleting lines does not trigger an ml_get error.

--- a/src/nvim/testdir/test_pyx2.vim
+++ b/src/nvim/testdir/test_pyx2.vim
@@ -1,8 +1,7 @@
 " Test for pyx* commands and functions with Python 2.
 
-if !has('python')
-  finish
-endif
+source check.vim
+CheckFeature python
 set pyx=2
 
 let s:py2pattern = '^2\.[0-7]\.\d\+'

--- a/src/nvim/testdir/test_pyx3.vim
+++ b/src/nvim/testdir/test_pyx3.vim
@@ -1,9 +1,8 @@
 " Test for pyx* commands and functions with Python 3.
 
 set pyx=3
-if !has('python3')
-  finish
-endif
+source check.vim
+CheckFeature python3
 
 let s:py2pattern = '^2\.[0-7]\.\d\+'
 let s:py3pattern = '^3\.\d\+\.\d\+'

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -1,10 +1,9 @@
 " *-register (quotestar) tests
 
-if !has('clipboard')
-  finish
-endif
-
 source shared.vim
+source check.vim
+
+CheckFeature clipboard_working
 
 func Do_test_quotestar_for_macunix()
   if empty(exepath('pbcopy')) || empty(exepath('pbpaste'))

--- a/src/nvim/testdir/test_reltime.vim
+++ b/src/nvim/testdir/test_reltime.vim
@@ -1,8 +1,8 @@
 " Tests for reltime()
 
-if !has('reltime') || !has('float')
-  finish
-endif
+source check.vim
+CheckFeature reltime
+CheckFeature float
 
 func Test_reltime()
   let now = reltime()

--- a/src/nvim/testdir/test_sha256.vim
+++ b/src/nvim/testdir/test_sha256.vim
@@ -1,8 +1,8 @@
 " Tests for the sha256() function.
 
-if !has('cryptv') || !exists('*sha256')
-  finish
-endif
+source check.vim
+CheckFeature cryptv
+CheckFunction sha256
 
 function Test_sha256()
   " test for empty string:

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -2,9 +2,7 @@
 " Note: this file uses latin1 encoding, but is used with utf-8 encoding.
 
 source check.vim
-if !has('spell')
-  finish
-endif
+CheckFeature spell
 
 source screendump.vim
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -1,5 +1,8 @@
 " Test for syntax and syntax iskeyword option
 
+source check.vim
+CheckFeature syntax
+
 source view_util.vim
 source screendump.vim
 

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -1,8 +1,7 @@
 " Test for textobjects
 
-if !has('textobjects')
-  finish
-endif
+source check.vim
+CheckFeature textobjects
 
 func CpoM(line, useM, expected)
   new

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -1,8 +1,7 @@
 " Test for timers
 
-if !has('timers')
-  finish
-endif
+source check.vim
+CheckFeature timers
 
 source shared.vim
 source term_util.vim
@@ -317,8 +316,8 @@ endfunc
 " Test that the garbage collector isn't triggered if a timer callback invokes
 " vgetc().
 func Test_nocatch_garbage_collect()
-  CheckFunction test_garbagecollect_soon
-  CheckFunction test_override
+  " skipped: Nvim does not support test_garbagecollect_soon(), test_override()
+  return
   " 'uptimetime. must be bigger than the timer timeout
   set ut=200
   call test_garbagecollect_soon()

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -1,8 +1,7 @@
 " Test for variable tabstops
 
-if !has("vartabs")
-  finish
-endif
+source check.vim
+CheckFeature vartabs
 
 source view_util.vim
 


### PR DESCRIPTION
This is a port of these two patches combined:

vim-patch:8.1.1524: tests are silently skipped

Problem:    Tests are silently skipped.
Solution:   Throw an exception for skipped tests in more places.
https://github.com/vim/vim/commit/b0f94c1ff34d27d33aa9f96204985ea29c2eb0a1

vim-patch:8.1.1544: some balloon tests don't run when they can

Problem:    Some balloon tests don't run when they can.
Solution:   Split GUI balloon tests off into a separate file. (Ozaki Kiichi,
            closes vim/vim#4538)  Change the feature check into a command for
            consistency.
https://github.com/vim/vim/commit/b46fecd3454399f8ebdc5055302e4bfc5a10f98b

Omit test_lua.vim: previous patches are N/A
Omit test_memory_usage.vim: previous patches are N/A
Omit test_textprop.vim: previous patches are N/A
Omit test_winbar.vim: previous patches are N/A
Omit test_termcodes.vim: mostly N/A
Skip Test_mouse_positon() because it uses test_setmouse().
Cannot throw error in a Test_nocatch_ test.
Use latest `CheckFeature clipboard_working` for test_quotestar.vim
