### PR TITLE
vim-patch:8.2.{3428,3567,3568,4074,4677}

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -80,10 +80,11 @@ void win_redr_status(win_T *wp)
     p = (char_u *)NameBuff;
     len = (int)STRLEN(p);
 
-    if (bt_help(wp->w_buffer)
-        || wp->w_p_pvw
-        || bufIsChanged(wp->w_buffer)
-        || wp->w_buffer->b_p_ro) {
+    if ((bt_help(wp->w_buffer)
+         || wp->w_p_pvw
+         || bufIsChanged(wp->w_buffer)
+         || wp->w_buffer->b_p_ro)
+        && len < MAXPATHL - 1) {
       *(p + len++) = ' ';
     }
     if (bt_help(wp->w_buffer)) {

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -64,8 +64,8 @@ func Test_client_server()
     " the GUI and check that the remote command still works.
     " Need to wait for the GUI to start up, otherwise the send hangs in trying
     " to send to the terminal window.
-    if has('gui_athena') || has('gui_motif')
-      " For those GUIs, ignore the 'failed to create input context' error.
+    if has('gui_motif')
+      " For this GUI ignore the 'failed to create input context' error.
       call remote_send(name, ":call test_ignore_error('E285') | gui -f\<CR>")
     else
       call remote_send(name, ":gui -f\<CR>")

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1966,7 +1966,11 @@ endfunc
 " Test toggling of input method. See :help i_CTRL-^
 func Test_edit_CTRL_hat()
   CheckFeature xim
-  CheckNotGui " FIXME: why does this test fail when running in the GUI?
+
+  " FIXME: test fails with Athena and Motif GUI.
+  "        test also fails when running in the GUI.
+  CheckFeature gui_gtk
+  CheckNotGui
 
   new
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1951,4 +1951,16 @@ func Test_edit_revins()
   bw!
 endfunc
 
+" Test for getting the character of the line below after "p"
+func Test_edit_put_CTRL_E()
+  " set encoding=latin1
+  new
+  let @" = ''
+  sil! norm orggRx
+  sil! norm pr
+  call assert_equal(['r', 'r'], getline(1, 2))
+  bwipe!
+  set encoding=utf-8
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1983,5 +1983,20 @@ func Test_edit_CTRL_hat()
   bwipe!
 endfunc
 
+" Weird long file name was going over the end of NameBuff
+func Test_edit_overlong_file_name()
+  CheckUnix
+
+  file 0000000000000000000000000000
+  file %%%%%%%%%%%%%%%%%%%%%%%%%%
+  file %%%%%%
+  set readonly
+  set ls=2 
+
+  redraw!
+  set noreadonly ls&
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1963,4 +1963,21 @@ func Test_edit_put_CTRL_E()
   set encoding=utf-8
 endfunc
 
+" Test toggling of input method. See :help i_CTRL-^
+func Test_edit_CTRL_hat()
+  CheckFeature xim
+  CheckNotGui " FIXME: why does this test fail when running in the GUI?
+
+  new
+
+  call assert_equal(0, &iminsert)
+  call feedkeys("i\<C-^>", 'xt')
+  call assert_equal(2, &iminsert)
+  call feedkeys("i\<C-^>", 'xt')
+  call assert_equal(0, &iminsert)
+
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1967,7 +1967,7 @@ endfunc
 func Test_edit_CTRL_hat()
   CheckFeature xim
 
-  " FIXME: test fails with Athena and Motif GUI.
+  " FIXME: test fails with Motif GUI.
   "        test also fails when running in the GUI.
   CheckFeature gui_gtk
   CheckNotGui

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -722,7 +722,7 @@ func Test_1_highlight_Normalgroup_exists()
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
     " expect is DEFAULT_FONT of gui_gtk_x11.c
     call assert_match('hi Normal\s*font=Monospace 10', hlNormal)
-  elseif has('gui_motif') || has('gui_athena')
+  elseif has('gui_motif')
     " expect is DEFAULT_FONT of gui_x11.c
     call assert_match('hi Normal\s*font=7x13', hlNormal)
   elseif has('win32')

--- a/src/nvim/testdir/test_quotestar.vim
+++ b/src/nvim/testdir/test_quotestar.vim
@@ -98,7 +98,7 @@ func Do_test_quotestar_for_x11()
 
     " Running in a terminal and the GUI is available: Tell the server to open
     " the GUI and check that the remote command still works.
-    if has('gui_athena') || has('gui_motif')
+    if has('gui_motif')
       " For those GUIs, ignore the 'failed to create input context' error.
       call remote_send(name, ":call test_ignore_error('E285') | gui -f\<CR>")
     else

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -431,7 +431,7 @@ endfunction
 " Test the -reverse and +reverse arguments (for GUI only).
 func Test_reverse()
   CheckCanRunGui
-  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
+  CheckAnyOf Feature:gui_gtk Feature:gui_motif
 
   let after =<< trim [CODE]
     call writefile([&background], "Xtest_reverse")
@@ -452,7 +452,7 @@ endfunc
 " Test the -background and -foreground arguments (for GUI only).
 func Test_background_foreground()
   CheckCanRunGui
-  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
+  CheckAnyOf Feature:gui_gtk Feature:gui_motif
 
   " Is there a better way to check the effect of -background & -foreground
   " other than merely looking at &background (dark or light)?
@@ -479,7 +479,7 @@ func Test_font()
 
   if has('gui_gtk')
     let font = 'Courier 14'
-  elseif has('gui_motif') || has('gui_athena')
+  elseif has('gui_motif')
     let font = '-misc-fixed-bold-*'
   else
     throw 'Skipped: test does not set a valid font for this GUI'
@@ -501,10 +501,10 @@ endfunc
 " Test the -geometry argument (for GUI only).
 func Test_geometry()
   CheckCanRunGui
-  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
+  CheckAnyOf Feature:gui_gtk Feature:gui_motif
 
-  if has('gui_motif') || has('gui_athena')
-    " FIXME: With GUI Athena or Motif, the value of getwinposx(),
+  if has('gui_motif')
+    " FIXME: With GUI Motif the value of getwinposx(),
     "        getwinposy() and getwinpos() do not match exactly the
     "        value given in -geometry. Why?
     "        So only check &columns and &lines for those GUIs.
@@ -533,7 +533,7 @@ endfunc
 " Test the -iconic argument (for GUI only).
 func Test_iconic()
   CheckCanRunGui
-  CheckAnyOf Feature:gui_gtk Feature:gui_motif Feature:gui_athena
+  CheckAnyOf Feature:gui_gtk Feature:gui_motif
 
   call RunVim([], [], '-f -g -iconic -cq')
 


### PR DESCRIPTION
#### vim-patch:8.2.3428: using freed memory when replacing

Problem:    Using freed memory when replacing. (Dhiraj Mishra)
Solution:   Get the line pointer after calling ins_copychar().
https://github.com/vim/vim/commit/35a9a00afcb20897d462a766793ff45534810dc3

This patch is N/A as it only applies to non-UTF-8 encoding.


#### vim-patch:8.2.3567: CTRL-I in Insert mode is not tested

Problem:    CTRL-I in Insert mode is not tested
Solution:   Add a test case. (Dominique Pellé, closes vim/vim#8866)
https://github.com/vim/vim/commit/9cd063e3195a4c250c8016fa340922ab21fda252


#### vim-patch:8.2.3568: ctrl-hat test fails with Athena and Motif

Problem:    Ctrl-hat test fails with Athena and Motif. (Elimar Riesebieter)
Solution:   Run the test only with GTK. (Dominique Pellé, closes vim/vim#9069)
https://github.com/vim/vim/commit/8753c1dd2c2a5c2c7ff63a9bfb14cd4b9bb9c87f


#### vim-patch:8.2.4074: going over the end of NameBuff

Problem:    Going over the end of NameBuff.
Solution:   Check length when appending a space.
https://github.com/vim/vim/commit/de05bb25733c3319e18dca44e9b59c6ee389eb26


#### vim-patch:8.2.4677: the Athena GUI support is outdated

Problem:    The Athena GUI support is outdated.
Solution:   Remove the Athena GUI code.
https://github.com/vim/vim/commit/0b962e5685edd41b55d5427b894797e725707639