### PR TITLE
refactor/vim opt

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -365,11 +365,6 @@ local convert_value_to_lua = (function()
   end
 end)()
 
---- Handles the mutation of various different values.
-local value_mutator = function(info, current, new, mutator)
-  return mutator[info.metatype](current, new)
-end
-
 --- Handles the '^' operator
 local prepend_value = (function()
   local methods = {
@@ -399,11 +394,9 @@ local prepend_value = (function()
   }
 
   return function(info, current, new)
-    return value_mutator(
-      info,
+    methods[info.metatype](
       convert_value_to_lua(info, current),
-      convert_value_to_lua(info, new),
-      methods
+      convert_value_to_lua(info, new)
     )
   end
 end)()
@@ -437,11 +430,9 @@ local add_value = (function()
   }
 
   return function(info, current, new)
-    return value_mutator(
-      info,
+    methods[info.metatype](
       convert_value_to_lua(info, current),
-      convert_value_to_lua(info, new),
-      methods
+      convert_value_to_lua(info, new)
     )
   end
 end)()
@@ -512,7 +503,7 @@ local remove_value = (function()
   }
 
   return function(info, current, new)
-    return value_mutator(info, convert_value_to_lua(info, current), new, methods)
+    return methods[info.metatype](convert_value_to_lua(info, current), new)
   end
 end)()
 

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -43,7 +43,7 @@ local function _setup()
   win_options = get_scoped_options('win')
 end
 
-local function make_meta_accessor(get, set, del, validator)
+local function make_meta_accessor(get, set, validator)
   validator = validator or function()
     return true
   end
@@ -51,7 +51,6 @@ local function make_meta_accessor(get, set, del, validator)
   validate({
     get = { get, 'f' },
     set = { set, 'f' },
-    del = { del, 'f', true },
     validator = { validator, 'f' },
   })
 
@@ -61,9 +60,6 @@ local function make_meta_accessor(get, set, del, validator)
       return
     end
 
-    if del and v == nil then
-      return del(k)
-    end
     return set(k, v)
   end
   function mt:__index(k)
@@ -98,7 +94,7 @@ do -- buffer option accessor
       return a.nvim_set_option_value(k, v, { buf = bufnr or 0 })
     end
 
-    return make_meta_accessor(get, set, nil, function(k)
+    return make_meta_accessor(get, set, function(k)
       if type(k) == 'string' then
         _setup()
         if win_options[k] then
@@ -132,7 +128,7 @@ do -- window option accessor
       return a.nvim_set_option_value(k, v, { win = winnr or 0 })
     end
 
-    return make_meta_accessor(get, set, nil, function(k)
+    return make_meta_accessor(get, set, function(k)
       if type(k) == 'string' then
         _setup()
         if buf_options[k] then

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -502,8 +502,6 @@ local create_option_accessor = function(scope)
     _set = function(self)
       local value = convert_value_to_vim(self._name, self._info, self._value)
       a.nvim_set_option_value(self._name, value, { scope = scope })
-
-      return self
     end,
 
     get = function(self)
@@ -511,7 +509,8 @@ local create_option_accessor = function(scope)
     end,
 
     append = function(self, right)
-      return self:__add(right):_set()
+      self._value = add_value(self._info, self._value, right)
+      self:_set()
     end,
 
     __add = function(self, right)
@@ -519,7 +518,8 @@ local create_option_accessor = function(scope)
     end,
 
     prepend = function(self, right)
-      return self:__pow(right):_set()
+      self._value = prepend_value(self._info, self._value, right)
+      self:_set()
     end,
 
     __pow = function(self, right)
@@ -527,7 +527,8 @@ local create_option_accessor = function(scope)
     end,
 
     remove = function(self, right)
-      return self:__sub(right):_set()
+      self._value = remove_value(self._info, self._value, right)
+      self:_set()
     end,
 
     __sub = function(self, right)

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -18,27 +18,18 @@ local key_value_options = {
 --- Convert a vimoption_T style dictionary to the correct OptionType associated with it.
 ---@return string
 local function get_option_metatype(name, info)
-  if info.type == 'boolean' then
-    return 'boolean'
-  elseif info.type == 'number' then
-    return 'number'
-  elseif info.type == 'string' then
-    if not info.commalist and not info.flaglist then
-      return 'string'
-    end
-
-    if key_value_options[name] then
-      assert(info.commalist, 'Must be a comma list to use key:value style')
-      return 'map'
-    end
-
+  if info.type == 'string' then
     if info.flaglist then
       return 'set'
     elseif info.commalist then
+      if key_value_options[name] then
+        return 'map'
+      end
       return 'array'
     end
+    return 'string'
   end
-  error('Not a known info.type:' .. info.type)
+  return info.type
 end
 
 local options_info = setmetatable({}, {

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -121,7 +121,7 @@ vim.o = setmetatable({}, {
 ---@brief ]]
 
 --- Preserves the order and does not mutate the original list
-local remove_duplicate_values = function(t)
+local function remove_duplicate_values(t)
   local result, seen = {}, {}
   for _, v in ipairs(t) do
     if not seen[v] then
@@ -430,7 +430,7 @@ end)()
 
 --- Handles the '-' operator
 local remove_value = (function()
-  local remove_one_item = function(t, val)
+  local function remove_one_item(t, val)
     if vim.tbl_islist(t) then
       local remove_index = nil
       for i, v in ipairs(t) do
@@ -477,10 +477,10 @@ local remove_value = (function()
   end
 end)()
 
-local create_option_accessor = function(scope)
+local function create_option_accessor(scope)
   local option_mt
 
-  local make_option = function(name, value)
+  local function make_option(name, value)
     local info = assert(options_info[name], 'Not a valid option name: ' .. name)
 
     if type(value) == 'table' and getmetatable(value) == option_mt then

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1396,7 +1396,7 @@ describe('lua stdlib', function()
     ]]
     eq('', funcs.luaeval "vim.bo.filetype")
     eq(true, funcs.luaeval "vim.bo[BUF].modifiable")
-    matches("unknown option 'nosuchopt'$",
+    matches("no such option: 'nosuchopt'$",
        pcall_err(exec_lua, 'return vim.bo.nosuchopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.bo[0][0].autoread'))
@@ -1417,7 +1417,7 @@ describe('lua stdlib', function()
     eq(0, funcs.luaeval "vim.wo.cole")
     eq(0, funcs.luaeval "vim.wo[0].cole")
     eq(0, funcs.luaeval "vim.wo[1001].cole")
-    matches("unknown option 'notanopt'$",
+    matches("no such option: 'notanopt'$",
        pcall_err(exec_lua, 'return vim.wo.notanopt'))
     matches("Expected lua string$",
        pcall_err(exec_lua, 'return vim.wo[0][0].list'))


### PR DESCRIPTION
Some spring-cleaning of `_meta.lua`

- Try to de-abstract the code to make it easier to understand
- Simplify things where possible
- Embed the option metatype (`map`, `set`, etc) into the `info` table which is now lazy populated and remove the `_setup()` function.
- Unify and simplify the metatable logic for `vim.bo` and `vim.wo`.
- Make it so `append`, `prepend` and `remove`:
  - operate on the option in-place and not create a new object
  - Do not return a value

Broke down into lots of small commits for easier reviewing.

