### PR TITLE
fix(signs)!: draw signs from left to right

### DIFF
--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -444,25 +444,22 @@ static linenr_T buf_change_sign_type(buf_T *buf, int markId, const char_u *group
 /// @return Attrs of the matching sign, or NULL
 sign_attrs_T *sign_get_attr(SignType type, sign_attrs_T sattrs[], int idx, int max_signs)
 {
-  sign_attrs_T *matches[SIGN_SHOW_MAX];
-  int nr_matches = 0;
+  int match_idx = 0;
 
   for (int i = 0; i < SIGN_SHOW_MAX; i++) {
     if ((type == SIGN_TEXT && sattrs[i].sat_text != NULL)
         || (type == SIGN_LINEHL && sattrs[i].sat_linehl != 0)
         || (type == SIGN_NUMHL && sattrs[i].sat_numhl != 0)) {
-      matches[nr_matches] = &sattrs[i];
-      nr_matches++;
+      if (match_idx == idx) {
+        return &sattrs[i];
+      }
+      match_idx++;
       // attr list is sorted with most important (priority, id), thus we
       // may stop as soon as we have max_signs matches
-      if (nr_matches >= max_signs) {
+      if (match_idx >= max_signs) {
         break;
       }
     }
-  }
-
-  if (nr_matches > idx) {
-    return matches[nr_matches - idx - 1];
   }
 
   return NULL;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1594,7 +1594,7 @@ l5
 
     screen:expect{grid=[[
       {1:    }^l1                                            |
-      S2S1l2                                            |
+      S1S2l2                                            |
       {1:    }l3                                            |
       {1:    }l4                                            |
       {1:    }l5                                            |
@@ -1680,8 +1680,8 @@ l5
     meths.buf_set_extmark(0, ns, 2, -1, {sign_text='S5'})
 
     screen:expect{grid=[[
-      S4S1^l1                                            |
-      x S2l2                                            |
+      S1S4^l1                                            |
+      S2x l2                                            |
       S5{1:  }l3                                            |
       {1:    }l4                                            |
       {1:    }l5                                            |
@@ -1766,15 +1766,15 @@ l5
     end
 
     screen:expect{grid=[[
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:^h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:^h}                 |
                                               |
     ]]}
   end)
@@ -1793,7 +1793,7 @@ l5
     meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1', priority=1})
 
     screen:expect{grid=[[
-      S1S2O3S4S5^l1        |
+      S5S4O3S2S1^l1        |
       {1:          }l2        |
                           |
     ]]}

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -269,9 +269,9 @@ describe('Signs', function()
       command('sign place 5 line=3 name=pietWarn buffer=1')
       command('sign place 3 line=3 name=pietError buffer=1')
       screen:expect([[
-        {1:>>}{8:XX}{6:  1 }a                                            |
-        {8:XX}{1:>>}{6:  2 }b                                            |
-        {1:>>}WW{6:  3 }c                                            |
+        {8:XX}{1:>>}{6:  1 }a                                            |
+        {1:>>}{8:XX}{6:  2 }b                                            |
+        WW{1:>>}{6:  3 }c                                            |
         {2:    }{6:  4 }^                                             |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -305,9 +305,9 @@ describe('Signs', function()
       -- "auto:3" accommodates all the signs we defined so far.
       command('set signcolumn=auto:3')
       screen:expect([[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}{2:  }{6:  2 }b                                          |
-        {8:XX}{1:>>}WW{6:  3 }c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        {1:>>}{8:XX}{2:  }{6:  2 }b                                          |
+        WW{1:>>}{8:XX}{6:  3 }c                                          |
         {2:      }{6:  4 }^                                           |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -323,9 +323,9 @@ describe('Signs', function()
       -- Check "yes:9".
       command('set signcolumn=yes:9')
       screen:expect([[
-        {1:>>}{8:XX}{2:              }{6:  1 }a                              |
-        {8:XX}{1:>>}{2:              }{6:  2 }b                              |
-        {8:XX}{1:>>}WW{2:            }{6:  3 }c                              |
+        {8:XX}{1:>>}{2:              }{6:  1 }a                              |
+        {1:>>}{8:XX}{2:              }{6:  2 }b                              |
+        WW{1:>>}{8:XX}{2:            }{6:  3 }c                              |
         {2:                  }{6:  4 }^                               |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -342,9 +342,9 @@ describe('Signs', function()
       -- a single line (same result as "auto:3").
       command('set signcolumn=auto:4')
       screen:expect{grid=[[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}{2:  }{6:  2 }b                                          |
-        {8:XX}{1:>>}WW{6:  3 }c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        {1:>>}{8:XX}{2:  }{6:  2 }b                                          |
+        WW{1:>>}{8:XX}{6:  3 }c                                          |
         {2:      }{6:  4 }^                                           |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -360,8 +360,8 @@ describe('Signs', function()
       -- line deletion deletes signs.
       command('2d')
       screen:expect([[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}WW{6:  2 }^c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        WW{1:>>}{8:XX}{6:  2 }^c                                          |
         {2:      }{6:  3 }                                           |
         {0:~                                                    }|
         {0:~                                                    }|


### PR DESCRIPTION
Fixes #16632

###  Example:
```lua
nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='H', priority=1})
nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='W', priority=2})
nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='E', priority=3})
```
Before:

```
            |     |
          H | W E |
          ^ |     |
Not visible
```

After:
```
|     |
| E W | H
|     | ^
        Not visible
```

So the signs are displayed in priority order but from LTR not RTL.
