### PR TITLE
build(treesitter): set CMAKE_C_STANDARD to C99

### DIFF
--- a/cmake.deps/cmake/TreesitterParserCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterParserCMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 project(parser C)
 
+set(CMAKE_C_STANDARD 99)
 file(GLOB source_files src/*.c)
 
 add_library(parser


### PR DESCRIPTION
#15391 bumped treesitter-vim to 0.1.0, and now C99 feature is required, i.e. `for` loop initial declaration. This leads to build failure if the C compiler’s default standard is prior to 99.