### PR TITLE
refactor(object): get rid of redundant FIXED_TEMP_ARRAY

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -538,9 +538,9 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
                        Integer end_row, Integer end_col, ArrayOf(String) replacement, Error *err)
   FUNC_API_SINCE(7)
 {
-  FIXED_TEMP_ARRAY(scratch, 1);
+  MAXSIZE_TEMP_ARRAY(scratch, 1);
   if (replacement.size == 0) {
-    scratch.items[0] = STRING_OBJ(STATIC_CSTR_AS_STRING(""));
+    ADD_C(scratch, STRING_OBJ(STATIC_CSTR_AS_STRING("")));
     replacement = scratch;
   }
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -74,12 +74,6 @@
 #define ADD_C(array, item) \
   kv_push_c(array, item)
 
-#define FIXED_TEMP_ARRAY(name, fixsize) \
-  Array name = ARRAY_DICT_INIT; \
-  Object name##__items[fixsize]; \
-  name.size = fixsize; \
-  name.items = name##__items; \
-
 #define MAXSIZE_TEMP_ARRAY(name, maxsize) \
   Array name = ARRAY_DICT_INIT; \
   Object name##__items[maxsize]; \

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -473,10 +473,10 @@ Object nvim_exec_lua(String code, Array args, Error *err)
 Object nvim_notify(String msg, Integer log_level, Dictionary opts, Error *err)
   FUNC_API_SINCE(7)
 {
-  FIXED_TEMP_ARRAY(args, 3);
-  args.items[0] = STRING_OBJ(msg);
-  args.items[1] = INTEGER_OBJ(log_level);
-  args.items[2] = DICTIONARY_OBJ(opts);
+  MAXSIZE_TEMP_ARRAY(args, 3);
+  ADD_C(args, STRING_OBJ(msg));
+  ADD_C(args, INTEGER_OBJ(log_level));
+  ADD_C(args, DICTIONARY_OBJ(opts));
 
   return nlua_exec(STATIC_CSTR_AS_STRING("return vim.notify(...)"), args, err);
 }
@@ -1010,10 +1010,10 @@ static void term_write(char *buf, size_t size, void *data)
   if (cb == LUA_NOREF) {
     return;
   }
-  FIXED_TEMP_ARRAY(args, 3);
-  args.items[0] = INTEGER_OBJ((Integer)chan->id);
-  args.items[1] = BUFFER_OBJ(terminal_buf(chan->term));
-  args.items[2] = STRING_OBJ(((String){ .data = buf, .size = size }));
+  MAXSIZE_TEMP_ARRAY(args, 3);
+  ADD_C(args, INTEGER_OBJ((Integer)chan->id));
+  ADD_C(args, BUFFER_OBJ(terminal_buf(chan->term)));
+  ADD_C(args, STRING_OBJ(((String){ .data = buf, .size = size })));
   textlock++;
   nlua_call_ref(cb, "input", args, false, NULL);
   textlock--;

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2052,8 +2052,8 @@ static bool call_autocmd_callback(const AutoCmd *ac, const AutoPatCmd *apc)
       break;
     }
 
-    FIXED_TEMP_ARRAY(args, 1);
-    args.items[0] = DICTIONARY_OBJ(data);
+    MAXSIZE_TEMP_ARRAY(args, 1);
+    ADD_C(args, DICTIONARY_OBJ(data));
 
     Object result = nlua_call_ref(callback.data.luaref, NULL, args, true, NULL);
     if (result.type == kObjectTypeBoolean) {

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -316,23 +316,23 @@ void buf_updates_send_splice(buf_T *buf, int start_row, colnr_T start_col, bcoun
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
     if (cb.on_bytes != LUA_NOREF && (cb.preview || !cmdpreview)) {
-      FIXED_TEMP_ARRAY(args, 11);
+      MAXSIZE_TEMP_ARRAY(args, 11);
 
       // the first argument is always the buffer handle
-      args.items[0] = BUFFER_OBJ(buf->handle);
+      ADD_C(args, BUFFER_OBJ(buf->handle));
 
       // next argument is b:changedtick
-      args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
+      ADD_C(args, INTEGER_OBJ(buf_get_changedtick(buf)));
 
-      args.items[2] = INTEGER_OBJ(start_row);
-      args.items[3] = INTEGER_OBJ(start_col);
-      args.items[4] = INTEGER_OBJ(start_byte);
-      args.items[5] = INTEGER_OBJ(old_row);
-      args.items[6] = INTEGER_OBJ(old_col);
-      args.items[7] = INTEGER_OBJ(old_byte);
-      args.items[8] = INTEGER_OBJ(new_row);
-      args.items[9] = INTEGER_OBJ(new_col);
-      args.items[10] = INTEGER_OBJ(new_byte);
+      ADD_C(args, INTEGER_OBJ(start_row));
+      ADD_C(args, INTEGER_OBJ(start_col));
+      ADD_C(args, INTEGER_OBJ(start_byte));
+      ADD_C(args, INTEGER_OBJ(old_row));
+      ADD_C(args, INTEGER_OBJ(old_col));
+      ADD_C(args, INTEGER_OBJ(old_byte));
+      ADD_C(args, INTEGER_OBJ(new_row));
+      ADD_C(args, INTEGER_OBJ(new_col));
+      ADD_C(args, INTEGER_OBJ(new_byte));
 
       textlock++;
       Object res = nlua_call_ref(cb.on_bytes, "bytes", args, true, NULL);
@@ -361,13 +361,13 @@ void buf_updates_changedtick(buf_T *buf)
     BufUpdateCallbacks cb = kv_A(buf->update_callbacks, i);
     bool keep = true;
     if (cb.on_changedtick != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 2);
+      MAXSIZE_TEMP_ARRAY(args, 2);
 
       // the first argument is always the buffer handle
-      args.items[0] = BUFFER_OBJ(buf->handle);
+      ADD_C(args, BUFFER_OBJ(buf->handle));
 
       // next argument is b:changedtick
-      args.items[1] = INTEGER_OBJ(buf_get_changedtick(buf));
+      ADD_C(args, INTEGER_OBJ(buf_get_changedtick(buf)));
 
       textlock++;
       Object res = nlua_call_ref(cb.on_changedtick, "changedtick",

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -63,9 +63,9 @@ void decor_providers_start(DecorProviders *providers, int type, char **err)
 
     bool active;
     if (p->redraw_start != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 2);
-      args.items[0] = INTEGER_OBJ((int)display_tick);
-      args.items[1] = INTEGER_OBJ(type);
+      MAXSIZE_TEMP_ARRAY(args, 2);
+      ADD_C(args, INTEGER_OBJ((int)display_tick));
+      ADD_C(args, INTEGER_OBJ(type));
       active = decor_provider_invoke(p->ns_id, "start", p->redraw_start, args, true, err);
     } else {
       active = true;
@@ -96,12 +96,12 @@ void decor_providers_invoke_win(win_T *wp, DecorProviders *providers,
   for (size_t k = 0; k < kv_size(*providers); k++) {
     DecorProvider *p = kv_A(*providers, k);
     if (p && p->redraw_win != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 4);
-      args.items[0] = WINDOW_OBJ(wp->handle);
-      args.items[1] = BUFFER_OBJ(wp->w_buffer->handle);
+      MAXSIZE_TEMP_ARRAY(args, 4);
+      ADD_C(args, WINDOW_OBJ(wp->handle));
+      ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
       // TODO(bfredl): we are not using this, but should be first drawn line?
-      args.items[2] = INTEGER_OBJ(wp->w_topline - 1);
-      args.items[3] = INTEGER_OBJ(knownmax);
+      ADD_C(args, INTEGER_OBJ(wp->w_topline - 1));
+      ADD_C(args, INTEGER_OBJ(knownmax));
       if (decor_provider_invoke(p->ns_id, "win", p->redraw_win, args, true, err)) {
         kvi_push(*line_providers, p);
       }
@@ -124,10 +124,10 @@ void providers_invoke_line(win_T *wp, DecorProviders *providers, int row, bool *
   for (size_t k = 0; k < kv_size(*providers); k++) {
     DecorProvider *p = kv_A(*providers, k);
     if (p && p->redraw_line != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 3);
-      args.items[0] = WINDOW_OBJ(wp->handle);
-      args.items[1] = BUFFER_OBJ(wp->w_buffer->handle);
-      args.items[2] = INTEGER_OBJ(row);
+      MAXSIZE_TEMP_ARRAY(args, 3);
+      ADD_C(args, WINDOW_OBJ(wp->handle));
+      ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
+      ADD_C(args, INTEGER_OBJ(row));
       if (decor_provider_invoke(p->ns_id, "line", p->redraw_line, args, true, err)) {
         *has_decor = true;
       } else {
@@ -150,8 +150,8 @@ void decor_providers_invoke_buf(buf_T *buf, DecorProviders *providers, char **er
   for (size_t i = 0; i < kv_size(*providers); i++) {
     DecorProvider *p = kv_A(*providers, i);
     if (p && p->redraw_buf != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 1);
-      args.items[0] = BUFFER_OBJ(buf->handle);
+      MAXSIZE_TEMP_ARRAY(args, 1);
+      ADD_C(args, BUFFER_OBJ(buf->handle));
       decor_provider_invoke(p->ns_id, "buf", p->redraw_buf, args, true, err);
     }
   }
@@ -167,8 +167,8 @@ void decor_providers_invoke_end(DecorProviders *providers, char **err)
   for (size_t i = 0; i < kv_size(*providers); i++) {
     DecorProvider *p = kv_A(*providers, i);
     if (p && p->active && p->redraw_end != LUA_NOREF) {
-      FIXED_TEMP_ARRAY(args, 1);
-      args.items[0] = INTEGER_OBJ((int)display_tick);
+      MAXSIZE_TEMP_ARRAY(args, 1);
+      ADD_C(args, INTEGER_OBJ((int)display_tick));
       decor_provider_invoke(p->ns_id, "end", p->redraw_end, args, true, err);
     }
   }

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -183,10 +183,10 @@ int ns_get_hl(NS ns_id, int hl_id, bool link, bool nodefault)
   bool valid_cache = it.version >= p->hl_valid;
 
   if (!valid_cache && p->hl_def != LUA_NOREF && !recursive) {
-    FIXED_TEMP_ARRAY(args, 3);
-    args.items[0] = INTEGER_OBJ((Integer)ns_id);
-    args.items[1] = STRING_OBJ(cstr_to_string((char *)syn_id2name(hl_id)));
-    args.items[2] = BOOLEAN_OBJ(link);
+    MAXSIZE_TEMP_ARRAY(args, 3);
+    ADD_C(args, INTEGER_OBJ((Integer)ns_id));
+    ADD_C(args, STRING_OBJ(cstr_to_string((char *)syn_id2name(hl_id))));
+    ADD_C(args, BOOLEAN_OBJ(link));
     // TODO(bfredl): preload the "global" attr dict?
 
     Error err = ERROR_INIT;


### PR DESCRIPTION
Recent `MAXSIZE_TEMP_ARRAY` was introduced, whose usage is more similar to dynamic arrays (and arena arrays). Get rid of the separate `FIXED_TEMP_ARRAY`  with the completely different usage pattern.