### PR TITLE
feat(term): pipe osc and dcs commands to underlying terminal emulator

### DIFF
--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -167,4 +167,6 @@ void msg_history_show(Array entries)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void msg_history_clear(void)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
+void term_unhandled(String command)
+   FUNC_API_SINCE(6);
 #endif  // NVIM_API_UI_EVENTS_IN_H


### PR DESCRIPTION
Cursor shape changes are working but `imgcat` of iTerm2 still doesn't work, I guess Neovim/libuv/ncurses library/something is changing terminal mode/settings. I don't have much knowledge about that but if I write the exact same bytes to a file and `tail -f` that file in another tab of iTerm2, image shows correctly, but in Neovim it shows like this:

<img width="190" alt="image" src="https://user-images.githubusercontent.com/1270688/189781970-83941b14-ce73-47df-8190-f6334384604a.png">
