### PR TITLE
vim-patch:8.2.3796: the funcexe_T struct members are not named consistently

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -204,10 +204,10 @@ static Object _call_function(String fn, Array args, dict_T *self, Error *err)
     try_start();
     typval_T rettv;
     funcexe_T funcexe = FUNCEXE_INIT;
-    funcexe.firstline = curwin->w_cursor.lnum;
-    funcexe.lastline = curwin->w_cursor.lnum;
-    funcexe.evaluate = true;
-    funcexe.selfdict = self;
+    funcexe.fe_firstline = curwin->w_cursor.lnum;
+    funcexe.fe_lastline = curwin->w_cursor.lnum;
+    funcexe.fe_evaluate = true;
+    funcexe.fe_selfdict = self;
     // call_func() retval is deceptive, ignore it.  Instead we set `msg_list`
     // (see above) to capture abort-causing non-exception errors.
     (void)call_func(fn.data, (int)fn.size, &rettv, (int)args.size,

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -757,7 +757,7 @@ int eval_expr_typval(const typval_T *expr, typval_T *argv, int argc, typval_T *r
     if (s == NULL || *s == NUL) {
       return FAIL;
     }
-    funcexe.evaluate = true;
+    funcexe.fe_evaluate = true;
     if (call_func(s, -1, rettv, argc, argv, &funcexe) == FAIL) {
       return FAIL;
     }
@@ -767,8 +767,8 @@ int eval_expr_typval(const typval_T *expr, typval_T *argv, int argc, typval_T *r
     if (s == NULL || *s == NUL) {
       return FAIL;
     }
-    funcexe.evaluate = true;
-    funcexe.partial = partial;
+    funcexe.fe_evaluate = true;
+    funcexe.fe_partial = partial;
     if (call_func(s, -1, rettv, argc, argv, &funcexe) == FAIL) {
       return FAIL;
     }
@@ -1093,10 +1093,10 @@ int call_vim_function(const char *func, int argc, typval_T *argv, typval_T *rett
 
   rettv->v_type = VAR_UNKNOWN;  // tv_clear() uses this.
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.firstline = curwin->w_cursor.lnum;
-  funcexe.lastline = curwin->w_cursor.lnum;
-  funcexe.evaluate = true;
-  funcexe.partial = pt;
+  funcexe.fe_firstline = curwin->w_cursor.lnum;
+  funcexe.fe_lastline = curwin->w_cursor.lnum;
+  funcexe.fe_evaluate = true;
+  funcexe.fe_partial = pt;
   ret = call_func(func, len, rettv, argc, argv, &funcexe);
 
 fail:
@@ -2227,11 +2227,11 @@ static int eval_func(char **const arg, char *const name, const int name_len, typ
 
   // Invoke the function.
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.firstline = curwin->w_cursor.lnum;
-  funcexe.lastline = curwin->w_cursor.lnum;
-  funcexe.evaluate = evaluate;
-  funcexe.partial = partial;
-  funcexe.basetv = basetv;
+  funcexe.fe_firstline = curwin->w_cursor.lnum;
+  funcexe.fe_lastline = curwin->w_cursor.lnum;
+  funcexe.fe_evaluate = evaluate;
+  funcexe.fe_partial = partial;
+  funcexe.fe_basetv = basetv;
   int ret = get_func_tv((char_u *)s, len, rettv, arg, &funcexe);
 
   xfree(s);
@@ -3211,12 +3211,12 @@ static int call_func_rettv(char **const arg, typval_T *const rettv, const bool e
   }
 
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.firstline = curwin->w_cursor.lnum;
-  funcexe.lastline = curwin->w_cursor.lnum;
-  funcexe.evaluate = evaluate;
-  funcexe.partial = pt;
-  funcexe.selfdict = selfdict;
-  funcexe.basetv = basetv;
+  funcexe.fe_firstline = curwin->w_cursor.lnum;
+  funcexe.fe_lastline = curwin->w_cursor.lnum;
+  funcexe.fe_evaluate = evaluate;
+  funcexe.fe_partial = pt;
+  funcexe.fe_selfdict = selfdict;
+  funcexe.fe_basetv = basetv;
   const int ret = get_func_tv((char_u *)funcname, is_lua ? (int)(*arg - funcname) : -1, rettv,
                               arg, &funcexe);
 
@@ -5869,10 +5869,10 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
   }
 
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.firstline = curwin->w_cursor.lnum;
-  funcexe.lastline = curwin->w_cursor.lnum;
-  funcexe.evaluate = true;
-  funcexe.partial = partial;
+  funcexe.fe_firstline = curwin->w_cursor.lnum;
+  funcexe.fe_lastline = curwin->w_cursor.lnum;
+  funcexe.fe_evaluate = true;
+  funcexe.fe_partial = partial;
   return call_func(name, -1, rettv, argcount_in, argvars_in, &funcexe);
 }
 
@@ -8491,9 +8491,9 @@ typval_T eval_call_provider(char *provider, char *method, list_T *arguments, boo
   tv_list_ref(arguments);
 
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.firstline = curwin->w_cursor.lnum;
-  funcexe.lastline = curwin->w_cursor.lnum;
-  funcexe.evaluate = true;
+  funcexe.fe_firstline = curwin->w_cursor.lnum;
+  funcexe.fe_lastline = curwin->w_cursor.lnum;
+  funcexe.fe_evaluate = true;
   (void)call_func(func, name_len, &rettv, 2, argvars, &funcexe);
 
   tv_list_unref(arguments);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6498,8 +6498,8 @@ static void f_reduce(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.evaluate = true;
-  funcexe.partial = partial;
+  funcexe.fe_evaluate = true;
+  funcexe.fe_partial = partial;
 
   typval_T initial;
   typval_T argv[3];

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1086,9 +1086,9 @@ static int item_compare2(const void *s1, const void *s2, bool keep_zero)
 
   rettv.v_type = VAR_UNKNOWN;  // tv_clear() uses this
   funcexe_T funcexe = FUNCEXE_INIT;
-  funcexe.evaluate = true;
-  funcexe.partial = partial;
-  funcexe.selfdict = sortinfo->item_compare_selfdict;
+  funcexe.fe_evaluate = true;
+  funcexe.fe_partial = partial;
+  funcexe.fe_selfdict = sortinfo->item_compare_selfdict;
   res = call_func(func_name, -1, &rettv, 2, argv, &funcexe);
   tv_clear(&argv[0]);
   tv_clear(&argv[1]);

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -55,26 +55,26 @@ typedef int (*ArgvFunc)(int current_argcount, typval_T *argv, int argskip,
 
 /// Structure passed between functions dealing with function call execution.
 typedef struct {
-  ArgvFunc argv_func;  ///< when not NULL, can be used to fill in arguments only
-                       ///< when the invoked function uses them
-  linenr_T firstline;  ///< first line of range
-  linenr_T lastline;   ///< last line of range
-  bool *doesrange;     ///< [out] if not NULL: function handled range
-  bool evaluate;       ///< actually evaluate expressions
-  partial_T *partial;  ///< for extra arguments
-  dict_T *selfdict;    ///< Dictionary for "self"
-  typval_T *basetv;    ///< base for base->method()
+  ArgvFunc fe_argv_func;  ///< when not NULL, can be used to fill in arguments only
+                          ///< when the invoked function uses them
+  linenr_T fe_firstline;  ///< first line of range
+  linenr_T fe_lastline;   ///< last line of range
+  bool *fe_doesrange;     ///< [out] if not NULL: function handled range
+  bool fe_evaluate;       ///< actually evaluate expressions
+  partial_T *fe_partial;  ///< for extra arguments
+  dict_T *fe_selfdict;    ///< Dictionary for "self"
+  typval_T *fe_basetv;    ///< base for base->method()
 } funcexe_T;
 
 #define FUNCEXE_INIT (funcexe_T) { \
-  .argv_func = NULL, \
-  .firstline = 0, \
-  .lastline = 0, \
-  .doesrange = NULL, \
-  .evaluate = false, \
-  .partial = NULL, \
-  .selfdict = NULL, \
-  .basetv = NULL, \
+  .fe_argv_func = NULL, \
+  .fe_firstline = 0, \
+  .fe_lastline = 0, \
+  .fe_doesrange = NULL, \
+  .fe_evaluate = false, \
+  .fe_partial = NULL, \
+  .fe_selfdict = NULL, \
+  .fe_basetv = NULL, \
 }
 
 #define FUNCARG(fp, j)  ((char **)(fp->uf_args.ga_data))[j]

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1110,9 +1110,9 @@ int nlua_call(lua_State *lstate)
     try_start();
     typval_T rettv;
     funcexe_T funcexe = FUNCEXE_INIT;
-    funcexe.firstline = curwin->w_cursor.lnum;
-    funcexe.lastline = curwin->w_cursor.lnum;
-    funcexe.evaluate = true;
+    funcexe.fe_firstline = curwin->w_cursor.lnum;
+    funcexe.fe_lastline = curwin->w_cursor.lnum;
+    funcexe.fe_evaluate = true;
     // call_func() retval is deceptive, ignore it.  Instead we set `msg_list`
     // (TRY_WRAP) to capture abort-causing non-exception errors.
     (void)call_func((char *)name, (int)name_len, &rettv, nargs, vim_args, &funcexe);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1803,8 +1803,8 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest, int des
         argv[0].v_type = VAR_LIST;
         argv[0].vval.v_list = &matchList.sl_list;
         funcexe_T funcexe = FUNCEXE_INIT;
-        funcexe.argv_func = fill_submatch_list;
-        funcexe.evaluate = true;
+        funcexe.fe_argv_func = fill_submatch_list;
+        funcexe.fe_evaluate = true;
         if (expr->v_type == VAR_FUNC) {
           s = (char_u *)expr->vval.v_string;
           call_func((char *)s, -1, &rettv, 1, argv, &funcexe);
@@ -1812,7 +1812,7 @@ static int vim_regsub_both(char_u *source, typval_T *expr, char_u *dest, int des
           partial_T *partial = expr->vval.v_partial;
 
           s = (char_u *)partial_name(partial);
-          funcexe.partial = partial;
+          funcexe.fe_partial = partial;
           call_func((char *)s, -1, &rettv, 1, argv, &funcexe);
         }
         if (tv_list_len(&matchList.sl_list) > 0) {


### PR DESCRIPTION
#### vim-patch:8.2.3796: the funcexe_T struct members are not named consistently

Problem:    The funcexe_T struct members are not named consistently.
Solution:   Prefix "fe_" to all the members.
https://github.com/vim/vim/commit/851f86b951cdd67ad9cf3149e46169d1375c8d82

Omit fe_check_type: always NULL in legacy Vim script.