### PR TITLE
vim-patch:9.0.{0220,0222}

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -890,9 +890,9 @@ int utf_ptr2len_len(const char_u *p, int size)
   return len;
 }
 
-/// Return the number of bytes occupied by a UTF-8 character in a string
-///
+/// Return the number of bytes occupied by a UTF-8 character in a string.
 /// This includes following composing characters.
+/// Returns zero for NUL.
 int utfc_ptr2len(const char *const p_in)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -75,6 +75,18 @@ func Test_for_invalid()
   redraw
 endfunc
 
+func Test_for_over_null_string()
+  let save_enc = &enc
+  " set enc=iso8859
+  let cnt = 0
+  for c in v:_null_string
+    let cnt += 1
+  endfor
+  call assert_equal(0, cnt)
+
+  let &enc = save_enc
+endfunc
+
 func Test_readfile_binary()
   new
   call setline(1, ['one', 'two', 'three'])

--- a/src/nvim/testdir/test_textobjects.vim
+++ b/src/nvim/testdir/test_textobjects.vim
@@ -1,7 +1,6 @@
 " Test for textobjects
 
 source check.vim
-CheckFeature textobjects
 
 func CpoM(line, useM, expected)
   new


### PR DESCRIPTION
#### vim-patch:9.0.0220: invalid memory access with for loop over NULL string

Problem:    Invalid memory access with for loop over NULL string.
Solution:   Make sure mb_ptr2len() consistently returns zero for NUL.
https://github.com/vim/vim/commit/f6d39c31d2177549a986d170e192d8351bd571e2


#### vim-patch:9.0.0222: no good reason why text objects are only in larger builds

Problem:    No good reason why text objects are only in larger builds.
Solution:   Graduate +textobjects.
https://github.com/vim/vim/commit/887748742deae3d6de7aa0fdbb042afe1ccf5e7a