### PR TITLE
vim-patch:9.0.0236: popup menu not removed when 'wildmenu' reset while visible

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2099,4 +2099,14 @@ func Test_cmdline_redraw_tabline()
   call delete('Xcmdline_redraw_tabline')
 endfunc
 
+func Test_wildmenu_pum_disable_while_shown()
+  set wildoptions=pum
+  set wildmenu
+  cnoremap <F2> <Cmd>set nowildmenu<CR>
+  call feedkeys(":sign \<Tab>\<F2>\<Esc>", 'tx')
+  call assert_equal(0, pumvisible())
+  cunmap <F2>
+  set wildoptions& wildmenu&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0236: popup menu not removed when 'wildmenu' reset while visible

Problem:    Popup menu not removed when 'wildmenu' reset while it is visible.
Solution:   Do not check p_wmnu, only pum_visible(). (closes vim/vim#10953)
https://github.com/vim/vim/commit/b82a2ab8ad7af52a327cdba013ec433f7caf550d