### PR TITLE
vim-patch:9.0.0085: ":write" fails after ":file name" and the ":edit"

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2725,6 +2725,12 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
   // Assume success now
   retval = OK;
 
+  // If the file name was changed, reset the not-edit flag so that ":write"
+  // works.
+  if (!other_file) {
+    curbuf->b_flags &= ~BF_NOTEDITED;
+  }
+
   /*
    * Check if we are editing the w_arg_idx file in the argument list.
    */

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -696,5 +696,21 @@ func Test_using_zero_in_range()
   bwipe!
 endfunc
 
+" Test :write after changing name with :file and loading it with :edit
+func Test_write_after_rename()
+  call writefile(['text'], 'Xfile')
+
+  enew
+  file Xfile
+  call assert_fails('write', 'E13: File exists (add ! to override)')
+
+  " works OK after ":edit"
+  edit
+  write
+
+  call delete('Xfile')
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    ":write" fails after ":file name" and the ":edit".
Solution:   Reset BF_NOTEDITED when using ":edit". (closes vim/vim#10790)
https://github.com/vim/vim/commit/1f0dc5e84f5cc530c0fb9d0789e3d42d644429d7