### PR TITLE
vim-patch:8.1.0832: confirm() is not tested

### DIFF
--- a/src/nvim/testdir/test_filechanged.vim
+++ b/src/nvim/testdir/test_filechanged.vim
@@ -140,7 +140,8 @@ func Test_FileChangedShell_edit()
 endfunc
 
 func Test_FileChangedShell_edit_dialog()
-  throw 'Skipped: requires a UI to be active'
+  " requires a UI to be active
+  throw 'Skipped: use test/functional/legacy/filechanged_spec.lua'
   CheckNotGui
   CheckUnix  " Using low level feedkeys() does not work on MS-Windows.
 
@@ -190,7 +191,8 @@ func Test_FileChangedShell_edit_dialog()
 endfunc
 
 func Test_file_changed_dialog()
-  throw 'Skipped: requires a UI to be active'
+  " requires a UI to be active
+  throw 'Skipped: use test/functional/legacy/filechanged_spec.lua'
   CheckUnix
   CheckNotGui
   au! FileChangedShell

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1700,6 +1700,63 @@ func Test_platform_name()
   endif
 endfunc
 
+" Test confirm({msg} [, {choices} [, {default} [, {type}]]])
+func Test_confirm()
+  " requires a UI to be active
+  throw 'Skipped: use test/functional/vimscript/input_spec.lua'
+  if !has('unix') || has('gui_running')
+    return
+  endif
+
+  call feedkeys('o', 'L')
+  let a = confirm('Press O to proceed')
+  call assert_equal(1, a)
+
+  call feedkeys('y', 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(1, a)
+
+  call feedkeys('n', 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(2, a)
+
+  " confirm() should return 0 when pressing CTRL-C.
+  call feedkeys("\<C-c>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(0, a)
+
+  " <Esc> requires another character to avoid it being seen as the start of an
+  " escape sequence.  Zero should be harmless.
+  call feedkeys("\<Esc>0", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(0, a)
+
+  " Default choice is returned when pressing <CR>.
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No")
+  call assert_equal(1, a)
+
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No", 2)
+  call assert_equal(2, a)
+
+  call feedkeys("\<CR>", 'L')
+  let a = confirm('Are you sure?', "&Yes\n&No", 0)
+  call assert_equal(0, a)
+
+  " Test with the {type} 4th argument
+  for type in ['Error', 'Question', 'Info', 'Warning', 'Generic']
+    call feedkeys('y', 'L')
+    let a = confirm('Are you sure?', "&Yes\n&No\n", 1, type)
+    call assert_equal(1, a)
+  endfor
+
+  call assert_fails('call confirm([])', 'E730:')
+  call assert_fails('call confirm("Are you sure?", [])', 'E730:')
+  call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", [])', 'E745:')
+  call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", 0, [])', 'E730:')
+endfunc
+
 func Test_readdir()
   call mkdir('Xdir')
   call writefile([], 'Xdir/foo.txt')

--- a/test/functional/vimscript/input_spec.lua
+++ b/test/functional/vimscript/input_spec.lua
@@ -8,7 +8,8 @@ local clear = helpers.clear
 local source = helpers.source
 local command = helpers.command
 local exc_exec = helpers.exc_exec
-local nvim_async = helpers.nvim_async
+local pcall_err = helpers.pcall_err
+local async_meths = helpers.async_meths
 local NIL = helpers.NIL
 
 local screen
@@ -449,6 +450,78 @@ describe('inputdialog()', function()
 end)
 
 describe('confirm()', function()
+  -- oldtest: Test_confirm()
+  it('works', function()
+    meths.set_option('more', false)  -- Avoid hit-enter prompt
+    meths.set_option('laststatus', 2)
+    -- screen:expect() calls are needed to avoid feeding input too early
+    screen:expect({any = 'No Name'})
+
+    async_meths.command([[let a = confirm('Press O to proceed')]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('o')
+    screen:expect({any = 'No Name'})
+    eq(1, meths.get_var('a'))
+
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('y')
+    screen:expect({any = 'No Name'})
+    eq(1, meths.get_var('a'))
+
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('n')
+    screen:expect({any = 'No Name'})
+    eq(2, meths.get_var('a'))
+
+    -- Not possible to match Vim's CTRL-C test here as CTRL-C always sets got_int in Nvim.
+
+    -- confirm() should return 0 when pressing ESC.
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('<Esc>')
+    screen:expect({any = 'No Name'})
+    eq(0, meths.get_var('a'))
+
+    -- Default choice is returned when pressing <CR>.
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('<CR>')
+    screen:expect({any = 'No Name'})
+    eq(1, meths.get_var('a'))
+
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No", 2)]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('<CR>')
+    screen:expect({any = 'No Name'})
+    eq(2, meths.get_var('a'))
+
+    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No", 0)]])
+    screen:expect({any = '{CONFIRM:.+: }'})
+    feed('<CR>')
+    screen:expect({any = 'No Name'})
+    eq(0, meths.get_var('a'))
+
+    -- Test with the {type} 4th argument
+    for _, type in ipairs({'Error', 'Question', 'Info', 'Warning', 'Generic'}) do
+      async_meths.command(([[let a = confirm('Are you sure?', "&Yes\n&No", 1, '%s')]]):format(type))
+      screen:expect({any = '{CONFIRM:.+: }'})
+      feed('y')
+      screen:expect({any = 'No Name'})
+      eq(1, meths.get_var('a'))
+    end
+
+    eq('Vim(call):E730: using List as a String',
+       pcall_err(command, 'call confirm([])'))
+    eq('Vim(call):E730: using List as a String',
+       pcall_err(command, 'call confirm("Are you sure?", [])'))
+    eq('Vim(call):E745: Using a List as a Number',
+       pcall_err(command, 'call confirm("Are you sure?", "&Yes\n&No\n", [])'))
+    eq('Vim(call):E730: using List as a String',
+       pcall_err(command, 'call confirm("Are you sure?", "&Yes\n&No\n", 0, [])'))
+  end)
+
   it("shows dialog even if :silent #8788", function()
     command("autocmd BufNewFile * call confirm('test')")
 
@@ -483,7 +556,7 @@ describe('confirm()', function()
     feed(':call nvim_command("edit x")<cr>')
     check_and_clear(':call nvim_command("edit |\n')
 
-    nvim_async('command', 'edit x')
+    async_meths.command('edit x')
     check_and_clear('                         |\n')
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.1.0832: confirm() is not tested

Problem:    confirm() is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#3868)
https://github.com/vim/vim/commit/2e0500921891e4fec57e97d3c0021aa2d2b4d7ae