### PR TITLE
docs(lsp): use direct link to formattingOptions in format docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1202,32 +1202,33 @@ format({options})                                       *vim.lsp.buf.format()*
                                • formatting_options (table|nil): Can be used
                                  to specify FormattingOptions. Some
                                  unspecified options will be automatically
-                                 derived from the current Neovim options.
-
-                See also: ~
-                    https://microsoft.github.io/language-server-protocol/specification#textDocument_formatting
-                    • timeout_ms (integer|nil, default 1000): Time in
-                      milliseconds to block for formatting requests. No effect
-                      if async=true
-                    • bufnr (number|nil): Restrict formatting to the clients
-                      attached to the given buffer, defaults to the current
-                      buffer (0).
-                    • filter (function|nil): Predicate used to filter clients.
-                      Receives a client as argument and must return a boolean.
-                      Clients matching the predicate are included. Example:    • >
+                                 derived from the current Neovim options. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
+                               • timeout_ms (integer|nil, default 1000): Time
+                                 in milliseconds to block for formatting
+                                 requests. No effect if async=true
+                               • bufnr (number|nil): Restrict formatting to
+                                 the clients attached to the given buffer,
+                                 defaults to the current buffer (0).
+                               • filter (function|nil): Predicate used to
+                                 filter clients. Receives a client as argument
+                                 and must return a boolean. Clients matching
+                                 the predicate are included. Example:               • >
 
                         -- Never request typescript-language-server for formatting
                         vim.lsp.buf.format {
                           filter = function(client) return client.name ~= "tsserver" end
                         }
 <
-                    • async boolean|nil If true the method won't block.
-                      Defaults to false. Editing the buffer while formatting
-                      asynchronous can lead to unexpected changes.
-                    • id (number|nil): Restrict formatting to the client with
-                      ID (client.id) matching this field.
-                    • name (string|nil): Restrict formatting to the client
-                      with name (client.name) matching this field.
+                               • async boolean|nil If true the method won't
+                                 block. Defaults to false. Editing the buffer
+                                 while formatting asynchronous can lead to
+                                 unexpected changes.
+                               • id (number|nil): Restrict formatting to the
+                                 client with ID (client.id) matching this
+                                 field.
+                               • name (string|nil): Restrict formatting to the
+                                 client with name (client.name) matching this
+                                 field.
 
 formatting({options})                               *vim.lsp.buf.formatting()*
                 Formats the current buffer.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -157,7 +157,7 @@ end
 ---     - formatting_options (table|nil):
 ---         Can be used to specify FormattingOptions. Some unspecified options will be
 ---         automatically derived from the current Neovim options.
----         @see https://microsoft.github.io/language-server-protocol/specification#textDocument_formatting
+---         See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
 ---     - timeout_ms (integer|nil, default 1000):
 ---         Time in milliseconds to block for formatting requests. No effect if async=true
 ---     - bufnr (number|nil):


### PR DESCRIPTION
Also changes `@see` to `See` to avoid the break to a dedicated "See
also" block in the generated vimdoc
