### PR TITLE
fix(treesitter): don't support legacy syntax in start()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -446,20 +446,21 @@ node_contains({node}, {range})                               *node_contains()*
     Return: ~
         (boolean) True if the node contains the range
 
-start({bufnr}, {lang}, {opts})                                       *start()*
+start({bufnr}, {lang})                                               *start()*
     Start treesitter highlighting for a buffer
 
     Can be used in an ftplugin or FileType autocommand
 
     Note: By default, disables regex syntax highlighting, which may be
-    required for some plugins. In this case, add `{ syntax = true }`.
+    required for some plugins. In this case, add vim.bo.syntax = 'on `after the call to` start`.
 
     Example:
 >
 
     vim.api.nvim_create_autocmd( 'FileType', { pattern = 'tex',
         callback = function(args)
-            vim.treesitter.start(args.buf, 'latex', { syntax = true })
+            vim.treesitter.start(args.buf, 'latex')
+            vim.bo[args.buf].syntax = 'on'  -- only if additional legacy syntax is needed
         end
     })
 <
@@ -469,9 +470,6 @@ start({bufnr}, {lang}, {opts})                                       *start()*
                  buffer)
         {lang}   (string|nil) Language of the parser (default: buffer
                  filetype)
-        {opts}   (table|nil) Optional keyword arguments:
-                 • `syntax` boolean Run regex syntax highlighting (default
-                   false)
 
 stop({bufnr})                                                         *stop()*
     Stop treesitter highlighting for a buffer

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -250,23 +250,22 @@ end
 --- Can be used in an ftplugin or FileType autocommand
 ---
 --- Note: By default, disables regex syntax highlighting, which may be required for some plugins.
---- In this case, add `{ syntax = true }`.
+--- In this case, add `vim.bo.syntax = 'on'` after the call to `start`.
 ---
 --- Example:
 ---
 --- <pre>
 --- vim.api.nvim_create_autocmd( 'FileType', { pattern = 'tex',
 ---     callback = function(args)
----         vim.treesitter.start(args.buf, 'latex', { syntax = true })
+---         vim.treesitter.start(args.buf, 'latex')
+---         vim.bo[args.buf].syntax = 'on'  -- only if additional legacy syntax is needed
 ---     end
 --- })
 --- </pre>
 ---
 ---@param bufnr number|nil Buffer to be highlighted (default: current buffer)
 ---@param lang string|nil Language of the parser (default: buffer filetype)
----@param opts table|nil Optional keyword arguments:
----             - `syntax` boolean Run regex syntax highlighting (default false)
-function M.start(bufnr, lang, opts)
+function M.start(bufnr, lang)
   bufnr = bufnr or a.nvim_get_current_buf()
 
   local parser = M.get_parser(bufnr, lang)
@@ -274,10 +273,6 @@ function M.start(bufnr, lang, opts)
   M.highlighter.new(parser)
 
   vim.b[bufnr].ts_highlight = true
-
-  if opts and opts.syntax then
-    vim.bo[bufnr].syntax = 'on'
-  end
 end
 
 ---Stop treesitter highlighting for a buffer


### PR DESCRIPTION
Not really relevant for 0.8 (where we focus on Lua), and interface will likely change for 0.9 anyway.