### PR TITLE
fix(lsp): set end_col in formatexpr

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -113,7 +113,7 @@ end
 --- Convert byte index to `encoding` index.
 --- Convenience wrapper around vim.str_utfindex
 ---@param line string line to be indexed
----@param index number byte index (utf-8), or `nil` for length
+---@param index number|nil byte index (utf-8), or `nil` for length
 ---@param encoding string utf-8|utf-16|utf-32|nil defaults to utf-16
 ---@return number `encoding` index of `index` in `line`
 function M._str_utfindex_enc(line, index, encoding)


### PR DESCRIPTION
The last line was excluded from formatting via formatexpr because the
character in the params was set to 0 instead of the end of line.
