### PR TITLE
build: bump minimum CMake version in cmake.deps

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is not meant to be included by the top-level.
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.10)
 project(NVIM_DEPS C)
 
 # Needed for: check_c_compiler_flag()

--- a/cmake.deps/cmake/Libvterm-tbl2inc_c.cmake
+++ b/cmake.deps/cmake/Libvterm-tbl2inc_c.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(HEX_ALPHABET "0123456789abcdef")
 


### PR DESCRIPTION
The minimum version for the main project was bumped in 035d82e0d3.
Align cmake.deps to the same version for consistency.