### PR TITLE
fix(lsp): create missing directory before creating file

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -772,7 +772,14 @@ local function create_file(change)
   -- from spec: Overwrite wins over `ignoreIfExists`
   local fname = vim.uri_to_fname(change.uri)
   if not opts.ignoreIfExists or opts.overwrite then
-    local file = io.open(fname, 'w')
+    io.create_missing_dir_open = function(filename, mode)
+        local dir = vim.fs.dirname(filename)
+        if vim.fn.isdirectory(dir) == 0 then
+            vim.fn.mkdir(dir, "p")
+        end
+        return io.open(filename, mode).
+    end
+    local file = io.create_missing_dir_open(fname, 'w')
     file:close()
   end
   vim.fn.bufadd(fname)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -772,9 +772,11 @@ local function create_file(change)
   -- from spec: Overwrite wins over `ignoreIfExists`
   local fname = vim.uri_to_fname(change.uri)
   if not opts.ignoreIfExists or opts.overwrite then
-    vim.fn.mkdir(vim.fs.dirname(fname), "p")
+    vim.fn.mkdir(vim.fs.dirname(fname), 'p')
     local file = io.open(fname, 'w')
-    file:close()
+    if file then
+      file:close()
+    end
   end
   vim.fn.bufadd(fname)
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -772,14 +772,8 @@ local function create_file(change)
   -- from spec: Overwrite wins over `ignoreIfExists`
   local fname = vim.uri_to_fname(change.uri)
   if not opts.ignoreIfExists or opts.overwrite then
-    io.create_missing_dir_open = function(filename, mode)
-        local dir = vim.fs.dirname(filename)
-        if vim.fn.isdirectory(dir) == 0 then
-            vim.fn.mkdir(dir, "p")
-        end
-        return io.open(filename, mode).
-    end
-    local file = io.create_missing_dir_open(fname, 'w')
+    vim.fn.mkdir(vim.fs.dirname(fname), "p")
+    local file = io.open(fname, 'w')
     file:close()
   end
   vim.fn.bufadd(fname)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1977,6 +1977,22 @@ describe('LSP', function()
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
       eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
     end)
+    it('Supports file creation in folder that needs to be created with CreateFile payload', function()
+      local tmpfile = helpers.tmpname()
+      os.remove(tmpfile) -- Should not exist, only interested in a tmpname
+      tmpfile = tmpfile .. '/dummy/x/'
+      local uri = exec_lua('return vim.uri_from_fname(...)', tmpfile)
+      local edit = {
+        documentChanges = {
+          {
+            kind = 'create',
+            uri = uri,
+          },
+        }
+      }
+      exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
+      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+    end)
     it('createFile does not touch file if it exists and ignoreIfExists is set', function()
       local tmpfile = helpers.tmpname()
       write_file(tmpfile, 'Dummy content')


### PR DESCRIPTION
Rust-analyzer has a "create module" assist, where it can create a module for you 

e.x. Hovering over the <nameofmodule> 

`mod <nameofmodule>;`

Will prompt you for the following as a code action:

```
Code actions:
1: Create module at `hello.rs`
2: Create module at `hello/mod.rs`
```

The first one would work fine, but #2 would fail with the following error: 
```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/util.lua:
759: attempt to index local 'file' (a nil value)
stack traceback:
        /usr/share/nvim/runtime/lua/vim/lsp/util.lua:759: in function 'create_file'
        /usr/share/nvim/runtime/lua/vim/lsp/util.lua:802: in function 'apply_workspace_edit'
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:754: in function 'apply_action'
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:808: in function 'on_choice'
        /usr/share/nvim/runtime/lua/vim/ui.lua:54: in function 'select'
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:819: in function 'on_code_action_results'
        /usr/share/nvim/runtime/lua/vim/lsp/buf.lua:837: in function 'callback'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1938: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/lsp.lua:1371: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

The issue is `io.open` didn't create the `hello/` directory before attempting to create `mod.rs`. This addition checks and creates a directory if it's missing before calling `io.open`

I'm going off of the precedent of https://github.com/kak-lsp/kak-lsp/commit/24fabbf60a511aa73b9fb343a0a6018eff7f73ac that this should be handled within neovim's lsp client.