### PR TITLE
vim-patch:8.1.2082: rename popupmnu.* to popupmenu.*

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -18,7 +18,7 @@
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/option.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -53,7 +53,7 @@
 #include "nvim/option.h"
 #include "nvim/os/input.h"
 #include "nvim/os/process.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/runtime.h"
 #include "nvim/screen.h"
 #include "nvim/state.h"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -47,7 +47,7 @@
 #include "nvim/os/time.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/quickfix.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -60,7 +60,7 @@
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -65,7 +65,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -67,7 +67,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/profile.h"
 #include "nvim/regexp.h"
 #include "nvim/screen.h"

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -13,7 +13,7 @@
 #include "nvim/map.h"
 #include "nvim/message.h"
 #include "nvim/option.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/screen.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -34,7 +34,7 @@
 #include "nvim/os/input.h"
 #include "nvim/os/time.h"
 #include "nvim/path.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/regexp.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -58,7 +58,7 @@
 #include "nvim/os/time.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/runtime.h"

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -23,7 +23,7 @@
 #include "nvim/memory.h"
 #include "nvim/menu.h"
 #include "nvim/message.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/screen.h"
 #include "nvim/state.h"
 #include "nvim/strings.h"

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -31,7 +31,7 @@
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/plines.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -68,7 +68,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/regexp.h"
 #include "nvim/runtime.h"
 #include "nvim/screen.h"

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1,7 +1,7 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-/// @file popupmnu.c
+/// @file popupmenu.c
 ///
 /// Popup menu (PUM)
 
@@ -24,7 +24,7 @@
 #include "nvim/menu.h"
 #include "nvim/move.h"
 #include "nvim/option.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/screen.h"
 #include "nvim/search.h"
 #include "nvim/strings.h"
@@ -57,7 +57,7 @@ static bool pum_external = false;
 static bool pum_invalid = false;  // the screen was just cleared
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "popupmnu.c.generated.h"
+# include "popupmenu.c.generated.h"
 #endif
 #define PUM_DEF_HEIGHT 10
 
@@ -465,7 +465,7 @@ void pum_redraw(void)
                 / (pum_size - pum_height);
   }
 
-  for (i = 0; i < pum_height; ++i) {
+  for (i = 0; i < pum_height; i++) {
     idx = i + pum_first;
     attr = (idx == pum_selected) ? attr_select : attr_norm;
 
@@ -485,7 +485,7 @@ void pum_redraw(void)
     grid_col = col_off;
     totwidth = 0;
 
-    for (round = 1; round <= 3; ++round) {
+    for (round = 1; round <= 3; round++) {
       width = 0;
       s = NULL;
 
@@ -641,11 +641,11 @@ void pum_redraw(void)
 /// @param n
 /// @param repeat
 ///
-/// @returns TRUE when the window was resized and the location of the popup
+/// @returns true when the window was resized and the location of the popup
 /// menu must be recomputed.
-static int pum_set_selected(int n, int repeat)
+static bool pum_set_selected(int n, int repeat)
 {
-  int resized = FALSE;
+  int resized = false;
   int context = pum_height / 2;
 
   pum_selected = n;
@@ -778,12 +778,12 @@ static int pum_set_selected(int n, int repeat)
 
             if (curwin->w_height < lnum) {
               win_setheight((int)lnum);
-              resized = TRUE;
+              resized = true;
             }
           }
 
           curbuf->b_changed = false;
-          curbuf->b_p_ma = FALSE;
+          curbuf->b_p_ma = false;
           curwin->w_cursor.lnum = 1;
           curwin->w_cursor.col = 0;
 
@@ -797,7 +797,7 @@ static int pum_set_selected(int n, int repeat)
             // window is not resized, skip the preview window's
             // status line redrawing.
             if (ins_compl_active() && !resized) {
-              curwin->w_redr_status = FALSE;
+              curwin->w_redr_status = false;
             }
 
             // Return cursor to where we were
@@ -906,7 +906,7 @@ void pum_recompose(void)
 /// Gets the height of the menu.
 ///
 /// @return the height of the popup menu, the number of entries visible.
-/// Only valid when pum_visible() returns TRUE!
+/// Only valid when pum_visible() returns true!
 int pum_get_height(void)
 {
   if (pum_external) {

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -1,5 +1,5 @@
-#ifndef NVIM_POPUPMNU_H
-#define NVIM_POPUPMNU_H
+#ifndef NVIM_POPUPMENU_H
+#define NVIM_POPUPMENU_H
 
 #include "nvim/grid_defs.h"
 #include "nvim/macros.h"
@@ -17,6 +17,6 @@ typedef struct {
 EXTERN ScreenGrid pum_grid INIT(= SCREEN_GRID_INIT);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "popupmnu.h.generated.h"
+# include "popupmenu.h.generated.h"
 #endif
-#endif  // NVIM_POPUPMNU_H
+#endif  // NVIM_POPUPMENU_H

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -110,7 +110,7 @@
 #include "nvim/os_unix.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/profile.h"
 #include "nvim/quickfix.h"
 #include "nvim/regexp.h"

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -31,7 +31,7 @@
 #include "nvim/os/signal.h"
 #include "nvim/os/time.h"
 #include "nvim/os_unix.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/screen.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -23,7 +23,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/os/os.h"
-#include "nvim/popupmnu.h"
+#include "nvim/popupmenu.h"
 #include "nvim/ugrid.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"


### PR DESCRIPTION
#### vim-patch:8.1.2082: some files have a weird name to fit in 8.3 characters

Problem:    Some files have a weird name to fit in 8.3 characters.
Solution:   Use a nicer names.
https://github.com/vim/vim/commit/30e8e73506e4522ef4aebf7d525c0e6ffe8805fd