### PR TITLE
vim-patch:8.2.{2902,2917}: spellfile functionality not fully tested

### DIFF
--- a/src/nvim/testdir/test_spellfile.vim
+++ b/src/nvim/testdir/test_spellfile.vim
@@ -525,6 +525,13 @@ func Test_mkspell()
   call assert_fails('mkspell! Xtest.spl Xtest.dic', 'E17:')
   call delete('Xtest.spl', 'rf')
 
+  " can't write the .spl file as its directory does not exist
+  call writefile([], 'Xtest.aff')
+  call writefile([], 'Xtest.dic')
+  call assert_fails('mkspell DOES_NOT_EXIT/Xtest.spl Xtest.dic', 'E484:')
+  call delete('Xtest.aff')
+  call delete('Xtest.dic')
+
   call assert_fails('mkspell en en_US abc_xyz', 'E755:')
 endfunc
 
@@ -733,36 +740,45 @@ func Test_spell_add_word()
   %bw!
 endfunc
 
-" When 'spellfile' is not set, adding a new good word will automatically set
-" the 'spellfile'
-func Test_init_spellfile()
-  let save_rtp = &rtp
-  let save_encoding = &encoding
-  call mkdir('Xrtp/spell', 'p')
-  call writefile(['vim'], 'Xrtp/spell/Xtest.dic')
-  silent mkspell Xrtp/spell/Xtest.utf-8.spl Xrtp/spell/Xtest.dic
-  set runtimepath=./Xrtp
-  set spelllang=Xtest
+func Test_spellfile_verbose()
+  call writefile(['1', 'one'], 'XtestVerbose.dic')
+  call writefile([], 'XtestVerbose.aff')
+  mkspell! XtestVerbose-utf8.spl XtestVerbose
   set spell
-  silent spellgood abc
-  call assert_equal('./Xrtp/spell/Xtest.utf-8.add', &spellfile)
-  call assert_equal(['abc'], readfile('Xrtp/spell/Xtest.utf-8.add'))
-  call assert_true(filereadable('Xrtp/spell/Xtest.utf-8.spl'))
-  set spell& spelllang& spellfile&
-  call delete('Xrtp', 'rf')
-  let &encoding = save_encoding
-  let &rtp = save_rtp
-  %bw!
+
+  " First time: the spl file should be read.
+  let a = execute('3verbose set spelllang=XtestVerbose-utf8.spl')
+  call assert_match('Reading spell file "XtestVerbose-utf8.spl"', a)
+
+  " Second time time: the spl file should not be read (already read).
+  let a = execute('3verbose set spelllang=XtestVerbose-utf8.spl')
+  call assert_notmatch('Reading spell file "XtestVerbose-utf8.spl"', a)
+
+  set spell& spelllang&
+  call delete('XtestVerbose.dic')
+  call delete('XtestVerbose.aff')
+  call delete('XtestVerbose-utf8.spl')
 endfunc
 
-" Test for the 'mkspellmem' option
-func Test_mkspellmem_opt()
-  call assert_fails('set mkspellmem=1000', 'E474:')
-  call assert_fails('set mkspellmem=1000,', 'E474:')
-  call assert_fails('set mkspellmem=1000,50', 'E474:')
-  call assert_fails('set mkspellmem=1000,50,', 'E474:')
-  call assert_fails('set mkspellmem=1000,50,10,', 'E474:')
-  call assert_fails('set mkspellmem=1000,50,0', 'E474:')
+" Test NOBREAK (see :help spell-NOBREAK)
+func Test_NOBREAK()
+  call writefile(['3', 'one', 'two', 'three' ], 'XtestNOBREAK.dic')
+  call writefile(['NOBREAK' ], 'XtestNOBREAK.aff')
+
+  mkspell! XtestNOBREAK-utf8.spl XtestNOBREAK
+  set spell spelllang=XtestNOBREAK-utf8.spl
+
+  call assert_equal(['', ''], spellbadword('One two three onetwo onetwothree threetwoone'))
+
+  call assert_equal(['x', 'bad'], spellbadword('x'))
+  call assert_equal(['y', 'bad'], spellbadword('yone'))
+  call assert_equal(['z', 'bad'], spellbadword('onez'))
+  call assert_equal(['zero', 'bad'], spellbadword('Onetwozerothree'))
+
+  set spell& spelllang&
+  call delete('XtestNOBREAK.dic')
+  call delete('XtestNOBREAK.aff')
+  call delete('XtestNOBREAK-utf8.spl')
 endfunc
 
 " Test CHECKCOMPOUNDPATTERN (see :help spell-CHECKCOMPOUNDPATTERN)
@@ -777,7 +793,7 @@ func Test_spellfile_CHECKCOMPOUNDPATTERN()
         \         'CHECKCOMPOUNDPATTERN wo on',
         \         'COMPOUNDFLAG c'], 'XtestCHECKCOMPOUNDPATTERN.aff')
 
-  let output = execute('mkspell! XtestCHECKCOMPOUNDPATTERN-utf8.spl XtestCHECKCOMPOUNDPATTERN')
+  mkspell! XtestCHECKCOMPOUNDPATTERN-utf8.spl XtestCHECKCOMPOUNDPATTERN
   set spell spelllang=XtestCHECKCOMPOUNDPATTERN-utf8.spl
 
   " Check valid words with and without valid compounds.
@@ -862,7 +878,7 @@ func Test_spellfile_COMMON()
         \         'ted'], 'XtestCOMMON.dic')
   call writefile(['COMMON the and'], 'XtestCOMMON.aff')
 
-  let output = execute('mkspell! XtestCOMMON-utf8.spl XtestCOMMON')
+  mkspell! XtestCOMMON-utf8.spl XtestCOMMON
   set spell spelllang=XtestCOMMON-utf8.spl
 
   " COMMON words 'and' and 'the' should be the top suggestions.
@@ -875,6 +891,81 @@ func Test_spellfile_COMMON()
   call delete('XtestCOMMON.dic')
   call delete('XtestCOMMON.aff')
   call delete('XtestCOMMON-utf8.spl')
+endfunc
+
+" Test CIRCUMFIX (see: :help spell-CIRCUMFIX)
+func Test_spellfile_CIRCUMFIX()
+  " Example taken verbatim from https://github.com/hunspell/hunspell/tree/master/tests
+  call writefile(['1',
+        \         'nagy/C	po:adj'], 'XtestCIRCUMFIX.dic')
+  call writefile(['# circumfixes: ~ obligate prefix/suffix combinations',
+        \         '# superlative in Hungarian: leg- (prefix) AND -bb (suffix)',
+        \         '',
+        \         'CIRCUMFIX X',
+        \         '',
+        \         'PFX A Y 1',
+        \         'PFX A 0 leg/X .',
+        \         '',
+        \         'PFX B Y 1',
+        \         'PFX B 0 legesleg/X .',
+        \         '',
+        \         'SFX C Y 3',
+        \         'SFX C 0 obb . is:COMPARATIVE',
+        \         'SFX C 0 obb/AX . is:SUPERLATIVE',
+        \         'SFX C 0 obb/BX . is:SUPERSUPERLATIVE'], 'XtestCIRCUMFIX.aff')
+
+  mkspell! XtestCIRCUMFIX-utf8.spl XtestCIRCUMFIX
+  set spell spelllang=XtestCIRCUMFIX-utf8.spl
+
+  " From https://catalog.ldc.upenn.edu/docs/LDC2008T01/acta04.pdf:
+  " Hungarian       English
+  " ---------       -------
+  " nagy            great
+  " nagyobb         greater
+  " legnagyobb      greatest
+  " legeslegnagyob  most greatest
+  call assert_equal(['', ''], spellbadword('nagy nagyobb legnagyobb legeslegnagyobb'))
+
+  for badword in ['legnagy', 'legeslegnagy', 'legobb', 'legeslegobb']
+    call assert_equal([badword, 'bad'], spellbadword(badword))
+  endfor
+
+  set spell& spelllang&
+  call delete('XtestCIRCUMFIX.dic')
+  call delete('XtestCIRCUMFIX.aff')
+  call delete('XtestCIRCUMFIX-utf8.spl')
+endfunc
+
+" When 'spellfile' is not set, adding a new good word will automatically set
+" the 'spellfile'
+func Test_init_spellfile()
+  let save_rtp = &rtp
+  let save_encoding = &encoding
+  call mkdir('Xrtp/spell', 'p')
+  call writefile(['vim'], 'Xrtp/spell/Xtest.dic')
+  silent mkspell Xrtp/spell/Xtest.utf-8.spl Xrtp/spell/Xtest.dic
+  set runtimepath=./Xrtp
+  set spelllang=Xtest
+  set spell
+  silent spellgood abc
+  call assert_equal('./Xrtp/spell/Xtest.utf-8.add', &spellfile)
+  call assert_equal(['abc'], readfile('Xrtp/spell/Xtest.utf-8.add'))
+  call assert_true(filereadable('Xrtp/spell/Xtest.utf-8.spl'))
+  set spell& spelllang& spellfile&
+  call delete('Xrtp', 'rf')
+  let &encoding = save_encoding
+  let &rtp = save_rtp
+  %bw!
+endfunc
+
+" Test for the 'mkspellmem' option
+func Test_mkspellmem_opt()
+  call assert_fails('set mkspellmem=1000', 'E474:')
+  call assert_fails('set mkspellmem=1000,', 'E474:')
+  call assert_fails('set mkspellmem=1000,50', 'E474:')
+  call assert_fails('set mkspellmem=1000,50,', 'E474:')
+  call assert_fails('set mkspellmem=1000,50,10,', 'E474:')
+  call assert_fails('set mkspellmem=1000,50,0', 'E474:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.2902: spellfile functionality not fully tested

Problem:    Spellfile functionality not fully tested.
Solution:   Add tests for CIRCUMFIX, NOBREAK and others. (Dominique Pellé,
            closes vim/vim#8283)
https://github.com/vim/vim/commit/5a6cfb3ff2f2f422a3732f3855616c89dd19c19d

Reorder test_spellfile.vim to match upstream.


#### vim-patch:8.2.2917: spellfile functionality not fully tested

Problem:    Spellfile functionality not fully tested.
Solution:   Add tests for SFX with removal of characters, spelling
            suggestions with NOBREAK and others. (Dominique Pellé,
            closes vim/vim#8293)
https://github.com/vim/vim/commit/bb162367ac77db877586086d7456685f2aeb8754