### PR TITLE
vim-patch:9.0.0234: cannot make difference between :normal end and argument char

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2400,7 +2400,8 @@ static int vgetorpeek(bool advance)
   vgetc_busy++;
 
   if (advance) {
-    KeyStuffed = FALSE;
+    KeyStuffed = false;
+    typebuf_was_empty = false;
   }
 
   init_typebuf();
@@ -2625,6 +2626,11 @@ static int vgetorpeek(bool advance)
             c = ESC;
           }
           tc = c;
+
+          // set a flag to indicate this wasn't a normal char
+          if (advance) {
+            typebuf_was_empty = true;
+          }
 
           // return 0 in normal_check()
           if (pending_exmode_active) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -705,6 +705,10 @@ EXTERN int recoverymode INIT(= false);      // Set to true for "-r" option
 // typeahead buffer
 EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
 
+/// Flag used to indicate that vgetorpeek() returned a char like Esc when the
+/// :normal argument was exhausted.
+EXTERN bool typebuf_was_empty INIT(= false);
+
 EXTERN int ex_normal_busy INIT(= 0);     // recursiveness of ex_normal()
 EXTERN int ex_normal_lock INIT(= 0);     // forbid use of ex_normal()
 EXTERN int ignore_script INIT(= false);  // ignore script input

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6943,10 +6943,10 @@ static void nv_esc(cmdarg_T *cap)
       got_int = false;          // don't stop executing autocommands et al.
       return;
     }
-  } else if (cmdwin_type != 0 && ex_normal_busy) {
+  } else if (cmdwin_type != 0 && ex_normal_busy && typebuf_was_empty) {
     // When :normal runs out of characters while in the command line window
-    // vgetorpeek() will return ESC.  Exit the cmdline window to break the
-    // loop.
+    // vgetorpeek() will repeatedly return ESC.  Exit the cmdline window to
+    // break the loop.
     cmdwin_result = K_IGNORE;
     return;
   }


### PR DESCRIPTION
#### vim-patch:9.0.0234: cannot make difference between :normal end and argument char

Problem:    Cannot make difference between the end of :normal and a character
            in its argument.
Solution:   Add the "typebuf_was_empty" flag.
https://github.com/vim/vim/commit/8d69637133e17370491b83da8657a15b991c2f76