### PR TITLE
build: allow patching dependencies with both `git` and `patch`

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -68,9 +68,17 @@ endif()
 
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
 
-find_package(Git)
-if(NOT Git_FOUND)
-  message(FATAL_ERROR "Git is required to apply patches.")
+find_package(Git QUIET)
+find_package(Patch QUIET)
+
+if(Git_FOUND)
+  set(PATCH_CMD git)
+  set(PATCH_EXE ${GIT_EXECUTABLE})
+elseif(Patch_FOUND AND UNIX)
+  set(PATCH_CMD patch)
+  set(PATCH_EXE ${Patch_EXECUTABLE})
+else()
+  message(FATAL_ERROR "Either git or patch is required to apply patches.")
 endif()
 
 if(UNIX)

--- a/cmake.deps/cmake/BuildLibuv.cmake
+++ b/cmake.deps/cmake/BuildLibuv.cmake
@@ -18,9 +18,11 @@ ExternalProject_Add(libuv
     -DTARGET=libuv
     -DUSE_EXISTING_SRC_DIR=${USE_EXISTING_SRC_DIR}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/DownloadAndExtractFile.cmake
-  PATCH_COMMAND
-    ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv init
-      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libuv apply --ignore-whitespace
-        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-disable-shared.patch)
+  PATCH_COMMAND ${CMAKE_COMMAND}
+    -D START_DIR=${DEPS_BUILD_DIR}/src/libuv
+    -D PATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/patches/libuv-disable-shared.patch
+    -D PATCH_CMD=${PATCH_CMD}
+    -D PATCH_EXE=${PATCH_EXE}
+    -P ${PROJECT_SOURCE_DIR}/cmake/Patch.cmake)
 
 list(APPEND THIRD_PARTY_DEPS libuv)

--- a/cmake.deps/cmake/BuildLibvterm.cmake
+++ b/cmake.deps/cmake/BuildLibvterm.cmake
@@ -34,9 +34,12 @@ endfunction()
 if(WIN32)
   if(MSVC)
     set(LIBVTERM_PATCH_COMMAND
-    ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm init
-      COMMAND ${GIT_EXECUTABLE} -C ${DEPS_BUILD_DIR}/src/libvterm apply --ignore-whitespace
-        ${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Remove-VLAs-for-MSVC.patch)
+    ${CMAKE_COMMAND}
+    -D START_DIR=${DEPS_BUILD_DIR}/src/libvterm
+    -D PATCH_FILE=${CMAKE_CURRENT_SOURCE_DIR}/patches/libvterm-Remove-VLAs-for-MSVC.patch
+    -D PATCH_CMD=${PATCH_CMD}
+    -D PATCH_EXE=${PATCH_EXE}
+    -P ${PROJECT_SOURCE_DIR}/cmake/Patch.cmake)
   endif()
   set(LIBVTERM_CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibvtermCMakeLists.txt

--- a/cmake.deps/cmake/Patch.cmake
+++ b/cmake.deps/cmake/Patch.cmake
@@ -1,0 +1,6 @@
+if(PATCH_CMD STREQUAL git)
+  execute_process(COMMAND ${PATCH_EXE} -C ${START_DIR} init)
+  execute_process(COMMAND ${PATCH_EXE} -C ${START_DIR} apply --ignore-whitespace ${PATCH_FILE})
+else()
+  execute_process(COMMAND ${PATCH_EXE} -d ${START_DIR} -i ${PATCH_FILE})
+endif()


### PR DESCRIPTION
Debian/Ubuntu package build didn't require git before commit
e23c5fda0a3fe385af615372c474d4dad3b74464. After the commit the builds
broke. This is meant to be an optional patch command for those
distributions.