### PR TITLE
vim-patch:9.0.0261: bufload() reads a file even if the name is not a file name

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -784,7 +784,8 @@ browsedir({title}, {initdir})
 		browsing is not possible, an empty string is returned.
 
 bufadd({name})						*bufadd()*
-		Add a buffer to the buffer list with String {name}.
+		Add a buffer to the buffer list with name {name} (must be a
+		String).
 		If a buffer for file {name} already exists, return that buffer
 		number.  Otherwise return the buffer number of the newly
 		created buffer.  When {name} is an empty string then a new
@@ -835,7 +836,8 @@ bufload({buf})						*bufload()*
 		Ensure the buffer {buf} is loaded.  When the buffer name
 		refers to an existing file then the file is read.  Otherwise
 		the buffer will be empty.  If the buffer was already loaded
-		then there is no change.
+		then there is no change.  If the buffer is not related to a
+		file the no file is read (e.g., when 'buftype' is "nofile").
 		If there is an existing swap file for the file of the buffer,
 		there will be no dialog, the buffer will be loaded anyway.
 		The {buf} argument is used like with |bufexists()|.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -224,7 +224,8 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags)
   // mark cursor position as being invalid
   curwin->w_valid = 0;
 
-  if (curbuf->b_ffname != NULL) {
+  // Read the file if there is one.
+  if (curbuf->b_ffname != NULL && !bt_quickfix(curbuf) && !bt_nofilename(curbuf)) {
 #ifdef UNIX
     int save_bin = curbuf->b_p_bin;
     int perm;

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1880,6 +1880,13 @@ func Test_bufadd_bufload()
   exe 'bwipe ' .. buf2
   call assert_equal(0, bufexists(buf2))
 
+  " when 'buftype' is "nofile" then bufload() does not read the file
+  bwipe! XotherName
+  let buf = bufadd('XotherName')
+  call setbufvar(buf, '&bt', 'nofile')
+  call bufload(buf)
+  call assert_equal([''], getbufline(buf, 1, '$'))
+
   bwipe someName
   bwipe XotherName
   call assert_equal(0, bufexists('someName'))


### PR DESCRIPTION
#### vim-patch:9.0.0261: bufload() reads a file even if the name is not a file name

Problem:    bufload() reads a file even if the name is not a file name. (Cyker
            Way)
Solution:   Do not read the file when the buffer name is not a file name.
https://github.com/vim/vim/commit/2eddbacd6dc17c84e4bdc41e60e81949a36bb973