### PR TITLE
feat(highlight)!: error on invalid names and allow '.' and '@'

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -181,16 +181,16 @@ Vim will only load the first syntax file found, assuming that it sets
 b:current_syntax.
 
 
-NAMING CONVENTIONS		    *group-name* *{group-name}* *E669* *W18*
+NAMING CONVENTIONS		    *group-name* *{group-name}* *E669* *E5248*
 
 A syntax group name is to be used for syntax items that match the same kind of
 thing.  These are then linked to a highlight group that specifies the color.
 A syntax group name doesn't specify any color or attributes itself.
 
-The name for a highlight or syntax group must consist of ASCII letters, digits
-and the underscore.  As a regexp: "[a-zA-Z0-9_]*".  However, Vim does not give
-an error when using other characters.  The maximum length of a group name is
-about 200 bytes.  *E1249*
+The name for a highlight or syntax group must consist of ASCII letters,
+digits, underscores, periods and `@` characters.  As a regexp it is
+`[a-zA-Z0-9_.@]*`. The maximum length of a group name is about 200 bytes.
+*E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -390,6 +390,9 @@ Highlight groups:
   using |n| or |N|
   |hl-CursorLine| is low-priority unless foreground color is set
   |hl-VertSplit| superseded by |hl-WinSeparator|
+  Highlight groups names are allowed to contain the characters `.` and `@`.
+  It is an error to define a highlight group with a name that doesn't match
+  the regexp `[a-zA-Z0-9_.@]*` (see |group-name|).
 
 Macro/|recording| behavior
   Replay of a macro recorded during :lmap produces the same actions as when it

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1021,6 +1021,8 @@ EXTERN char e_resulting_text_too_long[] INIT(= N_("E1240: Resulting text too lon
 
 EXTERN char e_line_number_out_of_range[] INIT(= N_("E1247: Line number out of range"));
 
+EXTERN char e_highlight_group_name_invalid_char[] INIT(= N_("E5248: Invalid character in group name"));
+
 EXTERN char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
 
 EXTERN char e_undobang_cannot_redo_or_move_branch[]

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1750,11 +1750,11 @@ static int syn_add_group(const char *name, size_t len)
     if (!vim_isprintc(c)) {
       emsg(_("E669: Unprintable character in group name"));
       return 0;
-    } else if (!ASCII_ISALNUM(c) && c != '_') {
-      // This is an error, but since there previously was no check only give a warning.
+    } else if (!ASCII_ISALNUM(c) && c != '_' && c != '.' && c != '@') {
+      // '.' and '@' are allowed characters for use with treesitter capture names.
       msg_source(HL_ATTR(HLF_W));
-      msg(_("W18: Invalid character in group name"));
-      break;
+      emsg(_(e_highlight_group_name_invalid_char));
+      return 0;
     }
   }
 

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -5320,8 +5320,8 @@ msgstr "E424: Te veel verskillende uitlig-eienskappe in gebruik"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Onvertoonbare karakter in groepnaam"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ongeldige karakter groepnaam"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ongeldige karakter groepnaam"
 
 #~ msgid "E849: Too many highlight and syntax groups"
 #~ msgstr ""

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -5983,9 +5983,9 @@ msgstr "E424: Hi ha massa atributs de ressalt diferents en ús"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Caràcter no imprimible en el nom del grup"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Hi ha un caràcter no vàlid en el nom del grup"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Hi ha un caràcter no vàlid en el nom del grup"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -6072,10 +6072,10 @@ msgstr ""
 msgid "E669: Unprintable character in group name"
 msgstr ""
 
-#: ../syntax.c:7434
+#: ../highlight_group.c:1756
 #, fuzzy
-msgid "W18: Invalid character in group name"
-msgstr "E182: Chybné jméno pøíkazu"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Chybné jméno pøíkazu"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -6072,10 +6072,10 @@ msgstr ""
 msgid "E669: Unprintable character in group name"
 msgstr ""
 
-#: ../syntax.c:7434
+#: ../highlight_group.c:1756
 #, fuzzy
-msgid "W18: Invalid character in group name"
-msgstr "E182: Chybné jméno pøíkazu"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Chybné jméno pøíkazu"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -5599,8 +5599,8 @@ msgstr "E424: For mange forskellige fremhævningsattributter i brug"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Tegn som ikke kan udskrives i gruppenavn"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ugyldige tegn i gruppenavn"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ugyldige tegn i gruppenavn"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: For mange fremhævnings- og syntaksgrupper"

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -5408,8 +5408,8 @@ msgid "E669: Unprintable character in group name"
 msgstr "E669: Nicht druckbare Zeichen im Namen der Gruppe"
 
 #: ../syntax.c:7304
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ungültiges Zeichen im Namen der Gruppe"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ungültiges Zeichen im Namen der Gruppe"
 
 #: ../syntax.c:7318
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -5730,8 +5730,8 @@ msgstr ""
 msgid "E669: Unprintable character in group name"
 msgstr ""
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
 msgstr ""
 
 #: ../syntax.c:7448

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -5378,8 +5378,8 @@ msgstr "E424: Tro da malsamaj atributoj de emfazo uzataj"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Nepresebla signo en nomo de grupo"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Nevalida signo en nomo de grupo"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Nevalida signo en nomo de grupo"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Tro da emfazaj kaj sintaksaj grupoj"

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -6053,9 +6053,9 @@ msgstr "E669: Carácter no imprimible en el nombre del grupo"
 
 # This is an error, but since there previously was no check only
 # * give a warning.
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Hay un carácter no válido en el nombre del grupo"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Hay un carácter no válido en el nombre del grupo"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -5369,8 +5369,8 @@ msgstr "E424: Liikaa eri korostusattribuutteja"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Tulostuskelvoton merkki ryhmän nimessä"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Virheellinen merkki ryhmän nimessä"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Virheellinen merkki ryhmän nimessä"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Liikaa korostuksia ja syntaksiryhmiä"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -2040,8 +2040,8 @@ msgstr ""
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Caractère non imprimable dans un nom de groupe"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Caractère invalide dans un nom de groupe"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Caractère invalide dans un nom de groupe"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Trop de groupes de surbrillance et de syntaxe"

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -5668,8 +5668,8 @@ msgstr "E424: An iomarca tréithe aibhsithe in úsáid"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Carachtar neamhghrafach in ainm grúpa"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Carachtar neamhbhailí in ainm grúpa"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Carachtar neamhbhailí in ainm grúpa"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: An iomarca grúpaí aibhsithe agus comhréire"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -6046,9 +6046,9 @@ msgstr "E424: Troppi gruppi evidenziazione differenti in uso"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Carattere non stampabile in un nome di gruppo"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Carattere non ammesso in un nome di gruppo"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Carattere non ammesso in un nome di gruppo"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -5913,9 +5913,9 @@ msgstr "E424: 너무 많은 다른 하이라이트 속성이 사용되고 있습
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 그룹 이름에 출력할 수 없는 문자가 있습니다"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: 그룹 이름에 이상한 문자"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: 그룹 이름에 이상한 문자"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -5930,9 +5930,9 @@ msgstr "E424: For mange forskjellige uthevingsattributter i bruk"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ikke-skrivbart tegn i gruppenavn"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ugyldig tegn i gruppenavn"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ugyldig tegn i gruppenavn"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -5913,8 +5913,8 @@ msgstr ""
 msgid "E669: Unprintable character in group name"
 msgstr ""
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
 msgstr ""
 
 #: ../syntax.c:7448

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -5930,9 +5930,9 @@ msgstr "E424: For mange forskjellige uthevingsattributter i bruk"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ikke-skrivbart tegn i gruppenavn"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ugyldig tegn i gruppenavn"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ugyldig tegn i gruppenavn"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -5908,9 +5908,9 @@ msgstr "E424: Zbyt wiele różnych atrybutów podkreślania w użyciu"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Niedrukowalny znak w nazwie grupy"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: nieprawidłowy znak w nazwie grupy"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: nieprawidłowy znak w nazwie grupy"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -6070,8 +6070,8 @@ msgid "E669: Unprintable character in group name"
 msgstr "E669: Caractere não-imprimível no nome do grupo"
 
 #: ../syntax.c:7320
-msgid "W18: Invalid character in group name"
-msgstr "W18: Caractere inválido no nome do grupo"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Caractere inválido no nome do grupo"
 
 #: ../syntax.c:7334
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -5977,9 +5977,9 @@ msgstr "E424: Используется слишком много разных а
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Непечатный символ в имени группы"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Недопустимый символ в имени группы"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Недопустимый символ в имени группы"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -5940,9 +5940,9 @@ msgstr "E424: Používaných príliš ve¾a odlišných zvýrazòovacích vlastností"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Netlaèitelný znak v mene skupiny"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Chybný znak v mene skupiny"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Chybný znak v mene skupiny"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -5940,9 +5940,9 @@ msgstr "E424: Pou¾ívaných príli¹ veµa odli¹ných zvýrazòovacích vlastností"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Netlaèitelný znak v mene skupiny"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Chybný znak v mene skupiny"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Chybný znak v mene skupiny"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -6050,8 +6050,8 @@ msgstr "E424: У употреби је превише различитих ат�
 msgid "E669: Unprintable character in group name"
 msgstr "E669: У имену групе је карактер који не може да се штампа"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Неважећи карактер у имену групе"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Неважећи карактер у имену групе"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Превише синтаксних и група истицања"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -2056,8 +2056,8 @@ msgid "E669: Unprintable character in group name"
 msgstr "E669: Outskrivbart tecken i gruppnamn"
 
 #: ../syntax.c:7292
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ogiltigt tecken i gruppnamn"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ogiltigt tecken i gruppnamn"
 
 #: ../syntax.c:7306
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -3054,8 +3054,8 @@ msgstr "E423: İzin verilmeyen argüman: %s"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Grup adında yazdırılamayan karakter"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Grup adında geçersiz karakter"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Grup adında geçersiz karakter"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Çok fazla vurgulama ve sözdizim grupları"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -3058,8 +3058,8 @@ msgstr "E423: Неправильний аргумент: %s"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Недруковний символ у назві групи"
 
-msgid "W18: Invalid character in group name"
-msgstr "W18: Некоректний символ у назві групи"
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Некоректний символ у назві групи"
 
 msgid "E849: Too many highlight and syntax groups"
 msgstr "E849: Забагато груп підсвічування і синтаксису"

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -5975,9 +5975,9 @@ msgstr "E424: Sử dụng quá nhiều thuộc tính chiếu sáng cú pháp"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ký tự không thể tin ra trong tên nhóm"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: Ký tự không cho phép trong tên nhóm"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: Ký tự không cho phép trong tên nhóm"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -5942,9 +5942,9 @@ msgstr "E424: 使用了太多不同的高亮度属性"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 组名中存在不可显示字符"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: 组名中含有无效字符"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: 组名中含有无效字符"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -5969,9 +5969,9 @@ msgstr "E424: 使用了過多相異的高亮度屬性"
 msgid "E669: Unprintable character in group name"
 msgstr "E669: 群組名稱中有無法列印的字元"
 
-#: ../syntax.c:7434
-msgid "W18: Invalid character in group name"
-msgstr "W18: 群組名稱中有不正確的字元"
+#: ../highlight_group.c:1756
+msgid "E5248: Invalid character in group name"
+msgstr "E5248: 群組名稱中有不正確的字元"
 
 #: ../syntax.c:7448
 msgid "E849: Too many highlight and syntax groups"

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -389,7 +389,7 @@ func Test_invalid_name()
   syn keyword Nop yes
   call assert_fails("syntax keyword Wr\x17ong bar", 'E669:')
   syntax keyword @Wrong bar
-  call assert_match('W18:', execute('1messages'))
+  call assert_fails("syntax keyword @#Wrong bar", 'E5248:')
   syn clear
   hi clear Nop
   hi clear @Wrong


### PR DESCRIPTION
Previously if a highlight group with a name outside the regexp `[a-zA-Z0-9_]` was defined, Nvim would emit an `invalid character` warning message. This was annoying for Lua scripts, as it was very hard to debug what line of code was triggering this message since it didn't produce a stack trace.

This has now been promoted to an error with the code ~E1248~ `E5248`.

Additionally the ASCII character period (`.`) and at-sign (`@`) has been added to the allowed list of characters of a highlight group name to support the application of defining hierarchical highlight groups, e.g. `@TS.keyword`.
