### PR TITLE
vim-patch:9.0.{0272,0274,0275,0276}: buffer loading fixes

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -227,7 +227,7 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags_arg)
 
   // A buffer without an actual file should not use the buffer name to read a
   // file.
-  if (bt_quickfix(curbuf) || bt_nofilename(curbuf)) {
+  if (bt_nofileread(curbuf)) {
     flags |= READ_NOFILE;
   }
 
@@ -812,6 +812,18 @@ static void free_buffer(buf_T *buf)
   }
 }
 
+/// Free the b_wininfo list for buffer "buf".
+static void clear_wininfo(buf_T *buf)
+{
+  wininfo_T *wip;
+
+  while (buf->b_wininfo != NULL) {
+    wip = buf->b_wininfo;
+    buf->b_wininfo = wip->wi_next;
+    free_wininfo(wip, buf);
+  }
+}
+
 /// Free stuff in the buffer for ":bdel" and when wiping out the buffer.
 ///
 /// @param buf  Buffer pointer
@@ -844,18 +856,6 @@ static void free_buffer_stuff(buf_T *buf, int free_flags)
   XFREE_CLEAR(buf->b_start_fenc);
 
   buf_updates_unload(buf, false);
-}
-
-/// Free the b_wininfo list for buffer "buf".
-static void clear_wininfo(buf_T *buf)
-{
-  wininfo_T *wip;
-
-  while (buf->b_wininfo != NULL) {
-    wip = buf->b_wininfo;
-    buf->b_wininfo = wip->wi_next;
-    free_wininfo(wip, buf);
-  }
 }
 
 /// Go to another buffer.  Handles the result of the ATTENTION dialog.
@@ -3834,13 +3834,25 @@ bool bt_terminal(const buf_T *const buf)
 }
 
 /// @return  true if "buf" is a "nofile", "acwrite", "terminal" or "prompt"
-///          buffer.  This means the buffer name is not a file name.
+///          buffer.  This means the buffer name may not be a file name,
+///          at least not for writing the buffer.
 bool bt_nofilename(const buf_T *const buf)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
                          || buf->b_p_bt[0] == 'a'
                          || buf->terminal
+                         || buf->b_p_bt[0] == 'p');
+}
+
+/// @return  true if "buf" is a "nofile", "quickfix", "terminal" or "prompt"
+///          buffer.  This means the buffer is not to be read from a file.
+static bool bt_nofileread(const buf_T *const buf)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return buf != NULL && ((buf->b_p_bt[0] == 'n' && buf->b_p_bt[2] == 'f')
+                         || buf->b_p_bt[0] == 't'
+                         || buf->b_p_bt[0] == 'q'
                          || buf->b_p_bt[0] == 'p');
 }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -337,7 +337,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     curbuf->b_op_start = orig_start;
 
     if (flags & READ_NOFILE) {
-      return FAIL;
+      return NOTDONE;  // so that BufEnter can be triggered
     }
   }
 

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -167,6 +167,7 @@ void filemess(buf_T *buf, char_u *name, char_u *s, int attr)
 /// READ_STDIN   read from stdin instead of a file
 /// READ_BUFFER  read from curbuf instead of a file (converting after reading
 ///              stdin)
+/// READ_NOFILE  do not read a file, only trigger BufReadCmd
 /// READ_DUMMY   read into a dummy buffer (to check if file contents changed)
 /// READ_KEEP_UNDO  don't clear undo info or read it from a file
 /// READ_FIFO    read from fifo/socket instead of a file
@@ -334,6 +335,10 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     }
 
     curbuf->b_op_start = orig_start;
+
+    if (flags & READ_NOFILE) {
+      return FAIL;
+    }
   }
 
   if ((shortmess(SHM_OVER) || curbuf->b_help) && p_verbose == 0) {

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -15,6 +15,7 @@
 #define READ_KEEP_UNDO  0x20    // keep undo info
 #define READ_FIFO       0x40    // read from fifo or socket
 #define READ_NOWINENTER 0x80    // do not trigger BufWinEnter
+#define READ_NOFILE     0x100   // do not read a file, do trigger BufReadCmd
 
 #define READ_STRING(x, y) (char_u *)read_string((x), (size_t)(y))
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -493,16 +493,24 @@ func Test_BufReadCmdHelpJump()
   au! BufReadCmd
 endfunc
 
-" BufReadCmd is triggered for a "nofile" buffer
+" BufReadCmd is triggered for a "nofile" buffer. Check all values.
 func Test_BufReadCmdNofile()
-  new somefile
-  set buftype=nofile
-  au BufReadCmd somefile call setline(1, 'triggered')
-  edit
-  call assert_equal('triggered', getline(1))
+  for val in ['nofile',
+            \ 'nowrite',
+            \ 'acwrite',
+            \ 'quickfix',
+            \ 'help',
+            \ 'prompt',
+            \ ]
+    new somefile
+    exe 'set buftype=' .. val
+    au BufReadCmd somefile call setline(1, 'triggered')
+    edit
+    call assert_equal('triggered', getline(1))
 
-  au! BufReadCmd
-  bwipe!
+    au! BufReadCmd
+    bwipe!
+  endfor
 endfunc
 
 func Test_augroup_deleted()
@@ -603,15 +611,22 @@ func Test_BufEnter()
   au! BufEnter
 
   " Editing a "nofile" buffer doesn't read the file but does trigger BufEnter
-  " for historic reasons.
-  new somefile
-  set buftype=nofile
-  au BufEnter somefile call setline(1, 'some text')
-  edit
-  call assert_equal('some text', getline(1))
-
-  bwipe!
-  au! BufEnter
+  " for historic reasons.  Also test other 'buftype' values.
+  for val in ['nofile',
+            \ 'nowrite',
+            \ 'acwrite',
+            \ 'quickfix',
+            \ 'help',
+            \ 'prompt',
+            \ ]
+    new somefile
+    exe 'set buftype=' .. val
+    au BufEnter somefile call setline(1, 'some text')
+    edit
+    call assert_equal('some text', getline(1))
+    bwipe!
+    au! BufEnter
+  endfor
 endfunc
 
 " Closing a window might cause an endless loop

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -493,6 +493,18 @@ func Test_BufReadCmdHelpJump()
   au! BufReadCmd
 endfunc
 
+" BufReadCmd is triggered for a "nofile" buffer
+func Test_BufReadCmdNofile()
+  new somefile
+  set buftype=nofile
+  au BufReadCmd somefile call setline(1, 'triggered')
+  edit
+  call assert_equal('triggered', getline(1))
+
+  au! BufReadCmd
+  bwipe!
+endfunc
+
 func Test_augroup_deleted()
   " This caused a crash before E936 was introduced
   augroup x

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -599,8 +599,18 @@ func Test_BufEnter()
   " On MS-Windows we can't edit the directory, make sure we wipe the right
   " buffer.
   bwipe! Xdir
-
   call delete('Xdir', 'd')
+  au! BufEnter
+
+  " Editing a "nofile" buffer doesn't read the file but does trigger BufEnter
+  " for historic reasons.
+  new somefile
+  set buftype=nofile
+  au BufEnter somefile call setline(1, 'some text')
+  edit
+  call assert_equal('some text', getline(1))
+
+  bwipe!
   au! BufEnter
 endfunc
 

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -187,4 +187,24 @@ func Test_deletebufline_select_mode()
   bwipe!
 endfunc
 
+func Test_setbufline_startup_nofile()
+  let before =<< trim [CODE]
+    set shortmess+=F
+    file Xresult
+    set buftype=nofile
+    call setbufline('', 1, 'success')
+  [CODE]
+  let after =<< trim [CODE]
+    set buftype=
+    write
+    quit
+  [CODE]
+
+  if !RunVim(before, after, '--clean')
+    return
+  endif
+  call assert_equal(['success'], readfile('Xresult'))
+  call delete('Xresult')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1880,19 +1880,21 @@ func Test_bufadd_bufload()
   exe 'bwipe ' .. buf2
   call assert_equal(0, bufexists(buf2))
 
-  " when 'buftype' is "nofile" then bufload() does not read the file
-  bwipe! XotherName
-  let buf = bufadd('XotherName')
-  call setbufvar(buf, '&bt', 'nofile')
-  call bufload(buf)
-  call assert_equal([''], getbufline(buf, 1, '$'))
-
-  " when 'buftype' is "acwrite" then bufload() DOES read the file
-  bwipe! XotherName
-  let buf = bufadd('XotherName')
-  call setbufvar(buf, '&bt', 'acwrite')
-  call bufload(buf)
-  call assert_equal(['some', 'text'], getbufline(buf, 1, '$'))
+  " When 'buftype' is "nofile" then bufload() does not read the file.
+  " Other values too.
+  for val in [['nofile', 0],
+            \ ['nowrite', 1],
+            \ ['acwrite', 1],
+            \ ['quickfix', 0],
+            \ ['help', 1],
+            \ ['prompt', 0],
+            \ ]
+    bwipe! XotherName
+    let buf = bufadd('XotherName')
+    call setbufvar(buf, '&bt', val[0])
+    call bufload(buf)
+    call assert_equal(val[1] ? ['some', 'text'] : [''], getbufline(buf, 1, '$'), val[0])
+  endfor
 
   bwipe someName
   bwipe XotherName

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1887,6 +1887,13 @@ func Test_bufadd_bufload()
   call bufload(buf)
   call assert_equal([''], getbufline(buf, 1, '$'))
 
+  " when 'buftype' is "acwrite" then bufload() DOES read the file
+  bwipe! XotherName
+  let buf = bufadd('XotherName')
+  call setbufvar(buf, '&bt', 'acwrite')
+  call bufload(buf)
+  call assert_equal(['some', 'text'], getbufline(buf, 1, '$'))
+
   bwipe someName
   bwipe XotherName
   call assert_equal(0, bufexists('someName'))


### PR DESCRIPTION
#### vim-patch:9.0.0272: BufReadCmd not triggered when loading a "nofile" buffer

Problem:    BufReadCmd not triggered when loading a "nofile" buffer. (Maxim
            Kim)
Solution:   Call readfile() but bail out before reading a file.
https://github.com/vim/vim/commit/b1d2c8116cb5577961ea109651fb888b5e58265f


#### vim-patch:9.0.0274: netrw plugin does not show remote files

Problem:    Netrw plugin does not show remote files.
Solution:   Do read a file when 'buftype' is "acwrite".
https://github.com/vim/vim/commit/c312619f7c0cf590d96e0b2ed891d1f6c43d769b


#### vim-patch:9.0.0275: BufEnter not triggered when using ":edit" in "nofile" buffer

Problem:    BufEnter not triggered when using ":edit" in "nofile" buffer.
Solution:   Let readfile() return NOTDONE.
https://github.com/vim/vim/commit/a9b5b85068b2fcb1c01ea20524e227bcad579ceb


#### vim-patch:9.0.0276: 'buftype' values not sufficiently tested

Problem:    'buftype' values not sufficiently tested.
Solution:   Add and extend tests with 'buftype' values. (closes vim/vim#10988)
https://github.com/vim/vim/commit/93f72cc119c796f1ccb75468ef9e446cbfb41e9b

"terminal" and "popup" buffer types cannot be tested, and commenting
them out causes an error, so just remove them.