### PR TITLE
[Backport release-0.7] fix(packaging): remove excess forward slash in Wix Patch

### DIFF
--- a/packaging/WixPatch.xml
+++ b/packaging/WixPatch.xml
@@ -10,7 +10,7 @@
         Permanent='no'
         System='yes'
         Part='last'
-        Value='[INSTALL_ROOT]/bin'
+        Value='[INSTALL_ROOT]bin'
       />
     </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
Backport https://github.com/neovim/neovim/pull/18121 for 0.7.

Fixes https://github.com/microsoft/winget-pkgs/issues/656#issuecomment-1135989173