### PR TITLE
vim-patch:8.2.4866,9.0.0066: duplicate code in "get" functions

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1506,6 +1506,7 @@ static void get_var_from(const char *varname, typval_T *rettv, typval_T *deftv, 
                          tabpage_T *tp, win_T *win, buf_T *buf)
 {
   bool done = false;
+  const bool do_change_curbuf = buf != NULL && htname == 'b';
 
   emsg_off++;
 
@@ -1518,19 +1519,19 @@ static void get_var_from(const char *varname, typval_T *rettv, typval_T *deftv, 
     // autocommands get blocked.
     // If we have a buffer reference avoid the switching, we're saving and
     // restoring curbuf directly.
-    const bool need_switch_win = !(tp == curtab && win == curwin) || (buf != NULL);
+    const bool need_switch_win = !(tp == curtab && win == curwin) && !do_change_curbuf;
     switchwin_T switchwin;
     if (!need_switch_win || switch_win(&switchwin, win, tp, true) == OK) {
       if (*varname == '&' && htname != 't') {
         buf_T *const save_curbuf = curbuf;
 
         // Change curbuf so the option is read from the correct buffer.
-        if (buf != NULL && htname == 'b') {
+        if (do_change_curbuf) {
           curbuf = buf;
         }
 
         if (varname[1] == NUL) {
-          // get all window-local options in a dict
+          // get all window-local or buffer-local options in a dict
           dict_T *opts = get_winbuf_options(htname == 'b');
 
           if (opts != NULL) {


### PR DESCRIPTION
#### vim-patch:8.2.4866: duplicate code in "get" functions

Problem:    Duplicate code in "get" functions.
Solution:   Use get_var_from() for getwinvar(), gettabvar(), gettabwinvar()
            and getbufvar(). (closes vim/vim#10335)
https://github.com/vim/vim/commit/47d4e317f85e4aeb3799d962f173bd0f1e7bc71c


#### vim-patch:9.0.0066: switching window uneccarily when getting buffer options

Problem:    Switching window uneccarily when getting buffer options.
Solution:   Do not switch window when getting buffer options. (closes vim/vim#10767)
https://github.com/vim/vim/commit/cd6ad6439da2ee2d1a8a6934c9d69e9c2664ba55