### PR TITLE
fix(lsp): send didOpen if name changes on write

### DIFF
--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -67,10 +67,12 @@ local function expect_notification(method, params, ...)
   local message = read_message()
   assert_eq(method, message.method,
       ..., "expect_notification", "method")
-  assert_eq(params, message.params,
-      ..., "expect_notification", method, "params")
-  assert_eq({jsonrpc = "2.0"; method=method, params=params}, message,
-      ..., "expect_notification", "message")
+  if params then
+    assert_eq(params, message.params,
+        ..., "expect_notification", method, "params")
+    assert_eq({jsonrpc = "2.0"; method=method, params=params}, message,
+        ..., "expect_notification", "message")
+  end
 end
 
 local function expect_request(method, handler, ...)
@@ -253,6 +255,26 @@ function tests.basic_check_capabilities()
       }
     end;
     body = function()
+    end;
+  }
+end
+
+function tests.text_document_save_did_open()
+  skeleton {
+    on_init = function()
+      return {
+        capabilities = {
+          textDocumentSync = {
+            save = true
+          }
+        }
+      }
+    end;
+    body = function()
+      notify('start')
+      expect_notification('textDocument/didOpen')
+      expect_notification('textDocument/didSave')
+      notify('shutdown')
     end;
   }
 end


### PR DESCRIPTION
`:saveas newName` changes the name of an existing buffer.
Due to the buffer re-use it skips the lsp attach phase and immediately
sends a `didSave` notification to the server.
Servers get confused about this, because they expect a `didOpen`
notification first.

Closes https://github.com/neovim/neovim/issues/18688


--- 

Could be that this also requires a close notification for the old URI. Would be great if people could give this a try and report back if there are still issues