### PR TITLE
fix(lsp): fix nil value error in get_group

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -400,7 +400,8 @@ do
   ---@return CTGroup
   local function get_group(client)
     local allow_inc_sync = if_nil(client.config.flags.allow_incremental_sync, true)
-    local change_capability = vim.tbl_get(client.server_capabilities, 'textDocumentSync', 'change')
+    local change_capability =
+      vim.tbl_get(client.server_capabilities or {}, 'textDocumentSync', 'change')
     local sync_kind = change_capability or protocol.TextDocumentSyncKind.None
     if not allow_inc_sync and change_capability == protocol.TextDocumentSyncKind.Incremental then
       sync_kind = protocol.TextDocumentSyncKind.Full


### PR DESCRIPTION
`server_capabilities` can be nil until the server is initialized.
Reproduced with:

    vim.lsp.stop_client(vim.lsp.start_client {
      cmd = { vim.v.progpath, '-es', '-u', 'NONE', '--headless' };
    })
