### PR TITLE
ci(clint): remove "Inner expression indentation should be 4" rule

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -1941,13 +1941,6 @@ def CheckExpressionAlignment(filename, clean_lines, linenum, error, startpos=0):
                             error(filename, linenum, 'whitespace/indent', 2,
                                   'End of the inner expression should have '
                                   'the same indent as start')
-                else:
-                    if (pos != depth_line_starts[depth][0] + 4
-                        and not (depth_line_starts[depth][1] == '{'
-                                 and pos == depth_line_starts[depth][0] + 2)):
-                        if depth not in ignore_error_levels:
-                            error(filename, linenum, 'whitespace/indent', 2,
-                                  'Inner expression indentation should be 4')
             else:
                 if (pos != level_starts[depth][0] + 1
                         + (level_starts[depth][2] == '{')):


### PR DESCRIPTION
It completely breaks down in shada.c and is generally useless.
