### PR TITLE
fix(treesitter): use the right loading order for base queries

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -187,6 +187,11 @@ Note: The predicates listed in the web page above differ from those Neovim
 supports. See |lua-treesitter-predicates| for a complete list of predicates
 supported by Neovim.
 
+By default, the first query on `runtimepath` is used (which usually implies
+that user config takes precedence over plugins, which take precedence over
+queries bundled with Neovim). If a query should extend other queries instead
+of replacing them, use the `; extends` modeline below.
+
 A `query` consists of one or more patterns. A `pattern` is defined over node
 types in the syntax tree.  A `match` corresponds to specific elements of the
 syntax tree which match a pattern. Patterns may optionally define captures

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -97,7 +97,7 @@ function M.get_query_files(lang, query_name, is_included)
 
     if extension then
       table.insert(extensions, filename)
-    else
+    elseif base_query == nil then
       base_query = filename
     end
     io.close(file)


### PR DESCRIPTION
An user query will override a site plugin query, which will override the runtime query.