### PR TITLE
vim-patch:8.2.0035: saving and restoring called_emsg is clumsy

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3136,18 +3136,16 @@ void maketitle(void)
     if (*p_titlestring != NUL) {
       if (stl_syntax & STL_IN_TITLE) {
         int use_sandbox = false;
-        int save_called_emsg = called_emsg;
+        const int called_emsg_before = called_emsg;
 
         use_sandbox = was_set_insecurely(curwin, "titlestring", 0);
-        called_emsg = false;
         build_stl_str_hl(curwin, buf, sizeof(buf),
                          (char *)p_titlestring, use_sandbox,
                          0, maxlen, NULL, NULL);
         title_str = buf;
-        if (called_emsg) {
+        if (called_emsg > called_emsg_before) {
           set_string_option_direct("titlestring", -1, "", OPT_FREE, SID_ERROR);
         }
-        called_emsg |= save_called_emsg;
       } else {
         title_str = (char *)p_titlestring;
       }
@@ -3252,17 +3250,15 @@ void maketitle(void)
     if (*p_iconstring != NUL) {
       if (stl_syntax & STL_IN_ICON) {
         int use_sandbox = false;
-        int save_called_emsg = called_emsg;
+        const int called_emsg_before = called_emsg;
 
         use_sandbox = was_set_insecurely(curwin, "iconstring", 0);
-        called_emsg = false;
         build_stl_str_hl(curwin, icon_str, sizeof(buf),
                          (char *)p_iconstring, use_sandbox,
                          0, 0, NULL, NULL);
-        if (called_emsg) {
+        if (called_emsg > called_emsg_before) {
           set_string_option_direct("iconstring", -1, "", OPT_FREE, SID_ERROR);
         }
-        called_emsg |= save_called_emsg;
       } else {
         icon_str = (char *)p_iconstring;
       }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7296,7 +7296,7 @@ void timer_due_cb(TimeWatcher *tw, void *data)
 {
   timer_T *timer = (timer_T *)data;
   int save_did_emsg = did_emsg;
-  int save_called_emsg = called_emsg;
+  const int called_emsg_before = called_emsg;
   const bool save_ex_pressedreturn = get_pressedreturn();
 
   if (timer->stopped || timer->paused) {
@@ -7313,19 +7313,17 @@ void timer_due_cb(TimeWatcher *tw, void *data)
   argv[0].v_type = VAR_NUMBER;
   argv[0].vval.v_number = timer->timer_id;
   typval_T rettv = TV_INITIAL_VALUE;
-  called_emsg = false;
 
   callback_call(&timer->callback, 1, argv, &rettv);
 
   // Handle error message
-  if (called_emsg && did_emsg) {
+  if (called_emsg > called_emsg_before && did_emsg) {
     timer->emsg_count++;
     if (current_exception != NULL) {
       discard_current_exception();
     }
   }
   did_emsg = save_did_emsg;
-  called_emsg = save_called_emsg;
   set_pressedreturn(save_ex_pressedreturn);
 
   if (timer->emsg_count >= 3) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -229,7 +229,7 @@ EXTERN bool did_emsg;                       // set by emsg() when the message
 EXTERN bool called_vim_beep;                // set if vim_beep() is called
 EXTERN bool did_emsg_syntax;                // did_emsg set because of a
                                             // syntax error
-EXTERN int called_emsg;                     // always set by emsg()
+EXTERN int called_emsg;                     // always incremented by emsg()
 EXTERN int ex_exitval INIT(= 0);            // exit value for ex mode
 EXTERN bool emsg_on_display INIT(= false);  // there is an error message
 EXTERN bool rc_did_emsg INIT(= false);      // vim_regcomp() called emsg()

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -398,7 +398,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
   linenr_T l;
   colnr_T matchcol;
   long nmatched = 0;
-  int save_called_emsg = called_emsg;
+  const int called_emsg_before = called_emsg;
 
   // for :{range}s/pat only highlight inside the range
   if (lnum < search_first_line || lnum > search_last_line) {
@@ -421,7 +421,6 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
 
   // Repeat searching for a match until one is found that includes "mincol"
   // or none is found in this line.
-  called_emsg = false;
   for (;;) {
     // Stop searching after passing the time limit.
     if (profile_passed_limit(shl->tm)) {
@@ -468,7 +467,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
       if (regprog_is_copy) {
         cur->match.regprog = cur->hl.rm.regprog;
       }
-      if (called_emsg || got_int || timed_out) {
+      if (called_emsg > called_emsg_before || got_int || timed_out) {
         // Error while handling regexp: stop using this regexp.
         if (shl == search_hl) {
           // don't free regprog in the match list, it's a copy
@@ -495,9 +494,6 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
       break;                            // useful match found
     }
   }
-
-  // Restore called_emsg for assert_fails().
-  called_emsg = save_called_emsg;
 }
 
 /// Advance to the match in window "wp" line "lnum" or past it.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -637,7 +637,7 @@ static bool emsg_multiline(const char *s, bool multiline)
     return true;
   }
 
-  called_emsg = true;
+  called_emsg++;
 
   // If "emsg_severe" is true: When an error exception is to be thrown,
   // prefer this message over previous messages for the same command.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6533,13 +6533,11 @@ static void win_redr_ruler(win_T *wp, bool always)
   }
 
   if (*p_ruf && p_ch > 0 && !ui_has(kUIMessages)) {
-    int save_called_emsg = called_emsg;
-    called_emsg = false;
+    const int called_emsg_before = called_emsg;
     win_redr_custom(wp, false, true);
-    if (called_emsg) {
+    if (called_emsg > called_emsg_before) {
       set_string_option_direct("rulerformat", -1, "", OPT_FREE, SID_ERROR);
     }
-    called_emsg |= save_called_emsg;
     return;
   }
 

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -405,15 +405,15 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const char *const cmd = tv_get_string_chk(&argvars[0]);
   garray_T ga;
   int save_trylevel = trylevel;
+  const int called_emsg_before = called_emsg;
 
   // trylevel must be zero for a ":throw" command to be considered failed
   trylevel = 0;
-  called_emsg = false;
   suppress_errthrow = true;
   emsg_silent = true;
 
   do_cmdline_cmd(cmd);
-  if (!called_emsg) {
+  if (called_emsg == called_emsg_before) {
     prepare_assert_error(&ga);
     ga_concat(&ga, "command did not fail: ");
     assert_append_cmd_or_arg(&ga, argvars, cmd);
@@ -438,7 +438,6 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   trylevel = save_trylevel;
-  called_emsg = false;
   suppress_errthrow = false;
   emsg_silent = false;
   emsg_on_display = false;


### PR DESCRIPTION
#### vim-patch:8.2.0035: saving and restoring called_emsg is clumsy

Problem:    Saving and restoring called_emsg is clumsy.
Solution:   Count the number of error messages.
https://github.com/vim/vim/commit/53989554a44caca0964376d60297f08ec257c53c