### PR TITLE
build(deps): bump tree-sitter-viml to 0.2.0

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -207,8 +207,8 @@ set(TREESITTER_C_SHA256 af66fde03feb0df4faf03750102a0d265b007e5d957057b6b293c131
 set(TREESITTER_LUA_URL https://github.com/MunifTanjim/tree-sitter-lua/archive/v0.0.12.tar.gz)
 set(TREESITTER_LUA_SHA256 b6d7c6d04e9101a2e589d25f1d61668301e776c0b8defa6eae8dd86272e9e7c3)
 
-set(TREESITTER_VIM_URL https://github.com/vigoux/tree-sitter-viml/archive/v0.1.0.tar.gz)
-set(TREESITTER_VIM_SHA256 ea64fa211ccc7197669017b55911fdb56e8d4b6de96ba25c32b9586ec1c4f4c5)
+set(TREESITTER_VIM_URL https://github.com/vigoux/tree-sitter-viml/archive/v0.2.0.tar.gz)
+set(TREESITTER_VIM_SHA256 608dcc31a7948cb66ae7f45494620e2e9face1af75598205541f80d782ec4501)
 
 set(TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.20.7.tar.gz)
 set(TREESITTER_SHA256 b355e968ec2d0241bbd96748e00a9038f83968f85d822ecb9940cbe4c42e182e)

--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -40,7 +40,7 @@
 (parameters (identifier) @parameter)
 (default_parameter (identifier) @parameter)
 
-[ (bang) (spread) (at) ] @punctuation.special
+[ (bang) (spread) ] @punctuation.special
 
 [ (no_option) (inv_option) (default_option) (option_name) ] @variable.builtin
 [
@@ -92,6 +92,12 @@
   "topleft"
   "botright"
   (unknown_command_name)
+  "edit"
+  "enew"
+  "find"
+  "ex"
+  "visual"
+  "view"
 ] @keyword
 (map_statement cmd: _ @keyword)
 (command_name) @function.macro
@@ -125,17 +131,18 @@
   "<unique>"
 ] @constant.builtin
 
-(hl_attribute
-  key: _ @property
-  val: _ @constant)
-
-(hl_group) @variable
 (augroup_name) @namespace
 
 (au_event) @constant
 (normal_statement (commands) @constant)
 
 ;; Highlight command
+
+(hl_attribute
+  key: _ @property
+  val: _ @constant)
+
+(hl_group) @type
 
 (highlight_statement [
   "default"
@@ -145,11 +152,18 @@
 
 ;; Command command
 
+(command) @string
+
 (command_attribute
   name: _ @property
   val: (behavior
     name: _ @constant
     val: (identifier)? @function)?)
+
+;; Edit command
+(plus_plus_opt
+  val: _? @constant) @property
+(plus_cmd "+" @property) @property
 
 ;; Runtime command
 
@@ -161,12 +175,10 @@
 
 ;; Literals
 
-(string_literal) @string
-(string_literal) @spell
+(string_literal) @string @spell
 (integer_literal) @number
 (float_literal) @float
-(comment) @comment
-(comment) @spell
+(comment) @comment @spell
 (pattern) @string.special
 (pattern_multi) @string.regex
 (filename) @string


### PR DESCRIPTION
bumping to make queries compatible with nvim-treesitter again (not as much of a concern after the query priority PR, but good nonetheless)