### PR TITLE
vim-patch:9.0.0320: command line type of CmdlineChange differs from getcmdtype()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2721,40 +2721,6 @@ static void f_getcharsearch(typval_T *argvars, typval_T *rettv, EvalFuncData fpt
   tv_dict_add_nr(dict, S_LEN("until"), last_csearch_until());
 }
 
-/// "getcmdcompltype()" function
-static void f_getcmdcompltype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = (char *)get_cmdline_completion();
-}
-
-/// "getcmdline()" function
-static void f_getcmdline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = (char *)get_cmdline_str();
-}
-
-/// "getcmdpos()" function
-static void f_getcmdpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->vval.v_number = get_cmdline_pos() + 1;
-}
-
-/// "getcmdscreenpos()" function
-static void f_getcmdscreenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->vval.v_number = get_cmdline_screen_pos() + 1;
-}
-
-/// "getcmdtype()" function
-static void f_getcmdtype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = xmallocz(1);
-  rettv->vval.v_string[0] = (char)get_cmdline_type();
-}
-
 /// "getcmdwintype()" function
 static void f_getcmdwintype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
@@ -7619,41 +7585,6 @@ static void f_setcharsearch(typval_T *argvars, typval_T *rettv, EvalFuncData fpt
     if (di != NULL) {
       set_csearch_until(!!tv_get_number(&di->di_tv));
     }
-  }
-}
-
-/// "setcmdline()" function
-static void f_setcmdline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  if (argvars[0].v_type != VAR_STRING || argvars[0].vval.v_string == NULL) {
-    emsg(_(e_stringreq));
-    return;
-  }
-
-  int pos = -1;
-  if (argvars[1].v_type != VAR_UNKNOWN) {
-    bool error = false;
-
-    pos = (int)tv_get_number_chk(&argvars[1], &error) - 1;
-    if (error) {
-      return;
-    }
-    if (pos < 0) {
-      emsg(_(e_positive));
-      return;
-    }
-  }
-
-  rettv->vval.v_number = set_cmdline_str(argvars[0].vval.v_string, pos);
-}
-
-/// "setcmdpos()" function
-static void f_setcmdpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  const int pos = (int)tv_get_number(&argvars[0]) - 1;
-
-  if (pos >= 0) {
-    rettv->vval.v_number = set_cmdline_pos(pos);
   }
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4042,7 +4042,7 @@ static int set_cmdline_str(const char *str, int pos)
   redrawcmd();
 
   // Trigger CmdlineChanged autocommands.
-  do_autocmd_cmdlinechanged(ccline.cmdfirstc == NUL ? '-' : ccline.cmdfirstc);
+  do_autocmd_cmdlinechanged(get_cmdline_type());
 
   return 0;
 }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2187,9 +2187,13 @@ endfunc
 
 func Test_setcmdline()
   func SetText(text, pos)
+    autocmd CmdlineChanged * let g:cmdtype = expand('<afile>')
     call assert_equal(0, setcmdline(a:text))
     call assert_equal(a:text, getcmdline())
     call assert_equal(len(a:text) + 1, getcmdpos())
+    call assert_equal(getcmdtype(), g:cmdtype)
+    unlet g:cmdtype
+    autocmd! CmdlineChanged
 
     call assert_equal(0, setcmdline(a:text, a:pos))
     call assert_equal(a:text, getcmdline())
@@ -2205,6 +2209,13 @@ func Test_setcmdline()
   call feedkeys(":\<C-R>=SetText('set rtp?', 2)\<CR>\<CR>", 'xt')
   call assert_equal('set rtp?', @:)
 
+  call feedkeys(":let g:str = input('? ')\<CR>", 't')
+  call feedkeys("\<C-R>=SetText('foo', 4)\<CR>\<CR>", 'xt')
+  call assert_equal('foo', g:str)
+  unlet g:str
+
+  delfunc SetText
+
   " setcmdline() returns 1 when not editing the command line.
   call assert_equal(1, 'foo'->setcmdline())
 
@@ -2217,6 +2228,8 @@ func Test_setcmdline()
   com! -nargs=* -complete=custom,CustomComplete DoCmd :
   call feedkeys(":DoCmd \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"DoCmd January February Mars', @:)
+  delcom DoCmd
+  delfunc CustomComplete
 
   " Called in <expr>
   cnoremap <expr>a setcmdline('let foo=')


### PR DESCRIPTION
#### vim-patch:9.0.0320: command line type of CmdlineChange differs from getcmdtype()

Problem:    Command line type of CmdlineChange differs from getcmdtype().
Solution:   Use the same type. (closes vim/vim#11005)
https://github.com/vim/vim/commit/54acb90d9e672315e3bd13f8dc71f828df97c868