### PR TITLE
feat(signs): align signs by priority

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -5396,6 +5396,10 @@ static int buf_signcols_inner(buf_T *buf, int maximum)
 
   buf->b_signcols.sentinel = 0;
 
+  for (int i = 0; i < SIGN_SHOW_MAX; i++) {
+    buf->b_signcols.col_pris[i] = -1;
+  }
+
   FOR_ALL_SIGNS_IN_BUF(buf, sign) {
     if (sign->se_lnum > curline) {
       // Counted all signs, now add extmark signs
@@ -5414,6 +5418,9 @@ static int buf_signcols_inner(buf_T *buf, int maximum)
       linesum = 0;
     }
     if (sign->se_has_text_or_icon) {
+      if (sign->se_priority > buf->b_signcols.col_pris[linesum]) {
+        buf->b_signcols.col_pris[linesum] = sign->se_priority;
+      }
       linesum++;
     }
   }
@@ -5451,6 +5458,9 @@ static int buf_signcols_inner(buf_T *buf, int maximum)
 /// @param line2 end of region being deleted
 void buf_signcols_del_check(buf_T *buf, linenr_T line1, linenr_T line2)
 {
+  // TODO(lewis6991): Need to invalidate so b_signcols.col_pris are recalculated
+  buf->b_signcols.valid = false;
+
   if (!buf->b_signcols.valid) {
     return;
   }
@@ -5474,6 +5484,9 @@ void buf_signcols_del_check(buf_T *buf, linenr_T line1, linenr_T line2)
 /// @param added sign being added
 void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
 {
+  // TODO(lewis6991): Need to invalidate so b_signcols.col_pris are recalculated
+  buf->b_signcols.valid = false;
+
   if (!buf->b_signcols.valid) {
     return;
   }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -873,6 +873,7 @@ struct file_buffer {
     bool valid;                 // calculated sign columns is valid
     linenr_T sentinel;          // a line number which is holding up the signcolumn
     int max;                    // Maximum value size is valid for.
+    int col_pris[SIGN_SHOW_MAX];
   } b_signcols;
 
   Terminal *terminal;           // Terminal instance associated with the buffer

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -416,12 +416,13 @@ next_mark:
 
 // Get the maximum required amount of sign columns needed between row and
 // end_row.
-int decor_signcols(buf_T *buf, DecorState *state, int row, int end_row, int max)
+int decor_signcols(buf_T *buf, DecorState *state, int row, int end_row, int max, int *col_pri)
 {
   int count = 0;         // count for the number of signs on a given row
   int count_remove = 0;  // how much to decrement count by when iterating marks for a new row
   int signcols = 0;      // highest value of count
   int currow = -1;       // current row
+  int col_pri_idx = 0;
 
   if (max <= 1 && buf->b_signs >= (size_t)max) {
     return max;
@@ -449,6 +450,22 @@ int decor_signcols(buf_T *buf, DecorState *state, int row, int end_row, int max)
 
     if (!decor.sign_text) {
       goto next_mark;
+    }
+
+    // Unlike the sign list, priorities in the mark tree are not pre-sorted
+    // so we need to mesh it in
+    if (col_pri != NULL) {
+      int i;
+      for (i = col_pri_idx; i > 0; i--) {
+        if (col_pri[i-1] >= decor.priority) {
+          break;
+        }
+        col_pri[i] = col_pri[i-1];
+      }
+      col_pri[i] = decor.priority;
+      if (col_pri_idx < max - 1) {
+        col_pri_idx++;
+      }
     }
 
     if (mark.pos.row > currow) {

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -414,6 +414,27 @@ next_mark:
   }
 }
 
+static void update_sign_col_pri(DecorPriority decor_pri, int *col_pri_idx, int col_pri[], int max)
+{
+  if (col_pri == NULL) {
+    return;
+  }
+
+  // Unlike the sign list, priorities in the mark tree are not pre-sorted
+  // so we need to mesh it in
+  int i;
+  for (i = *col_pri_idx; i > 0; i--) {
+    if (col_pri[i-1] >= decor_pri) {
+      break;
+    }
+    col_pri[i] = col_pri[i-1];
+  }
+  col_pri[i] = decor_pri;
+  if (*col_pri_idx < max - 1) {
+    (*col_pri_idx)++;
+  }
+}
+
 // Get the maximum required amount of sign columns needed between row and
 // end_row.
 int decor_signcols(buf_T *buf, DecorState *state, int row, int end_row, int max, int *col_pri)
@@ -452,21 +473,7 @@ int decor_signcols(buf_T *buf, DecorState *state, int row, int end_row, int max,
       goto next_mark;
     }
 
-    // Unlike the sign list, priorities in the mark tree are not pre-sorted
-    // so we need to mesh it in
-    if (col_pri != NULL) {
-      int i;
-      for (i = col_pri_idx; i > 0; i--) {
-        if (col_pri[i-1] >= decor.priority) {
-          break;
-        }
-        col_pri[i] = col_pri[i-1];
-      }
-      col_pri[i] = decor.priority;
-      if (col_pri_idx < max - 1) {
-        col_pri_idx++;
-      }
-    }
+    update_sign_col_pri(decor.priority, &col_pri_idx, col_pri, max);
 
     if (mark.pos.row > currow) {
       count -= count_remove;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -2405,7 +2405,7 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
 
   // If this line has a sign with line highlighting set line_attr.
   // TODO(bfredl, vigoux): this should not take priority over decoration!
-  sign_attrs_T *sattr = sign_get_attr(SIGN_LINEHL, sattrs, 0, 1);
+  sign_attrs_T *sattr = sign_get_attr(SIGN_LINEHL, sattrs, 0, 1, NULL);
   if (sattr != NULL) {
     line_attr = sattr->sat_linehl;
   }
@@ -2713,7 +2713,8 @@ static int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool noc
           // in 'lnum', then display the sign instead of the line
           // number.
           if (*wp->w_p_scl == 'n' && *(wp->w_p_scl + 1) == 'u'
-              && num_signs > 0 && sign_get_attr(SIGN_TEXT, sattrs, 0, 1)) {
+              && num_signs > 0
+              && sign_get_attr(SIGN_TEXT, sattrs, 0, 1, buf->b_signcols.col_pris)) {
             get_sign_display_info(true, wp, lnum, sattrs, row,
                                   startrow, filler_lines, filler_todo,
                                   &c_extra, &c_final, extra, sizeof(extra),
@@ -4426,7 +4427,7 @@ static bool use_cursor_line_nr(win_T *wp, linenr_T lnum, int row, int startrow, 
 static int get_line_number_attr(win_T *wp, linenr_T lnum, int row, int startrow, int filler_lines,
                                 sign_attrs_T *sattrs)
 {
-  sign_attrs_T *num_sattr = sign_get_attr(SIGN_NUMHL, sattrs, 0, 1);
+  sign_attrs_T *num_sattr = sign_get_attr(SIGN_NUMHL, sattrs, 0, 1, NULL);
   if (num_sattr != NULL) {
     // :sign defined with "numhl" highlight.
     return num_sattr->sat_numhl;
@@ -4479,7 +4480,8 @@ static void get_sign_display_info(bool nrcol, win_T *wp, linenr_T lnum, sign_att
   }
 
   if (row == startrow + filler_lines && filler_todo <= 0) {
-    sign_attrs_T *sattr = sign_get_attr(SIGN_TEXT, sattrs, sign_idx, wp->w_scwidth);
+    sign_attrs_T *sattr = sign_get_attr(SIGN_TEXT, sattrs, sign_idx, wp->w_scwidth,
+                                        wp->w_buffer->b_signcols.col_pris);
     if (sattr != NULL) {
       *pp_extra = sattr->sat_text;
       if (*pp_extra != NULL) {

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -444,25 +444,22 @@ static linenr_T buf_change_sign_type(buf_T *buf, int markId, const char_u *group
 /// @return Attrs of the matching sign, or NULL
 sign_attrs_T *sign_get_attr(SignType type, sign_attrs_T sattrs[], int idx, int max_signs)
 {
-  sign_attrs_T *matches[SIGN_SHOW_MAX];
-  int nr_matches = 0;
+  int match_idx = 0;
 
   for (int i = 0; i < SIGN_SHOW_MAX; i++) {
     if ((type == SIGN_TEXT && sattrs[i].sat_text != NULL)
         || (type == SIGN_LINEHL && sattrs[i].sat_linehl != 0)
         || (type == SIGN_NUMHL && sattrs[i].sat_numhl != 0)) {
-      matches[nr_matches] = &sattrs[i];
-      nr_matches++;
+      if (match_idx == idx) {
+        return &sattrs[i];
+      }
+      match_idx++;
       // attr list is sorted with most important (priority, id), thus we
       // may stop as soon as we have max_signs matches
-      if (nr_matches >= max_signs) {
+      if (match_idx >= max_signs) {
         break;
       }
     }
-  }
-
-  if (nr_matches > idx) {
-    return matches[nr_matches - idx - 1];
   }
 
   return NULL;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1594,7 +1594,7 @@ l5
 
     screen:expect{grid=[[
       {1:    }^l1                                            |
-      S2S1l2                                            |
+      S1S2l2                                            |
       {1:    }l3                                            |
       {1:    }l4                                            |
       {1:    }l5                                            |
@@ -1680,8 +1680,8 @@ l5
     meths.buf_set_extmark(0, ns, 2, -1, {sign_text='S5'})
 
     screen:expect{grid=[[
-      S4S1^l1                                            |
-      x S2l2                                            |
+      S1S4^l1                                            |
+      S2x l2                                            |
       S5{1:  }l3                                            |
       {1:    }l4                                            |
       {1:    }l5                                            |
@@ -1766,15 +1766,15 @@ l5
     end
 
     screen:expect{grid=[[
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
-      X Y Z W {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:^h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:h}                 |
+      W Z Y X {3:a} {3:b} {3:c} {3:d} {3:e} {3:f} {3:g} {3:^h}                 |
                                               |
     ]]}
   end)
@@ -1793,7 +1793,7 @@ l5
     meths.buf_set_extmark(0, ns, 0, -1, {sign_text='S1', priority=1})
 
     screen:expect{grid=[[
-      S1S2O3S4S5^l1        |
+      S5S4O3S2S1^l1        |
       {1:          }l2        |
                           |
     ]]}

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -269,9 +269,9 @@ describe('Signs', function()
       command('sign place 5 line=3 name=pietWarn buffer=1')
       command('sign place 3 line=3 name=pietError buffer=1')
       screen:expect([[
-        {1:>>}{8:XX}{6:  1 }a                                            |
-        {8:XX}{1:>>}{6:  2 }b                                            |
-        {1:>>}WW{6:  3 }c                                            |
+        {8:XX}{1:>>}{6:  1 }a                                            |
+        {1:>>}{8:XX}{6:  2 }b                                            |
+        WW{1:>>}{6:  3 }c                                            |
         {2:    }{6:  4 }^                                             |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -305,9 +305,9 @@ describe('Signs', function()
       -- "auto:3" accommodates all the signs we defined so far.
       command('set signcolumn=auto:3')
       screen:expect([[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}{2:  }{6:  2 }b                                          |
-        {8:XX}{1:>>}WW{6:  3 }c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        {1:>>}{8:XX}{2:  }{6:  2 }b                                          |
+        WW{1:>>}{8:XX}{6:  3 }c                                          |
         {2:      }{6:  4 }^                                           |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -323,9 +323,9 @@ describe('Signs', function()
       -- Check "yes:9".
       command('set signcolumn=yes:9')
       screen:expect([[
-        {1:>>}{8:XX}{2:              }{6:  1 }a                              |
-        {8:XX}{1:>>}{2:              }{6:  2 }b                              |
-        {8:XX}{1:>>}WW{2:            }{6:  3 }c                              |
+        {8:XX}{1:>>}{2:              }{6:  1 }a                              |
+        {1:>>}{8:XX}{2:              }{6:  2 }b                              |
+        WW{1:>>}{8:XX}{2:            }{6:  3 }c                              |
         {2:                  }{6:  4 }^                               |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -342,9 +342,9 @@ describe('Signs', function()
       -- a single line (same result as "auto:3").
       command('set signcolumn=auto:4')
       screen:expect{grid=[[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}{2:  }{6:  2 }b                                          |
-        {8:XX}{1:>>}WW{6:  3 }c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        {1:>>}{8:XX}{2:  }{6:  2 }b                                          |
+        WW{1:>>}{8:XX}{6:  3 }c                                          |
         {2:      }{6:  4 }^                                           |
         {0:~                                                    }|
         {0:~                                                    }|
@@ -360,8 +360,8 @@ describe('Signs', function()
       -- line deletion deletes signs.
       command('2d')
       screen:expect([[
-        {1:>>}{8:XX}{2:  }{6:  1 }a                                          |
-        {8:XX}{1:>>}WW{6:  2 }^c                                          |
+        {8:XX}{1:>>}{2:  }{6:  1 }a                                          |
+        WW{1:>>}{8:XX}{6:  2 }^c                                          |
         {2:      }{6:  3 }                                           |
         {0:~                                                    }|
         {0:~                                                    }|

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -638,5 +638,45 @@ describe('Signs', function()
                     |
       ]])
     end)
+
+    it('can align signs (extmarks)', function()
+      screen:try_resize(10, 4)
+
+      meths.set_option_value('signcolumn', 'auto:3', {})
+      curbufmeths.set_lines(0, -1, false, {'', '', ''})
+
+      local ns = meths.create_namespace('signs')
+
+      curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'A', priority=300})
+      curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'B', priority=200})
+      curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'C', priority=100})
+      curbufmeths.set_extmark(ns, 1, -1, {sign_text = 'B', priority=200})
+      curbufmeths.set_extmark(ns, 1, -1, {sign_text = 'C', priority=100})
+      curbufmeths.set_extmark(ns, 2, -1, {sign_text = 'C', priority=100})
+
+      screen:expect([[
+        A B C ^      |
+        {2:  }B C       |
+        {2:    }C       |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:2', {})
+
+      screen:expect([[
+        A B ^        |
+        B C         |
+        {2:  }C         |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:1', {})
+      screen:expect([[
+        A ^          |
+        B           |
+        C           |
+                    |
+      ]])
+    end)
   end)
 end)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -594,12 +594,41 @@ describe('Signs', function()
                                                              |
       ]])
     end)
+  end)
 
-    it('can align signs', function()
+  describe('alignment', function()
+    before_each(function()
       screen:try_resize(10, 4)
-
-      meths.set_option_value('signcolumn', 'auto:3', {})
       curbufmeths.set_lines(0, -1, false, {'', '', ''})
+    end)
+
+    local function check()
+      meths.set_option_value('signcolumn', 'auto:3', {})
+      screen:expect([[
+        A B C ^      |
+        {2:  }B C       |
+        {2:    }C       |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:2', {})
+      screen:expect([[
+        A B ^        |
+        B C         |
+        {2:  }C         |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:1', {})
+      screen:expect([[
+        A ^          |
+        B           |
+        C           |
+                    |
+      ]])
+    end
+
+    it('works with legacy signs', function()
 
       funcs.sign_define('SignA', { text = 'A' })
       funcs.sign_define('SignB', { text = 'B' })
@@ -614,69 +643,42 @@ describe('Signs', function()
 
       funcs.sign_place(0, '', 'SignC', 1, {lnum = 3, priority=100})
 
-      screen:expect([[
-        A B C ^      |
-        {2:  }B C       |
-        {2:    }C       |
-                    |
-      ]])
-
-      meths.set_option_value('signcolumn', 'auto:2', {})
-
-      screen:expect([[
-        A B ^        |
-        B C         |
-        {2:  }C         |
-                    |
-      ]])
-
-      meths.set_option_value('signcolumn', 'auto:1', {})
-      screen:expect([[
-        A ^          |
-        B           |
-        C           |
-                    |
-      ]])
+      check()
     end)
 
-    it('can align signs (extmarks)', function()
-      screen:try_resize(10, 4)
-
-      meths.set_option_value('signcolumn', 'auto:3', {})
-      curbufmeths.set_lines(0, -1, false, {'', '', ''})
-
+    it('works with extmarks', function()
       local ns = meths.create_namespace('signs')
 
       curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'A', priority=300})
       curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'B', priority=200})
       curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'C', priority=100})
+
       curbufmeths.set_extmark(ns, 1, -1, {sign_text = 'B', priority=200})
       curbufmeths.set_extmark(ns, 1, -1, {sign_text = 'C', priority=100})
+
       curbufmeths.set_extmark(ns, 2, -1, {sign_text = 'C', priority=100})
 
-      screen:expect([[
-        A B C ^      |
-        {2:  }B C       |
-        {2:    }C       |
-                    |
-      ]])
+      check()
+    end)
 
-      meths.set_option_value('signcolumn', 'auto:2', {})
+    it('works with mixed signs', function()
 
-      screen:expect([[
-        A B ^        |
-        B C         |
-        {2:  }C         |
-                    |
-      ]])
+      local ns = meths.create_namespace('signs')
 
-      meths.set_option_value('signcolumn', 'auto:1', {})
-      screen:expect([[
-        A ^          |
-        B           |
-        C           |
-                    |
-      ]])
+      funcs.sign_define('SignA', { text = 'A' })
+      funcs.sign_define('SignB', { text = 'B' })
+      funcs.sign_define('SignC', { text = 'C' })
+
+      funcs.sign_place(0, '', 'SignA', 1, {lnum = 1, priority=300})
+      funcs.sign_place(0, '', 'SignB', 1, {lnum = 1, priority=200})
+      curbufmeths.set_extmark(ns, 0, -1, {sign_text = 'C', priority=100})
+
+      curbufmeths.set_extmark(ns, 1, -1, {sign_text = 'B', priority=200})
+      funcs.sign_place(0, '', 'SignC', 1, {lnum = 2, priority=100})
+
+      curbufmeths.set_extmark(ns, 2, -1, {sign_text = 'C', priority=100})
+
+      check()
     end)
   end)
 end)

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -1,6 +1,9 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
+local funcs = helpers.funcs
+local meths = helpers.meths
+local curbufmeths = helpers.curbufmeths
 local source = helpers.source
 
 describe('Signs', function()
@@ -589,6 +592,50 @@ describe('Signs', function()
         {0:~                                                    }|
         {0:~                                                    }|
                                                              |
+      ]])
+    end)
+
+    it('can align signs', function()
+      screen:try_resize(10, 4)
+
+      meths.set_option_value('signcolumn', 'auto:3', {})
+      curbufmeths.set_lines(0, -1, false, {'', '', ''})
+
+      funcs.sign_define('SignA', { text = 'A' })
+      funcs.sign_define('SignB', { text = 'B' })
+      funcs.sign_define('SignC', { text = 'C' })
+
+      funcs.sign_place(0, '', 'SignA', 1, {lnum = 1, priority=300})
+      funcs.sign_place(0, '', 'SignB', 1, {lnum = 1, priority=200})
+      funcs.sign_place(0, '', 'SignC', 1, {lnum = 1, priority=100})
+
+      funcs.sign_place(0, '', 'SignB', 1, {lnum = 2, priority=200})
+      funcs.sign_place(0, '', 'SignC', 1, {lnum = 2, priority=100})
+
+      funcs.sign_place(0, '', 'SignC', 1, {lnum = 3, priority=100})
+
+      screen:expect([[
+        A B C ^      |
+        {2:  }B C       |
+        {2:    }C       |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:2', {})
+
+      screen:expect([[
+        A B ^        |
+        B C         |
+        {2:  }C         |
+                    |
+      ]])
+
+      meths.set_option_value('signcolumn', 'auto:1', {})
+      screen:expect([[
+        A ^          |
+        B           |
+        C           |
+                    |
       ]])
     end)
   end)


### PR DESCRIPTION
When scanning signs to calculate the sign column width, also store the column which each priority should be drawn at.

Currently works for this code:

```lua
vim.o.signcolumn = 'auto:3'

vim.api.nvim_buf_set_lines(0, 0, -1, false, {'', '', ''})

vim.cmd('sign define SignA text=A')
vim.cmd('sign define SignB text=B')
vim.cmd('sign define SignC text=C')

vim.fn.sign_place(0, '', 'SignA', 1, {lnum = 1, priority=300})
vim.fn.sign_place(0, '', 'SignB', 1, {lnum = 1, priority=200})
vim.fn.sign_place(0, '', 'SignC', 1, {lnum = 1, priority=100})

vim.fn.sign_place(0, '', 'SignB', 1, {lnum = 2, priority=200})
vim.fn.sign_place(0, '', 'SignC', 1, {lnum = 2, priority=100})

vim.fn.sign_place(0, '', 'SignC', 1, {lnum = 3, priority=100})
```

### TODO:

- [x] Make it work for extmark signs.
- [ ] Recalculate `col_pris` when adding/deleting signs that don't invalidate the sign column.