### PR TITLE
feat(api): add replace_keycodes to nvim_set_keymap

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1508,7 +1508,9 @@ nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
                             used to give a description to the mapping. When
                             called from Lua, also accepts a "callback" key
                             that takes a Lua function to call when the mapping
-                            is executed.
+                            is executed. "replace_keycodes" can be used with
+                            "expr" to replace keycodes, see
+                            |nvim_replace_termcodes()|.
 
 nvim_set_var({name}, {value})                                 *nvim_set_var()*
                 Sets a global (g:) variable.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2228,10 +2228,6 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                             • buffer: (number or boolean) Add a mapping to the
                               given buffer. When "true" or 0, use the current
                               buffer.
-                            • replace_keycodes: (boolean, default true) When
-                              both this and expr is "true",
-                              |nvim_replace_termcodes()| is applied to the
-                              result of Lua expr maps.
                             • remap: (boolean) Make the mapping recursive.
                               This is the inverse of the "noremap" option from
                               |nvim_set_keymap()|. Default `false`.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2231,6 +2231,7 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
                             • remap: (boolean) Make the mapping recursive.
                               This is the inverse of the "noremap" option from
                               |nvim_set_keymap()|. Default `false`.
+                            • replace_keycodes: (boolean) defaults to true.
 
                 See also: ~
                     |nvim_set_keymap()|

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -45,6 +45,7 @@ local keymap = {}
 ---                  - remap: (boolean) Make the mapping recursive. This is the
 ---                  inverse of the "noremap" option from |nvim_set_keymap()|.
 ---                  Default `false`.
+---                  - replace_keycodes: (boolean) defaults to true.
 ---@see |nvim_set_keymap()|
 function keymap.set(mode, lhs, rhs, opts)
   vim.validate({

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -42,8 +42,6 @@ local keymap = {}
 ---                  listed in |nvim_set_keymap()|, this table also accepts the following keys:
 ---                  - buffer: (number or boolean) Add a mapping to the given buffer. When "true"
 ---                    or 0, use the current buffer.
----                  - replace_keycodes: (boolean, default true) When both this and expr is "true",
----                  |nvim_replace_termcodes()| is applied to the result of Lua expr maps.
 ---                  - remap: (boolean) Make the mapping recursive. This is the
 ---                  inverse of the "noremap" option from |nvim_set_keymap()|.
 ---                  Default `false`.
@@ -60,22 +58,9 @@ function keymap.set(mode, lhs, rhs, opts)
   local is_rhs_luaref = type(rhs) == 'function'
   mode = type(mode) == 'string' and { mode } or mode
 
-  if is_rhs_luaref and opts.expr then
-    local user_rhs = rhs
-    rhs = function()
-      local res = user_rhs()
-      if res == nil then
-        -- TODO(lewis6991): Handle this in C?
-        return ''
-      elseif opts.replace_keycodes ~= false then
-        return vim.api.nvim_replace_termcodes(res, true, true, true)
-      else
-        return res
-      end
-    end
+  if opts.expr and opts.replace_keycodes ~= false then
+    opts.replace_keycodes = true
   end
-  -- clear replace_keycodes from opts table
-  opts.replace_keycodes = nil
 
   if opts.remap == nil then
     -- default remap value is false

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -39,6 +39,7 @@ return {
     "unique";
     "callback";
     "desc";
+    "replace_keycodes";
   };
   get_commands = {
     "builtin";

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1447,7 +1447,8 @@ ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
 ///               Unknown key is an error. "desc" can be used to give a
 ///               description to the mapping. When called from Lua, also accepts a
 ///               "callback" key that takes a Lua function to call when the
-///               mapping is executed.
+///               mapping is executed. "replace_keycodes" can be used with "expr"
+///               to replace keycodes, see |nvim_replace_termcodes()|.
 /// @param[out]   err   Error details, if any.
 void nvim_set_keymap(uint64_t channel_id, String mode, String lhs, String rhs, Dict(keymap) *opts,
                      Error *err)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -369,6 +369,7 @@ struct mapblock {
   char m_expr;                  // <expr> used, m_str is an expression
   sctx_T m_script_ctx;          // SCTX where map was defined
   char *m_desc;                 // description of keymap
+  bool m_replace_keycodes;      // replace termcodes in lua function
 };
 
 /// Used for highlighting in the status line.

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2023,7 +2023,9 @@ static void mapblock_fill_dict(dict_T *const dict, const mapblock_T *const mp, l
   tv_dict_add_nr(dict, S_LEN("lnum"), (varnumber_T)mp->m_script_ctx.sc_lnum);
   tv_dict_add_nr(dict, S_LEN("buffer"), (varnumber_T)buffer_value);
   tv_dict_add_nr(dict, S_LEN("nowait"), mp->m_nowait ? 1 : 0);
-  tv_dict_add_nr(dict, S_LEN("replace_keycodes"), mp->m_replace_keycodes ? 1 : 0);
+  if (mp->m_replace_keycodes) {
+    tv_dict_add_nr(dict, S_LEN("replace_keycodes"), 1);
+  }
   tv_dict_add_allocated_str(dict, S_LEN("mode"), mapmode);
 }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2027,6 +2027,7 @@ static void mapblock_fill_dict(dict_T *const dict, const mapblock_T *const mp, l
   tv_dict_add_nr(dict, S_LEN("lnum"), (varnumber_T)mp->m_script_ctx.sc_lnum);
   tv_dict_add_nr(dict, S_LEN("buffer"), (varnumber_T)buffer_value);
   tv_dict_add_nr(dict, S_LEN("nowait"), mp->m_nowait ? 1 : 0);
+  tv_dict_add_nr(dict, S_LEN("replace_keycodes"), mp->m_replace_keycodes ? 1 : 0);
   tv_dict_add_allocated_str(dict, S_LEN("mode"), mapmode);
 }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1556,9 +1556,7 @@ char_u *eval_map_expr(mapblock_T *mp, int c)
     }
     if (p && mp->m_replace_keycodes) {
       char *buf = NULL;
-      replace_termcodes((char *)p, STRLEN(p), &buf,
-                        REPTERM_FROM_PART|REPTERM_DO_LT,
-                        NULL, CPO_TO_CPO_FLAGS);
+      replace_termcodes((char *)p, STRLEN(p), &buf, REPTERM_DO_LT, NULL, CPO_TO_CPO_FLAGS);
       if (buf) {
         xfree(p);
         p = (char_u *)buf;

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1525,6 +1525,7 @@ char_u *eval_map_expr(mapblock_T *mp, int c)
   pos_T save_cursor;
   int save_msg_col;
   int save_msg_row;
+  bool replaced = false;
 
   // Remove escaping of K_SPECIAL, because "str" is in a format to be used as
   // typeahead.
@@ -1561,6 +1562,7 @@ char_u *eval_map_expr(mapblock_T *mp, int c)
       if (buf) {
         xfree(p);
         p = (char_u *)buf;
+        replaced = true;
       }
     }
   } else {
@@ -1577,7 +1579,7 @@ char_u *eval_map_expr(mapblock_T *mp, int c)
     return NULL;
   }
   // Escape K_SPECIAL in the result to be able to use the string as typeahead.
-  res = (char_u *)vim_strsave_escape_ks((char *)p);
+  res = replaced ? p : (char_u *)vim_strsave_escape_ks((char *)p);
   xfree(p);
 
   return res;

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2414,6 +2414,11 @@ void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mod
   }
   parsed_args.buffer = !global;
 
+  if (parsed_args.replace_keycodes && !parsed_args.expr) {
+    api_set_error(err, kErrorTypeValidation,  "\"replace_keycodes\" requires \"expr\"");
+    goto fail_and_free;
+  }
+
   if (!set_maparg_lhs_rhs(lhs.data, lhs.size,
                           rhs.data, rhs.size, lua_funcref,
                           CPO_TO_CPO_FLAGS, &parsed_args)) {

--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -21,6 +21,7 @@ struct map_arguments {
   bool script;
   bool silent;
   bool unique;
+  bool replace_keycodes;
 
   /// The {lhs} of the mapping.
   ///
@@ -44,7 +45,7 @@ struct map_arguments {
   char *desc;  /// map description
 };
 typedef struct map_arguments MapArguments;
-#define MAP_ARGUMENTS_INIT { false, false, false, false, false, false, false, \
+#define MAP_ARGUMENTS_INIT { false, false, false, false, false, false, false, false, \
                              { 0 }, 0, { 0 }, 0, NULL, 0, LUA_NOREF, false, NULL, 0, NULL }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -18,23 +18,23 @@ function Test_maparg()
   call assert_equal("is<F4>foo", maparg('foo<C-V>'))
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo<C-V>',
         \ 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1,
-        \ 'rhs': 'is<F4>foo', 'buffer': 0},
+        \ 'rhs': 'is<F4>foo', 'buffer': 0, 'replace_keycodes': 0},
         \ maparg('foo<C-V>', '', 0, 1))
   call assert_equal({'silent': 1, 'noremap': 1, 'script': 1, 'lhs': 'bar', 'mode': 'v',
         \ 'nowait': 0, 'expr': 1, 'sid': sid, 'lnum': lnum + 2,
-        \ 'rhs': 'isbar', 'buffer': 1},
+        \ 'rhs': 'isbar', 'buffer': 1, 'replace_keycodes': 0},
         \ 'bar'->maparg('', 0, 1))
   let lnum = expand('<sflnum>')
   map <buffer> <nowait> foo bar
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo', 'mode': ' ',
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'bar',
-        \ 'buffer': 1},
+        \ 'buffer': 1, 'replace_keycodes': 0},
         \ maparg('foo', '', 0, 1))
   let lnum = expand('<sflnum>')
   tmap baz foo
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'baz', 'mode': 't',
         \ 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'foo',
-        \ 'buffer': 0},
+        \ 'buffer': 0, 'replace_keycodes': 0},
         \ maparg('baz', 't', 0, 1))
 
   map abc x<char-114>x

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -18,23 +18,23 @@ function Test_maparg()
   call assert_equal("is<F4>foo", maparg('foo<C-V>'))
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo<C-V>',
         \ 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1,
-        \ 'rhs': 'is<F4>foo', 'buffer': 0, 'replace_keycodes': 0},
+        \ 'rhs': 'is<F4>foo', 'buffer': 0},
         \ maparg('foo<C-V>', '', 0, 1))
   call assert_equal({'silent': 1, 'noremap': 1, 'script': 1, 'lhs': 'bar', 'mode': 'v',
         \ 'nowait': 0, 'expr': 1, 'sid': sid, 'lnum': lnum + 2,
-        \ 'rhs': 'isbar', 'buffer': 1, 'replace_keycodes': 0},
+        \ 'rhs': 'isbar', 'buffer': 1},
         \ 'bar'->maparg('', 0, 1))
   let lnum = expand('<sflnum>')
   map <buffer> <nowait> foo bar
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo', 'mode': ' ',
         \ 'nowait': 1, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'bar',
-        \ 'buffer': 1, 'replace_keycodes': 0},
+        \ 'buffer': 1},
         \ maparg('foo', '', 0, 1))
   let lnum = expand('<sflnum>')
   tmap baz foo
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'baz', 'mode': 't',
         \ 'nowait': 0, 'expr': 0, 'sid': sid, 'lnum': lnum + 1, 'rhs': 'foo',
-        \ 'buffer': 0, 'replace_keycodes': 0},
+        \ 'buffer': 0},
         \ maparg('baz', 't', 0, 1))
 
   map abc x<char-114>x

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -822,7 +822,7 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
 
   it('can make lua expr mappings', function()
     exec_lua [[
-      vim.api.nvim_set_keymap ('n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', true, false, true) end, expr = true })
+      vim.api.nvim_set_keymap ('n', 'aa', '', {callback = function() return ':lua SomeValue = 99<cr>' end, expr = true, replace_keycodes = true })
     ]]
 
     feed('aa')
@@ -1020,7 +1020,7 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
 
   it('can make lua expr mappings', function()
     exec_lua [[
-      vim.api.nvim_buf_set_keymap (0, 'n', 'aa', '', {callback = function() return vim.api.nvim_replace_termcodes(':lua SomeValue = 99<cr>', true, false, true) end, expr = true })
+      vim.api.nvim_buf_set_keymap (0, 'n', 'aa', '', {callback = function() return ':lua SomeValue = 99<cr>' end, expr = true, replace_keycodes = true })
     ]]
 
     feed('aa')

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -830,6 +830,16 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
     eq(99, exec_lua[[return SomeValue]])
   end)
 
+  it('can make lua expr mappings without replacing keycodes', function()
+    exec_lua [[
+      vim.api.nvim_set_keymap ('i', 'aa', '', {callback = function() return '<space>' end, expr = true })
+    ]]
+
+    feed('iaa<esc>')
+
+    eq({'<space>'}, meths.buf_get_lines(0, 0, -1, false))
+  end)
+
   it('does not reset pum in lua mapping', function()
     eq(0, exec_lua [[
       VisibleCount = 0
@@ -1027,6 +1037,17 @@ describe('nvim_buf_set_keymap, nvim_buf_del_keymap', function()
 
     eq(99, exec_lua[[return SomeValue ]])
   end)
+
+  it('can make lua expr mappings without replacing keycodes', function()
+    exec_lua [[
+      vim.api.nvim_buf_set_keymap (0, 'i', 'aa', '', {callback = function() return '<space>' end, expr = true })
+    ]]
+
+    feed('iaa<esc>')
+
+    eq({'<space>'}, meths.buf_get_lines(0, 0, -1, false))
+  end)
+
 
   it('can overwrite lua mappings', function()
     eq(0, exec_lua [[

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -35,7 +35,6 @@ describe('nvim_get_keymap', function()
     mode='n',
     noremap=1,
     lnum=0,
-    replace_keycodes=0,
   }
 
   it('returns empty list when no map', function()
@@ -259,7 +258,6 @@ describe('nvim_get_keymap', function()
       nowait=0,
       noremap=1,
       lnum=0,
-      replace_keycodes=0,
     }
     local function cpomap(lhs, rhs, mode)
       local ret = shallowcopy(cpo_table)
@@ -318,7 +316,6 @@ describe('nvim_get_keymap', function()
       nowait=0,
       noremap=1,
       lnum=0,
-      replace_keycodes=0,
     }
     command('nnoremap \\|<Char-0x20><Char-32><Space><Bar> \\|<Char-0x20><Char-32><Space> <Bar>')
     eq({space_table}, meths.get_keymap('n'))
@@ -352,7 +349,6 @@ describe('nvim_get_keymap', function()
       mode='n',
       noremap=0,
       lnum=0,
-      replace_keycodes=0,
     }, mapargs[1])
   end)
 
@@ -370,8 +366,7 @@ describe('nvim_get_keymap', function()
       mode='n',
       noremap=0,
       lnum=0,
-      desc='map description',
-      replace_keycodes=0,
+      desc='map description'
     }, meths.get_keymap('n')[1])
   end)
 end)

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -35,6 +35,7 @@ describe('nvim_get_keymap', function()
     mode='n',
     noremap=1,
     lnum=0,
+    replace_keycodes=0,
   }
 
   it('returns empty list when no map', function()
@@ -258,6 +259,7 @@ describe('nvim_get_keymap', function()
       nowait=0,
       noremap=1,
       lnum=0,
+      replace_keycodes=0,
     }
     local function cpomap(lhs, rhs, mode)
       local ret = shallowcopy(cpo_table)
@@ -316,6 +318,7 @@ describe('nvim_get_keymap', function()
       nowait=0,
       noremap=1,
       lnum=0,
+      replace_keycodes=0,
     }
     command('nnoremap \\|<Char-0x20><Char-32><Space><Bar> \\|<Char-0x20><Char-32><Space> <Bar>')
     eq({space_table}, meths.get_keymap('n'))
@@ -349,6 +352,7 @@ describe('nvim_get_keymap', function()
       mode='n',
       noremap=0,
       lnum=0,
+      replace_keycodes=0,
     }, mapargs[1])
   end)
 
@@ -366,7 +370,8 @@ describe('nvim_get_keymap', function()
       mode='n',
       noremap=0,
       lnum=0,
-      desc='map description'
+      desc='map description',
+      replace_keycodes=0,
     }, meths.get_keymap('n')[1])
   end)
 end)


### PR DESCRIPTION
Move `replace_keycodes` option from `vim.keymap.set` to `nvim_set_keymap`.

Related: #19597