### PR TITLE
vim-patch:9.0.0510: Chatito files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -300,6 +300,9 @@ au BufNewFile,BufRead cfengine.conf		setf cfengine
 " ChaiScript
 au BufRead,BufNewFile *.chai			setf chaiscript
 
+" Chatito
+au BufNewFile,BufRead *.chatito			setf chatito
+
 " Comshare Dimension Definition Language
 au BufNewFile,BufRead *.cdl			setf cdl
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -202,6 +202,7 @@ local extension = {
     return require('vim.filetype.detect').change(bufnr)
   end,
   chs = 'chaskell',
+  chatito = 'chatito',
   chopro = 'chordpro',
   crd = 'chordpro',
   crdpro = 'chordpro',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -108,6 +108,7 @@ let s:filename_checks = {
     \ 'ch': ['file.chf'],
     \ 'chaiscript': ['file.chai'],
     \ 'chaskell': ['file.chs'],
+    \ 'chatito': ['file.chatito'],
     \ 'chill': ['file..ch'],
     \ 'chordpro': ['file.chopro', 'file.crd', 'file.cho', 'file.crdpro', 'file.chordpro'],
     \ 'cl': ['file.eni'],


### PR DESCRIPTION
Problem:    Chatito files are not recognized.
Solution:   Add a pattern for Chatito files. (closes vim/vim#11174)
https://github.com/vim/vim/commit/7c046ae99ba85a4fdf1a546157e2ed6f12b79ea6