### PR TITLE
vim-patch:8.2.4754: using cached values after unsetting some environment variables

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7629,9 +7629,9 @@ static void f_setenv(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   if (argvars[1].v_type == VAR_SPECIAL
       && argvars[1].vval.v_special == kSpecialVarNull) {
-    os_unsetenv(name);
+    vim_unsetenv_ext(name);
   } else {
-    os_setenv(name, tv_get_string_buf(&argvars[1], valbuf), 1);
+    vim_setenv_ext(name, tv_get_string_buf(&argvars[1], valbuf));
   }
 }
 

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -593,15 +593,7 @@ static char *ex_let_one(char *arg, typval_T *const tv, const bool copy, const bo
           }
         }
         if (p != NULL) {
-          os_setenv(name, p, 1);
-          if (STRICMP(name, "HOME") == 0) {
-            init_homedir();
-          } else if (didset_vim && STRICMP(name, "VIM") == 0) {
-            didset_vim = false;
-          } else if (didset_vimruntime
-                     && STRICMP(name, "VIMRUNTIME") == 0) {
-            didset_vimruntime = false;
-          }
+          vim_setenv_ext(name, p);
           arg_end = arg;
         }
         name[len] = c1;
@@ -859,7 +851,7 @@ static int do_unlet_var(lval_T *lp, char *name_end, exarg_T *eap, int deep FUNC_
 
     // Environment variable, normal name or expanded name.
     if (*lp->ll_name == '$') {
-      os_unsetenv(lp->ll_name + 1);
+      vim_unsetenv_ext(lp->ll_name + 1);
     } else if (do_unlet(lp->ll_name, lp->ll_name_len, forceit) == FAIL) {
       ret = FAIL;
     }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -614,7 +614,6 @@ static int shada_idx = -1;
 
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
-/// Returns NULL for success, or an error message for an error.
 ///
 /// @param opt_idx  index in options[] table
 /// @param varp  pointer to the option variable
@@ -623,6 +622,8 @@ static int shada_idx = -1;
 /// @param errbuflen  length of errors buffer
 /// @param opt_flags  OPT_LOCAL and/or OPT_GLOBAL
 /// @param value_checked  value was checked to be safe, no need to set P_INSECURE
+///
+/// @return  NULL for success, or an untranslated error message for an error
 char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *errbuf,
                             size_t errbuflen, int opt_flags, int *value_checked)
 {
@@ -698,12 +699,10 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
   } else if (varp == &p_hf) {  // 'helpfile'
     // May compute new values for $VIM and $VIMRUNTIME
     if (didset_vim) {
-      os_setenv("VIM", "", 1);
-      didset_vim = false;
+      vim_unsetenv_ext("VIM");
     }
     if (didset_vimruntime) {
-      os_setenv("VIMRUNTIME", "", 1);
-      didset_vimruntime = false;
+      vim_unsetenv_ext("VIMRUNTIME");
     }
   } else if (varp == &p_rtp || varp == &p_pp) {  // 'runtimepath' 'packpath'
     runtime_search_path_invalidate();

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -1229,3 +1229,29 @@ bool os_shell_is_cmdexe(const char *sh)
   }
   return striequal("cmd.exe", path_tail(sh));
 }
+
+/// Removes environment variable "name" and take care of side effects.
+void vim_unsetenv_ext(const char *var)
+{
+  os_unsetenv(var);
+
+  // "homedir" is not cleared, keep using the old value until $HOME is set.
+  if (STRICMP(var, "VIM") == 0) {
+    didset_vim = false;
+  } else if (STRICMP(var, "VIMRUNTIME") == 0) {
+    didset_vimruntime = false;
+  }
+}
+
+/// Set environment variable "name" and take care of side effects.
+void vim_setenv_ext(const char *name, const char *val)
+{
+  os_setenv(name, val, 1);
+  if (STRICMP(name, "HOME") == 0) {
+    init_homedir();
+  } else if (didset_vim && STRICMP(name, "VIM") == 0) {
+    didset_vim = false;
+  } else if (didset_vimruntime && STRICMP(name, "VIMRUNTIME") == 0) {
+    didset_vimruntime = false;
+  }
+}

--- a/src/nvim/testdir/test_environ.vim
+++ b/src/nvim/testdir/test_environ.vim
@@ -28,6 +28,26 @@ func Test_setenv()
   call assert_equal(v:null, getenv('TEST ENV'))
 endfunc
 
+func Test_special_env()
+  " The value for $HOME is cached internally by Vim, ensure the value is up to
+  " date.
+  let orig_ENV = $HOME
+
+  let $HOME = 'foo'
+  call assert_equal('foo', expand('~'))
+  " old $HOME value is kept until a new one is set
+  unlet $HOME
+  call assert_equal('foo', expand('~'))
+
+  call setenv('HOME', 'bar')
+  call assert_equal('bar', expand('~'))
+  " old $HOME value is kept until a new one is set
+  call setenv('HOME', v:null)
+  call assert_equal('bar', expand('~'))
+
+  let $HOME = orig_ENV
+endfunc
+
 func Test_external_env()
   call setenv('FOO', 'HelloWorld')
   if has('win32')


### PR DESCRIPTION
Fix #17501

#### vim-patch:8.2.4754: using cached values after unsetting some environment variables

Problem:    Still using cached values after unsetting some known environment
            variables.
Solution:   Take care of the side effects. (closes vim/vim#10194)
https://github.com/vim/vim/commit/7714231bb5b15f7c85453f3945c108478de1d08a

Cherry-pick vim_setenv_ext() from patch 8.2.0200.