### PR TITLE
feat(lsp): deprecate vim.lsp.buf.range_formatting

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -356,6 +356,7 @@ end
 ---@param end_pos ({number, number}, optional) mark-indexed position.
 ---Defaults to the end of the last visual selection.
 function M.range_formatting(options, start_pos, end_pos)
+  vim.deprecate('vim.lsp.buf.range_formatting', 'vim.lsp.formatexpr', '0.9.0')
   local params = util.make_given_range_params(start_pos, end_pos)
   params.options = util.make_formatting_params(options).options
   select_client('textDocument/rangeFormatting', function(client)


### PR DESCRIPTION
There is the `formatexpr` which can be used to format a selection which
is set by default since https://github.com/neovim/neovim/pull/19677

(Happy to hear any arguments for keeping this function. I don't see a good
reason for keeping around two ways to do the same thing)
