### PR TITLE
vim-patch:8.2.3702,9.0.0409

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4587,12 +4587,14 @@ static int dict_get_tv(char **arg, typval_T *rettv, int evaluate, bool literal)
   char *curly_expr = skipwhite(*arg + 1);
   char buf[NUMBUFLEN];
 
-  // First check if it's not a curly-braces thing: {expr}.
+  // First check if it's not a curly-braces expression: {expr}.
   // Must do this without evaluating, otherwise a function may be called
   // twice.  Unfortunately this means we need to call eval1() twice for the
   // first item.
-  // But {} is an empty Dictionary.
+  // "{}" is an empty Dictionary.
+  // "#{abc}" is never a curly-braces expression.
   if (*curly_expr != '}'
+      && !literal
       && eval1(&curly_expr, &tv, false) == OK
       && *skipwhite(curly_expr) == '}') {
     return NOTDONE;

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -168,6 +168,10 @@ func Test_dict()
 
   " allow key starting with number at the start, not a curly expression
   call assert_equal({'1foo': 77}, #{1foo: 77})
+
+  " #{expr} is not a curly expression
+  let x = 'x'
+  call assert_equal(#{g: x}, #{g:x})
 endfunc
 
 " Dictionary identity

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -165,6 +165,9 @@ func Test_dict()
   call assert_equal({'c': 'ccc', '1': 99, 'b': [1, 2, function('strlen')], '3': 33, '-1': {'a': 1}}, d)
   call filter(d, 'v:key =~ ''[ac391]''')
   call assert_equal({'c': 'ccc', '1': 99, '3': 33, '-1': {'a': 1}}, d)
+
+  " allow key starting with number at the start, not a curly expression
+  call assert_equal({'1foo': 77}, #{1foo: 77})
 endfunc
 
 " Dictionary identity

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -104,7 +104,7 @@ describe(':source', function()
     eq("0zBEEFCAFE", meths.exec('echo d', true))
 
     exec('set cpoptions+=C')
-    eq('Vim(let):E15: Invalid expression: #{', exc_exec('source'))
+    eq('Vim(let):E723: Missing end of Dictionary \'}\': ', exc_exec('source'))
   end)
 
   it('selection in current buffer', function()
@@ -138,7 +138,7 @@ describe(':source', function()
     eq('Vim(echo):E117: Unknown function: s:C', exc_exec('echo D()'))
 
     exec('set cpoptions+=C')
-    eq('Vim(let):E15: Invalid expression: #{', exc_exec("'<,'>source"))
+    eq('Vim(let):E723: Missing end of Dictionary \'}\': ', exc_exec("'<,'>source"))
   end)
 
   it('does not break if current buffer is modified while sourced', function()


### PR DESCRIPTION
Problem:    #{g:x} was seen as a curly-braces expression.
Solution:   Do never see #{} as a curly-braces expression. (closes vim/vim#11075)
https://github.com/vim/vim/commit/7c7e1e9b98d4e5dbe7358c795a635c6f1f36f418