### PR TITLE
[RFC] Remove double echo when :!{cmd}

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1231,14 +1231,6 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     free_newcmd = true;
   }
   if (addr_count == 0) {                // :!
-    // echo the command
-    msg_start();
-    msg_putchar(':');
-    msg_putchar('!');
-    msg_outtrans(newcmd);
-    msg_clr_eos();
-    ui_cursor_goto(msg_row, msg_col);
-
     do_shell(newcmd, 0);
   } else {                            // :range!
     // Careful: This may recursively call do_bang() again! (because of
@@ -1506,7 +1498,6 @@ void do_shell(char *cmd, int flags)
    * For autocommands we want to get the output on the current screen, to
    * avoid having to type return below.
    */
-  msg_putchar('\r');                    // put cursor at start of line
   msg_putchar('\n');                    // may shift screen one line up
 
   // warning message before calling the shell

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -398,7 +398,7 @@ describe('API', function()
 
     it('returns shell |:!| output', function()
       local win_lf = iswin() and '\r' or ''
-      eq(':!echo foo\r\n\nfoo'..win_lf..'\n', nvim('command_output', [[!echo foo]]))
+      eq('\nfoo'..win_lf..'\n', nvim('command_output', [[!echo foo]]))
     end)
 
     it('VimL validation error: fails with specific error', function()

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -176,16 +176,13 @@ describe("shell command :!", function()
       command(helpers.iswin()
         and [[nnoremap <silent>\l :!dir /b bang_filter_spec<cr>]]
         or  [[nnoremap <silent>\l :!ls bang_filter_spec<cr>]])
-      local result = (helpers.iswin()
-        and [[:!dir /b bang_filter_spec]]
-        or  [[:!ls bang_filter_spec    ]])
       feed([[\l]])
       screen:expect([[
                                                              |
         {1:~                                                    }|
         {1:~                                                    }|
         {4:                                                     }|
-        ]]..result..[[                            |
+                                                             |
         f1                                                   |
         f2                                                   |
         f3                                                   |

--- a/test/functional/vimscript/execute_spec.lua
+++ b/test/functional/vimscript/execute_spec.lua
@@ -266,7 +266,7 @@ describe('execute()', function()
   -- with how nvim currently displays the output.
   it('captures shell-command output', function()
     local win_lf = iswin() and '\13' or ''
-    eq('\n:!echo foo\r\n\nfoo'..win_lf..'\n', funcs.execute('!echo foo'))
+    eq('\n\nfoo'..win_lf..'\n', funcs.execute('!echo foo'))
   end)
 
   describe('{silent} argument', function()


### PR DESCRIPTION
Before: `nvim --clean`

![スクリーンショット_2022-08-19_09-26-15](https://user-images.githubusercontent.com/41495/185517539-f443cd2c-65ff-4a48-b095-67655e731117.png)

After:

![スクリーンショット_2022-08-19_09-31-16](https://user-images.githubusercontent.com/41495/185517553-60a44b2e-b4fe-47e9-8ab1-0158de8b7e59.png)
