### PR TITLE
fix(exceptions): restore `did_throw`

### DIFF
--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -134,6 +134,7 @@ typedef struct {
   const msglist_T *const *msg_list;
   int trylevel;
   int got_int;
+  bool did_throw;
   int need_rethrow;
   int did_emsg;
 } TryState;

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -137,7 +137,7 @@ Object nvim_eval(String expr, Error *err)
     if (!recursive) {
       force_abort = false;
       suppress_errthrow = false;
-      current_exception = NULL;
+      did_throw = false;
       // `did_emsg` is set by emsg(), which cancels execution.
       did_emsg = false;
     }
@@ -196,7 +196,7 @@ static Object _call_function(String fn, Array args, dict_T *self, Error *err)
     if (!recursive) {
       force_abort = false;
       suppress_errthrow = false;
-      current_exception = NULL;
+      did_throw = false;
       // `did_emsg` is set by emsg(), which cancels execution.
       did_emsg = false;
     }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5985,7 +5985,7 @@ void timer_due_cb(TimeWatcher *tw, void *data)
   // Handle error message
   if (called_emsg > called_emsg_before && did_emsg) {
     timer->emsg_count++;
-    if (current_exception != NULL) {
+    if (did_throw) {
       discard_current_exception();
     }
   }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3010,7 +3010,7 @@ void ex_call(exarg_T *eap)
 
   // When inside :try we need to check for following "| catch" or "| endtry".
   // Not when there was an error, but do check if an exception was thrown.
-  if ((!aborting() || current_exception != NULL) && (!failed || eap->cstack->cs_trylevel > 0)) {
+  if ((!aborting() || did_throw) && (!failed || eap->cstack->cs_trylevel > 0)) {
     // Check for trailing illegal characters and a following command.
     if (!ends_excmd(*arg)) {
       if (!failed && !aborting()) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -134,6 +134,7 @@ struct dbg_stuff {
   char *vv_throwpoint;
   int did_emsg;
   int got_int;
+  bool did_throw;
   int need_rethrow;
   int check_cstack;
   except_T *current_exception;
@@ -165,6 +166,7 @@ static void save_dbg_stuff(struct dbg_stuff *dsp)
   // Necessary for debugging an inactive ":catch", ":finally", ":endtry".
   dsp->did_emsg       = did_emsg;             did_emsg     = false;
   dsp->got_int        = got_int;              got_int      = false;
+  dsp->did_throw      = did_throw;            did_throw    = false;
   dsp->need_rethrow   = need_rethrow;         need_rethrow = false;
   dsp->check_cstack   = check_cstack;         check_cstack = false;
   dsp->current_exception = current_exception; current_exception = NULL;
@@ -180,6 +182,7 @@ static void restore_dbg_stuff(struct dbg_stuff *dsp)
   (void)v_throwpoint(dsp->vv_throwpoint);
   did_emsg = dsp->did_emsg;
   got_int = dsp->got_int;
+  did_throw = dsp->did_throw;
   need_rethrow = dsp->need_rethrow;
   check_cstack = dsp->check_cstack;
   current_exception = dsp->current_exception;
@@ -397,7 +400,8 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
 
   initial_trylevel = trylevel;
 
-  current_exception = NULL;
+  // "did_throw" will be set to true when an exception is being thrown.
+  did_throw = false;
   // "did_emsg" will be set to true when emsg() is used, in which case we
   // cancel the whole command line, and any if/endif or loop.
   // If force_abort is set, we cancel everything.
@@ -625,7 +629,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
         // not to use a cs_line[] from an entry that isn't a ":while"
         // or ":for": It would make "current_line" invalid and can
         // cause a crash.
-        if (!did_emsg && !got_int && !current_exception
+        if (!did_emsg && !got_int && !did_throw
             && cstack.cs_idx >= 0
             && (cstack.cs_flags[cstack.cs_idx]
                 & (CSF_WHILE | CSF_FOR))
@@ -667,7 +671,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       current_line = 0;
     }
 
-    // A ":finally" makes did_emsg, got_int and current_exception pending for
+    // A ":finally" makes did_emsg, got_int and did_throw pending for
     // being restored at the ":endtry".  Reset them here and set the
     // ACTIVE and FINALLY flags, so that the finally clause gets executed.
     // This includes the case where a missing ":endif", ":endwhile" or
@@ -676,9 +680,8 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       cstack.cs_lflags &= ~CSL_HAD_FINA;
       report_make_pending((cstack.cs_pending[cstack.cs_idx]
                            & (CSTP_ERROR | CSTP_INTERRUPT | CSTP_THROW)),
-                          current_exception);
-      did_emsg = got_int = false;
-      current_exception = NULL;
+                          did_throw ? current_exception : NULL);
+      did_emsg = got_int = did_throw = false;
       cstack.cs_flags[cstack.cs_idx] |= CSF_ACTIVE | CSF_FINALLY;
     }
 
@@ -691,7 +694,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
     // exception, cancel everything.  If it is left normally, reset
     // force_abort to get the non-EH compatible abortion behavior for
     // the rest of the script.
-    if (trylevel == 0 && !did_emsg && !got_int && !current_exception) {
+    if (trylevel == 0 && !did_emsg && !got_int && !did_throw) {
       force_abort = false;
     }
 
@@ -705,7 +708,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
     // - didn't get an error message or lines are not typed
     // - there is a command after '|', inside a :if, :while, :for or :try, or
     //   looping for ":source" command or function call.
-  } while (!((got_int || (did_emsg && force_abort) || current_exception)
+  } while (!((got_int || (did_emsg && force_abort) || did_throw)
              && cstack.cs_trylevel == 0)
            && !(did_emsg
                 // Keep going when inside try/catch, so that the error can be
@@ -725,7 +728,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
   if (cstack.cs_idx >= 0) {
     // If a sourced file or executed function ran to its end, report the
     // unclosed conditional.
-    if (!got_int && !current_exception
+    if (!got_int && !did_throw
         && ((getline_equal(fgetline, cookie, getsourceline)
              && !source_finished(fgetline, cookie))
             || (getline_equal(fgetline, cookie, get_func_line)
@@ -768,7 +771,8 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
     // conditional, discard the uncaught exception, disable the conversion
     // of interrupts or errors to exceptions, and ensure that no more
     // commands are executed.
-    if (current_exception) {
+    if (did_throw) {
+      assert(current_exception != NULL);
       char *p = NULL;
       msglist_T *messages = NULL;
       msglist_T *next;
@@ -830,14 +834,14 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
   // cstack belongs to the same function or, respectively, script file, it
   // will have to be checked for finally clauses to be executed due to the
   // ":return" or ":finish".  This is done in do_one_cmd().
-  if (current_exception) {
+  if (did_throw) {
     need_rethrow = true;
   }
   if ((getline_equal(fgetline, cookie, getsourceline)
        && ex_nesting_level > source_level(real_cookie))
       || (getline_equal(fgetline, cookie, get_func_line)
           && ex_nesting_level > func_level(real_cookie) + 1)) {
-    if (!current_exception) {
+    if (!did_throw) {
       check_cstack = true;
     }
   } else {
@@ -1676,7 +1680,7 @@ static void profile_cmd(const exarg_T *eap, cstack_T *cstack, LineGetter fgetlin
       && (!eap->skip || cstack->cs_idx == 0
           || (cstack->cs_idx > 0
               && (cstack->cs_flags[cstack->cs_idx - 1] & CSF_ACTIVE)))) {
-    int skip = did_emsg || got_int || current_exception;
+    bool skip = did_emsg || got_int || did_throw;
 
     if (eap->cmdidx == CMD_catch) {
       skip = !skip && !(cstack->cs_idx >= 0
@@ -1873,7 +1877,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
 
   ea.skip = (did_emsg
              || got_int
-             || current_exception
+             || did_throw
              || (cstack->cs_idx >= 0
                  && !(cstack->cs_flags[cstack->cs_idx] & CSF_ACTIVE)));
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -241,8 +241,12 @@ EXTERN int do_profiling INIT(= PROF_NONE);      ///< PROF_ values
 
 /// Exception currently being thrown.  Used to pass an exception to a different
 /// cstack.  Also used for discarding an exception before it is caught or made
-/// pending.
+/// pending.  Only valid when did_throw is true.
 EXTERN except_T *current_exception;
+
+/// An exception is being thrown.  Reset when the exception is caught or as
+/// long as it is pending in a finally clause.
+EXTERN bool did_throw INIT(= false);
 
 /// Set when a throw that cannot be handled in do_cmdline() must be propagated
 /// to the cstack of the previously called do_cmdline().

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1027,7 +1027,7 @@ int nlua_call(lua_State *lstate)
     // TODO(bfredl): this should be simplified in error handling refactor
     force_abort = false;
     suppress_errthrow = false;
-    current_exception = NULL;
+    did_throw = false;
     did_emsg = false;
 
     try_start();

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -6,6 +6,12 @@ local funcs = helpers.funcs
 local nvim_prog = helpers.nvim_prog
 local matches = helpers.matches
 
+clear()
+if funcs.executable('man') == 0 then
+  pending('missing "man" command', function() end)
+  return
+end
+
 describe(':Man', function()
   before_each(function()
     clear()


### PR DESCRIPTION
Closes #13490
Closes #13711
Closes #18842
Also doesn't seem to regress #7876... 

`!did_throw` doesn't exactly imply `!current_exception`, as `did_throw = false`
is sometimes used to defer exception handling for later (without forgetting the
exception). E.g: uncaught exception handling in `do_cmdline()` may be deferred
to a different call (e.g: when `try_level > 0`).

In #7881, `current_exception = NULL` in `do_cmdline()` is used as an analogue of
`did_throw = false`, but also causes the pending exception to be lost, which
also leaks as `discard_exception()` wasn't used.

It may be possible to fix this by saving/restoring `current_exception`, but
handling all of `did_throw`'s edge cases seems messier. Maybe not worth
diverging over.

This fix also uncovers a `man_spec.lua` bug on Windows: exceptions are thrown
due to Windows missing `man`, but they're lost; skip these tests if `man` isn't
executable.