### PR TITLE
vim-patch:fd999452adaf

### DIFF
--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -3,13 +3,19 @@
 let s:keepcpo= &cpo
 set cpo&vim
 
-" searchpair() can be slow, limit the time to 150 msec or what is put in
-" g:pyindent_searchpair_timeout
-let s:searchpair_timeout = get(g:, 'pyindent_searchpair_timeout', 150)
-
-" Identing inside parentheses can be very slow, regardless of the searchpair()
-" timeout, so let the user disable this feature if he doesn't need it
-let s:disable_parentheses_indenting = get(g:, 'pyindent_disable_parentheses_indenting', v:false)
+" need to inspect some old g:pyindent_* variables to be backward compatible
+let g:python_indent = extend(get(g:, 'python_indent', {}), #{
+  \ closed_paren_align_last_line: v:true,
+  \ open_paren: get(g:, 'pyindent_open_paren', 'shiftwidth() * 2'),
+  \ nested_paren: get(g:, 'pyindent_nested_paren', 'shiftwidth()'),
+  \ continue: get(g:, 'pyindent_continue', 'shiftwidth() * 2'),
+  "\ searchpair() can be slow, limit the time to 150 msec or what is put in
+  "\ g:python_indent.searchpair_timeout
+  \ searchpair_timeout: get(g:, 'pyindent_searchpair_timeout', 150),
+  "\ Identing inside parentheses can be very slow, regardless of the searchpair()
+  "\ timeout, so let the user disable this feature if he doesn't need it
+  \ disable_parentheses_indenting: get(g:, 'pyindent_disable_parentheses_indenting', v:false),
+  \ }, 'keep')
 
 let s:maxoff = 50       " maximum number of lines to look backwards for ()
 
@@ -18,7 +24,7 @@ function s:SearchBracket(fromlnum, flags)
           \ {-> synstack('.', col('.'))
           \   ->map({_, id -> id->synIDattr('name')})
           \   ->match('\%(Comment\|Todo\|String\)$') >= 0},
-          \ [0, a:fromlnum - s:maxoff]->max(), s:searchpair_timeout)
+          \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
 endfunction
 
 " See if the specified line is already user-dedented from the expected value.
@@ -38,7 +44,7 @@ function python#GetIndent(lnum, ...)
     if a:lnum > 1 && getline(a:lnum - 2) =~ '\\$'
       return indent(a:lnum - 1)
     endif
-    return indent(a:lnum - 1) + (exists("g:pyindent_continue") ? eval(g:pyindent_continue) : (shiftwidth() * 2))
+    return indent(a:lnum - 1) + get(g:, 'pyindent_continue', g:python_indent.continue)->eval()
   endif
 
   " If the start of the line is in a string don't change the indent.
@@ -55,7 +61,7 @@ function python#GetIndent(lnum, ...)
     return 0
   endif
 
-  if s:disable_parentheses_indenting == 1
+  if g:python_indent.disable_parentheses_indenting == 1
     let plindent = indent(plnum)
     let plnumstart = plnum
   else
@@ -70,8 +76,12 @@ function python#GetIndent(lnum, ...)
     "         100, 200, 300, 400)
     call cursor(a:lnum, 1)
     let [parlnum, parcol] = s:SearchBracket(a:lnum, 'nbW')
-    if parlnum > 0 && parcol != col([parlnum, '$']) - 1
-      return parcol
+    if parlnum > 0
+      if parcol != col([parlnum, '$']) - 1
+        return parcol
+      elseif getline(a:lnum) =~ '^\s*[])}]' && !g:python_indent.closed_paren_align_last_line
+        return indent(parlnum)
+      endif
     endif
 
     call cursor(plnum, 1)
@@ -123,9 +133,11 @@ function python#GetIndent(lnum, ...)
           " When the start is inside parenthesis, only indent one 'shiftwidth'.
           let [pp, _] = s:SearchBracket(a:lnum, 'bW')
           if pp > 0
-            return indent(plnum) + (exists("g:pyindent_nested_paren") ? eval(g:pyindent_nested_paren) : shiftwidth())
+            return indent(plnum)
+              \ + get(g:, 'pyindent_nested_paren', g:python_indent.nested_paren)->eval()
           endif
-          return indent(plnum) + (exists("g:pyindent_open_paren") ? eval(g:pyindent_open_paren) : (shiftwidth() * 2))
+          return indent(plnum)
+            \ + get(g:, 'pyindent_open_paren', g:python_indent.open_paren)->eval()
         endif
         if plnumstart == p
           return indent(plnum)

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6425,8 +6425,10 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 		starts in column zero and then matches before the cursor are
 		skipped.  When the 'c' flag is present in 'cpo' the next
 		search starts after the match.  Without the 'c' flag the next
-		search starts one column further.  This matters for
-		overlapping matches.
+		search starts one column after the start of the match.  This
+		matters for overlapping matches.  See |cpo-c|.  You can also
+		insert "\ze" to change where the match ends, see  |/\ze|.
+
 		When searching backwards and the 'z' flag is given then the
 		search starts in column zero, thus no match in the current
 		line will be found (unless wrapping around the end of the

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -979,25 +979,38 @@ indentation: >
 PYTHON							*ft-python-indent*
 
 The amount of indent can be set for the following situations.  The examples
-given are the defaults.  Note that the variables are set to an expression, so
-that you can change the value of 'shiftwidth' later.
+given are the defaults.  Note that the dictionary values are set to an
+expression, so that you can change the value of 'shiftwidth' later.
 
 Indent after an open paren: >
-	let g:pyindent_open_paren = 'shiftwidth() * 2'
+	let g:python_indent.open_paren = 'shiftwidth() * 2'
 Indent after a nested paren: >
-	let g:pyindent_nested_paren = 'shiftwidth()'
+	let g:python_indent.nested_paren = 'shiftwidth()'
 Indent for a continuation line: >
-	let g:pyindent_continue = 'shiftwidth() * 2'
+	let g:python_indent.continue = 'shiftwidth() * 2'
+
+By default, the closing paren on a multiline construct lines up under the first
+non-whitespace character of the previous line.
+If you prefer that it's lined up under the first character of the line that
+starts the multiline construct, reset this key: >
+	let g:python_indent.closed_paren_align_last_line = v:false
 
 The method uses |searchpair()| to look back for unclosed parentheses.  This
 can sometimes be slow, thus it timeouts after 150 msec.  If you notice the
 indenting isn't correct, you can set a larger timeout in msec: >
-	let g:pyindent_searchpair_timeout = 500
+	let g:python_indent.searchpair_timeout = 500
 
 If looking back for unclosed parenthesis is still too slow, especially during
 a copy-paste operation, or if you don't need indenting inside multi-line
 parentheses, you can completely disable this feature: >
-	let g:pyindent_disable_parentheses_indenting = 1
+	let g:python_indent.disable_parentheses_indenting = 1
+
+For backward compatibility, these variables are also supported: >
+	g:pyindent_open_paren
+	g:pyindent_nested_paren
+	g:pyindent_continue
+	g:pyindent_searchpair_timeout
+	g:pyindent_disable_parentheses_indenting
 
 
 R								*ft-r-indent*

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -163,6 +163,8 @@ CTRL-W v						*CTRL-W_v*
 		3. 'eadirection' isn't "ver", and
 		4. one of the other windows is wider than the current or new
 		   window.
+		If N was given make the new window N columns wide, if
+		possible.
 		Note: In other places CTRL-Q does the same as CTRL-V, but here
 		it doesn't!
 

--- a/runtime/indent/testdir/python.in
+++ b/runtime/indent/testdir/python.in
@@ -1,6 +1,24 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
+dict = {
+'a': 1,
+'b': 2,
+'c': 3,
+}
+# END_INDENT
+
+# START_INDENT
+# INDENT_EXE let [g:python_indent.open_paren, g:python_indent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
+dict = {
+'a': 1,
+'b': 2,
+'c': 3,
+}
+# END_INDENT
+
+# START_INDENT
+# INDENT_EXE let g:python_indent.open_paren = 'shiftwidth() * 2'
 # INDENT_EXE syntax match pythonFoldMarkers /{{{\d*/ contained containedin=pythonComment
 # xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1
 

--- a/runtime/indent/testdir/python.ok
+++ b/runtime/indent/testdir/python.ok
@@ -1,6 +1,24 @@
 # vim: set ft=python sw=4 et:
 
 # START_INDENT
+dict = {
+        'a': 1,
+        'b': 2,
+        'c': 3,
+        }
+# END_INDENT
+
+# START_INDENT
+# INDENT_EXE let [g:python_indent.open_paren, g:python_indent.closed_paren_align_last_line] = ['shiftwidth()', v:false]
+dict = {
+    'a': 1,
+    'b': 2,
+    'c': 3,
+}
+# END_INDENT
+
+# START_INDENT
+# INDENT_EXE let g:python_indent.open_paren = 'shiftwidth() * 2'
 # INDENT_EXE syntax match pythonFoldMarkers /{{{\d*/ contained containedin=pythonComment
 # xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx {{{1
 

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -5,8 +5,7 @@
 " Exit quickly when:
 " - this plugin was already loaded (or disabled)
 " - when 'compatible' is set
-" - the "CursorMoved" autocmd event is not available.
-if exists("g:loaded_matchparen") || &cp || !exists("##CursorMoved")
+if exists("g:loaded_matchparen") || &cp
   finish
 endif
 let g:loaded_matchparen = 1
@@ -20,7 +19,7 @@ endif
 
 augroup matchparen
   " Replace all matchparen autocommands
-  autocmd! CursorMoved,CursorMovedI,WinEnter * call s:Highlight_Matching_Pair()
+  autocmd! CursorMoved,CursorMovedI,WinEnter,WinScrolled * call s:Highlight_Matching_Pair()
   autocmd! WinLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/fd999452adaf529a30d78844b5fbee355943da29

omit context syntax files (in vim9script) and `getscriptinfo` docs

*(enjoying the funtime while it lasts)*