### PR TITLE
vim-patch:9.0.0517: when at the command line :redrawstatus does not work well

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6094,13 +6094,17 @@ static void ex_redrawstatus(exarg_T *eap)
   } else {
     status_redraw_curbuf();
   }
-  if (msg_scrolled) {
+  if (msg_scrolled && (State & MODE_CMDLINE)) {
     return;  // redraw later
   }
 
   RedrawingDisabled = 0;
   p_lz = false;
-  update_screen(VIsual_active ? UPD_INVERTED : 0);
+  if (State & MODE_CMDLINE) {
+    redraw_statuslines();
+  } else {
+    update_screen(VIsual_active ? UPD_INVERTED : 0);
+  }
   RedrawingDisabled = r;
   p_lz = p;
   ui_flush();

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -154,7 +154,7 @@ func Test_redrawstatus_in_autocmd()
   let lines =<< trim END
       set laststatus=2
       set statusline=%=:%{getcmdline()}
-      autocmd CmdlineChanged * if getcmdline() == 'foobar' | redrawstatus | endif
+      autocmd CmdlineChanged * redrawstatus
   END
   call writefile(lines, 'XTest_redrawstatus', 'D')
 
@@ -164,8 +164,17 @@ func Test_redrawstatus_in_autocmd()
   call term_sendkeys(buf, ":foobar")
   call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_1', {})
   " it is not postponed if messages have not scrolled
-  call term_sendkeys(buf, "\<Esc>:foobar")
+  call term_sendkeys(buf, "\<Esc>:for in in range(3)")
   call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_2', {})
+  " with cmdheight=1 messages have scrolled when typing :endfor
+  call term_sendkeys(buf, "\<CR>:endfor")
+  call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_3', {})
+  call term_sendkeys(buf, "\<CR>:set cmdheight=2\<CR>")
+  " with cmdheight=2 messages haven't scrolled when typing :for or :endfor
+  call term_sendkeys(buf, ":for in in range(3)")
+  call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_4', {})
+  call term_sendkeys(buf, "\<CR>:endfor")
+  call VerifyScreenDump(buf, 'Test_redrawstatus_in_autocmd_5', {})
 
   " clean up
   call term_sendkeys(buf, "\<CR>")


### PR DESCRIPTION
#### vim-patch:9.0.0517: when at the command line :redrawstatus does not work well

Problem:    When at the command line :redrawstatus does not work well.
Solution:   Only update the statuslines instead of the screen. (closes vim/vim#11180)
https://github.com/vim/vim/commit/320d910064320f894a09ffdd1cd800ff5371e97f