### PR TITLE
vim-patch:partial: 48c3f4e0bff7

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -348,7 +348,7 @@ func dist#ft#FTidl()
   setf idl
 endfunc
 
-" Distinguish between "default" and Cproto prototype file. */
+" Distinguish between "default", Prolog and Cproto prototype file. */
 func dist#ft#ProtoCheck(default)
   " Cproto files have a comment in the first line and a function prototype in
   " the second line, it always ends in ";".  Indent files may also have
@@ -358,7 +358,14 @@ func dist#ft#ProtoCheck(default)
   if getline(2) =~ '.;$'
     setf cpp
   else
-    exe 'setf ' . a:default
+    " recognize Prolog by specific text in the first non-empty line
+    " require a blank after the '%' because Perl uses "%list" and "%translate"
+    let l = getline(nextnonblank(1))
+    if l =~ '\<prolog\>' || l =~ '^\s*\(%\+\(\s\|$\)\|/\*\)' || l =~ ':-'
+      setf prolog
+    else
+      exe 'setf ' .. a:default
+    endif
   endif
 endfunc
 

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -25,6 +25,7 @@ Get specific help:  It is possible to go directly to whatever you want help
 		      Option			  '	   :help 'textwidth'
 		      Regular expression	  /	   :help /[
 		    See |help-summary| for more contexts and an explanation.
+		    See |notation| for an explanation of the help syntax.
 
   Search for help:  Type ":help word", then hit CTRL-D to see matching
 		    help entries for "word".

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1325,7 +1325,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	page can have a different value.
 
 	When 'cmdheight' is zero, there is no command-line unless it is being
-	used.  Any messages will cause the |hit-enter| prompt.
+	used.  Some informative messages will not be displayed, any other
+	messages will cause the |hit-enter| prompt.
 
 						*'cmdwinheight'* *'cwh'*
 'cmdwinheight' 'cwh'	number	(default 7)
@@ -3735,8 +3736,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'lispwords'* *'lw'*
 'lispwords' 'lw'	string	(default is very long)
 			global or local to buffer |global-local|
-	Comma-separated list of words that influence the Lisp indenting.
-	|'lisp'|
+	Comma-separated list of words that influence the Lisp indenting when
+	enabled with the |'lisp'| option.
 
 						*'list'* *'nolist'*
 'list'			boolean	(default off)

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -202,9 +202,9 @@ message when it doesn't, append !: >
 
 	:unlet! s:count
 
-When a script finishes, the local variables used there will not be
-automatically freed.  The next time the script executes, it can still use the
-old value.  Example: >
+When a script has been processed to the end, the local variables declared
+there will not be deleted.  Functions defined in the script can use them.
+Example:
 
 	:if !exists("s:call_count")
 	:  let s:call_count = 0

--- a/runtime/ftplugin/abaqus.vim
+++ b/runtime/ftplugin/abaqus.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:     Abaqus finite element input file (www.abaqus.com)
-" Maintainer:   Carl Osterwisch <osterwischc@asme.org>
-" Last Change:  2022 May 09
+" Maintainer:   Carl Osterwisch <costerwi@gmail.com>
+" Last Change:  2022 Aug 03
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -46,7 +46,7 @@ if has("folding")
 endif
 
 " Set the file browse filter (currently only supported under Win32 gui)
-if has("gui_win32") && !exists("b:browsefilter")
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Abaqus Input Files (*.inp *.inc)\t*.inp;*.inc\n" .
     \ "Abaqus Results (*.dat)\t*.dat\n" .
     \ "Abaqus Messages (*.pre *.msg *.sta)\t*.pre;*.msg;*.sta\n" .
@@ -57,7 +57,7 @@ endif
 " Define patterns for the matchit plugin
 if exists("loaded_matchit") && !exists("b:match_words")
     let b:match_ignorecase = 1
-    let b:match_words = 
+    let b:match_words =
     \ '\*part:\*end\s*part,' .
     \ '\*assembly:\*end\s*assembly,' .
     \ '\*instance:\*end\s*instance,' .
@@ -65,25 +65,27 @@ if exists("loaded_matchit") && !exists("b:match_words")
     let b:undo_ftplugin .= "|unlet! b:match_ignorecase b:match_words"
 endif
 
-" Define keys used to move [count] keywords backward or forward.
-noremap <silent><buffer> [[ ?^\*\a<CR>:nohlsearch<CR>
-noremap <silent><buffer> ]] /^\*\a<CR>:nohlsearch<CR>
+if !exists("no_plugin_maps") && !exists("no_abaqus_maps")
+  " Define keys used to move [count] keywords backward or forward.
+  noremap <silent><buffer> [[ ?^\*\a<CR>:nohlsearch<CR>
+  noremap <silent><buffer> ]] /^\*\a<CR>:nohlsearch<CR>
 
-" Define key to toggle commenting of the current line or range
-noremap <silent><buffer> <LocalLeader><LocalLeader> 
-    \ :call <SID>Abaqus_ToggleComment()<CR>j
-function! <SID>Abaqus_ToggleComment() range
-    if strpart(getline(a:firstline), 0, 2) == "**"
-        " Un-comment all lines in range
-        silent execute a:firstline . ',' . a:lastline . 's/^\*\*//'
-    else
-        " Comment all lines in range
-        silent execute a:firstline . ',' . a:lastline . 's/^/**/'
-    endif
-endfunction
+  " Define key to toggle commenting of the current line or range
+  noremap <silent><buffer> <LocalLeader><LocalLeader>
+      \ :call <SID>Abaqus_ToggleComment()<CR>j
+  function! <SID>Abaqus_ToggleComment() range
+      if strpart(getline(a:firstline), 0, 2) == "**"
+	  " Un-comment all lines in range
+	  silent execute a:firstline . ',' . a:lastline . 's/^\*\*//'
+      else
+	  " Comment all lines in range
+	  silent execute a:firstline . ',' . a:lastline . 's/^/**/'
+      endif
+  endfunction
 
-let b:undo_ftplugin .= "|unmap <buffer> [[|unmap <buffer> ]]"
-    \ . "|unmap <buffer> <LocalLeader><LocalLeader>"
+  let b:undo_ftplugin .= "|unmap <buffer> [[|unmap <buffer> ]]"
+      \ . "|unmap <buffer> <LocalLeader><LocalLeader>"
+endif
 
 " Undo must be done in nocompatible mode for <LocalLeader>.
 let b:undo_ftplugin = "let b:cpo_save = &cpoptions|"

--- a/runtime/ftplugin/php.vim
+++ b/runtime/ftplugin/php.vim
@@ -1,12 +1,12 @@
 " Vim filetype plugin file
-" Language:	php
-"
-" This runtime file is looking for a new maintainer.
-"
-" Former maintainer:	Dan Sharp
-" Last Changed: 20 Jan 2009
+" Language:		PHP
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Previous Maintainer:	Dan Sharp
+" Last Changed:		2022 Jul 20
 
-if exists("b:did_ftplugin") | finish | endif
+if exists("b:did_ftplugin")
+  finish
+endif
 
 " Make sure the continuation lines below do not cause problems in
 " compatibility mode.
@@ -15,8 +15,8 @@ set cpo&vim
 
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
-let s:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n" .
-	    \	     "All Files (*.*)\t*.*\n"
+let s:browsefilter = "HTML Files (*.html, *.htm)\t*.html;*.htm\n" ..
+      \		     "All Files (*.*)\t*.*\n"
 let s:match_words = ""
 
 runtime! ftplugin/html.vim ftplugin/html_*.vim ftplugin/html/*.vim
@@ -24,22 +24,39 @@ let b:did_ftplugin = 1
 
 " Override our defaults if these were set by an included ftplugin.
 if exists("b:undo_ftplugin")
-    let s:undo_ftplugin = b:undo_ftplugin
+" let b:undo_ftplugin = "setlocal comments< commentstring< formatoptions< omnifunc<"
+  let s:undo_ftplugin = b:undo_ftplugin
 endif
 if exists("b:browsefilter")
-    let s:browsefilter = b:browsefilter
+" let b:undo_ftplugin ..= " | unlet! b:browsefilter b:html_set_browsefilter"
+  let s:browsefilter = b:browsefilter
 endif
 if exists("b:match_words")
-    let s:match_words = b:match_words
+" let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words b:html_set_match_words"
+  let s:match_words = b:match_words
 endif
 if exists("b:match_skip")
-    unlet b:match_skip
+  unlet b:match_skip
 endif
 
-" Change the :browse e filter to primarily show PHP-related files.
-if has("gui_win32")
-    let  b:browsefilter="PHP Files (*.php)\t*.php\n" . s:browsefilter
+setlocal comments=s1:/*,mb:*,ex:*/,://,:#
+setlocal commentstring=/*%s*/
+setlocal formatoptions+=l formatoptions-=t
+
+if get(g:, "php_autocomment", 1)
+  setlocal formatoptions+=croq
+  " NOTE: set g:PHP_autoformatcomment = 0 to prevent the indent plugin from
+  "       overriding this 'comments' value 
+  setlocal comments-=:#
+  " space after # comments to exclude attributes
+  setlocal comments+=b:#
 endif
+
+if exists('&omnifunc')
+  setlocal omnifunc=phpcomplete#CompletePHP
+endif
+
+setlocal suffixesadd=.php
 
 " ###
 " Provided by Mikolaj Machowski <mikmach at wp dot pl>
@@ -47,40 +64,90 @@ setlocal include=\\\(require\\\|include\\\)\\\(_once\\\)\\\?
 " Disabled changing 'iskeyword', it breaks a command such as "*"
 " setlocal iskeyword+=$
 
-if exists("loaded_matchit")
-    let b:match_words = '<?php:?>,\<switch\>:\<endswitch\>,' .
-		      \ '\<if\>:\<elseif\>:\<else\>:\<endif\>,' .
-		      \ '\<while\>:\<endwhile\>,' .
-		      \ '\<do\>:\<while\>,' .
-		      \ '\<for\>:\<endfor\>,' .
-		      \ '\<foreach\>:\<endforeach\>,' .
-                      \ '(:),[:],{:},' .
-		      \ s:match_words
+let b:undo_ftplugin = "setlocal include< suffixesadd<"
+
+if exists("loaded_matchit") && exists("b:html_set_match_words")
+  let b:match_ignorecase = 1
+  let b:match_words = 'PhpMatchWords()'
+
+  if !exists("*PhpMatchWords")
+    function! PhpMatchWords()
+      " The PHP syntax file uses the Delimiter syntax group for the phpRegion
+      " matchgroups, without a "php" prefix, so use the stack to test for the
+      " outer phpRegion group.	This also means the closing ?> tag which is
+      " outside of the matched region just uses the Delimiter group for the
+      " end match.
+      let stack = synstack(line('.'), col('.'))
+      let php_region = !empty(stack) && synIDattr(stack[0], "name") =~# '\<php'
+      if php_region || getline(".") =~ '.\=\%.c\&?>'
+	let b:match_skip = "PhpMatchSkip('html')"
+	return '<?php\|<?=\=:?>,' ..
+	   \   '\<if\>:\<elseif\>:\<else\>:\<endif\>,' ..
+	   \   '\<switch\>:\<case\>:\<break\>:\<continue\>:\<endswitch\>,' ..
+	   \   '\<while\>.\{-})\s*\::\<break\>:\<continue\>:\<endwhile\>,' ..
+	   \   '\<do\>:\<break\>:\<continue\>:\<while\>,' ..
+	   \   '\<for\>:\<break\>:\<continue\>:\<endfor\>,' ..
+	   \   '\<foreach\>:\<break\>:\<continue\>:\<endforeach\>,' ..
+	   \   '\%(<<<\s*\)\@<=''\=\(\h\w*\)''\=:^\s*\1\>'
+
+	   " TODO: these probably aren't worth adding and really need syntax support
+	   "   '<\_s*script\_s*language\_s*=\_s*[''"]\=\_s*php\_s*[''"]\=\_s*>:<\_s*\_s*/\_s*script\_s*>,' ..
+	   "   '<%:%>,' ..
+      else
+	let b:match_skip = "PhpMatchSkip('php')"
+	return s:match_words
+      endif
+    endfunction
+  endif
+  if !exists("*PhpMatchSkip")
+    function! PhpMatchSkip(skip)
+      let name = synIDattr(synID(line('.'), col('.'), 1), 'name')
+      if a:skip == "html"
+	" ?> in line comments will also be correctly matched as Delimiter
+	return name =~? 'comment\|string' || name !~? 'php\|delimiter'
+      else " php
+	return name =~? 'comment\|string\|php'
+      endif
+    endfunction
+  endif
+  let b:undo_ftplugin ..= " | unlet! b:match_skip"
 endif
 " ###
 
-if exists('&omnifunc')
-  setlocal omnifunc=phpcomplete#CompletePHP
+" Change the :browse e filter to primarily show PHP-related files.
+if (has("gui_win32") || has("gui_gtk")) && exists("b:html_set_browsefilter")
+  let b:browsefilter = "PHP Files (*.php)\t*.php\n" ..
+	\	       "PHP Test Files (*.phpt)\t*.phpt\n" ..
+	\	       s:browsefilter
 endif
 
-" Section jumping: [[ and ]] provided by Antony Scriven <adscriven at gmail dot com>
-let s:function = '\(abstract\s\+\|final\s\+\|private\s\+\|protected\s\+\|public\s\+\|static\s\+\)*function'
-let s:class = '\(abstract\s\+\|final\s\+\)*class'
-let s:interface = 'interface'
-let s:section = '\(.*\%#\)\@!\_^\s*\zs\('.s:function.'\|'.s:class.'\|'.s:interface.'\)'
-exe 'nno <buffer> <silent> [[ ?' . escape(s:section, '|') . '?<CR>:nohls<CR>'
-exe 'nno <buffer> <silent> ]] /' . escape(s:section, '|') . '/<CR>:nohls<CR>'
-exe 'ono <buffer> <silent> [[ ?' . escape(s:section, '|') . '?<CR>:nohls<CR>'
-exe 'ono <buffer> <silent> ]] /' . escape(s:section, '|') . '/<CR>:nohls<CR>'
+if !exists("no_plugin_maps") && !exists("no_php_maps")
+  " Section jumping: [[ and ]] provided by Antony Scriven <adscriven at gmail dot com>
+  let s:function = '\%(abstract\s\+\|final\s\+\|private\s\+\|protected\s\+\|public\s\+\|static\s\+\)*function'
+  let s:class = '\%(abstract\s\+\|final\s\+\)*class'
+  let s:section = escape('^\s*\zs\%(' .. s:function .. '\|' .. s:class .. '\|interface\|trait\|enum\)\>', "|")
 
-setlocal suffixesadd=.php
-setlocal commentstring=/*%s*/
+  function! s:Jump(pattern, count, flags)
+    normal! m'
+    for i in range(a:count)
+      if !search(a:pattern, a:flags)
+	break
+      endif
+    endfor
+  endfunction
 
-" Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal suffixesadd< commentstring< include< omnifunc<" .
-	    \	      " | unlet! b:browsefilter b:match_words | " .
-	    \	      s:undo_ftplugin
+  for mode in ["n", "o", "x"]
+    exe mode .. "noremap <buffer> <silent> ]] <Cmd>call <SID>Jump('" .. s:section .. "', v:count1, 'W')<CR>"
+    exe mode .. "noremap <buffer> <silent> [[ <Cmd>call <SID>Jump('" .. s:section .. "', v:count1, 'bW')<CR>"
+    let b:undo_ftplugin ..= " | sil! exe '" .. mode .. "unmap <buffer> ]]'" ..
+	  \		    " | sil! exe '" .. mode .. "unmap <buffer> [['"
+  endfor
+endif
+
+let b:undo_ftplugin ..= " | " .. s:undo_ftplugin
 
 " Restore the saved compatibility options.
 let &cpo = s:keepcpo
 unlet s:keepcpo
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Vim
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Apr 11
+" Last Change:	2022 Aug 4
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -109,7 +109,7 @@ if exists("loaded_matchit")
   " - set spl=de,en
   " - au! FileType javascript syntax region foldBraces start=/{/ end=/}/ …
   let b:match_skip = 'synIDattr(synID(line("."),col("."),1),"name")
-        \ =~? "comment\\|string\\|vimSynReg\\|vimSet"'
+        \ =~? "comment\\|string\\|vimLetHereDoc\\|vimSynReg\\|vimSet"'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/indent/lisp.vim
+++ b/runtime/indent/lisp.vim
@@ -1,7 +1,7 @@
 " Vim indent file
 " Language:	Lisp
-" Maintainer:    Sergey Khorev <sergey.khorev@gmail.com>
-" URL:		 http://sites.google.com/site/khorser/opensource/vim
+" Maintainer:	Sergey Khorev <sergey.khorev@gmail.com>
+" URL:		http://sites.google.com/site/khorser/opensource/vim
 " Last Change:	2012 Jan 10
 
 " Only load this indent file when no other was loaded.

--- a/runtime/indent/systemverilog.vim
+++ b/runtime/indent/systemverilog.vim
@@ -2,7 +2,7 @@
 " Language:    SystemVerilog
 " Maintainer:  kocha <kocha.lsifrontend@gmail.com>
 " Last Change: 05-Feb-2017 by Bilal Wasim
-"		2022 April: b:undo_indent added by Doug Kearns
+"              03-Aug-2022 Improved indent
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -15,7 +15,7 @@ setlocal indentkeys=!^F,o,O,0),0},=begin,=end,=join,=endcase,=join_any,=join_non
 setlocal indentkeys+==endmodule,=endfunction,=endtask,=endspecify
 setlocal indentkeys+==endclass,=endpackage,=endsequence,=endclocking
 setlocal indentkeys+==endinterface,=endgroup,=endprogram,=endproperty,=endchecker
-setlocal indentkeys+==`else,=`endif
+setlocal indentkeys+==`else,=`elsif,=`endif
 
 let b:undo_indent = "setl inde< indk<"
 
@@ -26,6 +26,9 @@ endif
 
 let s:cpo_save = &cpo
 set cpo&vim
+
+let s:multiple_comment = 0
+let s:open_statement = 0
 
 function SystemVerilogIndent()
 
@@ -38,6 +41,12 @@ function SystemVerilogIndent()
     let indent_modules = offset
   else
     let indent_modules = 0
+  endif
+
+  if exists('b:systemverilog_indent_ifdef_off')
+    let indent_ifdef = 0
+  else
+    let indent_ifdef = 1
   endif
 
   " Find a non-blank line above the current line.
@@ -54,48 +63,55 @@ function SystemVerilogIndent()
   let last_line2 = getline(lnum2)
   let ind  = indent(lnum)
   let ind2 = indent(lnum - 1)
-  let offset_comment1 = 1
   " Define the condition of an open statement
   "   Exclude the match of //, /* or */
   let sv_openstat = '\(\<or\>\|\([*/]\)\@<![*(,{><+-/%^&|!=?:]\([*/]\)\@!\)'
   " Define the condition when the statement ends with a one-line comment
   let sv_comment = '\(//.*\|/\*.*\*/\s*\)'
-  if exists('b:verilog_indent_verbose')
-    let vverb_str = 'INDENT VERBOSE:'
+  if exists('b:systemverilog_indent_verbose')
+    let vverb_str = 'INDENT VERBOSE: '. v:lnum .":"
     let vverb = 1
   else
     let vverb = 0
   endif
 
-  " Indent according to last line
-  " End of multiple-line comment
-  if last_line =~ '\*/\s*$' && last_line !~ '/\*.\{-}\*/'
-    let ind = ind - offset_comment1
-    if vverb
-      echo vverb_str "De-indent after a multiple-line comment."
-    endif
+  " Multiple-line comment count
+  if curr_line =~ '^\s*/\*' && curr_line !~ '/\*.\{-}\*/'
+    let s:multiple_comment += 1
+    if vverb | echom vverb_str "Start of multiple-line commnt" | endif
+  elseif curr_line =~ '\*/\s*$' && curr_line !~ '/\*.\{-}\*/'
+    let s:multiple_comment -= 1
+    if vverb | echom vverb_str "End of multiple-line commnt" | endif
+    return ind
+  endif
+  " Maintain indentation during commenting.
+  if s:multiple_comment > 0
+    return ind
+  endif
 
   " Indent after if/else/for/case/always/initial/specify/fork blocks
-  elseif last_line =~ '`\@<!\<\(if\|else\)\>' ||
-    \ last_line =~ '^\s*\<\(for\|case\%[[zx]]\|do\|foreach\|forever\|randcase\)\>' ||
+  if last_line =~ '^\s*\(end\)\=\s*`\@<!\<\(if\|else\)\>' ||
+    \ last_line =~ '^\s*\<\(for\|while\|repeat\|case\%[[zx]]\|do\|foreach\|forever\|randcase\)\>' ||
     \ last_line =~ '^\s*\<\(always\|always_comb\|always_ff\|always_latch\)\>' ||
     \ last_line =~ '^\s*\<\(initial\|specify\|fork\|final\)\>'
-    if last_line !~ '\(;\|\<end\>\)\s*' . sv_comment . '*$' ||
+    if last_line !~ '\(;\|\<end\>\|\*/\)\s*' . sv_comment . '*$' ||
       \ last_line =~ '\(//\|/\*\).*\(;\|\<end\>\)\s*' . sv_comment . '*$'
       let ind = ind + offset
-      if vverb | echo vverb_str "Indent after a block statement." | endif
+      if vverb | echom vverb_str "Indent after a block statement." | endif
     endif
   " Indent after function/task/class/package/sequence/clocking/
   " interface/covergroup/property/checkerprogram blocks
   elseif last_line =~ '^\s*\<\(function\|task\|class\|package\)\>' ||
     \ last_line =~ '^\s*\<\(sequence\|clocking\|interface\)\>' ||
     \ last_line =~ '^\s*\(\w\+\s*:\)\=\s*\<covergroup\>' ||
-    \ last_line =~ '^\s*\<\(property\|checker\|program\)\>'
+    \ last_line =~ '^\s*\<\(property\|checker\|program\)\>' ||
+    \ ( last_line =~ '^\s*\<virtual\>' && last_line =~ '\<\(function\|task\|class\|interface\)\>' ) ||
+    \ ( last_line =~ '^\s*\<pure\>' &&  last_line =~ '\<virtual\>' && last_line =~ '\<\(function\|task\)\>' )
     if last_line !~ '\<end\>\s*' . sv_comment . '*$' ||
       \ last_line =~ '\(//\|/\*\).*\(;\|\<end\>\)\s*' . sv_comment . '*$'
       let ind = ind + offset
       if vverb
-	echo vverb_str "Indent after function/task/class block statement."
+        echom vverb_str "Indent after function/task/class block statement."
       endif
     endif
 
@@ -103,13 +119,13 @@ function SystemVerilogIndent()
   elseif last_line =~ '^\s*\(\<extern\>\s*\)\=\<module\>'
     let ind = ind + indent_modules
     if vverb && indent_modules
-      echo vverb_str "Indent after module statement."
+      echom vverb_str "Indent after module statement."
     endif
     if last_line =~ '[(,]\s*' . sv_comment . '*$' &&
       \ last_line !~ '\(//\|/\*\).*[(,]\s*' . sv_comment . '*$'
       let ind = ind + offset
       if vverb
-	echo vverb_str "Indent after a multiple-line module statement."
+        echom vverb_str "Indent after a multiple-line module statement."
       endif
     endif
 
@@ -119,7 +135,7 @@ function SystemVerilogIndent()
     \ ( last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$' ||
     \ last_line2 =~ '^\s*[^=!]\+\s*:\s*' . sv_comment . '*$' )
     let ind = ind + offset
-    if vverb | echo vverb_str "Indent after begin statement." | endif
+    if vverb | echom vverb_str "Indent after begin statement." | endif
 
   " Indent after a '{' or a '('
   elseif last_line =~ '[{(]' . sv_comment . '*$' &&
@@ -127,7 +143,21 @@ function SystemVerilogIndent()
     \ ( last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$' ||
     \ last_line2 =~ '^\s*[^=!]\+\s*:\s*' . sv_comment . '*$' )
     let ind = ind + offset
-    if vverb | echo vverb_str "Indent after begin statement." | endif
+    if vverb | echom vverb_str "Indent after begin statement." | endif
+
+  " Ignore de-indent for the end of one-line block
+  elseif ( last_line !~ '\<begin\>' ||
+    \ last_line =~ '\(//\|/\*\).*\<begin\>' ) &&
+    \ last_line2 =~ '\<\(`\@<!if\|`\@<!else\|for\|always\|initial\|do\|foreach\|forever\|final\)\>.*' .
+      \ sv_comment . '*$' &&
+    \ last_line2 !~ '\(//\|/\*\).*\<\(`\@<!if\|`\@<!else\|for\|always\|initial\|do\|foreach\|forever\|final\)\>' &&
+    \ last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$' &&
+    \ ( last_line2 !~ '\<begin\>' ||
+    \ last_line2 =~ '\(//\|/\*\).*\<begin\>' ) &&
+    \ last_line2 =~ ')*\s*;\s*' . sv_comment . '*$'
+    if vverb
+      echom vverb_str "Ignore de-indent after the end of one-line statement."
+    endif
 
   " De-indent for the end of one-line block
   elseif ( last_line !~ '\<begin\>' ||
@@ -136,39 +166,29 @@ function SystemVerilogIndent()
       \ sv_comment . '*$' &&
     \ last_line2 !~ '\(//\|/\*\).*\<\(`\@<!if\|`\@<!else\|for\|always\|initial\|do\|foreach\|forever\|final\)\>' &&
     \ last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$' &&
+    \ last_line2 !~ '\(;\|\<end\>\|\*/\)\s*' . sv_comment . '*$' &&
     \ ( last_line2 !~ '\<begin\>' ||
     \ last_line2 =~ '\(//\|/\*\).*\<begin\>' )
     let ind = ind - offset
     if vverb
-      echo vverb_str "De-indent after the end of one-line statement."
+      echom vverb_str "De-indent after the end of one-line statement."
     endif
 
-    " Multiple-line statement (including case statement)
-    " Open statement
-    "   Ident the first open line
-    elseif  last_line =~ sv_openstat . '\s*' . sv_comment . '*$' &&
-      \ last_line !~ '\(//\|/\*\).*' . sv_openstat . '\s*$' &&
-      \ last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$'
-      let ind = ind + offset
-      if vverb | echo vverb_str "Indent after an open statement." | endif
+  " Multiple-line statement (including case statement)
+  " Open statement
+  "   Ident the first open line
+  elseif  last_line =~ sv_openstat . '\s*' . sv_comment . '*$' &&
+   \ last_line !~ '\(//\|/\*\).*' . sv_openstat . '\s*$' &&
+   \ last_line2 !~ sv_openstat . '\s*' . sv_comment . '*$'
+    let ind = ind + offset
+    let s:open_statement = 1
+    if vverb | echom vverb_str "Indent after an open statement." | endif
 
-    " Close statement
-    "   De-indent for an optional close parenthesis and a semicolon, and only
-    "   if there exists precedent non-whitespace char
-    elseif last_line =~ ')*\s*;\s*' . sv_comment . '*$' &&
-      \ last_line !~ '^\s*)*\s*;\s*' . sv_comment . '*$' &&
-      \ last_line !~ '\(//\|/\*\).*\S)*\s*;\s*' . sv_comment . '*$' &&
-      \ ( last_line2 =~ sv_openstat . '\s*' . sv_comment . '*$' &&
-      \ last_line2 !~ ';\s*//.*$') &&
-      \ last_line2 !~ '^\s*' . sv_comment . '$'
-      let ind = ind - offset
-      if vverb | echo vverb_str "De-indent after a close statement." | endif
-
-  " `ifdef and `else
-  elseif last_line =~ '^\s*`\<\(ifdef\|else\)\>'
+  " `ifdef or `ifndef or `elsif or `else
+  elseif last_line =~ '^\s*`\<\(ifn\?def\|elsif\|else\)\>' && indent_ifdef
     let ind = ind + offset
     if vverb
-      echo vverb_str "Indent after a `ifdef or `else statement."
+      echom vverb_str "Indent after a `ifdef or `ifndef or `elsif or `else statement."
     endif
 
   endif
@@ -177,17 +197,21 @@ function SystemVerilogIndent()
 
   " De-indent on the end of the block
   " join/end/endcase/endfunction/endtask/endspecify
-  if curr_line =~ '^\s*\<\(join\|join_any\|join_none\|\|end\|endcase\|while\)\>' ||
+  if curr_line =~ '^\s*\<\(join\|join_any\|join_none\|\|end\|endcase\)\>' ||
       \ curr_line =~ '^\s*\<\(endfunction\|endtask\|endspecify\|endclass\)\>' ||
       \ curr_line =~ '^\s*\<\(endpackage\|endsequence\|endclocking\|endinterface\)\>' ||
-      \ curr_line =~ '^\s*\<\(endgroup\|endproperty\|endchecker\|endprogram\)\>' ||
-      \ curr_line =~ '^\s*}'
+      \ curr_line =~ '^\s*\<\(endgroup\|endproperty\|endchecker\|endprogram\)\>'
     let ind = ind - offset
-    if vverb | echo vverb_str "De-indent the end of a block." | endif
+    if vverb | echom vverb_str "De-indent the end of a block." | endif
+    if s:open_statement == 1
+      let ind = ind - offset
+      let s:open_statement = 0
+      if vverb | echom vverb_str "De-indent the close statement." | endif
+    endif
   elseif curr_line =~ '^\s*\<endmodule\>'
     let ind = ind - indent_modules
     if vverb && indent_modules
-      echo vverb_str "De-indent the end of a module."
+      echom vverb_str "De-indent the end of a module."
     endif
 
   " De-indent on a stand-alone 'begin'
@@ -202,25 +226,46 @@ function SystemVerilogIndent()
       \ last_line =~ sv_openstat . '\s*' . sv_comment . '*$' )
       let ind = ind - offset
       if vverb
-	echo vverb_str "De-indent a stand alone begin statement."
+        echom vverb_str "De-indent a stand alone begin statement."
+      endif
+      if s:open_statement == 1
+        let ind = ind - offset
+        let s:open_statement = 0
+        if vverb | echom vverb_str "De-indent the close statement." | endif
       endif
     endif
 
-  " De-indent after the end of multiple-line statement
-  elseif curr_line =~ '^\s*)' &&
-    \ ( last_line =~ sv_openstat . '\s*' . sv_comment . '*$' ||
-    \ last_line !~ sv_openstat . '\s*' . sv_comment . '*$' &&
-    \ last_line2 =~ sv_openstat . '\s*' . sv_comment . '*$' )
+  " " Close statement
+  " "   De-indent for an optional close parenthesis and a semicolon, and only
+  " "   if there exists precedent non-whitespace char
+  " elseif last_line =~ ')*\s*;\s*' . sv_comment . '*$' &&
+  "   \ last_line !~ '^\s*)*\s*;\s*' . sv_comment . '*$' &&
+  "   \ last_line !~ '\(//\|/\*\).*\S)*\s*;\s*' . sv_comment . '*$' &&
+  "   \ ( last_line2 =~ sv_openstat . '\s*' . sv_comment . '*$' &&
+  "   \ last_line2 !~ ';\s*//.*$') &&
+  "   \ last_line2 !~ '^\s*' . sv_comment . '$'
+  "   let ind = ind - offset
+  "   if vverb | echom vverb_str "De-indent after a close statement." | endif
+
+  " " De-indent after the end of multiple-line statement
+  " elseif curr_line =~ '^\s*)' &&
+  "  \ ( last_line =~ sv_openstat . '\s*' . sv_comment . '*$' ||
+  "  \ last_line !~ sv_openstat . '\s*' . sv_comment . '*$' &&
+  "  \ last_line2 =~ sv_openstat . '\s*' . sv_comment . '*$' )
+  "   let ind = ind - offset
+  "   if vverb
+  "     echom vverb_str "De-indent the end of a multiple statement."
+  "   endif
+
+  " De-indent `elsif or `else or `endif
+  elseif curr_line =~ '^\s*`\<\(elsif\|else\|endif\)\>' && indent_ifdef
     let ind = ind - offset
-    if vverb
-      echo vverb_str "De-indent the end of a multiple statement."
+    if vverb | echom vverb_str "De-indent `elsif or `else or `endif statement." | endif
+    if b:systemverilog_open_statement == 1
+      let ind = ind - offset
+      let b:systemverilog_open_statement = 0
+      if vverb | echom vverb_str "De-indent the open statement." | endif
     endif
-
-  " De-indent `else and `endif
-  elseif curr_line =~ '^\s*`\<\(else\|endif\)\>'
-    let ind = ind - offset
-    if vverb | echo vverb_str "De-indent `else and `endif statement." | endif
-
   endif
 
   " Return the indentation
@@ -231,3 +276,4 @@ let &cpo = s:cpo_save
 unlet s:cpo_save
 
 " vim:sw=2
+

--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,0 +1,68 @@
+" vim: set ft=python sw=4 et:
+
+" START_INDENT
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+(200,
+300),
+400)
+
+open_paren_at_EOL(
+100, 200, 300, 400)
+
+" END_INDENT

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,0 +1,68 @@
+" vim: set ft=python sw=4 et:
+
+" START_INDENT
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+open_paren_not_at_EOL(100,
+                      (200,
+                       300),
+                      400)
+
+open_paren_at_EOL(
+        100, 200, 300, 400)
+
+" END_INDENT

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -930,7 +930,7 @@ function M.progress_pascal(bufnr)
   return 'progress'
 end
 
--- Distinguish between "default" and Cproto prototype file.
+-- Distinguish between "default", Prolog and Cproto prototype file.
 function M.proto(bufnr, default)
   -- Cproto files have a comment in the first line and a function prototype in
   -- the second line, it always ends in ";".  Indent files may also have
@@ -940,7 +940,18 @@ function M.proto(bufnr, default)
   if getlines(bufnr, 2):find('.;$') then
     return 'cpp'
   else
-    return default
+    -- Recognize Prolog by specific text in the first non-empty line;
+    -- require a blank after the '%' because Perl uses "%list" and "%translate"
+    local line = nextnonblank(bufnr, 1)
+    if
+      line and line:find(':%-')
+      or matchregex(line, [[\c\<prolog\>]])
+      or findany(line, { '^%s*%%+%s', '^%s*%%+$', '^%s*/%*' })
+    then
+      return 'prolog'
+    else
+      return default
+    end
   end
 end
 

--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -243,9 +243,6 @@ Examples:
 	comment character) you can >
 		:let b:match_skip = 'r:\(^\|[^\\]\)\(\\\\\)*%'
 <
-	See the $VIMRUNTIME/ftplugin/vim.vim for an example that uses both
-	syntax and a regular expression.
-
 ==============================================================================
 4. Supporting a New Language				*matchit-newlang*
 							*b:match_words*

--- a/runtime/syntax/abaqus.vim
+++ b/runtime/syntax/abaqus.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	Abaqus finite element input file (www.hks.com)
-" Maintainer:	Carl Osterwisch <osterwischc@asme.org>
+" Maintainer:	Carl Osterwisch <costerwi@gmail.com>
 " Last Change:	2002 Feb 24
 " Remark:	Huge improvement in folding performance--see filetype plugin
 
@@ -28,8 +28,7 @@ syn match abaqusBadLine	"^\s\+\*.*" display
 hi def link abaqusComment	Comment
 hi def link abaqusKeyword	Statement
 hi def link abaqusParameter	Identifier
-hi def link abaqusValue	Constant
-hi def link abaqusBadLine    Error
-
+hi def link abaqusValue		Constant
+hi def link abaqusBadLine    	Error
 
 let b:current_syntax = "abaqus"


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/48c3f4e0bff7efd289a7001b68c777b6f89a7057

partially skip `options.txt` (needs 9.0.0138)
omit terminal autochdir snippets (for now)