### PR TITLE
vim-patch:8.2.{0712,2979,2994,3155}: options tests

### DIFF
--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1927,4 +1927,28 @@ func Test_read_invalid()
   set encoding=utf-8
 endfunc
 
+" Test for the 'revins' option
+func Test_edit_revins()
+  CheckFeature rightleft
+  new
+  set revins
+  exe "normal! ione\ttwo three"
+  call assert_equal("eerht owt\teno", getline(1))
+  call setline(1, "one\ttwo three")
+  normal! gg$bi a
+  call assert_equal("one\ttwo a three", getline(1))
+  exe "normal! $bi\<BS>\<BS>"
+  call assert_equal("one\ttwo a ree", getline(1))
+  exe "normal! 0wi\<C-W>"
+  call assert_equal("one\t a ree", getline(1))
+  exe "normal! 0wi\<C-U>"
+  call assert_equal("one\t ", getline(1))
+  " newline in insert mode starts at the end of the line
+  call setline(1, 'one two three')
+  exe "normal! wi\nfour"
+  call assert_equal(['one two three', 'ruof'], getline(1, '$'))
+  set revins&
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -662,6 +662,12 @@ func Sandbox_tests()
   if has('unix')
     call assert_fails('cd `pwd`', 'E48:')
   endif
+  " some options cannot be changed in a sandbox
+  call assert_fails('set exrc', 'E48:')
+  call assert_fails('set cdpath', 'E48:')
+  if has('xim')
+    call assert_fails('set imstyle', 'E48:')
+  endif
 endfunc
 
 func Test_sandbox()

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -665,7 +665,7 @@ func Sandbox_tests()
   " some options cannot be changed in a sandbox
   call assert_fails('set exrc', 'E48:')
   call assert_fails('set cdpath', 'E48:')
-  if has('xim')
+  if has('xim') && has('gui_gtk')
     call assert_fails('set imstyle', 'E48:')
   endif
 endfunc

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -462,6 +462,12 @@ func Test_tolower()
   " invalid memory.
   call tolower("\xC0\x80\xC0")
   call tolower("123\xC0\x80\xC0")
+
+  " Test in latin1 encoding
+  let save_enc = &encoding
+  " set encoding=latin1
+  call assert_equal("abc", tolower("ABC"))
+  let &encoding = save_enc
 endfunc
 
 func Test_toupper()
@@ -533,6 +539,12 @@ func Test_toupper()
   " invalid memory.
   call toupper("\xC0\x80\xC0")
   call toupper("123\xC0\x80\xC0")
+
+  " Test in latin1 encoding
+  let save_enc = &encoding
+  " set encoding=latin1
+  call assert_equal("ABC", toupper("abc"))
+  let &encoding = save_enc
 endfunc
 
 func Test_tr()
@@ -1095,6 +1107,10 @@ func Test_filewritable()
   call assert_equal(1, 'Xfilewritable'->filewritable())
 
   call assert_equal(0, filewritable('doesnotexist'))
+
+  call mkdir('Xdir')
+  call assert_equal(2, filewritable('Xdir'))
+  call delete('Xdir', 'd')
 
   call delete('Xfilewritable')
   bw!

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -141,6 +141,17 @@ func Test_helptag_cmd()
   call delete('Xdir', 'rf')
 endfunc
 
+" Test for setting the 'helpheight' option in the help window
+func Test_help_window_height()
+  let &cmdheight = &lines - 24
+  set helpheight=10
+  help
+  set helpheight=14
+  call assert_equal(14, winheight(0))
+  set helpheight& cmdheight=1
+  close
+endfunc
+
 func Test_help_long_argument()
   try
     exe 'help \%' .. repeat('0', 1021)

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -975,6 +975,21 @@ func Test_abbreviate_multi_byte()
   bwipe!
 endfunc
 
+" Test for abbreviations with 'latin1' encoding
+func Test_abbreviate_latin1_encoding()
+  " set encoding=latin1
+  call assert_fails('abbr ab#$c ABC', 'E474:')
+  new
+  iabbr <buffer> #i #include
+  iabbr <buffer> ## #enddef
+  exe "normal i#i\<C-]>"
+  call assert_equal('#include', getline(1))
+  exe "normal 0Di##\<C-]>"
+  call assert_equal('#enddef', getline(1))
+  %bw!
+  set encoding=utf-8
+endfunc
++
 " Test for <Plug> always being mapped, even when used with "noremap".
 func Test_plug_remap()
   let g:foo = 0

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -942,6 +942,19 @@ func Test_mkvimrc()
   endfor
 
   call s:ClearMappings()
+
+  " the 'pastetoggle', 'wildchar' and 'wildcharm' option values should be
+  " stored as key names in the vimrc file
+  set pastetoggle=<F5>
+  set wildchar=<F6>
+  set wildcharm=<F7>
+  call assert_fails('mkvimrc Xtestvimrc')
+  mkvimrc! Xtestvimrc
+  call assert_notequal(-1, index(readfile('Xtestvimrc'), 'set pastetoggle=<F5>'))
+  call assert_notequal(-1, index(readfile('Xtestvimrc'), 'set wildchar=<F6>'))
+  call assert_notequal(-1, index(readfile('Xtestvimrc'), 'set wildcharm=<F7>'))
+  set pastetoggle& wildchar& wildcharm&
+
   call delete('Xtestvimrc')
 endfunc
 

--- a/src/nvim/testdir/test_modeline.vim
+++ b/src/nvim/testdir/test_modeline.vim
@@ -1,5 +1,7 @@
 " Tests for parsing the modeline.
 
+source check.vim
+
 func Test_modeline_invalid()
   " This was reading allocated memory in the past.
   call writefile(['vi:0', 'nothing'], 'Xmodeline')
@@ -335,6 +337,32 @@ func Test_modeline_setoption_verbose()
 
   let &modeline = modeline
   call delete('Xmodeline')
+endfunc
+
+" Test for the 'modeline' default value in compatible and non-compatible modes
+" for root and non-root accounts
+func Test_modeline_default()
+  " set compatible
+  " call assert_false(&modeline)
+  set nocompatible
+  call assert_equal(IsRoot() ? 0 : 1, &modeline)
+  " set compatible&vi
+  " call assert_false(&modeline)
+  set compatible&vim
+  call assert_equal(IsRoot() ? 0 : 1, &modeline)
+  set compatible& modeline&
+endfunc
+
+" Some options cannot be set from the modeline when 'diff' option is set
+func Test_modeline_diff_buffer()
+  call writefile(['vim: diff foldmethod=marker wrap'], 'Xfile')
+  set foldmethod& nowrap
+  new Xfile
+  call assert_equal('manual', &foldmethod)
+  call assert_false(&wrap)
+  set wrap&
+  call delete('Xfile')
+  bw
 endfunc
 
 func Test_modeline_disable()

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -418,6 +418,7 @@ func Test_set_errors()
   set nomodifiable
   call assert_fails('set fileencoding=latin1', 'E21:')
   set modifiable&
+  " call assert_fails('set t_#-&', 'E522:')
 endfunc
 
 func CheckWasSet(name)
@@ -932,6 +933,18 @@ func Test_opt_local_to_global()
   call assert_equal('gnewprg', &l:equalprg)
   call assert_equal('gnewprg', &equalprg)
   set equalprg&
+
+  " Test for setting the global/local value of a boolean option
+  setglobal autoread
+  setlocal noautoread
+  call assert_false(&autoread)
+  set autoread<
+  call assert_true(&autoread)
+  setglobal noautoread
+  setlocal autoread
+  setlocal autoread<
+  call assert_false(&autoread)
+  set autoread&
 endfunc
 
 " Test for incrementing, decrementing and multiplying a number option value
@@ -1080,6 +1093,25 @@ func Test_opt_reset_scroll()
 
   " clean up
   call delete('Xscroll')
+endfunc
+
+" Test for setting an option to a Vi or Vim default
+func Test_opt_default()
+  throw 'Skipped: Nvim has different defaults'
+  set formatoptions&vi
+  call assert_equal('vt', &formatoptions)
+  set formatoptions&vim
+  call assert_equal('tcq', &formatoptions)
+endfunc
+
+" Test for the 'cmdheight' option
+func Test_cmdheight()
+  %bw!
+  let ht = &lines
+  set cmdheight=9999
+  call assert_equal(1, winheight(0))
+  call assert_equal(ht - 1, &cmdheight)
+  set cmdheight&
 endfunc
 
 " Test for the 'cdhome' option

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1114,6 +1114,23 @@ func Test_cmdheight()
   set cmdheight&
 endfunc
 
+" To specify a control character as a option value, '^' can be used
+func Test_opt_control_char()
+  set wildchar=^v
+  call assert_equal("\<C-V>", nr2char(&wildchar))
+  set wildcharm=^r
+  call assert_equal("\<C-R>", nr2char(&wildcharm))
+  " Bug: This doesn't work for the 'cedit' and 'termwinkey' options
+  set wildchar& wildcharm&
+endfunc
+
+" Test for the 'errorbells' option
+func Test_opt_errorbells()
+  set errorbells
+  call assert_beeps('s/a1b2/x1y2/')
+  set noerrorbells
+endfunc
+
 " Test for the 'cdhome' option
 func Test_opt_cdhome()
   if has('unix') || has('vms')

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -947,6 +947,28 @@ func Test_opt_local_to_global()
   set autoread&
 endfunc
 
+func Test_set_in_sandbox()
+  " Some boolean options cannot be set in sandbox, some can.
+  call assert_fails('sandbox set modelineexpr', 'E48:')
+  sandbox set number
+  call assert_true(&number)
+  set number&
+
+  " Some boolean options cannot be set in sandbox, some can.
+  if has('python') || has('python3')
+    call assert_fails('sandbox set pyxversion=3', 'E48:')
+  endif
+  sandbox set tabstop=4
+  call assert_equal(4, &tabstop)
+  set tabstop&
+
+  " Some string options cannot be set in sandbox, some can.
+  call assert_fails('sandbox set backupdir=/tmp', 'E48:')
+  sandbox set filetype=perl
+  call assert_equal('perl', &filetype)
+  set filetype&
+endfunc
+
 " Test for incrementing, decrementing and multiplying a number option value
 func Test_opt_num_op()
   set shiftwidth=4
@@ -1129,6 +1151,28 @@ func Test_opt_errorbells()
   set errorbells
   call assert_beeps('s/a1b2/x1y2/')
   set noerrorbells
+endfunc
+
+func Test_opt_scrolljump()
+  help
+  resize 10
+
+  " Test with positive 'scrolljump'.
+  set scrolljump=2
+  norm! Lj
+  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
+        \            'topline':3, 'coladd':0, 'skipcol':0, 'curswant':0},
+        \           winsaveview())
+
+  " Test with negative 'scrolljump' (percentage of window height).
+  set scrolljump=-40
+  norm! ggLj
+  call assert_equal({'lnum':11, 'leftcol':0, 'col':0, 'topfill':0,
+         \            'topline':5, 'coladd':0, 'skipcol':0, 'curswant':0},
+         \           winsaveview())
+
+  set scrolljump&
+  bw
 endfunc
 
 " Test for the 'cdhome' option

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -282,6 +282,15 @@ func Test_set_completion()
   call feedkeys(":set fileencodings:\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set fileencodings:ucs-bom,utf-8,default,latin1', @:)
 
+  " Expand key codes.
+  " call feedkeys(":set <H\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"set <Help> <Home>', @:)
+
+  " Expand terminal options.
+  " call feedkeys(":set t_A\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"set t_AB t_AF t_AU t_AL', @:)
+  " call assert_fails('call feedkeys(":set <t_afoo>=\<C-A>\<CR>", "xt")', 'E474:')
+
   " Expand directories.
   call feedkeys(":set cdpath=./\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('./samples/ ', @:)

--- a/src/nvim/testdir/test_paste.vim
+++ b/src/nvim/testdir/test_paste.vim
@@ -1,0 +1,76 @@
+
+" Test for 'pastetoggle'
+func Test_pastetoggle()
+  new
+  set pastetoggle=<F4>
+  set nopaste
+  call feedkeys("iHello\<F4>", 'xt')
+  call assert_true(&paste)
+  call feedkeys("i\<F4>", 'xt')
+  call assert_false(&paste)
+  call assert_equal('Hello', getline(1))
+  " command-line completion for 'pastetoggle' value
+  call feedkeys(":set pastetoggle=\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set pastetoggle=<F4>', @:)
+  set pastetoggle&
+  bwipe!
+endfunc
+
+" Test for restoring option values when 'paste' is disabled
+func Test_paste_opt_restore()
+  set autoindent expandtab ruler showmatch
+  if has('rightleft')
+    set revins hkmap
+  endif
+  set smarttab softtabstop=3 textwidth=27 wrapmargin=12
+  if has('vartabs')
+    set varsofttabstop=10,20
+  endif
+
+  " enabling 'paste' should reset the above options
+  set paste
+  call assert_false(&autoindent)
+  call assert_false(&expandtab)
+  if has('rightleft')
+    call assert_false(&revins)
+    call assert_false(&hkmap)
+  endif
+  call assert_false(&ruler)
+  call assert_false(&showmatch)
+  call assert_false(&smarttab)
+  call assert_equal(0, &softtabstop)
+  call assert_equal(0, &textwidth)
+  call assert_equal(0, &wrapmargin)
+  if has('vartabs')
+    call assert_equal('', &varsofttabstop)
+  endif
+
+  " disabling 'paste' should restore the option values
+  set nopaste
+  call assert_true(&autoindent)
+  call assert_true(&expandtab)
+  if has('rightleft')
+    call assert_true(&revins)
+    call assert_true(&hkmap)
+  endif
+  call assert_true(&ruler)
+  call assert_true(&showmatch)
+  call assert_true(&smarttab)
+  call assert_equal(3, &softtabstop)
+  call assert_equal(27, &textwidth)
+  call assert_equal(12, &wrapmargin)
+  if has('vartabs')
+    call assert_equal('10,20', &varsofttabstop)
+  endif
+
+  set autoindent& expandtab& ruler& showmatch&
+  if has('rightleft')
+    set revins& hkmap&
+  endif
+  set smarttab& softtabstop& textwidth& wrapmargin&
+  if has('vartabs')
+    set varsofttabstop&
+  endif
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_set.vim
+++ b/src/nvim/testdir/test_set.vim
@@ -26,4 +26,23 @@ function Test_set_add()
   let &wig = wig_save
 endfunction
 
+
+" :set, :setlocal, :setglobal without arguments show values of options.
+func Test_set_no_arg()
+  set textwidth=79
+  let a = execute('set')
+  call assert_match("^\n--- Options ---\n.*textwidth=79\\>", a)
+  set textwidth&
+
+  setlocal textwidth=78
+  let a = execute('setlocal')
+  call assert_match("^\n--- Local option values ---\n.*textwidth=78\\>", a)
+  setlocal textwidth&
+
+  setglobal textwidth=77
+  let a = execute('setglobal')
+  call assert_match("^\n--- Global option values ---\n.*textwidth=77\\>", a)
+  setglobal textwidth&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -141,3 +141,41 @@ func Test_system_with_shell_quote()
     call delete('Xdir with spaces', 'rf')
   endtry
 endfunc
+
+" Test for 'shellxquote'
+func Test_Shellxquote()
+  CheckUnix
+
+  let save_shell = &shell
+  let save_sxq = &shellxquote
+  let save_sxe = &shellxescape
+
+  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell')
+  call setfperm('Xtestshell', "r-x------")
+  set shell=./Xtestshell
+
+  set shellxquote=\\"
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c "pwd"]'], readfile('Xlog'))
+
+  set shellxquote=(
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c (pwd)]'], readfile('Xlog'))
+
+  set shellxquote=\\"(
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c "(pwd)"]'], readfile('Xlog'))
+
+  set shellxescape=\"&<<()@^
+  set shellxquote=(
+  call feedkeys(":!pwd\"&<<{}@^\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c (pwd^"^&^<^<{}^@^^)]'], readfile('Xlog'))
+
+  let &shell = save_shell
+  let &shellxquote = save_sxq
+  let &shellxescape = save_sxe
+  call delete('Xtestshell')
+  call delete('Xlog')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_termcodes.vim
+++ b/src/nvim/testdir/test_termcodes.vim
@@ -1,4 +1,30 @@
 
+" Test for translation of special key codes (<xF1>, <xF2>, etc.)
+func Test_Keycode_Translation()
+  let keycodes = [
+        \ ["<xUp>", "<Up>"],
+        \ ["<xDown>", "<Down>"],
+        \ ["<xLeft>", "<Left>"],
+        \ ["<xRight>", "<Right>"],
+        \ ["<xHome>", "<Home>"],
+        \ ["<xEnd>", "<End>"],
+        \ ["<zHome>", "<Home>"],
+        \ ["<zEnd>", "<End>"],
+        \ ["<xF1>", "<F1>"],
+        \ ["<xF2>", "<F2>"],
+        \ ["<xF3>", "<F3>"],
+        \ ["<xF4>", "<F4>"],
+        \ ["<S-xF1>", "<S-F1>"],
+        \ ["<S-xF2>", "<S-F2>"],
+        \ ["<S-xF3>", "<S-F3>"],
+        \ ["<S-xF4>", "<S-F4>"]]
+  for [k1, k2] in keycodes
+    exe "nnoremap " .. k1 .. " 2wx"
+    call assert_true(maparg(k1, 'n', 0, 1).lhs == k2)
+    exe "nunmap " .. k1
+  endfor
+endfunc
+
 " Test for terminal keycodes that doesn't have termcap entries
 func Test_special_term_keycodes()
   new

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -429,4 +429,18 @@ func Test_varsofttabstop()
   close!
 endfunc
 
+" Setting 'shiftwidth' to a negative value, should set it to either the value
+" of 'tabstop' (if 'vartabstop' is not set) or to the first value in
+" 'vartabstop'
+func Test_shiftwidth_vartabstop()
+  throw 'Skipped: Nvim removed this behavior in #6377'
+  setlocal tabstop=7 vartabstop=
+  call assert_fails('set shiftwidth=-1', 'E487:')
+  call assert_equal(7, &shiftwidth)
+  setlocal tabstop=7 vartabstop=5,7,10
+  call assert_fails('set shiftwidth=-1', 'E487:')
+  call assert_equal(5, &shiftwidth)
+  setlocal shiftwidth& vartabstop& tabstop&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -433,7 +433,15 @@ func Test_window_width()
   call assert_inrange(ww1, ww1 + 1, ww2)
   call assert_inrange(ww3, ww3 + 1, ww2)
 
-  bw Xa Xb Xc
+  " when the current window width is less than the new 'winwidth', the current
+  " window width should be increased.
+  enew | only
+  split
+  10vnew
+  set winwidth=15
+  call assert_equal(15, winwidth(0))
+
+  %bw!
 endfunc
 
 func Test_equalalways_on_close()


### PR DESCRIPTION
#### vim-patch:8.2.0712: various code not fully tested

Problem:    Various code not fully tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#6049)
https://github.com/vim/vim/commit/0ff5dedf0f69e56320199db7a2aad46be2a1f9b7


#### vim-patch:8.2.2979: not all options code is covered by tests

Problem:    Not all options code is covered by tests.
Solution:   Add more tests for options. (Yegappan Lakshmanan, closes vim/vim#8369)
https://github.com/vim/vim/commit/5958549760652c173b703613b9cbf09b25a4eddb


#### vim-patch:8.2.2994: various code is not fully tested

Problem:    Various code is not fully tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8378)
https://github.com/vim/vim/commit/2d6d718dde7163c971d37b8f4f1ed8f2d25de130


#### vim-patch:8.2.3155: some option related code not covered by tests

Problem:    Some option related code not covered by tests.
Solution:   Add a few test cases. (Dominique Pellé, closes vim/vim#8552)
https://github.com/vim/vim/commit/042414fa0053388f9a35cad61886405507554068