### PR TITLE
fix(diagnostic): remove buf from cache on `BufWipeout`

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -47,11 +47,11 @@ local bufnr_and_namespace_cacher_mt = {
 
 local diagnostic_cache
 do
-  local group = vim.api.nvim_create_augroup('DiagnosticBufDelete', {})
+  local group = vim.api.nvim_create_augroup('DiagnosticBufWipeout', {})
   diagnostic_cache = setmetatable({}, {
     __index = function(t, bufnr)
       assert(bufnr > 0, 'Invalid buffer number')
-      vim.api.nvim_create_autocmd('BufDelete', {
+      vim.api.nvim_create_autocmd('BufWipeout', {
         group = group,
         buffer = bufnr,
         callback = function()

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -148,6 +148,15 @@ describe('vim.diagnostic', function()
       vim.cmd('bwipeout!')
       return #vim.diagnostic.get()
     ]])
+    eq(2, exec_lua [[
+      vim.api.nvim_set_current_buf(diagnostic_bufnr)
+      vim.opt_local.buflisted = false
+      return #vim.diagnostic.get()
+    ]])
+    eq(0, exec_lua [[
+      vim.cmd('bwipeout!')
+      return #vim.diagnostic.get()
+    ]])
   end)
 
   it('resolves buffer number 0 to the current buffer', function()


### PR DESCRIPTION
Doing so on `BufDelete` has issues:
  - `BufDelete` is also fired for listed buffers that are made unlisted.
  - `BufDelete` is not fired for unlisted buffers that are deleted.

This means that diagnostics will be lost for a buffer that becomes unlisted.

It also means that if an entry exists for an unlisted buffer, deleting that
buffer later will not remove its entry from the cache (and you may see "Invalid
buffer id" errors when using diagnostic functions if it was wiped).

Instead, remove a buffer from the cache if it is wiped out.
This means simply `:bd`ing a buffer will not clear its diagnostics now.
