### PR TITLE
build(macos): use consistent MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   # them be included as one of the first places to look for dependencies.
   list(APPEND CMAKE_PREFIX_PATH /sw /opt/local)
 
+  # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
+  # fall back to local system version. Needs to be done both here and in cmake.deps.
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    execute_process(COMMAND sw_vers -productVersion
+                    OUTPUT_VARIABLE MACOS_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "${MACOS_VERSION}")
+  endif()
+  message("Using deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+
   # Work around some old, broken detection by CMake for knowing when to use the
   # isystem flag.  Apple's compilers have supported this for quite some time
   # now.

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -132,6 +132,18 @@ if(CMAKE_OSX_ARCHITECTURES)
   endforeach()
 endif()
 
+# If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
+# fall back to local system version. Needs to be done here and in top-level CMakeLists.txt.
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+    execute_process(COMMAND sw_vers -productVersion
+                    OUTPUT_VARIABLE MACOS_VERSION
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "${MACOS_VERSION}")
+  endif()
+  message("-- Using deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
 set(HOSTDEPS_INSTALL_DIR "${DEPS_INSTALL_DIR}")
 set(HOSTDEPS_BIN_DIR "${DEPS_BIN_DIR}")
 set(HOSTDEPS_LIB_DIR "${DEPS_LIB_DIR}")

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -60,17 +60,10 @@ set(BUILDCMD_UNIX ${MAKE_PRG} CFLAGS=-fPIC
                               CCDEBUG+=-g
                               Q=)
 
+# Setting MACOSX_DEPLOYMENT_TARGET is mandatory for LuaJIT; use version set by
+# cmake.deps/CMakeLists.txt (either environment variable or current system version).
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  if(CMAKE_OSX_DEPLOYMENT_TARGET)
-    set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
-  else()
-    execute_process(COMMAND sw_vers -productVersion
-                    OUTPUT_VARIABLE MACOS_VERSION
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=${MACOS_VERSION}")
-  endif()
-else()
-  set(DEPLOYMENT_TARGET "")
+  set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 
 if((UNIX AND NOT APPLE) OR (APPLE AND NOT CMAKE_OSX_ARCHITECTURES))


### PR DESCRIPTION
Use the same logic for both deps (including LuaJIT, for which setting
this variable is mandatory) and Nvim: either the eponymous environment
variable if set, or the current software version if not.

Removes annoying warnings when building locally on macOS.

@carlocab @lewis6991 