### PR TITLE
vim-patch:7.4.1724,8.2.1053: insufficient testing for 'statusline' and 'tabline'

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2669,6 +2669,27 @@ func Test_autocmd_window()
   %bw!
 endfunc
 
+" Test for trying to close the temporary window used for executing an autocmd
+func Test_close_autocmd_window()
+  %bw!
+  edit one.txt
+  tabnew two.txt
+  augroup aucmd_win_test2
+    au!
+    " Nvim makes aucmd_win the last window
+    " au BufEnter * if expand('<afile>') == 'one.txt' | 1close | endif
+    au BufEnter * if expand('<afile>') == 'one.txt' | close | endif
+  augroup END
+
+  call assert_fails('doautoall BufEnter', 'E813:')
+
+  augroup aucmd_win_test2
+    au!
+  augroup END
+  augroup! aucmd_win_test2
+  %bw!
+endfunc
+
 " Test for trying to close the tab that has the temporary window for exeucing
 " an autocmd.
 func Test_close_autocmd_tab()

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -2,8 +2,6 @@
 "
 " Not tested yet:
 "   %N
-"   %T
-"   %X
 
 source view_util.vim
 source check.vim
@@ -107,6 +105,18 @@ func Test_statusline()
   " %F: Full path to the file in the buffer.
   set statusline=%F
   call assert_match('/testdir/Xstatusline\s*$', s:get_statusline())
+
+  " Test for min and max width with %(. For some reason, if this test is moved
+  " after the below test for the help buffer flag, then the code to truncate
+  " the string is not executed.
+  set statusline=%015(%f%)
+  call assert_match('^    Xstatusline\s*$', s:get_statusline())
+  set statusline=%.6(%f%)
+  call assert_match('^<sline\s*$', s:get_statusline())
+  set statusline=%14f
+  call assert_match('^   Xstatusline\s*$', s:get_statusline())
+  set statusline=%.4L
+  call assert_match('^10>3\s*$', s:get_statusline())
 
   " %h: Help buffer flag, text is "[help]".
   " %H: Help buffer flag, text is ",HLP".

--- a/src/nvim/testdir/test_tabline.vim
+++ b/src/nvim/testdir/test_tabline.vim
@@ -1,3 +1,4 @@
+" Test for tabline
 
 source shared.vim
 
@@ -17,6 +18,9 @@ func TablineWithError()
 endfunc
 
 func Test_caught_error_in_tabline()
+  if has('gui')
+    set guioptions-=e
+  endif
   let showtabline_save = &showtabline
   set showtabline=2
   let s:func_in_tabline_called = 0
@@ -30,6 +34,9 @@ func Test_caught_error_in_tabline()
 endfunc
 
 func Test_tabline_will_be_disabled_with_error()
+  if has('gui')
+    set guioptions-=e
+  endif
   let showtabline_save = &showtabline
   set showtabline=2
   let s:func_in_tabline_called = 0

--- a/src/nvim/testdir/test_tabline.vim
+++ b/src/nvim/testdir/test_tabline.vim
@@ -72,6 +72,47 @@ func Test_redrawtabline()
   au! Bufadd
 endfunc
 
+" Test for the "%T" and "%X" flags in the 'tabline' option
+func MyTabLine()
+  let s = ''
+  for i in range(tabpagenr('$'))
+    " set the tab page number (for mouse clicks)
+    let s .= '%' . (i + 1) . 'T'
+
+    " the label is made by MyTabLabel()
+    let s .= ' %{MyTabLabel(' . (i + 1) . ')} '
+  endfor
+
+  " after the last tab fill with TabLineFill and reset tab page nr
+  let s .= '%T'
+
+  " right-align the label to close the current tab page
+  if tabpagenr('$') > 1
+    let s .= '%=%Xclose'
+  endif
+
+  return s
+endfunc
+
+func MyTabLabel(n)
+  let buflist = tabpagebuflist(a:n)
+  let winnr = tabpagewinnr(a:n)
+  return bufname(buflist[winnr - 1])
+endfunc
+
+func Test_tabline_flags()
+  if has('gui')
+    set guioptions-=e
+  endif
+  set tabline=%!MyTabLine()
+  edit Xtabline1
+  tabnew Xtabline2
+  redrawtabline
+  call assert_match('^ Xtabline1  Xtabline2\s\+close$', Screenline(1))
+  set tabline=
+  %bw!
+endfunc
+
 function EmptyTabname()
   return ""
 endfunction


### PR DESCRIPTION
#### vim-patch:7.4.1724

Problem:    Tabline test fails in GUI.
Solution:   Remove 'e' from 'guioptions'.
https://github.com/vim/vim/commit/73cd8fb3e87e4b29dfc489f58e56dee1839c18e5

Add missing file header.


#### vim-patch:8.2.1053: insufficient testing for 'statusline' and 'tabline'

Problem:    Insufficient testing for 'statusline' and 'tabline'.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6333)
https://github.com/vim/vim/commit/832adf9bb8cd39d8e982d8a35ed8a6d39b974494