### PR TITLE
docs: update Vim differences

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -209,7 +209,7 @@ Commands:
   |:Man| is available by default, with many improvements such as completion
   |:sign-define| accepts a `numhl` argument, to highlight the line number
   |:match| can be invoked before highlight group is defined
-  |:source| works with Lua and anonymous (no file) scripts
+  |:source| works with Lua
   User commands can support |:command-preview| to show results as you type
 
 Events:
@@ -271,7 +271,6 @@ Options:
   'signcolumn'  supports up to 9 dynamic/fixed columns
   'statusline'  supports unlimited alignment sections
   'tabline'     %@Func@foo%X can call any function on mouse-click
-  'wildoptions' "pum" flag to use popupmenu for wildmode completion
   'winblend'    pseudo-transparency in floating windows |api-floatwin|
   'winhighlight' window-local highlights
 


### PR DESCRIPTION

Patch 8.2.4594 (https://github.com/vim/vim/commit/36a5b6867bb6c0bd69c8da7d788000ab8a0b0ab0) added support for sourcing a buffer without a name.

Patch 8.2.4325 (https://github.com/vim/vim/commit/3908ef5017a6b4425727013588f72cc7343199b9) added support for using a popup menu for wildmode completion.
