### PR TITLE
vim-patch:9.0.0126

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -86,7 +86,7 @@ typedef struct ff_stack {
   // of wc_part
   char **ffs_filearray;
   int ffs_filearray_size;
-  char_u ffs_filearray_cur;                  // needed for partly handled dirs
+  int ffs_filearray_cur;                  // needed for partly handled dirs
 
   /* to store status of partly handled directories
    * 0: we work on this directory for the first time
@@ -860,8 +860,8 @@ char_u *vim_findfile(void *search_ctx_arg)
 #endif
 
                 // push dir to examine rest of subdirs later
-                assert(i < UCHAR_MAX - 1);
-                stackp->ffs_filearray_cur = (char_u)(i + 1);
+                assert(i < INT_MAX);
+                stackp->ffs_filearray_cur = i + 1;
                 ff_push(search_ctx, stackp);
 
                 if (!path_with_url((char *)file_path)) {

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -194,4 +194,27 @@ func Test_gf_includeexpr()
   delfunc IncFunc
 endfunc
 
+" Check that expanding directories can handle more than 255 entries.
+func Test_gf_subdirs_wildcard()
+  let cwd = getcwd()
+  let dir = 'Xtestgf_dir'
+  call mkdir(dir)
+  call chdir(dir)
+  for i in range(300)
+    call mkdir(i)
+    call writefile([], i .. '/' .. i, 'S')
+  endfor
+  set path=./**
+
+  new | only
+  call setline(1, '99')
+  w! Xtest1
+  normal gf
+  call assert_equal('99', fnamemodify(bufname(''), ":t"))
+
+  call chdir(cwd)
+  call delete(dir, 'rf')
+  set path&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0126: expanding file names fails in dir with more than 255 entries

Problem:    Expanding file names fails in directory with more than 255
            entries.
Solution:   Use an int instead of char_u to count. (John Drouhard,
            closes vim/vim#10818)
https://github.com/vim/vim/commit/95fca12b0e8a351ce4416417323db24c63eb940a

Fixes #12397
Fixes #13284 