### PR TITLE
vim-patch:8.1.{1915,1921,1953}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1136,6 +1136,9 @@ chdir({dir})						*chdir()*
 			   " ... do some work
 			   call chdir(save_dir)
 			endif
+
+<		Can also be used as a |method|: >
+			GetDir()->chdir()
 <
 cindent({lnum})						*cindent()*
 		Get the amount of indent for line {lnum} according the C
@@ -1525,6 +1528,18 @@ cursor({list})
 
 		Can also be used as a |method|: >
 			GetCursorPos()->cursor()
+
+debugbreak({pid})					*debugbreak()*
+		Specifically used to interrupt a program being debugged.  It
+		will cause process {pid} to get a SIGTRAP.  Behavior for other
+		processes is undefined. See |terminal-debugger|.
+		{Sends a SIGINT to a process {pid} other than MS-Windows}
+
+		Returns |TRUE| if successfully interrupted the program.
+		Otherwise returns |FALSE|.
+
+		Can also be used as a |method|: >
+			GetPid()->debugbreak()
 
 deepcopy({expr} [, {noref}])				*deepcopy()* *E698*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
@@ -1966,18 +1981,6 @@ exp({expr})						*exp()*
 
 		Can also be used as a |method|: >
 			Compute()->exp()
-
-debugbreak({pid})					*debugbreak()*
-		Specifically used to interrupt a program being debugged.  It
-		will cause process {pid} to get a SIGTRAP.  Behavior for other
-		processes is undefined. See |terminal-debugger|.
-		{Sends a SIGINT to a process {pid} other than MS-Windows}
-
-		Returns |TRUE| if successfully interrupted the program.
-		Otherwise returns |FALSE|.
-
-		Can also be used as a |method|: >
-			GetPid()->debugbreak()
 
 expand({string} [, {nosuf} [, {list}]])				*expand()*
 		Expand wildcards and the following special keywords in 

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -294,7 +294,7 @@ func Test_blob_index()
   call assert_equal(2, index(0zDEADBEEF, 0xBE))
   call assert_equal(-1, index(0zDEADBEEF, 0))
   call assert_equal(2, index(0z11111111, 0x11, 2))
-  call assert_equal(3, index(0z11110111, 0x11, 2))
+  call assert_equal(3, 0z11110111->index(0x11, 2))
   call assert_equal(2, index(0z11111111, 0x11, -2))
   call assert_equal(3, index(0z11110111, 0x11, -2))
 

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -19,7 +19,7 @@ func Test_setbufline_getbufline()
   let b = bufnr('%')
   wincmd w
   call assert_equal(1, setbufline(b, 5, ['x']))
-  call assert_equal(1, setbufline(bufnr('$') + 1, 1, ['x']))
+  call assert_equal(1, ['x']->setbufline(bufnr('$') + 1, 1))
   call assert_equal(0, setbufline(b, 4, ['d', 'e']))
   call assert_equal(['c'], b->getbufline(3))
   call assert_equal(['d'], getbufline(b, 4))

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -113,7 +113,7 @@ func Test_chdir_func()
   call assert_equal('z', fnamemodify(3->getcwd(2), ':t'))
   tabnext | wincmd t
   call assert_match('^\[tabpage\] .*/y$', trim(execute('verbose pwd')))
-  call chdir('..')
+  eval '..'->chdir()
   call assert_equal('Xdir', fnamemodify(getcwd(1, 2), ':t'))
   call assert_equal('Xdir', fnamemodify(getcwd(2, 2), ':t'))
   call assert_equal('z', fnamemodify(getcwd(3, 2), ':t'))

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -22,7 +22,7 @@ func Test_move_cursor()
   call cursor(3, 0)
   call assert_equal([3, 1, 0, 1], getcurpos()[1:])
   " below last line goes to last line
-  call cursor(9, 1)
+  eval [9, 1]->cursor()
   call assert_equal([4, 1, 0, 1], getcurpos()[1:])
   " pass string arguments
   call cursor('3', '3')

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -744,17 +744,13 @@ func Test_diff_hlID()
 
   call diff_hlID(-1, 1)->synIDattr("name")->assert_equal("")
 
-  call assert_equal(diff_hlID(1, 1), hlID("DiffChange"))
   call diff_hlID(1, 1)->synIDattr("name")->assert_equal("DiffChange")
-  call assert_equal(diff_hlID(1, 2), hlID("DiffText"))
   call diff_hlID(1, 2)->synIDattr("name")->assert_equal("DiffText")
   call diff_hlID(2, 1)->synIDattr("name")->assert_equal("")
-  call assert_equal(diff_hlID(3, 1), hlID("DiffAdd"))
   call diff_hlID(3, 1)->synIDattr("name")->assert_equal("DiffAdd")
-  call diff_hlID(4, 1)->synIDattr("name")->assert_equal("")
+  eval 4->diff_hlID(1)->synIDattr("name")->assert_equal("")
 
   wincmd w
-  call assert_equal(diff_hlID(1, 1), hlID("DiffChange"))
   call assert_equal(synIDattr(diff_hlID(1, 1), "name"), "DiffChange")
   call assert_equal(synIDattr(diff_hlID(2, 1), "name"), "")
   call assert_equal(synIDattr(diff_hlID(3, 1), "name"), "")

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1727,7 +1727,7 @@ func Test_confirm()
 
   " <Esc> requires another character to avoid it being seen as the start of an
   " escape sequence.  Zero should be harmless.
-  call feedkeys("\<Esc>0", 'L')
+  eval "\<Esc>0"->feedkeys('L')
   let a = confirm('Are you sure?', "&Yes\n&No")
   call assert_equal(0, a)
 

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1713,7 +1713,7 @@ func Test_confirm()
   call assert_equal(1, a)
 
   call feedkeys('y', 'L')
-  let a = confirm('Are you sure?', "&Yes\n&No")
+  let a = 'Are you sure?'->confirm("&Yes\n&No")
   call assert_equal(1, a)
 
   call feedkeys('n', 'L')
@@ -1784,7 +1784,7 @@ func Test_readdir()
   let files = readdir('Xdir', {x -> len(add(l, x)) == 2 ? -1 : 1})
   call assert_equal(1, len(files))
 
-  call delete('Xdir', 'rf')
+  eval 'Xdir'->delete('rf')
 endfunc
 
 func Test_delete_rf()
@@ -1827,6 +1827,7 @@ endfunc
 
 func Test_char2nr()
   call assert_equal(12354, char2nr('あ', 1))
+  call assert_equal(120, 'x'->char2nr())
 endfunc
 
 func Test_charclass()


### PR DESCRIPTION
#### vim-patch:8.1.1915: more functions can be used as methods

Problem:    More functions can be used as methods.
Solution:   Make various functions usable as a method.
https://github.com/vim/vim/commit/1a3a89168d61c2fed91cbca812cf1c6983901b79

Move debugbreak() to the right place.


#### vim-patch:8.1.1921: more functions can be used as methods

Problem:    More functions can be used as methods.
Solution:   Make various functions usable as a method.
https://github.com/vim/vim/commit/a4208966fb289a505ebdef62bbc37c214069bab4


#### vim-patch:8.1.1953: more functions can be used as a method

Problem:    More functions can be used as a method.
Solution:   Allow more functions to be used as a method.
https://github.com/vim/vim/commit/f9f24ce7a0e5988fedf2e2ff751818f9b07510a6

Omit test_termcodes.vim: cannot be used and superseded by later patches.
Cherry-pick test_bufline.vim change from patch 8.1.1993.