### PR TITLE
feat(treesitter): allow customizing language symbol name

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -387,16 +387,20 @@ inspect_language({lang})                                  *inspect_language()*
     Parameters: ~
         {lang}  The language.
 
-require_language({lang}, {path}, {silent})                *require_language()*
+                                                          *require_language()*
+require_language({lang}, {path}, {silent}, {symbol_name})
     Asserts that the provided language is installed, and optionally provide a
     path for the parser
 
     Parsers are searched in the `parser` runtime directory.
 
     Parameters: ~
-        {lang}    The language the parser should parse
-        {path}    Optional path the parser is located at
-        {silent}  Don't throw an error if language not found
+        {lang}         (string) The language the parser should parse
+        {path}         (string|nil) Optional path the parser is located at
+        {silent}       (boolean|nil) Don't throw an error if language not
+                       found
+        {symbol_name}  (string|nil) Internal symbol name for the language to
+                       load
 
 
 ==============================================================================

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -6,10 +6,11 @@ local M = {}
 ---
 --- Parsers are searched in the `parser` runtime directory.
 ---
----@param lang The language the parser should parse
----@param path Optional path the parser is located at
----@param silent Don't throw an error if language not found
-function M.require_language(lang, path, silent)
+---@param lang string The language the parser should parse
+---@param path string|nil Optional path the parser is located at
+---@param silent boolean|nil Don't throw an error if language not found
+---@param symbol_name string|nil Internal symbol name for the language to load
+function M.require_language(lang, path, silent, symbol_name)
   if vim._ts_has_language(lang) then
     return true
   end
@@ -21,7 +22,6 @@ function M.require_language(lang, path, silent)
         return false
       end
 
-      -- TODO(bfredl): help tag?
       error("no parser for '" .. lang .. "' language, see :help treesitter-parsers")
     end
     path = paths[1]
@@ -29,10 +29,10 @@ function M.require_language(lang, path, silent)
 
   if silent then
     return pcall(function()
-      vim._ts_add_language(path, lang)
+      vim._ts_add_language(path, lang, symbol_name)
     end)
   else
-    vim._ts_add_language(path, lang)
+    vim._ts_add_language(path, lang, symbol_name)
   end
 
   return true

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -14,10 +14,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <uv.h>
 
 #include "nvim/api/private/helpers.h"
 #include "nvim/buffer.h"
 #include "nvim/lib/kvec.h"
+#include "nvim/log.h"
 #include "nvim/lua/treesitter.h"
 #include "nvim/memline.h"
 #include "tree_sitter/api.h"
@@ -145,18 +147,27 @@ int tslua_has_language(lua_State *L)
   return 1;
 }
 
+// Creates the language into the internal language map.
+//
+// Returns true if the language is correctly loaded in the language map
 int tslua_add_language(lua_State *L)
 {
   const char *path = luaL_checkstring(L, 1);
   const char *lang_name = luaL_checkstring(L, 2);
+  const char *symbol_name = lang_name;
+
+  if (lua_gettop(L) >= 3 && !lua_isnil(L, 3)) {
+    symbol_name = luaL_checkstring(L, 3);
+  }
 
   if (pmap_has(cstr_t)(&langs, lang_name)) {
-    return 0;
+    lua_pushboolean(L, true);
+    return 1;
   }
 
 #define BUFSIZE 128
   char symbol_buf[BUFSIZE];
-  snprintf(symbol_buf, BUFSIZE, "tree_sitter_%s", lang_name);
+  snprintf(symbol_buf, BUFSIZE, "tree_sitter_%s", symbol_name);
 #undef BUFSIZE
 
   uv_lib_t lib;
@@ -179,6 +190,7 @@ int tslua_add_language(lua_State *L)
 
   TSLanguage *lang = lang_parser();
   if (lang == NULL) {
+    uv_dlclose(&lib);
     return luaL_error(L, "Failed to load parser %s: internal error", path);
   }
 

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -10,7 +10,7 @@ local pending_c_parser = helpers.pending_c_parser
 
 before_each(clear)
 
-describe('treesitter API', function()
+describe('treesitter language API', function()
   -- error tests not requiring a parser library
   it('handles missing language', function()
     eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
@@ -26,6 +26,9 @@ describe('treesitter API', function()
 
     eq("Error executing lua: .../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.inspect_language('borklang')"))
+
+    matches("Error executing lua: Failed to load parser: uv_dlsym: .+",
+       pcall_err(exec_lua, "parser = vim.treesitter.require_language('c', nil, false, 'borklang')"))
   end)
 
   it('inspects language', function()


### PR DESCRIPTION
This allows to load a language whose function name is different than
the language name that we set within the language table.

This use case should allow to have multiple conflicting language (i.e.
two different languages for lua), for the same filetype.

cc @clason @lewis6991
