### PR TITLE
vim-patch:8.2.3813: confusing error when using :cc without error list

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3586,6 +3586,9 @@ char *invalid_range(exarg_T *eap)
       assert(eap->line2 >= 0);
       // No error for value that is too big, will use the last entry.
       if (eap->line2 <= 0) {
+        if (eap->addr_count == 0) {
+          return _(e_no_errors);
+        }
         return _(e_invrange);
       }
       break;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -920,7 +920,7 @@ EXTERN char e_patnotf2[] INIT(= N_("E486: Pattern not found: %s"));
 EXTERN char e_positive[] INIT(= N_("E487: Argument must be positive"));
 EXTERN char e_prev_dir[] INIT(= N_("E459: Cannot go back to previous directory"));
 
-EXTERN char e_quickfix[] INIT(= N_("E42: No Errors"));
+EXTERN char e_no_errors[] INIT(= N_("E42: No Errors"));
 EXTERN char e_loclist[] INIT(= N_("E776: No location list"));
 EXTERN char e_re_damg[] INIT(= N_("E43: Damaged match string"));
 EXTERN char e_re_corr[] INIT(= N_("E44: Corrupted regexp program"));

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2932,7 +2932,7 @@ static void qf_jump_newwin(qf_info_T *qi, int dir, int errornr, int forceit, boo
   }
 
   if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi))) {
-    emsg(_(e_quickfix));
+    emsg(_(e_no_errors));
     return;
   }
 
@@ -3111,7 +3111,7 @@ void qf_list(exarg_T *eap)
   }
 
   if (qf_stack_empty(qi) || qf_list_empty(qf_get_curlist(qi))) {
-    emsg(_(e_quickfix));
+    emsg(_(e_no_errors));
     return;
   }
 
@@ -3467,7 +3467,7 @@ void qf_view_result(bool split)
     qi = GET_LOC_LIST(curwin);
   }
   if (qf_list_empty(qf_get_curlist(qi))) {
-    emsg(_(e_quickfix));
+    emsg(_(e_no_errors));
     return;
   }
 
@@ -4898,7 +4898,7 @@ void ex_cbelow(exarg_T *eap)
                       || eap->cmdidx == CMD_cafter) ? BUF_HAS_QF_ENTRY : BUF_HAS_LL_ENTRY;
 
   if (!(curbuf->b_has_qf_entry & buf_has_flag)) {
-    emsg(_(e_quickfix));
+    emsg(_(e_no_errors));
     return;
   }
 
@@ -4910,7 +4910,7 @@ void ex_cbelow(exarg_T *eap)
   qf_list_T *qfl = qf_get_curlist(qi);
   // check if the list has valid errors
   if (!qf_list_has_valid_entries(qfl)) {
-    emsg(_(e_quickfix));
+    emsg(_(e_no_errors));
     return;
   }
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -85,6 +85,12 @@ func s:setup_commands(cchar)
   endif
 endfunc
 
+" This must be run before any error lists are created.
+func Test_AA_cc_no_errors()
+  call assert_fails('cc', 'E42:')
+  call assert_fails('ll', 'E42:')
+endfunc
+
 " Tests for the :clist and :llist commands
 func XlistTests(cchar)
   call s:setup_commands(a:cchar)


### PR DESCRIPTION
#### vim-patch:8.2.3813: confusing error when using :cc without error list

Problem:    confusing error when using :cc without error list. (Gary Johnson)
Solution:   Give the "no errors" error.
https://github.com/vim/vim/commit/a5d78d1f1123d9ffccd5ba58f2d2dec44cc59e94

Cherry-pick e_quickfix -> e_no_errors rename from patch 8.2.3190.