### PR TITLE
test: increse expect_exit() timeouts

### DIFF
--- a/test/functional/legacy/arglist_spec.lua
+++ b/test/functional/legacy/arglist_spec.lua
@@ -276,6 +276,6 @@ describe('argument list commands', function()
       2 more files to edit.  Quit anyway?                         |
       [Y]es, (N)o: ^                                               |
     ]])
-    expect_exit(100, feed, 'Y')
+    expect_exit(1000, feed, 'Y')
   end)
 end)

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -94,7 +94,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xbar"?}                                                    |
       {3:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    expect_exit(100, feed, 'A')
+    expect_exit(1000, feed, 'A')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -132,7 +132,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xbar"?}                                                    |
       {3:[Y]es, (N)o, Save (A)ll, (D)iscard All, (C)ancel: }^                         |
     ]])
-    expect_exit(100, feed, 'D')
+    expect_exit(1000, feed, 'D')
 
     eq('foo2\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))
@@ -193,7 +193,7 @@ describe(':confirm command dialog', function()
       {3:Save changes to "Xfoo"?}                                                    |
       {3:[Y]es, (N)o, (C)ancel: }^                                                    |
     ]])
-    expect_exit(100, feed, 'Y')
+    expect_exit(1000, feed, 'Y')
 
     eq('foo4\n', read_file('Xfoo'))
     eq('bar2\n', read_file('Xbar'))


### PR DESCRIPTION
A timeout of 100 milliseconds is sometimes still too short for macOS.
Change it to 1000 milliseconds.
