### PR TITLE
vim-patch:9.0.0476: varargs does not work for replacement function of substitute()

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1529,8 +1529,7 @@ int call_func(const char *funcname, int len, typval_T *rettv, int argcount_in, t
       } else if (fp != NULL) {
         if (funcexe->fe_argv_func != NULL) {
           // postponed filling in the arguments, do it now
-          argcount = funcexe->fe_argv_func(argcount, argvars, argv_clear,
-                                           fp->uf_args.ga_len);
+          argcount = funcexe->fe_argv_func(argcount, argvars, argv_clear, fp);
         }
 
         argv_add_base(funcexe->fe_basetv, &argvars, &argcount, argv, &argv_base);

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -50,8 +50,8 @@ typedef enum {
 } FnameTransError;
 
 /// Used in funcexe_T. Returns the new argcount.
-typedef int (*ArgvFunc)(int current_argcount, typval_T *argv, int argskip,
-                        int called_func_argcount);
+typedef int (*ArgvFunc)(int current_argcount, typval_T *argv, int partial_argcount,
+                        ufunc_T *called_func);
 
 /// Structure passed between functions dealing with function call execution.
 typedef struct {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1605,12 +1605,12 @@ static regsubmatch_T rsm;  // can only be used when can_f_submatch is true
 
 /// Put the submatches in "argv[argskip]" which is a list passed into
 /// call_func() by vim_regsub_both().
-static int fill_submatch_list(int argc FUNC_ATTR_UNUSED, typval_T *argv, int argskip, int argcount)
+static int fill_submatch_list(int argc FUNC_ATTR_UNUSED, typval_T *argv, int argskip, ufunc_T *fp)
   FUNC_ATTR_NONNULL_ALL
 {
   typval_T *listarg = argv + argskip;
 
-  if (argcount == argskip) {
+  if (!fp->uf_varargs && fp->uf_args.ga_len <= argskip) {
     // called function doesn't take a submatches argument
     return argskip;
   }

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -639,12 +639,16 @@ endfunc
 func SubReplacer(text, submatches)
   return a:text .. a:submatches[0] .. a:text
 endfunc
+func SubReplacerVar(text, ...)
+  return a:text .. a:1[0] .. a:text
+endfunc
 func SubReplacer20(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, submatches)
   return a:t3 .. a:submatches[0] .. a:t11
 endfunc
 
 func Test_substitute_partial()
   call assert_equal('1foo2foo3', substitute('123', '2', function('SubReplacer', ['foo']), 'g'))
+  call assert_equal('1foo2foo3', substitute('123', '2', function('SubReplacerVar', ['foo']), 'g'))
 
   " 19 arguments plus one is just OK
   let Replacer = function('SubReplacer20', repeat(['foo'], 19))


### PR DESCRIPTION
#### vim-patch:9.0.0476: varargs does not work for replacement function of substitute()

Problem:    Varargs does not work for replacement function of substitute().
Solution:   Check the varargs flag of the function. (closes vim/vim#11142)
https://github.com/vim/vim/commit/48db5dafecacced4a9e42de3f92838b2d59beb4c