### PR TITLE
vim-patch:9.0.0299: error messages for setcmdline() could be better

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3843,6 +3843,14 @@ int tv_check_for_number_arg(const typval_T *const args, const int idx)
   return OK;
 }
 
+/// Check for an optional number argument at "idx"
+int tv_check_for_opt_number_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  return (args[idx].v_type == VAR_UNKNOWN
+          || tv_check_for_number_arg(args, idx) != FAIL) ? OK : FAIL;
+}
+
 /// Get the string value of a "stringish" VimL object.
 ///
 /// @param[in]  tv  Object to get value of.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4050,8 +4050,8 @@ static int set_cmdline_pos(int pos)
 /// "setcmdline()" function
 void f_setcmdline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (argvars[0].v_type != VAR_STRING || argvars[0].vval.v_string == NULL) {
-    emsg(_(e_stringreq));
+  if (tv_check_for_string_arg(argvars, 0) == FAIL
+      || tv_check_for_opt_number_arg(argvars, 1) == FAIL) {
     return;
   }
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2226,8 +2226,8 @@ func Test_setcmdline()
     call assert_equal(a:pos, getcmdpos())
 
     call assert_fails('call setcmdline("' .. a:text .. '", -1)', 'E487:')
-    call assert_fails('call setcmdline({}, 0)', 'E928:')
-    call assert_fails('call setcmdline("' .. a:text .. '", {})', 'E728:')
+    call assert_fails('call setcmdline({}, 0)', 'E1174:')
+    call assert_fails('call setcmdline("' .. a:text .. '", {})', 'E1210:')
 
     return ''
   endfunc


### PR DESCRIPTION
#### vim-patch:9.0.0299: error messages for setcmdline() could be better

Problem:    Error messages for setcmdline() could be better.
Solution:   Use more specific error messages. (Yegappan Lakshmanan,
            closes vim/vim#10995)
https://github.com/vim/vim/commit/25f1e5556259d536c8608185145b0769262873ff

Cherry-pick tv_check_for_opt_number_arg() from Vim.