### PR TITLE
vim-patch:8.1.2092: MS-Windows: redirect in system() does not work

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5453,7 +5453,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	to execute most external commands with cmd.exe.
 
 						*'shellxquote'* *'sxq'*
-'shellxquote' 'sxq'	string	(default: "", Windows: "\"")
+'shellxquote' 'sxq'	string	(default: "", Windows: "(")
 			global
 	Quoting character(s), put around the command passed to the shell, for
 	the "!" and ":!" commands.  Includes the redirection.  See

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1610,33 +1610,45 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 #else
   // For shells that don't understand braces around commands, at least allow
   // the use of commands in a pipe.
-  if (is_pwsh) {
-    xstrlcpy(buf, "Start-Process ", len);
-    xstrlcat(buf, cmd, len);
-  } else {
-    xstrlcpy(buf, cmd, len);
-  }
-  if (itmp != NULL) {
-    // If there is a pipe, we have to put the '<' in front of it.
-    // Don't do this when 'shellquote' is not empty, otherwise the
-    // redirection would be inside the quotes.
-    if (*p_shq == NUL) {
-      char *const p = find_pipe(buf);
-      if (p != NULL) {
-        *p = NUL;
-      }
-    }
-    if (is_pwsh) {
-      xstrlcat(buf, " -RedirectStandardInput ", len);
+  if (*p_sxe != NUL && *p_sxq == '(') {
+    if (itmp != NULL || otmp != NULL) {
+      vim_snprintf((char *)buf, len, "(%s)", (char *)cmd);
     } else {
-      xstrlcat(buf, " < ", len);
+      xstrlcpy(buf, cmd, len);
     }
-    xstrlcat(buf, itmp, len);
-    if (*p_shq == NUL) {
-      const char *const p = find_pipe(cmd);
-      if (p != NULL) {
-        xstrlcat(buf, " ", len - 1);  // Insert a space before the '|' for DOS
-        xstrlcat(buf, p, len - 1);
+    if (itmp != NULL) {
+      xstrlcat(buf, " < ", len - 1);
+      xstrlcat(buf, itmp, len - 1);
+    }
+  } else {
+    if (is_pwsh) {
+      xstrlcpy(buf, "Start-Process ", len);
+      xstrlcat(buf, cmd, len);
+    } else {
+      xstrlcpy(buf, cmd, len);
+    }
+    if (itmp != NULL) {
+      // If there is a pipe, we have to put the '<' in front of it.
+      // Don't do this when 'shellquote' is not empty, otherwise the
+      // redirection would be inside the quotes.
+      if (*p_shq == NUL) {
+        char *const p = find_pipe(buf);
+        if (p != NULL) {
+          *p = NUL;
+        }
+      }
+      if (is_pwsh) {
+        xstrlcat(buf, " -RedirectStandardInput ", len);
+      } else {
+        xstrlcat(buf, " < ", len);
+      }
+      xstrlcat(buf, itmp, len);
+      if (*p_shq == NUL) {
+        const char *const p = find_pipe(cmd);
+        if (p != NULL) {
+          xstrlcat(buf, " ", len - 1);  // Insert a space before the '|' for DOS
+          xstrlcat(buf, p, len - 1);
+        }
       }
     }
   }
@@ -1659,7 +1671,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 void append_redir(char *const buf, const size_t buflen, const char *const opt,
                   const char *const fname)
 {
-  char *const end = buf + strlen(buf);
+  char *end = buf + strlen(buf);
   // find "%s"
   const char *p = opt;
   for (; (p = strchr(p, '%')) != NULL; p++) {
@@ -1670,8 +1682,8 @@ void append_redir(char *const buf, const size_t buflen, const char *const opt,
     }
   }
   if (p != NULL) {
-    *end = ' ';  // not really needed? Not with sh, ksh or bash
-    vim_snprintf(end + 1, (size_t)((ptrdiff_t)buflen - (end + 1 - buf)), opt, fname);
+    *end++ = ' ';  // needed for powershell, etc.
+    vim_snprintf(end, (size_t)((ptrdiff_t)buflen - (end - buf)), opt, fname);
   } else {
     vim_snprintf(end, (size_t)((ptrdiff_t)buflen - (end - buf)), " %s %s", opt, fname);
   }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1610,7 +1610,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 #else
   // For shells that don't understand braces around commands, at least allow
   // the use of commands in a pipe.
-  if (*p_sxe != NUL && *p_sxq == '(') {
+  if (*p_sxq == '(') {
     if (itmp != NULL || otmp != NULL) {
       vim_snprintf((char *)buf, len, "(%s)", (char *)cmd);
     } else {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2164,7 +2164,7 @@ return {
       varname='p_sxq',
       defaults={
         condition='WIN32',
-        if_true="\"",
+        if_true="(",
         if_false="",
       }
     },

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1309,7 +1309,7 @@ static char *shell_xescape_xquote(const char *cmd)
   }
 
   const char *ecmd = cmd;
-  if (*p_sxe != NUL && STRCMP(p_sxq, "(") == 0) {
+  if (*p_sxe != NUL && *p_sxq == '(') {
     ecmd = (char *)vim_strsave_escaped_ext((char_u *)cmd, p_sxe, '^', false);
   }
   size_t ncmd_size = strlen(ecmd) + STRLEN(p_sxq) * 2 + 1;
@@ -1317,9 +1317,9 @@ static char *shell_xescape_xquote(const char *cmd)
 
   // When 'shellxquote' is ( append ).
   // When 'shellxquote' is "( append )".
-  if (STRCMP(p_sxq, "(") == 0) {
+  if (*p_sxq == '(') {
     vim_snprintf(ncmd, ncmd_size, "(%s)", ecmd);
-  } else if (STRCMP(p_sxq, "\"(") == 0) {
+  } else if (*p_sxq == '"' && *(p_sxq + 1) == '(') {
     vim_snprintf(ncmd, ncmd_size, "\"(%s)\"", ecmd);
   } else {
     vim_snprintf(ncmd, ncmd_size, "%s%s%s", p_sxq, ecmd, p_sxq);

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -57,8 +57,7 @@ if has('win32')
   let $SHELL = ''
   let $TERM = ''
   let &shell = empty($COMSPEC) ? exepath('cmd.exe') : $COMSPEC
-  set shellcmdflag=/s/c shellxquote=\" shellredir=>%s\ 2>&1
-  let &shellpipe = &shellredir
+  set shellcmdflag& shellpipe& shellredir& shellxquote&
 endif
 
 " Detect user modules for language providers

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -460,8 +460,7 @@ func Test_normal10_expand()
 
   if executable('echo')
     " Test expand(`...`) i.e. backticks command expansion.
-    " MS-Windows has a trailing space.
-    call assert_match('^abcde *$', expand('`echo abcde`'))
+    call assert_equal('abcde', expand('`echo abcde`'))
   endif
 
   " Test expand(`=...`) i.e. backticks expression expansion

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -13,9 +13,9 @@ func Test_System()
   else
     call assert_equal("123\n", system('echo 123'))
     call assert_equal(["123\r"], systemlist('echo 123'))
-    call assert_equal("123",   system('more', '123'))
-    call assert_equal(["123"], systemlist('more', '123'))
-    call assert_equal(["as\<NL>df"], systemlist('more', ["as\<NL>df"]))
+    call assert_equal("123\n",   system('more', '123'))
+    call assert_equal(["123\r"], systemlist('more', '123'))
+    call assert_equal(["as\r", "df\r"], systemlist('more', ["as\<NL>df"]))
   endif
 
   if !executable('cat') || !executable('wc')
@@ -60,7 +60,7 @@ func Test_System()
     call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
   else
     let out = systemlist('more', bufnr('%'))
-    call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
+    call assert_equal(["asdf\r", "pw\r", "er\r", "xxxx\r"],  out)
   endif
   bwipe!
 

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -13,9 +13,9 @@ func Test_System()
   else
     call assert_equal("123\n", system('echo 123'))
     call assert_equal(["123\r"], systemlist('echo 123'))
-    call assert_equal("123\n",   system('more', '123'))
-    call assert_equal(["123\r"], systemlist('more', '123'))
-    call assert_equal(["as\r", "df\r"], systemlist('more', ["as\<NL>df"]))
+    call assert_equal("123\n",   system('more.com', '123'))
+    call assert_equal(["123\r"], systemlist('more.com', '123'))
+    call assert_equal(["as\r", "df\r"], systemlist('more.com', ["as\<NL>df"]))
   endif
 
   new Xdummy
@@ -42,7 +42,7 @@ func Test_System()
     let out = systemlist('cat', bufnr('%'))
     call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
   else
-    let out = systemlist('more', bufnr('%'))
+    let out = systemlist('more.com', bufnr('%'))
     call assert_equal(["asdf\r", "pw\r", "er\r", "xxxx\r"],  out)
   endif
   bwipe!

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -18,41 +18,24 @@ func Test_System()
     call assert_equal(["as\r", "df\r"], systemlist('more', ["as\<NL>df"]))
   endif
 
-  if !executable('cat') || !executable('wc')
-    return
-  endif
-
-  let out = 'echo 123'->system()
-  call assert_equal("123\n", out)
-
-  let out = 'echo 123'->systemlist()
-  if !has('win32')
-    call assert_equal(["123"], out)
-  else
-    call assert_equal(["123\r"], out)
-  endif
-
-  if executable('cat')
-    call assert_equal('123',   system('cat', '123'))
-    call assert_equal(['123'], systemlist('cat', '123'))
-    call assert_equal(["as\<NL>df"], systemlist('cat', ["as\<NL>df"]))
-  endif
-
   new Xdummy
   call setline(1, ['asdf', "pw\<NL>er", 'xxxx'])
-  let out = system('wc -l', bufnr('%'))
-  " On OS/X we get leading spaces
-  let out = substitute(out, '^ *', '', '')
-  call assert_equal("3\n", out)
 
-  let out = systemlist('wc -l', bufnr('%'))
-  " On Windows we may get a trailing CR.
-  if out != ["3\r"]
+  if executable('wc')
+    let out = system('wc -l', bufnr('%'))
     " On OS/X we get leading spaces
-    if type(out) == v:t_list
-      let out[0] = substitute(out[0], '^ *', '', '')
+    let out = substitute(out, '^ *', '', '')
+    call assert_equal("3\n", out)
+
+    let out = systemlist('wc -l', bufnr('%'))
+    " On Windows we may get a trailing CR.
+    if out != ["3\r"]
+      " On OS/X we get leading spaces
+      if type(out) == v:t_list
+        let out[0] = substitute(out[0], '^ *', '', '')
+      endif
+      call assert_equal(['3'],  out)
     endif
-    call assert_equal(['3'],  out)
   endif
 
   if !has('win32')

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -4,22 +4,39 @@ source shared.vim
 source check.vim
 
 func Test_System()
-  if !executable('echo') || !executable('cat') || !executable('wc')
+  if !has('win32')
+    call assert_equal("123\n", system('echo 123'))
+    call assert_equal(['123'], systemlist('echo 123'))
+    call assert_equal('123',   system('cat', '123'))
+    call assert_equal(['123'], systemlist('cat', '123'))
+    call assert_equal(["as\<NL>df"], systemlist('cat', ["as\<NL>df"]))
+  else
+    call assert_equal("123\n", system('echo 123'))
+    call assert_equal(["123\r"], systemlist('echo 123'))
+    call assert_equal("123",   system('more', '123'))
+    call assert_equal(["123"], systemlist('more', '123'))
+    call assert_equal(["as\<NL>df"], systemlist('more', ["as\<NL>df"]))
+  endif
+
+  if !executable('cat') || !executable('wc')
     return
   endif
+
   let out = 'echo 123'->system()
   call assert_equal("123\n", out)
 
   let out = 'echo 123'->systemlist()
-  if &shell =~# 'cmd.exe$'
-    call assert_equal(["123\r"], out)
+  if !has('win32')
+    call assert_equal(["123"], out)
   else
-    call assert_equal(['123'], out)
+    call assert_equal(["123\r"], out)
   endif
 
-  call assert_equal('123',   system('cat', '123'))
-  call assert_equal(['123'], systemlist('cat', '123'))
-  call assert_equal(["as\<NL>df"], systemlist('cat', ["as\<NL>df"]))
+  if executable('cat')
+    call assert_equal('123',   system('cat', '123'))
+    call assert_equal(['123'], systemlist('cat', '123'))
+    call assert_equal(["as\<NL>df"], systemlist('cat', ["as\<NL>df"]))
+  endif
 
   new Xdummy
   call setline(1, ['asdf', "pw\<NL>er", 'xxxx'])
@@ -38,9 +55,11 @@ func Test_System()
     call assert_equal(['3'],  out)
   endif
 
-  let out = systemlist('cat', bufnr('%'))
-  " On Windows we may get a trailing CR.
-  if out != ["asdf\r", "pw\<NL>er\r", "xxxx\r"]
+  if !has('win32')
+    let out = systemlist('cat', bufnr('%'))
+    call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
+  else
+    let out = systemlist('more', bufnr('%'))
     call assert_equal(['asdf', "pw\<NL>er", 'xxxx'],  out)
   endif
   bwipe!

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -492,7 +492,7 @@ funct Test_undofile()
   " Test undofile() with 'undodir' set to a non-existing directory.
   " call assert_equal('', 'Xundofoo'->undofile())
 
-  if isdirectory('/tmp')
+  if !has('win32') && isdirectory('/tmp')
     set undodir=/tmp
     if has('osx')
       call assert_equal('/tmp/%private%tmp%file', undofile('///tmp/file'))

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -10,6 +10,12 @@
 #define SYS_OPTWIN_FILE "$VIMRUNTIME/optwin.vim"
 #define RUNTIME_DIRNAME "runtime"
 
+// _WIN32 is defined as 1 when the compilation target is 32-bit or 64-bit.
+// Note: If you want to check for 64-bit use the _WIN64 macro.
+#if defined(WIN32) || defined(_WIN32)
+# define MSWIN
+#endif
+
 #include "auto/config.h"
 #define HAVE_PATHDEF
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2090,7 +2090,7 @@ describe('API', function()
             eval('&shell'),
             '/s',
             '/c',
-            fmt('"%s -u NONE -i NONE"', eval('shellescape(v:progpath)')),
+            fmt('(%s -u NONE -i NONE)', eval('shellescape(v:progpath)')),
           } or {
             eval('&shell'),
             eval('&shellcmdflag'),

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -78,9 +78,6 @@ describe('startup', function()
   it('in a TTY: has("ttyin")==1 has("ttyout")==1', function()
     local screen = Screen.new(25, 4)
     screen:attach()
-    if iswin() then
-      command([[set shellcmdflag=/s\ /c shellxquote=\"]])
-    end
     -- Running in :terminal
     command([[exe printf("terminal %s -u NONE -i NONE --cmd \"]]
             ..nvim_set..[[\"]]
@@ -94,9 +91,6 @@ describe('startup', function()
     ]])
   end)
   it('output to pipe: has("ttyin")==1 has("ttyout")==0', function()
-    if iswin() then
-      command([[set shellcmdflag=/s\ /c shellxquote=\"]])
-    end
     -- Running in :terminal
     command([[exe printf("terminal %s -u NONE -i NONE --cmd \"]]
             ..nvim_set..[[\"]]
@@ -110,9 +104,6 @@ describe('startup', function()
     end)
   end)
   it('input from pipe: has("ttyin")==0 has("ttyout")==1', function()
-    if iswin() then
-      command([[set shellcmdflag=/s\ /c shellxquote=\"]])
-    end
     -- Running in :terminal
     command([[exe printf("terminal echo foo | ]]  -- Input from a pipe.
             ..[[%s -u NONE -i NONE --cmd \"]]
@@ -129,9 +120,6 @@ describe('startup', function()
   it('input from pipe (implicit) #7679', function()
     local screen = Screen.new(25, 4)
     screen:attach()
-    if iswin() then
-      command([[set shellcmdflag=/s\ /c shellxquote=\"]])
-    end
     -- Running in :terminal
     command([[exe printf("terminal echo foo | ]]  -- Input from a pipe.
             ..[[%s -u NONE -i NONE --cmd \"]]

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -41,7 +41,7 @@ describe(':edit term://*', function()
     local scr = get_screen(columns, lines)
     local rep = 97
     meths.set_option('shellcmdflag', 'REP ' .. rep)
-    command('set shellxquote=')  -- win: avoid extra quotes
+    command('set shellxquote=')  -- win: avoid extra quoting
     local sb = 10
     command('autocmd TermOpen * :setlocal scrollback='..tostring(sb)
             ..'|call feedkeys("G", "n")')

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -179,7 +179,7 @@ describe(':terminal (with fake shell)', function()
 
   it('executes a given command through the shell', function()
     if helpers.pending_win32(pending) then return end
-    command('set shellxquote=')   -- win: avoid extra quotes
+    command('set shellxquote=')   -- win: avoid extra quoting
     terminal_with_fake_shell('echo hi')
     screen:expect([[
       ^ready $ echo hi                                   |
@@ -192,7 +192,7 @@ describe(':terminal (with fake shell)', function()
   it("executes a given command through the shell, when 'shell' has arguments", function()
     if helpers.pending_win32(pending) then return end
     nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
-    command('set shellxquote=')   -- win: avoid extra quotes
+    command('set shellxquote=')   -- win: avoid extra quoting
     terminal_with_fake_shell('echo hi')
     screen:expect([[
       ^jeff $ echo hi                                    |
@@ -204,7 +204,7 @@ describe(':terminal (with fake shell)', function()
 
   it('allows quotes and slashes', function()
     if helpers.pending_win32(pending) then return end
-    command('set shellxquote=')   -- win: avoid extra quotes
+    command('set shellxquote=')   -- win: avoid extra quoting
     terminal_with_fake_shell([[echo 'hello' \ "world"]])
     screen:expect([[
       ^ready $ echo 'hello' \ "world"                    |
@@ -260,7 +260,7 @@ describe(':terminal (with fake shell)', function()
 
   it('works with gf', function()
     if helpers.pending_win32(pending) then return end
-    command('set shellxquote=')   -- win: avoid extra quotes
+    command('set shellxquote=')   -- win: avoid extra quoting
     terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
     retry(nil, 4 * screen.timeout, function()
     screen:expect([[

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -210,14 +210,13 @@ describe('system()', function()
     it('prints verbose information', function()
       nvim('set_option', 'shell', 'fake_shell')
       nvim('set_option', 'shellcmdflag', 'cmdflag')
+      nvim('set_option', 'shellquote', '')
+      nvim('set_option', 'shellxescape', '')
+      nvim('set_option', 'shellxquote', '')
 
       screen:try_resize(72, 14)
       feed(':4verbose echo system("echo hi")<cr>')
-      if iswin() then
-        screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' '"echo hi"'"]]}
-      else
-        screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
-      end
+      screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
       feed('<cr>')
     end)
 


### PR DESCRIPTION
Fix #19297

#### vim-patch:8.1.2092: MS-Windows: redirect in system() does not work

Problem:    MS-Windows: redirect in system() does not work.
Solution:   Handle 'shellxescape' and 'shellxquote' better. (Yasuhiro
            Matsumoto, closes vim/vim#2054)
https://github.com/vim/vim/commit/1a613398068580ca1286ac2ed920f20c978aa662