### PR TITLE
vim-patch:9.0.0318: clearing screen causes flicker

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1347,7 +1347,8 @@ static void do_filter(linenr_T line1, linenr_T line2, exarg_T *eap, char *cmd, b
     msg_putchar('\n');  // Keep message from buf_write().
     no_wait_return--;
     if (!aborting()) {
-      semsg(_("E482: Can't create file %s"), itmp);  // Will call wait_return.
+      // will call wait_return()
+      semsg(_("E482: Can't create file %s"), itmp);
     }
     goto filterend;
   }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -364,7 +364,7 @@ bool check_changed_any(bool hidden, bool unload)
   exiting = false;
   // When ":confirm" used, don't give an error message.
   if (!(p_confirm || (cmdmod.cmod_flags & CMOD_CONFIRM))) {
-    // There must be a wait_return for this message, do_buffer()
+    // There must be a wait_return() for this message, do_buffer()
     // may cause a redraw.  But wait_return() is a no-op when vgetc()
     // is busy (Quit used from window menu), then make sure we don't
     // cause a scroll up.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -516,7 +516,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
                                       cstack.cs_idx <
                                       0 ? 0 : (cstack.cs_idx + 1) * 2,
                                       true)) == NULL) {
-        // Don't call wait_return for aborted command line.  The NULL
+        // Don't call wait_return() for aborted command line.  The NULL
         // returned for the end of a sourced file or executed function
         // doesn't do this.
         if (KeyTyped && !(flags & DOCMD_REPEAT)) {
@@ -888,7 +888,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       need_wait_return = false;
       msg_didany = false;               // don't wait when restarting edit
     } else if (need_wait_return) {
-      // The msg_start() above clears msg_didout. The wait_return we do
+      // The msg_start() above clears msg_didout. The wait_return() we do
       // here should not overwrite the command that may be shown before
       // doing that.
       msg_didout |= msg_didout_before_start;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1768,7 +1768,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv)
 
   if (!ui_has_messages()) {
     // redraw the screen after getchar()
-    update_screen(UPD_CLEAR);
+    update_screen(UPD_NOT_VALID);
   }
 
   set_vim_var_nr(VV_MOUSE_WIN, 0);

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -2035,7 +2035,7 @@ static int cs_show(exarg_T *eap)
     }
   }
 
-  wait_return(true);
+  wait_return(false);
   return CSCOPE_SUCCESS;
 }
 

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -46,7 +46,7 @@ int ask_yesno(const char *const str, const bool direct)
 
   int r = ' ';
   while (r != 'y' && r != 'n') {
-    // Same highlighting as for wait_return.
+    // same highlighting as for wait_return()
     smsg_attr(HL_ATTR(HLF_R), "%s (y/n)?", str);
     if (direct) {
       r = get_keystroke(NULL);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -523,7 +523,7 @@ void ml_open_file(buf_T *buf)
   }
 
   if (*p_dir != NUL && mfp->mf_fname == NULL) {
-    need_wait_return = true;  // call wait_return later
+    need_wait_return = true;  // call wait_return() later
     no_wait_return++;
     (void)semsg(_("E303: Unable to open swap file for \"%s\", recovery impossible"),
                 buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname);

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -215,7 +215,7 @@ void msg_grid_validate(void)
 /// Displays the string 's' on the status line
 /// When terminal not initialized (yet) mch_errmsg(..) is used.
 ///
-/// @return  true if wait_return not called
+/// @return  true if wait_return() not called
 int msg(char *s)
 {
   return msg_attr_keep(s, 0, false, false);
@@ -745,7 +745,7 @@ static bool emsg_multiline(const char *s, bool multiline)
   attr = HL_ATTR(HLF_E);      // set highlight mode for error messages
   if (msg_scrolled != 0) {
     need_wait_return = true;  // needed in case emsg() is called after
-  }                           // wait_return has reset need_wait_return
+  }                           // wait_return() has reset need_wait_return
                               // and a redraw is expected because
                               // msg_scrolled is non-zero
   if (msg_ext_kind == NULL) {
@@ -766,7 +766,7 @@ static bool emsg_multiline(const char *s, bool multiline)
 /// Rings the bell, if appropriate, and calls message() to do the real work
 /// When terminal not initialized (yet) mch_errmsg(..) is used.
 ///
-/// @return true if wait_return not called
+/// @return true if wait_return() not called
 bool emsg(const char *s)
 {
   return emsg_multiline(s, false);
@@ -2243,7 +2243,7 @@ static void msg_puts_display(const char_u *str, int maxlen, int attr, int recurs
       }
 
       inc_msg_scrolled();
-      need_wait_return = true;       // may need wait_return in main()
+      need_wait_return = true;       // may need wait_return() in main()
       redraw_cmdline = true;
       if (cmdline_row > 0 && !exmode_active) {
         cmdline_row--;
@@ -3166,9 +3166,9 @@ void msg_clr_cmdline(void)
 }
 
 /// end putting a message on the screen
-/// call wait_return if the message does not fit in the available space
+/// call wait_return() if the message does not fit in the available space
 ///
-/// @return  true if wait_return not called.
+/// @return  true if wait_return() not called.
 int msg_end(void)
 {
   /*

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1553,7 +1553,7 @@ skip:
       // make sure all characters are printable
       trans_characters((char *)IObuff, IOSIZE);
 
-      no_wait_return++;         // wait_return done later
+      no_wait_return++;         // wait_return() done later
       emsg((char *)IObuff);     // show error highlighted
       no_wait_return--;
 

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -911,7 +911,7 @@ static int do_os_system(char **argv, const char *input, size_t len, char **outpu
     out_data_ring(NULL, SIZE_MAX);
   }
   if (forward_output) {
-    // caller should decide if wait_return is invoked
+    // caller should decide if wait_return() is invoked
     no_wait_return++;
     msg_end();
     no_wait_return--;


### PR DESCRIPTION
#### vim-patch:9.0.0318: clearing screen causes flicker

Problem:    Clearing screen causes flicker.
Solution:   Do not clear but redraw in more cases.  Add () to "wait_return".
https://github.com/vim/vim/commit/13608d851a0470ced30921428b3313c023d395d8

Only 2 lines of actual code change.