### PR TITLE
feat(lua)!: add.vim.ui.inputsecret equivalent

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2315,9 +2315,9 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                         "-complete=" argument. See |:command-completion|
                       • highlight (function) Function that will be used for
                         highlighting user inputs.
-                      • secret (boolean|nil) If `true`, the user's input will
-                        be shown as a series of asterisks ("*") (defaults to
-                        `false`). See |inputsecret()|.
+                      • secret (boolean|nil) (default: false) If `true`, user
+                        input is hidden (displayed as asterisks "*") instead
+                        of echoed. See |inputsecret()|.
       • {on_confirm}  (function) ((input|nil) -> ()) Called once the user
                       confirms or abort the input. `input` is what the user
                       typed (it might be an empty string if nothing was

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2315,6 +2315,9 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                         "-complete=" argument. See |:command-completion|
                       • highlight (function) Function that will be used for
                         highlighting user inputs.
+                      • secret (boolean|nil) If `true`, the user's input will
+                        be shown as a series of asterisks ("*") (defaults to
+                        `false`). See |inputsecret()|.
       • {on_confirm}  (function) ((input|nil) -> ()) Called once the user
                       confirms or abort the input. `input` is what the user
                       typed (it might be an empty string if nothing was

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -73,9 +73,9 @@ end
 ---               Function that will be used for highlighting
 ---               user inputs.
 ---     - secret (boolean|nil)
----               If `true`, the user's input will be shown as
----               a series of asterisks ("*") (defaults to `false`).
----               See |inputsecret()|
+---               (default: false) If `true`, user input is hidden (displayed as asterisks "*")
+---               instead of echoed.
+---               See |inputsecret()|.
 ---
 ---@param on_confirm function ((input|nil) -> ())
 ---               Called once the user confirms or abort the input.

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -72,6 +72,11 @@ end
 ---     - highlight (function)
 ---               Function that will be used for highlighting
 ---               user inputs.
+---     - secret (boolean|nil)
+---               If `true`, the user's input will be shown as
+---               a series of asterisks ("*") (defaults to `false`).
+---               See |inputsecret()|
+---
 ---@param on_confirm function ((input|nil) -> ())
 ---               Called once the user confirms or abort the input.
 ---               `input` is what the user typed (it might be
@@ -96,7 +101,7 @@ function M.input(opts, on_confirm)
   local _canceled = vim.NIL
   opts = vim.tbl_extend('keep', opts, { cancelreturn = _canceled })
 
-  local ok, input = pcall(vim.fn.input, opts)
+  local ok, input = pcall(opts.secret and vim.fn.inputsecret or vim.fn.input, opts)
   if not ok or input == _canceled then
     on_confirm(nil)
   else


### PR DESCRIPTION
Supersedes #19413 as the original contributor seems inactive.

Closes #18781.