### PR TITLE
vim-patch:9.0.0124: code has more indent than needed

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -656,6 +656,7 @@ void diff_redraw(bool dofold)
     if (!wp->w_p_diff || !buf_valid(wp->w_buffer)) {
       continue;
     }
+
     redraw_later(wp, SOME_VALID);
     if (wp != curwin) {
       wp_other = wp;
@@ -664,8 +665,8 @@ void diff_redraw(bool dofold)
       foldUpdateAll(wp);
     }
 
-    // A change may have made filler lines invalid, need to take care
-    // of that for other windows.
+    // A change may have made filler lines invalid, need to take care of
+    // that for other windows.
     int n = diff_check(wp, wp->w_topline);
 
     if (((wp != curwin) && (wp->w_topfill > 0)) || (n > 0)) {
@@ -682,6 +683,7 @@ void diff_redraw(bool dofold)
       check_topfill(wp, false);
     }
   }
+
   if (wp_other != NULL && curwin->w_p_scb) {
     if (used_max_fill_curwin) {
       // The current window was set to use the maximum number of filler

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -4311,8 +4311,8 @@ static bool ins_start_select(int c)
   case K_S_DOWN:
   case K_S_END:
   case K_S_HOME:
-    // Start selection right away, the cursor can move with
-    // CTRL-O when beyond the end of the line.
+    // Start selection right away, the cursor can move with CTRL-O when
+    // beyond the end of the line.
     start_selection();
 
     // Execute the key in (insert) Select mode.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5793,6 +5793,7 @@ static void do_helptags(char *dirname, bool add_help_tags, bool ignore_writeerr)
     if (len <= 4) {
       continue;
     }
+
     if (STRICMP(files[i] + len - 4, ".txt") == 0) {
       // ".txt" -> language "en"
       lang[0] = 'e';

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2922,10 +2922,11 @@ void check_scrollbind(linenr_T topline_diff, long leftcol_diff)
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     curwin = wp;
     curbuf = curwin->w_buffer;
-    // skip original window  and windows with 'noscrollbind'
+    // skip original window and windows with 'noscrollbind'
     if (curwin == old_curwin || !curwin->w_p_scb) {
       continue;
     }
+
     // do the vertical scroll
     if (want_ver) {
       if (old_curwin->w_p_diff && curwin->w_p_diff) {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -1390,24 +1390,21 @@ static bool syn_stack_equal(synstate_T *sp)
     if (bp[i].bs_extmatch == CUR_STATE(i).si_extmatch) {
       continue;
     }
-    // When the extmatch pointers are different, the strings in
-    // them can still be the same.  Check if the extmatch
-    // references are equal.
+    // When the extmatch pointers are different, the strings in them can
+    // still be the same.  Check if the extmatch references are equal.
     bsx = bp[i].bs_extmatch;
     six = CUR_STATE(i).si_extmatch;
-    // If one of the extmatch pointers is NULL the states are
-    // different.
+    // If one of the extmatch pointers is NULL the states are different.
     if (bsx == NULL || six == NULL) {
       break;
     }
     int j;
     for (j = 0; j < NSUBEXP; j++) {
-      // Check each referenced match string. They must all be
-      // equal.
+      // Check each referenced match string. They must all be equal.
       if (bsx->matches[j] != six->matches[j]) {
-        // If the pointer is different it can still be the
-        // same text.  Compare the strings, ignore case when
-        // the start item has the sp_ic flag set.
+        // If the pointer is different it can still be the same text.
+        // Compare the strings, ignore case when the start item has the
+        // sp_ic flag set.
         if (bsx->matches[j] == NULL || six->matches[j] == NULL) {
           break;
         }
@@ -1422,11 +1419,7 @@ static bool syn_stack_equal(synstate_T *sp)
       break;
     }
   }
-  if (i < 0) {
-    return true;
-  }
-
-  return false;
+  return i < 0 ? true : false;
 }
 
 /*

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1074,7 +1074,6 @@ func Test_split_cmds_with_no_room()
 endfunc
 
 func Test_window_resize()
-  throw 'Skipped: Nvim supports cmdheight=0'
   " Vertical :resize (absolute, relative, min and max size).
   vsplit
   vert resize 8

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2150,12 +2150,11 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       } else {
         next_curwin_size = -1;
         FOR_ALL_FRAMES(fr, topfr->fr_child) {
-          // If 'winfixwidth' set keep the window width if
-          // possible.
-          // Watch out for this window being the next_curwin.
           if (!frame_fixed_width(fr)) {
             continue;
           }
+          // If 'winfixwidth' set keep the window width if possible.
+          // Watch out for this window being the next_curwin.
           n = frame_minwidth(fr, NOWIN);
           new_size = fr->fr_width;
           if (frame_has_win(fr, next_curwin)) {
@@ -2281,12 +2280,11 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       } else {
         next_curwin_size = -1;
         FOR_ALL_FRAMES(fr, topfr->fr_child) {
-          // If 'winfixheight' set keep the window height if
-          // possible.
-          // Watch out for this window being the next_curwin.
           if (!frame_fixed_height(fr)) {
             continue;
           }
+          // If 'winfixheight' set keep the window height if possible.
+          // Watch out for this window being the next_curwin.
           n = frame_minheight(fr, NOWIN);
           new_size = fr->fr_height;
           if (frame_has_win(fr, next_curwin)) {
@@ -3898,9 +3896,7 @@ void close_others(int message, int forceit)
         continue;
       }
     }
-    win_close(wp,
-              !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer),
-              false);
+    win_close(wp, !buf_hide(wp->w_buffer) && !bufIsChanged(wp->w_buffer), false);
   }
 
   if (message && !ONE_WINDOW) {
@@ -5555,6 +5551,7 @@ static void frame_setheight(frame_T *curfrp, int height)
   }
 
   if (curfrp->fr_parent == NULL) {
+    // topframe: can only change the command line
     if (height > ROWS_AVAIL) {
       // If height is greater than the available space, try to create space for
       // the frame by reducing 'cmdheight' if possible, while making sure


### PR DESCRIPTION
#### vim-patch:9.0.0124: code has more indent than needed

Problem:    Code has more indent than needed.
Solution:   Use continue and return statements. (closes vim/vim#10824)
https://github.com/vim/vim/commit/101d57b34b72f4fbc7df1b6edfd64c64a6be14fc