### PR TITLE
vim-patch:8.2.0559: clearing a struct is verbose

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -300,10 +300,10 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
   FUNC_API_SINCE(10)
 {
   exarg_T ea;
-  memset(&ea, 0, sizeof(ea));
+  CLEAR_FIELD(ea);
 
   CmdParseInfo cmdinfo;
-  memset(&cmdinfo, 0, sizeof(cmdinfo));
+  CLEAR_FIELD(cmdinfo);
 
   char *cmdline = NULL;
   char *cmdname = NULL;

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -224,7 +224,7 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height, Dictiona
   ui->event = remote_ui_event;
   ui->inspect = remote_ui_inspect;
 
-  memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
+  CLEAR_FIELD(ui->ui_ext);
 
   for (size_t i = 0; i < options.size; i++) {
     ui_set_option(ui, true, options.items[i].key, options.items[i].value, err);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -793,8 +793,8 @@ static void free_buffer(buf_T *buf)
   if (autocmd_busy) {
     // Do not free the buffer structure while autocommands are executing,
     // it's still needed. Free it when autocmd_busy is reset.
-    memset(&buf->b_namedm[0], 0, sizeof(buf->b_namedm));
-    memset(&buf->b_changelist[0], 0, sizeof(buf->b_changelist));
+    CLEAR_FIELD(buf->b_namedm);
+    CLEAR_FIELD(buf->b_changelist);
     buf->b_next = au_pending_free_buf;
     au_pending_free_buf = buf;
   } else {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -126,7 +126,7 @@ int buf_init_chartab(buf_T *buf, int global)
   }
 
   // Init word char flags all to false
-  memset(buf->b_chartab, 0, (size_t)32);
+  CLEAR_FIELD(buf->b_chartab);
 
   // In lisp mode the '-' character is included in keywords.
   if (buf->b_p_lisp) {

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -178,7 +178,7 @@ static inline void hist_free_entry(histentry_T *hisptr)
 static inline void clear_hist_entry(histentry_T *hisptr)
   FUNC_ATTR_NONNULL_ALL
 {
-  memset(hisptr, 0, sizeof(*hisptr));
+  CLEAR_POINTER(hisptr);
 }
 
 /// Check if command line 'str' is already in history.
@@ -714,7 +714,7 @@ const void *hist_iter(const void *const iter, const uint8_t history_type, const 
   }
   *hist = *hiter;
   if (zero) {
-    memset(hiter, 0, sizeof(*hiter));
+    CLEAR_POINTER(hiter);
   }
   if (hiter == hlast) {
     return NULL;

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -391,7 +391,7 @@ void decor_redraw_signs(buf_T *buf, int row, int *num_signs, sign_attrs_T sattrs
       sattrs[j] = sattrs[j - 1];
     }
     if (j < SIGN_SHOW_MAX) {
-      memset(&sattrs[j], 0, sizeof(sign_attrs_T));
+      CLEAR_FIELD(sattrs[j]);
       sattrs[j].sat_text = decor->sign_text;
       if (decor->sign_hl_id != 0) {
         sattrs[j].sat_texthl = syn_id2attr(decor->sign_hl_id);

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -956,13 +956,13 @@ void ex_diffupdate(exarg_T *eap)
 
   // Only use the internal method if it did not fail for one of the buffers.
   diffio_T diffio;
-  memset(&diffio, 0, sizeof(diffio));
+  CLEAR_FIELD(diffio);
   diffio.dio_internal = diff_internal() && !diff_internal_failed();
 
   diff_try_update(&diffio, idx_orig, eap);
   if (diffio.dio_internal && diff_internal_failed()) {
     // Internal diff failed, use external diff instead.
-    memset(&diffio, 0, sizeof(diffio));
+    CLEAR_FIELD(diffio);
     diff_try_update(&diffio, idx_orig, eap);
   }
 
@@ -1075,9 +1075,9 @@ static int diff_file_internal(diffio_T *diffio)
   xdemitconf_t emit_cfg;
   xdemitcb_t emit_cb;
 
-  memset(&param, 0, sizeof(param));
-  memset(&emit_cfg, 0, sizeof(emit_cfg));
-  memset(&emit_cb, 0, sizeof(emit_cb));
+  CLEAR_FIELD(param);
+  CLEAR_FIELD(emit_cfg);
+  CLEAR_FIELD(emit_cb);
 
   param.flags = (unsigned long)diff_algorithm;
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1308,7 +1308,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
   int quiet = flags & GLV_QUIET;
 
   // Clear everything in "lp".
-  memset(lp, 0, sizeof(lval_T));
+  CLEAR_POINTER(lp);
 
   if (skip) {
     // When skipping just find the end of the name.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2640,7 +2640,7 @@ static void f_get(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (argvars[0].v_type == VAR_PARTIAL) {
       pt = argvars[0].vval.v_partial;
     } else {
-      memset(&fref_pt, 0, sizeof(fref_pt));
+      CLEAR_FIELD(fref_pt);
       fref_pt.pt_name = (char_u *)argvars[0].vval.v_string;
       pt = &fref_pt;
     }
@@ -7127,7 +7127,6 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
   long time_limit = 0;
   int options = SEARCH_KEEP;
   int subpatnum;
-  searchit_arg_T sia;
   bool use_skip = false;
 
   const char *const pat = tv_get_string(&argvars[0]);
@@ -7178,9 +7177,10 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 
   pos = save_cursor = curwin->w_cursor;
   pos_T firstpos = { 0 };
-  memset(&sia, 0, sizeof(sia));
-  sia.sa_stop_lnum = (linenr_T)lnum_stop;
-  sia.sa_tm = &tm;
+  searchit_arg_T sia = {
+    .sa_stop_lnum = (linenr_T)lnum_stop,
+    .sa_tm = &tm,
+  };
 
   // Repeat until {skip} returns false.
   for (;;) {
@@ -7799,10 +7799,10 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
   clearpos(&foundpos);
   pat = pat3;
   for (;;) {
-    searchit_arg_T sia;
-    memset(&sia, 0, sizeof(sia));
-    sia.sa_stop_lnum = lnum_stop;
-    sia.sa_tm = &tm;
+    searchit_arg_T sia = {
+      .sa_stop_lnum = lnum_stop,
+      .sa_tm = &tm,
+    };
 
     n = searchit(curwin, curbuf, &pos, NULL, dir, pat, 1L,
                  options, RE_SEARCH, &sia);
@@ -9500,7 +9500,7 @@ static void f_synconcealed(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   const linenr_T lnum = tv_get_lnum(argvars);
   const colnr_T col = (colnr_T)tv_get_number(&argvars[1]) - 1;
 
-  memset(str, NUL, sizeof(str));
+  CLEAR_FIELD(str);
 
   if (lnum >= 1 && lnum <= curbuf->b_ml.ml_line_count && col >= 0
       && (size_t)col <= STRLEN(ml_get(lnum)) && curwin->w_p_cole > 0) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -233,7 +233,7 @@ void tv_list_init_static10(staticList10_T *const sl)
 #define SL_SIZE ARRAY_SIZE(sl->sl_items)
   list_T *const l = &sl->sl_list;
 
-  memset(sl, 0, sizeof(staticList10_T));
+  CLEAR_POINTER(sl);
   l->lv_first = &sl->sl_items[0];
   l->lv_last = &sl->sl_items[SL_SIZE - 1];
   l->lv_refcount = DO_NOT_FREE_CNT;
@@ -261,7 +261,7 @@ void tv_list_init_static10(staticList10_T *const sl)
 void tv_list_init_static(list_T *const l)
   FUNC_ATTR_NONNULL_ALL
 {
-  memset(l, 0, sizeof(*l));
+  CLEAR_POINTER(l);
   l->lv_refcount = DO_NOT_FREE_CNT;
   list_log(l, NULL, NULL, "sinit");
 }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1702,7 +1702,7 @@ char_u *trans_function_name(char_u **pp, bool skip, int flags, funcdict_T *fdp, 
   lval_T lv;
 
   if (fdp != NULL) {
-    memset(fdp, 0, sizeof(funcdict_T));
+    CLEAR_POINTER(fdp);
   }
   start = *pp;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -391,7 +391,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
   if (flags & DOCMD_EXCRESET) {
     save_dbg_stuff(&debug_saved);
   } else {
-    memset(&debug_saved, 0, sizeof(debug_saved));
+    CLEAR_FIELD(debug_saved);
   }
 
   initial_trylevel = trylevel;
@@ -1428,16 +1428,17 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   char *after_modifier = NULL;
 
   // Initialize cmdinfo
-  memset(cmdinfo, 0, sizeof(*cmdinfo));
+  CLEAR_POINTER(cmdinfo);
 
   // Initialize eap
-  memset(eap, 0, sizeof(*eap));
-  eap->line1 = 1;
-  eap->line2 = 1;
-  eap->cmd = cmdline;
-  eap->cmdlinep = &cmdline;
-  eap->getline = NULL;
-  eap->cookie = NULL;
+  *eap = (exarg_T){
+    .line1 = 1,
+    .line2 = 1,
+    .cmd = cmdline,
+    .cmdlinep = &cmdline,
+    .getline = NULL,
+    .cookie = NULL,
+  };
 
   const bool save_ex_pressedreturn = ex_pressedreturn;
   // Parse command modifiers
@@ -1877,10 +1878,10 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
   const int save_reg_executing = reg_executing;
   const bool save_pending_end_reg_executing = pending_end_reg_executing;
 
-  exarg_T ea;
-  memset(&ea, 0, sizeof(ea));
-  ea.line1 = 1;
-  ea.line2 = 1;
+  exarg_T ea = {
+    .line1 = 1,
+    .line2 = 1,
+  };
   ex_nesting_level++;
 
   // When the last file has not been edited :q has to be typed twice.
@@ -6021,12 +6022,11 @@ theend:
 /// Open a new tab page.
 void tabpage_new(void)
 {
-  exarg_T ea;
-
-  memset(&ea, 0, sizeof(ea));
-  ea.cmdidx = CMD_tabnew;
-  ea.cmd = "tabn";
-  ea.arg = "";
+  exarg_T ea = {
+    .cmdidx = CMD_tabnew,
+    .cmd = "tabn",
+    .arg = "",
+  };
   ex_splitview(&ea);
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -311,7 +311,6 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
   int delim;
   char *end;
   char *dummy;
-  exarg_T ea;
   pos_T save_cursor;
   bool use_last_pat;
   bool retval = false;
@@ -336,11 +335,12 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
   }
 
   emsg_off++;
-  memset(&ea, 0, sizeof(ea));
-  ea.line1 = 1;
-  ea.line2 = 1;
-  ea.cmd = (char *)ccline.cmdbuff;
-  ea.addr_type = ADDR_LINES;
+  exarg_T ea = {
+    .line1 = 1,
+    .line2 = 1,
+    .cmd = (char *)ccline.cmdbuff,
+    .addr_type = ADDR_LINES,
+  };
 
   cmdmod_T dummy_cmdmod;
   parse_command_modifiers(&ea, &dummy, &dummy_cmdmod, true);
@@ -453,7 +453,6 @@ static void may_do_incsearch_highlighting(int firstc, long count, incsearch_stat
 {
   pos_T end_pos;
   proftime_T tm;
-  searchit_arg_T sia;
   int skiplen, patlen;
   char_u next_char;
   char_u use_last_pat;
@@ -516,8 +515,9 @@ static void may_do_incsearch_highlighting(int firstc, long count, incsearch_stat
       search_flags += SEARCH_START;
     }
     ccline.cmdbuff[skiplen + patlen] = NUL;
-    memset(&sia, 0, sizeof(sia));
-    sia.sa_tm = &tm;
+    searchit_arg_T sia = {
+      .sa_tm = &tm,
+    };
     found = do_search(NULL, firstc == ':' ? '/' : firstc, search_delim,
                       ccline.cmdbuff + skiplen, count,
                       search_flags, &sia);
@@ -731,7 +731,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
     save_cmdline(&save_ccline);
     did_save_ccline = true;
   } else if (init_ccline) {
-    memset(&ccline, 0, sizeof(struct cmdline_info));
+    CLEAR_FIELD(ccline);
   }
 
   if (s->firstc == -1) {
@@ -2677,7 +2677,7 @@ char *getcmdline_prompt(const int firstc, const char *const prompt, const int at
     save_cmdline(&save_ccline);
     did_save_ccline = true;
   } else {
-    memset(&ccline, 0, sizeof(struct cmdline_info));
+    CLEAR_FIELD(ccline);
   }
   ccline.prompt_id = last_prompt_id++;
   ccline.cmdprompt = (char_u *)prompt;
@@ -3640,7 +3640,7 @@ void put_on_cmdline(char_u *str, int len, int redraw)
 static void save_cmdline(struct cmdline_info *ccp)
 {
   *ccp = ccline;
-  memset(&ccline, 0, sizeof(struct cmdline_info));
+  CLEAR_FIELD(ccline);
   ccline.prev_ccline = ccp;
   ccline.cmdbuff = NULL;  // signal that ccline is not in use
 }
@@ -6029,7 +6029,7 @@ int get_list_range(char_u **str, int *num1, int *num2)
 
 void cmdline_init(void)
 {
-  memset(&ccline, 0, sizeof(struct cmdline_info));
+  CLEAR_FIELD(ccline);
 }
 
 /// Open a window on the current command line and history.  Allow editing in

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5122,7 +5122,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
   // file, not reset the syntax highlighting, clear marks, diff status, etc.
   // Force the fileformat and encoding to be the same.
   if (reload_options) {
-    memset(&ea, 0, sizeof(ea));
+    CLEAR_FIELD(ea);
   } else {
     prep_exarg(&ea, buf);
   }

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -632,8 +632,8 @@ void ex_hardcopy(exarg_T *eap)
   int page_line;
   int jobsplit;
 
-  memset(&settings, 0, sizeof(prt_settings_T));
-  settings.has_color = TRUE;
+  CLEAR_FIELD(settings);
+  settings.has_color = true;
 
   if (*eap->arg == '>') {
     char *errormsg = NULL;
@@ -734,7 +734,7 @@ void ex_hardcopy(exarg_T *eap)
     prt_pos_T page_prtpos;              // print position at page start
     int side;
 
-    memset(&page_prtpos, 0, sizeof(prt_pos_T));
+    CLEAR_FIELD(page_prtpos);
     page_prtpos.file_line = eap->line1;
     prtpos = page_prtpos;
 
@@ -1718,7 +1718,7 @@ static bool prt_open_resource(struct prt_ps_resource_S *resource)
     semsg(_("E624: Can't open file \"%s\""), resource->filename);
     return false;
   }
-  memset(prt_resfile.buffer, NUL, PRT_FILE_BUFFER_LEN);
+  CLEAR_FIELD(prt_resfile.buffer);
 
   // Parse first line to ensure valid resource file
   prt_resfile.len = (int)fread((char *)prt_resfile.buffer, sizeof(char_u),

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -45,7 +45,7 @@ char hash_removed;
 void hash_init(hashtab_T *ht)
 {
   // This zeroes all "ht_" entries and all the "hi_key" in "ht_smallarray".
-  memset(ht, 0, sizeof(hashtab_T));
+  CLEAR_POINTER(ht);
   ht->ht_array = ht->ht_smallarray;
   ht->ht_mask = HT_INIT_SIZE - 1;
 }
@@ -342,11 +342,13 @@ static void hash_may_resize(hashtab_T *ht, size_t minitems)
   hashitem_T *oldarray = keep_smallarray
     ? memcpy(temparray, ht->ht_smallarray, sizeof(temparray))
     : ht->ht_array;
+
+  if (newarray_is_small) {
+    CLEAR_FIELD(ht->ht_smallarray);
+  }
   hashitem_T *newarray = newarray_is_small
     ? ht->ht_smallarray
-    : xmalloc(sizeof(hashitem_T) * newsize);
-
-  memset(newarray, 0, sizeof(hashitem_T) * newsize);
+    : xcalloc(newsize, sizeof(hashitem_T));
 
   // Move all the items from the old array to the new one, placing them in
   // the right spot. The new array won't have any removed items, thus this

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1765,7 +1765,7 @@ static int syn_add_group(const char *name, size_t len)
 
   // Append another syntax_highlight entry.
   HlGroup *hlgp = GA_APPEND_VIA_PTR(HlGroup, &highlight_ga);
-  memset(hlgp, 0, sizeof(*hlgp));
+  CLEAR_POINTER(hlgp);
   hlgp->sg_name = (char_u *)arena_memdupz(&highlight_arena, name, len);
   hlgp->sg_rgb_bg = -1;
   hlgp->sg_rgb_fg = -1;
@@ -1863,7 +1863,7 @@ static void combine_stl_hlt(int id, int id_S, int id_alt, int hlcnt, int i, int 
   HlGroup *const hlt = hl_table;
 
   if (id_alt == 0) {
-    memset(&hlt[hlcnt + i], 0, sizeof(HlGroup));
+    CLEAR_POINTER(&hlt[hlcnt + i]);
     hlt[hlcnt + i].sg_cterm = highlight_attr[hlf];
     hlt[hlcnt + i].sg_gui = highlight_attr[hlf];
   } else {
@@ -1945,7 +1945,7 @@ void highlight_changed(void)
   hlcnt = highlight_ga.ga_len;
   if (id_S == -1) {
     // Make sure id_S is always valid to simplify code below. Use the last entry
-    memset(&hl_table[hlcnt + 9], 0, sizeof(HlGroup));
+    CLEAR_POINTER(&hl_table[hlcnt + 9]);
     id_S = hlcnt + 10;
   }
   for (int i = 0; i < 9; i++) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2139,7 +2139,7 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     }
   } else {
     word = tv_get_string_chk(tv);
-    memset(cptext, 0, sizeof(cptext));
+    CLEAR_FIELD(cptext);
   }
   if (word == NULL || (!empty && *word == NUL)) {
     for (size_t i = 0; i < CPT_COUNT; i++) {

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -59,7 +59,7 @@ static LuaTableProps nlua_traverse_table(lua_State *const lstate)
   size_t other_keys_num = 0;  // Number of keys that are not string, integral
                               // or type keys.
   LuaTableProps ret;
-  memset(&ret, 0, sizeof(ret));
+  CLEAR_FIELD(ret);
   if (!lua_checkstack(lstate, lua_gettop(lstate) + 3)) {
     semsg(_("E1502: Lua failed to grow stack to %i"), lua_gettop(lstate) + 2);
     ret.type = kObjectTypeNil;

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -447,7 +447,7 @@ static nlua_ref_state_t *nlua_new_ref_state(lua_State *lstate, bool is_thread)
   FUNC_ATTR_NONNULL_ALL
 {
   nlua_ref_state_t *ref_state = lua_newuserdata(lstate, sizeof(*ref_state));
-  memset(ref_state, 0, sizeof(*ref_state));
+  CLEAR_POINTER(ref_state);
   ref_state->nil_ref = LUA_NOREF;
   ref_state->empty_dict_ref = LUA_NOREF;
   if (!is_thread) {

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -269,9 +269,9 @@ int nlua_xdl_diff(lua_State *lstate)
   xpparam_t params;
   xdemitcb_t ecb;
 
-  memset(&cfg, 0, sizeof(cfg));
-  memset(&params, 0, sizeof(params));
-  memset(&ecb, 0, sizeof(ecb));
+  CLEAR_FIELD(cfg);
+  CLEAR_FIELD(params);
+  CLEAR_FIELD(ecb);
 
   NluaXdiffMode mode = kNluaXdiffModeUnified;
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1418,7 +1418,7 @@ scripterror:
  * copied, so that they can be changed. */
 static void init_params(mparm_T *paramp, int argc, char **argv)
 {
-  memset(paramp, 0, sizeof(*paramp));
+  CLEAR_POINTER(paramp);
   paramp->argc = argc;
   paramp->argv = argv;
   paramp->use_debug_break_level = -1;

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -333,7 +333,7 @@ static int str_to_mapargs(const char_u *strargs, bool is_unmap, MapArguments *ma
 {
   const char_u *to_parse = strargs;
   to_parse = (char_u *)skipwhite((char *)to_parse);
-  memset(mapargs, 0, sizeof(*mapargs));
+  CLEAR_POINTER(mapargs);
 
   // Accept <buffer>, <nowait>, <silent>, <expr>, <script>, and <unique> in
   // any order.

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -86,7 +86,7 @@ void clear_fmark(fmark_T *fm)
   FUNC_ATTR_NONNULL_ALL
 {
   free_fmark(*fm);
-  memset(fm, 0, sizeof(*fm));
+  CLEAR_POINTER(fm);
 }
 
 /*
@@ -1741,7 +1741,7 @@ void free_all_marks(void)
       free_xfmark(namedfm[i]);
     }
   }
-  memset(&namedfm[0], 0, sizeof(namedfm));
+  CLEAR_FIELD(namedfm);
 }
 #endif
 

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -821,7 +821,7 @@ static bool mf_do_open(memfile_T *mfp, char_u *fname, int flags)
 /// Initialize an empty hash table.
 static void mf_hash_init(mf_hashtab_T *mht)
 {
-  memset(mht, 0, sizeof(mf_hashtab_T));
+  CLEAR_POINTER(mht);
   mht->mht_buckets = mht->mht_small_buckets;
   mht->mht_mask = MHT_INIT_SIZE - 1;
 }
@@ -924,7 +924,7 @@ static void mf_hash_grow(mf_hashtab_T *mht)
     /// a power of two.
 
     mf_hashitem_T *tails[MHT_GROWTH_FACTOR];
-    memset(tails, 0, sizeof(tails));
+    CLEAR_FIELD(tails);
 
     for (mf_hashitem_T *mhi = mht->mht_buckets[i];
          mhi != NULL; mhi = mhi->mhi_next) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -466,7 +466,7 @@ void normal_enter(bool cmdwin, bool noexmode)
 
 static void normal_prepare(NormalState *s)
 {
-  memset(&s->ca, 0, sizeof(s->ca));  // also resets ca.retval
+  CLEAR_FIELD(s->ca);  // also resets s->ca.retval
   s->ca.oap = &s->oa;
 
   // Use a count remembered from before entering an operator. After typing "3d"
@@ -4149,7 +4149,7 @@ void do_nv_ident(int c1, int c2)
   cmdarg_T ca;
 
   clear_oparg(&oa);
-  memset(&ca, 0, sizeof(ca));
+  CLEAR_FIELD(ca);
   ca.oap = &oa;
   ca.cmdchar = c1;
   ca.nchar = c2;
@@ -4845,7 +4845,7 @@ static int normal_search(cmdarg_T *cap, int dir, char_u *pat, int opt, int *wrap
   cap->oap->use_reg_one = true;
   curwin->w_set_curswant = true;
 
-  memset(&sia, 0, sizeof(sia));
+  CLEAR_FIELD(sia);
   i = do_search(cap->oap, dir, dir, pat, cap->count1,
                 opt | SEARCH_OPT | SEARCH_ECHO | SEARCH_MSG, &sia);
   if (wrapped != NULL) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5789,7 +5789,7 @@ static void str_to_reg(yankreg_T *y_ptr, MotionType yank_type, const char_u *str
 
 void clear_oparg(oparg_T *oap)
 {
-  memset(oap, 0, sizeof(oparg_T));
+  CLEAR_POINTER(oap);
 }
 
 ///  Count the number of bytes, characters and "words" in a line.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6515,7 +6515,7 @@ void buf_copy_options(buf_T *buf, int flags)
     }
 
     if (should_copy || (flags & BCO_ALWAYS)) {
-      memset(buf->b_p_script_ctx, 0, sizeof(buf->b_p_script_ctx));
+      CLEAR_FIELD(buf->b_p_script_ctx);
       init_buf_opt_idx();
       // Don't copy the options specific to a help buffer when
       // BCO_NOHELP is given or the options were initialized already

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1051,7 +1051,7 @@ int os_remove(const char *path)
 bool os_fileinfo(const char *path, FileInfo *file_info)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  memset(file_info, 0, sizeof(*file_info));
+  CLEAR_POINTER(file_info);
   return os_stat(path, &(file_info->stat)) == kLibuvSuccess;
 }
 
@@ -1063,7 +1063,7 @@ bool os_fileinfo(const char *path, FileInfo *file_info)
 bool os_fileinfo_link(const char *path, FileInfo *file_info)
   FUNC_ATTR_NONNULL_ARG(2)
 {
-  memset(file_info, 0, sizeof(*file_info));
+  CLEAR_POINTER(file_info);
   if (path == NULL) {
     return false;
   }
@@ -1087,7 +1087,7 @@ bool os_fileinfo_fd(int file_descriptor, FileInfo *file_info)
   FUNC_ATTR_NONNULL_ALL
 {
   uv_fs_t request;
-  memset(file_info, 0, sizeof(*file_info));
+  CLEAR_POINTER(file_info);
   fs_loop_lock();
   bool ok = uv_fs_fstat(&fs_loop,
                         &request,

--- a/src/nvim/popupmnu.c
+++ b/src/nvim/popupmnu.c
@@ -999,7 +999,7 @@ static void pum_execute_menu(vimmenu_T *menu, int mode)
 
   for (vimmenu_T *mp = menu->children; mp != NULL; mp = mp->next) {
     if ((mp->modes & mp->enabled & mode) && idx++ == pum_selected) {
-      memset(&ea, 0, sizeof(ea));
+      CLEAR_FIELD(ea);
       execute_menu(&ea, mp, -1);
       break;
     }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -1224,7 +1224,7 @@ static void qf_new_list(qf_info_T *qi, const char *qf_title)
     qi->qf_curlist = qi->qf_listcount++;
   }
   qf_list_T *qfl = qf_get_curlist(qi);
-  memset(qfl, 0, sizeof(qf_list_T));
+  CLEAR_POINTER(qfl);
   qf_store_title(qfl, qf_title);
   qfl->qfl_type = qi->qfl_type;
   qfl->qf_id = ++last_qf_id;
@@ -5299,7 +5299,7 @@ static bool existing_swapfile(const buf_T *buf)
 /// :{count}vimgrep /{pattern}/[g][j] {file} ...
 static int vgr_process_args(exarg_T *eap, vgr_args_T *args)
 {
-  memset(args, 0, sizeof(*args));
+  CLEAR_POINTER(args);
 
   args->regmatch.regprog = NULL;
   args->qf_title = xstrdup(qf_cmdtitle(*eap->cmdlinep));

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -466,7 +466,7 @@ static void regcomp_start(char_u *expr, int re_flags)                        // 
 
   num_complex_braces = 0;
   regnpar = 1;
-  memset(had_endbrace, 0, sizeof(had_endbrace));
+  CLEAR_FIELD(had_endbrace);
   regnzpar = 1;
   re_has_z = 0;
   regsize = 0L;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -5055,7 +5055,7 @@ skip_add:
 
     // avoid compiler warnings
     save_ptr = NULL;
-    memset(&save_multipos, 0, sizeof(save_multipos));
+    CLEAR_FIELD(save_multipos);
 
     // Set the position (with "off" added) in the subexpression.  Save
     // and restore it when it was in use.  Otherwise fill any gap.
@@ -5180,7 +5180,7 @@ skip_add:
       save_ptr = sub->list.line[subidx].end;
       sub->list.line[subidx].end = rex.input + off;
       // avoid compiler warnings
-      memset(&save_multipos, 0, sizeof(save_multipos));
+      CLEAR_FIELD(save_multipos);
     }
 
     subs = addstate(l, state->out, subs, pim, off_arg);

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2399,7 +2399,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
     }
   }
 
-  memset(sattrs, 0, sizeof(sattrs));
+  CLEAR_FIELD(sattrs);
   num_signs = buf_get_signattrs(wp->w_buffer, lnum, sattrs);
   decor_redraw_signs(buf, lnum - 1, &num_signs, sattrs);
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -272,7 +272,7 @@ void free_search_patterns(void)
   free_spat(&spats[0]);
   free_spat(&spats[1]);
 
-  memset(spats, 0, sizeof(spats));
+  CLEAR_FIELD(spats);
 
   if (mr_pattern_alloced) {
     xfree(mr_pattern);
@@ -432,7 +432,7 @@ void set_last_csearch(int c, char_u *s, int len)
   if (len) {
     memcpy(lastc_bytes, s, (size_t)len);
   } else {
-    memset(lastc_bytes, 0, sizeof(lastc_bytes));
+    CLEAR_FIELD(lastc_bytes);
   }
 }
 
@@ -4552,7 +4552,7 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, searchst
   static buf_T *lbuf = NULL;
   proftime_T start;
 
-  memset(stat, 0, sizeof(searchstat_T));
+  CLEAR_POINTER(stat);
 
   if (dirc == 0 && !recompute && !EMPTY_POS(lastpos)) {
     stat->cur = cur;
@@ -5997,7 +5997,7 @@ void get_search_pattern(SearchPattern *const pat)
 void get_substitute_pattern(SearchPattern *const pat)
 {
   memcpy(pat, &(spats[1]), sizeof(spats[1]));
-  memset(&(pat->off), 0, sizeof(pat->off));
+  CLEAR_FIELD(pat->off);
 }
 
 /// Set last search pattern
@@ -6013,7 +6013,7 @@ void set_substitute_pattern(const SearchPattern pat)
 {
   free_spat(&spats[1]);
   memcpy(&(spats[1]), &pat, sizeof(spats[1]));
-  memset(&(spats[1].off), 0, sizeof(spats[1].off));
+  CLEAR_FIELD(spats[1].off);
 }
 
 /// Set last used search pattern

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2189,7 +2189,7 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
       k = kh_put(file_marks, &wms->file_marks, fname, &kh_ret);
       FileMarks *const filemarks = &kh_val(&wms->file_marks, k);
       if (kh_ret > 0) {
-        memset(filemarks, 0, sizeof(*filemarks));
+        CLEAR_POINTER(filemarks);
       }
       if (entry.timestamp > filemarks->greatest_timestamp) {
         filemarks->greatest_timestamp = entry.timestamp;
@@ -2752,7 +2752,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
       k = kh_put(file_marks, &wms->file_marks, fname, &kh_ret);
       FileMarks *const filemarks = &kh_val(&wms->file_marks, k);
       if (kh_ret > 0) {
-        memset(filemarks, 0, sizeof(*filemarks));
+        CLEAR_POINTER(filemarks);
       }
       do {
         fmark_T fm;
@@ -3478,7 +3478,7 @@ shada_read_next_item_start:
   // data union are NULL so they are safe to xfree(). This is needed in case
   // somebody calls goto shada_read_next_item_error before anything is set in
   // the switch.
-  memset(entry, 0, sizeof(*entry));
+  CLEAR_POINTER(entry);
   if (sd_reader->eof) {
     return kSDReadStatusFinished;
   }

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -490,7 +490,7 @@ int buf_get_signattrs(buf_T *buf, linenr_T lnum, sign_attrs_T sattrs[])
 
     if (sign->se_lnum == lnum) {
       sign_attrs_T sattr;
-      memset(&sattr, 0, sizeof(sattr));
+      CLEAR_FIELD(sattr);
       sattr.sat_typenr = sign->se_typenr;
       sp = find_sign_by_typenr(sign->se_typenr);
       if (sp != NULL) {

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -374,7 +374,7 @@ size_t spell_check(win_T *wp, char_u *ptr, hlf_T *attrp, int *capcol, bool docou
     return 1;
   }
 
-  memset(&mi, 0, sizeof(matchinf_T));
+  CLEAR_FIELD(mi);
 
   // A number is always OK.  Also skip hexadecimal numbers 0xFF99 and
   // 0X99FF.  But always do check spelling to find "3GPP" and "11
@@ -2338,7 +2338,7 @@ theend:
 // Clear the midword characters for buffer "buf".
 static void clear_midword(win_T *wp)
 {
-  memset(wp->w_s->b_spell_ismw, 0, 256);
+  CLEAR_FIELD(wp->w_s->b_spell_ismw);
   XFREE_CLEAR(wp->w_s->b_spell_ismw_mb);
 }
 
@@ -2610,9 +2610,9 @@ void clear_spell_chartab(spelltab_T *sp)
 {
   int i;
 
-  // Init everything to false.
-  memset(sp->st_isw, false, sizeof(sp->st_isw));
-  memset(sp->st_isu, false, sizeof(sp->st_isu));
+  // Init everything to false (zero).
+  CLEAR_FIELD(sp->st_isw);
+  CLEAR_FIELD(sp->st_isu);
 
   for (i = 0; i < 256; i++) {
     sp->st_fold[i] = (char_u)i;
@@ -3248,7 +3248,7 @@ static void spell_find_suggest(char_u *badptr, int badlen, suginfo_T *su, int ma
   bool did_intern = false;
 
   // Set the info in "*su".
-  memset(su, 0, sizeof(suginfo_T));
+  CLEAR_POINTER(su);
   ga_init(&su->su_ga, (int)sizeof(suggest_T), 10);
   ga_init(&su->su_sga, (int)sizeof(suggest_T), 10);
   if (*badptr == NUL) {
@@ -3760,7 +3760,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char_u *fword, bool so
   // word).
   depth = 0;
   sp = &stack[0];
-  memset(sp, 0, sizeof(trystate_T));  // -V512
+  CLEAR_POINTER(sp);  // -V1068
   sp->ts_curi = 1;
 
   if (soundfold) {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -4146,8 +4146,8 @@ static wordnode_T *get_wordnode(spellinfo_T *spin)
   } else {
     n = spin->si_first_free;
     spin->si_first_free = n->wn_child;
-    memset(n, 0, sizeof(wordnode_T));
-    --spin->si_free_count;
+    CLEAR_POINTER(n);
+    spin->si_free_count--;
   }
 #ifdef SPELL_PRINTTREE
   if (n != NULL) {
@@ -5282,7 +5282,7 @@ static void mkspell(int fcount, char **fnames, bool ascii, bool over_write, bool
   bool error = false;
   spellinfo_T spin;
 
-  memset(&spin, 0, sizeof(spin));
+  CLEAR_FIELD(spin);
   spin.si_verbose = !added_word;
   spin.si_ascii = ascii;
   spin.si_followup = true;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2506,7 +2506,7 @@ static void update_si_end(stateitem_T *sip, int startcol, bool force)
 static void push_current_state(int idx)
 {
   stateitem_T *p = GA_APPEND_VIA_PTR(stateitem_T, &current_state);
-  memset(p, 0, sizeof(*p));
+  CLEAR_POINTER(p);
   p->si_idx = idx;
 }
 
@@ -4453,7 +4453,7 @@ static void syn_cmd_match(exarg_T *eap, int syncing)
 
   // get the pattern.
   init_syn_patterns();
-  memset(&item, 0, sizeof(item));
+  CLEAR_FIELD(item);
   rest = get_syn_pattern(rest, &item);
   if (vim_regcomp_had_eol() && !(syn_opt_arg.flags & HL_EXCLUDENL)) {
     syn_opt_arg.flags |= HL_HAS_EOL;
@@ -4945,7 +4945,7 @@ static int syn_add_cluster(char_u *name)
 
   syn_cluster_T *scp = GA_APPEND_VIA_PTR(syn_cluster_T,
                                          &curwin->w_s->b_syn_clusters);
-  memset(scp, 0, sizeof(*scp));
+  CLEAR_POINTER(scp);
   scp->scl_name = name;
   scp->scl_name_u = vim_strsave_up(name);
   scp->scl_list = NULL;
@@ -5624,8 +5624,7 @@ void ex_ownsyntax(exarg_T *eap)
   char_u *new_value;
 
   if (curwin->w_s == &curwin->w_buffer->b_s) {
-    curwin->w_s = xmalloc(sizeof(synblock_T));
-    memset(curwin->w_s, 0, sizeof(synblock_T));
+    curwin->w_s = xcalloc(1, sizeof(synblock_T));
     hash_init(&curwin->w_s->b_keywtab);
     hash_init(&curwin->w_s->b_keywtab_ic);
     // TODO: Keep the spell checking as it was. NOLINT(readability/todo)

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1520,7 +1520,7 @@ int find_tags(char_u *pat, int *num_matches, char ***matchesp, int flags, int mi
 
   // This is only to avoid a compiler warning for using search_info
   // uninitialised.
-  memset(&search_info, 0, 1);  // -V512
+  CLEAR_FIELD(search_info);
 
   if (*curbuf->b_p_tfu != NUL && use_tfu && !tfu_in_use) {
     tfu_in_use = true;
@@ -1860,7 +1860,7 @@ parse_line:
         // For "normal" tags: Do a quick check if the tag matches.
         // This speeds up tag searching a lot!
         if (orgpat.headlen) {
-          memset(&tagp, 0, sizeof(tagp));
+          CLEAR_FIELD(tagp);
           tagp.tagname = lbuf;
           tagp.tagname_end = (char_u *)vim_strchr((char *)lbuf, TAB);
           if (tagp.tagname_end == NULL) {
@@ -2342,7 +2342,7 @@ int get_tagfname(tagname_T *tnp, int first, char_u *buf)
   char_u *r_ptr;
 
   if (first) {
-    memset(tnp, 0, sizeof(tagname_T));
+    CLEAR_POINTER(tnp);
   }
 
   if (curbuf->b_help) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -171,7 +171,7 @@ UI *tui_start(void)
   ui->option_set = tui_option_set;
   ui->raw_line = tui_raw_line;
 
-  memset(ui->ui_ext, 0, sizeof(ui->ui_ext));
+  CLEAR_FIELD(ui->ui_ext);
   ui->ui_ext[kUILinegrid] = true;
   ui->ui_ext[kUITermColors] = true;
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -565,7 +565,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, int re
    * add lines in front of entry list
    */
   uep = xmalloc(sizeof(u_entry_T));
-  memset(uep, 0, sizeof(u_entry_T));
+  CLEAR_POINTER(uep);
 #ifdef U_DEBUG
   uep->ue_magic = UE_MAGIC;
 #endif
@@ -895,7 +895,7 @@ static bool serialize_uhp(bufinfo_T *bi, u_header_T *uhp)
 static u_header_T *unserialize_uhp(bufinfo_T *bi, const char *file_name)
 {
   u_header_T *uhp = xmalloc(sizeof(u_header_T));
-  memset(uhp, 0, sizeof(u_header_T));
+  CLEAR_POINTER(uhp);
 #ifdef U_DEBUG
   uhp->uh_magic = UH_MAGIC;
 #endif
@@ -1083,7 +1083,7 @@ static bool serialize_uep(bufinfo_T *bi, u_entry_T *uep)
 static u_entry_T *unserialize_uep(bufinfo_T *bi, bool *error, const char *file_name)
 {
   u_entry_T *uep = xmalloc(sizeof(u_entry_T));
-  memset(uep, 0, sizeof(u_entry_T));
+  CLEAR_POINTER(uep);
 #ifdef U_DEBUG
   uep->ue_magic = UE_MAGIC;
 #endif
@@ -1183,7 +1183,6 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   FILE *fp = NULL;
   int perm;
   bool write_ok = false;
-  bufinfo_T bi;
 
   if (name == NULL) {
     file_name = u_get_undo_file_name(buf->b_ffname, false);
@@ -1310,11 +1309,11 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   // Undo must be synced.
   u_sync(true);
 
-  /*
-   * Write the header.
-   */
-  bi.bi_buf = buf;
-  bi.bi_fp = fp;
+  // Write the header.
+  bufinfo_T bi = {
+    .bi_buf = buf,
+    .bi_fp = fp,
+  };
   if (!serialize_header(&bi, hash)) {
     goto write_error;
   }
@@ -1437,9 +1436,10 @@ void u_read_undo(char *name, const char_u *hash, const char_u *orig_name FUNC_AT
     goto error;
   }
 
-  bufinfo_T bi;
-  bi.bi_buf = curbuf;
-  bi.bi_fp = fp;
+  bufinfo_T bi = {
+    .bi_buf = curbuf,
+    .bi_fp = fp,
+  };
 
   // Read the undo file header.
   char_u magic_buf[UF_START_MAGIC_LEN];

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -199,6 +199,7 @@ enum { FOLD_TEXT_LEN = 51, };  //!< buffer size for get_foldtext()
 // Size in bytes of the hash used in the undo file.
 #define UNDO_HASH_SIZE 32
 
+#define CLEAR_FIELD(field)  memset(&(field), 0, sizeof(field))
 #define CLEAR_POINTER(ptr)  memset((ptr), 0, sizeof(*(ptr)))
 
 // defines to avoid typecasts from (char_u *) to (char *) and back

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1270,7 +1270,7 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
     wp->w_floating = false;
     // non-floating window doesn't store float config or have a border.
     wp->w_float_config = FLOAT_CONFIG_INIT;
-    memset(wp->w_border_adj, 0, sizeof(wp->w_border_adj));
+    CLEAR_FIELD(wp->w_border_adj);
   }
 
   /*
@@ -5175,7 +5175,7 @@ void win_free_grid(win_T *wp, bool reinit)
   grid_free(&wp->w_grid_alloc);
   if (reinit) {
     // if a float is turned into a split, the grid data structure will be reused
-    memset(&wp->w_grid_alloc, 0, sizeof(wp->w_grid_alloc));
+    CLEAR_FIELD(wp->w_grid_alloc);
   }
 }
 
@@ -7095,7 +7095,7 @@ int switch_win(switchwin_T *switchwin, win_T *win, tabpage_T *tp, bool no_displa
 // As switch_win() but without blocking autocommands.
 int switch_win_noblock(switchwin_T *switchwin, win_T *win, tabpage_T *tp, bool no_display)
 {
-  memset(switchwin, 0, sizeof(switchwin_T));
+  CLEAR_POINTER(switchwin);
   switchwin->sw_curwin = curwin;
   if (win == curwin) {
     switchwin->sw_same_win = true;


### PR DESCRIPTION
#### vim-patch:8.2.0559: clearing a struct is verbose

Problem:    Clearing a struct is verbose.
Solution:   Define and use CLEAR_FIELD() and CLEAR_POINTER().
https://github.com/vim/vim/commit/a80faa8930ed5a554beeb2727762538873135e83