### PR TITLE
vim-patch:9.0.{0051,

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1004,6 +1004,8 @@ static int command_line_check(VimState *state)
                            // that occurs while typing a command should
                            // cause the command not to be executed.
 
+  got_int = false;         // avoid infinite Ctrl-C loop in Ex mode
+
   cursorcmd();             // set the cursor on the right spot
   ui_cursor_shape();
   return 1;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3905,12 +3905,12 @@ static wordnode_T *wordtree_alloc(spellinfo_T *spin)
 
 /// Return true if "word" contains valid word characters.
 /// Control characters and trailing '/' are invalid.  Space is OK.
-static bool valid_spell_word(const char_u *word)
+static bool valid_spell_word(const char_u *word, const char_u *end)
 {
-  if (!utf_valid_string(word, NULL)) {
+  if (!utf_valid_string(word, end)) {
     return false;
   }
-  for (const char_u *p = word; *p != NUL; p += utfc_ptr2len((const char *)p)) {
+  for (const char_u *p = word; *p != NUL && p < end; p += utfc_ptr2len((const char *)p)) {
     if (*p < ' ' || (p[0] == '/' && p[1] == NUL)) {
       return false;
     }
@@ -3939,7 +3939,7 @@ static int store_word(spellinfo_T *spin, char_u *word, int flags, int region, co
   int res = OK;
 
   // Avoid adding illegal bytes to the word tree.
-  if (!valid_spell_word(word)) {
+  if (!valid_spell_word(word, word + len)) {
     return FAIL;
   }
 
@@ -5536,7 +5536,7 @@ void spell_add_word(char_u *word, int len, SpellAddType what, int idx, bool undo
   int i;
   char_u *spf;
 
-  if (!valid_spell_word(word)) {
+  if (!valid_spell_word(word, word + len)) {
     emsg(_(e_illegal_character_in_word));
     return;
   }

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -135,6 +135,29 @@ func Test_Ex_global()
   bwipe!
 endfunc
 
+" Test for pressing Ctrl-C in :append inside a loop in Ex mode
+" This used to hang Vim
+func Test_Ex_append_in_loop()
+  CheckRunVimInTerminal
+  let buf = RunVimInTerminal('', {'rows': 6})
+
+  call term_sendkeys(buf, "gQ")
+  call term_sendkeys(buf, "for i in range(1)\<CR>")
+  call term_sendkeys(buf, "append\<CR>")
+  call WaitForAssert({-> assert_match(':  append', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, "\<C-C>")
+  call term_wait(buf)
+  call term_sendkeys(buf, "foo\<CR>")
+  call WaitForAssert({-> assert_match('foo', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, ".\<CR>")
+  call WaitForAssert({-> assert_match('.', term_getline(buf, 5))}, 1000)
+  call term_sendkeys(buf, "endfor\<CR>")
+  call term_sendkeys(buf, "vi\<CR>")
+  call WaitForAssert({-> assert_match('foo', term_getline(buf, 1))}, 1000)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " In Ex-mode, a backslash escapes a newline
 func Test_Ex_escape_enter()
   call feedkeys("gQlet l = \"a\\\<kEnter>b\"\<cr>vi\<cr>", 'xt')

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -827,6 +827,16 @@ func Test_spell_good_word_invalid()
   bwipe!
 endfunc
 
+func Test_spell_good_word_slash()
+  " This caused E1280.
+  new
+  norm afoo /
+  1
+  norm zG
+
+  bwipe!
+endfunc
+
 func LoadAffAndDic(aff_contents, dic_contents)
   throw 'skipped: Nvim does not support enc=latin1'
   set enc=latin1

--- a/test/functional/legacy/ex_mode_spec.lua
+++ b/test/functional/legacy/ex_mode_spec.lua
@@ -6,6 +6,7 @@ local eq = helpers.eq
 local eval = helpers.eval
 local feed = helpers.feed
 local meths = helpers.meths
+local sleep = helpers.sleep
 
 before_each(clear)
 
@@ -119,6 +120,56 @@ describe('Ex mode', function()
       {1:  3 }^foo foo                                                 |
       {2:~                                                           }|
       {2:~                                                           }|
+                                                                  |
+    ]])
+  end)
+
+  it('pressing Ctrl-C in :append inside a loop in Ex mode does not hang', function()
+    local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, reverse = true},  -- MsgSeparator
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    feed('gQ')
+    feed('for i in range(1)<CR>')
+    feed('append<CR>')
+    screen:expect([[
+      {0:                                                            }|
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :for i in range(1)                                          |
+                                                                  |
+      :  append                                                   |
+      ^                                                            |
+    ]])
+    feed('<C-C>')
+    sleep(10)  -- Wait for Ctrl-C to flush input
+    feed('foo<CR>')
+    screen:expect([[
+      Entering Ex mode.  Type "visual" to go to Normal mode.      |
+      :for i in range(1)                                          |
+                                                                  |
+      :  append                                                   |
+      foo                                                         |
+      ^                                                            |
+    ]])
+    feed('.<CR>')
+    screen:expect([[
+      :for i in range(1)                                          |
+                                                                  |
+      :  append                                                   |
+      foo                                                         |
+      .                                                           |
+      :  ^                                                         |
+    ]])
+    feed('endfor<CR>')
+    feed('vi<CR>')
+    screen:expect([[
+      ^foo                                                         |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
                                                                   |
     ]])
   end)


### PR DESCRIPTION
#### vim-patch:9.0.0051: using CTRL-C wih :append may hang Vim

Problem:    Using CTRL-C wih :append may hang Vim.
Solution:   Reset got_int. (closes vim/vim#10729)
https://github.com/vim/vim/commit/f754fe6a3d5384b5146c38a32db6da9d46e00c40