### PR TITLE
vim-patch:9.0.0511: unnecessary scrolling for message of only one line

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -596,10 +596,10 @@ void msg_source(int attr)
   }
   recursive = true;
 
-  msg_scroll = true;  // this will take more than one line
   no_wait_return++;
   char *p = get_emsg_source();
   if (p != NULL) {
+    msg_scroll = true;  // this will take more than one line
     msg_attr(p, attr);
     xfree(p);
   }
@@ -739,7 +739,7 @@ static bool emsg_multiline(const char *s, bool multiline)
   }
 
   // Display name and line number for the source of the error.
-  // Sets "msg_scroll".
+  msg_scroll = true;
   msg_source(attr);
 
   // Display the error message itself.

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -10,6 +10,43 @@ before_each(clear)
 describe('messages', function()
   local screen
 
+  -- oldtest: Test_warning_scroll()
+  it('a warning causes scrolling if and only if it has a stacktrace', function()
+    screen = Screen.new(75, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, foreground = Screen.colors.SeaGreen},  -- MoreMsg
+      [2] = {bold = true, reverse = true},  -- MsgSeparator
+      [3] = {foreground = Screen.colors.Red},  -- WarningMsg
+    })
+    screen:attach()
+
+    -- When the warning comes from a script, messages are scrolled so that the
+    -- stacktrace is visible.
+    -- It is a bit hard to assert the screen when sourcing a script, so skip this part.
+
+    -- When the warning does not come from a script, messages are not scrolled.
+    command('enew')
+    command('set readonly')
+    feed('u')
+    screen:expect({grid = [[
+                                                                                 |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {3:W10: Warning: Changing a readonly file}^                                     |
+    ]], timeout = 500})
+    screen:expect([[
+      ^                                                                           |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      Already at oldest change                                                   |
+    ]])
+  end)
+
   describe('more prompt', function()
     before_each(function()
       screen = Screen.new(75, 6)


### PR DESCRIPTION
#### vim-patch:9.0.0511: unnecessary scrolling for message of only one line

Problem:    Unnecessary scrolling for message of only one line.
Solution:   Only set msg_scroll when needed. (closes vim/vim#11178)
https://github.com/vim/vim/commit/bdedd2bcce3a59028c7504a397ff77d901b1b12a