### PR TITLE
test(remote_spec): reduce flakiness in waiting for client exit

### DIFF
--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
+local exec_lua = helpers.exec_lua
 local expect = helpers.expect
 local funcs = helpers.funcs
 local insert = helpers.insert
@@ -48,8 +49,8 @@ describe('Remote', function()
       -- our incoming --remote calls.
       local client_starter = spawn(new_argv(), false, nil, true)
       set_session(client_starter)
-      local client_job_id = funcs.jobstart(client_argv)
-      eq({ 0 }, funcs.jobwait({client_job_id}))
+      -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
+      eq({ 0 }, exec_lua([[return vim.fn.jobwait({ vim.fn.jobstart(...) })]], client_argv))
       client_starter:close()
       set_session(server)
     end
@@ -121,8 +122,8 @@ describe('Remote', function()
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
       clear()
-      local bogus_job_id = funcs.jobstart(bogus_argv)
-      eq({2}, funcs.jobwait({bogus_job_id}))
+      -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
+      eq({ 2 }, exec_lua([[return vim.fn.jobwait({ vim.fn.jobstart(...) })]], bogus_argv))
     end
     it('bogus subcommand', function()
       run_and_check_exit_code('--remote-bogus')


### PR DESCRIPTION
It is less likely for client to exit between jobstart() and jobwait() if
they are invoked in the same RPC request instead of two separate ones.
