### PR TITLE
ci(cirrus): skip cirrus CI on draft PRs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ env:
 
 freebsd_task:
   name: FreeBSD
-  only_if: $BRANCH != "master"
+  only_if: $BRANCH != "master" && $CIRRUS_PR_DRAFT != "true"
   freebsd_instance:
     image_family: freebsd-13-1
   timeout_in: 30m


### PR DESCRIPTION
This will help prevent problems with excessive queues.
