### PR TITLE
vim-patch:9.0.{0262,0263,0266,0268,0270}: too many #ifdefs

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -96,8 +96,7 @@ void changed(void)
 
     // Create a swap file if that is wanted.
     // Don't do this for "nofile" and "nowrite" buffer types.
-    if (curbuf->b_may_swap
-        && !bt_dontwrite(curbuf)) {
+    if (curbuf->b_may_swap && !bt_dontwrite(curbuf)) {
       bool save_need_wait_return = need_wait_return;
 
       need_wait_return = false;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1880,8 +1880,7 @@ int do_write(exarg_T *eap)
   // Writing to the current file is not allowed in readonly mode
   // and a file name is required.
   // "nofile" and "nowrite" buffers cannot be written implicitly either.
-  if (!other && (bt_dontwrite_msg(curbuf)
-                 || check_fname() == FAIL
+  if (!other && (bt_dontwrite_msg(curbuf) || check_fname() == FAIL
                  || check_readonly(&eap->forceit, curbuf))) {
     goto theend;
   }

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -110,16 +110,15 @@ typedef struct ff_stack {
 typedef struct ff_visited {
   struct ff_visited *ffv_next;
 
-  /* Visited directories are different if the wildcard string are
-   * different. So we have to save it.
-   */
+  // Visited directories are different if the wildcard string are
+  // different. So we have to save it.
   char_u *ffv_wc_path;
+
   // use FileID for comparison (needed because of links), else use filename.
   bool file_id_valid;
   FileID file_id;
-  /* The memory for this struct is allocated according to the length of
-   * ffv_fname.
-   */
+  // The memory for this struct is allocated according to the length of
+  // ffv_fname.
   char_u ffv_fname[1];                  // actually longer
 } ff_visited_T;
 
@@ -510,9 +509,7 @@ void *vim_findfile_init(char_u *path, char_u *filename, char_u *stopdirs, int le
     xfree(buf);
   }
 
-  sptr = ff_create_stack_element(ff_expand_buffer,
-                                 search_ctx->ffsc_wc_path,
-                                 level, 0);
+  sptr = ff_create_stack_element(ff_expand_buffer, search_ctx->ffsc_wc_path, level, 0);
 
   ff_push(search_ctx, sptr);
   search_ctx->ffsc_file_to_search = vim_strsave(filename);
@@ -641,11 +638,8 @@ char_u *vim_findfile(void *search_ctx_arg)
        * first time (hence stackp->ff_filearray == NULL)
        */
       if (stackp->ffs_filearray == NULL
-          && ff_check_visited(&search_ctx->ffsc_dir_visited_list
-                              ->ffvl_visited_list,
-                              stackp->ffs_fix_path,
-                              stackp->ffs_wc_path
-                              ) == FAIL) {
+          && ff_check_visited(&search_ctx->ffsc_dir_visited_list->ffvl_visited_list,
+                              stackp->ffs_fix_path, stackp->ffs_wc_path) == FAIL) {
 #ifdef FF_VERBOSE
         if (p_verbose >= 5) {
           verbose_enter_scroll();
@@ -790,8 +784,7 @@ char_u *vim_findfile(void *search_ctx_arg)
         stackp->ffs_filearray_cur = 0;
         stackp->ffs_stage = 0;
       } else {
-        rest_of_wildcards = &stackp->ffs_wc_path[
-                                                 STRLEN(stackp->ffs_wc_path)];
+        rest_of_wildcards = &stackp->ffs_wc_path[STRLEN(stackp->ffs_wc_path)];
       }
 
       if (stackp->ffs_stage == 0) {
@@ -833,23 +826,17 @@ char_u *vim_findfile(void *search_ctx_arg)
               // if file exists and we didn't already find it
               if ((path_with_url((char *)file_path)
                    || (os_path_exists(file_path)
-                       && (search_ctx->ffsc_find_what
-                           == FINDFILE_BOTH
-                           || ((search_ctx->ffsc_find_what
-                                == FINDFILE_DIR)
+                       && (search_ctx->ffsc_find_what == FINDFILE_BOTH
+                           || ((search_ctx->ffsc_find_what == FINDFILE_DIR)
                                == os_isdir(file_path)))))
 #ifndef FF_VERBOSE
                   && (ff_check_visited(&search_ctx->ffsc_visited_list->ffvl_visited_list,
-                                       file_path,
-                                       (char_u *)""
-                                       ) == OK)
+                                       file_path, (char_u *)"") == OK)
 #endif
                   ) {
 #ifdef FF_VERBOSE
                 if (ff_check_visited(&search_ctx->ffsc_visited_list->ffvl_visited_list,
-                                     file_path,
-                                     (char_u *)""
-                                     ) == FAIL) {
+                                     file_path, (char_u *)"") == FAIL) {
                   if (p_verbose >= 5) {
                     verbose_enter_scroll();
                     smsg("Already: %s", file_path);


### PR DESCRIPTION
#### vim-patch:9.0.0263: too many #ifdefs

Problem:    Too many #ifdefs.
Solution:   Make some functions always available.
https://github.com/vim/vim/commit/6d4b2f54df5d533eb0794331f38445a6ca5d3a3f

N/A patches for version.c:

vim-patch:9.0.0262: build failure without the +quickfix feature

Problem:    Build failure without the +quickfix feature.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/2e6dcbc4450c98bd12faace5d77a65f2afddae44

vim-patch:9.0.0266: compiler warning for unused argument

Problem:    Compiler warning for unused argument.
Solution:   Add UNUSED.
https://github.com/vim/vim/commit/340dafd155222ac96304107542344faf3c56e12b

vim-patch:9.0.0268: build error without the +eval feature

Problem:    Build error without the +eval feature.
Solution:   Remove #ifdef.
https://github.com/vim/vim/commit/0166e398d11a09662d783fe5db62b414045880f8


#### vim-patch:9.0.0270: some values of 'path' and 'tags' invalid in the tiny version

Problem:    Some values of 'path' and 'tags' do not work in the tiny version.
Solution:   Graduate the +path_extra feature.
https://github.com/vim/vim/commit/2bd9dbc19fc67395cfa1226dda7326071ab22464