### PR TITLE
vim-patch:8.2.{0342,0347,0369}: insufficient test coverage

### DIFF
--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -544,6 +544,11 @@ func Test_quit_with_arglist()
   call term_wait(buf)
   call WaitForAssert({-> assert_equal("finished", term_getstatus(buf))})
   only!
+  " When this test fails, swap files are left behind which breaks subsequent
+  " tests
+  call delete('.a.swp')
+  call delete('.b.swp')
+  call delete('.c.swp')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_changelist.vim
+++ b/src/nvim/testdir/test_changelist.vim
@@ -46,3 +46,5 @@ func Test_getchangelist()
   call delete('Xfile1.txt')
   call delete('Xfile2.txt')
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -1,3 +1,4 @@
+" Test for character search commands - t, T, f, F, ; and ,
 
 func Test_charsearch()
   enew!
@@ -60,3 +61,16 @@ func Test_search_cmds()
   call assert_equal('ddd yee y', getline(6))
   enew!
 endfunc
+
+" Test for character search in virtual edit mode with <Tab>
+func Test_csearch_virtualedit()
+  new
+  set virtualedit=all
+  call setline(1, "a\tb")
+  normal! tb
+  call assert_equal([0, 1, 2, 6], getpos('.'))
+  set virtualedit&
+  close!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1278,6 +1278,10 @@ endfunc
 func Test_cmdwin_feedkeys()
   " This should not generate E488
   call feedkeys("q:\<CR>", 'x')
+  " Using feedkeys with q: only should automatically close the cmd window
+  call feedkeys('q:', 'xt')
+  call assert_equal(1, winnr('$'))
+  call assert_equal('', getcmdwintype())
 endfunc
 
 " Tests for the issues fixed in 7.4.441.

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -603,11 +603,21 @@ func Test_cmdline_paste()
   call feedkeys(":\"one\<C-R>\<C-X>two\<CR>", 'xt')
   call assert_equal('"onetwo', @:)
 
+  " Test for pasting register containing CTRL-H using CTRL-R and CTRL-R CTRL-R
   let @a = "xy\<C-H>z"
   call feedkeys(":\"\<C-R>a\<CR>", 'xt')
   call assert_equal('"xz', @:)
+  call feedkeys(":\"\<C-R>\<C-R>a\<CR>", 'xt')
+  call assert_equal("\"xy\<C-H>z", @:)
   call feedkeys(":\"\<C-R>\<C-O>a\<CR>", 'xt')
   call assert_equal("\"xy\<C-H>z", @:)
+
+  " Test for pasting register containing CTRL-V using CTRL-R and CTRL-R CTRL-R
+  let @a = "xy\<C-V>z"
+  call feedkeys(":\"\<C-R>=@a\<CR>\<cr>", 'xt')
+  call assert_equal('"xyz', @:)
+  call feedkeys(":\"\<C-R>\<C-R>=@a\<CR>\<cr>", 'xt')
+  call assert_equal("\"xy\<C-V>z", @:)
 
   call assert_beeps('call feedkeys(":\<C-R>=\<C-R>=\<Esc>", "xt")')
 
@@ -1558,7 +1568,7 @@ endfunc
 func Test_cmdline_edit()
   let str = ":one two\<C-U>"
   let str ..= "one two\<C-W>\<C-W>"
-  let str ..= "one\<BS>\<C-H>\<Del>"
+  let str ..= "four\<BS>\<C-H>\<Del>\<kDel>"
   let str ..= "\<Left>five\<Right>"
   let str ..= "\<Home>two "
   let str ..= "\<C-Left>one "
@@ -1577,7 +1587,7 @@ func Test_cmdline_edit_rightleft()
   set rightleftcmd=search
   let str = "/one two\<C-U>"
   let str ..= "one two\<C-W>\<C-W>"
-  let str ..= "one\<BS>\<C-H>\<Del>"
+  let str ..= "four\<BS>\<C-H>\<Del>\<kDel>"
   let str ..= "\<Right>five\<Left>"
   let str ..= "\<Home>two "
   let str ..= "\<C-Right>one "
@@ -1636,6 +1646,44 @@ func Test_cmdline_inputmethod()
 
   set imcmdline&
   %bwipe!
+endfunc
+
+" Test for opening the command-line window when too many windows are present
+func Test_cmdwin_fail_to_open()
+  " Open as many windows as possible
+  for i in range(100)
+    try
+      new
+    catch /E36:/
+      break
+    endtry
+  endfor
+  call assert_beeps('call feedkeys("q:\<CR>", "xt")')
+  only
+endfunc
+
+" Test for recursively getting multiple command line inputs
+func Test_cmdwin_multi_input()
+  call feedkeys(":\<C-R>=input('P: ')\<CR>\"cyan\<CR>\<CR>", 'xt')
+  call assert_equal('"cyan', @:)
+endfunc
+
+" Test for using CTRL-_ in the command line with 'allowrevins'
+func Test_cmdline_revins()
+  CheckNotMSWindows
+  CheckFeature rightleft
+  call feedkeys(":\"abc\<c-_>\<cr>", 'xt')
+  call assert_equal("\"abc\<c-_>", @:)
+  set allowrevins
+  call feedkeys(":\"abc\<c-_>xyz\<c-_>\<CR>", 'xt')
+  call assert_equal('"abcñèæ', @:)
+  set allowrevins&
+endfunc
+
+" Test for typing UTF-8 composing characters in the command line
+func Test_cmdline_composing_chars()
+  call feedkeys(":\"\<C-V>u3046\<C-V>u3099\<CR>", 'xt')
+  call assert_equal('"ゔ', @:)
 endfunc
 
 " Test for normal mode commands not supported in the cmd window

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1558,6 +1558,7 @@ endfunc
 func Test_cmdline_edit()
   let str = ":one two\<C-U>"
   let str ..= "one two\<C-W>\<C-W>"
+  let str ..= "one\<BS>\<C-H>\<Del>"
   let str ..= "\<Left>five\<Right>"
   let str ..= "\<Home>two "
   let str ..= "\<C-Left>one "
@@ -1576,6 +1577,7 @@ func Test_cmdline_edit_rightleft()
   set rightleftcmd=search
   let str = "/one two\<C-U>"
   let str ..= "one two\<C-W>\<C-W>"
+  let str ..= "one\<BS>\<C-H>\<Del>"
   let str ..= "\<Right>five\<Left>"
   let str ..= "\<Home>two "
   let str ..= "\<C-Right>one "
@@ -1601,6 +1603,39 @@ func Test_cmdline_expr()
   " Insert literal <CTRL-\> in the command line
   call feedkeys(":\"e \<C-\>\<C-Y>\<CR>", 'xt')
   call assert_equal("\"e \<C-\>\<C-Y>", @:)
+endfunc
+
+" Test for 'imcmdline' and 'imsearch'
+" This test doesn't actually test the input method functionality.
+func Test_cmdline_inputmethod()
+  new
+  call setline(1, ['', 'abc', ''])
+  set imcmdline
+
+  call feedkeys(":\"abc\<CR>", 'xt')
+  call assert_equal("\"abc", @:)
+  call feedkeys(":\"\<C-^>abc\<C-^>\<CR>", 'xt')
+  call assert_equal("\"abc", @:)
+  call feedkeys("/abc\<CR>", 'xt')
+  call assert_equal([2, 1], [line('.'), col('.')])
+  call feedkeys("/\<C-^>abc\<C-^>\<CR>", 'xt')
+  call assert_equal([2, 1], [line('.'), col('.')])
+
+  " set imsearch=2
+  call cursor(1, 1)
+  call feedkeys("/abc\<CR>", 'xt')
+  call assert_equal([2, 1], [line('.'), col('.')])
+  call cursor(1, 1)
+  call feedkeys("/\<C-^>abc\<C-^>\<CR>", 'xt')
+  call assert_equal([2, 1], [line('.'), col('.')])
+  set imdisable
+  call feedkeys("/\<C-^>abc\<C-^>\<CR>", 'xt')
+  call assert_equal([2, 1], [line('.'), col('.')])
+  set imdisable&
+  set imsearch&
+
+  set imcmdline&
+  %bwipe!
 endfunc
 
 " Test for normal mode commands not supported in the cmd window

--- a/src/nvim/testdir/test_digraph.vim
+++ b/src/nvim/testdir/test_digraph.vim
@@ -466,10 +466,12 @@ endfunc
 
 func Test_digraph_cmndline()
   " Create digraph on commandline
-  " This is a hack, to let Vim create the digraph in commandline mode
-  let s = ''
-  exe "sil! norm! :let s.='\<c-k>Eu'\<cr>"
-  call assert_equal("€", s)
+  call feedkeys(":\"\<c-k>Eu\<cr>", 'xt')
+  call assert_equal('"€', @:)
+
+  " Canceling a CTRL-K on the cmdline
+  call feedkeys(":\"a\<c-k>\<esc>b\<cr>", 'xt')
+  call assert_equal('"ab', @:)
 endfunc
 
 func Test_show_digraph()

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -286,7 +286,7 @@ func Test_edit_11()
   call cursor(2, 1)
   call feedkeys("i\<c-f>int c;\<esc>", 'tnix')
   call cursor(3, 1)
-  call feedkeys("i/* comment */", 'tnix')
+  call feedkeys("\<Insert>/* comment */", 'tnix')
   call assert_equal(['{', "\<tab>int c;", "/* comment */"], getline(1, '$'))
   " added changed cindentkeys slightly
   set cindent cinkeys+=*/
@@ -1651,6 +1651,39 @@ func Test_edit_noesckeys()
 
   bwipe!
   " set esckeys
+endfunc
+
+" Test for running an invalid ex command in insert mode using CTRL-O
+" Note that vim has a hard-coded sleep of 3 seconds. So this test will take
+" more than 3 seconds to complete.
+func Test_edit_ctrl_o_invalid_cmd()
+  new
+  set showmode showcmd
+  let caught_e492 = 0
+  try
+    call feedkeys("i\<C-O>:invalid\<CR>abc\<Esc>", "xt")
+  catch /E492:/
+    let caught_e492 = 1
+  endtry
+  call assert_equal(1, caught_e492)
+  call assert_equal('abc', getline(1))
+  set showmode& showcmd&
+  close!
+endfunc
+
+" Test for inserting text at the beginning of a line
+func Test_insert_before_first_nonblank()
+  throw 'Skipped: Nvim does not support cpoptions flag "H"'
+  new
+  call setline(1, '    ')
+  normal! Ia
+  call assert_equal('    a', getline(1))
+  set cpo+=H
+  call setline(1, '    ')
+  normal! Ia
+  call assert_equal('   a ', getline(1))
+  set cpo-=H
+  close!
 endfunc
 
 " Test for editing a directory

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -151,6 +151,21 @@ func Test_Ex_append()
   close!
 endfunc
 
+" In Ex-mode, backslashes at the end of a command should be halved.
+func Test_Ex_echo_backslash()
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  " This test works only when the language is English
+  if v:lang != "C" && v:lang !~ '^[Ee]n'
+    return
+  endif
+  let bsl = '\\\\'
+  let bsl2 = '\\\'
+  call assert_fails('call feedkeys("Qecho " .. bsl .. "\nvisual\n", "xt")',
+        \ "E15: Invalid expression: \\\\")
+  call assert_fails('call feedkeys("Qecho " .. bsl2 .. "\nm\nvisual\n", "xt")',
+        \ "E15: Invalid expression: \\\nm")
+endfunc
+
 func Test_ex_mode_errors()
   " Not allowed to enter ex mode when text is locked
   au InsertCharPre <buffer> normal! gQ<CR>

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -141,6 +141,16 @@ func Test_Ex_escape_enter()
   call assert_equal("a\rb", l)
 endfunc
 
+" Test for :append! command in Ex mode
+func Test_Ex_append()
+  throw 'Skipped: Nvim only supports Vim Ex mode'
+  new
+  call setline(1, "\t   abc")
+  call feedkeys("Qappend!\npqr\nxyz\n.\nvisual\n", 'xt')
+  call assert_equal(["\t   abc", "\t   pqr", "\t   xyz"], getline(1, '$'))
+  close!
+endfunc
+
 func Test_ex_mode_errors()
   " Not allowed to enter ex mode when text is locked
   au InsertCharPre <buffer> normal! gQ<CR>

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -66,6 +66,10 @@ func Test_copy()
   1,3copy 2
   call assert_equal(['L1', 'L2', 'L1', 'L2', 'L3', 'L3', 'L4'], getline(1, 7))
 
+  " Specifying a count before using : to run an ex-command
+  exe "normal! gg4:yank\<CR>"
+  call assert_equal("L1\nL2\nL1\nL2\n", @")
+
   close!
 endfunc
 

--- a/src/nvim/testdir/test_history.vim
+++ b/src/nvim/testdir/test_history.vim
@@ -114,6 +114,7 @@ function Test_Search_history_window()
   bwipe!
 endfunc
 
+" Test for :history command option completion
 function Test_history_completion()
   call feedkeys(":history \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"history / : = > ? @ all cmd debug expr input search', @:)
@@ -122,8 +123,9 @@ endfunc
 " Test for increasing the 'history' option value
 func Test_history_size()
   let save_histsz = &history
-  call histdel(':')
   set history=10
+  call histadd(':', 'ls')
+  call histdel(':')
   for i in range(1, 5)
     call histadd(':', 'cmd' .. i)
   endfor
@@ -173,6 +175,13 @@ func Test_history_search()
   call assert_equal(['pat2', 'pat1', ''], g:pat)
   cunmap <F2>
   delfunc SavePat
+
+  " Recall patterns with 'history' set to 0
+  set history=0
+  let @/ = 'abc'
+  let cmd = 'call feedkeys("/\<Up>\<Down>\<S-Up>\<S-Down>\<CR>", "xt")'
+  call assert_fails(cmd, 'E486:')
+  set history&
 endfunc
 
 " Test for making sure the key value is not stored in history

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -776,6 +776,14 @@ func Test_increment_empty_line()
   call setline(1, ['0', '0', '0', '0', '0', '0', ''])
   exe "normal Gvgg\<C-A>"
   call assert_equal(['1', '1', '1', '1', '1', '1', ''], getline(1, 7))
+
+  " Ctrl-A/Ctrl-X should do nothing in operator pending mode
+  %d
+  call setline(1, 'one two')
+  exe "normal! c\<C-A>l"
+  exe "normal! c\<C-X>l"
+  call assert_equal('one two', getline(1))
+
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -215,6 +215,7 @@ func Test_mark_error()
   call assert_fails('mark', 'E471:')
   call assert_fails('mark xx', 'E488:')
   call assert_fails('mark _', 'E191:')
+  call assert_beeps('normal! m~')
 endfunc
 
 " Test for :lockmarks when pasting content
@@ -239,6 +240,29 @@ func Test_marks_k_cmd()
   1,3kr
   call assert_equal([0, 3, 1, 0], getpos("'r"))
   close!
+endfunc
+
+" Test for file marks (A-Z)
+func Test_file_mark()
+  new Xone
+  call setline(1, ['aaa', 'bbb'])
+  norm! G$mB
+  w!
+  new Xtwo
+  call setline(1, ['ccc', 'ddd'])
+  norm! GmD
+  w!
+
+  enew
+  normal! `B
+  call assert_equal('Xone', bufname())
+  call assert_equal([2, 3], [line('.'), col('.')])
+  normal! 'D
+  call assert_equal('Xtwo', bufname())
+  call assert_equal([2, 1], [line('.'), col('.')])
+
+  call delete('Xone')
+  call delete('Xtwo')
 endfunc
 
 " Test for the getmarklist() function

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -53,7 +53,7 @@ func OpfuncDummy(type, ...)
   let g:bufnr=bufnr('%')
 endfunc
 
-fun! Test_normal00_optrans()
+func Test_normal00_optrans()
   new
   call append(0, ['1 This is a simple test: abcd', '2 This is the second line', '3 this is the third line'])
   1
@@ -95,6 +95,12 @@ func Test_normal01_keymodel()
   50
   call feedkeys("\<S-Up>y", 'tx')
   call assert_equal(['49', '5'], getreg(0, 0, 1))
+  " Use the different Shift special keys
+  50
+  call feedkeys("\<S-Right>\<S-Left>\<S-Up>\<S-Down>\<S-Home>\<S-End>y", 'tx')
+  call assert_equal(['50'], getline("'<", "'>"))
+  call assert_equal(['50', ''], getreg(0, 0, 1))
+
   " Do not start visual mode when keymodel=
   set keymodel=
   50
@@ -486,8 +492,8 @@ func Test_normal11_showcmd()
   bw!
 endfunc
 
+" Test for nv_error and normal command errors
 func Test_normal12_nv_error()
-  " Test for nv_error
   10new
   call setline(1, range(1,5))
   " should not do anything, just beep
@@ -497,6 +503,22 @@ func Test_normal12_nv_error()
   call assert_beeps("normal! g\<C-A>")
   call assert_beeps("normal! g\<C-X>")
   call assert_beeps("normal! g\<C-B>")
+  " call assert_beeps("normal! vQ\<Esc>")
+  call assert_beeps("normal! 2[[")
+  call assert_beeps("normal! 2]]")
+  call assert_beeps("normal! 2[]")
+  call assert_beeps("normal! 2][")
+  call assert_beeps("normal! 4[z")
+  call assert_beeps("normal! 4]z")
+  call assert_beeps("normal! 4[c")
+  call assert_beeps("normal! 4]c")
+  call assert_beeps("normal! 200%")
+  call assert_beeps("normal! %")
+  call assert_beeps("normal! 2{")
+  call assert_beeps("normal! 2}")
+  call assert_beeps("normal! r\<Right>")
+  call assert_beeps("normal! 8ry")
+  call assert_beeps('normal! "@')
   bw!
 endfunc
 
@@ -658,6 +680,13 @@ func Test_normal16_z_scroll_hor()
   $put =lineB
   1d
 
+  " Test for zl and zh with a count
+  norm! 0z10l
+  call assert_equal([11, 1], [col('.'), wincol()])
+  norm! z4h
+  call assert_equal([11, 5], [col('.'), wincol()])
+  normal! 2gg
+
   " Test for zl
   1
   norm! 5zl
@@ -780,6 +809,27 @@ func Test_normal17_z_scroll_hor2()
   bw!
 endfunc
 
+" Test for H, M and L commands with folds
+func Test_scroll_cmds()
+  15new
+  call setline(1, range(1, 100))
+  exe "normal! 30ggz\<CR>"
+  set foldenable
+  33,36fold
+  40,43fold
+  46,49fold
+  let h = winheight(0)
+  " Top of the screen = 30
+  " Folded lines = 9
+  " Bottom of the screen = 30 + h + 9 - 1
+  normal! 4L
+  call assert_equal(35 + h, line('.'))
+  normal! 4H
+  call assert_equal(33, line('.'))
+  set foldenable&
+  close!
+endfunc
+
 func Test_normal18_z_fold()
   " basic tests for foldopen/folddelete
   if !has("folding")
@@ -788,6 +838,9 @@ func Test_normal18_z_fold()
   call Setup_NewWindow()
   50
   setl foldenable fdm=marker foldlevel=5
+
+  call assert_beeps('normal! zj')
+  call assert_beeps('normal! zk')
 
   " Test for zF
   " First fold
@@ -1221,6 +1274,9 @@ func Test_normal22_zet()
   let a = readfile('Xfile_Test_normal22_zet')
   call assert_equal(['1', '2'], a)
 
+  " Unsupported Z command
+  call assert_beeps('normal! ZW')
+
   " Nvim: This sometimes hangs the TSAN build.
   " for file in ['Xfile_Test_normal22_zet']
   "   call delete(file)
@@ -1288,6 +1344,15 @@ func Test_normal23_K()
   else
     call assert_match("man --pager=cat 'man'", a)
   endif
+
+  " Error cases
+  call setline(1, '#$#')
+  call assert_fails('normal! ggK', 'E349:')
+  call setline(1, '---')
+  call assert_fails('normal! ggv2lK', 'E349:')
+  call setline(1, ['abc', 'xyz'])
+  call assert_fails("normal! gg2lv2h\<C-]>", 'E426:')
+  call assert_beeps("normal! ggVjK")
 
   " clean up
   let &keywordprg = k
@@ -1499,12 +1564,27 @@ func Test_normal28_parenthesis()
   norm! $d(
   call assert_equal(['With some sentences!', '', ' ', '', 'This is a long sentence', ''], getline(1, '$'))
 
+  " It is an error if a next sentence is not found
+  %d
+  call setline(1, '.SH')
+  call assert_beeps('normal )')
+
+  " Jumping to a fold should open the fold
+  call setline(1, ['', '', 'one', 'two', 'three'])
+  set foldenable
+  2,$fold
+  call feedkeys(')', 'xt')
+  call assert_equal(3, line('.'))
+  call assert_equal(1, foldlevel('.'))
+  call assert_equal(-1, foldclosed('.'))
+  set foldenable&
+
   " clean up
   bw!
 endfunc
 
-fun! Test_normal29_brace()
-  " basic test for { and } movements
+" Test for { and } paragraph movements
+func Test_normal29_brace()
   let text =<< trim [DATA]
     A paragraph begins after each empty line, and also at each of a set of
     paragraph macros, specified by the pairs of characters in the 'paragraphs'
@@ -1657,12 +1737,24 @@ fun! Test_normal29_brace()
   " [DATA]
   " call assert_equal(expected, getline(1, '$'))
 
+  " Jumping to a fold should open the fold
+  " %d
+  " call setline(1, ['', 'one', 'two', ''])
+  " set foldenable
+  " 2,$fold
+  " call feedkeys('}', 'xt')
+  " call assert_equal(4, line('.'))
+  " call assert_equal(1, foldlevel('.'))
+  " call assert_equal(-1, foldclosed('.'))
+  " set foldenable&
+
   " clean up
   set cpo-={
   bw!
 endfunc
 
-fun! Test_normal30_changecase()
+" Test for ~ command
+func Test_normal30_changecase()
   new
   call append(0, 'This is a simple test: äüöß')
   norm! 1ggVu
@@ -1682,8 +1774,23 @@ fun! Test_normal30_changecase()
   norm! V~
   call assert_equal('THIS IS A simple test: äüöss', getline('.'))
 
-  " Turkish ASCII turns to multi-byte.  On some systems Turkish locale
-  " is available but toupper()/tolower() don't do the right thing.
+  " Test for changing case across lines using 'whichwrap'
+  call setline(1, ['aaaaaa', 'aaaaaa'])
+  normal! gg10~
+  call assert_equal(['AAAAAA', 'aaaaaa'], getline(1, 2))
+  set whichwrap+=~
+  normal! gg10~
+  call assert_equal(['aaaaaa', 'AAAAaa'], getline(1, 2))
+  set whichwrap&
+
+  " clean up
+  bw!
+endfunc
+
+" Turkish ASCII turns to multi-byte.  On some systems Turkish locale
+" is available but toupper()/tolower() don't do the right thing.
+func Test_normal_changecase_turkish()
+  new
   try
     lang tr_TR.UTF-8
     set casemap=
@@ -1727,21 +1834,11 @@ fun! Test_normal30_changecase()
     " can't use Turkish locale
     throw 'Skipped: Turkish locale not available'
   endtry
-
-  call setline(1, ['aaaaaa', 'aaaaaa'])
-  normal! gg10~
-  call assert_equal(['AAAAAA', 'aaaaaa'], getline(1, 2))
-  set whichwrap+=~
-  normal! gg10~
-  call assert_equal(['aaaaaa', 'AAAAaa'], getline(1, 2))
-  set whichwrap&
-
-  " clean up
-  bw!
+  close!
 endfunc
 
-fun! Test_normal31_r_cmd()
-  " Test for r command
+" Test for r (replace) command
+func Test_normal31_r_cmd()
   new
   call append(0, 'This is a simple test: abcd')
   exe "norm! 1gg$r\<cr>"
@@ -1759,6 +1856,22 @@ fun! Test_normal31_r_cmd()
   call setline(1, 'This is a')
   exe "norm! 1gg05rf"
   call assert_equal('fffffis a', getline(1))
+
+  " When replacing characters, copy characters from above and below lines
+  " using CTRL-Y and CTRL-E.
+  " Different code paths are used for utf-8 and latin1 encodings
+  set showmatch
+  for enc in ['latin1', 'utf-8']
+    enew!
+    let &encoding = enc
+    call setline(1, [' {a}', 'xxxxxxxxxx', '      [b]'])
+    exe "norm! 2gg5r\<C-Y>l5r\<C-E>"
+    call assert_equal(' {a}x [b]x', getline(2))
+  endfor
+  set showmatch&
+
+  " r command should fail in operator pending mode
+  call assert_beeps('normal! cr')
 
   " clean up
   set noautoindent
@@ -1783,7 +1896,7 @@ endfunc
 
 " Test for g`, g;, g,, g&, gv, gk, gj, gJ, g0, g^, g_, gm, g$, gM, g CTRL-G,
 " gi and gI commands
-fun! Test_normal33_g_cmd2()
+func Test_normal33_g_cmd2()
   if !has("jumplist")
     return
   endif
@@ -1831,6 +1944,16 @@ fun! Test_normal33_g_cmd2()
   exe "norm! /[1-8]\<cr>"
   norm! g&
   call assert_equal(['11', '22', '33', '44', '55', '66', '77', '88', '9', '110', 'a', 'b', 'c', 'dd'], getline(1, '$'))
+
+  " Jumping to a fold using gg should open the fold
+  set foldenable
+  set foldopen+=jump
+  5,8fold
+  call feedkeys('6gg', 'xt')
+  call assert_equal(1, foldlevel('.'))
+  call assert_equal(-1, foldclosed('.'))
+  set foldopen-=jump
+  set foldenable&
 
   " Test for gv
   %d
@@ -1975,6 +2098,10 @@ fun! Test_normal33_g_cmd2()
   call assert_equal('foo       first line', getline(1))
   set virtualedit&
 
+  " Test for aboring a g command using CTRL-\ CTRL-G
+  exe "normal! g\<C-\>\<C-G>"
+  call assert_equal('foo       first line', getline('.'))
+
   " clean up
   bw!
 endfunc
@@ -1994,6 +2121,10 @@ func Test_g_ctrl_g()
 
   let a = execute(":norm! g\<c-g>")
   call assert_equal("\n--No lines in buffer--", a)
+
+  " Test for CTRL-G (same as :file)
+  let a = execute(":norm! \<c-g>")
+  call assert_equal("\n\n\"[No Name]\" --No lines in buffer--", a)
 
   call setline(1, ['first line', 'second line'])
 
@@ -2063,7 +2194,7 @@ func Test_g_ctrl_g()
 endfunc
 
 " Test for g8
-fun! Test_normal34_g_cmd3()
+func Test_normal34_g_cmd3()
   new
   let a=execute(':norm! 1G0g8')
   call assert_equal("\nNUL", a)
@@ -2113,7 +2244,7 @@ func Test_normal_8g8()
 endfunc
 
 " Test for g<
-fun! Test_normal35_g_cmd4()
+func Test_normal35_g_cmd4()
   " Cannot capture its output,
   " probably a bug, therefore, test disabled:
   throw "Skipped: output of g< can't be tested currently"
@@ -2123,7 +2254,7 @@ fun! Test_normal35_g_cmd4()
 endfunc
 
 " Test for gp gP go
-fun! Test_normal36_g_cmd5()
+func Test_normal36_g_cmd5()
   new
   call append(0, 'abcdefghijklmnopqrstuvwxyz')
   set ff=unix
@@ -2162,7 +2293,7 @@ fun! Test_normal36_g_cmd5()
 endfunc
 
 " Test for gt and gT
-fun! Test_normal37_g_cmd6()
+func Test_normal37_g_cmd6()
   tabnew 1.txt
   tabnew 2.txt
   tabnew 3.txt
@@ -2189,7 +2320,7 @@ fun! Test_normal37_g_cmd6()
 endfunc
 
 " Test for <Home> and <C-Home> key
-fun! Test_normal38_nvhome()
+func Test_normal38_nvhome()
   new
   call setline(1, range(10))
   $
@@ -2211,8 +2342,21 @@ fun! Test_normal38_nvhome()
   bw!
 endfunc
 
+" Test for <End> and <C-End> keys
+func Test_normal_nvend()
+  new
+  call setline(1, map(range(1, 10), '"line" .. v:val'))
+  exe "normal! \<End>"
+  call assert_equal(5, col('.'))
+  exe "normal! 4\<End>"
+  call assert_equal([4, 5], [line('.'), col('.')])
+  exe "normal! \<C-End>"
+  call assert_equal([10, 6], [line('.'), col('.')])
+  close!
+endfunc
+
 " Test for cw cW ce
-fun! Test_normal39_cw()
+func Test_normal39_cw()
   " Test for cw and cW on whitespace
   " and cpo+=w setting
   new
@@ -2253,7 +2397,7 @@ fun! Test_normal39_cw()
 endfunc
 
 " Test for CTRL-\ commands
-fun! Test_normal40_ctrl_bsl()
+func Test_normal40_ctrl_bsl()
   new
   call append(0, 'here      are   some words')
   exe "norm! 1gg0a\<C-\>\<C-N>"
@@ -2271,14 +2415,19 @@ fun! Test_normal40_ctrl_bsl()
   exe ":norm! \<c-\>\<c-n>dw"
   " set noim
   call assert_equal('are   some words', getline(1))
-  " call assert_false(&insertmode)
+  call assert_false(&insertmode)
+  call assert_beeps("normal! \<C-\>\<C-A>")
+
+  " Using CTRL-\ CTRL-N in cmd window should close the window
+  call feedkeys("q:\<C-\>\<C-N>", 'xt')
+  call assert_equal('', getcmdwintype())
 
   " clean up
   bw!
 endfunc
 
 " Test for <c-r>=, <c-r><c-r>= and <c-r><c-o>= in insert mode
-fun! Test_normal41_insert_reg()
+func Test_normal41_insert_reg()
   new
   set sts=2 sw=2 ts=8 tw=0
   call append(0, ["aaa\tbbb\tccc", '', '', ''])
@@ -2334,7 +2483,7 @@ func Test_normal42_halfpage()
 endfunc
 
 " Tests for text object aw
-fun! Test_normal43_textobject1()
+func Test_normal43_textobject1()
   new
   call append(0, ['foobar,eins,foobar', 'foo,zwei,foo    '])
   " diw
@@ -2567,6 +2716,8 @@ func Test_normal52_rl()
   call assert_equal(19, col('.'))
   call feedkeys("\<right>", 'tx')
   call assert_equal(18, col('.'))
+  call feedkeys("\<left>", 'tx')
+  call assert_equal(19, col('.'))
   call feedkeys("\<s-right>", 'tx')
   call assert_equal(13, col('.'))
   call feedkeys("\<c-right>", 'tx')
@@ -2690,6 +2841,8 @@ func Test_changelist()
   normal g;
   call assert_equal([2, 2], [line('.'), col('.')])
   call assert_fails('normal g;', 'E662:')
+  new
+  call assert_fails('normal g;', 'E664:')
   %bwipe!
   let &ul = save_ul
 endfunc
@@ -2736,6 +2889,10 @@ endfunc
 " Jumping to beginning and end of methods in Java-like languages
 func Test_java_motion()
   new
+  call assert_beeps('normal! [m')
+  call assert_beeps('normal! ]m')
+  call assert_beeps('normal! [M')
+  call assert_beeps('normal! ]M')
   a
 Piece of Java
 {
@@ -2810,7 +2967,7 @@ Piece of Java
   close!
 endfunc
 
-fun! Test_normal_gdollar_cmd()
+func Test_normal_gdollar_cmd()
   if !has("jumplist")
     return
   endif
@@ -2975,12 +3132,28 @@ func Test_wincmd_with_count()
 endfunc
 
 " Test for 'b', 'B' 'ge' and 'gE' commands
-func Test_backward_motion()
+func Test_horiz_motion()
+  new
   normal! gg
   call assert_beeps('normal! b')
   call assert_beeps('normal! B')
   call assert_beeps('normal! gE')
   call assert_beeps('normal! ge')
+  " <S-Backspace> moves one word left and <C-Backspace> moves one WORD left
+  call setline(1, 'one ,two ,three')
+  exe "normal! $\<S-BS>"
+  call assert_equal(11, col('.'))
+  exe "normal! $\<C-BS>"
+  call assert_equal(10, col('.'))
+  close!
+endfunc
+
+" Test for using a : command in operator pending mode
+func Test_normal_colon_op()
+  new
+  call setline(1, ['one', 'two'])
+  call assert_beeps("normal! Gc:d\<CR>")
+  close!
 endfunc
 
 " Some commands like yy, cc, dd, >>, << and !! accept a count after

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -114,6 +114,16 @@ func Test_put_p_indent_visual()
   bwipe!
 endfunc
 
+" Test for deleting all the contents of a buffer with a put
+func Test_put_visual_delete_all_lines()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  let @r = ''
+  normal! VG"rgp
+  call assert_equal(1, line('$'))
+  close!
+endfunc
+
 func Test_gp_with_count_leaves_cursor_at_end()
   new
   call setline(1, '<---->')

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -425,6 +425,9 @@ func Test_execute_register()
   @q
   @
   call assert_equal(3, i)
+
+  " cannot execute a register in operator pending mode
+  call assert_beeps('normal! c@r')
 endfunc
 
 " Test for getting register info

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -1304,6 +1304,37 @@ func Test_define_search()
   bwipe!
 endfunc
 
+" Test for [*, [/, ]* and ]/
+func Test_comment_search()
+  new
+  call setline(1, ['', '/*', ' *', ' *', ' */'])
+  normal! 4gg[/
+  call assert_equal([2, 1], [line('.'), col('.')])
+  normal! 3gg[*
+  call assert_equal([2, 1], [line('.'), col('.')])
+  normal! 3gg]/
+  call assert_equal([5, 3], [line('.'), col('.')])
+  normal! 3gg]*
+  call assert_equal([5, 3], [line('.'), col('.')])
+  %d
+  call setline(1, ['', '/*', ' *', ' *'])
+  call assert_beeps('normal! 3gg]/')
+  %d
+  call setline(1, ['', ' *', ' *', ' */'])
+  call assert_beeps('normal! 4gg[/')
+  %d
+  call setline(1, '        /* comment */')
+  normal! 15|[/
+  call assert_equal(9, col('.'))
+  normal! 15|]/
+  call assert_equal(21, col('.'))
+  call setline(1, '         comment */')
+  call assert_beeps('normal! 15|[/')
+  call setline(1, '        /* comment')
+  call assert_beeps('normal! 15|]/')
+  close!
+endfunc
+
 " Test for the 'taglength' option
 func Test_tag_length()
   set tags=Xtags

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1169,8 +1169,8 @@ func Test_exclusive_selection()
   close!
 endfunc
 
-" Test for starting visual mode with a count
-" This test should be run withou any previous visual modes. So this should be
+" Test for starting visual mode with a count.
+" This test should be run without any previous visual modes. So this should be
 " run as a first test.
 func Test_AAA_start_visual_mode_with_count()
   new


### PR DESCRIPTION
#### vim-patch:8.2.0342: some code in ex_getln.c not covered by tests

Problem:    Some code in ex_getln.c not covered by tests.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5717)
https://github.com/vim/vim/commit/0546d7df13b041833121b2d56036e1c62ea3b0c1

Nvim doesn't support imsearch=2, commenting out that line is enough.
Test_Ex_append() is not applicable to Vim enhanced Ex mode.
Omit test_iminsert.vim as previous patches to that file are N/A.


#### vim-patch:8.2.0347: various code not covered by tests

Problem:    Various code not covered by tests.
Solution:   Add more test coverage. (Yegappan Lakshmanan, closes vim/vim#5720)
https://github.com/vim/vim/commit/91ffc8a5f5c7b1c6979b3352a12ed779d11173a9

Test_Ex_echo_backslash() is not applicable to Vim enhanced Ex mode.


#### vim-patch:8.2.0369: various Normal mode commands not fully tested

Problem:    Various Normal mode commands not fully tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5751)
https://github.com/vim/vim/commit/1671f4488105ee12a6a8558ae351436c26ab55fc

Cherry-pick a fix from patch 8.2.3162.
Omit test_iminsert.vim as previous patches to that file are N/A, and
Nvim doesn't support iminsert=2 either, so that test isn't useful.
