### PR TITLE
build: fix git version generation on makefiles with older cmake versions

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -268,7 +268,7 @@ foreach(sfile ${NVIM_SOURCES}
   set(depends "${HEADER_GENERATOR}" "${sfile}")
   if("${f}" STREQUAL "version.c")
     # Ensure auto/versiondef_git.h exists after "make clean".
-    list(APPEND depends "${NVIM_VERSION_GIT_H}")
+    list(APPEND depends update_version_stamp "${NVIM_VERSION_GIT_H}")
   endif()
   add_custom_command(
     OUTPUT "${gf_c_h}" "${gf_h_h}"


### PR DESCRIPTION
When using a Makefile generator, older CMake versions are not building
custom targets when depending on their byproducts, making version
generation fail. (works on 3.19.4, fails on 3.10.2) As a workaround,
add a dependency on the custom target explicitly.