### PR TITLE
Generate empty file on missing git executable

### DIFF
--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -8,6 +8,7 @@ endif()
 find_program(GIT_EXECUTABLE git)
 if(NOT GIT_EXECUTABLE)
   message(AUTHOR_WARNING "Skipping version-string generation (cannot find git)")
+  file(WRITE "${OUTPUT}" "")
   return()
 endif()
 


### PR DESCRIPTION
On commit https://github.com/neovim/neovim/commit/912dbbdd77f382d90e4d8ef8ffa483037248b83a there is a new method to generate version file from git. But when git not found, then the file is not generated and get error because this https://github.com/neovim/neovim/blob/001f19de2880192006eda139aa07c62a7f481422/src/nvim/CMakeLists.txt#L271