### PR TITLE
test(old): add a function roughly equivalent to test_setmouse()

### DIFF
--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -45,6 +45,11 @@ mapclear!
 aunmenu *
 tlunmenu *
 
+" roughly equivalent to test_setmouse() in Vim
+func Ntest_setmouse(row, col)
+  call nvim_input_mouse('move', '', '', 0, a:row - 1, a:col - 1)
+endfunc
+
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/src/nvim/testdir/test_assert.vim
+++ b/src/nvim/testdir/test_assert.vim
@@ -278,19 +278,18 @@ func Test_assert_with_msg()
 endfunc
 
 func Test_mouse_position()
-  throw 'Skipped: Nvim does not have test_setmouse()'
   let save_mouse = &mouse
   set mouse=a
   new
   call setline(1, ['line one', 'line two'])
   call assert_equal([0, 1, 1, 0], getpos('.'))
-  call test_setmouse(1, 5)
+  call Ntest_setmouse(1, 5)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 5, 0], getpos('.'))
-  call test_setmouse(2, 20)
+  call Ntest_setmouse(2, 20)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 2, 8, 0], getpos('.'))
-  call test_setmouse(5, 1)
+  call Ntest_setmouse(5, 1)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 2, 1, 0], getpos('.'))
   bwipe!

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1228,15 +1228,11 @@ func Test_edit_MOUSE()
   call assert_equal(24, line('w0'))
 
   call assert_equal([0, 24, 2, 0], getpos('.'))
-  " call test_setmouse(4, 3)
-  call nvim_input_mouse('left', 'press', '', 0, 3, 2) " set mouse position
-  call getchar() " discard mouse event but keep mouse position
+  call Ntest_setmouse(4, 3)
   call feedkeys("A\<LeftMouse>\<esc>", 'tnix')
   call assert_equal([0, 27, 2, 0], getpos('.'))
   set mousemodel=extend
-  " call test_setmouse(5, 3)
-  call nvim_input_mouse('right', 'press', '', 0, 4, 2) " set mouse position
-  call getchar() " discard mouse event but keep mouse position
+  call Ntest_setmouse(5, 3)
   call feedkeys("A\<RightMouse>\<esc>\<esc>", 'tnix')
   call assert_equal([0, 28, 2, 0], getpos('.'))
   set mousemodel&

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1270,15 +1270,11 @@ func Test_inputlist()
   call assert_equal(2, c)
 
   " Use mouse to make a selection
-  " call test_setmouse(&lines - 3, 2)
-  call nvim_input_mouse('left', 'press', '', 0, &lines - 4, 1) " set mouse position
-  call getchar() " discard mouse event but keep mouse position
+  call Ntest_setmouse(&lines - 3, 2)
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<LeftMouse>", 'tx')
   call assert_equal(1, c)
   " Mouse click outside of the list
-  " call test_setmouse(&lines - 6, 2)
-  call nvim_input_mouse('left', 'press', '', 0, &lines - 7, 1) " set mouse position
-  call getchar() " discard mouse event but keep mouse position
+  call Ntest_setmouse(&lines - 6, 2)
   call feedkeys(":let c = inputlist(['Select color:', '1. red', '2. green', '3. blue'])\<cr>\<LeftMouse>", 'tx')
   call assert_equal(-2, c)
 
@@ -1537,13 +1533,12 @@ func Test_getchar()
   call assert_equal(0, getchar(0))
 
   call setline(1, 'xxxx')
-  " call test_setmouse(1, 3)
-  " let v:mouse_win = 9
-  " let v:mouse_winid = 9
-  " let v:mouse_lnum = 9
-  " let v:mouse_col = 9
-  " call feedkeys("\<S-LeftMouse>", '')
-  call nvim_input_mouse('left', 'press', 'S', 0, 0, 2)
+  call Ntest_setmouse(1, 3)
+  let v:mouse_win = 9
+  let v:mouse_winid = 9
+  let v:mouse_lnum = 9
+  let v:mouse_col = 9
+  call feedkeys("\<S-LeftMouse>", '')
   call assert_equal("\<S-LeftMouse>", getchar())
   call assert_equal(1, v:mouse_win)
   call assert_equal(win_getid(1), v:mouse_winid)
@@ -1975,9 +1970,7 @@ endfunc
 func Test_getmousepos()
   enew!
   call setline(1, "\t\t\t1234")
-  " call test_setmouse(1, 1)
-  call nvim_input_mouse('left', 'press', '', 0, 0, 0)
-  call getchar() " wait for and consume the mouse press
+  call Ntest_setmouse(1, 1)
   call assert_equal(#{
         \ screenrow: 1,
         \ screencol: 1,
@@ -1987,9 +1980,7 @@ func Test_getmousepos()
         \ line: 1,
         \ column: 1,
         \ }, getmousepos())
-  " call test_setmouse(1, 25)
-  call nvim_input_mouse('left', 'press', '', 0, 0, 24)
-  call getchar() " wait for and consume the mouse press
+  call Ntest_setmouse(1, 25)
   call assert_equal(#{
         \ screenrow: 1,
         \ screencol: 25,
@@ -1999,9 +1990,7 @@ func Test_getmousepos()
         \ line: 1,
         \ column: 4,
         \ }, getmousepos())
-  " call test_setmouse(1, 50)
-  call nvim_input_mouse('left', 'press', '', 0, 0, 49)
-  call getchar() " wait for and consume the mouse press
+  call Ntest_setmouse(1, 50)
   call assert_equal(#{
         \ screenrow: 1,
         \ screencol: 50,
@@ -2014,9 +2003,7 @@ func Test_getmousepos()
 
   " If the mouse is positioned past the last buffer line, "line" and "column"
   " should act like it's positioned on the last buffer line.
-  " call test_setmouse(2, 25)
-  call nvim_input_mouse('left', 'press', '', 0, 1, 24)
-  call getchar() " wait for and consume the mouse press
+  call Ntest_setmouse(2, 25)
   call assert_equal(#{
         \ screenrow: 2,
         \ screencol: 25,
@@ -2026,9 +2013,7 @@ func Test_getmousepos()
         \ line: 1,
         \ column: 4,
         \ }, getmousepos())
-  " call test_setmouse(2, 50)
-  call nvim_input_mouse('left', 'press', '', 0, 1, 49)
-  call getchar() " wait for and consume the mouse press
+  call Ntest_setmouse(2, 50)
   call assert_equal(#{
         \ screenrow: 2,
         \ screencol: 50,

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1006,15 +1006,14 @@ func Test_plug_remap()
 endfunc
 
 func Test_mouse_drag_mapped_start_select()
-  CheckFunction test_setmouse
   set mouse=a
   set selectmode=key,mouse
   func ClickExpr()
-    call test_setmouse(1, 1)
+    call Ntest_setmouse(1, 1)
     return "\<LeftMouse>"
   endfunc
   func DragExpr()
-    call test_setmouse(1, 2)
+    call Ntest_setmouse(1, 2)
     return "\<LeftDrag>"
   endfunc
   nnoremap <expr> <F2> ClickExpr()
@@ -1036,14 +1035,13 @@ endfunc
 
 " Test for mapping <LeftDrag> in Insert mode
 func Test_mouse_drag_insert_map()
-  CheckFunction test_setmouse
   set mouse=a
   func ClickExpr()
-    call test_setmouse(1, 1)
+    call Ntest_setmouse(1, 1)
     return "\<LeftMouse>"
   endfunc
   func DragExpr()
-    call test_setmouse(1, 2)
+    call Ntest_setmouse(1, 2)
     return "\<LeftDrag>"
   endfunc
   inoremap <expr> <F2> ClickExpr()


### PR DESCRIPTION
Mouse movement events usually have no effect, so passing "move" to
nvim_input_mouse() works in most cases.
