### PR TITLE
Add a TL;DR to `option-backslash`

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -135,6 +135,11 @@ A few examples: >
    :set tags=tags\ /usr/tags	    results in "tags /usr/tags"
    :set tags=tags\\,file	    results in "tags\,file"
    :set tags=tags\\\ file	    results in "tags\ file"
+   
+TLDR: You can handle all edge cases explained below thus: >
+   :s/\v%(\=)\zs(.*)/\=substitute(substitute(submatch(1), '\\', '\\\\', 'g'), '[ "'."'".'|]', '\\\0', 'g')
+Assuming your cursor is on the line containing the option value you need to
+fix.
 
 The "|" character separates a ":set" command from a following command.  To
 include the "|" in the option value, use "\|" instead.  This example sets the


### PR DESCRIPTION
This whole section feels like an exercise left to the reader and no one else should have to do it.

Apologize for the mess at #19951. This session is a tale of woe:

```bash
cd /tmp
git clone -h https://github.com/ctrlcctrlv/neovim
git clone --depth 1 --branch patch-1 https://github.com/ctrlcctrlv/neovim # initial error
cd neovim
vim runtime/doc/options.txt
git add -u
git commit --amend
git push -f # point of no return
git checkout -b doc-option-backslash
git push --set-upstream origin doc-option-backslash
git pull --unshallow # capitulation
git checkout c12f6002a15b27ada972b997bc0950f37d06027d
git checkout -b tmp
git cherry-pick 5cce1d40f6
vim runtime/doc/options.txt
git diff
git add -u
git cherry-pick --continue
git branch -D patch-1
git checkout -b patch-1
git push -f --set-upstream origin patch-1
```