### PR TITLE
vim-patch:9.0.{0059,0061}

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1837,9 +1837,13 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     }
     ap->last = true;
 
+    // Make sure cursor and topline are valid.  The first time the current
+    // values are saved, restored by reset_lnums().  When nested only the
+    // values are corrected when needed.
     if (nesting == 1) {
-      // make sure cursor and topline are valid
       check_lnums(true);
+    } else {
+      check_lnums_nested(true);
     }
 
     // Execute the autocmd. The `getnextac` callback handles iteration.

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1808,7 +1808,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
   int local_State = get_real_state();
   bool is_plug_map = false;
 
-  // If typehead starts with <Plug> then remap, even for a "noremap" mapping.
+  // If typeahead starts with <Plug> then remap, even for a "noremap" mapping.
   if (typebuf.tb_len >= 3
       && typebuf.tb_buf[typebuf.tb_off] == K_SPECIAL
       && typebuf.tb_buf[typebuf.tb_off + 1] == KS_EXTRA

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -10,7 +10,6 @@ source test_ex_z.vim
 source test_ex_mode.vim
 source test_expand.vim
 source test_expand_func.vim
-source test_feedkeys.vim
 source test_file_perm.vim
 source test_fnamemodify.vim
 source test_ga.vim

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2170,6 +2170,25 @@ func Test_autocmd_nested()
   call assert_fails('au WinNew * nested nested echo bad', 'E983:')
 endfunc
 
+func Test_autocmd_nested_cursor_invalid()
+  set laststatus=0
+  copen
+  cclose
+  call setline(1, ['foo', 'bar', 'baz'])
+  3
+  augroup nested_inv
+    autocmd User foo ++nested copen
+    autocmd BufAdd * let &laststatus = 2 - &laststatus
+  augroup END
+  doautocmd User foo
+
+  augroup nested_inv
+    au!
+  augroup END
+  set laststatus&
+  bwipe!
+endfunc
+
 func Test_autocmd_once()
   " Without ++once WinNew triggers twice
   let g:did_split = 0

--- a/src/nvim/testdir/test_input.vim
+++ b/src/nvim/testdir/test_input.vim
@@ -1,4 +1,4 @@
-" Test feedkeys() function.
+" Tests for character input and feedkeys() function.
 
 func Test_feedkeys_x_with_empty_string()
   new
@@ -32,6 +32,30 @@ func Test_feedkeys_escape_special()
   call assert_equal(1, g:got_ellipsis)
   unlet g:got_ellipsis
   nunmap …
+endfunc
+
+func Test_input_simplify_ctrl_at()
+  new
+  " feeding unsimplified CTRL-@ should still trigger i_CTRL-@
+  call feedkeys("ifoo\<Esc>A\<*C-@>x", 'xt')
+  call assert_equal('foofo', getline(1))
+  bw!
+endfunc
+
+func Test_input_simplify_noremap()
+  call feedkeys("i\<*C-M>", 'nx')
+  call assert_equal('', getline(1))
+  call assert_equal([0, 2, 1, 0, 1], getcurpos())
+  bw!
+endfunc
+
+func Test_input_simplify_timedout()
+  inoremap <C-M>a b
+  call feedkeys("i\<*C-M>", 'xt')
+  call assert_equal('', getline(1))
+  call assert_equal([0, 2, 1, 0, 1], getcurpos())
+  iunmap <C-M>a
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -49,7 +49,9 @@ func Test_pastetoggle()
   let &pastetoggle = str
   call assert_equal(str, &pastetoggle)
   call assert_equal("\n  pastetoggle=" .. strtrans(str), execute('set pastetoggle?'))
+
   unlet str
+  set pastetoggle&
 endfunc
 
 func Test_wildchar()
@@ -783,7 +785,6 @@ endfunc
 func Test_rightleftcmd()
   CheckFeature rightleft
   set rightleft
-  set rightleftcmd
 
   let g:l = []
   func AddPos()
@@ -792,6 +793,13 @@ func Test_rightleftcmd()
   endfunc
   cmap <expr> <F2> AddPos()
 
+  set rightleftcmd=
+  call feedkeys("/\<F2>abc\<Right>\<F2>\<Left>\<Left>\<F2>" ..
+        \ "\<Right>\<F2>\<Esc>", 'xt')
+  call assert_equal([2, 5, 3, 4], g:l)
+
+  let g:l = []
+  set rightleftcmd=search
   call feedkeys("/\<F2>abc\<Left>\<F2>\<Right>\<Right>\<F2>" ..
         \ "\<Left>\<F2>\<Esc>", 'xt')
   call assert_equal([&co - 1, &co - 4, &co - 2, &co - 3], g:l)

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -11,6 +11,10 @@ func SetUp()
   set laststatus=2
 endfunc
 
+func TearDown()
+  set laststatus&
+endfunc
+
 func s:get_statusline()
   return ScreenLines(&lines - 1, &columns)[0]
 endfunc
@@ -39,7 +43,6 @@ endfunc
 
 func Test_caught_error_in_statusline()
   let s:func_in_statusline_called = 0
-  set laststatus=2
   let statusline = '%{StatuslineWithCaughtError()}'
   let &statusline = statusline
   redrawstatus
@@ -50,7 +53,6 @@ endfunc
 
 func Test_statusline_will_be_disabled_with_error()
   let s:func_in_statusline_called = 0
-  set laststatus=2
   let statusline = '%{StatuslineWithError()}'
   try
     let &statusline = statusline
@@ -77,7 +79,6 @@ func Test_statusline()
   call assert_match('^ ((2) of 2)\s*$', s:get_statusline())
 
   only
-  set laststatus=2
   set splitbelow
   call setline(1, range(1, 10000))
 
@@ -436,7 +437,6 @@ func Test_statusline()
   %bw!
   call delete('Xstatusline')
   set statusline&
-  set laststatus&
   set splitbelow&
 endfunc
 
@@ -524,7 +524,6 @@ endfunc
 " with a custom 'statusline'
 func Test_statusline_mbyte_fillchar()
   only
-  set laststatus=2
   set fillchars=vert:\|,fold:-,stl:━,stlnc:═
   set statusline=a%=b
   call assert_match('^a\+━\+b$', s:get_statusline())
@@ -532,7 +531,7 @@ func Test_statusline_mbyte_fillchar()
   call assert_match('^a\+━\+b━a\+═\+b$', s:get_statusline())
   wincmd w
   call assert_match('^a\+═\+b═a\+━\+b$', s:get_statusline())
-  set statusline& fillchars& laststatus&
+  set statusline& fillchars&
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_termcodes.vim
+++ b/src/nvim/testdir/test_termcodes.vim
@@ -33,28 +33,5 @@ func Test_special_term_keycodes()
   bw!
 endfunc
 
-func Test_simplify_ctrl_at()
-  " feeding unsimplified CTRL-@ should still trigger i_CTRL-@
-  call feedkeys("ifoo\<Esc>A\<*C-@>x", 'xt')
-  call assert_equal('foofo', getline(1))
-  bw!
-endfunc
-
-func Test_simplify_noremap()
-  call feedkeys("i\<*C-M>", 'nx')
-  call assert_equal('', getline(1))
-  call assert_equal([0, 2, 1, 0, 1], getcurpos())
-  bw!
-endfunc
-
-func Test_simplify_timedout()
-  inoremap <C-M>a b
-  call feedkeys("i\<*C-M>", 'xt')
-  call assert_equal('', getline(1))
-  call assert_equal([0, 2, 1, 0, 1], getcurpos())
-  iunmap <C-M>a
-  bw!
-endfunc
-
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -337,7 +337,7 @@ endfunc
 
 " Test that the garbage collector isn't triggered if a timer callback invokes
 " vgetc().
-func Test_timer_nocatch_garbage_collect()
+func Test_nocatch_timer_garbage_collect()
   " skipped: Nvim does not support test_garbagecollect_soon(), test_override()
   return
   " 'uptimetime. must be bigger than the timer timeout

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6858,17 +6858,16 @@ bool only_one_window(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
   return count <= 1;
 }
 
-/// Correct the cursor line number in other windows.  Used after changing the
-/// current buffer, and before applying autocommands.
-///
-/// @param do_curwin  when true, also check current window.
-void check_lnums(bool do_curwin)
+/// Implementation of check_lnums() and check_lnums_nested().
+static void check_lnums_both(bool do_curwin, bool nested)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if ((do_curwin || wp != curwin) && wp->w_buffer == curbuf) {
-      // save the original cursor position and topline
-      wp->w_save_cursor.w_cursor_save = wp->w_cursor;
-      wp->w_save_cursor.w_topline_save = wp->w_topline;
+      if (!nested) {
+        // save the original cursor position and topline
+        wp->w_save_cursor.w_cursor_save = wp->w_cursor;
+        wp->w_save_cursor.w_topline_save = wp->w_topline;
+      }
 
       if (wp->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
         wp->w_cursor.lnum = curbuf->b_ml.ml_line_count;
@@ -6877,11 +6876,26 @@ void check_lnums(bool do_curwin)
         wp->w_topline = curbuf->b_ml.ml_line_count;
       }
 
-      // save the corrected cursor position and topline
+      // save the (corrected) cursor position and topline
       wp->w_save_cursor.w_cursor_corr = wp->w_cursor;
       wp->w_save_cursor.w_topline_corr = wp->w_topline;
     }
   }
+}
+
+/// Correct the cursor line number in other windows.  Used after changing the
+/// current buffer, and before applying autocommands.
+///
+/// @param do_curwin  when true, also check current window.
+void check_lnums(bool do_curwin)
+{
+  check_lnums_both(do_curwin, false);
+}
+
+/// Like check_lnums() but for when check_lnums() was already called.
+void check_lnums_nested(bool do_curwin)
+{
+  check_lnums_both(do_curwin, true);
 }
 
 /// Reset cursor and topline to its stored values from check_lnums().


### PR DESCRIPTION
#### vim-patch:9.0.0059: test file has wrong name

Problem:    Test file has wrong name.
Solution:   Rename the file.  Various small fixes. (closes vim/vim#10674)
https://github.com/vim/vim/commit/bb404f5ad5ec909318bc24e5b82e4ed7b87ba8f4


#### vim-patch:9.0.0061: ml_get error with nested autocommand

Problem:    ml_get error with nested autocommand.
Solution:   Also check line numbers for a nested autocommand.
https://github.com/vim/vim/commit/5fa9f23a63651a8abdb074b4fc2ec9b1adc6b089