### PR TITLE
fix(lua): did_load_filetypes is not a boolean

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -1,5 +1,5 @@
 -- Skip if legacy filetype is enabled or filetype detection is disabled
-if vim.g.do_legacy_filetype or vim.g.did_load_filetypes then
+if vim.g.do_legacy_filetype or vim.g.did_load_filetypes == 1 then
   return
 end
 vim.g.did_load_filetypes = 1


### PR DESCRIPTION
fixes an edge-case where the loader was bailing early due to having this

```lua
vim.g.do_filetype_lua = 1
vim.g.did_load_filetypes = 0
```

which used to be the recommended way to enable `filetype.lua` before #19216
