### PR TITLE
fix(exit): drain fast and non-fast events repeatedly

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -366,12 +366,6 @@ static void nlua_schedule_event(void **argv)
 static int nlua_schedule(lua_State *const lstate)
   FUNC_ATTR_NONNULL_ALL
 {
-  // If Nvim is exiting don't schedule tasks to run in the future. Any refs
-  // allocated here will not be cleaned up otherwise
-  if (exiting) {
-    return 0;
-  }
-
   if (lua_type(lstate, 1) != LUA_TFUNCTION) {
     lua_pushliteral(lstate, "vim.schedule: expected function");
     return lua_error(lstate);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -151,8 +151,10 @@ bool event_teardown(void)
     return true;
   }
 
-  multiqueue_process_events(main_loop.events);
-  loop_poll_events(&main_loop, 0);  // Drain thread_events, fast_events.
+  do {
+    multiqueue_process_events(main_loop.events);
+    loop_poll_events(&main_loop, 0);  // Drain thread_events, fast_events.
+  } while (!multiqueue_empty(main_loop.events));
   input_stop();
   channel_teardown();
   process_teardown(&main_loop);

--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -104,3 +104,11 @@ describe(':cquit', function()
     test_cq('cquit -1', nil, 'nvim_exec2(): Vim(cquit):E488: Trailing characters: -1: cquit -1')
   end)
 end)
+
+it('no memory leak with nested vim.defer_fn() on exit #19727', function()
+  helpers.clear()
+  funcs.system({nvim_prog, '-u', 'NONE', '-i', 'NONE', '--headless', '-c',
+                'lua ' .. ('vim.defer_fn(function() '):rep(5) .. (' end, 0)'):rep(5),
+                '-c', 'quit'})
+  eq(0, eval('v:shell_error'))
+end)


### PR DESCRIPTION
Fix #19727

Because a fast event may produce a non-fast event, or vice versa.