### PR TITLE
feat(decor): allow providers to handle errors

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2722,6 +2722,8 @@ nvim_set_decoration_provider({ns_id}, {*opts})
                    interaction with fold lines is subject to change) ["win",
                    winid, bufnr, row]
                  • on_end: called at the end of a redraw cycle ["end", tick]
+                 • on_error: called when any other callback errors ["end",
+                   callback_name, message]
 
 
 ==============================================================================

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -993,6 +993,8 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 ///                 ["win", winid, bufnr, row]
 ///             - on_end: called at the end of a redraw cycle
 ///                 ["end", tick]
+///             - on_error: called when any other callback errors
+///                 ["end", callback_name, message]
 void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *opts, Error *err)
   FUNC_API_SINCE(7) FUNC_API_LUA_ONLY
 {
@@ -1013,6 +1015,7 @@ void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *
     { "on_win", &opts->on_win, &p->redraw_win },
     { "on_line", &opts->on_line, &p->redraw_line },
     { "on_end", &opts->on_end, &p->redraw_end },
+    { "on_error", &opts->on_error, &p->error },
     { "_on_hl_def", &opts->_on_hl_def, &p->hl_def },
     { "_on_spell_nav", &opts->_on_spell_nav, &p->spell_nav },
     { NULL, NULL, NULL },

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -8,6 +8,7 @@ return {
     "on_win";
     "on_line";
     "on_end";
+    "on_error";
     "_on_hl_def";
     "_on_spell_nav";
   };

--- a/src/nvim/decoration_provider.h
+++ b/src/nvim/decoration_provider.h
@@ -13,6 +13,7 @@ typedef struct {
   LuaRef redraw_end;
   LuaRef hl_def;
   LuaRef spell_nav;
+  LuaRef error;
   int hl_valid;
   bool hl_cached;
 } DecorProvider;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -476,7 +476,7 @@ static bool check_mb_utf8(int *c, int *u8cc)
 ///
 /// @return             the number of last row the line occupies.
 int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, bool number_only,
-             foldinfo_T foldinfo, DecorProviders *providers, char **provider_err)
+             foldinfo_T foldinfo, DecorProviders *providers)
 {
   int c = 0;                          // init for GCC
   long vcol = 0;                      // virtual column (for tabs)
@@ -656,13 +656,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
 
     has_decor = decor_redraw_line(buf, lnum - 1, &decor_state);
 
-    decor_providers_invoke_line(wp, providers, lnum - 1, &has_decor, provider_err);
-
-    if (*provider_err) {
-      provider_err_virt_text(lnum, *provider_err);
-      has_decor = true;
-      *provider_err = NULL;
-    }
+    decor_providers_invoke_line(wp, providers, lnum - 1, &has_decor);
 
     if (has_decor) {
       extra_check = true;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -99,8 +99,6 @@ static bool redraw_popupmenu = false;
 static bool msg_grid_invalid = false;
 static bool resizing = false;
 
-static char *provider_err = NULL;
-
 /// Check if the cursor line needs to be redrawn because of 'concealcursor'.
 ///
 /// When cursor is moved at the same time, both lines will be redrawn regardless.
@@ -539,7 +537,7 @@ int update_screen(int type)
   ui_comp_set_screen_valid(true);
 
   DecorProviders providers;
-  decor_providers_start(&providers, &provider_err);
+  decor_providers_start(&providers);
 
   // "start" callback could have changed highlights for global elements
   if (win_check_ns_hl(NULL)) {
@@ -603,7 +601,7 @@ int update_screen(int type)
       }
 
       if (buf->b_mod_tick_decor < display_tick) {
-        decor_providers_invoke_buf(buf, &providers, &provider_err);
+        decor_providers_invoke_buf(buf, &providers);
         buf->b_mod_tick_decor = display_tick;
       }
     }
@@ -673,7 +671,7 @@ int update_screen(int type)
   }
   did_intro = true;
 
-  decor_providers_invoke_end(&providers, &provider_err);
+  decor_providers_invoke_end(&providers);
   kvi_destroy(providers);
 
   // either cmdline is cleared, not drawn or mode is last drawn
@@ -1573,7 +1571,7 @@ win_update_start:
   decor_redraw_reset(buf, &decor_state);
 
   DecorProviders line_providers;
-  decor_providers_invoke_win(wp, providers, &line_providers, &provider_err);
+  decor_providers_invoke_win(wp, providers, &line_providers);
   (void)win_signcol_count(wp);  // check if provider changed signcol width
   if (must_redraw != 0) {
     must_redraw = 0;
@@ -1803,7 +1801,7 @@ win_update_start:
         // Display one line
         row = win_line(wp, lnum, srow,
                        foldinfo.fi_lines ? srow : wp->w_grid.rows,
-                       mod_top == 0, false, foldinfo, &line_providers, &provider_err);
+                       mod_top == 0, false, foldinfo, &line_providers);
 
         if (foldinfo.fi_lines == 0) {
           wp->w_lines[idx].wl_folded = false;
@@ -1840,7 +1838,7 @@ win_update_start:
         // text doesn't need to be drawn, but the number column does.
         foldinfo_T info = fold_info(wp, lnum);
         (void)win_line(wp, lnum, srow, wp->w_grid.rows, true, true,
-                       info, &line_providers, &provider_err);
+                       info, &line_providers);
       }
 
       // This line does not need to be drawn, advance to the next one.
@@ -1919,7 +1917,7 @@ win_update_start:
         // for ml_line_count+1 and only draw filler lines
         foldinfo_T info = FOLDINFO_INIT;
         row = win_line(wp, wp->w_botline, row, wp->w_grid.rows,
-                       false, false, info, &line_providers, &provider_err);
+                       false, false, info, &line_providers);
       }
     } else if (dollar_vcol == -1) {
       wp->w_botline = lnum;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1205,11 +1205,10 @@ static void decor_spell_nav_start(win_T *wp)
   decor_redraw_reset(wp->w_buffer, &decor_state);
 }
 
-static bool decor_spell_nav_col(win_T *wp, linenr_T lnum, linenr_T *decor_lnum, int col,
-                                char **decor_error)
+static bool decor_spell_nav_col(win_T *wp, linenr_T lnum, linenr_T *decor_lnum, int col)
 {
   if (*decor_lnum != lnum) {
-    decor_providers_invoke_spell(wp, lnum - 1, col, lnum - 1, -1, decor_error);
+    decor_providers_invoke_spell(wp, lnum - 1, col, lnum - 1, -1);
     decor_redraw_line(wp->w_buffer, lnum - 1, &decor_state);
     *decor_lnum = lnum;
   }
@@ -1261,7 +1260,6 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
   linenr_T lnum = wp->w_cursor.lnum;
   clearpos(&found_pos);
 
-  char *decor_error = NULL;
   // Ephemeral extmarks are currently stored in the global decor_state.
   // When looking for spell errors, we need to:
   //  - temporarily reset decor_state
@@ -1347,7 +1345,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
             bool can_spell = (wp->w_s->b_p_spo_flags & SPO_NPBUFFER) == 0;
 
             if (!can_spell) {
-              can_spell = decor_spell_nav_col(wp, lnum, &decor_lnum, col, &decor_error);
+              can_spell = decor_spell_nav_col(wp, lnum, &decor_lnum, col);
             }
 
             if (!can_spell && has_syntax) {
@@ -1469,7 +1467,6 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
 
 theend:
   decor_state_free(&decor_state);
-  xfree(decor_error);
   decor_state = saved_decor_start;
   xfree(buf);
   return ret;


### PR DESCRIPTION
Alternative/complement to #19814

Allow decor providers to handle errors for any callback.

Roughly translates:
```lua
local function error_wrap(fn, handler)
  return function(...)
    local ok, ret = pcall(fn, ...)
    if not ok then
      if handler then
        local name = select(1, ...)
        handler('error', name, ret)
      else
        error(ret)
      end
    end
    return ok and ret
  end
end

vim.api.nvim_set_decoration_provider(ns, {
  on_win = error_wrap(my_on_win, my_on_error)
  on_line = error_wrap(my_on_line, my_on_error)
})
```

to:
```lua
vim.api.nvim_set_decoration_provider(ns, {
  on_win = my_on_win
  on_line = my_on_line
  on_error = my_on_error
})
```

We're basically trading 14 LOC of Lua for ~20 LOC of slightly more efficient C, so the main argument for this is less boilerplate which I think is strong enough given the low complexity of the change.