### PR TITLE
docs: remove link that has been dead for 2 years by now

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [Twitter](https://twitter.com/Neovim)
 
 [![GitHub CI](https://github.com/neovim/neovim/workflows/CI/badge.svg)](https://github.com/neovim/neovim/actions?query=workflow%3ACI+branch%3Amaster+event%3Apush)
-[![Codecov coverage](https://img.shields.io/codecov/c/github/neovim/neovim.svg)](https://codecov.io/gh/neovim/neovim)
 [![Coverity Scan analysis](https://scan.coverity.com/projects/2227/badge.svg)](https://scan.coverity.com/projects/2227)
 [![Clang analysis](https://neovim.io/doc/reports/clang/badge.svg)](https://neovim.io/doc/reports/clang)
 [![PVS-Studio analysis](https://neovim.io/doc/reports/pvs/badge.svg)](https://neovim.io/doc/reports/pvs/PVS-studio.html.d)


### PR DESCRIPTION
I looked through the README.md and noticed that there is a link that has been dead for 2 years. I don't know if this is intentional. But, as this link is 2 years old. I don't know how accurate those numbers (coverage 78%) are and I think that it therefore should be removed.

Sorry for my not too good english.
Ty in advance