### PR TITLE
feat(diagnostic): pass diagnostics as data to DiagnosticChanged autocmd

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -295,10 +295,18 @@ option in the "signs" table of |vim.diagnostic.config()| or 10 if unset).
 EVENTS                                                  *diagnostic-events*
 
                                                         *DiagnosticChanged*
-DiagnosticChanged       After diagnostics have changed.
+DiagnosticChanged       After diagnostics have changed. When used from Lua,
+                        the new diagnostics are passed to the autocmcd
+                        callback in the "data" table.
 
 Example: >
-    autocmd DiagnosticChanged * lua vim.diagnostic.setqflist({ open = false })
+
+    vim.api.nvim_create_autocmd('DiagnosticChanged', {
+      callback = function(args)
+        local diagnostics = args.data.diagnostics
+        vim.pretty_print(diagnostics)
+      end,
+    })
 <
 ==============================================================================
 Lua module: vim.diagnostic                                    *diagnostic-api*

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -727,6 +727,7 @@ function M.set(namespace, bufnr, diagnostics, opts)
   vim.api.nvim_exec_autocmds('DiagnosticChanged', {
     modeline = false,
     buffer = bufnr,
+    data = { diagnostics = diagnostics },
   })
 end
 


### PR DESCRIPTION
A minor convenience, taking advantage of the new data passing capability of Lua
autocommand callbacks. Saves a roundtrip through `vim.diagnostic.get`.
