### PR TITLE
vim-patch:9.0.0198: ml_get error when switching buffer in Visual mode

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1533,6 +1533,15 @@ void set_curbuf(buf_T *buf, int action)
 /// be pointing to freed memory.
 void enter_buffer(buf_T *buf)
 {
+  // when closing the current buffer stop Visual mode
+  if (VIsual_active
+#if defined(EXITFREE)
+      && !entered_free_all_mem
+#endif
+      ) {
+    end_visual_mode();
+  }
+
   // Get the buffer in the current window.
   curwin->w_buffer = buf;
   curbuf = buf;

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1550,5 +1550,25 @@ func Test_visual_area_adjusted_when_hiding()
   bwipe!
 endfunc
 
+func Test_switch_buffer_ends_visual_mode()
+  enew
+  call setline(1, 'foo')
+  set hidden
+  set virtualedit=all
+  let buf1 = bufnr()
+  enew
+  let buf2 = bufnr()
+  call setline(1, ['', '', '', ''])
+  call cursor(4, 5)
+  call feedkeys("\<C-V>3k4h", 'xt')
+  exe 'buffer' buf1
+  call assert_equal('n', mode())
+
+  set nohidden
+  set virtualedit=
+  bwipe!
+  exe 'bwipe!' buf2
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #19744

#### vim-patch:9.0.0198: ml_get error when switching buffer in Visual mode

Problem:    ml_get error when switching buffer in Visual mode.
Solution:   End Visual mode when switching buffer.
https://github.com/vim/vim/commit/cfeb8a584be11758cf71ae02f6c937b06d6bb66f