### PR TITLE
test(old): align defaults to Vim after every test

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -161,10 +161,6 @@ func RunTheTest(test)
     endtry
   endif
 
-  " Make "Q" switch to Ex mode.
-  " This does not work for all tests.
-  nnoremap Q gQ
-
   if a:test =~ 'Test_nocatch_'
     " Function handles errors itself.  This avoids skipping commands after the
     " error.
@@ -194,6 +190,9 @@ func RunTheTest(test)
       call add(v:errors, 'Caught exception in TearDown() after ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
     endtry
   endif
+
+  " Align Nvim defaults to Vim.
+  source setup.vim
 
   " Clear any autocommands and put back the catch-all for SwapExists.
   au!

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -1,3 +1,34 @@
+" Align Nvim defaults to Vim.
+set backspace=
+set complete=.,w,b,u,t,i
+set directory&
+set directory^=.
+set fillchars=vert:\|,fold:-
+set formatoptions=tcq
+set fsync
+set laststatus=1
+set listchars=eol:$
+set joinspaces
+set nohidden nosmarttab noautoindent noautoread noruler noshowcmd
+set nohlsearch noincsearch
+set nrformats=bin,octal,hex
+set shortmess=filnxtToOS
+set sidescroll=0
+set tags=./tags,tags
+set undodir&
+set undodir^=.
+set wildoptions=
+set startofline
+set sessionoptions&
+set sessionoptions+=options
+set viewoptions&
+set viewoptions+=options
+set switchbuf=
+
+" Make "Q" switch to Ex mode.
+" This does not work for all tests.
+nnoremap Q gQ
+
 " Common preparations for running tests.
 
 " Only load this once.
@@ -5,27 +36,6 @@ if exists('s:did_load')
   finish
 endif
 let s:did_load = 1
-
-" Align Nvim defaults to Vim.
-set backspace=
-set directory^=.
-set fillchars=vert:\|,fold:-
-set fsync
-set laststatus=1
-set listchars=eol:$
-set joinspaces
-set nohidden nosmarttab noautoindent noautoread complete-=i noruler noshowcmd
-set nohlsearch noincsearch
-set nrformats+=octal
-set shortmess-=F
-set sidescroll=0
-set tags=./tags,tags
-set undodir^=.
-set wildoptions=
-set startofline
-set sessionoptions+=options
-set viewoptions+=options
-set switchbuf=
 
 " Clear Nvim default mappings.
 mapclear

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1720,7 +1720,7 @@ func Test_Cmd_Autocmds()
   au BufWriteCmd XtestE call extend(g:lines, getline(0, '$'))
   wall				" will write other window to 'lines'
   call assert_equal(4, len(g:lines), g:lines)
-  call assert_equal("\tasdf", g:lines[2])
+  call assert_equal("asdf", g:lines[2])
 
   au! BufReadCmd
   au! BufWriteCmd

--- a/src/nvim/testdir/test_command_count.vim
+++ b/src/nvim/testdir/test_command_count.vim
@@ -33,7 +33,7 @@ func Test_command_count_0()
   delcommand RangeBuffers
   delcommand RangeBuffersAll
 
-  set nohidden
+  set hidden&
   set swapfile&
 endfunc
 

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -540,7 +540,7 @@ func Test_diffopt_hiddenoff()
 
   bwipe!
   bwipe!
-  set nohidden diffopt&
+  set hidden& diffopt&
 endfunc
 
 func Test_diffoff_hidden()
@@ -577,7 +577,7 @@ func Test_diffoff_hidden()
 
   bwipe!
   bwipe!
-  set nohidden diffopt&
+  set hidden& diffopt&
 endfunc
 
 func Test_setting_cursor()

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -147,7 +147,6 @@ endfunc
 
 " Test for the :insert command
 func Test_insert_cmd()
-  set noautoindent " test assumes noautoindent, but it's on by default in Nvim
   new
   call setline(1, ['  L1'])
   call feedkeys(":insert\<CR>  L2\<CR>  L3\<CR>.\<CR>", 'xt')
@@ -197,7 +196,6 @@ endfunc
 
 " Test for the :change command
 func Test_change_cmd()
-  set noautoindent " test assumes noautoindent, but it's on by default in Nvim
   new
   call setline(1, ['  L1', 'L2', 'L3'])
   call feedkeys(":change\<CR>  L4\<CR>  L5\<CR>.\<CR>", 'xt')

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -137,7 +137,7 @@ func Test_gf_visual()
 
   bwipe!
   call delete('Xtest_gf_visual')
-  set nohidden
+  set hidden&
 endfunc
 
 func Test_gf_error()

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -95,7 +95,7 @@ func Test_ins_complete()
   call delete('Xtest11.one')
   call delete('Xtest11.two')
   call delete('Xtestdata')
-  set cpt& cot& def& tags& tagbsearch& nohidden
+  set cpt& cot& def& tags& tagbsearch& hidden&
   cd ..
   call delete('Xdir', 'rf')
 endfunc

--- a/src/nvim/testdir/test_join.vim
+++ b/src/nvim/testdir/test_join.vim
@@ -51,7 +51,7 @@ func Test_join_marks()
 
   /^This line/;'}-join
   call assert_equal([0, 4, 11, 0], getpos("'["))
-  call assert_equal([0, 4, 66, 0], getpos("']"))
+  call assert_equal([0, 4, 67, 0], getpos("']"))
   enew!
 endfunc
 

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -630,7 +630,7 @@ func Test_copy_winopt()
   call assert_equal(4,&numberwidth)
   bw!
 
-  set nohidden
+  set hidden&
 endfunc
 
 func Test_shortmess_F()

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -9,6 +9,10 @@ source view_util.vim
 source check.vim
 source term_util.vim
 
+func SetUp()
+  set laststatus=2
+endfunc
+
 func s:get_statusline()
   return ScreenLines(&lines - 1, &columns)[0]
 endfunc

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -612,7 +612,7 @@ func Test_window_prevwin()
   " reset
   q
   call delete('tmp.txt')
-  set nohidden autoread&vim
+  set hidden&vim autoread&vim
   delfunc Fun_RenewFile
 endfunc
 


### PR DESCRIPTION
This can avoid divergences from Vim in some small places.
