### PR TITLE
vim-patch:9.0.0101: invalid memory access in diff mode with "dp" and undo

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -419,10 +419,13 @@ static void diff_mark_adjust_tp(tabpage_T *tp, int idx, linenr_T line1, linenr_T
             }
           }
 
-          int i;
-          for (i = 0; i < DB_COUNT; i++) {
+          for (int i = 0; i < DB_COUNT; i++) {
             if ((tp->tp_diffbuf[i] != NULL) && (i != idx)) {
-              dp->df_lnum[i] -= off;
+              if (dp->df_lnum[i] > off) {
+                dp->df_lnum[i] -= off;
+              } else {
+                dp->df_lnum[i] = 1;
+              }
               dp->df_count[i] += n;
             }
           }
@@ -2707,8 +2710,9 @@ void ex_diffgetput(exarg_T *eap)
       for (i = 0; i < count; i++) {
         // remember deleting the last line of the buffer
         buf_empty = curbuf->b_ml.ml_line_count == 1;
-        ml_delete(lnum, false);
-        added--;
+        if (ml_delete(lnum, false) == OK) {
+          added--;
+        }
       }
 
       for (i = 0; i < dp->df_count[idx_from] - start_skip - end_skip; i++) {

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1471,5 +1471,19 @@ func Test_diff_manipulations()
   %bwipe!
 endfunc
 
+" This was causing the line number in the diff block to go below one.
+" FIXME: somehow this causes a valgrind error when run directly but not when
+" run as a test.
+func Test_diff_put_and_undo()
+  set diff
+  next 0
+  split 00
+  sil! norm o0gguudpo0ggJuudp
+
+  bwipe!
+  bwipe!
+  set nodiff
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0101: invalid memory access in diff mode with "dp" and undo

Problem:    Invalid memory access in diff mode with "dp" and undo.
Solution:   Make sure the line number does not go below one.
https://github.com/vim/vim/commit/4e677b9c40ccbc5f090971b31dc2fe07bf05541d