### PR TITLE
vim-patch:8.1.1547,8.2.0403: when 'buftype' is "nofile" there is no overwrite check

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5271,15 +5271,22 @@ bool bt_terminal(const buf_T *const buf)
   return buf != NULL && buf->b_p_bt[0] == 't';
 }
 
-/// @return  true if "buf" is a "nofile", "acwrite", "terminal" or "prompt" /
+/// @return  true if "buf" is a "nofile", "acwrite", "terminal" or "prompt"
 ///          buffer.  This means the buffer name is not a file name.
-bool bt_nofile(const buf_T *const buf)
+bool bt_nofilename(const buf_T *const buf)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
                          || buf->b_p_bt[0] == 'a'
                          || buf->terminal
                          || buf->b_p_bt[0] == 'p');
+}
+
+/// @return  true if "buf" has 'buftype' set to "nofile".
+bool bt_nofile(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return buf != NULL && buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f';
 }
 
 /// @return  true if "buf" is a "nowrite", "nofile", "terminal" or "prompt"
@@ -5333,7 +5340,7 @@ char *buf_spname(buf_T *buf)
   }
   // There is no _file_ when 'buftype' is "nofile", b_sfname
   // contains the name as specified by the user.
-  if (bt_nofile(buf)) {
+  if (bt_nofilename(buf)) {
     if (buf->b_fname != NULL) {
       return buf->b_fname;
     }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -482,7 +482,7 @@ static buf_T *find_buffer(typval_T *avar)
        * buffer, these don't use the full path. */
       FOR_ALL_BUFFERS(bp) {
         if (bp->b_fname != NULL
-            && (path_with_url(bp->b_fname) || bt_nofile(bp))
+            && (path_with_url(bp->b_fname) || bt_nofilename(bp))
             && STRCMP(bp->b_fname, avar->vval.v_string) == 0) {
           buf = bp;
           break;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1980,17 +1980,14 @@ theend:
 /// @return  OK if it's OK, FAIL if it is not.
 int check_overwrite(exarg_T *eap, buf_T *buf, char *fname, char *ffname, int other)
 {
-  /*
-   * write to other file or b_flags set or not writing the whole file:
-   * overwriting only allowed with '!'
-   */
+  // Write to another file or b_flags set or not writing the whole file:
+  // overwriting only allowed with '!'
   if ((other
        || (buf->b_flags & BF_NOTEDITED)
        || ((buf->b_flags & BF_NEW)
            && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
        || (buf->b_flags & BF_READERR))
       && !p_wa
-      && !bt_nofilename(buf)
       && os_path_exists((char_u *)ffname)) {
     if (!eap->forceit && !eap->append) {
 #ifdef UNIX

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1990,7 +1990,7 @@ int check_overwrite(exarg_T *eap, buf_T *buf, char *fname, char *ffname, int oth
            && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
        || (buf->b_flags & BF_READERR))
       && !p_wa
-      && !bt_nofile(buf)
+      && !bt_nofilename(buf)
       && os_path_exists((char_u *)ffname)) {
     if (!eap->forceit && !eap->append) {
 #ifdef UNIX

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -187,7 +187,7 @@ static int ses_do_win(win_T *wp)
   }
   if (wp->w_buffer->b_fname == NULL
       // When 'buftype' is "nofile" can't restore the window contents.
-      || (!wp->w_buffer->terminal && bt_nofile(wp->w_buffer))) {
+      || (!wp->w_buffer->terminal && bt_nofilename(wp->w_buffer))) {
     return ssop_flags & SSOP_BLANK;
   }
   if (bt_help(wp->w_buffer)) {
@@ -363,7 +363,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
         return FAIL;
       }
     } else if (wp->w_buffer->b_ffname != NULL
-               && (!bt_nofile(wp->w_buffer) || wp->w_buffer->terminal)) {
+               && (!bt_nofilename(wp->w_buffer) || wp->w_buffer->terminal)) {
       // Load the file.
 
       // Editing a file in this buffer: use ":edit file".
@@ -706,7 +706,7 @@ static int makeopens(FILE *fd, char_u *dirnow)
       if (ses_do_win(wp)
           && wp->w_buffer->b_ffname != NULL
           && !bt_help(wp->w_buffer)
-          && !bt_nofile(wp->w_buffer)) {
+          && !bt_nofilename(wp->w_buffer)) {
         if (need_tabnext && put_line(fd, "tabnext") == FAIL) {
           return FAIL;
         }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2286,7 +2286,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
       && reset_changed
       && whole
       && buf == curbuf
-      && !bt_nofile(buf)
+      && !bt_nofilename(buf)
       && !filtering
       && (!append || vim_strchr(p_cpo, CPO_FNAMEAPP) != NULL)
       && vim_strchr(p_cpo, CPO_FNAMEW) != NULL) {
@@ -2360,22 +2360,22 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
 
     if (append) {
       if (!(did_cmd = apply_autocmds_exarg(EVENT_FILEAPPENDCMD,
-                                           sfname, sfname, FALSE, curbuf, eap))) {
-        if (overwriting && bt_nofile(curbuf)) {
-          nofile_err = TRUE;
+                                           sfname, sfname, false, curbuf, eap))) {
+        if (overwriting && bt_nofilename(curbuf)) {
+          nofile_err = true;
         } else {
           apply_autocmds_exarg(EVENT_FILEAPPENDPRE,
-                               sfname, sfname, FALSE, curbuf, eap);
+                               sfname, sfname, false, curbuf, eap);
         }
       }
     } else if (filtering) {
       apply_autocmds_exarg(EVENT_FILTERWRITEPRE,
-                           NULL, sfname, FALSE, curbuf, eap);
+                           NULL, sfname, false, curbuf, eap);
     } else if (reset_changed && whole) {
       int was_changed = curbufIsChanged();
 
       did_cmd = apply_autocmds_exarg(EVENT_BUFWRITECMD,
-                                     sfname, sfname, FALSE, curbuf, eap);
+                                     sfname, sfname, false, curbuf, eap);
       if (did_cmd) {
         if (was_changed && !curbufIsChanged()) {
           /* Written everything correctly and BufWriteCmd has reset
@@ -2385,21 +2385,21 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
           u_update_save_nr(curbuf);
         }
       } else {
-        if (overwriting && bt_nofile(curbuf)) {
-          nofile_err = TRUE;
+        if (overwriting && bt_nofilename(curbuf)) {
+          nofile_err = true;
         } else {
           apply_autocmds_exarg(EVENT_BUFWRITEPRE,
-                               sfname, sfname, FALSE, curbuf, eap);
+                               sfname, sfname, false, curbuf, eap);
         }
       }
     } else {
       if (!(did_cmd = apply_autocmds_exarg(EVENT_FILEWRITECMD,
-                                           sfname, sfname, FALSE, curbuf, eap))) {
-        if (overwriting && bt_nofile(curbuf)) {
-          nofile_err = TRUE;
+                                           sfname, sfname, false, curbuf, eap))) {
+        if (overwriting && bt_nofilename(curbuf)) {
+          nofile_err = true;
         } else {
           apply_autocmds_exarg(EVENT_FILEWRITEPRE,
-                               sfname, sfname, FALSE, curbuf, eap);
+                               sfname, sfname, false, curbuf, eap);
         }
       }
     }
@@ -4306,7 +4306,7 @@ void shorten_buf_fname(buf_T *buf, char_u *dirname, int force)
   char *p;
 
   if (buf->b_fname != NULL
-      && !bt_nofile(buf)
+      && !bt_nofilename(buf)
       && !path_with_url(buf->b_fname)
       && (force
           || buf->b_sfname == NULL

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -726,8 +726,7 @@ static int pum_set_selected(int n, int repeat)
         if (!resized
             && (curbuf->b_nwindows == 1)
             && (curbuf->b_fname == NULL)
-            && (curbuf->b_p_bt[0] == 'n')
-            && (curbuf->b_p_bt[2] == 'f')
+            && bt_nofile(curbuf)
             && (curbuf->b_p_bh[0] == 'w')) {
           // Already a "wipeout" buffer, make it empty.
           while (!buf_is_empty(curbuf)) {

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -741,7 +741,16 @@ func Test_buftype()
   call setline(1, ['L1'])
   set buftype=nowrite
   call assert_fails('write', 'E382:')
-  close!
+
+  " for val in ['', 'nofile', 'nowrite', 'acwrite', 'quickfix', 'help', 'terminal', 'prompt', 'popup']
+  for val in ['', 'nofile', 'nowrite', 'acwrite', 'quickfix', 'help', 'prompt']
+    exe 'set buftype=' .. val
+    call writefile(['something'], 'XBuftype')
+    call assert_fails('write XBuftype', 'E13:', 'with buftype=' .. val)
+  endfor
+
+  call delete('XBuftype')
+  bwipe!
 endfunc
 
 " Test for the 'shellquote' option


### PR DESCRIPTION
#### vim-patch:8.1.1547: functionality of bt_nofile() is confusing

Problem:    Functionality of bt_nofile() is confusing.
Solution:   Split into bt_nofile() and bt_nofilename().
https://github.com/vim/vim/commit/26910de8b0da6abab87bd5a397330f9cbe483309


#### vim-patch:8.2.0403: when 'buftype' is "nofile" there is no overwrite check

Problem:    When 'buftype' is "nofile" there is no overwrite check.
Solution:   Also check for existing file when 'buftype' is set.
https://github.com/vim/vim/commit/a3a9c8ef697bbf6f640cde99710b6f534f29f77d

Nvim doesn't have buftype=popup and doesn't allow buftype=terminal for
non-terminal buffer.