### PR TITLE
vim-patch:8.2.{0274,0325}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7899,9 +7899,11 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
         need_wait_return = false;
         msg_scroll = 0;
         redraw_all_later(NOT_VALID);
+        pending_exmode_active = true;
 
         normal_enter(false, true);
 
+        pending_exmode_active = false;
         RedrawingDisabled = rd;
         no_wait_return = nwr;
         msg_scroll = ms;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2475,6 +2475,11 @@ static int vgetorpeek(bool advance)
           }
           tc = c;
 
+          // return 0 in normal_check()
+          if (pending_exmode_active) {
+            exmode_active = true;
+          }
+
           // no chars to block abbreviations for
           typebuf.tb_no_abbr_cnt = 0;
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -636,6 +636,10 @@ EXTERN int motion_force INIT(=0);       // motion force for pending operator
 
 // Ex Mode (Q) state
 EXTERN bool exmode_active INIT(= false);  // true if Ex mode is active
+
+/// Flag set when normal_check() should return 0 when entering Ex mode.
+EXTERN bool pending_exmode_active INIT(= false);
+
 EXTERN bool ex_no_reprint INIT(=false);   // No need to print after z or p.
 
 // 'inccommand' command preview state

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -15,6 +15,7 @@ set laststatus=1
 set listchars=eol:$
 set joinspaces
 set nohidden nosmarttab noautoindent noautoread complete-=i noruler noshowcmd
+set nohlsearch noincsearch
 set nrformats+=octal
 set shortmess-=F
 set sidescroll=0

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -64,12 +64,21 @@ func Test_ex_mode()
   let &encoding = encoding_save
 endfunc
 
-func Test_Ex_feedkeys()
-  " this doesn't do anything useful, just check it doesn't hang
+" Test for :g/pat/visual to run vi commands in Ex mode
+" This used to hang Vim before 8.2.0274.
+func Test_Ex_global()
   new
-  call setline(1, ["foo"])
-  call feedkeys("Qg/foo/visual\<CR>", "xt")
+  call setline(1, ['', 'foo', 'bar', 'foo', 'bar', 'foo'])
+  call feedkeys("Q\<bs>g/bar/visual\<CR>$rxQ$ryQvisual\<CR>j", "xt")
+  call assert_equal('bax', getline(3))
+  call assert_equal('bay', getline(5))
   bwipe!
+endfunc
+
+" In Ex-mode, a backslash escapes a newline
+func Test_Ex_escape_enter()
+  call feedkeys("gQlet l = \"a\\\<kEnter>b\"\<cr>vi\<cr>", 'xt')
+  call assert_equal("a\rb", l)
 endfunc
 
 func Test_ex_mode_errors()

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -64,6 +64,14 @@ func Test_ex_mode()
   let &encoding = encoding_save
 endfunc
 
+func Test_Ex_feedkeys()
+  " this doesn't do anything useful, just check it doesn't hang
+  new
+  call setline(1, ["foo"])
+  call feedkeys("Qg/foo/visual\<CR>", "xt")
+  bwipe!
+endfunc
+
 func Test_ex_mode_errors()
   " Not allowed to enter ex mode when text is locked
   au InsertCharPre <buffer> normal! gQ<CR>

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1218,6 +1218,16 @@ func Test_input_func()
   call assert_fails("call input('F:', '', [])", 'E730:')
 endfunc
 
+" Test for the inputdialog() function
+func Test_inputdialog()
+  CheckNotGui
+
+  call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<CR>", 'xt')
+  call assert_equal('xx', v)
+  call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<Esc>", 'xt')
+  call assert_equal('yy', v)
+endfunc
+
 " Test for inputlist()
 func Test_inputlist()
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>1\<cr>", 'tx')

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -752,6 +752,29 @@ func Test_shellquote()
   call assert_match(': "#echo Hello#"', v)
 endfunc
 
+" Test for the 'rightleftcmd' option
+func Test_rightleftcmd()
+  CheckFeature rightleft
+  set rightleft
+  set rightleftcmd
+
+  let g:l = []
+  func AddPos()
+    call add(g:l, screencol())
+    return ''
+  endfunc
+  cmap <expr> <F2> AddPos()
+
+  call feedkeys("/\<F2>abc\<Left>\<F2>\<Right>\<Right>\<F2>" ..
+        \ "\<Left>\<F2>\<Esc>", 'xt')
+  call assert_equal([&co - 1, &co - 4, &co - 2, &co - 3], g:l)
+
+  cunmap <F2>
+  unlet g:l
+  set rightleftcmd&
+  set rightleft&
+endfunc
+
 " Test for setting option values using v:false and v:true
 func Test_opt_boolean()
   set number&


### PR DESCRIPTION
#### vim-patch:8.2.0274: hang with combination of feedkeys(), Ex mode and :global

Problem:    Hang with combination of feedkeys(), Ex mode and :global.
            (Yegappan Lakshmanan)
Solution:   Add the pending_exmode_active flag.
https://github.com/vim/vim/commit/9e2bcb5d23138d45a0b6f9c1542b5facc807efe7


#### vim-patch:8.2.0325: ex_getln.c code not covered by tests

Problem:    Ex_getln.c code not covered by tests.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#5702)
https://github.com/vim/vim/commit/578fe947e3ad0cc7313c798cf76cc43dbf9b4ea6

Cherry-pick Test_Ex_global() from patch 8.2.0293.
Test_rightleftcmd() fails if incsearch is enabled, so disable it.