### PR TITLE
fix: Escape path characters in username for tempdir #19240

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5296,7 +5296,6 @@ static void vim_mktempdir(void)
   char user[40] = { 0 };
 
   (void)os_get_username(user, sizeof(user));
-
   // Usernames may contain slashes! #19240
   memchrsub(user, '/', '_', sizeof(user));
   memchrsub(user, '\\', '_', sizeof(user));

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5297,6 +5297,10 @@ static void vim_mktempdir(void)
 
   (void)os_get_username(user, sizeof(user));
 
+  // Usernames may contain slashes! #19240
+  memchrsub(user, '/', '_', sizeof(user));
+  memchrsub(user, '\\', '_', sizeof(user));
+
   // Make sure the umask doesn't remove the executable bit.
   // "repl" has been reported to use "0177".
   mode_t umask_save = umask(0077);


### PR DESCRIPTION
"Hotfix" for path characters in the output of `os_get_username` resulting in an invalid path for things like `:h tempname`.