### PR TITLE
fix(lsp): set workspace.configuration capability

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -759,6 +759,7 @@ function protocol.make_client_capabilities()
         },
         hierarchicalWorkspaceSymbolSupport = true,
       },
+      configuration = true,
       workspaceFolders = true,
       applyEdit = true,
       workspaceEdit = {


### PR DESCRIPTION
Neovim implements `workspace/configuration`
It should set the capability accordingly.

From https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities:

    /**
     * The client supports `workspace/configuration` requests.
     *
     * @since 3.6.0
     */
    configuration?: boolean;
