### PR TITLE
vim-patch:9.0.0349: filetype of *.sil files not well detected

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -468,7 +468,7 @@ endfunc
 
 " Returns true if file content looks like LambdaProlog module
 func IsLProlog()
-  " skip apparent comments and blank lines, what looks like 
+  " skip apparent comments and blank lines, what looks like
   " LambdaProlog comment may be RAPID header
   let l = nextnonblank(1)
   while l > 0 && l < line('$') && getline(l) =~ '^\s*%' " LambdaProlog comment
@@ -875,6 +875,23 @@ func dist#ft#FTsig()
   elseif line =~ sml_comment || line =~# sml_keyword
     setf sml
   endif
+endfunc
+
+" This function checks the first 100 lines of files matching "*.sil" to
+" resolve detection between Swift Intermediate Language and SILE.
+func dist#ft#FTsil()
+  for lnum in range(1, [line('$'), 100]->min())
+    let line = getline(lnum)
+    if line =~ '^\s*[\\%]'
+      setf sile
+      return
+    elseif line =~ '^\s*\S'
+      setf sil
+      return
+    endif
+  endfor
+  " no clue, default to "sil"
+  setf sil
 endfunc
 
 func dist#ft#FTsys()

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1820,7 +1820,7 @@ au BufNewFile,BufRead *.score			setf slrnsc
 au BufNewFile,BufRead *.st			setf st
 
 " Smalltalk (and Rexx, TeX, and Visual Basic)
-au BufNewFile,BufRead *.cls                     call dist#ft#FTcls()
+au BufNewFile,BufRead *.cls			call dist#ft#FTcls()
 
 " Smarty templates
 au BufNewFile,BufRead *.tpl			setf smarty
@@ -1927,8 +1927,8 @@ au BufNewFile,BufRead *.cm			setf voscm
 au BufNewFile,BufRead *.swift			setf swift
 au BufNewFile,BufRead *.swift.gyb		setf swiftgyb
 
-" Swift Intermediate Language
-au BufNewFile,BufRead *.sil			setf sil
+" Swift Intermediate Language or SILE
+au BufNewFile,BufRead *.sil			call dist#ft#FTsil()
 
 " Sysctl
 au BufNewFile,BufRead */etc/sysctl.conf,*/etc/sysctl.d/*.conf	setf sysctl

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -900,7 +900,9 @@ local extension = {
   sig = function(path, bufnr)
     return require('vim.filetype.detect').sig(bufnr)
   end,
-  sil = 'sil',
+  sil = function(path, bufnr)
+    return require('vim.filetype.detect').sil(bufnr)
+  end,
   sim = 'simula',
   ['s85'] = 'sinda',
   sin = 'sinda',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1194,6 +1194,19 @@ function M.shell(path, contents, name)
   return name
 end
 
+-- Swift Intermediate Language or SILE
+function M.sil(bufnr)
+  for _, line in ipairs(getlines(bufnr, 1, 100)) do
+    if line:find('^%s*[\\%%]') then
+      return 'sile'
+    elseif line:find('^%s*%S') then
+      return 'sil'
+    end
+  end
+  -- No clue, default to "sil"
+  return 'sil'
+end
+
 -- SMIL or SNMP MIB file
 function M.smi(bufnr)
   local line = getlines(bufnr, 1)

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1820,6 +1820,44 @@ func Test_sig_file()
   filetype off
 endfunc
 
+" Test dist#ft#FTsil()
+func Test_sil_file()
+  filetype on
+
+  split Xfile.sil
+  call assert_equal('sil', &filetype)
+  bwipe!
+
+  let lines =<< trim END
+  // valid
+  let protoErasedPathA = \ABCProtocol.a
+
+  // also valid
+  let protoErasedPathA =
+          \ABCProtocol.a
+  END
+  call writefile(lines, 'Xfile.sil')
+
+  split Xfile.sil
+  call assert_equal('sil', &filetype)
+  bwipe!
+
+  " SILE
+
+  call writefile(['% some comment'], 'Xfile.sil')
+  split Xfile.sil
+  call assert_equal('sile', &filetype)
+  bwipe!
+
+  call writefile(['\begin[papersize=a6]{document}foo\end{document}'], 'Xfile.sil')
+  split Xfile.sil
+  call assert_equal('sile', &filetype)
+  bwipe!
+
+  call delete('Xfile.sil')
+  filetype off
+endfunc
+
 func Test_inc_file()
   filetype on
 


### PR DESCRIPTION
Problem:    Filetype of *.sil files not well detected.
Solution:   Inspect the file contents to guess the filetype.
https://github.com/vim/vim/commit/be807d582499acbe314ead3891481cba6ca136df