### PR TITLE
vim-patch:8.2.{0911,0923}: cmdwin interrupted

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4184,9 +4184,13 @@ void wipe_buffer(buf_T *buf, bool aucmd)
 /// @param bufnr     Buffer to switch to, or 0 to create a new buffer.
 ///
 /// @see curbufIsChanged()
-void buf_open_scratch(handle_T bufnr, char *bufname)
+///
+/// @return  FAIL for failure, OK otherwise
+int buf_open_scratch(handle_T bufnr, char *bufname)
 {
-  (void)do_ecmd((int)bufnr, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, NULL);
+  if (do_ecmd((int)bufnr, NULL, NULL, NULL, ECMD_ONE, ECMD_HIDE, NULL) == FAIL) {
+    return FAIL;
+  }
   apply_autocmds(EVENT_BUFFILEPRE, NULL, NULL, false, curbuf);
   (void)setfname(curbuf, bufname, NULL, true);
   apply_autocmds(EVENT_BUFFILEPOST, NULL, NULL, false, curbuf);
@@ -4194,4 +4198,5 @@ void buf_open_scratch(handle_T bufnr, char *bufname)
   set_option_value_give_err("bt", 0L, "nofile", OPT_LOCAL);
   set_option_value_give_err("swf", 0L, NULL, OPT_LOCAL);
   RESET_BINDING(curwin);
+  return OK;
 }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -3,6 +3,7 @@
 source check.vim
 source screendump.vim
 source view_util.vim
+source shared.vim
 
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
@@ -1464,13 +1465,12 @@ func Test_cmdwin_interrupted()
   call writefile(lines, 'XTest_cmdwin')
 
   let buf = RunVimInTerminal('-S XTest_cmdwin', {'rows': 18})
-  call TermWait(buf, 1000)
   " open cmdwin
   call term_sendkeys(buf, "q:")
-  call TermWait(buf, 500)
+  call WaitForAssert({-> assert_match('-- More --', term_getline(buf, 18))})
   " quit more prompt for :smile command
   call term_sendkeys(buf, "q")
-  call TermWait(buf, 500)
+  call WaitForAssert({-> assert_match('^$', term_getline(buf, 18))})
   " execute a simple command
   call term_sendkeys(buf, "aecho 'done'\<CR>")
   call VerifyScreenDump(buf, 'Test_cmdwin_interrupted', {})

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1453,6 +1453,33 @@ func Test_cmdwin_tabpage()
   tabclose!
 endfunc
 
+func Test_cmdwin_interrupted()
+  CheckScreendump
+
+  " aborting the :smile output caused the cmdline window to use the current
+  " buffer.
+  let lines =<< trim [SCRIPT]
+    au WinNew * smile
+  [SCRIPT]
+  call writefile(lines, 'XTest_cmdwin')
+
+  let buf = RunVimInTerminal('-S XTest_cmdwin', {'rows': 18})
+  call TermWait(buf, 1000)
+  " open cmdwin
+  call term_sendkeys(buf, "q:")
+  call TermWait(buf, 500)
+  " quit more prompt for :smile command
+  call term_sendkeys(buf, "q")
+  call TermWait(buf, 500)
+  " execute a simple command
+  call term_sendkeys(buf, "aecho 'done'\<CR>")
+  call VerifyScreenDump(buf, 'Test_cmdwin_interrupted', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('XTest_cmdwin')
+endfunc
+
 " Test for backtick expression in the command line
 func Test_cmd_backtick()
   CheckNotMSWindows  " FIXME: see #19297

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
+local command = helpers.command
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local exec = helpers.exec
@@ -138,6 +139,84 @@ describe('cmdline', function()
       {0:~                             }|
       {0:~                             }|
       :^                             |
+    ]])
+  end)
+end)
+
+describe('cmdwin', function()
+  before_each(clear)
+
+  -- oldtest: Test_cmdwin_interrupted()
+  it('still uses a new buffer when interrupting more prompt on open', function()
+    local screen = Screen.new(30, 16)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, reverse = true},  -- StatusLine
+      [2] = {reverse = true},  -- StatusLineNC
+      [3] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
+      [4] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+    command('set more')
+    command('autocmd WinNew * highlight')
+    feed('q:')
+    screen:expect({any = '{3:%-%- More %-%-}^'})
+    feed('q')
+    screen:expect([[
+                                    |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {2:[No Name]                     }|
+      {0::}^                             |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {1:[Command Line]                }|
+                                    |
+    ]])
+    feed([[aecho 'done']])
+    screen:expect([[
+                                    |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {2:[No Name]                     }|
+      {0::}echo 'done'^                  |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {1:[Command Line]                }|
+      {4:-- INSERT --}                  |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                              |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      done                          |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.0911: crash when opening a buffer for the cmdline window fails

Problem:    Crash when opening a buffer for the cmdline window fails. (Chris
            Barber)
Solution:   Check do_ecmd() succeeds.  Reset got_int if "q" was used at the
            more prompt.
https://github.com/vim/vim/commit/9b7cce28d568f0622d77c6c9878c2d4770c3b164

Make code match latest Vim instead.


#### vim-patch:8.2.0923: cmdline test is slow

Problem:    Cmdline test is slow.
Solution:   Use WaitForAssert().
https://github.com/vim/vim/commit/c82dd86084581afa5113b0dd9ade7a631b89b4fc