### PR TITLE
vim-patch:8.1.0941: macros for MS-Windows are inconsistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ if(MSVC)
   # XXX: /W4 gives too many warnings. #3241
   add_compile_options(/W3)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
-  add_definitions(-DWIN32)
+  add_definitions(-DMSWIN)
 else()
   add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,7 @@ endif()
 if(MINGW)
   # Use POSIX compatible stdio in Mingw
   add_definitions(-D__USE_MINGW_ANSI_STDIO)
+  add_definitions(-DMSWIN)
 endif()
 if(WIN32)
   # Windows Vista is the minimum supported version

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1882,7 +1882,7 @@ Object nvim_get_proc(Integer pid, Error *err)
     api_set_error(err, kErrorTypeException, "Invalid pid: %" PRId64, pid);
     return NIL;
   }
-#ifdef WIN32
+#ifdef MSWIN
   rvobj.data.dictionary = os_proc_info((int)pid);
   if (rvobj.data.dictionary.size == 0) {  // Process not found.
     return NIL;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3448,7 +3448,7 @@ void fname_expand(buf_T *buf, char **ffname, char **sfname)
   }
   *ffname = fix_fname((*ffname));     // expand to full path
 
-#ifdef WIN32
+#ifdef MSWIN
   if (!buf->b_p_bin) {
     // If the file name is a shortcut file, use the file it links to.
     char *rfname = os_resolve_shortcut((const char *)(*ffname));

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -14,7 +14,7 @@
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/fs.h"
 #include "nvim/os/shell.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/os_win_console.h"
 # include "nvim/os/pty_conpty_win.h"
 #endif
@@ -492,7 +492,7 @@ uint64_t channel_from_stdio(bool rpc, CallbackReader on_output, const char **err
 
   int stdin_dup_fd = STDIN_FILENO;
   int stdout_dup_fd = STDOUT_FILENO;
-#ifdef WIN32
+#ifdef MSWIN
   // Strangely, ConPTY doesn't work if stdin and stdout are pipes. So replace
   // stdin and stdout with CONIN$ and CONOUT$, respectively.
   if (embedded_mode && os_has_conpty_working()) {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1344,7 +1344,7 @@ static void f_debugbreak(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (pid == 0) {
     emsg(_(e_invarg));
   } else {
-#ifdef WIN32
+#ifdef MSWIN
     HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
 
     if (hProcess != NULL) {
@@ -1695,7 +1695,7 @@ static void f_environ(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     char c = env[i][len];
     env[i][len] = NUL;
 
-#ifdef WIN32
+#ifdef MSWIN
     // Upper-case all the keys for Windows so we can detect duplicates
     char *const key = strcase_save(str, true);
 #else
@@ -3532,7 +3532,7 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 #ifdef UNIX
     "unix",
 #endif
-#if defined(WIN32)
+#if defined(MSWIN)
     "win32",
 #endif
 #ifdef _WIN64
@@ -4257,7 +4257,7 @@ static void f_jobresize(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 }
 
 static const char *ignored_env_vars[] = {
-#ifndef WIN32
+#ifndef MSWIN
   "COLUMNS",
   "LINES",
   "TERMCAP",
@@ -4269,7 +4269,7 @@ static const char *ignored_env_vars[] = {
 /// According to comments in src/win/process.c of libuv, Windows has a few
 /// "essential" environment variables.
 static const char *required_env_vars[] = {
-#ifdef WIN32
+#ifdef MSWIN
   "HOMEDRIVE",
   "HOMEPATH",
   "LOGONSERVER",
@@ -4308,7 +4308,7 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
           tv_dict_item_remove(env, dv);
         }
       }
-#ifndef WIN32
+#ifndef MSWIN
       // Set COLORTERM to "truecolor" if termguicolors is set and 256
       // otherwise, but only if it was set in the parent terminal at all
       dictitem_T *dv = tv_dict_find(env, S_LEN("COLORTERM"));
@@ -4343,7 +4343,7 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
   }
 
   if (job_env) {
-#ifdef WIN32
+#ifdef MSWIN
     TV_DICT_ITER(job_env->di_tv.vval.v_dict, var, {
       // Always use upper-case keys for Windows so we detect duplicate keys
       char *const key = strcase_save((const char *)var->di_key, true);
@@ -4443,7 +4443,7 @@ static void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       return;
     }
 
-#ifdef WIN32
+#ifdef MSWIN
     if (pty && overlapped) {
       semsg(_(e_invarg2),
             "job cannot have both 'pty' and 'overlapped' options set");
@@ -6286,7 +6286,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   rettv->v_type = VAR_STRING;
   const char *fname = tv_get_string(&argvars[0]);
-#ifdef WIN32
+#ifdef MSWIN
   char *v = os_resolve_shortcut(fname);
   if (v == NULL) {
     if (os_is_reparse_point_include(fname)) {

--- a/src/nvim/event/libuv_process.c
+++ b/src/nvim/event/libuv_process.c
@@ -25,7 +25,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   uvproc->uvopts.file = proc->argv[0];
   uvproc->uvopts.args = proc->argv;
   uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
-#ifdef WIN32
+#ifdef MSWIN
   // libuv collapses the argv to a CommandLineToArgvW()-style string. cmd.exe
   // expects a different syntax (must be prepared by the caller before now).
   if (os_shell_is_cmdexe(proc->argv[0])) {
@@ -55,7 +55,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   if (!proc->in.closed) {
     uvproc->uvstdio[0].flags = UV_CREATE_PIPE | UV_READABLE_PIPE;
-#ifdef WIN32
+#ifdef MSWIN
     uvproc->uvstdio[0].flags |= proc->overlapped ? UV_OVERLAPPED_PIPE : 0;
 #endif
     uvproc->uvstdio[0].data.stream = STRUCT_CAST(uv_stream_t,
@@ -64,7 +64,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
 
   if (!proc->out.closed) {
     uvproc->uvstdio[1].flags = UV_CREATE_PIPE | UV_WRITABLE_PIPE;
-#ifdef WIN32
+#ifdef MSWIN
     // pipe must be readable for IOCP to work on Windows.
     uvproc->uvstdio[1].flags |= proc->overlapped ?
                                 (UV_READABLE_PIPE | UV_OVERLAPPED_PIPE) : 0;
@@ -113,7 +113,7 @@ static void close_cb(uv_handle_t *handle)
 static void exit_cb(uv_process_t *handle, int64_t status, int term_signal)
 {
   Process *proc = handle->data;
-#if defined(WIN32)
+#if defined(MSWIN)
   // Use stored/expected signal.
   term_signal = proc->exit_signal;
 #endif

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -10,7 +10,7 @@
 #include "nvim/log.h"
 #include "nvim/macros.h"
 #include "nvim/rbuffer.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/os_win_console.h"
 #endif
 
@@ -60,7 +60,7 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
       stream->uv.idle.data = stream;
     } else {
       assert(type == UV_NAMED_PIPE || type == UV_TTY);
-#ifdef WIN32
+#ifdef MSWIN
       if (type == UV_TTY) {
         uv_tty_init(&loop->uv, &stream->uv.tty, fd, 0);
         uv_tty_set_mode(&stream->uv.tty, UV_TTY_MODE_RAW);
@@ -75,7 +75,7 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
       uv_pipe_init(&loop->uv, &stream->uv.pipe, 0);
       uv_pipe_open(&stream->uv.pipe, fd);
       stream->uvstream = STRUCT_CAST(uv_stream_t, &stream->uv.pipe);
-#ifdef WIN32
+#ifdef MSWIN
     }
 #endif
     }
@@ -109,7 +109,7 @@ void stream_close(Stream *stream, stream_close_cb on_stream_close, void *data)
   stream->close_cb = on_stream_close;
   stream->close_cb_data = data;
 
-#ifdef WIN32
+#ifdef MSWIN
   if (UV_TTY == uv_guess_handle(stream->fd)) {
     // Undo UV_TTY_MODE_RAW from stream_init(). #10801
     uv_tty_set_mode(&stream->uv.tty, UV_TTY_MODE_NORMAL);

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -35,7 +35,7 @@ struct stream {
     uv_pipe_t pipe;
     uv_tcp_t tcp;
     uv_idle_t idle;
-#ifdef WIN32
+#ifdef MSWIN
     uv_tty_t tty;
 #endif
   } uv;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1378,7 +1378,7 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
   if (vim_isAbsName((char_u *)ff_file_to_find)
       // "..", "../path", "." and "./path": don't use the path_option
       || rel_to_curdir
-#if defined(WIN32)
+#if defined(MSWIN)
       // handle "\tmp" as absolute path
       || vim_ispathsep(ff_file_to_find[0])
       // handle "c:name" as absolute path

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1673,7 +1673,7 @@ failed:
   if (read_stdin) {
     close(fd);
     if (stdin_fd < 0) {
-#ifndef WIN32
+#ifndef MSWIN
       // On Unix, use stderr for stdin, makes shell commands work.
       vim_ignored = dup(2);
 #else

--- a/src/nvim/generators/gen_declarations.lua
+++ b/src/nvim/generators/gen_declarations.lua
@@ -218,7 +218,7 @@ local footer = [[
 
 local non_static = header .. [[
 #ifndef DLLEXPORT
-#  ifdef WIN32
+#  ifdef MSWIN
 #    define DLLEXPORT __declspec(dllexport)
 #  else
 #    define DLLEXPORT

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -23,7 +23,7 @@
 #define MSG_BUF_CLEN  (MSG_BUF_LEN / 6)  // cell length (worst case: utf-8
                                          // takes 6 bytes for one cell)
 
-#ifdef WIN32
+#ifdef MSWIN
 # define _PATHSEPSTR "\\"
 #else
 # define _PATHSEPSTR "/"

--- a/src/nvim/if_cscope.c
+++ b/src/nvim/if_cscope.c
@@ -768,7 +768,7 @@ err_closing:
 #if defined(UNIX)
     (void)snprintf(cmd, len, "exec %s -dl -f %s", prog, csinfo[i].fname);
 #else
-    // WIN32
+    // MS-Windows
     (void)snprintf(cmd, len, "%s -dl -f %s", prog, csinfo[i].fname);
 #endif
     if (csinfo[i].ppath != NULL) {
@@ -820,7 +820,7 @@ err_closing:
   }
 
 #else
-    // WIN32
+    // MS-Windows
     // Create a new process to run cscope and use pipes to talk with it
     GetStartupInfo(&si);
     si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;

--- a/src/nvim/locale.c
+++ b/src/nvim/locale.c
@@ -270,7 +270,7 @@ void ex_language(exarg_T *eap)
 
 static char **locales = NULL;       // Array of all available locales
 
-# ifndef WIN32
+# ifndef MSWIN
 static bool did_init_locales = false;
 
 /// @return  an array of strings for all available locales + NULL for the
@@ -311,7 +311,7 @@ static char **find_locales(void)
 /// Lazy initialization of all available locales.
 static void init_locales(void)
 {
-# ifndef WIN32
+# ifndef MSWIN
   if (!did_init_locales) {
     did_init_locales = true;
     locales = find_locales();

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -248,7 +248,7 @@ static int nlua_luv_thread_common_cfpcall(lua_State *lstate, int nargs, int nres
       mch_errmsg(e_outofmem);
       mch_errmsg("\n");
       lua_close(lstate);
-#ifdef WIN32
+#ifdef MSWIN
       ExitThread(0);
 #else
       pthread_exit(0);
@@ -673,7 +673,7 @@ static bool nlua_state_init(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   lua_setfield(lstate, -2, "debug");
   lua_pop(lstate, 1);
 
-#ifdef WIN32
+#ifdef MSWIN
   // os.getenv
   lua_getglobal(lstate, "os");
   lua_pushcfunction(lstate, &nlua_getenv);
@@ -1201,7 +1201,7 @@ static int nlua_empty_dict_tostring(lua_State *lstate)
   return 1;
 }
 
-#ifdef WIN32
+#ifdef MSWIN
 /// os.getenv: override os.getenv to maintain coherency. #9681
 ///
 /// uv_os_setenv uses SetEnvironmentVariableW which does not update _environ.

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -86,7 +86,7 @@
 // mch_open_rw(): invoke os_open() with third argument for user R/W.
 #if defined(UNIX)  // open in rw------- mode
 # define MCH_OPEN_RW(n, f)      os_open((n), (f), (mode_t)0600)
-#elif defined(WIN32)
+#elif defined(MSWIN)
 # define MCH_OPEN_RW(n, f)      os_open((n), (f), S_IREAD | S_IWRITE)
 #else
 # define MCH_OPEN_RW(n, f)      os_open((n), (f), 0)
@@ -178,14 +178,14 @@
 
 // Type of uv_buf_t.len is platform-dependent.
 // Related: https://github.com/libuv/libuv/pull/1236
-#if defined(WIN32)
+#if defined(MSWIN)
 # define UV_BUF_LEN(x)  (ULONG)(x)
 #else
 # define UV_BUF_LEN(x)  (x)
 #endif
 
 // Type of read()/write() `count` param is platform-dependent.
-#if defined(WIN32)
+#if defined(MSWIN)
 # define IO_COUNT(x)  (unsigned)(x)
 #else
 # define IO_COUNT(x)  (x)

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -71,7 +71,7 @@
 #include "nvim/version.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/os_win_console.h"
 #endif
 #include "nvim/api/private/defs.h"
@@ -84,7 +84,7 @@
 #include "nvim/msgpack_rpc/helpers.h"
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/signal.h"
-#ifndef WIN32
+#ifndef MSWIN
 # include "nvim/os/pty_process_unix.h"
 #endif
 #include "nvim/api/extmark.h"
@@ -168,7 +168,7 @@ void early_init(mparm_T *paramp)
   runtime_init();
   highlight_init();
 
-#ifdef WIN32
+#ifdef MSWIN
   OSVERSIONINFO ovi;
   ovi.dwOSVersionInfoSize = sizeof(ovi);
   GetVersionEx(&ovi);
@@ -210,13 +210,13 @@ void early_init(mparm_T *paramp)
 #ifdef MAKE_LIB
 int nvim_main(int argc, char **argv);  // silence -Wmissing-prototypes
 int nvim_main(int argc, char **argv)
-#elif defined(WIN32)
+#elif defined(MSWIN)
 int wmain(int argc, wchar_t **argv_w)  // multibyte args on Windows. #7060
 #else
 int main(int argc, char **argv)
 #endif
 {
-#if defined(WIN32) && !defined(MAKE_LIB)
+#if defined(MSWIN) && !defined(MAKE_LIB)
   char **argv = xmalloc((size_t)argc * sizeof(char *));
   for (int i = 0; i < argc; i++) {
     char *buf = NULL;
@@ -582,7 +582,7 @@ int main(int argc, char **argv)
   // Main loop: never returns.
   normal_enter(false, false);
 
-#if defined(WIN32) && !defined(MAKE_LIB)
+#if defined(MSWIN) && !defined(MAKE_LIB)
   xfree(argv);
 #endif
   return 0;
@@ -1273,7 +1273,7 @@ scripterror:
           int error;
           if (strequal(argv[0], "-")) {
             const int stdin_dup_fd = os_dup(STDIN_FILENO);
-#ifdef WIN32
+#ifdef MSWIN
             // Replace the original stdin with the console input handle.
             os_replace_stdin_to_conin();
 #endif
@@ -1426,7 +1426,7 @@ static void check_and_set_isatty(mparm_T *paramp)
   stdout_isatty
     = paramp->output_isatty = os_isatty(STDOUT_FILENO);
   paramp->err_isatty = os_isatty(STDERR_FILENO);
-#ifndef WIN32
+#ifndef MSWIN
   int tty_fd = paramp->input_isatty
     ? STDIN_FILENO
     : (paramp->output_isatty
@@ -1451,7 +1451,7 @@ static void init_path(const char *exename)
   set_vim_var_string(VV_PROGPATH, exepath, -1);
   set_vim_var_string(VV_PROGNAME, path_tail(exename), -1);
 
-#ifdef WIN32
+#ifdef MSWIN
   // Append the process start directory to $PATH, so that ":!foo" finds tools
   // shipped with Windows package. This also mimics SearchPath().
   os_setenv_append_path(exepath);

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1350,7 +1350,7 @@ static int utf_strnicmp(const char_u *s1, const char_u *s2, size_t n1, size_t n2
   return n1 == 0 ? -1 : 1;
 }
 
-#ifdef WIN32
+#ifdef MSWIN
 # ifndef CP_UTF8
 #  define CP_UTF8 65001  // magic number from winnls.h
 # endif

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3012,7 +3012,7 @@ static int do_more_prompt(int typed_char)
   return retval;
 }
 
-#if defined(WIN32)
+#if defined(MSWIN)
 void mch_errmsg(char *str)
 {
   assert(str != NULL);
@@ -3039,7 +3039,7 @@ void mch_msg(char *str)
     xfree(utf16str);
   }
 }
-#endif  // WIN32
+#endif  // MSWIN
 
 /// Put a character on the screen at the current message position and advance
 /// to the next position.  Only for printable ASCII!

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -94,7 +94,7 @@ char *server_address_new(const char *name)
 {
   static uint32_t count = 0;
   char fmt[ADDRESS_MAX_SIZE];
-#ifdef WIN32
+#ifdef MSWIN
   int r = snprintf(fmt, sizeof(fmt), "\\\\.\\pipe\\%s.%" PRIu64 ".%" PRIu32,
                    name ? name : "nvim", os_get_pid(), count++);
 #else

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -83,7 +83,7 @@
 #include "nvim/undo.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/pty_conpty_win.h"
 #endif
 #include "nvim/api/extmark.h"
@@ -1274,7 +1274,7 @@ int do_set(char *arg, int opt_flags)
               s = newval;
 
               // Copy the string, skip over escaped chars.
-              // For WIN32 backslashes before normal
+              // For MS-Windows backslashes before normal
               // file name characters are not removed, and keep
               // backslash at start, for "\\machine\path", but
               // do remove it for "\\\\machine\\path".

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -97,7 +97,7 @@ typedef enum {
 // Default values for 'errorformat'.
 // The "%f|%l| %m" one is used for when the contents of the quickfix window is
 // written to a file.
-#ifdef WIN32
+#ifdef MSWIN
 # define DFLT_EFM \
   "%f(%l) \\=: %t%*\\D%n: %m,%*[^\"]\"%f\"%*\\D%l: %m,%f(%l) \\=: %m,%*[^ ] %f %l: %m,%f:%l:%c:%m,%f(%l):%m,%f:%l:%m,%f|%l| %m"
 #else

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1014,7 +1014,7 @@ return {
       expand=true,
       varname='p_gp',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         -- Add an extra file name so that grep will always
         -- insert a file name in the match line. */
         if_true="findstr /n $* nul",
@@ -1276,7 +1276,7 @@ return {
       deny_duplicates=true,
       varname='p_isi',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true="@,48-57,_,128-167,224-235",
         if_false="@,48-57,_,192-255"
       }
@@ -2100,7 +2100,7 @@ return {
       expand=true,
       varname='p_sh',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true="cmd.exe",
         if_false="sh"
       }
@@ -2112,7 +2112,7 @@ return {
       secure=true,
       varname='p_shcf',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true="/s /c",
         if_false="-c"
       }
@@ -2124,7 +2124,7 @@ return {
       secure=true,
       varname='p_sp',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true=">%s 2>&1",
         if_false="| tee",
       }
@@ -2144,7 +2144,7 @@ return {
       secure=true,
       varname='p_srr',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true=">%s 2>&1",
         if_false=">"
       }
@@ -2171,7 +2171,7 @@ return {
       secure=true,
       varname='p_sxq',
       defaults={
-        condition='WIN32',
+        condition='MSWIN',
         if_true="\"",
         if_false="",
       }

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -20,7 +20,7 @@
 #include "nvim/version.h"
 #include "nvim/vim.h"
 
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
 #endif
 
@@ -128,7 +128,7 @@ int os_setenv(const char *name, const char *value, int overwrite)
   if (name[0] == '\0') {
     return -1;
   }
-#ifdef WIN32
+#ifdef MSWIN
   if (!overwrite && os_getenv(name) != NULL) {
     return 0;
   }
@@ -143,7 +143,7 @@ int os_setenv(const char *name, const char *value, int overwrite)
 #endif
   uv_mutex_lock(&mutex);
   int r;
-#ifdef WIN32
+#ifdef MSWIN
   // libintl uses getenv() for LC_ALL/LANG/etc., so we must use _putenv_s().
   if (striequal(name, "LC_ALL") || striequal(name, "LANGUAGE")
       || striequal(name, "LANG") || striequal(name, "LC_MESSAGES")) {
@@ -186,7 +186,7 @@ int os_unsetenv(const char *name)
 size_t os_get_fullenv_size(void)
 {
   size_t len = 0;
-#ifdef _WIN32
+#ifdef MSWIN
   wchar_t *envstrings = GetEnvironmentStringsW();
   wchar_t *p = envstrings;
   size_t l;
@@ -235,7 +235,7 @@ void os_free_fullenv(char **env)
 /// @param  env_size  size of `env`, @see os_fullenv_size
 void os_copy_fullenv(char **env, size_t env_size)
 {
-#ifdef _WIN32
+#ifdef MSWIN
   wchar_t *envstrings = GetEnvironmentStringsW();
   if (!envstrings) {
     return;
@@ -280,7 +280,7 @@ void os_copy_fullenv(char **env, size_t env_size)
 /// @return [allocated] environment variable's value, or NULL
 char *os_getenvname_at_index(size_t index)
 {
-#ifdef _WIN32
+#ifdef MSWIN
   wchar_t *envstrings = GetEnvironmentStringsW();
   if (!envstrings) {
     return NULL;
@@ -347,7 +347,7 @@ char *os_getenvname_at_index(size_t index)
 /// @return the process ID.
 int64_t os_get_pid(void)
 {
-#ifdef _WIN32
+#ifdef MSWIN
   return (int64_t)GetCurrentProcessId();
 #else
   return (int64_t)getpid();
@@ -368,7 +368,7 @@ void os_get_hostname(char *hostname, size_t size)
   } else {
     xstrlcpy(hostname, vutsname.nodename, size);
   }
-#elif defined(WIN32)
+#elif defined(MSWIN)
   wchar_t host_utf16[MAX_COMPUTERNAME_LENGTH + 1];
   DWORD host_wsize = sizeof(host_utf16) / sizeof(host_utf16[0]);
   if (GetComputerNameW(host_utf16, &host_wsize) == 0) {
@@ -418,7 +418,7 @@ void init_homedir(void)
 
   const char *var = os_getenv("HOME");
 
-#ifdef WIN32
+#ifdef MSWIN
   // Typically, $HOME is not defined on Windows, unless the user has
   // specifically defined it for Vim's sake. However, on Windows NT
   // platforms, $HOMEDRIVE and $HOMEPATH are automatically defined for
@@ -900,7 +900,7 @@ char *vim_getenv(const char *name)
   // init_path() should have been called before now.
   assert(get_vim_var_str(VV_PROGPATH)[0] != NUL);
 
-#ifdef WIN32
+#ifdef MSWIN
   if (strcmp(name, "HOME") == 0) {
     return xstrdup(homedir);
   }
@@ -1056,7 +1056,7 @@ size_t home_replace(const buf_T *const buf, const char *src, char *const dst, si
   }
 
   const char *homedir_env = os_getenv("HOME");
-#ifdef WIN32
+#ifdef MSWIN
   if (homedir_env == NULL) {
     homedir_env = os_getenv("USERPROFILE");
   }
@@ -1174,7 +1174,7 @@ char *get_env_name(expand_T *xp, int idx)
 bool os_setenv_append_path(const char *fname)
   FUNC_ATTR_NONNULL_ALL
 {
-#ifdef WIN32
+#ifdef MSWIN
 // 8191 (plus NUL) is considered the practical maximum.
 # define MAX_ENVPATHLEN 8192
 #else

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -27,7 +27,7 @@
 #include "nvim/path.h"
 #include "nvim/strings.h"
 
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
 #endif
 
@@ -151,7 +151,7 @@ bool os_isdir(const char *name)
 int os_nodetype(const char *name)
   FUNC_ATTR_NONNULL_ALL
 {
-#ifndef WIN32  // Unix
+#ifndef MSWIN  // Unix
   uv_stat_t statbuf;
   if (0 != os_stat(name, &statbuf)) {
     return NODE_NORMAL;  // File doesn't exist.
@@ -241,7 +241,7 @@ bool os_can_exe(const char *name, char **abspath, bool use_path)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   if (!use_path || gettail_dir(name) != name) {
-#ifdef WIN32
+#ifdef MSWIN
     if (is_executable_ext(name, abspath)) {
 #else
     // Must have path separator, cannot execute files in the current directory.
@@ -270,7 +270,7 @@ static bool is_executable(const char *name, char **abspath)
     return false;
   }
 
-#ifdef WIN32
+#ifdef MSWIN
   // Windows does not have exec bit; just check if the file exists and is not
   // a directory.
   const bool ok = S_ISREG(mode);
@@ -287,7 +287,7 @@ static bool is_executable(const char *name, char **abspath)
   return ok;
 }
 
-#ifdef WIN32
+#ifdef MSWIN
 /// Checks if file `name` is executable under any of these conditions:
 /// - extension is in $PATHEXT and `name` is executable
 /// - result of any $PATHEXT extension appended to `name` is executable
@@ -351,7 +351,7 @@ static bool is_executable_in_path(const char *name, char **abspath)
     return false;
   }
 
-#ifdef WIN32
+#ifdef MSWIN
   // Prepend ".;" to $PATH.
   size_t pathlen = strlen(path_env);
   char *path = memcpy(xmallocz(pathlen + 2), "." ENV_SEPSTR, 2);
@@ -374,7 +374,7 @@ static bool is_executable_in_path(const char *name, char **abspath)
     STRLCPY(buf, p, e - p + 1);
     append_path(buf, name, buf_len);
 
-#ifdef WIN32
+#ifdef MSWIN
     if (is_executable_ext(buf, abspath)) {
 #else
     if (is_executable(buf, abspath)) {
@@ -446,7 +446,7 @@ FILE *os_fopen(const char *path, const char *flags)
     default:
       abort();
     }
-#ifdef WIN32
+#ifdef MSWIN
     if (flags[1] == 'b') {
       iflags |= O_BINARY;
     }
@@ -1208,7 +1208,7 @@ char *os_realpath(const char *name, char *buf)
   return result == kLibuvSuccess ? buf : NULL;
 }
 
-#ifdef WIN32
+#ifdef MSWIN
 # include <shlobj.h>
 
 /// When "fname" is the name of a shortcut (*.lnk) resolve the file it points

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/win_defs.h"
 #else
 # include "nvim/os/unix_defs.h"
@@ -43,7 +43,7 @@
 /// Converts system error code to libuv error code.
 #define os_translate_sys_error uv_translate_sys_error
 
-#ifdef WIN32
+#ifdef MSWIN
 # define os_strtok strtok_s
 #else
 # define os_strtok strtok_r

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -8,7 +8,7 @@
 
 #include <uv.h>  // for HANDLE (win32)
 
-#ifdef WIN32
+#ifdef MSWIN
 # include <tlhelp32.h>  // for CreateToolhelp32Snapshot
 #endif
 
@@ -38,7 +38,7 @@
 # include "os/process.c.generated.h"
 #endif
 
-#ifdef WIN32
+#ifdef MSWIN
 static bool os_proc_tree_kill_rec(HANDLE process, int sig)
 {
   if (process == NULL) {
@@ -114,7 +114,7 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
   *proc_list = NULL;
   *proc_count = 0;
 
-#ifdef WIN32
+#ifdef MSWIN
   PROCESSENTRY32 pe;
 
   // Snapshot of all processes.
@@ -215,7 +215,7 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
   return 0;
 }
 
-#ifdef WIN32
+#ifdef MSWIN
 /// Gets various properties of the process identified by `pid`.
 ///
 /// @param pid Process to inspect.

--- a/src/nvim/os/pty_process.h
+++ b/src/nvim/os/pty_process.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_OS_PTY_PROCESS_H
 #define NVIM_OS_PTY_PROCESS_H
 
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/pty_process_win.h"
 #else
 # include "nvim/os/pty_process_unix.h"

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -4,7 +4,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <uv.h>
-#ifndef WIN32
+#ifndef MSWIN
 # include <signal.h>  // for sigset_t
 #endif
 
@@ -34,7 +34,7 @@ static bool rejecting_deadly;
 
 void signal_init(void)
 {
-#ifndef WIN32
+#ifndef MSWIN
   // Ensure a clean slate by unblocking all signals. For example, if SIGCHLD is
   // blocked, libuv may hang after spawning a subprocess on Linux. #5230
   sigset_t mask;

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -21,7 +21,7 @@ static const char *xdg_env_vars[] = {
   [kXDGDataDirs] = "XDG_DATA_DIRS",
 };
 
-#ifdef WIN32
+#ifdef MSWIN
 static const char *const xdg_defaults_env_vars[] = {
   [kXDGConfigHome] = "LOCALAPPDATA",
   [kXDGDataHome] = "LOCALAPPDATA",
@@ -37,7 +37,7 @@ static const char *const xdg_defaults_env_vars[] = {
 ///
 /// Used in case environment variables contain nothing. Need to be expanded.
 static const char *const xdg_defaults[] = {
-#ifdef WIN32
+#ifdef MSWIN
   [kXDGConfigHome] = "~\\AppData\\Local",
   [kXDGDataHome] = "~\\AppData\\Local",
   [kXDGCacheHome] = "~\\AppData\\Local\\Temp",
@@ -69,7 +69,7 @@ char *stdpaths_get_xdg_var(const XDGVarType idx)
 
   const char *env_val = os_getenv(env);
 
-#ifdef WIN32
+#ifdef MSWIN
   if (env_val == NULL && xdg_defaults_env_vars[idx] != NULL) {
     env_val = os_getenv(xdg_defaults_env_vars[idx]);
   }
@@ -107,7 +107,7 @@ char *get_xdg_home(const XDGVarType idx)
 {
   char *dir = stdpaths_get_xdg_var(idx);
   if (dir) {
-#if defined(WIN32)
+#if defined(MSWIN)
     dir = concat_fnames_realloc(dir,
                                 ((idx == kXDGDataHome
                                   || idx == kXDGStateHome) ? "nvim-data" : "nvim"),

--- a/src/nvim/os/tty.c
+++ b/src/nvim/os/tty.c
@@ -12,7 +12,7 @@
 # include "os/tty.c.generated.h"
 #endif
 
-#ifdef WIN32
+#ifdef MSWIN
 # if !defined(ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 #  define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 # endif

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -14,7 +14,7 @@
 #ifdef HAVE_PWD_H
 # include <pwd.h>
 #endif
-#ifdef WIN32
+#ifdef MSWIN
 # include <lm.h>
 #endif
 
@@ -56,7 +56,7 @@ int os_get_usernames(garray_T *users)
     }
     endpwent();
   }
-#elif defined(WIN32)
+#elif defined(MSWIN)
   {
     DWORD nusers = 0, ntotal = 0, i;
     PUSER_INFO_0 uinfo;

--- a/src/nvim/os/win_defs.h
+++ b/src/nvim/os/win_defs.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_OS_WIN_DEFS_H
 #define NVIM_OS_WIN_DEFS_H
 
-#ifndef WIN32
+#ifndef MSWIN
 # error Header must be included only when compiling for Windows.
 #endif
 

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -190,7 +190,7 @@ const char *path_next_component(const char *fname)
 ///   - 1 otherwise
 int path_head_length(void)
 {
-#ifdef WIN32
+#ifdef MSWIN
   return 3;
 #else
   return 1;
@@ -205,7 +205,7 @@ int path_head_length(void)
 ///   - False otherwise
 bool is_path_head(const char_u *path)
 {
-#ifdef WIN32
+#ifdef MSWIN
   return isalpha(path[0]) && path[1] == ':';
 #else
   return vim_ispathsep(*path);
@@ -219,7 +219,7 @@ char *get_past_head(const char *path)
 {
   const char *retval = path;
 
-#ifdef WIN32
+#ifdef MSWIN
   // May skip "c:"
   if (is_path_head((char_u *)path)) {
     retval = path + 2;
@@ -642,7 +642,7 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
       s = p + 1;
     } else if (path_end >= (char_u *)path + wildoff
                && (vim_strchr("*?[{~$", *path_end) != NULL
-#ifndef WIN32
+#ifndef MSWIN
                    || (!p_fic && (flags & EW_ICASE) && mb_isalpha(utf_ptr2char((char *)path_end)))
 #endif
                    )) {
@@ -897,7 +897,7 @@ static char_u *get_path_cutoff(char_u *fname, garray_T *gap)
     int j = 0;
 
     while ((fname[j] == path_part[i][j]
-#ifdef WIN32
+#ifdef MSWIN
             || (vim_ispathsep(fname[j]) && vim_ispathsep(path_part[i][j]))
 #endif
             )  // NOLINT(whitespace/parens)
@@ -1816,7 +1816,7 @@ int vim_FullName(const char *fname, char *buf, size_t len, bool force)
 
   if (strlen(fname) > (len - 1)) {
     xstrlcpy(buf, fname, len);  // truncate
-#ifdef WIN32
+#ifdef MSWIN
     slash_adjust((char_u *)buf);
 #endif
     return FAIL;
@@ -1831,7 +1831,7 @@ int vim_FullName(const char *fname, char *buf, size_t len, bool force)
   if (rv == FAIL) {
     xstrlcpy(buf, fname, len);  // something failed; use the filename
   }
-#ifdef WIN32
+#ifdef MSWIN
   slash_adjust((char_u *)buf);
 #endif
   return rv;
@@ -2356,7 +2356,7 @@ static int path_to_absolute(const char *fname, char *buf, size_t len, int force)
   // expand it if forced or not an absolute path
   if (force || !path_is_absolute((char_u *)fname)) {
     p = strrchr(fname, '/');
-#ifdef WIN32
+#ifdef MSWIN
     if (p == NULL) {
       p = strrchr(fname, '\\');
     }
@@ -2392,7 +2392,7 @@ static int path_to_absolute(const char *fname, char *buf, size_t len, int force)
 /// @return `true` if "fname" is absolute.
 int path_is_absolute(const char_u *fname)
 {
-#ifdef WIN32
+#ifdef MSWIN
   if (*fname == NUL) {
     return false;
   }

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1451,7 +1451,7 @@ static inline char *add_dir(char *dest, const char *const dir, const size_t dir_
     if (!after_pathsep(dest - 1, dest)) {
       *dest++ = PATHSEP;
     }
-#if defined(WIN32)
+#if defined(MSWIN)
     size_t size = (type == kXDGDataHome ? sizeof("nvim-data") - 1 : NVIM_SIZE);
     memmove(dest, (type == kXDGDataHome ? "nvim-data" : "nvim"), size);
     dest += size;
@@ -1521,7 +1521,7 @@ char *runtimepath_default(bool clean_arg)
   if (data_home != NULL) {
     data_len = strlen(data_home);
     if (data_len != 0) {
-#if defined(WIN32)
+#if defined(MSWIN)
       size_t nvim_size = (sizeof("nvim-data") - 1);
 #else
       size_t nvim_size = NVIM_SIZE;
@@ -1664,7 +1664,7 @@ int source_level(void *cookie)
 /// If possible the handle is closed on exec().
 static FILE *fopen_noinh_readbin(char *filename)
 {
-#ifdef WIN32
+#ifdef MSWIN
   int fd_tmp = os_open(filename, O_RDONLY | O_BINARY | O_NOINHERIT, 0);
 #else
   int fd_tmp = os_open(filename, O_RDONLY, 0);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -186,7 +186,7 @@ char_u *vim_strsave_shellescape(const char_u *string, bool do_special, bool do_n
   // First count the number of extra bytes required.
   size_t length = STRLEN(string) + 3;       // two quotes and a trailing NUL
   for (const char_u *p = string; *p != NUL; MB_PTR_ADV(p)) {
-#ifdef WIN32
+#ifdef MSWIN
     if (!p_ssl) {
       if (*p == '"') {
         length++;                       // " -> ""
@@ -217,7 +217,7 @@ char_u *vim_strsave_shellescape(const char_u *string, bool do_special, bool do_n
   d = (char *)escaped_string;
 
   // add opening quote
-#ifdef WIN32
+#ifdef MSWIN
   if (!p_ssl) {
     *d++ = '"';
   } else
@@ -225,7 +225,7 @@ char_u *vim_strsave_shellescape(const char_u *string, bool do_special, bool do_n
   *d++ = '\'';
 
   for (const char *p = (char *)string; *p != NUL;) {
-#ifdef WIN32
+#ifdef MSWIN
     if (!p_ssl) {
       if (*p == '"') {
         *d++ = '"';
@@ -269,7 +269,7 @@ char_u *vim_strsave_shellescape(const char_u *string, bool do_special, bool do_n
   }
 
   // add terminating quote and finish with a NUL
-#ifdef WIN32
+#ifdef MSWIN
   if (!p_ssl) {
     *d++ = '"';
   } else

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -15,7 +15,7 @@
 #include "nvim/tui/input.h"
 #include "nvim/tui/tui.h"
 #include "nvim/vim.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/os_win_console.h"
 #endif
 #include "nvim/event/rstream.h"
@@ -143,7 +143,7 @@ void tinput_init(TermInput *input, Loop *loop)
   // If stdin is not a pty, switch to stderr. For cases like:
   //    echo q | nvim -es
   //    ls *.md | xargs nvim
-#ifdef WIN32
+#ifdef MSWIN
   if (!os_isatty(input->in_fd)) {
     input->in_fd = os_get_conin_fd();
   }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -31,7 +31,7 @@
 #include "nvim/os/tty.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
-#ifdef WIN32
+#ifdef MSWIN
 # include "nvim/os/os_win_console.h"
 #endif
 #include "nvim/cursor_shape.h"
@@ -263,7 +263,7 @@ static void terminfo_start(UI *ui)
   data->input.tui_data = data;
 
   const char *term = os_getenv("TERM");
-#ifdef WIN32
+#ifdef MSWIN
   os_tty_guess_term(&term, data->out_fd);
   os_setenv("TERM", term, 1);
   // Old os_getenv() pointer is invalid after os_setenv(), fetch it again.
@@ -353,7 +353,7 @@ static void terminfo_start(UI *ui)
     if (ret) {
       ELOG("uv_tty_init failed: %s", uv_strerror(ret));
     }
-#ifdef WIN32
+#ifdef MSWIN
     ret = uv_tty_set_mode(&data->output_handle.tty, UV_TTY_MODE_RAW);
     if (ret) {
       ELOG("uv_tty_set_mode failed: %s", uv_strerror(ret));
@@ -1810,7 +1810,7 @@ static void patch_terminfo_bugs(TUIData *data, const char *term, const char *col
       }
     }
 
-#ifdef WIN32
+#ifdef MSWIN
     // XXX: workaround libuv implicit LF => CRLF conversion. #10558
     unibi_set_str(ut, unibi_cursor_down, "\x1b[B");
 #endif

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -256,7 +256,7 @@ enum { FOLD_TEXT_LEN = 51, };  //!< buffer size for get_foldtext()
 // functions of these names. The declarations would break if the defines had
 // been seen at that stage.  But it must be before globals.h, where error_ga
 // is declared.
-#ifndef WIN32
+#ifndef MSWIN
 # define mch_errmsg(str)        fprintf(stderr, "%s", (str))
 # define mch_msg(str)           printf("%s", (str))
 #endif

--- a/test/functional/fixtures/printenv-test.c
+++ b/test/functional/fixtures/printenv-test.c
@@ -3,13 +3,13 @@
 
 #include <stdio.h>
 
-#ifdef WIN32
+#ifdef MSWIN
 # include <windows.h>
 #else
 # include <stdlib.h>
 #endif
 
-#ifdef WIN32
+#ifdef MSWIN
 int wmain(int argc, wchar_t **argv)
 #else
 int main(int argc, char **argv)
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
     return 1;
   }
 
-#ifdef WIN32
+#ifdef MSWIN
   wchar_t *value = _wgetenv(argv[1]);
   if (value == NULL) {
     return 1;


### PR DESCRIPTION
####  vim-patch:8.1.0941: macros for MS-Windows are inconsistent

Problem:    Macros for MS-Windows are inconsistent, using "32", "3264 and
            others.
Solution:   Use MSWIN for all MS-Windows builds.  Use FEAT_GUI_MSWIN for the
            GUI build. (Hirohito Higashi, closes vim/vim#3932)
https://github.com/vim/vim/commit/4f97475d326c2773a78561fb874e4f23c25cbcd9