### PR TITLE
test(job_spec): accept alternate messages for "append environment" tests

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -73,9 +73,16 @@ describe('jobs', function()
       nvim('command', [[call jobstart('echo $TOTO $VAR', g:job_opts)]])
     end
 
-    expect_msg_seq({
-      {'notification', 'stdout', {0, {'hello world abc', ''}}},
-    })
+    expect_msg_seq(
+      {
+        {'notification', 'stdout', {0, {'hello world abc'}}},
+        {'notification', 'stdout', {0, {'', ''}}},
+      },
+      {
+        {'notification', 'stdout', {0, {'hello world abc', ''}}},
+        {'notification', 'stdout', {0, {''}}}
+      }
+    )
   end)
 
   it('append environment with pty #env', function()
@@ -89,9 +96,16 @@ describe('jobs', function()
     else
       nvim('command', [[call jobstart('echo $TOTO $VAR', g:job_opts)]])
     end
-    expect_msg_seq({
-      {'notification', 'stdout', {0, {'hello world abc', ''}}},
-    })
+    expect_msg_seq(
+      {
+        {'notification', 'stdout', {0, {'hello world abc'}}},
+        {'notification', 'stdout', {0, {'', ''}}},
+      },
+      {
+        {'notification', 'stdout', {0, {'hello world abc', ''}}},
+        {'notification', 'stdout', {0, {''}}}
+      }
+    )
   end)
 
   it('replace environment #env', function()


### PR DESCRIPTION
These tests commonly fail in Debian with

    [  ERROR   ] test/functional/core/job_spec.lua @ 81: jobs append environment with pty #env
    test/functional/helpers.lua:198:
    ==============================================================================
    test/helpers.lua:73: Expected objects to be the same.
    Passed in:
    (table: 0x2aa4bcc1040) {
     *[1] = {
        [1] = 'notification'
        [2] = 'stdout'
       *[3] = {
          [1] = 0
         *[2] = {
            [1] = 'hello world abc' } } } }
    Expected:
    (table: 0x2aa4bcc0d70) {
     *[1] = {
        [1] = 'notification'
        [2] = 'stdout'
       *[3] = {
          [1] = 0
         *[2] = {
            [1] = 'hello world abc'
           *[2] = '' } } } }

Since the test is validating the "hello world abc" message, not the newlines, accept either set of message sequences.