### PR TITLE
vim-patch:8.2.{5155,5163,5164,5166}: diff fixes

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -372,9 +372,8 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
 
         // 2. 3. 4. 5.: inserted/deleted lines touching this diff.
         if (deleted > 0) {
+          off = 0;
           if (dp->df_lnum[idx] >= line1) {
-            off = dp->df_lnum[idx] - lnum_deleted;
-
             if (last <= line2) {
               // 4. delete all lines of diff
               if ((dp->df_next != NULL)
@@ -391,14 +390,13 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
               dp->df_count[idx] = 0;
             } else {
               // 5. delete lines at or just before top of diff
+              off = dp->df_lnum[idx] - lnum_deleted;
               n = off;
               dp->df_count[idx] -= line2 - dp->df_lnum[idx] + 1;
               check_unchanged = true;
             }
             dp->df_lnum[idx] = line1;
           } else {
-            off = 0;
-
             if (last < line2) {
               // 2. delete at end of diff
               dp->df_count[idx] -= last - lnum_deleted + 1;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -115,7 +115,10 @@ void diff_buf_delete(buf_T *buf)
       tp->tp_diff_invalid = true;
 
       if (tp == curtab) {
-        diff_redraw(true);
+        // don't redraw right away, more might change or buffer state
+        // is invalid right now
+        need_diff_redraw = true;
+        redraw_later(curwin, VALID);
       }
     }
   }
@@ -648,7 +651,8 @@ void diff_redraw(bool dofold)
 
   need_diff_redraw = false;
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (!wp->w_p_diff) {
+    // when closing windows or wiping buffers skip invalid window
+    if (!wp->w_p_diff || !buf_valid(wp->w_buffer)) {
       continue;
     }
     redraw_later(wp, SOME_VALID);

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2271,7 +2271,13 @@ void do_check_cursorbind(void)
         int restart_edit_save = restart_edit;
         restart_edit = true;
         check_cursor();
-        validate_cursor();
+
+        // Avoid a scroll here for the cursor position, 'scrollbind' is
+        // more important.
+        if (!curwin->w_p_scb) {
+          validate_cursor();
+        }
+
         restart_edit = restart_edit_save;
       }
       // Correct cursor for multi-byte character.

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1446,5 +1446,17 @@ func Test_diff_scroll()
   call delete('Xright')
 endfunc
 
+" This was trying to update diffs for a buffer being closed
+func Test_diff_only()
+  silent! lfile
+  set diff
+  lopen
+  norm o
+  silent! norm o
+
+  set nodiff
+  %bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1458,5 +1458,17 @@ func Test_diff_only()
   %bwipe!
 endfunc
 
+" This was causing invalid diff block values
+" FIXME: somehow this causes a valgrind error when run directly but not when
+" run as a test.
+func Test_diff_manipulations()
+  set diff
+  split 0
+  sil! norm RdoobdeuRdoobdeuRdoobdeu
+
+  set nodiff
+  %bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -33,7 +33,8 @@ func Test_diff_fold_sync()
   call win_gotoid(winone)
   call assert_equal(23, getcurpos()[1])
 
-  call assert_equal(1, g:update_count)
+  " depending on how redraw is done DiffUpdated may be triggered once or twice
+  call assert_inrange(1, 2, g:update_count)
   au! DiffUpdated
 
   windo diffoff

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1378,4 +1378,73 @@ func Test_diff_foldinvert()
   set scrollbind&
 endfunc
 
+" This was scrolling for 'cursorbind' but 'scrollbind' is more important
+func Test_diff_scroll()
+  CheckScreendump
+
+  let left =<< trim END
+      line 1
+      line 2
+      line 3
+      line 4
+
+      // Common block
+      // one
+      // containing
+      // four lines
+
+      // Common block
+      // two
+      // containing
+      // four lines
+  END
+  call writefile(left, 'Xleft')
+  let right =<< trim END
+      line 1
+      line 2
+      line 3
+      line 4
+
+      Lorem
+      ipsum
+      dolor
+      sit
+      amet,
+      consectetur
+      adipiscing
+      elit.
+      Etiam
+      luctus
+      lectus
+      sodales,
+      dictum
+
+      // Common block
+      // one
+      // containing
+      // four lines
+
+      Vestibulum
+      tincidunt
+      aliquet
+      nulla.
+
+      // Common block
+      // two
+      // containing
+      // four lines
+  END
+  call writefile(right, 'Xright')
+  let buf = RunVimInTerminal('-d Xleft Xright', {'rows': 12})
+  call term_sendkeys(buf, "\<C-W>\<C-W>jjjj")
+  call VerifyScreenDump(buf, 'Test_diff_scroll_1', {})
+  call term_sendkeys(buf, "j")
+  call VerifyScreenDump(buf, 'Test_diff_scroll_2', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xleft')
+  call delete('Xright')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.5155: in diff mode windows may get out of sync

Problem:    In diff mode windows may get out of sync. (Gary Johnson)
Solution:   Avoid that the other window scrolls for 'cursorbind'.
https://github.com/vim/vim/commit/a315ce1f326b836167ca8b1037dafd93eb8d4d4e


#### vim-patch:8.2.5163: crash when deleting buffers in diff mode

Problem:    Crash when deleting buffers in diff mode.
Solution:   Recompute diffs later.  Skip window without a valid buffer.
https://github.com/vim/vim/commit/cd38bb4d83c942c4bad596835c6766cbf32e5195


#### vim-patch:8.2.5164: invalid memory access after diff buffer manipulations

Problem:    Invalid memory access after diff buffer manipulations.
Solution:   Use zero offset when change removes all lines in a diff block.
https://github.com/vim/vim/commit/c101abff4c6756db4f5e740fde289decb9452efa


#### vim-patch:8.2.5166: test for DiffUpdated fails

Problem:    Test for DiffUpdated fails.
Solution:   Also accept a count of two.
https://github.com/vim/vim/commit/f65cc665fa751bad3ffe75f58ce1251d6695949f