### PR TITLE
fix: powershell redirection for filtered bang commands

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5357,7 +5357,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	To use PowerShell: >
 		let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
 		let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;'
-		let &shellredir = '-RedirectStandardOutput %s -NoNewWindow -Wait'
+		let &shellredir = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
 		let &shellpipe = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
 		set shellquote= shellxquote=
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1549,7 +1549,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
                                   : 0;
 
   if (itmp != NULL) {
-    len += is_pwsh  ? strlen(itmp) + sizeof("Get-Content " " | & ") - 1
+    len += is_pwsh  ? strlen(itmp) + sizeof("& { Get-Content " " | & " " }") - 1
                     : strlen(itmp) + sizeof(" { " " < " " } ") - 1;
   }
   if (otmp != NULL) {
@@ -1560,10 +1560,11 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 
   if (is_pwsh) {
     if (itmp != NULL) {
-      xstrlcpy(buf, "Get-Content ", len - 1);  // FIXME: should we add "-Encoding utf8"?
+      xstrlcpy(buf, "& { Get-Content ", len - 1);  // FIXME: should we add "-Encoding utf8"?
       xstrlcat(buf, (const char *)itmp, len - 1);
       xstrlcat(buf, " | & ", len - 1);  // FIXME: add `&` ourself or leave to user?
       xstrlcat(buf, cmd, len - 1);
+      xstrlcat(buf, " }", len - 1);
     } else {
       xstrlcpy(buf, cmd, len - 1);
     }

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -562,16 +562,16 @@ function module.set_shell_powershell(fake)
     assert(found)
   end
   local shell = found and (iswin() and 'powershell' or 'pwsh') or module.testprg('pwsh-test')
-  local set_encoding = '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;'
+  local set_encoding = '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();'
   local cmd = set_encoding..'Remove-Item -Force '..table.concat(iswin()
-    and {'alias:cat', 'alias:echo', 'alias:sleep'}
+    and {'alias:cat', 'alias:echo', 'alias:sleep', 'alias:sort'}
     or  {'alias:echo'}, ',')..';'
   module.exec([[
     let &shell = ']]..shell..[['
     set shellquote= shellxquote=
     let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ]]..cmd..[['
     let &shellpipe = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
-    let &shellredir = '-RedirectStandardOutput %s -NoNewWindow -Wait'
+    let &shellredir = '2>&1 | Out-File -Encoding UTF8 %s; exit $LastExitCode'
   ]])
   return found
 end

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -642,12 +642,12 @@ describe('shell :!', function()
     if iswin() then
       feed(':4verbose %!sort /R<cr>')
       screen:expect{
-        any=[[Executing command: .?Get%-Content .* | & sort /R 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode]]
+        any=[[Executing command: .?& { Get%-Content .* | & sort /R } 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode"]]
       }
     else
       feed(':4verbose %!sort -r<cr>')
       screen:expect{
-        any=[[Executing command: .?Get%-Content .* | & sort %-r 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode]]
+        any=[[Executing command: .?& { Get%-Content .* | & sort %-r } 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode"]]
       }
     end
     feed('<CR>')

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -642,12 +642,12 @@ describe('shell :!', function()
     if iswin() then
       feed(':4verbose %!sort /R<cr>')
       screen:expect{
-        any=[[Executing command: .?Start%-Process sort %-ArgumentList "/R" %-RedirectStandardInput .* %-RedirectStandardOutput .* %-NoNewWindow %-Wait]]
+        any=[[Executing command: .?Get%-Content .* | & sort /R 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode]]
       }
     else
       feed(':4verbose %!sort -r<cr>')
       screen:expect{
-        any=[[Executing command: .?Start%-Process sort %-ArgumentList "%-r" %-RedirectStandardInput .* %-RedirectStandardOutput .* %-NoNewWindow %-Wait]]
+        any=[[Executing command: .?Get%-Content .* | & sort %-r 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode]]
       }
     end
     feed('<CR>')


### PR DESCRIPTION
Revert #16271 and fix #15913.

Problem:
Since #16271, `make_filter_cmd` uses `Start-Process` cmdlet to execute the user
provided shell command for `:%!`. `Start-Process` requires the command to be
split into the shell command and its arguments. This was implemented in #19268
by parsing (splitting the user-provided command at the first space) which didn't
handle cases such as --
  - commands with escaped space in their filepath
  - quoted commands with space in their filepath

Solution: Use piping.

The total shell command formats (excluding noise of unimportant parameters):

1. Before #16271
    ```powershell
    pwsh -C "(shell_cmd) < tmp.in | 2>&1 Out-File -Encoding UTF8 <tmp.out>"
    # not how powershell commands work
    ```
2. Since #16271
    ```powershell
    pwsh -C "Start-Process shell_cmd -RedirectStandardInput <tmp.in> -RedirectStandardOutput <tmp.out>"
    # doesn't handle executable path with space in it
    # doesn't write error to <tmp.out>
    ```
3. This PR
    ```powershell
    pwsh -C "& { Get-Content <tmp.in> | & 'path\with space\to\shell_cmd.exe' arg1 arg2 } 2>&1 | Out-File -Encoding UTF8 <tmp.out>"
    # also works with forward slash in the filepath
    # also works with double quotes around shell command
    ```

After this PR, the user can use the following formats:
```
:%!c:\Program` Files\Git\usr\bin\sort.exe
:%!'c:\Program Files\Git\usr\bin\sort.exe'
:%!"c:\Program Files\Git\usr\bin\sort.exe"
:%!"c:\Program` Files\Git\usr\bin\sort.exe"
```

They can even chain different commands
```
:%!"c:\Program` Files\Git\usr\bin\sort.exe" | sort.exe -r
```

But if they want to call a stringed executable path, they have to provide the
Invoke-Command operator (&). In fact, the first stringed executable path also
needs this & operator, but this PR adds that behind the scene.
```
:%!"c:\Program` Files\Git\usr\bin\sort.exe" | sort.exe -r | & 'c:\Program Files\Git\usr\bin\sort.exe'
```

## What this PR solves

- Having to parse the user-provided bang ex-command (for splitting into shell
  cmd and its args).
- Removes a lot of human-unreadable `#ifdef` blocks.
- Accepting escaped spaces in executable path.
- Accepting quoted string of executable path.
- Redirects error and exception to tmp.out (exception for when `wrong_cmd.exe
  not found`)

## What this PR doesn't solve

- Handling wrongly escaped path to executable, which the user may pass because of cmdline tab-completion (see #18592).

## Edge cases
- [ ] If the user themself provides the `&` sign (means `call this.exe` in
  powershell) (I don't plan to handle it)
- [ ] Use `-Encoding utf8` parameter for `Get-Content`? (need to know about
  encoding, which I don't)
- [X] Doesn't write to tmp.out if shell command is not found (I have a fix:
  using anonymous function (`{wrong_cmd.exe}`))

## Changes other than `make_filter_cmd()` function

- Encoding (see [BOM-less UTF8][bomlessutf8]) for piping to external executables


[bomlessutf8]: https://github.com/PowerShell/PowerShell/issues/4681