### PR TITLE
vim-patch:8.2.{0385,0392,3459}: menu_info()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -319,6 +319,7 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])
 				List	{count}'th match of {pat} in {expr}
 max({expr})			Number	maximum value of items in {expr}
 menu_get({path} [, {modes}])	List	description of |menus| matched by {path}
+menu_info({name} [, {mode}])	Dict	get menu item information
 min({expr})			Number	minimum value of items in {expr}
 mkdir({name} [, {path} [, {prot}]])
 				Number	create directory {name}
@@ -5194,6 +5195,7 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])		*matchstrpos()*
 		Can also be used as a |method|: >
 			GetText()->matchstrpos('word')
 <
+
 							*max()*
 max({expr})	Return the maximum value of all items in {expr}. Example: >
 			echo max([apples, pears, oranges])
@@ -5206,6 +5208,7 @@ max({expr})	Return the maximum value of all items in {expr}. Example: >
 
 		Can also be used as a |method|: >
 			mylist->max()
+
 
 menu_get({path} [, {modes}])				*menu_get()*
 		Returns a |List| of |Dictionaries| describing |menus| (defined
@@ -5253,7 +5256,66 @@ menu_get({path} [, {modes}])				*menu_get()*
 			} ]
 <
 
-							*min()*
+menu_info({name} [, {mode}])				*menu_info()*
+		Return information about the specified menu {name} in
+		mode {mode}. The menu name should be specified without the
+		shortcut character ('&').
+
+		{mode} can be one of these strings:
+			"n"	Normal
+			"v"	Visual (including Select)
+			"o"	Operator-pending
+			"i"	Insert
+			"c"	Cmd-line
+			"s"	Select
+			"x"	Visual
+			"t"	Terminal-Job
+			""	Normal, Visual and Operator-pending
+			"!"	Insert and Cmd-line
+		When {mode} is omitted, the modes for "" are used.
+
+		Returns a |Dictionary| containing the following items:
+		  accel		menu item accelerator text |menu-text|
+		  display	display name (name without '&')
+		  enabled	v:true if this menu item is enabled
+				Refer to |:menu-enable|
+		  icon		name of the icon file (for toolbar)
+				|toolbar-icon|
+		  iconidx	index of a built-in icon
+		  modes		modes for which the menu is defined. In
+				addition to the modes mentioned above, these
+				characters will be used:
+				" "	Normal, Visual and Operator-pending
+		  name		menu item name.
+		  noremenu	v:true if the {rhs} of the menu item is not
+				remappable else v:false.
+		  priority	menu order priority |menu-priority|
+		  rhs		right-hand-side of the menu item. The returned
+				string has special characters translated like
+				in the output of the ":menu" command listing.
+				When the {rhs} of a menu item is empty, then
+				"<Nop>" is returned.
+		  script	v:true if script-local remapping of {rhs} is
+				allowed else v:false.  See |:menu-script|.
+		  shortcut	shortcut key (character after '&' in
+				the menu name) |menu-shortcut|
+		  silent	v:true if the menu item is created
+				with <silent> argument |:menu-silent|
+		  submenus	|List| containing the names of
+				all the submenus.  Present only if the menu
+				item has submenus.
+
+		Returns an empty dictionary if the menu item is not found.
+
+		Examples: >
+			:echo menu_info('Edit.Cut')
+			:echo menu_info('File.Save', 'n')
+<
+		Can also be used as a |method|: >
+			GetMenuName()->menu_info('v')
+
+
+<							*min()*
 min({expr})	Return the minimum value of all items in {expr}. Example:  >
 			echo min([apples, pears, oranges])
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5259,7 +5259,8 @@ menu_get({path} [, {modes}])				*menu_get()*
 menu_info({name} [, {mode}])				*menu_info()*
 		Return information about the specified menu {name} in
 		mode {mode}. The menu name should be specified without the
-		shortcut character ('&').
+		shortcut character ('&'). If {name} is "", then the top-level
+		menu names are returned.
 
 		{mode} can be one of these strings:
 			"n"	Normal
@@ -5310,6 +5311,20 @@ menu_info({name} [, {mode}])				*menu_info()*
 		Examples: >
 			:echo menu_info('Edit.Cut')
 			:echo menu_info('File.Save', 'n')
+
+			" Display the entire menu hierarchy in a buffer
+			func ShowMenu(name, pfx)
+			  let m = menu_info(a:name)
+			  call append(line('$'), a:pfx .. m.display)
+			  for child in m->get('submenus', [])
+			    call ShowMenu(a:name .. '.' .. escape(child, '.'),
+							\ a:pfx .. '    ')
+			  endfor
+			endfunc
+			new
+			for topmenu in menu_info('').submenus
+			  call ShowMenu(topmenu, '')
+			endfor
 <
 		Can also be used as a |method|: >
 			GetMenuName()->menu_info('v')

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -201,9 +201,11 @@ tooltips for menus. See |terminal-input|.
 
 Special characters in a menu name:
 
+							*menu-shortcut*
 	&	The next character is the shortcut key.  Make sure each
 		shortcut key is only used once in a (sub)menu.  If you want to
 		insert a literal "&" in the menu name use "&&".
+							*menu-text*
 	<Tab>	Separates the menu name from right-aligned text.  This can be
 		used to show the equivalent typed command.  The text "<Tab>"
 		can be used here for convenience.  If you are using a real
@@ -561,7 +563,7 @@ item for the keyword under the cursor.  The register "z" is used. >
 mappings, or put these lines in your gvimrc; "<C-R>" is CTRL-R, "<CR>" is
 the <CR> key.  |<>|)
 
-
+							*tooltips* *menu-tips*
 Tooltips & Menu tips
 
 See section |42.4| in the user manual.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -972,7 +972,7 @@ Window size and position:			*window-size-functions*
 	winsaveview()		get view of current window
 	winrestview()		restore saved view of current window
 
-Mappings:				    *mapping-functions*
+Mappings and Menus:			    *mapping-functions*
 	digraph_get()		get |digraph|
 	digraph_getlist()	get all |digraph|s
 	digraph_set()		register |digraph|
@@ -981,6 +981,7 @@ Mappings:				    *mapping-functions*
 	mapcheck()		check if a matching mapping exists
 	maparg()		get rhs of a mapping
 	mapset()		restore a mapping
+	menu_info()		get information about a menu item
 	wildmenumode()		check if the wildmode is active
 
 Signs:						*sign-functions*

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -264,6 +264,7 @@ return {
     matchstrpos={args={2,4}, base=1},
     max={args=1, base=1},
     menu_get={args={1, 2}},
+    menu_info={args={1, 2}, base=1},
     min={args=1, base=1},
     mkdir={args={1, 3}, base=1},
     mode={args={0, 1}, base=1},

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1892,9 +1892,22 @@ static char *menu_translate_tab_and_shift(char *arg_start)
 }
 
 /// Get the information about a menu item in mode 'which'
-static void menuitem_getinfo(const vimmenu_T *menu, int modes, dict_T *dict)
+static void menuitem_getinfo(const char *menu_name, const vimmenu_T *menu, int modes, dict_T *dict)
   FUNC_ATTR_NONNULL_ALL
 {
+  if (*menu_name == NUL) {
+    // Return all the top-level menus
+    list_T *const l = tv_list_alloc(kListLenMayKnow);
+    tv_dict_add_list(dict, S_LEN("submenus"), l);
+    // get all the children.  Skip PopUp[nvoci].
+    for (const vimmenu_T *topmenu = menu; topmenu != NULL; topmenu = topmenu->next) {
+      if (!menu_is_hidden(topmenu->dname)) {
+        tv_list_append_string(l, topmenu->dname, -1);
+      }
+    }
+    return;
+  }
+
   tv_dict_add_str(dict, S_LEN("name"), menu->name);
   tv_dict_add_str(dict, S_LEN("display"), menu->dname);
   if (menu->actext != NULL) {
@@ -1990,6 +2003,6 @@ void f_menu_info(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   if (menu->modes & modes) {
-    menuitem_getinfo(menu, modes, retdict);
+    menuitem_getinfo(menu_name, menu, modes, retdict);
   }
 }

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1913,16 +1913,18 @@ static void menuitem_getinfo(const vimmenu_T *menu, int modes, dict_T *dict)
     // Get the first mode in which the menu is available
     for (bit = 0; (bit < MENU_MODES) && !((1 << bit) & modes); bit++) {}
 
-    if (menu->strings[bit] != NULL) {
-      tv_dict_add_allocated_str(dict, S_LEN("rhs"),
-                                *menu->strings[bit] == NUL
-                                ? xstrdup("<Nop>")
-                                : str2special_save(menu->strings[bit], false, false));
+    if (bit < MENU_MODES) {  // just in case, avoid Coverity warning
+      if (menu->strings[bit] != NULL) {
+        tv_dict_add_allocated_str(dict, S_LEN("rhs"),
+                                  *menu->strings[bit] == NUL
+                                  ? xstrdup("<Nop>")
+                                  : str2special_save(menu->strings[bit], false, false));
+      }
+      tv_dict_add_bool(dict, S_LEN("noremenu"), menu->noremap[bit] == REMAP_NONE);
+      tv_dict_add_bool(dict, S_LEN("script"), menu->noremap[bit] == REMAP_SCRIPT);
+      tv_dict_add_bool(dict, S_LEN("silent"), menu->silent[bit]);
+      tv_dict_add_bool(dict, S_LEN("enabled"), (menu->enabled & (1 << bit)) != 0);
     }
-    tv_dict_add_bool(dict, S_LEN("noremenu"), menu->noremap[bit] == REMAP_NONE);
-    tv_dict_add_bool(dict, S_LEN("script"), menu->noremap[bit] == REMAP_SCRIPT);
-    tv_dict_add_bool(dict, S_LEN("silent"), menu->silent[bit]);
-    tv_dict_add_bool(dict, S_LEN("enabled"), (menu->enabled & (1 << bit)) != 0);
   } else {
     // If there are submenus, add all the submenu display names
     list_T *const l = tv_list_alloc(kListLenMayKnow);

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -810,17 +810,23 @@ static vimmenu_T *find_menu(vimmenu_T *menu, char *name, int modes)
 /// Show the mapping associated with a menu item or hierarchy in a sub-menu.
 static int show_menus(char *const path_name, int modes)
 {
-  // First, find the (sub)menu with the given name
-  vimmenu_T *menu = find_menu(*get_root_menu(path_name), path_name, modes);
-  if (!menu) {
-    return FAIL;
+  vimmenu_T *menu = *get_root_menu(path_name);
+  if (menu != NULL) {
+    // First, find the (sub)menu with the given name
+    menu = find_menu(menu, path_name, modes);
+    if (menu == NULL) {
+      return FAIL;
+    }
   }
+  // When there are no menus at all, the title still needs to be shown.
 
   // Now we have found the matching menu, and we list the mappings
   // Highlight title
   msg_puts_title(_("\n--- Menus ---"));
 
-  show_menus_recursive(menu->parent, modes, 0);
+  if (menu != NULL) {
+    show_menus_recursive(menu->parent, modes, 0);
+  }
   return OK;
 }
 

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -362,6 +362,9 @@ func Test_menu_info()
         \ shortcut: '', modes: ' ', submenus: ['menu']},
         \ menu_info(']Test'))
   unmenu ]Test
+
+  " Test for getting all the top-level menu names
+  call assert_notequal(menu_info('').submenus, [])
 endfunc
 
 " Test for <special> keyword in a menu with 'cpo' containing '<'

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -89,6 +89,35 @@ func Test_menu_commands()
   unlet g:did_menu
 endfun
 
+" Test various menu related errors
+func Test_menu_errors()
+  menu Test.Foo  :version<CR>
+
+  " Error cases
+  call assert_fails('menu .Test.Foo :ls<CR>', 'E475:')
+  call assert_fails('menu Test. :ls<CR>', 'E330:')
+  call assert_fails('menu Foo. :ls<CR>', 'E331:')
+  call assert_fails('unmenu Test.Foo abc', 'E488:')
+  call assert_fails('menu <Tab>:ls  :ls<CR>', 'E792:')
+  call assert_fails('menu Test.<Tab>:ls  :ls<CR>', 'E792:')
+  call assert_fails('menu Test.Foo.Bar  :ls<CR>', 'E327:')
+  call assert_fails('menu Test.-Sep-.Baz  :ls<CR>', 'E332:')
+  call assert_fails('menu Foo.Bar.--.Baz  :ls<CR>', 'E332:')
+  call assert_fails('menu disable Test.Foo.Bar', 'E327:')
+  call assert_fails('menu disable T.Foo', 'E329:')
+  call assert_fails('unmenu Test.Foo.Bar', 'E327:')
+  call assert_fails('cunmenu Test.Foo', 'E328:')
+  call assert_fails('unmenu Test.Bar', 'E329:')
+  call assert_fails('menu Test.Foo.Bar', 'E327:')
+  call assert_fails('cmenu Test.Foo', 'E328:')
+  call assert_fails('emenu x Test.Foo', 'E475:')
+  call assert_fails('emenu Test.Foo.Bar', 'E334:')
+  call assert_fails('menutranslate Test', 'E474:')
+
+  silent! unmenu Foo
+  unmenu Test
+endfunc
+
 " Test for menu item completion in command line
 func Test_menu_expand()
   " Create the menu itmes for test
@@ -119,8 +148,337 @@ func Test_menu_expand()
         \ "\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"emenu Buffers. Xmenu.', @:)
 
+  " Test for expanding only submenus
+  call feedkeys(":popup Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"popup Xmenu.A1 A2 A3 A4', @:)
+
+  " Test for expanding menus after enable/disable
+  call feedkeys(":menu enable Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu enable Xmenu.A1. A2. A3. A4.', @:)
+  call feedkeys(":menu disable Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu disable Xmenu.A1. A2. A3. A4.', @:)
+
+  " Test for expanding non-existing menu path
+  call feedkeys(":menu xyz.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu xyz.', @:)
+  call feedkeys(":menu Xmenu.A1.A1B1.xyz.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"menu Xmenu.A1.A1B1.xyz.', @:)
+
   set wildmenu&
   unmenu Xmenu
+
+  " Test for expanding popup menus with some hidden items
+  menu Xmenu.foo.A1 a1
+  menu Xmenu.]bar bar
+  menu Xmenu.]baz.B1 b1
+  menu Xmenu.-sep- :
+  call feedkeys(":popup Xmenu.\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"popup Xmenu.foo', @:)
+  unmenu Xmenu
+
+endfunc
+
+" Test for the menu_info() function
+func Test_menu_info()
+  " Define menus with various attributes
+  10nnoremenu 10.10 T&est.F&oo  :echo 'foo'<CR>
+  10nmenu <silent> 10.20 T&est.B&ar<Tab>:bar  :echo 'bar'<CR>
+  10nmenu <script> 10.30.5 T&est.Ba&z.Qu&x  :echo 'qux'<CR>
+
+  let d = #{name: "B&ar\t:bar", display: 'Bar', modes: 'n', shortcut: 'a',
+        \ accel: ':bar', priority: 20, enabled: v:true, silent: v:true,
+        \ noremenu: v:false, script: v:false, rhs: ":echo 'bar'<CR>"}
+  call assert_equal(d, menu_info('Test.Bar'))
+
+  let d = #{name: 'Ba&z', display: 'Baz', modes: 'n', shortcut: 'z',
+        \ priority: 30, submenus: ['Qux']}
+  call assert_equal(d, menu_info('Test.Baz'))
+
+  let d = #{name: 'T&est', display: 'Test', modes: 'n', shortcut: 'e',
+        \ priority: 10, submenus: ['Foo', 'Bar', 'Baz']}
+  call assert_equal(d, menu_info('Test'))
+  call assert_equal({}, menu_info('Test.Dummy'))
+  call assert_equal({}, menu_info('Dummy'))
+
+  nmenu disable Test.Foo
+  call assert_equal(v:false, menu_info('Test.Foo').enabled)
+  nmenu enable Test.Foo
+  call assert_equal(v:true, menu_info('Test.Foo').enabled)
+
+  call assert_equal(menu_info('Test.Foo'), menu_info('Test.Foo', ''))
+  nmenu Test.abc  <Nop>
+  call assert_equal('<Nop>', menu_info('Test.abc').rhs)
+  call assert_fails('call menu_info([])', 'E730:')
+  nunmenu Test
+
+  " Test for defining menus in different modes
+  menu Test.menu :menu<CR>
+  menu! Test.menu! :menu!<CR>
+  amenu Test.amenu  :amenu<CR>
+  nmenu Test.nmenu  :nmenu<CR>
+  omenu Test.omenu  :omenu<CR>
+  vmenu Test.vmenu  :vmenu<CR>
+  xmenu Test.xmenu  :xmenu<CR>
+  smenu Test.smenu  :smenu<CR>
+  imenu <silent> <script> Test.imenu  :imenu<CR>
+  cmenu Test.cmenu  :cmenu<CR>
+  tlmenu Test.tlmenu  :tlmenu<CR>
+  tmenu Test.nmenu Normal mode menu
+  tmenu Test.omenu Op-pending mode menu
+  noremenu Test.noremenu :noremenu<CR>
+  noremenu! Test.noremenu! :noremenu!<CR>
+  anoremenu Test.anoremenu  :anoremenu<CR>
+  nnoremenu Test.nnoremenu  :nnoremenu<CR>
+  onoremenu Test.onoremenu  :onoremenu<CR>
+  vnoremenu Test.vnoremenu  :vnoremenu<CR>
+  xnoremenu Test.xnoremenu  :xnoremenu<CR>
+  snoremenu Test.snoremenu  :snoremenu<CR>
+  inoremenu <silent> Test.inoremenu  :inoremenu<CR>
+  cnoremenu Test.cnoremenu  :cnoremenu<CR>
+  tlnoremenu Test.tlnoremenu  :tlnoremenu<CR>
+  call assert_equal(#{name: 'menu', priority: 500, shortcut: '',
+        \ display: 'menu', modes: ' ', enabled: v:true, silent: v:false,
+        \ rhs: ":menu<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.menu'))
+  call assert_equal(#{name: 'menu!', priority: 500, shortcut: '',
+        \ display: 'menu!', modes: '!', enabled: v:true, silent: v:false,
+        \ rhs: ":menu!<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.menu!', '!'))
+  call assert_equal(#{name: 'amenu', priority: 500, shortcut: '',
+        \ display: 'amenu', modes: 'a', enabled: v:true, silent: v:false,
+        \ rhs: ":amenu<CR>", noremenu: v:false, script: v:false},
+        \ menu_info('Test.amenu', 'a'))
+  call assert_equal(#{name: 'nmenu', priority: 500, shortcut: '',
+        \ display: 'nmenu', modes: 'n', enabled: v:true, silent: v:false,
+        \ rhs: ':nmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.nmenu', 'n'))
+  call assert_equal(#{name: 'omenu', priority: 500, shortcut: '',
+        \ display: 'omenu', modes: 'o', enabled: v:true, silent: v:false,
+        \ rhs: ':omenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.omenu', 'o'))
+  call assert_equal(#{name: 'vmenu', priority: 500, shortcut: '',
+        \ display: 'vmenu', modes: 'v', enabled: v:true, silent: v:false,
+        \ rhs: ':vmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.vmenu', 'v'))
+  call assert_equal(#{name: 'xmenu', priority: 500, shortcut: '',
+        \ display: 'xmenu', modes: 'x', enabled: v:true, silent: v:false,
+        \ rhs: ':xmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.xmenu', 'x'))
+  call assert_equal(#{name: 'smenu', priority: 500, shortcut: '',
+        \ display: 'smenu', modes: 's', enabled: v:true, silent: v:false,
+        \ rhs: ':smenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.smenu', 's'))
+  call assert_equal(#{name: 'imenu', priority: 500, shortcut: '',
+        \ display: 'imenu', modes: 'i', enabled: v:true, silent: v:true,
+        \ rhs: ':imenu<CR>', noremenu: v:false, script: v:true},
+        \ menu_info('Test.imenu', 'i'))
+  call assert_equal(#{ name: 'cmenu', priority: 500, shortcut: '',
+        \ display: 'cmenu', modes: 'c', enabled: v:true, silent: v:false,
+        \ rhs: ':cmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.cmenu', 'c'))
+  call assert_equal(#{name: 'tlmenu', priority: 500, shortcut: '',
+        \ display: 'tlmenu', modes: 'tl', enabled: v:true, silent: v:false,
+        \ rhs: ':tlmenu<CR>', noremenu: v:false, script: v:false},
+        \ menu_info('Test.tlmenu', 'tl'))
+  call assert_equal(#{name: 'noremenu', priority: 500, shortcut: '',
+        \ display: 'noremenu', modes: ' ', enabled: v:true, silent: v:false,
+        \ rhs: ":noremenu<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.noremenu'))
+  call assert_equal(#{name: 'noremenu!', priority: 500, shortcut: '',
+        \ display: 'noremenu!', modes: '!', enabled: v:true, silent: v:false,
+        \ rhs: ":noremenu!<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.noremenu!', '!'))
+  call assert_equal(#{name: 'anoremenu', priority: 500, shortcut: '',
+        \ display: 'anoremenu', modes: 'a', enabled: v:true, silent: v:false,
+        \ rhs: ":anoremenu<CR>", noremenu: v:true, script: v:false},
+        \ menu_info('Test.anoremenu', 'a'))
+  call assert_equal(#{name: 'nnoremenu', priority: 500, shortcut: '',
+        \ display: 'nnoremenu', modes: 'n', enabled: v:true, silent: v:false,
+        \ rhs: ':nnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.nnoremenu', 'n'))
+  call assert_equal(#{name: 'onoremenu', priority: 500, shortcut: '',
+        \ display: 'onoremenu', modes: 'o', enabled: v:true, silent: v:false,
+        \ rhs: ':onoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.onoremenu', 'o'))
+  call assert_equal(#{name: 'vnoremenu', priority: 500, shortcut: '',
+        \ display: 'vnoremenu', modes: 'v', enabled: v:true, silent: v:false,
+        \ rhs: ':vnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.vnoremenu', 'v'))
+  call assert_equal(#{name: 'xnoremenu', priority: 500, shortcut: '',
+        \ display: 'xnoremenu', modes: 'x', enabled: v:true, silent: v:false,
+        \ rhs: ':xnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.xnoremenu', 'x'))
+  call assert_equal(#{name: 'snoremenu', priority: 500, shortcut: '',
+        \ display: 'snoremenu', modes: 's', enabled: v:true, silent: v:false,
+        \ rhs: ':snoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.snoremenu', 's'))
+  call assert_equal(#{name: 'inoremenu', priority: 500, shortcut: '',
+        \ display: 'inoremenu', modes: 'i', enabled: v:true, silent: v:true,
+        \ rhs: ':inoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.inoremenu', 'i'))
+  call assert_equal(#{ name: 'cnoremenu', priority: 500, shortcut: '',
+        \ display: 'cnoremenu', modes: 'c', enabled: v:true, silent: v:false,
+        \ rhs: ':cnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.cnoremenu', 'c'))
+  call assert_equal(#{name: 'tlnoremenu', priority: 500, shortcut: '',
+        \ display: 'tlnoremenu', modes: 'tl', enabled: v:true, silent: v:false,
+        \ rhs: ':tlnoremenu<CR>', noremenu: v:true, script: v:false},
+        \ menu_info('Test.tlnoremenu', 'tl'))
+  aunmenu Test
+  tlunmenu Test
+  call assert_equal({}, menu_info('Test'))
+  call assert_equal({}, menu_info('Test', '!'))
+  call assert_equal({}, menu_info('Test', 'a'))
+  call assert_equal({}, menu_info('Test', 'n'))
+  call assert_equal({}, menu_info('Test', 'o'))
+  call assert_equal({}, menu_info('Test', 'v'))
+  call assert_equal({}, menu_info('Test', 'x'))
+  call assert_equal({}, menu_info('Test', 's'))
+  call assert_equal({}, menu_info('Test', 'i'))
+  call assert_equal({}, menu_info('Test', 'c'))
+  call assert_equal({}, menu_info('Test', 't'))
+  call assert_equal({}, menu_info('Test', 'tl'))
+
+  amenu Test.amenu  :amenu<CR>
+  call assert_equal(':amenu<CR>', menu_info('Test.amenu', '').rhs)
+  call assert_equal('<C-\><C-O>:amenu<CR>', menu_info('Test.amenu', '!').rhs)
+  call assert_equal(':amenu<CR>', menu_info('Test.amenu', 'n').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'o').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'v').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'x').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 's').rhs)
+  call assert_equal('<C-\><C-O>:amenu<CR>', menu_info('Test.amenu', 'i').rhs)
+  call assert_equal('<C-C>:amenu<CR><C-\><C-G>',
+        \ menu_info('Test.amenu', 'c').rhs)
+  aunmenu Test.amenu
+
+  " Test for hidden menus
+  menu ]Test.menu :menu<CR>
+  call assert_equal(#{name: ']Test', display: ']Test', priority: 500,
+        \ shortcut: '', modes: ' ', submenus: ['menu']},
+        \ menu_info(']Test'))
+  unmenu ]Test
+endfunc
+
+" Test for <special> keyword in a menu with 'cpo' containing '<'
+func Test_menu_special()
+  throw 'Skipped: Nvim does not support cpoptions flag "<"'
+  new
+  set cpo+=<
+  nmenu Test.Sign  am<Tab>n<Esc>
+  call feedkeys(":emenu n Test.Sign\<CR>", 'x')
+  call assert_equal("m<Tab>n<Esc>", getline(1))
+  nunmenu Test.Sign
+  nmenu <special> Test.Sign  am<Tab>n<Esc>
+  call setline(1, '')
+  call feedkeys(":emenu n Test.Sign\<CR>", 'x')
+  call assert_equal("m\tn", getline(1))
+  set cpo-=<
+  close!
+  nunmenu Test.Sign
+endfunc
+
+" Test for "icon=filname" in a toolbar
+func Test_menu_icon()
+  CheckFeature toolbar
+  nmenu icon=myicon.xpm Toolbar.Foo  :echo "Foo"<CR>
+  call assert_equal('myicon.xpm', "Toolbar.Foo"->menu_info().icon)
+  nunmenu Toolbar.Foo
+
+  " Test for using the builtin icon
+  amenu ToolBar.BuiltIn22 :echo "BuiltIn22"<CR>
+  call assert_equal(#{name: 'BuiltIn22', display: 'BuiltIn22',
+        \ enabled: v:true, shortcut: '', modes: 'a', script: v:false,
+        \ iconidx: 22, priority: 500, silent: v:false,
+        \ rhs: ':echo "BuiltIn22"<CR>', noremenu: v:false},
+        \ menu_info("ToolBar.BuiltIn22"))
+  aunmenu ToolBar.BuiltIn22
+endfunc
+
+" Test for ":emenu" command in different modes
+func Test_emenu_cmd()
+  new
+  xmenu Test.foo rx
+  call setline(1, ['aaaa', 'bbbb'])
+  normal ggVj
+  %emenu Test.foo
+  call assert_equal(['xxxx', 'xxxx'], getline(1, 2))
+  call setline(1, ['aaaa', 'bbbb'])
+  exe "normal ggVj\<Esc>"
+  %emenu Test.foo
+  call assert_equal(['xxxx', 'xxxx'], getline(1, 2))
+  call setline(1, ['aaaa', 'bbbb'])
+  exe "normal ggV\<Esc>"
+  2emenu Test.foo
+  call assert_equal(['aaaa', 'xxxx'], getline(1, 2))
+  xunmenu Test.foo
+  close!
+endfunc
+
+" Test for PopUp menus
+func Test_popup_menu()
+  20menu PopUp.foo :echo 'foo'<CR>
+  20menu PopUp.bar :echo 'bar'<CR>
+  call assert_equal(#{name: 'PopUp', display: 'PopUp', priority: 20,
+        \ shortcut: '', modes: ' ', submenus: ['foo', 'bar']},
+        \ menu_info('PopUp'))
+  menu disable PopUp.bar
+  call assert_equal(v:true, "PopUp.foo"->menu_info().enabled)
+  call assert_equal(v:false, "PopUp.bar"->menu_info().enabled)
+  menu enable PopUp.bar
+  call assert_equal(v:true, "PopUp.bar"->menu_info().enabled)
+  unmenu PopUp
+endfunc
+
+" Test for listing the menus using the :menu command
+func Test_show_menus()
+  " In the GUI, tear-off menu items are present in the output below
+  " So skip this test
+  CheckNotGui
+  aunmenu *
+  call assert_equal(['--- Menus ---'], split(execute('menu'), "\n"))
+  nmenu <script> 200.10 Test.nmenu1 :nmenu1<CR>
+  nmenu 200.20 Test.nmenu2 :nmenu2<CR>
+  nnoremenu 200.30 Test.nmenu3 :nmenu3<CR>
+  nmenu 200.40 Test.nmenu4 :nmenu4<CR>
+  nmenu 200.50 disable Test.nmenu4
+  let exp =<< trim [TEXT]
+  --- Menus ---
+  200 Test
+    10 nmenu1
+        n&   :nmenu1<CR>
+    20 nmenu2
+        n    :nmenu2<CR>
+    30 nmenu3
+        n*   :nmenu3<CR>
+    40 nmenu4
+        n  - :nmenu4<CR>
+  [TEXT]
+  call assert_equal(exp, split(execute('nmenu'), "\n"))
+  nunmenu Test
+endfunc
+
+" Test for menu tips
+func Test_tmenu()
+  tunmenu *
+  call assert_equal(['--- Menus ---'], split(execute('tmenu'), "\n"))
+  tmenu Test.nmenu1 nmenu1
+  tmenu Test.nmenu2.sub1 nmenu2.sub1
+  let exp =<< trim [TEXT]
+  --- Menus ---
+  500 Test
+    500 nmenu1
+        t  - nmenu1
+    500 nmenu2
+      500 sub1
+          t  - nmenu2.sub1
+  [TEXT]
+  call assert_equal(exp, split(execute('tmenu'), "\n"))
+  tunmenu Test
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -864,15 +864,21 @@ func Test_popup_position()
 endfunc
 
 func Test_popup_command()
-  if !CanRunVimInTerminal() || !has('menu')
-    return
-  endif
+  CheckScreendump
+  CheckFeature menu
 
-  call writefile([
-	\ 'one two three four five',
-	\ 'and one two Xthree four five',
-	\ 'one more two three four five',
-	\ ], 'Xtest')
+  menu Test.Foo Foo
+  call assert_fails('popup Test.Foo', 'E336:')
+  call assert_fails('popup Test.Foo.X', 'E327:')
+  call assert_fails('popup Foo', 'E337:')
+  unmenu Test.Foo
+
+  let lines =<< trim END
+	one two three four five
+	and one two Xthree four five
+	one more two three four five
+  END
+  call writefile(lines, 'Xtest')
   let buf = RunVimInTerminal('Xtest', {})
   call term_sendkeys(buf, ":source $VIMRUNTIME/menu.vim\<CR>")
   call term_sendkeys(buf, "/X\<CR>:popup PopUp\<CR>")


### PR DESCRIPTION
#### vim-patch:8.2.0385: menu functionality insufficiently tested

Problem:    Menu functionality insufficiently tested.
Solution:   Add tests.  Add menu_info(). (Yegappan Lakshmanan, closes vim/vim#5760)
https://github.com/vim/vim/commit/0eabd4dc8ff50658f0ea0e92c7918a42242f6b80

Omit feedkeys() change: even if "L" flag is implemented it will likely
use input_enqueue(), which already checks for interrupts.

Omit Test_mouse_popup_menu(): already tested in Lua.


#### vim-patch:8.2.0392: Coverity warns for using array index out of range

Problem:    Coverity warns for using array index out of range.
Solution:   Add extra "if" to avoid warning.
https://github.com/vim/vim/commit/56cb3378727783da2d246b9c5091784821666cfa


#### vim-patch:8.2.3459: Vim9: need more tests for empty string arguments

Problem:    Vim9: need more tests for empty string arguments.
Solution:   Add more tests.  Also use empty argument with menu_info() to get
            the top-level menu names. (Yegappan Lakshmanan, closes vim/vim#8925)
https://github.com/vim/vim/commit/51491adfa86fd66a857cd7ec50d0b57dbdf3da59