### PR TITLE
vim-patch:8.2.{0212,0243,0250}: insufficient tests

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -908,6 +908,15 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
 
   msg_list = saved_msg_list;
 
+  // Cleanup if "cs_emsg_silent_list" remains.
+  if (cstack.cs_emsg_silent_list != NULL) {
+    eslist_T *elem, *temp;
+    for (elem = cstack.cs_emsg_silent_list; elem != NULL; elem = temp) {
+      temp = elem->next;
+      xfree(elem);
+    }
+  }
+
   /*
    * If there was too much output to fit on the command line, ask the user to
    * hit return before redrawing the screen. With the ":global" command we do

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -153,6 +153,9 @@ func RunTheTest(test)
   " directory after executing the test.
   let save_cwd = getcwd()
 
+  " Align Nvim defaults to Vim.
+  source setup.vim
+
   if exists("*SetUp")
     try
       call SetUp()
@@ -190,9 +193,6 @@ func RunTheTest(test)
       call add(v:errors, 'Caught exception in TearDown() after ' . a:test . ': ' . v:exception . ' @ ' . v:throwpoint)
     endtry
   endif
-
-  " Align Nvim defaults to Vim.
-  source setup.vim
 
   " Clear any autocommands and put back the catch-all for SwapExists.
   au!

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -1,33 +1,34 @@
-" Align Nvim defaults to Vim.
-set backspace=
-set complete=.,w,b,u,t,i
-set directory&
-set directory^=.
-set fillchars=vert:\|,fold:-
-set formatoptions=tcq
-set fsync
-set laststatus=1
-set listchars=eol:$
-set joinspaces
-set nohidden nosmarttab noautoindent noautoread noruler noshowcmd
-set nohlsearch noincsearch
-set nrformats=bin,octal,hex
-set shortmess=filnxtToOS
-set sidescroll=0
-set tags=./tags,tags
-set undodir&
-set undodir^=.
-set wildoptions=
-set startofline
-set sessionoptions&
-set sessionoptions+=options
-set viewoptions&
-set viewoptions+=options
-set switchbuf=
-
-" Make "Q" switch to Ex mode.
-" This does not work for all tests.
-nnoremap Q gQ
+if exists('s:did_load')
+  " Align Nvim defaults to Vim.
+  set backspace=
+  set complete=.,w,b,u,t,i
+  set directory&
+  set directory^=.
+  set fillchars=vert:\|,fold:-
+  set formatoptions=tcq
+  set fsync
+  set laststatus=1
+  set listchars=eol:$
+  set joinspaces
+  set nohidden nosmarttab noautoindent noautoread noruler noshowcmd
+  set nohlsearch noincsearch
+  set nrformats=bin,octal,hex
+  set shortmess=filnxtToOS
+  set sidescroll=0
+  set tags=./tags,tags
+  set undodir&
+  set undodir^=.
+  set wildoptions=
+  set startofline
+  set sessionoptions&
+  set sessionoptions+=options
+  set viewoptions&
+  set viewoptions+=options
+  set switchbuf=
+  " Make "Q" switch to Ex mode.
+  " This does not work for all tests.
+  nnoremap Q gQ
+endif
 
 " Common preparations for running tests.
 

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -1,5 +1,8 @@
 " Test argument list commands
 
+source shared.vim
+source term_util.vim
+
 func Reset_arglist()
   args a | %argd
 endfunc
@@ -510,3 +513,17 @@ func Test_argdo()
   call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
   bwipe Xa.c Xb.c Xc.c
 endfunc
+
+" Test for quiting Vim with unedited files in the argument list
+func Test_quit_with_arglist()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot run vim in terminal'
+  endif
+  let buf = RunVimInTerminal('', {'rows': 6})
+  call term_sendkeys(buf, ":args a b c\n")
+  call term_sendkeys(buf, ":quit\n")
+  call WaitForAssert({-> assert_match('^E173:', term_getline(buf, 6))})
+  call StopVimInTerminal(buf)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -64,6 +64,29 @@ func Test_ex_mode()
   let &encoding = encoding_save
 endfunc
 
+" Test for displaying lines from an empty buffer in Ex mode
+func Test_Ex_emptybuf()
+  new
+  call assert_fails('call feedkeys("Q\<CR>", "xt")', 'E749:')
+  call setline(1, "abc")
+  call assert_fails('call feedkeys("Q\<CR>", "xt")', 'E501:')
+  call assert_fails('call feedkeys("Q%d\<CR>", "xt")', 'E749:')
+  close!
+endfunc
+
+" Test for the :open command
+func Test_open_command()
+  throw 'Skipped: Nvim does not have :open'
+  new
+  call setline(1, ['foo foo', 'foo bar', 'foo baz'])
+  call feedkeys("Qopen\<CR>j", 'xt')
+  call assert_equal('foo bar', getline('.'))
+  call feedkeys("Qopen /bar/\<CR>", 'xt')
+  call assert_equal(5, col('.'))
+  call assert_fails('call feedkeys("Qopen /baz/\<CR>", "xt")', 'E479:')
+  close!
+endfunc
+
 " Test for :g/pat/visual to run vi commands in Ex mode
 " This used to hang Vim before 8.2.0274.
 func Test_Ex_global()

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -22,6 +22,7 @@ func Test_range_error()
   call assert_fails(':\/echo 1', 'E481:')
   normal vv
   call assert_fails(":'<,'>echo 1", 'E481:')
+  call assert_fails(":\\xcenter", 'E10:')
 endfunc
 
 func Test_buffers_lastused()
@@ -391,12 +392,44 @@ func Test_confirm_write_partial_file()
   call delete('Xscript')
 endfunc
 
+" Test for the :print command
+func Test_print_cmd()
+  call assert_fails('print', 'E749:')
+endfunc
+
 " Test for the :winsize command
 func Test_winsize_cmd()
   call assert_fails('winsize 1', 'E465:')
   call assert_fails('winsize 1 x', 'E465:')
   call assert_fails('win_getid(1)', 'E475: Invalid argument: _getid(1)')
   " Actually changing the window size would be flaky.
+endfunc
+
+" Test for the :redir command
+func Test_redir_cmd()
+  call assert_fails('redir @@', 'E475:')
+  call assert_fails('redir abc', 'E475:')
+  if has('unix')
+    call mkdir('Xdir')
+    call assert_fails('redir > Xdir', 'E17:')
+    call delete('Xdir', 'd')
+  endif
+  if !has('bsd')
+    call writefile([], 'Xfile')
+    call setfperm('Xfile', 'r--r--r--')
+    call assert_fails('redir! > Xfile', 'E190:')
+    call delete('Xfile')
+  endif
+endfunc
+
+" Test for the :filetype command
+func Test_filetype_cmd()
+  call assert_fails('filetype abc', 'E475:')
+endfunc
+
+" Test for the :mode command
+func Test_mode_cmd()
+  call assert_fails('mode abc', 'E359:')
 endfunc
 
 " Test for running Ex commands when text is locked.

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -643,6 +643,13 @@ func Test_map_error()
   map <expr> ,f abc
   call assert_fails('normal ,f', 'E121:')
   unmap <expr> ,f
+
+  " Recursive use of :normal in a map
+  set maxmapdepth=100
+  map gq :normal gq<CR>
+  call assert_fails('normal gq', 'E192:')
+  unmap gq
+  set maxmapdepth&
 endfunc
 
 " Test for <special> key mapping

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2858,6 +2858,10 @@ func XvimgrepTests(cchar)
   call assert_equal(0, getbufinfo('Xtestfile1')[0].loaded)
   call assert_equal([], getbufinfo('Xtestfile2'))
 
+  " Test with the last search pattern not set
+  call test_clear_search_pat()
+  call assert_fails('Xvimgrep // *', 'E35:')
+
   call delete('Xtestfile1')
   call delete('Xtestfile2')
 endfunc

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2858,10 +2858,6 @@ func XvimgrepTests(cchar)
   call assert_equal(0, getbufinfo('Xtestfile1')[0].loaded)
   call assert_equal([], getbufinfo('Xtestfile2'))
 
-  " Test with the last search pattern not set
-  call test_clear_search_pat()
-  call assert_fails('Xvimgrep // *', 'E35:')
-
   call delete('Xtestfile1')
   call delete('Xtestfile2')
 endfunc
@@ -2893,6 +2889,21 @@ func Test_vimgrep_incsearch()
 
   call test_override("ALL", 0)
   set noincsearch
+endfunc
+
+" Test vimgrep with the last search pattern not set
+func Test_vimgrep_with_no_last_search_pat()
+  let lines =<< trim [SCRIPT]
+    call assert_fails('vimgrep // *', 'E35:')
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 " Test vimgrep without swap file

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1542,42 +1542,62 @@ func Test_search_special()
 endfunc
 
 " Test for command failures when the last search pattern is not set.
+" Need to run this in a new vim instance where last search pattern is not set.
 func Test_search_with_no_last_pat()
-  call test_clear_search_pat()
-  call assert_fails("normal i\<C-R>/\e", 'E35:')
-  call assert_fails("exe '/'", 'E35:')
-  call assert_fails("exe '?'", 'E35:')
-  call assert_fails("/", 'E35:')
-  call assert_fails("?", 'E35:')
-  call assert_fails("normal n", 'E35:')
-  call assert_fails("normal N", 'E35:')
-  call assert_fails("normal gn", 'E35:')
-  call assert_fails("normal gN", 'E35:')
-  call assert_fails("normal cgn", 'E35:')
-  call assert_fails("normal cgN", 'E35:')
-  let p = []
-  let p = @/
-  call assert_equal('', p)
-  call assert_fails("normal :\<C-R>/", 'E35:')
-  call assert_fails("//p", 'E35:')
-  call assert_fails(";//p", 'E35:')
-  call assert_fails("??p", 'E35:')
-  call assert_fails(";??p", 'E35:')
-  call assert_fails('g//p', 'E476:')
-  call assert_fails('v//p', 'E476:')
+  let lines =<< trim [SCRIPT]
+    call assert_fails("normal i\<C-R>/\e", 'E35:')
+    call assert_fails("exe '/'", 'E35:')
+    call assert_fails("exe '?'", 'E35:')
+    call assert_fails("/", 'E35:')
+    call assert_fails("?", 'E35:')
+    call assert_fails("normal n", 'E35:')
+    call assert_fails("normal N", 'E35:')
+    call assert_fails("normal gn", 'E35:')
+    call assert_fails("normal gN", 'E35:')
+    call assert_fails("normal cgn", 'E35:')
+    call assert_fails("normal cgN", 'E35:')
+    let p = []
+    let p = @/
+    call assert_equal('', p)
+    call assert_fails("normal :\<C-R>/", 'E35:')
+    call assert_fails("//p", 'E35:')
+    call assert_fails(";//p", 'E35:')
+    call assert_fails("??p", 'E35:')
+    call assert_fails(";??p", 'E35:')
+    call assert_fails('g//p', 'E476:')
+    call assert_fails('v//p', 'E476:')
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 " Test for using tilde (~) atom in search. This should use the last used
 " substitute pattern
 func Test_search_tilde_pat()
-  call test_clear_search_pat()
-  set regexpengine=1
-  call assert_fails('exe "normal /~\<CR>"', 'E33:')
-  call assert_fails('exe "normal ?~\<CR>"', 'E33:')
-  set regexpengine=2
-  call assert_fails('exe "normal /~\<CR>"', 'E383:')
-  call assert_fails('exe "normal ?~\<CR>"', 'E383:')
-  set regexpengine&
+  let lines =<< trim [SCRIPT]
+    set regexpengine=1
+    call assert_fails('exe "normal /~\<CR>"', 'E33:')
+    call assert_fails('exe "normal ?~\<CR>"', 'E33:')
+    set regexpengine=2
+    call assert_fails('exe "normal /~\<CR>"', 'E383:')
+    call assert_fails('exe "normal ?~\<CR>"', 'E383:')
+    set regexpengine&
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 " Test 'smartcase' with utf-8.

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1541,6 +1541,45 @@ func Test_search_special()
   exe "norm /\x80PS"
 endfunc
 
+" Test for command failures when the last search pattern is not set.
+func Test_search_with_no_last_pat()
+  call test_clear_search_pat()
+  call assert_fails("normal i\<C-R>/\e", 'E35:')
+  call assert_fails("exe '/'", 'E35:')
+  call assert_fails("exe '?'", 'E35:')
+  call assert_fails("/", 'E35:')
+  call assert_fails("?", 'E35:')
+  call assert_fails("normal n", 'E35:')
+  call assert_fails("normal N", 'E35:')
+  call assert_fails("normal gn", 'E35:')
+  call assert_fails("normal gN", 'E35:')
+  call assert_fails("normal cgn", 'E35:')
+  call assert_fails("normal cgN", 'E35:')
+  let p = []
+  let p = @/
+  call assert_equal('', p)
+  call assert_fails("normal :\<C-R>/", 'E35:')
+  call assert_fails("//p", 'E35:')
+  call assert_fails(";//p", 'E35:')
+  call assert_fails("??p", 'E35:')
+  call assert_fails(";??p", 'E35:')
+  call assert_fails('g//p', 'E476:')
+  call assert_fails('v//p', 'E476:')
+endfunc
+
+" Test for using tilde (~) atom in search. This should use the last used
+" substitute pattern
+func Test_search_tilde_pat()
+  call test_clear_search_pat()
+  set regexpengine=1
+  call assert_fails('exe "normal /~\<CR>"', 'E33:')
+  call assert_fails('exe "normal ?~\<CR>"', 'E33:')
+  set regexpengine=2
+  call assert_fails('exe "normal /~\<CR>"', 'E383:')
+  call assert_fails('exe "normal ?~\<CR>"', 'E383:')
+  set regexpengine&
+endfunc
+
 " Test 'smartcase' with utf-8.
 func Test_search_smartcase_utf8()
   new

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1486,9 +1486,23 @@ func Test_sort_last_search_pat()
   call setline(1, ['3b', '1c', '2a'])
   sort //
   call assert_equal(['2a', '3b', '1c'], getline(1, '$'))
-  call test_clear_search_pat()
-  call assert_fails('sort //', 'E35:')
   close!
+endfunc
+
+" Test for :sort with no last search pattern
+func Test_sort_with_no_last_search_pat()
+  let lines =<< trim [SCRIPT]
+    call setline(1, ['3b', '1c', '2a'])
+    call assert_fails('sort //', 'E35:')
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 " Test for retaining marks across a :sort

--- a/src/nvim/testdir/test_sort.vim
+++ b/src/nvim/testdir/test_sort.vim
@@ -1486,6 +1486,8 @@ func Test_sort_last_search_pat()
   call setline(1, ['3b', '1c', '2a'])
   sort //
   call assert_equal(['2a', '3b', '1c'], getline(1, '$'))
+  call test_clear_search_pat()
+  call assert_fails('sort //', 'E35:')
   close!
 endfunc
 

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -57,3 +57,13 @@ func Test_different_script()
   call assert_fails('source XtwoScript', 'E121:')
   call delete('XtwoScript')
 endfunc
+
+" When sourcing a vim script, shebang should be ignored.
+func Test_source_ignore_shebang()
+  call writefile(['#!./xyzabc', 'let g:val=369'], 'Xfile.vim')
+  source Xfile.vim
+  call assert_equal(g:val, 369)
+  call delete('Xfile.vim')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -294,7 +294,7 @@ endfunc
 
 " Test for *:s%* on :substitute.
 func Test_sub_cmd_6()
-  throw "skipped: Nvim removed POSIX-related 'cpoptions' flags"
+  throw 'Skipped: Nvim does not support cpoptions flag "/"'
   set magic&
   set cpo+=/
 
@@ -810,17 +810,33 @@ endfunc
 
 " Test for command failures when the last substitute pattern is not set.
 func Test_sub_with_no_last_pat()
-  call test_clear_search_pat()
-  call assert_fails('~', 'E33:')
-  call assert_fails('s//abc/g', 'E476:')
-  call assert_fails('s\/bar', 'E476:')
-  call assert_fails('s\&bar&', 'E476:')
+  let lines =<< trim [SCRIPT]
+    call assert_fails('~', 'E33:')
+    call assert_fails('s//abc/g', 'E476:')
+    call assert_fails('s\/bar', 'E476:')
+    call assert_fails('s\&bar&', 'E476:')
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
 
-  call test_clear_search_pat()
-  let save_cpo = &cpo
-  set cpo+=/
-  call assert_fails('s/abc/%/', 'E33:')
-  let &cpo = save_cpo
+  " Nvim does not support cpoptions flag "/"'
+  " let lines =<< trim [SCRIPT]
+  "   set cpo+=/
+  "   call assert_fails('s/abc/%/', 'E33:')
+  "   call writefile(v:errors, 'Xresult')
+  "   qall!
+  " [SCRIPT]
+  " call writefile(lines, 'Xscript')
+  " if RunVim([], [], '--clean -S Xscript')
+  "   call assert_equal([], readfile('Xresult'))
+  " endif
+
+  call delete('Xscript')
+  call delete('Xresult')
 endfunc
 
 func Test_submatch_list_concatenate()

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -808,6 +808,21 @@ func Test_sub_expand_text()
   close!
 endfunc
 
+" Test for command failures when the last substitute pattern is not set.
+func Test_sub_with_no_last_pat()
+  call test_clear_search_pat()
+  call assert_fails('~', 'E33:')
+  call assert_fails('s//abc/g', 'E476:')
+  call assert_fails('s\/bar', 'E476:')
+  call assert_fails('s\&bar&', 'E476:')
+
+  call test_clear_search_pat()
+  let save_cpo = &cpo
+  set cpo+=/
+  call assert_fails('s/abc/%/', 'E33:')
+  let &cpo = save_cpo
+endfunc
+
 func Test_submatch_list_concatenate()
   let pat = 'A\(.\)'
   let Rep = {-> string([submatch(0, 1)] + [[submatch(1)]])}

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -299,6 +299,8 @@ func Test_undo_write()
   close!
   call delete('Xtest')
   bwipe! Xtest
+
+  call assert_fails('earlier xyz', 'E475:')
 endfunc
 
 func Test_insert_expr()

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -886,6 +886,30 @@ func Test_floatwin_splitmove()
   bwipe
 endfunc
 
+" Test for the :only command
+func Test_window_only()
+  new
+  set modified
+  new
+  call assert_fails('only', 'E445:')
+  only!
+endfunc
+
+" Test for errors with :wincmd
+func Test_wincmd_errors()
+  call assert_fails('wincmd g', 'E474:')
+  call assert_fails('wincmd ab', 'E474:')
+endfunc
+
+" Test for errors with :winpos
+func Test_winpos_errors()
+  throw 'Skipped: Nvim does not have :winpos'
+  if !has("gui_running") && !has('win32')
+    call assert_fails('winpos', 'E188:')
+  endif
+  call assert_fails('winpos 10', 'E466:')
+endfunc
+
 func Test_window_resize()
   throw 'Skipped: Nvim supports cmdheight=0'
   " Vertical :resize (absolute, relative, min and max size).

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -206,6 +206,10 @@ func Test_write_errors()
   call assert_fails('1,2write', 'E140:')
   close!
 
+  call assert_fails('w > Xtest', 'E494:')
+
+  call assert_fails('w > Xtest', 'E494:')
+
   " Try to overwrite a directory
   if has('unix')
     call mkdir('Xdir1')

--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -3,6 +3,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, command, eq = helpers.clear, helpers.command, helpers.eq
 local eval, exc_exec, neq = helpers.eval, helpers.exc_exec, helpers.neq
+local pcall_err = helpers.pcall_err
 
 describe('argument list commands', function()
   before_each(clear)
@@ -206,7 +207,6 @@ describe('argument list commands', function()
     command('%argd')
   end)
 
-
   it('test for autocommand that redefines the argument list, when doing ":all"', function()
     command('autocmd BufReadPost Xxx2 next Xxx2 Xxx1')
     command("call writefile(['test file Xxx1'], 'Xxx1')")
@@ -233,5 +233,10 @@ describe('argument list commands', function()
     command("call delete('Xxx3')")
     command('argdelete Xxx*')
     command('bwipe! Xxx1 Xxx2 Xxx3')
+  end)
+
+  it('quitting Vim with unedited files in the argument list throws E173', function()
+    command('args a b c')
+    eq('Vim(quit):E173: 2 more files to edit', pcall_err(command, 'quit'))
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.{0212,0250}

vim-patch:8.2.0212: missing search/substitute pattern hardly tested

Problem:    Missing search/substitute pattern hardly tested.
Solution:   Add test_clear_search_pat() and tests. (Yegappan Lakshmanan,
            closes vim/vim#5579)
https://github.com/vim/vim/commit/07ada5ff2fd8f22ed3233ae5c4ddf87c7b3f56fe

vim-patch:8.2.0250: test_clear_search_pat() is unused

Problem:    test_clear_search_pat() is unused.
Solution:   Remove the function. (Yegappan Lakshmanan, closes vim/vim#5624)
https://github.com/vim/vim/commit/4f5776c17cd86f904a7e2f92db297c73e28939b7


#### vim-patch:8.2.0243: insufficient code coverage for ex_docmd.c functions

Problem:    Insufficient code coverage for ex_docmd.c functions.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5618)
https://github.com/vim/vim/commit/9f6277bdde97b7767ded43a0b5a2023eb601b3b7

Cherry-pick Test_window_only() from patch 8.2.0203.
Cherry-pick a memory leak fix from patch 8.2.0399.

Fix #19281