### PR TITLE
feat(query): extracts get_range_text from get_node_text

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -208,11 +208,33 @@ end
 ---@param opts table Optional parameters.
 ---          - concat: (boolean default true) Concatenate result in a string
 function M.get_node_text(node, source, opts)
-  opts = opts or {}
-  local concat = vim.F.if_nil(opts.concat, true)
 
   local start_row, start_col, start_byte = node:start()
   local end_row, end_col, end_byte = node:end_()
+
+  return M.get_range_text({start_row, start_col, start_byte, end_row, end_col, end_byte}, source, opts)
+end
+
+--- Gets the text corresponding to a given range
+--- This may be for example the range of a node or its offset metadata.range
+---
+---@param range table The range
+---@param source table The buffer or string from which the node is extracted
+---@param opts table Optional parameters.
+---          - concat: (boolean default true) Concatenate result in a string
+function M.get_range_text(range, source, opts)
+  opts = opts or {}
+  local concat = vim.F.if_nil(opts.concat, true)
+
+  local start_row, start_col, start_byte, end_row, end_col, end_byte
+  if #range == 4 then
+    start_row, start_col, end_row, end_col = unpack(range)
+  elseif #range == 6 then
+    start_row, start_col, start_byte, end_row, end_col, end_byte = unpack(range)
+  else
+    error(string.format('Expected range to have 4 or 6 entries, got %d', #range))
+    return nil
+  end
 
   if type(source) == 'number' then
     local lines


### PR DESCRIPTION
Currently we have `get_node_text` which gets the text corresponding to a node using the values from `node:start()` and `node:end_()`. When `#offset!` is used in a query (for example for injections or text objects) the range of the match will not equal the range of the node.

In https://github.com/nvim-treesitter/nvim-treesitter/pull/3486 for example the metadata is now included in the matches of the query. So with this change here one could then simply do `get_range_text(match.metadata.range)` to get the text using the same logic as `get_node_text`.

Tagging @clason since I briefly asked about this on matrix.