### PR TITLE
feat: lua functions and closure support for '*expr'/'*func' options

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -312,15 +312,22 @@ Note: In the future more global options can be made |global-local|.  Using
 ":setlocal" on a global option might work differently then.
 
 
-						*option-value-function*
+						*option-value-function* *E5378*
 Some options ('completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
-'operatorfunc', 'quickfixtextfunc' and 'tagfunc') are set to a function name
-or a function reference or a lambda function.  Examples:
+'operatorfunc', 'quickfixtextfunc' and 'tagfunc') are set to a function name,
+function reference, or a lambda function.  Examples:
 >
 	set opfunc=MyOpFunc
 	set opfunc=function("MyOpFunc")
 	set opfunc=funcref("MyOpFunc")
 	set opfunc={t\ ->\ MyOpFunc(t)}
+<
+They can also be set to |Lua| functions using |vim.o|, |vim.opt| or the Nvim
+|API|:
+>
+	vim.o.opfunc = my_op_func
+	vim.opt.opfunc = my_op_func
+	vim.api.nvim_set_option_value("opfunc", my_op_func, {})
 <
 
 Setting the filetype
@@ -1429,7 +1436,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
 
 						*'completefunc'* *'cfu'*
-'completefunc' 'cfu'	string	(default: empty)
+'completefunc' 'cfu'	|option-value-function|	(default: empty)
 			local to buffer
 	This option specifies a function to be used for Insert mode completion
 	with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
@@ -1959,7 +1966,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	between files.  See |diff-mode|.
 
 						*'dex'* *'diffexpr'*
-'diffexpr' 'dex'	string	(default "")
+'diffexpr' 'dex'	|option-value-function|	(default "")
 			global
 	Expression which is evaluated to obtain a diff file (either ed-style
 	or unified-style) from two versions of a file.  See |diff-diffexpr|.
@@ -2556,7 +2563,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |folding|.
 
 						*'foldexpr'* *'fde'*
-'foldexpr' 'fde'	string (default: "0")
+'foldexpr' 'fde'	|option-value-function| (default: "0")
 			local to window
 	The expression used for when 'foldmethod' is "expr".  It is evaluated
 	for each line to obtain its fold level.  See |fold-expr|.
@@ -2685,7 +2692,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	evaluating 'foldtext' |textlock|.
 
 						*'formatexpr'* *'fex'*
-'formatexpr' 'fex'	string (default "")
+'formatexpr' 'fex'	|option-value-function| (default "")
 			local to buffer
 	Expression which is evaluated to format a range of lines for the |gq|
 	operator or automatic formatting (see 'formatoptions').  When this
@@ -3321,7 +3328,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |option-backslash| about including spaces and backslashes.
 
 						*'includeexpr'* *'inex'*
-'includeexpr' 'inex'	string	(default "")
+'includeexpr' 'inex'	|option-value-function|	(default "")
 			local to buffer
 	Expression to be used to transform the string found with the 'include'
 	option to a file name.  Mostly useful to change "." to "/" for Java: >
@@ -3375,7 +3382,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	match, excluding the characters that were already typed.
 
 						*'indentexpr'* *'inde'*
-'indentexpr' 'inde'	string	(default "")
+'indentexpr' 'inde'	|option-value-function|	(default "")
 			local to buffer
 	Expression which is evaluated to obtain the proper indent for a line.
 	It is used when a new line is created, for the |=| operator and
@@ -4052,7 +4059,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	no lines are checked.  See |modeline|.
 
 			   *'modelineexpr'* *'mle'* *'nomodelineexpr'* *'nomle'*
-'modelineexpr' 'mle'	boolean (default: off)
+'modelineexpr' 'mle'	|option-value-function| (default: off)
 			global
 	When on allow some options that are an expression to be set in the
 	modeline.  Check the option for whether it is affected by
@@ -4398,7 +4405,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The minimum value is 1, the maximum value is 20.
 
 						*'omnifunc'* *'ofu'*
-'omnifunc' 'ofu'	string	(default: empty)
+'omnifunc' 'ofu'	|option-value-function|	(default: empty)
 			local to buffer
 	This option specifies a function to be used for Insert mode omni
 	completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
@@ -4422,12 +4429,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 
 						*'operatorfunc'* *'opfunc'*
-'operatorfunc' 'opfunc'	string	(default: empty)
+'operatorfunc' 'opfunc'	|option-value-function|	(default: empty)
 			global
 	This option specifies a function to be called by the |g@| operator.
 	See |:map-operator| for more info and an example.  The value can be
-	the name of a function, a |lambda| or a |Funcref|. See
-	|option-value-function| for more information.
+	the name of a function, a |lambda| or a |Funcref|.
 
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
@@ -4515,13 +4521,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the value has several bytes 'ttimeoutlen' applies.
 
 						*'pex'* *'patchexpr'*
-'patchexpr' 'pex'	string	(default "")
+'patchexpr' 'pex'	|option-value-function|	(default "")
 			global
 	Expression which is evaluated to apply a patch to a file and generate
 	the resulting new version of the file.  See |diff-patchexpr|.
 
 					*'patchmode'* *'pm'* *E205* *E206*
-'patchmode' 'pm'	string	(default "")
+'patchmode' 'pm'	|option-value-function|	(default "")
 			global
 	When non-empty the oldest version of a file is kept.  This can be used
 	to keep the original version of a file if you are changing files in a
@@ -4637,7 +4643,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See |penc-option|.
 
 						*'printexpr'* *'pexpr'*
-'printexpr' 'pexpr'	string	(default: see below)
+'printexpr' 'pexpr'	|option-value-function|	(default: see below)
 			global
 	Expression used to print the PostScript produced with |:hardcopy|.
 	See |pexpr-option|.
@@ -4714,16 +4720,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	security reasons.
 
 						*'quickfixtextfunc'* *'qftf'*
-'quickfixtextfunc' 'qftf'	string (default "")
+'quickfixtextfunc' 'qftf'	|option-value-function| (default "")
 			global
 	This option specifies a function to be used to get the text to display
 	in the quickfix and location list windows.  This can be used to
 	customize the information displayed in the quickfix or location window
 	for each entry in the corresponding quickfix or location list.  See
 	|quickfix-window-function| for an explanation of how to write the
-	function and an example.  The value can be the name of a function, a
-	|lambda| or a |Funcref|. See |option-value-function| for more
-	information.
+	function and an example.
 
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
@@ -6413,7 +6417,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   smart	Ignore case unless an upper case letter is used
 
 							*'tagfunc'* *'tfu'*
-'tagfunc' 'tfu'		string	(default: empty)
+'tagfunc' 'tfu'		|option-value-function|	(default: empty)
 			local to buffer
 	This option specifies a function to be used to perform tag searches.
 	The function gets the tag pattern and should return a List of matching
@@ -6537,7 +6541,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	reasons.
 
 						*'thesaurusfunc'* *'tsrfu'*
-'thesaurusfunc' 'tsrfu'	string	(default: empty)
+'thesaurusfunc' 'tsrfu'	|option-value-function|	(default: empty)
 			global or local to buffer |global-local|
 	This option specifies a function to be used for thesaurus completion
 	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.

--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -357,6 +357,13 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
     break;
   }
 
+  case kObjectTypePartial: {
+    tv->v_type = VAR_PARTIAL;
+    tv->vval.v_partial = obj.data.partial;
+    tv->vval.v_partial->pt_refcount++;
+    break;
+  }
+
   default:
     abort();
   }

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -8,6 +8,7 @@
 #include "nvim/func_attr.h"
 #include "nvim/lib/kvec.h"
 #include "nvim/types.h"
+#include "nvim/eval/typval_defs.h"
 
 #define ARRAY_DICT_INIT KV_INITIAL_VALUE
 #define STRING_INIT { .data = NULL, .size = 0 }
@@ -87,6 +88,7 @@ REMOTE_TYPE(Tabpage);
 
 typedef struct object Object;
 typedef kvec_t(Object) Array;
+typedef partial_T * Partial;
 
 typedef struct key_value_pair KeyValuePair;
 typedef kvec_t(KeyValuePair) Dictionary;
@@ -100,6 +102,7 @@ typedef enum {
   kObjectTypeArray,
   kObjectTypeDictionary,
   kObjectTypeLuaRef,
+  kObjectTypePartial,
   // EXT types, cannot be split or reordered, see #EXT_OBJECT_TYPE_SHIFT
   kObjectTypeBuffer,
   kObjectTypeWindow,
@@ -116,6 +119,7 @@ struct object {
     Array array;
     Dictionary dictionary;
     LuaRef luaref;
+    Partial partial;
   } data;
 };
 

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -54,6 +54,10 @@
     .type = kObjectTypeLuaRef, \
     .data.luaref = r })
 
+#define PARTIAL_OBJ(p) ((Object) { \
+    .type = kObjectTypePartial, \
+    .data.partial = p })
+
 #define NIL ((Object)OBJECT_INIT)
 #define NULL_STRING ((String)STRING_INIT)
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -177,7 +177,7 @@ typedef struct {
 #define w_p_fml w_onebuf_opt.wo_fml    // 'foldminlines'
   long wo_fdn;
 #define w_p_fdn w_onebuf_opt.wo_fdn    // 'foldnestmax'
-  char *wo_fde;
+  Callback wo_fde;
 #define w_p_fde w_onebuf_opt.wo_fde    // 'foldexpr'
   char *wo_fdt;
 #define w_p_fdt w_onebuf_opt.wo_fdt   // 'foldtext'
@@ -672,9 +672,9 @@ struct file_buffer {
 #ifdef BACKSLASH_IN_FILENAME
   char *b_p_csl;                ///< 'completeslash'
 #endif
-  char *b_p_cfu;                ///< 'completefunc'
-  char *b_p_ofu;                ///< 'omnifunc'
-  char *b_p_tfu;                ///< 'tagfunc'
+  Callback b_p_cfu;             ///< 'completefunc'
+  Callback b_p_ofu;             ///< 'omnifunc'
+  Callback b_p_tfu;             ///< 'tagfunc'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'
   int b_p_et;                   ///< 'expandtab'
@@ -689,13 +689,13 @@ struct file_buffer {
   char *b_p_isk;                ///< 'iskeyword'
   char *b_p_def;                ///< 'define' local value
   char *b_p_inc;                ///< 'include'
-  char *b_p_inex;               ///< 'includeexpr'
+  Callback b_p_inex;           ///< 'includeexpr'
   uint32_t b_p_inex_flags;      ///< flags for 'includeexpr'
-  char *b_p_inde;               ///< 'indentexpr'
+  Callback b_p_inde;               ///< 'indentexpr'
   uint32_t b_p_inde_flags;      ///< flags for 'indentexpr'
   char *b_p_indk;               ///< 'indentkeys'
   char *b_p_fp;                 ///< 'formatprg'
-  char *b_p_fex;                ///< 'formatexpr'
+  Callback b_p_fex;             ///< 'formatexpr'
   uint32_t b_p_fex_flags;       ///< flags for 'formatexpr'
   char *b_p_kp;                 ///< 'keywordprg'
   int b_p_lisp;                 ///< 'lisp'
@@ -743,7 +743,7 @@ struct file_buffer {
   unsigned b_tc_flags;          ///< flags for 'tagcase'
   char *b_p_dict;               ///< 'dictionary' local value
   char *b_p_tsr;                ///< 'thesaurus' local value
-  char *b_p_tsrfu;              ///< 'thesaurusfunc' local value
+  Callback b_p_tsrfu;           ///< 'thesaurusfunc' local value
   long b_p_ul;                  ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char *b_p_lw;                 ///< 'lispwords' local value

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <stdlib.h>
 
+#include "nvim/api/private/converter.h"
 #include "nvim/ascii.h"
 #include "nvim/autocmd.h"
 #include "nvim/buffer.h"
@@ -3676,37 +3677,22 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
     return OK;
   }
 
-  long numval;
-  char *stringval;
   int ret = OK;
-
+  bool hidden;
   char c = *option_end;
   *option_end = NUL;
-  getoption_T opt_type = get_option_value(*arg, &numval,
-                                          rettv == NULL ? NULL : &stringval, opt_flags);
+  Object val = get_option_value(*arg, &hidden, opt_flags);
 
-  if (opt_type == gov_unknown) {
+  if (val.type == kObjectTypeNil) {
     if (rettv != NULL) {
       semsg(_("E113: Unknown option: %s"), *arg);
     }
     ret = FAIL;
   } else if (rettv != NULL) {
-    if (opt_type == gov_hidden_string) {
-      rettv->v_type = VAR_STRING;
-      rettv->vval.v_string = NULL;
-    } else if (opt_type == gov_hidden_bool || opt_type == gov_hidden_number) {
-      rettv->v_type = VAR_NUMBER;
-      rettv->vval.v_number = 0;
-    } else if (opt_type == gov_bool || opt_type == gov_number) {
-      rettv->v_type = VAR_NUMBER;
-      rettv->vval.v_number = numval;
-    } else {                          // string option
-      rettv->v_type = VAR_STRING;
-      rettv->vval.v_string = stringval;
-    }
-  } else if (working && (opt_type == gov_hidden_bool
-                         || opt_type == gov_hidden_number
-                         || opt_type == gov_hidden_string)) {
+    Error err;
+    object_to_vim(val, rettv, &err);
+    assert(err.type == kErrorTypeNone);
+  } else if (working && hidden) {
     ret = FAIL;
   }
 

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -26,6 +26,7 @@ local type_flags={
   bool='P_BOOL',
   number='P_NUM',
   string='P_STRING',
+  ['function']='P_FUNC',
 }
 
 local redraw_flags={

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1012,6 +1012,8 @@ EXTERN char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group 
 EXTERN char e_undobang_cannot_redo_or_move_branch[]
 INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
 
+EXTERN char e_inv_func_opt[] INIT(= N_("E5378: Invalid value for function option"));
+
 EXTERN char top_bot_msg[] INIT(= N_("search hit TOP, continuing at BOTTOM"));
 EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 

--- a/src/nvim/msgpack_rpc/helpers.c
+++ b/src/nvim/msgpack_rpc/helpers.c
@@ -334,6 +334,7 @@ void msgpack_rpc_from_object(const Object result, msgpack_packer *const res)
     switch (cur.aobj->type) {
     case kObjectTypeNil:
     case kObjectTypeLuaRef:
+    case kObjectTypePartial:
       // TODO(bfredl): could also be an error. Though kObjectTypeLuaRef
       // should only appear when the caller has opted in to handle references,
       // see nlua_pop_Object.

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5567,23 +5567,6 @@ static void op_colon(oparg_T *oap)
   // do_cmdline() does the rest
 }
 
-/// callback function for 'operatorfunc'
-static Callback opfunc_cb;
-
-/// Process the 'operatorfunc' option value.
-/// @return  OK or FAIL
-int set_operatorfunc_option(void)
-{
-  return option_set_callback_func(p_opfunc, &opfunc_cb);
-}
-
-#if defined(EXITFREE)
-void free_operatorfunc_option(void)
-{
-  callback_free(&opfunc_cb);
-}
-#endif
-
 /// Handle the "g@" operator: call 'operatorfunc'.
 static void op_function(const oparg_T *oap)
   FUNC_ATTR_NONNULL_ALL
@@ -5593,7 +5576,7 @@ static void op_function(const oparg_T *oap)
   const pos_T orig_start = curbuf->b_op_start;
   const pos_T orig_end = curbuf->b_op_end;
 
-  if (*p_opfunc == NUL) {
+  if (p_opfunc.type == kCallbackNone) {
     emsg(_("E774: 'operatorfunc' is empty"));
   } else {
     // Set '[ and '] marks to text to be operated on.

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -3,17 +3,6 @@
 
 #include "nvim/ex_cmds_defs.h"  // for exarg_T
 
-/// Returned by get_option_value().
-typedef enum {
-  gov_unknown,
-  gov_bool,
-  gov_number,
-  gov_string,
-  gov_hidden_bool,
-  gov_hidden_number,
-  gov_hidden_string,
-} getoption_T;
-
 // flags for buf_copy_options()
 #define BCO_ENTER       1       // going to enter the buffer
 #define BCO_ALWAYS      2       // always copy the options

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -53,6 +53,8 @@
 #define P_NO_DEF_EXP   0x40000000U  ///< Do not expand default value.
 #define P_UI_OPTION    0x80000000U  ///< send option to remote ui
 
+#define P_FUNC         0x100000000U ///< this option is a function
+
 /// Flags for option-setting functions
 ///
 /// When OPT_GLOBAL and OPT_LOCAL are both missing, set both local and global
@@ -393,9 +395,9 @@ EXTERN long p_channel;          ///< 'channel'
 EXTERN char *p_cink;            ///< 'cinkeys'
 EXTERN char *p_cinsd;           ///< 'cinscopedecls'
 EXTERN char *p_cinw;            ///< 'cinwords'
-EXTERN char *p_cfu;             ///< 'completefunc'
-EXTERN char *p_ofu;             ///< 'omnifunc'
-EXTERN char *p_tsrfu;           ///< 'thesaurusfunc'
+EXTERN Callback p_cfu;          ///< 'completefunc'
+EXTERN Callback p_ofu;          ///< 'omnifunc'
+EXTERN Callback p_tsrfu;        ///< 'thesaurusfunc'
 EXTERN int p_ci;                ///< 'copyindent'
 EXTERN int p_ar;                // 'autoread'
 EXTERN int p_aw;                // 'autowrite'
@@ -483,7 +485,7 @@ EXTERN char *p_debug;           // 'debug'
 EXTERN char *p_def;             // 'define'
 EXTERN char *p_inc;
 EXTERN char *p_dip;             // 'diffopt'
-EXTERN char *p_dex;             // 'diffexpr'
+EXTERN Callback p_dex;          // 'diffexpr'
 EXTERN char *p_dict;            // 'dictionary'
 EXTERN int p_dg;                // 'digraph'
 EXTERN char *p_dir;             // 'directory'
@@ -531,7 +533,7 @@ EXTERN unsigned fdo_flags;
 #define FDO_INSERT             0x100
 #define FDO_UNDO               0x200
 #define FDO_JUMP               0x400
-EXTERN char *p_fex;             ///< 'formatexpr'
+EXTERN Callback p_fex;          ///< 'formatexpr'
 EXTERN char *p_flp;             ///< 'formatlistpat'
 EXTERN char *p_fo;              ///< 'formatoptions'
 EXTERN char_u *p_fp;            // 'formatprg'
@@ -539,7 +541,7 @@ EXTERN int p_fs;                // 'fsync'
 EXTERN int p_gd;                // 'gdefault'
 EXTERN char_u *p_pdev;          // 'printdevice'
 EXTERN char *p_penc;            // 'printencoding'
-EXTERN char *p_pexpr;           // 'printexpr'
+EXTERN Callback p_pexpr;        // 'printexpr'
 EXTERN char *p_pmfn;            // 'printmbfont'
 EXTERN char *p_pmcs;            // 'printmbcharset'
 EXTERN char *p_pfn;             // 'printfont'
@@ -564,9 +566,9 @@ EXTERN int p_ic;                // 'ignorecase'
 EXTERN long p_iminsert;         ///< 'iminsert'
 EXTERN long p_imsearch;         ///< 'imsearch'
 EXTERN int p_inf;               ///< 'infercase'
-EXTERN char *p_inex;            ///< 'includeexpr'
+EXTERN Callback p_inex;         ///< 'includeexpr'
 EXTERN int p_is;                // 'incsearch'
-EXTERN char *p_inde;            ///< 'indentexpr'
+EXTERN Callback p_inde;         ///< 'indentexpr'
 EXTERN char *p_indk;            ///< 'indentkeys'
 EXTERN char *p_icm;             // 'inccommand'
 EXTERN char *p_isf;             // 'isfname'
@@ -624,11 +626,11 @@ EXTERN long p_mousescroll_hor INIT(= MOUSESCROLL_HOR_DFLT);
 EXTERN long p_mouset;           // 'mousetime'
 EXTERN int p_more;              // 'more'
 EXTERN char *p_nf;              ///< 'nrformats'
-EXTERN char *p_opfunc;          // 'operatorfunc'
+EXTERN Callback p_opfunc;       // 'operatorfunc'
 EXTERN char_u *p_para;          // 'paragraphs'
 EXTERN int p_paste;             // 'paste'
 EXTERN char *p_pt;              // 'pastetoggle'
-EXTERN char_u *p_pex;           // 'patchexpr'
+EXTERN Callback p_pex;          // 'patchexpr'
 EXTERN char *p_pm;              // 'patchmode'
 EXTERN char_u *p_path;          // 'path'
 EXTERN char_u *p_cdpath;        // 'cdpath'
@@ -652,7 +654,7 @@ EXTERN int p_ri;              // 'revins'
 EXTERN int p_ru;              // 'ruler'
 EXTERN char *p_ruf;           // 'rulerformat'
 EXTERN char *p_pp;            // 'packpath'
-EXTERN char *p_qftf;          // 'quickfixtextfunc'
+EXTERN Callback p_qftf;       // 'quickfixtextfunc'
 EXTERN char *p_rtp;           // 'runtimepath'
 EXTERN long p_scbk;           // 'scrollback'
 EXTERN long p_sj;             // 'scrolljump'
@@ -726,7 +728,7 @@ EXTERN unsigned int tpf_flags;  ///< flags from 'termpastefilter'
 #define TPF_DEL                0x010
 #define TPF_C0                 0x020
 #define TPF_C1                 0x040
-EXTERN char *p_tfu;             ///< 'tagfunc'
+EXTERN Callback p_tfu;           ///< 'tagfunc'
 EXTERN char *p_spc;             ///< 'spellcapcheck'
 EXTERN char *p_spf;             ///< 'spellfile'
 EXTERN char *p_spl;             ///< 'spelllang'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -455,11 +455,10 @@ return {
     {
       full_name='completefunc', abbreviation='cfu',
       short_desc=N_("function to be used for Insert mode completion"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       secure=true,
       alloced=true,
       varname='p_cfu',
-      defaults={if_true=""}
     },
     {
       full_name='completeopt', abbreviation='cot',
@@ -623,11 +622,10 @@ return {
     {
       full_name='diffexpr', abbreviation='dex',
       short_desc=N_("expression used to obtain a diff file"),
-      type='string', scope={'global'},
+      type='function', scope={'global'},
       secure=true,
       redraw={'curswant'},
       varname='p_dex',
-      defaults={if_true=""}
     },
     {
       full_name='diffopt', abbreviation='dip',
@@ -871,11 +869,10 @@ return {
     {
       full_name='foldexpr', abbreviation='fde',
       short_desc=N_("expression used when 'foldmethod' is \"expr\""),
-      type='string', scope={'window'},
+      type='function', scope={'window'},
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="0"}
     },
     {
       full_name='foldignore', abbreviation='fdi',
@@ -952,11 +949,10 @@ return {
     {
       full_name='formatexpr', abbreviation='fex',
       short_desc=N_("expression used with \"gq\" command"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       modelineexpr=true,
       alloced=true,
       varname='p_fex',
-      defaults={if_true=""}
     },
     {
       full_name='formatoptions', abbreviation='fo',
@@ -1210,11 +1206,10 @@ return {
     {
       full_name='includeexpr', abbreviation='inex',
       short_desc=N_("expression used to process an include line"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       modelineexpr=true,
       alloced=true,
       varname='p_inex',
-      defaults={if_true=""}
     },
     {
       full_name='incsearch', abbreviation='is',
@@ -1226,11 +1221,10 @@ return {
     {
       full_name='indentexpr', abbreviation='inde',
       short_desc=N_("expression used to obtain the indent of a line"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       modelineexpr=true,
       alloced=true,
       varname='p_inde',
-      defaults={if_true=""}
     },
     {
       full_name='indentkeys', abbreviation='indk',
@@ -1559,7 +1553,6 @@ return {
       type='bool', scope={'global'},
       secure=true,
       varname='p_mle',
-      defaults={if_true=false}
     },
     {
       full_name='modelines', abbreviation='mls',
@@ -1677,11 +1670,10 @@ return {
     {
       full_name='omnifunc', abbreviation='ofu',
       short_desc=N_("function for filetype-specific completion"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       secure=true,
       alloced=true,
       varname='p_ofu',
-      defaults={if_true=""}
     },
     {
       full_name='opendevice', abbreviation='odev',
@@ -1693,10 +1685,9 @@ return {
     {
       full_name='operatorfunc', abbreviation='opfunc',
       short_desc=N_("function to be called for |g@| operator"),
-      type='string', scope={'global'},
+      type='function', scope={'global'},
       secure=true,
       varname='p_opfunc',
-      defaults={if_true=""}
     },
     {
       full_name='packpath', abbreviation='pp',
@@ -1733,10 +1724,9 @@ return {
     {
       full_name='patchexpr', abbreviation='pex',
       short_desc=N_("expression used to patch a file"),
-      type='string', scope={'global'},
+      type='function', scope={'global'},
       secure=true,
       varname='p_pex',
-      defaults={if_true=""}
     },
     {
       full_name='patchmode', abbreviation='pm',
@@ -1795,10 +1785,9 @@ return {
     {
       full_name='printexpr', abbreviation='pexpr',
       short_desc=N_("expression used to print PostScript for :hardcopy"),
-      type='string', scope={'global'},
+      type='function', scope={'global'},
       secure=true,
       varname='p_pexpr',
-      defaults={if_true=""}
     },
     {
       full_name='printfont', abbreviation='pfn',
@@ -1876,9 +1865,8 @@ return {
     {
       full_name='quickfixtextfunc', abbreviation='qftf',
       short_desc=N_("customize the quickfix window"),
-      type='string', scope={'global'},
+      type='function', scope={'global'},
       varname='p_qftf',
-      defaults={if_true=""}
     },
     {
       full_name='quoteescape', abbreviation='qe',
@@ -2444,9 +2432,8 @@ return {
     {
       full_name='tagfunc', abbreviation='tfu',
       short_desc=N_("function used to perform tag searches"),
-      type='string', scope={'buffer'},
+      type='function', scope={'buffer'},
       varname='p_tfu',
-      defaults={if_true=""}
     },
     {
       full_name='tabline', abbreviation='tal',
@@ -2572,11 +2559,10 @@ return {
     {
       full_name='thesaurusfunc', abbreviation='tsrfu',
       short_desc=N_("function used for thesaurus completion"),
-      type='string', scope={'global', 'buffer'},
+      type='function', scope={'global', 'buffer'},
       secure=true,
       alloced=true,
       varname='p_tsrfu',
-      defaults={if_true=""}
     },
     {
       full_name='tildeop', abbreviation='top',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -17,7 +17,9 @@
 #include "nvim/digraph.h"
 #include "nvim/drawscreen.h"
 #include "nvim/eval.h"
+#include "nvim/eval/typval.h"
 #include "nvim/eval/vars.h"
+#include "nvim/lua/executor.h"
 #include "nvim/ex_getln.h"
 #include "nvim/hardcopy.h"
 #include "nvim/highlight_group.h"
@@ -1469,14 +1471,6 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
           errmsg = e_invarg;
         }
       }
-    }
-  } else if (varp == &p_opfunc) {  // 'operatorfunc'
-    if (set_operatorfunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
-  } else if (varp == &p_qftf) {  // 'quickfixtextfunc'
-    if (qf_process_qftf_option() == FAIL) {
-      errmsg = e_invarg;
     }
   } else {
     // Options that are a list of flags.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -530,9 +530,6 @@ static int efm_to_regpat(const char *efm, int len, efm_T *fmt_ptr, char *regpat)
 
 static efm_T *fmt_start = NULL;  // cached across qf_parse_line() calls
 
-// callback function for 'quickfixtextfunc'
-static Callback qftf_cb;
-
 static void free_efm_list(efm_T **efm_first)
 {
   for (efm_T *efm_ptr = *efm_first; efm_ptr != NULL; efm_ptr = *efm_first) {
@@ -3828,13 +3825,6 @@ static buf_T *qf_find_buf(qf_info_T *qi)
   return NULL;
 }
 
-/// Process the 'quickfixtextfunc' option value.
-/// @return  OK or FAIL
-int qf_process_qftf_option(void)
-{
-  return option_set_callback_func(p_qftf, &qftf_cb);
-}
-
 /// Update the w:quickfix_title variable in the quickfix/location list window in
 /// all the tab pages.
 static void qf_update_win_titlevar(qf_info_T *qi)
@@ -3976,7 +3966,7 @@ static int qf_buf_add_line(qf_list_T *qfl, buf_T *buf, linenr_T lnum, const qfli
 // the quickfix window for the entries 'start_idx' to 'end_idx'.
 static list_T *call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
 {
-  Callback *cb = &qftf_cb;
+  Callback *cb = &p_qftf;
   list_T *qftf_list = NULL;
 
   // If 'quickfixtextfunc' is set, then use the user-supplied function to get


### PR DESCRIPTION
Adds support for Lua functions and Vim script closures for `*expr`/`*func` options. (eg: `'indentexpr'`. `'tagfunc'`, etc.)

Very WIP and currently in a broken and uncompilable state.