### PR TITLE
ci(openbsd): don't specify versions for dependencies if possible

### DIFF
--- a/.builds/openbsd.yml
+++ b/.builds/openbsd.yml
@@ -6,11 +6,11 @@ packages:
 - autoconf-2.71
 - automake-1.16.3
 - cmake
-- gettext-runtime-0.21p1
-- gettext-tools-0.21p1
+- gettext-runtime
+- gettext-tools
 - gmake
 - libtool
-- ninja-1.10.2p0
+- ninja
 - unzip-6.0p14
 - gdb
 


### PR DESCRIPTION
It's more convenient to not specify the version and let openbsd's
package manager figure it out. This will help us avoid manually bumping
dependency versions when a new version of openbsd is released.

Some packages have multiple versions and not specifying a version in
those cases fails the CI job, so providing a version seems to be
necessary for some key packages.