### PR TITLE
docs(typo): vim.cmd example

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1315,7 +1315,7 @@ cmd({command})                                                     *vim.cmd()*
                    vim.cmd('write! myfile.txt')
                    vim.cmd { cmd = 'write', args = { "myfile.txt" }, bang = true }
                    vim.cmd.write { args = { "myfile.txt" }, bang = true }
-                   vim.cmd.write {"myfile.txt", bang = true })
+                   vim.cmd.write { "myfile.txt", bang = true }
 
                    -- Ex command :colorscheme blue
                    vim.cmd('colorscheme blue')

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -312,7 +312,7 @@ end
 ---   vim.cmd('write! myfile.txt')
 ---   vim.cmd { cmd = 'write', args = { "myfile.txt" }, bang = true }
 ---   vim.cmd.write { args = { "myfile.txt" }, bang = true }
----   vim.cmd.write {"myfile.txt", bang = true })
+---   vim.cmd.write { "myfile.txt", bang = true }
 ---
 ---   -- Ex command :colorscheme blue
 ---   vim.cmd('colorscheme blue')


### PR DESCRIPTION
This fixes a typo.