### PR TITLE
ci: test only a single macos version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,10 +161,7 @@ jobs:
             runner: ubuntu-20.04
             os: linux
           - cc: clang
-            runner: macos-10.15
-            os: osx
-          - cc: clang
-            runner: macos-11.0
+            runner: macos-11
             os: osx
 
             # functionaltest-lua is our dumping ground for non-mainline configurations.


### PR DESCRIPTION
The differences in MacOS releases are smaller since they're now upgraded yearly, meaning the need to test each version is reduced.
