### PR TITLE
vim-patch:9.0.0448: SubRip files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1724,6 +1724,9 @@ au BufNewFile,BufRead *.sdl,*.pr		setf sdl
 " sed
 au BufNewFile,BufRead *.sed			setf sed
 
+" SubRip
+au BufNewFile,BufRead *.srt			setf srt
+
 " svelte
 au BufNewFile,BufRead *.svelte			setf svelte
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -959,6 +959,7 @@ local extension = {
   srec = 'srec',
   mot = 'srec',
   ['s19'] = 'srec',
+  srt = 'srt',
   st = 'st',
   imata = 'stata',
   ['do'] = 'stata',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -530,6 +530,7 @@ let s:filename_checks = {
     \ 'squid': ['squid.conf'],
     \ 'squirrel': ['file.nut'],
     \ 'srec': ['file.s19', 'file.s28', 'file.s37', 'file.mot', 'file.srec'],
+    \ 'srt': ['file.srt'],
     \ 'sshconfig': ['ssh_config', '/.ssh/config', '/etc/ssh/ssh_config.d/file.conf', 'any/etc/ssh/ssh_config.d/file.conf', 'any/.ssh/config', 'any/.ssh/file.conf'],
     \ 'sshdconfig': ['sshd_config', '/etc/ssh/sshd_config.d/file.conf', 'any/etc/ssh/sshd_config.d/file.conf'],
     \ 'st': ['file.st'],


### PR DESCRIPTION
Problem:    SubRip files are not recognized.
Solution:   Add a pattern for SubRip. (closes vim/vim#11113)
https://github.com/vim/vim/commit/5a4eb55122e45444d3a6c56ce108ce29bc8e52ab