### PR TITLE
fix(filetype): run filetype.match on StdinReadPost

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -6,7 +6,7 @@ vim.g.did_load_filetypes = 1
 
 vim.api.nvim_create_augroup('filetypedetect', { clear = false })
 
-vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
   group = 'filetypedetect',
   callback = function(args)
     local ft, on_detect = vim.filetype.match({ filename = args.match, buf = args.buf })


### PR DESCRIPTION
Problem: filetype detection does not run on piped input
Solution: add `StdinReadPost` to main filetype.lua autocommand

Rationale: legacy filetype detection checked contents by sourcing `scripts.vim` in separate autocommands, including on `StdinReadPost`. For Lua filetype detection, this was moved into the main autocommand, with bundled `scripts.vim` gated behind `g:do_legacy_filetype` (i.e., only user `scripts.vim` are sourced for compatibility by default). Adding `StdinReadPost` to the main autocommand again runs content checks on piped input without requiring code duplication and low-payoff refactoring.

Fixes #20061 