### PR TITLE
vim-patch:9.0.0090: no error when assigning bool to a string option

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1617,6 +1617,10 @@ static void set_option_from_tv(const char *varname, typval_T *varp)
   char nbuf[NUMBUFLEN];
 
   if (varp->v_type == VAR_BOOL) {
+    if (is_string_option(varname)) {
+      emsg(_(e_stringreq));
+      return;
+    }
     numval = (long)varp->vval.v_number;
     strval = "0";  // avoid using "false"
   } else {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5301,6 +5301,14 @@ char *set_option_value(const char *const name, const long number, const char *co
   return NULL;
 }
 
+/// Return true if "name" is a string option.
+/// Returns false if option "name" does not exist.
+bool is_string_option(const char *name)
+{
+  int idx = findoption(name);
+  return idx >= 0 && (options[idx].flags & P_STRING);
+}
+
 // Translate a string like "t_xx", "<t_xx>" or "<S-Tab>" to a key number.
 // When "has_lt" is true there is a '<' before "*arg_arg".
 // Returns 0 when the key is not recognized.

--- a/test/functional/vimscript/buf_functions_spec.lua
+++ b/test/functional/vimscript/buf_functions_spec.lua
@@ -303,4 +303,8 @@ describe('setbufvar() function', function()
       pcall_err(funcs.setbufvar, 1, 'changedtick', true))
     eq(2, funcs.getbufvar(1, 'changedtick'))
   end)
+  it('throws error when setting a string option to a boolean value vim-patch:9.0.0090', function()
+    eq('Vim:E928: String required',
+      pcall_err(funcs.setbufvar, '', '&errorformat', true))
+  end)
 end)


### PR DESCRIPTION
#### vim-patch:9.0.0090: no error when assigning bool to a string option

Problem:    No error when assigning bool to a string option with setwinvar().
Solution:   Give an error
https://github.com/vim/vim/commit/28f84e17b068daca2635692d279930dcb7a150d0