### PR TITLE
test: refactor helpers.lua

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -7,15 +7,6 @@ if(POLICY CMP0012)
 endif()
 
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
-set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
-set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
-set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
-unset(ENV{XDG_DATA_DIRS})
-unset(ENV{NVIM})  # Clear $NVIM in case tests are running from Nvim. #11009
-
-if(NOT DEFINED ENV{NVIM_LOG_FILE})
-  set(ENV{NVIM_LOG_FILE} ${BUILD_DIR}/.nvimlog)
-endif()
 
 if(NVIM_PRG)
   set(ENV{NVIM_PRG} "${NVIM_PRG}")
@@ -51,10 +42,6 @@ if(DEFINED ENV{TEST_FILTER_OUT} AND NOT "$ENV{TEST_FILTER_OUT}" STREQUAL "")
   list(APPEND BUSTED_ARGS --filter-out $ENV{TEST_FILTER_OUT})
 endif()
 
-# TMPDIR: for helpers.tmpname() and Nvim tempname().
-set(ENV{TMPDIR} "${BUILD_DIR}/Xtest_tmpdir")
-execute_process(COMMAND ${CMAKE_COMMAND} -E make_directory $ENV{TMPDIR})
-
 # HISTFILE: do not write into user's ~/.bash_history
 set(ENV{HISTFILE} "/dev/null")
 
@@ -62,7 +49,6 @@ if(NOT DEFINED ENV{TEST_TIMEOUT} OR "$ENV{TEST_TIMEOUT}" STREQUAL "")
   set(ENV{TEST_TIMEOUT} 1200)
 endif()
 
-set(ENV{SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_NAME})  # used by test/helpers.lua.
 execute_process(
   COMMAND ${BUSTED_PRG} -v -o test.busted.outputHandlers.${BUSTED_OUTPUT_TYPE}
     --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
@@ -76,9 +62,6 @@ execute_process(
   ERROR_VARIABLE err
   RESULT_VARIABLE res
   ${EXTRA_ARGS})
-
-file(GLOB RM_FILES ${BUILD_DIR}/Xtest_*)
-file(REMOVE_RECURSE ${RM_FILES})
 
 if(NOT res EQUAL 0)
   message(STATUS "Tests exited non-zero: ${res}")

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -13,28 +13,3 @@ if iswin() then
   ]]
   ffi.C._set_fmode(0x8000)
 end
-
-local testid = (function()
-  local id = 0
-  return (function()
-    id = id + 1
-    return id
-  end)
-end)()
-
--- Global before_each. https://github.com/Olivine-Labs/busted/issues/613
-local function before_each(_element, _parent)
-  local id = ('T%d'):format(testid())
-  _G._nvim_test_id = id
-  return nil, true
-end
-busted.subscribe({ 'test', 'start' },
-  before_each,
-  {
-    -- Ensure our --helper is handled before --output (see busted/runner.lua).
-    priority = 1,
-    -- Don't generate a test-id for skipped tests. /shrug
-    predicate = function (element, _, status)
-      return not ((element.descriptor == 'pending' or status == 'pending'))
-    end
-  })


### PR DESCRIPTION
- move all the setup and teardown logic from cmake to lua callbacks
- move some utility functions into the global_helpers
- use luv for performant cross-platform file I/O operations, e.g. rmdir

based on the work done in #18674
