### PR TITLE
feat(lsp): add range option to code_action; deprecate range_code_action

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1096,7 +1096,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                 Parameters: ~
                     {options}  (table|nil) Optional table which holds the
                                following optional fields:
-                               • context (table|nil): Corresponds to `CodeActionContext` of the LSP specification:
+                               • context: (table|nil) Corresponds to `CodeActionContext` of the LSP specification:
                                  • diagnostics (table|nil): LSP`Diagnostic[]` . Inferred from the current position if not
                                    provided.
                                  • only (table|nil): List of LSP
@@ -1104,13 +1104,18 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                                    actions. Most language servers support
                                    values like `refactor` or `quickfix`.
 
-                               • filter (function|nil): Predicate function
-                                 taking an `CodeAction` and returning a
-                                 boolean.
-                               • apply (boolean|nil): When set to `true`, and
+                               • filter: (function|nil) Predicate taking an
+                                 `CodeAction` and returning a boolean.
+                               • apply: (boolean|nil) When set to `true`, and
                                  there is just one remaining action (after
                                  filtering), the action is applied without
                                  user query.
+                               • range: (table|nil) Range for which code
+                                 actions should be requested. If in visual
+                                 mode this defaults to the active selection.
+                                 Table must contain `start` and `end` keys
+                                 with {row, col} tuples using mark-like
+                                 indexing. See |api-indexing|
 
                 See also: ~
                     https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
@@ -1606,7 +1611,7 @@ character_offset({buf}, {row}, {col}, {offset_encoding})
                 certain buffer.
 
                 Parameters: ~
-                    {buf}              buffer id (0 for current)
+                    {buf}              (number) buffer number (0 for current)
                     {row}              0-indexed line
                     {col}              0-indexed byte offset in line
                     {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
@@ -1768,17 +1773,17 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
                 that is similar to |vim.lsp.util.make_range_params()|.
 
                 Parameters: ~
-                    {start_pos}        ({number, number}, optional)
-                                       mark-indexed position. Defaults to the
-                                       start of the last visual selection.
-                    {end_pos}          ({number, number}, optional)
-                                       mark-indexed position. Defaults to the
-                                       end of the last visual selection.
-                    {bufnr}            (optional, number): buffer handle or 0
-                                       for current, defaults to current
-                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
-                                       defaults to `offset_encoding` of first
-                                       client of `bufnr`
+                    {start_pos}        number[]|nil {row, col} mark-indexed
+                                       position. Defaults to the start of the
+                                       last visual selection.
+                    {end_pos}          number[]|nil {row, col} mark-indexed
+                                       position. Defaults to the end of the
+                                       last visual selection.
+                    {bufnr}            (number|nil) buffer handle or 0 for
+                                       current, defaults to current
+                    {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults
+                                       to `offset_encoding` of first client of
+                                       `bufnr`
 
                 Return: ~
                     { textDocument = { uri = `current_file_uri` }, range = {
@@ -1790,8 +1795,8 @@ make_position_params({window}, {offset_encoding})
                 buffer and cursor position.
 
                 Parameters: ~
-                    {window}           (optional, number): window handle or 0
-                                       for current, defaults to current
+                    {window}           number|nil: window handle or 0 for
+                                       current, defaults to current
                     {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
                                        defaults to `offset_encoding` of first
                                        client of buffer of `window`
@@ -1811,11 +1816,11 @@ make_range_params({window}, {offset_encoding})
                 `textDocument/rangeFormatting`.
 
                 Parameters: ~
-                    {window}           (optional, number): window handle or 0
-                                       for current, defaults to current
-                    {offset_encoding}  (string) utf-8|utf-16|utf-32|nil
-                                       defaults to `offset_encoding` of first
-                                       client of buffer of `window`
+                    {window}           number|nil: window handle or 0 for
+                                       current, defaults to current
+                    {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults
+                                       to `offset_encoding` of first client of
+                                       buffer of `window`
 
                 Return: ~
                     { textDocument = { uri = `current_file_uri` }, range = {
@@ -1827,8 +1832,7 @@ make_text_document_params({bufnr})
                 buffer.
 
                 Parameters: ~
-                    {bufnr}  (optional, number): Buffer handle, defaults to
-                             current
+                    {bufnr}  number|nil: Buffer handle, defaults to current
 
                 Return: ~
                     `TextDocumentIdentifier`

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1821,7 +1821,7 @@ function M.try_trim_markdown_code_blocks(lines)
 end
 
 ---@private
----@param window (optional, number): window handle or 0 for current, defaults to current
+---@param window number|nil: window handle or 0 for current, defaults to current
 ---@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 local function make_position_param(window, offset_encoding)
   window = window or 0
@@ -1841,7 +1841,7 @@ end
 
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
 ---
----@param window (optional, number): window handle or 0 for current, defaults to current
+---@param window number|nil: window handle or 0 for current, defaults to current
 ---@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@returns `TextDocumentPositionParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
@@ -1894,8 +1894,8 @@ end
 --- `textDocument/codeAction`, `textDocument/colorPresentation`,
 --- `textDocument/rangeFormatting`.
 ---
----@param window (optional, number): window handle or 0 for current, defaults to current
----@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
+---@param window number|nil: window handle or 0 for current, defaults to current
+---@param offset_encoding "utf-8"|"utf-16"|"utf-32"|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@returns { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`current_position`, end = `current_position` } }
 function M.make_range_params(window, offset_encoding)
@@ -1911,12 +1911,12 @@ end
 --- Using the given range in the current buffer, creates an object that
 --- is similar to |vim.lsp.util.make_range_params()|.
 ---
----@param start_pos ({number, number}, optional) mark-indexed position.
----Defaults to the start of the last visual selection.
----@param end_pos ({number, number}, optional) mark-indexed position.
----Defaults to the end of the last visual selection.
----@param bufnr (optional, number): buffer handle or 0 for current, defaults to current
----@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of `bufnr`
+---@param start_pos number[]|nil {row, col} mark-indexed position.
+--- Defaults to the start of the last visual selection.
+---@param end_pos number[]|nil {row, col} mark-indexed position.
+--- Defaults to the end of the last visual selection.
+---@param bufnr number|nil buffer handle or 0 for current, defaults to current
+---@param offset_encoding "utf-8"|"utf-16"|"utf-32"|nil defaults to `offset_encoding` of first client of `bufnr`
 ---@returns { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`start_position`, end = `end_position` } }
 function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
@@ -1956,7 +1956,7 @@ end
 
 --- Creates a `TextDocumentIdentifier` object for the current buffer.
 ---
----@param bufnr (optional, number): Buffer handle, defaults to current
+---@param bufnr number|nil: Buffer handle, defaults to current
 ---@returns `TextDocumentIdentifier`
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier
 function M.make_text_document_params(bufnr)
@@ -2000,7 +2000,7 @@ end
 
 --- Returns the UTF-32 and UTF-16 offsets for a position in a certain buffer.
 ---
----@param buf buffer id (0 for current)
+---@param buf number buffer number (0 for current)
 ---@param row 0-indexed line
 ---@param col 0-indexed byte offset in line
 ---@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of `buf`


### PR DESCRIPTION
`code_action` gained extra functions (`filter` and `apply`) which
`range_code_action` didn't have.

To close this gap, this adds a `range` option to `code_action` and
deprecates `range_code_action`.

The option defaults to the current selection if in visual mode.
This allows users to setup a mapping like `vim.keymap.set({'v', 'n'},
'<a-CR>', vim.lsp.buf.code_action)`

`range_code_action` used to use the `<` and `>` markers to get the
_last_ selection which required using a `<Esc><Cmd>lua
vim.lsp.buf.range_code_action()<CR>` (note the `<ESC>`) mapping.

Closes https://github.com/neovim/neovim/issues/18533
Closes https://github.com/neovim/neovim/issues/19482


(I also got annoyed by some warnings and did some drive-by `@param` lua doc fixes)