### PR TITLE
fix(lsp): ensure uri_from_fname always returns valid URI

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -61,6 +61,8 @@ end
 ---@param path string Path to file
 ---@return string URI
 local function uri_from_fname(path)
+  -- ensure we are working with absolute paths (required by URI)
+  path = vim.fn.fnamemodify(path, ':p')
   local volume_path, fname = path:match('^([a-zA-Z]:)(.*)')
   local is_windows = volume_path ~= nil
   if is_windows then

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -3,6 +3,7 @@ local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
 local write_file = require('test.helpers').write_file
+local iswin = helpers.iswin
 
 describe('URI methods', function()
   before_each(function()
@@ -11,6 +12,9 @@ describe('URI methods', function()
 
   describe('file path to uri', function()
     describe('encode Unix file path', function()
+      -- skip on Windows
+      if iswin() then return end
+
       it('file path includes only ascii charactors', function()
         exec_lua("filepath = '/Foo/Bar/Baz.txt'")
 
@@ -32,6 +36,9 @@ describe('URI methods', function()
     end)
 
     describe('encode Windows filepath', function()
+      -- only on Windows
+      if not iswin() then return end
+
       it('file path includes only ascii charactors', function()
         exec_lua([[filepath = 'C:\\Foo\\Bar\\Baz.txt']])
 


### PR DESCRIPTION
Problem: if fname is a relative path, the returned URI is invalid (only absolute paths are allowed)
Solution: call `vim.fn.fnamemodify(fname, ':p') to force absolute path

Adapt tests so Windows file paths are only tested on Windows.