### PR TITLE
build(deps): bump libvterm to v0.3

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -173,8 +173,8 @@ set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a
 set(LIBTERMKEY_URL https://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
 set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
 
-set(LIBVTERM_URL https://www.leonerd.org.uk/code/libvterm/libvterm-0.3-RC1.tar.gz)
-set(LIBVTERM_SHA256 441d1c372b84a0df12525100ab06c0366260fb4f6252abd1665ee4fa571b5134)
+set(LIBVTERM_URL https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz)
+set(LIBVTERM_SHA256 61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358)
 
 set(LUV_VERSION 1.44.2-1)
 set(LUV_URL https://github.com/luvit/luv/archive/1.44.2-1.tar.gz)


### PR DESCRIPTION
This includes -- but does not yet enable -- reflow functionality in `:terminal` (i.e., output adapts to resizing the Neovim window).

This seems to be stable in a very brief test, so we could think of just enabling it by default after 0.8. (There are still issues with resizing pushing content into scrollback, where information gets lost, but it's already a strict improvement over the status quo.)

For those adventurous enough and building from source, it can be enabled by adding
```
vterm_screen_enable_reflow(rv->vts, true)
```
after this line: https://github.com/neovim/neovim/blob/e512d3ecf2b6e0104d2df0d863c8d51a2d7e5ab1/src/nvim/terminal.c#L211