### PR TITLE
fix(ui): ui compositor does not correctly free event callbacks

### DIFF
--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -98,7 +98,7 @@ void ui_comp_free_all_mem(void)
 {
   UIEventCallback *event_cb;
   map_foreach_value(&ui_event_cbs, event_cb, {
-    xfree(event_cb);
+    free_ui_event_callback(event_cb);
   })
   pmap_destroy(uint32_t)(&ui_event_cbs);
 }


### PR DESCRIPTION
Prior to this PR, when freeing event callbacks, UI compositor did not
free the luarefs which could cause potential memory leaks. This PR fixes
that by freeing the luarefs properly.