### PR TITLE
vim-patch:9.0.0141: "delmenu" does not remove autocmmands

### DIFF
--- a/runtime/delmenu.vim
+++ b/runtime/delmenu.vim
@@ -7,6 +7,31 @@
 aunmenu *
 tlunmenu *
 
+if exists('#SetupLazyloadMenus')
+  au! SetupLazyloadMenus
+  augroup! SetupLazyloadMenus
+endif
+
+if exists('#buffer_list')
+  au! buffer_list
+  augroup! buffer_list
+endif
+
+if exists('#LoadBufferMenu')
+  au! LoadBufferMenu
+  augroup! LoadBufferMenu
+endif
+
+if exists('#spellmenu')
+  au! spellmenu
+  augroup! spellmenu
+endif
+
+if exists('#SpellPopupMenu')
+  au! SpellPopupMenu
+  augroup! SpellPopupMenu
+endif
+
 unlet! g:did_install_default_menus
 unlet! g:did_install_syntax_menu
 

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -162,9 +162,6 @@ endfunc
 
 " Test for menu item completion in command line
 func Test_menu_expand()
-  " Make sure we don't have stale menu items like Buffers menu.
-  source $VIMRUNTIME/delmenu.vim
-
   " Create the menu itmes for test
   menu Dummy.Nothing lll
   for i in range(1, 4)
@@ -370,6 +367,10 @@ func Test_menu_info()
         \ display: 'tlnoremenu', modes: 'tl', enabled: v:true, silent: v:false,
         \ rhs: ':tlnoremenu<CR>', noremenu: v:true, script: v:false},
         \ menu_info('Test.tlnoremenu', 'tl'))
+
+  " Test for getting all the top-level menu names
+  call assert_notequal(menu_info('').submenus, [])
+
   aunmenu Test
   tlunmenu Test
   call assert_equal({}, menu_info('Test'))
@@ -408,9 +409,6 @@ func Test_menu_info()
         \ shortcut: '', modes: ' ', submenus: ['menu']},
         \ menu_info(']Test'))
   unmenu ]Test
-
-  " Test for getting all the top-level menu names
-  call assert_notequal(menu_info('').submenus, [])
 endfunc
 
 " Test for <special> keyword in a menu with 'cpo' containing '<'


### PR DESCRIPTION
Problem:    "delmenu" does not remove autocmmands. Running menu test function
            alone fails.
Solution:   Delete autocommands Make sure there is at least one menu.
            (closes vim/vim#10848)
https://github.com/vim/vim/commit/206fce307b265f7f6c6290b623a80c1d846dd131