### PR TITLE
feat(lua): print source locations of lua callbacks

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -939,7 +939,7 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
   cmd_addr_T addr_type_arg = ADDR_NONE;
   int compl = EXPAND_NOTHING;
   char *compl_arg = NULL;
-  char *rep = NULL;
+  const char *rep = NULL;
   LuaRef luaref = LUA_NOREF;
   LuaRef compl_luaref = LUA_NOREF;
   LuaRef preview_luaref = LUA_NOREF;

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1105,14 +1105,16 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
     goto err;
   }
 
+  bool rep_free = false;
   switch (command.type) {
   case kObjectTypeLuaRef:
     luaref = api_new_luaref(command.data.luaref);
     if (opts->desc.type == kObjectTypeString) {
       rep = opts->desc.data.string.data;
     } else {
-      snprintf((char *)IObuff, IOSIZE, "<Lua function %d>", luaref);
-      rep = (char *)IObuff;
+      // TODO(ii14): print both luaref and desc
+      rep = nlua_funcref_str(luaref);
+      rep_free = true;
     }
     break;
   case kObjectTypeString:
@@ -1127,6 +1129,10 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
                      preview_luaref, addr_type_arg, luaref, force) != OK) {
     api_set_error(err, kErrorTypeException, "Failed to create user command");
     // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
+  }
+
+  if (rep_free) {
+    xfree(rep);
   }
 
   return;

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1105,16 +1105,13 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
     goto err;
   }
 
-  bool rep_free = false;
   switch (command.type) {
   case kObjectTypeLuaRef:
     luaref = api_new_luaref(command.data.luaref);
     if (opts->desc.type == kObjectTypeString) {
       rep = opts->desc.data.string.data;
     } else {
-      // TODO(ii14): print both luaref and desc
-      rep = nlua_funcref_str(luaref);
-      rep_free = true;
+      rep = "";
     }
     break;
   case kObjectTypeString:
@@ -1129,10 +1126,6 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
                      preview_luaref, addr_type_arg, luaref, force) != OK) {
     api_set_error(err, kErrorTypeException, "Failed to create user command");
     // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
-  }
-
-  if (rep_free) {
-    xfree(rep);
   }
 
   return;

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -196,6 +196,7 @@ static void aupat_show(AutoPat *ap, event_T event, int previous_group)
     if (ac->desc != NULL) {
       size_t msglen = 100;
       char *msg = (char *)xmallocz(msglen);
+      // TODO(ii14): move desc to a new line
       snprintf(msg, msglen, "%s [%s]", exec_to_string, ac->desc);
       msg_outtrans(msg);
       XFREE_CLEAR(msg);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -197,9 +197,16 @@ static void aupat_show(AutoPat *ap, event_T event, int previous_group)
       size_t msglen = 100;
       char *msg = (char *)xmallocz(msglen);
       // TODO(ii14): move desc to a new line
-      snprintf(msg, msglen, "%s [%s]", exec_to_string, ac->desc);
+      if (ac->exec.type == CALLABLE_CB) {
+        msg_puts_attr(exec_to_string, HL_ATTR(HLF_8));
+        snprintf(msg, msglen, " [%s]", ac->desc);
+      } else {
+        snprintf(msg, msglen, "%s [%s]", exec_to_string, ac->desc);
+      }
       msg_outtrans(msg);
       XFREE_CLEAR(msg);
+    } else if (ac->exec.type == CALLABLE_CB) {
+      msg_puts_attr(exec_to_string, HL_ATTR(HLF_8));
     } else {
       msg_outtrans(exec_to_string);
     }

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -196,7 +196,6 @@ static void aupat_show(AutoPat *ap, event_T event, int previous_group)
     if (ac->desc != NULL) {
       size_t msglen = 100;
       char *msg = (char *)xmallocz(msglen);
-      // TODO(ii14): move desc to a new line
       if (ac->exec.type == CALLABLE_CB) {
         msg_puts_attr(exec_to_string, HL_ATTR(HLF_8));
         snprintf(msg, msglen, " [%s]", ac->desc);

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1657,13 +1657,14 @@ void callback_copy(Callback *dest, Callback *src)
 /// Generate a string description of a callback
 char *callback_to_string(Callback *cb)
 {
-  size_t msglen = 100;
+  if (cb->type == kCallbackLua) {
+    return nlua_funcref_str(cb->data.luaref);
+  }
+
+  const size_t msglen = 100;
   char *msg = (char *)xmallocz(msglen);
 
   switch (cb->type) {
-  case kCallbackLua:
-    snprintf(msg, msglen, "<lua: %d>", cb->data.luaref);
-    break;
   case kCallbackFuncref:
     // TODO(tjdevries): Is this enough space for this?
     snprintf(msg, msglen, "<vim function: %s>", cb->data.funcref);
@@ -1672,7 +1673,7 @@ char *callback_to_string(Callback *cb)
     snprintf(msg, msglen, "<vim partial: %s>", cb->data.partial->pt_name);
     break;
   default:
-    snprintf(msg, msglen, "%s", "");
+    *msg = '\0';
     break;
   }
   return msg;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5829,8 +5829,11 @@ static void uc_list(char *name, size_t name_len)
       if (cmd->uc_luaref != LUA_NOREF) {
         char *fn = nlua_funcref_str(cmd->uc_luaref);
         msg_puts_attr(fn, HL_ATTR(HLF_8));
-        msg_putchar(' ');
         xfree(fn);
+        // put the description on a new line
+        if (*cmd->uc_rep != NUL) {
+          msg_puts("\n                                               ");
+        }
       }
 
       msg_outtrans_special(cmd->uc_rep, false,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5826,14 +5826,15 @@ static void uc_list(char *name, size_t name_len)
       IObuff[len] = '\0';
       msg_outtrans((char *)IObuff);
 
-      if (cmd->uc_luaref == LUA_NOREF || *cmd->uc_rep != NUL) {
-        msg_outtrans_special(cmd->uc_rep, false,
-                            name_len == 0 ? Columns - 47 : 0);
-      } else {
+      if (cmd->uc_luaref != LUA_NOREF) {
         char *fn = nlua_funcref_str(cmd->uc_luaref);
         msg_puts_attr(fn, HL_ATTR(HLF_8));
+        msg_putchar(' ');
         xfree(fn);
       }
+
+      msg_outtrans_special(cmd->uc_rep, false,
+                           name_len == 0 ? Columns - 47 : 0);
       if (p_verbose > 0) {
         last_set_msg(cmd->uc_script_ctx);
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5504,7 +5504,7 @@ char *uc_validate_name(char *name)
 /// This function takes ownership of compl_arg, compl_luaref, and luaref.
 ///
 /// @return  OK if the command is created, FAIL otherwise.
-int uc_add_command(char *name, size_t name_len, char *rep, uint32_t argt, long def, int flags,
+int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, long def, int flags,
                    int compl, char *compl_arg, LuaRef compl_luaref, LuaRef preview_luaref,
                    cmd_addr_T addr_type, LuaRef luaref, bool force)
   FUNC_ATTR_NONNULL_ARG(1, 3)

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5826,8 +5826,14 @@ static void uc_list(char *name, size_t name_len)
       IObuff[len] = '\0';
       msg_outtrans((char *)IObuff);
 
-      msg_outtrans_special(cmd->uc_rep, false,
-                           name_len == 0 ? Columns - 47 : 0);
+      if (cmd->uc_luaref == LUA_NOREF || *cmd->uc_rep != NUL) {
+        msg_outtrans_special(cmd->uc_rep, false,
+                            name_len == 0 ? Columns - 47 : 0);
+      } else {
+        char *fn = nlua_funcref_str(cmd->uc_luaref);
+        msg_puts_attr(fn, HL_ATTR(HLF_8));
+        xfree(fn);
+      }
       if (p_verbose > 0) {
         last_set_msg(cmd->uc_script_ctx);
       }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -196,9 +196,9 @@ static void showmap(mapblock_T *mp, bool local)
   // Use false below if we only want things like <Up> to show up as such on
   // the rhs, and not M-x etc, true gets both -- webb
   if (mp->m_luaref != LUA_NOREF) {
-    char msg[100];
-    snprintf(msg, sizeof(msg), "<Lua function %d>", mp->m_luaref);
-    msg_puts_attr(msg, HL_ATTR(HLF_8));
+    char *str = nlua_funcref_str(mp->m_luaref);
+    msg_puts_attr(str, HL_ATTR(HLF_8));
+    xfree(str);
   } else if (mp->m_str[0] == NUL) {
     msg_puts_attr("<Nop>", HL_ATTR(HLF_8));
   } else {
@@ -2091,10 +2091,7 @@ static void get_maparg(typval_T *argvars, typval_T *rettv, int exact)
         rettv->vval.v_string = str2special_save((char *)rhs, false, false);
       }
     } else if (rhs_lua != LUA_NOREF) {
-      size_t msglen = 100;
-      char *msg = (char *)xmalloc(msglen);
-      snprintf(msg, msglen, "<Lua function %d>", mp->m_luaref);
-      rettv->vval.v_string = msg;
+      rettv->vval.v_string = nlua_funcref_str(mp->m_luaref);
     }
   } else {
     tv_dict_alloc_ret(rettv);

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -1143,7 +1143,7 @@ size_t home_replace(const buf_T *const buf, const char *src, char *const dst, si
 /// Like home_replace, store the replaced string in allocated memory.
 /// @param buf When not NULL, check for help files
 /// @param src Input file name
-char *home_replace_save(buf_T *buf, char *src)
+char *home_replace_save(buf_T *buf, const char *src)
   FUNC_ATTR_NONNULL_RET
 {
   size_t len = 3;             // space for "~/" and trailing NUL

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -797,7 +797,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
       vim.api.nvim_set_keymap ('n', 'asdf', '', {callback = function() print('jkl;') end })
     ]]
     assert.truthy(string.match(exec_lua[[return vim.api.nvim_exec(':nmap asdf', true)]],
-                  "^\nn  asdf          <Lua function %d+>"))
+                  "^\nn  asdf          <Lua %d+>"))
   end)
 
   it ('mapcheck() returns lua mapping correctly', function()
@@ -805,7 +805,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
       vim.api.nvim_set_keymap ('n', 'asdf', '', {callback = function() print('jkl;') end })
     ]]
     assert.truthy(string.match(funcs.mapcheck('asdf', 'n'),
-                  "^<Lua function %d+>"))
+                  "^<Lua %d+>"))
   end)
 
   it ('maparg() returns lua mapping correctly', function()
@@ -813,7 +813,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
       vim.api.nvim_set_keymap ('n', 'asdf', '', {callback = function() print('jkl;') end })
     ]]
     assert.truthy(string.match(funcs.maparg('asdf', 'n'),
-                  "^<Lua function %d+>"))
+                  "^<Lua %d+>"))
     local mapargs = funcs.maparg('asdf', 'n', false, true)
     assert(type(mapargs.callback) == 'number', 'callback is not luaref number')
     mapargs.callback = nil


### PR DESCRIPTION
Prints locations of lua callback functions in `:map`, `:autocmd` and `:command`.

### `:map`
```
n  <Space>b    * <Lua 4: ~/repos/neovim/foo.lua:5>
                 my mapping B
n  <Space>a    * <Lua 3: ~/repos/neovim/foo.lua:1>
                 my mapping A
```

### `:command`
```
    Name              Args Address Complete    Definition
    MyCmd             0                        <Lua 8: ~/repos/neovim/foo.lua:9>
                                               my command
```

### `:autocmd`
```
--- Autocommands ---
VimEnter
    *         <Lua 10: ~/repos/neovim/foo.lua:13> [my autocommand]
```