### PR TITLE
ci(release): use `cpack` on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,14 +112,12 @@ jobs:
                CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH= $OSX_FLAGS" \
                DEPS_CMAKE_FLAGS="$OSX_FLAGS"
           make DESTDIR="$GITHUB_WORKSPACE/build/release/nvim-macos" install
-      - name: Create package
-        run: |
-          cd "$GITHUB_WORKSPACE/build/release"
-          tar cfz nvim-macos.tar.gz nvim-macos
+          cd "$GITHUB_WORKSPACE/build/"
+          cpack -C "$NVIM_BUILD_TYPE"
       - uses: actions/upload-artifact@v3
         with:
           name: nvim-macos
-          path: build/release/nvim-macos.tar.gz
+          path: build/nvim-macos.tar.gz
           retention-days: 1
 
   windows:


### PR DESCRIPTION
We use `cpack` to generate the release tarballs on Linux. Now that we
don't need to bundle `libintl`, we can do the same on macOS.

-----

I'll admit that I'm of two minds about this PR. It simplifies the workflow a little in that it reduces the packaging surface now that we have a common interface for generating release tarballs on Linux and macOS.

On the other hand, the original code is probably a bit more transparent. And I think one major reason to use `cpack` on Linux doesn't apply to macOS: `cpack` makes it simple to generate both `*.tar.gz` and a `*.deb` assets in one go.

I've opened this anyway in case this change is desired, but I also understand why it wouldn't be.
