### PR TITLE
fix(eval): check for v:lua when calling callback

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5842,7 +5842,17 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
   switch (callback->type) {
   case kCallbackFuncref:
     name = callback->data.funcref;
-    partial = NULL;
+    int len = (int)STRLEN(name);
+    if (len >= 6 && !memcmp(name, "v:lua.", 6)) {
+      name += 6;
+      len = check_luafunc_name(name, false);
+      if (len == 0) {
+        return false;
+      }
+      partial = vvlua_partial;
+    } else {
+      partial = NULL;
+    }
     break;
 
   case kCallbackPartial:

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -6191,7 +6191,7 @@ static void op_function(const oparg_T *oap)
     finish_op = false;
 
     typval_T rettv;
-    if (callback_call(&opfunc_cb, 1, argv, &rettv) != FAIL) {
+    if (callback_call(&opfunc_cb, 1, argv, &rettv)) {
       tv_clear(&rettv);
     }
 

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -467,7 +467,6 @@ describe('v:lua', function()
           end
         end
       end
-      vim.api.nvim_buf_set_option(0, 'omnifunc', 'v:lua.mymod.omni')
     ]])
   end)
 
@@ -515,6 +514,7 @@ describe('v:lua', function()
       [5] = {bold = true, foreground = Screen.colors.SeaGreen4},
     })
     screen:attach()
+    meths.buf_set_option(0, 'omnifunc', 'v:lua.mymod.omni')
     feed('isome st<c-x><c-o>')
     screen:expect{grid=[[
       some stuff^                                                  |
@@ -526,6 +526,9 @@ describe('v:lua', function()
       {1:~                                                           }|
       {4:-- Omni completion (^O^N^P) }{5:match 1 of 3}                    |
     ]]}
+    meths.set_option('operatorfunc', 'v:lua.mymod.noisy')
+    feed('<Esc>g@g@')
+    eq("hey line", meths.get_current_line())
   end)
 
   it('supports packages', function()


### PR DESCRIPTION
This makes callback_call() match call_vim_function() when calling a function.