### PR TITLE
refactor: fix clang and PVS warnings

### DIFF
--- a/scripts/pvscheck.sh
+++ b/scripts/pvscheck.sh
@@ -380,7 +380,7 @@ run_analysis() {(
       --sourcetree-root . || true
 
   rm -rf PVS-studio.{xml,err,tsk,html.d}
-  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V002,V011,V1024,V1042,V1051,V1074"
+  local plog_args="PVS-studio.log --srcRoot . --excludedCodes V002,V011,V1028,V1042,V1051,V1074"
   plog-converter $plog_args --renderTypes xml       --output PVS-studio.xml
   plog-converter $plog_args --renderTypes errorfile --output PVS-studio.err
   plog-converter $plog_args --renderTypes tasklist  --output PVS-studio.tsk

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -412,7 +412,6 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     }
 
     if (!argc_valid) {
-      argc = 0;  // Ensure that args array isn't erroneously freed at the end.
       VALIDATION_ERROR("Incorrect number of arguments supplied");
     }
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1268,7 +1268,7 @@ void free_all_functions(void)
   // Clean up the current_funccal chain and the funccal stack.
   while (current_funccal != NULL) {
     tv_clear(current_funccal->rettv);
-    cleanup_function_call(current_funccal);
+    cleanup_function_call(current_funccal);  // -V595
     if (current_funccal == NULL && funccal_stack != NULL) {
       restore_funccal();
     }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2481,7 +2481,7 @@ size_t find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char_u **te
   col = 0;
   // Search for point of changing multibyte character class.
   this_class = mb_get_class(ptr);
-  while (ptr[col] != NUL
+  while (ptr[col] != NUL  // -V781
          && ((i == 0
               ? mb_get_class(ptr + col) == this_class
               : mb_get_class(ptr + col) != 0)

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3153,11 +3153,7 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
 
   if (len > IOSIZE) {
     tbuf = xmalloc(len);
-    if (tbuf != NULL) {
-      tbuflen = len;
-    } else {
-      tbuf = IObuff;
-    }
+    tbuflen = len;
   }
 
   // Remove newlines and leading whitespace from the text.  For an


### PR DESCRIPTION
The last commit didn't actually disable V1028 because of a typo.
Fix the typo so it is actually disabled.
