### PR TITLE
vim-patch:8.2.{3623,4667}: expandcmd() fixes

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2074,10 +2074,13 @@ expandcmd({string})					*expandcmd()*
 		like with |expand()|, and environment variables, anywhere in
 		{string}.  "~user" and "~/path" are only expanded at the
 		start.
-		Returns the expanded string.  Example: >
+		Returns the expanded string.  If an error is encountered
+		during expansion, the unmodified {string} is returned.
+		Example: >
 			:echo expandcmd('make %<.o')
+<			make /path/runtime/doc/builtin.o ~
 
-<		Can also be used as a |method|: >
+		Can also be used as a |method|: >
 			GetCommand()->expandcmd()
 <
 extend({expr1}, {expr2} [, {expr3}])			*extend()*

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2052,10 +2052,10 @@ static void f_expandcmd(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   };
   eap.argt |= EX_NOSPC;
 
+  emsg_off++;
   expand_filename(&eap, &cmdstr, &errormsg);
-  if (errormsg != NULL && *errormsg != NUL) {
-    emsg(errormsg);
-  }
+  emsg_off--;
+
   rettv->vval.v_string = cmdstr;
 }
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -249,10 +249,16 @@ int os_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, in
     }
     STRCAT(command, ">");
   } else {
-    if (flags & EW_NOTFOUND) {
-      STRCPY(command, "set nonomatch; ");
-    } else {
-      STRCPY(command, "unset nonomatch; ");
+    STRCPY(command, "");
+    if (shell_style == STYLE_GLOB) {
+      // Assume the nonomatch option is valid only for csh like shells,
+      // otherwise, this may set the positional parameters for the shell,
+      // e.g. "$*".
+      if (flags & EW_NOTFOUND) {
+        STRCAT(command, "set nonomatch; ");
+      } else {
+        STRCAT(command, "unset nonomatch; ");
+      }
     }
     if (shell_style == STYLE_GLOB) {
       STRCAT(command, "glob >");

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -78,10 +78,11 @@ func Test_expandcmd()
   edit a1a2a3.rb
   call assert_equal('make b1b2b3.rb a1a2a3 Xfile.o', expandcmd('make %:gs?a?b? %< #<.o'))
 
-  call assert_fails('call expandcmd("make <afile>")', 'E495:')
-  call assert_fails('call expandcmd("make <afile>")', 'E495:')
+  call assert_equal('make <afile>', expandcmd("make <afile>"))
+  call assert_equal('make <amatch>', expandcmd("make <amatch>"))
+  call assert_equal('make <abuf>', expandcmd("make <abuf>"))
   enew
-  call assert_fails('call expandcmd("make %")', 'E499:')
+  call assert_equal('make %', expandcmd("make %"))
   let $FOO="blue\tsky"
   call setline(1, "$FOO")
   call assert_equal("grep pat blue\tsky", expandcmd('grep pat <cfile>'))
@@ -94,6 +95,11 @@ func Test_expandcmd()
   let $FOO= "foo bar baz"
   call assert_equal("e foo bar baz", expandcmd("e $FOO"))
 
+  if has('unix')
+    " test for using the shell to expand a command argument
+    call assert_equal('{1..4}', expandcmd('{1..4}'))
+  endif
+
   unlet $FOO
   close!
 endfunc
@@ -101,14 +107,14 @@ endfunc
 " Test for expanding <sfile>, <slnum> and <sflnum> outside of sourcing a script
 func Test_source_sfile()
   let lines =<< trim [SCRIPT]
-    :call assert_fails('echo expandcmd("<sfile>")', 'E498:')
-    :call assert_fails('echo expandcmd("<slnum>")', 'E842:')
-    :call assert_fails('echo expandcmd("<sflnum>")', 'E961:')
-    :call assert_fails('call expandcmd("edit <cfile>")', 'E446:')
-    :call assert_fails('call expandcmd("edit #")', 'E194:')
-    :call assert_fails('call expandcmd("edit #<2")', 'E684:')
-    :call assert_fails('call expandcmd("edit <cword>")', 'E348:')
-    :call assert_fails('call expandcmd("edit <cexpr>")', 'E348:')
+    :call assert_equal('<sfile>', expandcmd("<sfile>"))
+    :call assert_equal('<slnum>', expandcmd("<slnum>"))
+    :call assert_equal('<sflnum>', expandcmd("<sflnum>"))
+    :call assert_equal('edit <cfile>', expandcmd("edit <cfile>"))
+    :call assert_equal('edit #', expandcmd("edit #"))
+    :call assert_equal('edit #<2', expandcmd("edit #<2"))
+    :call assert_equal('edit <cword>', expandcmd("edit <cword>"))
+    :call assert_equal('edit <cexpr>', expandcmd("edit <cexpr>"))
     :call assert_fails('autocmd User MyCmd echo "<sfile>"', 'E498:')
     :call writefile(v:errors, 'Xresult')
     :qall!

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -1,6 +1,7 @@
 " Test for expanding file names
 
 source shared.vim
+source check.vim
 
 func Test_with_directories()
   call mkdir('Xdir1')
@@ -131,7 +132,13 @@ func Test_expand_filename_multicmd()
   call assert_equal(4, winnr('$'))
   call assert_equal('foo!', bufname(winbufnr(1)))
   call assert_equal('foo', bufname(winbufnr(2)))
+  call assert_fails('e %:s/.*//', 'E500:')
   %bwipe!
+endfunc
+
+func Test_expandcmd_shell_nonomatch()
+  CheckNotMSWindows
+  call assert_equal('$*', expandcmd('$*'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3623: "$*" is expanded to "nonomatch"

Problem:    "$*" is expanded to "nonomatch".
Solution:   Only add "set nonomatch" when using a csh-like shell. (Christian
            Brabandt, closes vim/vim#9159)
https://github.com/vim/vim/commit/8b8d829faf04fe3706c04f7f7000054acd3254e7

Cherry-pick a line from patch 8.2.0522.


#### vim-patch:8.2.4667: expandcmd() fails on an error

Problem:    expandcmd() fails on an error.
Solution:   On failure return the command unmodified. (yegappan Lakshmanan,
            closes vim/vim#10063)
https://github.com/vim/vim/commit/5018a836c030988944a9bbe2fd2e538bf5261a72