### PR TITLE
vim-patch:8.2.{0056,0061,0078,0097,0823}: execution stack

### DIFF
--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -22,7 +22,8 @@ typedef struct {
   bool save_VIsual_active;        ///< saved VIsual_active
 } aco_save_T;
 
-typedef struct AutoCmd {
+typedef struct AutoCmd_S AutoCmd;
+struct AutoCmd_S {
   AucmdExecutable exec;
   bool once;                            // "One shot": removed after execution
   bool nested;                          // If autocommands nest here
@@ -30,11 +31,12 @@ typedef struct AutoCmd {
   int64_t id;                           // ID used for uniquely tracking an autocmd.
   sctx_T script_ctx;                    // script context where defined
   char *desc;                           // Description for the autocmd.
-  struct AutoCmd *next;                 // Next AutoCmd in list
-} AutoCmd;
+  AutoCmd *next;                        // Next AutoCmd in list
+};
 
-typedef struct AutoPat {
-  struct AutoPat *next;                 // next AutoPat in AutoPat list; MUST
+typedef struct AutoPat_S AutoPat;
+struct AutoPat_S {
+  AutoPat *next;                        // next AutoPat in AutoPat list; MUST
                                         // be the first entry
   char *pat;                            // pattern as typed (NULL when pattern
                                         // has been removed)
@@ -45,10 +47,11 @@ typedef struct AutoPat {
   int buflocal_nr;                      // !=0 for buffer-local AutoPat
   char allow_dirs;                      // Pattern may match whole path
   char last;                            // last pattern for apply_autocmds()
-} AutoPat;
+};
 
 /// Struct used to keep status while executing autocommands for an event.
-typedef struct AutoPatCmd {
+typedef struct AutoPatCmd_S AutoPatCmd;
+struct AutoPatCmd_S {
   AutoPat *curpat;          // next AutoPat to examine
   AutoCmd *nextcmd;         // next AutoCmd to execute
   int group;                // group being used
@@ -58,8 +61,8 @@ typedef struct AutoPatCmd {
   event_T event;            // current event
   int arg_bufnr;            // initially equal to <abuf>, set to zero when buf is deleted
   Object *data;             // arbitrary data
-  struct AutoPatCmd *next;  // chain of active apc-s for auto-invalidation
-} AutoPatCmd;
+  AutoPatCmd *next;         // chain of active apc-s for auto-invalidation
+};
 
 // Set by the apply_autocmds_group function if the given event is equal to
 // EVENT_FILETYPE. Used by the readfile function in order to determine if

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -49,6 +49,7 @@
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/sign.h"
@@ -8613,8 +8614,8 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments, boo
   struct caller_scope saved_provider_caller_scope = provider_caller_scope;
   provider_caller_scope = (struct caller_scope) {
     .script_ctx = current_sctx,
-    .sourcing_name = sourcing_name,
-    .sourcing_lnum = sourcing_lnum,
+    .sourcing_name = SOURCING_NAME,
+    .sourcing_lnum = SOURCING_LNUM,
     .autocmd_fname = autocmd_fname,
     .autocmd_match = autocmd_match,
     .autocmd_bufnr = autocmd_bufnr,
@@ -8713,8 +8714,8 @@ bool eval_has_provider(const char *feat)
 /// Writes "<sourcing_name>:<sourcing_lnum>" to `buf[bufsize]`.
 void eval_fmt_source_name_line(char *buf, size_t bufsize)
 {
-  if (sourcing_name) {
-    snprintf(buf, bufsize, "%s:%" PRIdLINENR, sourcing_name, sourcing_lnum);
+  if (SOURCING_NAME) {
+    snprintf(buf, bufsize, "%s:%" PRIdLINENR, SOURCING_NAME, SOURCING_LNUM);
   } else {
     snprintf(buf, bufsize, "?");
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8614,8 +8614,7 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments, boo
   struct caller_scope saved_provider_caller_scope = provider_caller_scope;
   provider_caller_scope = (struct caller_scope) {
     .script_ctx = current_sctx,
-    .sourcing_name = SOURCING_NAME,
-    .sourcing_lnum = SOURCING_LNUM,
+    .es_entry = ((estack_T *)exestack.ga_data)[exestack.ga_len - 1],
     .autocmd_fname = autocmd_fname,
     .autocmd_match = autocmd_match,
     .autocmd_bufnr = autocmd_bufnr,

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4188,6 +4188,23 @@ bool garbage_collect(bool testing)
     garbage_collect_at_exit = false;
   }
 
+  // The execution stack can grow big, limit the size.
+  if (exestack.ga_maxlen - exestack.ga_len > 500) {
+    // Keep 150% of the current size, with a minimum of the growth size.
+    int n = exestack.ga_len / 2;
+    if (n < exestack.ga_growsize) {
+      n = exestack.ga_growsize;
+    }
+
+    // Don't make it bigger though.
+    if (exestack.ga_len + n < exestack.ga_maxlen) {
+      size_t new_len = (size_t)exestack.ga_itemsize * (size_t)(exestack.ga_len + n);
+      char *pp = xrealloc(exestack.ga_data, new_len);
+      exestack.ga_maxlen = exestack.ga_len + n;
+      exestack.ga_data = pp;
+    }
+  }
+
   // We advance by two (COPYID_INC) because we add one for items referenced
   // through previous_funccal.
   const int copyID = get_copyID();

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7293,7 +7293,6 @@ static void f_rpcnotify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "rpcrequest()" function
 static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-#if 0  // TODO:
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
   const int l_provider_call_nesting = provider_call_nesting;
@@ -7319,8 +7318,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   sctx_T save_current_sctx;
-  char *save_sourcing_name, *save_autocmd_fname, *save_autocmd_match;
-  linenr_T save_sourcing_lnum;
+  char *save_autocmd_fname, *save_autocmd_match;
   int save_autocmd_bufnr;
   funccal_entry_T funccal_entry;
 
@@ -7328,16 +7326,14 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     // If this is called from a provider function, restore the scope
     // information of the caller.
     save_current_sctx = current_sctx;
-    save_sourcing_name = sourcing_name;
-    save_sourcing_lnum = sourcing_lnum;
     save_autocmd_fname = autocmd_fname;
     save_autocmd_match = autocmd_match;
     save_autocmd_bufnr = autocmd_bufnr;
     save_funccal(&funccal_entry);
 
     current_sctx = provider_caller_scope.script_ctx;
-    sourcing_name = provider_caller_scope.sourcing_name;
-    sourcing_lnum = provider_caller_scope.sourcing_lnum;
+    ga_grow(&exestack, 1);
+    ((estack_T *)exestack.ga_data)[exestack.ga_len++] = provider_caller_scope.es_entry;
     autocmd_fname = provider_caller_scope.autocmd_fname;
     autocmd_match = provider_caller_scope.autocmd_match;
     autocmd_bufnr = provider_caller_scope.autocmd_bufnr;
@@ -7354,8 +7350,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (l_provider_call_nesting) {
     current_sctx = save_current_sctx;
-    sourcing_name = save_sourcing_name;
-    sourcing_lnum = save_sourcing_lnum;
+    exestack.ga_len--;
     autocmd_fname = save_autocmd_fname;
     autocmd_match = save_autocmd_match;
     autocmd_bufnr = save_autocmd_bufnr;
@@ -7387,7 +7382,6 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 end:
   arena_mem_free(res_mem, NULL);
   api_clear_error(&err);
-#endif
 }
 
 /// "rpcstart()" function (DEPRECATED)

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -62,6 +62,7 @@
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/sha256.h"
@@ -7292,6 +7293,7 @@ static void f_rpcnotify(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "rpcrequest()" function
 static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
+#if 0  // TODO:
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
   const int l_provider_call_nesting = provider_call_nesting;
@@ -7385,6 +7387,7 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 end:
   arena_mem_free(res_mem, NULL);
   api_clear_error(&err);
+#endif
 }
 
 /// "rpcstart()" function (DEPRECATED)

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -355,6 +355,8 @@ struct ufunc {
                            ///< used for s: variables
   int uf_refcount;      ///< reference count, see func_name_refcount()
   funccall_T *uf_scoped;       ///< l: local variables for closure
+  char_u *uf_name_exp;  ///< if "uf_name[]" starts with SNR the name with
+                        ///< "<SNR>" as a string, otherwise NULL
   char_u uf_name[];  ///< Name of function (actual size equals name);
                      ///< can start with <SNR>123_
                      ///< (<SNR> is K_SPECIAL KS_EXTRA KE_SNR)

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2442,9 +2442,12 @@ void ex_function(exarg_T *eap)
         fp = NULL;
         overwrite = true;
       } else {
-        // redefine existing function
+        char_u *exp_name = fp->uf_name_exp;
+        // redefine existing function, keep the expanded name
         XFREE_CLEAR(name);
+        fp->uf_name_exp = NULL;
         func_clear_items(fp);
+        fp->uf_name_exp = exp_name;
         fp->uf_profiling = false;
         fp->uf_prof_initialized = false;
       }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1015,7 +1015,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     sandbox++;
   }
 
-  estack_push_ufunc(ETYPE_UFUNC, fp, 1);
+  estack_push_ufunc(fp, 1);
   if (p_verbose >= 12) {
     ++no_wait_return;
     verbose_enter_scroll();

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -23,6 +23,7 @@
 #include "nvim/os/input.h"
 #include "nvim/profile.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/search.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
@@ -219,6 +220,17 @@ char_u *get_lambda_name(void)
   return name;
 }
 
+static void set_ufunc_name(ufunc_T *fp, char_u *name)
+{
+  STRCPY(fp->uf_name, name);
+
+  if (name[0] == K_SPECIAL) {
+    fp->uf_name_exp = xmalloc(STRLEN(name) + 3);
+    STRCPY(fp->uf_name_exp, "<SNR>");
+    STRCAT(fp->uf_name_exp, fp->uf_name + 3);
+  }
+}
+
 /// Parse a lambda expression and get a Funcref from "*arg".
 ///
 /// @return OK or FAIL.  Returns NOTDONE for dict or {expr}.
@@ -297,7 +309,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, bool evaluate)
     }
 
     fp->uf_refcount = 1;
-    STRCPY(fp->uf_name, name);
+    set_ufunc_name(fp, name);
     hash_add(&func_hashtab, UF2HIKEY(fp));
     fp->uf_args = newargs;
     ga_init(&fp->uf_def_args, (int)sizeof(char_u *), 1);
@@ -319,7 +331,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, bool evaluate)
     fp->uf_flags = flags;
     fp->uf_calls = 0;
     fp->uf_script_ctx = current_sctx;
-    fp->uf_script_ctx.sc_lnum += sourcing_lnum - newlines.ga_len;
+    fp->uf_script_ctx.sc_lnum += SOURCING_LNUM - newlines.ga_len;
 
     pt->pt_func = fp;
     pt->pt_refcount = 1;
@@ -744,6 +756,7 @@ static void func_clear_items(ufunc_T *fp)
   ga_clear_strings(&(fp->uf_args));
   ga_clear_strings(&(fp->uf_def_args));
   ga_clear_strings(&(fp->uf_lines));
+  XFREE_CLEAR(fp->uf_name_exp);
 
   if (fp->uf_cb_free != NULL) {
     fp->uf_cb_free(fp->uf_cb_state);
@@ -807,8 +820,6 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
                     linenr_T firstline, linenr_T lastline, dict_T *selfdict)
   FUNC_ATTR_NONNULL_ARG(1, 3, 4)
 {
-  char_u *save_sourcing_name;
-  linenr_T save_sourcing_lnum;
   bool using_sandbox = false;
   funccall_T *fc;
   int save_did_emsg;
@@ -998,73 +1009,49 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
 
   // Don't redraw while executing the function.
   RedrawingDisabled++;
-  save_sourcing_name = (char_u *)sourcing_name;
-  save_sourcing_lnum = sourcing_lnum;
-  sourcing_lnum = 1;
 
   if (fp->uf_flags & FC_SANDBOX) {
     using_sandbox = true;
     sandbox++;
   }
 
-  // need space for new sourcing_name:
-  // * save_sourcing_name
-  // * "["number"].." or "function "
-  // * "<SNR>" + fp->uf_name - 3
-  // * terminating NUL
-  size_t len = (save_sourcing_name == NULL ? 0 : STRLEN(save_sourcing_name))
-               + STRLEN(fp->uf_name) + 27;
-  sourcing_name = xmalloc(len);
-  {
-    if (save_sourcing_name != NULL
-        && STRNCMP(save_sourcing_name, "function ", 9) == 0) {
-      vim_snprintf(sourcing_name,
-                   len,
-                   "%s[%" PRId64 "]..",
-                   save_sourcing_name,
-                   (int64_t)save_sourcing_lnum);
-    } else {
-      STRCPY(sourcing_name, "function ");
-    }
-    cat_func_name((char_u *)sourcing_name + STRLEN(sourcing_name), fp);
+  estack_push_ufunc(ETYPE_UFUNC, fp, 1);
+  if (p_verbose >= 12) {
+    ++no_wait_return;
+    verbose_enter_scroll();
 
-    if (p_verbose >= 12) {
-      ++no_wait_return;
-      verbose_enter_scroll();
-
-      smsg(_("calling %s"), sourcing_name);
-      if (p_verbose >= 14) {
-        msg_puts("(");
-        for (int i = 0; i < argcount; i++) {
-          if (i > 0) {
-            msg_puts(", ");
-          }
-          if (argvars[i].v_type == VAR_NUMBER) {
-            msg_outnum((long)argvars[i].vval.v_number);
-          } else {
-            // Do not want errors such as E724 here.
-            emsg_off++;
-            char *tofree = encode_tv2string(&argvars[i], NULL);
-            emsg_off--;
-            if (tofree != NULL) {
-              char *s = tofree;
-              char buf[MSG_BUF_LEN];
-              if (vim_strsize(s) > MSG_BUF_CLEN) {
-                trunc_string(s, buf, MSG_BUF_CLEN, sizeof(buf));
-                s = buf;
-              }
-              msg_puts(s);
-              xfree(tofree);
+    smsg(_("calling %s"), SOURCING_NAME);
+    if (p_verbose >= 14) {
+      msg_puts("(");
+      for (int i = 0; i < argcount; i++) {
+        if (i > 0) {
+          msg_puts(", ");
+        }
+        if (argvars[i].v_type == VAR_NUMBER) {
+          msg_outnum((long)argvars[i].vval.v_number);
+        } else {
+          // Do not want errors such as E724 here.
+          emsg_off++;
+          char *tofree = encode_tv2string(&argvars[i], NULL);
+          emsg_off--;
+          if (tofree != NULL) {
+            char *s = tofree;
+            char buf[MSG_BUF_LEN];
+            if (vim_strsize(s) > MSG_BUF_CLEN) {
+              trunc_string(s, buf, MSG_BUF_CLEN, sizeof(buf));
+              s = buf;
             }
+            msg_puts(s);
+            xfree(tofree);
           }
         }
-        msg_puts(")");
       }
-      msg_puts("\n");  // don't overwrite this either
-
-      verbose_leave_scroll();
-      --no_wait_return;
+      msg_puts(")");
     }
+    msg_puts("\n");  // don't overwrite this either
+
+    verbose_leave_scroll();
+    --no_wait_return;
   }
 
   const bool do_profiling_yes = do_profiling == PROF_YES;
@@ -1148,10 +1135,10 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     verbose_enter_scroll();
 
     if (aborting()) {
-      smsg(_("%s aborted"), sourcing_name);
+      smsg(_("%s aborted"), SOURCING_NAME);
     } else if (fc->rettv->v_type == VAR_NUMBER) {
       smsg(_("%s returning #%" PRId64 ""),
-           sourcing_name, (int64_t)fc->rettv->vval.v_number);
+           SOURCING_NAME, (int64_t)fc->rettv->vval.v_number);
     } else {
       char buf[MSG_BUF_LEN];
 
@@ -1167,7 +1154,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
           trunc_string(s, buf, MSG_BUF_CLEN, MSG_BUF_LEN);
           s = buf;
         }
-        smsg(_("%s returning %s"), sourcing_name, s);
+        smsg(_("%s returning %s"), SOURCING_NAME, s);
         xfree(tofree);
       }
     }
@@ -1177,9 +1164,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     --no_wait_return;
   }
 
-  xfree(sourcing_name);
-  sourcing_name = (char *)save_sourcing_name;
-  sourcing_lnum = save_sourcing_lnum;
+  estack_pop();
   current_sctx = save_current_sctx;
   if (do_profiling_yes) {
     script_prof_restore(&wait_start);
@@ -1188,15 +1173,15 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     sandbox--;
   }
 
-  if (p_verbose >= 12 && sourcing_name != NULL) {
-    ++no_wait_return;
+  if (p_verbose >= 12 && SOURCING_NAME != NULL) {
+    no_wait_return++;
     verbose_enter_scroll();
 
-    smsg(_("continuing in %s"), sourcing_name);
+    smsg(_("continuing in %s"), SOURCING_NAME);
     msg_puts("\n");  // don't overwrite this either
 
     verbose_leave_scroll();
-    --no_wait_return;
+    no_wait_return--;
   }
 
   did_emsg |= save_did_emsg;
@@ -1637,9 +1622,8 @@ static void list_func_head(ufunc_T *fp, int indent, bool force)
     msg_puts("   ");
   }
   msg_puts(force ? "function! " : "function ");
-  if (fp->uf_name[0] == K_SPECIAL) {
-    msg_puts_attr("<SNR>", HL_ATTR(HLF_8));
-    msg_puts((const char *)fp->uf_name + 3);
+  if (fp->uf_name_exp != NULL) {
+    msg_puts((const char *)fp->uf_name_exp);
   } else {
     msg_puts((const char *)fp->uf_name);
   }
@@ -2196,7 +2180,7 @@ void ex_function(exarg_T *eap)
   }
 
   // Save the starting line number.
-  sourcing_lnum_top = sourcing_lnum;
+  sourcing_lnum_top = SOURCING_LNUM;
 
   indent = 2;
   nesting = 0;
@@ -2238,10 +2222,10 @@ void ex_function(exarg_T *eap)
       ui_ext_cmdline_block_append((size_t)indent, (const char *)theline);
     }
 
-    // Detect line continuation: sourcing_lnum increased more than one.
+    // Detect line continuation: SOURCING_LNUM increased more than one.
     sourcing_lnum_off = get_sourced_lnum(eap->getline, eap->cookie);
-    if (sourcing_lnum < sourcing_lnum_off) {
-      sourcing_lnum_off -= sourcing_lnum;
+    if (SOURCING_LNUM < sourcing_lnum_off) {
+      sourcing_lnum_off -= SOURCING_LNUM;
     } else {
       sourcing_lnum_off = 0;
     }
@@ -2499,13 +2483,12 @@ void ex_function(exarg_T *eap)
 
       // Check that the autoload name matches the script name.
       int j = FAIL;
-      if (sourcing_name != NULL) {
+      if (SOURCING_NAME != NULL) {
         scriptname = (char_u *)autoload_name((const char *)name, STRLEN(name));
         p = (char_u *)vim_strchr((char *)scriptname, '/');
         plen = (int)STRLEN(p);
-        slen = (int)STRLEN(sourcing_name);
-        if (slen > plen && FNAMECMP(p,
-                                    sourcing_name + slen - plen) == 0) {
+        slen = (int)STRLEN(SOURCING_NAME);
+        if (slen > plen && FNAMECMP(p, SOURCING_NAME + slen - plen) == 0) {
           j = OK;
         }
         xfree(scriptname);
@@ -2540,7 +2523,7 @@ void ex_function(exarg_T *eap)
     }
 
     // insert the new function in the function list
-    STRCPY(fp->uf_name, name);
+    set_ufunc_name(fp, name);
     if (overwrite) {
       hi = hash_find(&func_hashtab, (char *)name);
       hi->hi_key = UF2HIKEY(fp);
@@ -3148,8 +3131,7 @@ char *get_func_line(int c, void *cookie, int indent, bool do_concat)
 
   // If breakpoints have been added/deleted need to check for it.
   if (fcp->dbg_tick != debug_tick) {
-    fcp->breakpoint = dbg_find_breakpoint(FALSE, fp->uf_name,
-                                          sourcing_lnum);
+    fcp->breakpoint = dbg_find_breakpoint(false, fp->uf_name, SOURCING_LNUM);
     fcp->dbg_tick = debug_tick;
   }
   if (do_profiling == PROF_YES) {
@@ -3170,7 +3152,7 @@ char *get_func_line(int c, void *cookie, int indent, bool do_concat)
       retval = NULL;
     } else {
       retval = (char_u *)xstrdup(((char **)(gap->ga_data))[fcp->linenr++]);
-      sourcing_lnum = fcp->linenr;
+      SOURCING_LNUM = fcp->linenr;
       if (do_profiling == PROF_YES) {
         func_line_start(cookie);
       }
@@ -3178,11 +3160,10 @@ char *get_func_line(int c, void *cookie, int indent, bool do_concat)
   }
 
   // Did we encounter a breakpoint?
-  if (fcp->breakpoint != 0 && fcp->breakpoint <= sourcing_lnum) {
-    dbg_breakpoint(fp->uf_name, sourcing_lnum);
+  if (fcp->breakpoint != 0 && fcp->breakpoint <= SOURCING_LNUM) {
+    dbg_breakpoint(fp->uf_name, SOURCING_LNUM);
     // Find next breakpoint.
-    fcp->breakpoint = dbg_find_breakpoint(false, fp->uf_name,
-                                          sourcing_lnum);
+    fcp->breakpoint = dbg_find_breakpoint(false, fp->uf_name, SOURCING_LNUM);
     fcp->dbg_tick = debug_tick;
   }
 

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -275,6 +275,11 @@ bool cause_errthrow(const char *mesg, bool severe, bool *ignore)
           (*msg_list)->throw_msg = tmsg;
         }
       }
+
+      // Get the source name and lnum now, it may change before
+      // reaching do_errthrow().
+      elem->sfile = estack_sfile();
+      elem->slnum = SOURCING_LNUM;
     }
     return true;
   }
@@ -289,6 +294,7 @@ static void free_msglist(msglist_T *l)
   while (messages != NULL) {
     next = messages->next;
     xfree(messages->msg);
+    xfree(messages->sfile);
     xfree(messages);
     messages = next;
   }
@@ -478,11 +484,18 @@ static int throw_exception(void *value, except_type_T type, char *cmdname)
   }
 
   excp->type = type;
-  excp->throw_name = estack_sfile();
-  if (excp->throw_name == NULL) {
-    excp->throw_name = xstrdup("");
+  if (type == ET_ERROR && ((msglist_T *)value)->sfile != NULL) {
+    msglist_T *entry = (msglist_T *)value;
+    excp->throw_name = entry->sfile;
+    entry->sfile = NULL;
+    excp->throw_lnum = entry->slnum;
+  } else {
+    excp->throw_name = estack_sfile();
+    if (excp->throw_name == NULL) {
+      excp->throw_name = xstrdup("");
+    }
+    excp->throw_lnum = SOURCING_LNUM;
   }
-  excp->throw_lnum = SOURCING_LNUM;
 
   if (p_verbose >= 13 || debug_break_level > 0) {
     int save_msg_silent = msg_silent;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -478,8 +478,11 @@ static int throw_exception(void *value, except_type_T type, char *cmdname)
   }
 
   excp->type = type;
-  excp->throw_name = xstrdup(sourcing_name == NULL ? "" : sourcing_name);
-  excp->throw_lnum = sourcing_lnum;
+  excp->throw_name = estack_sfile();
+  if (excp->throw_name == NULL) {
+    excp->throw_name = xstrdup("");
+  }
+  excp->throw_lnum = SOURCING_LNUM;
 
   if (p_verbose >= 13 || debug_break_level > 0) {
     int save_msg_silent = msg_silent;

--- a/src/nvim/ex_eval_defs.h
+++ b/src/nvim/ex_eval_defs.h
@@ -38,11 +38,13 @@ enum {
 /// A list of error messages that can be converted to an exception.  "throw_msg"
 /// is only set in the first element of the list.  Usually, it points to the
 /// original message stored in that element, but sometimes it points to a later
-/// message in the list.  See cause_errthrow() below.
+/// message in the list.  See cause_errthrow().
 typedef struct msglist msglist_T;
 struct msglist {
-  char *msg;        ///< original message
+  char *msg;        ///< original message, allocated
   char *throw_msg;  ///< msg to throw: usually original one
+  char *sfile;      ///< value from estack_sfile(), allocated
+  linenr_T slnum;   ///< line number for "sfile"
   msglist_T *next;  ///< next of several messages in a row
 };
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -12,6 +12,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/menu.h"
 #include "nvim/os/os_defs.h"
+#include "nvim/runtime.h"
 #include "nvim/syntax_defs.h"
 #include "nvim/types.h"
 
@@ -345,8 +346,8 @@ EXTERN bool did_source_packages INIT(= false);
 // provider function call
 EXTERN struct caller_scope {
   sctx_T script_ctx;
-  char *sourcing_name, *autocmd_fname, *autocmd_match;
-  linenr_T sourcing_lnum;
+  estack_T es_entry;
+  char *autocmd_fname, *autocmd_match;
   int autocmd_bufnr;
   void *funccalp;
 } provider_caller_scope;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -248,9 +248,6 @@ EXTERN int lines_left INIT(= -1);           // lines left for listing
 EXTERN int msg_no_more INIT(= false);       // don't use more prompt, truncate
                                             // messages
 
-EXTERN char *sourcing_name INIT(= NULL);    // name of error message source
-EXTERN linenr_T sourcing_lnum INIT(= 0);    // line number of the source file
-
 EXTERN int ex_nesting_level INIT(= 0);          // nesting level
 EXTERN int debug_break_level INIT(= -1);        // break below this level
 EXTERN bool debug_did_msg INIT(= false);        // did "debug mode" message

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -691,12 +691,12 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     g->sg_cleared = false;
     g->sg_link = link_id;
     g->sg_script_ctx = current_sctx;
-    g->sg_script_ctx.sc_lnum += sourcing_lnum;
+    g->sg_script_ctx.sc_lnum += SOURCING_LNUM;
     g->sg_set |= SG_LINK;
     if (is_default) {
       g->sg_deflink = link_id;
       g->sg_deflink_sctx = current_sctx;
-      g->sg_deflink_sctx.sc_lnum += sourcing_lnum;
+      g->sg_deflink_sctx.sc_lnum += SOURCING_LNUM;
     }
     return;
   }
@@ -735,7 +735,7 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
   g->sg_blend = attrs.hl_blend;
 
   g->sg_script_ctx = current_sctx;
-  g->sg_script_ctx.sc_lnum += sourcing_lnum;
+  g->sg_script_ctx.sc_lnum += SOURCING_LNUM;
 
   g->sg_attr = hl_get_syn_attr(0, id, attrs);
 
@@ -863,7 +863,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       if (dodefault && (forceit || hlgroup->sg_deflink == 0)) {
         hlgroup->sg_deflink = to_id;
         hlgroup->sg_deflink_sctx = current_sctx;
-        hlgroup->sg_deflink_sctx.sc_lnum += sourcing_lnum;
+        hlgroup->sg_deflink_sctx.sc_lnum += SOURCING_LNUM;
         nlua_set_sctx(&hlgroup->sg_deflink_sctx);
       }
     }
@@ -873,7 +873,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       // for the group, unless '!' is used
       if (to_id > 0 && !forceit && !init
           && hl_has_settings(from_id - 1, dodefault)) {
-        if (sourcing_name == NULL && !dodefault) {
+        if (SOURCING_NAME == NULL && !dodefault) {
           emsg(_("E414: group has settings, highlight link ignored"));
         }
       } else if (hlgroup->sg_link != to_id
@@ -884,7 +884,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         }
         hlgroup->sg_link = to_id;
         hlgroup->sg_script_ctx = current_sctx;
-        hlgroup->sg_script_ctx.sc_lnum += sourcing_lnum;
+        hlgroup->sg_script_ctx.sc_lnum += SOURCING_LNUM;
         nlua_set_sctx(&hlgroup->sg_script_ctx);
         hlgroup->sg_cleared = false;
         redraw_all_later(SOME_VALID);
@@ -1274,7 +1274,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     set_hl_attr(idx);
   }
   hl_table[idx].sg_script_ctx = current_sctx;
-  hl_table[idx].sg_script_ctx.sc_lnum += sourcing_lnum;
+  hl_table[idx].sg_script_ctx.sc_lnum += SOURCING_LNUM;
   nlua_set_sctx(&hl_table[idx].sg_script_ctx);
 
   // Only call highlight_changed() once, after a sequence of highlight

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1313,6 +1313,7 @@ static void nlua_typval_exec(const char *lcmd, size_t lcmd_len, const char *name
 
 int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
 {
+#if 0  // TODO:
   const linenr_T save_sourcing_lnum = sourcing_lnum;
   const sctx_T save_current_sctx = current_sctx;
   current_sctx.sc_sid = SID_STR;
@@ -1336,6 +1337,7 @@ int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
   ga_clear_strings(&ga);
   xfree(code);
   return OK;
+#endif
 }
 
 /// Call a LuaCallable given some typvals

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -37,6 +37,7 @@
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/os/os.h"
 #include "nvim/profile.h"
+#include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/undo.h"
 #include "nvim/usercmd.h"
@@ -1313,13 +1314,11 @@ static void nlua_typval_exec(const char *lcmd, size_t lcmd_len, const char *name
 
 int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
 {
-#if 0  // TODO:
-  const linenr_T save_sourcing_lnum = sourcing_lnum;
   const sctx_T save_current_sctx = current_sctx;
   current_sctx.sc_sid = SID_STR;
   current_sctx.sc_seq = 0;
   current_sctx.sc_lnum = 0;
-  sourcing_lnum = 0;
+  estack_push(ETYPE_SCRIPT, NULL, 0);
 
   garray_T ga;
   char_u *line = NULL;
@@ -1332,12 +1331,11 @@ int nlua_source_using_linegetter(LineGetter fgetline, void *cookie, char *name)
   size_t len = strlen(code);
   nlua_typval_exec(code, len, name, NULL, 0, false, NULL);
 
-  sourcing_lnum = save_sourcing_lnum;
+  estack_pop();
   current_sctx = save_current_sctx;
   ga_clear_strings(&ga);
   xfree(code);
   return OK;
-#endif
 }
 
 /// Call a LuaCallable given some typvals

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -29,6 +29,7 @@
 #include "nvim/message.h"
 #include "nvim/option.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
 
@@ -469,7 +470,7 @@ static void map_add(buf_T *buf, mapblock_T **map_table, mapblock_T **abbr_table,
     mp->m_script_ctx.sc_lnum = lnum;
   } else {
     mp->m_script_ctx = current_sctx;
-    mp->m_script_ctx.sc_lnum += sourcing_lnum;
+    mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
     nlua_set_sctx(&mp->m_script_ctx);
   }
   mp->m_desc = NULL;
@@ -776,7 +777,7 @@ static int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev,
                   mp->m_expr = args->expr;
                   mp->m_replace_keycodes = args->replace_keycodes;
                   mp->m_script_ctx = current_sctx;
-                  mp->m_script_ctx.sc_lnum += sourcing_lnum;
+                  mp->m_script_ctx.sc_lnum += SOURCING_LNUM;
                   nlua_set_sctx(&mp->m_script_ctx);
                   if (args->desc != NULL) {
                     mp->m_desc = xstrdup(args->desc);

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -38,6 +38,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
@@ -524,7 +525,7 @@ int smsg_attr_keep(int attr, const char *s, ...)
  * isn't printed each time when it didn't change.
  */
 static int last_sourcing_lnum = 0;
-static char_u *last_sourcing_name = NULL;
+static char *last_sourcing_name = NULL;
 
 /// Reset the last used sourcing name/lnum.  Makes sure it is displayed again
 /// for the next error message;
@@ -534,16 +535,16 @@ void reset_last_sourcing(void)
   last_sourcing_lnum = 0;
 }
 
-/// @return  TRUE if "sourcing_name" differs from "last_sourcing_name".
-static int other_sourcing_name(void)
+/// @return  true if "SOURCING_NAME" differs from "last_sourcing_name".
+static bool other_sourcing_name(void)
 {
-  if (sourcing_name != NULL) {
+  if (SOURCING_NAME != NULL) {
     if (last_sourcing_name != NULL) {
-      return STRCMP(sourcing_name, last_sourcing_name) != 0;
+      return strcmp(SOURCING_NAME, last_sourcing_name) != 0;
     }
-    return TRUE;
+    return true;
   }
-  return FALSE;
+  return false;
 }
 
 /// Get the message about the source, as used for an error message
@@ -553,11 +554,19 @@ static int other_sourcing_name(void)
 static char *get_emsg_source(void)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  if (sourcing_name != NULL && other_sourcing_name()) {
+  if (SOURCING_NAME != NULL && other_sourcing_name()) {
+    char *sname = estack_sfile();
+    char *tofree = sname;
+
+    if (sname == NULL) {
+      sname = SOURCING_NAME;
+    }
+
     const char *const p = _("Error detected while processing %s:");
-    const size_t buf_len = STRLEN(sourcing_name) + strlen(p) + 1;
+    const size_t buf_len = STRLEN(sname) + strlen(p) + 1;
     char *const buf = xmalloc(buf_len);
-    snprintf(buf, buf_len, p, sourcing_name);
+    snprintf(buf, buf_len, p, sname);
+    xfree(tofree);
     return buf;
   }
   return NULL;
@@ -572,13 +581,13 @@ static char *get_emsg_lnum(void)
 {
   // lnum is 0 when executing a command from the command line
   // argument, we don't want a line number then
-  if (sourcing_name != NULL
-      && (other_sourcing_name() || sourcing_lnum != last_sourcing_lnum)
-      && sourcing_lnum != 0) {
+  if (SOURCING_NAME != NULL
+      && (other_sourcing_name() || SOURCING_LNUM != last_sourcing_lnum)
+      && SOURCING_LNUM != 0) {
     const char *const p = _("line %4ld:");
     const size_t buf_len = 20 + strlen(p);
     char *const buf = xmalloc(buf_len);
-    snprintf(buf, buf_len, p, (long)sourcing_lnum);
+    snprintf(buf, buf_len, p, (long)SOURCING_LNUM);
     return buf;
   }
   return NULL;
@@ -599,16 +608,16 @@ void msg_source(int attr)
   if (p != NULL) {
     msg_attr(p, HL_ATTR(HLF_N));
     xfree(p);
-    last_sourcing_lnum = sourcing_lnum;      // only once for each line
+    last_sourcing_lnum = SOURCING_LNUM;      // only once for each line
   }
 
   // remember the last sourcing name printed, also when it's empty
-  if (sourcing_name == NULL || other_sourcing_name()) {
+  if (SOURCING_NAME == NULL || other_sourcing_name()) {
     xfree(last_sourcing_name);
-    if (sourcing_name == NULL) {
+    if (SOURCING_NAME == NULL) {
       last_sourcing_name = NULL;
     } else {
-      last_sourcing_name = vim_strsave((char_u *)sourcing_name);
+      last_sourcing_name = xstrdup(SOURCING_NAME);
     }
   }
   --no_wait_return;
@@ -686,9 +695,9 @@ static bool emsg_multiline(const char *s, bool multiline)
       }
 
       // Log (silent) errors as debug messages.
-      if (sourcing_name != NULL && sourcing_lnum != 0) {
+      if (SOURCING_NAME != NULL && SOURCING_LNUM != 0) {
         DLOG("(:silent) %s (%s (line %ld))",
-             s, sourcing_name, (long)sourcing_lnum);
+             s, SOURCING_NAME, (long)SOURCING_LNUM);
       } else {
         DLOG("(:silent) %s", s);
       }
@@ -697,8 +706,8 @@ static bool emsg_multiline(const char *s, bool multiline)
     }
 
     // Log editor errors as INFO.
-    if (sourcing_name != NULL && sourcing_lnum != 0) {
-      ILOG("%s (%s (line %ld))", s, sourcing_name, (long)sourcing_lnum);
+    if (SOURCING_NAME != NULL && SOURCING_LNUM != 0) {
+      ILOG("%s (%s (line %ld))", s, SOURCING_NAME, (long)SOURCING_LNUM);
     } else {
       ILOG("%s", s);
     }
@@ -2457,7 +2466,7 @@ void msg_reset_scroll(void)
 static void inc_msg_scrolled(void)
 {
   if (*get_vim_var_str(VV_SCROLLSTART) == NUL) {
-    char *p = sourcing_name;
+    char *p = SOURCING_NAME;
     char *tofree = NULL;
 
     // v:scrollstart is empty, set it to the script/function name and line
@@ -2468,7 +2477,7 @@ static void inc_msg_scrolled(void)
       size_t len = strlen(p) + 40;
       tofree = xmalloc(len);
       vim_snprintf(tofree, len, _("%s line %" PRId64),
-                   p, (int64_t)sourcing_lnum);
+                   p, (int64_t)SOURCING_LNUM);
       p = tofree;
     }
     set_vim_var_string(VV_SCROLLSTART, p, -1);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3996,7 +3996,7 @@ static void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
     .script_ctx = {
       script_ctx.sc_sid,
       script_ctx.sc_seq,
-      script_ctx.sc_lnum + sourcing_lnum
+      script_ctx.sc_lnum + SOURCING_LNUM
     },
     current_channel_id
   };

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -532,9 +532,8 @@ void func_line_start(void *cookie)
   funccall_T *fcp = (funccall_T *)cookie;
   ufunc_T *fp = fcp->func;
 
-  if (fp->uf_profiling && sourcing_lnum >= 1
-      && sourcing_lnum <= fp->uf_lines.ga_len) {
-    fp->uf_tml_idx = sourcing_lnum - 1;
+  if (fp->uf_profiling && SOURCING_LNUM >= 1 && SOURCING_LNUM <= fp->uf_lines.ga_len) {
+    fp->uf_tml_idx = SOURCING_LNUM - 1;
     // Skip continuation lines.
     while (fp->uf_tml_idx > 0 && FUNCLINE(fp, fp->uf_tml_idx) == NULL) {
       fp->uf_tml_idx--;
@@ -798,11 +797,11 @@ void script_line_start(void)
     return;
   }
   si = &SCRIPT_ITEM(current_sctx.sc_sid);
-  if (si->sn_prof_on && sourcing_lnum >= 1) {
+  if (si->sn_prof_on && SOURCING_LNUM >= 1) {
     // Grow the array before starting the timer, so that the time spent
     // here isn't counted.
-    (void)ga_grow(&si->sn_prl_ga, sourcing_lnum - si->sn_prl_ga.ga_len);
-    si->sn_prl_idx = sourcing_lnum - 1;
+    (void)ga_grow(&si->sn_prl_ga, SOURCING_LNUM - si->sn_prl_ga.ga_len);
+    si->sn_prl_idx = SOURCING_LNUM - 1;
     while (si->sn_prl_ga.ga_len <= si->sn_prl_idx
            && si->sn_prl_ga.ga_len < si->sn_prl_ga.ga_maxlen) {
       // Zero counters for a line that was not used before.

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -80,9 +80,9 @@ estack_T *estack_push(etype_T type, char *name, linenr_T lnum)
 }
 
 /// Add a user function to the execution stack.
-void estack_push_ufunc(etype_T type, ufunc_T *ufunc, linenr_T lnum)
+void estack_push_ufunc(ufunc_T *ufunc, linenr_T lnum)
 {
-  estack_T *entry = estack_push(type,
+  estack_T *entry = estack_push(ETYPE_UFUNC,
                                 (char *)(ufunc->uf_name_exp != NULL
                                          ? ufunc->uf_name_exp : ufunc->uf_name),
                                 lnum);

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -3,7 +3,44 @@
 
 #include <stdbool.h>
 
+#include "nvim/autocmd.h"
+#include "nvim/eval/typval.h"
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/ex_eval_defs.h"
+
+/// Entry in the execution stack "exestack".
+typedef enum {
+  ETYPE_TOP,       // toplevel
+  ETYPE_SCRIPT,    // sourcing script, use es_info.sctx
+  ETYPE_UFUNC,     // user function, use es_info.ufunc
+  ETYPE_AUCMD,     // autocomand, use es_info.aucmd
+  ETYPE_MODELINE,  // modeline, use es_info.sctx
+  ETYPE_EXCEPT,    // exception, use es_info.exception
+  ETYPE_ARGS,      // command line argument
+  ETYPE_ENV,       // environment variable
+  ETYPE_INTERNAL,  // internal operation
+  ETYPE_SPELL,     // loading spell file
+} etype_T;
+
+typedef struct {
+  linenr_T es_lnum;     ///< replaces "sourcing_lnum"
+  char *es_name;        ///< replaces "sourcing_name"
+  etype_T es_type;
+  union {
+    sctx_T *sctx;       ///< script and modeline info
+    ufunc_T *ufunc;     ///< function info
+    AutoPatCmd *aucmd;  ///< autocommand info
+    except_T *except;   ///< exception info
+  } es_info;
+} estack_T;
+
+/// Stack of execution contexts.  Each entry is an estack_T.
+/// Current context is at ga_len - 1.
+extern garray_T exestack;
+/// name of error message source
+#define SOURCING_NAME (((estack_T *)exestack.ga_data)[exestack.ga_len - 1].es_name)
+/// line number in the message source or zero
+#define SOURCING_LNUM (((estack_T *)exestack.ga_data)[exestack.ga_len - 1].es_lnum)
 
 typedef struct scriptitem_S {
   char_u *sn_name;

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -8,20 +8,20 @@
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_eval_defs.h"
 
-/// Entry in the execution stack "exestack".
 typedef enum {
-  ETYPE_TOP,       // toplevel
-  ETYPE_SCRIPT,    // sourcing script, use es_info.sctx
-  ETYPE_UFUNC,     // user function, use es_info.ufunc
-  ETYPE_AUCMD,     // autocomand, use es_info.aucmd
-  ETYPE_MODELINE,  // modeline, use es_info.sctx
-  ETYPE_EXCEPT,    // exception, use es_info.exception
-  ETYPE_ARGS,      // command line argument
-  ETYPE_ENV,       // environment variable
-  ETYPE_INTERNAL,  // internal operation
-  ETYPE_SPELL,     // loading spell file
+  ETYPE_TOP,       ///< toplevel
+  ETYPE_SCRIPT,    ///< sourcing script, use es_info.sctx
+  ETYPE_UFUNC,     ///< user function, use es_info.ufunc
+  ETYPE_AUCMD,     ///< autocomand, use es_info.aucmd
+  ETYPE_MODELINE,  ///< modeline, use es_info.sctx
+  ETYPE_EXCEPT,    ///< exception, use es_info.exception
+  ETYPE_ARGS,      ///< command line argument
+  ETYPE_ENV,       ///< environment variable
+  ETYPE_INTERNAL,  ///< internal operation
+  ETYPE_SPELL,     ///< loading spell file
 } etype_T;
 
+/// Entry in the execution stack "exestack".
 typedef struct {
   linenr_T es_lnum;     ///< replaces "sourcing_lnum"
   char *es_name;        ///< replaces "sourcing_name"

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -580,6 +580,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   slang_T *lp = NULL;
   int c = 0;
   int res;
+  bool did_estack_push = false;
 
   fd = os_fopen((char *)fname, "r");
   if (fd == NULL) {
@@ -612,6 +613,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
 
   // Set sourcing_name, so that error messages mention the file name.
   estack_push(ETYPE_SPELL, (char *)fname, 0);
+  did_estack_push = true;
 
   // <HEADER>: <fileID>
   const int scms_ret = spell_check_magic_string(fd);
@@ -807,7 +809,9 @@ endOK:
   if (fd != NULL) {
     fclose(fd);
   }
-  estack_pop();
+  if (did_estack_push) {
+    estack_pop();
+  }
 
   return lp;
 }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -242,6 +242,7 @@
 #include "nvim/os/os.h"
 #include "nvim/path.h"
 #include "nvim/regexp.h"
+#include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/spell.h"
 #include "nvim/spell_defs.h"
@@ -576,8 +577,6 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   char_u *p;
   int n;
   int len;
-  char_u *save_sourcing_name = (char_u *)sourcing_name;
-  linenr_T save_sourcing_lnum = sourcing_lnum;
   slang_T *lp = NULL;
   int c = 0;
   int res;
@@ -612,8 +611,7 @@ slang_T *spell_load_file(char_u *fname, char_u *lang, slang_T *old_lp, bool sile
   }
 
   // Set sourcing_name, so that error messages mention the file name.
-  sourcing_name = (char *)fname;
-  sourcing_lnum = 0;
+  estack_push(ETYPE_SPELL, (char *)fname, 0);
 
   // <HEADER>: <fileID>
   const int scms_ret = spell_check_magic_string(fd);
@@ -809,8 +807,7 @@ endOK:
   if (fd != NULL) {
     fclose(fd);
   }
-  sourcing_name = (char *)save_sourcing_name;
-  sourcing_lnum = save_sourcing_lnum;
+  estack_pop();
 
   return lp;
 }

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2614,6 +2614,28 @@ func Test_BufWrite_lockmarks()
   call delete('Xtest2')
 endfunc
 
+func Test_FileType_spell()
+  if !isdirectory('/tmp')
+    throw "Skipped: requires /tmp directory"
+  endif
+
+  " this was crashing with an invalid free()
+  setglobal spellfile=/tmp/en.utf-8.add
+  augroup crash
+    autocmd!
+    autocmd BufNewFile,BufReadPost crashfile setf somefiletype
+    autocmd BufNewFile,BufReadPost crashfile set ft=anotherfiletype
+    autocmd FileType anotherfiletype setlocal spell
+  augroup END
+  func! NoCrash() abort
+    edit /tmp/crashfile
+  endfunc
+  call NoCrash()
+
+  au! crash
+  setglobal spellfile=
+endfunc
+
 " Test closing a window or editing another buffer from a FileChangedRO handler
 " in a readonly buffer
 func Test_FileChangedRO_winclose()

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1573,6 +1573,23 @@ func Test_script_local_func()
   enew! | close
 endfunc
 
+func Test_script_expand_sfile()
+  let lines =<< trim END
+    func s:snr()
+      return expand('<sfile>')
+    endfunc
+    let g:result = s:snr()
+  END
+  call writefile(lines, 'Xexpand')
+  source Xexpand
+  call assert_match('<SNR>\d\+_snr', g:result)
+  source Xexpand
+  call assert_match('<SNR>\d\+_snr', g:result)
+
+  call delete('Xexpand')
+  unlet g:result
+endfunc
+
 func Test_compound_assignment_operators()
     " Test for number
     let x = 1

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -7,6 +7,7 @@
 #include "nvim/eval/encode.h"
 #include "nvim/ex_docmd.h"
 #include "nvim/os/os.h"
+#include "nvim/runtime.h"
 #include "nvim/testing.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
@@ -17,21 +18,23 @@
 static void prepare_assert_error(garray_T *gap)
 {
   char buf[NUMBUFLEN];
+  char *sname = estack_sfile();
 
   ga_init(gap, 1, 100);
-  if (sourcing_name != NULL) {
-    ga_concat(gap, (char *)sourcing_name);
-    if (sourcing_lnum > 0) {
+  if (sname != NULL) {
+    ga_concat(gap, sname);
+    if (SOURCING_LNUM > 0) {
       ga_concat(gap, " ");
     }
   }
-  if (sourcing_lnum > 0) {
-    vim_snprintf(buf, ARRAY_SIZE(buf), "line %" PRId64, (int64_t)sourcing_lnum);
+  if (SOURCING_LNUM > 0) {
+    vim_snprintf(buf, ARRAY_SIZE(buf), "line %" PRId64, (int64_t)SOURCING_LNUM);
     ga_concat(gap, buf);
   }
-  if (sourcing_name != NULL || sourcing_lnum > 0) {
+  if (sname != NULL || SOURCING_LNUM > 0) {
     ga_concat(gap, ": ");
   }
+  xfree(sname);
 }
 
 /// Append "p[clen]" to "gap", escaping unprintable characters.

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -17,6 +17,7 @@
 #include "nvim/garray.h"
 #include "nvim/lua/executor.h"
 #include "nvim/os/input.h"
+#include "nvim/runtime.h"
 #include "nvim/usercmd.h"
 #include "nvim/window.h"
 
@@ -168,7 +169,7 @@ char *find_ucmd(exarg_T *eap, char *p, int *full, expand_T *xp, int *complp)
             xp->xp_luaref = uc->uc_compl_luaref;
             xp->xp_arg = (char *)uc->uc_compl_arg;
             xp->xp_script_ctx = uc->uc_script_ctx;
-            xp->xp_script_ctx.sc_lnum += sourcing_lnum;
+            xp->xp_script_ctx.sc_lnum += SOURCING_LNUM;
           }
           // Do not search for further abbreviations
           // if this is an exact match.
@@ -890,7 +891,7 @@ int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, 
   cmd->uc_def = def;
   cmd->uc_compl = compl;
   cmd->uc_script_ctx = current_sctx;
-  cmd->uc_script_ctx.sc_lnum += sourcing_lnum;
+  cmd->uc_script_ctx.sc_lnum += SOURCING_LNUM;
   nlua_set_sctx(&cmd->uc_script_ctx);
   cmd->uc_compl_arg = (char_u *)compl_arg;
   cmd->uc_compl_luaref = compl_luaref;


### PR DESCRIPTION
#### vim-patch:8.2.0056: execution stack is incomplete and inefficient

Problem:    Execution stack is incomplete and inefficient.
Solution:   Introduce a proper execution stack and use it instead of
            sourcing_name/sourcing_lnum.  Create a string only when used.
https://github.com/vim/vim/commit/1a47ae32cdc19b0fd5a82e19fe5fddf45db1a506

Omit test_debugger.vim: superseded by later patches.
Omit check_map_keycodes(): N/A.
Omit kword_test.c: N/A (converted to a unit test).


#### vim-patch:8.2.0061: the execute stack can grow big and never shrinks

Problem:    The execute stack can grow big and never shrinks.
Solution:   Reduce the size in gargage collect.
https://github.com/vim/vim/commit/3fbcc128cbd2311819cc5a7bb89e45669860f008


#### vim-patch:8.2.0078: expanding <sfile> works differently the second time

Problem:    Expanding <sfile> works differently the second time.
Solution:   Keep the expanded name when redefining a function.
https://github.com/vim/vim/commit/b9adef79eca6f95bc7376ff3a6a383e436c5d6ea


#### vim-patch:8.2.0097: crash with autocommand and spellfile

Problem:    Crash with autocommand and spellfile. (Tim Pope)
Solution:   Do not pop exestack when not pushed.
https://github.com/vim/vim/commit/ce6db0273f2c4359f48d75103a42991aa481f14e


#### vim-patch:8.2.0823: Vim9: script reload test is disabled

Problem:    Vim9: script reload test is disabled.
Solution:   Compile a function in the context of the script where it was
            defined.  Set execution stack for compiled function.  Add a test
            that an error is reported for the right file/function.
https://github.com/vim/vim/commit/25e0f5863e9010a75a1ff0d04e8f886403968755

Omit stack_top_is_ufunc(): only used by Vim9 script.