### PR TITLE
[Backport release-0.7] fix(signs): priority of extmark signs (#19718)

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2582,8 +2582,8 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
                                 inserted (true for right, false for left).
                                 Defaults to false.
                               • priority: a priority value for the highlight
-                                group. For example treesitter highlighting
-                                uses a value of 100.
+                                group or sign attribute. For example
+                                treesitter highlighting uses a value of 100.
                               • strict: boolean that indicates extmark should
                                 not be placed if the line or column value is
                                 past the end of the buffer or end of the line

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -441,8 +441,9 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///                   the extmark end position (if it exists) will be shifted
 ///                   in when new text is inserted (true for right, false
 ///                   for left). Defaults to false.
-///               - priority: a priority value for the highlight group. For
-///                   example treesitter highlighting uses a value of 100.
+///               - priority: a priority value for the highlight group or sign
+///                   attribute. For example treesitter highlighting uses a
+///                   value of 100.
 ///               - strict: boolean that indicates extmark should not be placed
 ///                   if the line or column value is past the end of the
 ///                   buffer or end of the line respectively. Defaults to true.

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -394,7 +394,7 @@ void decor_redraw_signs(buf_T *buf, int row, int *num_signs, sign_attrs_T sattrs
 
     int j;
     for (j = (*num_signs); j > 0; j--) {
-      if (sattrs[j].sat_prio <= decor->priority) {
+      if (sattrs[j - 1].sat_prio >= decor->priority) {
         break;
       }
       sattrs[j] = sattrs[j-1];

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1636,7 +1636,7 @@ l5
 
     screen:expect{grid=[[
       S4S1^l1                                            |
-      S2x l2                                            |
+      x S2l2                                            |
       S5{1:  }l3                                            |
       {1:    }l4                                            |
       {1:    }l5                                            |
@@ -1734,6 +1734,34 @@ l5
     ]]}
   end)
 
+  it('works with priority #19716', function()
+    screen:try_resize(20, 3)
+    insert(example_text)
+    feed 'gg'
+
+    helpers.command('sign define Oldsign text=O3')
+    helpers.command([[exe 'sign place 42 line=1 name=Oldsign priority=10 buffer=' . bufnr('')]])
+
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S4', priority=100})
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S2', priority=5})
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S5', priority=200})
+    meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1', priority=1})
+
+    screen:expect{grid=[[
+      S1S2O3S4S5^l1        |
+      {1:          }l2        |
+                          |
+    ]]}
+
+    -- Check truncation works too
+    meths.win_set_option(0, 'signcolumn', 'auto')
+
+    screen:expect{grid=[[
+      S5^l1                |
+      {1:  }l2                |
+                          |
+    ]]}
+  end)
 end)
 
 describe('decorations: virt_text', function()


### PR DESCRIPTION
Backport of https://github.com/neovim/neovim/pull/19718 to `release-0.7`