### PR TITLE
`spelllang`: use locale's default language

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5819,7 +5819,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'spelllang'* *'spl'*
-'spelllang' 'spl'	string	(default "en")
+'spelllang' 'spl'	string	(default locale's language or "en")
 			local to buffer
 	A comma-separated list of word list names.  When the 'spell' option is
 	on spellchecking will be done for these languages.  Example: >

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #include "nvim/arglist.h"
 #include "nvim/ascii.h"
@@ -211,6 +212,29 @@ void set_init_1(bool clean_arg)
         set_string_default("sh", cmd, true);
       } else {
         set_string_default("sh", (char *)shell, false);
+      }
+    }
+  }
+
+  /*
+   * Find default value for 'spelllang' option.
+   * Don't use it if it is empty.
+   */
+  {
+    const char *lang = os_getenv("LANG");
+    if (lang != NULL) {
+      int n = (lang[2] == '_') ? 5 : 3;
+      char spelllang[n];
+      for (int i = 0; i < n; i++) spelllang[i] = tolower(lang[i]);
+      spelllang[n] = '\0';
+
+      if (vim_strchr(spelllang, ' ') != NULL) {
+        const size_t len = strlen(spelllang) + 3;
+        char *const cmd = xmalloc(len);
+        snprintf(cmd, len, "\"%s\"", spelllang);
+        set_string_default("spelllang", cmd, true);
+      } else {
+        set_string_default("spelllang", (char *)spelllang, false);
       }
     }
   }


### PR DESCRIPTION
It makes much more sense to have the default spelling language to be the locale's default language instead of just `en`. This is beneficial for non-English speakers and English speakers too because the default will be more accurate (e.g. `en_us` or `en_ca` instead of just `en). See issue #20049.