### PR TITLE
vim-patch:8.2.3363: when :edit reuses the current buffer the alternate file is set

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2415,6 +2415,8 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
    * Otherwise we re-use the current buffer.
    */
   if (other_file) {
+    const int prev_alt_fnum = curwin->w_alt_fnum;
+
     if (!(flags & (ECMD_ADDBUF | ECMD_ALTBUF))) {
       if ((cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
         curwin->w_alt_fnum = curbuf->b_fnum;
@@ -2457,6 +2459,10 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     }
     if (buf == NULL) {
       goto theend;
+    }
+    if (curwin->w_alt_fnum == buf->b_fnum && prev_alt_fnum != 0) {
+      // reusing the buffer, keep the old alternate file
+      curwin->w_alt_fnum = prev_alt_fnum;
     }
     if (buf->b_ml.ml_mfp == NULL) {
       // No memfile yet.

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1319,14 +1319,6 @@ func Test_cmdwin_jump_to_win()
   call assert_equal(1, winnr('$'))
 endfunc
 
-" Test for backtick expression in the command line
-func Test_cmd_backtick()
-  %argd
-  argadd `=['a', 'b', 'c']`
-  call assert_equal(['a', 'b', 'c'], argv())
-  %argd
-endfunc
-
 func Test_cmdlineclear_tabenter()
   " See test/functional/legacy/cmdline_spec.lua
   CheckScreendump
@@ -1344,6 +1336,32 @@ func Test_cmdlineclear_tabenter()
 
   call StopVimInTerminal(buf)
   call delete('XtestCmdlineClearTabenter')
+endfunc
+
+" Test for expanding special keywords in cmdline
+func Test_cmdline_expand_special()
+  new
+  %bwipe!
+  call assert_fails('e #', 'E194:')
+  call assert_fails('e <afile>', 'E495:')
+  call assert_fails('e <abuf>', 'E496:')
+  call assert_fails('e <amatch>', 'E497:')
+  call writefile([], 'Xfile.cpp')
+  call writefile([], 'Xfile.java')
+  new Xfile.cpp
+  call feedkeys(":e %:r\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e Xfile.cpp Xfile.java', @:)
+  close
+  call delete('Xfile.cpp')
+  call delete('Xfile.java')
+endfunc
+
+" Test for backtick expression in the command line
+func Test_cmd_backtick()
+  %argd
+  argadd `=['a', 'b', 'c']`
+  call assert_equal(['a', 'b', 'c'], argv())
+  %argd
 endfunc
 
 func Test_cmdwin_tabpage()

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -579,7 +579,7 @@ func Test_undofile_2()
 
   " add 10 lines, delete 6 lines, undo 3
   set undofile
-  call setbufline(0, 1, ['one', 'two', 'three', 'four', 'five', 'six',
+  call setbufline('%', 1, ['one', 'two', 'three', 'four', 'five', 'six',
 	      \ 'seven', 'eight', 'nine', 'ten'])
   set undolevels=100
   normal 3Gdd


### PR DESCRIPTION
#### vim-patch:8.2.3363: when :edit reuses the current buffer the alternate file is set

Problem:    When :edit reuses the current buffer the alternate file is set to
            the same buffer.
Solution:   Only set the alternate file when not reusing the buffer.
https://github.com/vim/vim/commit/b8bd2e6ebab03baf2672067067a599df69a278c0

Cherry-pick Test_cmdline_expand_special() from patches 8.2.{0243,2873}.
Move Test_cmd_backtick() to the right place.