### PR TITLE
Fix terminal session save that is restored even if a option is disabled

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5112,7 +5112,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'sessionoptions'* *'ssop'*
 'sessionoptions' 'ssop'	string	(default: "blank,buffers,curdir,folds,
-					       help,tabpages,winsize")
+					       help,tabpages,winsize,terminal")
 			global
 	Changes the effect of the |:mksession| command.  It is a comma-
 	separated list of words.  Each word enables saving and restoring

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -410,6 +410,8 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
     if ((flagp == &ssop_flags) && alt != NULL && alt->b_fname != NULL
         && *alt->b_fname != NUL
         && alt->b_p_bl
+        // do not set balt if buffer is terminal and "terminal" is not set in options
+        && ( bt_terminal(wp->w_buffer) && ssop_flags & SSOP_TERMINAL)
         && (fputs("balt ", fd) < 0
             || ses_fname(fd, alt, flagp, true) == FAIL)) {
       return FAIL;

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -193,6 +193,9 @@ static int ses_do_win(win_T *wp)
   if (bt_help(wp->w_buffer)) {
     return ssop_flags & SSOP_HELP;
   }
+  if (bt_terminal(wp->w_buffer)) {
+    return ssop_flags & SSOP_TERMINAL;
+  }
   return true;
 }
 
@@ -616,6 +619,7 @@ static int makeopens(FILE *fd, char_u *dirnow)
   FOR_ALL_BUFFERS(buf) {
     if (!(only_save_windows && buf->b_nwindows == 0)
         && !(buf->b_help && !(ssop_flags & SSOP_HELP))
+        && !(bt_terminal(buf) && !(ssop_flags & SSOP_TERMINAL))
         && buf->b_fname != NULL
         && buf->b_p_bl) {
       if (fprintf(fd, "badd +%" PRId64 " ",

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -411,7 +411,7 @@ static int put_view(FILE *fd, win_T *wp, int add_edit, unsigned *flagp, int curr
         && *alt->b_fname != NUL
         && alt->b_p_bl
         // do not set balt if buffer is terminal and "terminal" is not set in options
-        && ( bt_terminal(wp->w_buffer) && ssop_flags & SSOP_TERMINAL)
+        && !(bt_terminal(alt) && !(ssop_flags & SSOP_TERMINAL))
         && (fputs("balt ", fd) < 0
             || ses_fname(fd, alt, flagp, true) == FAIL)) {
       return FAIL;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2063,7 +2063,7 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ssop',
-      defaults={if_true="blank,buffers,curdir,folds,help,tabpages,winsize"}
+      defaults={if_true="blank,buffers,curdir,folds,help,tabpages,winsize,terminal"}
     },
     {
       full_name='shada', abbreviation='sd',

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -37,7 +37,6 @@ describe(':mksession', function()
 
     -- Create three windows: first two from top show same terminal, third -
     -- another one (created earlier).
-    command('set sessionoptions+=terminal')
     command('terminal')
     command('split')
     command('terminal')
@@ -173,7 +172,6 @@ describe(':mksession', function()
     cwd_dir = cwd_dir:gsub([[\]], '/') -- :mksession always uses unix slashes.
     local session_path = cwd_dir .. '/' .. session_file
 
-    command('set sessionoptions+=terminal')
     command('cd ' .. tab_dir)
     command('terminal')
     command('cd ' .. cwd_dir)
@@ -223,7 +221,6 @@ describe(':mksession', function()
     screen:expect(expected_screen)
 
     command('cd ' .. cwd_dir)
-    command('set sessionoptions+=terminal')
     command('mksession ' .. session_path)
     command('%bwipeout!')
 

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -37,20 +37,105 @@ describe(':mksession', function()
 
     -- Create three windows: first two from top show same terminal, third -
     -- another one (created earlier).
+    command('set sessionoptions+=terminal')
     command('terminal')
     command('split')
     command('terminal')
     command('split')
-    command('mksession '..session_file)
+    command('mksession ' .. session_file)
     command('%bwipeout!')
 
     -- Create a new test instance of Nvim.
     clear()
     -- Restore session.
-    command('source '..session_file)
+    command('source ' .. session_file)
 
     eq(funcs.winbufnr(1), funcs.winbufnr(2))
     neq(funcs.winbufnr(1), funcs.winbufnr(3))
+  end)
+
+  it(
+    'do not restore :terminal if not set in sessionoptions, terminal in current window #13078',
+    function()
+      command('set sessionoptions-=terminal')
+
+      local tmpfile_base = file_prefix .. '-tmpfile'
+
+      command('edit ' .. tmpfile_base .. '1')
+      command('terminal')
+
+      local buf_count = #meths.list_bufs()
+      eq(2, buf_count)
+
+      eq('terminal', meths.buf_get_option(0, 'buftype'))
+
+      command('mksession ' .. session_file)
+      command('%bwipeout!')
+
+      -- Create a new test instance of Nvim.
+      clear()
+
+      -- Restore session.
+      command('source ' .. session_file)
+
+      -- no terminal should be set. As a side effect we end up with a blank buffer
+      eq(2, #meths.list_bufs())
+      eq('', meths.buf_get_option(meths.list_bufs()[1], 'buftype'))
+      eq('', meths.buf_get_option(meths.list_bufs()[2], 'buftype'))
+    end
+  )
+
+  it('do not restore :terminal if not set in sessionoptions, terminal hidden #13078', function()
+    command('set sessionoptions-=terminal')
+
+    local tmpfile_base = file_prefix .. '-tmpfile'
+
+    command('terminal')
+    local terminal_bufnr = meths.get_current_buf()
+
+    -- make terminal hidden by opening a new file
+    command('edit ' .. tmpfile_base .. '1')
+
+    local buf_count = #meths.list_bufs()
+    eq(2, buf_count)
+
+    eq(1, funcs.getbufinfo(terminal_bufnr)[1].hidden)
+
+    command('mksession ' .. session_file)
+    command('%bwipeout!')
+
+    eq(1, #meths.list_bufs())
+
+    -- Create a new test instance of Nvim.
+    clear()
+    -- Restore session.
+    command('source ' .. session_file)
+
+    -- no terminal should exist here
+    eq(1, #meths.list_bufs())
+    neq('', meths.buf_get_name(meths.list_bufs()[1]))
+  end)
+
+  it('do not restore :terminal if not set in sessionoptions, only buffer #13078', function()
+    command('set sessionoptions-=terminal')
+
+    command('terminal')
+    eq('terminal', meths.buf_get_option(0, 'buftype'))
+
+    local buf_count = #meths.list_bufs()
+    eq(1, buf_count)
+
+    command('mksession ' .. session_file)
+    command('%bwipeout!')
+
+    -- Create a new test instance of Nvim.
+    clear()
+    -- Restore session.
+    command('source ' .. session_file)
+
+    -- no terminal should be set
+    eq(1, #meths.list_bufs())
+    eq('', meths.buf_get_option(0, 'buftype'))
   end)
 
   it('restores tab-local working directories', function()
@@ -102,27 +187,28 @@ describe(':mksession', function()
 
   it('restores CWD for :terminal buffers #11288', function()
     local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
-    cwd_dir = cwd_dir:gsub([[\]], '/')  -- :mksession always uses unix slashes.
-    local session_path = cwd_dir..'/'..session_file
+    cwd_dir = cwd_dir:gsub([[\]], '/') -- :mksession always uses unix slashes.
+    local session_path = cwd_dir .. '/' .. session_file
 
-    command('cd '..tab_dir)
+    command('set sessionoptions+=terminal')
+    command('cd ' .. tab_dir)
     command('terminal')
-    command('cd '..cwd_dir)
-    command('mksession '..session_path)
+    command('cd ' .. cwd_dir)
+    command('mksession ' .. session_path)
     command('%bwipeout!')
     if iswin() then
-      sleep(100)  -- Make sure all child processes have exited.
+      sleep(100) -- Make sure all child processes have exited.
     end
 
     -- Create a new test instance of Nvim.
     clear()
-    command('silent source '..session_path)
+    command('silent source ' .. session_path)
 
-    local expected_cwd = cwd_dir..'/'..tab_dir
-    matches('^term://'..pesc(expected_cwd)..'//%d+:', funcs.expand('%'))
+    local expected_cwd = cwd_dir .. '/' .. tab_dir
+    matches('^term://' .. pesc(expected_cwd) .. '//%d+:', funcs.expand('%'))
     command('%bwipeout!')
     if iswin() then
-      sleep(100)  -- Make sure all child processes have exited.
+      sleep(100) -- Make sure all child processes have exited.
     end
   end)
 
@@ -134,10 +220,10 @@ describe(':mksession', function()
 
     local screen
     local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')
-    local session_path = cwd_dir..'/'..session_file
+    local session_path = cwd_dir .. '/' .. session_file
 
     screen = Screen.new(50, 6)
-    screen:attach({rgb=false})
+    screen:attach({ rgb = false })
     local expected_screen = [[
       ^/                                                 |
                                                         |
@@ -153,15 +239,16 @@ describe(':mksession', function()
     -- Verify that the terminal's working directory is "/".
     screen:expect(expected_screen)
 
-    command('cd '..cwd_dir)
-    command('mksession '..session_path)
+    command('cd ' .. cwd_dir)
+    command('set sessionoptions+=terminal')
+    command('mksession ' .. session_path)
     command('%bwipeout!')
 
     -- Create a new test instance of Nvim.
     clear()
     screen = Screen.new(50, 6)
-    screen:attach({rgb=false})
-    command('silent source '..session_path)
+    screen:attach({ rgb = false })
+    command('silent source ' .. session_path)
 
     -- Verify that the terminal's working directory is "/".
     screen:expect(expected_screen)
@@ -179,7 +266,7 @@ describe(':mksession', function()
       height = 3,
       row = 0,
       col = 1,
-      style = 'minimal'
+      style = 'minimal',
     }
     meths.open_win(buf, false, config)
     local cmdheight = meths.get_option('cmdheight')


### PR DESCRIPTION
This is a continuation of https://github.com/neovim/neovim/pull/14797

This patch fixes https://github.com/neovim/neovim/issues/13078

Thanks to @yutkat for starting this out!