### PR TITLE
fix(options)!: unrecognized key-value options

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -198,7 +198,10 @@ end
 --                  Can be done in a separate PR.
 local key_value_options = {
   fillchars = true,
+  fcs = true,
   listchars = true,
+  lcs = true,
+  winhighlight = true,
   winhl = true,
 }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2868,7 +2868,8 @@ return {
     {
       full_name='winhighlight', abbreviation='winhl',
       short_desc=N_("Setup window-local highlights");
-      type='string', scope={'window'},
+      type='string', list='onecomma', scope={'window'},
+      deny_duplicates=true,
       alloced=true,
       redraw={'current_window'},
       defaults={if_true=""}

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2732,8 +2732,8 @@ describe('API', function()
 
     it('should have information about window options', function()
       eq({
-        allows_duplicates = true,
-        commalist = false;
+        allows_duplicates = false,
+        commalist = true;
         default = "";
         flaglist = false;
         global_local = false;


### PR DESCRIPTION
fcs, lcs and winhl/winhighlight are now recognized as key-value options.
Breaks all previous use of vim.opt* metamethods on those options.
(nothing changes on fillchars and listchars, these were already working correctly)

`vim.opt.winhl:append({ Normal = 'Normal' })` didn't work, because `winhighlight` option was not considered a list.