### PR TITLE
vim-patch:9.0.0092: plugins cannot change v:completed_item

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1736,6 +1736,8 @@ v:completed_item
 		Dictionary containing the most recent |complete-items| after
 		|CompleteDone|.  Empty if the completion failed, or after
 		leaving and re-entering insert mode.
+		Note: Plugins can modify the value to emulate the builtin
+		|CompleteDone| event behavior.
 
 					*v:count* *count-variable*
 v:count		The count given for the last Normal mode command.  Can be used

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -206,7 +206,7 @@ static struct vimvar {
   VV(VV_OLDFILES,         "oldfiles",         VAR_LIST, 0),
   VV(VV_WINDOWID,         "windowid",         VAR_NUMBER, VV_RO_SBX),
   VV(VV_PROGPATH,         "progpath",         VAR_STRING, VV_RO),
-  VV(VV_COMPLETED_ITEM,   "completed_item",   VAR_DICT, VV_RO),
+  VV(VV_COMPLETED_ITEM,   "completed_item",   VAR_DICT, 0),
   VV(VV_OPTION_NEW,       "option_new",       VAR_STRING, VV_RO),
   VV(VV_OPTION_OLD,       "option_old",       VAR_STRING, VV_RO),
   VV(VV_OPTION_OLDLOCAL,  "option_oldlocal",  VAR_STRING, VV_RO),

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -336,6 +336,19 @@ func Test_CompleteDone_undo()
   au! CompleteDone
 endfunc
 
+func Test_CompleteDone_modify()
+  let value = {
+        \ 'word': '',
+        \ 'abbr': '',
+        \ 'menu': '',
+        \ 'info': '',
+        \ 'kind': '',
+        \ 'user_data': '',
+        \ }
+  let v:completed_item = value
+  call assert_equal(v:completed_item, value)
+endfunc
+
 func CompleteTest(findstart, query)
   if a:findstart
     return col('.')


### PR DESCRIPTION
#### vim-patch:9.0.0092: plugins cannot change v:completed_item

Problem:    Plugins cannot change v:completed_item.
Solution:   Make v:completed_item writeable. (Shougo Matsushita,
            closes vim/vim#10801)
https://github.com/vim/vim/commit/61021aa318ca4c4a6b0182ee93388b2e9b5eefba