### PR TITLE
vim-patch:9.0.0497: LyRiCs files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -449,6 +449,9 @@ endif
 " Lynx config files
 au BufNewFile,BufRead lynx.cfg			setf lynx
 
+" LyRiCs
+au BufNewFile,BufRead *.lrc			setf lyrics
+
 " Modula-3 configuration language (must be before *.cfg and *makefile)
 au BufNewFile,BufRead *.quake,cm3.cfg		setf m3quake
 au BufNewFile,BufRead m3makefile,m3overrides	setf m3build

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -611,6 +611,7 @@ local extension = {
   nse = 'lua',
   rockspec = 'lua',
   lua = 'lua',
+  lrc = 'lyrics',
   m = function(path, bufnr)
     return require('vim.filetype.detect').m(bufnr)
   end,

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -327,6 +327,7 @@ let s:filename_checks = {
     \ 'lss': ['file.lss'],
     \ 'lua': ['file.lua', 'file.rockspec', 'file.nse'],
     \ 'lynx': ['lynx.cfg'],
+    \ 'lyrics': ['file.lrc'],
     \ 'm3build': ['m3makefile', 'm3overrides'],
     \ 'm3quake': ['file.quake', 'cm3.cfg'],
     \ 'm4': ['file.at'],


### PR DESCRIPTION
Problem:    LyRiCs files are not recognized.
Solution:   Add a pattern to detect LyRiCs files. (closes vim/vim#11155)
https://github.com/vim/vim/commit/65ee49decf5677690cd695d5d288e39344965fff