### PR TITLE
vim-patch:8.2.{partial:0425,0982}: insufficient tests

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2737,6 +2737,59 @@ func Test_autocmd_sigusr1()
   unlet g:sigusr1_passed
 endfunc
 
+" Test for BufReadPre autocmd deleting the file
+func Test_BufReadPre_delfile()
+  augroup TestAuCmd
+    au!
+    autocmd BufReadPre Xfile call delete('Xfile')
+  augroup END
+  call writefile([], 'Xfile')
+  call assert_fails('new Xfile', 'E200:')
+  call assert_equal('Xfile', @%)
+  call assert_equal(1, &readonly)
+  call delete('Xfile')
+  augroup TestAuCmd
+    au!
+  augroup END
+  close!
+endfunc
+
+" Test for BufReadPre autocmd changing the current buffer
+func Test_BufReadPre_changebuf()
+  augroup TestAuCmd
+    au!
+    autocmd BufReadPre Xfile edit Xsomeotherfile
+  augroup END
+  call writefile([], 'Xfile')
+  call assert_fails('new Xfile', 'E201:')
+  call assert_equal('Xsomeotherfile', @%)
+  call assert_equal(1, &readonly)
+  call delete('Xfile')
+  augroup TestAuCmd
+    au!
+  augroup END
+  close!
+endfunc
+
+" Test for BufWipeouti autocmd changing the current buffer when reading a file
+" in an empty buffer with 'f' flag in 'cpo'
+func Test_BufDelete_changebuf()
+  new
+  augroup TestAuCmd
+    au!
+    autocmd BufWipeout * let bufnr = bufadd('somefile') | exe "b " .. bufnr
+  augroup END
+  let save_cpo = &cpo
+  set cpo+=f
+  call assert_fails('r Xfile', 'E484:')
+  call assert_equal('somefile', @%)
+  let &cpo = save_cpo
+  augroup TestAuCmd
+    au!
+  augroup END
+  close!
+endfunc
+
 " Test for the temporary internal window used to execute autocmds
 func Test_autocmd_window()
   %bw!

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -262,22 +262,6 @@ func Test_edit_09()
   bw!
 endfunc
 
-func Test_edit_10()
-  " Test for starting selectmode
-  new
-  set selectmode=key keymodel=startsel
-  call setline(1, ['abc', 'def', 'ghi'])
-  call cursor(1, 4)
-  call feedkeys("A\<s-home>start\<esc>", 'txin')
-  call assert_equal(['startdef', 'ghi'], getline(1, '$'))
-  " start select mode again with gv
-  set selectmode=cmd
-  call feedkeys('gvabc', 'xt')
-  call assert_equal('abctdef', getline(1))
-  set selectmode= keymodel=
-  bw!
-endfunc
-
 func Test_edit_11()
   " Test that indenting kicks in
   new

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1604,6 +1604,7 @@ func Test_edit_InsertLeave_undo()
   bwipe!
   au! InsertLeave
   call delete('XtestUndo')
+  call delete(undofile('XtestUndo'))
   set undofile&
 endfunc
 
@@ -1671,11 +1672,11 @@ func Test_edit_noesckeys()
 endfunc
 
 " Test for running an invalid ex command in insert mode using CTRL-O
-" Note that vim has a hard-coded sleep of 3 seconds. So this test will take
-" more than 3 seconds to complete.
 func Test_edit_ctrl_o_invalid_cmd()
   new
   set showmode showcmd
+  " Avoid a sleep of 3 seconds. Zero might have side effects.
+  " call test_override('ui_delay', 50)
   let caught_e492 = 0
   try
     call feedkeys("i\<C-O>:invalid\<CR>abc\<Esc>", "xt")
@@ -1685,6 +1686,18 @@ func Test_edit_ctrl_o_invalid_cmd()
   call assert_equal(1, caught_e492)
   call assert_equal('abc', getline(1))
   set showmode& showcmd&
+  " call test_override('ui_delay', 0)
+  close!
+endfunc
+
+" Test for editing a file with a very long name
+func Test_edit_illegal_filename()
+  CheckEnglish
+  new
+  redir => msg
+  exe 'edit ' . repeat('f', 5000)
+  redir END
+  call assert_match("Illegal file name$", split(msg, "\n")[0])
   close!
 endfunc
 
@@ -1745,6 +1758,102 @@ func Test_edit_is_a_directory()
   bwipe!
 
   call delete(dirname, 'rf')
+endfunc
+
+" Test for editing a file using invalid file encoding
+func Test_edit_invalid_encoding()
+  CheckEnglish
+  call writefile([], 'Xfile')
+  redir => msg
+  new ++enc=axbyc Xfile
+  redir END
+  call assert_match('\[NOT converted\]', msg)
+  call delete('Xfile')
+  close!
+endfunc
+
+" Test for the "charconvert" option
+func Test_edit_charconvert()
+  CheckEnglish
+  call writefile(['one', 'two'], 'Xfile')
+
+  " set 'charconvert' to a non-existing function
+  set charconvert=NonExitingFunc()
+  new
+  let caught_e117 = v:false
+  try
+    redir => msg
+    edit ++enc=axbyc Xfile
+  catch /E117:/
+    let caught_e117 = v:true
+  finally
+    redir END
+  endtry
+  call assert_true(caught_e117)
+  call assert_equal(['one', 'two'], getline(1, '$'))
+  call assert_match("Conversion with 'charconvert' failed", msg)
+  close!
+  set charconvert&
+
+  " 'charconvert' function doesn't create a output file
+  func Cconv1()
+  endfunc
+  set charconvert=Cconv1()
+  new
+  redir => msg
+  edit ++enc=axbyc Xfile
+  redir END
+  call assert_equal(['one', 'two'], getline(1, '$'))
+  call assert_match("can't read output of 'charconvert'", msg)
+  close!
+  delfunc Cconv1
+  set charconvert&
+
+  " 'charconvert' function to convert to upper case
+  func Cconv2()
+    let data = readfile(v:fname_in)
+    call map(data, 'toupper(v:val)')
+    call writefile(data, v:fname_out)
+  endfunc
+  set charconvert=Cconv2()
+  new Xfile
+  write ++enc=ucase Xfile1
+  call assert_equal(['ONE', 'TWO'], readfile('Xfile1'))
+  call delete('Xfile1')
+  close!
+  delfunc Cconv2
+  set charconvert&
+
+  " 'charconvert' function removes the input file
+  func Cconv3()
+    call delete(v:fname_in)
+  endfunc
+  set charconvert=Cconv3()
+  new
+  call assert_fails('edit ++enc=lcase Xfile', 'E202:')
+  call assert_equal([''], getline(1, '$'))
+  close!
+  delfunc Cconv3
+  set charconvert&
+
+  call delete('Xfile')
+endfunc
+
+" Test for editing a file without read permission
+func Test_edit_file_no_read_perm()
+  CheckUnix
+  CheckNotBSD
+  call writefile(['one', 'two'], 'Xfile')
+  call setfperm('Xfile', '-w-------')
+  new
+  redir => msg
+  edit Xfile
+  redir END
+  call assert_equal(1, &readonly)
+  call assert_equal([''], getline(1, '$'))
+  call assert_match('\[Permission Denied\]', msg)
+  close!
+  call delete('Xfile')
 endfunc
 
 " Using :edit without leaving 'insertmode' should not cause Insert mode to be

--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -242,6 +242,15 @@ func Test_file_changed_dialog()
   call assert_equal(1, line('$'))
   call assert_equal('new line', getline(1))
 
+  " File created after starting to edit it
+  call delete('Xchanged_d')
+  new Xchanged_d
+  call writefile(['one'], 'Xchanged_d')
+  call feedkeys('L', 'L')
+  checktime Xchanged_d
+  call assert_equal(['one'], getline(1, '$'))
+  close!
+
   bwipe!
   call delete('Xchanged_d')
 endfunc

--- a/src/nvim/testdir/test_global.vim
+++ b/src/nvim/testdir/test_global.vim
@@ -9,7 +9,10 @@ func Test_yank_put_clipboard()
   set clipboard=unnamed
   g/^/normal yyp
   call assert_equal(['a', 'a', 'b', 'b', 'c', 'c'], getline(1, 6))
-
+  set clipboard=unnamed,unnamedplus
+  call setline(1, ['a', 'b', 'c'])
+  g/^/normal yyp
+  call assert_equal(['a', 'a', 'b', 'b', 'c', 'c'], getline(1, 6))
   set clipboard&
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -124,31 +124,6 @@ func Test_normal01_keymodel()
   bw!
 endfunc
 
-" Test for select mode
-func Test_normal02_selectmode()
-  call Setup_NewWindow()
-  50
-  norm! gHy
-  call assert_equal('y51', getline('.'))
-  call setline(1, range(1,100))
-  50
-  exe ":norm! V9jo\<c-g>y"
-  call assert_equal('y60', getline('.'))
-  " clean up
-  bw!
-endfunc
-
-func Test_normal02_selectmode2()
-  " some basic select mode tests
-  call Setup_NewWindow()
-  50
-  " call feedkeys(":set im\n\<c-o>gHc\<c-o>:set noim\n", 'tx')
-  call feedkeys("i\<c-o>gHc\<esc>", 'tx')
-  call assert_equal('c51', getline('.'))
-  " clean up
-  bw!
-endfunc
-
 func Test_normal03_join()
   " basic join test
   call Setup_NewWindow()

--- a/src/nvim/testdir/test_selectmode.vim
+++ b/src/nvim/testdir/test_selectmode.vim
@@ -2,6 +2,156 @@
 
 source shared.vim
 
+" Test for select mode
+func Test_selectmode_basic()
+  new
+  call setline(1, range(1,100))
+  50
+  norm! gHy
+  call assert_equal('y51', getline('.'))
+  call setline(1, range(1,100))
+  50
+  exe ":norm! V9jo\<c-g>y"
+  call assert_equal('y60', getline('.'))
+  call setline(1, range(1,100))
+  50
+  " call feedkeys(":set im\n\<c-o>gHc\<c-o>:set noim\n", 'tx')
+  call feedkeys("i\<c-o>gHc\<esc>", 'tx')
+  call assert_equal('c51', getline('.'))
+  " clean up
+  bw!
+endfunc
+
+" Test for starting selectmode
+func Test_selectmode_start()
+  new
+  set selectmode=key keymodel=startsel
+  call setline(1, ['abc', 'def', 'ghi'])
+  call cursor(1, 4)
+  call feedkeys("A\<s-home>start\<esc>", 'txin')
+  call assert_equal(['startdef', 'ghi'], getline(1, '$'))
+  " start select mode again with gv
+  set selectmode=cmd
+  call feedkeys('gvabc', 'xt')
+  call assert_equal('abctdef', getline(1))
+  set selectmode= keymodel=
+  bw!
+endfunc
+
+" Test for characterwise select mode
+func Test_characterwise_select_mode()
+  new
+
+  " Select mode maps
+  snoremap <lt>End> <End>
+  snoremap <lt>Down> <Down>
+  snoremap <lt>Del> <Del>
+
+  " characterwise select mode: delete middle line
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal Gkkgh\<End>\<Del>"
+  call assert_equal(['', 'b', 'c'], getline(1, '$'))
+
+  " characterwise select mode: delete middle two lines
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal Gkkgh\<Down>\<End>\<Del>"
+  call assert_equal(['', 'c'], getline(1, '$'))
+
+  " characterwise select mode: delete last line
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal Ggh\<End>\<Del>"
+  call assert_equal(['', 'a', 'b', ''], getline(1, '$'))
+
+  " characterwise select mode: delete last two lines
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal Gkgh\<Down>\<End>\<Del>"
+  call assert_equal(['', 'a', ''], getline(1, '$'))
+
+  " CTRL-H in select mode behaves like 'x'
+  call setline(1, 'abcdef')
+  exe "normal! gggh\<Right>\<Right>\<Right>\<C-H>"
+  call assert_equal('ef', getline(1))
+
+  " CTRL-O in select mode switches to visual mode for one command
+  call setline(1, 'abcdef')
+  exe "normal! gggh\<C-O>3lm"
+  call assert_equal('mef', getline(1))
+
+  sunmap <lt>End>
+  sunmap <lt>Down>
+  sunmap <lt>Del>
+  bwipe!
+endfunc
+
+" Test for linewise select mode
+func Test_linewise_select_mode()
+  new
+
+  " linewise select mode: delete middle line
+  call append('$', ['a', 'b', 'c'])
+  exe "normal GkkgH\<Del>"
+  call assert_equal(['', 'b', 'c'], getline(1, '$'))
+
+  " linewise select mode: delete middle two lines
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal GkkgH\<Down>\<Del>"
+  call assert_equal(['', 'c'], getline(1, '$'))
+
+  " linewise select mode: delete last line
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal GgH\<Del>"
+  call assert_equal(['', 'a', 'b'], getline(1, '$'))
+
+  " linewise select mode: delete last two lines
+  call deletebufline('', 1, '$')
+  call append('$', ['a', 'b', 'c'])
+  exe "normal GkgH\<Down>\<Del>"
+  call assert_equal(['', 'a'], getline(1, '$'))
+
+  bwipe!
+endfunc
+
+" Test for blockwise select mode (g CTRL-H)
+func Test_blockwise_select_mode()
+  new
+  call setline(1, ['foo', 'bar'])
+  call feedkeys("g\<BS>\<Right>\<Down>mm", 'xt')
+  call assert_equal(['mmo', 'mmr'], getline(1, '$'))
+  close!
+endfunc
+
+" Test for using visual mode maps in select mode
+func Test_select_mode_map()
+  new
+  vmap <buffer> <F2> 3l
+  call setline(1, 'Test line')
+  call feedkeys("gh\<F2>map", 'xt')
+  call assert_equal('map line', getline(1))
+
+  vmap <buffer> <F2> ygV
+  call feedkeys("0gh\<Right>\<Right>\<F2>cwabc", 'xt')
+  call assert_equal('abc line', getline(1))
+
+  vmap <buffer> <F2> :<C-U>let v=100<CR>
+  call feedkeys("gggh\<Right>\<Right>\<F2>foo", 'xt')
+  call assert_equal('foo line', getline(1))
+
+  " reselect the select mode using gv from a visual mode map
+  vmap <buffer> <F2> gv
+  set selectmode=cmd
+  call feedkeys("0gh\<F2>map", 'xt')
+  call assert_equal('map line', getline(1))
+  set selectmode&
+
+  close!
+endfunc
+
 " Test for selecting a register with CTRL-R
 func Test_selectmode_register()
   new

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -664,92 +664,6 @@ func Test_characterwise_visual_mode()
   bwipe!
 endfunc
 
-func Test_characterwise_select_mode()
-  new
-
-  " Select mode maps
-  snoremap <lt>End> <End>
-  snoremap <lt>Down> <Down>
-  snoremap <lt>Del> <Del>
-
-  " characterwise select mode: delete middle line
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal Gkkgh\<End>\<Del>"
-  call assert_equal(['', 'b', 'c'], getline(1, '$'))
-
-  " characterwise select mode: delete middle two lines
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal Gkkgh\<Down>\<End>\<Del>"
-  call assert_equal(['', 'c'], getline(1, '$'))
-
-  " characterwise select mode: delete last line
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal Ggh\<End>\<Del>"
-  call assert_equal(['', 'a', 'b', ''], getline(1, '$'))
-
-  " characterwise select mode: delete last two lines
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal Gkgh\<Down>\<End>\<Del>"
-  call assert_equal(['', 'a', ''], getline(1, '$'))
-
-  " CTRL-H in select mode behaves like 'x'
-  call setline(1, 'abcdef')
-  exe "normal! gggh\<Right>\<Right>\<Right>\<C-H>"
-  call assert_equal('ef', getline(1))
-
-  " CTRL-O in select mode switches to visual mode for one command
-  call setline(1, 'abcdef')
-  exe "normal! gggh\<C-O>3lm"
-  call assert_equal('mef', getline(1))
-
-  sunmap <lt>End>
-  sunmap <lt>Down>
-  sunmap <lt>Del>
-  bwipe!
-endfunc
-
-func Test_linewise_select_mode()
-  new
-
-  " linewise select mode: delete middle line
-  call append('$', ['a', 'b', 'c'])
-  exe "normal GkkgH\<Del>"
-  call assert_equal(['', 'b', 'c'], getline(1, '$'))
-
-  " linewise select mode: delete middle two lines
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal GkkgH\<Down>\<Del>"
-  call assert_equal(['', 'c'], getline(1, '$'))
-
-  " linewise select mode: delete last line
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal GgH\<Del>"
-  call assert_equal(['', 'a', 'b'], getline(1, '$'))
-
-  " linewise select mode: delete last two lines
-  call deletebufline('', 1, '$')
-  call append('$', ['a', 'b', 'c'])
-  exe "normal GkgH\<Down>\<Del>"
-  call assert_equal(['', 'a'], getline(1, '$'))
-
-  bwipe!
-endfunc
-
-" Test for blockwise select mode (g CTRL-H)
-func Test_blockwise_select_mode()
-  new
-  call setline(1, ['foo', 'bar'])
-  call feedkeys("g\<BS>\<Right>\<Down>mm", 'xt')
-  call assert_equal(['mmo', 'mmr'], getline(1, '$'))
-  close!
-endfunc
-
 func Test_visual_mode_put()
   new
 
@@ -789,16 +703,16 @@ func Test_visual_mode_put()
   bwipe!
 endfunc
 
-func Test_select_mode_gv()
+func Test_gv_with_exclusive_selection()
   new
 
-  " gv in exclusive select mode after operation
+  " gv with exclusive selection after an operation
   call append('$', ['zzz ', 'Ã¤Ã '])
   set selection=exclusive
   normal Gkv3lyjv3lpgvcxxx
   call assert_equal(['', 'zzz ', 'xxx '], getline(1, '$'))
 
-  " gv in exclusive select mode without operation
+  " gv with exclusive selection without an operation
   call deletebufline('', 1, '$')
   call append('$', 'zzz ')
   set selection=exclusive
@@ -1144,32 +1058,6 @@ func Test_star_register()
 
   delmarks < >
   call assert_fails('*yank', 'E20:')
-  close!
-endfunc
-
-" Test for using visual mode maps in select mode
-func Test_select_mode_map()
-  new
-  vmap <buffer> <F2> 3l
-  call setline(1, 'Test line')
-  call feedkeys("gh\<F2>map", 'xt')
-  call assert_equal('map line', getline(1))
-
-  vmap <buffer> <F2> ygV
-  call feedkeys("0gh\<Right>\<Right>\<F2>cwabc", 'xt')
-  call assert_equal('abc line', getline(1))
-
-  vmap <buffer> <F2> :<C-U>let v=100<CR>
-  call feedkeys("gggh\<Right>\<Right>\<F2>foo", 'xt')
-  call assert_equal('foo line', getline(1))
-
-  " reselect the select mode using gv from a visual mode map
-  vmap <buffer> <F2> gv
-  set selectmode=cmd
-  call feedkeys("0gh\<F2>map", 'xt')
-  call assert_equal('map line', getline(1))
-  set selectmode&
-
   close!
 endfunc
 

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -128,6 +128,25 @@ func Test_nowrite_quit_split()
   bwipe Xfile
 endfunc
 
+func Test_writefile_sync_arg()
+  " This doesn't check if fsync() works, only that the argument is accepted.
+  call writefile(['one'], 'Xtest', 's')
+  call writefile(['two'], 'Xtest', 'S')
+  call delete('Xtest')
+endfunc
+
+func Test_writefile_sync_dev_stdout()
+  if !has('unix')
+    return
+  endif
+  if filewritable('/dev/stdout')
+    " Just check that this doesn't cause an error.
+    call writefile(['one'], '/dev/stdout', 's')
+  else
+    throw 'Skipped: /dev/stdout is not writable'
+  endif
+endfunc
+
 func Test_writefile_autowrite()
   set autowrite
   new
@@ -237,29 +256,18 @@ func Test_write_errors()
   call delete('Xfile')
 endfunc
 
-func Test_writefile_sync_dev_stdout()
-  if !has('unix')
-    return
-  endif
-  if filewritable('/dev/stdout')
-    " Just check that this doesn't cause an error.
-    call writefile(['one'], '/dev/stdout', 's')
-  else
-    throw 'Skipped: /dev/stdout is not writable'
-  endif
-endfunc
-
-func Test_writefile_sync_arg()
-  " This doesn't check if fsync() works, only that the argument is accepted.
-  call writefile(['one'], 'Xtest', 's')
-  call writefile(['two'], 'Xtest', 'S')
-  call delete('Xtest')
+" Test for writing a file using invalid file encoding
+func Test_write_invalid_encoding()
+  new
+  call setline(1, 'abc')
+  call assert_fails('write ++enc=axbyc Xfile', 'E213:')
+  close!
 endfunc
 
 " Tests for reading and writing files with conversion for Win32.
 func Test_write_file_encoding()
-  CheckMSWindows
   throw 'skipped: Nvim does not support :w ++enc=cp1251'
+  CheckMSWindows
   let save_encoding = &encoding
   let save_fileencodings = &fileencodings
   set encoding& fileencodings&

--- a/test/functional/legacy/filechanged_spec.lua
+++ b/test/functional/legacy/filechanged_spec.lua
@@ -67,6 +67,15 @@ describe('file changed dialog', function()
         call assert_equal(1, line('$'))
         call assert_equal('new line', getline(1))
 
+        " File created after starting to edit it
+        call delete('Xchanged_d')
+        new Xchanged_d
+        call writefile(['one'], 'Xchanged_d')
+        call nvim_input('L')
+        checktime Xchanged_d
+        call assert_equal(['one'], getline(1, '$'))
+        close!
+
         bwipe!
         call delete('Xchanged_d')
       endfunc


### PR DESCRIPTION
#### vim-patch:partial:8.2.0425: code for modeless selection not sufficiently tested

Problem:    Code for modeless selection not sufficiently tested.
Solution:   Add tests.  Move mouse code functionality to a common script file.
            (Yegappan Lakshmanan, closes vim/vim#5821)
https://github.com/vim/vim/commit/515545e11f523d14343b1e588dc0b9bd3d362bc2

Skip termcode tests for now.


#### vim-patch:8.2.0982: insufficient testing for reading/writing files

Problem:    Insufficient testing for reading/writing files.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6257)
            Add "ui_delay" to test_override() and use it for the CTRL-O test.
https://github.com/vim/vim/commit/b340baed9f7fc1c19a0742e2214d54982190c15e

Omit test_override().
Reorder test_writefile.vim to match Vim.