### PR TITLE
vim-patch:9.0.0509: confusing error for "saveas" command with "nofile" buffer

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -116,6 +116,8 @@ struct bw_info {
 #endif
 
 static char *e_auchangedbuf = N_("E812: Autocommands changed buffer or buffer name");
+static char e_no_matching_autocommands_for_buftype_str_buffer[]
+  = N_("E676: No matching autocommands for buftype=%s buffer");
 
 void filemess(buf_T *buf, char *name, char *s, int attr)
 {
@@ -2366,7 +2368,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
       no_wait_return--;
       msg_scroll = msg_save;
       if (nofile_err) {
-        emsg(_("E676: No matching autocommands for acwrite buffer"));
+        semsg(_(e_no_matching_autocommands_for_buftype_str_buffer), curbuf->b_p_bt);
       }
 
       if (nofile_err

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -216,6 +216,12 @@ func Test_saveas()
   syntax off
   %bw!
   call delete('Xsaveas.pl')
+
+  " :saveas fails for "nofile" buffer
+  set buftype=nofile
+  call assert_fails('saveas Xsafile', 'E676: No matching autocommands for buftype=nofile buffer')
+
+  bwipe!
 endfunc
 
 func Test_write_errors()


### PR DESCRIPTION
#### vim-patch:9.0.0509: confusing error for "saveas" command with "nofile" buffer

Problem:    Confusing error for "saveas" command with "nofile" buffer.
Solution:   Give a clearer error message.
https://github.com/vim/vim/commit/500a1f9972afa354f0bc77bc535aabf9f5f0116d