### PR TITLE
vim-patch:9.0.0539: long message test can be flaky

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -533,7 +533,9 @@ func Test_BufReadCmdNofile()
             \ 'acwrite',
             \ 'quickfix',
             \ 'help',
+            "\ 'terminal',
             \ 'prompt',
+            "\ 'popup',
             \ ]
     new somefile
     exe 'set buftype=' .. val
@@ -650,7 +652,9 @@ func Test_BufEnter()
             \ 'acwrite',
             \ 'quickfix',
             \ 'help',
+            "\ 'terminal',
             \ 'prompt',
+            "\ 'popup',
             \ ]
     new somefile
     exe 'set buftype=' .. val

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1898,7 +1898,9 @@ func Test_bufadd_bufload()
             \ ['acwrite', 1],
             \ ['quickfix', 0],
             \ ['help', 1],
+            "\ ['terminal', 0],
             \ ['prompt', 0],
+            "\ ['popup', 0],
             \ ]
     bwipe! XotherName
     let buf = bufadd('XotherName')

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -358,7 +358,8 @@ func Test_quit_long_message()
     echom range(9999)->join("\x01")
   END
   call writefile(content, 'Xtest_quit_message')
-  let buf = RunVimInTerminal('-S Xtest_quit_message', #{rows: 6})
+  let buf = RunVimInTerminal('-S Xtest_quit_message', #{rows: 6, wait_for_ruler: 0})
+  call WaitForAssert({-> assert_match('^-- More --', term_getline(buf, 6))})
   call term_sendkeys(buf, "q")
   call VerifyScreenDump(buf, 'Test_quit_long_message', {})
 


### PR DESCRIPTION
#### vim-patch:9.0.0539: long message test can be flaky

Problem:    Long message test can be flaky.
Solution:   Wait for more prompt instead of ruler.
https://github.com/vim/vim/commit/21d393a12be86126d9326ea0c244d3a101b77151

Comment N/A lines out instead of deleting in buftype tests.