### PR TITLE
vim-patch:9.0.{0095,0096}: remove dead code

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3470,7 +3470,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
 
   // Proceed character by character through the statusline format string
   // fmt_p is the current position in the input buffer
-  for (char *fmt_p = usefmt; *fmt_p;) {
+  for (char *fmt_p = usefmt; *fmt_p != NUL;) {
     if (curitem == (int)stl_items_len) {
       size_t new_len = stl_items_len * 3 / 2;
 
@@ -3484,7 +3484,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
       stl_items_len = new_len;
     }
 
-    if (*fmt_p != NUL && *fmt_p != '%') {
+    if (*fmt_p != '%') {
       prevchar_isflag = prevchar_isitem = false;
     }
 

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -3569,7 +3569,7 @@ term_again:
     // Are we at the start of a cpp base class declaration or
     // constructor initialization?  XXX
     n = 0;
-    if (curbuf->b_ind_cpp_baseclass != 0 && theline[0] != '{') {
+    if (curbuf->b_ind_cpp_baseclass != 0) {
       n = cin_is_cpp_baseclass(&cache_cpp_baseclass);
       l = get_cursor_line_ptr();
     }


### PR DESCRIPTION
#### vim-patch:9.0.0095: conditions are always true

Problem:    Conditions are always true.
Solution:   Remove useless conditions. (closes vim/vim#10802)
https://github.com/vim/vim/commit/122dea70073d140aa89212d344c3f62bd3b5b3fa


#### vim-patch:9.0.0096: flag "new_value_alloced" is always true

Problem:    Flag "new_value_alloced" is always true.
Solution:   Remove "new_value_alloced". (closes vim/vim#10792)
https://github.com/vim/vim/commit/f6782732ab4acd02211923fbdccb457dacaf277e