### PR TITLE
vim-patch:8.2.0593: finding a user command is not optimal

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3298,6 +3298,7 @@ module.cmds = {
     addr_type='ADDR_LINES',
     func='ex_z',
   },
+  -- commands that don't start with a letter
   {
     command='!',
     enum='CMD_bang',
@@ -3348,17 +3349,18 @@ module.cmds = {
     func='ex_at',
   },
   {
-    command='Next',
-    flags=bit.bor(EXTRA, RANGE, COUNT, BANG, CMDARG, ARGOPT, TRLBAR),
-    addr_type='ADDR_OTHER',
-    func='ex_previous',
-  },
-  {
     command='~',
     enum='CMD_tilde',
     flags=bit.bor(RANGE, WHOLEFOLD, EXTRA, CMDWIN, MODIFY),
     addr_type='ADDR_LINES',
     func='ex_substitute',
+  },
+  -- commands that start with an uppercase letter
+  {
+    command='Next',
+    flags=bit.bor(EXTRA, RANGE, COUNT, BANG, CMDARG, ARGOPT, TRLBAR),
+    addr_type='ADDR_OTHER',
+    func='ex_previous',
   },
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3028,6 +3028,8 @@ char *find_ex_command(exarg_T *eap, int *full)
       if (ASCII_ISLOWER(c2)) {
         eap->cmdidx += cmdidxs2[CHAR_ORD_LOW(c1)][CHAR_ORD_LOW(c2)];
       }
+    } else if (ASCII_ISUPPER(eap->cmd[0])) {
+      eap->cmdidx = CMD_Next;
     } else {
       eap->cmdidx = CMD_bang;
     }


### PR DESCRIPTION
#### vim-patch:8.2.0593: finding a user command is not optimal

Problem:    Finding a user command is not optimal.
Solution:   Start further down in the list of commands.
https://github.com/vim/vim/commit/a494f56f885876c98a276f7acfa386bfbb344680