### PR TITLE
vim-patch:8.2.1505,9.0.{0360,0362}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -642,7 +642,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
 
           // Check for the next breakpoint at or after the ":while"
           // or ":for".
-          if (breakpoint != NULL) {
+          if (breakpoint != NULL && lines_ga.ga_len > current_line) {
             *breakpoint = dbg_find_breakpoint(getline_equal(fgetline, cookie, getsourceline), fname,
                                               ((wcmd_T *)lines_ga.ga_data)[current_line].lnum - 1);
             *dbg_tick = debug_tick;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1055,6 +1055,18 @@ func Test_cmdline_write_alternatefile()
   bw!
 endfunc
 
+func Test_cmdline_expand_cur_alt_file()
+  enew
+  file http://some.com/file.txt
+  call feedkeys(":e %\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e http://some.com/file.txt', @:)
+  edit another
+  call feedkeys(":e #\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"e http://some.com/file.txt', @:)
+  bwipe
+  bwipe http://some.com/file.txt
+endfunc
+
 " using a leading backslash here
 set cpo+=C
 

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -1,5 +1,8 @@
 " Tests for various eval things.
 
+source view_util.vim
+source shared.vim
+
 function s:foo() abort
   try
     return [] == 0
@@ -85,6 +88,18 @@ func Test_for_over_null_string()
   call assert_equal(0, cnt)
 
   let &enc = save_enc
+endfunc
+
+func Test_for_invalid_line_count()
+  let lines =<< trim END
+      111111111111111111111111 for line in ['one']
+      endfor
+  END
+  call writefile(lines, 'XinvalidFor')
+  " only test that this doesn't crash
+  call RunVim([], [], '-u NONE -e -s -S XinvalidFor -c qa')
+
+  call delete('XinvalidFor')
 endfunc
 
 func Test_readfile_binary()

--- a/src/nvim/testdir/test_eval_stuff.vim
+++ b/src/nvim/testdir/test_eval_stuff.vim
@@ -91,18 +91,31 @@ func Test_readfile_binary()
   new
   call setline(1, ['one', 'two', 'three'])
   setlocal ff=dos
-  silent write XReadfile
-  let lines = readfile('XReadfile')
+  silent write XReadfile_bin
+  let lines = 'XReadfile_bin'->readfile()
   call assert_equal(['one', 'two', 'three'], lines)
-  let lines = readfile('XReadfile', '', 2)
+  let lines = readfile('XReadfile_bin', '', 2)
   call assert_equal(['one', 'two'], lines)
-  let lines = readfile('XReadfile', 'b')
+  let lines = readfile('XReadfile_bin', 'b')
   call assert_equal(["one\r", "two\r", "three\r", ""], lines)
-  let lines = readfile('XReadfile', 'b', 2)
+  let lines = readfile('XReadfile_bin', 'b', 2)
   call assert_equal(["one\r", "two\r"], lines)
 
   bwipe!
-  call delete('XReadfile')
+  call delete('XReadfile_bin')
+endfunc
+
+func Test_readfile_bom()
+  call writefile(["\ufeffFOO", "FOO\ufeffBAR"], 'XReadfile_bom')
+  call assert_equal(['FOO', 'FOOBAR'], readfile('XReadfile_bom'))
+  call delete('XReadfile_bom')
+endfunc
+
+func Test_readfile_max()
+  call writefile(range(1, 4), 'XReadfile_max')
+  call assert_equal(['1', '2'], readfile('XReadfile_max', '', 2))
+  call assert_equal(['3', '4'], readfile('XReadfile_max', '', -2))
+  call delete('XReadfile_max')
 endfunc
 
 func Test_let_errmsg()

--- a/src/nvim/testdir/test_fnamemodify.vim
+++ b/src/nvim/testdir/test_fnamemodify.vim
@@ -11,6 +11,7 @@ func Test_fnamemodify()
   call assert_equal('/', fnamemodify('.', ':p')[-1:])
   call assert_equal('r', fnamemodify('.', ':p:h')[-1:])
   call assert_equal('t', fnamemodify('test.out', ':p')[-1:])
+  call assert_equal($HOME .. "/foo" , fnamemodify('~/foo', ':p'))
   call assert_equal('test.out', fnamemodify('test.out', ':.'))
   call assert_equal('a', fnamemodify('../testdir/a', ':.'))
   call assert_equal('~/testdir/test.out', fnamemodify('test.out', ':~'))
@@ -93,6 +94,11 @@ func Test_fnamemodify_er()
 
   call assert_equal('', fnamemodify('', ':p:t'))
   call assert_equal('', fnamemodify(v:_null_string, v:_null_string))
+endfunc
+
+func Test_fnamemodify_fail()
+  call assert_fails('call fnamemodify({}, ":p")', 'E731:')
+  call assert_fails('call fnamemodify("x", {})', 'E731:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -2015,6 +2015,25 @@ func Test_getmousepos()
   bwipe!
 endfunc
 
+" Test for glob()
+func Test_glob()
+  call assert_equal('', glob(v:_null_string))
+  call assert_equal('', globpath(v:_null_string, v:_null_string))
+
+  call writefile([], 'Xglob1')
+  call writefile([], 'XGLOB2')
+  set wildignorecase
+  " Sort output of glob() otherwise we end up with different
+  " ordering depending on whether file system is case-sensitive.
+  call assert_equal(['XGLOB2', 'Xglob1'], sort(glob('Xglob[12]', 0, 1)))
+  set wildignorecase&
+
+  call delete('Xglob1')
+  call delete('XGLOB2')
+
+  call assert_fails("call glob('*', 0, {})", 'E728:')
+endfunc
+
 func HasDefault(msg = 'msg')
   return a:msg
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.1505: not all file read and writecode is tested

Problem:    Not all file read and writecode is tested.
Solution:   Add a few tests. (Dominique Pellé, closes vim/vim#6764)
https://github.com/vim/vim/commit/1b04ce2d400fda97410a961288c496bd8f445a9c

Cherry-pick Test_glob() from patch 8.2.0634.


#### vim-patch:9.0.0360: crash when invalid line number on :for is ignored

Problem:    Crash when invalid line number on :for is ignored.
Solution:   Do not check breakpoint for non-existing line.
https://github.com/vim/vim/commit/35d21c6830fc2d68aca838424a0e786821c5891c

Test does not fail without the fix in Nvim as Nvim uses 0 when line
number overflows. If it is changed to MAXLNUM then the test does fail
without the fix, but using 0 seems better as E481 is still given.


#### vim-patch:9.0.0362: expanding ":e %" does not work for remote files

Problem:    Expanding ":e %" does not work for remote files.
Solution:   If the "%" or "#" file does not exist add the expansion anyway.
https://github.com/vim/vim/commit/f5724376ab7362b5a98eaa8a331d663ef722c2a2