### PR TITLE
fix flaky tests

### DIFF
--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -4,6 +4,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, command, eq = helpers.clear, helpers.command, helpers.eq
 local eval, exc_exec, neq = helpers.eval, helpers.exc_exec, helpers.neq
+local expect_exit = helpers.expect_exit
 local feed = helpers.feed
 local pcall_err = helpers.pcall_err
 
@@ -275,6 +276,6 @@ describe('argument list commands', function()
       2 more files to edit.  Quit anyway?                         |
       [Y]es, (N)o: ^                                               |
     ]])
-    feed('Y')
+    expect_exit(100, feed, 'Y')
   end)
 end)

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -4,11 +4,11 @@ local clear = helpers.clear
 local command = helpers.command
 local exec = helpers.exec
 local exec_lua = helpers.exec_lua
+local expect_exit = helpers.expect_exit
 local feed = helpers.feed
 local funcs = helpers.funcs
 local iswin = helpers.iswin
 local meths = helpers.meths
-local poke_eventloop = helpers.poke_eventloop
 local read_file = helpers.read_file
 local source = helpers.source
 local eq = helpers.eq
@@ -94,8 +94,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xbar"?}                                                    |
       {3:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    feed('A')
-    poke_eventloop()
+    expect_exit(100, feed, 'A')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -133,8 +132,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xbar"?}                                                    |
       {3:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    feed('D')
-    poke_eventloop()
+    expect_exit(100, feed, 'D')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -195,8 +193,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xfoo"?}                                                    |
       {3:[Y]es, (N)o, (C)ancel: }^                                                    |
     ]])
-    feed('Y')
-    poke_eventloop()
+    expect_exit(100, feed, 'Y')
 
     eq('foo4\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -407,12 +407,12 @@ describe(':confirm command dialog', function()
 
     -- Try to write with read-only file permissions.
     funcs.setfperm('Xconfirm_write_ro', 'r--r--r--')
-    feed(':set noro | undo | confirm w\n')
+    feed(':set noro | silent undo | confirm w\n')
     screen:expect([[
       foobar                                                                     |
       {0:~                                                                          }|
       {1:                                                                           }|
-      1 change; before #1  0 seconds ago                                         |
+      :set noro | silent undo | confirm w                                        |
       {3:File permissions of "Xconfirm_write_ro" are read-only.}                     |
       {3:It may still be possible to write it.}                                      |
       {3:Do you wish to try?}                                                        |
@@ -423,7 +423,7 @@ describe(':confirm command dialog', function()
       screen:expect([[
         foobar                                                                     |
         {1:                                                                           }|
-        1 change; before #1  0 seconds ago                                         |
+        :set noro | silent undo | confirm w                                        |
         {3:File permissions of "Xconfirm_write_ro" are read-only.}                     |
         {3:It may still be possible to write it.}                                      |
         {3:Do you wish to try?}                                                        |
@@ -434,7 +434,7 @@ describe(':confirm command dialog', function()
       screen:expect([[
         foobar                                                                     |
         {1:                                                                           }|
-        1 change; before #1  0 seconds ago                                         |
+        :set noro | silent undo | confirm w                                        |
         {3:File permissions of "Xconfirm_write_ro" are read-only.}                     |
         {3:It may still be possible to write it.}                                      |
         {3:Do you wish to try?}                                                        |

--- a/test/functional/vimscript/let_spec.lua
+++ b/test/functional/vimscript/let_spec.lua
@@ -7,6 +7,7 @@ local eval = helpers.eval
 local meths = helpers.meths
 local exec = helpers.exec
 local exec_capture = helpers.exec_capture
+local expect_exit = helpers.expect_exit
 local source = helpers.source
 local testprg = helpers.testprg
 
@@ -28,7 +29,7 @@ describe(':let', function()
   it(":unlet self-referencing node in a List graph #6070", function()
     -- :unlet-ing a self-referencing List must not allow GC on indirectly
     -- referenced in-scope Lists. Before #6070 this caused use-after-free.
-    source([=[
+    expect_exit(100, source, [=[
       let [l1, l2] = [[], []]
       echo 'l1:' . id(l1)
       echo 'l2:' . id(l2)


### PR DESCRIPTION
- test: avoid timing-sensitive undo message
- test: deal with RPC call causing Nvim to exit later
