### PR TITLE
docs(lsp): replace formatting_sync example in lsp-faq

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -126,13 +126,14 @@ FAQ                                                     *lsp-faq*
      "after/ftplugin/python.vim".
 
 - Q: How do I run a request synchronously (e.g. for formatting on file save)?
-  A: Use the `_sync` variant of the function provided by |lsp-buf|, if it
-     exists.
+  A: Check if the function has an `async` parameter and set the value to
+  false.
 
      E.g. code formatting: >
 
      " Auto-format *.rs (rust) files prior to saving them
-     autocmd BufWritePre *.rs lua vim.lsp.buf.formatting_sync(nil, 1000)
+     " (async = false is the default for format)
+     autocmd BufWritePre *.rs lua vim.lsp.buf.format({ async = false })
 
 <
                                                            *lsp-vs-treesitter*


### PR DESCRIPTION
`formatting_sync` is deprecated
