### PR TITLE
refactor(plines): use a struct for chartabsize state

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -653,9 +653,9 @@ void ins_char_bytes(char_u *buf, size_t charlen)
       // cells.  May result in adding spaces to fill a gap.
       colnr_T vcol;
       getvcol(curwin, &curwin->w_cursor, NULL, &vcol, NULL);
-      colnr_T new_vcol = vcol + win_chartabsize(curwin, buf, vcol);
+      colnr_T new_vcol = vcol + win_chartabsize(curwin, (char *)buf, vcol);
       while (oldp[col + oldlen] != NUL && vcol < new_vcol) {
-        vcol += win_chartabsize(curwin, oldp + col + oldlen, vcol);
+        vcol += win_chartabsize(curwin, (char *)oldp + col + oldlen, vcol);
         // Don't need to remove a TAB that takes us to the right
         // position.
         if (vcol > new_vcol && oldp[col + oldlen] == TAB) {

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -137,14 +137,18 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
       }
     }
 
-    char_u *ptr = line;
-    while (col <= wcol && *ptr != NUL) {
+    chartabsize_T cts;
+    init_chartabsize_arg(&cts, curwin, pos->lnum, 0, line, line);
+    while (cts.cts_vcol <= wcol && *cts.cts_ptr != NUL) {
       // Count a tab for what it's worth (if list mode not on)
-      csize = win_lbr_chartabsize(curwin, line, ptr, col, &head);
-      MB_PTR_ADV(ptr);
-      col += csize;
+      csize = win_lbr_chartabsize(&cts, &head);
+      MB_PTR_ADV(cts.cts_ptr);
+      cts.cts_vcol += csize;
     }
-    idx = (int)(ptr - line);
+    col = cts.cts_vcol;
+    idx = (int)(cts.cts_ptr - (char *)line);
+    clear_chartabsize_arg(&cts);
+
     // Handle all the special cases.  The virtual_active() check
     // is needed to ensure that a virtual position off the end of
     // a line has the correct indexing.  The one_more comparison

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -849,11 +849,11 @@ static void get_col(typval_T *argvars, typval_T *rettv, bool charcol)
       // col(".") when the cursor is on the NUL at the end of the line
       // because of "coladd" can be seen as an extra column.
       if (virtual_active() && fp == &curwin->w_cursor) {
-        char_u *p = get_cursor_pos_ptr();
+        char *p = (char *)get_cursor_pos_ptr();
         if (curwin->w_cursor.coladd >=
             (colnr_T)win_chartabsize(curwin, p, curwin->w_virtcol - curwin->w_cursor.coladd)) {
           int l;
-          if (*p != NUL && p[(l = utfc_ptr2len((char *)p))] == NUL) {
+          if (*p != NUL && p[(l = utfc_ptr2len(p))] == NUL) {
             col += l;
           }
         }
@@ -8512,7 +8512,7 @@ static void f_strdisplaywidth(typval_T *argvars, typval_T *rettv, EvalFuncData f
     col = (int)tv_get_number(&argvars[1]);
   }
 
-  rettv->vval.v_number = (varnumber_T)(linetabsize_col(col, (char_u *)s) - col);
+  rettv->vval.v_number = (varnumber_T)(linetabsize_col(col, (char *)s) - col);
 }
 
 /// "strwidth()" function

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -841,7 +841,7 @@ void ex_retab(exarg_T *eap)
       if (ptr[col] == NUL) {
         break;
       }
-      vcol += win_chartabsize(curwin, (char_u *)ptr + col, (colnr_T)vcol);
+      vcol += win_chartabsize(curwin, ptr + col, (colnr_T)vcol);
       if (vcol >= MAXCOL) {
         emsg(_(e_resulting_text_too_long));
         break;

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -631,14 +631,16 @@ colnr_T vcol2col(win_T *const wp, const linenr_T lnum, const colnr_T vcol)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   // try to advance to the specified column
-  char_u *ptr = ml_get_buf(wp->w_buffer, lnum, false);
-  char_u *const line = ptr;
-  colnr_T count = 0;
-  while (count < vcol && *ptr != NUL) {
-    count += win_lbr_chartabsize(wp, line, ptr, count, NULL);
-    MB_PTR_ADV(ptr);
+  char_u *line = ml_get_buf(wp->w_buffer, lnum, false);
+  chartabsize_T cts;
+  init_chartabsize_arg(&cts, wp, lnum, 0, line, line);
+  while (cts.cts_vcol < vcol && *cts.cts_ptr != NUL) {
+    cts.cts_vcol += win_lbr_chartabsize(&cts, NULL);
+    MB_PTR_ADV(cts.cts_ptr);
   }
-  return (colnr_T)(ptr - line);
+  clear_chartabsize_arg(&cts);
+
+  return (colnr_T)((char_u *)cts.cts_ptr - line);
 }
 
 /// Set UI mouse depending on current mode and 'mouse'.
@@ -667,7 +669,7 @@ static colnr_T scroll_line_len(linenr_T lnum)
   char_u *line = ml_get(lnum);
   if (*line != NUL) {
     for (;;) {
-      int numchar = win_chartabsize(curwin, line, col);
+      int numchar = win_chartabsize(curwin, (char *)line, col);
       MB_PTR_ADV(line);
       if (*line == NUL) {    // don't count the last character
         break;
@@ -790,7 +792,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
     // checked for concealed characters.
     vcol = 0;
     while (vcol < offset && *ptr != NUL) {
-      vcol += win_chartabsize(curwin, ptr, vcol);
+      vcol += win_chartabsize(curwin, (char *)ptr, vcol);
       ptr += utfc_ptr2len((char *)ptr);
     }
 
@@ -801,7 +803,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
   vcol = offset;
   ptr_end = ptr_row_offset;
   while (vcol < col && *ptr_end != NUL) {
-    vcol += win_chartabsize(curwin, ptr_end, vcol);
+    vcol += win_chartabsize(curwin, (char *)ptr_end, vcol);
     ptr_end += utfc_ptr2len((char *)ptr_end);
   }
 
@@ -816,7 +818,7 @@ static int mouse_adjust_click(win_T *wp, int row, int col)
 #define DECR() nudge--; ptr_end -= utfc_ptr2len((char *)ptr_end)
 
   while (ptr < ptr_end && *ptr != NUL) {
-    cwidth = win_chartabsize(curwin, ptr, vcol);
+    cwidth = win_chartabsize(curwin, (char *)ptr, vcol);
     vcol += cwidth;
     if (cwidth > 1 && *ptr == '\t' && nudge > 0) {
       // A tab will "absorb" any previous adjustments.

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -98,15 +98,15 @@ int plines_win_nofill(win_T *wp, linenr_T lnum, bool winheight)
 /// "wp".  Does not care about folding, 'wrap' or 'diff'.
 int plines_win_nofold(win_T *wp, linenr_T lnum)
 {
-  char_u *s;
+  char *s;
   unsigned int col;
   int width;
 
-  s = ml_get_buf(wp->w_buffer, lnum, false);
+  s = (char *)ml_get_buf(wp->w_buffer, lnum, false);
   if (*s == NUL) {  // empty line
     return 1;
   }
-  col = win_linetabsize(wp, s, MAXCOL);
+  col = win_linetabsize(wp, lnum, (char_u *)s, MAXCOL);
 
   // If list mode is on, then the '$' at the end of the line may take up one
   // extra column.
@@ -145,23 +145,27 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
   }
 
   char_u *line = ml_get_buf(wp->w_buffer, lnum, false);
-  char_u *s = line;
 
   colnr_T col = 0;
-  while (*s != NUL && --column >= 0) {
-    col += win_lbr_chartabsize(wp, line, s, col, NULL);
-    MB_PTR_ADV(s);
+  chartabsize_T cts;
+
+  init_chartabsize_arg(&cts, wp, lnum, 0, line, line);
+  while (*cts.cts_ptr != NUL && --column >= 0) {
+    cts.cts_vcol += win_lbr_chartabsize(&cts, NULL);
+    MB_PTR_ADV(cts.cts_ptr);
   }
 
-  // If *s is a TAB, and the TAB is not displayed as ^I, and we're not in
-  // MODE_INSERT state, then col must be adjusted so that it represents the
+  // If *cts.cts_ptr is a TAB, and the TAB is not displayed as ^I, and we're not
+  // in MODE_INSERT state, then col must be adjusted so that it represents the
   // last screen position of the TAB.  This only fixes an error when the TAB
   // wraps from one screen line to the next (when 'columns' is not a multiple
   // of 'ts') -- webb.
-  if (*s == TAB && (State & MODE_NORMAL)
+  col = cts.cts_vcol;
+  if (*cts.cts_ptr == TAB && (State & MODE_NORMAL)
       && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
-    col += win_lbr_chartabsize(wp, line, s, col, NULL) - 1;
+    col += win_lbr_chartabsize(&cts, NULL) - 1;
   }
+  clear_chartabsize_arg(&cts);
 
   // Add column offset for 'number', 'relativenumber', 'foldcolumn', etc.
   int width = wp->w_width_inner - win_col_off(wp);
@@ -223,7 +227,7 @@ int plines_m_win(win_T *wp, linenr_T first, linenr_T last)
 /// @param col
 ///
 /// @return Number of characters.
-int win_chartabsize(win_T *wp, char_u *p, colnr_T col)
+int win_chartabsize(win_T *wp, char *p, colnr_T col)
 {
   buf_T *buf = wp->w_buffer;
   if (*p == TAB && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
@@ -241,24 +245,24 @@ int win_chartabsize(win_T *wp, char_u *p, colnr_T col)
 /// @return Number of characters the string will take on the screen.
 int linetabsize(char_u *s)
 {
-  return linetabsize_col(0, s);
+  return linetabsize_col(0, (char *)s);
 }
 
-/// Like linetabsize(), but starting at column "startcol".
+/// Like linetabsize(), but "s" starts at column "startcol".
 ///
 /// @param startcol
 /// @param s
 ///
 /// @return Number of characters the string will take on the screen.
-int linetabsize_col(int startcol, char_u *s)
+int linetabsize_col(int startcol, char *s)
 {
-  colnr_T col = startcol;
-  char_u *line = s;  // pointer to start of line, for breakindent
-
-  while (*s != NUL) {
-    col += lbr_chartabsize_adv(line, &s, col);
+  chartabsize_T cts;
+  init_chartabsize_arg(&cts, curwin, 0, startcol, (char_u *)s, (char_u *)s);
+  while (*cts.cts_ptr != NUL) {
+    cts.cts_vcol += lbr_chartabsize_adv(&cts);
   }
-  return (int)col;
+  clear_chartabsize_arg(&cts);
+  return (int)cts.cts_vcol;
 }
 
 /// Like linetabsize(), but for a given window instead of the current one.
@@ -268,18 +272,38 @@ int linetabsize_col(int startcol, char_u *s)
 /// @param len
 ///
 /// @return Number of characters the string will take on the screen.
-unsigned int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
+unsigned int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len)
 {
-  colnr_T col = 0;
-
-  for (char_u *s = line;
-       *s != NUL && (len == MAXCOL || s < line + len);
-       MB_PTR_ADV(s)) {
-    col += win_lbr_chartabsize(wp, line, s, col, NULL);
+  chartabsize_T cts;
+  init_chartabsize_arg(&cts, wp, lnum, 0, line, line);
+  for (; *cts.cts_ptr != NUL && (len == MAXCOL || cts.cts_ptr < (char *)line + len);
+       MB_PTR_ADV(cts.cts_ptr)) {
+    cts.cts_vcol += win_lbr_chartabsize(&cts, NULL);
   }
-
-  return (unsigned int)col;
+  clear_chartabsize_arg(&cts);
+  return (unsigned int)cts.cts_vcol;
 }
+
+/// Prepare the structure passed to chartabsize functions.
+///
+/// "line" is the start of the line, "ptr" is the first relevant character.
+/// When "lnum" is zero do not use text properties that insert text.
+void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T col, char_u *line,
+                          char_u *ptr)
+{
+  cts->cts_win = wp;
+  cts->cts_lnum = lnum;
+  cts->cts_vcol = col;
+  cts->cts_line = (char *)line;
+  cts->cts_ptr = (char *)ptr;
+  cts->cts_cur_text_width = 0;
+  // TODO(bfredl): actually lookup inline virtual text here
+  cts->cts_has_virt_text = false;
+}
+
+/// Free any allocated item in "cts".
+void clear_chartabsize_arg(chartabsize_T *cts)
+{}
 
 /// like win_chartabsize(), but also check for line breaks on the screen
 ///
@@ -288,16 +312,16 @@ unsigned int win_linetabsize(win_T *wp, char_u *line, colnr_T len)
 /// @param col
 ///
 /// @return The number of characters taken up on the screen.
-int lbr_chartabsize(char_u *line, unsigned char *s, colnr_T col)
+int lbr_chartabsize(chartabsize_T *cts)
 {
   if (!curwin->w_p_lbr && *get_showbreak_value(curwin) == NUL
-      && !curwin->w_p_bri) {
+      && !curwin->w_p_bri && !cts->cts_has_virt_text) {
     if (curwin->w_p_wrap) {
-      return win_nolbr_chartabsize(curwin, s, col, NULL);
+      return win_nolbr_chartabsize(cts, NULL);
     }
-    return win_chartabsize(curwin, s, col);
+    return win_chartabsize(curwin, cts->cts_ptr, cts->cts_vcol);
   }
-  return win_lbr_chartabsize(curwin, line == NULL ? s: line, s, col, NULL);
+  return win_lbr_chartabsize(cts, NULL);
 }
 
 /// Call lbr_chartabsize() and advance the pointer.
@@ -307,12 +331,12 @@ int lbr_chartabsize(char_u *line, unsigned char *s, colnr_T col)
 /// @param col
 ///
 /// @return The number of characters take up on the screen.
-int lbr_chartabsize_adv(char_u *line, char_u **s, colnr_T col)
+int lbr_chartabsize_adv(chartabsize_T *cts)
 {
   int retval;
 
-  retval = lbr_chartabsize(line, *s, col);
-  MB_PTR_ADV(*s);
+  retval = lbr_chartabsize(cts);
+  MB_PTR_ADV(cts->cts_ptr);
   return retval;
 }
 
@@ -322,17 +346,19 @@ int lbr_chartabsize_adv(char_u *line, char_u **s, colnr_T col)
 /// string at start of line.  Warning: *headp is only set if it's a non-zero
 /// value, init to 0 before calling.
 ///
-/// @param wp
-/// @param line
-/// @param s
-/// @param col
+/// @param cts
 /// @param headp
 ///
 /// @return The number of characters taken up on the screen.
-int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *headp)
+int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
 {
+  win_T *wp = cts->cts_win;
+  char *line = cts->cts_line;  // start of the line
+  char_u *s = (char_u *)cts->cts_ptr;
+  colnr_T vcol = cts->cts_vcol;
+
   colnr_T col2;
-  colnr_T col_adj = 0;  // col + screen size of tab
+  colnr_T col_adj = 0;  // vcol + screen size of tab
   colnr_T colmax;
   int added;
   int mb_added = 0;
@@ -340,16 +366,23 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
   char_u *ps;
   int n;
 
+  cts->cts_cur_text_width = 0;
+
   // No 'linebreak', 'showbreak' and 'breakindent': return quickly.
-  if (!wp->w_p_lbr && !wp->w_p_bri && *get_showbreak_value(wp) == NUL) {
+  if (!wp->w_p_lbr && !wp->w_p_bri && *get_showbreak_value(wp) == NUL
+      && !cts->cts_has_virt_text) {
     if (wp->w_p_wrap) {
-      return win_nolbr_chartabsize(wp, s, col, headp);
+      return win_nolbr_chartabsize(cts, headp);
     }
-    return win_chartabsize(wp, s, col);
+    return win_chartabsize(wp, (char *)s, vcol);
   }
 
-  // First get normal size, without 'linebreak'
-  int size = win_chartabsize(wp, s, col);
+  // First get normal size, without 'linebreak' or virtual text
+  int size = win_chartabsize(wp, (char *)s, vcol);
+  if (cts->cts_has_virt_text) {
+    // TODO(bfredl): inline virtual text
+  }
+
   int c = *s;
   if (*s == TAB) {
     col_adj = size - 1;
@@ -365,15 +398,15 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
     // Count all characters from first non-blank after a blank up to next
     // non-blank after a blank.
     numberextra = win_col_off(wp);
-    col2 = col;
+    col2 = vcol;
     colmax = (colnr_T)(wp->w_width_inner - numberextra - col_adj);
 
-    if (col >= colmax) {
+    if (vcol >= colmax) {
       colmax += col_adj;
       n = colmax + win_col_off2(wp);
 
       if (n > 0) {
-        colmax += (((col - colmax) / n) + 1) * n - col_adj;
+        colmax += (((vcol - colmax) / n) + 1) * n - col_adj;
       }
     }
 
@@ -383,21 +416,21 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
       c = *s;
 
       if (!(c != NUL
-            && (vim_isbreak(c) || col2 == col || !vim_isbreak((int)(*ps))))) {
+            && (vim_isbreak(c) || col2 == vcol || !vim_isbreak((int)(*ps))))) {
         break;
       }
 
-      col2 += win_chartabsize(wp, s, col2);
+      col2 += win_chartabsize(wp, (char *)s, col2);
 
       if (col2 >= colmax) {  // doesn't fit
-        size = colmax - col + col_adj;
+        size = colmax - vcol + col_adj;
         break;
       }
     }
   } else if ((size == 2)
              && (MB_BYTE2LEN(*s) > 1)
              && wp->w_p_wrap
-             && in_win_border(wp, col)) {
+             && in_win_border(wp, vcol)) {
     // Count the ">" in the last column.
     size++;
     mb_added = 1;
@@ -409,40 +442,40 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
   added = 0;
 
   char *const sbr = (char *)get_showbreak_value(wp);
-  if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap && col != 0) {
+  if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap && vcol != 0) {
     colnr_T sbrlen = 0;
     int numberwidth = win_col_off(wp);
 
     numberextra = numberwidth;
-    col += numberextra + mb_added;
+    vcol += numberextra + mb_added;
 
-    if (col >= (colnr_T)wp->w_width_inner) {
-      col -= wp->w_width_inner;
+    if (vcol >= (colnr_T)wp->w_width_inner) {
+      vcol -= wp->w_width_inner;
       numberextra = wp->w_width_inner - (numberextra - win_col_off2(wp));
-      if (col >= numberextra && numberextra > 0) {
-        col %= numberextra;
+      if (vcol >= numberextra && numberextra > 0) {
+        vcol %= numberextra;
       }
       if (*sbr != NUL) {
         sbrlen = (colnr_T)mb_charlen((char_u *)sbr);
-        if (col >= sbrlen) {
-          col -= sbrlen;
+        if (vcol >= sbrlen) {
+          vcol -= sbrlen;
         }
       }
-      if (col >= numberextra && numberextra > 0) {
-        col %= numberextra;
-      } else if (col > 0 && numberextra > 0) {
-        col += numberwidth - win_col_off2(wp);
+      if (vcol >= numberextra && numberextra > 0) {
+        vcol %= numberextra;
+      } else if (vcol > 0 && numberextra > 0) {
+        vcol += numberwidth - win_col_off2(wp);
       }
 
       numberwidth -= win_col_off2(wp);
     }
 
-    if (col == 0 || (col + size + sbrlen > (colnr_T)wp->w_width_inner)) {
+    if (vcol == 0 || (vcol + size + sbrlen > (colnr_T)wp->w_width_inner)) {
       if (*sbr != NUL) {
         if (size + sbrlen + numberwidth > (colnr_T)wp->w_width_inner) {
           // Calculate effective window width.
           int width = (colnr_T)wp->w_width_inner - sbrlen - numberwidth;
-          int prev_width = col ? ((colnr_T)wp->w_width_inner - (sbrlen + col))
+          int prev_width = vcol ? ((colnr_T)wp->w_width_inner - (sbrlen + vcol))
                                : 0;
 
           if (width <= 0) {
@@ -459,11 +492,11 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
       }
 
       if (wp->w_p_bri) {
-        added += get_breakindent_win(wp, line);
+        added += get_breakindent_win(wp, (char_u *)line);
       }
 
       size += added;
-      if (col != 0) {
+      if (vcol != 0) {
         added = 0;
       }
     }
@@ -485,8 +518,11 @@ int win_lbr_chartabsize(win_T *wp, char_u *line, char_u *s, colnr_T col, int *he
 /// @param headp
 ///
 /// @return The number of characters take up on the screen.
-static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
+static int win_nolbr_chartabsize(chartabsize_T *cts, int *headp)
 {
+  win_T *wp = cts->cts_win;
+  char *s = cts->cts_ptr;
+  colnr_T col = cts->cts_vcol;
   int n;
 
   if ((*s == TAB) && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
@@ -498,7 +534,7 @@ static int win_nolbr_chartabsize(win_T *wp, char_u *s, colnr_T col, int *headp)
 
   // Add one cell for a double-width character in the last column of the
   // window, displayed with a ">".
-  if ((n == 2) && (MB_BYTE2LEN(*s) > 1) && in_win_border(wp, col)) {
+  if ((n == 2) && (MB_BYTE2LEN((uint8_t)(*s)) > 1) && in_win_border(wp, col)) {
     if (headp != NULL) {
       *headp = 1;
     }

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -3,6 +3,20 @@
 
 #include "nvim/vim.h"
 
+// Argument for lbr_chartabsize().
+typedef struct {
+  win_T *cts_win;
+  linenr_T cts_lnum;   // zero when not using text properties
+  char *cts_line;    // start of the line
+  char *cts_ptr;     // current position in line
+
+  bool cts_has_virt_text;  // true if if a property inserts text
+  int cts_cur_text_width;     // width of current inserted text
+  // TODO(bfredl): iterator in to the marktree for scanning virt text
+
+  int cts_vcol;    // virtual column at current position
+} chartabsize_T;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "plines.h.generated.h"
 #endif

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1165,7 +1165,7 @@ static bool reg_match_visual(void)
     rex.line = reg_getline(rex.lnum);
     rex.input = rex.line + col;
 
-    unsigned int cols_u = win_linetabsize(wp, rex.line, col);
+    unsigned int cols_u = win_linetabsize(wp, rex.reg_firstlnum + rex.lnum, rex.line, col);
     assert(cols_u <= MAXCOL);
     colnr_T cols = (colnr_T)cols_u;
     if (cols < start || cols > end - (*p_sel == 'e')) {

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -3764,6 +3764,7 @@ static bool regmatch(char_u *scan, proftime_T *tm, int *timed_out)
         case RE_VCOL:
           if (!re_num_cmp(win_linetabsize(rex.reg_win == NULL
                                           ? curwin : rex.reg_win,
+                                          rex.reg_firstlnum + rex.lnum,
                                           rex.line,
                                           (colnr_T)(rex.input - rex.line)) + 1,
                           scan)) {

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -6910,7 +6910,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
           result = col > t->state->val * ts;
         }
         if (!result) {
-          uintmax_t lts = win_linetabsize(wp, rex.line, col);
+          uintmax_t lts = win_linetabsize(wp, rex.reg_firstlnum + rex.lnum, rex.line, col);
           assert(t->state->val >= 0);
           result = nfa_re_num_cmp((uintmax_t)t->state->val, op, lts + 1);
         }


### PR DESCRIPTION
This is a _refactor_ extracted from `vim-patch 9.0.0067: cannot show virtual text`

The logic for inline virtual text is going to be different in nvim than text property based text in vim, but this refactor is still useful, as calculation of displayed linesize is going to be stateful in a similar way.

Do not mark the patch as included, this will be done later when the functional change later is ported. Still merging this refactor makes sense as there is a lot of churn around the codebase (so it will quickly conflict with other refactor efforts).

still some failing tests, will debug more later