### PR TITLE
vim-patch:9.0.0386: some code blocks are nested too deep

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5544,27 +5544,26 @@ void ex_cd(exarg_T *eap)
   // for non-UNIX ":cd" means: print current directory unless 'cdhome' is set
   if (*new_dir == NUL && !p_cdh) {
     ex_pwd(NULL);
-  } else
+    return;
+  }
 #endif
-  {
-    CdScope scope = kCdScopeGlobal;
-    switch (eap->cmdidx) {
-    case CMD_tcd:
-    case CMD_tchdir:
-      scope = kCdScopeTabpage;
-      break;
-    case CMD_lcd:
-    case CMD_lchdir:
-      scope = kCdScopeWindow;
-      break;
-    default:
-      break;
-    }
-    if (changedir_func(new_dir, scope)) {
-      // Echo the new current directory if the command was typed.
-      if (KeyTyped || p_verbose >= 5) {
-        ex_pwd(eap);
-      }
+  CdScope scope = kCdScopeGlobal;
+  switch (eap->cmdidx) {
+  case CMD_tcd:
+  case CMD_tchdir:
+    scope = kCdScopeTabpage;
+    break;
+  case CMD_lcd:
+  case CMD_lchdir:
+    scope = kCdScopeWindow;
+    break;
+  default:
+    break;
+  }
+  if (changedir_func(new_dir, scope)) {
+    // Echo the new current directory if the command was typed.
+    if (KeyTyped || p_verbose >= 5) {
+      ex_pwd(eap);
     }
   }
 }

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -506,16 +506,18 @@ bool striequal(const char *a, const char *b)
 // Did_outofmem_msg is reset when a character is read.
 void do_outofmem_msg(size_t size)
 {
-  if (!did_outofmem_msg) {
-    // Don't hide this message
-    emsg_silent = 0;
-
-    /* Must come first to avoid coming back here when printing the error
-     * message fails, e.g. when setting v:errmsg. */
-    did_outofmem_msg = true;
-
-    semsg(_("E342: Out of memory!  (allocating %" PRIu64 " bytes)"), (uint64_t)size);
+  if (did_outofmem_msg) {
+    return;
   }
+
+  // Don't hide this message
+  emsg_silent = 0;
+
+  // Must come first to avoid coming back here when printing the error
+  // message fails, e.g. when setting v:errmsg.
+  did_outofmem_msg = true;
+
+  semsg(_("E342: Out of memory!  (allocating %" PRIu64 " bytes)"), (uint64_t)size);
 }
 
 /// Writes time_t to "buf[8]".

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1042,13 +1042,13 @@ void pum_show_popupmenu(vimmenu_T *menu)
   pum_scrollbar = 0;
   pum_height = pum_size;
   pum_position_at_mouse(20);
+
+  pum_selected = -1;
+  pum_first = 0;
   if (!p_mousemev) {
     // Pretend 'mousemoveevent' is set.
     ui_call_option_set(STATIC_CSTR_AS_STRING("mousemoveevent"), BOOLEAN_OBJ(true));
   }
-
-  pum_selected = -1;
-  pum_first = 0;
 
   for (;;) {
     pum_is_visible = true;


### PR DESCRIPTION
#### vim-patch:9.0.0386: some code blocks are nested too deep

Problem:    Some code blocks are nested too deep.
Solution:   Bail out earlier. (Yegappan Lakshmanan, closes vim/vim#11058)
https://github.com/vim/vim/commit/b1f471ee20b0fa783ecd6e29aa69067e6c821376