### PR TITLE
vim-patch:9.0.{0278,0279,0283,0284}: cmdline completion patches

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6940,12 +6940,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'wildmenu'* *'wmnu'* *'nowildmenu'* *'nowmnu'*
 'wildmenu' 'wmnu'	boolean	(default on)
 			global
-	Enables "enhanced mode" of command-line completion. When user hits
-	<Tab> (or 'wildchar') to invoke completion, the possible matches are
-	shown in a menu just above the command-line (see 'wildoptions'), with
-	the first match highlighted (overwriting the statusline).  Keys that
-	show the previous/next match (<Tab>/CTRL-P/CTRL-N) highlight the
-	match.
+	When 'wildmenu' is on, command-line completion operates in an enhanced
+	mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
+	the possible matches are shown.
+	When 'wildoptions' contains "pum", then the completion matches are
+	shown in a popup menu.  Otherwise they are displayed just above the
+	command line, with the first match highlighted (overwriting the status
+	line, if there is one).
+	Keys that show the previous/next match, such as <Tab> or
+	CTRL-P/CTRL-N, cause the highlight to move to the appropriate match.
 	'wildmode' must specify "full": "longest" and "list" do not start
 	'wildmenu' mode. You can check the current mode with |wildmenumode()|.
 	The menu is canceled when a key is hit that is not used for selecting

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -90,14 +90,14 @@ static char *(history_names[]) = {
 /// arguments of the ":history command.
 char *get_history_arg(expand_T *xp, int idx)
 {
-  static char_u compl[2] = { NUL, NUL };
-  char *short_names = ":=@>?/";
-  int short_names_count = (int)STRLEN(short_names);
-  int history_name_count = ARRAY_SIZE(history_names) - 1;
+  const char *short_names = ":=@>?/";
+  const int short_names_count = (int)STRLEN(short_names);
+  const int history_name_count = ARRAY_SIZE(history_names) - 1;
 
   if (idx < short_names_count) {
-    compl[0] = (char_u)short_names[idx];
-    return (char *)compl;
+    xp->xp_buf[0] = short_names[idx];
+    xp->xp_buf[1] = NUL;
+    return xp->xp_buf;
   }
   if (idx < short_names_count + history_name_count) {
     return history_names[idx - short_names_count];

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -237,6 +237,8 @@ struct expand {
   int xp_col;                   // cursor position in line
   char **xp_files;              // list of files
   char *xp_line;                // text being completed
+#define EXPAND_BUF_LEN 256
+  char xp_buf[EXPAND_BUF_LEN];  // buffer for returned match
 };
 
 // values for xp_backslash

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1808,6 +1808,7 @@ static int command_line_handle_key(CommandLineState *s)
       // menu (if present)
       cmdline_pum_cleanup(&ccline);
     }
+
     if (nextwild(&s->xpc, WILD_ALL, 0, s->firstc != '@') == FAIL) {
       break;
     }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -337,7 +337,9 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     curbuf->b_op_start = orig_start;
 
     if (flags & READ_NOFILE) {
-      return NOTDONE;  // so that BufEnter can be triggered
+      // Return NOTDONE instead of FAIL so that BufEnter can be triggered
+      // and other operations don't fail.
+      return NOTDONE;
     }
   }
 

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -1156,15 +1156,12 @@ char *home_replace_save(buf_T *buf, const char *src)
 /// Function given to ExpandGeneric() to obtain an environment variable name.
 char *get_env_name(expand_T *xp, int idx)
 {
-#define ENVNAMELEN 100
-  // this static buffer is needed to avoid a memory leak in ExpandGeneric
-  static char_u name[ENVNAMELEN];
   assert(idx >= 0);
   char *envname = os_getenvname_at_index((size_t)idx);
   if (envname) {
-    STRLCPY(name, envname, ENVNAMELEN);
+    STRLCPY(xp->xp_buf, envname, EXPAND_BUF_LEN);
     xfree(envname);
-    return (char *)name;
+    return xp->xp_buf;
   }
   return NULL;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5737,9 +5737,6 @@ void set_context_in_syntax_cmd(expand_T *xp, const char *arg)
  */
 char *get_syntax_name(expand_T *xp, int idx)
 {
-#define CBUFFER_LEN 256
-  static char cbuffer[CBUFFER_LEN]; // TODO: better solution
-
   switch (expand_what) {
   case EXP_SUBCMD:
     return subcommands[idx].name;
@@ -5761,9 +5758,9 @@ char *get_syntax_name(expand_T *xp, int idx)
   }
   case EXP_CLUSTER:
     if (idx < curwin->w_s->b_syn_clusters.ga_len) {
-      vim_snprintf(cbuffer, CBUFFER_LEN, "@%s",
+      vim_snprintf(xp->xp_buf, EXPAND_BUF_LEN, "@%s",
                    SYN_CLSTR(curwin->w_s)[idx].scl_name);
-      return cbuffer;
+      return xp->xp_buf;
     } else {
       return NULL;
     }

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -198,6 +198,10 @@ func Test_syntax_completion()
 
   call feedkeys(":syn match \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^"syn match @boolean @character ', @:)
+
+  syn cluster Aax contains=Aap
+  call feedkeys(":syn list @A\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_match('^"syn list @Aax', @:)
 endfunc
 
 func Test_echohl_completion()


### PR DESCRIPTION
#### vim-patch:9.0.0278: the +wildignore feature is nearly always available

Problem:    The +wildignore feature is nearly always available.
Solution:   Graduate +wildignore for consistency.
https://github.com/vim/vim/commit/074fbd413172edc6f4936296a28bf8fd5cdfa38b


#### vim-patch:9.0.0279: the tiny version has the popup menu but not 'wildmenu'

Problem:    The tiny version has the popup menu but not 'wildmenu'.
Solution:   Graduate the wildmenu feature.
https://github.com/vim/vim/commit/5416232707349d5f24294178f47544f2024b73ed

N/A patches for version.c:

vim-patch:9.0.0281: build failure without the +eval feature

Problem:    Build failure without the +eval feature.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/58dcbf1c6586d3873702e035b47829178a91250e


#### vim-patch:9.0.0283: cannot complete "syn list @cluster"

Problem:    Cannot complete "syn list @cluster".
Solution:   Recognize and handle "list @". (Björn Linse, closes vim/vim#10990)
https://github.com/vim/vim/commit/af9a6002e0761012cb7108cbfa179a880d3cb49b


#### vim-patch:9.0.0284: using static buffer for multiple completion functions

Problem:    Using static buffer for multiple completion functions.
Solution:   Use one buffer in expand_T.
https://github.com/vim/vim/commit/5ff595d9db2d9a33aa10cc9f18f256826226862f