### PR TITLE
fix(ex command): now passes count as arg for keywordprg

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4169,9 +4169,10 @@ static size_t nv_K_getcmd(cmdarg_T *cap, char_u *kp, bool kp_help, bool kp_ex, c
   if (kp_ex) {
     // 'keywordprg' is an ex command
     if (cap->count0 != 0) {  // Send the count to the ex command.
-      snprintf(buf, buf_size, "%" PRId64, (int64_t)(cap->count0));
+      snprintf(buf, buf_size, "%s %ld", kp, cap->count0);
+    } else {
+      STRCPY(buf, kp);
     }
-    STRCAT(buf, kp);
     STRCAT(buf, " ");
     return n;
   }


### PR DESCRIPTION
Fixes #19436 

Now passes count as the first arguments to `keywordprg` if it is an ex command.