### PR TITLE
build: fix version generation to its previous behavior

### DIFF
--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -7,7 +7,7 @@ set(NVIM_VERSION_MEDIUM
     "v${NVIM_VERSION_MAJOR}.${NVIM_VERSION_MINOR}.${NVIM_VERSION_PATCH}${NVIM_VERSION_PRERELEASE}")
 
 execute_process(
-  COMMAND git describe --first-parent --tags --always --dirty
+  COMMAND git describe --first-parent --dirty
   OUTPUT_VARIABLE GIT_TAG
   ERROR_VARIABLE ERR
   RESULT_VARIABLE RES


### PR DESCRIPTION
This will change the version format from

v0.8.0-dev-nightly-12-g1a07044c1

to

v0.8.0-dev-698-ga5920e98f

Closes https://github.com/neovim/neovim/issues/19499
