### PR TITLE
feat(eval)!: make Vim functions return inner window width and height

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5228,12 +5228,12 @@ dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
   tv_dict_add_nr(dict, S_LEN("tabnr"), tpnr);
   tv_dict_add_nr(dict, S_LEN("winnr"), winnr);
   tv_dict_add_nr(dict, S_LEN("winid"), wp->handle);
-  tv_dict_add_nr(dict, S_LEN("height"), wp->w_height);
+  tv_dict_add_nr(dict, S_LEN("height"), wp->w_height_inner);
   tv_dict_add_nr(dict, S_LEN("winrow"), wp->w_winrow + 1);
   tv_dict_add_nr(dict, S_LEN("topline"), wp->w_topline);
   tv_dict_add_nr(dict, S_LEN("botline"), wp->w_botline - 1);
   tv_dict_add_nr(dict, S_LEN("winbar"), wp->w_winbar_height);
-  tv_dict_add_nr(dict, S_LEN("width"), wp->w_width);
+  tv_dict_add_nr(dict, S_LEN("width"), wp->w_width_inner);
   tv_dict_add_nr(dict, S_LEN("bufnr"), wp->w_buffer->b_fnum);
   tv_dict_add_nr(dict, S_LEN("wincol"), wp->w_wincol + 1);
   tv_dict_add_nr(dict, S_LEN("textoff"), win_col_off(wp));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9771,7 +9771,7 @@ static void f_winheight(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (wp == NULL) {
     rettv->vval.v_number = -1;
   } else {
-    rettv->vval.v_number = wp->w_height;
+    rettv->vval.v_number = wp->w_height_inner;
   }
 }
 
@@ -9909,7 +9909,7 @@ static void f_winwidth(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (wp == NULL) {
     rettv->vval.v_number = -1;
   } else {
-    rettv->vval.v_number = wp->w_width;
+    rettv->vval.v_number = wp->w_width_inner;
   }
 }
 

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -3,7 +3,9 @@ local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local feed, command, insert = helpers.feed, helpers.command, helpers.insert
 local eq = helpers.eq
+local funcs = helpers.funcs
 local meths = helpers.meths
+local curwin = helpers.curwin
 local poke_eventloop = helpers.poke_eventloop
 
 
@@ -871,6 +873,15 @@ describe('ext_multigrid', function()
     before_each(function()
       screen:try_resize_grid(2, 60, 20)
     end)
+
+    it('winwidth() winheight() getwininfo() return inner width and height #19743', function()
+      eq(60, funcs.winwidth(0))
+      eq(20, funcs.winheight(0))
+      local win_info = funcs.getwininfo(curwin().id)[1]
+      eq(60, win_info.width)
+      eq(20, win_info.height)
+    end)
+
     it('gets written till grid width', function()
       insert(('a'):rep(60).."\n")
 

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -7,6 +7,8 @@ local meths = helpers.meths
 local eq = helpers.eq
 local poke_eventloop = helpers.poke_eventloop
 local feed = helpers.feed
+local funcs = helpers.funcs
+local curwin = helpers.curwin
 local pcall_err = helpers.pcall_err
 
 describe('winbar', function()
@@ -48,6 +50,11 @@ describe('winbar', function()
       {3:~                                                           }|
                                                                   |
     ]])
+    -- winbar is excluded from the heights returned by winheight() and getwininfo()
+    eq(11, funcs.winheight(0))
+    local win_info = funcs.getwininfo(curwin().id)[1]
+    eq(11, win_info.height)
+    eq(1, win_info.winbar)
   end)
 
   it('works with custom \'fillchars\' value', function()


### PR DESCRIPTION
Close #18753

In non-multigrid UI the only change is that the returned height now
excludes winbar, and this is compatible with Vim.

In multigrid UI this means the return value of these functions now
reflect the space available for buffer lines in a window.

No change in nvim_win_get_height() and nvim_win_get_width().
