### PR TITLE
vim-patch:9.0.0231: expanding "**" may loop forever with directory links

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -456,9 +456,10 @@ char_u *ExpandOne(expand_T *xp, char_u *str, char_u *orig, int options, int mode
     findex = -1;  // next p_wc gets first one
   }
 
-  // Concatenate all matching names
+  // Concatenate all matching names.  Unless interrupted, this can be slow
+  // and the result probably won't be used.
   // TODO(philix): use xstpcpy instead of strcat in a loop (ExpandOne)
-  if (mode == WILD_ALL && xp->xp_numfiles > 0) {
+  if (mode == WILD_ALL && xp->xp_numfiles > 0 && !got_int) {
     size_t len = 0;
     for (i = 0; i < xp->xp_numfiles; i++) {
       len += STRLEN(xp->xp_files[i]) + 1;


### PR DESCRIPTION
#### vim-patch:9.0.0231: expanding "**" may loop forever with directory links

Problem:    Expanding "**" may loop forever with directory links.
Solution:   Check for being interrupted.
https://github.com/vim/vim/commit/57e95179abdd851cb2d0c06d4f973575a768e3bb