### PR TITLE
vim-patch:8.1.1424,9.0.0076: crash when popup menu is deleted while waiting for char

### DIFF
--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -1055,8 +1055,8 @@ void pum_show_popupmenu(vimmenu_T *menu)
 
     int c = vgetc();
 
-    // Bail out when typing Esc, CTRL-C or some callback closed the popup
-    // menu.
+    // Bail out when typing Esc, CTRL-C or some callback or <expr> mapping
+    // closed the popup menu.
     if (c == ESC || c == Ctrl_C || pum_array == NULL) {
       break;
     } else if (c == CAR || c == NL) {

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -1054,7 +1054,10 @@ void pum_show_popupmenu(vimmenu_T *menu)
     ui_flush();
 
     int c = vgetc();
-    if (c == ESC || c == Ctrl_C) {
+
+    // Bail out when typing Esc, CTRL-C or some callback closed the popup
+    // menu.
+    if (c == ESC || c == Ctrl_C || pum_array == NULL) {
       break;
     } else if (c == CAR || c == NL) {
       // enter: select current item, if any, and close

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -955,6 +955,25 @@ func Test_menu_only_exists_in_terminal()
   endtry
 endfunc
 
+" This used to crash before patch 8.1.1424
+func Test_popup_delete_when_shown()
+  CheckFeature menu
+  CheckNotGui
+
+  func Func()
+    popup Foo
+    return "\<Ignore>"
+  endfunc
+
+  nmenu Foo.Bar :
+  nnoremap <expr> <F2> Func()
+  call feedkeys("\<F2>\<F2>\<Esc>", 'xt')
+
+  delfunc Func
+  nunmenu Foo.Bar
+  nunmap <F2>
+endfunc
+
 func Test_popup_complete_info_01()
   new
   inoremap <buffer><F5> <C-R>=complete_info().mode<CR>


### PR DESCRIPTION
#### vim-patch:8.1.1424: crash when popup menu is deleted while waiting for char

Problem:    Crash when popup menu is deleted while waiting for char.
Solution:   Bail out when pum_array was cleared.
https://github.com/vim/vim/commit/5c3fb04623d0260762f1c3c1ba250a407098ff2a


#### vim-patch:9.0.0076: no test for what patch 8.1.1424 fixes

Problem:    No test for what patch 8.1.1424 fixes.
Solution:   Add a test. (closes vim/vim#10789)
https://github.com/vim/vim/commit/92a1678d488b7d023ddf2cd493a6ee0d7fcf1928