### PR TITLE
refactor: suppress PVS false positives

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -894,7 +894,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
       } else {
         // Long line, use only the last SPWORDLEN bytes.
         nextlinecol = (int)v - SPWORDLEN;
-        memmove(nextline, line + nextlinecol, SPWORDLEN);  // -V512
+        memmove(nextline, line + nextlinecol, SPWORDLEN);  // -V1086
         nextline_idx = SPWORDLEN + 1;
       }
     }

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -58,9 +58,9 @@ bool loop_uv_run(Loop *loop, int ms, bool once)
     mode = UV_RUN_NOWAIT;
   }
 
-  do {
+  do {  // -V1044
     uv_run(&loop->uv, mode);
-  } while (ms > 0 && !once && !*timeout_expired);
+  } while (ms > 0 && !once && !*timeout_expired);  // -V560
 
   if (ms > 0) {
     uv_timer_stop(&loop->poll_timer);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -570,7 +570,7 @@ static bool ml_check_b0_strings(ZERO_BL *b0p)
   return (memchr(b0p->b0_version, NUL, 10)
           && memchr(b0p->b0_uname, NUL, B0_UNAME_SIZE)
           && memchr(b0p->b0_hname, NUL, B0_HNAME_SIZE)
-          && memchr(b0p->b0_fname, NUL, B0_FNAME_SIZE_CRYPT));  // -V512
+          && memchr(b0p->b0_fname, NUL, B0_FNAME_SIZE_CRYPT));  // -V1086
 }
 
 /// Update the timestamp or the B0_SAME_DIR flag of the .swp file.


### PR DESCRIPTION
Some V512 warnings have changed to V1086, and PVS apparently does not
know `uv_run()` can change `*timeout_expired`.
