### PR TITLE
vim-patch:8.2.4249: the timeout limit for spell suggestions is always 5000

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5876,6 +5876,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 			suggestions is never more than the value of 'lines'
 			minus two.
 
+	timeout:{millisec}   Limit the time searching for suggestions to
+			{millisec} milli seconds.  Applies to the following
+			methods.  When omitted the limit is 5000. When
+			negative there is no limit.
+
 	file:{filename} Read file {filename}, which must have two columns,
 			separated by a slash.  The first column contains the
 			bad word, the second column the suggested good word.

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -474,6 +474,16 @@ func Test_spellsuggest_option_expr()
   bwipe!
 endfunc
 
+func Test_spellsuggest_timeout()
+  set spellsuggest=timeout:30
+  set spellsuggest=timeout:-123
+  set spellsuggest=timeout:999999
+  call assert_fails('set spellsuggest=timeout', 'E474:')
+  call assert_fails('set spellsuggest=timeout:x', 'E474:')
+  call assert_fails('set spellsuggest=timeout:-x', 'E474:')
+  call assert_fails('set spellsuggest=timeout:--9', 'E474:')
+endfunc
+
 func Test_spellinfo()
   throw 'skipped: Nvim does not support enc=latin1'
   new


### PR DESCRIPTION
#### vim-patch:8.2.4249: the timeout limit for spell suggestions is always 5000

Problem:    The timeout limit for spell suggestions is always 5000 milli
            seconds.
Solution:   Add the "timeout" entry to 'spellsuggest'.
https://github.com/vim/vim/commit/585ee07cfef307b2fc828537e0d31fdc22d7e79f