### PR TITLE
feat(options): Add the option "colorcol" to the fillchars setting to set a character that neovim should draw at the colorcolumn if no other character is there.

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1372,7 +1372,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to window
 	'colorcolumn' is a comma-separated list of screen columns that are
 	highlighted with ColorColumn |hl-ColorColumn| and drawn using the
-	colocol option from 'fillchars'.  Useful to align
+	"colorcol" option from 'fillchars'.  Useful to align
 	text.  Will make screen redrawing slower.
 	The screen column can be an absolute number, or a number preceded with
 	'+' or '-', which is added to or subtracted from 'textwidth'. >

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1372,10 +1372,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to window
 	'colorcolumn' is a comma-separated list of screen columns that are
 	highlighted with ColorColumn |hl-ColorColumn| and drawn using the
-	"colorcol" option from 'fillchars'.  Useful to align
-	text.  Will make screen redrawing slower.
-	The screen column can be an absolute number, or a number preceded with
-	'+' or '-', which is added to or subtracted from 'textwidth'. >
+	"colorc" option from 'fillchars'.  Useful to align text.  Will make
+	screen redrawing slower. The screen column can be an absolute number,
+	or a number preceded with '+' or '-', which is added to or subtracted
+	from 'textwidth'. >
 
 		:set cc=+1  " highlight column after 'textwidth'
 		:set cc=+1,+2,+3  " highlight three columns after 'textwidth'

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1372,10 +1372,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to window
 	'colorcolumn' is a comma-separated list of screen columns that are
 	highlighted with ColorColumn |hl-ColorColumn| and drawn using the
-	"colorc" option from 'fillchars'.  Useful to align text.  Will make
-	screen redrawing slower. The screen column can be an absolute number,
-	or a number preceded with '+' or '-', which is added to or subtracted
-	from 'textwidth'. >
+	"colorcol" option from 'fillchars'.  Useful to align
+	text.  Will make screen redrawing slower.
+	The screen column can be an absolute number, or a number preceded with
+	'+' or '-', which is added to or subtracted from 'textwidth'. >
 
 		:set cc=+1  " highlight column after 'textwidth'
 		:set cc=+1,+2,+3  " highlight three columns after 'textwidth'

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1371,7 +1371,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'colorcolumn' 'cc'	string	(default "")
 			local to window
 	'colorcolumn' is a comma-separated list of screen columns that are
-	highlighted with ColorColumn |hl-ColorColumn|.  Useful to align
+	highlighted with ColorColumn |hl-ColorColumn| and drawn using the
+	colocol option from 'fillchars'.  Useful to align
 	text.  Will make screen redrawing slower.
 	The screen column can be an absolute number, or a number preceded with
 	'+' or '-', which is added to or subtracted from 'textwidth'. >
@@ -2502,6 +2503,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  msgsep	' '		message separator 'display'
 	  eob		'~'		empty lines at the end of a buffer
 	  lastline	'@'		'display' contains lastline/truncate
+	  colorcol:c	' '		character to display in the colorcolumn
 
 	Any one that is omitted will fall back to the default.  For "stl" and
 	"stlnc" the space will be used when there is highlighting, '^' or '='
@@ -2539,7 +2541,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  fold		Folded			|hl-Folded|
 	  diff		DiffDelete		|hl-DiffDelete|
 	  eob		EndOfBuffer		|hl-EndOfBuffer|
+<<<<<<< HEAD
 	  lastline	NonText			|hl-NonText|
+=======
+	  colorcol:c	ColorColumn		|hl-ColorColumn|
+>>>>>>> 4825baba8 (feat(colorcolchar): add the option "colorcol" to the fillchars setting)
 
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1176,7 +1176,7 @@ struct window_S {
     int msgsep;
     int eob;
     int lastline;
-    int colorc;
+    int colorcol;
   } w_p_fcs_chars;
 
   // "w_topline", "w_leftcol" and "w_skipcol" specify the offsets for

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1176,6 +1176,7 @@ struct window_S {
     int msgsep;
     int eob;
     int lastline;
+    int colorcol;
   } w_p_fcs_chars;
 
   // "w_topline", "w_leftcol" and "w_skipcol" specify the offsets for

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1176,7 +1176,7 @@ struct window_S {
     int msgsep;
     int eob;
     int lastline;
-    int colorcol;
+    int colorc;
   } w_p_fcs_chars;
 
   // "w_topline", "w_leftcol" and "w_skipcol" specify the offsets for

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2502,7 +2502,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             col_attr = cuc_attr;
           } else if (draw_color_col && VCOL_HLC == *color_cols) {
             col_attr = mc_attr;
-            c = wp->w_p_fcs_chars.colorcol;
+            c = wp->w_p_fcs_chars.colorc;
             schar_from_char(linebuf_char[off], c);
           }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2502,6 +2502,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             col_attr = cuc_attr;
           } else if (draw_color_col && VCOL_HLC == *color_cols) {
             col_attr = mc_attr;
+            c = wp->w_p_fcs_chars.colorcol;
+            schar_from_char(linebuf_char[off], c);
           }
 
           col_attr = hl_combine_attr(col_attr, line_attr);

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2502,7 +2502,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             col_attr = cuc_attr;
           } else if (draw_color_col && VCOL_HLC == *color_cols) {
             col_attr = mc_attr;
-            c = wp->w_p_fcs_chars.colorc;
+            c = wp->w_p_fcs_chars.colorcol;
             schar_from_char(linebuf_char[off], c);
           }
 

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -882,7 +882,7 @@ char *set_chars_option(win_T *wp, char **varp, bool apply)
     { &wp->w_p_fcs_chars.msgsep,     "msgsep",    ' ' },
     { &wp->w_p_fcs_chars.eob,        "eob",       '~' },
     { &wp->w_p_fcs_chars.lastline,   "lastline",  '@' },
-    { &wp->w_p_fcs_chars.colorc,     "colorc",  ' ' },
+    { &wp->w_p_fcs_chars.colorcol,   "colorcol",  ' ' },
   };
 
   struct chars_tab lcs_tab[] = {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -882,6 +882,7 @@ char *set_chars_option(win_T *wp, char **varp, bool apply)
     { &wp->w_p_fcs_chars.msgsep,     "msgsep",    ' ' },
     { &wp->w_p_fcs_chars.eob,        "eob",       '~' },
     { &wp->w_p_fcs_chars.lastline,   "lastline",  '@' },
+    { &wp->w_p_fcs_chars.colorcol,   "colorcol",  ' ' },
   };
 
   struct chars_tab lcs_tab[] = {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -882,7 +882,7 @@ char *set_chars_option(win_T *wp, char **varp, bool apply)
     { &wp->w_p_fcs_chars.msgsep,     "msgsep",    ' ' },
     { &wp->w_p_fcs_chars.eob,        "eob",       '~' },
     { &wp->w_p_fcs_chars.lastline,   "lastline",  '@' },
-    { &wp->w_p_fcs_chars.colorcol,   "colorcol",  ' ' },
+    { &wp->w_p_fcs_chars.colorc,     "colorc",  ' ' },
   };
 
   struct chars_tab lcs_tab[] = {

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -859,7 +859,7 @@ describe('CursorLine and CursorLineNr highlights', function()
                                                         |
     ]])
 
-    command('set fillchars=colorc:.')
+    command('set fillchars=colorcol:.')
     command('set colorcolumn=3')
     feed('i  <esc>')
     screen:expect([[

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -859,14 +859,14 @@ describe('CursorLine and CursorLineNr highlights', function()
                                                         |
     ]])
 
-    command('set fillchars=colorc:|')
+    command('set fillchars=colorc:.')
     command('set colorcolumn=3')
     feed('i  <esc>')
     screen:expect([[
-      {1:{} {7:|}                                               |
+      {1:{} {7:.}                                               |
       "{2:a}{7:"} : {3:abc} {3:// 10;}                                  |
-      {1:}} {7:|}                                               |
-      {5: ^ }{7:|}{5:                                               }|
+      {1:}} {7:.}                                               |
+      {5: ^ }{7:.}{5:                                               }|
                                                         |
     ]])
   end)

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -859,7 +859,7 @@ describe('CursorLine and CursorLineNr highlights', function()
                                                         |
     ]])
 
-    command('set fillchars=colorcol:|')
+    command('set fillchars=colorc:|')
     command('set colorcolumn=3')
     feed('i  <esc>')
     screen:expect([[

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -859,13 +859,14 @@ describe('CursorLine and CursorLineNr highlights', function()
                                                         |
     ]])
 
+    command('set fillchars=colorcol:|')
     command('set colorcolumn=3')
     feed('i  <esc>')
     screen:expect([[
-      {1:{} {7: }                                               |
+      {1:{} {7:|}                                               |
       "{2:a}{7:"} : {3:abc} {3:// 10;}                                  |
-      {1:}} {7: }                                               |
-      {5: ^ }{7: }{5:                                               }|
+      {1:}} {7:|}                                               |
+      {5: ^ }{7:|}{5:                                               }|
                                                         |
     ]])
   end)


### PR DESCRIPTION
Hey all, I've been keeping this little change under my belt for a couple years and thought it might be time to share with the world. All this change does is add an option to the `fillchars` setting: colorcol. This sets the character that neovim should fill the Color Column with when no other character is present. I like this because I find it more sleek to have a 1px line down my color column (by using '│' as my colorcol char) than to have a whole cell highlighted.

Feel free to accept, ignore, whatever, just thought it was time to bring it forth. This is my first neovim pull request, so be gentle please :)

(screenshot is with fillchars+=colorcol:│)

![colorcol](https://user-images.githubusercontent.com/3434593/185770890-52fd59ba-ed2f-49d6-a613-17e8c3375a43.png)
