### PR TITLE
refactor(highlight): make hlattrs2dict always use pre-allocated dict

### DIFF
--- a/src/nvim/highlight.h
+++ b/src/nvim/highlight.h
@@ -19,6 +19,8 @@ static inline int win_hl_attr(win_T *wp, int hlf)
   return ((wp->w_ns_hl_attr && ns_hl_fast < 0) ? wp->w_ns_hl_attr : hl_attr_active)[hlf];
 }
 
+#define HLATTRS_DICT_SIZE 16
+
 #define HL_SET_DEFAULT_COLORS(rgb_fg, rgb_bg, rgb_sp) \
   do { \
     bool dark_ = (*p_bg == 'd'); \

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1466,19 +1466,21 @@ static void highlight_list_one(const int id)
   }
 }
 
-Dictionary get_global_hl_defs(void)
+Dictionary get_global_hl_defs(Arena *arena)
 {
-  Dictionary rv = ARRAY_DICT_INIT;
-  for (int i = 1; i <= highlight_ga.ga_len && !got_int; i++) {
+  Dictionary rv = arena_dict(arena, (size_t)highlight_ga.ga_len);
+  for (int i = 1; i <= highlight_ga.ga_len; i++) {
     Dictionary attrs = ARRAY_DICT_INIT;
     HlGroup *h = &hl_table[i - 1];
     if (h->sg_attr > 0) {
-      attrs = hlattrs2dict(NULL, syn_attr2entry(h->sg_attr), true);
+      attrs = arena_dict(arena, HLATTRS_DICT_SIZE);
+      hlattrs2dict(&attrs, syn_attr2entry(h->sg_attr), true);
     } else if (h->sg_link > 0) {
-      const char *link = (const char *)hl_table[h->sg_link - 1].sg_name;
-      PUT(attrs, "link", STRING_OBJ(cstr_to_string(link)));
+      attrs = arena_dict(arena, 1);
+      char *link = (char *)hl_table[h->sg_link - 1].sg_name;
+      PUT_C(attrs, "link", STRING_OBJ(cstr_as_string(link)));
     }
-    PUT(rv, (const char *)h->sg_name, DICTIONARY_OBJ(attrs));
+    PUT_C(rv, (char *)h->sg_name, DICTIONARY_OBJ(attrs));
   }
 
   return rv;


### PR DESCRIPTION
hlattrs2dict used to work with both allocated and unallocated
dicts which was quite messy. Now always delegate allocation to caller.