### PR TITLE
vim-patch:8.2.3699: the +title feature adds a lot of #ifdef but little code

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1006,8 +1006,9 @@ int utf_char2len(const int c)
 
 /// Convert Unicode character to UTF-8 string
 ///
-/// @param c character to convert to \p buf
-/// @param[out] buf UTF-8 string generated from \p c, does not add \0
+/// @param c         character to convert to UTF-8 string in \p buf
+/// @param[out] buf  UTF-8 string generated from \p c, does not add \0
+///                  must have room for at least 6 bytes
 /// @return Number of bytes (1-6).
 int utf_char2bytes(const int c, char *const buf)
 {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -6400,6 +6400,7 @@ void showruler(bool always)
       || (p_title && (stl_syntax & STL_IN_TITLE))) {
     maketitle();
   }
+
   // Redraw the tab pages line if needed.
   if (redraw_tabline) {
     draw_tabline();
@@ -6714,6 +6715,7 @@ void screen_resize(int width, int height)
 
   if (starting != NO_SCREEN) {
     maketitle();
+
     changed_line_abv_curs();
     invalidate_botline();
 


### PR DESCRIPTION
#### vim-patch:8.2.3699: the +title feature adds a lot of #ifdef but little code

Problem:    The +title feature adds a lot of #ifdef but little code.
Solution:   Graduate the +title feature.
https://github.com/vim/vim/commit/651fca85c71a4c5807f8f828f9ded30fbd754325