### PR TITLE
vim-patch:8.2.{3942,partial:4001}

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -757,7 +757,7 @@ void clearFolding(win_T *win)
 /// The changes in lines from top to bot (inclusive).
 void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
 {
-  if (disable_fold_update || compl_busy || State & MODE_INSERT) {
+  if (disable_fold_update || State & MODE_INSERT) {
     return;
   }
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1881,7 +1881,7 @@ static bool at_ins_compl_key(void)
     c = p[3] & 0x1f;
   }
   return (ctrl_x_mode_not_default() && vim_is_ctrl_x_key(c))
-         || ((compl_cont_status & CONT_LOCAL) && (c == Ctrl_N || c == Ctrl_P));
+         || (compl_status_local() && (c == Ctrl_N || c == Ctrl_P));
 }
 
 /// Check if typebuf.tb_buf[] contains a modifier plus key that can be changed

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -159,27 +159,6 @@ EXTERN colnr_T dollar_vcol INIT(= -1);
 
 // Variables for Insert mode completion.
 
-// Length in bytes of the text being completed (this is deleted to be replaced
-// by the match.)
-EXTERN int compl_length INIT(= 0);
-
-// Set when doing something for completion that may call edit() recursively,
-// which is not allowed. Also used to disable folding during completion
-EXTERN bool compl_busy INIT(= false);
-
-// List of flags for method of completion.
-EXTERN int compl_cont_status INIT(= 0);
-#define CONT_ADDING    1       // "normal" or "adding" expansion
-#define CONT_INTRPT   (2 + 4)  // a ^X interrupted the current expansion
-                               // it's set only iff N_ADDS is set
-#define CONT_N_ADDS    4       // next ^X<> will add-new or expand-current
-#define CONT_S_IPOS    8       // next ^X<> will set initial_pos?
-                               // if so, word-wise-expansion will set SOL
-#define CONT_SOL       16      // pattern includes start of line, just for
-                               // word-wise expansion, not set for ^X^L
-#define CONT_LOCAL     32      // for ctrl_x_mode 0, ^X^P/^X^N do a local
-                               // expansion, (eg use complete=.)
-
 EXTERN char_u *edit_submode INIT(= NULL);        // msg for CTRL-X submode
 EXTERN char_u *edit_submode_pre INIT(= NULL);    // prepended to edit_submode
 EXTERN char_u *edit_submode_extra INIT(= NULL);  // appended to edit_submode

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2820,6 +2820,8 @@ static void get_next_spell_completion(linenr_T lnum)
   int num_matches = expand_spelling(lnum, (char_u *)compl_pattern, &matches);
   if (num_matches > 0) {
     ins_compl_add_matches(num_matches, matches, p_ic);
+  } else {
+    xfree(matches);
   }
 }
 


### PR DESCRIPTION
#### vim-patch:8.2.3942: Coverity reports a possible memory leak

Problem:    Coverity reports a possible memory leak.
Solution:   Free the array if allocation fails.
https://github.com/vim/vim/commit/8e7cc6b920ddea37deaa5e6b7b3bdfff2222d137


#### vim-patch:partial:8.2.4001: insert complete code uses global variables

Problem:    Insert complete code uses global variables.
Solution:   Make variables local to the file and use accessor functions.
            (Yegappan Lakshmanan, closes vim/vim#9470)
https://github.com/vim/vim/commit/d94fbfc74a8b8073e7a256c95fa6f39fc527c726

Skip changes in comments for callback-related functions (not ported).
Also make compl_busy static again.