### PR TITLE
vim-patch:9.0.0483: illegal memory access when replacing in virtualedit mode

### DIFF
--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -481,4 +481,53 @@ func Test_global_local_virtualedit()
   set virtualedit&
 endfunc
 
+func Test_virtualedit_mouse()
+  let save_mouse = &mouse
+  set mouse=a
+  set virtualedit=all
+  new
+
+  call setline(1, ["text\tword"])
+  redraw
+  call Ntest_setmouse(1, 4)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
+  call Ntest_setmouse(1, 5)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 5, 0, 5], getcurpos())
+  call Ntest_setmouse(1, 6)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 5, 1, 6], getcurpos())
+  call Ntest_setmouse(1, 7)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 5, 2, 7], getcurpos())
+  call Ntest_setmouse(1, 8)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 5, 3, 8], getcurpos())
+  call Ntest_setmouse(1, 9)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 6, 0, 9], getcurpos())
+  call Ntest_setmouse(1, 15)
+  call feedkeys("\<LeftMouse>", "xt")
+  call assert_equal([0, 1, 10, 2, 15], getcurpos())
+
+  bwipe!
+  let &mouse = save_mouse
+  set virtualedit&
+endfunc
+
+" this was replacing the NUL at the end of the line 
+func Test_virtualedit_replace_after_tab()
+  new
+  s/\v/	0
+  set ve=all
+  let @" = ''
+  sil! norm vPvr0
+  
+  call assert_equal("\t0", getline(1))
+  set ve&
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0483: illegal memory access when replacing in virtualedit mode

Problem:    Illegal memory access when replacing in virtualedit mode.
Solution:   Check for replacing NUL after Tab.
https://github.com/vim/vim/commit/c249913edc35c0e666d783bfc21595cf9f7d9e0d

Cherry-pick Test_virtualedit_mouse() from patch 9.0.0177.