### PR TITLE
perf(messages): don't call ui_flush() per message line in various places

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -717,7 +717,6 @@ int showmatches(expand_T *xp, int wildmenu)
         msg_clr_eos();
         msg_putchar('\n');
       }
-      ui_flush();                          // show one line at a time
       if (got_int) {
         got_int = false;
         break;

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -650,7 +650,6 @@ void ex_history(exarg_T *eap)
             STRCAT(IObuff, hist[i].hisstr);
           }
           msg_outtrans((char *)IObuff);
-          ui_flush();
         }
         if (i == idx) {
           break;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -5004,7 +5004,6 @@ void ex_oldfiles(exarg_T *eap)
         msg_outtrans((char *)tv_get_string(TV_LIST_ITEM_TV(li)));
         msg_clr_eos();
         msg_putchar('\n');
-        ui_flush();                  // output one line at a time
         os_breakcheck();
       }
     });

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4833,7 +4833,6 @@ static void ex_print(exarg_T *eap)
       if (++eap->line1 > eap->line2) {
         break;
       }
-      ui_flush();                  // show one line at a time
     }
     setpcmark();
     // put cursor at last line
@@ -5035,7 +5034,6 @@ static void ex_tabs(exarg_T *eap)
     msg_putchar('\n');
     vim_snprintf((char *)IObuff, IOSIZE, _("Tab page %d"), tabcount++);
     msg_outtrans_attr((char *)IObuff, HL_ATTR(HLF_T));
-    ui_flush();            // output one line at a time
     os_breakcheck();
 
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
@@ -5054,7 +5052,6 @@ static void ex_tabs(exarg_T *eap)
         home_replace(wp->w_buffer, wp->w_buffer->b_fname, (char *)IObuff, IOSIZE, true);
       }
       msg_outtrans((char *)IObuff);
-      ui_flush();                  // output one line at a time
       os_breakcheck();
     }
   }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -214,7 +214,6 @@ static void showmap(mapblock_T *mp, bool local)
     last_set_msg(mp->m_script_ctx);
   }
   msg_clr_eos();
-  ui_flush();                          // show one line at a time
 }
 
 /// Replace termcodes in the given LHS and RHS and store the results into the

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -925,7 +925,6 @@ static void show_one_mark(int c, char_u *arg, pos_T *p, char_u *name_arg, int cu
           msg_outtrans_attr((char *)name, current ? HL_ATTR(HLF_D) : 0);
         }
       }
-      ui_flush();  // show one line at a time
     }
     if (mustfree) {
       xfree(name);
@@ -1058,7 +1057,6 @@ void ex_jumps(exarg_T *eap)
       xfree(name);
       os_breakcheck();
     }
-    ui_flush();
   }
   if (curwin->w_jumplistidx == curwin->w_jumplistlen) {
     msg_puts("\n>");
@@ -1101,7 +1099,6 @@ void ex_changes(exarg_T *eap)
       xfree(name);
       os_breakcheck();
     }
-    ui_flush();
   }
   if (curwin->w_changelistidx == curbuf->b_changelistlen) {
     msg_puts("\n>");

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3866,7 +3866,6 @@ void ex_display(exarg_T *eap)
         if (n > 1 && yb->y_type == kMTLineWise) {
           msg_puts_attr("^J", attr);
         }
-        ui_flush();  // show one line at a time
       }
       os_breakcheck();
     }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3355,7 +3355,6 @@ static void showoptions(int all, int opt_flags)
         showoneopt(items[i], opt_flags);
         col += INC;
       }
-      ui_flush();
       os_breakcheck();
     }
   }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3094,8 +3094,6 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   if (tbuf != IObuff) {
     xfree(tbuf);
   }
-
-  ui_flush();  // show one line at a time
 }
 
 // ":clist": list all errors

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3714,7 +3714,6 @@ void find_pattern_in_path(char_u *ptr, Direction dir, size_t len, bool whole, bo
             }
           }
         }
-        ui_flush();                // output each line directly
       }
 
       if (new_fname != NULL) {
@@ -4147,7 +4146,6 @@ static void show_pat_in_path(char_u *line, int type, bool did_show, int action, 
       msg_puts(" ");
     }
     msg_prt_line((char *)line, false);
-    ui_flush();                        // show one line at a time
 
     // Definition continues until line that doesn't end with '\'
     if (got_int || type != FIND_DEFINE || p < line || *p != '\\') {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1056,7 +1056,6 @@ void do_tags(exarg_T *eap)
                         ? HL_ATTR(HLF_D) : 0);
       xfree(name);
     }
-    ui_flush();                    // show one line at a time
   }
   if (tagstackidx == tagstacklen) {     // idx at top of stack
     msg_puts("\n>");


### PR DESCRIPTION
When msgsep is used, message scrolling is emulated, which can be slow if done per line. To make message output fast, inhibit emulated scrolling until the full message text is known.