### PR TITLE
fix(tests): remove irrelevant usage of display-=msgsep

### DIFF
--- a/test/functional/ex_cmds/oldfiles_spec.lua
+++ b/test/functional/ex_cmds/oldfiles_spec.lua
@@ -29,7 +29,6 @@ describe(':oldfiles', function()
   it('shows most recently used files', function()
     local screen = Screen.new(100, 5)
     screen:attach()
-    feed_command("set display-=msgsep")
     feed_command('edit testfile1')
     feed_command('edit testfile2')
     feed_command('wshada')
@@ -37,7 +36,7 @@ describe(':oldfiles', function()
     local oldfiles = helpers.meths.get_vvar('oldfiles')
     feed_command('oldfiles')
     screen:expect([[
-      testfile2                                                                                           |
+                                                                                                          |
       1: ]].. add_padding(oldfiles[1]) ..[[ |
       2: ]].. add_padding(oldfiles[2]) ..[[ |
                                                                                                           |

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -144,13 +144,14 @@ describe('debug.debug', function()
   before_each(function()
     screen = Screen.new()
     screen:attach()
-    screen:set_default_attr_ids({
-      [0] = {bold=true, foreground=255},
-      E = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-      cr = {bold = true, foreground = Screen.colors.SeaGreen4},
-    })
-    command("set display-=msgsep")
+    screen:set_default_attr_ids {
+      [0] = {bold=true, foreground=255};
+      [1] = {bold = true, reverse = true};
+      E = {foreground = Screen.colors.Grey100, background = Screen.colors.Red};
+      cr = {bold = true, foreground = Screen.colors.SeaGreen4};
+    }
   end)
+
   it('works', function()
     command([[lua
       function Test(a)
@@ -160,7 +161,8 @@ describe('debug.debug', function()
       end
     ]])
     feed(':lua Test()\n')
-    screen:expect([[
+    screen:expect{grid=[[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -171,13 +173,13 @@ describe('debug.debug', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       nil                                                  |
       lua_debug> ^                                          |
-    ]])
+    ]]}
     feed('print("TEST")\n')
     screen:expect([[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -186,8 +188,7 @@ describe('debug.debug', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       nil                                                  |
       lua_debug> print("TEST")                             |
       TEST                                                 |
@@ -195,10 +196,10 @@ describe('debug.debug', function()
     ]])
     feed('<C-c>')
     screen:expect{grid=[[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       nil                                                  |
       lua_debug> print("TEST")                             |
       TEST                                                 |
@@ -212,6 +213,7 @@ describe('debug.debug', function()
     ]]}
     feed('<C-l>:lua Test()\n')
     screen:expect([[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -222,19 +224,18 @@ describe('debug.debug', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       nil                                                  |
       lua_debug> ^                                          |
     ]])
     feed('\n')
     screen:expect{grid=[[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       nil                                                  |
       lua_debug>                                           |
       {E:E5108: Error executing lua [string ":lua"]:5: attempt}|
@@ -268,6 +269,7 @@ describe('debug.debug', function()
 
     feed("conttt<cr>") -- misspelled cont; invalid syntax
     screen:expect{grid=[[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
@@ -276,8 +278,7 @@ describe('debug.debug', function()
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       lua_debug> conttt                                    |
       {E:E5115: Error while loading debug string: (debug comma}|
       {E:nd):1: '=' expected near '<eof>'}                     |
@@ -286,14 +287,14 @@ describe('debug.debug', function()
 
     feed("cont<cr>") -- exactly "cont", exit now
     screen:expect{grid=[[
+                                                           |
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
       {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
+      {1:                                                     }|
       lua_debug> conttt                                    |
       {E:E5115: Error while loading debug string: (debug comma}|
       {E:nd):1: '=' expected near '<eof>'}                     |

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -96,9 +96,9 @@ describe('clipboard', function()
       [0] = {bold = true, foreground = Screen.colors.Blue},
       [1] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [2] = {bold = true, foreground = Screen.colors.SeaGreen4},
+      [3] = {bold = true, reverse = true};
     })
     screen:attach()
-    command("set display-=msgsep")
   end)
 
   it('unnamed register works without provider', function()
@@ -123,10 +123,10 @@ describe('clipboard', function()
     command("let g:clipboard = 'bogus'")
     feed_command('redir @+> | bogus_cmd | redir END')
     screen:expect{grid=[[
-      {0:~                                                                       }|
-      clipboard: No provider. Try ":checkhealth" or ":h clipboard".           |
-      {1:E492: Not an editor command: bogus_cmd | redir END}                      |
-      {2:Press ENTER or type command to continue}^                                 |
+    {3:                                                                        }|
+    clipboard: No provider. Try ":checkhealth" or ":h clipboard".           |
+    {1:E492: Not an editor command: bogus_cmd | redir END}                      |
+    {2:Press ENTER or type command to continue}^                                 |
     ]]}
   end)
 

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -24,7 +24,6 @@ before_each(function()
   clear()
   screen = Screen.new(40, 8)
   screen:attach()
-  command("set display-=msgsep")
   source([[
     highlight RBP1 guibg=Red
     highlight RBP2 guibg=Yellow
@@ -152,6 +151,7 @@ before_each(function()
     SB={foreground = Screen.colors.Blue4},
     E={foreground = Screen.colors.Red, background = Screen.colors.Blue},
     M={bold = true},
+    MSEP={bold = true, reverse = true};
   })
 end)
 
@@ -298,22 +298,22 @@ describe('Command-line coloring', function()
   function()
     set_color_cb('SplittedMultibyteStart')
     start_prompt('echo "«')
-    screen:expect([[
+    screen:expect{grid=[[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :echo "                                 |
       {ERR:E5405: Chunk 0 start 7 splits multibyte }|
       {ERR:character}                               |
       :echo "«^                                |
-    ]])
+    ]]}
     feed('»')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :echo "                                 |
       {ERR:E5405: Chunk 0 start 7 splits multibyte }|
       {ERR:character}                               |
@@ -325,10 +325,10 @@ describe('Command-line coloring', function()
     set_color_cb('SplittedMultibyteEnd')
     start_prompt('echo "«')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :echo "                                 |
       {ERR:E5406: Chunk 0 end 7 splits multibyte ch}|
       {ERR:aracter}                                 |
@@ -339,10 +339,10 @@ describe('Command-line coloring', function()
     set_color_cb('Echoerring')
     start_prompt('e')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5407: Callback has thrown an exception:}|
       {ERR: Vim(echoerr):HERE}                      |
@@ -398,10 +398,10 @@ describe('Command-line coloring', function()
     set_color_cb('Throwing')
     start_prompt('e')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5407: Callback has thrown an exception:}|
       {ERR: ABC}                                    |
@@ -412,10 +412,10 @@ describe('Command-line coloring', function()
     set_color_cb('SplittedMultibyteStart')
     start_prompt('let x = "«»«»«»«»«»"')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :let x = "                              |
       {ERR:E5405: Chunk 0 start 10 splits multibyte}|
       {ERR: character}                              |
@@ -453,10 +453,10 @@ describe('Command-line coloring', function()
     screen:sleep(500)
     feed('<C-c>')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5407: Callback has thrown an exception:}|
       {ERR: Keyboard interrupt}                     |
@@ -517,11 +517,11 @@ describe('Command-line coloring', function()
     set_color_cb('ReturningGlobal', '')
     start_prompt('#')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5400: Callback should return list}      |
       :#^                                      |
@@ -531,11 +531,11 @@ describe('Command-line coloring', function()
     set_color_cb('ReturningGlobal', {{0, 1, 'Normal'}, 42})
     start_prompt('#')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5401: List item 1 is not a List}        |
       :#^                                      |
@@ -545,10 +545,10 @@ describe('Command-line coloring', function()
     set_color_cb('ReturningGlobal2', {{0, 1, 'Normal'}, {1}})
     start_prompt('+')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :+                                      |
       {ERR:E5402: List item 1 has incorrect length:}|
       {ERR: 1 /= 3}                                 |
@@ -559,10 +559,10 @@ describe('Command-line coloring', function()
     set_color_cb('ReturningGlobal2', {{0, 1, 'Normal'}, {2, 3, 'Normal'}})
     start_prompt('+')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :+                                      |
       {ERR:E5403: Chunk 1 start 2 not in range [1, }|
       {ERR:2)}                                      |
@@ -573,10 +573,10 @@ describe('Command-line coloring', function()
     set_color_cb('ReturningGlobal2', {{0, 1, 'Normal'}, {1, 3, 'Normal'}})
     start_prompt('+')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :+                                      |
       {ERR:E5404: Chunk 1 end 3 not in range (1, 2]}|
                                               |
@@ -800,10 +800,10 @@ describe('Ex commands coloring', function()
   it('does not crash when using `n` in debug mode', function()
     feed(':debug execute "echo 1"\n')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       Entering Debug mode.  Type "cont" to con|
       tinue.                                  |
       cmd: execute "echo 1"                   |
@@ -811,8 +811,8 @@ describe('Ex commands coloring', function()
     ]])
     feed('n\n')
     screen:expect([[
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+                                              |
+      {MSEP:                                        }|
       Entering Debug mode.  Type "cont" to con|
       tinue.                                  |
       cmd: execute "echo 1"                   |
@@ -836,10 +836,10 @@ describe('Ex commands coloring', function()
     command("cnoremap <expr> x execute('throw 42')[-1]")
     feed(':#x')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :#                                      |
       {ERR:Error detected while processing :}       |
       {ERR:E605: Exception not caught: 42}          |
@@ -847,9 +847,9 @@ describe('Ex commands coloring', function()
     ]])
     feed('<CR>')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :#                                      |
       {ERR:Error detected while processing :}       |
       {ERR:E605: Exception not caught: 42}          |
@@ -864,9 +864,9 @@ describe('Ex commands coloring', function()
     meths.set_var('Nvim_color_cmdline', 42)
     feed(':#')
     screen:expect([[
+                                              |
       {EOB:~                                       }|
-      {EOB:~                                       }|
-      {EOB:~                                       }|
+      {MSEP:                                        }|
       :                                       |
       {ERR:E5408: Unable to get g:Nvim_color_cmdlin}|
       {ERR:e callback: Vim:E6000: Argument is not a}|

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -93,16 +93,22 @@ describe('highlight defaults', function()
   before_each(function()
     clear()
     screen = Screen.new()
+    screen:set_default_attr_ids {
+      [0] = {bold=true, foreground=Screen.colors.Blue};
+      [1] = {reverse = true, bold = true};
+      [2] = {reverse = true};
+      [3] = {bold = true};
+      [4] = {bold = true, foreground = Screen.colors.SeaGreen};
+      [5] = {foreground = Screen.colors.Red1, background = Screen.colors.WebGreen};
+      [6] = {background = Screen.colors.Red1, foreground = Screen.colors.Grey100};
+      [7] = {foreground = Screen.colors.Red};
+      [8] = {foreground = Screen.colors.Blue};
+      [9] = {italic = true};
+    }
     screen:attach()
-    command("set display-=msgsep")
   end)
 
   it('window status bar', function()
-    screen:set_default_attr_ids({
-      [0] = {bold=true, foreground=Screen.colors.Blue},
-      [1] = {reverse = true, bold = true},  -- StatusLine
-      [2] = {reverse = true}                -- StatusLineNC
-    })
     feed_command('sp', 'vsp', 'vsp')
     screen:expect([[
       ^                    │                │               |
@@ -201,31 +207,29 @@ describe('highlight defaults', function()
       ^                                                     |
       {0:~                                                    }|
       {0:~                                                    }|
-      {1:-- INSERT --}                                         |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
-    [1] = {bold = true}})
+      {3:-- INSERT --}                                         |
+    ]])
   end)
 
   it('end of file markers', function()
     screen:try_resize(53, 4)
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|
-      {1:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
                                                            |
-    ]], {[1] = {bold = true, foreground = Screen.colors.Blue}})
+    ]])
   end)
 
   it('"wait return" text', function()
     screen:try_resize(53, 4)
     feed(':ls<cr>')
     screen:expect([[
-      {0:~                                                    }|
+      {1:                                                     }|
       :ls                                                  |
         1 %a   "[No Name]"                    line 1       |
-      {1:Press ENTER or type command to continue}^              |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
-    [1] = {bold = true, foreground = Screen.colors.SeaGreen}})
+      {4:Press ENTER or type command to continue}^              |
+    ]])
     feed('<cr>') --  skip the "Press ENTER..." state or tests will hang
   end)
 
@@ -238,8 +242,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
       -- INSERT --                                         |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
-    [1] = {bold=true}})
+    ]])
     feed('<esc>')
     feed_command('highlight CustomHLGroup guifg=red guibg=green')
     feed_command('highlight link ModeMsg CustomHLGroup')
@@ -248,9 +251,8 @@ describe('highlight defaults', function()
       ^                                                     |
       {0:~                                                    }|
       {0:~                                                    }|
-      {1:-- INSERT --}                                         |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue},
-    [1] = {foreground = Screen.colors.Red, background = Screen.colors.Green}})
+      {5:-- INSERT --}                                         |
+    ]])
   end)
 
   it('can be cleared by assigning NONE', function()
@@ -259,14 +261,11 @@ describe('highlight defaults', function()
     feed_command('hi link TmpKeyword ErrorMsg')
     insert('neovim')
     screen:expect([[
-      {1:neovi^m}                                               |
+      {6:neovi^m}                                               |
       {0:~                                                    }|
       {0:~                                                    }|
                                                            |
-    ]], {
-      [0] = {bold=true, foreground=Screen.colors.Blue},
-      [1] = {foreground = Screen.colors.White, background = Screen.colors.Red}
-    })
+    ]])
     feed_command("hi ErrorMsg term=NONE cterm=NONE ctermfg=NONE ctermbg=NONE"
             .. " gui=NONE guifg=NONE guibg=NONE guisp=NONE")
     screen:expect([[
@@ -274,7 +273,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
                                                            |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue}})
+    ]])
   end)
 
   it('linking updates window highlight immediately #16552', function()
@@ -284,7 +283,7 @@ describe('highlight defaults', function()
       {0:~                                                    }|
       {0:~                                                    }|
                                                            |
-    ]], {[0] = {bold=true, foreground=Screen.colors.Blue}})
+    ]])
     feed_command("hi NonTextAlt guifg=Red")
     feed_command("hi! link NonText NonTextAlt")
     screen:expect([[
@@ -306,56 +305,44 @@ describe('highlight defaults', function()
     feed_command('set listchars=space:.,tab:>-,trail:*,eol:¬ list')
     insert('   ne \t o\tv  im  ')
     screen:expect([[
-      ne{0:.>----.}o{0:>-----}v{0:..}im{0:*^*¬}                             |
-      {0:~                                                    }|
-      {0:~                                                    }|
+      ne{7:.>----.}o{7:>-----}v{7:..}im{7:*^*¬}                             |
+      {7:~                                                    }|
+      {7:~                                                    }|
                                                            |
-    ]], {
-      [0] = {foreground=Screen.colors.Red},
-      [1] = {foreground=Screen.colors.Blue},
-    })
+    ]])
     feed_command('highlight Whitespace gui=NONE guifg=#0000FF')
     screen:expect([[
-      ne{1:.>----.}o{1:>-----}v{1:..}im{1:*^*}{0:¬}                             |
-      {0:~                                                    }|
-      {0:~                                                    }|
+      ne{8:.>----.}o{8:>-----}v{8:..}im{8:*^*}{7:¬}                             |
+      {7:~                                                    }|
+      {7:~                                                    }|
       :highlight Whitespace gui=NONE guifg=#0000FF         |
-    ]], {
-      [0] = {foreground=Screen.colors.Red},
-      [1] = {foreground=Screen.colors.Blue},
-    })
+    ]])
   end)
 
   it('are sent to UIs', function()
     screen:try_resize(53, 4)
-    screen:set_default_attr_ids({
-      [0] = {},
-      [1] = {bold = true, foreground = Screen.colors.Blue1},
-      [2] = {bold = true, reverse = true},
-      [3] = {italic=true}
-    })
     screen:expect{grid=[[
       ^                                                     |
-      {1:~                                                    }|
-      {1:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
                                                            |
-    ]], hl_groups={EndOfBuffer=1, MsgSeparator=2}}
+    ]], hl_groups={EndOfBuffer=0, MsgSeparator=1}}
 
     command('highlight EndOfBuffer gui=italic')
     screen:expect{grid=[[
       ^                                                     |
-      {3:~                                                    }|
-      {3:~                                                    }|
+      {9:~                                                    }|
+      {9:~                                                    }|
                                                            |
-    ]], hl_groups={EndOfBuffer=3, MsgSeparator=2}}
+    ]], hl_groups={EndOfBuffer=9, MsgSeparator=1}}
 
     command('highlight clear EndOfBuffer')
     screen:expect{grid=[[
       ^                                                     |
-      {1:~                                                    }|
-      {1:~                                                    }|
+      {0:~                                                    }|
+      {0:~                                                    }|
                                                            |
-    ]], hl_groups={EndOfBuffer=1, MsgSeparator=2}}
+    ]], hl_groups={EndOfBuffer=0, MsgSeparator=1}}
   end)
 end)
 

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -66,7 +66,6 @@ local function common_setup(screen, inccommand, text)
     command("syntax on")
     command("set nohlsearch")
     command("hi Substitute guifg=red guibg=yellow")
-    command("set display-=msgsep")
     screen:attach()
     screen:set_default_attr_ids({
       [1]  = {foreground = Screen.colors.Fuchsia},
@@ -142,11 +141,11 @@ describe(":substitute, 'inccommand' preserves", function()
     feed_command("ls")
 
     screen:expect([[
+      BAC                           |
       {15:~                             }|
       {15:~                             }|
       {15:~                             }|
-      {15:~                             }|
-      {15:~                             }|
+      {11:                              }|
       :ls                           |
         1 %a + "[No Name]"          |
                 line 1              |
@@ -1469,14 +1468,14 @@ describe("inccommand=nosplit", function()
     -- non-modifier prefix
     feed(':silent tabedit %s/tw/to')
     screen:expect([[
+      Inc substitution on |
       two lines           |
       Inc substitution on |
       two lines           |
                           |
       {15:~                   }|
       {15:~                   }|
-      {15:~                   }|
-      {15:~                   }|
+      {11:                    }|
       :silent tabedit %s/t|
       w/to^                |
     ]])
@@ -2656,6 +2655,7 @@ describe(":substitute", function()
 
     feed("\\rѫ ab   \\rXXXX")
     screen:expect([[
+      7 8 9                         |
       K L M                         |
       {12:JLKR £}                        |
       {12:ѫ ab   }                       |
@@ -2667,8 +2667,7 @@ describe(":substitute", function()
       {12:ѫ ab   }                       |
       {11:[No Name] [+]                 }|
       | 7| {12:JLKR £}                   |
-      | 8|{12: ѫ ab   }                  |
-      {10:[Preview]                     }|
+      {11:                              }|
       :%s/[a-z]/JLKR £\rѫ ab   \rXXX|
       X^                             |
     ]])
@@ -3001,8 +3000,8 @@ it('long :%s/ with inccommand does not collapse cmdline', function()
   feed(':%s/AAAAAAA', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
     'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A')
   screen:expect([[
-    {15:~           }|
-    {15:~           }|
+                |
+    {11:            }|
     :%s/AAAAAAAA|
     AAAAAAAAAAAA|
     AAAAAAA^     |

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -321,13 +321,14 @@ describe('input non-printable chars', function()
   it("doesn't crash when echoing them back", function()
     write_file("Xtest-overwrite", [[foobar]])
     local screen = Screen.new(60,8)
-    screen:set_default_attr_ids({
-      [1] = {bold = true, foreground = Screen.colors.Blue1},
-      [2] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-      [3] = {bold = true, foreground = Screen.colors.SeaGreen4}
-    })
+    screen:set_default_attr_ids {
+      [1] = {bold = true, foreground = Screen.colors.Blue1};
+      [2] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red};
+      [3] = {bold = true, foreground = Screen.colors.SeaGreen4};
+      [4] = {bold = true, reverse = true};
+    }
     screen:attach()
-    command("set display-=msgsep shortmess-=F")
+    command("set shortmess-=F")
 
     feed_command("e Xtest-overwrite")
     screen:expect([[
@@ -346,11 +347,11 @@ describe('input non-printable chars', function()
     write_file("Xtest-overwrite", [[smurf]])
     feed_command("w")
     screen:expect([[
+      foobar                                                      |
       {1:~                                                           }|
       {1:~                                                           }|
       {1:~                                                           }|
-      {1:~                                                           }|
-      {1:~                                                           }|
+      {4:                                                            }|
       "Xtest-overwrite"                                           |
       {2:WARNING: The file has been changed since reading it!!!}      |
       {3:Do you really want to write to it (y/n)?}^                    |
@@ -358,10 +359,10 @@ describe('input non-printable chars', function()
 
     feed("u")
     screen:expect([[
+      foobar                                                      |
       {1:~                                                           }|
       {1:~                                                           }|
-      {1:~                                                           }|
-      {1:~                                                           }|
+      {4:                                                            }|
       "Xtest-overwrite"                                           |
       {2:WARNING: The file has been changed since reading it!!!}      |
       {3:Do you really want to write to it (y/n)?}u                   |
@@ -370,9 +371,9 @@ describe('input non-printable chars', function()
 
     feed("\005")
     screen:expect([[
+      foobar                                                      |
       {1:~                                                           }|
-      {1:~                                                           }|
-      {1:~                                                           }|
+      {4:                                                            }|
       "Xtest-overwrite"                                           |
       {2:WARNING: The file has been changed since reading it!!!}      |
       {3:Do you really want to write to it (y/n)?}u                   |
@@ -382,8 +383,8 @@ describe('input non-printable chars', function()
 
     feed("n")
     screen:expect([[
-      {1:~                                                           }|
-      {1:~                                                           }|
+      foobar                                                      |
+      {4:                                                            }|
       "Xtest-overwrite"                                           |
       {2:WARNING: The file has been changed since reading it!!!}      |
       {3:Do you really want to write to it (y/n)?}u                   |

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -32,7 +32,7 @@ describe('ui/mouse/input', function()
       [6] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
       [7] = {bold = true, foreground = Screen.colors.SeaGreen4},
     })
-    command("set display-=msgsep mousemodel=extend")
+    command("set mousemodel=extend")
     feed('itesting<cr>mouse<cr>support and selection<esc>')
     screen:expect([[
       testing                  |

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -100,45 +100,52 @@ describe("shell command :!", function()
       pending('missing printf')
     end
     local screen = Screen.new(50, 4)
+    screen:set_default_attr_ids {
+      [1] = {bold = true, reverse = true};
+      [2] = {bold = true, foreground = Screen.colors.SeaGreen};
+      [3] = {foreground = Screen.colors.Blue};
+    }
     screen:attach()
-    command("set display-=msgsep")
     -- Print TAB chars. #2958
     feed([[:!printf '1\t2\t3'<CR>]])
-    screen:expect([[
-      ~                                                 |
+    screen:expect{grid=[[
+      {1:                                                  }|
       :!printf '1\t2\t3'                                |
       1       2       3                                 |
-      Press ENTER or type command to continue^           |
-    ]])
+      {2:Press ENTER or type command to continue}^           |
+    ]]}
     feed([[<CR>]])
+
     -- Print BELL control code. #4338
     screen.bell = false
     feed([[:!printf '\007\007\007\007text'<CR>]])
     screen:expect{grid=[[
-      ~                                                 |
+      {1:                                                  }|
       :!printf '\007\007\007\007text'                   |
       text                                              |
-      Press ENTER or type command to continue^           |
+      {2:Press ENTER or type command to continue}^           |
     ]], condition=function()
       eq(true, screen.bell)
     end}
     feed([[<CR>]])
+
     -- Print BS control code.
     feed([[:echo system('printf ''\010\n''')<CR>]])
     screen:expect([[
-      ~                                                 |
-      ^H                                                |
+      {1:                                                  }|
+      {3:^H}                                                |
                                                         |
-      Press ENTER or type command to continue^           |
+      {2:Press ENTER or type command to continue}^           |
     ]])
     feed([[<CR>]])
+
     -- Print LF control code.
     feed([[:!printf '\n'<CR>]])
     screen:expect([[
       :!printf '\n'                                     |
                                                         |
                                                         |
-      Press ENTER or type command to continue^           |
+      {2:Press ENTER or type command to continue}^           |
     ]])
     feed([[<CR>]])
   end)


### PR DESCRIPTION
These were just added to avoid churn when changing the default of 'display'. To simplify message handling logic, we might want to remove support for printing messages in `default_grid` later on.
This would allow things like printing error messages safely in the middle of redraw, or a future graduation of the 'multigrid' feature.

This keeps the dedicated tests for `display-=msgsep` untouched.