### PR TITLE
vim-patch:9.0.0071: command overlaps with printed text in scrollback

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2548,6 +2548,7 @@ void sb_text_start_cmdline(void)
 void sb_text_end_cmdline(void)
 {
   do_clear_sb_text = SB_CLEAR_CMDLINE_DONE;
+  msg_sb_eol();
 }
 
 /// Clear any text remembered for scrolling back.
@@ -2564,7 +2565,7 @@ void clear_sb_text(int all)
     if (last_msgchunk == NULL) {
       return;
     }
-    lastp = &last_msgchunk->sb_prev;
+    lastp = &msg_sb_start(last_msgchunk)->sb_prev;
   }
 
   while (*lastp != NULL) {

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -175,7 +175,8 @@ func Test_message_more()
 
   " Up all the way with 'g'.
   call term_sendkeys(buf, 'g')
-  call WaitForAssert({-> assert_equal('  5 5', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal('  4 4', term_getline(buf, 5))})
+  call WaitForAssert({-> assert_equal(':%p#', term_getline(buf, 1))})
   call WaitForAssert({-> assert_equal('-- More --', term_getline(buf, 6))})
 
   " All the way down. Pressing f should do nothing but pressing

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -199,11 +199,11 @@ describe('messages', function()
       -- Up all the way with 'g'.
       feed('g')
       screen:expect([[
+        :%p#                                                                       |
         {2:  1 }1                                                                      |
         {2:  2 }2                                                                      |
         {2:  3 }3                                                                      |
         {2:  4 }4                                                                      |
-        {2:  5 }5                                                                      |
         {1:-- More --}^                                                                 |
       ]])
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -144,10 +144,9 @@ describe('TUI', function()
       {3:-- TERMINAL --}                                    |
     ]]}
 
-    -- TODO(bfredl): messes up the output (just like vim does).
     feed_data('g')
     screen:expect{grid=[[
-                    )                                   |
+      :call ManyErr()                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
       {10:-- More --}{1: }                                       |
@@ -156,7 +155,7 @@ describe('TUI', function()
 
     screen:try_resize(50,10)
     screen:expect{grid=[[
-                    )                                   |
+      :call ManyErr()                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
       {8:FAIL 0}                                            |

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1854,7 +1854,7 @@ aliquip ex ea commodo consequat.]])
 
     feed('k')
     screen:expect{grid=[[
-      {7:0}{8:                          }{7:)}{8:       }|
+      {7:0}{8:                                  }|
       {9:1}{10:                                  }|
       {9:2}{10:                                  }|
       {9:3}{10:                                  }|
@@ -1943,6 +1943,7 @@ aliquip ex ea commodo consequat.]])
     -- text is not reflown; existing lines get cut
     screen:try_resize(30, 12)
     screen:expect{grid=[[
+      :lua error(_G.x)              |
       {2:E5108: Error executing lua [st}|
       {2:":lua"]:1: Lorem ipsum dolor s}|
       {2:et, consectetur}               |
@@ -1953,12 +1954,27 @@ aliquip ex ea commodo consequat.]])
                                     |
                                     |
                                     |
-                                    |
       {4:-- More --}^                    |
     ]]}
 
     -- continues in a mostly consistent state, but only new lines are
     -- wrapped at the new screen size.
+    feed('<cr>')
+    screen:expect{grid=[[
+      {2:E5108: Error executing lua [st}|
+      {2:":lua"]:1: Lorem ipsum dolor s}|
+      {2:et, consectetur}               |
+      {2:adipisicing elit, sed do eiusm}|
+      {2:mpore}                         |
+      {2:incididunt ut labore et dolore}|
+      {2:a aliqua.}                     |
+      {2:Ut enim ad minim veniam, quis }|
+      {2:nostrud xercitation}           |
+      {2:ullamco laboris nisi ut}       |
+      {2:aliquip ex ea commodo consequa}|
+      {4:-- More --}^                    |
+    ]]}
+
     feed('<cr>')
     screen:expect{grid=[[
       {2:":lua"]:1: Lorem ipsum dolor s}|


### PR DESCRIPTION
#### vim-patch:9.0.0071: command overlaps with printed text in scrollback

Problem:    Command overlaps with printed text in scrollback.
Solution:   Clear until end-of-line and use correct message chunk.
            (closes vim/vim#10765)
https://github.com/vim/vim/commit/ecdc82e74e6a7e73d9067ece1d5eac33abfde5ed

N/A patches for version.c:

vim-patch:9.0.0070: using utfc_ptr2char_len() when length is negative

Problem:    Using utfc_ptr2char_len() when length is negative.
Solution:   Check value of length. (closes vim/vim#10760)
https://github.com/vim/vim/commit/4dc513a22c017b3061287deac74fa55f70a3214c