### PR TITLE
build: separate dev files from user files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,7 +667,7 @@ add_custom_target(formatlua
   COMMAND ${CMAKE_COMMAND}
     -D FORMAT_PRG=${STYLUA_PRG}
     -D LANG=lua
-    -P ${PROJECT_SOURCE_DIR}/cmake/Format.cmake
+    -P ${PROJECT_SOURCE_DIR}/cmake.dev/Format.cmake
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 
 add_custom_target(format)
@@ -721,7 +721,7 @@ if(BUSTED_PRG)
         -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
         -DBUILD_DIR=${CMAKE_BINARY_DIR}
         -DTEST_TYPE=unit
-        -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+        -P ${PROJECT_SOURCE_DIR}/cmake.dev/RunTests.cmake
       DEPENDS ${UNITTEST_PREREQS}
       ${TEST_TARGET_ARGS})
     set_target_properties(unittest PROPERTIES FOLDER test)
@@ -751,7 +751,7 @@ if(BUSTED_PRG)
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=functional
-      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+      -P ${PROJECT_SOURCE_DIR}/cmake.dev/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     ${TEST_TARGET_ARGS})
   set_target_properties(functionaltest PROPERTIES FOLDER test)
@@ -766,7 +766,7 @@ if(BUSTED_PRG)
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=benchmark
-      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+      -P ${PROJECT_SOURCE_DIR}/cmake.dev/RunTests.cmake
     DEPENDS ${BENCHMARK_PREREQS}
     ${TEST_TARGET_ARGS})
   set_target_properties(benchmark PROPERTIES FOLDER test)
@@ -783,7 +783,7 @@ if(BUSTED_LUA_PRG)
       -DTEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test
       -DBUILD_DIR=${CMAKE_BINARY_DIR}
       -DTEST_TYPE=functional
-      -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
+      -P ${PROJECT_SOURCE_DIR}/cmake.dev/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     ${TEST_TARGET_ARGS})
     set_target_properties(functionaltest-lua PROPERTIES FOLDER test)

--- a/cmake.dev/CheckUncrustifyVersion.cmake
+++ b/cmake.dev/CheckUncrustifyVersion.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
 if(UNCRUSTIFY_PRG)
   execute_process(COMMAND uncrustify --version
     OUTPUT_VARIABLE user_version

--- a/cmake.dev/Format.cmake
+++ b/cmake.dev/Format.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
 # Returns a list of all files that has been changed in current branch compared
 # to master branch. This includes unstaged, staged and committed files.
 function(get_changed_files outvar)

--- a/cmake.dev/RunTests.cmake
+++ b/cmake.dev/RunTests.cmake
@@ -1,3 +1,9 @@
+# This is technically a dev dependency. However, since we run some tests with
+# the minimum cmake version in our CI, then the required minimum version has to
+# be the same as the actual neovim's minimum version defined in the top
+# CMakeLists.txt.
+cmake_minimum_required(VERSION 3.10)
+
 # Set LC_ALL to meet expectations of some locale-sensitive tests.
 set(ENV{LC_ALL} "en_US.UTF-8")
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -760,7 +760,7 @@ add_custom_target(uncrustify-version
   COMMAND ${CMAKE_COMMAND}
     -D UNCRUSTIFY_PRG=${UNCRUSTIFY_PRG}
     -D CONFIG_FILE=${PROJECT_SOURCE_DIR}/src/uncrustify.cfg
-    -P ${PROJECT_SOURCE_DIR}/cmake/CheckUncrustifyVersion.cmake)
+    -P ${PROJECT_SOURCE_DIR}/cmake.dev/CheckUncrustifyVersion.cmake)
 
 add_glob_targets(
   TARGET lintuncrustify
@@ -774,7 +774,7 @@ add_custom_target(formatc
   COMMAND ${CMAKE_COMMAND}
     -D FORMAT_PRG=${UNCRUSTIFY_PRG}
     -D LANG=c
-    -P ${PROJECT_SOURCE_DIR}/cmake/Format.cmake
+    -P ${PROJECT_SOURCE_DIR}/cmake.dev/Format.cmake
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 add_dependencies(formatc uncrustify-version)
 

--- a/test/README.md
+++ b/test/README.md
@@ -13,7 +13,7 @@ and *old tests* ([src/nvim/testdir/](https://github.com/neovim/neovim/tree/maste
 You can learn the [key concepts of Lua in 15 minutes](http://learnxinyminutes.com/docs/lua/).
 Use any existing test as a template to start writing new tests.
 
-Tests are run by `/cmake/RunTests.cmake` file, using `busted` (a Lua test-runner).
+Tests are run by `/cmake.dev/RunTests.cmake` file, using `busted` (a Lua test-runner).
 For some failures, `.nvimlog` (or `$NVIM_LOG_FILE`) may provide insight.
 
 Depending on the presence of binaries (e.g., `xclip`) some tests will be


### PR DESCRIPTION
The benefit of a clean separation is that it allows us to get the most
out of cmake: we get compatibility when building neovim, but also allow
newer features for the developer-only parts of the cmake scripts.
