### PR TITLE
refactor(typval): change FC_CFUNC abstraction into FC_LUAREF

### DIFF
--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -65,8 +65,8 @@ typedef struct {
 #define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun) \
   do { \
     ufunc_T *fp = find_func(fun); \
-    if (fp != NULL && fp->uf_cb == nlua_CFunction_func_call) { \
-      LuaRef ref = api_new_luaref(((LuaCFunctionState *)fp->uf_cb_state)->lua_callable.func_ref); \
+    if (fp != NULL && (fp->uf_flags & FC_LUAREF)) { \
+      LuaRef ref = api_new_luaref(fp->uf_luaref); \
       kvi_push(edata->stack, LUAREF_OBJ(ref)); \
     } else { \
       TYPVAL_ENCODE_CONV_NIL(tv); \
@@ -351,10 +351,7 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
   }
 
   case kObjectTypeLuaRef: {
-    LuaCFunctionState *state = xmalloc(sizeof(LuaCFunctionState));
-    state->lua_callable.func_ref = api_new_luaref(obj.data.luaref);
-    char *name =
-      (char *)register_cfunc(&nlua_CFunction_func_call, &nlua_CFunction_func_free, state);
+    char *name = (char *)register_luafunc(api_new_luaref(obj.data.luaref));
     tv->v_type = VAR_FUNC;
     tv->vval.v_string = xstrdup(name);
     break;

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -286,12 +286,6 @@ typedef struct {
 /// Number of fixed variables used for arguments
 #define FIXVAR_CNT 12
 
-/// Callback interface for C function reference>
-///     Used for managing functions that were registered with |register_cfunc|
-typedef int (*cfunc_T)(int argcount, typval_T *argvars, typval_T *rettv, void *state);  // NOLINT
-/// Callback to clear cfunc_T and any associated state.
-typedef void (*cfunc_free_T)(void *state);
-
 // Structure to hold info for a function that is currently being executed.
 typedef struct funccall_S funccall_T;
 
@@ -330,10 +324,7 @@ struct ufunc {
   garray_T uf_lines;         ///< function lines
   int uf_profiling;     ///< true when func is being profiled
   int uf_prof_initialized;
-  // Managing cfuncs
-  cfunc_T uf_cb;            ///< C function extension callback
-  cfunc_free_T uf_cb_free;       ///< C function extension free callback
-  void *uf_cb_state;      ///< State of C function extension.
+  LuaRef uf_luaref;      ///< lua callback, used if (uf_flags & FC_LUAREF)
   // Profiling the function as a whole.
   int uf_tm_count;      ///< nr of calls
   proftime_T uf_tm_total;      ///< time spent in function + children

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -9,6 +9,20 @@
 #define HIKEY2UF(p)  ((ufunc_T *)(p - offsetof(ufunc_T, uf_name)))
 #define HI2UF(hi)    HIKEY2UF((hi)->hi_key)
 
+// flags used in uf_flags
+#define FC_ABORT    0x01          // abort function on error
+#define FC_RANGE    0x02          // function accepts range
+#define FC_DICT     0x04          // Dict function, uses "self"
+#define FC_CLOSURE  0x08          // closure, uses outer scope variables
+#define FC_DELETED  0x10          // :delfunction used while uf_refcount > 0
+#define FC_REMOVED  0x20          // function redefined while uf_refcount > 0
+#define FC_SANDBOX  0x40          // function defined in the sandbox
+#define FC_DEAD     0x80          // function kept only for reference to dfunc
+#define FC_EXPORT   0x100         // "export def Func()"
+#define FC_NOARGS   0x200         // no a: variables in lambda
+#define FC_VIM9     0x400         // defined in vim9 script file
+#define FC_LUAREF  0x800          // luaref callback
+
 ///< Structure used by trans_function_name()
 typedef struct {
   dict_T *fd_dict;  ///< Dictionary used.

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -385,12 +385,9 @@ nlua_pop_typval_table_processing_end:
       break;
     }
     case LUA_TFUNCTION: {
-      LuaCFunctionState *state = xmalloc(sizeof(LuaCFunctionState));
-      state->lua_callable.func_ref = nlua_ref_global(lstate, -1);
+      LuaRef func = nlua_ref_global(lstate, -1);
 
-      char *name = (char *)register_cfunc(&nlua_CFunction_func_call,
-                                          &nlua_CFunction_func_free,
-                                          state);
+      char *name = (char *)register_luafunc(func);
 
       cur.tv->v_type = VAR_FUNC;
       cur.tv->vval.v_string = xstrdup(name);
@@ -476,8 +473,8 @@ static bool typval_conv_special = false;
 #define TYPVAL_ENCODE_CONV_FUNC_START(tv, fun) \
   do { \
     ufunc_T *fp = find_func(fun); \
-    if (fp != NULL && fp->uf_cb == nlua_CFunction_func_call) { \
-      nlua_pushref(lstate, ((LuaCFunctionState *)fp->uf_cb_state)->lua_callable.func_ref); \
+    if (fp != NULL && fp->uf_flags & FC_LUAREF) { \
+      nlua_pushref(lstate, fp->uf_luaref); \
     } else { \
       TYPVAL_ENCODE_CONV_NIL(tv); \
     } \

--- a/src/nvim/lua/converter.h
+++ b/src/nvim/lua/converter.h
@@ -9,14 +9,6 @@
 #include "nvim/eval/typval.h"
 #include "nvim/func_attr.h"
 
-typedef struct {
-  LuaRef func_ref;
-} LuaCallable;
-
-typedef struct {
-  LuaCallable lua_callable;
-} LuaCFunctionState;
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "lua/converter.h.generated.h"
 #endif


### PR DESCRIPTION
"cfuncs" was only ever used to wrap luarefs. As vim8script is
finished and will not be developed further, support for "cfuncs"
for other usecases are not planned. This abstraction was immediately
broken anyway in order to get luarefs out of userfuncs again.

Even if a new kind of userfunc needs to be invented in the future,
likely just extending the FC_... flag union directy, instead of
invoking unnecessary heap object and c function pointer indirection,
will be a more straightforward design pattern.