### PR TITLE
Ignore format result on change

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2663,6 +2663,9 @@ getbufinfo([{dict}])
 			lastused	Timestamp in seconds, like
 					|localtime()|, when the buffer was
 					last used.
+			undotimecurrent	Timestamp in seconds, like
+					|localtime()|, when the last  change
+					was made to the buffer.
 			listed		TRUE if the buffer is listed.
 			lnum		Line number used for the buffer when
 					opened in the current window.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1131,7 +1131,7 @@ format({options})                                       *vim.lsp.buf.format()*
 <
                    • async boolean|nil If true the method won't block.
                      Defaults to false. Editing the buffer while formatting
-                     asynchronous can lead to unexpected changes.
+                     asynchronous will invalidate the formatting result.
                    • id (number|nil): Restrict formatting to the client with
                      ID (client.id) matching this field.
                    • name (string|nil): Restrict formatting to the client with

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5166,6 +5166,7 @@ dict_T *get_buffer_info(buf_T *buf)
   }
 
   tv_dict_add_nr(dict, S_LEN("lastused"), buf->b_last_used);
+  tv_dict_add_nr(dict, S_LEN("undotimecurrent"), buf->b_u_time_cur);
 
   return dict;
 }


### PR DESCRIPTION
When requesting async formatting from LSP with `vim.lsp.buf.format()`, and the buffer content has changed before the formatting is done, instead of overwriting the buffer, the formatting result is invalidated.

I think from a user perspective, this is what I would want to happen. User input should take priority over LSP.