### PR TITLE
vim-patch:8.2.{0332,0396}: insufficient tests for cmdline

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -161,6 +161,10 @@ func RunTheTest(test)
     endtry
   endif
 
+  " Make "Q" switch to Ex mode.
+  " This does not work for all tests.
+  nnoremap Q gQ
+
   if a:test =~ 'Test_nocatch_'
     " Function handles errors itself.  This avoids skipping commands after the
     " error.

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -31,10 +31,6 @@ set switchbuf=
 mapclear
 mapclear!
 
-" Make "Q" switch to Ex mode.
-" This does not work for all tests.
-nnoremap Q gQ
-
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_arabic.vim
+++ b/src/nvim/testdir/test_arabic.vim
@@ -562,3 +562,26 @@ func Test_shape_combination_isolated()
   set arabicshape&
   bwipe!
 endfunc
+
+" Test for entering arabic character in a search command
+func Test_arabic_chars_in_search_cmd()
+  new
+  set arabic
+  call feedkeys("i\nsghl!\<C-^>vim\<C-^>", 'tx')
+  call cursor(1, 1)
+  call feedkeys("/^sghl!\<C-^>vim$\<C-^>\<CR>", 'tx')
+  call assert_equal([2, 1], [line('.'), col('.')])
+
+  " Try searching in left-to-right mode
+  set rightleftcmd=
+  call cursor(1, 1)
+  call feedkeys("/^sghl!\<C-^>vim$\<CR>", 'tx')
+  call assert_equal([2, 1], [line('.'), col('.')])
+
+  set rightleftcmd&
+  set rightleft&
+  set arabic&
+  bwipe!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2,6 +2,7 @@
 
 source check.vim
 source screendump.vim
+source view_util.vim
 
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
@@ -806,6 +807,149 @@ func Test_cmdline_complete_expression()
   unlet g:SomeVar
 endfunc
 
+" Test for various command-line completion
+func Test_cmdline_complete_various()
+  " completion for a command starting with a comment
+  call feedkeys(": :|\"\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\" :|\"\<C-A>", @:)
+
+  " completion for a range followed by a comment
+  call feedkeys(":1,2\"\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"1,2\"\<C-A>", @:)
+
+  " completion for :k command
+  call feedkeys(":ka\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"ka\<C-A>", @:)
+
+  " completion for short version of the :s command
+  call feedkeys(":sI \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"sI \<C-A>", @:)
+
+  " completion for :write command
+  call mkdir('Xdir')
+  call writefile(['one'], 'Xdir/Xfile1')
+  let save_cwd = getcwd()
+  cd Xdir
+  call feedkeys(":w >> \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"w >> Xfile1", @:)
+  call chdir(save_cwd)
+  call delete('Xdir', 'rf')
+
+  " completion for :w ! and :r ! commands
+  call feedkeys(":w !invalid_xyz_cmd\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"w !invalid_xyz_cmd", @:)
+  call feedkeys(":r !invalid_xyz_cmd\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"r !invalid_xyz_cmd", @:)
+
+  " completion for :>> and :<< commands
+  call feedkeys(":>>>\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\">>>\<C-A>", @:)
+  call feedkeys(":<<<\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"<<<\<C-A>", @:)
+
+  " completion for command with +cmd argument
+  call feedkeys(":buffer +/pat Xabc\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"buffer +/pat Xabc", @:)
+  call feedkeys(":buffer +/pat\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"buffer +/pat\<C-A>", @:)
+
+  " completion for a command with a trailing comment
+  call feedkeys(":ls \" comment\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"ls \" comment\<C-A>", @:)
+
+  " completion for a command with a trailing command
+  call feedkeys(":ls | ls\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"ls | ls", @:)
+
+  " completion for a command with an CTRL-V escaped argument
+  call feedkeys(":ls \<C-V>\<C-V>a\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"ls \<C-V>a\<C-A>", @:)
+
+  " completion for a command that doesn't take additional arguments
+  call feedkeys(":all abc\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"all abc\<C-A>", @:)
+
+  " completion for a command with a command modifier
+  call feedkeys(":topleft new\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"topleft new", @:)
+
+  " completion for the :match command
+  call feedkeys(":match Search /pat/\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"match Search /pat/\<C-A>", @:)
+
+  " completion for the :s command
+  call feedkeys(":s/from/to/g\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"s/from/to/g\<C-A>", @:)
+
+  " completion for the :dlist command
+  call feedkeys(":dlist 10 /pat/ a\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"dlist 10 /pat/ a\<C-A>", @:)
+
+  " completion for the :doautocmd command
+  call feedkeys(":doautocmd User MyCmd a.c\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"doautocmd User MyCmd a.c\<C-A>", @:)
+
+  " completion for the :augroup command
+  augroup XTest
+  augroup END
+  call feedkeys(":augroup X\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"augroup XTest", @:)
+  augroup! XTest
+
+  " completion for the :unlet command
+  call feedkeys(":unlet one two\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"unlet one two", @:)
+
+  " completion for the :bdelete command
+  call feedkeys(":bdel a b c\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"bdel a b c", @:)
+
+  " completion for the :mapclear command
+  call feedkeys(":mapclear \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"mapclear <buffer>", @:)
+
+  " completion for user defined commands with menu names
+  menu Test.foo :ls<CR>
+  com -nargs=* -complete=menu MyCmd
+  call feedkeys(":MyCmd Te\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd Test.', @:)
+  delcom MyCmd
+  unmenu Test
+
+  " completion for user defined commands with mappings
+  mapclear
+  map <F3> :ls<CR>
+  com -nargs=* -complete=mapping MyCmd
+  call feedkeys(":MyCmd <F\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"MyCmd <F3>', @:)
+  mapclear
+  delcom MyCmd
+
+  " completion for :set path= with multiple backslashes
+  call feedkeys(":set path=a\\\\\\ b\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set path=a\\\ b', @:)
+
+  " completion for :set dir= with a backslash
+  call feedkeys(":set dir=a\\ b\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set dir=a\ b', @:)
+
+  " completion for the :py3 commands
+  call feedkeys(":py3\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"py3 py3do py3file', @:)
+
+  " redir @" is not the start of a comment. So complete after that
+  call feedkeys(":redir @\" | cwin\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"redir @" | cwindow', @:)
+
+  " completion after a backtick
+  call feedkeys(":e `a1b2c\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e `a1b2c', @:)
+
+  " completion for the expression register
+  call feedkeys(":\"\<C-R>=float2\t\"\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"float2nr("', @=)
+endfunc
+
 func Test_cmdline_write_alternatefile()
   new
   call setline('.', ['one', 'two'])
@@ -1264,15 +1408,6 @@ func Test_cmdline_ctrl_g()
   close!
 endfunc
 
-" Return the 'len' characters in screen starting from (row,col)
-func s:ScreenLine(row, col, len)
-  let s = ''
-  for i in range(a:len)
-    let s .= nr2char(screenchar(a:row, a:col + i))
-  endfor
-  return s
-endfunc
-
 " Test for 'wildmode'
 func Test_wildmode()
   func T(a, c, p)
@@ -1281,7 +1416,7 @@ func Test_wildmode()
   command -nargs=1 -complete=custom,T MyCmd
 
   func SaveScreenLine()
-    let g:Sline = s:ScreenLine(&lines - 1, 1, 20)
+    let g:Sline = Screenline(&lines - 1)
     return ''
   endfunc
   cnoremap <expr> <F2> SaveScreenLine()
@@ -1290,7 +1425,7 @@ func Test_wildmode()
   set wildmode=full,list
   let g:Sline = ''
   call feedkeys(":MyCmd \t\t\<F2>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('oneA  oneB  oneC    ', g:Sline)
+  call assert_equal('oneA  oneB  oneC', g:Sline)
   call assert_equal('"MyCmd oneA', @:)
 
   set wildmode=longest,full
@@ -1306,18 +1441,35 @@ func Test_wildmode()
   set wildmode=list:longest
   let g:Sline = ''
   call feedkeys(":MyCmd \t\<F2>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('oneA  oneB  oneC    ', g:Sline)
+  call assert_equal('oneA  oneB  oneC', g:Sline)
   call assert_equal('"MyCmd one', @:)
 
   set wildmode=""
   call feedkeys(":MyCmd \t\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd oneA', @:)
 
+  " Test for wildmode=longest with 'fileignorecase' set
+  set wildmode=longest
+  set fileignorecase
+  argadd AA AAA AAAA
+  call feedkeys(":buffer \t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"buffer AA', @:)
+  set fileignorecase&
+
+  " Test for listing files with wildmode=list
+  set wildmode=list
+  let g:Sline = ''
+  call feedkeys(":b A\t\t\<F2>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('AA    AAA   AAAA', g:Sline)
+  call assert_equal('"b A', @:)
+
+  %argdelete
   delcommand MyCmd
   delfunc T
   delfunc SaveScreenLine
   cunmap <F2>
   set wildmode&
+  %bwipe!
 endfunc
 
 " Test for interrupting the command-line completion

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -1,5 +1,7 @@
 " test taglist(), tagfiles() functions and :tags command
 
+source view_util.vim
+
 func Test_taglist()
   call writefile([
 	\ "FFoo\tXfoo\t1",
@@ -222,3 +224,21 @@ func Test_format_error()
   set tags&
   call delete('Xtags')
 endfunc
+
+" Test for :tag command completion with 'wildoptions' set to 'tagfile'
+func Test_tag_complete_wildoptions()
+  call writefile(["foo\ta.c\t10;\"\tf", "bar\tb.c\t20;\"\td"], 'Xtags')
+  set tags=Xtags
+  set wildoptions=tagfile
+
+  call feedkeys(":tag \<C-D>\<C-R>=Screenline(&lines - 1)\<CR> : "
+        \ .. "\<C-R>=Screenline(&lines - 2)\<CR>\<C-B>\"\<CR>", 'xt')
+
+  call assert_equal('"tag bar d b.c : foo f a.c', @:)
+
+  call delete('Xtags')
+  set wildoptions&
+  set tags&
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -313,7 +313,7 @@ func CustomComplete(A, L, P)
 endfunc
 
 func CustomCompleteList(A, L, P)
-  return [ "Monday", "Tuesday", "Wednesday" ]
+  return [ "Monday", "Tuesday", "Wednesday", {}]
 endfunc
 
 func Test_CmdCompletion()


### PR DESCRIPTION
#### vim-patch:8.2.0332: some code in ex_getln.c not covered by tests

Problem:    Some code in ex_getln.c not covered by tests.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#5710)
https://github.com/vim/vim/commit/d30ae2fc4acb3861fc7dc9618c1f90eee997d412


#### vim-patch:8.2.0396: cmdexpand.c insufficiently tested

Problem:    Cmdexpand.c insufficiently tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5789)
https://github.com/vim/vim/commit/24ebd83e030e1c6f9a6be1f06232756ba4d00a8c

Map Q to gQ before every test since a test uses :mapclear.