### PR TITLE
vim-patch:8.2.{0509,2632}: startup tests

### DIFF
--- a/src/nvim/testdir/term_util.vim
+++ b/src/nvim/testdir/term_util.vim
@@ -9,3 +9,5 @@ func CanRunVimInTerminal()
   " Nvim: always false, we use Lua screen-tests instead.
   return 0
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -1,16 +1,12 @@
 " Tests for the +clientserver feature.
 
-if !has('job') || !has('clientserver')
-  throw 'Skipped: job and/or clientserver feature missing'
-endif
+source check.vim
+CheckFeature job
+CheckFeature clientserver
 
 source shared.vim
 
-func Test_client_server()
-  let cmd = GetVimCommand()
-  if cmd == ''
-    return
-  endif
+func Check_X11_Connection()
   if has('x11')
     if empty($DISPLAY)
       throw 'Skipped: $DISPLAY is not set'
@@ -19,11 +15,19 @@ func Test_client_server()
       call remote_send('xxx', '')
     catch
       if v:exception =~ 'E240:'
-	throw 'Skipped: no connection to the X server'
+        throw 'Skipped: no connection to the X server'
       endif
       " ignore other errors
     endtry
   endif
+endfunc
+
+func Test_client_server()
+  let cmd = GetVimCommand()
+  if cmd == ''
+    return
+  endif
+  call Check_X11_Connection()
 
   let name = 'XVIMTEST'
   let cmd .= ' --servername ' . name
@@ -81,6 +85,10 @@ func Test_client_server()
   endif
   let g:testvar = 'myself'
   call assert_equal('myself', remote_expr(v:servername, 'testvar'))
+  call remote_send(v:servername, ":let g:testvar2 = 75\<CR>")
+  call feedkeys('', 'x')
+  call assert_equal(75, g:testvar2)
+  call assert_fails('let v = remote_expr(v:servername, "/2")', 'E449:')
 
   call remote_send(name, ":call server2client(expand('<client>'), 'got it')\<CR>", 'g:myserverid')
   call assert_equal('got it', g:myserverid->remote_read(2))
@@ -101,6 +109,55 @@ func Test_client_server()
   call assert_equal('another', g:peek_result)
   call assert_equal('another', remote_read(g:myserverid, 2))
 
+  if !has('gui_running')
+    " In GUI vim, the following tests display a dialog box
+
+    let cmd = GetVimProg() .. ' --servername ' .. name
+
+    " Run a separate instance to send a command to the server
+    call remote_expr(name, 'execute("only")')
+    call system(cmd .. ' --remote-send ":new Xfile<CR>"')
+    call assert_equal('2', remote_expr(name, 'winnr("$")'))
+    call assert_equal('Xfile', remote_expr(name, 'winbufnr(1)->bufname()'))
+    call remote_expr(name, 'execute("only")')
+
+    " Invoke a remote-expr. On MS-Windows, the returned value has a carriage
+    " return.
+    let l = system(cmd .. ' --remote-expr "2 + 2"')
+    call assert_equal(['4'], split(l, "\n"))
+
+    " Edit multiple files using --remote
+    call system(cmd .. ' --remote Xfile1 Xfile2 Xfile3')
+    call assert_equal("Xfile1\nXfile2\nXfile3\n", remote_expr(name, 'argv()'))
+    eval name->remote_send(":%bw!\<CR>")
+
+    " Edit files in separate tab pages
+    call system(cmd .. ' --remote-tab Xfile1 Xfile2 Xfile3')
+    call assert_equal('3', remote_expr(name, 'tabpagenr("$")'))
+    call assert_equal('Xfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
+    eval name->remote_send(":%bw!\<CR>")
+
+    " Edit a file using --remote-wait
+    eval name->remote_send(":source $VIMRUNTIME/plugin/rrhelper.vim\<CR>")
+    call system(cmd .. ' --remote-wait +enew Xfile1')
+    call assert_equal("Xfile1", remote_expr(name, 'bufname("#")'))
+    eval name->remote_send(":%bw!\<CR>")
+
+    " Edit files using --remote-tab-wait
+    call system(cmd .. ' --remote-tabwait +tabonly\|enew Xfile1 Xfile2')
+    call assert_equal('1', remote_expr(name, 'tabpagenr("$")'))
+    eval name->remote_send(":%bw!\<CR>")
+
+    " Error cases
+    if v:lang == "C" || v:lang =~ '^[Ee]n'
+      let l = split(system(cmd .. ' --remote +pwd'), "\n")
+      call assert_equal("Argument missing after: \"+pwd\"", l[1])
+    endif
+    let l = system(cmd .. ' --remote-expr "abcd"')
+    call assert_match('^E449: ', l)
+  endif
+
+  eval name->remote_send(":%bw!\<CR>")
   eval name->remote_send(":qa!\<CR>")
   try
     call WaitForAssert({-> assert_equal("dead", job_status(job))})
@@ -111,8 +168,8 @@ func Test_client_server()
     endif
   endtry
 
-  call assert_fails("let x=remote_peek([])", 'E730:')
-  call assert_fails("let x=remote_read('vim10')", 'E277:')
+  call assert_fails("let x = remote_peek([])", 'E730:')
+  call assert_fails("let x = remote_read('vim10')", 'E277:')
 endfunc
 
 " Uncomment this line to get a debugging log

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -38,6 +38,14 @@ func Test_client_server()
   " When using valgrind it takes much longer.
   call WaitForAssert({-> assert_match(name, serverlist())})
 
+  if !has('win32')
+    if RunVim([], [], '--serverlist >Xtest_serverlist')
+      let lines = readfile('Xtest_serverlist')
+      call assert_true(index(lines, 'XVIMTEST') >= 0)
+    endif
+    call delete('Xtest_serverlist')
+  endif
+
   eval name->remote_foreground()
 
   call remote_send(name, ":let testvar = 'yes'\<CR>")

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -155,9 +155,7 @@ endfunc
 func Test_Ex_echo_backslash()
   throw 'Skipped: Nvim only supports Vim Ex mode'
   " This test works only when the language is English
-  if v:lang != "C" && v:lang !~ '^[Ee]n'
-    return
-  endif
+  CheckEnglish
   let bsl = '\\\\'
   let bsl2 = '\\\'
   call assert_fails('call feedkeys("Qecho " .. bsl .. "\nvisual\n", "xt")',

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -84,6 +84,15 @@ func Test_expandcmd()
   let $FOO="blue\tsky"
   call setline(1, "$FOO")
   call assert_equal("grep pat blue\tsky", expandcmd('grep pat <cfile>'))
+
+  " Test for expression expansion `=
+  let $FOO= "blue"
+  call assert_equal("blue sky", expandcmd("`=$FOO .. ' sky'`"))
+
+  " Test for env variable with spaces
+  let $FOO= "foo bar baz"
+  call assert_equal("e foo bar baz", expandcmd("e $FOO"))
+
   unlet $FOO
   close!
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -547,6 +547,7 @@ func Save_mode()
   return ''
 endfunc
 
+" Test for the mode() function
 func Test_mode()
   new
   call append(0, ["Blue Ball Black", "Brown Band Bowl", ""])
@@ -717,6 +718,8 @@ func Test_mode()
   call assert_equal('c-c', g:current_modes)
   call feedkeys("gQecho \<C-R>=Save_mode()\<CR>\<CR>vi\<CR>", 'xt')
   call assert_equal('c-cv', g:current_modes)
+  " call feedkeys("Qcall Save_mode()\<CR>vi\<CR>", 'xt')
+  " call assert_equal('c-ce', g:current_modes)
   " How to test Ex mode?
 
   " Test mode in operatorfunc (it used to be Operator-pending).
@@ -1261,6 +1264,23 @@ func Test_inputlist()
   " Cancel after inputting a number
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>5q", 'tx')
   call assert_equal(0, c)
+
+  " Use backspace to delete characters in the prompt
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>1\<BS>3\<BS>2\<cr>", 'tx')
+  call assert_equal(2, c)
+
+  " Use mouse to make a selection
+  " call test_setmouse(&lines - 3, 2)
+  call nvim_input_mouse('left', 'press', '', 0, &lines - 4, 1) " set mouse position
+  call getchar() " discard mouse event but keep mouse position
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<LeftMouse>", 'tx')
+  call assert_equal(1, c)
+  " Mouse click outside of the list
+  " call test_setmouse(&lines - 6, 2)
+  call nvim_input_mouse('left', 'press', '', 0, &lines - 7, 1) " set mouse position
+  call getchar() " discard mouse event but keep mouse position
+  call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<LeftMouse>", 'tx')
+  call assert_equal(-2, c)
 
   call assert_fails('call inputlist("")', 'E686:')
 endfunc

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1,6 +1,7 @@
 " Test for options
 
 source check.vim
+source view_util.vim
 
 func Test_whichwrap()
   set whichwrap=b,s
@@ -799,6 +800,14 @@ func Test_rightleftcmd()
   unlet g:l
   set rightleftcmd&
   set rightleft&
+endfunc
+
+" Test for the "debug" option
+func Test_debug_option()
+  set debug=beep
+  exe "normal \<C-c>"
+  call assert_equal('Beep!', Screenline(&lines))
+  set debug&
 endfunc
 
 " Test for setting option values using v:false and v:true

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -1130,7 +1130,6 @@ func Test_n_arg()
     call assert_equal([], readfile('Xtestout'))
     call delete('Xtestout')
   endif
-  call delete('Xafter')
 endfunc
 
 " Test for the "-h" (help) argument
@@ -1164,7 +1163,21 @@ func Test_E_arg()
     call assert_equal([], readfile('Xtestout'))
     call delete('Xtestout')
   endif
-  call delete('Xafter')
+endfunc
+
+" Test for the "-D" (debugger) argument
+func Test_D_arg()
+  CheckRunVimInTerminal
+
+  let cmd = GetVimCommandCleanTerm() .. ' -D'
+  let buf = term_start(cmd, {'term_rows' : 10})
+  call WaitForAssert({-> assert_equal("running", term_getstatus(buf))})
+
+  call WaitForAssert({-> assert_equal('Entering Debug mode.  Type "cont" to continue.',
+  \                  term_getline(buf, 7))})
+  call WaitForAssert({-> assert_equal('>', term_getline(buf, 10))})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " Test for too many edit argument errors

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -12,6 +12,9 @@ func Test_startup_script()
   source $VIMRUNTIME/defaults.vim
 
   call assert_equal(0, &compatible)
+  " Restore some options, so that the following tests doesn't break
+  set nomore
+  set noshowmode
 endfunc
 
 " Verify the order in which plugins are loaded:
@@ -814,6 +817,25 @@ func Test_v_argv()
   call assert_equal(['arg1', '--cmd', 'echo v:argv', '--cmd', 'q'']'], list[idx:])
 endfunc
 
+" Test for the "-r" recovery mode option
+func Test_r_arg()
+  throw 'Skipped: Nvim has different directories'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  CheckUnix
+  CheckEnglish
+  let cmd = GetVimCommand()
+  " There can be swap files anywhere, only check for the headers.
+  let expected =<< trim END
+    Swap files found:.*
+    In current directory:.*
+    In directory \~/tmp:.*
+    In directory /var/tmp:.*
+    In directory /tmp:.*
+  END
+  call assert_match(join(expected, ""), system(cmd .. " -r")->substitute("[\r\n]\\+", '', ''))
+endfunc
+
 " Test for the '-t' option to jump to a tag
 func Test_t_arg()
   let before =<< trim [CODE]
@@ -824,6 +846,7 @@ func Test_t_arg()
     call writefile([s], "Xtestout")
     qall
   [CODE]
+
   call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
         \ "first\tXfile1\t/^    \\zsfirst$/",
         \ "second\tXfile1\t/^    \\zssecond$/",
@@ -890,6 +913,138 @@ func Test_x_arg()
   call delete('Xtest_x_arg')
 endfunc
 
+" Test for entering the insert mode on startup
+func Test_start_insertmode()
+  throw "Skipped: Nvim does not support setting 'insertmode'"
+  let before =<< trim [CODE]
+    set insertmode
+  [CODE]
+  let after =<< trim [CODE]
+    call writefile(['insertmode=' .. &insertmode], 'Xtestout')
+    qall
+  [CODE]
+  if RunVim(before, after, '')
+    call assert_equal(['insertmode=1'], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+endfunc
+
+" Test for enabling the binary mode on startup
+func Test_b_arg()
+  let after =<< trim [CODE]
+    call writefile(['binary=' .. &binary], 'Xtestout')
+    qall
+  [CODE]
+  if RunVim([], after, '-b')
+    call assert_equal(['binary=1'], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+endfunc
+
+" Test for enabling the lisp mode on startup
+func Test_l_arg()
+  let after =<< trim [CODE]
+    let s = 'lisp=' .. &lisp .. ', showmatch=' .. &showmatch
+    call writefile([s], 'Xtestout')
+    qall
+  [CODE]
+  if RunVim([], after, '-l')
+    call assert_equal(['lisp=1, showmatch=1'], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+endfunc
+
+" Test for specifying a non-existing vimrc file using "-u"
+func Test_missing_vimrc()
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot run vim in terminal'
+  endif
+  let after =<< trim [CODE]
+    call assert_match('^E282:', v:errmsg)
+    call writefile(v:errors, 'Xtestout')
+  [CODE]
+  call writefile(after, 'Xafter')
+
+  let cmd = GetVimCommandCleanTerm() . ' -u Xvimrc_missing -S Xafter'
+  let buf = term_start(cmd, {'term_rows' : 10})
+  call WaitForAssert({-> assert_equal("running", term_getstatus(buf))})
+  call term_wait(buf)
+  call term_sendkeys(buf, "\n:")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 10))})
+  call StopVimInTerminal(buf)
+  call assert_equal([], readfile('Xtestout'))
+  call delete('Xafter')
+  call delete('Xtestout')
+endfunc
+
+" Test for using the $VIMINIT environment variable
+func Test_VIMINIT()
+  let after =<< trim [CODE]
+    call assert_equal(1, exists('viminit_found'))
+    call assert_equal('yes', viminit_found)
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  call writefile(after, 'Xafter')
+  " let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "set enc=utf8"'
+  let cmd = GetVimProg() . ' -S Xafter --cmd "set enc=utf8"'
+  call setenv('VIMINIT', 'let viminit_found="yes"')
+  exe "silent !" . cmd
+  call assert_equal([], readfile('Xtestout'))
+  call delete('Xtestout')
+  call delete('Xafter')
+endfunc
+
+" Test for using the $EXINIT environment variable
+func Test_EXINIT()
+  let after =<< trim [CODE]
+    call assert_equal(1, exists('exinit_found'))
+    call assert_equal('yes', exinit_found)
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  call writefile(after, 'Xafter')
+  " let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "set enc=utf8"'
+  let cmd = GetVimProg() . ' -S Xafter --cmd "set enc=utf8"'
+  call setenv('EXINIT', 'let exinit_found="yes"')
+  exe "silent !" . cmd
+  call assert_equal([], readfile('Xtestout'))
+  call delete('Xtestout')
+  call delete('Xafter')
+endfunc
+
+" Test for using the 'exrc' option
+func Test_exrc()
+  let after =<< trim [CODE]
+    call assert_equal(1, &exrc)
+    call assert_equal(1, &secure)
+    call assert_equal(37, exrc_found)
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  call mkdir('Xdir')
+  call writefile(['let exrc_found=37'], 'Xdir/.exrc')
+  call writefile(after, 'Xdir/Xafter')
+  " let cmd = GetVimProg() . ' --not-a-term -S Xafter --cmd "cd Xdir" --cmd "set enc=utf8 exrc secure"'
+  let cmd = GetVimProg() . ' -S Xafter --cmd "cd Xdir" --cmd "set enc=utf8 exrc secure"'
+  exe "silent !" . cmd
+  call assert_equal([], readfile('Xdir/Xtestout'))
+  call delete('Xdir', 'rf')
+endfunc
+
+" Test for starting Vim with a non-terminal as input/output
+func Test_io_not_a_terminal()
+  throw 'Skipped: Nvim does not support --ttyfail'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  CheckUnix
+  CheckEnglish
+  let l = systemlist(GetVimProg() .. ' --ttyfail')
+  call assert_equal(['Vim: Warning: Output is not to a terminal',
+        \ 'Vim: Warning: Input is not from a terminal'], l)
+endfunc
+
 " Test for --not-a-term avoiding escape codes.
 func Test_not_a_term()
   CheckUnix
@@ -946,6 +1101,80 @@ func Test_w_arg()
     endif
   endfor
   call delete('Xscriptin')
+endfunc
+
+" Test for the "-s scriptin" argument
+func Test_s_arg()
+  " Can't catch the output of gvim.
+  CheckNotGui
+  CheckEnglish
+  " Test for failing to open the script input file.
+  let m = system(GetVimCommand() .. " -s abcxyz")
+  " call assert_equal("Cannot open for reading: \"abcxyz\"\n", m)
+  call assert_equal("Cannot open for reading: \"abcxyz\": no such file or directory\n", m)
+
+  call writefile([], 'Xinput')
+  let m = system(GetVimCommand() .. " -s Xinput -s Xinput")
+  call assert_equal("Attempt to open script file again: \"-s Xinput\"\n", m)
+  call delete('Xinput')
+endfunc
+
+" Test for the "-n" (no swap file) argument
+func Test_n_arg()
+  let after =<< trim [CODE]
+    call assert_equal(0, &updatecount)
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  if RunVim([], after, '-n')
+    call assert_equal([], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+  call delete('Xafter')
+endfunc
+
+" Test for the "-h" (help) argument
+func Test_h_arg()
+  throw 'Skipped: Nvim has different output for "-h" argument'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  let l = systemlist(GetVimProg() .. ' -h')
+  call assert_match('^VIM - Vi IMproved', l[0])
+  let l = systemlist(GetVimProg() .. ' -?')
+  call assert_match('^VIM - Vi IMproved', l[0])
+endfunc
+
+" Test for the "-F" (farsi) argument
+func Test_F_arg()
+  throw 'Skipped: Nvim does not recognize "-F" argument'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  let l = systemlist(GetVimProg() .. ' -F')
+  call assert_match('^E27:', l[0])
+endfunc
+
+" Test for the "-E" (improved Ex mode) argument
+func Test_E_arg()
+  let after =<< trim [CODE]
+    call assert_equal('cv', mode(1))
+    call writefile(v:errors, 'Xtestout')
+    qall
+  [CODE]
+  if RunVim([], after, '-E')
+    call assert_equal([], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+  call delete('Xafter')
+endfunc
+
+" Test for too many edit argument errors
+func Test_too_many_edit_args()
+  throw 'Skipped: N/A'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  CheckEnglish
+  let l = systemlist(GetVimProg() .. ' - -')
+  call assert_match('^Too many edit arguments: "-"', l[1])
 endfunc
 
 " Test starting vim with various names: vim, ex, view, evim, etc.

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1260,6 +1260,41 @@ func Test_comment_nested()
   %bw!
 endfunc
 
+" Test for a space character in 'comments' setting
+func Test_comment_space()
+  new
+  setlocal comments=b:\ > fo+=ro
+  exe "normal i> B\nD\<C-C>ggOA\<C-C>joC"
+  exe "normal Go > F\nH\<C-C>kOE\<C-C>joG"
+  let expected =<< trim END
+    A
+    > B
+    C
+    D
+     > E
+     > F
+     > G
+     > H
+  END
+  call assert_equal(expected, getline(1, '$'))
+  %bw!
+endfunc
+
+" Test for the 'O' flag in 'comments'
+func Test_comment_O()
+  new
+  setlocal comments=Ob:* fo+=ro
+  exe "normal i* B\nD\<C-C>kOA\<C-C>joC"
+  let expected =<< trim END
+    A
+    * B
+    * C
+    * D
+  END
+  call assert_equal(expected, getline(1, '$'))
+  %bw!
+endfunc
+
 " Test for 'a' and 'w' flags in 'formatoptions'
 func Test_fo_a_w()
   new
@@ -1296,6 +1331,25 @@ func Test_fo_a_w()
 
   set tw=0
   set fo&
+  %bw!
+endfunc
+
+" Test for 'j' flag in 'formatoptions'
+func Test_fo_j()
+  new
+  setlocal fo+=j comments=://
+  call setline(1, ['i++; // comment1', '           // comment2'])
+  normal J
+  call assert_equal('i++; // comment1 comment2', getline(1))
+  setlocal fo-=j
+  call setline(1, ['i++; // comment1', '           // comment2'])
+  normal J
+  call assert_equal('i++; // comment1 // comment2', getline(1))
+  " Test with nested comments
+  setlocal fo+=j comments=n:>,n:)
+  call setline(1, ['i++; > ) > ) comment1', '           > ) comment2'])
+  normal J
+  call assert_equal('i++; > ) > ) comment1 comment2', getline(1))
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_trycatch.vim
+++ b/src/nvim/testdir/test_trycatch.vim
@@ -2014,11 +2014,11 @@ endfunc
 " Test for verbose messages with :try :catch, and :finally                 {{{1
 func Test_try_catch_verbose()
   " This test works only when the language is English
-  if v:lang != "C" && v:lang !~ '^[Ee]n'
-    return
-  endif
+  CheckEnglish
 
   set verbose=14
+
+  " Test for verbose messages displayed when an exception is caught
   redir => msg
   try
     echo i


### PR DESCRIPTION
#### vim-patch:8.2.0509: various code is not properly tested.

Problem:    various code is not properly tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5871)
https://github.com/vim/vim/commit/cde0ff39da2459b16007fef701ebaa449fb6fe9d

Cherry-pick test_clientserver.vim change from patch 8.1.1826.
Cherry-pick a comment from patch 8.2.0301.
Omit test_viminfo.vim.


#### vim-patch:8.2.2632: not all command line arguments are tested

Problem:    Not all command line arguments are tested.
Solution:   Add tests for -D and -serverlist. (Dominique Pellé, closes vim/vim#7992)
https://github.com/vim/vim/commit/c5cf369e9543ff065e2e1da91da3218c223840e2

Cherry-pick two deletions from patch 8.2.1799.