### PR TITLE
vim-patch:9.0.0316: screen flickers when 'cmdheight' is zero

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -918,7 +918,7 @@ theend:
     // Restore cmdheight
     set_option_value("ch", 0L, NULL, 0);
     // Redraw is needed for command line completion
-    redraw_all_later(UPD_CLEAR);
+    redraw_all_later(UPD_NOT_VALID);
 
     made_cmdheight_nonzero = false;
   }


### PR DESCRIPTION
#### vim-patch:9.0.0316: screen flickers when 'cmdheight' is zero

Problem:    Screen flickers when 'cmdheight' is zero.
Solution:   Redraw over existing text instead of clearing.
https://github.com/vim/vim/commit/f73e5ba56f4aca1cd6e38f1c8ea24e941bf6b33f