### PR TITLE
vim-patch:8.2.{4726,4740,4741,4749,4841,4842}: expand('<script>')

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2048,6 +2048,9 @@ expand({string} [, {nosuf} [, {list}]])				*expand()*
 		is not defined, an empty string is used.  Using "%:p" in a
 		buffer with no name, results in the current directory, with a
 		'/' added.
+		When 'verbose' is set then expanding '%', '#' and <> items
+		will result in an error message if the argument cannot be
+		expanded.
 
 		When {string} does not start with '%', '#' or '<', it is
 		expanded like a file name is expanded on the command line.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2013,6 +2013,8 @@ expand({string} [, {nosuf} [, {list}]])				*expand()*
 					a function
 			<SID>		"<SNR>123_"  where "123" is the
 					current script ID  |<SID>|
+			<script>	sourced script file, or script file
+					where the current function was defined
 			<stack>		call stack
 			<cword>		word under the cursor
 			<cWORD>		WORD under the cursor

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -881,7 +881,7 @@ Note: these are typed literally, they are not special keys!
 		   file name of the sourced file.  *E498*
 		   When executing a function, is replaced with the call stack,
 		   as with <stack> (this is for backwards compatibility, using
-		   <stack> is preferred).
+		   <stack> or <script> is preferred).
 		   Note that filename-modifiers are useless when <sfile> is
 		   not used inside a script.
 							*:<stack>* *<stack>*
@@ -891,6 +891,12 @@ Note: these are typed literally, they are not special keys!
 		   ".." in between items.  E.g.:
 		   "function {function-name1}[{lnum}]..{function-name2}[{lnum}]"
 		   If there is no call stack you get error *E489* .
+							*:<script>* *<script>*
+	<script>   When executing a `:source` command, is replaced with the file
+		   name of the sourced file.  When executing a function, is
+		   replaced with the file name of the script where it is
+		   defined.
+		   If the file name cannot be determined you get error *E1274* .
 							*:<slnum>* *<slnum>*
 	<slnum>	   When executing a `:source` command, is replaced with the
 		   line number.  *E842*

--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -30,7 +30,7 @@ fun! s:SynSet()
     unlet b:current_syntax
   endif
 
-  let s = expand("<amatch>")
+  0verbose let s = expand("<amatch>")
   if s == "ON"
     " :set syntax=ON
     if &filetype == ""

--- a/runtime/syntax/syntax.vim
+++ b/runtime/syntax/syntax.vim
@@ -28,8 +28,9 @@ endif
 
 " Set up the connection between FileType and Syntax autocommands.
 " This makes the syntax automatically set when the file type is detected.
+" Avoid an error when 'verbose' is set and <amatch> expansion fails.
 augroup syntaxset
-  au! FileType *	exe "set syntax=" . expand("<amatch>")
+  au! FileType *	0verbose exe "set syntax=" . expand("<amatch>")
 augroup END
 
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -29,7 +29,7 @@ struct AutoCmd_S {
   bool nested;                          // If autocommands nest here
   bool last;                            // last command in list
   int64_t id;                           // ID used for uniquely tracking an autocmd.
-  sctx_T script_ctx;                    // script context where defined
+  sctx_T script_ctx;                    // script context where it is defined
   char *desc;                           // Description for the autocmd.
   AutoCmd *next;                        // Next AutoCmd in list
 };
@@ -59,6 +59,7 @@ struct AutoPatCmd_S {
   char *sfname;             // sfname to match with
   char *tail;               // tail of fname
   event_T event;            // current event
+  sctx_T script_ctx;        // script context where it is defined
   int arg_bufnr;            // initially equal to <abuf>, set to zero when buf is deleted
   Object *data;             // arbitrary data
   AutoPatCmd *next;         // chain of active apc-s for auto-invalidation

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1982,7 +1982,7 @@ static void f_expand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
     }
     size_t len;
     char *errormsg = NULL;
-    char_u *result = eval_vars((char_u *)s, (char_u *)s, &len, NULL, &errormsg, NULL);
+    char_u *result = eval_vars((char_u *)s, (char_u *)s, &len, NULL, &errormsg, NULL, false);
     if (p_verbose == 0) {
       emsg_off--;
     } else if (errormsg != NULL) {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1958,7 +1958,6 @@ static void f_exists(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 /// "expand()" function
 static void f_expand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 {
-  char *errormsg;
   int options = WILD_SILENT|WILD_USE_NL|WILD_LIST_NOTFOUND;
   bool error = false;
 #ifdef BACKSLASH_IN_FILENAME
@@ -1978,10 +1977,17 @@ static void f_expand(typval_T *argvars, typval_T *rettv, FunPtr fptr)
 
   const char *s = tv_get_string(&argvars[0]);
   if (*s == '%' || *s == '#' || *s == '<') {
-    emsg_off++;
+    if (p_verbose == 0) {
+      emsg_off++;
+    }
     size_t len;
+    char *errormsg = NULL;
     char_u *result = eval_vars((char_u *)s, (char_u *)s, &len, NULL, &errormsg, NULL);
-    emsg_off--;
+    if (p_verbose == 0) {
+      emsg_off--;
+    } else if (errormsg != NULL) {
+      emsg(errormsg);
+    }
     if (rettv->v_type == VAR_LIST) {
       tv_list_alloc_ret(rettv, (result != NULL));
       if (result != NULL) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6891,12 +6891,14 @@ char_u *eval_vars(char_u *src, char_u *srcstart, size_t *usedlen, linenr_T *lnum
     }
   }
 
-  if (empty_is_error && (resultlen == 0 || valid != VALID_HEAD + VALID_PATH)) {
-    if (valid != VALID_HEAD + VALID_PATH) {
-      // xgettext:no-c-format
-      *errormsg = _("E499: Empty file name for '%' or '#', only works with \":p:h\"");
-    } else {
-      *errormsg = _("E500: Evaluates to an empty string");
+  if (resultlen == 0 || valid != VALID_HEAD + VALID_PATH) {
+    if (empty_is_error) {
+      if (valid != VALID_HEAD + VALID_PATH) {
+        // xgettext:no-c-format
+        *errormsg = _("E499: Empty file name for '%' or '#', only works with \":p:h\"");
+      } else {
+        *errormsg = _("E500: Evaluates to an empty string");
+      }
     }
     result = NULL;
   } else {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6617,18 +6617,19 @@ ssize_t find_cmdline_var(const char_u *src, size_t *usedlen)
 
 /// Evaluate cmdline variables.
 ///
-/// change '%'       to curbuf->b_ffname
-///        '#'       to curwin->w_alt_fnum
-///        '<cword>' to word under the cursor
-///        '<cWORD>' to WORD under the cursor
-///        '<cexpr>' to C-expression under the cursor
-///        '<cfile>' to path name under the cursor
-///        '<sfile>' to sourced file name
-///        '<stack>' to call stack
-///        '<slnum>' to sourced file line number
-///        '<afile>' to file name for autocommand
-///        '<abuf>'  to buffer number for autocommand
-///        '<amatch>' to matching name for autocommand
+/// change "%"       to curbuf->b_ffname
+///        "#"       to curwin->w_alt_fnum
+///        "<cword>" to word under the cursor
+///        "<cWORD>" to WORD under the cursor
+///        "<cexpr>" to C-expression under the cursor
+///        "<cfile>" to path name under the cursor
+///        "<sfile>" to sourced file name
+///        "<stack>" to call stack
+///        "<script>" to current script name
+///        "<slnum>" to sourced file line number
+///        "<afile>" to file name for autocommand
+///        "<abuf>"  to buffer number for autocommand
+///        "<amatch>" to matching name for autocommand
 ///
 /// When an error is detected, "errormsg" is set to a non-NULL pointer (may be
 /// "" for error without a message) and NULL is returned.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -94,6 +94,12 @@ static char e_ambiguous_use_of_user_defined_command[]
   = N_("E464: Ambiguous use of user-defined command");
 static char e_not_an_editor_command[]
   = N_("E492: Not an editor command");
+static char e_no_source_file_name_to_substitute_for_sfile[]
+  = N_("E498: no :source file name to substitute for \"<sfile>\"");
+static char e_no_call_stack_to_substitute_for_stack[]
+  = N_("E489: no call stack to substitute for \"<stack>\"");
+static char e_no_script_file_name_to_substitute_for_script[]
+  = N_("E1274: No script file name to substitute for \"<script>\"");
 
 static int quitmore = 0;
 static bool ex_pressedreturn = false;
@@ -6564,6 +6570,7 @@ enum {
   SPEC_SFILE,
   SPEC_SLNUM,
   SPEC_STACK,
+  SPEC_SCRIPT,
   SPEC_AFILE,
   SPEC_ABUF,
   SPEC_AMATCH,
@@ -6588,6 +6595,7 @@ ssize_t find_cmdline_var(const char_u *src, size_t *usedlen)
     [SPEC_SFILE] = "<sfile>",           // ":so" file name
     [SPEC_SLNUM] = "<slnum>",           // ":so" file line number
     [SPEC_STACK] = "<stack>",           // call stack
+    [SPEC_SCRIPT] = "<script>",         // script file name
     [SPEC_AFILE] = "<afile>",           // autocommand file name
     [SPEC_ABUF] = "<abuf>",             // autocommand buffer number
     [SPEC_AMATCH] = "<amatch>",         // autocommand match name
@@ -6801,12 +6809,25 @@ char_u *eval_vars(char_u *src, char_u *srcstart, size_t *usedlen, linenr_T *lnum
       break;
 
     case SPEC_SFILE:            // file name for ":so" command
-    case SPEC_STACK:            // call stack
-      result = estack_sfile(spec_idx == SPEC_SFILE ? ESTACK_SFILE : ESTACK_STACK);
+      result = estack_sfile(ESTACK_SFILE);
       if (result == NULL) {
-        *errormsg = spec_idx == SPEC_SFILE
-          ? _("E498: no :source file name to substitute for \"<sfile>\"")
-          : _("E489: no call stack to substitute for \"<stack>\"");
+        *errormsg = _(e_no_source_file_name_to_substitute_for_sfile);
+        return NULL;
+      }
+      resultbuf = result;  // remember allocated string
+      break;
+    case SPEC_STACK:            // call stack
+      result = estack_sfile(ESTACK_STACK);
+      if (result == NULL) {
+        *errormsg = _(e_no_call_stack_to_substitute_for_stack);
+        return NULL;
+      }
+      resultbuf = result;  // remember allocated string
+      break;
+    case SPEC_SCRIPT:           // script file name
+      result = estack_sfile(ESTACK_SCRIPT);
+      if (result == NULL) {
+        *errormsg = _(e_no_script_file_name_to_substitute_for_script);
         return NULL;
       }
       resultbuf = result;  // remember allocated string

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2135,7 +2135,8 @@ int expand_wildcards_eval(char_u **pat, int *num_file, char ***file, int flags)
 
   if (*exp_pat == '%' || *exp_pat == '#' || *exp_pat == '<') {
     emsg_off++;
-    eval_pat = eval_vars((char_u *)exp_pat, (char_u *)exp_pat, &usedlen, NULL, &ignored_msg, NULL);
+    eval_pat = eval_vars((char_u *)exp_pat, (char_u *)exp_pat, &usedlen, NULL, &ignored_msg, NULL,
+                         true);
     emsg_off--;
     if (eval_pat != NULL) {
       exp_pat = (char *)concat_str(eval_pat, (char_u *)exp_pat + usedlen);

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -104,7 +104,7 @@ void estack_pop(void)
 ///               ESTACK_SCRIPT for <script>.
 char *estack_sfile(estack_arg_T which)
 {
-  estack_T *entry = ((estack_T *)exestack.ga_data) + exestack.ga_len - 1;
+  const estack_T *entry = ((estack_T *)exestack.ga_data) + exestack.ga_len - 1;
   if (which == ESTACK_SFILE && entry->es_type != ETYPE_UFUNC) {
     if (entry->es_name == NULL) {
       return NULL;
@@ -112,22 +112,31 @@ char *estack_sfile(estack_arg_T which)
     return xstrdup(entry->es_name);
   }
 
-  // If evaluated in a function return the path of the script where the
-  // function is defined, at script level the current script path is returned
+  // If evaluated in a function or autocommand, return the path of the script
+  // where it is defined, at script level the current script path is returned
   // instead.
   if (which == ESTACK_SCRIPT) {
-    if (entry->es_type == ETYPE_UFUNC) {
-      sctx_T *def_ctx = &entry->es_info.ufunc->uf_script_ctx;
-      if (def_ctx->sc_sid > 0) {
-        return xstrdup((char *)(SCRIPT_ITEM(def_ctx->sc_sid).sn_name));
-      }
-    } else if (exestack.ga_len > 0) {
-      // Walk the stack backwards, starting from the current frame.
-      for (int idx = exestack.ga_len - 1; idx; idx--) {
-        entry = ((estack_T *)exestack.ga_data) + idx;
-        if (entry->es_type == ETYPE_SCRIPT) {
-          return xstrdup(entry->es_name);
+    assert(entry == ((estack_T *)exestack.ga_data) + exestack.ga_len - 1);
+    // Walk the stack backwards, starting from the current frame.
+    for (int idx = exestack.ga_len - 1; idx >= 0; idx--, entry--) {
+      if (entry->es_type == ETYPE_UFUNC) {
+        const sctx_T *const def_ctx = &entry->es_info.ufunc->uf_script_ctx;
+
+        if (def_ctx->sc_sid > 0) {
+          return xstrdup((char *)(SCRIPT_ITEM(def_ctx->sc_sid).sn_name));
+        } else {
+          return NULL;
         }
+      } else if (entry->es_type == ETYPE_AUCMD) {
+        const sctx_T *const def_ctx = &entry->es_info.aucmd->script_ctx;
+
+        if (def_ctx->sc_sid > 0) {
+          return xstrdup((char *)(SCRIPT_ITEM(def_ctx->sc_sid).sn_name));
+        } else {
+          return NULL;
+        }
+      } else if (entry->es_type == ETYPE_SCRIPT) {
+        return xstrdup(entry->es_name);
       }
     }
     return NULL;

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -47,6 +47,7 @@ typedef enum {
   ESTACK_NONE,
   ESTACK_SFILE,
   ESTACK_STACK,
+  ESTACK_SCRIPT,
 } estack_arg_T;
 
 typedef struct scriptitem_S {

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -568,10 +568,12 @@ endfunc
 
 " Test for the :verbose command
 func Test_verbose_cmd()
-  call assert_equal(['  verbose=1'], split(execute('verbose set vbs'), "\n"))
+  set verbose=3
+  call assert_match('  verbose=1\n\s*Last set from ', execute('verbose set vbs'), "\n")
   call assert_equal(['  verbose=0'], split(execute('0verbose set vbs'), "\n"))
-  let l = execute("4verbose set verbose | set verbose")
-  call assert_equal(['  verbose=4', '  verbose=0'], split(l, "\n"))
+  set verbose=0
+  call assert_match('  verbose=4\n\s*Last set from .*\n  verbose=0',
+        \ execute("4verbose set verbose | set verbose"))
 endfunc
 
 " Test for the :delete command and the related abbreviated commands

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -157,43 +157,52 @@ endfunc
 
 func Test_expand_script_source()
   let lines0 =<< trim [SCRIPT]
-    let g:script_level[0] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     so Xscript1
     func F0()
-      let g:func_level[0] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   let lines1 =<< trim [SCRIPT]
-    let g:script_level[1] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     so Xscript2
     func F1()
-      let g:func_level[1] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   let lines2 =<< trim [SCRIPT]
-    let g:script_level[2] = expand('<script>:t')
+    call extend(g:script_level, [expand('<script>:t')])
     func F2()
-      let g:func_level[2] = expand('<script>:t')
+      call extend(g:func_level, [expand('<script>:t')])
     endfunc
+
+    au User * call extend(g:au_level, [expand('<script>:t')])
   [SCRIPT]
 
   call writefile(lines0, 'Xscript0')
   call writefile(lines1, 'Xscript1')
   call writefile(lines2, 'Xscript2')
 
-  " Check the expansion of <script> at script and function level.
-  let g:script_level = ['', '', '']
-  let g:func_level = ['', '', '']
+  " Check the expansion of <script> at different levels.
+  let g:script_level = []
+  let g:func_level = []
+  let g:au_level = []
 
   so Xscript0
   call F0()
   call F1()
   call F2()
+  doautocmd User
 
   call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:script_level)
   call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:func_level)
+  call assert_equal(['Xscript2', 'Xscript1', 'Xscript0'], g:au_level)
 
   unlet g:script_level g:func_level
   delfunc F0

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -147,4 +147,54 @@ func Test_expandcmd_shell_nonomatch()
   call assert_equal('$*', expandcmd('$*'))
 endfunc
 
+func Test_expand_script_source()
+  let lines0 =<< trim [SCRIPT]
+    let g:script_level[0] = expand('<script>:t')
+    so Xscript1
+    func F0()
+      let g:func_level[0] = expand('<script>:t')
+    endfunc
+  [SCRIPT]
+
+  let lines1 =<< trim [SCRIPT]
+    let g:script_level[1] = expand('<script>:t')
+    so Xscript2
+    func F1()
+      let g:func_level[1] = expand('<script>:t')
+    endfunc
+  [SCRIPT]
+
+  let lines2 =<< trim [SCRIPT]
+    let g:script_level[2] = expand('<script>:t')
+    func F2()
+      let g:func_level[2] = expand('<script>:t')
+    endfunc
+  [SCRIPT]
+
+  call writefile(lines0, 'Xscript0')
+  call writefile(lines1, 'Xscript1')
+  call writefile(lines2, 'Xscript2')
+
+  " Check the expansion of <script> at script and function level.
+  let g:script_level = ['', '', '']
+  let g:func_level = ['', '', '']
+
+  so Xscript0
+  call F0()
+  call F1()
+  call F2()
+
+  call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:script_level)
+  call assert_equal(['Xscript0', 'Xscript1', 'Xscript2'], g:func_level)
+
+  unlet g:script_level g:func_level
+  delfunc F0
+  delfunc F1
+  delfunc F2
+
+  call delete('Xscript0')
+  call delete('Xscript1')
+  call delete('Xscript2')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_expand.vim
+++ b/src/nvim/testdir/test_expand.vim
@@ -116,13 +116,21 @@ func Test_source_sfile()
     :call assert_equal('edit <cword>', expandcmd("edit <cword>"))
     :call assert_equal('edit <cexpr>', expandcmd("edit <cexpr>"))
     :call assert_fails('autocmd User MyCmd echo "<sfile>"', 'E498:')
+    :
+    :call assert_equal('', expand('<script>'))
+    :verbose echo expand('<script>')
+    :call add(v:errors, v:errmsg)
+    :verbose echo expand('<sfile>')
+    :call add(v:errors, v:errmsg)
     :call writefile(v:errors, 'Xresult')
     :qall!
-
   [SCRIPT]
   call writefile(lines, 'Xscript')
   if RunVim([], [], '--clean -s Xscript')
-    call assert_equal([], readfile('Xresult'))
+    call assert_equal([
+          \ 'E1274: No script file name to substitute for "<script>"',
+          \ 'E498: no :source file name to substitute for "<sfile>"'],
+          \ readfile('Xresult'))
   endif
   call delete('Xscript')
   call delete('Xresult')

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -107,7 +107,7 @@ endfunc
 
 func Test_expand()
   new
-  call assert_equal("''", expand('%:S'))
+  call assert_equal("", expand('%:S'))
   call assert_equal('3', '<slnum>'->expand())
   call assert_equal(['4'], expand('<slnum>', v:false, v:true))
   " Don't add any line above this, otherwise <slnum> will change.
@@ -115,6 +115,7 @@ func Test_expand()
   set verbose=1
   call assert_equal("", expand('%'))
   set verbose=0
+  call assert_equal("", expand('%:p'))
   quit
 endfunc
 

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -107,10 +107,14 @@ endfunc
 
 func Test_expand()
   new
-  call assert_equal("",  expand('%:S'))
+  call assert_equal("''", expand('%:S'))
   call assert_equal('3', '<slnum>'->expand())
   call assert_equal(['4'], expand('<slnum>', v:false, v:true))
   " Don't add any line above this, otherwise <slnum> will change.
+  call assert_equal("", expand('%'))
+  set verbose=1
+  call assert_equal("", expand('%'))
+  set verbose=0
   quit
 endfunc
 

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -166,6 +166,7 @@ describe(':source', function()
       vim.g.sourced_lua = 1
       vim.g.sfile_value = vim.fn.expand('<sfile>')
       vim.g.stack_value = vim.fn.expand('<stack>')
+      vim.g.script_value = vim.fn.expand('<script>')
     ]])
 
     command('set shellslash')
@@ -173,6 +174,7 @@ describe(':source', function()
     eq(1, eval('g:sourced_lua'))
     matches([[/test%.lua$]], meths.get_var('sfile_value'))
     matches([[/test%.lua$]], meths.get_var('stack_value'))
+    matches([[/test%.lua$]], meths.get_var('script_value'))
 
     os.remove(test_file)
   end)
@@ -214,6 +216,7 @@ describe(':source', function()
        "\ 2]=]
       vim.g.sfile_value = vim.fn.expand('<sfile>')
       vim.g.stack_value = vim.fn.expand('<stack>')
+      vim.g.script_value = vim.fn.expand('<script>')
     ]])
 
     command('edit '..test_file)
@@ -223,6 +226,7 @@ describe(':source', function()
     eq('    \\ 1\n   "\\ 2', exec_lua('return _G.a'))
     eq(':source (no file)', meths.get_var('sfile_value'))
     eq(':source (no file)', meths.get_var('stack_value'))
+    eq(':source (no file)', meths.get_var('script_value'))
 
     os.remove(test_file)
   end)


### PR DESCRIPTION
#### vim-patch:8.2.4726: cannot use expand() to get the script name

Problem:    Cannot use expand() to get the script name.
Solution:   Support expand('<script>'). (closes vim/vim#10121)
https://github.com/vim/vim/commit/6013d0045dec7ca7c0068fbe186c42d754a7368b

Use `.sn_name` instead of `->sn_name` as v8.2.0154 hasn't been ported.
Cherry-pick builtin.txt expand() doc from latest Vim.


#### vim-patch:8.2.4740: when expand() fails there is no error message

Problem:    When expand() fails there is no error message.
Solution:   When 'verbose' is set give an error message.
https://github.com/vim/vim/commit/575445200bd35283191ecd7a0d596b37c5b477a4


#### vim-patch:8.2.4741: startup test fails

Problem:    Startup test fails.
Solution:   Avoid an error for verbose expansion.  Fix that the "0verbose"
            command modifier doesn't work.
https://github.com/vim/vim/commit/60895f3e36def9beb7d5463e792e5154ad9a7a0a

Most code change has already been ported.
Pass `-u NONE -i NONE` in core/job_spec to avoid errors from netrw.


#### vim-patch:8.2.4749: <script> is not expanded in autocmd context

Problem:    <script> is not expanded in autocmd context.
Solution:   Add the context to the pattern struct. (closes vim/vim#10144)
            Rename AutoPatCmd to AutoPatCmd_T.
https://github.com/vim/vim/commit/eca7c60d68e63001dbe3c8e5d240b0895e607fc3

Omit AutoPatCmd -> AutoPatCmd_T rename as it is inconsistent.
Use `.sn_name` instead of `->sn_name` as v8.2.0154 hasn't been ported.
Omit acp_script_stx(), use member directly.


#### vim-patch:8.2.4841: empty string considered an error for expand()

Problem:    Empty string considered an error for expand() when 'verbose' is
            set. (Christian Brabandt)
Solution:   Do not give an error for an empty result.
https://github.com/vim/vim/commit/a96edb736d4274fc4aea460800780e06e1510812


#### vim-patch:8.2.4842: expand("%:p") is not empty when there is no buffer name

Problem:    expand("%:p") is not empty when there is no buffer name.
Solution:   When ignoring errors still return NULL.
https://github.com/vim/vim/commit/211a5bb2353c66684f38527184a258921f95c9d9
