### PR TITLE
feat(ts): allow capture text to be transformed

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -306,6 +306,14 @@ local function get_node_range(node, id, metadata)
   return { node:range() }
 end
 
+---@private
+local function get_node_text(node, id, metadata, source)
+  if metadata[id] and metadata[id].text then
+    return metadata[id].text
+  end
+  return query.get_node_text(node, source)
+end
+
 --- Gets language injection points by language.
 ---
 --- This is where most of the injection processing occurs.
@@ -358,7 +366,7 @@ function LanguageTree:_get_injections()
 
         -- Lang should override any other language tag
         if name == 'language' and not lang then
-          lang = query.get_node_text(node, self._source)
+          lang = get_node_text(node, id, metadata, self._source)
         elseif name == 'combined' then
           combined = true
         elseif name == 'content' and #ranges == 0 then

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -363,6 +363,22 @@ local directive_handlers = {
       metadata[capture_id].range = range
     end
   end,
+
+  -- Transform the content of the node
+  -- Example: (#gsub! @_node ".*%.(.*)" "%1")
+  ['gsub!'] = function(match, _, bufnr, pred, metadata)
+    assert(#pred == 4)
+
+    local id = pred[2]
+    local node = match[id]
+    local text = M.get_node_text(node, bufnr) or ""
+
+    if not metadata[id] then
+      metadata[id] = {}
+    end
+    metadata[id].text = text:gsub(pred[3], pred[4])
+  end
+
 }
 
 --- Adds a new predicate to be used in queries


### PR DESCRIPTION
## Goal

Allow language injections of the form:

```bash
#!/bin/bash

echo ' 
local x = function() end
' > file.lua
```

For this we need to transform `file.lua` -> `lua`.

For reference the above injection requires the following bash query:

```scheme
; echo ' ' > file.ext
(redirected_statement
  body: (command
    name: (_)
    argument: (raw_string) @content
  )
  redirect: (file_redirect
    destination: (
      (word) @language
      (#gsub @language ".*%.(.*)" "%1")
    )
  )
)
```