### PR TITLE
Use Strings instead of Tables in vim.filetype.matchregex Doc

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2087,9 +2087,9 @@ add({filetypes})                                          *vim.filetype.add()*
                        priority = -math.huge,
                        function(path, bufnr)
                          local content = vim.filetype.getlines(bufnr, 1)
-                         if vim.filetype.matchregex(content, { [[^#!.*\<mine\>]] }) then
+                         if vim.filetype.matchregex(content, [[^#!.*\<mine\>]]) then
                            return 'mine'
-                         elseif vim.filetype.matchregex(content, { [[\<drawing\>]] }) then
+                         elseif vim.filetype.matchregex(content, [[\<drawing\>]]) then
                            return 'drawing'
                          end
                        end,

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2275,9 +2275,9 @@ end
 ---       priority = -math.huge,
 ---       function(path, bufnr)
 ---         local content = vim.filetype.getlines(bufnr, 1)
----         if vim.filetype.matchregex(content, { [[^#!.*\\<mine\\>]] }) then
+---         if vim.filetype.matchregex(content, [[^#!.*\\<mine\\>]]) then
 ---           return 'mine'
----         elseif vim.filetype.matchregex(content, { [[\\<drawing\\>]] }) then
+---         elseif vim.filetype.matchregex(content, [[\\<drawing\\>]]) then
 ---           return 'drawing'
 ---         end
 ---       end,


### PR DESCRIPTION
Hi, when using the example:

```lua
vim.filetype.add {
  pattern = {
    ['.*'] = {
      priority = -math.huge,
      function(path, bufnr)
        local content = vim.filetype.getlines(bufnr, 1)
        if vim.filetype.matchregex(content, { [[^#!.*\<mine\>]] }) then
          return 'mine'
        elseif vim.filetype.matchregex(content, { [[\<drawing\>]] }) then
          return 'drawing'
        end
      end,
    },
  },
}
```

In the doc of `vim.filetype.add`, I get the error: `Error executing lua callback: vim/filetype.lua:0: bad argument #1 to 'regex' (
string expected, got table)`, so I've changed the doc to use strings instead of tables.

I'm new to vim so I apologise if I'm missing something, thanks :slightly_smiling_face: 