### PR TITLE
feat(terminal): recognize underdouble and undercurl

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -759,6 +759,22 @@ static int get_rgb(VTermState *state, VTermColor color)
   return RGB_(color.rgb.red, color.rgb.green, color.rgb.blue);
 }
 
+static int get_underline_hl_flag(VTermScreenCellAttrs attrs)
+{
+  switch (attrs.underline) {
+  case VTERM_UNDERLINE_OFF:
+    return 0;
+  case VTERM_UNDERLINE_SINGLE:
+    return HL_UNDERLINE;
+  case VTERM_UNDERLINE_DOUBLE:
+    return HL_UNDERDOUBLE;
+  case VTERM_UNDERLINE_CURLY:
+    return HL_UNDERCURL;
+  default:
+    return HL_UNDERLINE;
+  }
+}
+
 void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *term_attrs)
 {
   int height, width;
@@ -795,7 +811,7 @@ void terminal_get_line_attributes(Terminal *term, win_T *wp, int linenr, int *te
     int hl_attrs = (cell.attrs.bold ? HL_BOLD : 0)
                    | (cell.attrs.italic ? HL_ITALIC : 0)
                    | (cell.attrs.reverse ? HL_INVERSE : 0)
-                   | (cell.attrs.underline ? HL_UNDERLINE : 0)
+                   | get_underline_hl_flag(cell.attrs)
                    | (cell.attrs.strike ? HL_STRIKETHROUGH: 0)
                    | ((fg_indexed && !fg_set) ? HL_FG_INDEXED : 0)
                    | ((bg_indexed && !bg_set) ? HL_BG_INDEXED : 0);

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -31,6 +31,8 @@ local function set_bg(num) feed_termcode('[48;5;'..num..'m') end
 local function set_bold() feed_termcode('[1m') end
 local function set_italic() feed_termcode('[3m') end
 local function set_underline() feed_termcode('[4m') end
+local function set_underdouble() feed_termcode('[4:2m') end
+local function set_undercurl() feed_termcode('[4:3m') end
 local function set_strikethrough() feed_termcode('[9m') end
 local function clear_attrs() feed_termcode('[0;10m') end
 -- mouse
@@ -116,6 +118,8 @@ return {
   set_bold = set_bold,
   set_italic = set_italic,
   set_underline = set_underline,
+  set_underdouble = set_underdouble,
+  set_undercurl = set_undercurl,
   set_strikethrough = set_strikethrough,
   clear_attrs = clear_attrs,
   enable_mouse = enable_mouse,

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -26,6 +26,8 @@ describe(':terminal highlight', function()
       [9] = {foreground = 130},
       [10] = {reverse = true},
       [11] = {background = 11},
+      [12] = {bold = true, underdouble = true},
+      [13] = {italic = true, undercurl = true},
     })
     screen:attach({rgb=false})
     command(("enew | call termopen(['%s'])"):format(testprg('tty-test')))
@@ -113,6 +115,14 @@ describe(':terminal highlight', function()
     thelpers.set_italic()
     thelpers.set_underline()
     thelpers.set_strikethrough()
+  end)
+  descr('bold and underdouble', 12, function()
+    thelpers.set_bold()
+    thelpers.set_underdouble()
+  end)
+  descr('italics and undercurl', 13, function()
+    thelpers.set_italic()
+    thelpers.set_undercurl()
   end)
 end)
 


### PR DESCRIPTION
libvterm provides more underline types. It seems there is no obstacle in passing them.