### PR TITLE
feat: allow :wincmd to accept a count

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -372,6 +372,7 @@ Lua interface (|lua.txt|):
 
 Commands:
   |:doautocmd| does not warn about "No matching autocommands".
+  |:wincmd| accepts a count.
 
 Functions:
   |input()| and |inputdialog()| support for each other’s features (return on

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -442,6 +442,7 @@ position is set to keep the same Visual area selected.
 These commands can also be executed with ":wincmd":
 
 :[count]winc[md] {arg}
+:winc[md] [count] {arg}
 		Like executing CTRL-W [count] {arg}.  Example: >
 			:wincmd j
 <		Moves to the window below the current one.

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3181,7 +3181,7 @@ module.cmds = {
   },
   {
     command='wincmd',
-    flags=bit.bor(NEEDARG, WORD1, RANGE, CMDWIN, LOCK_OK),
+    flags=bit.bor(NEEDARG, WORD1, RANGE, COUNT, CMDWIN, LOCK_OK),
     addr_type='ADDR_OTHER',
     func='ex_wincmd',
   },

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -137,7 +137,7 @@ func Common_vert_split()
 
   " Test diffoff
   diffoff!
-  1wincmd 2
+  1wincmd w
   let &diff = 1
   let &fdm = diff_fdm
   let &fdc = diff_fdc

--- a/test/functional/ex_cmds/wincmd_spec.lua
+++ b/test/functional/ex_cmds/wincmd_spec.lua
@@ -1,0 +1,13 @@
+local helpers = require("test.functional.helpers")(after_each)
+local clear = helpers.clear
+local eq = helpers.eq
+local funcs = helpers.funcs
+local command = helpers.command
+
+it(':wincmd accepts a count', function()
+  clear()
+  command('vsplit')
+  eq(1, funcs.winnr())
+  command('wincmd 2 w')
+  eq(2, funcs.winnr())
+end)


### PR DESCRIPTION
Lets the `:wincmd` command accept a count like its documentation suggests, previously it could only accept a range, which lead to some ambiguity on which attribute should be used when executing `wincmd` using `nvim_cmd`.

Closes #19662.

Also fixes a typo in a related Vim test which should be fixed in Vim by https://github.com/vim/vim/pull/10932.