### PR TITLE
vim-patch:9.0.0443: blueprint files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -875,11 +875,11 @@ au BufNewFile,BufRead *.htt,*.htb		setf httest
 
 " i3
 au BufNewFile,BufRead */i3/config		setf i3config
-au BufNewFile,BufRead */.i3/config  	setf i3config
+au BufNewFile,BufRead */.i3/config		setf i3config
 
 " sway
 au BufNewFile,BufRead */sway/config		setf swayconfig
-au BufNewFile,BufRead */.sway/config	setf swayconfig
+au BufNewFile,BufRead */.sway/config		setf swayconfig
 
 " Icon
 au BufNewFile,BufRead *.icn			setf icon
@@ -2582,6 +2582,9 @@ au BufNewFile,BufRead *.txt
         \  if getline('$') !~ 'vim:.*ft=help'
         \|   setf text
         \| endif       
+
+" Blueprint markup files
+au BufNewFile,BufRead *.blp			setf blueprint
 
 if !exists('g:did_load_ftdetect')
   " Use the filetype detect plugins.  They may overrule any of the previously

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -177,6 +177,7 @@ local extension = {
   bbappend = 'bitbake',
   bbclass = 'bitbake',
   bl = 'blank',
+  blp = 'blueprint',
   bsd = 'bsdl',
   bsdl = 'bsdl',
   bst = 'bst',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -88,6 +88,7 @@ let s:filename_checks = {
     \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
     \ 'blank': ['file.bl'],
+    \ 'blueprint': ['file.blp'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
     \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE'],


### PR DESCRIPTION
Problem:    Blueprint files are not recognized.
Solution:   Add a pattern for blueprint files. (Gabriele Musco, closes vim/vim#11107)
https://github.com/vim/vim/commit/cce82a55b8105560a2ef724999c856966337b48e