### PR TITLE
vim-patch:8.2.{2646,2664}: string argument type check

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1772,7 +1772,7 @@ static void f_eventhandler(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
 /// "executable()" function
 static void f_executable(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_string(&argvars[0]) == FAIL) {
+  if (tv_check_for_string(&argvars[0], 1) == FAIL) {
     return;
   }
 
@@ -1901,7 +1901,7 @@ static void f_win_execute(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "exepath()" function
 static void f_exepath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_nonempty_string(&argvars[0]) == FAIL) {
+  if (tv_check_for_nonempty_string(&argvars[0], 1) == FAIL) {
     return;
   }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1772,7 +1772,7 @@ static void f_eventhandler(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
 /// "executable()" function
 static void f_executable(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_string(&argvars[0], 1) == FAIL) {
+  if (tv_check_for_string_arg(argvars, 0) == FAIL) {
     return;
   }
 
@@ -1901,7 +1901,7 @@ static void f_win_execute(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "exepath()" function
 static void f_exepath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_nonempty_string(&argvars[0], 1) == FAIL) {
+  if (tv_check_for_nonempty_string_arg(argvars, 0) == FAIL) {
     return;
   }
 

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -40,6 +40,11 @@
 # include "eval/typval.c.generated.h"
 #endif
 
+static char e_string_required_for_argument_nr[]
+  = N_("E1174: String required for argument %d");
+static char e_non_empty_string_required_for_argument_nr[]
+  = N_("E1142: Non-empty string required for argument %d");
+
 bool tv_in_free_unref_items = false;
 
 // TODO(ZyX-I): Remove DICT_MAXNEST, make users be non-recursive instead
@@ -3800,26 +3805,34 @@ float_T tv_get_float(const typval_T *const tv)
   return 0;
 }
 
-// Give an error and return FAIL unless "tv" is a string.
-int tv_check_for_string(const typval_T *const tv)
+/// Give an error and return FAIL unless "tv" is a string.
+int tv_check_for_string(const typval_T *const tv, const int arg)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
   if (tv->v_type != VAR_STRING) {
-    emsg(_(e_stringreq));
+    if (arg > 0) {
+      semsg(_(e_string_required_for_argument_nr), arg);
+    } else {
+      emsg(_(e_stringreq));
+    }
     return FAIL;
   }
   return OK;
 }
 
-// Give an error and return FAIL unless "tv" is a non-empty string.
-int tv_check_for_nonempty_string(const typval_T *const tv)
+/// Give an error and return FAIL unless "tv" is a non-empty string.
+int tv_check_for_nonempty_string(const typval_T *const tv, const int arg)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
-  if (tv_check_for_string(tv) == FAIL) {
+  if (tv_check_for_string(tv, arg) == FAIL) {
     return FAIL;
   }
   if (tv->vval.v_string == NULL || *tv->vval.v_string == NUL) {
-    emsg(_(e_non_empty_string_required));
+    if (arg > 0) {
+      semsg(_(e_non_empty_string_required_for_argument_nr), arg);
+    } else {
+      emsg(_(e_non_empty_string_required));
+    }
     return FAIL;
   }
   return OK;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3805,34 +3805,26 @@ float_T tv_get_float(const typval_T *const tv)
   return 0;
 }
 
-/// Give an error and return FAIL unless "tv" is a string.
-int tv_check_for_string(const typval_T *const tv, const int arg)
+/// Give an error and return FAIL unless "args[idx]" is a string.
+int tv_check_for_string_arg(const typval_T *const args, const int idx)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
-  if (tv->v_type != VAR_STRING) {
-    if (arg > 0) {
-      semsg(_(e_string_required_for_argument_nr), arg);
-    } else {
-      emsg(_(e_stringreq));
-    }
+  if (args[idx].v_type != VAR_STRING) {
+    semsg(_(e_string_required_for_argument_nr), idx + 1);
     return FAIL;
   }
   return OK;
 }
 
-/// Give an error and return FAIL unless "tv" is a non-empty string.
-int tv_check_for_nonempty_string(const typval_T *const tv, const int arg)
+/// Give an error and return FAIL unless "args[idx]" is a non-empty string.
+int tv_check_for_nonempty_string_arg(const typval_T *const args, const int idx)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
-  if (tv_check_for_string(tv, arg) == FAIL) {
+  if (tv_check_for_string_arg(args, idx) == FAIL) {
     return FAIL;
   }
-  if (tv->vval.v_string == NULL || *tv->vval.v_string == NUL) {
-    if (arg > 0) {
-      semsg(_(e_non_empty_string_required_for_argument_nr), arg);
-    } else {
-      emsg(_(e_non_empty_string_required));
-    }
+  if (args[idx].vval.v_string == NULL || *args[idx].vval.v_string == NUL) {
+    semsg(_(e_non_empty_string_required_for_argument_nr), idx + 1);
     return FAIL;
   }
   return OK;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2793,7 +2793,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
 void f_charclass(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_string(&argvars[0], 1) == FAIL
+  if (tv_check_for_string_arg(argvars, 0) == FAIL
       || argvars[0].vval.v_string == NULL) {
     return;
   }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2793,7 +2793,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
 void f_charclass(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (tv_check_for_string(&argvars[0]) == FAIL
+  if (tv_check_for_string(&argvars[0], 1) == FAIL
       || argvars[0].vval.v_string == NULL) {
     return;
   }

--- a/test/functional/vimscript/executable_spec.lua
+++ b/test/functional/vimscript/executable_spec.lua
@@ -34,11 +34,13 @@ describe('executable()', function()
 
   it('fails for invalid values', function()
     for _, input in ipairs({'v:null', 'v:true', 'v:false', '{}', '[]'}) do
-      eq('Vim(call):E928: String required', exc_exec('call executable('..input..')'))
+      eq('Vim(call):E1174: String required for argument 1',
+         exc_exec('call executable('..input..')'))
     end
     command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
     for _, input in ipairs({'v:null', 'v:true', 'v:false'}) do
-      eq('Vim(call):E928: String required', exc_exec('call executable('..input..')'))
+      eq('Vim(call):E1174: String required for argument 1',
+         exc_exec('call executable('..input..')'))
     end
   end)
 

--- a/test/functional/vimscript/exepath_spec.lua
+++ b/test/functional/vimscript/exepath_spec.lua
@@ -21,12 +21,12 @@ describe('exepath()', function()
 
   it('fails for invalid values', function()
     for _, input in ipairs({'v:null', 'v:true', 'v:false', '{}', '[]'}) do
-      eq('Vim(call):E928: String required', exc_exec('call exepath('..input..')'))
+      eq('Vim(call):E1174: String required for argument 1', exc_exec('call exepath('..input..')'))
     end
-    eq('Vim(call):E1142: Non-empty string required', exc_exec('call exepath("")'))
+    eq('Vim(call):E1142: Non-empty string required for argument 1', exc_exec('call exepath("")'))
     command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
     for _, input in ipairs({'v:null', 'v:true', 'v:false'}) do
-      eq('Vim(call):E928: String required', exc_exec('call exepath('..input..')'))
+      eq('Vim(call):E1174: String required for argument 1', exc_exec('call exepath('..input..')'))
     end
   end)
 


### PR DESCRIPTION
#### vim-patch:8.2.2646: Vim9: error for not using string doesn't mention argument

Problem:    Vim9: error for not using string doesn't mention argument.
Solution:   Add argument number.
https://github.com/vim/vim/commit/f28f2ac425600b88da0bdcc12a82cd620f575681


#### vim-patch:8.2.2664: Vim9: not enough function arguments checked for string

Problem:    Vim9: not enough function arguments checked for string.
Solution:   Check in balloon functions.  Refactor function arguments.
https://github.com/vim/vim/commit/32105ae88f3aa6a6af30336f0bc9f8eb81292cd7

Cherry-pick removal of useless check from patch 8.2.3840.

vim-patch:8.2.3083: crash when passing null string to charclass()

Problem:    Crash when passing null string to charclass().
Solution:   Bail out when string pointer is NULL. (Christian Brabandt,
            closes vim/vim#8498)
https://github.com/vim/vim/commit/72463f883cdfd08e29ab0018ef3889284848d5f1