### PR TITLE
fix(cmdline): trigger CmdlineEnter and ModeChanged earlier

### DIFF
--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -96,119 +96,6 @@ local function test_cmdline(linegrid)
     ]]}
   end)
 
-  describe("redraws statusline on entering", function()
-    before_each(function()
-      command('set laststatus=2')
-      command('set statusline=%{mode()}')
-    end)
-
-    it('from normal mode', function()
-      screen:expect{grid=[[
-        ^                         |
-        {1:~                        }|
-        {1:~                        }|
-        {3:n                        }|
-                                 |
-      ]]}
-
-      feed(':')
-      screen:expect{grid=[[
-        ^                         |
-        {1:~                        }|
-        {1:~                        }|
-        {3:c                        }|
-                                 |
-      ]], cmdline={{
-        firstc = ":",
-        content = {{""}},
-        pos = 0,
-      }}}
-    end)
-
-    it('from normal mode when : is mapped', function()
-      command('nnoremap ; :')
-
-      screen:expect{grid=[[
-        ^                         |
-        {1:~                        }|
-        {1:~                        }|
-        {3:n                        }|
-                                 |
-      ]]}
-
-      feed(';')
-      screen:expect{grid=[[
-        ^                         |
-        {1:~                        }|
-        {1:~                        }|
-        {3:c                        }|
-                                 |
-      ]], cmdline={{
-        firstc = ":",
-        content = {{""}},
-        pos = 0,
-      }}}
-    end)
-
-    it('but not with scrolled messages', function()
-      screen:try_resize(35,10)
-      feed(':echoerr doesnotexist<cr>')
-      screen:expect{grid=[[
-                                           |
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {3:                                   }|
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {5:inue}^                               |
-      ]]}
-      feed(':echoerr doesnotexist<cr>')
-      screen:expect{grid=[[
-                                           |
-        {1:~                                  }|
-        {3:                                   }|
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {5:inue}^                               |
-      ]]}
-
-      feed(':echoerr doesnotexist<cr>')
-      screen:expect{grid=[[
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {4:E121: Undefined variable: doesnotex}|
-        {4:ist}                                |
-        {5:Press ENTER or type command to cont}|
-        {5:inue}^                               |
-      ]]}
-
-      feed('<cr>')
-      screen:expect{grid=[[
-        ^                                   |
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {1:~                                  }|
-        {3:n                                  }|
-                                           |
-      ]]}
-    end)
-  end)
-
   it("works with input()", function()
     feed(':call input("input", "default")<cr>')
     screen:expect{grid=[[
@@ -880,6 +767,154 @@ describe('cmdline redraw', function()
       {3:[Command Line]                          }|
       :^abc                                    |
     ]])
+  end)
+end)
+
+describe('statusline is redrawn on entering cmdline', function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = new_screen()
+    command('set laststatus=2')
+  end)
+
+  it('from normal mode', function()
+    command('set statusline=%{mode()}')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {3:n                        }|
+                               |
+    ]]}
+
+    feed(':')
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {3:c                        }|
+      :^                        |
+    ]]}
+  end)
+
+  it('from normal mode when : is mapped', function()
+    command('set statusline=%{mode()}')
+    command('nnoremap ; :')
+
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {3:n                        }|
+                               |
+    ]]}
+
+    feed(';')
+    screen:expect{grid=[[
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {3:c                        }|
+      :^                        |
+    ]]}
+  end)
+
+  it('but not with scrolled messages', function()
+    command('set statusline=%{mode()}')
+    screen:try_resize(35,10)
+    feed(':echoerr doesnotexist<cr>')
+    screen:expect{grid=[[
+                                         |
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {3:                                   }|
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {5:inue}^                               |
+    ]]}
+    feed(':echoerr doesnotexist<cr>')
+    screen:expect{grid=[[
+                                         |
+      {1:~                                  }|
+      {3:                                   }|
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {5:inue}^                               |
+    ]]}
+
+    feed(':echoerr doesnotexist<cr>')
+    screen:expect{grid=[[
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {4:E121: Undefined variable: doesnotex}|
+      {4:ist}                                |
+      {5:Press ENTER or type command to cont}|
+      {5:inue}^                               |
+    ]]}
+
+    feed('<cr>')
+    screen:expect{grid=[[
+      ^                                   |
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
+      {3:n                                  }|
+                                         |
+    ]]}
+  end)
+
+  describe('if custom statusline is set by', function()
+    before_each(function()
+      command('set statusline=')
+      screen:expect{grid=[[
+        ^                         |
+        {1:~                        }|
+        {1:~                        }|
+        {3:[No Name]                }|
+                                 |
+      ]]}
+    end)
+
+    it('CmdlineEnter autocommand', function()
+      command('autocmd CmdlineEnter * set statusline=command')
+      feed(':')
+      screen:expect{grid=[[
+                                 |
+        {1:~                        }|
+        {1:~                        }|
+        {3:command                  }|
+        :^                        |
+      ]]}
+    end)
+
+    it('ModeChanged autocommand', function()
+      command('autocmd ModeChanged *:c set statusline=command')
+      feed(':')
+      screen:expect{grid=[[
+                                 |
+        {1:~                        }|
+        {1:~                        }|
+        {3:command                  }|
+        :^                        |
+      ]]}
+    end)
   end)
 end)
 


### PR DESCRIPTION
Match Vim's ordering in code.
These tests are unrelated to ext_cmdline. Move them out of that block.
