### PR TITLE
vim-patch:9.0.0206: redraw flags are not named specifically

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -993,7 +993,7 @@ void nvim_set_decoration_provider(Integer ns_id, DictionaryOf(LuaRef) opts, Erro
   decor_provider_clear(p);
 
   // regardless of what happens, it seems good idea to redraw
-  redraw_all_later(NOT_VALID);  // TODO(bfredl): too soon?
+  redraw_all_later(UPD_NOT_VALID);  // TODO(bfredl): too soon?
 
   struct {
     const char *name;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -198,7 +198,7 @@ void nvim_set_hl_ns(Integer ns_id, Error *err)
 
   ns_hl_global = (NS)ns_id;
   hl_check_ns();
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
 }
 
 /// Set active namespace for highlights while redrawing.

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -202,7 +202,7 @@ void nvim_win_set_config(Window window, Dict(float_config) *config, Error *err)
     if (!win_new_float(win, false, fconfig, err)) {
       return;
     }
-    redraw_later(win, NOT_VALID);
+    redraw_later(win, UPD_NOT_VALID);
   } else {
     win_config_float(win, fconfig);
     win->w_pos_changed = true;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -118,7 +118,7 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   // make sure cursor is in visible range even if win != curwin
   update_topline_win(win);
 
-  redraw_later(win, VALID);
+  redraw_later(win, UPD_VALID);
   win->w_redr_status = true;
 }
 
@@ -449,5 +449,5 @@ void nvim_win_set_hl_ns(Window window, Integer ns_id, Error *err)
 
   win->w_ns_hl = (NS)ns_id;
   win->w_hl_needs_update = true;
-  redraw_later(win, NOT_VALID);
+  redraw_later(win, UPD_NOT_VALID);
 }

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1623,7 +1623,7 @@ void enter_buffer(buf_T *buf)
   }
   curbuf->b_last_used = time(NULL);
 
-  redraw_later(curwin, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
 }
 
 /// Change to the directory of the current buffer.
@@ -4034,7 +4034,7 @@ void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
       buf->b_signcols.max++;
     }
     buf->b_signcols.size++;
-    redraw_buf_later(buf, NOT_VALID);
+    redraw_buf_later(buf, UPD_NOT_VALID);
     return;
   }
 
@@ -4055,7 +4055,7 @@ void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
     buf->b_signcols.size = linesum;
     buf->b_signcols.max = linesum;
     buf->b_signcols.sentinel = added->se_lnum;
-    redraw_buf_later(buf, NOT_VALID);
+    redraw_buf_later(buf, UPD_NOT_VALID);
   }
 }
 
@@ -4074,7 +4074,7 @@ int buf_signcols(buf_T *buf, int maximum)
     if (signcols != buf->b_signcols.size) {
       buf->b_signcols.size = signcols;
       buf->b_signcols.max = maximum;
-      redraw_buf_later(buf, NOT_VALID);
+      redraw_buf_later(buf, UPD_NOT_VALID);
     }
 
     buf->b_signcols.valid = true;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1353,7 +1353,7 @@ struct window_S {
 
   int w_redr_type;                  // type of redraw to be performed on win
   int w_upd_rows;                   // number of window lines to update when
-                                    // w_redr_type is REDRAW_TOP
+                                    // w_redr_type is UPD_REDRAW_TOP
   linenr_T w_redraw_top;            // when != 0: first line needing redraw
   linenr_T w_redraw_bot;            // when != 0: last line needing redraw
   bool w_redr_status;               // if true statusline/winbar must be redrawn

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -223,8 +223,8 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == curbuf) {
       // Mark this window to be redrawn later.
-      if (wp->w_redr_type < VALID) {
-        wp->w_redr_type = VALID;
+      if (wp->w_redr_type < UPD_VALID) {
+        wp->w_redr_type = UPD_VALID;
       }
 
       // Check if a change in the buffer has invalidated the cached
@@ -301,17 +301,17 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
       // requires a redraw.
       if (wp->w_p_rnu && xtra != 0) {
         wp->w_last_cursor_lnum_rnu = 0;
-        redraw_later(wp, VALID);
+        redraw_later(wp, UPD_VALID);
       }
 
       // Cursor line highlighting probably need to be updated with
-      // "VALID" if it's below the change.
+      // "UPD_VALID" if it's below the change.
       // If the cursor line is inside the change we need to redraw more.
       if (wp->w_p_cul) {
         if (xtra == 0) {
-          redraw_later(wp, VALID);
+          redraw_later(wp, UPD_VALID);
         } else if (lnum <= wp->w_last_cursorline) {
-          redraw_later(wp, SOME_VALID);
+          redraw_later(wp, UPD_SOME_VALID);
         }
       }
     }
@@ -319,8 +319,8 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
 
   // Call update_screen() later, which checks out what needs to be redrawn,
   // since it notices b_mod_set and then uses b_mod_*.
-  if (must_redraw < VALID) {
-    must_redraw = VALID;
+  if (must_redraw < UPD_VALID) {
+    must_redraw = UPD_VALID;
   }
 
   // when the cursor line is changed always trigger CursorMoved
@@ -364,7 +364,7 @@ void changed_bytes(linenr_T lnum, colnr_T col)
   if (curwin->w_p_diff) {
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_diff && wp != curwin) {
-        redraw_later(wp, VALID);
+        redraw_later(wp, UPD_VALID);
         linenr_T wlnum = diff_lnum_win(lnum, wp);
         if (wlnum > 0) {
           changedOneline(wp->w_buffer, wlnum);
@@ -493,7 +493,7 @@ void changed_lines(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T xtra, bo
 
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_p_diff && wp != curwin) {
-        redraw_later(wp, VALID);
+        redraw_later(wp, UPD_VALID);
         wlnum = diff_lnum_win(lnum, wp);
         if (wlnum > 0) {
           changed_lines_buf(wp->w_buffer, wlnum,

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2732,7 +2732,7 @@ void wildmenu_cleanup(CmdlineInfo *cclp)
     p_ls = save_p_ls;
     p_wmh = save_p_wmh;
     last_status(false);
-    update_screen(VALID);                 // redraw the screen NOW
+    update_screen(UPD_VALID);  // redraw the screen NOW
     redrawcmd();
     save_p_ls = -1;
     wild_menu_showing = 0;

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -471,7 +471,7 @@ bool leftcol_changed(void)
   if (retval) {
     curwin->w_set_curswant = true;
   }
-  redraw_later(curwin, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
   return retval;
 }
 

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -275,7 +275,7 @@ void do_debug(char_u *cmd)
 
   RedrawingDisabled--;
   no_wait_return--;
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
   need_wait_return = false;
   msg_scroll = save_msg_scroll;
   lines_left = Rows - 1;

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -120,7 +120,7 @@ void diff_buf_delete(buf_T *buf)
         // don't redraw right away, more might change or buffer state
         // is invalid right now
         need_diff_redraw = true;
-        redraw_later(curwin, VALID);
+        redraw_later(curwin, UPD_VALID);
       }
     }
   }
@@ -659,7 +659,7 @@ void diff_redraw(bool dofold)
       continue;
     }
 
-    redraw_later(wp, SOME_VALID);
+    redraw_later(wp, UPD_SOME_VALID);
     if (wp != curwin) {
       wp_other = wp;
     }
@@ -1448,7 +1448,7 @@ void diff_win_options(win_T *wp, int addbuf)
   if (addbuf) {
     diff_buf_add(wp->w_buffer);
   }
-  redraw_later(wp, NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
 }
 
 /// Set options not to show diffs.  For the current window or all windows.

--- a/src/nvim/drawscreen.h
+++ b/src/nvim/drawscreen.h
@@ -6,13 +6,13 @@
 /// flags for update_screen()
 /// The higher the value, the higher the priority
 enum {
-  VALID        = 10,  ///< buffer not changed, or changes marked with b_mod_*
-  INVERTED     = 20,  ///< redisplay inverted part that changed
-  INVERTED_ALL = 25,  ///< redisplay whole inverted part
-  REDRAW_TOP   = 30,  ///< display first w_upd_rows screen lines
-  SOME_VALID   = 35,  ///< like NOT_VALID but may scroll
-  NOT_VALID    = 40,  ///< buffer needs complete redraw
-  CLEAR        = 50,  ///< screen messed up, clear it
+  UPD_VALID        = 10,  ///< buffer not changed, or changes marked with b_mod_*
+  UPD_INVERTED     = 20,  ///< redisplay inverted part that changed
+  UPD_INVERTED_ALL = 25,  ///< redisplay whole inverted part
+  UPD_REDRAW_TOP   = 30,  ///< display first w_upd_rows screen lines
+  UPD_SOME_VALID   = 35,  ///< like UPD_NOT_VALID but may scroll
+  UPD_NOT_VALID    = 40,  ///< buffer needs complete redraw
+  UPD_CLEAR        = 50,  ///< screen messed up, clear it
 };
 
 /// While redrawing the screen this flag is set.  It means the screen size

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2621,7 +2621,7 @@ static void internal_format(int textwidth, int second_indent, int flags, int for
 
   if (!format_only && haveto_redraw) {
     update_topline(curwin);
-    redraw_curbuf_later(VALID);
+    redraw_curbuf_later(UPD_VALID);
   }
 }
 
@@ -5024,7 +5024,7 @@ static void ins_up(bool startcol)
     }
     if (old_topline != curwin->w_topline
         || old_topfill != curwin->w_topfill) {
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
     }
     start_arrow(&tpos);
     can_cindent = true;
@@ -5072,7 +5072,7 @@ static void ins_down(bool startcol)
     }
     if (old_topline != curwin->w_topline
         || old_topfill != curwin->w_topfill) {
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
     }
     start_arrow(&tpos);
     can_cindent = true;
@@ -5487,7 +5487,7 @@ static int ins_ctrl_ey(int tc)
     } else {
       scrollup_clamp();
     }
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
   } else {
     c = ins_copychar(curwin->w_cursor.lnum + (c == Ctrl_Y ? -1 : 1));
     if (c != NUL) {

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1300,7 +1300,7 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
           set_search_direction(v->di_tv.vval.v_number ? '/' : '?');
         } else if (strcmp(varname, "hlsearch") == 0) {
           no_hlsearch = !v->di_tv.vval.v_number;
-          redraw_all_later(SOME_VALID);
+          redraw_all_later(UPD_SOME_VALID);
         }
         return;
       } else if (v->di_tv.v_type != tv->v_type) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -867,7 +867,7 @@ void ex_retab(exarg_T *eap)
              && tabstop_eq(curbuf->b_p_vts_array, new_vts_array)) {
     // not changed
   } else {
-    redraw_curbuf_later(NOT_VALID);
+    redraw_curbuf_later(UPD_NOT_VALID);
   }
   if (first_line != 0) {
     changed_lines(first_line, 0, last_line + 1, 0L, true);
@@ -1368,7 +1368,7 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char *cmd, b
       xfree(cmd_buf);
       goto error;
     }
-    redraw_curbuf_later(VALID);
+    redraw_curbuf_later(UPD_VALID);
   }
   read_linecount = curbuf->b_ml.ml_line_count;
 
@@ -2910,7 +2910,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     update_topline(curwin);
     curwin->w_scbind_pos = curwin->w_topline;
     *so_ptr = n;
-    redraw_curbuf_later(NOT_VALID);     // redraw this buffer later
+    redraw_curbuf_later(UPD_NOT_VALID);  // redraw this buffer later
   }
 
   // Change directories when the 'acd' option is set.
@@ -3959,9 +3959,9 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
 
               update_topline(curwin);
               validate_cursor();
-              update_screen(SOME_VALID);
+              update_screen(UPD_SOME_VALID);
               highlight_match = false;
-              redraw_later(curwin, SOME_VALID);
+              redraw_later(curwin, UPD_SOME_VALID);
 
               curwin->w_p_fen = save_p_fen;
               if (msg_row == Rows - 1) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -249,8 +249,8 @@ void do_exmode(void)
 
   RedrawingDisabled--;
   no_wait_return--;
-  redraw_all_later(NOT_VALID);
-  update_screen(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
+  update_screen(UPD_NOT_VALID);
   need_wait_return = false;
   msg_scroll = save_msg_scroll;
 }
@@ -5059,7 +5059,7 @@ static void ex_tabs(exarg_T *eap)
 static void ex_mode(exarg_T *eap)
 {
   if (*eap->arg == NUL) {
-    must_redraw = CLEAR;
+    must_redraw = UPD_CLEAR;
     ex_redraw(eap);
   } else {
     emsg(_(e_screenmode));
@@ -5151,7 +5151,7 @@ void do_exedit(exarg_T *eap, win_T *old_curwin)
         no_wait_return = 0;
         need_wait_return = false;
         msg_scroll = 0;
-        redraw_all_later(NOT_VALID);
+        redraw_all_later(UPD_NOT_VALID);
         pending_exmode_active = true;
 
         normal_enter(false, true);
@@ -5313,7 +5313,7 @@ static void ex_syncbind(exarg_T *eap)
         scrolldown(-y, true);
       }
       curwin->w_scbind_pos = topline;
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
       cursor_correct();
       curwin->w_redr_status = true;
     }
@@ -5381,7 +5381,7 @@ static void ex_read(exarg_T *eap)
           deleted_lines_mark(lnum, 1L);
         }
       }
-      redraw_curbuf_later(VALID);
+      redraw_curbuf_later(UPD_VALID);
     }
   }
 }
@@ -6052,11 +6052,11 @@ static void ex_redraw(exarg_T *eap)
   validate_cursor();
   update_topline(curwin);
   if (eap->forceit) {
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
     redraw_cmdline = true;
   }
-  update_screen(eap->forceit ? NOT_VALID
-                : VIsual_active ? INVERTED : 0);
+  update_screen(eap->forceit ? UPD_NOT_VALID
+                : VIsual_active ? UPD_INVERTED : 0);
   if (need_maketitle) {
     maketitle();
   }
@@ -6089,7 +6089,7 @@ static void ex_redrawstatus(exarg_T *eap)
   } else {
     status_redraw_curbuf();
   }
-  update_screen(VIsual_active ? INVERTED : 0);
+  update_screen(VIsual_active ? UPD_INVERTED : 0);
   RedrawingDisabled = r;
   p_lz = p;
   ui_flush();
@@ -6492,7 +6492,7 @@ static void ex_pedit(exarg_T *eap)
   if (curwin != curwin_save && win_valid(curwin_save)) {
     // Return cursor to where we were
     validate_cursor();
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
     win_enter(curwin_save, true);
   }
   g_do_tagpreview = 0;
@@ -7134,7 +7134,7 @@ void set_no_hlsearch(bool flag)
 static void ex_nohlsearch(exarg_T *eap)
 {
   set_no_hlsearch(true);
-  redraw_all_later(SOME_VALID);
+  redraw_all_later(UPD_SOME_VALID);
 }
 
 static void ex_fold(exarg_T *eap)

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -415,7 +415,7 @@ static void may_do_incsearch_highlighting(int firstc, long count, incsearch_stat
   if (patlen == 0 && !use_last_pat) {
     found = 0;
     set_no_hlsearch(true);  // turn off previous highlight
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   } else {
     int search_flags = SEARCH_OPT + SEARCH_NOOF + SEARCH_PEEK;
     ui_busy_start();
@@ -488,7 +488,7 @@ static void may_do_incsearch_highlighting(int firstc, long count, incsearch_stat
     next_char = ccline.cmdbuff[skiplen + patlen];
     ccline.cmdbuff[skiplen + patlen] = NUL;
     if (empty_pattern(ccline.cmdbuff) && !no_hlsearch) {
-      redraw_all_later(SOME_VALID);
+      redraw_all_later(UPD_SOME_VALID);
       set_no_hlsearch(true);
     }
     ccline.cmdbuff[skiplen + patlen] = next_char;
@@ -500,7 +500,7 @@ static void may_do_incsearch_highlighting(int firstc, long count, incsearch_stat
     curwin->w_redr_status = true;
   }
 
-  update_screen(SOME_VALID);
+  update_screen(UPD_SOME_VALID);
   highlight_match = false;
   restore_last_search_pattern();
 
@@ -585,9 +585,9 @@ static void finish_incsearch_highlighting(int gotesc, incsearch_state_T *s, bool
     p_magic = s->magic_save;
 
     validate_cursor();          // needed for TAB
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
     if (call_update_screen) {
-      update_screen(SOME_VALID);
+      update_screen(UPD_SOME_VALID);
     }
   }
 }
@@ -611,7 +611,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
 
     lastwin->w_p_so = 0;
     set_option_value("ch", 1L, NULL, 0);
-    update_screen(VALID);                 // redraw the screen NOW
+    update_screen(UPD_VALID);                 // redraw the screen NOW
 
     made_cmdheight_nonzero = false;
     lastwin->w_p_so = save_so;
@@ -883,7 +883,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
   State = s->save_State;
   if (cmdpreview != save_cmdpreview) {
     cmdpreview = save_cmdpreview;  // restore preview state
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   }
   may_trigger_modechanged();
   setmouse();
@@ -916,7 +916,7 @@ theend:
     // Restore cmdheight
     set_option_value("ch", 0L, NULL, 0);
     // Redraw is needed for command line completion
-    redraw_all_later(CLEAR);
+    redraw_all_later(UPD_CLEAR);
 
     made_cmdheight_nonzero = false;
   }
@@ -1395,7 +1395,7 @@ static int may_do_command_line_next_incsearch(int firstc, long count, incsearch_
     validate_cursor();
     highlight_match = true;
     save_viewstate(curwin, &s->old_viewstate);
-    update_screen(NOT_VALID);
+    update_screen(UPD_NOT_VALID);
     highlight_match = false;
     redrawcmdline();
     curwin->w_cursor = s->match_end;
@@ -2343,7 +2343,7 @@ static bool cmdpreview_may_show(CommandLineState *s)
   if (cmdpreview_type != 0) {
     int save_rd = RedrawingDisabled;
     RedrawingDisabled = 0;
-    update_screen(SOME_VALID);
+    update_screen(UPD_SOME_VALID);
     RedrawingDisabled = save_rd;
   }
 
@@ -2405,7 +2405,7 @@ static int command_line_changed(CommandLineState *s)
     // 'inccommand' preview has been shown.
   } else if (cmdpreview) {
     cmdpreview = false;
-    update_screen(SOME_VALID);  // Clear 'inccommand' preview.
+    update_screen(UPD_SOME_VALID);  // Clear 'inccommand' preview.
   } else {
     if (s->xpc.xp_context == EXPAND_NOTHING && (KeyTyped || vpeekc() == NUL)) {
       may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
@@ -4128,7 +4128,7 @@ static int open_cmdwin(void)
     ccline.redraw_state = kCmdRedrawNone;
     ui_call_cmdline_hide(ccline.level);
   }
-  redraw_later(curwin, SOME_VALID);
+  redraw_later(curwin, UPD_SOME_VALID);
 
   // No Ex mode here!
   exmode_active = false;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1749,7 +1749,7 @@ failed:
       linecnt = 0;
     }
     if (newfile || read_buffer) {
-      redraw_curbuf_later(NOT_VALID);
+      redraw_curbuf_later(UPD_NOT_VALID);
       // After reading the text into the buffer the diff info needs to
       // be updated.
       diff_invalidate(curbuf);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -394,7 +394,7 @@ void opFoldRange(pos_T firstpos, pos_T lastpos, int opening, int recurse, int ha
   }
   // Force a redraw to remove the Visual highlighting.
   if (had_visual) {
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 }
 
@@ -721,7 +721,7 @@ void deleteFold(win_T *const wp, const linenr_T start, const linenr_T end, const
     emsg(_(e_nofold));
     // Force a redraw to remove the Visual highlighting.
     if (had_visual) {
-      redraw_buf_later(wp->w_buffer, INVERTED);
+      redraw_buf_later(wp->w_buffer, UPD_INVERTED);
     }
   } else {
     // Deleting markers may make cursor column invalid
@@ -819,7 +819,7 @@ void foldUpdateAfterInsert(void)
 void foldUpdateAll(win_T *win)
 {
   win->w_foldinvalid = true;
-  redraw_later(win, NOT_VALID);
+  redraw_later(win, UPD_NOT_VALID);
 }
 
 // foldMoveTo() {{{2

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1750,7 +1750,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
 
   if (!ui_has_messages()) {
     // redraw the screen after getchar()
-    update_screen(CLEAR);
+    update_screen(UPD_CLEAR);
   }
 
   set_vim_var_nr(VV_MOUSE_WIN, 0);

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -756,7 +756,7 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
 
 update:
   if (!updating_screen) {
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
   need_highlight_changed = true;
 }
@@ -893,7 +893,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
         hlgroup->sg_script_ctx.sc_lnum += SOURCING_LNUM;
         nlua_set_sctx(&hlgroup->sg_script_ctx);
         hlgroup->sg_cleared = false;
-        redraw_all_later(SOME_VALID);
+        redraw_all_later(UPD_SOME_VALID);
 
         // Only call highlight changed() once after multiple changes
         need_highlight_changed = true;
@@ -916,7 +916,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       }
       init_highlight(true, true);
       highlight_changed();
-      redraw_all_later(NOT_VALID);
+      redraw_all_later(UPD_NOT_VALID);
       return;
     }
     name_end = (const char *)skiptowhite((const char_u *)line);
@@ -1270,12 +1270,12 @@ void do_highlight(const char *line, const bool forceit, const bool init)
       // changed
       ui_refresh();
     } else {
-      // TUI and newer UIs will repaint the screen themselves. NOT_VALID
+      // TUI and newer UIs will repaint the screen themselves. UPD_NOT_VALID
       // redraw below will still handle usages of guibg=fg etc.
       ui_default_colors_set();
     }
     did_highlight_changed = true;
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   } else {
     set_hl_attr(idx);
   }
@@ -1292,7 +1292,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     // redrawing.  This may happen when evaluating 'statusline' changes the
     // StatusLine group.
     if (!updating_screen) {
-      redraw_all_later(NOT_VALID);
+      redraw_all_later(UPD_NOT_VALID);
     }
     need_highlight_changed = true;
   }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1578,7 +1578,7 @@ void ex_luado(exarg_T *const eap)
   }
   lua_pop(lstate, 1);
   check_cursor();
-  update_screen(NOT_VALID);
+  update_screen(UPD_NOT_VALID);
 }
 
 /// Run lua file

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -479,7 +479,7 @@ int main(int argc, char **argv)
   if (exmode_active || use_remote_ui || use_builtin_ui) {
     // Don't clear the screen when starting in Ex mode, or when a UI might have
     // displayed messages.
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
   } else {
     screenclear();  // clear screen
     TIME_MSG("clearing screen");
@@ -539,7 +539,7 @@ int main(int argc, char **argv)
   starting = 0;
 
   RedrawingDisabled = 0;
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
   no_wait_return = false;
 
   // 'autochdir' has been postponed.

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -47,7 +47,7 @@ static int match_add(win_T *wp, const char *const grp, const char *const pat, in
   matchitem_T *m;
   int hlg_id;
   regprog_T *regprog = NULL;
-  int rtype = SOME_VALID;
+  int rtype = UPD_SOME_VALID;
 
   if (*grp == NUL || (pat != NULL && *pat == NUL)) {
     return -1;
@@ -193,7 +193,7 @@ static int match_add(win_T *wp, const char *const grp, const char *const pat, in
       }
       m->pos.toplnum = toplnum;
       m->pos.botlnum = botlnum;
-      rtype = VALID;
+      rtype = UPD_VALID;
     }
   }
 
@@ -227,7 +227,7 @@ static int match_delete(win_T *wp, int id, bool perr)
 {
   matchitem_T *cur = wp->w_match_head;
   matchitem_T *prev = cur;
-  int rtype = SOME_VALID;
+  int rtype = UPD_SOME_VALID;
 
   if (id < 1) {
     if (perr) {
@@ -268,7 +268,7 @@ static int match_delete(win_T *wp, int id, bool perr)
       wp->w_buffer->b_mod_bot = cur->pos.botlnum;
       wp->w_buffer->b_mod_xlines = 0;
     }
-    rtype = VALID;
+    rtype = UPD_VALID;
   }
   xfree(cur);
   redraw_later(wp, rtype);
@@ -287,7 +287,7 @@ void clear_matches(win_T *wp)
     xfree(wp->w_match_head);
     wp->w_match_head = m;
   }
-  redraw_later(wp, SOME_VALID);
+  redraw_later(wp, UPD_SOME_VALID);
 }
 
 /// Get match from ID 'id' in window 'wp'.

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2857,7 +2857,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, FunPtr fptr)
   }
 
   xfree(cw_table_save);
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
 }
 
 void f_charclass(typval_T *argvars, typval_T *rettv, FunPtr fptr)

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1222,7 +1222,7 @@ void ml_recover(bool checkext)
     msg_puts(_("\nYou may want to delete the .swp file now.\n\n"));
     cmdline_row = msg_row;
   }
-  redraw_curbuf_later(NOT_VALID);
+  redraw_curbuf_later(UPD_NOT_VALID);
 
 theend:
   xfree(fname_used);
@@ -2453,7 +2453,7 @@ int ml_replace(linenr_T lnum, char *line, bool copy)
 /// Do not use it after calling ml_replace().
 ///
 /// Check: The caller of this function should probably also call
-/// changed_lines(), unless update_screen(NOT_VALID) is used.
+/// changed_lines(), unless update_screen(UPD_NOT_VALID) is used.
 ///
 /// @return  FAIL for failure, OK otherwise
 int ml_replace_buf(buf_T *buf, linenr_T lnum, char_u *line, bool copy)

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1131,7 +1131,7 @@ void msg_end_prompt(void)
 
 /// Wait for the user to hit a key (normally Enter)
 ///
-/// @param redraw  if true, redraw the entire screen NOT_VALID
+/// @param redraw  if true, redraw the entire screen UPD_NOT_VALID
 ///                if false, do a normal redraw
 ///                if -1, don't redraw at all
 void wait_return(int redraw)
@@ -1143,7 +1143,7 @@ void wait_return(int redraw)
   FILE *save_scriptout;
 
   if (redraw == true) {
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
 
   // If using ":silent cmd", don't wait for a return.  Also don't set
@@ -1316,7 +1316,7 @@ void wait_return(int redraw)
     ui_refresh();
   } else if (!skip_redraw) {
     if (redraw == true || (msg_scrolled != 0 && redraw != -1)) {
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
     }
     if (ui_has(kUIMessages)) {
       msg_ext_clear(true);
@@ -2478,7 +2478,7 @@ void msg_reset_scroll(void)
       }
     }
   } else {
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
   msg_scrolled = 0;
   msg_scrolled_at_flush = 0;
@@ -2506,8 +2506,8 @@ static void inc_msg_scrolled(void)
     xfree(tofree);
   }
   msg_scrolled++;
-  if (must_redraw < VALID) {
-    must_redraw = VALID;
+  if (must_redraw < UPD_VALID) {
+    must_redraw = UPD_VALID;
   }
 }
 
@@ -3245,8 +3245,8 @@ void msg_ext_clear_later(void)
 {
   if (msg_ext_is_visible()) {
     msg_ext_need_clear = true;
-    if (must_redraw < VALID) {
-      must_redraw = VALID;
+    if (must_redraw < UPD_VALID) {
+      must_redraw = UPD_VALID;
     }
   }
 }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -179,7 +179,7 @@ retnomove:
     }
     if (flags & MOUSE_MAY_STOP_VIS) {
       end_visual_mode();
-      redraw_curbuf_later(INVERTED);            // delete the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // delete the inversion
     }
     return IN_BUFFER;
   }
@@ -279,7 +279,7 @@ retnomove:
                     : col >= fdc + (cmdwin_type == 0 && wp == curwin ? 0 : 1))
                 && (flags & MOUSE_MAY_STOP_VIS)))) {
       end_visual_mode();
-      redraw_curbuf_later(INVERTED);            // delete the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // delete the inversion
     }
     if (cmdwin_type != 0 && wp != curwin) {
       // A click outside the command-line window: Use modeless
@@ -345,7 +345,7 @@ retnomove:
     // before moving the cursor for a left click, stop Visual mode
     if (flags & MOUSE_MAY_STOP_VIS) {
       end_visual_mode();
-      redraw_curbuf_later(INVERTED);            // delete the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // delete the inversion
     }
 
     if (grid == 0) {
@@ -381,7 +381,7 @@ retnomove:
       check_topfill(curwin, false);
       curwin->w_valid &=
         ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
       row = 0;
     } else if (row >= curwin->w_height_inner) {
       count = 0;
@@ -410,7 +410,7 @@ retnomove:
         }
       }
       check_topfill(curwin, false);
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
       curwin->w_valid &=
         ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_BOTLINE_AP);
       row = curwin->w_height_inner - 1;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -105,7 +105,7 @@ void redraw_for_cursorline(win_T *wp)
   if ((wp->w_valid & VALID_CROW) == 0 && !pum_visible()
       && (wp->w_p_rnu || win_cursorline_standout(wp))) {
     // win_line() will redraw the number column and cursorline only.
-    redraw_later(wp, VALID);
+    redraw_later(wp, UPD_VALID);
   }
 }
 
@@ -118,11 +118,11 @@ static void redraw_for_cursorcolumn(win_T *wp)
   if ((wp->w_valid & VALID_VIRTCOL) == 0 && !pum_visible()) {
     if (wp->w_p_cuc || ((HL_ATTR(HLF_LC) || win_hl_attr(wp, HLF_LC)) && using_hlsearch())) {
       // When 'cursorcolumn' is set or "CurSearch" is in use
-      // need to redraw with SOME_VALID.
-      redraw_later(wp, SOME_VALID);
+      // need to redraw with UPD_SOME_VALID.
+      redraw_later(wp, UPD_SOME_VALID);
     } else if (wp->w_p_cul && (wp->w_p_culopt_flags & CULOPT_SCRLINE)) {
-      // When 'cursorlineopt' contains "screenline" need to redraw with VALID.
-      redraw_later(wp, VALID);
+      // When 'cursorlineopt' contains "screenline" need to redraw with UPD_VALID.
+      redraw_later(wp, UPD_VALID);
     }
   }
   // If the cursor moves horizontally when 'concealcursor' is active, then the
@@ -184,7 +184,7 @@ void update_topline(win_T *wp)
   // If the buffer is empty, always set topline to 1.
   if (buf_is_empty(curbuf)) {             // special case - file is empty
     if (wp->w_topline != 1) {
-      redraw_later(wp, NOT_VALID);
+      redraw_later(wp, UPD_NOT_VALID);
     }
     wp->w_topline = 1;
     wp->w_botline = 2;
@@ -336,9 +336,9 @@ void update_topline(win_T *wp)
     dollar_vcol = -1;
     if (wp->w_skipcol != 0) {
       wp->w_skipcol = 0;
-      redraw_later(wp, NOT_VALID);
+      redraw_later(wp, UPD_NOT_VALID);
     } else {
-      redraw_later(wp, VALID);
+      redraw_later(wp, UPD_VALID);
     }
     // May need to set w_skipcol when cursor in w_topline.
     if (wp->w_cursor.lnum == wp->w_topline) {
@@ -450,7 +450,7 @@ void changed_window_setting_win(win_T *wp)
   wp->w_lines_valid = 0;
   changed_line_abv_curs_win(wp);
   wp->w_valid &= ~(VALID_BOTLINE|VALID_BOTLINE_AP|VALID_TOPLINE);
-  redraw_later(wp, NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
 }
 
 /*
@@ -472,7 +472,7 @@ void set_topline(win_T *wp, linenr_T lnum)
   }
   wp->w_valid &= ~(VALID_WROW|VALID_CROW|VALID_BOTLINE|VALID_TOPLINE);
   // Don't set VALID_TOPLINE here, 'scrolloff' needs to be checked.
-  redraw_later(wp, VALID);
+  redraw_later(wp, UPD_VALID);
 }
 
 /*
@@ -847,7 +847,7 @@ void curs_columns(win_T *wp, int may_scroll)
         wp->w_leftcol = new_leftcol;
         win_check_anchored_floats(wp);
         // screen has to be redrawn with new wp->w_leftcol
-        redraw_later(wp, NOT_VALID);
+        redraw_later(wp, UPD_NOT_VALID);
       }
     }
     wp->w_wcol -= wp->w_leftcol;
@@ -954,7 +954,7 @@ void curs_columns(win_T *wp, int may_scroll)
     wp->w_skipcol = 0;
   }
   if (prev_skipcol != wp->w_skipcol) {
-    redraw_later(wp, NOT_VALID);
+    redraw_later(wp, UPD_NOT_VALID);
   }
 
   redraw_for_cursorcolumn(curwin);
@@ -2040,7 +2040,7 @@ int onepage(Direction dir, long count)
     }
   }
 
-  redraw_later(curwin, VALID);
+  redraw_later(curwin, UPD_VALID);
   return retval;
 }
 
@@ -2232,7 +2232,7 @@ void halfpage(bool flag, linenr_T Prenum)
   check_topfill(curwin, !flag);
   cursor_correct();
   beginline(BL_SOL | BL_FIX);
-  redraw_later(curwin, VALID);
+  redraw_later(curwin, UPD_VALID);
 }
 
 void do_check_cursorbind(void)
@@ -2284,7 +2284,7 @@ void do_check_cursorbind(void)
       }
       // Correct cursor for multi-byte character.
       mb_adjust_cursor();
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
 
       // Only scroll when 'scrollbind' hasn't done this.
       if (!curwin->w_p_scb) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -523,7 +523,7 @@ static bool normal_handle_special_visual_command(NormalState *s)
       && (nv_cmds[s->idx].cmd_flags & NV_STS)
       && !(mod_mask & MOD_MASK_SHIFT)) {
     end_visual_mode();
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 
   // Keys that work different when 'keymodel' contains "startsel"
@@ -1281,7 +1281,7 @@ static void normal_redraw(NormalState *s)
   validate_cursor();
 
   if (VIsual_active) {
-    redraw_curbuf_later(INVERTED);  // update inverted part
+    redraw_curbuf_later(UPD_INVERTED);  // update inverted part
     update_screen(0);
   } else if (must_redraw) {
     update_screen(0);
@@ -1838,7 +1838,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       }
       if (jump_flags) {
         jump_flags = jump_to_mouse(jump_flags, NULL, which_button);
-        redraw_curbuf_later(VIsual_active ? INVERTED : VALID);
+        redraw_curbuf_later(VIsual_active ? UPD_INVERTED : UPD_VALID);
         update_screen(0);
         setcursor();
         ui_flush();  // Update before showing popup menu
@@ -2186,7 +2186,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       curwin->w_set_curswant = true;
     }
     if (is_click) {
-      redraw_curbuf_later(INVERTED);            // update the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     }
   } else if (VIsual_active && !old_active) {
     if (mod_mask & MOD_MASK_ALT) {
@@ -2311,7 +2311,7 @@ void reset_VIsual_and_resel(void)
 {
   if (VIsual_active) {
     end_visual_mode();
-    redraw_curbuf_later(INVERTED);      // delete the inversion later
+    redraw_curbuf_later(UPD_INVERTED);  // delete the inversion later
   }
   VIsual_reselect = false;
 }
@@ -2321,7 +2321,7 @@ void reset_VIsual(void)
 {
   if (VIsual_active) {
     end_visual_mode();
-    redraw_curbuf_later(INVERTED);      // delete the inversion later
+    redraw_curbuf_later(UPD_INVERTED);  // delete the inversion later
     VIsual_reselect = false;
   }
 }
@@ -2956,7 +2956,7 @@ void check_scrollbind(linenr_T topline_diff, long leftcol_diff)
         }
       }
 
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
       cursor_correct();
       curwin->w_redr_status = true;
     }
@@ -3490,7 +3490,7 @@ void scroll_redraw(int up, long count)
   if (moved) {
     curwin->w_viewport_invalid = true;
   }
-  redraw_later(curwin, VALID);
+  redraw_later(curwin, UPD_VALID);
 }
 
 /// Get the count specified after a 'z' command. Only the 'z<CR>', 'zl', 'zh',
@@ -3656,7 +3656,7 @@ static void nv_zet(cmdarg_T *cap)
 
   case 't':
     scroll_cursor_top(0, true);
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
     set_fraction(curwin);
     break;
 
@@ -3667,7 +3667,7 @@ static void nv_zet(cmdarg_T *cap)
 
   case 'z':
     scroll_cursor_halfway(true);
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
     set_fraction(curwin);
     break;
 
@@ -3690,7 +3690,7 @@ static void nv_zet(cmdarg_T *cap)
 
   case 'b':
     scroll_cursor_bot(0, true);
-    redraw_later(curwin, VALID);
+    redraw_later(curwin, UPD_VALID);
     set_fraction(curwin);
     break;
 
@@ -3742,7 +3742,7 @@ static void nv_zet(cmdarg_T *cap)
       }
       if (curwin->w_leftcol != col) {
         curwin->w_leftcol = col;
-        redraw_later(curwin, NOT_VALID);
+        redraw_later(curwin, UPD_NOT_VALID);
       }
     }
     break;
@@ -3763,7 +3763,7 @@ static void nv_zet(cmdarg_T *cap)
       }
       if (curwin->w_leftcol != col) {
         curwin->w_leftcol = col;
-        redraw_later(curwin, NOT_VALID);
+        redraw_later(curwin, UPD_NOT_VALID);
       }
     }
     break;
@@ -4098,7 +4098,7 @@ static void nv_clear(cmdarg_T *cap)
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       wp->w_s->b_syn_slow = false;
     }
-    redraw_later(curwin, CLEAR);
+    redraw_later(curwin, UPD_CLEAR);
   }
 }
 
@@ -5819,7 +5819,7 @@ static void nv_visual(cmdarg_T *cap)
       showmode();
       may_trigger_modechanged();
     }
-    redraw_curbuf_later(INVERTED);          // update the inversion
+    redraw_curbuf_later(UPD_INVERTED);  // update the inversion
   } else {                // start Visual mode
     if (cap->count0 > 0 && resel_VIsual_mode != NUL) {
       // use previously selected part
@@ -5865,7 +5865,7 @@ static void nv_visual(cmdarg_T *cap)
       } else {
         curwin->w_set_curswant = true;
       }
-      redraw_curbuf_later(INVERTED);            // show the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // show the inversion
     } else {
       if (!cap->arg) {
         // start Select mode when 'selectmode' contains "cmd"
@@ -5931,7 +5931,7 @@ static void n_start_visual_mode(int c)
   }
   // Only need to redraw this line, unless still need to redraw an old
   // Visual area (when 'lazyredraw' is set).
-  if (curwin->w_redr_type < INVERTED) {
+  if (curwin->w_redr_type < UPD_INVERTED) {
     curwin->w_old_cursor_lnum = curwin->w_cursor.lnum;
     curwin->w_old_visual_lnum = curwin->w_cursor.lnum;
   }
@@ -6018,7 +6018,7 @@ static void nv_gv_cmd(cmdarg_T *cap)
     may_start_select('c');
   }
   setmouse();
-  redraw_curbuf_later(INVERTED);
+  redraw_curbuf_later(UPD_INVERTED);
   showmode();
 }
 
@@ -6901,7 +6901,7 @@ static void nv_normal(cmdarg_T *cap)
     }
     if (VIsual_active) {
       end_visual_mode();                // stop Visual
-      redraw_curbuf_later(INVERTED);
+      redraw_curbuf_later(UPD_INVERTED);
     }
   } else {
     clearopbeep(cap->oap);
@@ -6955,7 +6955,7 @@ static void nv_esc(cmdarg_T *cap)
     end_visual_mode();          // stop Visual
     check_cursor_col();         // make sure cursor is not beyond EOL
     curwin->w_set_curswant = true;
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   } else if (no_reason) {
     vim_beep(BO_ESC);
   }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -682,7 +682,7 @@ void op_reindent(oparg_T *oap, Indenter how)
                   oap->is_VIsual ? start_lnum + (linenr_T)oap->line_count :
                   last_changed + 1, 0L, true);
   } else if (oap->is_VIsual) {
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 
   if (oap->line_count > p_report) {
@@ -909,7 +909,7 @@ int do_record(int c)
       if (!ui_has_messages()) {
         // Enable macro indicator temporarily
         set_option_value("ch", 1L, NULL, 0);
-        update_screen(VALID);
+        update_screen(UPD_VALID);
 
         changed_cmdheight = true;
       }
@@ -963,7 +963,7 @@ int do_record(int c)
     if (changed_cmdheight) {
       // Restore cmdheight
       set_option_value("ch", 0L, NULL, 0);
-      redraw_all_later(CLEAR);
+      redraw_all_later(UPD_CLEAR);
     }
   }
   return retval;
@@ -2143,7 +2143,7 @@ void op_tilde(oparg_T *oap)
 
   if (!did_change && oap->is_VIsual) {
     // No change: need to remove the Visual selection
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
@@ -2262,7 +2262,7 @@ void op_insert(oparg_T *oap, long count1)
 
   // vis block is still marked. Get rid of it now.
   curwin->w_cursor.lnum = oap->start.lnum;
-  update_screen(INVERTED);
+  update_screen(UPD_INVERTED);
 
   if (oap->motion_type == kMTBlockWise) {
     // When 'virtualedit' is used, need to insert the extra spaces before
@@ -4309,7 +4309,7 @@ static void op_format(oparg_T *oap, int keep_cursor)
 
   if (oap->is_VIsual) {
     // When there is no change: need to remove the Visual selection
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {
@@ -4370,7 +4370,7 @@ static void op_formatexpr(oparg_T *oap)
 {
   if (oap->is_VIsual) {
     // When there is no change: need to remove the Visual selection
-    redraw_curbuf_later(INVERTED);
+    redraw_curbuf_later(UPD_INVERTED);
   }
 
   if (fex_format(oap->start.lnum, oap->line_count, NUL) != 0) {
@@ -4962,7 +4962,7 @@ void op_addsub(oparg_T *oap, linenr_T Prenum1, bool g_cmd)
 
     if (!change_cnt && oap->is_VIsual) {
       // No change: need to remove the Visual selection
-      redraw_curbuf_later(INVERTED);
+      redraw_curbuf_later(UPD_INVERTED);
     }
 
     // Set '[ mark if something changed. Keep the last end
@@ -6596,7 +6596,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
             && oap->motion_force == NUL) {
           // Make sure redrawing is correct.
           curwin->w_p_lbr = lbr_saved;
-          redraw_curbuf_later(INVERTED);
+          redraw_curbuf_later(UPD_INVERTED);
         }
       }
     }
@@ -6628,7 +6628,7 @@ void do_pending_operator(cmdarg_T *cap, int old_col, bool gui_yank)
     if (oap->is_VIsual && (oap->empty || !MODIFIABLE(curbuf)
                            || oap->op_type == OP_FOLD)) {
       curwin->w_p_lbr = lbr_saved;
-      redraw_curbuf_later(INVERTED);
+      redraw_curbuf_later(UPD_INVERTED);
     }
 
     // If the end of an operator is in column one while oap->motion_type

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -847,7 +847,7 @@ int do_set(char *arg, int opt_flags)
         didset_options();
         didset_options2();
         ui_refresh_options();
-        redraw_all_later(CLEAR);
+        redraw_all_later(UPD_CLEAR);
       } else {
         showoptions(1, opt_flags);
         did_show = true;
@@ -2089,7 +2089,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
     paste_option_changed();
   } else if ((int *)varp == &p_ic && p_hls) {
     // when 'ignorecase' is set or reset and 'hlsearch' is set, redraw
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   } else if ((int *)varp == &p_hls) {
     // when 'hlsearch' is set or reset: reset no_hlsearch
     set_no_hlsearch(false);
@@ -2184,7 +2184,7 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
         // Enable Arabic shaping (major part of what Arabic requires)
         if (!p_arshape) {
           p_arshape = true;
-          redraw_all_later(NOT_VALID);
+          redraw_all_later(UPD_NOT_VALID);
         }
       }
 
@@ -2741,15 +2741,15 @@ void check_redraw(uint32_t flags)
     changed_window_setting();
   }
   if (flags & P_RBUF) {
-    redraw_curbuf_later(NOT_VALID);
+    redraw_curbuf_later(UPD_NOT_VALID);
   }
   if (flags & P_RWINONLY) {
-    redraw_later(curwin, NOT_VALID);
+    redraw_later(curwin, UPD_NOT_VALID);
   }
   if (doclear) {
-    redraw_all_later(CLEAR);
+    redraw_all_later(UPD_CLEAR);
   } else if (all) {
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
 }
 
@@ -3817,12 +3817,12 @@ void unset_global_local_option(char *name, void *from)
   case PV_LCS:
     clear_string_option(&((win_T *)from)->w_p_lcs);
     set_chars_option((win_T *)from, &((win_T *)from)->w_p_lcs, true);
-    redraw_later((win_T *)from, NOT_VALID);
+    redraw_later((win_T *)from, UPD_NOT_VALID);
     break;
   case PV_FCS:
     clear_string_option(&((win_T *)from)->w_p_fcs);
     set_chars_option((win_T *)from, &((win_T *)from)->w_p_fcs, true);
-    redraw_later((win_T *)from, NOT_VALID);
+    redraw_later((win_T *)from, UPD_NOT_VALID);
     break;
   case PV_VE:
     clear_string_option(&((win_T *)from)->w_p_ve);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -895,7 +895,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
       // Redraw needed when switching to/from "mac": a CR in the text
       // will be displayed differently.
       if (get_fileformat(curbuf) == EOL_MAC || *oldval == 'm') {
-        redraw_curbuf_later(NOT_VALID);
+        redraw_curbuf_later(UPD_NOT_VALID);
       }
     }
   } else if (varp == (char_u **)&p_ffs) {  // 'fileformats'
@@ -962,7 +962,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
         // here, so ignore the return value.
         (void)set_chars_option(wp, &wp->w_p_lcs, true);
       }
-      redraw_all_later(NOT_VALID);
+      redraw_all_later(UPD_NOT_VALID);
     }
   } else if (varp == &curwin->w_p_lcs) {  // local 'listchars'
     errmsg = set_chars_option(curwin, varp, true);
@@ -979,7 +979,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
         // here, so ignore the return value.
         (void)set_chars_option(wp, &wp->w_p_fcs, true);
       }
-      redraw_all_later(NOT_VALID);
+      redraw_all_later(UPD_NOT_VALID);
     }
   } else if (varp == &curwin->w_p_fcs) {  // local 'fillchars'
     errmsg = set_chars_option(curwin, varp, true);
@@ -1158,7 +1158,7 @@ char *did_set_string_option(int opt_idx, char_u **varp, char_u *oldval, char *er
     } else {
       if (curwin->w_status_height || global_stl_height()) {
         curwin->w_redr_status = true;
-        redraw_later(curwin, VALID);
+        redraw_later(curwin, UPD_VALID);
       }
       curbuf->b_help = (curbuf->b_p_bt[0] == 'h');
       redraw_titles();

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -802,7 +802,7 @@ static bool pum_set_selected(int n, int repeat)
 
             // Return cursor to where we were
             validate_cursor();
-            redraw_later(curwin, SOME_VALID);
+            redraw_later(curwin, UPD_SOME_VALID);
 
             // When the preview window was resized we need to
             // update the view on the buffer.  Only go back to

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3710,7 +3710,7 @@ static void qf_win_goto(win_T *win, linenr_T lnum)
   curwin->w_cursor.coladd = 0;
   curwin->w_curswant = 0;
   update_topline(curwin);              // scroll to show the line
-  redraw_later(curwin, VALID);
+  redraw_later(curwin, UPD_VALID);
   curwin->w_redr_status = true;  // update ruler
   curwin = old_curwin;
   curbuf = curwin->w_buffer;
@@ -3898,7 +3898,7 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
     // Only redraw when added lines are visible.  This avoids flickering when
     // the added lines are not visible.
     if ((win = qf_find_win(qi)) != NULL && old_line_count < win->w_botline) {
-      redraw_buf_later(buf, NOT_VALID);
+      redraw_buf_later(buf, UPD_NOT_VALID);
     }
   }
 }
@@ -4118,7 +4118,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     curbuf->b_ro_locked--;
 
     // make sure it will be redrawn
-    redraw_curbuf_later(NOT_VALID);
+    redraw_curbuf_later(UPD_NOT_VALID);
   }
 
   // Restore KeyTyped, setting 'filetype' may reset it.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -220,7 +220,7 @@ void save_re_pat(int idx, char_u *pat, int magic)
     last_idx = idx;
     // If 'hlsearch' set and search pat changed: need redraw.
     if (p_hls) {
-      redraw_all_later(SOME_VALID);
+      redraw_all_later(UPD_SOME_VALID);
     }
     set_no_hlsearch(false);
   }
@@ -498,7 +498,7 @@ void set_last_search_pat(const char_u *s, int idx, int magic, int setlast)
   }
   // If 'hlsearch' set and search pat changed: need redraw.
   if (p_hls && idx == last_idx && !no_hlsearch) {
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   }
 }
 
@@ -1093,7 +1093,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char_u *pat, long count,
    * Turn 'hlsearch' highlighting back on.
    */
   if (no_hlsearch && !(options & SEARCH_KEEP)) {
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
     set_no_hlsearch(false);
   }
 
@@ -2414,7 +2414,7 @@ void showmatch(int c)
         dollar_vcol = -1;
       }
       curwin->w_virtcol++;              // do display ')' just before "$"
-      update_screen(VALID);             // show the new char first
+      update_screen(UPD_VALID);         // show the new char first
 
       save_dollar_vcol = dollar_vcol;
       save_state = State;
@@ -3107,7 +3107,7 @@ int current_word(oparg_T *oap, long count, int include, int bigword)
     if (VIsual_active) {
       // should do something when inclusive == false !
       VIsual = start_pos;
-      redraw_curbuf_later(INVERTED);            // update the inversion
+      redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     } else {
       oap->start = start_pos;
       oap->motion_type = kMTCharWise;
@@ -3362,7 +3362,7 @@ extend:
     VIsual = start_pos;
     VIsual_mode = 'v';
     redraw_cmdline = true;    // show mode later
-    redraw_curbuf_later(INVERTED);      // update the inversion
+    redraw_curbuf_later(UPD_INVERTED);  // update the inversion
   } else {
     // include a newline after the sentence, if there is one
     if (incl(&curwin->w_cursor) == -1) {
@@ -3502,7 +3502,7 @@ int current_block(oparg_T *oap, long count, int include, int what, int other)
     }
     VIsual = start_pos;
     VIsual_mode = 'v';
-    redraw_curbuf_later(INVERTED);      // update the inversion
+    redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     showmode();
   } else {
     oap->start = start_pos;
@@ -3744,7 +3744,7 @@ again:
     }
     VIsual = start_pos;
     VIsual_mode = 'v';
-    redraw_curbuf_later(INVERTED);      // update the inversion
+    redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     showmode();
   } else {
     oap->start = start_pos;
@@ -3924,7 +3924,7 @@ extend:
       VIsual.col = 0;
     }
     VIsual_mode = 'V';
-    redraw_curbuf_later(INVERTED);      // update the inversion
+    redraw_curbuf_later(UPD_INVERTED);  // update the inversion
     showmode();
   } else {
     oap->start.lnum = start_lnum;
@@ -4196,7 +4196,7 @@ bool current_quote(oparg_T *oap, long count, bool include, int quotechar)
                     && (VIsual.col == 0
                         || line[VIsual.col - 1] != quotechar))))) {
       VIsual = curwin->w_cursor;
-      redraw_curbuf_later(INVERTED);
+      redraw_curbuf_later(UPD_INVERTED);
     }
   } else {
     oap->start = curwin->w_cursor;
@@ -4389,7 +4389,7 @@ int current_search(long count, bool forward)
 
   may_start_select('c');
   setmouse();
-  redraw_curbuf_later(INVERTED);
+  redraw_curbuf_later(UPD_INVERTED);
   showmode();
 
   return OK;
@@ -5827,7 +5827,7 @@ search_line:
             && curwin != curwin_save && win_valid(curwin_save)) {
           // Return cursor to where we were
           validate_cursor();
-          redraw_later(curwin, VALID);
+          redraw_later(curwin, UPD_VALID);
           win_enter(curwin_save, true);
         }
         break;

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -203,7 +203,7 @@ static void insert_sign(buf_T *buf, sign_entry_T *prev, sign_entry_T *next, int 
     // When adding first sign need to redraw the windows to create the
     // column for signs.
     if (buf->b_signlist == NULL) {
-      redraw_buf_later(buf, NOT_VALID);
+      redraw_buf_later(buf, UPD_NOT_VALID);
       changed_line_abv_curs();
     }
 
@@ -576,7 +576,7 @@ static linenr_T buf_delsign(buf_T *buf, linenr_T atlnum, int id, char_u *group)
   // When deleting the last sign the cursor position may change, because the
   // sign columns no longer shows.  And the 'signcolumn' may be hidden.
   if (buf->b_signlist == NULL) {
-    redraw_buf_later(buf, NOT_VALID);
+    redraw_buf_later(buf, UPD_NOT_VALID);
     changed_line_abv_curs();
   }
 
@@ -934,7 +934,7 @@ static int sign_define_by_name(char_u *name, char_u *icon, char_u *linehl, char_
     // non-empty sign list.
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer->b_signlist != NULL) {
-        redraw_buf_later(wp->w_buffer, NOT_VALID);
+        redraw_buf_later(wp->w_buffer, UPD_NOT_VALID);
       }
     }
   }
@@ -1084,7 +1084,7 @@ static int sign_unplace(int sign_id, char_u *sign_group, buf_T *buf, linenr_T at
   }
   if (sign_id == 0) {
     // Delete all the signs in the specified buffer
-    redraw_buf_later(buf, NOT_VALID);
+    redraw_buf_later(buf, UPD_NOT_VALID);
     buf_delete_signs(buf, (char *)sign_group);
   } else {
     linenr_T lnum;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2089,7 +2089,7 @@ char *did_set_spelllang(win_T *wp)
       }
     }
   }
-  redraw_later(wp, NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
 
 theend:
   xfree(spl_copy);
@@ -3117,7 +3117,7 @@ void ex_spelldump(exarg_T *eap)
   if (curbuf->b_ml.ml_line_count > 1) {
     ml_delete(curbuf->b_ml.ml_line_count, false);
   }
-  redraw_later(curwin, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
 }
 
 /// Go through all possible words and:

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1828,7 +1828,7 @@ static void spell_reload_one(char_u *fname, bool added_word)
         // reloading failed, clear the language
         slang_clear(slang);
       }
-      redraw_all_later(SOME_VALID);
+      redraw_all_later(UPD_SOME_VALID);
       didit = true;
     }
   }
@@ -5667,7 +5667,7 @@ void spell_add_word(char_u *word, int len, SpellAddType what, int idx, bool undo
       buf_reload(buf, buf->b_orig_mode, false);
     }
 
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   }
   xfree(fnamebuf);
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3143,7 +3143,7 @@ static void syn_cmd_spell(exarg_T *eap, int syncing)
   }
 
   // assume spell checking changed, force a redraw
-  redraw_later(curwin, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
 }
 
 /// Handle ":syntax iskeyword" command.
@@ -3183,7 +3183,7 @@ static void syn_cmd_iskeyword(exarg_T *eap, int syncing)
       curbuf->b_p_isk = save_isk;
     }
   }
-  redraw_later(curwin, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
 }
 
 /*
@@ -3383,7 +3383,7 @@ static void syn_cmd_clear(exarg_T *eap, int syncing)
       arg = (char_u *)skipwhite((char *)arg_end);
     }
   }
-  redraw_curbuf_later(SOME_VALID);
+  redraw_curbuf_later(UPD_SOME_VALID);
   syn_stack_free_all(curwin->w_s);              // Need to recompute all syntax.
 }
 
@@ -4420,7 +4420,7 @@ error:
     semsg(_(e_invarg2), arg);
   }
 
-  redraw_curbuf_later(SOME_VALID);
+  redraw_curbuf_later(UPD_SOME_VALID);
   syn_stack_free_all(curwin->w_s);              // Need to recompute all syntax.
 }
 
@@ -4502,7 +4502,7 @@ static void syn_cmd_match(exarg_T *eap, int syncing)
           ++curwin->w_s->b_syn_folditems;
         }
 
-        redraw_curbuf_later(SOME_VALID);
+        redraw_curbuf_later(UPD_SOME_VALID);
         syn_stack_free_all(curwin->w_s);          // Need to recompute all syntax.
         return;           // don't free the progs and patterns now
       }
@@ -4718,7 +4718,7 @@ static void syn_cmd_region(exarg_T *eap, int syncing)
           }
         }
 
-        redraw_curbuf_later(SOME_VALID);
+        redraw_curbuf_later(UPD_SOME_VALID);
         syn_stack_free_all(curwin->w_s);  // Need to recompute all syntax.
         success = true;                   // don't free the progs and patterns now
       }
@@ -5021,7 +5021,7 @@ static void syn_cmd_cluster(exarg_T *eap, int syncing)
     }
 
     if (got_clstr) {
-      redraw_curbuf_later(SOME_VALID);
+      redraw_curbuf_later(UPD_SOME_VALID);
       syn_stack_free_all(curwin->w_s);          // Need to recompute all.
     }
   }
@@ -5265,7 +5265,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
     semsg(_("E404: Illegal arguments: %s"), arg_start);
   } else if (!finished) {
     eap->nextcmd = (char *)check_nextcmd(arg_start);
-    redraw_curbuf_later(SOME_VALID);
+    redraw_curbuf_later(UPD_SOME_VALID);
     syn_stack_free_all(curwin->w_s);            // Need to recompute all syntax.
   }
 }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2944,7 +2944,7 @@ static int jumpto_tag(const char_u *lbuf_arg, int forceit, int keep_help)
         && curwin != curwin_save && win_valid(curwin_save)) {
       // Return cursor to where we were
       validate_cursor();
-      redraw_later(curwin, VALID);
+      redraw_later(curwin, UPD_VALID);
       win_enter(curwin_save, true);
     }
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1375,7 +1375,7 @@ static bool send_mouse_event(Terminal *term, int c)
     curwin->w_redr_status = true;
     curwin = save_curwin;
     curbuf = curwin->w_buffer;
-    redraw_later(mouse_win, NOT_VALID);
+    redraw_later(mouse_win, UPD_NOT_VALID);
     invalidate_terminal(term, -1, -1);
     // Only need to exit focus if the scrolled window is the terminal window
     return mouse_win == curwin;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2560,7 +2560,7 @@ static void u_undo_end(bool did_undo, bool absolute, bool quiet)
   {
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
       if (wp->w_buffer == curbuf && wp->w_p_cole > 0) {
-        redraw_later(wp, NOT_VALID);
+        redraw_later(wp, UPD_NOT_VALID);
       }
     }
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -712,7 +712,7 @@ win_T *win_new_float(win_T *wp, bool last, FloatConfig fconfig, Error *err)
   win_config_float(wp, fconfig);
   win_set_inner_size(wp, true);
   wp->w_pos_changed = true;
-  redraw_later(wp, VALID);
+  redraw_later(wp, UPD_VALID);
   return wp;
 }
 
@@ -797,12 +797,12 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
   }
 
   win_set_inner_size(wp, true);
-  must_redraw = MAX(must_redraw, VALID);
+  must_redraw = MAX(must_redraw, UPD_VALID);
 
   wp->w_pos_changed = true;
   if (change_external || change_border) {
     wp->w_hl_needs_update = true;
-    redraw_later(wp, NOT_VALID);
+    redraw_later(wp, UPD_NOT_VALID);
   }
 
   // compute initial position
@@ -839,7 +839,7 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
   // changing border style while keeping border only requires redrawing border
   if (fconfig.border) {
     wp->w_redr_border = true;
-    redraw_later(wp, VALID);
+    redraw_later(wp, UPD_VALID);
   }
 }
 
@@ -928,7 +928,7 @@ void ui_ext_win_position(win_T *wp)
       wp->w_grid_alloc.focusable = wp->w_float_config.focusable;
       if (!valid) {
         wp->w_grid_alloc.valid = false;
-        redraw_later(wp, NOT_VALID);
+        redraw_later(wp, UPD_NOT_VALID);
       }
     }
   } else {
@@ -1474,8 +1474,8 @@ int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 
   // Both windows need redrawing.  Update all status lines, in case they
   // show something related to the window count or position.
-  redraw_later(wp, NOT_VALID);
-  redraw_later(oldwin, NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
+  redraw_later(oldwin, UPD_NOT_VALID);
   status_redraw_all();
 
   if (need_status) {
@@ -1837,8 +1837,8 @@ static void win_exchange(long Prenum)
   }
 
   win_enter(wp, true);
-  redraw_later(curwin, NOT_VALID);
-  redraw_later(wp, NOT_VALID);
+  redraw_later(curwin, UPD_NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
 }
 
 // rotate windows: if upwards true the second window becomes the first one
@@ -1922,7 +1922,7 @@ static void win_rotate(bool upwards, int count)
   wp1->w_pos_changed = true;
   wp2->w_pos_changed = true;
 
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
 }
 
 /*
@@ -2034,7 +2034,7 @@ void win_move_after(win_T *win1, win_T *win2)
     frame_append(win2->w_frame, win1->w_frame);
 
     (void)win_comp_pos();  // recompute w_winrow for all windows
-    redraw_later(curwin, NOT_VALID);
+    redraw_later(curwin, UPD_NOT_VALID);
   }
   win_enter(win1, false);
 
@@ -2125,7 +2125,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
       frame_new_height(topfr, height, false, false);
       topfr->fr_win->w_wincol = col;
       frame_new_width(topfr, width, false, false);
-      redraw_all_later(NOT_VALID);
+      redraw_all_later(UPD_NOT_VALID);
     }
   } else if (topfr->fr_layout == FR_ROW) {
     topfr->fr_width = width;
@@ -2436,7 +2436,7 @@ void entering_window(win_T *const win)
 
 void win_init_empty(win_T *wp)
 {
-  redraw_later(wp, NOT_VALID);
+  redraw_later(wp, UPD_NOT_VALID);
   wp->w_lines_valid = 0;
   wp->w_cursor.lnum = 1;
   wp->w_curswant = wp->w_cursor.col = 0;
@@ -2935,7 +2935,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   }
 
   curwin->w_pos_changed = true;
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
   return OK;
 }
 
@@ -4115,7 +4115,7 @@ int win_new_tabpage(int after, char_u *filename)
     newtp->tp_topframe = topframe;
     last_status(false);
 
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
 
     tabpage_check_windows(old_curtab);
 
@@ -4373,7 +4373,7 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, bool trigger_enter_a
     }
   }
 
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
 }
 
 /// tells external UI that windows and inline floats in old_curtab are invisible
@@ -4867,7 +4867,7 @@ static void win_enter_ext(win_T *const wp, const int flags)
   curwin->w_redr_status = true;
   redraw_tabline = true;
   if (restart_edit) {
-    redraw_later(curwin, VALID);  // causes status line redraw
+    redraw_later(curwin, UPD_VALID);  // causes status line redraw
   }
 
   // change background color according to NormalNC,
@@ -4875,11 +4875,11 @@ static void win_enter_ext(win_T *const wp, const int flags)
   if (curwin->w_hl_attr_normal != curwin->w_hl_attr_normalnc) {
     // TODO(bfredl): eventually we should be smart enough
     // to only recompose the window, not redraw it.
-    redraw_later(curwin, NOT_VALID);
+    redraw_later(curwin, UPD_NOT_VALID);
   }
   if (prevwin) {
     if (prevwin->w_hl_attr_normal != prevwin->w_hl_attr_normalnc) {
-      redraw_later(prevwin, NOT_VALID);
+      redraw_later(prevwin, UPD_NOT_VALID);
     }
   }
 
@@ -5470,7 +5470,7 @@ static void frame_comp_pos(frame_T *topfrp, int *row, int *col)
       // position changed, redraw
       wp->w_winrow = *row;
       wp->w_wincol = *col;
-      redraw_later(wp, NOT_VALID);
+      redraw_later(wp, UPD_NOT_VALID);
       wp->w_redr_status = true;
       wp->w_pos_changed = true;
     }
@@ -5513,7 +5513,7 @@ void win_setheight_win(int height, win_T *win)
   if (win->w_floating) {
     win->w_float_config.height = height;
     win_config_float(win, win->w_float_config);
-    redraw_later(win, NOT_VALID);
+    redraw_later(win, UPD_NOT_VALID);
   } else {
     frame_setheight(win->w_frame, height + win->w_hsep_height + win->w_status_height);
 
@@ -5533,7 +5533,7 @@ void win_setheight_win(int height, win_T *win)
     curtab->tp_ch_used = p_ch;
     msg_row = row;
     msg_col = 0;
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
     redraw_cmdline = true;
   }
 }
@@ -5735,13 +5735,13 @@ void win_setwidth_win(int width, win_T *wp)
   if (wp->w_floating) {
     wp->w_float_config.width = width;
     win_config_float(wp, wp->w_float_config);
-    redraw_later(wp, NOT_VALID);
+    redraw_later(wp, UPD_NOT_VALID);
   } else {
     frame_setwidth(wp->w_frame, width + wp->w_vsep_width);
 
     // recompute the window positions
     (void)win_comp_pos();
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
 }
 
@@ -6046,7 +6046,7 @@ void win_drag_status_line(win_T *dragwin, int offset)
   cmdline_row = row;
   p_ch = MAX(Rows - cmdline_row, p_ch_was_zero ? 0 : 1);
   curtab->tp_ch_used = p_ch;
-  redraw_all_later(SOME_VALID);
+  redraw_all_later(UPD_SOME_VALID);
   showmode();
 }
 
@@ -6153,7 +6153,7 @@ void win_drag_vsep_line(win_T *dragwin, int offset)
     }
   }
   (void)win_comp_pos();
-  redraw_all_later(NOT_VALID);
+  redraw_all_later(UPD_NOT_VALID);
 }
 
 #define FRACTION_MULT   16384L
@@ -6291,7 +6291,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
   }
 
   win_comp_scroll(wp);
-  redraw_later(wp, SOME_VALID);
+  redraw_later(wp, UPD_SOME_VALID);
   wp->w_redr_status = true;
   invalidate_botline_win(wp);
 }
@@ -6332,7 +6332,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
     if (!exiting && !made_cmdheight_nonzero && valid_cursor) {
       scroll_to_fraction(wp, prev_height);
     }
-    redraw_later(wp, NOT_VALID);  // SOME_VALID??
+    redraw_later(wp, UPD_NOT_VALID);  // UPD_SOME_VALID??
   }
 
   if (width != wp->w_width_inner) {
@@ -6346,7 +6346,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
         curs_columns(wp, true);  // validate w_wrow
       }
     }
-    redraw_later(wp, NOT_VALID);
+    redraw_later(wp, UPD_NOT_VALID);
   }
 
   if (wp->w_buffer->terminal) {
@@ -6766,7 +6766,7 @@ static void last_status_rec(frame_T *fr, bool statusline, bool is_stl_global)
       wp->w_hsep_height = 0;
       comp_col();
     }
-    redraw_all_later(SOME_VALID);
+    redraw_all_later(UPD_SOME_VALID);
   } else {
     // For a column or row frame, recursively call this function for all child frames
     FOR_ALL_FRAMES(fp, fr->fr_child) {
@@ -7066,7 +7066,7 @@ void restore_snapshot(int idx, int close_curwin)
     if (wp != NULL && close_curwin) {
       win_goto(wp);
     }
-    redraw_all_later(NOT_VALID);
+    redraw_all_later(UPD_NOT_VALID);
   }
   clear_snapshot(curtab, idx);
 }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1077,10 +1077,10 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
     ]]}
   end)
 
-  it('redraws NOT_VALID correctly after message', function()
-    -- edge case: only one window was set NOT_VALID. Original report
+  it('redraws UPD_NOT_VALID correctly after message', function()
+    -- edge case: only one window was set UPD_NOT_VALID. Original report
     -- used :make, but fake it using one command to set the current
-    -- window NOT_VALID and another to show a long message.
+    -- window UPD_NOT_VALID and another to show a long message.
     command("set more")
     feed(':new<cr><c-w><c-w>')
     screen:expect{grid=[[


### PR DESCRIPTION
#### vim-patch:9.0.0206: redraw flags are not named specifically

Problem:    Redraw flags are not named specifically.
Solution:   Prefix "UPD_" to the flags, for UPDate_screen().
https://github.com/vim/vim/commit/a4d158b3c839e96ed98ff87c7b7124ff4518c4ff