### PR TITLE
vim-patch:8.2.3675

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -598,6 +598,14 @@ static char *get_emsg_lnum(void)
 /// is only displayed if it changed.
 void msg_source(int attr)
 {
+  static bool recursive = false;
+
+  // Bail out if something called here causes an error.
+  if (recursive) {
+    return;
+  }
+  recursive = true;
+
   no_wait_return++;
   char *p = get_emsg_source();
   if (p != NULL) {
@@ -613,14 +621,14 @@ void msg_source(int attr)
 
   // remember the last sourcing name printed, also when it's empty
   if (SOURCING_NAME == NULL || other_sourcing_name()) {
-    xfree(last_sourcing_name);
-    if (SOURCING_NAME == NULL) {
-      last_sourcing_name = NULL;
-    } else {
+    XFREE_CLEAR(last_sourcing_name);
+    if (SOURCING_NAME != NULL) {
       last_sourcing_name = xstrdup(SOURCING_NAME);
     }
   }
-  --no_wait_return;
+  no_wait_return--;
+
+  recursive = false;
 }
 
 /// @return  TRUE if not giving error messages right now:


### PR DESCRIPTION
#### vim-patch:8.2.3675: using freed memory when vim_strsave() fails

Problem:    Using freed memory when vim_strsave() fails.
Solution:   Clear "last_sourcing_name".  Check for msg_source() called
            recursively.
https://github.com/vim/vim/commit/ba8c92687d53c91bbc20c867a49e0988819ea2d5

Although xstrdup() cannot fail in Nvim, it may still be possible that an
error appears (e.g. in regexp engine) when printing the message.