### PR TITLE
fix(redraw): make redrawdebug=nodelta handle all the cases

### DIFF
--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -166,7 +166,7 @@ void grid_put_schar(ScreenGrid *grid, int row, int col, char_u *schar, int attr)
 {
   assert(put_dirty_row == row);
   size_t off = grid->line_offset[row] + (size_t)col;
-  if (grid->attrs[off] != attr || schar_cmp(grid->chars[off], schar)) {
+  if (grid->attrs[off] != attr || schar_cmp(grid->chars[off], schar) || rdb_flags & RDB_NODELTA) {
     schar_copy(grid->chars[off], schar);
     grid->attrs[off] = attr;
 
@@ -270,7 +270,8 @@ void grid_puts_len(ScreenGrid *grid, char_u *text, int textlen, int row, int col
     need_redraw = schar_cmp(grid->chars[off], buf)
                   || (mbyte_cells == 2 && grid->chars[off + 1][0] != 0)
                   || grid->attrs[off] != attr
-                  || exmode_active;
+                  || exmode_active
+                  || rdb_flags & RDB_NODELTA;
 
     if (need_redraw) {
       // When at the end of the text and overwriting a two-cell
@@ -402,8 +403,7 @@ void grid_fill(ScreenGrid *grid, int start_row, int end_row, int start_col, int 
     size_t lineoff = grid->line_offset[row];
     for (col = start_col; col < end_col; col++) {
       size_t off = lineoff + (size_t)col;
-      if (schar_cmp(grid->chars[off], sc)
-          || grid->attrs[off] != attr) {
+      if (schar_cmp(grid->chars[off], sc) || grid->attrs[off] != attr || rdb_flags & RDB_NODELTA) {
         schar_copy(grid->chars[off], sc);
         grid->attrs[off] = attr;
         if (dirty_first == INT_MAX) {
@@ -595,7 +595,8 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, int cle
     while (col < clear_width) {
       if (grid->chars[off_to][0] != ' '
           || grid->chars[off_to][1] != NUL
-          || grid->attrs[off_to] != bg_attr) {
+          || grid->attrs[off_to] != bg_attr
+          || rdb_flags & RDB_NODELTA) {
         grid->chars[off_to][0] = ' ';
         grid->chars[off_to][1] = NUL;
         grid->attrs[off_to] = bg_attr;


### PR DESCRIPTION
Before only win_line lines were considered. this applies nodelta to all screen elements. Causes some failures, which might indeed indicate excessive redraws.