### PR TITLE
feat(fs): extend fs.find to accept predicate

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2323,8 +2323,10 @@ find({names}, {opts})                                          *vim.fs.find()*
     specifying {type} to be "file" or "directory", respectively.
 
     Parameters: ~
-        {names}  (string|table) Names of the files and directories to find.
-                 Must be base names, paths and globs are not supported.
+        {names}  (string|table|fun(name: string): boolean) Names of the files
+                 and directories to find. Must be base names, paths and globs
+                 are not supported. If a function it is called per file and
+                 dir within the traversed directories to test if they match.
         {opts}   (table) Optional keyword arguments:
                  • path (string): Path to begin searching from. If omitted,
                    the current working directory is used.

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -78,6 +78,23 @@ describe('vim.fs', function()
         return vim.fs.find(nvim, { path = dir, type = 'file' })
       ]], test_build_dir, nvim_prog_basename))
     end)
+
+    it('accepts predicate as names', function()
+      eq({test_build_dir}, exec_lua([[
+        local dir = ...
+        local opts = { path = dir, upward = true, type = 'directory' }
+        return vim.fs.find(function(x) return x == 'build' end, opts)
+      ]], nvim_dir))
+      eq({nvim_prog}, exec_lua([[
+        local dir, nvim = ...
+        return vim.fs.find(function(x) return x == nvim end, { path = dir, type = 'file' })
+      ]], test_build_dir, nvim_prog_basename))
+      eq({}, exec_lua([[
+        local dir = ...
+        local opts = { path = dir, upward = true, type = 'directory' }
+        return vim.fs.find(function(x) return x == 'no-match' end, opts)
+      ]], nvim_dir))
+    end)
   end)
 
   describe('normalize()', function()


### PR DESCRIPTION
Makes it possible to use `vim.fs.find` to find files where only a
substring is known.
This is useful for `vim.lsp.start` to get the `root_dir` for languages
where the project-file is only known by its extension, not by the full
name.
For example in .NET projects there is usually a `<projectname>.csproj`
file in the project root.

Example:

    vim.fs.find(function(x) return vim.endswith(x, '.csproj') end, { upward = true })
