### PR TITLE
vim-patch:9.0.0047: using freed memory with recursive substitute

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1587,12 +1587,10 @@ char_u *regtilde(char_u *source, int magic, bool preview)
 
   // Only change reg_prev_sub when not previewing.
   if (!preview) {
+    // Store a copy of newsub  in reg_prev_sub.  It is always allocated,
+    // because recursive calls may make the returned string invalid.
     xfree(reg_prev_sub);
-    if (newsub != source) {             // newsub was allocated, just keep it
-      reg_prev_sub = newsub;
-    } else {                            // no ~ found, need to save newsub
-      reg_prev_sub = vim_strsave(newsub);
-    }
+    reg_prev_sub = vim_strsave(newsub);
   }
 
   return newsub;

--- a/src/nvim/testdir/test_regexp_latin.vim
+++ b/src/nvim/testdir/test_regexp_latin.vim
@@ -1027,4 +1027,15 @@ func Test_using_invalid_visual_position()
   bwipe!
 endfunc
 
+func Test_recursive_substitute_expr()
+  new
+  func Repl()
+    s
+  endfunc
+  silent! s/\%')/~\=Repl()
+
+  bwipe!
+  delfunc Repl
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0047: using freed memory with recursive substitute

Problem:    Using freed memory with recursive substitute.
Solution:   Always make a copy for reg_prev_sub.
https://github.com/vim/vim/commit/32acf1f1a72ebb9d8942b9c9d80023bf1bb668ea