### PR TITLE
refactor(mappings)!: mapblock_fill_dict() use API Dictionary

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -945,7 +945,7 @@ Integer nvim_buf_get_changedtick(Buffer buffer, Error *err)
 /// @param[out]  err   Error details, if any
 /// @returns Array of |maparg()|-like dictionaries describing mappings.
 ///          The "buffer" key holds the associated buffer handle.
-ArrayOf(Dictionary) nvim_buf_get_keymap(uint64_t channel_id, Buffer buffer, String mode, Error *err)
+ArrayOf(Dictionary) nvim_buf_get_keymap(Buffer buffer, String mode, Error *err)
   FUNC_API_SINCE(3)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
@@ -954,7 +954,7 @@ ArrayOf(Dictionary) nvim_buf_get_keymap(uint64_t channel_id, Buffer buffer, Stri
     return (Array)ARRAY_DICT_INIT;
   }
 
-  return keymap_array(mode, buf, channel_id == LUA_INTERNAL_CALL);
+  return keymap_array(mode, buf);
 }
 
 /// Sets a buffer-local |mapping| for the given mode.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1421,10 +1421,10 @@ Dictionary nvim_get_mode(void)
 /// @param  mode       Mode short-name ("n", "i", "v", ...)
 /// @returns Array of |maparg()|-like dictionaries describing mappings.
 ///          The "buffer" key is always zero.
-ArrayOf(Dictionary) nvim_get_keymap(uint64_t channel_id, String mode)
+ArrayOf(Dictionary) nvim_get_keymap(String mode)
   FUNC_API_SINCE(3)
 {
-  return keymap_array(mode, NULL, channel_id == LUA_INTERNAL_CALL);
+  return keymap_array(mode, NULL);
 }
 
 /// Sets a global |mapping| for the given mode.


### PR DESCRIPTION
This introduces the following breaking changes:
- `nvim_get_keymap` now always returns a LuaRef object as `callback` for a Lua mapping regardless of how it is called. The LuaRef object can be called from Lua and Vim script, but is lost over RPC.
- `maparg()` now returns a Funcref instead of a ref number as `callback` for a Lua mapping. The Funcref can be called from Lua and Vim script, but is lost over RPC.

This may also make `nvim_get_keymap` faster, but make `maparg()` slower.
