### PR TITLE
fix(lsp): clean the diagnostic cache  when buffer delete

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -715,6 +715,12 @@ function M.set(namespace, bufnr, diagnostics, opts)
   end
 
   if vim.api.nvim_buf_is_loaded(bufnr) then
+    vim.api.nvim_buf_attach(bufnr, false, {
+      on_detach = function()
+        rawset(diagnostic_cache, bufnr, nil) -- clear cache
+      end,
+    })
+
     M.show(namespace, bufnr, nil, opts)
   end
 
@@ -1597,18 +1603,16 @@ function M.toqflist(diagnostics)
 
   local list = {}
   for _, v in ipairs(diagnostics) do
-    if vim.api.nvim_buf_is_valid(v.bufnr) then
-      local item = {
-        bufnr = v.bufnr,
-        lnum = v.lnum + 1,
-        col = v.col and (v.col + 1) or nil,
-        end_lnum = v.end_lnum and (v.end_lnum + 1) or nil,
-        end_col = v.end_col and (v.end_col + 1) or nil,
-        text = v.message,
-        type = errlist_type_map[v.severity] or 'E',
-      }
-      table.insert(list, item)
-    end
+    local item = {
+      bufnr = v.bufnr,
+      lnum = v.lnum + 1,
+      col = v.col and (v.col + 1) or nil,
+      end_lnum = v.end_lnum and (v.end_lnum + 1) or nil,
+      end_col = v.end_col and (v.end_col + 1) or nil,
+      text = v.message,
+      type = errlist_type_map[v.severity] or 'E',
+    }
+    table.insert(list, item)
   end
   table.sort(list, function(a, b)
     if a.bufnr == b.bufnr then

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1597,16 +1597,18 @@ function M.toqflist(diagnostics)
 
   local list = {}
   for _, v in ipairs(diagnostics) do
-    local item = {
-      bufnr = v.bufnr,
-      lnum = v.lnum + 1,
-      col = v.col and (v.col + 1) or nil,
-      end_lnum = v.end_lnum and (v.end_lnum + 1) or nil,
-      end_col = v.end_col and (v.end_col + 1) or nil,
-      text = v.message,
-      type = errlist_type_map[v.severity] or 'E',
-    }
-    table.insert(list, item)
+    if vim.api.nvim_buf_is_valid(v.bufnr) then
+      local item = {
+        bufnr = v.bufnr,
+        lnum = v.lnum + 1,
+        col = v.col and (v.col + 1) or nil,
+        end_lnum = v.end_lnum and (v.end_lnum + 1) or nil,
+        end_col = v.end_col and (v.end_col + 1) or nil,
+        text = v.message,
+        type = errlist_type_map[v.severity] or 'E',
+      }
+      table.insert(list, item)
+    end
   end
   table.sort(list, function(a, b)
     if a.bufnr == b.bufnr then

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -45,19 +45,24 @@ local bufnr_and_namespace_cacher_mt = {
   end,
 }
 
-local diagnostic_cache = setmetatable({}, {
-  __index = function(t, bufnr)
-    assert(bufnr > 0, 'Invalid buffer number')
-    vim.fn.bufload(bufnr)
-    vim.api.nvim_buf_attach(bufnr, false, {
-      on_detach = function()
-        rawset(t, bufnr, nil) -- clear cache
-      end,
-    })
-    t[bufnr] = {}
-    return t[bufnr]
-  end,
-})
+local diagnostic_cache
+do
+  local group = vim.api.nvim_create_augroup('DiagnosticBufDelete', {})
+  diagnostic_cache = setmetatable({}, {
+    __index = function(t, bufnr)
+      assert(bufnr > 0, 'Invalid buffer number')
+      vim.api.nvim_create_autocmd('BufDelete', {
+        group = group,
+        buffer = bufnr,
+        callback = function()
+          rawset(t, bufnr, nil)
+        end,
+      })
+      t[bufnr] = {}
+      return t[bufnr]
+    end,
+  })
+end
 
 local diagnostic_cache_extmarks = setmetatable({}, bufnr_and_namespace_cacher_mt)
 local diagnostic_attached_buffers = {}

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -48,6 +48,7 @@ local bufnr_and_namespace_cacher_mt = {
 local diagnostic_cache = setmetatable({}, {
   __index = function(t, bufnr)
     assert(bufnr > 0, 'Invalid buffer number')
+    vim.fn.bufload(bufnr)
     vim.api.nvim_buf_attach(bufnr, false, {
       on_detach = function()
         rawset(t, bufnr, nil) -- clear cache
@@ -715,12 +716,6 @@ function M.set(namespace, bufnr, diagnostics, opts)
   end
 
   if vim.api.nvim_buf_is_loaded(bufnr) then
-    vim.api.nvim_buf_attach(bufnr, false, {
-      on_detach = function()
-        rawset(diagnostic_cache, bufnr, nil) -- clear cache
-      end,
-    })
-
     M.show(namespace, bufnr, nil, opts)
   end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -128,11 +128,13 @@ describe('vim.diagnostic', function()
     eq('Diagnostic #1', result[1].message)
   end)
 
-  it('clean the diagnostic cache when buf delete', function()
-    local result = exec_lua [[
-      local other_bufnr = vim.api.nvim_create_buf(true,false)
+  it('removes diagnostics from the cache when a buffer is removed', function()
+    eq(2, exec_lua [[
+      vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+      local other_bufnr = vim.fn.bufadd('test | test')
       local lines = vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, -1, true)
       vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
+      vim.cmd('bunload! ' .. other_bufnr)
 
       vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
         make_error('Diagnostic #1', 1, 1, 1, 1),
@@ -142,10 +144,10 @@ describe('vim.diagnostic', function()
         make_error('Diagnostic #3', 3, 1, 3, 1),
       })
       vim.api.nvim_set_current_buf(other_bufnr)
+      vim.opt_local.buflisted = true
       vim.cmd('bwipeout!')
-      return vim.diagnostic.get()
-    ]]
-    eq(2, #result)
+      return #vim.diagnostic.get()
+    ]])
   end)
 
   it('resolves buffer number 0 to the current buffer', function()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -128,6 +128,26 @@ describe('vim.diagnostic', function()
     eq('Diagnostic #1', result[1].message)
   end)
 
+  it('clean the diagnostic cache when buf delete', function()
+    local result = exec_lua [[
+      local other_bufnr = vim.api.nvim_create_buf(true,false)
+      local lines = vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, -1, true)
+      vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
+
+      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+        make_error('Diagnostic #1', 1, 1, 1, 1),
+        make_error('Diagnostic #2', 2, 1, 2, 1),
+      })
+      vim.diagnostic.set(diagnostic_ns, other_bufnr, {
+        make_error('Diagnostic #3', 3, 1, 3, 1),
+      })
+      vim.api.nvim_set_current_buf(other_bufnr)
+      vim.cmd('bwipeout!')
+      return vim.diagnostic.get()
+    ]]
+    eq(2, #result)
+  end)
+
   it('resolves buffer number 0 to the current buffer', function()
     eq(2, exec_lua [[
       vim.api.nvim_set_current_buf(diagnostic_bufnr)


### PR DESCRIPTION
when use `bwipeout` command to delete a buffer. this buffer will remove from `bufinfo` , but there check the buffer in list or not at  `quickfix.c`. if not get an error . so check the buffer is valid before convert the diagnostic to `qflist` table

https://github.com/neovim/neovim/blob/243038188bc74c008e36fc005aa18dc23d7ae3f0/src/nvim/quickfix.c#L6383-L6387


Fix #19322 