### PR TITLE
vim-patch:8.2.{0430,0482}: insufficient tests

### DIFF
--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -39,6 +39,8 @@ func Test_client_server()
   call remote_send(name, ":let testvar = 'yes'\<CR>")
   call WaitFor('remote_expr("' . name . '", "exists(\"testvar\") ? testvar : \"\"", "", 1) == "yes"')
   call assert_equal('yes', remote_expr(name, "testvar", "", 2))
+  call assert_fails("let x=remote_expr(name, '2+x')", 'E449:')
+  call assert_fails("let x=remote_expr('[], '2+2')", 'E116:')
 
   if has('unix') && has('gui') && !has('gui_running')
     " Running in a terminal and the GUI is available: Tell the server to open
@@ -75,6 +77,7 @@ func Test_client_server()
     eval 'MYSELF'->remote_startserver()
     " May get MYSELF1 when running the test again.
     call assert_match('MYSELF', v:servername)
+    call assert_fails("call remote_startserver('MYSELF')", 'E941:')
   endif
   let g:testvar = 'myself'
   call assert_equal('myself', remote_expr(v:servername, 'testvar'))
@@ -107,7 +110,12 @@ func Test_client_server()
       call job_stop(job, 'kill')
     endif
   endtry
+
+  call assert_fails("let x=remote_peek([])", 'E730:')
+  call assert_fails("let x=remote_read('vim10')", 'E277:')
 endfunc
 
 " Uncomment this line to get a debugging log
 " call ch_logfile('channellog', 'w')
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1652,20 +1652,6 @@ func Test_cmdline_inputmethod()
   %bwipe!
 endfunc
 
-" Test for opening the command-line window when too many windows are present
-func Test_cmdwin_fail_to_open()
-  " Open as many windows as possible
-  for i in range(100)
-    try
-      new
-    catch /E36:/
-      break
-    endtry
-  endfor
-  call assert_beeps('call feedkeys("q:\<CR>", "xt")')
-  only
-endfunc
-
 " Test for recursively getting multiple command line inputs
 func Test_cmdwin_multi_input()
   call feedkeys(":\<C-R>=input('P: ')\<CR>\"cyan\<CR>\<CR>", 'xt')

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1707,6 +1707,15 @@ func Test_cmdwin_blocked_commands()
   call assert_fails('call feedkeys("q:\<C-W>g\<CR>", "xt")', 'E11:')
 endfunc
 
+" Close the Cmd-line window in insert mode using CTRL-C
+func Test_cmdwin_insert_mode_close()
+  %bw!
+  let s = ''
+  exe "normal q:a\<C-C>let s='Hello'\<CR>"
+  call assert_equal('Hello', s)
+  call assert_equal(1, winnr('$'))
+endfunc
+
 " test that ";" works to find a match at the start of the first line
 func Test_zero_line_search()
   new

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1671,8 +1671,8 @@ func Test_edit_ctrl_o_invalid_cmd()
   close!
 endfunc
 
-" Test for inserting text at the beginning of a line
-func Test_insert_before_first_nonblank()
+" Test for inserting text in a line with only spaces ('H' flag in 'cpoptions')
+func Test_edit_cpo_H()
   throw 'Skipped: Nvim does not support cpoptions flag "H"'
   new
   call setline(1, '    ')
@@ -1684,6 +1684,25 @@ func Test_insert_before_first_nonblank()
   call assert_equal('   a ', getline(1))
   set cpo-=H
   close!
+endfunc
+
+" Test for inserting tab in virtual replace mode ('L' flag in 'cpoptions')
+func Test_edit_cpo_L()
+  new
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>ijklmnopqr", getline(1))
+  set cpo+=L
+  set list
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>cdefghijklmnopqr", getline(1))
+  set nolist
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>ijklmnopqr", getline(1))
+  set cpo-=L
+  %bw!
 endfunc
 
 " Test for editing a directory

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -547,6 +547,71 @@ func Test_excmd_delete()
   close!
 endfunc
 
+" Test for commands that are blocked in a sandbox
+func Sandbox_tests()
+  call assert_fails("call histadd(':', 'ls')", 'E48:')
+  call assert_fails("call mkdir('Xdir')", 'E48:')
+  call assert_fails("call rename('a', 'b')", 'E48:')
+  call assert_fails("call setbufvar(1, 'myvar', 1)", 'E48:')
+  call assert_fails("call settabvar(1, 'myvar', 1)", 'E48:')
+  call assert_fails("call settabwinvar(1, 1, 'myvar', 1)", 'E48:')
+  call assert_fails("call setwinvar(1, 'myvar', 1)", 'E48:')
+  call assert_fails("call timer_start(100, '')", 'E48:')
+  if has('channel')
+    call assert_fails("call prompt_setcallback(1, '')", 'E48:')
+    call assert_fails("call prompt_setinterrupt(1, '')", 'E48:')
+    call assert_fails("call prompt_setprompt(1, '')", 'E48:')
+  endif
+  call assert_fails("let $TESTVAR=1", 'E48:')
+  call assert_fails("call feedkeys('ivim')", 'E48:')
+  call assert_fails("source! Xfile", 'E48:')
+  call assert_fails("call delete('Xfile')", 'E48:')
+  call assert_fails("call writefile([], 'Xfile')", 'E48:')
+  call assert_fails('!ls', 'E48:')
+  " call assert_fails('shell', 'E48:')
+  call assert_fails('stop', 'E48:')
+  call assert_fails('exe "normal \<C-Z>"', 'E48:')
+  " set insertmode
+  " call assert_fails('call feedkeys("\<C-Z>", "xt")', 'E48:')
+  " set insertmode&
+  call assert_fails('suspend', 'E48:')
+  call assert_fails('call system("ls")', 'E48:')
+  call assert_fails('call systemlist("ls")', 'E48:')
+  if has('clientserver')
+    call assert_fails('let s=remote_expr("gvim", "2+2")', 'E48:')
+    if !has('win32')
+      " remote_foreground() doesn't thrown an error message on MS-Windows
+      call assert_fails('call remote_foreground("gvim")', 'E48:')
+    endif
+    call assert_fails('let s=remote_peek("gvim")', 'E48:')
+    call assert_fails('let s=remote_read("gvim")', 'E48:')
+    call assert_fails('let s=remote_send("gvim", "abc")', 'E48:')
+    call assert_fails('let s=server2client("gvim", "abc")', 'E48:')
+  endif
+  if has('terminal')
+    call assert_fails('terminal', 'E48:')
+    call assert_fails('call term_start("vim")', 'E48:')
+    call assert_fails('call term_dumpwrite(1, "Xfile")', 'E48:')
+  endif
+  if has('channel')
+    call assert_fails("call ch_logfile('chlog')", 'E48:')
+    call assert_fails("call ch_open('localhost:8765')", 'E48:')
+  endif
+  if has('job')
+    call assert_fails("call job_start('vim')", 'E48:')
+  endif
+  if has('unix') && has('libcall')
+    call assert_fails("echo libcall('libc.so', 'getenv', 'HOME')", 'E48:')
+  endif
+  if has('unix')
+    call assert_fails('cd `pwd`', 'E48:')
+  endif
+endfunc
+
+func Test_sandbox()
+  sandbox call Sandbox_tests()
+endfunc
+
 func Test_not_break_expression_register()
   call setreg('=', '1+1')
   if 0

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -1,6 +1,8 @@
 " Test for various Normal mode commands
 
 source shared.vim
+source check.vim
+source view_util.vim
 
 func Setup_NewWindow()
   10new
@@ -3090,6 +3092,29 @@ func Test_normal_cpo_minus()
   call assert_fails(10, 'E16:')
   let &cpo = save_cpo
   close!
+endfunc
+
+" Test for displaying dollar when changing text ('$' flag in 'cpoptions')
+func Test_normal_cpo_dollar()
+  throw 'Skipped: use test/functional/legacy/cpoptions_spec.lua'
+  new
+  let g:Line = ''
+  func SaveFirstLine()
+    let g:Line = Screenline(1)
+    return ''
+  endfunc
+  inoremap <expr> <buffer> <F2> SaveFirstLine()
+  call test_override('redraw_flag', 1)
+  set cpo+=$
+  call setline(1, 'one two three')
+  redraw!
+  exe "normal c2w\<F2>vim"
+  call assert_equal('one tw$ three', g:Line)
+  call assert_equal('vim three', getline(1))
+  set cpo-=$
+  call test_override('ALL', 0)
+  delfunc SaveFirstLine
+  %bw!
 endfunc
 
 " Test for using : to run a multi-line Ex command in operator pending mode

--- a/src/nvim/testdir/test_smartindent.vim
+++ b/src/nvim/testdir/test_smartindent.vim
@@ -21,9 +21,7 @@ endfunc
 func Test_smartindent_has_no_effect()
   new
   exe "normal! i\<Tab>one\<Esc>"
-  set noautoindent
-  set smartindent
-  set indentexpr=
+  setlocal noautoindent smartindent indentexpr=
   exe "normal! Gotwo\<Esc>"
   call assert_equal("\ttwo", getline("$"))
 
@@ -32,16 +30,13 @@ func Test_smartindent_has_no_effect()
   call assert_equal("three", getline("$"))
 
   delfunction! MyIndent
-  set autoindent&
-  set smartindent&
-  set indentexpr&
   bwipe!
 endfunc
 
 " Test for inserting '{' and '} with smartindent
 func Test_smartindent_braces()
   new
-  set smartindent shiftwidth=4
+  setlocal smartindent shiftwidth=4
   call setline(1, ['    if (a)', "\tif (b)", "\t    return 1"])
   normal 2ggO{
   normal 3ggA {
@@ -57,7 +52,62 @@ func Test_smartindent_braces()
         \ "\t}",
         \ '    }'
         \ ], getline(1, '$'))
-  set si& sw& ai&
+  close!
+endfunc
+
+" Test for adding a new line before and after comments with smartindent
+func Test_si_add_line_around_comment()
+  new
+  setlocal smartindent shiftwidth=4
+  call setline(1, ['    A', '# comment1', '# comment2'])
+  exe "normal GoC\<Esc>2GOB"
+  call assert_equal(['    A', '    B', '# comment1', '# comment2', '    C'],
+        \ getline(1, '$'))
+  close!
+endfunc
+
+" After a C style comment, indent for a following line should line up with the
+" line containing the start of the comment.
+func Test_si_indent_after_c_comment()
+  new
+  setlocal smartindent shiftwidth=4 fo+=ro
+  exe "normal i\<C-t>/*\ncomment\n/\n#define FOOBAR\n75\<Esc>ggOabc"
+  normal 3jOcont
+  call assert_equal(['    abc', '    /*', '     * comment', '     * cont',
+        \ '     */', '#define FOOBAR', '    75'], getline(1, '$'))
+  close!
+endfunc
+
+" Test for indenting a statement after a if condition split across lines
+func Test_si_if_cond_split_across_lines()
+  new
+  setlocal smartindent shiftwidth=4
+  exe "normal i\<C-t>if (cond1 &&\n\<C-t>cond2) {\ni = 10;\n}"
+  call assert_equal(['    if (cond1 &&', "\t    cond2) {", "\ti = 10;",
+        \ '    }'], getline(1, '$'))
+  close!
+endfunc
+
+" Test for inserting lines before and after a one line comment
+func Test_si_one_line_comment()
+  new
+  setlocal smartindent shiftwidth=4
+  exe "normal i\<C-t>abc;\n\<C-t>/* comment */"
+  normal oi = 10;
+  normal kOj = 1;
+  call assert_equal(['    abc;', "\tj = 1;", "\t/* comment */", "\ti = 10;"],
+        \ getline(1, '$'))
+  close!
+endfunc
+
+" Test for smartindent with a comment continued across multiple lines
+func Test_si_comment_line_continuation()
+  new
+  setlocal smartindent shiftwidth=4
+  call setline(1, ['# com1', '# com2 \', '    contd', '# com3', '  xyz'])
+  normal ggOabc
+  call assert_equal(['  abc', '# com1', '# com2 \', '    contd', '# com3',
+        \ '  xyz'], getline(1, '$'))
   close!
 endfunc
 

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -839,6 +839,10 @@ func Test_sub_with_no_last_pat()
   call delete('Xresult')
 endfunc
 
+func Test_substitute()
+  call assert_equal('a１a２a３a', substitute('１２３', '\zs', 'a', 'g'))
+endfunc
+
 func Test_submatch_list_concatenate()
   let pat = 'A\(.\)'
   let Rep = {-> string([submatch(0, 1)] + [[submatch(1)]])}

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1137,8 +1137,79 @@ func Test_whichwrap_multi_byte()
   bwipe!
 endfunc
 
-func Test_substitute()
-  call assert_equal('a１a２a３a', substitute('１２３', '\zs', 'a', 'g'))
+" Test for the 'f' flag in 'comments' (only the first line has the comment
+" string)
+func Test_firstline_comment()
+  new
+  setlocal comments=f:- fo+=ro
+  exe "normal i- B\nD\<C-C>ggoC\<C-C>ggOA\<C-C>"
+  call assert_equal(['A', '- B', '  C', '  D'], getline(1, '$'))
+  %d
+  setlocal comments=:-
+  exe "normal i- B\nD\<C-C>ggoC\<C-C>ggOA\<C-C>"
+  call assert_equal(['- A', '- B', '- C', '- D'], getline(1, '$'))
+  %bw!
+endfunc
+
+" Test for the 'r' flag in 'comments' (right align comment)
+func Test_comment_rightalign()
+  new
+  setlocal comments=sr:/***,m:**,ex-2:******/ fo+=ro
+  exe "normal i=\<C-C>o\t  /***\nD\n/"
+  exe "normal 2GOA\<C-C>joB\<C-C>jOC\<C-C>joE\<C-C>GOF\<C-C>joG"
+  let expected =<< trim END
+    =
+    A
+    	  /***
+    	    ** B
+    	    ** C
+    	    ** D
+    	    ** E
+    	    **     F
+    	    ******/
+    G
+  END
+  call assert_equal(expected, getline(1, '$'))
+  %bw!
+endfunc
+
+" Test for the 'b' flag in 'comments'
+func Test_comment_blank()
+  new
+  setlocal comments=b:* fo+=ro
+  exe "normal i* E\nF\n\<BS>G\nH\<C-C>ggOC\<C-C>O\<BS>B\<C-C>OA\<C-C>2joD"
+  let expected =<< trim END
+    A
+    *B
+    * C
+    * D
+    * E
+    * F
+    *G
+    H
+  END
+  call assert_equal(expected, getline(1, '$'))
+  %bw!
+endfunc
+
+" Test for the 'n' flag in comments
+func Test_comment_nested()
+  new
+  setlocal comments=n:> fo+=ro
+  exe "normal i> B\nD\<C-C>ggOA\<C-C>joC\<C-C>Go\<BS>>>> F\nH"
+  exe "normal 5GOE\<C-C>6GoG"
+  let expected =<< trim END
+    > A
+    > B
+    > C
+    > D
+    >>>> E
+    >>>> F
+    >>>> G
+    >>>> H
+  END
+  call assert_equal(expected, getline(1, '$'))
+  %bw!
 endfunc
 
 " Test for 'a' and 'w' flags in 'formatoptions'

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -284,6 +284,15 @@ func Test_virtual_replace2()
   call assert_equal(['abcd',
         \ 'efgh',
         \ 'ijkl'], getline(1, '$'))
+
+  " Test for truncating spaces in a newly added line using 'autoindent' if
+  " characters are not added to that line.
+  %d_
+  call setline(1, ['    app', '    bee', '    cat'])
+  setlocal autoindent
+  exe "normal gg$gRt\n\nr"
+  call assert_equal(['    apt', '', '    rat'], getline(1, '$'))
+
   " clean up
   %d_
   set bs&vim

--- a/test/functional/legacy/cpoptions_spec.lua
+++ b/test/functional/legacy/cpoptions_spec.lua
@@ -1,0 +1,34 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local command = helpers.command
+local feed = helpers.feed
+
+before_each(clear)
+
+describe('cpoptions', function()
+  it('$', function()
+    local screen = Screen.new(30, 6)
+    screen:attach()
+    command('set cpo+=$')
+    command([[call setline(1, 'one two three')]])
+    feed('c2w')
+    screen:expect([[
+      ^one tw$ three                 |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+      -- INSERT --                  |
+    ]])
+    feed('vim<Esc>')
+    screen:expect([[
+      vi^m three                     |
+      ~                             |
+      ~                             |
+      ~                             |
+      ~                             |
+                                    |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:8.2.0430: window creation failure not properly tested

Problem:    Window creation failure not properly tested.
Solution:   Improve the test. (Yegappan Lakshmanan, closes vim/vim#5826)
https://github.com/vim/vim/commit/5080b0a0470511bae6176a704d4591d1caba0d07


#### vim-patch:8.2.0482: channel and sandbox code not sufficiently tested

Problem:    Channel and sandbox code not sufficiently tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5855)
https://github.com/vim/vim/commit/ca68ae13114619df3e4c195b41ad0575516f5ff6

Cherry-pick test_clientserver.vim changes form patch 8.2.0448.