### PR TITLE
vim-patch:8.2.{3530,3531}: ":buf \{a}" fails while ":edit \{a}" works

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2467,7 +2467,7 @@ static void f_fmod(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "fnameescape({string})" function
 static void f_fnameescape(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  rettv->vval.v_string = vim_strsave_fnameescape(tv_get_string(&argvars[0]), false);
+  rettv->vval.v_string = vim_strsave_fnameescape(tv_get_string(&argvars[0]), VSE_NONE);
   rettv->v_type = VAR_STRING;
 }
 

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -34,6 +34,11 @@
 #define WILD_BUFLASTUSED        0x1000
 #define BUF_DIFF_FILTER         0x2000
 
+// flags used by vim_strsave_fnameescape()
+#define VSE_NONE        0
+#define VSE_SHELL       1       ///< escape for a shell command
+#define VSE_BUFFER      2       ///< escape for a ":buffer" command
+
 /// Present history tables
 typedef enum {
   HIST_DEFAULT = -2,  ///< Default (current) history.

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -285,7 +285,7 @@ static char *ses_escape_fname(char *name, unsigned *flagp)
   }
 
   // Escape special characters.
-  p = vim_strsave_fnameescape(sname, false);
+  p = vim_strsave_fnameescape(sname, VSE_NONE);
   xfree(sname);
   return p;
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4321,7 +4321,7 @@ static void nv_ident(cmdarg_T *cap)
     ptr = vim_strnsave(ptr, n);
     if (kp_ex) {
       // Escape the argument properly for an Ex command
-      p = (char_u *)vim_strsave_fnameescape((const char *)ptr, false);
+      p = (char_u *)vim_strsave_fnameescape((const char *)ptr, VSE_NONE);
     } else {
       // Escape the argument properly for a shell command
       p = vim_strsave_shellescape(ptr, true, true);

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -900,6 +900,12 @@ func Test_cmdline_complete_various()
   call feedkeys(":unlet one two\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"unlet one two", @:)
 
+  " completion for the :buffer command with curlies
+  edit \{someFile}
+  call feedkeys(":buf someFile\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"buf {someFile}", @:)
+  bwipe {someFile}
+
   " completion for the :bdelete command
   call feedkeys(":bdel a b c\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"bdel a b c", @:)

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -901,10 +901,13 @@ func Test_cmdline_complete_various()
   call assert_equal("\"unlet one two", @:)
 
   " completion for the :buffer command with curlies
-  edit \{someFile}
-  call feedkeys(":buf someFile\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal("\"buf {someFile}", @:)
-  bwipe {someFile}
+  " FIXME: what should happen on MS-Windows?
+  if !has('win32')
+    edit \{someFile}
+    call feedkeys(":buf someFile\<C-A>\<C-B>\"\<CR>", 'xt')
+    call assert_equal("\"buf {someFile}", @:)
+    bwipe {someFile}
+  endif
 
   " completion for the :bdelete command
   call feedkeys(":bdel a b c\<C-A>\<C-B>\"\<CR>", 'xt')


### PR DESCRIPTION
#### vim-patch:8.2.3530: ":buf \\{a}" fails while ":edit \\{a}" works

Problem:    ":buf \\{a}" fails while ":edit \\{a}" works.
Solution:   Unescape "\\{".
https://github.com/vim/vim/commit/21c1a0c2f10575dbb72fa873d33f0c1f6e170aa7


#### vim-patch:8.2.3531: command line completion test fails on MS-Windows

Problem:    Command line completion test fails on MS-Windows.
Solution:   Do not test with "\\{" on MS-Windows.
https://github.com/vim/vim/commit/39c47c310487b72bc78ff197b5a068a0bcf830de