### PR TITLE
test(mksession_spec): use %bwipeout! instead of qall! to close terminal

### DIFF
--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -14,7 +14,6 @@ local pesc = helpers.pesc
 local rmdir = helpers.rmdir
 local sleep = helpers.sleep
 local meths = helpers.meths
-local expect_exit = helpers.expect_exit
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -43,9 +42,9 @@ describe(':mksession', function()
     command('terminal')
     command('split')
     command('mksession '..session_file)
+    command('%bwipeout!')
 
     -- Create a new test instance of Nvim.
-    expect_exit(command, 'qall!')
     clear()
     -- Restore session.
     command('source '..session_file)
@@ -110,11 +109,10 @@ describe(':mksession', function()
     command('terminal')
     command('cd '..cwd_dir)
     command('mksession '..session_path)
-    command('bdelete!')
+    command('%bwipeout!')
     if iswin() then
       sleep(100)  -- Make sure all child processes have exited.
     end
-    expect_exit(command, 'qall!')
 
     -- Create a new test instance of Nvim.
     clear()
@@ -122,7 +120,7 @@ describe(':mksession', function()
 
     local expected_cwd = cwd_dir..'/'..tab_dir
     matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
-    command('bdelete!')
+    command('%bwipeout!')
     if iswin() then
       sleep(100)  -- Make sure all child processes have exited.
     end
@@ -157,7 +155,7 @@ describe(':mksession', function()
 
     command('cd '..cwd_dir)
     command('mksession '..session_path)
-    expect_exit(command, 'qall!')
+    command('%bwipeout!')
 
     -- Create a new test instance of Nvim.
     clear()


### PR DESCRIPTION
Avoid expect_exit, session will be closed when a new one is spawned.