### PR TITLE
build(gen_vimdoc): fall back to lua if luajit doesn't exist

### DIFF
--- a/scripts/lua2dox_filter
+++ b/scripts/lua2dox_filter
@@ -36,22 +36,14 @@ test_executable(){
 
 ##! \brief sets the lua interpreter
 set_lua(){
-	if test -z "${EXE}"
-	then
+	if test -z "${EXE}"; then
 		test_executable 'luajit'
 	fi
 
-	if test -z "${EXE}"
-	then
-        test_executable 'texlua'
-    fi
-
-	if test -z "${EXE}"
-	then
+	if test -z "${EXE}"; then
 		test_executable 'lua'
 	fi
-	#echo "final EXE=\"${EXE}\""
-	}
+}
 
 ##! \brief makes canonical name of file
 ##! 


### PR DESCRIPTION
It currently falls back to texlua if luajit doesn't exist. However,
the documentation generation does not work with texlua. Instead use lua
as a fall back instead.
