### PR TITLE
vim-patch:9.0.0097: long quickfix line is truncated for :clist

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3147,13 +3147,31 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   }
   msg_puts(" ");
 
+  char_u *tbuf = IObuff;
+  size_t tbuflen = IOSIZE;
+  size_t len = STRLEN(qfp->qf_text) + 3;
+
+  if (len > IOSIZE) {
+    tbuf = xmalloc(len);
+    if (tbuf != NULL) {
+      tbuflen = len;
+    } else {
+      tbuf = IObuff;
+    }
+  }
+
   // Remove newlines and leading whitespace from the text.  For an
   // unrecognized line keep the indent, the compiler may mark a word
-  // with ^^^^. */
+  // with ^^^^.
   qf_fmt_text((fname != NULL || qfp->qf_lnum != 0)
               ? skipwhite(qfp->qf_text) : qfp->qf_text,
-              (char *)IObuff, IOSIZE);
-  msg_prt_line(IObuff, false);
+              (char *)tbuf, (int)tbuflen);
+  msg_prt_line(tbuf, false);
+
+  if (tbuf != IObuff) {
+    xfree(tbuf);
+  }
+
   ui_flush();  // show one line at a time
 }
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -172,6 +172,14 @@ func XlistTests(cchar)
 	\ ' 2 Data.Text:20 col 10 warning  22: ModuleWarning',
 	\ ' 3 Data/Text.hs:30 col 15 warning  33: FileWarning'], l)
 
+  " Very long line should be displayed.
+  let text = 'Line' .. repeat('1234567890', 130)
+  let lines = ['Xtestfile9:2:9:' .. text]
+  Xgetexpr lines
+
+  let l = split(execute('Xlist', ''), "\n")
+  call assert_equal([' 1 Xtestfile9:2 col 9: ' .. text] , l)
+
   " For help entries in the quickfix list, only the filename without directory
   " should be displayed
   Xhelpgrep setqflist()


### PR DESCRIPTION
#### vim-patch:9.0.0097: long quickfix line is truncated for :clist

Problem:    Long quickfix line is truncated for :clist.
Solution:   Allocate a buffer if needed.
https://github.com/vim/vim/commit/5f30e26f6946f0d0396499f91fbcfaa9d1f8acf7