### PR TITLE
vim-patch:9.0.0403: 'equalalways' may be off when 'laststatus' is zero

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1464,4 +1464,19 @@ func Test_win_move_statusline()
   %bwipe!
 endfunc
 
+func Test_win_equal_last_status()
+  let save_lines = &lines
+  set lines=20
+  set splitbelow
+  set laststatus=0
+
+  split | split | quit
+  call assert_equal(winheight(1), winheight(2))
+
+  let &lines = save_lines
+  set splitbelow&
+  set laststatus&
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2849,6 +2849,11 @@ int win_close(win_T *win, bool free_buf, bool force)
     check_cursor();
   }
 
+  // If last window has a status line now and we don't want one,
+  // remove the status line. Do this before win_equal(), because
+  // it may change the height of a window.
+  last_status(false);
+
   if (!was_floating) {
     if (!curwin->w_floating && p_ea && (*p_ead == 'b' || *p_ead == dir)) {
       // If the frame of the closed window contains the new current window,
@@ -2869,10 +2874,6 @@ int win_close(win_T *win, bool free_buf, bool force)
   }
 
   split_disallowed--;
-
-  // If last window has a status line now and we don't want one,
-  // remove the status line.
-  last_status(false);
 
   // After closing the help window, try restoring the window layout from
   // before it was opened.


### PR DESCRIPTION
Problem:    'equalalways' may be off when 'laststatus' is zero.
Solution:   call last_status() before win_equal(). (Luuk van Baal,
            closes https://github.com/vim/vim/pull/11070)
https://github.com/vim/vim/commit/fd7e60a33ddd83a82da4eb6267f1c12fa926f32b

No idea how you guys handle porting vim patches but I thought I would open this PR since I'm it's author and am primarily a neovim user.