### PR TITLE
vim-patch:8.2.{2030,2031}: some tests fail

### DIFF
--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -114,6 +114,13 @@ if has('win32')
   let $PROMPT = '$P$G'
 endif
 
+if has('mac')
+  " In MacOS, when starting a shell in a terminal, a bash deprecation warning
+  " message is displayed. This breaks the terminal test. Disable the warning
+  " message.
+  let $BASH_SILENCE_DEPRECATION_WARNING = 1
+endif
+
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1
 

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -66,8 +66,9 @@ func Test_client_server()
       call remote_send(name, ":gui -f\<CR>")
     endif
     " Wait for the server to be up and answering requests.
-    sleep 100m
-    call WaitForAssert({-> assert_true(name->remote_expr("v:version", "", 1) != "")})
+    " When using valgrind this can be very, very slow.
+    sleep 1
+    call WaitForAssert({-> assert_match('\d', name->remote_expr("v:version", "", 1))}, 10000)
 
     call remote_send(name, ":let testvar = 'maybe'\<CR>")
     call WaitForAssert({-> assert_equal('maybe', remote_expr(name, "testvar", "", 2))})

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1809,6 +1809,36 @@ func Test_read_shellcmd()
   endif
 endfunc
 
+" Test for going up and down the directory tree using 'wildmenu'
+func Test_wildmenu_dirstack()
+  CheckUnix
+  %bw!
+  call mkdir('Xdir1/dir2/dir3', 'p')
+  call writefile([], 'Xdir1/file1_1.txt')
+  call writefile([], 'Xdir1/file1_2.txt')
+  call writefile([], 'Xdir1/dir2/file2_1.txt')
+  call writefile([], 'Xdir1/dir2/file2_2.txt')
+  call writefile([], 'Xdir1/dir2/dir3/file3_1.txt')
+  call writefile([], 'Xdir1/dir2/dir3/file3_2.txt')
+  cd Xdir1/dir2/dir3
+  set wildmenu
+
+  call feedkeys(":e \<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e file3_1.txt', @:)
+  call feedkeys(":e \<Tab>\<Up>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e ../dir3/', @:)
+  call feedkeys(":e \<Tab>\<Up>\<Up>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e ../../dir2/', @:)
+  call feedkeys(":e \<Tab>\<Up>\<Up>\<Down>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e ../../dir2/dir3/', @:)
+  call feedkeys(":e \<Tab>\<Up>\<Up>\<Down>\<Down>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e ../../dir2/dir3/file3_1.txt', @:)
+
+  cd -
+  call delete('Xdir1', 'rf')
+  set wildmenu&
+endfunc
+
 " Test for recalling newer or older cmdline from history with <Up>, <Down>,
 " <S-Up>, <S-Down>, <PageUp>, <PageDown>, <C-p>, or <C-n>.
 func Test_recalling_cmdline()

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -774,7 +774,13 @@ func Test_shell()
   CheckUnix
   let save_shell = &shell
   set shell=
-  call assert_fails('shell', 'E91:')
+  let caught_e91 = 0
+  try
+    shell
+  catch /E91:/
+    let caught_e91 = 1
+  endtry
+  call assert_equal(1, caught_e91)
   let &shell = save_shell
 endfunc
 

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -98,8 +98,6 @@ func Do_test_quotestar_for_x11()
 
     " Running in a terminal and the GUI is available: Tell the server to open
     " the GUI and check that the remote command still works.
-    " Need to wait for the GUI to start up, otherwise the send hangs in trying
-    " to send to the terminal window.
     if has('gui_athena') || has('gui_motif')
       " For those GUIs, ignore the 'failed to create input context' error.
       call remote_send(name, ":call test_ignore_error('E285') | gui -f\<CR>")
@@ -107,7 +105,10 @@ func Do_test_quotestar_for_x11()
       call remote_send(name, ":gui -f\<CR>")
     endif
     " Wait for the server in the GUI to be up and answering requests.
+    " First need to wait for the GUI to start up, otherwise the send hangs in
+    " trying to send to the terminal window.
     " On some systems and with valgrind this can be very slow.
+    sleep 1
     call WaitForAssert({-> assert_match("1", remote_expr(name, "has('gui_running')", "", 1))}, 10000)
 
     call remote_send(name, ":let @* = 'maybe'\<CR>")


### PR DESCRIPTION
#### vim-patch:8.2.2030: some tests fail on Mac

Problem:    Some tests fail on Mac.
Solution:   Avoid Mac test failures.  Add additional test for wildmenu.
            (Yegappan Lakshmanan, closes vim/vim#7341)
https://github.com/vim/vim/commit/4b2ce1297e6e991bf6a674f9465d26d28e648de7


#### vim-patch:8.2.2031: some tests fail when run under valgrind

Problem:    Some tests fail when run under valgrind.
Solution:   Avoid timing problems.
https://github.com/vim/vim/commit/18dc355395f2eac72ab83d984cacd26ae61c791f