### PR TITLE
vim-patch:9.0.0018: going over the end of the typahead

### DIFF
--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1127,4 +1127,14 @@ func Test_map_after_timed_out_nop()
   call delete('Xtest_map_after_timed_out_nop')
 endfunc
 
+func Test_using_past_typeahead()
+  nnoremap :00 0
+  exe "norm :set \x80\xfb0=0\<CR>"
+  exe "sil norm :0\x0f\<C-U>\<CR>"
+
+  exe "norm :set \x80\xfb0=\<CR>"
+  nunmap :00
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0018: going over the end of the typahead

Problem:    Going over the end of the typahead.
Solution:   Put a NUL after the typeahead.
https://github.com/vim/vim/commit/27efc62f5d86afcb2ecb7565587fe8dea4b036fe

check_termcode() is N/A.