### PR TITLE
feat(filetype): expand environment variables in filetype patterns

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2082,7 +2082,10 @@ add({filetypes})                                          *vim.filetype.add()*
 
     Filename patterns can specify an optional priority to resolve cases when a
     file path matches multiple patterns. Higher priorities are matched first.
-    When omitted, the priority defaults to 0.
+    When omitted, the priority defaults to 0. A pattern can contain
+    environment variables of the form "${SOME_VAR}" that will be automatically
+    expanded. If the environment variable is not set, the pattern won't be
+    matched.
 
     See $VIMRUNTIME/lua/vim/filetype.lua for more examples.
 
@@ -2112,6 +2115,8 @@ add({filetypes})                                          *vim.filetype.add()*
           ['.*/etc/foo/.*'] = 'fooscript',
           -- Using an optional priority
           ['.*/etc/foo/.*%.conf'] = { 'dosini', { priority = 10 } },
+          -- A pattern containing an environment variable
+          ['${XDG_CONFIG_HOME}/foo/git'] = 'git',
           ['README.(a+)$'] = function(path, bufnr, ext)
             if ext == 'md' then
               return 'markdown'


### PR DESCRIPTION
@clason Any idea why modifying `env_pattern` (e.g. replacing it with an empty table) still makes the tests pass (`make oldtest TEST_FILE=test_filetype`) (at least for me locally)? Same when deleting e.g. the entry for `'.*/xorg%.conf%.d/.*%.conf'`, i.e. any key/value pair that does not require `detect.lua`.