### PR TITLE
vim-patch:9.0.0537: the do_set() function is much too long

### DIFF
--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -238,6 +238,15 @@ describe('ShaDa support code', function()
     eq('', meths.get_option('shada'))
   end)
 
+  it('setting &shada gives proper error message on missing number', function()
+    eq([[Vim(set):E526: Missing number after <">: shada="]],
+       exc_exec([[set shada=\"]]))
+    for _, c in ipairs({"'", "/", ":", "<", "@", "s"}) do
+      eq(([[Vim(set):E526: Missing number after <%s>: shada=%s]]):format(c, c),
+         exc_exec(([[set shada=%s]]):format(c)))
+    end
+  end)
+
   it('does not crash when ShaDa file directory is not writable', function()
     if helpers.pending_win32(pending) then return end
 


### PR DESCRIPTION
#### vim-patch:9.0.0537: the do_set() function is much too long

Problem:    The do_set() function is much too long.
Solution:   Move setting of a string option to a separate function.
https://github.com/vim/vim/commit/4740394f230dda09d6e9337465305741d8ee4fa3

Cherry-pick some tests from Vim patch 8.2.0540.