### PR TITLE
vim-patch:9.0.0479: in :def function all closures in loop get the sam…

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -2112,6 +2112,9 @@ au BufNewFile,BufRead */.config/upstart/*.override	       setf upstart
 " Vala
 au BufNewFile,BufRead *.vala			setf vala
 
+" VDF
+au BufNewFile,BufRead *.vdf			setf vdf
+
 " VDM
 au BufRead,BufNewFile *.vdmpp,*.vpp		setf vdmpp
 au BufRead,BufNewFile *.vdmrt			setf vdmrt

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1021,6 +1021,7 @@ local extension = {
   dsm = 'vb',
   ctl = 'vb',
   vbs = 'vb',
+  vdf = 'vdf',
   vdmpp = 'vdmpp',
   vpp = 'vdmpp',
   vdmrt = 'vdmrt',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -594,6 +594,7 @@ let s:filename_checks = {
     \ 'usw2kagtlog': ['usw2kagt.log', 'USW2KAGT.LOG', 'usw2kagt.file.log', 'USW2KAGT.FILE.LOG', 'file.usw2kagt.log', 'FILE.USW2KAGT.LOG'],
     \ 'vala': ['file.vala'],
     \ 'vb': ['file.sba', 'file.vb', 'file.vbs', 'file.dsm', 'file.ctl'],
+    \ 'vdf': ['file.vdf'],
     \ 'vdmpp': ['file.vpp', 'file.vdmpp'],
     \ 'vdmrt': ['file.vdmrt'],
     \ 'vdmsl': ['file.vdm', 'file.vdmsl'],


### PR DESCRIPTION
…e variables

Problem:    In a :def function all closures in a loop get the same variables.
Solution:   Use a separate list of variables for LOADOUTER and SAVEOUTER.
https://github.com/vim/vim/commit/1aea184a0dc558a222cc5bcbaad9ab0fd700c7b9

(The patch description is a lie.)