### PR TITLE
build(pvscheck): disable PVS/V1028

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -380,7 +380,7 @@ run_analysis() {(
       --sourcetree-root . || true
 
   rm -rf PVS-studio.{xml,err,tsk,html.d}
-  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V011,V1042,V1051,V1074,V002"
+  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V002,V011,V1024,V1042,V1051,V1074"
   plog-converter $plog_args --renderTypes xml       --output PVS-studio.xml
   plog-converter $plog_args --renderTypes errorfile --output PVS-studio.err
   plog-converter $plog_args --renderTypes tasklist  --output PVS-studio.tsk


### PR DESCRIPTION
Most casts where PVS warns for V1028 aren't added to prevent overflows
in the first place, but to avoid other warnings, like printf argument or
-Wconversion warnings. PVS/V1028 is more annoying than useful.
