### PR TITLE
revert: "jobstart(): Fix hang on non-executable cwd #9204"

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -315,8 +315,6 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout, CallbackReader
                            ChannelStdinMode stdin_mode, const char *cwd, uint16_t pty_width,
                            uint16_t pty_height, dict_T *env, varnumber_T *status_out)
 {
-  assert(cwd == NULL || os_isdir_executable(cwd));
-
   Channel *chan = channel_alloc(kChannelStreamProc);
   chan->on_data = on_stdout;
   chan->on_stderr = on_stderr;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4567,7 +4567,7 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (new_cwd && *new_cwd != NUL) {
       cwd = new_cwd;
       // The new cwd must be a directory.
-      if (!os_isdir_executable((const char *)cwd)) {
+      if (!os_isdir((const char_u *)cwd)) {
         semsg(_(e_invarg2), "expected valid directory");
         shell_free_argv(argv);
         return;
@@ -9361,7 +9361,7 @@ static void f_termopen(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     if (new_cwd && *new_cwd != NUL) {
       cwd = new_cwd;
       // The new cwd must be a directory.
-      if (!os_isdir_executable(cwd)) {
+      if (!os_isdir((const char_u *)cwd)) {
         semsg(_(e_invarg2), "expected valid directory");
         shell_free_argv(argv);
         return;

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -144,25 +144,6 @@ bool os_isdir(const char_u *name)
   return true;
 }
 
-/// Check if the given path is a directory and is executable.
-/// Gives the same results as `os_isdir()` on Windows.
-///
-/// @return `true` if `name` is a directory and executable.
-bool os_isdir_executable(const char *name)
-  FUNC_ATTR_NONNULL_ALL
-{
-  int32_t mode = os_getperm(name);
-  if (mode < 0) {
-    return false;
-  }
-
-#ifdef WIN32
-  return (S_ISDIR(mode));
-#else
-  return (S_ISDIR(mode) && (S_IXUSR & mode));
-#endif
-}
-
 /// Check what `name` is:
 /// @return NODE_NORMAL: file or directory (or doesn't exist)
 ///         NODE_WRITABLE: writable device, socket, fifo, etc.

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -21,6 +21,7 @@ local nvim_set = helpers.nvim_set
 local expect_twostreams = helpers.expect_twostreams
 local expect_msg_seq = helpers.expect_msg_seq
 local pcall_err = helpers.pcall_err
+local matches = helpers.matches
 local Screen = require('test.functional.ui.screen')
 
 describe('jobs', function()
@@ -229,8 +230,8 @@ describe('jobs', function()
     local dir = 'Xtest_not_executable_dir'
     mkdir(dir)
     funcs.setfperm(dir, 'rw-------')
-    eq('Vim(call):E475: Invalid argument: expected valid directory',
-      pcall_err(nvim, 'command', "call jobstart('pwd', {'cwd': '"..dir.."'})"))
+    matches('^Vim%(call%):E903: Process failed to start: permission denied: .*',
+            pcall_err(nvim, 'command', "call jobstart(['pwd'], {'cwd': '"..dir.."'})"))
     rmdir(dir)
   end)
 


### PR DESCRIPTION
Fix #19825

This reverts commit c4c74c3883aa3122c0c877ca8dd7b26beb5cc4aa.

LibUV already gives an error for this, so this isn't needed.
