### PR TITLE
vim-patch:9.0.0052: "zG" may throw an error if invalid character follows

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3905,12 +3905,12 @@ static wordnode_T *wordtree_alloc(spellinfo_T *spin)
 
 /// Return true if "word" contains valid word characters.
 /// Control characters and trailing '/' are invalid.  Space is OK.
-static bool valid_spell_word(const char_u *word)
+static bool valid_spell_word(const char_u *word, const char_u *end)
 {
-  if (!utf_valid_string(word, NULL)) {
+  if (!utf_valid_string(word, end)) {
     return false;
   }
-  for (const char_u *p = word; *p != NUL; p += utfc_ptr2len((const char *)p)) {
+  for (const char_u *p = word; *p != NUL && p < end; p += utfc_ptr2len((const char *)p)) {
     if (*p < ' ' || (p[0] == '/' && p[1] == NUL)) {
       return false;
     }
@@ -3939,7 +3939,7 @@ static int store_word(spellinfo_T *spin, char_u *word, int flags, int region, co
   int res = OK;
 
   // Avoid adding illegal bytes to the word tree.
-  if (!valid_spell_word(word)) {
+  if (!valid_spell_word(word, word + len)) {
     return FAIL;
   }
 
@@ -5536,7 +5536,7 @@ void spell_add_word(char_u *word, int len, SpellAddType what, int idx, bool undo
   int i;
   char_u *spf;
 
-  if (!valid_spell_word(word)) {
+  if (!valid_spell_word(word, word + len)) {
     emsg(_(e_illegal_character_in_word));
     return;
   }

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -827,6 +827,16 @@ func Test_spell_good_word_invalid()
   bwipe!
 endfunc
 
+func Test_spell_good_word_slash()
+  " This caused E1280.
+  new
+  norm afoo /
+  1
+  norm zG
+
+  bwipe!
+endfunc
+
 func LoadAffAndDic(aff_contents, dic_contents)
   throw 'skipped: Nvim does not support enc=latin1'
   set enc=latin1


### PR DESCRIPTION
#### vim-patch:9.0.0052: "zG" may throw an error if invalid character follows

Problem:    "zG" may throw an error if invalid character follows.
Solution:   Pass the word length to valid_spell_word(). (Ken Takata,
            closes vim/vim#10737)
https://github.com/vim/vim/commit/2ebcc35826bc2deb04e5fc6d73332f55783e7f52