### PR TITLE
docs: fix vim.filetype.add by avoiding quotes

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2029,30 +2029,30 @@ add({filetypes})                                          *vim.filetype.add()*
 
                   vim.filetype.add({
                     extension = {
-                      foo = "fooscript",
+                      foo = 'fooscript',
                       bar = function(path, bufnr)
                         if some_condition() then
-                          return "barscript", function(bufnr)
+                          return 'barscript', function(bufnr)
                             -- Set a buffer variable
                             vim.b[bufnr].barscript_version = 2
                           end
                         end
-                        return "bar"
+                        return 'bar'
                       end,
                     },
                     filename = {
-                      [".foorc"] = "toml",
-                      ["/etc/foo/config"] = "toml",
+                      ['.foorc'] = 'toml',
+                      ['/etc/foo/config'] = 'toml',
                     },
                     pattern = {
-                      [".*&zwj;/etc/foo/.*"] = "fooscript",
+                      ['.*/etc/foo/.*'] = 'fooscript',
                       -- Using an optional priority
-                      [".*&zwj;/etc/foo/.*%.conf"] = { "dosini", { priority = 10 } },
-                      ["README.(%a+)$"] = function(path, bufnr, ext)
-                        if ext == "md" then
-                          return "markdown"
-                        elseif ext == "rst" then
-                          return "rst"
+                      ['.*/etc/foo/.*%.conf'] = { 'dosini', { priority = 10 } },
+                      ['README.(a+)$'] = function(path, bufnr, ext)
+                        if ext == 'md' then
+                          return 'markdown'
+                        elseif ext == 'rst' then
+                          return 'rst'
                         end
                       end,
                     },

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2241,30 +2241,30 @@ end
 --- <pre>
 ---  vim.filetype.add({
 ---    extension = {
----      foo = "fooscript",
+---      foo = 'fooscript',
 ---      bar = function(path, bufnr)
 ---        if some_condition() then
----          return "barscript", function(bufnr)
+---          return 'barscript', function(bufnr)
 ---            -- Set a buffer variable
 ---            vim.b[bufnr].barscript_version = 2
 ---          end
 ---        end
----        return "bar"
+---        return 'bar'
 ---      end,
 ---    },
 ---    filename = {
----      [".foorc"] = "toml",
----      ["/etc/foo/config"] = "toml",
+---      ['.foorc'] = 'toml',
+---      ['/etc/foo/config'] = 'toml',
 ---    },
 ---    pattern = {
----      [".*/etc/foo/.*"] = "fooscript",
+---      ['.*/etc/foo/.*'] = 'fooscript',
 ---      -- Using an optional priority
----      [".*/etc/foo/.*%.conf"] = { "dosini", { priority = 10 } },
----      ["README.(%a+)$"] = function(path, bufnr, ext)
----        if ext == "md" then
----          return "markdown"
----        elseif ext == "rst" then
----          return "rst"
+---      ['.*/etc/foo/.*%.conf'] = { 'dosini', { priority = 10 } },
+---      ['README.(%a+)$'] = function(path, bufnr, ext)
+---        if ext == 'md' then
+---          return 'markdown'
+---        elseif ext == 'rst' then
+---          return 'rst'
 ---        end
 ---      end,
 ---    },


### PR DESCRIPTION
# Problem

Quotes are special in doxygen, and should be escaped. *Sometimes* they
cause doc generation issues. Like in #17785

# Solution

Replace double quotes with single quotes

Fixes https://github.com/neovim/neovim/issues/19431

CC: @gpanders 