### PR TITLE
vim-patch:9.0.{0410,0412}: unused cts_lnum

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -292,7 +292,6 @@ void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T 
                           char *ptr)
 {
   cts->cts_win = wp;
-  cts->cts_lnum = lnum;
   cts->cts_vcol = col;
   cts->cts_line = line;
   cts->cts_ptr = ptr;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -288,8 +288,8 @@ unsigned int win_linetabsize(win_T *wp, linenr_T lnum, char_u *line, colnr_T len
 ///
 /// "line" is the start of the line, "ptr" is the first relevant character.
 /// When "lnum" is zero do not use text properties that insert text.
-void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T col, char *line,
-                          char *ptr)
+void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum FUNC_ATTR_UNUSED,
+                          colnr_T col, char *line, char *ptr)
 {
   cts->cts_win = wp;
   cts->cts_vcol = col;

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -6,7 +6,6 @@
 // Argument for lbr_chartabsize().
 typedef struct {
   win_T *cts_win;
-  linenr_T cts_lnum;   // zero when not using text properties
   char *cts_line;    // start of the line
   char *cts_ptr;     // current position in line
 


### PR DESCRIPTION
#### vim-patch:9.0.0410: struct member cts_lnum is unused

Problem:    Struct member cts_lnum is unused.
Solution:   Delete it.
https://github.com/vim/vim/commit/d7633114af2365e32080b61af473db347a3489c2


#### vim-patch:9.0.0412: compiler warning for unused argument

Problem:    Compiler warning for unused argument.
Solution:   Add UNUSED.
https://github.com/vim/vim/commit/e5a420fb33518e08313f653f3031bc36f949e086