### PR TITLE
fix(lsp): when buffer detach remove buffer from client attached buffers

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1644,6 +1644,7 @@ function lsp.buf_attach_client(bufnr, client_id)
           if vim.tbl_get(client.server_capabilities, 'textDocumentSync', 'openClose') then
             client.notify('textDocument/didClose', params)
           end
+          client.attached_buffers[bufnr] = nil
         end)
         util.buf_versions[bufnr] = nil
         all_buffer_active_clients[bufnr] = nil


### PR DESCRIPTION
when buffer detached by using `bd` or `bw` .the buffer should remove from client acttached buffers list

Fix #20025 