### PR TITLE
vim-patch:9.0.0111: "nocombine" is missing from synIDattr()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8041,6 +8041,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		"underdotted"	"1" if dotted underlined
 		"underdashed"	"1" if dashed underlined
 		"strikethrough" "1" if struckthrough
+		"nocombine"	"1" if nocombine
 
 		Example (echoes the color of the syntax item under the
 		cursor): >

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9498,8 +9498,12 @@ static void f_synIDattr(typval_T *argvars, typval_T *rettv, FunPtr fptr)
       p = highlight_has_attr(id, HL_ITALIC, modec);
     }
     break;
-  case 'n':    // name
-    p = get_highlight_name_ext(NULL, id - 1, false);
+  case 'n':
+    if (TOLOWER_ASC(what[1]) == 'o') {  // nocombine
+      p = highlight_has_attr(id, HL_NOCOMBINE, modec);
+    } else {  // name
+      p = get_highlight_name_ext(NULL, id - 1, false);
+    }
     break;
   case 'r':    // reverse
     p = highlight_has_attr(id, HL_INVERSE, modec);

--- a/src/nvim/testdir/test_syn_attr.vim
+++ b/src/nvim/testdir/test_syn_attr.vim
@@ -1,19 +1,39 @@
 " Test syntax highlighting functions.
 
 func Test_missing_attr()
-  hi Mine cterm=italic
+  throw 'Skipped: use test/functional/legacy/syn_attr_spec.lua'
+
+  hi Mine term=bold cterm=italic
   call assert_equal('Mine', synIDattr(hlID("Mine"), "name"))
+  call assert_equal('', synIDattr("Mine"->hlID(), "bg", 'term'))
+  call assert_equal('', synIDattr("Mine"->hlID(), "fg", 'term'))
+  call assert_equal('', synIDattr("Mine"->hlID(), "sp", 'term'))
+  call assert_equal('1', synIDattr(hlID("Mine"), "bold", 'term'))
   call assert_equal('1', synIDattr(hlID("Mine"), "italic", 'cterm'))
-  hi Mine cterm=inverse
+  hi Mine term=reverse cterm=inverse
+  call assert_equal('1', synIDattr(hlID("Mine"), "reverse", 'term'))
   call assert_equal('1', synIDattr(hlID("Mine"), "inverse", 'cterm'))
-  hi Mine cterm=standout gui=undercurl
+
+  hi Mine term=underline cterm=standout gui=undercurl
+  call assert_equal('1', synIDattr(hlID("Mine"), "underline", 'term'))
   call assert_equal('1', synIDattr(hlID("Mine"), "standout", 'cterm'))
   call assert_equal('1', synIDattr("Mine"->hlID(), "undercurl", 'gui'))
-  hi Mine gui=strikethrough
+
+  hi Mine term=underdouble cterm=underdotted gui=underdashed
+  call assert_equal('1', synIDattr(hlID("Mine"), "underdouble", 'term'))
+  call assert_equal('1', synIDattr(hlID("Mine"), "underdotted", 'cterm'))
+  call assert_equal('1', synIDattr("Mine"->hlID(), "underdashed", 'gui'))
+
+  hi Mine term=nocombine gui=strikethrough
   call assert_equal('1', synIDattr(hlID("Mine"), "strikethrough", 'gui'))
-  hi Mine cterm=NONE gui=NONE
+  call assert_equal('1', synIDattr(hlID("Mine"), "nocombine", 'term'))
+  call assert_equal('', synIDattr(hlID("Mine"), "nocombine", 'gui'))
+  hi Mine term=NONE cterm=NONE gui=NONE
+  call assert_equal('', synIDattr(hlID("Mine"), "bold", 'term'))
   call assert_equal('', synIDattr(hlID("Mine"), "italic", 'cterm'))
+  call assert_equal('', synIDattr(hlID("Mine"), "reverse", 'term'))
   call assert_equal('', synIDattr(hlID("Mine"), "inverse", 'cterm'))
+  call assert_equal('', synIDattr(hlID("Mine"), "underline", 'term'))
   call assert_equal('', synIDattr(hlID("Mine"), "standout", 'cterm'))
   call assert_equal('', synIDattr(hlID("Mine"), "undercurl", 'gui'))
   call assert_equal('', synIDattr(hlID("Mine"), "strikethrough", 'gui'))

--- a/test/functional/legacy/syn_attr_spec.lua
+++ b/test/functional/legacy/syn_attr_spec.lua
@@ -1,0 +1,60 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
+
+before_each(clear)
+
+-- oldtest: Test_missing_attr()
+it('synIDattr() works', function()
+  local bool_attrs = {
+    'bold',
+    'italic',
+    'reverse',
+    'standout',
+    'underline',
+    'undercurl',
+    'underdouble',
+    'underdotted',
+    'underdashed',
+    'strikethrough',
+    'nocombine',
+  }
+
+  command('hi Mine cterm=NONE gui=NONE')
+  eq('Mine', eval([[synIDattr(hlID("Mine"), "name")]]))
+  for _, mode in ipairs({'cterm', 'gui'}) do
+    eq('', eval(([[synIDattr("Mine"->hlID(), "bg", '%s')]]):format(mode)))
+    eq('', eval(([[synIDattr("Mine"->hlID(), "fg", '%s')]]):format(mode)))
+    eq('', eval(([[synIDattr("Mine"->hlID(), "sp", '%s')]]):format(mode)))
+    for _, attr in ipairs(bool_attrs) do
+      eq('', eval(([[synIDattr(hlID("Mine"), "%s", '%s')]]):format(attr, mode)))
+      eq('', eval(([[synIDattr(hlID("Mine"), "%s", '%s')]]):format(attr, mode)))
+      eq('', eval(([[synIDattr(hlID("Mine"), "%s", '%s')]]):format(attr, mode)))
+    end
+    eq('', eval(([[synIDattr(hlID("Mine"), "inverse", '%s')]]):format(mode)))
+  end
+
+  for i, attr1 in ipairs(bool_attrs) do
+    local attr2 = bool_attrs[i - 1] or bool_attrs[#bool_attrs]
+
+    command(('hi Mine cterm=%s gui=%s'):format(attr1, attr2))
+    eq('1', eval(([[synIDattr(hlID("Mine"), "%s", 'cterm')]]):format(attr1)))
+    eq('', eval(([[synIDattr(hlID("Mine"), "%s", 'cterm')]]):format(attr2)))
+    eq('', eval(([[synIDattr("Mine"->hlID(), "%s", 'gui')]]):format(attr1)))
+    eq('1', eval(([[synIDattr("Mine"->hlID(), "%s", 'gui')]]):format(attr2)))
+
+    command(('hi Mine cterm=%s gui=%s'):format(attr2, attr1))
+    eq('', eval(([[synIDattr("Mine"->hlID(), "%s", 'cterm')]]):format(attr1)))
+    eq('1', eval(([[synIDattr("Mine"->hlID(), "%s", 'cterm')]]):format(attr2)))
+    eq('1', eval(([[synIDattr(hlID("Mine"), "%s", 'gui')]]):format(attr1)))
+    eq('', eval(([[synIDattr(hlID("Mine"), "%s", 'gui')]]):format(attr2)))
+  end
+
+  command('hi Mine cterm=reverse gui=inverse')
+  eq('1', eval([[synIDattr(hlID("Mine"), "reverse", 'cterm')]]))
+  eq('1', eval([[synIDattr(hlID("Mine"), "inverse", 'cterm')]]))
+  eq('1', eval([[synIDattr(hlID("Mine"), "reverse", 'gui')]]))
+  eq('1', eval([[synIDattr(hlID("Mine"), "inverse", 'gui')]]))
+end)


### PR DESCRIPTION
Problem:    "nocombine" is missing from synIDattr().
Solution:   Add "nocombine". (Munif Tanjim, closes vim/vim#10816)
https://github.com/vim/vim/commit/de78632c41d870d5254e9ccd285f53674b955f4e