### PR TITLE
build: create a matrix for supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pre-built packages for Windows, macOS, and Linux are found on the
 Install from source
 -------------------
 
-See the [Building Neovim](https://github.com/neovim/neovim/wiki/Building-Neovim) wiki page for details.
+See the [Building Neovim](https://github.com/neovim/neovim/wiki/Building-Neovim) wiki page and [Support](https://neovim.io/doc/user/support.html) for details.
 
 The build is CMake-based, but a Makefile is provided as a convenience.
 After installing the dependencies, run the following command.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Pre-built packages for Windows, macOS, and Linux are found on the
 Install from source
 -------------------
 
-See the [Building Neovim](https://github.com/neovim/neovim/wiki/Building-Neovim) wiki page and [Support](https://neovim.io/doc/user/support.html) for details.
+See the [Building Neovim](https://github.com/neovim/neovim/wiki/Building-Neovim) wiki page and [supported platforms](https://neovim.io/doc/user/support.html#supported-platforms) for details.
 
 The build is CMake-based, but a Makefile is provided as a convenience.
 After installing the dependencies, run the following command.

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -179,6 +179,7 @@ Versions ~
 |deprecated.txt|  Deprecated items that have been or will be removed
 
 Other ~
+|news.txt|		News and notable changes in the latest release
 |terminal_emulator.txt|	Terminal buffers
 |term.txt|		Terminal UI
 |ui.txt|		Nvim UI protocol
@@ -187,6 +188,7 @@ Other ~
 |job_control.txt|	Spawn and control multiple processes
 |luaref.txt|		Lua reference manual
 |luvref.txt|		Luv (|vim.loop|) reference manual
+|support.txt|		Supported platforms
 
 						*standard-plugin-list*
 Standard plugins ~

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -1,0 +1,55 @@
+*support.txt*			    Nvim
+
+
+                            NVIM REFERENCE MANUAL
+
+
+Supported platforms					*supported-platforms*
+
+This is a list of supported platforms for Nvim.
+
+                                      Type |gO| to see the table of contents.
+
+==============================================================================
+Supported platforms
+
+`System`          `Tier`      `Versions`                  `Tested versions`
+Linux            1      >= 2.6.32, glibc >= 2.12     Ubuntu 20.04
+macOS (Intel)    1      >= 10.15                     macOS 11
+Windows 64-bit   1      >= 8                         Windows Server 2019
+FreeBSD          1      >= 10                        FreeBSD 13
+macOS (M1)       2      >= 10.15
+OpenBSD          2      >= 7
+MinGW            2      MinGW-w64
+
+Support types ~
+
+* Tier 1: Officially supported and tested with CI. Any contributed patch
+  MUST NOT break such systems.
+
+* Tier 2: Officially supported, but not necessarily tested with CI. These
+  systems are maintained to the best of our ability, without being a top
+  priority.
+
+* Tier 3: Not tested and no guarantees, but may work.
+
+Adding support for a new platform ~
+
+IMPORTANT: Before attempting to add support for a new platform please open
+an issue about it for discussion.
+
+
+==============================================================================
+Common
+
+Some common notes when adding support for new platforms:
+
+Cmake is the only supported build system. The platform must be buildable with cmake.
+
+All functionality related to the new platform must be implemented in its own
+file inside `src/nvim/os` unless it's already done in a common file, in which
+case adding an `#ifdef` is fine.
+
+
+ vim:tw=78:ts=8:et:ft=help:norl:
+

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -4,14 +4,12 @@
                             NVIM REFERENCE MANUAL
 
 
-Supported platforms					*supported-platforms*
-
-This is a list of supported platforms for Nvim.
+Support
 
                                       Type |gO| to see the table of contents.
 
 ==============================================================================
-Supported platforms
+Supported platforms					 *supported-platforms*
 
 `System`          `Tier`      `Versions`                  `Tested versions`
 Linux            1      >= 2.6.32, glibc >= 2.12     Ubuntu 20.04
@@ -52,4 +50,3 @@ case adding an `#ifdef` is fine.
 
 
  vim:tw=78:ts=8:et:ft=help:norl:
-


### PR DESCRIPTION
Shamelessly sto-, I mean *inspired* from [libuv's support matrix](https://github.com/libuv/libuv/blob/v1.x/SUPPORTED_PLATFORMS.md)