### PR TITLE
vim-patch:9.0.0457: substitute prompt does not highlight an empty match

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3887,6 +3887,10 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
                                    - regmatch.startpos[0].lnum;
               search_match_endcol = regmatch.endpos[0].col
                                     + len_change;
+              if (search_match_lines == 0 && search_match_endcol == 0) {
+                // highlight at least one character for /^/
+                search_match_endcol = 1;
+              }
               highlight_match = true;
 
               update_topline(curwin);

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -1,6 +1,8 @@
 " Tests for the substitute (:s) command
 
 source shared.vim
+source check.vim
+source screendump.vim
 
 func Test_multiline_subst()
   enew!
@@ -666,6 +668,21 @@ func Test_sub_cmd_9()
 
   delfunc Foo
   bw!
+endfunc
+
+func Test_sub_highlight_zero_match()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    call setline(1, ['one', 'two', 'three'])
+  END
+  call writefile(lines, 'XscriptSubHighlight', 'D')
+  let buf = RunVimInTerminal('-S XscriptSubHighlight', #{rows: 8, cols: 60})
+  call term_sendkeys(buf, ":%s/^/   /c\<CR>")
+  call VerifyScreenDump(buf, 'Test_sub_highlight_zer_match_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_nocatch_sub_failure_handling()


### PR DESCRIPTION
#### vim-patch:9.0.0457: substitute prompt does not highlight an empty match

Problem:    Substitute prompt does not highlight an empty match.
Solution:   Highlight at least one character.
https://github.com/vim/vim/commit/a04f457a6c071179bac4088c9314007d39d5c5e0