### PR TITLE
ci(lint): various improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,18 @@ jobs:
         name: uncrustify
         run: |
           ${{ env.CACHE_UNCRUSTIFY }} -c ./src/uncrustify.cfg -q --replace --no-backup $(find ./src/nvim -name "*.[ch]")
+
+      - if: "!cancelled()"
+        name: suggester / uncrustify
+        uses: reviewdog/action-suggester@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: uncrustify
+          cleanup: false
+
+      - if: "!cancelled()"
+        name: check uncrustify
+        run: |
           git diff --color --exit-code
 
       - if: "!cancelled()"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ concurrency:
 
 jobs:
   lint:
-    # This job tests two things: it lints the code but also builds neovim using
-    # system dependencies instead of bundled dependencies. This is to make sure
-    # we are able to build neovim without pigeonholing ourselves into specifics
-    # of the bundled dependencies.
-
     if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-20.04
     timeout-minutes: 10
@@ -64,7 +59,6 @@ jobs:
             luajit \
             ninja-build \
             pkg-config
-
 
       - name: Cache uncrustify
         id: cache-uncrustify
@@ -137,6 +131,66 @@ jobs:
         name: check uncrustify
         run: |
           git diff --color --exit-code
+
+      - name: Cache dependencies
+        run: ./ci/before_cache.sh
+
+  lintc:
+    # This job tests two things: it lints the code but also builds neovim using
+    # system dependencies instead of bundled dependencies. This is to make sure
+    # we are able to build neovim without pigeonholing ourselves into specifics
+    # of the bundled dependencies.
+
+    if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    env:
+      CC: gcc
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup common environment variables
+        run: ./.github/workflows/env.sh lint
+
+      - name: Install apt packages
+        run: |
+          sudo add-apt-repository ppa:neovim-ppa/stable
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            cmake \
+            gettext \
+            libluajit-5.1-dev \
+            libmsgpack-dev \
+            libtermkey-dev \
+            libtool-bin \
+            libtree-sitter-dev \
+            libunibilium-dev \
+            libuv1-dev \
+            libvterm-dev \
+            locales \
+            lua-busted \
+            lua-check \
+            lua-filesystem \
+            lua-inspect \
+            lua-lpeg \
+            lua-luv-dev \
+            lua-nvim \
+            luajit \
+            ninja-build \
+            pkg-config
+
+      - name: Cache artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{ env.CACHE_NVIM_DEPS_DIR }}
+          key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!cmake.deps/**CMakeLists.txt') }}-${{ github.base_ref }}
+
+      - name: Build third-party deps
+        run: ./ci/before_script.sh
 
       - name: Build nvim
         run: ./ci/run_tests.sh build_nvim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,33 +98,8 @@ jobs:
             ${{ env.CACHE_NVIM_DEPS_DIR }}
           key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!cmake.deps/**CMakeLists.txt') }}-${{ github.base_ref }}
 
-      - if: "!cancelled()"
-        name: uncrustify
-        run: |
-          ${{ env.CACHE_UNCRUSTIFY }} -c ./src/uncrustify.cfg -q --replace --no-backup $(find ./src/nvim -name "*.[ch]")
-
-      - if: "!cancelled()"
-        name: suggester / uncrustify
-        uses: reviewdog/action-suggester@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tool_name: uncrustify
-          cleanup: false
-
-      - if: "!cancelled()"
-        name: check uncrustify
-        run: |
-          git diff --color --exit-code
-
       - name: Build third-party deps
         run: ./ci/before_script.sh
-
-      - name: Build nvim
-        run: ./ci/run_tests.sh build_nvim
-
-      - if: "!cancelled()"
-        name: lintc
-        run: make lintc
 
       - if: "!cancelled()"
         name: lintstylua
@@ -144,6 +119,31 @@ jobs:
       - if: "!cancelled()"
         name: lintsh
         run: make lintsh
+
+      - if: "!cancelled()"
+        name: uncrustify
+        run: |
+          ${{ env.CACHE_UNCRUSTIFY }} -c ./src/uncrustify.cfg -q --replace --no-backup $(find ./src/nvim -name "*.[ch]")
+
+      - if: "!cancelled()"
+        name: suggester / uncrustify
+        uses: reviewdog/action-suggester@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tool_name: uncrustify
+          cleanup: false
+
+      - if: "!cancelled()"
+        name: check uncrustify
+        run: |
+          git diff --color --exit-code
+
+      - name: Build nvim
+        run: ./ci/run_tests.sh build_nvim
+
+      - if: "!cancelled()"
+        name: lintc
+        run: make lintc
 
       - if: "!cancelled()"
         name: check-single-includes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,23 +98,6 @@ jobs:
             ${{ env.CACHE_NVIM_DEPS_DIR }}
           key: lint-${{ hashFiles('cmake/*', '**/CMakeLists.txt', '!cmake.deps/**CMakeLists.txt') }}-${{ github.base_ref }}
 
-      - name: Build third-party deps
-        run: ./ci/before_script.sh
-
-      - name: Build nvim
-        run: ./ci/run_tests.sh build_nvim
-
-      - if: "!cancelled()"
-        name: lintcfull
-        run: make lintcfull
-
-      - if: "!cancelled()"
-        name: lintstylua
-        uses: JohnnyMorganz/stylua-action@1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --check runtime/
-
       - if: "!cancelled()"
         name: uncrustify
         run: |
@@ -132,6 +115,23 @@ jobs:
         name: check uncrustify
         run: |
           git diff --color --exit-code
+
+      - name: Build third-party deps
+        run: ./ci/before_script.sh
+
+      - name: Build nvim
+        run: ./ci/run_tests.sh build_nvim
+
+      - if: "!cancelled()"
+        name: lintcfull
+        run: make lintcfull
+
+      - if: "!cancelled()"
+        name: lintstylua
+        uses: JohnnyMorganz/stylua-action@1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --check runtime/
 
       - if: "!cancelled()"
         name: lintlua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
         run: ./ci/run_tests.sh build_nvim
 
       - if: "!cancelled()"
-        name: lintcfull
-        run: make lintcfull
+        name: lintc
+        run: make lintc
 
       - if: "!cancelled()"
         name: lintstylua


### PR DESCRIPTION
- Added https://github.com/reviewdog/action-suggester for uncrustify results:
  - The workflow doesn't have the required level of permissions to post suggestion comments, so the step fallbacks to writing annotated messages in the log.
- Run `lintc` instead of `lintcfull`:
   - `lintcfull` == `lintc` + `uncrustify`, however `uncrustify` already has it's own step.
- Separated `lintc` from `lint`:
  - Before `lint` took around `3m30s`
  - Now `lint` takes around `1m30s` and `lintc` takes around `3m`, BUT, they are done in parallel.