### PR TITLE
vim-patch:8.2.4753: error from setting an option is silently ignored

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4189,8 +4189,8 @@ void buf_open_scratch(handle_T bufnr, char *bufname)
   apply_autocmds(EVENT_BUFFILEPRE, NULL, NULL, false, curbuf);
   (void)setfname(curbuf, bufname, NULL, true);
   apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, false, curbuf);
-  set_option_value("bh", 0L, "hide", OPT_LOCAL);
-  set_option_value("bt", 0L, "nofile", OPT_LOCAL);
-  set_option_value("swf", 0L, NULL, OPT_LOCAL);
+  set_option_value_give_err("bh", 0L, "hide", OPT_LOCAL);
+  set_option_value_give_err("bt", 0L, "nofile", OPT_LOCAL);
+  set_option_value_give_err("swf", 0L, NULL, OPT_LOCAL);
   RESET_BINDING(curwin);
 }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1374,7 +1374,7 @@ static void set_diff_option(win_T *wp, int value)
   curwin = wp;
   curbuf = curwin->w_buffer;
   curbuf->b_ro_locked++;
-  set_option_value("diff", (long)value, NULL, OPT_LOCAL);
+  set_option_value_give_err("diff", (long)value, NULL, OPT_LOCAL);
   curbuf->b_ro_locked--;
   curwin = old_curwin;
   curbuf = curwin->w_buffer;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8392,7 +8392,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, char *flags
     // If it's still empty it was changed and restored, need to restore in
     // the complicated way.
     if (*p_cpo == NUL) {
-      set_option_value("cpo", 0L, save_cpo, 0);
+      set_option_value_give_err("cpo", 0L, save_cpo, 0);
     }
     free_string_option((char_u *)save_cpo);
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7416,7 +7416,7 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
     // If it's still empty it was changed and restored, need to restore in
     // the complicated way.
     if (*p_cpo == NUL) {
-      set_option_value("cpo", 0L, save_cpo, 0);
+      set_option_value_give_err("cpo", 0L, save_cpo, 0);
     }
     free_string_option((char_u *)save_cpo);
   }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1627,7 +1627,7 @@ static void set_option_from_tv(const char *varname, typval_T *varp)
     strval = tv_get_string_buf_chk(varp, nbuf);
   }
   if (!error && strval != NULL) {
-    set_option_value(varname, numval, strval, OPT_LOCAL);
+    set_option_value_give_err(varname, numval, strval, OPT_LOCAL);
   }
 }
 

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -544,9 +544,9 @@ void ex_listdo(exarg_T *eap)
           // Clear 'shm' to avoid that the file message overwrites
           // any output from the command.
           p_shm_save = (char *)vim_strsave(p_shm);
-          set_option_value("shm", 0L, "", 0);
+          set_option_value_give_err("shm", 0L, "", 0);
           do_argfile(eap, i);
-          set_option_value("shm", 0L, p_shm_save, 0);
+          set_option_value_give_err("shm", 0L, p_shm_save, 0);
           xfree(p_shm_save);
         }
         if (curwin->w_arg_idx != i) {
@@ -613,9 +613,9 @@ void ex_listdo(exarg_T *eap)
         // Go to the next buffer.  Clear 'shm' to avoid that the file
         // message overwrites any output from the command.
         p_shm_save = (char *)vim_strsave(p_shm);
-        set_option_value("shm", 0L, "", 0);
+        set_option_value_give_err("shm", 0L, "", 0);
         goto_buffer(eap, DOBUF_FIRST, FORWARD, next_fnum);
-        set_option_value("shm", 0L, p_shm_save, 0);
+        set_option_value_give_err("shm", 0L, p_shm_save, 0);
         xfree(p_shm_save);
 
         // If autocommands took us elsewhere, quit here.
@@ -636,9 +636,9 @@ void ex_listdo(exarg_T *eap)
         // Clear 'shm' to avoid that the file message overwrites
         // any output from the command.
         p_shm_save = (char *)vim_strsave(p_shm);
-        set_option_value("shm", 0L, "", 0);
+        set_option_value_give_err("shm", 0L, "", 0);
         ex_cnext(eap);
-        set_option_value("shm", 0L, p_shm_save, 0);
+        set_option_value_give_err("shm", 0L, p_shm_save, 0);
         xfree(p_shm_save);
 
         // If jumping to the next quickfix entry fails, quit here.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6945,15 +6945,15 @@ void dialog_msg(char *buff, char *format, char *fname)
 static void ex_behave(exarg_T *eap)
 {
   if (STRCMP(eap->arg, "mswin") == 0) {
-    set_option_value("selection", 0L, "exclusive", 0);
-    set_option_value("selectmode", 0L, "mouse,key", 0);
-    set_option_value("mousemodel", 0L, "popup", 0);
-    set_option_value("keymodel", 0L, "startsel,stopsel", 0);
+    set_option_value_give_err("selection", 0L, "exclusive", 0);
+    set_option_value_give_err("selectmode", 0L, "mouse,key", 0);
+    set_option_value_give_err("mousemodel", 0L, "popup", 0);
+    set_option_value_give_err("keymodel", 0L, "startsel,stopsel", 0);
   } else if (STRCMP(eap->arg, "xterm") == 0) {
-    set_option_value("selection", 0L, "inclusive", 0);
-    set_option_value("selectmode", 0L, "", 0);
-    set_option_value("mousemodel", 0L, "extend", 0);
-    set_option_value("keymodel", 0L, "", 0);
+    set_option_value_give_err("selection", 0L, "inclusive", 0);
+    set_option_value_give_err("selectmode", 0L, "", 0);
+    set_option_value_give_err("mousemodel", 0L, "extend", 0);
+    set_option_value_give_err("keymodel", 0L, "", 0);
   } else {
     semsg(_(e_invarg2), eap->arg);
   }
@@ -7073,7 +7073,7 @@ static void ex_setfiletype(exarg_T *eap)
       arg += 9;
     }
 
-    set_option_value("filetype", 0L, arg, OPT_LOCAL);
+    set_option_value_give_err("filetype", 0L, arg, OPT_LOCAL);
     if (arg != eap->arg) {
       did_filetype = false;
     }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4074,7 +4074,7 @@ static int open_cmdwin(void)
   // Create empty command-line buffer.
   buf_open_scratch(0, _("[Command Line]"));
   // Command-line buffer has bufhidden=wipe, unlike a true "scratch" buffer.
-  set_option_value("bh", 0L, "wipe", OPT_LOCAL);
+  set_option_value_give_err("bh", 0L, "wipe", OPT_LOCAL);
   curwin->w_p_rl = cmdmsg_rl;
   cmdmsg_rl = false;
   curbuf->b_p_ma = true;
@@ -4092,7 +4092,7 @@ static int open_cmdwin(void)
       add_map("<Tab>", "<C-X><C-V>", MODE_INSERT, true);
       add_map("<Tab>", "a<C-X><C-V>", MODE_NORMAL, true);
     }
-    set_option_value("ft", 0L, "vim", OPT_LOCAL);
+    set_option_value_give_err("ft", 0L, "vim", OPT_LOCAL);
   }
   curbuf->b_ro_locked--;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2112,7 +2112,7 @@ static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
       }
 
       del_typebuf(mlen, 0);  // remove the chars
-      set_option_value("paste", !p_paste, NULL, 0);
+      set_option_value_give_err("paste", !p_paste, NULL, 0);
       if (!(State & MODE_INSERT)) {
         msg_col = 0;
         msg_row = Rows - 1;

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -652,7 +652,7 @@ void fix_help_buffer(void)
   // Set filetype to "help".
   if (STRCMP(curbuf->b_p_ft, "help") != 0) {
     curbuf->b_ro_locked++;
-    set_option_value("ft", 0L, "help", OPT_LOCAL);
+    set_option_value_give_err("ft", 0L, "help", OPT_LOCAL);
     curbuf->b_ro_locked--;
   }
 

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1156,7 +1156,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
                   if (dark != -1
                       && dark != (*p_bg == 'd')
                       && !option_was_set("bg")) {
-                    set_option_value("bg", 0L, (dark ? "dark" : "light"), 0);
+                    set_option_value_give_err("bg", 0L, (dark ? "dark" : "light"), 0);
                     reset_option_was_set("bg");
                   }
                 }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1052,7 +1052,7 @@ static void command_line_scan(mparm_T *parmp)
         } else if (STRNICMP(argv[0] + argv_idx, "clean", 5) == 0) {
           parmp->use_vimrc = "NONE";
           parmp->clean = true;
-          set_option_value("shadafile", 0L, "NONE", 0);
+          set_option_value_give_err("shadafile", 0L, "NONE", 0);
         } else if (STRNICMP(argv[0] + argv_idx, "luamod-dev", 9) == 0) {
           nlua_disable_preload = true;
         } else {
@@ -1066,7 +1066,7 @@ static void command_line_scan(mparm_T *parmp)
         }
         break;
       case 'A':    // "-A" start in Arabic mode.
-        set_option_value("arabic", 1L, NULL, 0);
+        set_option_value_give_err("arabic", 1L, NULL, 0);
         break;
       case 'b':    // "-b" binary mode.
         // Needs to be effective before expanding file names, because
@@ -1097,10 +1097,10 @@ static void command_line_scan(mparm_T *parmp)
         os_exit(0);
       case 'H':    // "-H" start in Hebrew mode: rl + hkmap set.
         p_hkmap = true;
-        set_option_value("rl", 1L, NULL, 0);
+        set_option_value_give_err("rl", 1L, NULL, 0);
         break;
       case 'l':    // "-l" lisp mode, 'lisp' and 'showmatch' on.
-        set_option_value("lisp", 1L, NULL, 0);
+        set_option_value_give_err("lisp", 1L, NULL, 0);
         p_sm = true;
         break;
       case 'M':    // "-M"  no changes or writing of files
@@ -1181,7 +1181,7 @@ static void command_line_scan(mparm_T *parmp)
         // default is 10: a little bit verbose
         p_verbose = get_number_arg(argv[0], &argv_idx, 10);
         if (argv[0][argv_idx] != NUL) {
-          set_option_value("verbosefile", 0L, argv[0] + argv_idx, 0);
+          set_option_value_give_err("verbosefile", 0L, argv[0] + argv_idx, 0);
           argv_idx = (int)STRLEN(argv[0]);
         }
         break;
@@ -1189,7 +1189,7 @@ static void command_line_scan(mparm_T *parmp)
         // "-w {scriptout}" write to script
         if (ascii_isdigit(((char_u *)argv[0])[argv_idx])) {
           n = get_number_arg(argv[0], &argv_idx, 10);
-          set_option_value("window", n, NULL, 0);
+          set_option_value_give_err("window", n, NULL, 0);
           break;
         }
         want_argument = true;
@@ -1284,7 +1284,7 @@ static void command_line_scan(mparm_T *parmp)
           break;
 
         case 'i':    // "-i {shada}" use for shada
-          set_option_value("shadafile", 0L, argv[0], 0);
+          set_option_value_give_err("shadafile", 0L, argv[0], 0);
           break;
 
         case 's': {  // "-s {scriptin}" read from script file
@@ -1334,7 +1334,7 @@ scripterror:
           if (ascii_isdigit(*((char_u *)argv[0]))) {
             argv_idx = 0;
             n = get_number_arg(argv[0], &argv_idx, 10);
-            set_option_value("window", n, NULL, 0);
+            set_option_value_give_err("window", n, NULL, 0);
             argv_idx = -1;
             break;
           }
@@ -1735,7 +1735,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
 
           p_shm_save = xstrdup((char *)p_shm);
           snprintf(buf, sizeof(buf), "F%s", p_shm);
-          set_option_value("shm", 0L, buf, 0);
+          set_option_value_give_err("shm", 0L, buf, 0);
         }
       } else {
         if (curwin->w_next == NULL) {           // just checking
@@ -1779,7 +1779,7 @@ static void edit_buffers(mparm_T *parmp, char_u *cwd)
   }
 
   if (p_shm_save != NULL) {
-    set_option_value("shm", 0L, p_shm_save, 0);
+    set_option_value_give_err("shm", 0L, p_shm_save, 0);
     xfree(p_shm_save);
   }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -993,7 +993,7 @@ void ml_recover(bool checkext)
     set_fileformat(b0_ff - 1, OPT_LOCAL);
   }
   if (b0_fenc != NULL) {
-    set_option_value("fenc", 0L, (char *)b0_fenc, OPT_LOCAL);
+    set_option_value_give_err("fenc", 0L, (char *)b0_fenc, OPT_LOCAL);
     xfree(b0_fenc);
   }
   unchanged(curbuf, true, true);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -45,8 +45,14 @@
 # include "optionstr.c.generated.h"
 #endif
 
-static char e_unclosed_expression_sequence[] = N_("E540: Unclosed expression sequence");
-static char e_unbalanced_groups[] = N_("E542: unbalanced groups");
+static char e_unclosed_expression_sequence[]
+  = N_("E540: Unclosed expression sequence");
+static char e_unbalanced_groups[]
+  = N_("E542: unbalanced groups");
+static char e_backupext_and_patchmode_are_equal[]
+  = N_("E589: 'backupext' and 'patchmode' are equal");
+static char e_showbreak_contains_unprintable_or_wide_character[]
+  = N_("E595: 'showbreak' contains unprintable or wide character");
 
 static char *(p_ambw_values[]) = { "single", "double", NULL };
 static char *(p_bg_values[]) = { "light", "dark", NULL };
@@ -381,7 +387,7 @@ void set_string_option_direct_in_win(win_T *wp, const char *name, int opt_idx, c
 /// @param[in]  opt_flags  Option flags: expected to contain #OPT_LOCAL and/or
 ///                        #OPT_GLOBAL.
 ///
-/// @return NULL on success, error message on error.
+/// @return NULL on success, an untranslated error message on error.
 char *set_string_option(const int opt_idx, const char *const value, const int opt_flags)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -413,15 +419,15 @@ char *set_string_option(const int opt_idx, const char *const value, const int op
   char *const saved_newval = xstrdup(s);
 
   int value_checked = false;
-  char *const r = did_set_string_option(opt_idx, (char_u **)varp, (char_u *)oldval,
-                                        NULL, 0,
-                                        opt_flags, &value_checked);
-  if (r == NULL) {
+  char *const errmsg = did_set_string_option(opt_idx, (char_u **)varp, (char_u *)oldval,
+                                             NULL, 0,
+                                             opt_flags, &value_checked);
+  if (errmsg == NULL) {
     did_set_option(opt_idx, opt_flags, true, value_checked);
   }
 
   // call autocommand after handling side effects
-  if (r == NULL) {
+  if (errmsg == NULL) {
     if (!starting) {
       trigger_optionsset_string(opt_idx, opt_flags, saved_oldval, saved_oldval_l, saved_oldval_g,
                                 saved_newval);
@@ -436,7 +442,7 @@ char *set_string_option(const int opt_idx, const char *const value, const int op
   xfree(saved_oldval_g);
   xfree(saved_newval);
 
-  return r;
+  return errmsg;
 }
 
 /// Return true if "val" is a valid 'filetype' name.
@@ -679,7 +685,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
   } else if (varp == &p_bex || varp == &p_pm) {  // 'backupext' and 'patchmode'
     if (STRCMP(*p_bex == '.' ? p_bex + 1 : p_bex,
                *p_pm == '.' ? p_pm + 1 : p_pm) == 0) {
-      errmsg = N_("E589: 'backupext' and 'patchmode' are equal");
+      errmsg = e_backupext_and_patchmode_are_equal;
     }
   } else if (varp == &curwin->w_p_briopt) {  // 'breakindentopt'
     if (briopt_check(curwin) == FAIL) {
@@ -1041,7 +1047,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
   } else if (gvarp == &p_sbr) {  // 'showbreak'
     for (s = (char *)(*varp); *s;) {
       if (ptr2cells(s) != 1) {
-        errmsg = N_("E595: 'showbreak' contains unprintable or wide character");
+        errmsg = e_showbreak_contains_unprintable_or_wide_character;
       }
       MB_PTR_ADV(s);
     }

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -744,11 +744,11 @@ static bool pum_set_selected(int n, int repeat)
           if (res == OK) {
             // Edit a new, empty buffer. Set options for a "wipeout"
             // buffer.
-            set_option_value("swf", 0L, NULL, OPT_LOCAL);
-            set_option_value("bl", 0L, NULL, OPT_LOCAL);
-            set_option_value("bt", 0L, "nofile", OPT_LOCAL);
-            set_option_value("bh", 0L, "wipe", OPT_LOCAL);
-            set_option_value("diff", 0L, NULL, OPT_LOCAL);
+            set_option_value_give_err("swf", 0L, NULL, OPT_LOCAL);
+            set_option_value_give_err("bl", 0L, NULL, OPT_LOCAL);
+            set_option_value_give_err("bt", 0L, "nofile", OPT_LOCAL);
+            set_option_value_give_err("bh", 0L, "wipe", OPT_LOCAL);
+            set_option_value_give_err("diff", 0L, NULL, OPT_LOCAL);
           }
         }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3558,12 +3558,12 @@ static int qf_goto_cwindow(const qf_info_T *qi, bool resize, int sz, bool vertsp
 static void qf_set_cwindow_options(void)
 {
   // switch off 'swapfile'
-  set_option_value("swf", 0L, NULL, OPT_LOCAL);
-  set_option_value("bt", 0L, "quickfix", OPT_LOCAL);
-  set_option_value("bh", 0L, "hide", OPT_LOCAL);
+  set_option_value_give_err("swf", 0L, NULL, OPT_LOCAL);
+  set_option_value_give_err("bt", 0L, "quickfix", OPT_LOCAL);
+  set_option_value_give_err("bh", 0L, "hide", OPT_LOCAL);
   RESET_BINDING(curwin);
   curwin->w_p_diff = false;
-  set_option_value("fdm", 0L, "manual", OPT_LOCAL);
+  set_option_value_give_err("fdm", 0L, "manual", OPT_LOCAL);
 }
 
 // Open a new quickfix or location list window, load the quickfix buffer and
@@ -4108,7 +4108,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     // resembles reading a file into a buffer, it's more logical when using
     // autocommands.
     curbuf->b_ro_locked++;
-    set_option_value("ft", 0L, "qf", OPT_LOCAL);
+    set_option_value_give_err("ft", 0L, "qf", OPT_LOCAL);
     curbuf->b_p_ma = false;
 
     keep_filetype = true;                 // don't detect 'filetype'
@@ -7102,7 +7102,7 @@ void ex_helpgrep(exarg_T *eap)
     // Darn, some plugin changed the value.  If it's still empty it was
     // changed and restored, need to restore in the complicated way.
     if (*p_cpo == NUL) {
-      set_option_value("cpo", 0L, save_cpo, 0);
+      set_option_value_give_err("cpo", 0L, save_cpo, 0);
     }
     free_string_option((char_u *)save_cpo);
   }

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -923,7 +923,7 @@ static int add_pack_dir_to_rtp(char_u *fname, bool is_pack)
     xstrlcat(new_rtp, afterdir, new_rtp_capacity);
   }
 
-  set_option_value("rtp", 0L, new_rtp, 0);
+  set_option_value_give_err("rtp", 0L, new_rtp, 0);
   xfree(new_rtp);
   retval = OK;
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1828,8 +1828,8 @@ static int count_syllables(slang_T *slang, const char_u *word)
   return cnt;
 }
 
-// Parse 'spelllang' and set w_s->b_langp accordingly.
-// Returns NULL if it's OK, an error message otherwise.
+/// Parse 'spelllang' and set w_s->b_langp accordingly.
+/// @return  NULL if it's OK, an untranslated error message otherwise.
 char *did_set_spelllang(win_T *wp)
 {
   garray_T ga;
@@ -3155,8 +3155,8 @@ void ex_spelldump(exarg_T *eap)
   do_cmdline_cmd("new");
 
   // enable spelling locally in the new window
-  set_option_value("spell", true, "", OPT_LOCAL);
-  set_option_value("spl",  dummy, spl, OPT_LOCAL);
+  set_option_value_give_err("spell", true, "", OPT_LOCAL);
+  set_option_value_give_err("spl",  dummy, spl, OPT_LOCAL);
   xfree(spl);
 
   if (!buf_is_empty(curbuf)) {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5735,7 +5735,7 @@ static void init_spellfile(void)
                        && strstr(path_tail((char *)fname), ".ascii.") != NULL)
                       ? "ascii"
                       : (const char *)spell_enc()));
-        set_option_value("spellfile", 0L, (const char *)buf, OPT_LOCAL);
+        set_option_value_give_err("spellfile", 0L, (const char *)buf, OPT_LOCAL);
         break;
       }
       aspath = false;


### PR DESCRIPTION
#### vim-patch:8.2.4753: error from setting an option is silently ignored

Problem:    Error from setting an option is silently ignored.
Solution:   Handle option value errors better.  Fix uses of N_().
https://github.com/vim/vim/commit/31e5c60a682840959cae6273ccadd9aae48c928d