### PR TITLE
revert: "vim-patch:9.0.0061: ml_get error with nested autocommand"

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1837,13 +1837,9 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     }
     ap->last = true;
 
-    // Make sure cursor and topline are valid.  The first time the current
-    // values are saved, restored by reset_lnums().  When nested only the
-    // values are corrected when needed.
     if (nesting == 1) {
+      // make sure cursor and topline are valid
       check_lnums(true);
-    } else {
-      check_lnums_nested(true);
     }
 
     // Execute the autocmd. The `getnextac` callback handles iteration.

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2170,25 +2170,6 @@ func Test_autocmd_nested()
   call assert_fails('au WinNew * nested nested echo bad', 'E983:')
 endfunc
 
-func Test_autocmd_nested_cursor_invalid()
-  set laststatus=0
-  copen
-  cclose
-  call setline(1, ['foo', 'bar', 'baz'])
-  3
-  augroup nested_inv
-    autocmd User foo ++nested copen
-    autocmd BufAdd * let &laststatus = 2 - &laststatus
-  augroup END
-  doautocmd User foo
-
-  augroup nested_inv
-    au!
-  augroup END
-  set laststatus&
-  bwipe!
-endfunc
-
 func Test_autocmd_once()
   " Without ++once WinNew triggers twice
   let g:did_split = 0


### PR DESCRIPTION
Fix #19490

This reverts commit 6cee15da7235b6ba9c428ee43346415fe6a64e6c.

Port this again when https://github.com/vim/vim/issues/10780 is fixed.
