### PR TITLE
refactor: rename function prefix mb to the more accurate utf_cp

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3288,7 +3288,7 @@ void maketitle(void)
       len = (int)STRLEN(buf_p);
       if (len > 100) {
         len -= 100;
-        len += mb_tail_off(buf_p, buf_p + len) + 1;
+        len += utf_cp_tail_off(buf_p, buf_p + len) + 1;
         buf_p += len;
       }
       STRCPY(icon_str, buf_p);

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -232,7 +232,7 @@ static int nlua_str_utf_start(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   if (offset < 0 || offset > (intptr_t)s1_len) {
     return luaL_error(lstate, "index out of range");
   }
-  int head_offset = mb_head_off((char_u *)s1, (char_u *)s1 + offset - 1);
+  int head_offset = utf_cp_head_off((char_u *)s1, (char_u *)s1 + offset - 1);
   lua_pushinteger(lstate, head_offset);
   return 1;
 }
@@ -252,7 +252,7 @@ static int nlua_str_utf_end(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   if (offset < 0 || offset > (intptr_t)s1_len) {
     return luaL_error(lstate, "index out of range");
   }
-  int tail_offset = mb_tail_off(s1, s1 + offset - 1);
+  int tail_offset = utf_cp_tail_off(s1, s1 + offset - 1);
   lua_pushinteger(lstate, tail_offset);
   return 1;
 }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1837,10 +1837,10 @@ int mb_off_next(const char_u *base, const char_u *p)
   return i;
 }
 
-/// Return the offset from "p" to the last byte of the character it points
-/// into.  Can start anywhere in a stream of bytes.
-/// Composing characters are not included.
-int mb_tail_off(const char *base, const char *p_in)
+/// Return the offset from `p_in` to the last byte of the codepoint it points
+/// to.  Can start anywhere in a stream of bytes.
+/// Note: Counts individual codepoints of composed characters separately.
+int utf_cp_tail_off(const char *base, const char *p_in)
 {
   const uint8_t *p = (uint8_t *)p_in;
   int i;
@@ -1866,15 +1866,16 @@ int mb_tail_off(const char *base, const char *p_in)
   return i;
 }
 
-/// Return the offset from "p" to the first byte of the character it points
-/// into. Can start anywhere in a stream of bytes.
-/// Unlike utf_head_off() this doesn't include composing characters and returns a negative value.
+/// Return the offset from "p" to the first byte of the codepoint it points
+/// to. Can start anywhere in a stream of bytes.
+/// Note: Unlike `utf_head_off`, this counts individual codepoints of composed characters
+/// separately and returns a negative offset.
 ///
 /// @param[in] base  Pointer to start of string
 /// @param[in] p     Pointer to byte for which to return the offset to the previous codepoint
 //
 /// @return 0 if invalid sequence, else offset to previous codepoint
-int mb_head_off(const char_u *base, const char_u *p)
+int utf_cp_head_off(const char_u *base, const char_u *p)
 {
   int i;
   int j;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1828,7 +1828,7 @@ static void mb_adjust_opend(oparg_T *oap)
 {
   if (oap->inclusive) {
     char *p = (char *)ml_get(oap->end.lnum);
-    oap->end.col += mb_tail_off(p, p + oap->end.col);
+    oap->end.col += utf_cp_tail_off(p, p + oap->end.col);
   }
 }
 


### PR DESCRIPTION
The "cp" stands for codepoint.

Closes https://github.com/neovim/neovim/issues/7401
