### PR TITLE
fix(keywordprg): default to :help if set to empty string

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4278,13 +4278,12 @@ static void nv_ident(cmdarg_T *cap)
   // double the length of the word.  p_kp / curbuf->b_p_kp could be added
   // and some numbers.
   char_u *kp = *curbuf->b_p_kp == NUL ? p_kp : (char_u *)curbuf->b_p_kp;  // 'keywordprg'
-  assert(*kp != NUL);  // option.c:do_set() should default to ":help" if empty.
-  bool kp_ex = (*kp == ':');  // 'keywordprg' is an ex command
-  bool kp_help = (STRCMP(kp, ":he") == 0 || STRCMP(kp, ":help") == 0);
+  bool kp_help = (*kp == NUL || STRCMP(kp, ":he") == 0 || STRCMP(kp, ":help") == 0);
   if (kp_help && *skipwhite(ptr) == NUL) {
     emsg(_(e_noident));   // found white space only
     return;
   }
+  bool kp_ex = (*kp == ':');  // 'keywordprg' is an ex command
   size_t buf_size = n * 2 + 30 + STRLEN(kp);
   char *buf = xmalloc(buf_size);
   buf[0] = NUL;

--- a/test/functional/editor/K_spec.lua
+++ b/test/functional/editor/K_spec.lua
@@ -1,6 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
-local eq, clear, eval, feed, retry =
-  helpers.eq, helpers.clear, helpers.eval, helpers.feed, helpers.retry
+local eq, clear, eval, feed, meths, retry =
+  helpers.eq, helpers.clear, helpers.eval, helpers.feed, helpers.meths, helpers.retry
 
 describe('K', function()
   local test_file = 'K_spec_out'
@@ -56,6 +56,13 @@ describe('K', function()
     feed('<esc>')
     eq('n', eval('mode()'))
     helpers.neq(bufnr, eval('bufnr()'))
+  end)
+
+  it('empty string falls back to :help #19298', function()
+    meths.set_option('keywordprg', '')
+    meths.buf_set_lines(0, 0, -1, true, {'doesnotexist'})
+    feed('K')
+    eq('E149: Sorry, no help for doesnotexist', meths.get_vvar('errmsg'))
   end)
 
 end)


### PR DESCRIPTION
Fix #19298
