### PR TITLE
vim-patch:8.2.{1786,1799}: Normal mode commands not fully tested

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6994,6 +6994,7 @@ static void ex_redraw(exarg_T *eap)
   update_topline(curwin);
   if (eap->forceit) {
     redraw_all_later(NOT_VALID);
+    redraw_cmdline = true;
   }
   update_screen(eap->forceit ? NOT_VALID
                 : VIsual_active ? INVERTED : 0);

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -191,6 +191,22 @@ func Test_gf_error()
   au! InsertCharPre
 
   bwipe!
+
+  " gf is not allowed when buffer is locked
+  new
+  augroup Test_gf
+    au!
+    au OptionSet diff norm! gf
+  augroup END
+  call setline(1, ['Xfile1', 'line2', 'line3', 'line4'])
+  " Nvim does not support test_override()
+  " call test_override('starting', 1)
+  " call assert_fails('diffthis', 'E788:')
+  " call test_override('starting', 0)
+  augroup Test_gf
+    au!
+  augroup END
+  bw!
 endfunc
 
 " If a file is not found by 'gf', then 'includeexpr' should be used to locate

--- a/src/nvim/testdir/test_goto.vim
+++ b/src/nvim/testdir/test_goto.vim
@@ -122,6 +122,24 @@ func Test_gd()
   call XTest_goto_decl('gd', lines, 3, 14)
 endfunc
 
+" Using gd to jump to a declaration in a fold
+func Test_gd_with_fold()
+  new
+  let lines =<< trim END
+    #define ONE 1
+    #define TWO 2
+    #define THREE 3
+
+    TWO
+  END
+  call setline(1, lines)
+  1,3fold
+  call feedkeys('Ggd', 'xt')
+  call assert_equal(2, line('.'))
+  call assert_equal(-1, foldclosedend(2))
+  bw!
+endfunc
+
 func Test_gd_not_local()
   let lines =<< trim [CODE]
     int func1(void)

--- a/src/nvim/testdir/test_regexp_utf8.vim
+++ b/src/nvim/testdir/test_regexp_utf8.vim
@@ -522,8 +522,8 @@ endfunc
 func Test_search_with_end_offset()
   new
   call setline(1, ['', 'dog(a', 'cat('])
-  exe "normal /(/e+" .. "\<CR>"
-  normal "ayn
+  exe "normal /(/e+\<CR>"
+  normal n"ayn
   call assert_equal("a\ncat(", @a)
   close!
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -426,6 +426,12 @@ func Test_execute_register()
   @
   call assert_equal(3, i)
 
+  " try to execute expression register and use a backspace to cancel it
+  new
+  call feedkeys("@=\<BS>ax\<CR>y", 'xt')
+  call assert_equal(['x', 'y'], getline(1, '$'))
+  close!
+
   " cannot execute a register in operator pending mode
   call assert_beeps('normal! c@r')
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -279,7 +279,12 @@ func Test_get_register()
   call feedkeys(":\<C-R>r\<Esc>", 'xt')
   call assert_equal("a\rb", histget(':', -1))  " Modified because of #6137
 
+  call assert_fails('let r = getreg("=", [])', 'E745:')
+  call assert_fails('let r = getreg("=", 1, [])', 'E745:')
   enew!
+
+  " Using a register in operator-pending mode should fail
+  call assert_beeps('norm! c"')
 endfunc
 
 func Test_set_register()

--- a/src/nvim/testdir/test_spellfile.vim
+++ b/src/nvim/testdir/test_spellfile.vim
@@ -25,6 +25,18 @@ func Test_spell_normal()
   let cnt=readfile('./Xspellfile.add')
   call assert_equal('goood', cnt[0])
 
+  " zg should fail in operator-pending mode
+  call assert_beeps('norm! czg')
+
+  " zg fails in visual mode when not able to get the visual text
+  call assert_beeps('norm! ggVjzg')
+  norm! V
+
+  " zg fails for a non-identifier word
+  call append(line('$'), '###')
+  call assert_fails('norm! Gzg', 'E349:')
+  $d
+
   " Test for zw
   2
   norm! $zw

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -670,15 +670,19 @@ func Test_tabline_tabmenu()
   call assert_equal(3, tabpagenr('$'))
 
   " go to tab page 2 in operator-pending mode (should beep)
-  call assert_beeps('call feedkeys("f" .. TabLineSelectPageCode(2), "Lx!")')
+  call assert_beeps('call feedkeys("c" .. TabLineSelectPageCode(2), "Lx!")')
+  call assert_equal(2, tabpagenr())
+  call assert_equal(3, tabpagenr('$'))
 
   " open new tab page before tab page 1 in operator-pending mode (should beep)
-  call assert_beeps('call feedkeys("f" .. TabMenuNewItemCode(1), "Lx!")')
+  call assert_beeps('call feedkeys("c" .. TabMenuNewItemCode(1), "Lx!")')
+  call assert_equal(1, tabpagenr())
+  call assert_equal(4, tabpagenr('$'))
 
   " open new tab page after tab page 3 in normal mode
   call feedkeys(TabMenuNewItemCode(4), "Lx!")
   call assert_equal(4, tabpagenr())
-  call assert_equal(4, tabpagenr('$'))
+  call assert_equal(5, tabpagenr('$'))
 
   " go to tab page 2 in insert mode
   call feedkeys("i" .. TabLineSelectPageCode(2) .. "\<C-C>", "Lx!")
@@ -686,17 +690,17 @@ func Test_tabline_tabmenu()
 
   " close tab page 2 in insert mode
   call feedkeys("i" .. TabMenuCloseItemCode(2) .. "\<C-C>", "Lx!")
-  call assert_equal(3, tabpagenr('$'))
+  call assert_equal(4, tabpagenr('$'))
 
   " open new tab page before tab page 3 in insert mode
   call feedkeys("i" .. TabMenuNewItemCode(3) .. "\<C-C>", "Lx!")
   call assert_equal(3, tabpagenr())
-  call assert_equal(4, tabpagenr('$'))
+  call assert_equal(5, tabpagenr('$'))
 
   " open new tab page after tab page 4 in insert mode
   call feedkeys("i" .. TabMenuNewItemCode(5) .. "\<C-C>", "Lx!")
   call assert_equal(5, tabpagenr())
-  call assert_equal(5, tabpagenr('$'))
+  call assert_equal(6, tabpagenr('$'))
 
   %bw!
 endfunc

--- a/src/nvim/testdir/test_tagjump.vim
+++ b/src/nvim/testdir/test_tagjump.vim
@@ -1133,7 +1133,7 @@ endfunc
 " Test for [i, ]i, [I, ]I, [ CTRL-I, ] CTRL-I and CTRL-W i commands
 func Test_inc_search()
   new
-  call setline(1, ['1:foo', '2:foo', 'foo', '3:foo', '4:foo'])
+  call setline(1, ['1:foo', '2:foo', 'foo', '3:foo', '4:foo', '==='])
   call cursor(3, 1)
 
   " Test for [i and ]i
@@ -1143,6 +1143,9 @@ func Test_inc_search()
   call assert_equal('3:foo', execute('normal ]i'))
   call assert_equal('4:foo', execute('normal 2]i'))
   call assert_fails('normal 3]i', 'E389:')
+  call assert_fails('normal G]i', 'E349:')
+  call assert_fails('normal [i', 'E349:')
+  call cursor(3, 1)
 
   " Test for :isearch
   call assert_equal('1:foo', execute('isearch foo'))
@@ -1163,6 +1166,9 @@ func Test_inc_search()
   call assert_equal([
         \ '  1:    4 3:foo',
         \ '  2:    5 4:foo'], split(execute('normal ]I'), "\n"))
+  call assert_fails('normal G]I', 'E349:')
+  call assert_fails('normal [I', 'E349:')
+  call cursor(3, 1)
 
   " Test for :ilist
   call assert_equal([
@@ -1188,6 +1194,9 @@ func Test_inc_search()
   exe "normal k2]\t"
   call assert_equal([5, 3], [line('.'), col('.')])
   call assert_fails("normal 2k3]\t", 'E389:')
+  call assert_fails("normal G[\t", 'E349:')
+  call assert_fails("normal ]\t", 'E349:')
+  call cursor(3, 1)
 
   " Test for :ijump
   call cursor(3, 1)
@@ -1212,6 +1221,8 @@ func Test_inc_search()
   close
   call assert_fails('3wincmd i', 'E387:')
   call assert_fails('6wincmd i', 'E389:')
+  call assert_fails("normal G\<C-W>i", 'E349:')
+  call cursor(3, 1)
 
   " Test for :isplit
   isplit foo

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -642,12 +642,6 @@ func Test_characterwise_visual_mode()
   normal Gkvj$d
   call assert_equal(['', 'a', ''], getline(1, '$'))
 
-  " characterwise visual mode: use a count with the visual mode
-  %d _
-  call setline(1, 'one two three')
-  norm! vy5vy
-  call assert_equal('one t', @")
-
   " characterwise visual mode: use a count with the visual mode from the last
   " line in the buffer
   %d _
@@ -1195,15 +1189,38 @@ func Test_exclusive_selection()
   close!
 endfunc
 
-" Test for starting visual mode with a count.
-" This test should be run without any previous visual modes. So this should be
-" run as a first test.
-func Test_AAA_start_visual_mode_with_count()
-  new
-  call setline(1, ['aaaaaaa', 'aaaaaaa', 'aaaaaaa', 'aaaaaaa'])
-  normal! gg2Vy
-  call assert_equal("aaaaaaa\naaaaaaa\n", @")
-  close!
+" Test for starting linewise visual with a count.
+" This test needs to be run without any previous visual mode. Otherwise the
+" count will use the count from the previous visual mode.
+func Test_linewise_visual_with_count()
+  let after =<< trim [CODE]
+    call setline(1, ['one', 'two', 'three', 'four'])
+    norm! 3Vy
+    call assert_equal("one\ntwo\nthree\n", @")
+    call writefile(v:errors, 'Xtestout')
+    qall!
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal([], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
+endfunc
+
+" Test for starting characterwise visual with a count.
+" This test needs to be run without any previous visual mode. Otherwise the
+" count will use the count from the previous visual mode.
+func Test_characterwise_visual_with_count()
+  let after =<< trim [CODE]
+    call setline(1, ['one two', 'three'])
+    norm! l5vy
+    call assert_equal("ne tw", @")
+    call writefile(v:errors, 'Xtestout')
+    qall!
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal([], readfile('Xtestout'))
+    call delete('Xtestout')
+  endif
 endfunc
 
 " Test for visually selecting an inner block (iB)

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -378,14 +378,17 @@ endfunc
 
 func Test_Visual_paragraph_textobject()
   new
-  call setline(1, ['First line.',
-  \                '',
-  \                'Second line.',
-  \                'Third line.',
-  \                'Fourth line.',
-  \                'Fifth line.',
-  \                '',
-  \                'Sixth line.'])
+  let lines =<< trim [END]
+    First line.
+
+    Second line.
+    Third line.
+    Fourth line.
+    Fifth line.
+
+    Sixth line.
+  [END]
+  call setline(1, lines)
 
   " When start and end of visual area are identical, 'ap' or 'ip' select
   " the whole paragraph.
@@ -638,6 +641,20 @@ func Test_characterwise_visual_mode()
   call append('$', ['a', 'b', 'c'])
   normal Gkvj$d
   call assert_equal(['', 'a', ''], getline(1, '$'))
+
+  " characterwise visual mode: use a count with the visual mode
+  %d _
+  call setline(1, 'one two three')
+  norm! vy5vy
+  call assert_equal('one t', @")
+
+  " characterwise visual mode: use a count with the visual mode from the last
+  " line in the buffer
+  %d _
+  call setline(1, ['one', 'two', 'three', 'four'])
+  norm! vj$y
+  norm! G1vy
+  call assert_equal('four', @")
 
   " characterwise visual mode: replace a single character line and the eol
   %d _

--- a/test/functional/legacy/gf_spec.lua
+++ b/test/functional/legacy/gf_spec.lua
@@ -1,0 +1,15 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local pcall_err = helpers.pcall_err
+
+describe('gf', function()
+  before_each(clear)
+
+  it('is not allowed when buffer is locked', function()
+    command('au OptionSet diff norm! gf')
+    command([[call setline(1, ['Xfile1', 'line2', 'line3', 'line4'])]])
+    eq('Vim(normal):E788: Not allowed to edit another buffer now', pcall_err(command, 'diffthis'))
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:8.2.1786: various Normal mode commands not fully tested

Problem:    Various Normal mode commands not fully tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#7059)
https://github.com/vim/vim/commit/8a9bc95eaec53f4e0c951ff8f2686ae5113a5709

Cherry-pick Test_normal_gdollar_cmd() change from patch 8.2.0540.


#### vim-patch:8.2.1799: some Normal mode commands not fully tested

Problem:    Some Normal mode commands not fully tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#7073)
https://github.com/vim/vim/commit/d1ad99b65470d3e754f6a0588a6b0dc2214a1eab

Cherry-pick test_registers.vim change from patch 8.2.0644.