### PR TITLE
ci: bump Ubuntu images for workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 # Upgrade to gcc-11 to prevent it from using its builtins (#14150)
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     outputs:
       version: ${{ steps.build.outputs.version }}
       release: ${{ steps.build.outputs.release }}
@@ -50,7 +50,7 @@ jobs:
           retention-days: 1
 
   appimage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -150,7 +150,7 @@ jobs:
 
   publish:
     needs: [linux, appimage, macOS, windows]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 # Build on the oldest supported images, so we have broader compatibility
-# Upgrade to gcc-11 to prevent it from using its builtins (#14150)
+# Build with gcc-10 to prevent triggering #14150 (default is still gcc-9 on 20.04)
 jobs:
   linux:
     runs-on: ubuntu-20.04
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential cmake gcc-11 gettext libtool-bin locales ninja-build pkg-config unzip
+          sudo apt-get install -y autoconf automake build-essential cmake gettext libtool-bin locales ninja-build pkg-config unzip
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
@@ -35,7 +35,7 @@ jobs:
       - name: Build release
         id: build
         run: |
-          CC=gcc-11 make CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
+          CC=gcc-10 make CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH="
           printf '::set-output name=version::%s\n' "$(./build/bin/nvim --version | head -n 3 | sed -z 's/\n/%0A/g')"
           printf '::set-output name=release::%s\n' "$(./build/bin/nvim --version | head -n 1)"
           make DESTDIR="$GITHUB_WORKSPACE/build/release/nvim-linux64" install
@@ -58,11 +58,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential cmake gcc-11 gettext libtool-bin locales ninja-build pkg-config unzip
+          sudo apt-get install -y autoconf automake build-essential cmake gettext libtool-bin locales ninja-build pkg-config unzip
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
-        run: CC=gcc-11 make appimage-latest
+        run: CC=gcc-10 make appimage-latest
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
-        run: CC=gcc-11 make appimage-nightly
+        run: CC=gcc-10 make appimage-nightly
       - uses: actions/upload-artifact@v3
         with:
           name: appimage


### PR DESCRIPTION
* use `ubuntu-latest` instead of `ubuntu-20.04` (which is currently `latest`)
* use `ubuntu-20.04` instead of `ubuntu-18.04` (which is now deprecated and subject to outages, see
  https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)

This leaves a single `ubuntu-22.04` job, which is intentional. (`latest` will update to `22.04` in the near future, at which point this will be updated as well.)