### PR TITLE
vim-patch:8.2.{0270,2732}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3874,6 +3874,7 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
                 curwin->w_cursor.col = 0;
               }
               getvcol(curwin, &curwin->w_cursor, NULL, NULL, &ec);
+              curwin->w_cursor.col = regmatch.startpos[0].col;
               if (subflags.do_number || curwin->w_p_nu) {
                 int numw = number_width(curwin) + 1;
                 sc += numw;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -233,6 +233,7 @@ void do_exmode(void)
           if (prev_msg_row == Rows - 1) {
             msg_row--;
           }
+          msg_grid.throttled = false;
         }
         msg_col = 0;
         print_line_no_prefix(curwin->w_cursor.lnum, FALSE, FALSE);

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -105,9 +105,9 @@ func Test_buflist_browse()
   call assert_equal(b2, bufnr())
   call assert_equal(1, line('.'))
 
-  brewind +/foo3
+  brewind +
   call assert_equal(b1, bufnr())
-  call assert_equal(3, line('.'))
+  call assert_equal(4, line('.'))
 
   blast +/baz2
   call assert_equal(b3, bufnr())

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1617,6 +1617,22 @@ func Test_edit_startinsert()
   bwipe!
 endfunc
 
+" Test for :startreplace and :startgreplace
+func Test_edit_startreplace()
+  new
+  call setline(1, 'abc')
+  call feedkeys("l:startreplace\<CR>xyz\e", 'xt')
+  call assert_equal('axyz', getline(1))
+  call feedkeys("0:startreplace!\<CR>abc\e", 'xt')
+  call assert_equal('axyzabc', getline(1))
+  call setline(1, "a\tb")
+  call feedkeys("0l:startgreplace\<CR>xyz\e", 'xt')
+  call assert_equal("axyz\tb", getline(1))
+  call feedkeys("0i\<C-R>=execute('startreplace')\<CR>12\e", 'xt')
+  call assert_equal("12axyz\tb", getline(1))
+  close!
+endfunc
+
 func Test_edit_noesckeys()
   CheckNotGui
   new

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -78,6 +78,9 @@ func Test_Ex_substitute()
   call WaitForAssert({-> assert_match('  1 foo foo', term_getline(buf, 5))},
         \ 1000)
   call WaitForAssert({-> assert_match('    ^^^', term_getline(buf, 6))}, 1000)
+  call term_sendkeys(buf, "N\<CR>")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_match('    ^^^', term_getline(buf, 6))}, 1000)
   call term_sendkeys(buf, "n\<CR>")
   call WaitForAssert({-> assert_match('        ^^^', term_getline(buf, 6))},
         \ 1000)

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -64,7 +64,7 @@ func Test_ex_mode()
   let &encoding = encoding_save
 endfunc
 
-" Test subsittute confirmation prompt :%s/pat/str/c in Ex mode
+" Test substitute confirmation prompt :%s/pat/str/c in Ex mode
 func Test_Ex_substitute()
   CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
@@ -85,6 +85,11 @@ func Test_Ex_substitute()
 
   call term_sendkeys(buf, "q\<CR>")
   call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
+
+  " Pressing enter in ex mode should print the current line
+  call term_sendkeys(buf, "\<CR>")
+  call WaitForAssert({-> assert_match('  3 foo foo',
+        \ term_getline(buf, 5))}, 1000)
 
   call term_sendkeys(buf, ":vi\<CR>")
   call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -437,6 +437,16 @@ func Test_redir_cmd()
     call assert_fails('redir! > Xfile', 'E190:')
     call delete('Xfile')
   endif
+
+  " Test for redirecting to a register
+  redir @q> | echon 'clean ' | redir END
+  redir @q>> | echon 'water' | redir END
+  call assert_equal('clean water', @q)
+
+  " Test for redirecting to a variable
+  redir => color | echon 'blue ' | redir END
+  redir =>> color | echon 'sky' | redir END
+  call assert_equal('blue sky', color)
 endfunc
 
 " Test for the :filetype command
@@ -447,6 +457,30 @@ endfunc
 " Test for the :mode command
 func Test_mode_cmd()
   call assert_fails('mode abc', 'E359:')
+endfunc
+
+" Test for the :sleep command
+func Test_sleep_cmd()
+  call assert_fails('sleep x', 'E475:')
+endfunc
+
+" Test for the :read command
+func Test_read_cmd()
+  call writefile(['one'], 'Xfile')
+  new
+  call assert_fails('read', 'E32:')
+  edit Xfile
+  read
+  call assert_equal(['one', 'one'], getline(1, '$'))
+  close!
+  new
+  read Xfile
+  call assert_equal(['', 'one'], getline(1, '$'))
+  call deletebufline('', 1, '$')
+  call feedkeys("Qr Xfile\<CR>visual\<CR>", 'xt')
+  call assert_equal(['one'], getline(1, '$'))
+  close!
+  call delete('Xfile')
 endfunc
 
 " Test for running Ex commands when text is locked.

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -1,5 +1,7 @@
 " Test for expanding file names
 
+source shared.vim
+
 func Test_with_directories()
   call mkdir('Xdir1')
   call mkdir('Xdir2')
@@ -81,3 +83,30 @@ func Test_expandcmd()
   call assert_fails('call expandcmd("make %")', 'E499:')
   close
 endfunc
+
+" Test for expanding <sfile>, <slnum> and <sflnum> outside of sourcing a script
+func Test_source_sfile()
+  let lines =<< trim [SCRIPT]
+    :call assert_fails('echo expandcmd("<sfile>")', 'E498:')
+    :call assert_fails('echo expandcmd("<slnum>")', 'E842:')
+    :call assert_fails('echo expandcmd("<sflnum>")', 'E961:')
+    :call assert_fails('call expandcmd("edit <cfile>")', 'E446:')
+    :call assert_fails('call expandcmd("edit #")', 'E194:')
+    :call assert_fails('call expandcmd("edit #<2")', 'E684:')
+    :call assert_fails('call expandcmd("edit <cword>")', 'E348:')
+    :call assert_fails('call expandcmd("edit <cexpr>")', 'E348:')
+    :call assert_fails('autocmd User MyCmd echo "<sfile>"', 'E498:')
+    :call writefile(v:errors, 'Xresult')
+    :qall!
+
+  [SCRIPT]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--clean -s Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -757,6 +757,26 @@ func Test_setfiletype_completion()
   call assert_equal('"setfiletype java javacc javascript javascriptreact', @:)
 endfunc
 
+" Test for ':filetype detect' command for a buffer without a file
+func Test_emptybuf_ftdetect()
+  new
+  call setline(1, '#!/bin/sh')
+  call assert_equal('', &filetype)
+  filetype detect
+  call assert_equal('sh', &filetype)
+  close!
+endfunc
+
+" Test for ':filetype indent on' and ':filetype indent off' commands
+func Test_filetype_indent_off()
+  new Xtest.vim
+  filetype indent on
+  call assert_equal(1, g:did_indent_on)
+  filetype indent off
+  call assert_equal(0, exists('g:did_indent_on'))
+  close
+endfunc
+
 """""""""""""""""""""""""""""""""""""""""""""""""
 " Tests for specific extensions and filetypes.
 " Keep sorted.

--- a/src/nvim/testdir/test_findfile.vim
+++ b/src/nvim/testdir/test_findfile.vim
@@ -193,12 +193,14 @@ func Test_find_cmd()
   set path=.,./**/*
   call CreateFiles()
   cd Xdir1
+
   " Test for :find
   find foo
   call assert_equal('foo', expand('%:.'))
   2find foo
   call assert_equal('Xdir2/foo', expand('%:.'))
   call assert_fails('3find foo', 'E347:')
+
   " Test for :sfind
   enew
   sfind barfoo
@@ -207,6 +209,7 @@ func Test_find_cmd()
   close
   call assert_fails('sfind baz', 'E345:')
   call assert_equal(2, winnr('$'))
+
   " Test for :tabfind
   enew
   tabfind foobar
@@ -215,7 +218,8 @@ func Test_find_cmd()
   tabclose
   call assert_fails('tabfind baz', 'E345:')
   call assert_equal(1, tabpagenr('$'))
-  " call chdir(save_dir)
+
+  call chdir(save_dir)
   exe 'cd ' . save_dir
   call CleanFiles()
   let &path = save_path

--- a/src/nvim/testdir/test_join.vim
+++ b/src/nvim/testdir/test_join.vim
@@ -437,5 +437,11 @@ func Test_join_lines()
   call setline(1, ['a', 'b', '', 'c', 'd'])
   normal 5J
   call assert_equal('a b c d', getline(1))
+  call setline(1, ['a', 'b', 'c'])
+  2,2join
+  call assert_equal(['a', 'b', 'c'], getline(1, '$'))
+  call assert_equal(2, line('.'))
+  2join
+  call assert_equal(['a', 'b c'], getline(1, '$'))
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_move.vim
+++ b/src/nvim/testdir/test_move.vim
@@ -38,6 +38,7 @@ func Test_move()
   call assert_fails("move -100", 'E16:')
   call assert_fails("move +100", 'E16:')
   call assert_fails('move', 'E16:')
+  call assert_fails("move 'r", 'E20:')
 
   %bwipeout!
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -416,6 +416,17 @@ func Test_put_reg_restart_mode()
   bwipe!
 endfunc
 
+" Test for executing a register using :@ command
+func Test_execute_register()
+  call setreg('r', [])
+  call assert_beeps('@r')
+  let i = 1
+  let @q = 'let i+= 1'
+  @q
+  @
+  call assert_equal(3, i)
+endfunc
+
 " Test for getting register info
 func Test_get_reginfo()
   enew

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -66,4 +66,25 @@ func Test_source_ignore_shebang()
   call delete('Xfile.vim')
 endfunc
 
+" Test for expanding <sfile> in a autocmd and for <slnum> and <sflnum>
+func Test_source_autocmd_sfile()
+  let code =<< trim [CODE]
+    let g:SfileName = ''
+    augroup sfiletest
+      au!
+      autocmd User UserAutoCmd let g:Sfile = '<sfile>:t'
+    augroup END
+    doautocmd User UserAutoCmd
+    let g:Slnum = expand('<slnum>')
+    let g:Sflnum = expand('<sflnum>')
+    augroup! sfiletest
+  [CODE]
+  call writefile(code, 'Xscript.vim')
+  source Xscript.vim
+  call assert_equal('Xscript.vim', g:Sfile)
+  call assert_equal('7', g:Slnum)
+  call assert_equal('8', g:Sflnum)
+  call delete('Xscript.vim')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -139,7 +139,11 @@ function Test_tabpage()
   call assert_fails("tabmove -99", 'E474:')
   call assert_fails("tabmove -3+", 'E474:')
   call assert_fails("tabmove $3", 'E474:')
+  call assert_fails("%tabonly", 'E16:')
   1tabonly!
+  tabnew
+  call assert_fails("-2tabmove", 'E474:')
+  tabonly!
 endfunc
 
 " Test autocommands
@@ -605,6 +609,16 @@ func Test_tabpage_cmdheight()
 
   call StopVimInTerminal(buf)
   call delete('XTest_tabpage_cmdheight')
+endfunc
+
+" Test for closing the tab page from a command window
+func Test_tabpage_close_cmdwin()
+  tabnew
+  call feedkeys("q/:tabclose\<CR>\<Esc>", 'xt')
+  call assert_equal(2, tabpagenr('$'))
+  call feedkeys("q/:tabonly\<CR>\<Esc>", 'xt')
+  call assert_equal(2, tabpagenr('$'))
+  tabonly
 endfunc
 
 " Return the terminal key code for selecting a tab page from the tabline. This

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1857,6 +1857,16 @@ func Test_deep_nest()
   call delete('Xscript')
 endfunc
 
+" Test for <sfile>, <slnum> in a function                           {{{1
+func Test_sfile_in_function()
+  func Xfunc()
+    call assert_match('..Test_sfile_in_function\[5]..Xfunc', expand('<sfile>'))
+    call assert_equal('2', expand('<slnum>'))
+  endfunc
+  call Xfunc()
+  delfunc Xfunc
+endfunc
+
 func Test_for_over_string()
   let res = ''
   for c in 'aéc̀d'

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -893,6 +893,15 @@ func Test_window_only()
   new
   call assert_fails('only', 'E445:')
   only!
+  " Test for :only with a count
+  let wid = win_getid()
+  new
+  new
+  3only
+  call assert_equal(1, winnr('$'))
+  call assert_equal(wid, win_getid())
+  call assert_fails('close', 'E444:')
+  call assert_fails('%close', 'E16:')
 endfunc
 
 " Test for errors with :wincmd

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -207,9 +207,7 @@ func Test_write_errors()
   close!
 
   call assert_fails('w > Xtest', 'E494:')
-
-  call assert_fails('w > Xtest', 'E494:')
-
+ 
   " Try to overwrite a directory
   if has('unix')
     call mkdir('Xdir1')

--- a/test/functional/legacy/ex_mode_spec.lua
+++ b/test/functional/legacy/ex_mode_spec.lua
@@ -44,67 +44,81 @@ describe('Ex mode', function()
   it('substitute confirmation prompt', function()
     command('set noincsearch nohlsearch inccommand=')
     local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, reverse = true},  -- MsgSeparator
+      [1] = {foreground = Screen.colors.Brown},  -- LineNr
+      [2] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
     screen:attach()
     command([[call setline(1, ['foo foo', 'foo foo', 'foo foo'])]])
     command([[set number]])
     feed('gQ')
     screen:expect([[
-        1 foo foo                                                 |
-        2 foo foo                                                 |
-        3 foo foo                                                 |
-                                                                  |
+      {1:  1 }foo foo                                                 |
+      {1:  2 }foo foo                                                 |
+      {1:  3 }foo foo                                                 |
+      {0:                                                            }|
       Entering Ex mode.  Type "visual" to go to Normal mode.      |
       :^                                                           |
     ]])
 
     feed('%s/foo/bar/gc<CR>')
     screen:expect([[
-        1 foo foo                                                 |
-                                                                  |
+      {1:  1 }foo foo                                                 |
+      {0:                                                            }|
       Entering Ex mode.  Type "visual" to go to Normal mode.      |
       :%s/foo/bar/gc                                              |
-        1 foo foo                                                 |
+      {1:  1 }foo foo                                                 |
+          ^^^^                                                     |
+    ]])
+    feed('N<CR>')
+    screen:expect([[
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :%s/foo/bar/gc                                              |
+      {1:  1 }foo foo                                                 |
+          ^^^N                                                    |
+      {1:  1 }foo foo                                                 |
           ^^^^                                                     |
     ]])
     feed('n<CR>')
     screen:expect([[
-      Entering Ex mode.  Type "visual" to go to Normal mode.      |
-      :%s/foo/bar/gc                                              |
-        1 foo foo                                                 |
+      {1:  1 }foo foo                                                 |
+          ^^^N                                                    |
+      {1:  1 }foo foo                                                 |
           ^^^n                                                    |
-        1 foo foo                                                 |
+      {1:  1 }foo foo                                                 |
               ^^^^                                                 |
     ]])
     feed('y<CR>')
 
     feed('q<CR>')
     screen:expect([[
-        1 foo foo                                                 |
+      {1:  1 }foo foo                                                 |
               ^^^y                                                |
-        2 foo foo                                                 |
+      {1:  2 }foo foo                                                 |
           ^^^q                                                    |
-        2 foo foo                                                 |
+      {1:  2 }foo foo                                                 |
       :^                                                           |
     ]])
 
     -- Pressing enter in ex mode should print the current line
     feed('<CR>')
     screen:expect([[
-        1 foo foo                                                 |
+      {1:  1 }foo foo                                                 |
               ^^^y                                                |
-        2 foo foo                                                 |
+      {1:  2 }foo foo                                                 |
           ^^^q                                                    |
-        3 foo foo                                                 |
+      {1:  3 }foo foo                                                 |
       :^                                                           |
     ]])
 
     feed(':vi<CR>')
     screen:expect([[
-        1 foo bar                                                 |
-        2 foo foo                                                 |
-        3 ^foo foo                                                 |
-      ~                                                           |
-      ~                                                           |
+      {1:  1 }foo bar                                                 |
+      {1:  2 }foo foo                                                 |
+      {1:  3 }^foo foo                                                 |
+      {2:~                                                           }|
+      {2:~                                                           }|
                                                                   |
     ]])
   end)

--- a/test/functional/legacy/ex_mode_spec.lua
+++ b/test/functional/legacy/ex_mode_spec.lua
@@ -87,11 +87,22 @@ describe('Ex mode', function()
       :^                                                           |
     ]])
 
+    -- Pressing enter in ex mode should print the current line
+    feed('<CR>')
+    screen:expect([[
+        1 foo foo                                                 |
+              ^^^y                                                |
+        2 foo foo                                                 |
+          ^^^q                                                    |
+        3 foo foo                                                 |
+      :^                                                           |
+    ]])
+
     feed(':vi<CR>')
     screen:expect([[
         1 foo bar                                                 |
-        2 fo^o foo                                                 |
-        3 foo foo                                                 |
+        2 foo foo                                                 |
+        3 ^foo foo                                                 |
       ~                                                           |
       ~                                                           |
                                                                   |


### PR DESCRIPTION
#### vim-patch:8.2.0270: some code not covered by tests

Problem:    Some code not covered by tests.
Solution:   Add test cases. (Yegappan Lakshmanan, closes vim/vim#5649)
https://github.com/vim/vim/commit/bc2b71d44a0b90b6aeb3534a76912fccbe5577df


#### vim-patch:8.2.2732: prompt for s///c in Ex mode can be wrong

Problem:    Prompt for s///c in Ex mode can be wrong.
Solution:   Position the cursor before showing the prompt. (closes vim/vim#8073)
https://github.com/vim/vim/commit/e5b0b98a90acf420bb611fc99534982c98d0645b