### PR TITLE
vim-patch:9.0.0081: command line completion of user command may have duplicates

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6788,9 +6788,18 @@ char *get_user_commands(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   if (idx < buf->b_ucmds.ga_len) {
     return (char *)USER_CMD_GA(&buf->b_ucmds, idx)->uc_name;
   }
+
   idx -= buf->b_ucmds.ga_len;
   if (idx < ucmds.ga_len) {
-    return (char *)USER_CMD(idx)->uc_name;
+    char *name = (char *)USER_CMD(idx)->uc_name;
+
+    for (int i = 0; i < buf->b_ucmds.ga_len; i++) {
+      if (STRCMP(name, USER_CMD_GA(&buf->b_ucmds, i)->uc_name) == 0) {
+        // global command is overruled by buffer-local one
+        return "";
+      }
+    }
+    return name;
   }
   return NULL;
 }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -704,6 +704,16 @@ func Test_cmdline_complete_user_cmd()
   delcommand Foo
 endfunc
 
+func Test_complete_user_cmd()
+  command FooBar echo 'global'
+  command -buffer FooBar echo 'local'
+  call feedkeys(":Foo\<C-A>\<Home>\"\<CR>", 'tx')
+  call assert_equal('"FooBar', @:)
+
+  delcommand -buffer FooBar
+  delcommand FooBar
+endfunc
+
 func s:ScriptLocalFunction()
   echo 'yes'
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.0081: command line completion of user command may have duplicates

Problem:    Command line completion of user command may have duplicates.
            (Dani Dickstein)
Solution:   Skip global user command if an identical buffer-local one is
            defined.
https://github.com/vim/vim/commit/c2842adfb2ca0637f13e2793fefa18e7818684f9