### PR TITLE
fix(uri): don't use full path for custom schema

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -83,10 +83,7 @@ local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
 ---@param bufnr number
 ---@return string URI
 local function uri_from_bufnr(bufnr)
-  local relative_name
-  vim.api.nvim_buf_call(bufnr, function()
-    relative_name = vim.api.nvim_exec(":echo @%", true)
-  end)
+  local relative_name = vim.fn.bufname(bufnr)
   if relative_name:match("deno:") then
     return relative_name
   end

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -78,14 +78,17 @@ end
 
 local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*'
 local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
+--https://url.spec.whatwg.org/#special-scheme
+local SPECIAL_SCHEME  = {'ftp', 'file', 'http', 'https', 'ws', 'wss'}
 
 --- Get a URI from a bufnr
 ---@param bufnr number
 ---@return string URI
 local function uri_from_bufnr(bufnr)
   local relative_name = vim.fn.bufname(bufnr)
-  if relative_name:match("deno:") then
-    return relative_name
+  local maybe_scheme = relative_name:match(URI_SCHEME_PATTERN)
+  if maybe_scheme and not vim.tbl_contains(SPECIAL_SCHEME, maybe_scheme) then
+          return relative_name
   end
 
   local fname = vim.api.nvim_buf_get_name(bufnr)

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -83,6 +83,14 @@ local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
 ---@param bufnr number
 ---@return string URI
 local function uri_from_bufnr(bufnr)
+  local relative_name
+  vim.api.nvim_buf_call(bufnr, function()
+    relative_name = vim.api.nvim_exec(":echo @%", true)
+  end)
+  if relative_name:match("deno:") then
+    return relative_name
+  end
+
   local fname = vim.api.nvim_buf_get_name(bufnr)
   local volume_path = fname:match('^([a-zA-Z]:).*')
   local is_windows = volume_path ~= nil


### PR DESCRIPTION
deno lsp uses a custom schema `deno:`

`uri_from_bufnr` returns the full path of the buf file but this doesn't work with custom schema

This fixes the last remaining  bug here <https://github.com/neovim/nvim-lspconfig/issues/2005> `relative dependencies inside virtual text document is not resolved correctly`

Notes:
- maybe `if relative_name:match("deno:")` should become `if is_custom_schema(realtive_name)` where `is_custom_schema` returns true for any schema that matches `URI_SCHEME_PATTERN` but is not equal to `file:///`
- this changes fixes all my issues with denols (with some minor modifications that I can pr later)

This is more to start a discussion I thought showing code is easier to discuss then raising an issue