### PR TITLE
refactor: move FunPtr to types.h

### DIFF
--- a/src/nvim/digraph.h
+++ b/src/nvim/digraph.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_DIGRAPH_H
 #define NVIM_DIGRAPH_H
 
-#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/types.h"
 

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -3,7 +3,6 @@
 
 #include "nvim/buffer_defs.h"
 #include "nvim/channel.h"
-#include "nvim/eval/funcs.h"  // For FunPtr
 #include "nvim/event/time.h"  // For TimeWatcher
 #include "nvim/ex_cmds_defs.h"  // For exarg_T
 #include "nvim/os/fileio.h"  // For FileDescriptor

--- a/src/nvim/eval/funcs.h
+++ b/src/nvim/eval/funcs.h
@@ -4,8 +4,6 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/eval/typval.h"
 
-typedef void (*FunPtr)(void);
-
 /// Prototype of C function that implements VimL function
 typedef void (*VimLFunc)(typval_T *args, typval_T *rvar, FunPtr data);
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -9,6 +9,7 @@
 #include "nvim/edit.h"
 #include "nvim/eval.h"
 #include "nvim/eval/encode.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/eval/vars.h"
 #include "nvim/ex_cmds2.h"

--- a/src/nvim/eval/vars.h
+++ b/src/nvim/eval/vars.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_EVAL_VARS_H
 #define NVIM_EVAL_VARS_H
 
-#include "nvim/eval/funcs.h"  // For FunPtr
 #include "nvim/ex_cmds_defs.h"  // For exarg_T
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_EX_DOCMD_H
 #define NVIM_EX_DOCMD_H
 
-#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/globals.h"
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -24,6 +24,7 @@
 #include "nvim/digraph.h"
 #include "nvim/edit.h"
 #include "nvim/eval.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/event/loop.h"
 #include "nvim/ex_cmds.h"

--- a/src/nvim/insexpand.h
+++ b/src/nvim/insexpand.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_INSEXPAND_H
 #define NVIM_INSEXPAND_H
 
-#include "nvim/eval/funcs.h"
 #include "nvim/vim.h"
 
 /// state for pum_ext_select_item.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -15,6 +15,7 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/cursor.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/event/loop.h"

--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -2,7 +2,6 @@
 #define NVIM_MAPPING_H
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/types.h"
 #include "nvim/vim.h"

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -7,6 +7,7 @@
 
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/fold.h"
 #include "nvim/highlight_group.h"
 #include "nvim/match.h"

--- a/src/nvim/match.h
+++ b/src/nvim/match.h
@@ -2,7 +2,6 @@
 #define NVIM_MATCH_H
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -18,6 +18,7 @@
 #include "nvim/cursor.h"
 #include "nvim/edit.h"
 #include "nvim/eval.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_getln.h"

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 #include "nvim/normal.h"
 #include "nvim/os/time.h"

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -10,6 +10,7 @@
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
 #include "nvim/edit.h"
+#include "nvim/eval/funcs.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/fold.h"
 #include "nvim/highlight_group.h"

--- a/src/nvim/sign.h
+++ b/src/nvim/sign.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/funcs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/sign_defs.h"
 

--- a/src/nvim/testing.h
+++ b/src/nvim/testing.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_TESTING_H
 #define NVIM_TESTING_H
 
-#include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -22,6 +22,8 @@ typedef int handle_T;
 // absent callback etc.
 typedef int LuaRef;
 
+typedef void (*FunPtr)(void);
+
 typedef handle_T NS;
 
 typedef struct expand expand_T;


### PR DESCRIPTION
This type itself is not eval-specific. Moving it to types.h can avoid
including eval/funcs.h in many headers, and types.h is already included
by many headers.
