### PR TITLE
fix(highlight): set the window namespace when redrawing statusline

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -748,6 +748,8 @@ void show_cursor_info(bool always)
   if (!always && !redrawing()) {
     return;
   }
+
+  win_check_ns_hl(curwin);
   if ((*p_stl != NUL || *curwin->w_p_stl != NUL)
       && (curwin->w_status_height || global_stl_height())) {
     redraw_custom_statusline(curwin);
@@ -764,6 +766,7 @@ void show_cursor_info(bool always)
     maketitle();
   }
 
+  win_check_ns_hl(NULL);
   // Redraw the tab pages line if needed.
   if (redraw_tabline) {
     draw_tabline();
@@ -2119,10 +2122,13 @@ void redraw_statuslines(void)
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_redr_status) {
+      win_check_ns_hl(wp);
       win_redr_winbar(wp);
       win_redr_status(wp);
     }
   }
+
+  win_check_ns_hl(NULL);
   if (redraw_tabline) {
     draw_tabline();
   }

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -2333,6 +2333,51 @@ describe("'winhighlight' highlight", function()
 
     helpers.assert_alive()
   end)
+
+  it('can redraw statusline on cursor movement', function()
+    screen:try_resize(40, 8)
+    exec [[
+      set statusline=%f%=%#Background1#%l,%c%V\ %P
+      split
+    ]]
+    insert [[
+      some text
+      more text]]
+    screen:expect{grid=[[
+      some text                               |
+      more tex^t                               |
+      {0:~                                       }|
+      {3:[No Name]                        }{1:2,9 All}|
+      some text                               |
+      more text                               |
+      {4:[No Name]                        }{1:1,1 All}|
+                                              |
+    ]]}
+
+    command 'set winhl=Background1:Background2'
+    screen:expect{grid=[[
+      some text                               |
+      more tex^t                               |
+      {0:~                                       }|
+      {3:[No Name]                        }{5:2,9 All}|
+      some text                               |
+      more text                               |
+      {4:[No Name]                        }{1:1,1 All}|
+                                              |
+    ]]}
+
+    feed 'k'
+    screen:expect{grid=[[
+      some tex^t                               |
+      more text                               |
+      {0:~                                       }|
+      {3:[No Name]                        }{5:1,9 All}|
+      some text                               |
+      more text                               |
+      {4:[No Name]                        }{1:1,1 All}|
+                                              |
+    ]]}
+  end)
 end)
 
 describe('highlight namespaces', function()


### PR DESCRIPTION
otherwise highlights will be missing when redrawing statusline/ruler outside of `update_screen` (i e, only the cursor was moved)