### PR TITLE
fix(lsp): split newText should support windows

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -443,7 +443,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     }
   end)()
 
-  local is_windows = vim.loop.os_uname().sysname == 'Windows'
+  local is_windows = vim.fn.windowsversion()
   -- Apply text edits.
   local is_cursor_fixed = false
   local has_eol_text_edit = false
@@ -459,7 +459,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
       end_col = get_line_byte_from_position(bufnr, text_edit.range['end'], offset_encoding),
     }
 
-    if not is_windows then
+    if string.len(is_windows) == 0 then
       e.text = split(text_edit.newText, '\n', true)
     else
       e.text = split(text_edit.newText, '\\r\\n', true)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -443,6 +443,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     }
   end)()
 
+  local is_windows = vim.loop.os_uname().sysname == 'Windows'
   -- Apply text edits.
   local is_cursor_fixed = false
   local has_eol_text_edit = false
@@ -456,8 +457,13 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
       start_col = get_line_byte_from_position(bufnr, text_edit.range.start, offset_encoding),
       end_row = text_edit.range['end'].line,
       end_col = get_line_byte_from_position(bufnr, text_edit.range['end'], offset_encoding),
-      text = split(text_edit.newText, '\n', true),
     }
+
+    if not is_windows then
+      e.text = split(text_edit.newText, '\n', true)
+    else
+      e.text = split(text_edit.newText, '\\r\\n', true)
+    end
 
     -- Some LSP servers may return +1 range of the buffer content but nvim_buf_set_text can't accept it so we should fix it here.
     local max = api.nvim_buf_line_count(bufnr)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -443,7 +443,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     }
   end)()
 
-  local is_windows = vim.fn.windowsversion()
+  local is_windows = #vim.fn.windowsversion() > 0
   -- Apply text edits.
   local is_cursor_fixed = false
   local has_eol_text_edit = false
@@ -459,7 +459,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
       end_col = get_line_byte_from_position(bufnr, text_edit.range['end'], offset_encoding),
     }
 
-    if string.len(is_windows) == 0 then
+    if not is_windows then
       e.text = split(text_edit.newText, '\n', true)
     else
       e.text = split(text_edit.newText, '\\r\\n', true)


### PR DESCRIPTION
`newText` will have `\r\n` in windows.  so we should judge the current system env is windows or not.
another way is use `newText:find('\\r\\n')`. I am not sure which is best. but in my opinion use loop system is better than use regex.

Fix #20116 