### PR TITLE
feat(defaults): nnoremap & :&&<CR>

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -633,6 +633,9 @@ Directory for temporary files is created in the first possible directory of:
 			actually work differently.  You can use `:&&` to keep
 			the flags.
 
+								*&-default*
+			Mapped to ":&&<CR>" by default. |default-mappings|
+
 								*g&*
 g&			Synonym for `:%s//~/&` (repeat last substitute with
 			last search pattern on all lines with the same flags).

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -89,6 +89,7 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 	inoremap <C-W> <C-G>u<C-W>
 	xnoremap * y/\V<C-R>"<CR>
 	xnoremap # y?\V<C-R>"<CR>
+	nnoremap & :&&<CR>
 <
 Default Autocommands ~
 							*default-autocmds*

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2125,6 +2125,7 @@ void init_default_mappings(void)
   add_map("<C-W>", "<C-G>u<C-W>", MODE_INSERT, false);
   add_map("*", "y/\\\\V<C-R>\"<CR>", MODE_VISUAL, false);
   add_map("#", "y?\\\\V<C-R>\"<CR>", MODE_VISUAL, false);
+  add_map("&", ":&&<CR>", MODE_NORMAL, false);
 }
 
 /// Add a mapping. Unlike @ref do_map this copies the string arguments, so

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2125,6 +2125,9 @@ void init_default_mappings(void)
   add_map("<C-W>", "<C-G>u<C-W>", MODE_INSERT, false);
   add_map("*", "y/\\\\V<C-R>\"<CR>", MODE_VISUAL, false);
   add_map("#", "y?\\\\V<C-R>\"<CR>", MODE_VISUAL, false);
+
+  // Use : instead of <Cmd> so that ranges are supported (e.g. 3& repeats the substitution on the
+  // next 3 lines)
   add_map("&", ":&&<CR>", MODE_NORMAL, false);
 }
 


### PR DESCRIPTION
Ref #19354

Note that I intentionally used `:` instead of `<Cmd>` so that `&` can be used with ranges (e.g. `3&` to repeat the substitute on the next 3 lines).
