### PR TITLE
vim-patch:8.2.1061: insufficient testing for src/window.c

### DIFF
--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -509,6 +509,11 @@ func Test_run_excmd_with_text_locked()
   close
 
   call assert_fails("call feedkeys(\":\<C-R>=execute('bnext')\<CR>\", 'xt')", 'E565:')
+
+  " :tabfirst
+  tabnew
+  call assert_fails("call feedkeys(\":\<C-R>=execute('tabfirst')\<CR>\", 'xt')", 'E565:')
+  tabclose
 endfunc
 
 " Test for the :verbose command

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -63,11 +63,18 @@ func Test_gF()
   call assert_equal('Xfile', bufname('%'))
   call assert_equal(2, getcurpos()[1])
 
+  " jumping to the file/line with CTRL-W_F
+  %bw!
+  edit Xfile1
+  call setline(1, ['one', 'Xfile:4', 'three'])
+  exe "normal 2G\<C-W>F"
+  call assert_equal('Xfile', bufname('%'))
+  call assert_equal(4, getcurpos()[1])
+
   set isfname&
   call delete('Xfile')
   call delete('Xfile2')
-  bwipe Xfile
-  bwipe Xfile2
+  %bw!
 endfunc
 
 " Test for invoking 'gf' on a ${VAR} variable

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -813,6 +813,16 @@ func Test_opt_boolean()
   set number&
 endfunc
 
+" Test for the 'winminheight' option
+func Test_opt_winminheight()
+  only!
+  let &winheight = &lines + 4
+  call assert_fails('let &winminheight = &lines + 2', 'E36:')
+  call assert_true(&winminheight <= &lines)
+  set winminheight&
+  set winheight&
+endfunc
+
 func Test_opt_winminheight_term()
   " See test/functional/legacy/options_spec.lua
   CheckRunVimInTerminal
@@ -854,6 +864,16 @@ func Test_opt_winminheight_term_tabs()
 
   call StopVimInTerminal(buf)
   call delete('Xwinminheight')
+endfunc
+
+" Test for the 'winminwidth' option
+func Test_opt_winminwidth()
+  only!
+  let &winwidth = &columns + 4
+  call assert_fails('let &winminwidth = &columns + 2', 'E36:')
+  call assert_true(&winminwidth <= &columns)
+  set winminwidth&
+  set winwidth&
 endfunc
 
 " Test for setting option value containing spaces with isfname+=32

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -301,6 +301,23 @@ func XwindowTests(cchar)
   call assert_equal(12, winwidth(0))
   Xclose
 
+  " Horizontally or vertically splitting the quickfix window should create a
+  " normal window/buffer
+  Xopen
+  wincmd s
+  call assert_equal(0, getwininfo(win_getid())[0].quickfix)
+  call assert_equal(0, getwininfo(win_getid())[0].loclist)
+  call assert_notequal('quickfix', &buftype)
+  close
+  Xopen
+  wincmd v
+  call assert_equal(0, getwininfo(win_getid())[0].quickfix)
+  call assert_equal(0, getwininfo(win_getid())[0].loclist)
+  call assert_notequal('quickfix', &buftype)
+  close
+  Xopen
+  Xclose
+
   if a:cchar == 'c'
       " Opening the quickfix window in multiple tab pages should reuse the
       " quickfix buffer

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -141,6 +141,8 @@ function Test_tabpage()
   call assert_fails("tabmove $3", 'E474:')
   call assert_fails("%tabonly", 'E16:')
   1tabonly!
+  tabmove 1
+  call assert_equal(1, tabpagenr())
   tabnew
   call assert_fails("-2tabmove", 'E474:')
   tabonly!
@@ -696,6 +698,69 @@ func Test_tabline_tabmenu()
   call assert_equal(5, tabpagenr())
   call assert_equal(5, tabpagenr('$'))
 
+  %bw!
+endfunc
+
+" Test for changing the current tab page from an autocmd when closing a tab
+" page.
+func Test_tabpage_switchtab_on_close()
+  only
+  tabnew
+  tabnew
+  " Test for BufLeave
+  augroup T1
+    au!
+    au BufLeave * tabfirst
+  augroup END
+  tabclose
+  call assert_equal(1, tabpagenr())
+  augroup T1
+    au!
+  augroup END
+
+  " Test for WinLeave
+  $tabnew
+  augroup T1
+    au!
+    au WinLeave * tabfirst
+  augroup END
+  tabclose
+  call assert_equal(1, tabpagenr())
+  augroup T1
+    au!
+  augroup END
+
+  " Test for TabLeave
+  $tabnew
+  augroup T1
+    au!
+    au TabLeave * tabfirst
+  augroup END
+  tabclose
+  call assert_equal(1, tabpagenr())
+  augroup T1
+    au!
+  augroup END
+  augroup! T1
+  tabonly
+endfunc
+
+" Test for closing the destination tabpage when jumping from one to another.
+func Test_tabpage_close_on_switch()
+  tabnew
+  tabnew
+  edit Xfile
+  augroup T2
+    au!
+    au BufLeave Xfile 1tabclose
+  augroup END
+  tabfirst
+  call assert_equal(2, tabpagenr())
+  call assert_equal('Xfile', @%)
+  augroup T2
+    au!
+  augroup END
+  augroup! T2
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -34,7 +34,16 @@ func Test_window_cmd_cmdwin_with_vsp()
   set ls&vim
 endfunc
 
-function Test_window_cmd_wincmd_gf()
+" Test for jumping to windows
+func Test_window_jump()
+  new
+  " jumping to a window with a count greater than the max windows
+  exe "normal 4\<C-W>w"
+  call assert_equal(2, winnr())
+  only
+endfunc
+
+func Test_window_cmd_wincmd_gf()
   let fname = 'test_gf.txt'
   let swp_fname = '.' . fname . '.swp'
   call writefile([], fname)
@@ -1117,6 +1126,181 @@ func Test_window_resize()
   call assert_equal(0, winwidth(other_winnr))
 
   %bwipe!
+endfunc
+
+" Test for adjusting the window width when a window is closed with some
+" windows using 'winfixwidth'
+func Test_window_width_adjust()
+  only
+  " Three vertical windows. Windows 1 and 2 have 'winfixwidth' set and close
+  " window 2.
+  wincmd v
+  vert resize 10
+  set winfixwidth
+  wincmd v
+  set winfixwidth
+  wincmd c
+  call assert_inrange(10, 12, winwidth(1))
+  " Three vertical windows. Windows 2 and 3 have 'winfixwidth' set and close
+  " window 3.
+  only
+  set winfixwidth
+  wincmd v
+  vert resize 10
+  set winfixwidth
+  wincmd v
+  set nowinfixwidth
+  wincmd b
+  wincmd c
+  call assert_inrange(10, 12, winwidth(2))
+
+  new | only
+endfunc
+
+" Test for jumping to a vertical/horizontal neighbor window based on the
+" current cursor position
+func Test_window_goto_neightbor()
+  %bw!
+
+  " Vertical window movement
+
+  " create the following window layout:
+  "     +--+--+
+  "     |w1|w3|
+  "     +--+  |
+  "     |w2|  |
+  "     +--+--+
+  "     |w4   |
+  "     +-----+
+  new
+  vsplit
+  split
+  " vertically jump from w4
+  wincmd b
+  call setline(1, repeat(' ', &columns))
+  call cursor(1, 1)
+  wincmd k
+  call assert_equal(2, winnr())
+  wincmd b
+  call cursor(1, &columns)
+  redraw!
+  wincmd k
+  call assert_equal(3, winnr())
+  %bw!
+
+  " create the following window layout:
+  "     +--+--+--+
+  "     |w1|w2|w3|
+  "     +--+--+--+
+  "     |w4      |
+  "     +--------+
+  new
+  vsplit
+  vsplit
+  wincmd b
+  call setline(1, repeat(' ', &columns))
+  call cursor(1, 1)
+  wincmd k
+  call assert_equal(1, winnr())
+  wincmd b
+  call cursor(1, &columns / 2)
+  redraw!
+  wincmd k
+  call assert_equal(2, winnr())
+  wincmd b
+  call cursor(1, &columns)
+  redraw!
+  wincmd k
+  call assert_equal(3, winnr())
+  %bw!
+
+  " Horizontal window movement
+
+  " create the following window layout:
+  "     +--+--+--+
+  "     |w1|w2|w4|
+  "     +--+--+  |
+  "     |w3   |  |
+  "     +-----+--+
+  vsplit
+  split
+  vsplit
+  4wincmd l
+  call setline(1, repeat([' '], &lines))
+  call cursor(1, 1)
+  redraw!
+  wincmd h
+  call assert_equal(2, winnr())
+  4wincmd l
+  call cursor(&lines, 1)
+  redraw!
+  wincmd h
+  call assert_equal(3, winnr())
+  %bw!
+
+  " create the following window layout:
+  "     +--+--+
+  "     |w1|w4|
+  "     +--+  +
+  "     |w2|  |
+  "     +--+  +
+  "     |w3|  |
+  "     +--+--+
+  vsplit
+  split
+  split
+  wincmd l
+  call setline(1, repeat([' '], &lines))
+  call cursor(1, 1)
+  redraw!
+  wincmd h
+  call assert_equal(1, winnr())
+  wincmd l
+  call cursor(&lines / 2, 1)
+  redraw!
+  wincmd h
+  call assert_equal(2, winnr())
+  wincmd l
+  call cursor(&lines, 1)
+  redraw!
+  wincmd h
+  call assert_equal(3, winnr())
+  %bw!
+endfunc
+
+" Test for an autocmd closing the destination window when jumping from one
+" window to another.
+func Test_close_dest_window()
+  split
+  edit Xfile
+
+  " Test for BufLeave
+  augroup T1
+    au!
+    au BufLeave Xfile $wincmd c
+  augroup END
+  wincmd b
+  call assert_equal(1, winnr('$'))
+  call assert_equal('Xfile', @%)
+  augroup T1
+    au!
+  augroup END
+
+  " Test for WinLeave
+  new
+  wincmd p
+  augroup T1
+    au!
+    au WinLeave * 1wincmd c
+  augroup END
+  wincmd t
+  call assert_equal(1, winnr('$'))
+  call assert_equal('Xfile', @%)
+  augroup T1
+    au!
+  augroup END
+  augroup! T1
+  %bw!
 endfunc
 
 func Test_win_move_separator()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1982,7 +1982,7 @@ void win_move_after(win_T *win1, win_T *win2)
       return;
     }
 
-    // may need move the status line, window bar, horizontal or vertical separator of the last
+    // may need to move the status line, window bar, horizontal or vertical separator of the last
     // window
     if (win1 == lastwin) {
       height = win1->w_prev->w_status_height;


### PR DESCRIPTION
#### vim-patch:8.2.1061: insufficient testing for src/window.c

Problem:    Insufficient testing for src/window.c.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6345)
https://github.com/vim/vim/commit/5d3c9f8c2a0fc29ba4ac8e0f052378b64d9e3dd3

Cherry-pick test_tagjump.vim changes from patch 8.1.2373.