### PR TITLE
fix(lsp): don't attach a client in lsp.start() if there is none

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -746,6 +746,9 @@ function lsp.start(config, opts)
     end
   end
   local client_id = lsp.start_client(config)
+  if client_id == nil then
+    return nil -- lsp.start_client will have printed an error
+  end
   lsp.buf_attach_client(bufnr, client_id)
   return client_id
 end


### PR DESCRIPTION
`vim.lsp.start_client()` may fail (for example if the `cmd` is not
executable). It produces a nice error notification in this case. Passing
the `nil` value returned from an failed `vim.lsp.start_client()` call
into `vim.lsp.buf_attach_client()` causes a meaty param validate
exception message. Avoid this, it's duplicative, confusing and spammy.