### PR TITLE
vim-patch:8.2.0690: line number of option set by modeline is wrong

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1891,14 +1891,15 @@ void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
   int both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
   int indir = (int)options[opt_idx].indir;
   nlua_set_sctx(&script_ctx);
-  const LastSet last_set = {
-    .script_ctx = {
-      script_ctx.sc_sid,
-      script_ctx.sc_seq,
-      script_ctx.sc_lnum + SOURCING_LNUM
-    },
-    current_channel_id
+  LastSet last_set = {
+    .script_ctx = script_ctx,
+    .channel_id = current_channel_id,
   };
+
+  // Modeline already has the line number set.
+  if (!(opt_flags & OPT_MODELINE)) {
+    last_set.script_ctx.sc_lnum += SOURCING_LNUM;
+  }
 
   // Remember where the option was set.  For local options need to do that
   // in the buffer or window structure.

--- a/src/nvim/testdir/test_modeline.vim
+++ b/src/nvim/testdir/test_modeline.vim
@@ -281,6 +281,62 @@ func Test_modeline_fails_modelineexpr()
   call s:modeline_fails('titlestring', 'titlestring=Something()', 'E992:')
 endfunc
 
+func Test_modeline_setoption_verbose()
+  let modeline = &modeline
+  set modeline
+
+  let lines =<< trim END
+  1 vim:ts=2
+  2 two
+  3 three
+  4 four
+  5 five
+  6 six
+  7 seven
+  8 eight
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 1$', info[-1])
+  bwipe!
+
+  let lines =<< trim END
+  1 one
+  2 two
+  3 three
+  4 vim:ts=4
+  5 five
+  6 six
+  7 seven
+  8 eight
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 4$', info[-1])
+  bwipe!
+
+  let lines =<< trim END
+  1 one
+  2 two
+  3 three
+  4 four
+  5 five
+  6 six
+  7 seven
+  8 vim:ts=8
+  END
+  call writefile(lines, 'Xmodeline')
+  edit Xmodeline
+  let info = split(execute('verbose set tabstop?'), "\n")
+  call assert_match('^\s*Last set from modeline line 8$', info[-1])
+  bwipe!
+
+  let &modeline = modeline
+  call delete('Xmodeline')
+endfunc
+
 func Test_modeline_disable()
   set modeline
   call writefile(['vim: sw=2', 'vim: nomodeline', 'vim: sw=3'], 'Xmodeline_disable')


### PR DESCRIPTION
#### vim-patch:8.2.0690: line number of option set by modeline is wrong

Problem:    Line number of option set by modeline is wrong.
Solution:   Do not double the line number. (Ozaki Kiichi, closes vim/vim#6035)
https://github.com/vim/vim/commit/5125874951669944a5f6a4163d6e5d437ae6321e