### PR TITLE
vim-patch:9.0.0182: quarto files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1532,6 +1532,9 @@ au BufNewFile,BufRead *.ptl,*.pyi,SConstruct		   setf python
 " QL
 au BufRead,BufNewFile *.ql,*.qll		setf ql
 
+" Quarto
+au BufRead,BufNewFile *.qmd     setf quarto
+
 " Radiance
 au BufNewFile,BufRead *.rad,*.mat		setf radiance
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -776,6 +776,7 @@ local extension = {
   ptl = 'python',
   ql = 'ql',
   qll = 'ql',
+  qmd = 'quarto',
   R = function(path, bufnr)
     return require('vim.filetype.detect').r(bufnr)
   end,

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -441,6 +441,7 @@ let s:filename_checks = {
     \ 'python': ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', 'file.ptl', 'file.pyi', 'SConstruct'],
     \ 'ql': ['file.ql', 'file.qll'],
     \ 'quake': ['anybaseq2/file.cfg', 'anyid1/file.cfg', 'quake3/file.cfg', 'baseq2/file.cfg', 'id1/file.cfg', 'quake1/file.cfg', 'some-baseq2/file.cfg', 'some-id1/file.cfg', 'some-quake1/file.cfg'],
+    \ 'quarto': ['file.qmd'],
     \ 'r': ['file.r'],
     \ 'radiance': ['file.rad', 'file.mat'],
     \ 'raku': ['file.pm6', 'file.p6', 'file.t6', 'file.pod6', 'file.raku', 'file.rakumod', 'file.rakudoc', 'file.rakutest'],


### PR DESCRIPTION
vim-patch:9.0.0182: quarto files are not recognized
    
Problem:    Quarto files are not recognized.
Solution:   Recognize quarto files by the extension (Jonas Strittmatter,
                closes vim/vim#10880)
https://github.com/vim/vim/commit/3a9687fb2749cb3da6e3bbf60cb9eaa81f7889ae
