### PR TITLE
feat(fs): add `ignore` predicate to `vim.fs.find()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2272,6 +2272,9 @@ find({names}, {opts})                                          *vim.fs.find()*
                  • limit (number, default 1): Stop the search after finding
                    this many matches. Use `math.huge` to place no limit on the
                    number of matches.
+                 • ignore (function): Predicate used to ignore paths. Receives
+                   file path as its single argument. If the function returns
+                   true then the given path will not be searched recursively.
 
     Return: ~
         (table) The paths of all matching files or directories

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -9,6 +9,7 @@ local nvim_dir = helpers.nvim_dir
 local test_build_dir = helpers.test_build_dir
 local iswin = helpers.iswin
 local nvim_prog = helpers.nvim_prog
+local exec = helpers.exec_capture
 
 local nvim_prog_basename = iswin() and 'nvim.exe' or 'nvim'
 
@@ -77,6 +78,16 @@ describe('vim.fs', function()
         local dir, nvim = ...
         return vim.fs.find(nvim, { path = dir, type = 'file' })
       ]], test_build_dir, nvim_prog_basename))
+    end)
+    it('works with ignore()', function()
+      eq({exec('pwd')..'/test/unit/os/fs_spec.lua'}, exec_lua([[
+        return vim.fs.find('fs_spec.lua', {
+          type = 'file',
+          ignore = function (path)
+            return not path:match('test$') and path:match('test/functional.*')
+          end
+        })
+      ]]))
     end)
   end)
 


### PR DESCRIPTION
This will allow user to ignore unwanted folder that they don't
want to recursively search for files i.e., `.git/`, `node_modules/`.

Example: finding prettier config, excluding `node_modules` etc. folders. 

```lua
local files = {
    '.prettierrc',
    '.prettierrc.json',
    '.prettierrc.yml',
    '.prettierrc.yaml',
    '.prettierrc.toml',
}

vim.fs.find(files, {
    type = 'file',
    ignore = function(path)
        return (path:find('node_.-$') or path:find('%.git.-$') or path:find('%.next$'))
    end,
})
```

### Side note

I also thought about adding `hidden` option to exclude hidden files without providing the ignore predicate but couldn't find any reliable way to check hidden attribute.