### PR TITLE
fix(api): nvim_exec and nvim_cmd restore msg_col when capturing output

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -626,6 +626,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
   garray_T capture_local;
   const int save_msg_silent = msg_silent;
   garray_T * const save_capture_ga = capture_ga;
+  const int save_msg_col = msg_col;
 
   if (output) {
     ga_init(&capture_local, 1, 80);
@@ -636,6 +637,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     try_start();
     if (output) {
       msg_silent++;
+      msg_col = 0;  // prevent leading spaces
     }
 
     WITH_SCRIPT_CONTEXT(channel_id, {
@@ -645,6 +647,8 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     if (output) {
       capture_ga = save_capture_ga;
       msg_silent = save_msg_silent;
+      // Put msg_col back where it was, since nothing should have been written.
+      msg_col = save_msg_col;
     }
 
     try_end(err);

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -49,6 +49,7 @@ String nvim_exec(uint64_t channel_id, String src, Boolean output, Error *err)
 {
   const int save_msg_silent = msg_silent;
   garray_T *const save_capture_ga = capture_ga;
+  const int save_msg_col = msg_col;
   garray_T capture_local;
   if (output) {
     ga_init(&capture_local, 1, 80);
@@ -58,6 +59,7 @@ String nvim_exec(uint64_t channel_id, String src, Boolean output, Error *err)
   try_start();
   if (output) {
     msg_silent++;
+    msg_col = 0;  // prevent leading spaces
   }
 
   const sctx_T save_current_sctx = api_set_sctx(channel_id);
@@ -66,6 +68,8 @@ String nvim_exec(uint64_t channel_id, String src, Boolean output, Error *err)
   if (output) {
     capture_ga = save_capture_ga;
     msg_silent = save_msg_silent;
+    // Put msg_col back where it was, since nothing should have been written.
+    msg_col = save_msg_col;
   }
 
   current_sctx = save_current_sctx;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -281,8 +281,8 @@ describe('API', function()
       ]]}
     end)
 
-    it('does\'t display messages when output=true', function()
-      local screen = Screen.new(40, 8)
+    it('doesn\'t display messages when output=true', function()
+      local screen = Screen.new(40, 6)
       screen:attach()
       screen:set_default_attr_ids({
         [0] = {bold=true, foreground=Screen.colors.Blue},
@@ -294,9 +294,21 @@ describe('API', function()
         {0:~                                       }|
         {0:~                                       }|
         {0:~                                       }|
-        {0:~                                       }|
-        {0:~                                       }|
                                                 |
+      ]]}
+      exec([[
+        func Print()
+          call nvim_exec('echo "hello"', v:true)
+        endfunc
+      ]])
+      feed([[:echon 1 | call Print() | echon 5<CR>]])
+      screen:expect{grid=[[
+        ^                                        |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        15                                      |
       ]]}
     end)
   end)
@@ -3835,6 +3847,36 @@ describe('API', function()
       assert_alive()
       meths.cmd({ cmd = 'make', args = { 'foo', 'bar' } }, {})
       assert_alive()
+    end)
+    it('doesn\'t display messages when output=true', function()
+      local screen = Screen.new(40, 6)
+      screen:attach()
+      screen:set_default_attr_ids({
+        [0] = {bold=true, foreground=Screen.colors.Blue},
+      })
+      meths.cmd({cmd = 'echo', args = {[['hello']]}}, {output = true})
+      screen:expect{grid=[[
+        ^                                        |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+                                                |
+      ]]}
+      exec([[
+        func Print()
+          call nvim_cmd(#{cmd: 'echo', args: ['"hello"']}, #{output: v:true})
+        endfunc
+      ]])
+      feed([[:echon 1 | call Print() | echon 5<CR>]])
+      screen:expect{grid=[[
+        ^                                        |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        15                                      |
+      ]]}
     end)
   end)
 end)


### PR DESCRIPTION
This matches the code in execute_common(), preventing messages after the
API call from being printed at the wrong column.
