### PR TITLE
vim-patch:8.2.1587: loop for handling keys for the command line is too long

### DIFF
--- a/src/nvim/cmdexpand.h
+++ b/src/nvim/cmdexpand.h
@@ -2,6 +2,7 @@
 #define NVIM_CMDEXPAND_H
 
 #include "nvim/eval/typval.h"
+#include "nvim/ex_getln.h"
 #include "nvim/garray.h"
 #include "nvim/types.h"
 


### PR DESCRIPTION
#### vim-patch:8.2.1587: loop for handling keys for the command line is too long

Problem:    Loop for handling keys for the command line is too long.
Solution:   Move wild menu handling to separate functions. (Yegappan
            Lakshmanan, closes vim/vim#6856)
https://github.com/vim/vim/commit/eadee486c70946ad0e1746d77898d6f4f4acc817