### PR TITLE
vim-patch:8.2.0067: ERROR_UNKNOWN clashes on some systems

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -195,15 +195,15 @@ int call_internal_func(const char_u *const fname, const int argcount, typval_T *
 {
   const EvalFuncDef *const fdef = find_internal_func((const char *)fname);
   if (fdef == NULL) {
-    return ERROR_UNKNOWN;
+    return FCERR_UNKNOWN;
   } else if (argcount < fdef->min_argc) {
-    return ERROR_TOOFEW;
+    return FCERR_TOOFEW;
   } else if (argcount > fdef->max_argc) {
-    return ERROR_TOOMANY;
+    return FCERR_TOOMANY;
   }
   argvars[argcount].v_type = VAR_UNKNOWN;
   fdef->func(argvars, rettv, fdef->data);
-  return ERROR_NONE;
+  return FCERR_NONE;
 }
 
 /// Invoke a method for base->method().
@@ -213,13 +213,13 @@ int call_internal_method(const char_u *const fname, const int argcount, typval_T
 {
   const EvalFuncDef *const fdef = find_internal_func((const char *)fname);
   if (fdef == NULL) {
-    return ERROR_UNKNOWN;
+    return FCERR_UNKNOWN;
   } else if (fdef->base_arg == BASE_NONE) {
-    return ERROR_NOTMETHOD;
+    return FCERR_NOTMETHOD;
   } else if (argcount + 1 < fdef->min_argc) {
-    return ERROR_TOOFEW;
+    return FCERR_TOOFEW;
   } else if (argcount + 1 > fdef->max_argc) {
-    return ERROR_TOOMANY;
+    return FCERR_TOOMANY;
   }
 
   typval_T argv[MAX_FUNC_ARGS + 1];
@@ -231,7 +231,7 @@ int call_internal_method(const char_u *const fname, const int argcount, typval_T
   argv[argcount + 1].v_type = VAR_UNKNOWN;
 
   fdef->func(argv, rettv, fdef->data);
-  return ERROR_NONE;
+  return FCERR_NONE;
 }
 
 /// @return  true for a non-zero Number and a non-empty String.

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -38,16 +38,15 @@ struct funccal_entry {
 
 /// errors for when calling a function
 typedef enum {
-  ERROR_UNKNOWN = 0,
-  ERROR_TOOMANY,
-  ERROR_TOOFEW,
-  ERROR_SCRIPT,
-  ERROR_DICT,
-  ERROR_NONE,
-  ERROR_OTHER,
-  ERROR_BOTH,
-  ERROR_DELETED,
-  ERROR_NOTMETHOD,
+  FCERR_UNKNOWN = 0,
+  FCERR_TOOMANY = 1,
+  FCERR_TOOFEW = 2,
+  FCERR_SCRIPT = 3,
+  FCERR_DICT = 4,
+  FCERR_NONE = 5,
+  FCERR_OTHER = 6,
+  FCERR_DELETED = 7,
+  FCERR_NOTMETHOD = 8,  ///< function cannot be used as a method
 } FnameTransError;
 
 /// Used in funcexe_T. Returns the new argcount.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1435,12 +1435,12 @@ int typval_exec_lua_callable(LuaRef lua_cb, int argcount, typval_T *argvars, typ
 
   if (nlua_pcall(lstate, argcount, 1)) {
     nlua_print(lstate);
-    return ERROR_OTHER;
+    return FCERR_OTHER;
   }
 
   nlua_pop_typval(lstate, rettv);
 
-  return ERROR_NONE;
+  return FCERR_NONE;
 }
 
 /// Execute Lua string


### PR DESCRIPTION
#### vim-patch:8.2.0067: ERROR_UNKNOWN clashes on some systems

Problem:    ERROR_UNKNOWN clashes on some systems.
Solution:   Rename ERROR_ to FCERR_. (Ola Söder, closes vim/vim#5415)
https://github.com/vim/vim/commit/ef140544f6703a7a4c0f6a15f610508ed6b09e89

Remove ERROR_BOTH which was removed from Vim in patch 7.4.1582.