### PR TITLE
vim-patch:8.2.{0535,0542}: regexp patterns not fully tested

### DIFF
--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -216,6 +216,9 @@ func Test_mark_error()
   call assert_fails('mark xx', 'E488:')
   call assert_fails('mark _', 'E191:')
   call assert_beeps('normal! m~')
+
+  call setpos("'k", [0, 100, 1, 0])
+  call assert_fails("normal 'k", 'E19:')
 endfunc
 
 " Test for :lockmarks when pasting content

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -753,6 +753,16 @@ func Test_buftype()
   bwipe!
 endfunc
 
+" Test for the 'shell' option
+func Test_shell()
+  throw 'Skipped: Nvim does not have :shell'
+  CheckUnix
+  let save_shell = &shell
+  set shell=
+  call assert_fails('shell', 'E91:')
+  let &shell = save_shell
+endfunc
+
 " Test for the 'shellquote' option
 func Test_shellquote()
   CheckUnix

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -122,7 +122,10 @@ endfunc
 " Tests for regexp patterns without multi-byte support.
 func Test_regexp_single_line_pat()
   " tl is a List of Lists with:
-  "    regexp engine
+  "    regexp engines to test
+  "       0 - test with 'regexpengine' values 0 and 1
+  "       1 - test with 'regexpengine' values 0 and 2
+  "       2 - test with 'regexpengine' values 0, 1 and 2
   "    regexp pattern
   "    text to test the pattern on
   "    expected match (optional)
@@ -143,6 +146,8 @@ func Test_regexp_single_line_pat()
   call add(tl, [2, 'c*', 'abdef', ''])
   call add(tl, [2, 'bc\+', 'abccccdef', 'bcccc'])
   call add(tl, [2, 'bc\+', 'abdef']) " no match
+  " match newline character in a string
+  call add(tl, [2, 'o\nb', "foo\nbar", "o\nb"])
 
   " operator \|
   call add(tl, [2, 'a\|ab', 'cabd', 'a']) " alternation is ordered
@@ -566,6 +571,9 @@ func Test_regexp_single_line_pat()
   " Test \%V atom
   call add(tl, [2, '\%>70vGesamt', 'Jean-Michel Charlier & Victor Hubinon\Gesamtausgabe [Salleck]    Buck Danny {Jean-Michel Charlier & Victor Hubinon}\Gesamtausgabe', 'Gesamt'])
 
+  " Test for ignoring case and matching repeated characters
+  call add(tl, [2, '\cb\+', 'aAbBbBcC', 'bBbB'])
+
   " Run the tests
   for t in tl
     let re = t[0]
@@ -625,6 +633,14 @@ endfunc
 
 " Tests for multi-line regexp patterns without multi-byte support.
 func Test_regexp_multiline_pat()
+  " tl is a List of Lists with:
+  "    regexp engines to test
+  "       0 - test with 'regexpengine' values 0 and 1
+  "       1 - test with 'regexpengine' values 0 and 2
+  "       2 - test with 'regexpengine' values 0, 1 and 2
+  "    regexp pattern
+  "    List with text to test the pattern on
+  "    List with the expected match
   let tl = []
 
   " back references
@@ -633,6 +649,70 @@ func Test_regexp_multiline_pat()
 
   " line breaks
   call add(tl, [2, '\S.*\nx', ['abc', 'def', 'ghi', 'xjk', 'lmn'], ['abc', 'def', 'XXjk', 'lmn']])
+
+  " Any single character or end-of-line
+  call add(tl, [2, '\_.\+', ['a', 'b', 'c'], ['XX']])
+  " Any identifier or end-of-line
+  call add(tl, [2, '\_i\+', ['a', 'b', ';', '2'], ['XX;XX']])
+  " Any identifier but excluding digits or end-of-line
+  call add(tl, [2, '\_I\+', ['a', 'b', ';', '2'], ['XX;XX2XX']])
+  " Any keyword or end-of-line
+  call add(tl, [2, '\_k\+', ['a', 'b', '=', '2'], ['XX=XX']])
+  " Any keyword but excluding digits or end-of-line
+  call add(tl, [2, '\_K\+', ['a', 'b', '=', '2'], ['XX=XX2XX']])
+  " Any filename character or end-of-line
+  call add(tl, [2, '\_f\+', ['a', 'b', '.', '5'], ['XX']])
+  " Any filename character but excluding digits or end-of-line
+  call add(tl, [2, '\_F\+', ['a', 'b', '.', '5'], ['XX5XX']])
+  " Any printable character or end-of-line
+  call add(tl, [2, '\_p\+', ['a', 'b', '=', '4'], ['XX']])
+  " Any printable character excluding digits or end-of-line
+  call add(tl, [2, '\_P\+', ['a', 'b', '=', '4'], ['XX4XX']])
+  " Any whitespace character or end-of-line
+  call add(tl, [2, '\_s\+', [' ', ' ', 'a', 'b'], ['XXaXXbXX']])
+  " Any non-whitespace character or end-of-line
+  call add(tl, [2, '\_S\+', [' ', ' ', 'a', 'b'], [' XX XX']])
+  " Any decimal digit or end-of-line
+  call add(tl, [2, '\_d\+', ['1', 'a', '2', 'b', '3'], ['XXaXXbXX']])
+  " Any non-decimal digit or end-of-line
+  call add(tl, [2, '\_D\+', ['1', 'a', '2', 'b', '3'], ['1XX2XX3XX']])
+  " Any hexadecimal digit or end-of-line
+  call add(tl, [2, '\_x\+', ['1', 'a', 'g', '9', '8'], ['XXgXX']])
+  " Any non-hexadecimal digit or end-of-line
+  call add(tl, [2, '\_X\+', ['1', 'a', 'g', '9', '8'], ['1XXaXX9XX8XX']])
+  " Any octal digit or end-of-line
+  call add(tl, [2, '\_o\+', ['0', '7', '8', '9', '0'], ['XX8XX9XX']])
+  " Any non-octal digit or end-of-line
+  call add(tl, [2, '\_O\+', ['0', '7', '8', '9', '0'], ['0XX7XX0XX']])
+  " Any word character or end-of-line
+  call add(tl, [2, '\_w\+', ['A', 'B', '=', 'C', 'D'], ['XX=XX']])
+  " Any non-word character or end-of-line
+  call add(tl, [2, '\_W\+', ['A', 'B', '=', 'C', 'D'], ['AXXBXXCXXDXX']])
+  " Any head-of-word character or end-of-line
+  call add(tl, [2, '\_h\+', ['a', '1', 'b', '2', 'c'], ['XX1XX2XX']])
+  " Any non-head-of-word character or end-of-line
+  call add(tl, [2, '\_H\+', ['a', '1', 'b', '2', 'c'], ['aXXbXXcXX']])
+  " Any alphabetic character or end-of-line
+  call add(tl, [2, '\_a\+', ['a', '1', 'b', '2', 'c'], ['XX1XX2XX']])
+  " Any non-alphabetic character or end-of-line
+  call add(tl, [2, '\_A\+', ['a', '1', 'b', '2', 'c'], ['aXXbXXcXX']])
+  " Any lowercase character or end-of-line
+  call add(tl, [2, '\_l\+', ['a', 'A', 'b', 'B'], ['XXAXXBXX']])
+  " Any non-lowercase character or end-of-line
+  call add(tl, [2, '\_L\+', ['a', 'A', 'b', 'B'], ['aXXbXX']])
+  " Any uppercase character or end-of-line
+  call add(tl, [2, '\_u\+', ['a', 'A', 'b', 'B'], ['aXXbXX']])
+  " Any non-uppercase character or end-of-line
+  call add(tl, [2, '\_U\+', ['a', 'A', 'b', 'B'], ['XXAXXBXX']])
+  " Collection or end-of-line
+  call add(tl, [2, '\_[a-z]\+', ['a', 'A', 'b', 'B'], ['XXAXXBXX']])
+  " start of line anywhere in the text
+  call add(tl, [2, 'one\zs\_s*\_^\zetwo',
+        \ ['', 'one', ' two', 'one', '', 'two'],
+        \ ['', 'one', ' two', 'oneXXtwo']])
+  " end of line anywhere in the text
+  call add(tl, [2, 'one\zs\_$\_s*two',
+        \ ['', 'one', ' two', 'one', '', 'two'], ['', 'oneXX', 'oneXX']])
 
   " Check that \_[0-9] matching EOL does not break a following \>
   call add(tl, [2, '\<\(\(25\_[0-5]\|2\_[0-4]\_[0-9]\|\_[01]\?\_[0-9]\_[0-9]\?\)\.\)\{3\}\(25\_[0-5]\|2\_[0-4]\_[0-9]\|\_[01]\?\_[0-9]\_[0-9]\?\)\>', ['', 'localnet/192.168.0.1', ''], ['', 'localnet/XX', '']])
@@ -649,7 +729,7 @@ func Test_regexp_multiline_pat()
     let before = t[2]
     let after = t[3]
     for engine in [0, 1, 2]
-      if engine == 2 && re == 0 || engine == 1 && re ==1
+      if engine == 2 && re == 0 || engine == 1 && re == 1
         continue
       endif
       let &regexpengine = engine
@@ -697,9 +777,8 @@ func Test_lookbehind_across_line()
   bwipe!
 endfunc
 
-" Check matching Visual area
-func Test_matching_visual_area()
-  new
+" Test for the \%V atom (match inside the visual area)
+func Regex_Match_Visual_Area()
   call append(0, ['Visual:', 'thexe the thexethe', 'andaxand andaxand',
         \ 'oooxofor foroxooo', 'oooxofor foroxooo'])
   call cursor(1, 1)
@@ -708,12 +787,22 @@ func Test_matching_visual_area()
   exe "normal jfx\<C-V>fxj:s/\\%Vo/O/g\<CR>"
   call assert_equal(['Visual:', 'thexE thE thExethe', 'AndAxAnd AndAxAnd',
         \ 'oooxOfOr fOrOxooo', 'oooxOfOr fOrOxooo', ''], getline(1, '$'))
+  %d
+endfunc
+
+" Check matching Visual area
+func Test_matching_visual_area()
+  new
+  set regexpengine=1
+  call Regex_Match_Visual_Area()
+  set regexpengine=2
+  call Regex_Match_Visual_Area()
+  set regexpengine&
   bwipe!
 endfunc
 
 " Check matching marks
-func Test_matching_marks()
-  new
+func Regex_Mark()
   call append(0, ['', '', '', 'Marks:', 'asdfSasdfsadfEasdf', 'asdfSas',
         \ 'dfsadfEasdf', '', '', '', '', ''])
   call cursor(4, 1)
@@ -721,6 +810,15 @@ func Test_matching_marks()
   exe "normal jfSmsj0fEme:.-4,.+6s/.\\%>'s\\_.*\\%<'e../again/\<CR>"
   call assert_equal(['', '', '', 'Marks:', 'asdfhereasdf', 'asdfagainasdf',
         \ '', '', '', '', '', ''], getline(1, '$'))
+  %d
+endfunc
+
+func Test_matching_marks()
+  new
+  set regexpengine=1
+  call Regex_Mark()
+  set regexpengine=2
+  call Regex_Mark()
   bwipe!
 endfunc
 
@@ -761,8 +859,7 @@ func Test_matching_curpos()
 endfunc
 
 " Test for matching the start and end of a buffer
-func Test_start_end_of_buffer_match()
-  new
+func Regex_start_end_buffer()
   call setline(1, repeat(['vim edit'], 20))
   /\%^
   call assert_equal([0, 1, 1, 0], getpos('.'))
@@ -772,6 +869,15 @@ func Test_start_end_of_buffer_match()
   call assert_equal([0, 20, 8, 0], getpos('.'))
   exe "normal 6gg/..\\%$\<CR>"
   call assert_equal([0, 20, 7, 0], getpos('.'))
+  %d
+endfunc
+
+func Test_start_end_of_buffer_match()
+  new
+  set regexpengine=1
+  call Regex_start_end_buffer()
+  set regexpengine=2
+  call Regex_start_end_buffer()
   bwipe!
 endfunc
 
@@ -784,10 +890,20 @@ endfunc
 
 " Check for detecting error
 func Test_regexp_error()
-  set regexpengine=2
-  call assert_fails("call matchlist('x x', ' \\ze*')", 'E888:')
-  call assert_fails("call matchlist('x x', ' \\zs*')", 'E888:')
-  set re&
+  call assert_fails("call matchlist('x x', '\\%#=1 \\zs*')", 'E888:')
+  call assert_fails("call matchlist('x x', '\\%#=1 \\ze*')", 'E888:')
+  call assert_fails("call matchlist('x x', '\\%#=2 \\zs*')", 'E888:')
+  call assert_fails("call matchlist('x x', '\\%#=2 \\ze*')", 'E888:')
+  call assert_fails('exe "normal /\\%#=1\\%[x\\%[x]]\<CR>"', 'E369:')
+endfunc
+
+" Test for using the last substitute string pattern (~)
+func Test_regexp_last_subst_string()
+  new
+  s/bar/baz/e
+  call assert_equal(matchstr("foo\nbaz\nbar", "\\%#=1\~"), "baz")
+  call assert_equal(matchstr("foo\nbaz\nbar", "\\%#=2\~"), "baz")
+  close!
 endfunc
 
 " Check patterns matching cursor position.

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -655,10 +655,49 @@ func Test_search_cmdline7()
   bw!
 endfunc
 
-" Tests for regexp with various magic settings
-func Test_search_regexp()
-  enew!
+func Test_search_cmdline8()
+  " Highlighting is cleared in all windows
+  " since hls applies to all windows
+  CheckOption incsearch
+  CheckFeature terminal
+  CheckNotGui
+  if has("win32")
+    throw "Skipped: Bug with sending <ESC> to terminal window not fixed yet"
+  endif
 
+  let h = winheight(0)
+  if h < 3
+    return
+  endif
+  " Prepare buffer text
+  let lines = ['abb vim vim vi', 'vimvivim']
+  call writefile(lines, 'Xsearch.txt')
+  let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
+
+  call WaitForAssert({-> assert_equal(lines, [term_getline(buf, 1), term_getline(buf, 2)])})
+
+  call term_sendkeys(buf, ":set incsearch hlsearch\<cr>")
+  call term_sendkeys(buf, ":14vsp\<cr>")
+  call term_sendkeys(buf, "/vim\<cr>")
+  call term_sendkeys(buf, "/b\<esc>")
+  call term_sendkeys(buf, "gg0")
+  call TermWait(buf, 250)
+  let screen_line = term_scrape(buf, 1)
+  let [a0,a1,a2,a3] = [screen_line[3].attr, screen_line[4].attr,
+        \ screen_line[18].attr, screen_line[19].attr]
+  call assert_notequal(a0, a1)
+  call assert_notequal(a0, a3)
+  call assert_notequal(a1, a2)
+  call assert_equal(a0, a2)
+  call assert_equal(a1, a3)
+  " clean up
+  call delete('Xsearch.txt')
+
+  bwipe!
+endfunc
+
+" Tests for regexp with various magic settings
+func Run_search_regexp_magic_opt()
   put ='1 a aa abb abbccc'
   exe 'normal! /a*b\{2}c\+/e' . "\<CR>"
   call assert_equal([0, 2, 17, 0], getpos('.'))
@@ -693,6 +732,18 @@ func Test_search_regexp()
   exe 'normal! /\V[ab]\(\[xy]\)\1' . "\<CR>"
   call assert_equal([0, 9, 7, 0], getpos('.'))
 
+  %d
+endfunc
+
+func Test_search_regexp()
+  enew!
+
+  set regexpengine=1
+  call Run_search_regexp_magic_opt()
+  set regexpengine=2
+  call Run_search_regexp_magic_opt()
+  set regexpengine&
+
   set undolevels=100
   put ='9 foobar'
   put =''
@@ -700,12 +751,12 @@ func Test_search_regexp()
   normal G
   exe 'normal! dv?bar?' . "\<CR>"
   call assert_equal('9 foo', getline('.'))
-  call assert_equal([0, 10, 5, 0], getpos('.'))
-  call assert_equal(10, line('$'))
+  call assert_equal([0, 2, 5, 0], getpos('.'))
+  call assert_equal(2, line('$'))
   normal u
   call assert_equal('9 foobar', getline('.'))
-  call assert_equal([0, 10, 6, 0], getpos('.'))
-  call assert_equal(11, line('$'))
+  call assert_equal([0, 2, 6, 0], getpos('.'))
+  call assert_equal(3, line('$'))
 
   set undolevels&
   enew!
@@ -1625,6 +1676,46 @@ func Test_searchforward_var()
   normal N
   call assert_equal(1, line('.'))
   close!
+endfunc
+
+" Test for invalid regular expressions
+func Test_invalid_regexp()
+  set regexpengine=1
+  call assert_fails("call search(repeat('\\(.\\)', 10))", 'E51:')
+  call assert_fails("call search('\\%(')", 'E53:')
+  call assert_fails("call search('\\(')", 'E54:')
+  call assert_fails("call search('\\)')", 'E55:')
+  call assert_fails("call search('x\\@#')", 'E59:')
+  call assert_fails('call search(''\v%(%(%(%(%(%(%(%(%(%(%(a){1}){1}){1}){1}){1}){1}){1}){1}){1}){1}){1}'')', 'E60:')
+  call assert_fails("call search('a\\+*')", 'E61:')
+  call assert_fails("call search('\\_m')", 'E63:')
+  call assert_fails("call search('\\+')", 'E64:')
+  call assert_fails("call search('\\1')", 'E65:')
+  call assert_fails("call search('\\z\\(\\)')", 'E66:')
+  call assert_fails("call search('\\z2')", 'E67:')
+  call assert_fails("call search('\\zx')", 'E68:')
+  call assert_fails("call search('\\%[ab')", 'E69:')
+  call assert_fails("call search('\\%[]')", 'E70:')
+  call assert_fails("call search('\\%a')", 'E71:')
+  call assert_fails("call search('ab\\%[\\(cd\\)]')", 'E369:')
+  call assert_fails("call search('ab\\%[\\%(cd\\)]')", 'E369:')
+  set regexpengine=2
+  call assert_fails("call search('\\_')", 'E865:')
+  call assert_fails("call search('\\+')", 'E866:')
+  call assert_fails("call search('\\zx')", 'E867:')
+  call assert_fails("call search('\\%a')", 'E867:')
+  call assert_fails("call search('x\\@#')", 'E869:')
+  call assert_fails("call search(repeat('\\(.\\)', 10))", 'E872:')
+  call assert_fails("call search('\\_m')", 'E877:')
+  call assert_fails("call search('\\%(')", 'E53:')
+  call assert_fails("call search('\\(')", 'E54:')
+  call assert_fails("call search('\\)')", 'E55:')
+  call assert_fails("call search('\\z\\(\\)')", 'E66:')
+  call assert_fails("call search('\\%[ab')", 'E69:')
+  call assert_fails("call search('\\%[]')", 'E70:')
+  call assert_fails("call search('\\%9999999999999999999999999999v')", 'E951:')
+  set regexpengine&
+  call assert_fails("call search('\\%#=3ab')", 'E864:')
 endfunc
 
 " Test 'smartcase' with utf-8.

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -19,9 +19,9 @@ func Test_search_cmdline()
   set noincsearch
   :1
   call feedkeys("/foobar\<cr>", 'tx')
-  call feedkeys("/the\<cr>",'tx')
+  call feedkeys("/the\<cr>", 'tx')
   call assert_equal('the', @/)
-  call feedkeys("/thes\<C-P>\<C-P>\<cr>",'tx')
+  call feedkeys("/thes\<C-P>\<C-P>\<cr>", 'tx')
   call assert_equal('foobar', @/)
 
   " Test 2
@@ -1484,7 +1484,7 @@ func Test_large_hex_chars2()
 endfunc
 
 func Test_one_error_msg()
-  " This  was also giving an internal error
+  " This was also giving an internal error
   call assert_fails('call search(" \\((\\v[[=P=]]){185}+             ")', 'E871:')
 endfunc
 
@@ -1527,6 +1527,20 @@ func Test_search_match_at_curpos()
   call assert_equal([3, 5], [line('.'), col('.')])
 
   close!
+endfunc
+
+" Test for error cases with the search() function
+func Test_search_errors()
+  call assert_fails("call search('pat', [])", 'E730:')
+  call assert_fails("call search('pat', 'b', {})", 'E728:')
+  call assert_fails("call search('pat', 'b', 1, [])", 'E745:')
+  call assert_fails("call search('pat', 'ns')", 'E475:')
+  call assert_fails("call search('pat', 'mr')", 'E475:')
+
+  new
+  call setline(1, ['foo', 'bar'])
+  call assert_fails('call feedkeys("/foo/;/bar/;\<CR>", "tx")', 'E386:')
+  bwipe!
 endfunc
 
 func Test_search_display_pattern()


### PR DESCRIPTION
#### vim-patch:8.2.0535: regexp patterns not fully tested

Problem:    Regexp patterns not fully tested.
Solution:   Add more regexp tests and others. (Yegappan Lakshmanan,
            closes vim/vim#5901)
https://github.com/vim/vim/commit/4d23c52824dd2f4577eb980e7d91feed34052755

Add missing Test_search_cmdline8().
Cherry-pick Test_invalid_regexp() from patch 8.2.0531.


#### vim-patch:8.2.0542: no test for E386

Problem:    No test for E386.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#5911)
https://github.com/vim/vim/commit/8832a3457831707286dd2d9252ba14a5f9fd4c60

Cherry-pick Test_search_errors() from patch 8.2.0448.