### PR TITLE
vim-patch:8.2.{1297,1653,1658}: expand('<stack>')

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2010,6 +2010,7 @@ expand({string} [, {nosuf} [, {list}]])				*expand()*
 					a function
 			<SID>		"<SNR>123_"  where "123" is the
 					current script ID  |<SID>|
+			<stack>		call stack
 			<cword>		word under the cursor
 			<cWORD>		WORD under the cursor
 			<client>	the {clientid} of the last received

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -879,12 +879,18 @@ Note: these are typed literally, they are not special keys!
 							*:<sfile>* *<sfile>*
 	<sfile>    When executing a `:source` command, is replaced with the
 		   file name of the sourced file.  *E498*
-		   When executing a function, is replaced with:
-		   "function {function-name}[{lnum}]"
-		   function call nesting is indicated like this:
-		   "function {function-name1}[{lnum}]..{function-name2}[{lnum}]"
+		   When executing a function, is replaced with the call stack,
+		   as with <stack> (this is for backwards compatibility, using
+		   <stack> is preferred).
 		   Note that filename-modifiers are useless when <sfile> is
-		   used inside a function.
+		   not used inside a script.
+							*:<stack>* *<stack>*
+	<stack>	   is replaced with the call stack, using
+		   "function {function-name}[{lnum}]" for a function line
+		   and "script {file-name}[{lnum}]" for a script line, and
+		   ".." in between items.  E.g.:
+		   "function {function-name1}[{lnum}]..{function-name2}[{lnum}]"
+		   If there is no call stack you get error *E489* .
 							*:<slnum>* *<slnum>*
 	<slnum>	   When executing a `:source` command, is replaced with the
 		   line number.  *E842*

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -99,7 +99,7 @@ void do_debug(char_u *cmd)
     xfree(debug_newval);
     debug_newval = NULL;
   }
-  char *sname = estack_sfile();
+  char *sname = estack_sfile(false);
   if (sname != NULL) {
     msg(sname);
   }
@@ -324,7 +324,7 @@ static void do_checkbacktracelevel(void)
     debug_backtrace_level = 0;
     msg(_("frame is zero"));
   } else {
-    char *sname = estack_sfile();
+    char *sname = estack_sfile(false);
     int max = get_maxbacktrace_level(sname);
 
     if (debug_backtrace_level > max) {
@@ -337,7 +337,7 @@ static void do_checkbacktracelevel(void)
 
 static void do_showbacktrace(char_u *cmd)
 {
-  char *sname = estack_sfile();
+  char *sname = estack_sfile(false);
   int max = get_maxbacktrace_level(sname);
   if (sname != NULL) {
     int i = 0;

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -99,7 +99,7 @@ void do_debug(char_u *cmd)
     xfree(debug_newval);
     debug_newval = NULL;
   }
-  char *sname = estack_sfile(false);
+  char *sname = estack_sfile(ESTACK_NONE);
   if (sname != NULL) {
     msg(sname);
   }
@@ -324,7 +324,7 @@ static void do_checkbacktracelevel(void)
     debug_backtrace_level = 0;
     msg(_("frame is zero"));
   } else {
-    char *sname = estack_sfile(false);
+    char *sname = estack_sfile(ESTACK_NONE);
     int max = get_maxbacktrace_level(sname);
 
     if (debug_backtrace_level > max) {
@@ -337,7 +337,7 @@ static void do_checkbacktracelevel(void)
 
 static void do_showbacktrace(char_u *cmd)
 {
-  char *sname = estack_sfile(false);
+  char *sname = estack_sfile(ESTACK_NONE);
   int max = get_maxbacktrace_level(sname);
   if (sname != NULL) {
     int i = 0;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7912,9 +7912,12 @@ char_u *eval_vars(char_u *src, char_u *srcstart, size_t *usedlen, linenr_T *lnum
       break;
 
     case SPEC_SFILE:            // file name for ":so" command
-      result = estack_sfile();
+    case SPEC_STACK:            // call stack
+      result = estack_sfile(spec_idx == SPEC_SFILE);
       if (result == NULL) {
-        *errormsg = _("E498: no :source file name to substitute for \"<sfile>\"");
+        *errormsg = spec_idx == SPEC_SFILE
+          ? _("E498: no :source file name to substitute for \"<sfile>\"")
+          : _("E489: no call stack to substitute for \"<stack>\"");
         return NULL;
       }
       resultbuf = result;  // remember allocated string

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7719,6 +7719,7 @@ ssize_t find_cmdline_var(const char_u *src, size_t *usedlen)
 ///        '<cexpr>' to C-expression under the cursor
 ///        '<cfile>' to path name under the cursor
 ///        '<sfile>' to sourced file name
+///        '<stack>' to call stack
 ///        '<slnum>' to sourced file line number
 ///        '<afile>' to file name for autocommand
 ///        '<abuf>'  to buffer number for autocommand
@@ -7913,7 +7914,7 @@ char_u *eval_vars(char_u *src, char_u *srcstart, size_t *usedlen, linenr_T *lnum
 
     case SPEC_SFILE:            // file name for ":so" command
     case SPEC_STACK:            // call stack
-      result = estack_sfile(spec_idx == SPEC_SFILE);
+      result = estack_sfile(spec_idx == SPEC_SFILE ? ESTACK_SFILE : ESTACK_STACK);
       if (result == NULL) {
         *errormsg = spec_idx == SPEC_SFILE
           ? _("E498: no :source file name to substitute for \"<sfile>\"")

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -278,7 +278,7 @@ bool cause_errthrow(const char *mesg, bool severe, bool *ignore)
 
       // Get the source name and lnum now, it may change before
       // reaching do_errthrow().
-      elem->sfile = estack_sfile(false);
+      elem->sfile = estack_sfile(ESTACK_NONE);
       elem->slnum = SOURCING_LNUM;
     }
     return true;
@@ -490,7 +490,7 @@ static int throw_exception(void *value, except_type_T type, char *cmdname)
     entry->sfile = NULL;
     excp->throw_lnum = entry->slnum;
   } else {
-    excp->throw_name = estack_sfile(false);
+    excp->throw_name = estack_sfile(ESTACK_NONE);
     if (excp->throw_name == NULL) {
       excp->throw_name = xstrdup("");
     }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -278,7 +278,7 @@ bool cause_errthrow(const char *mesg, bool severe, bool *ignore)
 
       // Get the source name and lnum now, it may change before
       // reaching do_errthrow().
-      elem->sfile = estack_sfile();
+      elem->sfile = estack_sfile(false);
       elem->slnum = SOURCING_LNUM;
     }
     return true;
@@ -490,7 +490,7 @@ static int throw_exception(void *value, except_type_T type, char *cmdname)
     entry->sfile = NULL;
     excp->throw_lnum = entry->slnum;
   } else {
-    excp->throw_name = estack_sfile();
+    excp->throw_name = estack_sfile(false);
     if (excp->throw_name == NULL) {
       excp->throw_name = xstrdup("");
     }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1906,7 +1906,7 @@ void nlua_set_sctx(sctx_T *current)
     break;
   }
   char *source_path = fix_fname(info->source + 1);
-  get_current_script_id((char_u *)source_path, current);
+  get_current_script_id(&source_path, current);
   xfree(source_path);
   current->sc_lnum = info->currentline;
   current->sc_seq = -1;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -555,7 +555,7 @@ static char *get_emsg_source(void)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (SOURCING_NAME != NULL && other_sourcing_name()) {
-    char *sname = estack_sfile(false);
+    char *sname = estack_sfile(ESTACK_NONE);
     char *tofree = sname;
 
     if (sname == NULL) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -555,7 +555,7 @@ static char *get_emsg_source(void)
   FUNC_ATTR_MALLOC FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (SOURCING_NAME != NULL && other_sourcing_name()) {
-    char *sname = estack_sfile();
+    char *sname = estack_sfile(false);
     char *tofree = sname;
 
     if (sname == NULL) {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -135,21 +135,19 @@ char *estack_sfile(estack_arg_T which)
       }
       len += strlen(type_name);
       ga_grow(&ga, (int)len);
-      linenr_T lnum = 0;
-      if (idx == exestack.ga_len - 1) {
-        lnum = which == ESTACK_STACK ? SOURCING_LNUM : 0;
-      } else {
-        lnum = entry->es_lnum;
-      }
+      linenr_T lnum = idx == exestack.ga_len - 1
+        ? which == ESTACK_STACK ? SOURCING_LNUM : 0
+        : entry->es_lnum;
+      char *dots = idx == exestack.ga_len - 1 ? "" : "..";
       if (lnum == 0) {
         // For the bottom entry of <sfile>: do not add the line number,
         // it is used in <slnum>.  Also leave it out when the number is
         // not set.
         vim_snprintf((char *)ga.ga_data + ga.ga_len, len, "%s%s%s",
-                     type_name, entry->es_name, idx == exestack.ga_len - 1 ? "" : "..");
+                     type_name, entry->es_name, dots);
       } else {
-        vim_snprintf((char *)ga.ga_data + ga.ga_len, len, "%s%s[%" PRIdLINENR "]..",
-                     type_name, entry->es_name, lnum);
+        vim_snprintf((char *)ga.ga_data + ga.ga_len, len, "%s%s[%" PRIdLINENR "]%s",
+                     type_name, entry->es_name, lnum, dots);
       }
       ga.ga_len += (int)strlen((char *)ga.ga_data + ga.ga_len);
     }

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -42,6 +42,13 @@ extern garray_T exestack;
 /// line number in the message source or zero
 #define SOURCING_LNUM (((estack_T *)exestack.ga_data)[exestack.ga_len - 1].es_lnum)
 
+/// Argument for estack_sfile().
+typedef enum {
+  ESTACK_NONE,
+  ESTACK_SFILE,
+  ESTACK_STACK,
+} estack_arg_T;
+
 typedef struct scriptitem_S {
   char_u *sn_name;
   bool sn_prof_on;              ///< true when script is/was profiled

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -58,7 +58,7 @@ func Test_expand_sfile_and_stack()
   END
   call writefile(lines, 'Xstack')
   source Xstack
-  call assert_match('\<Xstack\[2\]', g:stack_value)
+  call assert_match('\<Xstack\[2\]$', g:stack_value)
   call delete('Xstack')
 endfunc
 

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -39,9 +39,9 @@ endfunc
 
 func Test_expand_sfile_and_stack()
   call assert_match('test_expand_func\.vim$', s:sfile)
-  let expected = 'script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack$'
-  call assert_match(expected , expand('<sfile>'))
-  call assert_match(expected , expand('<stack>'))
+  let expected = 'script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack'
+  call assert_match(expected .. '$', expand('<sfile>'))
+  call assert_match(expected .. '\[4\]' , expand('<stack>'))
 
   " Call in script-local function
   call assert_match('script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack\[7\]\.\.<SNR>\d\+_expand_sfile$', s:expand_sfile())
@@ -53,11 +53,12 @@ func Test_expand_sfile_and_stack()
 
   " Use <stack> from sourced script.
   let lines =<< trim END
+    " comment here
     let g:stack_value = expand('<stack>')
   END
   call writefile(lines, 'Xstack')
   source Xstack
-  call assert_match('\<Xstack$', g:stack_value)
+  call assert_match('\<Xstack\[2\]', g:stack_value)
   call delete('Xstack')
 endfunc
 

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -37,17 +37,28 @@ func Test_expand_sflnum()
   delcommand Flnum
 endfunc
 
-func Test_expand_sfile()
+func Test_expand_sfile_and_stack()
   call assert_match('test_expand_func\.vim$', s:sfile)
-  call assert_match('^function .*\.\.Test_expand_sfile$', expand('<sfile>'))
+  let expected = 'script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack$'
+  call assert_match(expected , expand('<sfile>'))
+  call assert_match(expected , expand('<stack>'))
 
   " Call in script-local function
-  call assert_match('^function .*\.\.Test_expand_sfile\[5\]\.\.<SNR>\d\+_expand_sfile$', s:expand_sfile())
+  call assert_match('script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack\[7\]\.\.<SNR>\d\+_expand_sfile$', s:expand_sfile())
 
   " Call in command
   command Sfile echo expand('<sfile>')
-  call assert_match('^function .*\.\.Test_expand_sfile$', trim(execute('Sfile')))
+  call assert_match('script .*testdir/runtest.vim\[\d\+\]\.\.function RunTheTest\[\d\+\]\.\.Test_expand_sfile_and_stack$', trim(execute('Sfile')))
   delcommand Sfile
+
+  " Use <stack> from sourced script.
+  let lines =<< trim END
+    let g:stack_value = expand('<stack>')
+  END
+  call writefile(lines, 'Xstack')
+  source Xstack
+  call assert_match('\<Xstack$', g:stack_value)
+  call delete('Xstack')
 endfunc
 
 func Test_expand_slnum()

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -18,7 +18,7 @@
 static void prepare_assert_error(garray_T *gap)
 {
   char buf[NUMBUFLEN];
-  char *sname = estack_sfile();
+  char *sname = estack_sfile(false);
 
   ga_init(gap, 1, 100);
   if (sname != NULL) {

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -18,7 +18,7 @@
 static void prepare_assert_error(garray_T *gap)
 {
   char buf[NUMBUFLEN];
-  char *sname = estack_sfile(false);
+  char *sname = estack_sfile(ESTACK_NONE);
 
   ga_init(gap, 1, 100);
   if (sname != NULL) {

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -13,6 +13,10 @@ local exec_lua = helpers.exec_lua
 local eval = helpers.eval
 local exec_capture = helpers.exec_capture
 local neq = helpers.neq
+local matches = helpers.matches
+local iswin = helpers.iswin
+local mkdir = helpers.mkdir
+local rmdir = helpers.rmdir
 
 describe(':source', function()
   before_each(function()
@@ -37,6 +41,30 @@ describe(':source', function()
     command('source ' .. test_file)
     os.remove(other_file)
     os.remove(test_file)
+  end)
+
+  it("changing 'shellslash' changes the result of expand()", function()
+    if not iswin() then
+      pending("'shellslash' only works on Windows")
+      return
+    end
+    mkdir('Xshellslash')
+    local script = [[
+      let g:result1 = expand('<stack>')
+      set shellslash
+      let g:result2 = expand('<stack>')
+      set noshellslash
+      let g:result3 = expand('<stack>')
+    ]]
+    write_file([[Xshellslash/Xexpand.vim]], script)
+
+    meths.set_option('shellslash', false)
+    command([[source Xshellslash/Xexpand.vim]])
+    matches([[Xshellslash\Xexpand%.vim]], meths.get_var('result1'))
+    matches([[Xshellslash/Xexpand%.vim]], meths.get_var('result2'))
+    matches([[Xshellslash\Xexpand%.vim]], meths.get_var('result3'))
+
+    rmdir('Xshellslash')
   end)
 
   it('current buffer', function()


### PR DESCRIPTION
#### vim-patch:8.2.1297: when a test fails it's often not easy to see where

Problem:    When a test fails it's often not easy to see what the call stack
            is.
Solution:   Add more entries from the call stack in the exception message.
https://github.com/vim/vim/commit/a5d0423fa16f18b4576a2a07e50034e489587a7d

Use docs from latest Vim.


#### vim-patch:8.2.1653: expand('\<stack>') does not include the final line number

Problem:    Expand('\<stack>') does not include the final line number.
Solution:   Add the line nuber.
https://github.com/vim/vim/commit/4f25b1aba050b85fa97ca2316aa04dd4b0b22530


#### vim-patch:8.2.1658: expand('\<stack>') has trailing ".."

Problem:    Expand('\<stack>') has trailing "..".
Solution:   Remove the "..".
https://github.com/vim/vim/commit/a810db3f17d477e057059c72062c08fd97bcea43