### PR TITLE
feat(eval)!: input() support any type for "cancelreturn" in a dict

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -350,7 +350,8 @@ Commands:
 Functions:
   |input()| and |inputdialog()| support for each other’s features (return on
   cancel and completion respectively) via dictionary argument (replaces all
-  other arguments if used).
+  other arguments if used), and "cancelreturn" can have any type if passed in
+  a dictionary.
   |input()| and |inputdialog()| support user-defined cmdline highlighting.
 
 Highlight groups:

--- a/test/functional/vimscript/input_spec.lua
+++ b/test/functional/vimscript/input_spec.lua
@@ -9,6 +9,7 @@ local source = helpers.source
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local nvim_async = helpers.nvim_async
+local NIL = helpers.NIL
 
 local screen
 
@@ -200,6 +201,15 @@ describe('input()', function()
     feed(':let var = input({"cancelreturn": "BAR"})<CR>')
     feed('<Esc>')
     eq('BAR', meths.get_var('var'))
+    feed(':let var = input({"cancelreturn": []})<CR>')
+    feed('<Esc>')
+    eq({}, meths.get_var('var'))
+    feed(':let var = input({"cancelreturn": v:false})<CR>')
+    feed('<Esc>')
+    eq(false, meths.get_var('var'))
+    feed(':let var = input({"cancelreturn": v:null})<CR>')
+    feed('<Esc>')
+    eq(NIL, meths.get_var('var'))
   end)
   it('supports default string', function()
     feed(':let var = input("", "DEF1")<CR>')
@@ -219,8 +229,6 @@ describe('input()', function()
        exc_exec('call input("", "", [])'))
     eq('Vim(call):E730: using List as a String',
        exc_exec('call input({"prompt": []})'))
-    eq('Vim(call):E730: using List as a String',
-       exc_exec('call input({"cancelreturn": []})'))
     eq('Vim(call):E730: using List as a String',
        exc_exec('call input({"default": []})'))
     eq('Vim(call):E730: using List as a String',
@@ -417,8 +425,6 @@ describe('inputdialog()', function()
        exc_exec('call inputdialog("", "", [])'))
     eq('Vim(call):E730: using List as a String',
        exc_exec('call inputdialog({"prompt": []})'))
-    eq('Vim(call):E730: using List as a String',
-       exc_exec('call inputdialog({"cancelreturn": []})'))
     eq('Vim(call):E730: using List as a String',
        exc_exec('call inputdialog({"default": []})'))
     eq('Vim(call):E730: using List as a String',


### PR DESCRIPTION
Close #19356

This does change behavior. `cancelreturn` is no longer converted to a string if it is passed as a number or boolean or `v:null` in a dictionary, so this may be considered a breaking change.
