### PR TITLE
vim-patch:8.2.{4731,5035}: changelist patches

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2483,6 +2483,9 @@ void buflist_setfpos(buf_T *const buf, win_T *const win, linenr_T lnum, colnr_T 
       wip->wi_mark.view = mark_view_make(win->w_topline, wip->wi_mark.mark);
     }
   }
+  if (win != NULL) {
+    wip->wi_changelistidx = win->w_changelistidx;
+  }
   if (copy_options && win != NULL) {
     // Save the window-specific option values.
     copy_winopt(&win->w_onebuf_opt, &wip->wi_opt);
@@ -2585,6 +2588,9 @@ void get_winopts(buf_T *buf)
     cloneFoldGrowArray(&wip->wi_folds, &curwin->w_folds);
   } else {
     copy_winopt(&curwin->w_allbuf_opt, &curwin->w_onebuf_opt);
+  }
+  if (wip != NULL) {
+    curwin->w_changelistidx = wip->wi_changelistidx;
   }
 
   if (curwin->w_float_config.style == kWinStyleMinimal) {

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -289,6 +289,7 @@ struct wininfo_S {
   winopt_T wi_opt;              // local window options
   bool wi_fold_manual;          // copy of w_fold_manual
   garray_T wi_folds;            // clone of w_folds
+  int wi_changelistidx;         // copy of w_changelistidx
 };
 
 /*

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -467,6 +467,9 @@ EXTERN buf_T *curbuf INIT(= NULL);    // currently active buffer
 #define FOR_ALL_BUFFERS_BACKWARDS(buf) \
   for (buf_T *buf = lastbuf; buf != NULL; buf = buf->b_prev)
 
+#define FOR_ALL_BUF_WININFO(buf, wip) \
+  for ((wip) = (buf)->b_wininfo; (wip) != NULL; (wip) = (wip)->wi_next)   // NOLINT
+
 // Iterate through all the signs placed in a buffer
 #define FOR_ALL_SIGNS_IN_BUF(buf, sign) \
   for ((sign) = (buf)->b_signlist; (sign) != NULL; (sign) = (sign)->se_next)   // NOLINT

--- a/src/nvim/testdir/test_changelist.vim
+++ b/src/nvim/testdir/test_changelist.vim
@@ -1,5 +1,40 @@
 " Tests for the changelist functionality
 
+" When splitting a window the changelist position is wrong.
+" Test the changelist position after splitting a window.
+" Test for the bug fixed by 7.4.386
+func Test_changelist()
+  let save_ul = &ul
+  enew!
+  call append('$', ['1', '2'])
+  exe "normal i\<C-G>u"
+  exe "normal Gkylpa\<C-G>u"
+  set ul=100
+  exe "normal Gylpa\<C-G>u"
+  set ul=100
+  normal gg
+  vsplit
+  normal g;
+  call assert_equal([3, 2], [line('.'), col('.')])
+  normal g;
+  call assert_equal([2, 2], [line('.'), col('.')])
+  call assert_fails('normal g;', 'E662:')
+  new
+  call assert_fails('normal g;', 'E664:')
+  %bwipe!
+  let &ul = save_ul
+endfunc
+
+" Moving a split should not change its changelist index.
+func Test_changelist_index_move_split()
+  exe "norm! iabc\<C-G>u\ndef\<C-G>u\nghi"
+  vsplit
+  normal 99g;
+  call assert_equal(0, getchangelist('%')[1])
+  wincmd L
+  call assert_equal(0, getchangelist('%')[1])
+endfunc
+
 " Tests for the getchangelist() function
 func Test_changelist_index()
   edit Xfile1.txt

--- a/src/nvim/testdir/test_changelist.vim
+++ b/src/nvim/testdir/test_changelist.vim
@@ -1,11 +1,29 @@
 " Tests for the changelist functionality
 
 " Tests for the getchangelist() function
-func Test_getchangelist()
-  if !has("jumplist")
-    return
-  endif
+func Test_changelist_index()
+  edit Xfile1.txt
+  exe "normal iabc\<C-G>u\ndef\<C-G>u\nghi"
+  call assert_equal(3, getchangelist('%')[1])
+  " Move one step back in the changelist.
+  normal 2g;
 
+  hide edit Xfile2.txt
+  exe "normal iabcd\<C-G>u\ndefg\<C-G>u\nghij"
+  call assert_equal(3, getchangelist('%')[1])
+  " Move to the beginning of the changelist.
+  normal 99g;
+
+  " Check the changelist indices.
+  call assert_equal(0, getchangelist('%')[1])
+  call assert_equal(1, getchangelist('#')[1])
+
+  bwipe!
+  call delete('Xfile1.txt')
+  call delete('Xfile2.txt')
+endfunc
+
+func Test_getchangelist()
   bwipe!
   enew
   call assert_equal([], 10->getchangelist())
@@ -15,6 +33,7 @@ func Test_getchangelist()
   call writefile(['line1', 'line2', 'line3'], 'Xfile2.txt')
 
   edit Xfile1.txt
+  let buf_1 = bufnr()
   exe "normal 1Goline\<C-G>u1.1"
   exe "normal 3Goline\<C-G>u2.1"
   exe "normal 5Goline\<C-G>u3.1"
@@ -26,6 +45,7 @@ func Test_getchangelist()
 	      \ getchangelist('%'))
 
   hide edit Xfile2.txt
+  let buf_2 = bufnr()
   exe "normal 1GOline\<C-G>u1.0"
   exe "normal 2Goline\<C-G>u2.0"
   call assert_equal([[
@@ -37,10 +57,12 @@ func Test_getchangelist()
   call assert_equal([[
 	      \ {'lnum' : 2, 'col' : 4, 'coladd' : 0},
 	      \ {'lnum' : 4, 'col' : 4, 'coladd' : 0},
-	      \ {'lnum' : 6, 'col' : 4, 'coladd' : 0}], 3], getchangelist(2))
+	      \ {'lnum' : 6, 'col' : 4, 'coladd' : 0}], 2],
+	      \ getchangelist(buf_1))
   call assert_equal([[
 	      \ {'lnum' : 1, 'col' : 6, 'coladd' : 0},
-	      \ {'lnum' : 3, 'col' : 6, 'coladd' : 0}], 2], getchangelist(3))
+	      \ {'lnum' : 3, 'col' : 6, 'coladd' : 0}], 2],
+	      \ getchangelist(buf_2))
 
   bwipe!
   call delete('Xfile1.txt')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2849,35 +2849,10 @@ func Test_gr_command()
   enew!
 endfunc
 
-" When splitting a window the changelist position is wrong.
-" Test the changelist position after splitting a window.
-" Test for the bug fixed by 7.4.386
-func Test_changelist()
-  let save_ul = &ul
-  enew!
-  call append('$', ['1', '2'])
-  exe "normal i\<C-G>u"
-  exe "normal Gkylpa\<C-G>u"
-  set ul=100
-  exe "normal Gylpa\<C-G>u"
-  set ul=100
-  normal gg
-  vsplit
-  normal g;
-  call assert_equal([3, 2], [line('.'), col('.')])
-  normal g;
-  call assert_equal([2, 2], [line('.'), col('.')])
-  call assert_fails('normal g;', 'E662:')
-  new
-  call assert_fails('normal g;', 'E664:')
-  %bwipe!
-  let &ul = save_ul
-endfunc
-
 func Test_nv_hat_count()
   %bwipeout!
   let l:nr = bufnr('%') + 1
-  call assert_fails(':execute "normal! ' . l:nr . '\<C-^>"', 'E92')
+  call assert_fails(':execute "normal! ' . l:nr . '\<C-^>"', 'E92:')
 
   edit Xfoo
   let l:foo_nr = bufnr('Xfoo')

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1501,9 +1501,6 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     }
   }
 
-  // Keep same changelist position in new window.
-  wp->w_changelistidx = oldwin->w_changelistidx;
-
   // make the new window the current window
   win_enter_ext(wp, WEE_TRIGGER_NEW_AUTOCMDS | WEE_TRIGGER_ENTER_AUTOCMDS
                 | WEE_TRIGGER_LEAVE_AUTOCMDS);
@@ -1574,6 +1571,10 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
   }
   newp->w_tagstackidx = oldp->w_tagstackidx;
   newp->w_tagstacklen = oldp->w_tagstacklen;
+
+  // Keep same changelist position in new window.
+  newp->w_changelistidx = oldp->w_changelistidx;
+
   copyFoldingState(oldp, newp);
 
   win_init_some(newp, oldp);


### PR DESCRIPTION
#### vim-patch:8.2.4731: the changelist index is not remembered per buffer

Problem:    The changelist index is not remembered per buffer.
Solution:   Keep the changelist index per window and buffer. (closes vim/vim#10135)
https://github.com/vim/vim/commit/db0ea7f2b00c84d84f188c9e9953c4f1887528e7

Cherry-pick FOR_ALL_BUF_WININFO from patch 8.2.0500.
Cherry-pick test_changelist.vim change from patch 8.2.3795.


#### vim-patch:8.2.5035: when splitting a window the changelist position moves

Problem:    When splitting a window the changelist position moves.
Solution:   Set the changelist index a bit later. (closes vim/vim#10493)
https://github.com/vim/vim/commit/e6f13b473cf2c270e4eab214e09be9825320c11b

Cherry-pick Test_nv_hat_count() change from patch 8.2.1593.