### PR TITLE
fix(lsp): abort pending changes after flush when debouncing

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -500,6 +500,9 @@ do
         table.insert(buf_state.pending_changes, incremental_changes(client, buf_state))
       end
       buf_state.pending_change = function()
+        if buf_state.pending_change == nil then
+          return
+        end
         buf_state.pending_change = nil
         buf_state.last_flush = uv.hrtime()
         if client.is_stopped() or not vim.api.nvim_buf_is_valid(bufnr) then


### PR DESCRIPTION
Issuing a server request triggers `changetracking.flush` so as to make sure we're not operating on a stale state. This immediately triggers notification of any pending changes (as a result of debouncing) to the server. However, this happens *in addition to* the notification that is waiting on the debounce delay. Because we `nil` `buf_state.pending_change` when it is called, the fix is to also check that this is non-`nil` when it is called and exit if it is, as this being `nil` would mean that it originates from a pending change that has already been flushed out.