### PR TITLE
vim-patch:8.2.3946,9.0.0227: internal error improvements

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -830,8 +830,13 @@ static bool semsgv(const char *fmt, va_list ap)
 /// detected when fuzzing vim.
 void iemsg(const char *s)
 {
+  if (emsg_not_now()) {
+    return;
+  }
+
   emsg(s);
 #ifdef ABORT_ON_INTERNAL_ERROR
+  set_vim_var_string(VV_ERRMSG, s, -1);
   abort();
 #endif
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -837,6 +837,8 @@ void iemsg(const char *s)
   emsg(s);
 #ifdef ABORT_ON_INTERNAL_ERROR
   set_vim_var_string(VV_ERRMSG, s, -1);
+  msg_putchar('\n');  // avoid overwriting the error message
+  ui_flush();
   abort();
 #endif
 }
@@ -846,11 +848,17 @@ void iemsg(const char *s)
 /// detected when fuzzing vim.
 void siemsg(const char *s, ...)
 {
+  if (emsg_not_now()) {
+    return;
+  }
+
   va_list ap;
   va_start(ap, s);
   (void)semsgv(s, ap);
   va_end(ap);
 #ifdef ABORT_ON_INTERNAL_ERROR
+  msg_putchar('\n');  // avoid overwriting the error message
+  ui_flush();
   abort();
 #endif
 }

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -257,6 +257,7 @@ endfunc
 func EarlyExit(test)
   " It's OK for the test we use to test the quit detection.
   if a:test != 'Test_zz_quit_detected()'
+    call add(v:errors, v:errmsg)
     call add(v:errors, 'Test caused Vim to exit: ' . a:test)
   endif
 


### PR DESCRIPTION
#### vim-patch:8.2.3946: when an internal error makes Vim exit the error is not seen

Problem:    When an internal error makes Vim exit the error is not seen.
Solution:   Add the error to the test output.
https://github.com/vim/vim/commit/1c67f3a9779b99bed7aacb3108abbb649445d3ed

Add emsg_not_now() check to make code equivalent.


#### vim-patch:9.0.0227: cannot read error message when abort() is called

Problem:    Cannot read error message when abort() is called.
Solution:   Output a newline before calling abort().
https://github.com/vim/vim/commit/213e70e284b0975dd34525e94e59e26811097c72

Add emsg_not_now() check to make code equivalent.