### PR TITLE
vim-patch:8.2.{2534,3989,4037}: Insert mode completion tests and fixes

### DIFF
--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -730,8 +730,13 @@ func Test_edit_CTRL_N()
     call feedkeys("Ii\<c-n>\<cr>\<esc>", "tnix")
     call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
     call assert_equal(['INFER', 'loWER', 'infer', 'LOWER', '', ''], getline(1, '$'), e)
-
-    set noignorecase noinfercase complete&
+    set noignorecase noinfercase
+    %d
+    call setline(1, ['one word', 'two word'])
+    exe "normal! Goo\<C-P>\<C-X>\<C-P>"
+    call assert_equal('one word', getline(3))
+    %d
+    set complete&
     bw!
   endfor
 endfunc
@@ -895,6 +900,24 @@ func Test_edit_CTRL_T()
   call assert_equal(['mad'], getline(1, '$'))
   call delete('Xthesaurus')
   bw!
+endfunc
+
+" Test thesaurus completion with different encodings
+func Test_thesaurus_complete_with_encoding()
+  call writefile(['angry furious mad enraged'], 'Xthesaurus')
+  set thesaurus=Xthesaurus
+  " for e in ['latin1', 'utf-8']
+  for e in ['utf-8']
+    exe 'set encoding=' .. e
+    new
+    call setline(1, 'mad')
+    call cursor(1, 1)
+    call feedkeys("A\<c-x>\<c-t>\<cr>\<esc>", 'tnix')
+    call assert_equal(['mad', ''], getline(1, '$'))
+    bw!
+  endfor
+  set thesaurus=
+  call delete('Xthesaurus')
 endfunc
 
 " Test 'thesaurusfunc'

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -713,23 +713,27 @@ endfunc
 
 func Test_edit_CTRL_N()
   " Check keyword completion
-  new
-  set complete=.
-  call setline(1, ['INFER', 'loWER', '', '', ])
-  call cursor(3, 1)
-  call feedkeys("Ai\<c-n>\<cr>\<esc>", "tnix")
-  call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
-  call assert_equal(['INFER', 'loWER', 'i', 'LO', '', ''], getline(1, '$'))
-  %d
-  call setline(1, ['INFER', 'loWER', '', '', ])
-  call cursor(3, 1)
-  set ignorecase infercase
-  call feedkeys("Ii\<c-n>\<cr>\<esc>", "tnix")
-  call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
-  call assert_equal(['INFER', 'loWER', 'infer', 'LOWER', '', ''], getline(1, '$'))
+  " for e in ['latin1', 'utf-8']
+  for e in ['utf-8']
+    exe 'set encoding=' .. e
+    new
+    set complete=.
+    call setline(1, ['INFER', 'loWER', '', '', ])
+    call cursor(3, 1)
+    call feedkeys("Ai\<c-n>\<cr>\<esc>", "tnix")
+    call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
+    call assert_equal(['INFER', 'loWER', 'i', 'LO', '', ''], getline(1, '$'), e)
+    %d
+    call setline(1, ['INFER', 'loWER', '', '', ])
+    call cursor(3, 1)
+    set ignorecase infercase
+    call feedkeys("Ii\<c-n>\<cr>\<esc>", "tnix")
+    call feedkeys("ILO\<c-n>\<cr>\<esc>", 'tnix')
+    call assert_equal(['INFER', 'loWER', 'infer', 'LOWER', '', ''], getline(1, '$'), e)
 
-  set noignorecase noinfercase complete&
-  bw!
+    set noignorecase noinfercase complete&
+    bw!
+  endfor
 endfunc
 
 func Test_edit_CTRL_O()

--- a/src/nvim/testdir/test_maparg.vim
+++ b/src/nvim/testdir/test_maparg.vim
@@ -248,6 +248,8 @@ func Test_mapset()
   bwipe!
 
   call assert_fails('call mapset([], v:false, {})', 'E730:')
+  call assert_fails('call mapset("i", 0, "")', 'E715:')
+  call assert_fails('call mapset("i", 0, {})', 'E460:')
 endfunc
 
 func Check_ctrlb_map(d, check_alt)


### PR DESCRIPTION
#### vim-patch:8.2.2534: missing test coverage

Problem:    Missing test coverage.
Solution:   Improve test coverage for completion with different encodings,
            mapset(), and term function failures. (Dominique Pellé,
            closes vim/vim#7877)
https://github.com/vim/vim/commit/a1070eae77f635f08b6f2612726b905796baaa58

Cherry-pick E716 -> E715 change from patch 8.2.4861.


#### vim-patch:8.2.3989: some insert completion code is not tested

Problem:    Some insert completion code is not tested.
Solution:   Add a few tests.  Refactor thesaurus completion. (Yegappan
            Lakshmanan, closes vim/vim#9460)
https://github.com/vim/vim/commit/e982586f8eebf2b055987218f6d3f7a084c4bf69

vim-patch:9.0.0254: typo in function name

Problem:    Typo in function name.
Solution:   Rename the function. (closes vim/vim#10971)
https://github.com/vim/vim/commit/5fb3aabc2b0edd5573e107bb3bc103c348771f61


#### vim-patch:8.2.4037: Insert mode completion is insufficiently tested

Problem:    Insert mode completion is insufficiently tested.
Solution:   Add more tests.  Fix uncovered memory leak. (Yegappan Lakshmanan,
            closes vim/vim#9489)
https://github.com/vim/vim/commit/370791465e745354d66696de8cbd15504cf958c0