### PR TITLE
vim-patch:8.1.2037: can call win_gotoid() in cmdline window

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9659,7 +9659,19 @@ static void f_win_gettype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "win_gotoid()" function
 static void f_win_gotoid(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  rettv->vval.v_number = win_gotoid(argvars);
+  int id = (int)tv_get_number(&argvars[0]);
+
+  if (cmdwin_type != 0) {
+    emsg(_(e_cmdwin));
+    return;
+  }
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if (wp->handle == id) {
+      goto_tabpage_win(tp, wp);
+      rettv->vval.v_number = 1;
+      return;
+    }
+  }
 }
 
 /// "win_id2tabwin()" function

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1260,6 +1260,16 @@ func Test_cmdline_overstrike()
   let &encoding = encoding_save
 endfunc
 
+func Test_cmdwin_bug()
+  let winid = win_getid()
+  sp
+  try
+    call feedkeys("q::call win_gotoid(" .. winid .. ")\<CR>:q\<CR>", 'x!')
+  catch /^Vim\%((\a\+)\)\=:E11/
+  endtry
+  bw!
+endfunc
+
 func Test_cmdwin_restore()
   CheckScreendump
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7396,19 +7396,6 @@ int win_getid(typval_T *argvars)
   return 0;
 }
 
-int win_gotoid(typval_T *argvars)
-{
-  int id = (int)tv_get_number(&argvars[0]);
-
-  FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (wp->handle == id) {
-      goto_tabpage_win(tp, wp);
-      return 1;
-    }
-  }
-  return 0;
-}
-
 void win_get_tabwin(handle_T id, int *tabnr, int *winnr)
 {
   *tabnr = 0;


### PR DESCRIPTION
#### vim-patch:8.1.2037: can call win_gotoid() in cmdline window

Problem:    Can call win_gotoid() in cmdline window.
Solution:   Disallow switching windows. (Yasuhiro Matsumoto, closes vim/vim#4940)
https://github.com/vim/vim/commit/a046b37c22bcabdea5f0fd6d21ca4bd0aa4c768e