### PR TITLE
fix(mpack): make sure a `bool` always is a `bool`

### DIFF
--- a/src/mpack/mpack_core.h
+++ b/src/mpack/mpack_core.h
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <stddef.h>
+#include <stdbool.h>
 
 #ifdef __GNUC__
 # define FPURE __attribute__((const))


### PR DESCRIPTION
before, RelWithDebInfo linking gave this warning:

    src/mpack/conv.h:36:16: warning: type of ‘mpack_unpack_boolean’ does not match original declaration [-Wlto-type-mismatch]
       36 | MPACK_API bool mpack_unpack_boolean(mpack_token_t t) FUNUSED FPURE;
          |                ^
    src/mpack/conv.c:196:16: note: return value type mismatch
      196 | MPACK_API bool mpack_unpack_boolean(mpack_token_t t)
          |                ^