### PR TITLE
vim-patch:9.0.0456: function called at debug prompt is also debugged

### DIFF
--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -128,10 +128,15 @@ void do_debug(char *cmd)
       ignore_script = true;
     }
 
+    // don't debug any function call, e.g. from an expresion mapping
+    n = debug_break_level;
+    debug_break_level = -1;
+
     xfree(cmdline);
     cmdline = getcmdline_prompt('>', NULL, 0, EXPAND_NOTHING, NULL,
                                 CALLBACK_NONE);
 
+    debug_break_level = n;
     if (typeahead_saved) {
       restore_typeahead(&typeaheadbuf);
       ignore_script = save_ignore_script;


### PR DESCRIPTION
#### vim-patch:9.0.0456: function called at debug prompt is also debugged

Problem:    Function called at debug prompt is also debugged.
Solution:   Reset the debug level while entering the debug command.
https://github.com/vim/vim/commit/b1842de5ca77205993e8ef76cf29803822e0e3ab