### PR TITLE
fix(winhl): do not crash when unsetting winhl in just opened window

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -319,7 +319,7 @@ void update_window_hl(win_T *wp, bool invalid)
   int ns_id = wp->w_ns_hl;
 
   update_ns_hl(ns_id);
-  if (ns_id != wp->w_ns_hl_active) {
+  if (ns_id != wp->w_ns_hl_active || wp->w_ns_hl_attr == NULL) {
     wp->w_ns_hl_active = ns_id;
 
     wp->w_ns_hl_attr = *(NSHlAttr *)pmap_get(handle_T)(&ns_hl_attr, ns_id);

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -2317,6 +2317,22 @@ describe("'winhighlight' highlight", function()
                           |
     ]]}
   end)
+
+  it('can be disabled in newly opened window #19823', function()
+    command('split | set winhl=Normal:ErrorMsg | set winhl=')
+    screen:expect{grid=[[
+      ^                    |
+      {0:~                   }|
+      {0:~                   }|
+      {3:[No Name]           }|
+                          |
+      {0:~                   }|
+      {4:[No Name]           }|
+                          |
+    ]]}
+
+    helpers.assert_alive()
+  end)
 end)
 
 describe('highlight namespaces', function()


### PR DESCRIPTION
fixes #19823