### PR TITLE
vim-patch:9.0.0109: writing over the end of a buffer on stack

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2965,12 +2965,11 @@ void spell_suggest(int count)
       stp = &SUG(sug.su_ga, i);
 
       // The suggested word may replace only part of the bad word, add
-      // the not replaced part.
+      // the not replaced part.  But only when it's not getting too long.
       STRLCPY(wcopy, stp->st_word, MAXWLEN + 1);
-      if (sug.su_badlen > stp->st_orglen) {
-        STRLCPY(wcopy + stp->st_wordlen,
-                sug.su_badptr + stp->st_orglen,
-                sug.su_badlen - stp->st_orglen + 1);
+      int el = sug.su_badlen - stp->st_orglen;
+      if (el > 0 && stp->st_wordlen + el <= MAXWLEN) {
+        STRLCPY(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen, el + 1);
       }
       vim_snprintf((char *)IObuff, IOSIZE, "%2d", i + 1);
       if (cmdmsg_rl) {

--- a/src/nvim/testdir/test_spell_utf8.vim
+++ b/src/nvim/testdir/test_spell_utf8.vim
@@ -820,5 +820,13 @@ func Test_check_empty_line()
   bwipe!
 endfunc
 
+func Test_spell_suggest_too_long()
+  " this was creating a word longer than MAXWLEN
+  new
+  call setline(1, 'a' .. repeat("\u0333", 150))
+  norm! z=
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0109: writing over the end of a buffer on stack

Problem:    Writing over the end of a buffer on stack when making list of
            spell suggestions.
Solution:   Make sure suggested word is not too long.
https://github.com/vim/vim/commit/1eead4cf1daf87ee41aeb4de3b3e38708417f9d5