### PR TITLE
feat(lsp): hide backticks in LSP docstrings

### DIFF
--- a/runtime/syntax/lsp_markdown.vim
+++ b/runtime/syntax/lsp_markdown.vim
@@ -1,23 +1,34 @@
 " Vim syntax file
-" Language:	lsp_markdown
-" Maintainer:	Michael Lingelbach <m.j.lbach@gmail.com
-" URL:		http://neovim.io
-" Remark:	Uses markdown syntax file
+" Language:     Markdown-like LSP docstrings
+" Maintainer:   https://github.com/neovim/neovim
+" URL:          http://neovim.io
+" Remark:       Uses markdown syntax file
 
-" always source the system included markdown instead of any other installed
-" markdown.vim syntax files
+" Source the default Nvim markdown syntax, not other random ones.
 execute 'source' expand('<sfile>:p:h') .. '/markdown.vim'
 
 syn cluster mkdNonListItem add=mkdEscape,mkdNbsp
 
+" Don't highlight invalid markdown syntax in LSP docstrings.
+syn clear markdownError
+
 syn clear markdownEscape
 syntax region markdownEscape matchgroup=markdownEscape start=/\\\ze[\\\x60*{}\[\]()#+\-,.!_>~|"$%&'\/:;<=?@^ ]/ end=/./ containedin=ALL keepend oneline concealends
 
-" conceal html entities
+" Conceal backticks (which delimit code fragments).
+" We ignore g:markdown_syntax_conceal here.
+syn region markdownCode matchgroup=markdownCodeDelimiter start="`" end="`" keepend contains=markdownLineStart concealends
+syn region markdownCode matchgroup=markdownCodeDelimiter start="`` \=" end=" \=``" keepend contains=markdownLineStart concealends
+syn region markdownCode matchgroup=markdownCodeDelimiter start="^\s*````*.*$" end="^\s*````*\ze\s*$" keepend concealends
+
+" Highlight code fragments.
+hi def link markdownCode Special
+
+" Conceal HTML entities.
 syntax match mkdNbsp /&nbsp;/ conceal cchar= 
 syntax match mkdLt /&lt;/  conceal cchar=<
 syntax match mkdGt /&gt;/  conceal cchar=>
 syntax match mkdAmp /&amp;/  conceal cchar=&
 syntax match mkdQuot /&quot;/  conceal cchar="
 
-hi def link mkdEscape special
+hi def link mkdEscape Special


### PR DESCRIPTION
- fix #16114
- also clear `markdownError`, there's no point in showing markdown syntax errors in LSP docstrings

## before:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/1359421/179230638-2c0fddbd-4098-4767-aabe-dd0a23a0993f.png">


## after:

<img width="583" alt="image" src="https://user-images.githubusercontent.com/1359421/179230566-e46428b7-7660-4e13-96b3-f86c1e3069b4.png">
