### PR TITLE
refactor(signs): handle non-sign attrs separately

### DIFF
--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -223,4 +223,10 @@ typedef struct {
 #define COLOR_ITEM_INITIALIZER { .attr_id = -1, .link_id = -1, \
                                  .version = -1, .is_default = false }
 
+/// highlight attributes with associated priorities
+typedef struct {
+  int attr_id;
+  int priority;
+} HlPriAttr;
+
 #endif  // NVIM_HIGHLIGHT_DEFS_H

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -33,15 +33,11 @@ struct sign_entry {
 };
 
 /// Sign attributes. Used by the screen refresh routines.
-typedef struct sign_attrs_S {
-  int sat_typenr;
-  char_u *sat_text;
-  int sat_texthl;
-  int sat_linehl;
-  int sat_culhl;
-  int sat_numhl;
-  int sat_prio;  // Used for inserting extmark signs
-} sign_attrs_T;
+typedef struct {
+  char_u *text;
+  int hl_attr_id;
+  int priority;
+} SignTextAttrs;
 
 #define SIGN_SHOW_MAX 9
 


### PR DESCRIPTION
The main motivation of this change is to make it so `sign_get_attr` doesn't need to deal with `linehl`, `numhl` or `culhl`. This will hopefully make #10106 easier to implement, since we'll be able to treat each index in `sattr` like a column position.