### PR TITLE
vim-patch:9.0.0176: checking character options is duplicated and incomplete

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1000,11 +1000,6 @@ EXTERN char e_fnametoolong[] INIT(= N_("E856: Filename too long"));
 EXTERN char e_float_as_string[] INIT(= N_("E806: using Float as a String"));
 EXTERN char e_cannot_edit_other_buf[] INIT(= N_("E788: Not allowed to edit another buffer now"));
 
-EXTERN char e_conflicts_with_value_of_listchars[]
-INIT(= N_("E834: Conflicts with value of 'listchars'"));
-EXTERN char e_conflicts_with_value_of_fillchars[]
-INIT(= N_("E835: Conflicts with value of 'fillchars'"));
-
 EXTERN char e_autocmd_err[] INIT(= N_("E5500: autocmd has thrown an exception: %s"));
 EXTERN char e_cmdmap_err[] INIT(= N_("E5520: <Cmd> mapping must end with <CR>"));
 EXTERN char e_cmdmap_repeated[]

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2844,25 +2844,9 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   cw_table = table;
   cw_table_size = (size_t)tv_list_len(l);
 
-  // Check that the new value does not conflict with 'fillchars' or
-  // 'listchars'.
-  char *error = NULL;
-  if (set_chars_option(curwin, &p_fcs, false) != NULL) {
-    error = e_conflicts_with_value_of_fillchars;
-  } else if (set_chars_option(curwin, &p_lcs, false) != NULL) {
-    error = e_conflicts_with_value_of_listchars;
-  } else {
-    FOR_ALL_TAB_WINDOWS(tp, wp) {
-      if (set_chars_option(wp, &wp->w_p_lcs, true) != NULL) {
-        error = e_conflicts_with_value_of_listchars;
-        break;
-      }
-      if (set_chars_option(wp, &wp->w_p_fcs, true) != NULL) {
-        error = e_conflicts_with_value_of_fillchars;
-        break;
-      }
-    }
-  }
+  // Check that the new value does not conflict with 'listchars' or
+  // 'fillchars'.
+  const char *const error = check_chars_options();
   if (error != NULL) {
     emsg(_(error));
     cw_table = cw_table_save;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -368,9 +368,17 @@ func Test_set_errors()
   call assert_fails('set sessionoptions=curdir,sesdir', 'E474:')
   call assert_fails('set foldmarker={{{,', 'E474:')
   call assert_fails('set sessionoptions=sesdir,curdir', 'E474:')
-  call assert_fails('set listchars=trail:· ambiwidth=double', 'E834:')
+  setlocal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
+  setlocal listchars=trail:-
+  setglobal listchars=trail:·
+  call assert_fails('set ambiwidth=double', 'E834:')
   set listchars&
-  call assert_fails('set fillchars=stl:· ambiwidth=double', 'E835:')
+  setlocal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
+  setlocal fillchars=stl:-
+  setglobal fillchars=stl:·
+  call assert_fails('set ambiwidth=double', 'E835:')
   set fillchars&
   call assert_fails('set fileencoding=latin1,utf-8', 'E474:')
   set nomodifiable


### PR DESCRIPTION
#### vim-patch:9.0.0176: checking character options is duplicated and incomplete

Problem:    Checking character options is duplicated and incomplete.
Solution:   Move checking to check_chars_options(). (closes vim/vim#10863)
https://github.com/vim/vim/commit/8ca29b6a3599b82b8822b7697cad63d0244c2d59