### PR TITLE
vim-patch:8.2.0522: several errors are not tested for

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1247,14 +1247,14 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
            ; li != NULL;) {
         listitem_T *const prev_li = TV_LIST_ITEM_PREV(l, li);
         if (item_compare_func_ptr(&prev_li, &li) == 0) {
-          if (info.item_compare_func_err) {  // -V547
-            emsg(_("E882: Uniq compare function failed"));
-            break;
-          }
           li = tv_list_item_remove(l, li);
         } else {
           idx++;
           li = TV_LIST_ITEM_NEXT(l, li);
+        }
+        if (info.item_compare_func_err) {
+          emsg(_("E882: Uniq compare function failed"));
+          break;
         }
       }
     }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1885,6 +1885,8 @@ theend:
   return name;
 }
 
+#define MAX_FUNC_NESTING 50
+
 /// ":function"
 void ex_function(exarg_T *eap)
 {
@@ -2304,8 +2306,12 @@ void ex_function(exarg_T *eap)
         p += eval_fname_script((const char *)p);
         xfree(trans_function_name((char **)&p, true, 0, NULL, NULL));
         if (*skipwhite((char *)p) == '(') {
-          nesting++;
-          indent += 2;
+          if (nesting == MAX_FUNC_NESTING - 1) {
+            emsg(_("E1058: function nesting too deep"));
+          } else {
+            nesting++;
+            indent += 2;
+          }
         }
       }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2724,6 +2724,30 @@ func Test_autocmd_FileReadCmd()
   delfunc ReadFileCmd
 endfunc
 
+" Test for passing invalid arguments to autocmd
+func Test_autocmd_invalid_args()
+  " Additional character after * for event
+  call assert_fails('autocmd *a Xfile set ff=unix', 'E215:')
+  augroup Test
+  augroup END
+  " Invalid autocmd event
+  call assert_fails('autocmd Bufabc Xfile set ft=vim', 'E216:')
+  " Invalid autocmd event in a autocmd group
+  call assert_fails('autocmd Test Bufabc Xfile set ft=vim', 'E216:')
+  augroup! Test
+  " Execute all autocmds
+  call assert_fails('doautocmd * BufEnter', 'E217:')
+  call assert_fails('augroup! x1a2b3', 'E367:')
+  call assert_fails('autocmd BufNew <buffer=999> pwd', 'E680:')
+endfunc
+
+" Test for deep nesting of autocmds
+func Test_autocmd_deep_nesting()
+  autocmd BufEnter Xfile doautocmd BufEnter Xfile
+  call assert_fails('doautocmd BufEnter Xfile', 'E218:')
+  autocmd! BufEnter Xfile
+endfunc
+
 " Tests for SigUSR1 autocmd event, which is only available on posix systems.
 func Test_autocmd_sigusr1()
   CheckUnix

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -2,6 +2,11 @@
 
 source check.vim
 CheckFeature job
+
+if !has('clientserver')
+  call assert_fails('call remote_startserver("local")', 'E942:')
+endif
+
 CheckFeature clientserver
 
 source shared.vim
@@ -179,6 +184,7 @@ func Test_client_server()
 
   call assert_fails("let x = remote_peek([])", 'E730:')
   call assert_fails("let x = remote_read('vim10')", 'E277:')
+  call assert_fails("call server2client('abc', 'xyz')", 'E258:')
 endfunc
 
 " Uncomment this line to get a debugging log

--- a/src/nvim/testdir/test_digraph.vim
+++ b/src/nvim/testdir/test_digraph.vim
@@ -211,6 +211,8 @@ func Test_digraphs()
   call Put_Dig("00")
   call Put_Dig("el")
   call assert_equal(['␀', 'ü', '∞', 'l'], getline(line('.')-3,line('.')))
+  call assert_fails('exe "digraph a\<Esc> 100"', 'E104:')
+  call assert_fails('exe "digraph \<Esc>a 100"', 'E104:')
   call assert_fails('digraph xy z', 'E39:')
   call assert_fails('digraph x', 'E1214:')
   bw!
@@ -489,6 +491,17 @@ func Test_show_digraph_cp1251()
   call assert_equal("\n<\xfa>  <|z>  <M-z>  250,  Hex fa,  Oct 372, Digr ='", execute('ascii'))
   set encoding=utf-8
   bwipe!
+endfunc
+
+" Test for error in a keymap file
+func Test_loadkeymap_error()
+  if !has('keymap')
+    return
+  endif
+  call assert_fails('loadkeymap', 'E105:')
+  call writefile(['loadkeymap', 'a'], 'Xkeymap')
+  call assert_fails('source Xkeymap', 'E791:')
+  call delete('Xkeymap')
 endfunc
 
 " Test for the characters displayed on the screen when entering a digraph

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -547,6 +547,7 @@ func Test_funcref()
   call assert_fails('echo funcref("{")', 'E475:')
   let OneByRef = funcref("One", repeat(["foo"], 20))
   call assert_fails('let OneByRef = funcref("One", repeat(["foo"], 21))', 'E118:')
+  call assert_fails('echo function("min") =~ function("min")', 'E694:')
 endfunc
 
 func Test_setmatches()

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -731,7 +731,8 @@ func Test_1_highlight_Normalgroup_exists()
   endif
 endfunc
 
-function Test_no_space_before_xxx()
+" Do this test last, sometimes restoring the columns doesn't work
+func Test_z_no_space_before_xxx()
   " Note: we need to create this highlight group in the test because it does not exist in Neovim
   execute('hi StatusLineTermNC ctermfg=green')
   let l:org_columns = &columns
@@ -739,7 +740,7 @@ function Test_no_space_before_xxx()
   let l:hi_StatusLineTermNC = join(split(execute('hi StatusLineTermNC')))
   call assert_match('StatusLineTermNC xxx', l:hi_StatusLineTermNC)
   let &columns = l:org_columns
-endfunction
+endfunc
 
 " Test for :highlight command errors
 func Test_highlight_cmd_errors()

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -308,3 +308,21 @@ func Test_lambda_error()
   " This was causing a crash
   call assert_fails('ec{@{->{d->()()', 'E15')
 endfunc
+
+func Test_closure_error()
+  let l =<< trim END
+    func F1() closure
+      return 1
+    endfunc
+  END
+  call writefile(l, 'Xscript')
+  let caught_932 = 0
+  try
+    source Xscript
+  catch /E932:/
+    let caught_932 = 1
+  endtry
+  call assert_equal(1, caught_932)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -604,20 +604,23 @@ func Test_reverse_sort_uniq()
   call assert_equal(['-0', 'A11', 2, 'xaaa', 4, 'foo', 'foo6', 'foo', [0, 1, 2], 'x8', [0, 1, 2], 1.5], uniq(copy(l)))
   call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(l))
   call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(reverse(l)))
-  call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(l))
-  call assert_equal([[0, 1, 2], [0, 1, 2], 4, 2, 2, 1.5, 'xaaa', 'x8', 'foo6', 'foo', 'foo', 'A11', '-0'], reverse(sort(l)))
-  call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(reverse(sort(l))))
-  call assert_equal(['-0', 'A11', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 4, [0, 1, 2]], uniq(sort(l)))
+  if has('float')
+    call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(l))
+    call assert_equal([[0, 1, 2], [0, 1, 2], 4, 2, 2, 1.5, 'xaaa', 'x8', 'foo6', 'foo', 'foo', 'A11', '-0'], reverse(sort(l)))
+    call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(reverse(sort(l))))
+    call assert_equal(['-0', 'A11', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 4, [0, 1, 2]], uniq(sort(l)))
 
-  let l=[7, 9, 'one', 18, 12, 22, 'two', 10.0e-16, -1, 'three', 0xff, 0.22, 'four']
-  call assert_equal([-1, 'one', 'two', 'three', 'four', 1.0e-15, 0.22, 7, 9, 12, 18, 22, 255], sort(copy(l), 'n'))
+    let l = [7, 9, 'one', 18, 12, 22, 'two', 10.0e-16, -1, 'three', 0xff, 0.22, 'four']
+    call assert_equal([-1, 'one', 'two', 'three', 'four', 1.0e-15, 0.22, 7, 9, 12, 18, 22, 255], sort(copy(l), 'n'))
 
-  let l=[7, 9, 18, 12, 22, 10.0e-16, -1, 0xff, 0, -0, 0.22, 'bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', {}, []]
-  call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 1))
-  call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 'i'))
-  call assert_equal(['BAR', 'Bar', 'FOO', 'FOOBAR', 'Foo', 'bar', 'foo', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l)))
+    let l = [7, 9, 18, 12, 22, 10.0e-16, -1, 0xff, 0, -0, 0.22, 'bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', {}, []]
+    call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 1))
+    call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 'i'))
+    call assert_equal(['BAR', 'Bar', 'FOO', 'FOOBAR', 'Foo', 'bar', 'foo', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l)))
+  endif
 
   call assert_fails('call reverse("")', 'E899:')
+  call assert_fails('call uniq([1, 2], {x, y -> []})', 'E882:')
 endfunc
 
 " reduce a list or a blob

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -234,6 +234,7 @@ func Test_complete()
   new
   call feedkeys("i\<C-N>\<Esc>", 'xt')
   bwipe!
+  call assert_fails('set complete=ix', 'E535:')
   set complete&
 endfun
 
@@ -431,32 +432,37 @@ func Test_copy_context()
 endfunc
 
 func Test_set_ttytype()
-  " Nvim does not support 'ttytype'.
-  if !has('nvim') && !has('gui_running') && has('unix')
-    " Setting 'ttytype' used to cause a double-free when exiting vim and
-    " when vim is compiled with -DEXITFREE.
-    set ttytype=ansi
-    call assert_equal('ansi', &ttytype)
-    call assert_equal(&ttytype, &term)
-    set ttytype=xterm
-    call assert_equal('xterm', &ttytype)
-    call assert_equal(&ttytype, &term)
-    try
-      set ttytype=
-      call assert_report('set ttytype= did not fail')
-    catch /E529/
-    endtry
+  throw "Skipped: Nvim does not support 'ttytype'"
+  CheckUnix
+  CheckNotGui
 
-    " Some systems accept any terminal name and return dumb settings,
-    " check for failure of finding the entry and for missing 'cm' entry.
-    try
-      set ttytype=xxx
-      call assert_report('set ttytype=xxx did not fail')
-    catch /E522\|E437/
-    endtry
+  " Setting 'ttytype' used to cause a double-free when exiting vim and
+  " when vim is compiled with -DEXITFREE.
+  set ttytype=ansi
+  call assert_equal('ansi', &ttytype)
+  call assert_equal(&ttytype, &term)
+  set ttytype=xterm
+  call assert_equal('xterm', &ttytype)
+  call assert_equal(&ttytype, &term)
+  try
+    set ttytype=
+    call assert_report('set ttytype= did not fail')
+  catch /E529/
+  endtry
 
-    set ttytype&
-    call assert_equal(&ttytype, &term)
+  " Some systems accept any terminal name and return dumb settings,
+  " check for failure of finding the entry and for missing 'cm' entry.
+  try
+    set ttytype=xxx
+    call assert_report('set ttytype=xxx did not fail')
+  catch /E522\|E437/
+  endtry
+
+  set ttytype&
+  call assert_equal(&ttytype, &term)
+
+  if has('gui') && !has('gui_running')
+    call assert_fails('set term=gui', 'E531:')
   endif
 endfunc
 

--- a/src/nvim/testdir/test_preview.vim
+++ b/src/nvim/testdir/test_preview.vim
@@ -1,5 +1,8 @@
 " Tests for the preview window
 
+source check.vim
+CheckFeature quickfix
+
 func Test_Psearch()
   " this used to cause ml_get errors
   help
@@ -13,6 +16,8 @@ func Test_Psearch()
 endfunc
 
 func Test_window_preview()
+  CheckFeature quickfix
+
   " Open a preview window
   pedit Xa
   call assert_equal(2, winnr('$'))
@@ -32,6 +37,8 @@ func Test_window_preview()
 endfunc
 
 func Test_window_preview_from_help()
+  CheckFeature quickfix
+
   filetype on
   call writefile(['/* some C code */'], 'Xpreview.c')
   help

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -169,3 +169,10 @@ endfunc
 func Test_failed_call_in_try()
   try | call UnknownFunc() | catch | endtry
 endfunc
+
+" Test for listing user-defined functions
+func Test_function_list()
+  call assert_fails("function Xabc", 'E123:')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_viminfo.vim
+++ b/src/nvim/testdir/test_viminfo.vim
@@ -1,0 +1,21 @@
+
+" Test for errors in setting 'viminfo'
+func Test_viminfo_option_error()
+  " Missing number
+  call assert_fails('set viminfo=\"', 'E526:')
+  for c in split("'/:<@s", '\zs')
+    call assert_fails('set viminfo=' .. c, 'E526:')
+  endfor
+
+  " Missing comma
+  call assert_fails('set viminfo=%10!', 'E527:')
+  call assert_fails('set viminfo=!%10', 'E527:')
+  call assert_fails('set viminfo=h%10', 'E527:')
+  call assert_fails('set viminfo=c%10', 'E527:')
+  call assert_fails('set viminfo=:10%10', 'E527:')
+
+  " Missing ' setting
+  call assert_fails('set viminfo=%10', 'E528:')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/vimscript/eval_spec.lua
+++ b/test/functional/vimscript/eval_spec.lua
@@ -10,11 +10,13 @@
 --    test/functional/vimscript/functions_spec.lua
 
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 
 local lfs = require('lfs')
 local clear = helpers.clear
 local eq = helpers.eq
 local exc_exec = helpers.exc_exec
+local exec = helpers.exec
 local eval = helpers.eval
 local command = helpers.command
 local write_file = helpers.write_file
@@ -143,4 +145,77 @@ describe('List support code', function()
       eq(nil, ('Took too long to cancel: %g >= %g'):format(t_dur, dur / 8))
     end
   end)
+end)
+
+-- oldtest: Test_deep_nest()
+it('Error when if/for/while/try/function is nested too deep',function()
+  clear()
+  local screen = Screen.new(80, 24)
+  screen:attach()
+  meths.set_option('laststatus', 2)
+  exec([[
+    " Deep nesting of if ... endif
+    func Test1()
+      let @a = join(repeat(['if v:true'], 51), "\n")
+      let @a ..= "\n"
+      let @a ..= join(repeat(['endif'], 51), "\n")
+      @a
+      let @a = ''
+    endfunc
+
+    " Deep nesting of for ... endfor
+    func Test2()
+      let @a = join(repeat(['for i in [1]'], 51), "\n")
+      let @a ..= "\n"
+      let @a ..= join(repeat(['endfor'], 51), "\n")
+      @a
+      let @a = ''
+    endfunc
+
+    " Deep nesting of while ... endwhile
+    func Test3()
+      let @a = join(repeat(['while v:true'], 51), "\n")
+      let @a ..= "\n"
+      let @a ..= join(repeat(['endwhile'], 51), "\n")
+      @a
+      let @a = ''
+    endfunc
+
+    " Deep nesting of try ... endtry
+    func Test4()
+      let @a = join(repeat(['try'], 51), "\n")
+      let @a ..= "\necho v:true\n"
+      let @a ..= join(repeat(['endtry'], 51), "\n")
+      @a
+      let @a = ''
+    endfunc
+
+    " Deep nesting of function ... endfunction
+    func Test5()
+      let @a = join(repeat(['function X()'], 51), "\n")
+      let @a ..= "\necho v:true\n"
+      let @a ..= join(repeat(['endfunction'], 51), "\n")
+      @a
+      let @a = ''
+    endfunc
+  ]])
+  screen:expect({any = '%[No Name%]'})
+  feed(':call Test1()<CR>')
+  screen:expect({any = 'E579: '})
+  feed('<C-C>')
+  screen:expect({any = '%[No Name%]'})
+  feed(':call Test2()<CR>')
+  screen:expect({any = 'E585: '})
+  feed('<C-C>')
+  screen:expect({any = '%[No Name%]'})
+  feed(':call Test3()<CR>')
+  screen:expect({any = 'E585: '})
+  feed('<C-C>')
+  screen:expect({any = '%[No Name%]'})
+  feed(':call Test4()<CR>')
+  screen:expect({any = 'E601: '})
+  feed('<C-C>')
+  screen:expect({any = '%[No Name%]'})
+  feed(':call Test5()<CR>')
+  screen:expect({any = 'E1058: '})
 end)

--- a/test/functional/vimscript/input_spec.lua
+++ b/test/functional/vimscript/input_spec.lua
@@ -455,24 +455,24 @@ describe('confirm()', function()
     meths.set_option('more', false)  -- Avoid hit-enter prompt
     meths.set_option('laststatus', 2)
     -- screen:expect() calls are needed to avoid feeding input too early
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
 
     async_meths.command([[let a = confirm('Press O to proceed')]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('o')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(1, meths.get_var('a'))
 
-    async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
+    async_meths.command([[let a = 'Are you sure?'->confirm("&Yes\n&No")]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('y')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(1, meths.get_var('a'))
 
     async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('n')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(2, meths.get_var('a'))
 
     -- Not possible to match Vim's CTRL-C test here as CTRL-C always sets got_int in Nvim.
@@ -481,26 +481,26 @@ describe('confirm()', function()
     async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('<Esc>')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(0, meths.get_var('a'))
 
     -- Default choice is returned when pressing <CR>.
     async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No")]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('<CR>')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(1, meths.get_var('a'))
 
     async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No", 2)]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('<CR>')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(2, meths.get_var('a'))
 
     async_meths.command([[let a = confirm('Are you sure?', "&Yes\n&No", 0)]])
     screen:expect({any = '{CONFIRM:.+: }'})
     feed('<CR>')
-    screen:expect({any = 'No Name'})
+    screen:expect({any = '%[No Name%]'})
     eq(0, meths.get_var('a'))
 
     -- Test with the {type} 4th argument
@@ -508,7 +508,7 @@ describe('confirm()', function()
       async_meths.command(([[let a = confirm('Are you sure?', "&Yes\n&No", 1, '%s')]]):format(type))
       screen:expect({any = '{CONFIRM:.+: }'})
       feed('y')
-      screen:expect({any = 'No Name'})
+      screen:expect({any = '%[No Name%]'})
       eq(1, meths.get_var('a'))
     end
 


### PR DESCRIPTION
#### vim-patch:8.2.0522: several errors are not tested for

Problem:    Several errors are not tested for.
Solution:   Add tests. (Yegappan Lakshmanan, closes vim/vim#5892)
https://github.com/vim/vim/commit/ee4e0c1e9a81cb5d96e0060203a9033c2f28588e

Omit Test_range() change: reverted in patch 8.2.0615.
Cherry-pick Test_z_no_space_before_xxx() from patch 8.2.0195.
Cherry-pick Test_reverse_sort_uniq() change from patch 8.2.0183.
Make uniq() error behavior consistent with sort().
Cherry-pick Test_set_ttytype() change from patch 8.1.1826.
Cherry-pick quickfix checks from patch 8.1.2373 to test_preview.vim.
Test_viminfo_error() is applicable.
Cherry-pick E1058 from patch 8.2.0149 and port Test_deep_nest() to Lua.