### PR TITLE
vim-patch:8.2.4671: 'wildignorecase' is sometimes not used for glob()

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1272,12 +1272,12 @@ int gen_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, i
         }
       }
 
-      // If there are wildcards: Expand file names and add each match to
-      // the list.  If there is no match, and EW_NOTFOUND is given, add
-      // the pattern.
-      // If there are no wildcards: Add the file name if it exists or
-      // when EW_NOTFOUND is given.
-      if (path_has_exp_wildcard(p)) {
+      // If there are wildcards or case-insensitive expansion is
+      // required: Expand file names and add each match to the list.  If
+      // there is no match, and EW_NOTFOUND is given, add the pattern.
+      // Otherwise: Add the file name if it exists or when EW_NOTFOUND is
+      // given.
+      if (path_has_exp_wildcard(p) || (flags & EW_ICASE)) {
         if ((flags & EW_PATH)
             && !path_is_absolute(p)
             && !(p[0] == '.'

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -2026,6 +2026,8 @@ func Test_glob()
   " Sort output of glob() otherwise we end up with different
   " ordering depending on whether file system is case-sensitive.
   call assert_equal(['XGLOB2', 'Xglob1'], sort(glob('Xglob[12]', 0, 1)))
+  " wildignorecase shall be applied even when the pattern contains no wildcards.
+  call assert_equal('XGLOB2', glob('xglob2'))
   set wildignorecase&
 
   call delete('Xglob1')


### PR DESCRIPTION
#### vim-patch:8.2.4671: 'wildignorecase' is sometimes not used for glob()

Problem:    'wildignorecase' is sometimes not used for glob().
Solution:   Also use 'wildignorecase' when there are no wildcards.
            (closes vim/vim#10066)
https://github.com/vim/vim/commit/a3157a476bfa8c3077d510cc8400093c0d115df5