### PR TITLE
vim-patch:8.2.3421: a bit of code is not covered by tests

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -874,7 +874,8 @@ static void f_charidx(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   if (argvars[0].v_type != VAR_STRING
       || argvars[1].v_type != VAR_NUMBER
       || (argvars[2].v_type != VAR_UNKNOWN
-          && argvars[2].v_type != VAR_NUMBER)) {
+          && argvars[2].v_type != VAR_NUMBER
+          && argvars[2].v_type != VAR_BOOL)) {
     emsg(_(e_invarg));
     return;
   }
@@ -9457,6 +9458,11 @@ static void f_trim(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
   if (head == NULL) {
+    return;
+  }
+
+  if (argvars[1].v_type != VAR_UNKNOWN && argvars[1].v_type != VAR_STRING) {
+    semsg(_(e_invarg2), tv_get_string(&argvars[1]));
     return;
   }
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1420,12 +1420,15 @@ func Test_trim()
   call assert_equal("vim", trim("  vim  ", " ", 0))
   call assert_equal("vim  ", trim("  vim  ", " ", 1))
   call assert_equal("  vim", trim("  vim  ", " ", 2))
-  call assert_fails('call trim("  vim  ", " ", [])', 'E745:')
-  call assert_fails('call trim("  vim  ", " ", -1)', 'E475:')
-  call assert_fails('call trim("  vim  ", " ", 3)', 'E475:')
+  call assert_fails('eval trim("  vim  ", " ", [])', 'E745:')
+  call assert_fails('eval trim("  vim  ", " ", -1)', 'E475:')
+  call assert_fails('eval trim("  vim  ", " ", 3)', 'E475:')
+  call assert_fails('eval trim("  vim  ", 0)', 'E475:')
 
   let chars = join(map(range(1, 0x20) + [0xa0], {n -> n->nr2char()}), '')
   call assert_equal("x", trim(chars . "x" . chars))
+
+  call assert_fails('let c=trim([])', 'E730:')
 endfunc
 
 " Test for reg_recording() and reg_executing()

--- a/src/nvim/testdir/test_history.vim
+++ b/src/nvim/testdir/test_history.vim
@@ -95,6 +95,23 @@ function Test_History()
   call assert_fails('call histnr([])', 'E730:')
   call assert_fails('history xyz', 'E488:')
   call assert_fails('history ,abc', 'E488:')
+  call assert_fails('call histdel(":", "\\%(")', 'E53:')
+endfunction
+
+function Test_history_truncates_long_entry()
+  " History entry short enough to fit on the screen should not be truncated.
+  call histadd(':', 'echo x' .. repeat('y', &columns - 17) .. 'z')
+  let a = execute('history : -1')
+
+  call assert_match("^\n      #  cmd history\n"
+        \        .. "> *\\d\\+  echo x" .. repeat('y', &columns - 17) ..  'z$', a)
+
+  " Long history entry should be truncated to fit on the screen, with, '...'
+  " inserted in the string to indicate the that there is truncation.
+  call histadd(':', 'echo x' .. repeat('y', &columns - 16) .. 'z')
+  let a = execute('history : -1')
+  call assert_match("^\n      #  cmd history\n"
+        \        .. ">  *\\d\\+  echo xy\\+\.\.\.y\\+z$", a)
 endfunction
 
 function Test_Search_history_window()

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -603,7 +603,7 @@ func Test_invalid_args()
   call assert_equal(0, v:shell_error)
 
   if has('quickfix')
-    " Detect invalid repeated arguments '-t foo -t foo", '-q foo -q foo'.
+    " Detect invalid repeated arguments '-t foo -t foo', '-q foo -q foo'.
     for opt in ['-t', '-q']
       let out = split(system(GetVimCommand() .. repeat(' ' .. opt .. ' foo', 2)), "\n")
       call assert_equal(1, v:shell_error)
@@ -855,7 +855,7 @@ func Test_t_arg()
   call writefile(['    first', '    second', '    third'], 'Xfile1')
 
   for t_arg in ['-t second', '-tsecond']
-    if RunVim(before, after, '-t second')
+    if RunVim(before, after, t_arg)
       call assert_equal(['Xfile1:L2C5'], readfile('Xtestout'), t_arg)
       call delete('Xtestout')
     endif


### PR DESCRIPTION
#### vim-patch:8.2.3421: a bit of code is not covered by tests

Problem:    A bit of code is not covered by tests.
Solution:   Add a few more test cases. (Dominique Pellé, closes vim/vim#8857)
https://github.com/vim/vim/commit/d176ca3dde47c11aae0376c31b7e1ba0939c8c6c

Cherry-pick Test_trim() change from patch 8.2.0448.
Cherry-pick Test_History() change from patch 8.2.1736.
Cherry-pick charidx() and trim() type checks from patch 8.2.3135.