### PR TITLE
vim-patch:9.0.{0061,partial:0077,0094}

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1837,9 +1837,13 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     }
     ap->last = true;
 
+    // Make sure cursor and topline are valid.  The first time the current
+    // values are saved, restored by reset_lnums().  When nested only the
+    // values are corrected when needed.
     if (nesting == 1) {
-      // make sure cursor and topline are valid
       check_lnums(true);
+    } else {
+      check_lnums_nested(true);
     }
 
     // Execute the autocmd. The `getnextac` callback handles iteration.

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2170,6 +2170,25 @@ func Test_autocmd_nested()
   call assert_fails('au WinNew * nested nested echo bad', 'E983:')
 endfunc
 
+func Test_autocmd_nested_cursor_invalid()
+  set laststatus=0
+  copen
+  cclose
+  call setline(1, ['foo', 'bar', 'baz'])
+  3
+  augroup nested_inv
+    autocmd User foo ++nested copen
+    autocmd BufAdd * let &laststatus = 2 - &laststatus
+  augroup END
+  doautocmd User foo
+
+  augroup nested_inv
+    au!
+  augroup END
+  set laststatus&
+  bwipe!
+endfunc
+
 func Test_autocmd_once()
   " Without ++once WinNew triggers twice
   let g:did_split = 0

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2186,7 +2186,28 @@ func Test_autocmd_nested_cursor_invalid()
     au!
   augroup END
   set laststatus&
+  cclose
   bwipe!
+endfunc
+
+func Test_autocmd_nested_switch_window()
+  " run this in a separate Vim so that SafeState works
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      vim9script
+      ['()']->writefile('Xautofile')
+      autocmd VimEnter * ++nested edit Xautofile | split
+      autocmd BufReadPost * autocmd SafeState * ++once foldclosed('.')
+      autocmd WinEnter * matchadd('ErrorMsg', 'pat')
+  END
+  call writefile(lines, 'Xautoscript')
+  let buf = RunVimInTerminal('-S Xautoscript', {'rows': 10})
+  call VerifyScreenDump(buf, 'Test_autocmd_nested_switch', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xautofile')
+  call delete('Xautoscript')
 endfunc
 
 func Test_autocmd_once()

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2190,6 +2190,17 @@ func Test_autocmd_nested_cursor_invalid()
   bwipe!
 endfunc
 
+func Test_autocmd_nested_keeps_cursor_pos()
+  enew
+  call setline(1, 'foo')
+  autocmd User foo ++nested normal! $a
+  autocmd InsertLeave * :
+  doautocmd User foo
+  call assert_equal([0, 1, 3, 0], getpos('.'))
+
+  bwipe!
+endfunc
+
 func Test_autocmd_nested_switch_window()
   " run this in a separate Vim so that SafeState works
   CheckRunVimInTerminal

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6855,17 +6855,16 @@ bool only_one_window(void) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
   return count <= 1;
 }
 
-/// Correct the cursor line number in other windows.  Used after changing the
-/// current buffer, and before applying autocommands.
-///
-/// @param do_curwin  when true, also check current window.
-void check_lnums(bool do_curwin)
+/// Implementation of check_lnums() and check_lnums_nested().
+static void check_lnums_both(bool do_curwin, bool nested)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if ((do_curwin || wp != curwin) && wp->w_buffer == curbuf) {
-      // save the original cursor position and topline
-      wp->w_save_cursor.w_cursor_save = wp->w_cursor;
-      wp->w_save_cursor.w_topline_save = wp->w_topline;
+      if (!nested) {
+        // save the original cursor position and topline
+        wp->w_save_cursor.w_cursor_save = wp->w_cursor;
+        wp->w_save_cursor.w_topline_save = wp->w_topline;
+      }
 
       if (wp->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
         wp->w_cursor.lnum = curbuf->b_ml.ml_line_count;
@@ -6874,11 +6873,26 @@ void check_lnums(bool do_curwin)
         wp->w_topline = curbuf->b_ml.ml_line_count;
       }
 
-      // save the corrected cursor position and topline
+      // save the (corrected) cursor position and topline
       wp->w_save_cursor.w_cursor_corr = wp->w_cursor;
       wp->w_save_cursor.w_topline_corr = wp->w_topline;
     }
   }
+}
+
+/// Correct the cursor line number in other windows.  Used after changing the
+/// current buffer, and before applying autocommands.
+///
+/// @param do_curwin  when true, also check current window.
+void check_lnums(bool do_curwin)
+{
+  check_lnums_both(do_curwin, false);
+}
+
+/// Like check_lnums() but for when check_lnums() was already called.
+void check_lnums_nested(bool do_curwin)
+{
+  check_lnums_both(do_curwin, true);
 }
 
 /// Reset cursor and topline to its stored values from check_lnums().

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6866,16 +6866,23 @@ static void check_lnums_both(bool do_curwin, bool nested)
         wp->w_save_cursor.w_topline_save = wp->w_topline;
       }
 
-      if (wp->w_cursor.lnum > curbuf->b_ml.ml_line_count) {
+      bool need_adjust = wp->w_cursor.lnum > curbuf->b_ml.ml_line_count;
+      if (need_adjust) {
         wp->w_cursor.lnum = curbuf->b_ml.ml_line_count;
       }
-      if (wp->w_topline > curbuf->b_ml.ml_line_count) {
-        wp->w_topline = curbuf->b_ml.ml_line_count;
+      if (need_adjust || !nested) {
+        // save the (corrected) cursor position
+        wp->w_save_cursor.w_cursor_corr = wp->w_cursor;
       }
 
-      // save the (corrected) cursor position and topline
-      wp->w_save_cursor.w_cursor_corr = wp->w_cursor;
-      wp->w_save_cursor.w_topline_corr = wp->w_topline;
+      need_adjust = wp->w_topline > curbuf->b_ml.ml_line_count;
+      if (need_adjust) {
+        wp->w_topline = curbuf->b_ml.ml_line_count;
+      }
+      if (need_adjust || !nested) {
+        // save the (corrected) topline
+        wp->w_save_cursor.w_topline_corr = wp->w_topline;
+      }
     }
   }
 }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6901,11 +6901,14 @@ void reset_lnums(void)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == curbuf) {
-      // Restore the value if the autocommand didn't change it.
-      if (equalpos(wp->w_save_cursor.w_cursor_corr, wp->w_cursor)) {
+      // Restore the value if the autocommand didn't change it and it was
+      // set.
+      if (equalpos(wp->w_save_cursor.w_cursor_corr, wp->w_cursor)
+          && wp->w_save_cursor.w_cursor_save.lnum != 0) {
         wp->w_cursor = wp->w_save_cursor.w_cursor_save;
       }
-      if (wp->w_save_cursor.w_topline_corr == wp->w_topline) {
+      if (wp->w_save_cursor.w_topline_corr == wp->w_topline
+          && wp->w_save_cursor.w_topline_save != 0) {
         wp->w_topline = wp->w_save_cursor.w_topline_save;
       }
     }


### PR DESCRIPTION
#### vim-patch:9.0.0061: ml_get error with nested autocommand

Problem:    ml_get error with nested autocommand.
Solution:   Also check line numbers for a nested autocommand.
https://github.com/vim/vim/commit/5fa9f23a63651a8abdb074b4fc2ec9b1adc6b089


#### vim-patch:partial:9.0.0077: wrong restored cursor position when switching window in autocmd

Problem:    When switching window in autocmd the restored cursor position may
            be wrong.
Solution:   Do not restore the cursor if it was not set.
https://github.com/vim/vim/commit/b03950fafa07e8b8d975eeb345ad08b8b62e67ce

This patch cannot be fully ported because it depends on patch 8.2.3518.


#### vim-patch:9.0.0094: cursor restored unexpected with nested autocommand

Problem:    Cursor restored unexpected with nested autocommand.
Solution:   Do not restore the cursor when it was moved intentionally.
https://github.com/vim/vim/commit/3d6ee8bda0550a01346f5992bbce09c0eb6d7569