### PR TITLE
feat(vim.ui): add vim.ui.inputsecret equivalent

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -71,6 +71,8 @@ end
 ---     - highlight (function)
 ---               Function that will be used for highlighting
 ---               user inputs.
+---     - secret (bool|false)
+---               If true, `*` will be shown when user types.
 ---@param on_confirm function ((input|nil) -> ())
 ---               Called once the user confirms or abort the input.
 ---               `input` is what the user typed.
@@ -87,8 +89,18 @@ function M.input(opts, on_confirm)
     on_confirm = { on_confirm, 'function', false },
   })
 
+  local secret = opts['secret']
+  opts['secret'] = nil
+
   opts = (opts and not vim.tbl_isempty(opts)) and opts or vim.empty_dict()
-  local input = vim.fn.input(opts)
+
+  local input
+  if secret ~= nil then
+    input = vim.fn.inputsecret(opts)
+  else
+    input = vim.fn.input(opts)
+  end
+
   if #input > 0 then
     on_confirm(input)
   else

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -71,7 +71,7 @@ end
 ---     - highlight (function)
 ---               Function that will be used for highlighting
 ---               user inputs.
----     - secret (bool|false)
+---     - secret (boolean)
 ---               If true, `*` will be shown when user types.
 ---@param on_confirm function ((input|nil) -> ())
 ---               Called once the user confirms or abort the input.
@@ -89,13 +89,13 @@ function M.input(opts, on_confirm)
     on_confirm = { on_confirm, 'function', false },
   })
 
-  local secret = opts['secret']
-  opts['secret'] = nil
-
   opts = (opts and not vim.tbl_isempty(opts)) and opts or vim.empty_dict()
 
+  local secret = opts.secret
+  opts.secret = nil
+
   local input
-  if secret ~= nil then
+  if secret then
     input = vim.fn.inputsecret(opts)
   else
     input = vim.fn.input(opts)


### PR DESCRIPTION
This implements the feature request here: https://github.com/neovim/neovim/issues/18781.

This is done by adding an extra key to the dictionary. An example would be:

```lua
vim.ui.input(
  {prompt = 'test', secret = true},
  function(input) print(input)
end)
```

An alternative I thought of was to just make a new function `vim.ui.inputsecret`, but I'm unsure which is preferred. Thanks!