### PR TITLE
feat(lsp): disable exit_timeout by default

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1015,12 +1015,13 @@ start_client({config})                                *vim.lsp.start_client()*
                                            notifications to the server by the
                                            given number in milliseconds. No
                                            debounce occurs if nil
-                                         • exit_timeout (number, default 500):
-                                           Milliseconds to wait for server to
-                                           exit cleanly after sending the
-                                           'shutdown' request before sending
-                                           kill -15. If set to false, nvim
-                                           exits immediately after sending the
+                                         • exit_timeout (number|boolean,
+                                           default false): Milliseconds to
+                                           wait for server to exit cleanly
+                                           after sending the 'shutdown'
+                                           request before sending kill -15. If
+                                           set to false, nvim exits
+                                           immediately after sending the
                                            'shutdown' request to the server.
                     {root_dir}           (string) Directory where the LSP
                                          server will base its

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -871,7 +871,7 @@ end
 --- - debounce_text_changes (number, default 150): Debounce didChange
 ---       notifications to the server by the given number in milliseconds. No debounce
 ---       occurs if nil
---- - exit_timeout (number, default 500): Milliseconds to wait for server to
+--- - exit_timeout (number|boolean, default false): Milliseconds to wait for server to
 ---       exit cleanly after sending the 'shutdown' request before sending kill -15.
 ---       If set to false, nvim exits immediately after sending the 'shutdown' request to the server.
 ---
@@ -1681,7 +1681,7 @@ api.nvim_create_autocmd('VimLeavePre', {
     local send_kill = false
 
     for client_id, client in pairs(active_clients) do
-      local timeout = if_nil(client.config.flags.exit_timeout, 500)
+      local timeout = if_nil(client.config.flags.exit_timeout, false)
       if timeout then
         send_kill = true
         timeouts[client_id] = timeout


### PR DESCRIPTION
The lsp client used to wait up to 500ms for a language server to
shutdown before sending a TERM signal.

The intention behind the 500ms grace period was to ensure the language
server exits to prevent stale processes, but it has the side-effect that
it can interrupt language-servers which are too slow to shutdown within
500ms. Language servers tend to write out index files or project files
on shutdown, and being interrupted during this process can cause
corruption of those files.

This changes the default to not wait at all, at the risk of leaving
stale processes around if the language server isn't well behaved.

An alternative would be to wait indefinitely, but that can cause neovim
to take several seconds to exit.
