### PR TITLE
vim-patch:8.2.{4623,4625}: coverity warnings

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5580,11 +5580,14 @@ static void helptags_one(char *dir, const char *ext, const char *tagfname, bool 
   // Note: We cannot just do `&NameBuff` because it is a statically sized array
   //       so `NameBuff == &NameBuff` according to C semantics.
   char *buff_list[1] = { (char *)NameBuff };
-  if (gen_expand_wildcards(1, (char_u **)buff_list, &filecount, (char_u ***)&files,
-                           EW_FILE|EW_SILENT) == FAIL
-      || filecount == 0) {
+  const int res = gen_expand_wildcards(1, (char_u **)buff_list, &filecount, (char_u ***)&files,
+                                       EW_FILE|EW_SILENT);
+  if (res == FAIL || filecount == 0) {
     if (!got_int) {
       semsg(_("E151: No match: %s"), NameBuff);
+    }
+    if (res != FAIL) {
+      FreeWild(filecount, (char_u **)files);
     }
     return;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3271,6 +3271,7 @@ int cmd_exists(const char *const name)
   // For ":2match" and ":3match" we need to skip the number.
   ea.cmd = (char *)((*name == '2' || *name == '3') ? name + 1 : name);
   ea.cmdidx = (cmdidx_T)0;
+  ea.flags = 0;
   int full = false;
   p = find_ex_command(&ea, &full);
   if (p == NULL) {
@@ -3288,6 +3289,7 @@ int cmd_exists(const char *const name)
 /// "fullcommand" function
 void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
+  exarg_T ea;
   char *name = argvars[0].vval.v_string;
 
   rettv->v_type = VAR_STRING;
@@ -3301,10 +3303,9 @@ void f_fullcommand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
   name = skip_range(name, NULL);
 
-  exarg_T ea = {
-    .cmd = (*name == '2' || *name == '3') ? name + 1 : name,
-    .cmdidx = (cmdidx_T)0,
-  };
+  ea.cmd = (*name == '2' || *name == '3') ? name + 1 : name;
+  ea.cmdidx = (cmdidx_T)0;
+  ea.flags = 0;
   char *p = find_ex_command(&ea, NULL);
   if (p == NULL || ea.cmdidx == CMD_SIZE) {
     return;


### PR DESCRIPTION
#### vim-patch:8.2.4623: Coverity warns for using uninitialized field

Problem:    Coverity warns for using uninitialized field.
Solution:   Initialize he field to zero.
https://github.com/vim/vim/commit/03a297c63f1512ba9783104a343dc7e2024e0bb0

Also only initialize used fields in f_fullcommand().


#### vim-patch:8.2.4625: old Coverity warning for resource leak

Problem:    Old Coverity warning for resource leak.
Solution:   Call FreeWild() if expanding matches did not fail.
https://github.com/vim/vim/commit/90da27b9277d74521202e5c146a09056696898ee