### PR TITLE
vim-patch:8.2.{0052,0198,2608,2643}: code not fully tested

### DIFF
--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -956,6 +956,16 @@ func Test_map_cmdkey_redo()
   ounmap i-
 endfunc
 
+" Test for using <script> with a map to remap characters in rhs
+func Test_script_local_remap()
+  new
+  inoremap <buffer> <SID>xyz mno
+  inoremap <buffer> <script> abc st<SID>xyzre
+  normal iabc
+  call assert_equal('stmnore', getline(1))
+  bwipe!
+endfunc
+
 func Test_abbreviate_multi_byte()
   new
   iabbrev foo bar

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -114,9 +114,7 @@ endfunc
 
 " Test more-prompt (see :help more-prompt).
 func Test_message_more()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
   call term_sendkeys(buf, ":call setline(1, range(1, 100))\n")
 
@@ -203,14 +201,22 @@ func Test_message_more()
   call term_sendkeys(buf, 'q')
   call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
 
-  call term_sendkeys(buf, ":q!\n")
+  " Execute a : command from the more prompt
+  call term_sendkeys(buf, ":%p#\n")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, ":")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_equal(':', term_getline(buf, 6))})
+  call term_sendkeys(buf, "echo 'Hello'\n")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_equal('Hello ', term_getline(buf, 5))})
+
   call StopVimInTerminal(buf)
 endfunc
 
 func Test_ask_yesno()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
   call term_sendkeys(buf, ":call setline(1, range(1, 2))\n")
 
@@ -233,7 +239,6 @@ func Test_ask_yesno()
   call WaitForAssert({-> assert_equal('y1', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('y2', term_getline(buf, 2))})
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc
 

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -112,6 +112,101 @@ func Test_echospace()
   set ruler& showcmd&
 endfunc
 
+" Test more-prompt (see :help more-prompt).
+func Test_message_more()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot run vim in terminal'
+  endif
+  let buf = RunVimInTerminal('', {'rows': 6})
+  call term_sendkeys(buf, ":call setline(1, range(1, 100))\n")
+
+  call term_sendkeys(buf, ":%p#\n")
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
+  call term_sendkeys(buf, '?')
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More -- SPACE/d/j: screen/page/line down, b/u/k: up, q: quit ', term_getline(buf, 6))})
+
+  " Down a line with j, <CR>, <NL> or <Down>.
+  call term_sendkeys(buf, "j")
+  call WaitForAssert({-> assert_equal('  6 6', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, "\<NL>")
+  call WaitForAssert({-> assert_equal('  7 7', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<CR>")
+  call WaitForAssert({-> assert_equal('  8 8', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<Down>")
+  call WaitForAssert({-> assert_equal('  9 9', term_getline(buf, 5))})
+
+  " Down a screen with <Space>, f, or <PageDown>.
+  call term_sendkeys(buf, 'f')
+  call WaitForAssert({-> assert_equal(' 14 14', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+  call term_sendkeys(buf, ' ')
+  call WaitForAssert({-> assert_equal(' 19 19', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageDown>")
+  call WaitForAssert({-> assert_equal(' 24 24', term_getline(buf, 5))})
+
+  " Down a page (half a screen) with d.
+  call term_sendkeys(buf, 'd')
+  call WaitForAssert({-> assert_equal(' 27 27', term_getline(buf, 5))})
+
+  " Down all the way with 'G'.
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  " Up a line k, <BS> or <Up>.
+  call term_sendkeys(buf, 'k')
+  call WaitForAssert({-> assert_equal(' 99 99', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<BS>")
+  call WaitForAssert({-> assert_equal(' 98 98', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<Up>")
+  call WaitForAssert({-> assert_equal(' 97 97', term_getline(buf, 5))})
+
+  " Up a screen with b or <PageUp>.
+  call term_sendkeys(buf, 'b')
+  call WaitForAssert({-> assert_equal(' 92 92', term_getline(buf, 5))})
+  call term_sendkeys(buf, "\<PageUp>")
+  call WaitForAssert({-> assert_equal(' 87 87', term_getline(buf, 5))})
+
+  " Up a page (half a screen) with u.
+  call term_sendkeys(buf, 'u')
+  call WaitForAssert({-> assert_equal(' 84 84', term_getline(buf, 5))})
+
+  " Up all the way with 'g'.
+  call term_sendkeys(buf, 'g')
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
+  " All the way down. Pressing f should do nothing but pressing
+  " space should end the more prompt.
+  call term_sendkeys(buf, 'G')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+  call term_sendkeys(buf, 'f')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call term_sendkeys(buf, ' ')
+  call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
+
+  " Pressing g< shows the previous command output.
+  call term_sendkeys(buf, 'g<')
+  call WaitForAssert({-> assert_equal('100 100', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('Press ENTER or type command to continue', term_getline(buf, 6))})
+
+  call term_sendkeys(buf, ":%p#\n")
+  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
+
+  " Stop command output with q, <Esc> or CTRL-C.
+  call term_sendkeys(buf, 'q')
+  call WaitForAssert({-> assert_equal('100', term_getline(buf, 5))})
+
+  call term_sendkeys(buf, ':q!')
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_mapping_at_hit_return_prompt()
   nnoremap <C-B> :echo "hit ctrl-b"<CR>
   call feedkeys(":ls\<CR>", "xt")

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -684,6 +684,16 @@ func Test_insert_small_delete()
   bwipe!
 endfunc
 
+" Record in insert mode using CTRL-O
+func Test_record_in_insert_mode()
+  new
+  let @r = ''
+  call setline(1, ['foo'])
+  call feedkeys("i\<C-O>qrbaz\<C-O>q", 'xt')
+  call assert_equal('baz', @r)
+  bwipe!
+endfunc
+
 func Test_record_in_select_mode()
   new
   call setline(1, 'text')

--- a/src/nvim/testdir/test_termcodes.vim
+++ b/src/nvim/testdir/test_termcodes.vim
@@ -1,4 +1,38 @@
 
+" Test for terminal keycodes that doesn't have termcap entries
+func Test_special_term_keycodes()
+  new
+  " Test for <xHome>, <S-xHome> and <C-xHome>
+  " send <K_SPECIAL> <KS_EXTRA> keycode
+  call feedkeys("i\<C-K>\x80\xfd\x3f\n", 'xt')
+  " send <K_SPECIAL> <KS_MODIFIER> bitmap <K_SPECIAL> <KS_EXTRA> keycode
+  call feedkeys("i\<C-K>\x80\xfc\x2\x80\xfd\x3f\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x4\x80\xfd\x3f\n", 'xt')
+  " Test for <xEnd>, <S-xEnd> and <C-xEnd>
+  call feedkeys("i\<C-K>\x80\xfd\x3d\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x2\x80\xfd\x3d\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x4\x80\xfd\x3d\n", 'xt')
+  " Test for <zHome>, <S-zHome> and <C-zHome>
+  call feedkeys("i\<C-K>\x80\xfd\x40\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x2\x80\xfd\x40\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x4\x80\xfd\x40\n", 'xt')
+  " Test for <zEnd>, <S-zEnd> and <C-zEnd>
+  call feedkeys("i\<C-K>\x80\xfd\x3e\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x2\x80\xfd\x3e\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfc\x4\x80\xfd\x3e\n", 'xt')
+  " Test for <xUp>, <xDown>, <xLeft> and <xRight>
+  call feedkeys("i\<C-K>\x80\xfd\x41\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfd\x42\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfd\x43\n", 'xt')
+  call feedkeys("i\<C-K>\x80\xfd\x44\n", 'xt')
+  call assert_equal(['<Home>', '<S-Home>', '<C-Home>',
+        \ '<End>', '<S-End>', '<C-End>',
+        \ '<Home>', '<S-Home>', '<C-Home>',
+        \ '<End>', '<S-End>', '<C-End>',
+        \ '<Up>', '<Down>', '<Left>', '<Right>', ''], getline(1, '$'))
+  bw!
+endfunc
+
 func Test_simplify_ctrl_at()
   " feeding unsimplified CTRL-@ should still trigger i_CTRL-@
   call feedkeys("ifoo\<Esc>A\<*C-@>x", 'xt')

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -735,6 +735,20 @@ func Test_undofile_cryptmethod_blowfish2()
   set undofile& undolevels& cryptmethod&
 endfunc
 
+" Test for redoing with incrementing numbered registers
+func Test_redo_repeat_numbered_register()
+  new
+  for [i, v] in [[1, 'one'], [2, 'two'], [3, 'three'],
+        \ [4, 'four'], [5, 'five'], [6, 'six'],
+        \ [7, 'seven'], [8, 'eight'], [9, 'nine']]
+    exe 'let @' .. i .. '="' .. v .. '\n"'
+  endfor
+  call feedkeys('"1p.........', 'xt')
+  call assert_equal(['', 'one', 'two', 'three', 'four', 'five', 'six',
+        \ 'seven', 'eight', 'nine', 'nine'], getline(1, '$'))
+  bwipe!
+endfunc
+
 func Test_undo_mark()
   new
   " The undo is applied to the only line.

--- a/src/nvim/testdir/test_undo.vim
+++ b/src/nvim/testdir/test_undo.vim
@@ -3,8 +3,6 @@
 " undo-able pieces.  Do that by setting 'undolevels'.
 " Also tests :earlier and :later.
 
-source check.vim
-
 func Test_undotree()
   new
 
@@ -137,8 +135,7 @@ func BackOne(expected)
 endfunc
 
 func Test_undo_del_chars()
-  CheckFunction test_settime
-
+  throw 'Skipped: Nvim does not support test_settime()'
   " Setup a buffer without creating undo entries
   new
   set ul=-1
@@ -334,8 +331,9 @@ func Test_insert_expr()
 endfunc
 
 func Test_undofile_earlier()
-  CheckFunction test_settime
-
+  throw 'Skipped: Nvim does not support test_settime()'
+  " Issue #1254
+  " create undofile with timestamps older than Vim startup time.
   let t0 = localtime() - 43200
   call test_settime(t0)
   new Xfile
@@ -368,7 +366,7 @@ func Test_wundo_errors()
   bwipe!
 endfunc
 
-" Check that reading a truncted undo file doesn't hang.
+" Check that reading a truncated undo file doesn't hang.
 func Test_undofile_truncated()
   new
   call setline(1, 'hello')
@@ -431,31 +429,6 @@ func Test_cmd_in_reg_undo()
   let @a = ''
 endfunc
 
-" undo or redo are noop if there is nothing to undo or redo
-func Test_undo_redo_noop()
-  new
-  call assert_fails('undo 2', 'E830:')
-
-  message clear
-  undo
-  let messages = split(execute('message'), "\n")
-  call assert_equal('Already at oldest change', messages[-1])
-
-  message clear
-  redo
-  let messages = split(execute('message'), "\n")
-  call assert_equal('Already at newest change', messages[-1])
-
-  bwipe!
-endfunc
-
-func Test_redo_empty_line()
-  new
-  exe "norm\x16r\x160"
-  exe "norm."
-  bwipe!
-endfunc
-
 " This used to cause an illegal memory access
 func Test_undo_append()
   new
@@ -463,47 +436,6 @@ func Test_undo_append()
   undo
   norm o
   quit
-endfunc
-
-funct Test_undofile()
-  " Test undofile() without setting 'undodir'.
-  if has('persistent_undo')
-    call assert_equal(fnamemodify('.Xundofoo.un~', ':p'), undofile('Xundofoo'))
-  else
-    call assert_equal('', undofile('Xundofoo'))
-  endif
-  call assert_equal('', undofile(''))
-
-  " Test undofile() with 'undodir' set to to an existing directory.
-  call mkdir('Xundodir')
-  set undodir=Xundodir
-  let cwd = getcwd()
-  if has('win32')
-    " Replace windows drive such as C:... into C%...
-    let cwd = substitute(cwd, '^\([a-zA-Z]\):', '\1%', 'g')
-  endif
-  let cwd = substitute(cwd . '/Xundofoo', '/', '%', 'g')
-  if has('persistent_undo')
-    call assert_equal('Xundodir/' . cwd, undofile('Xundofoo'))
-  else
-    call assert_equal('', undofile('Xundofoo'))
-  endif
-  call assert_equal('', undofile(''))
-  call delete('Xundodir', 'd')
-
-  " Test undofile() with 'undodir' set to a non-existing directory.
-  " call assert_equal('', 'Xundofoo'->undofile())
-
-  if isdirectory('/tmp')
-    set undodir=/tmp
-    if has('osx')
-      call assert_equal('/tmp/%private%tmp%file', undofile('///tmp/file'))
-    else
-      call assert_equal('/tmp/%tmp%file', undofile('///tmp/file'))
-    endif
-  endif
-
-  set undodir&
 endfunc
 
 func Test_undo_0()
@@ -548,6 +480,72 @@ func Test_undo_0()
   call assert_equal(1, d.seq_cur)
 
   bwipe!
+endfunc
+
+" undo or redo are noop if there is nothing to undo or redo
+func Test_undo_redo_noop()
+  new
+  call assert_fails('undo 2', 'E830:')
+
+  message clear
+  undo
+  let messages = split(execute('message'), "\n")
+  call assert_equal('Already at oldest change', messages[-1])
+
+  message clear
+  redo
+  let messages = split(execute('message'), "\n")
+  call assert_equal('Already at newest change', messages[-1])
+
+  bwipe!
+endfunc
+
+func Test_redo_empty_line()
+  new
+  exe "norm\x16r\x160"
+  exe "norm."
+  bwipe!
+endfunc
+
+funct Test_undofile()
+  " Test undofile() without setting 'undodir'.
+  if has('persistent_undo')
+    call assert_equal(fnamemodify('.Xundofoo.un~', ':p'), undofile('Xundofoo'))
+  else
+    call assert_equal('', undofile('Xundofoo'))
+  endif
+  call assert_equal('', undofile(''))
+
+  " Test undofile() with 'undodir' set to to an existing directory.
+  call mkdir('Xundodir')
+  set undodir=Xundodir
+  let cwd = getcwd()
+  if has('win32')
+    " Replace windows drive such as C:... into C%...
+    let cwd = substitute(cwd, '^\([a-zA-Z]\):', '\1%', 'g')
+  endif
+  let cwd = substitute(cwd . '/Xundofoo', '/', '%', 'g')
+  if has('persistent_undo')
+    call assert_equal('Xundodir/' . cwd, undofile('Xundofoo'))
+  else
+    call assert_equal('', undofile('Xundofoo'))
+  endif
+  call assert_equal('', undofile(''))
+  call delete('Xundodir', 'd')
+
+  " Test undofile() with 'undodir' set to a non-existing directory.
+  " call assert_equal('', 'Xundofoo'->undofile())
+
+  if isdirectory('/tmp')
+    set undodir=/tmp
+    if has('osx')
+      call assert_equal('/tmp/%private%tmp%file', undofile('///tmp/file'))
+    else
+      call assert_equal('/tmp/%tmp%file', undofile('///tmp/file'))
+    endif
+  endif
+
+  set undodir&
 endfunc
 
 " Tests for the undo file
@@ -746,6 +744,15 @@ func Test_redo_repeat_numbered_register()
   call feedkeys('"1p.........', 'xt')
   call assert_equal(['', 'one', 'two', 'three', 'four', 'five', 'six',
         \ 'seven', 'eight', 'nine', 'nine'], getline(1, '$'))
+  bwipe!
+endfunc
+
+" Test for redo in insert mode using CTRL-O with multibyte characters
+func Test_redo_multibyte_in_insert_mode()
+  new
+  call feedkeys("a\<C-K>ft", 'xt')
+  call feedkeys("uiHe\<C-O>.llo", 'xt')
+  call assert_equal("He\ufb05llo", getline(1))
   bwipe!
 endfunc
 

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -1,0 +1,26 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local command = helpers.command
+local expect = helpers.expect
+local feed = helpers.feed
+local sleep = helpers.sleep
+
+before_each(clear)
+
+-- oldtest: Test_autoindent_remove_indent()
+it('autoindent removes indent when Insert mode is stopped', function()
+  command('set autoindent')
+  -- leaving insert mode in a new line with indent added by autoindent, should
+  -- remove the indent.
+  feed('i<Tab>foo<CR><Esc>')
+  -- Need to delay for sometime, otherwise the code in getchar.c will not be
+  -- exercised.
+  sleep(50)
+  -- when a line is wrapped and the cursor is at the start of the second line,
+  -- leaving insert mode, should move the cursor back to the first line.
+  feed('o' .. ('x'):rep(20) .. '<Esc>')
+  -- Need to delay for sometime, otherwise the code in getchar.c will not be
+  -- exercised.
+  sleep(50)
+  expect('\tfoo\n\n' .. ('x'):rep(20))
+end)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -261,6 +261,35 @@ describe('messages', function()
         ^100                                                                        |
                                                                                    |
       ]])
+
+      -- Execute a : command from the more prompt
+      feed(':%p#\n')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed(':')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        :^                                                                          |
+      ]])
+      feed("echo 'Hello'\n")
+      screen:expect([[
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        Hello                                                                      |
+        {1:Press ENTER or type command to continue}^                                    |
+      ]])
     end)
 
     -- oldtest: Test_quit_long_message()

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -287,6 +287,76 @@ describe('messages', function()
     end)
   end)
 
+  -- oldtest: Test_ask_yesno()
+  it('y/n prompt works', function()
+    screen = Screen.new(75, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
+      [2] = {bold = true, reverse = true},  -- MsgSeparator
+    })
+    screen:attach()
+    command('set noincsearch nohlsearch inccommand=')
+    command('call setline(1, range(1, 2))')
+
+    feed(':2,1s/^/n/\n')
+    screen:expect([[
+      1                                                                          |
+      2                                                                          |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}^                                   |
+    ]])
+    feed('n')
+    screen:expect([[
+      ^1                                                                          |
+      2                                                                          |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}n                                  |
+    ]])
+
+    feed(':2,1s/^/Esc/\n')
+    screen:expect([[
+      1                                                                          |
+      2                                                                          |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}^                                   |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^1                                                                          |
+      2                                                                          |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}n                                  |
+    ]])
+
+    feed(':2,1s/^/y/\n')
+    screen:expect([[
+      1                                                                          |
+      2                                                                          |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}^                                   |
+    ]])
+    feed('y')
+    screen:expect([[
+      y1                                                                         |
+      ^y2                                                                         |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:Backwards range given, OK to swap (y/n)?}y                                  |
+    ]])
+  end)
+
   -- oldtest: Test_fileinfo_after_echo()
   it('fileinfo does not overwrite echo message vim-patch:8.2.4156', function()
     screen = Screen.new(40, 6)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -8,39 +8,290 @@ local feed = helpers.feed
 before_each(clear)
 
 describe('messages', function()
-  it('more prompt with control characters can be quit vim-patch:8.2.1844', function()
-    local screen = Screen.new(40, 6)
-    screen:set_default_attr_ids({
-      [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
-      [2] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
-      [3] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
-    })
-    screen:attach()
-    command('set more')
-    feed([[:echom range(9999)->join("\x01")<CR>]])
-    screen:expect([[
-      0{1:^A}1{1:^A}2{1:^A}3{1:^A}4{1:^A}5{1:^A}6{1:^A}7{1:^A}8{1:^A}9{1:^A}10{1:^A}11{1:^A}12|
-      {1:^A}13{1:^A}14{1:^A}15{1:^A}16{1:^A}17{1:^A}18{1:^A}19{1:^A}20{1:^A}21{1:^A}22|
-      {1:^A}23{1:^A}24{1:^A}25{1:^A}26{1:^A}27{1:^A}28{1:^A}29{1:^A}30{1:^A}31{1:^A}32|
-      {1:^A}33{1:^A}34{1:^A}35{1:^A}36{1:^A}37{1:^A}38{1:^A}39{1:^A}40{1:^A}41{1:^A}42|
-      {1:^A}43{1:^A}44{1:^A}45{1:^A}46{1:^A}47{1:^A}48{1:^A}49{1:^A}50{1:^A}51{1:^A}52|
-      {2:-- More --}^                              |
-    ]])
-    feed('q')
-    screen:expect([[
-      ^                                        |
-      {3:~                                       }|
-      {3:~                                       }|
-      {3:~                                       }|
-      {3:~                                       }|
-                                              |
-    ]])
+  local screen
+
+  describe('more prompt', function()
+    before_each(function()
+      screen = Screen.new(75, 6)
+      screen:set_default_attr_ids({
+        [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+        [1] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
+        [2] = {foreground = Screen.colors.Brown},  -- LineNr
+        [3] = {foreground = Screen.colors.Blue},  -- SpecialKey
+      })
+      screen:attach()
+      command('set more')
+    end)
+
+    -- oldtest: Test_message_more()
+    it('works', function()
+      command('call setline(1, range(1, 100))')
+
+      feed(':%p#\n')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      feed('?')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {1:-- More -- SPACE/d/j: screen/page/line down, b/u/k: up, q: quit }^           |
+      ]])
+
+      -- Down a line with j, <CR>, <NL> or <Down>.
+      feed('j')
+      screen:expect([[
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {2:  6 }6                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<NL>')
+      screen:expect([[
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {2:  6 }6                                                                      |
+        {2:  7 }7                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<CR>')
+      screen:expect([[
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {2:  6 }6                                                                      |
+        {2:  7 }7                                                                      |
+        {2:  8 }8                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<Down>')
+      screen:expect([[
+        {2:  5 }5                                                                      |
+        {2:  6 }6                                                                      |
+        {2:  7 }7                                                                      |
+        {2:  8 }8                                                                      |
+        {2:  9 }9                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Down a screen with <Space>, f, or <PageDown>.
+      feed('f')
+      screen:expect([[
+        {2: 10 }10                                                                     |
+        {2: 11 }11                                                                     |
+        {2: 12 }12                                                                     |
+        {2: 13 }13                                                                     |
+        {2: 14 }14                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<Space>')
+      screen:expect([[
+        {2: 15 }15                                                                     |
+        {2: 16 }16                                                                     |
+        {2: 17 }17                                                                     |
+        {2: 18 }18                                                                     |
+        {2: 19 }19                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<PageDown>')
+      screen:expect([[
+        {2: 20 }20                                                                     |
+        {2: 21 }21                                                                     |
+        {2: 22 }22                                                                     |
+        {2: 23 }23                                                                     |
+        {2: 24 }24                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Down a page (half a screen) with d.
+      feed('d')
+      screen:expect([[
+        {2: 23 }23                                                                     |
+        {2: 24 }24                                                                     |
+        {2: 25 }25                                                                     |
+        {2: 26 }26                                                                     |
+        {2: 27 }27                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Down all the way with 'G'.
+      feed('G')
+      screen:expect([[
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {2: 98 }98                                                                     |
+        {2: 99 }99                                                                     |
+        {2:100 }100                                                                    |
+        {1:Press ENTER or type command to continue}^                                    |
+      ]])
+
+      -- Up a line k, <BS> or <Up>.
+      feed('k')
+      screen:expect([[
+        {2: 95 }95                                                                     |
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {2: 98 }98                                                                     |
+        {2: 99 }99                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<BS>')
+      screen:expect([[
+        {2: 94 }94                                                                     |
+        {2: 95 }95                                                                     |
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {2: 98 }98                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<Up>')
+      screen:expect([[
+        {2: 93 }93                                                                     |
+        {2: 94 }94                                                                     |
+        {2: 95 }95                                                                     |
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Up a screen with b or <PageUp>.
+      feed('b')
+      screen:expect([[
+        {2: 88 }88                                                                     |
+        {2: 89 }89                                                                     |
+        {2: 90 }90                                                                     |
+        {2: 91 }91                                                                     |
+        {2: 92 }92                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+      feed('<PageUp>')
+      screen:expect([[
+        {2: 83 }83                                                                     |
+        {2: 84 }84                                                                     |
+        {2: 85 }85                                                                     |
+        {2: 86 }86                                                                     |
+        {2: 87 }87                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Up a page (half a screen) with u.
+      feed('u')
+      screen:expect([[
+        {2: 80 }80                                                                     |
+        {2: 81 }81                                                                     |
+        {2: 82 }82                                                                     |
+        {2: 83 }83                                                                     |
+        {2: 84 }84                                                                     |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Up all the way with 'g'.
+      feed('g')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- All the way down. Pressing f should do nothing but pressing
+      -- space should end the more prompt.
+      feed('G')
+      screen:expect([[
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {2: 98 }98                                                                     |
+        {2: 99 }99                                                                     |
+        {2:100 }100                                                                    |
+        {1:Press ENTER or type command to continue}^                                    |
+      ]])
+      feed('f')
+      screen:expect_unchanged()
+      feed('<Space>')
+      screen:expect([[
+        96                                                                         |
+        97                                                                         |
+        98                                                                         |
+        99                                                                         |
+        ^100                                                                        |
+                                                                                   |
+      ]])
+
+      -- Pressing g< shows the previous command output.
+      feed('g<lt>')
+      screen:expect([[
+        {2: 96 }96                                                                     |
+        {2: 97 }97                                                                     |
+        {2: 98 }98                                                                     |
+        {2: 99 }99                                                                     |
+        {2:100 }100                                                                    |
+        {1:Press ENTER or type command to continue}^                                    |
+      ]])
+
+      feed(':%p#\n')
+      screen:expect([[
+        {2:  1 }1                                                                      |
+        {2:  2 }2                                                                      |
+        {2:  3 }3                                                                      |
+        {2:  4 }4                                                                      |
+        {2:  5 }5                                                                      |
+        {1:-- More --}^                                                                 |
+      ]])
+
+      -- Stop command output with q, <Esc> or CTRL-C.
+      feed('q')
+      screen:expect([[
+        96                                                                         |
+        97                                                                         |
+        98                                                                         |
+        99                                                                         |
+        ^100                                                                        |
+                                                                                   |
+      ]])
+    end)
+
+    -- oldtest: Test_quit_long_message()
+    it('with control characters can be quit vim-patch:8.2.1844', function()
+      screen:try_resize(40, 6)
+      feed([[:echom range(9999)->join("\x01")<CR>]])
+      screen:expect([[
+        0{3:^A}1{3:^A}2{3:^A}3{3:^A}4{3:^A}5{3:^A}6{3:^A}7{3:^A}8{3:^A}9{3:^A}10{3:^A}11{3:^A}12|
+        {3:^A}13{3:^A}14{3:^A}15{3:^A}16{3:^A}17{3:^A}18{3:^A}19{3:^A}20{3:^A}21{3:^A}22|
+        {3:^A}23{3:^A}24{3:^A}25{3:^A}26{3:^A}27{3:^A}28{3:^A}29{3:^A}30{3:^A}31{3:^A}32|
+        {3:^A}33{3:^A}34{3:^A}35{3:^A}36{3:^A}37{3:^A}38{3:^A}39{3:^A}40{3:^A}41{3:^A}42|
+        {3:^A}43{3:^A}44{3:^A}45{3:^A}46{3:^A}47{3:^A}48{3:^A}49{3:^A}50{3:^A}51{3:^A}52|
+        {1:-- More --}^                              |
+      ]])
+      feed('q')
+      screen:expect([[
+        ^                                        |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+                                                |
+      ]])
+    end)
   end)
 
+  -- oldtest: Test_fileinfo_after_echo()
   it('fileinfo does not overwrite echo message vim-patch:8.2.4156', function()
-    local screen = Screen.new(40, 6)
+    screen = Screen.new(40, 6)
     screen:set_default_attr_ids({
-      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
     })
     screen:attach()
     exec([[
@@ -60,10 +311,10 @@ describe('messages', function()
     feed('0$')
     screen:expect([[
       ^hi                                      |
-      {1:~                                       }|
-      {1:~                                       }|
-      {1:~                                       }|
-      {1:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
       'b' written                             |
     ]])
     os.remove('b.txt')


### PR DESCRIPTION
#### vim-patch:8.2.0052: more-prompt not properly tested

Problem:    More-prompt not properly tested.
Solution:   Add a test case. (Dominique Pelle, closes vim/vim#5404)
https://github.com/vim/vim/commit/c6d539b67181ad573452e919e58ecbfa362f4c49


#### vim-patch:8.2.0198: no tests for y/n prompt

Problem:    No tests for y/n prompt.
Solution:   Add tests. (Dominique Pelle, closes vim/vim#5564)
https://github.com/vim/vim/commit/43c60eda2aa22ba3d7aaf418cfbdb75f1a008e67


#### vim-patch:8.2.2608: character input not fully tested

Problem:    Character input not fully tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#7963)
https://github.com/vim/vim/commit/f4fcedc59d4cc5ae6b5270a933e8377030283c1c

Cherry-pick related changes from patches 8.2.{0433,0866}.


#### vim-patch:8.2.2643: various code not covered by tests

Problem:    Various code not covered by tests.
Solution:   Add a few more test. (Yegappan Lakshmanan, closes vim/vim#7995)
https://github.com/vim/vim/commit/1f448d906b3c516e5864dc5bae3ddbf3664ee649

Cherry-pick some test_edit.vim changes from patches 8.2.{1022,1432}.
Reorder test_undo.vim to match upstream.