### PR TITLE
vim-patch:8.2.{0655,1040}: not enough tests

### DIFF
--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -29,6 +29,17 @@ func Test_charsearch()
   set cpo-=;
   normal! ;;p
   call assert_equal('ZabcdeZfghijkZZemnokqretkZvwxyz', getline(3))
+
+  " check that repeating a search before and after a line fails
+  normal 3Gfv
+  call assert_beeps('normal ;')
+  call assert_beeps('normal ,')
+
+  " clear the character search
+  call setcharsearch({'char' : ''})
+  call assert_equal('', getcharsearch().char)
+
+  call assert_fails("call setcharsearch([])", 'E715:')
   enew!
 endfunc
 
@@ -70,6 +81,20 @@ func Test_csearch_virtualedit()
   normal! tb
   call assert_equal([0, 1, 2, 6], getpos('.'))
   set virtualedit&
+  close!
+endfunc
+
+" Test for character search failure in latin1 encoding
+func Test_charsearch_latin1()
+  new
+  let save_enc = &encoding
+  " set encoding=latin1
+  call setline(1, 'abcdefghijk')
+  call assert_beeps('normal fz')
+  call assert_beeps('normal tx')
+  call assert_beeps('normal $Fz')
+  call assert_beeps('normal $Tx')
+  let &encoding = save_enc
   close!
 endfunc
 

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -99,6 +99,7 @@ func Test_screenpos()
     \ 'curscol': wincol + 9,
     \ 'endcol': wincol + 9}, screenpos(winid, 2, 22))
   close
+  call assert_equal({}, screenpos(999, 1, 1))
   bwipe!
 
   call assert_equal({'col': 1, 'row': 1, 'endcol': 1, 'curscol': 1}, screenpos(win_getid(), 1, 1))

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -185,7 +185,9 @@ func Test_str2nr()
 
   call assert_fails('call str2nr([])', 'E730:')
   call assert_fails('call str2nr({->2})', 'E729:')
-  call assert_fails('call str2nr(1.2)', 'E806:')
+  if has('float')
+    call assert_fails('call str2nr(1.2)', 'E806:')
+  endif
   call assert_fails('call str2nr(10, [])', 'E474:')
 endfunc
 
@@ -325,11 +327,18 @@ func Test_simplify()
   call assert_equal('./file',      simplify('./dir/../file'))
   call assert_equal('../dir/file', simplify('dir/../../dir/file'))
   call assert_equal('./file',      simplify('dir/.././file'))
+  call assert_equal('../dir',      simplify('./../dir'))
+  call assert_equal('..',          simplify('../testdir/..'))
+  call mkdir('Xdir')
+  call assert_equal('.',           simplify('Xdir/../.'))
+  call delete('Xdir', 'd')
 
   call assert_fails('call simplify({->0})', 'E729:')
   call assert_fails('call simplify([])', 'E730:')
   call assert_fails('call simplify({})', 'E731:')
-  call assert_fails('call simplify(1.2)', 'E806:')
+  if has('float')
+    call assert_fails('call simplify(1.2)', 'E806:')
+  endif
 endfunc
 
 func Test_pathshorten()

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -35,6 +35,13 @@ func Test_gf_url()
   call search("URL")
   call assert_equal("URL://machine.name:1234?q=vim", expand("<cfile>"))
 
+  %d
+  call setline(1, "demo://remote_file")
+  wincmd f
+  call assert_equal('demo://remote_file', @%)
+  call assert_equal(2, winnr('$'))
+  close!
+
   set isf&vim
   enew!
 endfunc
@@ -168,6 +175,23 @@ func Test_gf_error()
   au! InsertCharPre
 
   bwipe!
+endfunc
+
+" If a file is not found by 'gf', then 'includeexpr' should be used to locate
+" the file.
+func Test_gf_includeexpr()
+  new
+  let g:Inc_fname = ''
+  func IncFunc()
+    let g:Inc_fname = v:fname
+    return v:fname
+  endfunc
+  setlocal includeexpr=IncFunc()
+  call setline(1, 'somefile.java')
+  call assert_fails('normal gf', 'E447:')
+  call assert_equal('somefile.java', g:Inc_fname)
+  close!
+  delfunc IncFunc
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_gn.vim
+++ b/src/nvim/testdir/test_gn.vim
@@ -154,8 +154,24 @@ func Test_gn_command()
   norm! gg0f2vf7gNd
   call assert_equal(['1678'], getline(1,'$'))
   sil! %d _
-
   set wrapscan&vim
+
+  " Without 'wrapscan', in visual mode, running gn without a match should fail
+  " but the visual mode should be kept.
+  set nowrapscan
+  call setline('.', 'one two')
+  let @/ = 'one'
+  call assert_beeps('normal 0wvlgn')
+  exe "normal y"
+  call assert_equal('tw', @")
+
+  " with exclusive selection, run gn and gN
+  set selection=exclusive
+  normal 0gny
+  call assert_equal('one', @")
+  normal 0wgNy
+  call assert_equal('one', @")
+  set selection&
 endfunc
 
 func Test_gN_repeat()

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -334,21 +334,24 @@ endfunc
 
 func Test_motion_if_elif_else_endif()
   new
-  a
-/* Test pressing % on #if, #else #elsif and #endif,
- * with nested #if
- */
-#if FOO
-/* ... */
-#  if BAR
-/* ... */
-#  endif
-#elif BAR
-/* ... */
-#else
-/* ... */
-#endif
-.
+  let lines =<< trim END
+    /* Test pressing % on #if, #else #elsif and #endif,
+     * with nested #if
+     */
+    #if FOO
+    /* ... */
+    #  if BAR
+    /* ... */
+    #  endif
+    #elif BAR
+    /* ... */
+    #else
+    /* ... */
+    #endif
+
+    #define FOO 1
+  END
+  call setline(1, lines)
   /#if FOO
   norm %
   call assert_equal([9, 1], getpos('.')[1:2])
@@ -363,6 +366,30 @@ func Test_motion_if_elif_else_endif()
   call assert_equal([8, 1], getpos('.')[1:2])
   norm $%
   call assert_equal([6, 1], getpos('.')[1:2])
+
+  " Test for [# and ]# command
+  call cursor(5, 1)
+  normal [#
+  call assert_equal([4, 1], getpos('.')[1:2])
+  call cursor(5, 1)
+  normal ]#
+  call assert_equal([9, 1], getpos('.')[1:2])
+  call cursor(10, 1)
+  normal [#
+  call assert_equal([9, 1], getpos('.')[1:2])
+  call cursor(10, 1)
+  normal ]#
+  call assert_equal([11, 1], getpos('.')[1:2])
+
+  " Finding a match before the first line or after the last line should fail
+  normal gg
+  call assert_beeps('normal [#')
+  normal G
+  call assert_beeps('normal ]#')
+
+  " Finding a match for a macro definition (#define) should fail
+  normal G
+  call assert_beeps('normal %')
 
   bw!
 endfunc
@@ -393,3 +420,5 @@ func Test_motion_c_comment()
 
   bw!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -601,6 +601,26 @@ func Test_ins_compl_tag_sft()
   %bwipe!
 endfunc
 
+" Test for completing words following a completed word in a line
+func Test_complete_wrapscan()
+  " complete words from another buffer
+  new
+  call setline(1, ['one two', 'three four'])
+  new
+  setlocal complete=w
+  call feedkeys("itw\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>", 'xt')
+  call assert_equal('two three four', getline(1))
+  close!
+  " complete words from the current buffer
+  setlocal complete=.
+  %d
+  call setline(1, ['one two', ''])
+  call cursor(2, 1)
+  call feedkeys("ion\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>", 'xt')
+  call assert_equal('one two one two', getline(2))
+  close!
+endfunc
+
 " Test for completing special characters
 func Test_complete_special_chars()
   new

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -466,9 +466,11 @@ func Test_set_one_column()
 endfunc
 
 func Test_set_values()
-  " The file is only generated when running "make test" in the src directory.
+  " opt_test.vim is generated from ../optiondefs.h using gen_opt_test.vim
   if filereadable('opt_test.vim')
     source opt_test.vim
+  else
+    throw 'Skipped: opt_test.vim does not exist'
   endif
 endfunc
 
@@ -811,6 +813,37 @@ func Test_opt_boolean()
   let &nu = v:false
   call assert_equal(0, &nu)
   set number&
+endfunc
+
+" Test for the 'window' option
+func Test_window_opt()
+  " Needs only one open widow
+  %bw!
+  call setline(1, range(1, 8))
+  set window=5
+  exe "normal \<C-F>"
+  call assert_equal(4, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(7, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(8, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(5, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(1, line('w0'))
+  set window=1
+  exe "normal gg\<C-F>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-F>"
+  call assert_equal(3, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(2, line('w0'))
+  exe "normal \<C-B>"
+  call assert_equal(1, line('w0'))
+  enew!
+  set window&
 endfunc
 
 " Test for the 'winminheight' option

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -520,10 +520,10 @@ func Xtest_browse(cchar)
   call assert_fails('Xprev', 'E553')
   call assert_fails('Xpfile', 'E553')
   Xnfile
-  call assert_equal('Xqftestfile2', bufname('%'))
+  call assert_equal('Xqftestfile2', @%)
   call assert_equal(10, line('.'))
   Xpfile
-  call assert_equal('Xqftestfile1', bufname('%'))
+  call assert_equal('Xqftestfile1', @%)
   call assert_equal(6, line('.'))
   5Xcc
   call assert_equal(5, g:Xgetlist({'idx':0}).idx)
@@ -539,7 +539,7 @@ func Xtest_browse(cchar)
   call assert_equal(6, g:Xgetlist({'idx':0}).idx)
   Xlast
   Xprev
-  call assert_equal('Xqftestfile2', bufname('%'))
+  call assert_equal('Xqftestfile2', @%)
   call assert_equal(11, line('.'))
   call assert_fails('Xnext', 'E553')
   call assert_fails('Xnfile', 'E553')
@@ -552,14 +552,14 @@ func Xtest_browse(cchar)
   endif
   call assert_equal(6, g:Xgetlist({'idx':0}).idx)
   Xrewind
-  call assert_equal('Xqftestfile1', bufname('%'))
+  call assert_equal('Xqftestfile1', @%)
   call assert_equal(5, line('.'))
 
   10Xnext
-  call assert_equal('Xqftestfile2', bufname('%'))
+  call assert_equal('Xqftestfile2', @%)
   call assert_equal(11, line('.'))
   10Xprev
-  call assert_equal('Xqftestfile1', bufname('%'))
+  call assert_equal('Xqftestfile1', @%)
   call assert_equal(5, line('.'))
 
   " Jumping to an error from the error window using cc command
@@ -570,7 +570,7 @@ func Xtest_browse(cchar)
   Xopen
   10Xcc
   call assert_equal(11, line('.'))
-  call assert_equal('Xqftestfile2', bufname('%'))
+  call assert_equal('Xqftestfile2', @%)
   Xopen
   call cursor(2, 1)
   if a:cchar == 'c'
@@ -579,14 +579,14 @@ func Xtest_browse(cchar)
     .ll
   endif
   call assert_equal(6, line('.'))
-  call assert_equal('Xqftestfile1', bufname('%'))
+  call assert_equal('Xqftestfile1', @%)
 
   " Jumping to an error from the error window (when only the error window is
   " present)
   Xopen | only
   Xlast 1
   call assert_equal(5, line('.'))
-  call assert_equal('Xqftestfile1', bufname('%'))
+  call assert_equal('Xqftestfile1', @%)
 
   Xexpr ""
   call assert_fails('Xnext', 'E42:')
@@ -1961,7 +1961,7 @@ func Test_switchbuf()
   copen | only
   cfirst
   call assert_equal(1, tabpagenr())
-  call assert_equal('Xqftestfile1', bufname(''))
+  call assert_equal('Xqftestfile1', @%)
 
   " If opening a file changes 'switchbuf', then the new value should be
   " retained.
@@ -2777,7 +2777,7 @@ func Test_cwindow_jump()
   wincmd b
   cfirst
   call assert_equal(2, winnr())
-  call assert_equal('F1', bufname(''))
+  call assert_equal('F1', @%)
   enew | only
   exe 'sb' bnum
   exe 'botright sb' bnum
@@ -2867,7 +2867,7 @@ func XvimgrepTests(cchar)
   edit +3 Xtestfile2
   Xvimgrep +\cemacs+j Xtestfile1
   let l = g:Xgetlist()
-  call assert_equal('Xtestfile2', bufname(''))
+  call assert_equal('Xtestfile2', @%)
   call assert_equal('Editor:Emacs EmAcS', l[0].text)
 
   " Test for unloading a buffer after vimgrep searched the buffer
@@ -3536,7 +3536,7 @@ func Xqfjump_tests(cchar)
   Xopen | only
   2Xnext
   call assert_equal(3, g:Xgetlist({'idx' : 0}).idx)
-  call assert_equal('F3', bufname('%'))
+  call assert_equal('F3', @%)
   Xnext
   call assert_equal(7, col('.'))
   Xnext
@@ -4230,20 +4230,20 @@ func Xjumpto_first_error_test(cchar)
   " Test for cexpr/lexpr
   enew
   Xexpr l
-  call assert_equal('Xtestfile1', bufname(''))
+  call assert_equal('Xtestfile1', @%)
   call assert_equal(2, line('.'))
 
   " Test for cfile/lfile
   enew
   call writefile(l, 'Xerr')
   Xfile Xerr
-  call assert_equal('Xtestfile1', bufname(''))
+  call assert_equal('Xtestfile1', @%)
   call assert_equal(2, line('.'))
 
   " Test for cbuffer/lbuffer
   edit Xerr
   Xbuffer
-  call assert_equal('Xtestfile1', bufname(''))
+  call assert_equal('Xtestfile1', @%)
   call assert_equal(2, line('.'))
 
   call delete('Xerr')
@@ -4268,7 +4268,7 @@ func Xautocmd_changelist(cchar)
   autocmd QuickFixCmdPost * Xolder
   call writefile(['Xtestfile2:4:Line4'], 'Xerr')
   Xfile Xerr
-  call assert_equal('Xtestfile2', bufname(''))
+  call assert_equal('Xtestfile2', @%)
   call assert_equal(4, line('.'))
   autocmd! QuickFixCmdPost
 
@@ -4279,7 +4279,7 @@ func Xautocmd_changelist(cchar)
   call writefile(['Xtestfile2:4:Line4'], 'Xerr')
   edit Xerr
   Xbuffer
-  call assert_equal('Xtestfile2', bufname(''))
+  call assert_equal('Xtestfile2', @%)
   call assert_equal(4, line('.'))
   autocmd! QuickFixCmdPost
 
@@ -4288,7 +4288,7 @@ func Xautocmd_changelist(cchar)
   Xexpr 'Xtestfile1:2:Line2'
   autocmd QuickFixCmdPost * Xolder
   Xexpr 'Xtestfile2:4:Line4'
-  call assert_equal('Xtestfile2', bufname(''))
+  call assert_equal('Xtestfile2', @%)
   call assert_equal(4, line('.'))
   autocmd! QuickFixCmdPost
 
@@ -4299,7 +4299,7 @@ func Xautocmd_changelist(cchar)
     Xexpr 'Xtestfile1:2:Line2'
     autocmd QuickFixCmdPost * Xolder
     silent Xgrep Line5 Xtestfile2
-    call assert_equal('Xtestfile2', bufname(''))
+    call assert_equal('Xtestfile2', @%)
     call assert_equal(5, line('.'))
     autocmd! QuickFixCmdPost
   endif
@@ -4309,7 +4309,7 @@ func Xautocmd_changelist(cchar)
   Xexpr 'Xtestfile1:2:Line2'
   autocmd QuickFixCmdPost * Xolder
   silent Xvimgrep Line5 Xtestfile2
-  call assert_equal('Xtestfile2', bufname(''))
+  call assert_equal('Xtestfile2', @%)
   call assert_equal(5, line('.'))
   autocmd! QuickFixCmdPost
 
@@ -4624,7 +4624,7 @@ func Test_winonly_autocmd()
   " positioned correctly.
   ll 3
   call assert_equal(loclistid, getloclist(0, {'id' : 0}).id)
-  call assert_equal('Xtest1', bufname(''))
+  call assert_equal('Xtest1', @%)
   call assert_equal(15, line('.'))
   " Cleanup
   autocmd! WinEnter
@@ -4685,51 +4685,51 @@ func Xtest_below(cchar)
   Xexpr ["X1:5:3:L5", "X2:5:2:L5", "X2:10:3:L10", "X2:15:4:L15", "X3:3:5:L3"]
   edit +7 X2
   Xabove
-  call assert_equal(['X2', 5], [bufname(''), line('.')])
+  call assert_equal(['X2', 5], [@%, line('.')])
   call assert_fails('Xabove', 'E553:')
   normal 7G
   Xbefore
-  call assert_equal(['X2', 5, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 2], [@%, line('.'), col('.')])
   call assert_fails('Xbefore', 'E553:')
 
   normal 2j
   Xbelow
-  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  call assert_equal(['X2', 10], [@%, line('.')])
   normal 7G
   Xafter
-  call assert_equal(['X2', 10, 3], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 3], [@%, line('.'), col('.')])
 
   " Last error in this file
   Xbelow 99
-  call assert_equal(['X2', 15], [bufname(''), line('.')])
+  call assert_equal(['X2', 15], [@%, line('.')])
   call assert_fails('Xbelow', 'E553:')
   normal gg
   Xafter 99
-  call assert_equal(['X2', 15, 4], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 4], [@%, line('.'), col('.')])
   call assert_fails('Xafter', 'E553:')
 
   " First error in this file
   Xabove 99
-  call assert_equal(['X2', 5], [bufname(''), line('.')])
+  call assert_equal(['X2', 5], [@%, line('.')])
   call assert_fails('Xabove', 'E553:')
   normal G
   Xbefore 99
-  call assert_equal(['X2', 5, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 2], [@%, line('.'), col('.')])
   call assert_fails('Xbefore', 'E553:')
 
   normal gg
   Xbelow 2
-  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  call assert_equal(['X2', 10], [@%, line('.')])
   normal gg
   Xafter 2
-  call assert_equal(['X2', 10, 3], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 3], [@%, line('.'), col('.')])
 
   normal G
   Xabove 2
-  call assert_equal(['X2', 10], [bufname(''), line('.')])
+  call assert_equal(['X2', 10], [@%, line('.')])
   normal G
   Xbefore 2
-  call assert_equal(['X2', 10, 3], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 3], [@%, line('.'), col('.')])
 
   edit X4
   call assert_fails('Xabove', 'E42:')
@@ -4753,45 +4753,45 @@ func Xtest_below(cchar)
 	      \ "X2:15:1:L15_1", "X2:15:2:L15_2", "X2:15:3:L15_3", "X3:3:L3"]
   edit +1 X2
   Xbelow 2
-  call assert_equal(['X2', 10, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 1], [@%, line('.'), col('.')])
   normal 1G
   Xafter 2
-  call assert_equal(['X2', 5, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 2], [@%, line('.'), col('.')])
 
   normal gg
   Xbelow 99
-  call assert_equal(['X2', 15, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 1], [@%, line('.'), col('.')])
   normal gg
   Xafter 99
-  call assert_equal(['X2', 15, 3], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 3], [@%, line('.'), col('.')])
 
   normal G
   Xabove 2
-  call assert_equal(['X2', 10, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 1], [@%, line('.'), col('.')])
   normal G
   Xbefore 2
-  call assert_equal(['X2', 15, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 2], [@%, line('.'), col('.')])
 
   normal G
   Xabove 99
-  call assert_equal(['X2', 5, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 1], [@%, line('.'), col('.')])
   normal G
   Xbefore 99
-  call assert_equal(['X2', 5, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 1], [@%, line('.'), col('.')])
 
   normal 10G
   Xabove
-  call assert_equal(['X2', 5, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 5, 1], [@%, line('.'), col('.')])
   normal 10G$
   2Xbefore
-  call assert_equal(['X2', 10, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 10, 2], [@%, line('.'), col('.')])
 
   normal 10G
   Xbelow
-  call assert_equal(['X2', 15, 1], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 1], [@%, line('.'), col('.')])
   normal 9G
   5Xafter
-  call assert_equal(['X2', 15, 2], [bufname(''), line('.'), col('.')])
+  call assert_equal(['X2', 15, 2], [@%, line('.'), col('.')])
 
   " Invalid range
   if a:cchar == 'c'

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1060,7 +1060,7 @@ func Test_tw_2_fo_tm_replace()
 endfunc
 
 " Test for 'matchpairs' with multibyte chars
-func Test_mps()
+func Test_mps_multibyte()
   new
   let t =<< trim END
     {
@@ -1082,6 +1082,30 @@ func Test_mps()
 
   set mps&
   bwipe!
+endfunc
+
+" Test for 'matchpairs' in latin1 encoding
+func Test_mps_latin1()
+  new
+  let save_enc = &encoding
+  " set encoding=latin1
+  call setline(1, 'abc(def)ghi')
+  normal %
+  call assert_equal(8, col('.'))
+  normal %
+  call assert_equal(4, col('.'))
+  call cursor(1, 6)
+  normal [(
+  call assert_equal(4, col('.'))
+  normal %
+  call assert_equal(8, col('.'))
+  call cursor(1, 6)
+  normal ])
+  call assert_equal(8, col('.'))
+  normal %
+  call assert_equal(4, col('.'))
+  let &encoding = save_enc
+  close!
 endfunc
 
 func Test_empty_matchpairs()

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -233,6 +233,10 @@ func Test_empty_html_tag()
   normal 0f<vitsaaa
   call assert_equal('aaa', getline(1))
 
+  " selecting a tag block in an non-empty blank line should fail
+  call setline(1, '    ')
+  call assert_beeps('normal $vaty')
+
   bwipe!
 endfunc
 
@@ -365,6 +369,168 @@ func Test_sentence_with_cursor_on_delimiter()
   call assert_equal(3, getcurpos()[1])
 
   %delete _
+endfunc
+
+" Test for the paragraph (ap) text object
+func Test_paragraph()
+  new
+  call setline(1, ['First line.', 'Second line.', 'Third line.'])
+  call cursor(2, 1)
+  normal vapy
+  call assert_equal("First line.\nSecond line.\nThird line.\n", @")
+
+  call cursor(2, 1)
+  call assert_beeps('normal vapapy')
+
+  call setline(1, ['First line.', 'Second line.', '  ', ''])
+  call cursor(1, 1)
+  normal vapy
+  call assert_equal("First line.\nSecond line.\n  \n\n", @")
+
+  call setline(1, ['', '', '', 'First line.', 'Second line.'])
+  call cursor(2, 1)
+  normal yap
+  call assert_equal("\n\n\nFirst line.\nSecond line.\n", @")
+  call assert_beeps('normal 3yap')
+  exe "normal \<C-C>"
+
+  %d
+  call setline(1, ['  ', '  ', '  '])
+  call cursor(2, 1)
+  normal Vipy
+  call assert_equal("  \n  \n  \n", @")
+  call cursor(2, 1)
+  call assert_beeps("normal Vipip")
+  exe "normal \<C-C>"
+
+  close!
+endfunc
+
+" Tests for text object aw
+func Test_textobj_a_word()
+  new
+  call append(0, ['foobar,eins,foobar', 'foo,zwei,foo    '])
+  " diw
+  norm! 1gg0diw
+  call assert_equal([',eins,foobar', 'foo,zwei,foo    ', ''], getline(1,'$'))
+  " daw
+  norm! 2ggEdaw
+  call assert_equal([',eins,foobar', 'foo,zwei,', ''], getline(1, '$'))
+  " daw the last word in a line
+  call setline(1, ['foo bar', 'foo bar', ''])
+  call cursor(1, 5)
+  normal daw
+  call assert_equal('foo', getline(1))
+  " aw in visual mode
+  call cursor(2, 5)
+  normal! vawx
+  call assert_equal('foo', getline(2))
+  %d
+  call append(0, ["foo\teins\tfoobar", "foo\tzwei\tfoo   "])
+  " diW
+  norm! 2ggwd2iW
+  call assert_equal(['foo	eins	foobar', 'foo	foo   ', ''], getline(1,'$'))
+  " daW
+  norm! 1ggd2aW
+  call assert_equal(['foobar', 'foo	foo   ', ''], getline(1,'$'))
+
+  %d
+  call append(0, ["foo\teins\tfoobar", "foo\tzwei\tfoo   "])
+  " aw in visual line mode switches to characterwise mode
+  norm! 2gg$Vawd
+  call assert_equal(['foo	eins	foobar', 'foo	zwei	foo'], getline(1,'$'))
+  norm! 1gg$Viwd
+  call assert_equal(['foo	eins	', 'foo	zwei	foo'], getline(1,'$'))
+
+  " visually selecting a tab before a word with 'selection' set to 'exclusive'
+  set selection=exclusive
+  normal gg3lvlawy
+  call assert_equal("\teins", @")
+  " visually selecting a tab before a word with 'selection' set to 'inclusive'
+  set selection=inclusive
+  normal gg3lvlawy
+  call assert_equal("\teins\t", @")
+  set selection&
+
+  " selecting a word with no non-space characters in a buffer fails
+  %d
+  call setline(1, '    ')
+  call assert_beeps('normal 3lyaw')
+
+  " visually selecting words backwards with no more words to select
+  call setline(1, 'one two')
+  call assert_beeps('normal 2lvh2aw')
+  exe "normal \<C-C>"
+  call assert_beeps('normal $vh3aw')
+  exe "normal \<C-C>"
+  call setline(1, ['', 'one two'])
+  call assert_beeps('normal 2G2lvh3aw')
+  exe "normal \<C-C>"
+
+  " selecting words forward with no more words to select
+  %d
+  call setline(1, 'one a')
+  call assert_beeps('normal 0y3aw')
+  call setline(1, 'one two ')
+  call assert_beeps('normal 0y3aw')
+  call assert_beeps('normal 03ly2aw')
+
+  " clean up
+  bw!
+endfunc
+
+" Test for is and as text objects
+func Test_textobj_sentence()
+  new
+  call append(0, ['This is a test. With some sentences!', '',
+        \ 'Even with a question? And one more. And no sentence here'])
+  " Test for dis - does not remove trailing whitespace
+  norm! 1gg0dis
+  call assert_equal([' With some sentences!', '',
+        \ 'Even with a question? And one more. And no sentence here', ''],
+        \ getline(1,'$'))
+  " Test for das - removes leading whitespace
+  norm! 3ggf?ldas
+  call assert_equal([' With some sentences!', '',
+        \ 'Even with a question? And no sentence here', ''], getline(1,'$'))
+  " when used in visual mode, is made characterwise
+  norm! 3gg$Visy
+  call assert_equal('v', visualmode())
+  " reset visualmode()
+  norm! 3ggVy
+  norm! 3gg$Vasy
+  call assert_equal('v', visualmode())
+  " basic testing for textobjects a< and at
+  %d
+  call setline(1, ['<div> ','<a href="foobar" class="foo">xyz</a>','    </div>', ' '])
+  " a<
+  norm! 1gg0da<
+  call assert_equal([' ', '<a href="foobar" class="foo">xyz</a>', '    </div>', ' '], getline(1,'$'))
+  norm! 1pj
+  call assert_equal([' <div>', '<a href="foobar" class="foo">xyz</a>', '    </div>', ' '], getline(1,'$'))
+  " at
+  norm! d2at
+  call assert_equal([' '], getline(1,'$'))
+  %d
+  call setline(1, ['<div> ','<a href="foobar" class="foo">xyz</a>','    </div>', ' '])
+  " i<
+  norm! 1gg0di<
+  call assert_equal(['<> ', '<a href="foobar" class="foo">xyz</a>', '    </div>', ' '], getline(1,'$'))
+  norm! 1Pj
+  call assert_equal(['<div> ', '<a href="foobar" class="foo">xyz</a>', '    </div>', ' '], getline(1,'$'))
+  norm! d2it
+  call assert_equal(['<div></div>',' '], getline(1,'$'))
+  " basic testing for a[ and i[ text object
+  %d
+  call setline(1, [' ', '[', 'one [two]', 'thre', ']'])
+  norm! 3gg0di[
+  call assert_equal([' ', '[', ']'], getline(1,'$'))
+  call setline(1, [' ', '[', 'one [two]', 'thre', ']'])
+  norm! 3gg0ftd2a[
+  call assert_equal([' '], getline(1,'$'))
+
+  " clean up
+  bw!
 endfunc
 
 " Test for quote (', " and `) textobjects

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1189,6 +1189,29 @@ func Test_AAA_start_visual_mode_with_count()
   close!
 endfunc
 
+" Test for visually selecting an inner block (iB)
+func Test_visual_inner_block()
+  new
+  call setline(1, ['one', '{', 'two', '{', 'three', '}', 'four', '}', 'five'])
+  call cursor(5, 1)
+  " visually select all the lines in the block and then execute iB
+  call feedkeys("ViB\<C-C>", 'xt')
+  call assert_equal([0, 5, 1, 0], getpos("'<"))
+  call assert_equal([0, 5, 6, 0], getpos("'>"))
+  " visually select two inner blocks
+  call feedkeys("ViBiB\<C-C>", 'xt')
+  call assert_equal([0, 3, 1, 0], getpos("'<"))
+  call assert_equal([0, 7, 5, 0], getpos("'>"))
+  " try to select non-existing inner block
+  call cursor(5, 1)
+  call assert_beeps('normal ViBiBiB')
+  " try to select a unclosed inner block
+  8,9d
+  call cursor(5, 1)
+  call assert_beeps('normal ViBiB')
+  close!
+endfunc
+
 func Test_visual_put_in_block()
   new
   call setline(1, ['xxxx', 'y∞yy', 'zzzz'])


### PR DESCRIPTION
#### vim-patch:8.2.0655: search code not sufficiently tested

Problem:    Search code not sufficiently tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5999)
https://github.com/vim/vim/commit/224a5f17c6ec9e98322a4c6792ce4f9bb31a4cce

Cherry-pick test_charsearch.vim change from patch 8.2.0448.
Cherry-pick test_search.vim changes from patch 8.2.0619.


#### vim-patch:8.2.1040: not enough testing for movement commands

Problem:    Not enough testing for movement commands.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6313)
https://github.com/vim/vim/commit/bdd2c290d3cda69e0046c42f0c651f60bc510a16

Cherry-pick test_functions.vim changes from patch 8.2.0183.
Cherry-pick Test_normal18_z_fold() change from patch 8.2.0540.