### PR TITLE
docs: fix small typo in lsp docs.

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -468,7 +468,11 @@ LspCodeLens
     |nvim_buf_set_extmark()|.
 
 LspCodeLensSeparator                                 *hl-LspCodeLensSeparator*
+<<<<<<< HEAD
     Used to color the separator between two or more code lens.
+=======
+   Used to color the separator between two or more code lenses.
+>>>>>>> 99bf52ad2 (docs: fix small typo in lsp docs.)
 
                                                      *lsp-highlight-signature*
 


### PR DESCRIPTION
I saw the [comment](https://github.com/neovim/neovim/pull/19589#issuecomment-1200398561) regarding typo collection. Not sure if that implies these small PRs shouldn't be made, or just that they get absorbed into another big PR.