### PR TITLE
feat(lsp): provide feedback if server can't compute rename result

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -257,6 +257,7 @@ end)
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename
 M['textDocument/rename'] = function(_, result, ctx, _)
   if not result then
+    vim.notify("Language server couldn't provide rename result", vim.log.levels.INFO)
     return
   end
   local client = vim.lsp.get_client_by_id(ctx.client_id)


### PR DESCRIPTION
Without some form of feedback a user cannot easily tell if the server is
still computing the result (which can take a while in large projects),
or whether the server couldn't compute the rename result.
