### PR TITLE
ci(stylua): change action version to v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
       - if: "!cancelled()"
         name: lintstylua
-        uses: JohnnyMorganz/stylua-action@1.0.0
+        uses: JohnnyMorganz/stylua-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check runtime/


### PR DESCRIPTION
Changing the action version to v1 allows us to automatically get patch
updates as it points to the latest stable version.