### PR TITLE
vim-patch:9.0.{0507,0512}: cmdline cleared when using :redrawstatus

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6094,7 +6094,7 @@ static void ex_redrawstatus(exarg_T *eap)
   } else {
     status_redraw_curbuf();
   }
-  if (State & MODE_CMDLINE) {
+  if (msg_scrolled) {
     return;  // redraw later
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6089,13 +6089,17 @@ static void ex_redrawstatus(exarg_T *eap)
   int r = RedrawingDisabled;
   int p = p_lz;
 
-  RedrawingDisabled = 0;
-  p_lz = false;
   if (eap->forceit) {
     status_redraw_all();
   } else {
     status_redraw_curbuf();
   }
+  if (State & MODE_CMDLINE) {
+    return;  // redraw later
+  }
+
+  RedrawingDisabled = 0;
+  p_lz = false;
   update_screen(VIsual_active ? UPD_INVERTED : 0);
   RedrawingDisabled = r;
   p_lz = p;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -127,6 +127,46 @@ func Test_wildmenu_screendump()
   call delete('XTest_wildmenu')
 endfunc
 
+func Test_redraw_in_autocmd()
+  CheckScreendump
+
+  let lines =<< trim END
+      set cmdheight=2
+      autocmd CmdlineChanged * redraw
+  END
+  call writefile(lines, 'XTest_redraw', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_redraw', {'rows': 8})
+  call term_sendkeys(buf, ":for i in range(3)\<CR>")
+  call VerifyScreenDump(buf, 'Test_redraw_in_autocmd_1', {})
+
+  call term_sendkeys(buf, "let i =")
+  call VerifyScreenDump(buf, 'Test_redraw_in_autocmd_2', {})
+
+  " clean up
+  call term_sendkeys(buf, "\<CR>")
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_redrawstatus_in_autocmd()
+  CheckScreendump
+
+  let lines =<< trim END
+      set cmdheight=2
+      autocmd CmdlineChanged * if getcmdline() == 'foobar' | redrawstatus | endif
+  END
+  call writefile(lines, 'XTest_redrawstatus', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_redrawstatus', {'rows': 8})
+  call term_sendkeys(buf, ":echo \"one\\ntwo\\nthree\\nfour\"\<CR>")
+  call term_sendkeys(buf, ":foobar")
+  call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_1', {})
+
+  " clean up
+  call term_sendkeys(buf, "\<CR>")
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_changing_cmdheight()
   CheckScreendump
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -152,15 +152,20 @@ func Test_redrawstatus_in_autocmd()
   CheckScreendump
 
   let lines =<< trim END
-      set cmdheight=2
+      set laststatus=2
+      set statusline=%=:%{getcmdline()}
       autocmd CmdlineChanged * if getcmdline() == 'foobar' | redrawstatus | endif
   END
   call writefile(lines, 'XTest_redrawstatus', 'D')
 
   let buf = RunVimInTerminal('-S XTest_redrawstatus', {'rows': 8})
+  " :redrawstatus is postponed if messages have scrolled
   call term_sendkeys(buf, ":echo \"one\\ntwo\\nthree\\nfour\"\<CR>")
   call term_sendkeys(buf, ":foobar")
   call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_1', {})
+  " it is not postponed if messages have not scrolled
+  call term_sendkeys(buf, "\<Esc>:foobar")
+  call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_2', {})
 
   " clean up
   call term_sendkeys(buf, "\<CR>")

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -140,6 +140,62 @@ describe('cmdline', function()
       :^                             |
     ]])
   end)
+
+  -- oldtest: Test_redraw_in_autocmd()
+  it('cmdline cursor position is correct after :redraw with cmdheight=2', function()
+    local screen = Screen.new(30, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      set cmdheight=2
+      autocmd CmdlineChanged * redraw
+    ]])
+    feed(':for i in range(3)<CR>')
+    screen:expect([[
+                                    |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      :for i in range(3)            |
+      :  ^                           |
+    ]])
+    feed(':let i =')
+    -- Note: this may still be considered broken, ref #18140
+    screen:expect([[
+                                    |
+      {0:~                             }|
+      {0:~                             }|
+      {0:~                             }|
+      :  :let i =^                   |
+                                    |
+    ]])
+  end)
+
+  -- oldtest: Test_redrawstatus_in_autocmd()
+  it(':redrawstatus in cmdline mode', function()
+    local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, reverse = true},  -- MsgSeparator
+    })
+    screen:attach()
+    exec([[
+      set cmdheight=2
+      autocmd CmdlineChanged * if getcmdline() == 'foobar' | redrawstatus | endif
+    ]])
+    feed([[:echo "one\ntwo\nthree\nfour"<CR>]])
+    feed(':foobar')
+    screen:expect([[
+      {1:                                                            }|
+      one                                                         |
+      two                                                         |
+      three                                                       |
+      four                                                        |
+      :foobar^                                                     |
+    ]])
+  end)
 end)
 
 describe('cmdwin', function()

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -178,13 +178,15 @@ describe('cmdline', function()
     local screen = Screen.new(60, 6)
     screen:set_default_attr_ids({
       [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
-      [1] = {bold = true, reverse = true},  -- MsgSeparator
+      [1] = {bold = true, reverse = true},  -- MsgSeparator, StatusLine
     })
     screen:attach()
     exec([[
-      set cmdheight=2
+      set laststatus=2
+      set statusline=%=:%{getcmdline()}
       autocmd CmdlineChanged * if getcmdline() == 'foobar' | redrawstatus | endif
     ]])
+    -- :redrawstatus is postponed if messages have scrolled
     feed([[:echo "one\ntwo\nthree\nfour"<CR>]])
     feed(':foobar')
     screen:expect([[
@@ -193,6 +195,16 @@ describe('cmdline', function()
       two                                                         |
       three                                                       |
       four                                                        |
+      :foobar^                                                     |
+    ]])
+    -- it is not postponed if messages have not scrolled
+    feed('<Esc>:foobar')
+    screen:expect([[
+                                                                  |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {1:                                                     :foobar}|
       :foobar^                                                     |
     ]])
   end)


### PR DESCRIPTION
#### vim-patch:9.0.0507: cmdline cleared when using :redrawstatus in CmdlineChanged

Problem:    Command line cleared when using :redrawstatus in CmdlineChanged
            autocommand event.
Solution:   Postpone the redraw.
https://github.com/vim/vim/commit/bcd6924245c0e73d8be256282656c06aaf91f17c

Cherry-pick Test_redraw_in_autocmd() from Vim patch 8.2.4789.


#### vim-patch:9.0.0512: cannot redraw the status lines when editing a command

Problem:    Cannot redraw the status lines when editing a command.
Solution:   Only postpone the redraw when messages have scrolled.
            (closes vim/vim#11170)
https://github.com/vim/vim/commit/c14bfc31d907cbee6a3636f780561ad1787cdb9b