### PR TITLE
fix(lua): free vim.ui_attach callback before lua close

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -821,9 +821,9 @@ void free_all_mem(void)
 
   decor_free_all_mem();
 
-  nlua_free_all_mem();
   ui_free_all_mem();
   ui_comp_free_all_mem();
+  nlua_free_all_mem();
 
   // should be last, in case earlier free functions deallocates arenas
   arena_free_reuse_blks();

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -105,4 +105,16 @@ describe('vim.ui_attach', function()
     }
 
   end)
+
+  it('does not crash on exit', function()
+    helpers.funcs.system({
+      helpers.nvim_prog,
+      '-u', 'NONE',
+      '-i', 'NONE',
+      '--cmd', [[ lua ns = vim.api.nvim_create_namespace 'testspace' ]],
+      '--cmd', [[ lua vim.ui_attach(ns, {ext_popupmenu=true}, function() end) ]],
+      '--cmd', 'quitall!',
+    })
+    eq(0, helpers.eval('v:shell_error'))
+  end)
 end)


### PR DESCRIPTION
vim.ui_attach() causes crash on exit if we don't vim.ui_detach().

minimal.lua
```lua
local ns = vim.api.nvim_create_namespace("test")
vim.ui_attach(ns, { ext_popupmenu = true }, function() end)
vim.cmd.quit()
```

```
./build/bin/nvim --clean +"luafile ./minimal.lua"
```

<details>
<summary>Full backtrace</summary>

```
[New LWP 13724]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `/home/notomo/workspace/neovim/build/bin/nvim --clean --headless +luafile ./mini'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000000000061fc71 in nlua_unref (lstate=0x7fc2880ac380, ref_state=0x7fc2880bce38, ref=3) at /home/notomo/workspace/neovim/src/nvim/lua/executor.c:1244
1244	    ref_state->ref_count--;

Thread 1 (Thread 0x7fc2884b4740 (LWP 13724)):
#0  0x000000000061fc71 in nlua_unref (lstate=0x7fc2880ac380, ref_state=0x7fc2880bce38, ref=3) at /home/notomo/workspace/neovim/src/nvim/lua/executor.c:1244
No locals.
#1  0x000000000061f7a3 in nlua_unref_global (lstate=0x7fc2880ac380, ref=3) at /home/notomo/workspace/neovim/src/nvim/lua/executor.c:1257
No locals.
#2  0x000000000061fcbb in api_free_luaref (ref=3) at /home/notomo/workspace/neovim/src/nvim/lua/executor.c:1262
No locals.
#3  0x00000000007eb787 in free_ui_event_callback (event_cb=0x283dbf0) at /home/notomo/workspace/neovim/src/nvim/ui_compositor.c:732
No locals.
#4  0x00000000007eb746 in ui_comp_free_all_mem () at /home/notomo/workspace/neovim/src/nvim/ui_compositor.c:100
        __i = 1
        event_cb = 0x283dbf0
#5  0x000000000066f377 in free_all_mem () at /home/notomo/workspace/neovim/src/nvim/memory.c:826
        buf = 0x0
        nextbuf = 0x0
#6  0x000000000062cca1 in os_exit (r=0) at /home/notomo/workspace/neovim/src/nvim/main.c:610
No locals.
#7  0x00000000006314c7 in getout (exitval=0) at /home/notomo/workspace/neovim/src/nvim/main.c:731
No locals.
#8  0x00000000005a2af9 in ex_quit_all (eap=0x7ffe3e65bea0) at /home/notomo/workspace/neovim/src/nvim/ex_docmd.c:4536
No locals.
#9  0x0000000000599c3f in execute_cmd0 (retv=0x7ffe3e65be9c, eap=0x7ffe3e65bea0, errormsg=0x7ffe3e65bf58, preview=false) at /home/notomo/workspace/neovim/src/nvim/ex_docmd.c:1590
No locals.
#10 0x0000000000595c2f in do_one_cmd (cmdlinep=0x7ffe3e65c278, flags=10, cstack=0x7ffe3e65c280, fgetline=0x0, cookie=0x0) at /home/notomo/workspace/neovim/src/nvim/ex_docmd.c:2240
        errormsg = 0x0
        save_reg_executing = 0
        save_pending_end_reg_executing = false
        ea = {arg = 0x289d138 "", args = 0x0, arglens = 0x0, argc = 0, nextcmd = 0x0, cmd = 0x289d130 "quitall!", cmdlinep = 0x7ffe3e65c278, cmdidx = CMD_quitall, argt = 258, skip = 0, forceit = 1, addr_count = 0, line1 = 1, line2 = 1, addr_type = ADDR_NONE, flags = 0, do_ecmd_cmd = 0x0, do_ecmd_lnum = 0, append = 0, usefilter = 0, amount = 0, regname = 0, force_bin = 0, read_edit = 0, force_ff = 0, force_enc = 0, bad_char = 0, useridx = 0, errmsg = 0x0, getline = 0x0, cookie = 0x0, cstack = 0x7ffe3e65c280}
        save_cmdmod = {cmod_flags = 0, cmod_split = 0, cmod_tab = 0, cmod_filter_pat = 0x0, cmod_filter_regmatch = {regprog = 0x0, startp = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, endp = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, rm_ic = false}, cmod_filter_force = false, cmod_verbose = 0, cmod_save_ei = 0x0, cmod_did_sandbox = 0, cmod_verbose_save = 0, cmod_save_msg_silent = 0, cmod_save_msg_scroll = 0, cmod_did_esilent = 0}
        after_modifier = 0x289d130 "quitall!"
        cmd = 0x289d130 "quitall!"
        p = 0x289d138 ""
        ni = 0
        retv = 0
#11 0x000000000059347f in do_cmdline (cmdline=0x7ffe3e65dcd1 "quitall!", fgetline=0x0, cookie=0x0, flags=10) at /home/notomo/workspace/neovim/src/nvim/ex_docmd.c:584
        recursive = 1
        call_depth = 1
        next_cmdline = 0x289d130 "quitall!"
        cmdline_copy = 0x289d130 "quitall!"
        used_getline = false
        msg_didout_before_start = false
        count = 1
        did_inc = false
        retval = 1
        cstack = {cs_flags = {0 <repeats 50 times>}, cs_pending = '\000' <repeats 49 times>, cs_pend = {csp_rv = {0x0 <repeats 50 times>}, csp_ex = {0x0 <repeats 50 times>}}, cs_forinfo = {0x0 <repeats 50 times>}, cs_line = {0 <repeats 50 times>}, cs_idx = -1, cs_looplevel = 0, cs_trylevel = 0, cs_emsg_silent_list = 0x0, cs_lflags = 0}
        lines_ga = {ga_len = 0, ga_maxlen = 0, ga_itemsize = 16, ga_growsize = 10, ga_data = 0x0}
        current_line = 0
        fname = 0x0
        breakpoint = 0x0
        dbg_tick = 0x0
        debug_saved = {trylevel = 0, force_abort = 0, caught_stack = 0x0, vv_exception = 0x0, vv_throwpoint = 0x0, did_emsg = 0, got_int = 0, did_throw = false, need_rethrow = 0, check_cstack = 0, current_exception = 0x0}
        initial_trylevel = 0
        saved_msg_list = 0x0
        private_msg_list = 0x0
        cmd_getline = 0x0
        cmd_cookie = 0x0
        cmd_loop_cookie = {lines_gap = 0x0, current_line = 0, repeating = 510, getline = 0x95a112, cookie = 0xa481d8 <vimvars+3144>}
        real_cookie = 0x0
        getline_is_func = 0
#12 0x0000000000594424 in do_cmdline_cmd (cmd=0x7ffe3e65dcd1 "quitall!") at /home/notomo/workspace/neovim/src/nvim/ex_docmd.c:287
No locals.
#13 0x0000000000630e2f in exe_commands (parmp=0x7ffe3e65c930) at /home/notomo/workspace/neovim/src/nvim/main.c:1807
        i = 1
#14 0x000000000062d914 in main (argc=5, argv=0x7ffe3e65cb48) at /home/notomo/workspace/neovim/src/nvim/main.c:534
        fname = 0x0
        params = {argc = 5, argv = 0x7ffe3e65cb48, use_vimrc = 0x96ca64 "NONE", clean = true, n_commands = 2, commands = {0x7ffe3e65dcba "luafile ./minimal.lua", 0x7ffe3e65dcd1 "quitall!", 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, cmds_tofree = "\000\000\000\000\000\000\000\000\000", n_pre_commands = 0, pre_commands = {0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, edit_type = 0, tagname = 0x0, use_ef = 0x0, input_isatty = true, output_isatty = true, err_isatty = true, input_neverscript = false, no_swap_file = 0, use_debug_break_level = -1, window_count = 1, window_layout = 0, diff_mode = 0, listen_addr = 0x0, remote = 0, server_addr = 0x0}
        cwd = 0x0
        use_remote_ui = false
        use_builtin_ui = false
        err = {type = kErrorTypeNone, msg = 0x0}
        o = {type = kObjectTypeNil, data = {boolean = false, integer = 0, floating = 0, string = {data = 0x0, size = 0}, array = {size = 0, capacity = 0, items = 0x0}, dictionary = {size = 0, capacity = 0, items = 0x0}, luaref = 0}}
        vimrc_none = true
```

</details>
