### PR TITLE
vim-patch:9.0.0332: overwrite check may block BufWriteCmd

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1996,11 +1996,16 @@ int check_overwrite(exarg_T *eap, buf_T *buf, char *fname, char *ffname, int oth
 {
   // Write to another file or b_flags set or not writing the whole file:
   // overwriting only allowed with '!'
+  // If "other" is false and bt_nofilename(buf) is true, this must be
+  // writing an "acwrite" buffer to the same file as its b_ffname, and
+  // buf_write() will only allow writing with BufWriteCmd autocommands,
+  // so there is no need for an overwrite check.
   if ((other
-       || (buf->b_flags & BF_NOTEDITED)
-       || ((buf->b_flags & BF_NEW)
-           && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
-       || (buf->b_flags & BF_READERR))
+       || (!bt_nofilename(buf)
+           && ((buf->b_flags & BF_NOTEDITED)
+               || ((buf->b_flags & BF_NEW)
+                   && vim_strchr(p_cpo, CPO_OVERNEW) == NULL)
+               || (buf->b_flags & BF_READERR))))
       && !p_wa
       && os_path_exists((char_u *)ffname)) {
     if (!eap->forceit && !eap->append) {

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1836,6 +1836,21 @@ func Test_BufReadCmd()
   au! BufWriteCmd
 endfunc
 
+func Test_BufWriteCmd()
+  autocmd BufWriteCmd Xbufwritecmd let g:written = 1
+  new
+  file Xbufwritecmd
+  set buftype=acwrite
+  call mkdir('Xbufwritecmd')
+  write
+  " BufWriteCmd should be triggered even if a directory has the same name
+  call assert_equal(1, g:written)
+  call delete('Xbufwritecmd', 'd')
+  unlet g:written
+  au! BufWriteCmd
+  bwipe!
+endfunc
+
 func SetChangeMarks(start, end)
   exe a:start .. 'mark ['
   exe a:end .. 'mark ]'


### PR DESCRIPTION
Fix #20002

#### vim-patch:9.0.0332: overwrite check may block BufWriteCmd

Problem:    Overwrite check may block BufWriteCmd.
Solution:   Do not use overwrite check when 'buftype' is "acwrite".
            (closes vim/vim#11011)
https://github.com/vim/vim/commit/9c8f94636b3610b898ffbbd07f6b75866d16cbca