### PR TITLE
vim-patch: compiler warnings

### DIFF
--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -320,22 +320,22 @@ int arabic_shape(int c, int *ccp, int *c1p, int prev_c, int prev_c1, int next_c)
     int backward_combine = !prev_laa && can_join(prev_c, c);
     int forward_combine = can_join(c, next_c);
 
-    if (backward_combine && forward_combine) {
-      curr_c = (int)curr_a->medial;
-    }
-    if (backward_combine && !forward_combine) {
-      curr_c = (int)curr_a->final;
-    }
-    if (!backward_combine && forward_combine) {
-      curr_c = (int)curr_a->initial;
-    }
-    if (!backward_combine && !forward_combine) {
-      curr_c = (int)curr_a->isolated;
+    if (backward_combine) {
+      if (forward_combine) {
+        curr_c = (int)curr_a->medial;
+      } else {
+        curr_c = (int)curr_a->final;
+      }
+    } else {
+      if (forward_combine) {
+        curr_c = (int)curr_a->initial;
+      } else {
+        curr_c = (int)curr_a->isolated;
+      }
     }
   }
 
-  // Sanity check -- curr_c should, in the future, never be 0.
-  // We should, in the future, insert a fatal error here.
+  // Character missing from the table means using original character.
   if (curr_c == NUL) {
     curr_c = c;
   }

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1939,13 +1939,12 @@ static int ExpandFromContext(expand_T *xp, char_u *pat, int *num_file, char ***f
       || xp->xp_context == EXPAND_FILES_IN_PATH) {
     // Expand file or directory names.
     bool free_pat = false;
-    int i;
 
     // for ":set path=" and ":set tags=" halve backslashes for escaped space
     if (xp->xp_backslash != XP_BS_NONE) {
       free_pat = true;
       pat = vim_strsave(pat);
-      for (i = 0; pat[i]; i++) {
+      for (int i = 0; pat[i]; i++) {
         if (pat[i] == '\\') {
           if (xp->xp_backslash == XP_BS_THREE
               && pat[i + 1] == '\\'
@@ -1979,8 +1978,8 @@ static int ExpandFromContext(expand_T *xp, char_u *pat, int *num_file, char ***f
     }
 #ifdef BACKSLASH_IN_FILENAME
     if (p_csl[0] != NUL && (options & WILD_IGNORE_COMPLETESLASH) == 0) {
-      for (int i = 0; i < *num_file; i++) {
-        char_u *ptr = (*file)[i];
+      for (int j = 0; j < *num_file; j++) {
+        char_u *ptr = (*file)[j];
         while (*ptr != NUL) {
           if (p_csl[0] == 's' && *ptr == '\\') {
             *ptr = '/';

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5714,7 +5714,7 @@ static void f_rand(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     // When no argument is given use the global seed list.
     if (!initialized) {
       // Initialize the global seed list.
-      uint32_t x;
+      uint32_t x = 0;
       init_srand(&x);
 
       gx = splitmix32(&x);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5140,6 +5140,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
   FUNC_ATTR_NONNULL_ARG(1, 3, 4, 5, 6)
 {
   bool found_match = false;
+  const size_t pat_len = STRLEN(spat);
 
   for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count && *tomatch > 0; lnum++) {
     colnr_T col = 0;
@@ -5181,7 +5182,6 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
         }
       }
     } else {
-      const size_t pat_len = STRLEN(spat);
       char *const str = (char *)ml_get_buf(buf, lnum, false);
       int score;
       uint32_t matches[MAX_FUZZY_MATCHES];

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4868,7 +4868,7 @@ static int fuzzy_match_compute_score(const char_u *const str, const int strSz,
     if (currIdx > 0) {
       // Camel case
       const char_u *p = str;
-      int neighbor;
+      int neighbor = ' ';
 
       for (uint32_t sidx = 0; sidx < currIdx; sidx++) {
         neighbor = utf_ptr2char((char *)p);


### PR DESCRIPTION
#### vim-patch:8.1.1085: compiler warning for possibly uninitialized variable

Problem:    Compiler warning for possibly uninitialized variable. (Tony
            Mechelynck)
Solution:   Make conditions more logical.
https://github.com/vim/vim/commit/bd9bf266fccbf7b7f09e476e09b61f0133e914db


#### vim-patch:8.2.1728: compiler warning for using uninitialized variable

Problem:    Compiler warning for using uninitialized variable. (John Marriott)
Solution:   Initialize "neighbor".
https://github.com/vim/vim/commit/c53e9c57a9846655c2d3169788f4beefa6d22d90


#### vim-patch:8.2.1960: warning for uninitialized variable

Problem:    Warning for uninitialized variable.
Solution:   Initialize the variable.
https://github.com/vim/vim/commit/0fd797eacd569a0680a86452c18713eacf6608fe


#### vim-patch:8.2.2826: compiler warnings for int to size_t conversion

Problem:    Compiler warnings for int to size_t conversion. (Randall W.
            Morris)
Solution:   Add type casts.
https://github.com/vim/vim/commit/551c1aed65817558ac1ece541c246ea585645807

Still keep it size_t, but avoid calculating multiple times.


#### vim-patch:8.2.4289: warnings reported by MSVC

Problem:    Warnings reported by MSVC.
Solution:   Rename variables and other fixes. (Ken Takata, closes vim/vim#9689)
https://github.com/vim/vim/commit/5411910c77cba85212963a2fb71d8c71f8a5d203

N/A patches for version.c:

vim-patch:8.2.0091: compiler warnings for size_t / int types

Problem:    Compiler warnings for size_t / int types.
Solution:   Change type to size_t. (Mike Williams)
https://github.com/vim/vim/commit/4d7a248b644b647340ed1a25729e2ed586a54864

vim-patch:8.2.1299: compiler warning for using size_t for int and void pointer

Problem:    Compiler warning for using size_t for int and void pointer.
Solution:   Add type casts.
https://github.com/vim/vim/commit/d3bb6a82a51d549bbd597bb4e94d8f074009be2a

vim-patch:8.2.1906: warning for signed/unsigned

Problem:    Warning for signed/unsigned.
Solution:   Use size_t instead of int. (Mike Williams)
https://github.com/vim/vim/commit/a360dbe3b63bdca93bbf8cc431578a446e8ce14c

vim-patch:8.2.4531: LGTM warnings for condition and buffer size

Problem:    LGTM warnings for condition always true and buffer size too small.
Solution:   Remove the useless condition.  Make the buffer larger. (Goc
            Dundar, closes vim/vim#9914)
https://github.com/vim/vim/commit/f01a653ac50bb3542c24d26bb3fa5371cc3b2ed7

vim-patch:8.2.4624: old Coverity warning for resource leak

Problem:    Old Coverity warning for resource leak.
Solution:   Close the file if memory allocation fails.
https://github.com/vim/vim/commit/5d46dcfeed4fcbbab371e17e1072b0cc9abe5217

vim-patch:9.0.0129: compiler warning for int/size_t usage

Problem:    Compiler warning for int/size_t usage.
Solution:   Add a type cast. (Mike Williams, closes vim/vim#10830)
https://github.com/vim/vim/commit/ab146dac6b4148e770eb2bf61c72ef62d3ecfc65