### PR TITLE
test(lsp): call clear() before bufwipe test

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -419,6 +419,7 @@ describe('LSP', function()
     end)
 
     it('should detach buffer on bufwipe', function()
+      clear()
       local result = exec_lua([[
         local server = function(dispatchers)
           local closing = false


### PR DESCRIPTION
Otherwise this test cannot be run alone, and fails frequently on CI.
