### PR TITLE
feat(ts): upstream spellsitter.nvim

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -340,7 +340,7 @@ identical identifiers, highlighting both as |hl-WarningMsg|: >
 <
 Treesitter Highlighting Priority            *lua-treesitter-highlight-priority*
 
-Tree-sitter uses |nvim_buf_set_extmark()| to set highlights with a default 
+Tree-sitter uses |nvim_buf_set_extmark()| to set highlights with a default
 priority of 100. This enables plugins to set a highlighting priority lower or
 higher than tree-sitter. It is also possible to change the priority of an
 individual query pattern manually by setting its `"priority"` metadata
@@ -352,6 +352,38 @@ attribute: >
       (set! "priority" 105)
     )
 <
+
+Treesitter Spell Highlighting                            *lua-treesitter-spell*
+
+Similar to syntax highlighting, spell regions are defined in the same query
+format. The spell regions are passed through |vim.spell.check()| to determine
+sub-strings to highlight.
+
+The exact query used is determined, in order, by:
+
+    1. First by looking for a `spell.scm` query file for the required language.
+    2. Then an attempt to define an inline query for all `(comment)` nodes.
+    3. Finally using `@comment` captures from `highlights.scm`.
+
+The `@spell` capture is used from queries in `spell.scm` files to define spell
+regions. For example, the following query will enable spellchecking on all
+comments and string literals:
+>
+    (comment) @spell
+    (string_literal) @spell
+<
+
+Spell highlighting is integrated with Nvim's built-in spellchecker, and nearly
+all spell related mappings and options should work as expected.
+
+This includes:
+
+    - Controllable with `set[local] [no]spell` (see |'spell'|).
+    - Functional mappings: `[s`, `]s`, `zg`, `zw`, etc. Note: `[S` and `]S` is
+      not currently implemented.
+    - Uses the built-in highlight groups: |hl-SpellBad|, |hl-SpellCap|,
+      |hl-SpellRare|, |hl-SpellLocal|.
+
 
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -218,6 +218,9 @@ function TSHighlighter:get_highlight_state(tstree)
     self._highlight_states[tstree] = {
       next_row = 0,
       iter = nil,
+
+      spell_next_row = 0,
+      spell_iter = nil,
     }
   end
 

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -1,5 +1,6 @@
 local a = vim.api
 local query = require('vim.treesitter.query')
+local spell = require('vim.treesitter.spell')
 
 -- support reload for quick experimentation
 local TSHighlighter = rawget(vim.treesitter, 'TSHighlighter') or {}
@@ -312,13 +313,14 @@ local function on_line_impl(self, buf, line)
 end
 
 ---@private
-function TSHighlighter._on_line(_, _win, buf, line, _)
+function TSHighlighter._on_line(_, win, buf, line, _)
   local self = TSHighlighter.active[buf]
   if not self then
     return
   end
 
   on_line_impl(self, buf, line)
+  spell.on_line(self, win, buf, line)
 end
 
 ---@private
@@ -330,7 +332,7 @@ function TSHighlighter._on_buf(_, buf)
 end
 
 ---@private
-function TSHighlighter._on_win(_, _win, buf, _topline)
+function TSHighlighter._on_win(_, win, buf, _topline)
   local self = TSHighlighter.active[buf]
   if not self then
     return false
@@ -338,6 +340,9 @@ function TSHighlighter._on_win(_, _win, buf, _topline)
 
   self:reset_highlight_state()
   self.redraw_count = self.redraw_count + 1
+
+  spell.on_win(win, buf)
+
   return true
 end
 

--- a/runtime/lua/vim/treesitter/spell.lua
+++ b/runtime/lua/vim/treesitter/spell.lua
@@ -1,0 +1,210 @@
+local api = vim.api
+local query = require('vim.treesitter.query')
+
+-- TODO(lewis6991): copied from languagetree.lua - consolidate
+local function get_node_range(node, id, metadata)
+  if metadata[id] and metadata[id].range then
+    return metadata[id].range
+  end
+  return { node:range() }
+end
+
+local function get_query(lang, default)
+  -- Use the spell query if there is one available otherwise just
+  -- spellcheck comments.
+  local lang_query = query.get_query(lang, 'spell')
+
+  if lang_query then
+    return lang_query
+  end
+
+  -- First fallback is to use the comment nodes, if defined
+  local ok, ret = pcall(query.parse_query, lang, '(comment)  @spell')
+  if ok then
+    return ret
+  end
+
+  -- Second fallback is to use comments from the highlight captures
+  return default
+end
+
+local function get_spell_marks(highlighter, bufnr, row)
+  highlighter = highlighter or vim.treesitter.highlighter.active[bufnr]
+
+  local marks = {}
+
+  highlighter.tree:for_each_tree(function(tstree, langtree)
+    local hl_query = highlighter:get_query(langtree:lang())
+
+    if hl_query._spell_query == nil then
+      -- Make sure we set _spell_query to non-nil in order to avoid constantly trying to get the
+      -- query if it fails the first time.
+      hl_query._spell_query = get_query(langtree:lang(), hl_query:query()) or false
+    end
+
+    local spell_query = hl_query._spell_query
+
+    if not spell_query then
+      return
+    end
+
+    local root_node = tstree:root()
+
+    local root_start_row, _, root_end_row, _ = root_node:range()
+
+    -- Only worry about trees within the line range
+    if root_start_row > row or root_end_row < row then
+      return
+    end
+
+    -- TODO(lewis6991): Figure out how we can re-use the iterator. Note for navigation we need to be
+    -- able to iterate forwards and backwards.
+    for id, node, metadata in spell_query:iter_captures(root_node, bufnr, row, row + 1) do
+      if vim.tbl_contains({ 'spell', 'comment' }, spell_query.captures[id]) then
+        local start_row, start_col, end_row, end_col = unpack(get_node_range(node, id, metadata))
+
+        start_col = row == start_row and start_col or 0
+        local sub_end_col = row == end_row and end_col + 1 or -1
+
+        local line = api.nvim_buf_get_lines(bufnr, row, row + 1, true)[1]
+        local l = line:sub(start_col + 1, sub_end_col)
+
+        for _, r in ipairs(vim.spell.check(l)) do
+          local word, type, col = unpack(r)
+          marks[#marks + 1] = { start_col + col - 1, #word, type }
+        end
+      end
+    end
+  end)
+
+  return marks
+end
+
+local function enabled(winid, bufnr)
+  if not vim.treesitter.highlighter.active[bufnr] then
+    return false
+  end
+  return vim.wo[winid].spell
+end
+
+local function get_nav_target_forward(bufnr, row, col)
+  -- TODO(lewis6991): support 'wrapscan' (with message)
+  for i = row, api.nvim_buf_line_count(bufnr) do
+    local marks = get_spell_marks(nil, bufnr, i - 1)
+    for j = 1, #marks do
+      local mcol = marks[j][1]
+      if i ~= row or col < mcol then
+        return { i, mcol }
+      end
+    end
+  end
+end
+
+local function get_nav_target_backward(bufnr, row, col)
+  -- TODO(lewis6991): support 'wrapscan' (with message)
+  for i = row, 1, -1 do
+    local marks = get_spell_marks(nil, bufnr, i - 1)
+    for j = #marks, 1, -1 do
+      local mcol = marks[j][1]
+      if i ~= row or col > mcol then
+        return { i, mcol }
+      end
+    end
+  end
+end
+
+local function nav(backward, fallback)
+  return function()
+    local bufnr = api.nvim_get_current_buf()
+    local winid = api.nvim_get_current_win()
+
+    if not enabled(winid, bufnr) then
+      return fallback
+    end
+
+    local row, col = unpack(api.nvim_win_get_cursor(winid))
+    local get_nav_target = backward and get_nav_target_backward or get_nav_target_forward
+    local target = get_nav_target(bufnr, row, col)
+
+    if target then
+      vim.schedule(function()
+        vim.cmd({ cmd = 'normal', bang = true, args = { "m'" } }) -- add current cursor position to the jump list
+        api.nvim_win_set_cursor(winid, target)
+      end)
+      return '<Ignore>'
+    end
+  end
+end
+
+local M = {}
+
+function M.on_win(winid, bufnr)
+  if not enabled(winid, bufnr) then
+    return
+  end
+
+  -- HACK ALERT: To prevent the internal spellchecker from spellchecking, we
+  -- need to define a 'Spell' syntax group which contains nothing.
+  api.nvim_win_call(winid, function()
+    if vim.fn.has('syntax_items') == 0 then
+      vim.cmd({ cmd = 'syntax', args = { 'cluster', 'Spell', 'contains=NONE' } })
+    end
+  end)
+end
+
+local ns = api.nvim_create_namespace('treesitter/spell')
+
+local HIGHLIGHTS = {
+  bad = 'SpellBad',
+  caps = 'SpellCap',
+  rare = 'SpellRare',
+  ['local'] = 'SpellLocal',
+}
+
+function M.on_line(highlighter, winid, bufnr, row)
+  if not enabled(winid, bufnr) then
+    return
+  end
+
+  local cur_lnum, cur_col = unpack(api.nvim_win_get_cursor(winid))
+
+  for _, mark in ipairs(get_spell_marks(highlighter, bufnr, row)) do
+    local col, len, type = unpack(mark)
+
+    if cur_lnum - 1 == row and col <= cur_col and col + len >= cur_col then
+      if api.nvim_get_mode().mode == 'i' then
+        -- Don't highlight current word
+        return
+      end
+    end
+
+    api.nvim_buf_set_extmark(bufnr, ns, row, col, {
+      end_line = row,
+      end_col = col + len,
+      hl_group = HIGHLIGHTS[type],
+      ephemeral = true,
+    })
+  end
+end
+
+if vim.fn.hasmapto(']s', 'n') == 0 then
+  vim.keymap.set(
+    'n',
+    ']s',
+    nav(false, ']s'),
+    { expr = true, desc = 'vim.treesitter.spell.nav (forward)' }
+  )
+end
+
+if vim.fn.hasmapto('[s', 'n') == 0 then
+  vim.keymap.set(
+    'n',
+    '[s',
+    nav(true, '[s'),
+    { expr = true, desc = 'vim.treesitter.spell.nav (backward)' }
+  )
+end
+
+-- TODO(lewis6991): implement ]S and [S
+
+return M

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -1172,7 +1172,7 @@ Doxyfile = textwrap.dedent('''
     INPUT_FILTER           = "{filter}"
     EXCLUDE                =
     EXCLUDE_SYMLINKS       = NO
-    EXCLUDE_PATTERNS       = */private/* */health.lua */_*.lua
+    EXCLUDE_PATTERNS       = */private/* */health.lua */_*.lua */spell.lua
     EXCLUDE_SYMBOLS        =
     EXTENSION_MAPPING      = lua=C
     EXTRACT_PRIVATE        = NO

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -100,6 +100,7 @@ describe('treesitter highlighting', function()
       [9] = {foreground = Screen.colors.Magenta, background = Screen.colors.Red};
       [10] = {foreground = Screen.colors.Red, background = Screen.colors.Red};
       [11] = {foreground = Screen.colors.Cyan4};
+      [12] = {foreground = Screen.colors.Blue, special = Screen.colors.Red, undercurl = true};
     }
 
     exec_lua([[ hl_query = ... ]], hl_query)
@@ -268,6 +269,38 @@ describe('treesitter highlighting', function()
       {8:}}                                                                |
                                                                        |
     ]]}
+  end)
+
+  it('supports spellchecking', function()
+    if pending_c_parser(pending) then return end
+    screen:try_resize(30, 4)
+
+    insert(table.concat({
+      '// This is a baad word',
+      'int baad = 1;'
+    }, '\n'))
+
+    screen:expect{grid=[[
+      // This is a baad word        |
+      int baad = 1^;                 |
+      {1:~                             }|
+                                    |
+    ]]}
+
+    exec_lua [[
+      vim.wo.spell = true
+      local parser = vim.treesitter.get_parser(0, "c")
+      local highlighter = vim.treesitter.highlighter
+      test_hl = highlighter.new(parser, {queries = {c = hl_query}})
+    ]]
+
+    screen:expect{grid=[[
+      {2:// This is a }{12:baad}{2: word}        |
+      {3:int} baad = {5:1}^;                 |
+      {1:~                             }|
+                                    |
+    ]]}
+
   end)
 
   it('is updated with :sort', function()


### PR DESCRIPTION
Alternative to #16650

- Unlike #16650 this runs an additional query.

### Question
* Should spell regions be defined in their own query file `spell.scm`, or should they be integrated in `highlights.scm`? This PR implements both with `spell.scm` taking higher precedence. Integrating into `highlights.scm` will allow us to run one query for both syntax highlighting and spelling.