### PR TITLE
feat(treesitter): upstream get_{node,captures} utility functions

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -370,6 +370,15 @@ attribute: >
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*
 
+get_captures_at_cursor({winnr})                     *get_captures_at_cursor()*
+    Gets a list of captures under the cursor
+
+    Parameters: ~
+        {winnr}  (number|nil) Window handle or 0 for current window (default)
+
+    Return: ~
+        (table) Named node under the cursor
+
                                                   *get_captures_at_position()*
 get_captures_at_position({bufnr}, {row}, {col})
     Gets a list of captures for a given cursor position
@@ -380,7 +389,31 @@ get_captures_at_position({bufnr}, {row}, {col})
         {col}    (number) Position column
 
     Return: ~
-        (table) A table of captures
+        (table) Table of captures
+
+get_node_at_cursor({winnr})                             *get_node_at_cursor()*
+    Gets the smallest named node under the cursor
+
+    Parameters: ~
+        {winnr}  (number|nil) Window handle or 0 for current window (default)
+
+    Return: ~
+        (string) Named node under the cursor
+
+                                                      *get_node_at_position()*
+get_node_at_position({bufnr}, {row}, {col}, {opts})
+    Gets the smallest named node at position
+
+    Parameters: ~
+        {bufnr}  (number) Buffer number (0 for current buffer)
+        {row}    (number) Position row
+        {col}    (number) Position column
+        {opts}   (table) Optional keyword arguments:
+                 • ignore_injections boolean Ignore injected languages
+                   (default true)
+
+    Return: ~
+        (table) Named node under the cursor
 
 get_node_range({node_or_range})                             *get_node_range()*
     Get the node's range or unpack a range table
@@ -389,7 +422,7 @@ get_node_range({node_or_range})                             *get_node_range()*
         {node_or_range}  (table)
 
     Return: ~
-        start_row, start_col, end_row, end_col
+        (table) start_row, start_col, end_row, end_col
 
 get_parser({bufnr}, {lang}, {opts})                             *get_parser()*
     Gets the parser for this bufnr / ft combination.
@@ -398,7 +431,7 @@ get_parser({bufnr}, {lang}, {opts})                             *get_parser()*
     callback
 
     Parameters: ~
-        {bufnr}  (number|nil) Buffer the parser should be tied to: (default
+        {bufnr}  (number|nil) Buffer the parser should be tied to (default:
                  current buffer)
         {lang}   (string) |nil Filetype of this parser (default: buffer
                  filetype)

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -81,7 +81,7 @@ end
 --- If needed this will create the parser.
 --- Unconditionally attach the provided callback
 ---
----@param bufnr number|nil Buffer the parser should be tied to: (default current buffer)
+---@param bufnr number|nil Buffer the parser should be tied to (default: current buffer)
 ---@param lang string |nil Filetype of this parser (default: buffer filetype)
 ---@param opts table|nil Options to pass to the created language tree
 ---
@@ -243,6 +243,27 @@ function M.get_captures_at_position(bufnr, row, col)
     end
   end, true)
   return matches
+end
+
+--- Gets the smallest named node under the cursor
+---
+---@param winnr number Window handle or 0 for current window
+---@param opts table Options table
+---@param opts.ignore_injections boolean (default true) Ignore injected languages.
+---
+---@returns (table) The named node under the cursor
+function M.get_node_at_cursor(winnr, opts)
+  winnr = winnr or 0
+  local cursor = a.nvim_win_get_cursor(winnr)
+  local ts_cursor_range = { cursor[1] - 1, cursor[2], cursor[1] - 1, cursor[2] }
+
+  local buf = a.nvim_win_get_buf(winnr)
+  local root_lang_tree = M.get_parser(buf)
+  if not root_lang_tree then
+    return
+  end
+
+  return root_lang_tree:named_node_for_range(ts_cursor_range, opts)
 end
 
 --- Start treesitter highlighting for a buffer


### PR DESCRIPTION
Useful for debugging when working with treesitter highlighting:
* `get_captures_at_position(bufnr, line, col)`
* `get_captures_at_cursor()` wraps above with position corrections
* `get_node_at_position(bufnr, line, col)`
* `get_node_at_cursor()` wraps above with position corrections, returns node type as string (and follows injections)

cherry-picked from #18232