### PR TITLE
fix(charclass): make behavior with empty str match latest Vim

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6838,9 +6838,9 @@ setcellwidths({list})					*setcellwidths()*
 		tells Vim how wide characters are, counted in screen cells.
 		This overrides 'ambiwidth'.  Example: >
 		   setcellwidths([[0xad, 0xad, 1],
-		   		\ [0x2194, 0x2199, 2]])
+				\ [0x2194, 0x2199, 2]])
 
-<					*E1109* *E1110* *E1111* *E1112* *E1113*
+<				*E1109* *E1110* *E1111* *E1112* *E1113* *E1114*
 		The {list} argument is a list of lists with each three
 		numbers. These three numbers are [low, high, width].  "low"
 		and "high" can be the same, in which case this refers to one
@@ -6856,7 +6856,8 @@ setcellwidths({list})					*setcellwidths()*
 
 		To clear the overrides pass an empty list: >
 		   setcellwidths([]);
-
+<		You can use the script $VIMRUNTIME/tools/emoji_list.vim to see
+		the effect for known emoji characters.
 
 setcharpos({expr}, {list})				*setcharpos()*
 		Same as |setpos()| but uses the specified column number as the

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2861,10 +2861,8 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
 void f_charclass(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  if (argvars[0].v_type != VAR_STRING
-      || argvars[0].vval.v_string == NULL
-      || *argvars[0].vval.v_string == NUL) {
-    emsg(_(e_stringreq));
+  if (tv_check_for_string(&argvars[0]) == FAIL
+      || argvars[0].vval.v_string == NULL) {
     return;
   }
   rettv->vval.v_number = mb_get_class((const char_u *)argvars[0].vval.v_string);

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1774,6 +1774,8 @@ func Test_charclass()
   call assert_equal(1, charclass('.'))
   call assert_equal(2, charclass('x'))
   call assert_equal(3, charclass("\u203c"))
+  " this used to crash vim
+  call assert_equal(0, "xxx"[-1]->charclass())
 endfunc
 
 func Test_eventhandler()


### PR DESCRIPTION
Later Vim patches changed to return 0 for empty string and null string.
Also update setcellwidth() docs to match latest Vim.
