### PR TITLE
vim-patch:8.2.2289: Vim9: 'cpo' can become empty

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2192,7 +2192,7 @@ int pattern_match(char *pat, char *text, bool ic)
 
   // avoid 'l' flag in 'cpoptions'
   char *save_cpo = p_cpo;
-  p_cpo = "";
+  p_cpo = (char *)empty_option;
   regmatch.regprog = vim_regcomp(pat, RE_MAGIC + RE_STRING);
   if (regmatch.regprog != NULL) {
     regmatch.rm_ic = ic;
@@ -8389,6 +8389,11 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, char *flags
     p_cpo = save_cpo;
   } else {
     // Darn, evaluating {sub} expression or {expr} changed the value.
+    // If it's still empty it was changed and restored, need to restore in
+    // the complicated way.
+    if (*p_cpo == NUL) {
+      set_option_value("cpo", 0L, save_cpo, 0);
+    }
     free_string_option((char_u *)save_cpo);
   }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -588,7 +588,7 @@ buf_T *tv_get_buf(typval_T *tv, int curtab_only)
   int save_magic = p_magic;
   p_magic = true;
   char *save_cpo = p_cpo;
-  p_cpo = "";
+  p_cpo = (char *)empty_option;
 
   buf_T *buf = buflist_findnr(buflist_findpat((char *)name, (char *)name + STRLEN(name),
                                               true, false, curtab_only));
@@ -4893,7 +4893,7 @@ static void find_some_match(typval_T *const argvars, typval_T *const rettv,
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *save_cpo = p_cpo;
-  p_cpo = "";
+  p_cpo = (char *)empty_option;
 
   rettv->vval.v_number = -1;
   switch (type) {
@@ -7413,6 +7413,11 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
     p_cpo = save_cpo;
   } else {
     // Darn, evaluating the {skip} expression changed the value.
+    // If it's still empty it was changed and restored, need to restore in
+    // the complicated way.
+    if (*p_cpo == NUL) {
+      set_option_value("cpo", 0L, save_cpo, 0);
+    }
     free_string_option((char_u *)save_cpo);
   }
 
@@ -8167,7 +8172,7 @@ static void f_split(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *save_cpo = p_cpo;
-  p_cpo = "";
+  p_cpo = (char *)empty_option;
 
   const char *str = tv_get_string(&argvars[0]);
   const char *pat = NULL;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -1376,7 +1376,7 @@ void ex_catch(exarg_T *eap)
           *end = NUL;
         }
         save_cpo = p_cpo;
-        p_cpo = "";
+        p_cpo = (char *)empty_option;
         // Disable error messages, it will make current exception
         // invalid
         emsg_off++;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5070,7 +5070,7 @@ static char_u *get_syn_pattern(char_u *arg, synpat_T *ci)
 
   // Make 'cpoptions' empty, to avoid the 'l' flag
   cpo_save = p_cpo;
-  p_cpo = "";
+  p_cpo = (char *)empty_option;
   ci->sp_prog = vim_regcomp((char *)ci->sp_pattern, RE_MAGIC);
   p_cpo = cpo_save;
 
@@ -5231,7 +5231,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
 
         // Make 'cpoptions' empty, to avoid the 'l' flag
         cpo_save = p_cpo;
-        p_cpo = "";
+        p_cpo = (char *)empty_option;
         curwin->w_s->b_syn_linecont_prog =
           vim_regcomp((char *)curwin->w_s->b_syn_linecont_pat, RE_MAGIC);
         p_cpo = cpo_save;


### PR DESCRIPTION
#### vim-patch:8.2.2289: Vim9: 'cpo' can become empty

Problem:    Vim9: 'cpo' can become empty.
Solution:   Use empty_option instead of an empty string.  Update quickfix
            buffer after restoring 'cpo'.
https://github.com/vim/vim/commit/e5a2dc87fd9d63dfd0d9c379e363ee8b8c05b14c

Omit test as it is Vim9 script.