### PR TITLE
fix: remote UI may get invalid 'pumblend' value

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4784,7 +4784,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
 
   if (errmsg == NULL && options[opt_idx].flags & P_UI_OPTION) {
     ui_call_option_set(cstr_as_string(options[opt_idx].fullname),
-                       INTEGER_OBJ(value));
+                       INTEGER_OBJ(*pp));
   }
 
   comp_col();                       // in case 'columns' or 'ls' changed

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4343,7 +4343,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
 
   if (options[opt_idx].flags & P_UI_OPTION) {
     ui_call_option_set(cstr_as_string(options[opt_idx].fullname),
-                       BOOLEAN_OBJ(value));
+                       BOOLEAN_OBJ(*varp));
   }
 
   comp_col();                       // in case 'ruler' or 'showcmd' changed

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -86,7 +86,6 @@ describe('UI receives option updates', function()
     screen:expect(function()
       eq(expected, screen.options)
     end)
-    
     command("set pumblend=-1")
     expected.pumblend = 0
     screen:expect(function()

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -86,6 +86,7 @@ describe('UI receives option updates', function()
     screen:expect(function()
       eq(expected, screen.options)
     end)
+
     command("set pumblend=-1")
     expected.pumblend = 0
     screen:expect(function()

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -86,6 +86,11 @@ describe('UI receives option updates', function()
     screen:expect(function()
       eq(expected, screen.options)
     end)
+    command("set pumblend=-1")
+    expected.pumblend = 0
+    screen:expect(function()
+        eq(expected, screen.options)
+    end)
 
     command("set guifont=Comic\\ Sans")
     expected.guifont = "Comic Sans"

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -86,6 +86,7 @@ describe('UI receives option updates', function()
     screen:expect(function()
       eq(expected, screen.options)
     end)
+    
     command("set pumblend=-1")
     expected.pumblend = 0
     screen:expect(function()


### PR DESCRIPTION
fixes: https://github.com/neovim/neovim/issues/19340

After looking at this function I believe the issue that caused #19340 is due to `p_pb` being updated [here](https://github.com/0x00002a/neovim/blob/0b1b37e50e6032bc9420590580c768672e43bca8/src/nvim/option.c#L4640) (which `pp` points too) but `value` (which the value of `pp` was set too) not. I did a quick search and I couldn't find anywhere `value` was updated after `*pp` was set too it so I _think_ this is ok. 

I've verified it no longer causes neovide to crash but I haven't really tested it beyond that