### PR TITLE
feat(filetype.lua): add astro filetype

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -142,6 +142,7 @@ local extension = {
   asp = function(path, bufnr)
     return require('vim.filetype.detect').asp(bufnr)
   end,
+  astro = 'astro',
   atl = 'atlas',
   as = 'atlas',
   ahk = 'autohotkey',


### PR DESCRIPTION
Astro files are somewhat popular in frontend, and nvim-treesitter already has syntax highlighting for those, figured I could make this official