### PR TITLE
vim-patch:9.0.{0045,0046,0060,0102}: Insert mode completion crash fixes

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -709,7 +709,7 @@ static int ins_compl_add(char_u *const str, int len, char_u *const fname,
     do {
       if (!match_at_original_text(match)
           && STRNCMP(match->cp_str, str, len) == 0
-          && match->cp_str[len] == NUL) {
+          && ((int)STRLEN(match->cp_str) <= len || match->cp_str[len] == NUL)) {
         FREE_CPTEXT(cptext, cptext_allocated);
         return NOTDONE;
       }

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2813,7 +2813,7 @@ static char_u *ins_comp_get_next_word_or_line(buf_T *ins_buf, pos_T *cur_match_p
   } else {
     char_u *tmp_ptr = ptr;
 
-    if (compl_cont_status & CONT_ADDING) {
+    if (compl_cont_status & CONT_ADDING && compl_length <= (int)STRLEN(tmp_ptr)) {
       tmp_ptr += compl_length;
       // Skip if already inside a word.
       if (vim_iswordp(tmp_ptr)) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -502,17 +502,18 @@ bool ins_compl_accept_char(int c)
 }
 
 /// Get the completed text by inferring the case of the originally typed text.
-static char_u *ins_compl_infercase_gettext(char_u *str, int actual_len, int actual_compl_length,
-                                           int min_len)
+/// If the result is in allocated memory "tofree" is set to it.
+static char_u *ins_compl_infercase_gettext(char_u *str, int char_len, int compl_char_len,
+                                           int min_len, char **tofree)
 {
   bool has_lower = false;
   bool was_letter = false;
 
   // Allocate wide character array for the completion and fill it.
-  int *const wca = xmalloc((size_t)actual_len * sizeof(*wca));
+  int *const wca = xmalloc((size_t)char_len * sizeof(*wca));
   {
     const char_u *p = str;
-    for (int i = 0; i < actual_len; i++) {
+    for (int i = 0; i < char_len; i++) {
       wca[i] = mb_ptr2char_adv(&p);
     }
   }
@@ -526,7 +527,7 @@ static char_u *ins_compl_infercase_gettext(char_u *str, int actual_len, int actu
         has_lower = true;
         if (mb_isupper(wca[i])) {
           // Rule 1 is satisfied.
-          for (i = actual_compl_length; i < actual_len; i++) {
+          for (i = compl_char_len; i < char_len; i++) {
             wca[i] = mb_tolower(wca[i]);
           }
           break;
@@ -543,7 +544,7 @@ static char_u *ins_compl_infercase_gettext(char_u *str, int actual_len, int actu
       const int c = mb_ptr2char_adv(&p);
       if (was_letter && mb_isupper(c) && mb_islower(wca[i])) {
         // Rule 2 is satisfied.
-        for (i = actual_compl_length; i < actual_len; i++) {
+        for (i = compl_char_len; i < char_len; i++) {
           wca[i] = mb_toupper(wca[i]);
         }
         break;
@@ -566,20 +567,35 @@ static char_u *ins_compl_infercase_gettext(char_u *str, int actual_len, int actu
   }
 
   // Generate encoding specific output from wide character array.
-  // Multi-byte characters can occupy up to five bytes more than
-  // ASCII characters, and we also need one byte for NUL, so stay
-  // six bytes away from the edge of IObuff.
-  {
-    char_u *p = IObuff;
-    int i = 0;
-    while (i < actual_len && (p - IObuff + 6) < IOSIZE) {
-      p += utf_char2bytes(wca[i++], (char *)p);
+  garray_T gap;
+  char *p = (char *)IObuff;
+  int i = 0;
+  ga_init(&gap, 1, 500);
+  while (i < char_len) {
+    if (gap.ga_data != NULL) {
+      ga_grow(&gap, 10);
+      p = (char *)gap.ga_data + gap.ga_len;
+      gap.ga_len += utf_char2bytes(wca[i++], p);
+    } else if ((p - (char *)IObuff) + 6 >= IOSIZE) {
+      // Multi-byte characters can occupy up to five bytes more than
+      // ASCII characters, and we also need one byte for NUL, so when
+      // getting to six bytes from the edge of IObuff switch to using a
+      // growarray.  Add the character in the next round.
+      ga_grow(&gap, IOSIZE);
+      STRCPY(gap.ga_data, IObuff);
+      gap.ga_len = (int)STRLEN(IObuff);
+    } else {
+      p += utf_char2bytes(wca[i++], p);
     }
-    *p = NUL;
   }
-
   xfree(wca);
 
+  if (gap.ga_data != NULL) {
+    *tofree = gap.ga_data;
+    return gap.ga_data;
+  }
+
+  *p = NUL;
   return IObuff;
 }
 
@@ -594,10 +610,10 @@ int ins_compl_add_infercase(char_u *str_arg, int len, bool icase, char_u *fname,
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u *str = str_arg;
-  int actual_len;                       // Take multi-byte characters
-  int actual_compl_length;              // into account.
-  int min_len;
+  int char_len;  // count multi-byte characters
+  int compl_char_len;
   int flags = 0;
+  char *tofree = NULL;
 
   if (p_ic && curbuf->b_p_inf && len > 0) {
     // Infer case of completed part.
@@ -605,29 +621,28 @@ int ins_compl_add_infercase(char_u *str_arg, int len, bool icase, char_u *fname,
     // Find actual length of completion.
     {
       const char_u *p = str;
-      actual_len = 0;
+      char_len = 0;
       while (*p != NUL) {
         MB_PTR_ADV(p);
-        actual_len++;
+        char_len++;
       }
     }
 
     // Find actual length of original text.
     {
       const char_u *p = compl_orig_text;
-      actual_compl_length = 0;
+      compl_char_len = 0;
       while (*p != NUL) {
         MB_PTR_ADV(p);
-        actual_compl_length++;
+        compl_char_len++;
       }
     }
 
-    // "actual_len" may be smaller than "actual_compl_length" when using
+    // "char_len" may be smaller than "compl_char_len" when using
     // thesaurus, only use the minimum when comparing.
-    min_len = actual_len < actual_compl_length
-              ? actual_len : actual_compl_length;
+    int min_len = char_len < compl_char_len ? char_len : compl_char_len;
 
-    str = ins_compl_infercase_gettext(str, actual_len, actual_compl_length, min_len);
+    str = ins_compl_infercase_gettext(str, char_len, compl_char_len, min_len, &tofree);
   }
   if (cont_s_ipos) {
     flags |= CP_CONT_S_IPOS;
@@ -636,7 +651,9 @@ int ins_compl_add_infercase(char_u *str_arg, int len, bool icase, char_u *fname,
     flags |= CP_ICASE;
   }
 
-  return ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false);
+  int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false);
+  xfree(tofree);
+  return res;
 }
 
 /// Add a match to the list of matches

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -582,6 +582,7 @@ static char_u *ins_compl_infercase_gettext(char_u *str, int char_len, int compl_
       // getting to six bytes from the edge of IObuff switch to using a
       // growarray.  Add the character in the next round.
       ga_grow(&gap, IOSIZE);
+      *p = NUL;
       STRCPY(gap.ga_data, IObuff);
       gap.ga_len = (int)STRLEN(IObuff);
     } else {

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -954,5 +954,20 @@ func Test_complete_overrun()
   bwipe!
 endfunc
 
+func Test_infercase_very_long_line()
+  " this was truncating the line when inferring case
+  new
+  let longLine = "blah "->repeat(300)
+  let verylongLine = "blah "->repeat(400)
+  call setline(1, verylongLine)
+  call setline(2, longLine)
+  set ic infercase
+  exe "normal 2Go\<C-X>\<C-L>\<Esc>"
+  call assert_equal(longLine, getline(3))
+
+  bwipe!
+  set noic noinfercase
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -965,6 +965,13 @@ func Test_infercase_very_long_line()
   exe "normal 2Go\<C-X>\<C-L>\<Esc>"
   call assert_equal(longLine, getline(3))
 
+  " check that the too long text is NUL terminated
+  %del
+  norm o
+  norm 1987ax
+  exec "norm ox\<C-X>\<C-L>"
+  call assert_equal(repeat('x', 1987), getline(3))
+
   bwipe!
   set noic noinfercase
 endfunc

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -986,5 +986,13 @@ func Test_ins_complete_add()
   bwipe!
 endfunc
 
+func Test_ins_complete_end_of_line()
+  " this was reading past the end of the line
+  new  
+  norm 8oý 
+  sil! norm o
+
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -969,5 +969,15 @@ func Test_infercase_very_long_line()
   set noic noinfercase
 endfunc
 
+func Test_ins_complete_add()
+  " this was reading past the end of allocated memory
+  new
+  norm o
+  norm 7o
+  sil! norm o
+
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0045: reading past end of completion with a long line

Problem:    Reading past end of completion with a long line and 'infercase'
            set.
Solution:   Allocate the string if needed.
https://github.com/vim/vim/commit/caea66442d86e7bbba3bf3dc202c3c0d549b9853

Cherry-pick the deletion of a blank line from patch 9.0.0027.


#### vim-patch:9.0.0046: reading past end of completion with duplicate match

Problem:    Reading past end of completion with duplicate match.
Solution:   Check string length
https://github.com/vim/vim/commit/baefde14550231f6468ac2ed2ed495bc381c0c92


#### vim-patch:9.0.0060: accessing uninitialized memory when completing long line

Problem:    Accessing uninitialized memory when completing long line.
Solution:   Terminate string with NUL.
https://github.com/vim/vim/commit/b9e717367c395490149495cf375911b5d9de889e


#### vim-patch:9.0.0102: reading past end of line with insert mode completion

Problem:    Reading past end of line with insert mode completion.
Solution:   Check text length.
https://github.com/vim/vim/commit/a6f9e300161f4cb54713da22f65b261595e8e614