### PR TITLE
vim-patch:9.0.0020: with some completion reading past end of string

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1839,10 +1839,18 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
   // but only do this, if the Popup is still visible
   if (c == Ctrl_E) {
     ins_compl_delete();
+    char_u *p = NULL;
     if (compl_leader != NULL) {
-      ins_bytes(compl_leader + get_compl_len());
+      p = compl_leader;
     } else if (compl_first_match != NULL) {
-      ins_bytes(compl_orig_text + get_compl_len());
+      p = compl_orig_text;
+    }
+    if (p != NULL) {
+      const int compl_len = get_compl_len();
+      const int len = (int)STRLEN(p);
+      if (len > compl_len) {
+        ins_bytes_len(p + compl_len, (size_t)(len - compl_len));
+      }
     }
     retval = true;
   }

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -947,4 +947,12 @@ func Test_complete_smartindent()
   delfunction! FooBarComplete
 endfunc
 
+func Test_complete_overrun()
+  " this was going past the end of the copied text
+  new
+  sil norm si0s0
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0020: with some completion reading past end of string

Problem:    With some completion reading past end of string.
Solution:   Check the length of the string.
https://github.com/vim/vim/commit/f12129f1714f7d2301935bb21d896609bdac221c