### PR TITLE
fix(lsp): account for initializing servers in vim.lsp.start

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -739,10 +739,12 @@ function lsp.start(config, opts)
     end
   config.name = config.name or (config.cmd[1] and vim.fs.basename(config.cmd[1])) or nil
   local bufnr = api.nvim_get_current_buf()
-  for _, client in pairs(lsp.get_active_clients()) do
-    if reuse_client(client, config) then
-      lsp.buf_attach_client(bufnr, client.id)
-      return client.id
+  for _, clients in ipairs({ uninitialized_clients, lsp.get_active_clients() }) do
+    for _, client in pairs(clients) do
+      if reuse_client(client, config) then
+        lsp.buf_attach_client(bufnr, client.id)
+        return client.id
+      end
     end
   end
   local client_id = lsp.start_client(config)


### PR DESCRIPTION
Fixes #19326 (see that issue for more context).

I've tested locally that this fixes the issue, in that `nvim -O ...` with N files that could reuse LSP clients no longer spawns N LSP processes.