### PR TITLE
docs(lsp): remove lsp.buf_request from docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -568,24 +568,6 @@ buf_notify({bufnr}, {method}, {params})                 *vim.lsp.buf_notify()*
     Return: ~
         true if any client returns true; false otherwise
 
-                                                       *vim.lsp.buf_request()*
-buf_request({bufnr}, {method}, {params}, {handler})
-    Sends an async request for all active clients attached to the buffer.
-
-    Parameters: ~
-        {bufnr}    (number) Buffer handle, or 0 for current.
-        {method}   (string) LSP method name
-        {params}   (optional, table) Parameters to send to the server
-        {handler}  (optional, function) See |lsp-handler| If nil, follows
-                   resolution strategy defined in |lsp-handler-configuration|
-
-    Return: ~
-        2-tuple:
-        • Map of client-id:request-id pairs for all successful requests.
-        • Function which can be used to cancel all the requests. You could
-          instead iterate all clients and call their `cancel_request()`
-          methods.
-
                                                    *vim.lsp.buf_request_all()*
 buf_request_all({bufnr}, {method}, {params}, {callback})
     Sends an async request for all active clients attached to the buffer.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1845,13 +1845,14 @@ api.nvim_create_autocmd('VimLeavePre', {
   end,
 })
 
+---@private
 --- Sends an async request for all active clients attached to the
 --- buffer.
 ---
 ---@param bufnr (number) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
----@param params (optional, table) Parameters to send to the server
----@param handler (optional, function) See |lsp-handler|
+---@param params table|nil Parameters to send to the server
+---@param handler function|nil See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@returns 2-tuple:


### PR DESCRIPTION
This starts a soft phase-out of `buf_request`.

`buf_request` is quite error prone:

- Positional `params` depend on the client because of the
  `offset_encoding`. Currently if there is one client using UTF-8 offset
  encoding and another using UTF-16, the positions in the request are
  wrong for one of the clients. To solve this the params would need to
  be created per client instead of once for all of them.

- `handler` is called *per* client but many users of it assume it is
  only called once.

  This can lead to a "select n + 1"
  kind of problem, where the handler makes another call to `buf_request`,
  multiplying the amount of requests.
  (There are in fact still some places where this happens in core)

  Or it leads to erratic behavior if called multiple times (E.g. the
  quicklist list flickering & being overwritten)
  (See hover or references implementation)

  `buf_request_all` returns an aggregate of the responses which is more
  sensible as it avoids this problem.

  For off-spec extensions it also has the problem that it sends requests to
  clients which cannot handle a given request.

Given that `buf_request` is in use by a lot of plugins this starts a
soft-phase out. Planned Steps:

- Remove from docs
- Provide an alternative, either `buf_request_all`, maybe with
  extensions (params being a function), or an entirely new method.
- Mark as deprecated in 0.9 (or one release after ↑, if above isn't ready for 0.8)
- Remove in 0.10 (or one release after ↑)

To note:

- `buf_request_all` currently isn't ideal either because it suffers from
the `params` problem as well.

- This implies that the `vim.lsp.with` pattern will die, because the
  global handlers as they are don't fit a multi-client model, as most of
  the time an aggregate is needed.
