### PR TITLE
vim-patch:8.2.0203: :helptags and some other functionality not tested

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3883,7 +3883,7 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
               prompt = xmallocz((size_t)ec + 1);
               memset(prompt, ' ', (size_t)sc);
               memset(prompt + sc, '^', (size_t)(ec - sc) + 1);
-              resp = getcmdline_prompt((char)(-1), prompt, 0, EXPAND_NOTHING, NULL, CALLBACK_NONE);
+              resp = getcmdline_prompt(-1, prompt, 0, EXPAND_NOTHING, NULL, CALLBACK_NONE);
               msg_putchar('\n');
               xfree(prompt);
               if (resp != NULL) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2646,7 +2646,7 @@ char_u *getcmdline(int firstc, long count, int indent, bool do_concat FUNC_ATTR_
 /// @param[in]  highlight_callback  Callback used for highlighting user input.
 ///
 /// @return [allocated] Command line or NULL.
-char *getcmdline_prompt(const char firstc, const char *const prompt, const int attr,
+char *getcmdline_prompt(const int firstc, const char *const prompt, const int attr,
                         const int xp_context, const char *const xp_arg,
                         const Callback highlight_callback)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_MALLOC

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -68,5 +68,9 @@ func Test_compiler_completion()
 endfunc
 
 func Test_compiler_error()
+  let g:current_compiler = 'abc'
   call assert_fails('compiler doesnotexist', 'E666:')
+  call assert_equal('abc', g:current_compiler)
+  call assert_fails('compiler! doesnotexist', 'E666:')
+  unlet! g:current_compiler
 endfunc

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -64,6 +64,35 @@ func Test_ex_mode()
   let &encoding = encoding_save
 endfunc
 
+" Test subsittute confirmation prompt :%s/pat/str/c in Ex mode
+func Test_Ex_substitute()
+  CheckRunVimInTerminal
+  let buf = RunVimInTerminal('', {'rows': 6})
+
+  call term_sendkeys(buf, ":call setline(1, ['foo foo', 'foo foo', 'foo foo'])\<CR>")
+  call term_sendkeys(buf, ":set number\<CR>")
+  call term_sendkeys(buf, "gQ")
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
+
+  call term_sendkeys(buf, "%s/foo/bar/gc\<CR>")
+  call WaitForAssert({-> assert_match('  1 foo foo', term_getline(buf, 5))},
+        \ 1000)
+  call WaitForAssert({-> assert_match('    ^^^', term_getline(buf, 6))}, 1000)
+  call term_sendkeys(buf, "n\<CR>")
+  call WaitForAssert({-> assert_match('        ^^^', term_getline(buf, 6))},
+        \ 1000)
+  call term_sendkeys(buf, "y\<CR>")
+
+  call term_sendkeys(buf, "q\<CR>")
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
+
+  call term_sendkeys(buf, ":vi\<CR>")
+  call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)
+
+  call term_sendkeys(buf, ":q!\n")
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test for displaying lines from an empty buffer in Ex mode
 func Test_Ex_emptybuf()
   new

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -223,12 +223,24 @@ func Test_change_cmd()
   close!
 endfunc
 
+" Test for the :language command
+func Test_language_cmd()
+  CheckNotMSWindows  " FIXME: why does this fail on Windows CI?
+  CheckNotBSD  " FIXME: why does this fail on OpenBSD CI?
+  CheckFeature multi_lang
+
+  call assert_fails('language ctype non_existing_lang', 'E197:')
+  call assert_fails('language time non_existing_lang', 'E197:')
+endfunc
+
 " Test for the :confirm command dialog
 func Test_confirm_cmd()
   CheckNotGui
   CheckRunVimInTerminal
+
   call writefile(['foo1'], 'foo')
   call writefile(['bar1'], 'bar')
+
   " Test for saving all the modified buffers
   let buf = RunVimInTerminal('', {'rows': 20})
   call term_sendkeys(buf, ":set nomore\n")
@@ -241,8 +253,10 @@ func Test_confirm_cmd()
   call WaitForAssert({-> assert_match('\[Y\]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ', term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "A")
   call StopVimInTerminal(buf)
+
   call assert_equal(['foo2'], readfile('foo'))
   call assert_equal(['bar2'], readfile('bar'))
+
   " Test for discarding all the changes to modified buffers
   let buf = RunVimInTerminal('', {'rows': 20})
   call term_sendkeys(buf, ":set nomore\n")
@@ -255,8 +269,10 @@ func Test_confirm_cmd()
   call WaitForAssert({-> assert_match('\[Y\]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ', term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "D")
   call StopVimInTerminal(buf)
+
   call assert_equal(['foo2'], readfile('foo'))
   call assert_equal(['bar2'], readfile('bar'))
+
   " Test for saving and discarding changes to some buffers
   let buf = RunVimInTerminal('', {'rows': 20})
   call term_sendkeys(buf, ":set nomore\n")
@@ -271,6 +287,7 @@ func Test_confirm_cmd()
   call WaitForAssert({-> assert_match('\[Y\]es, (N)o, (C)ancel: ', term_getline(buf, 20))}, 1000)
   call term_sendkeys(buf, "Y")
   call StopVimInTerminal(buf)
+
   call assert_equal(['foo4'], readfile('foo'))
   call assert_equal(['bar2'], readfile('bar'))
 

--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -237,7 +237,7 @@ func Test_file_changed_dialog()
   sleep 2
   silent !touch Xchanged_d
   let v:warningmsg = ''
-  checktime
+  checktime Xchanged_d
   call assert_equal('', v:warningmsg)
   call assert_equal(1, line('$'))
   call assert_equal('new line', getline(1))

--- a/src/nvim/testdir/test_help_tagjump.vim
+++ b/src/nvim/testdir/test_help_tagjump.vim
@@ -125,6 +125,11 @@ func Test_help_tagjump()
   call assert_true(getline('.') =~ '\*/\\bar\*')
   helpclose
 
+  help \_$
+  call assert_equal("help", &filetype)
+  call assert_true(getline('.') =~ '\*/\\_$\*')
+  helpclose
+
   help CTRL-\_CTRL-N
   call assert_equal("help", &filetype)
   call assert_true(getline('.') =~ '\*CTRL-\\_CTRL-N\*')

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -94,6 +94,8 @@ func Test_timer_info()
 
   call timer_stop(id)
   call assert_equal([], timer_info(id))
+
+  call assert_fails('call timer_info("abc")', 'E39:')
 endfunc
 
 func Test_timer_stopall()
@@ -131,6 +133,8 @@ func Test_timer_paused()
   else
     call assert_inrange(0, 10, slept)
   endif
+
+  call assert_fails('call timer_pause("abc", 1)', 'E39:')
 endfunc
 
 func StopMyself(timer)
@@ -225,6 +229,10 @@ func Test_timer_errors()
   call WaitForAssert({-> assert_equal(3, g:call_count)})
   sleep 50m
   call assert_equal(3, g:call_count)
+
+  call assert_fails('call timer_start(100, "MyHandler", "abc")', 'E475:')
+  call assert_fails('call timer_start(100, [])', 'E921:')
+  call assert_fails('call timer_stop("abc")', 'E39:')
 endfunc
 
 func FuncWithCaughtError(timer)
@@ -386,6 +394,15 @@ func Test_timer_error_in_timer_callback()
 
   call delete('Xtest.vim')
   exe buf .. 'bwipe!'
+endfunc
+
+" Test for garbage collection when a timer is still running
+func Test_timer_garbage_collect()
+  let timer = timer_start(1000, function('MyHandler'), {'repeat' : 10})
+  call test_garbagecollect_now()
+  let l = timer_info(timer)
+  call assert_equal(function('MyHandler'), l[0].callback)
+  call timer_stop(timer)
 endfunc
 
 func Test_timer_invalid_callback()

--- a/test/functional/legacy/ex_mode_spec.lua
+++ b/test/functional/legacy/ex_mode_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
@@ -38,5 +39,62 @@ describe('Ex mode', function()
     test_ex_edit('a\tb', 'a\t\t<C-H>b')
     test_ex_edit('\tm<C-T>n', '\tm<C-T>n')
     command('set wildchar&')
+  end)
+
+  it('substitute confirmation prompt', function()
+    command('set noincsearch nohlsearch inccommand=')
+    local screen = Screen.new(60, 6)
+    screen:attach()
+    command([[call setline(1, ['foo foo', 'foo foo', 'foo foo'])]])
+    command([[set number]])
+    feed('gQ')
+    screen:expect([[
+        1 foo foo                                                 |
+        2 foo foo                                                 |
+        3 foo foo                                                 |
+                                                                  |
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :^                                                           |
+    ]])
+
+    feed('%s/foo/bar/gc<CR>')
+    screen:expect([[
+        1 foo foo                                                 |
+                                                                  |
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :%s/foo/bar/gc                                              |
+        1 foo foo                                                 |
+          ^^^^                                                     |
+    ]])
+    feed('n<CR>')
+    screen:expect([[
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :%s/foo/bar/gc                                              |
+        1 foo foo                                                 |
+          ^^^n                                                    |
+        1 foo foo                                                 |
+              ^^^^                                                 |
+    ]])
+    feed('y<CR>')
+
+    feed('q<CR>')
+    screen:expect([[
+        1 foo foo                                                 |
+              ^^^y                                                |
+        2 foo foo                                                 |
+          ^^^q                                                    |
+        2 foo foo                                                 |
+      :^                                                           |
+    ]])
+
+    feed(':vi<CR>')
+    screen:expect([[
+        1 foo bar                                                 |
+        2 fo^o foo                                                 |
+        3 foo foo                                                 |
+      ~                                                           |
+      ~                                                           |
+                                                                  |
+    ]])
   end)
 end)

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -1,9 +1,15 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
+local command = helpers.command
 local exec_lua = helpers.exec_lua
+local feed = helpers.feed
 local meths = helpers.meths
+local poke_eventloop = helpers.poke_eventloop
+local read_file = helpers.read_file
 local source = helpers.source
 local eq = helpers.eq
+local write_file = helpers.write_file
 
 local function sizeoflong()
   if not exec_lua('return pcall(require, "ffi")') then
@@ -29,4 +35,154 @@ describe('Ex command', function()
       bwipe!
     ]]
   end)
+end)
+
+it(':confirm command dialog', function()
+  local screen
+
+  local function start_new()
+    clear()
+    screen = Screen.new(60, 20)
+    screen:attach()
+  end
+
+  write_file('foo', 'foo1\n')
+  write_file('bar', 'bar1\n')
+
+  -- Test for saving all the modified buffers
+  start_new()
+  command("set nomore")
+  command("new foo")
+  command("call setline(1, 'foo2')")
+  command("new bar")
+  command("call setline(1, 'bar2')")
+  command("wincmd b")
+  feed(':confirm qall\n')
+  screen:expect([[
+    bar2                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    bar [+]                                                     |
+    foo2                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    foo [+]                                                     |
+                                                                |
+    ~                                                           |
+    ~                                                           |
+                                                                |
+    :confirm qall                                               |
+    Save changes to "bar"?                                      |
+    [Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ^          |
+  ]])
+  feed('A')
+  poke_eventloop()
+
+  eq('foo2\n', read_file('foo'))
+  eq('bar2\n', read_file('bar'))
+
+  -- Test for discarding all the changes to modified buffers
+  start_new()
+  command("set nomore")
+  command("new foo")
+  command("call setline(1, 'foo3')")
+  command("new bar")
+  command("call setline(1, 'bar3')")
+  command("wincmd b")
+  feed(':confirm qall\n')
+  screen:expect([[
+    bar3                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    bar [+]                                                     |
+    foo3                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    foo [+]                                                     |
+                                                                |
+    ~                                                           |
+    ~                                                           |
+                                                                |
+    :confirm qall                                               |
+    Save changes to "bar"?                                      |
+    [Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ^          |
+  ]])
+  feed('D')
+  poke_eventloop()
+
+  eq('foo2\n', read_file('foo'))
+  eq('bar2\n', read_file('bar'))
+
+  -- Test for saving and discarding changes to some buffers
+  start_new()
+  command("set nomore")
+  command("new foo")
+  command("call setline(1, 'foo4')")
+  command("new bar")
+  command("call setline(1, 'bar4')")
+  command("wincmd b")
+  feed(':confirm qall\n')
+  screen:expect([[
+    bar4                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    bar [+]                                                     |
+    foo4                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    foo [+]                                                     |
+                                                                |
+    ~                                                           |
+    ~                                                           |
+                                                                |
+    :confirm qall                                               |
+    Save changes to "bar"?                                      |
+    [Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: ^          |
+  ]])
+  feed('N')
+  screen:expect([[
+    bar4                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    bar [+]                                                     |
+    foo4                                                        |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    ~                                                           |
+    foo [+]                                                     |
+                                                                |
+                                                                |
+    :confirm qall                                               |
+    Save changes to "bar"?                                      |
+                                                                |
+    Save changes to "foo"?                                      |
+    [Y]es, (N)o, (C)ancel: ^                                     |
+  ]])
+  feed('Y')
+  poke_eventloop()
+
+  eq('foo4\n', read_file('foo'))
+  eq('bar2\n', read_file('bar'))
+
+  os.remove('foo')
+  os.remove('bar')
 end)

--- a/test/functional/legacy/filechanged_spec.lua
+++ b/test/functional/legacy/filechanged_spec.lua
@@ -62,7 +62,7 @@ describe('file changed dialog', function()
         sleep 2
         silent !touch Xchanged_d
         let v:warningmsg = ''
-        checktime
+        checktime Xchanged_d
         call assert_equal('', v:warningmsg)
         call assert_equal(1, line('$'))
         call assert_equal('new line', getline(1))


### PR DESCRIPTION
#### vim-patch:8.2.0203: :helptags and some other functionality not tested

Problem:    :helptags and some other functionality not tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5567)
https://github.com/vim/vim/commit/e20b9ececa37a81c0340a78f61e57fa1bf46b06d