### PR TITLE
vim-patch:9.0.0207: stacktrace not shown when debugging

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -606,6 +606,7 @@ void msg_source(int attr)
   }
   recursive = true;
 
+  msg_scroll = true;  // this will take more than one line
   no_wait_return++;
   char *p = get_emsg_source();
   if (p != NULL) {
@@ -739,7 +740,6 @@ static bool emsg_multiline(const char *s, bool multiline)
   }
 
   emsg_on_display = true;     // remember there is an error message
-  msg_scroll++;               // don't overwrite a previous message
   attr = HL_ATTR(HLF_E);      // set highlight mode for error messages
   if (msg_scrolled != 0) {
     need_wait_return = true;  // needed in case emsg() is called after
@@ -750,9 +750,8 @@ static bool emsg_multiline(const char *s, bool multiline)
     msg_ext_set_kind("emsg");
   }
 
-  /*
-   * Display name and line number for the source of the error.
-   */
+  // Display name and line number for the source of the error.
+  // Sets "msg_scroll".
   msg_source(attr);
 
   // Display the error message itself.

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -820,11 +820,16 @@ func Test_rightleftcmd()
   set rightleft&
 endfunc
 
-" Test for the "debug" option
+" Test for the 'debug' option
 func Test_debug_option()
+  " redraw to avoid matching previous messages
+  redraw
   set debug=beep
   exe "normal \<C-c>"
   call assert_equal('Beep!', Screenline(&lines))
+  call assert_equal('line    4:', Screenline(&lines - 1))
+  " only match the final colon in the line that shows the source
+  call assert_match(':$', Screenline(&lines - 2))
   set debug&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.0207: stacktrace not shown when debugging

Problem:    Stacktrace not shown when debugging.
Solution:   Set msg_scroll in msg_source(). (closes vim/vim#10917)
https://github.com/vim/vim/commit/28c162f6f1f525882a9a60f10ab4836dee7eb59f