### PR TITLE
vim-patch:8.2.{4899,4956,5013}

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4349,6 +4349,9 @@ static void op_format(oparg_T *oap, int keep_cursor)
   if (keep_cursor) {
     curwin->w_cursor = saved_cursor;
     saved_cursor.lnum = 0;
+
+    // formatting may have made the cursor position invalid
+    check_cursor();
   }
 
   if (oap->is_VIsual) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -642,6 +642,9 @@ func Test_cmdline_remove_char()
 
     call feedkeys(":abc def\<S-Left>\<C-U>\<C-B>\"\<CR>", 'tx')
     call assert_equal('"def', @:, e)
+
+    " This was going before the start in latin1.
+    call feedkeys(": \<C-W>\<CR>", 'tx')
   endfor
 
   let &encoding = encoding_save

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -138,6 +138,22 @@ func Test_gf_visual()
   call assert_equal('Xtest_gf_visual', bufname('%'))
   call assert_equal(3, getcurpos()[1])
 
+  " do not include the NUL at the end
+  call writefile(['x'], 'X')
+  let save_enc = &enc
+  " for enc in ['latin1', 'utf-8']
+  for enc in ['utf-8']
+    exe "set enc=" .. enc
+    new
+    call setline(1, 'X')
+    set nomodified
+    exe "normal \<C-V>$gf"
+    call assert_equal('X', bufname())
+    bwipe!
+  endfor
+  let &enc = save_enc
+  call delete('X')
+
   " line number in visual area is used for file name
   if has('unix')
     bwipe!

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1534,4 +1534,16 @@ func Test_autoformat_comments()
   close!
 endfunc
 
+" This was leaving the cursor after the end of a line.  Complicated way to
+" have the problem show up with valgrind.
+func Test_correct_cursor_position()
+  " set encoding=iso8859
+  new
+  norm a0000
+  sil! norm gggg0i0gw0gg
+
+  bwipe!
+  set encoding=utf8
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4899: with latin1 encoding CTRL-W might go before the cmdline

Problem:    With latin1 encoding CTRL-W might go before the start of the
            command line.
Solution:   Check already being at the start of the command line.
https://github.com/vim/vim/commit/ef02f16609ff0a26ffc6e20263523424980898fe


#### vim-patch:8.2.4956: reading past end of line with "gf" in Visual block mode

Problem:    Reading past end of line with "gf" in Visual block mode.
Solution:   Do not include the NUL in the length.
https://github.com/vim/vim/commit/395bd1f6d3edc9f7edb5d1f2d7deaf5a9e3ab93c

Omit trailing space: removed in patch 9.0.0126.


#### vim-patch:8.2.5013: after text formatting cursor may be in an invalid position

Problem:    After text formatting the cursor may be in an invalid position.
Solution:   Correct the cursor position after formatting.
https://github.com/vim/vim/commit/78d52883e10d71f23ab72a3d8b9733b00da8c9ad