### PR TITLE
vim-patch:9.0.{0540,0544}: assigning stack variable to argument confuses Coverity

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -854,11 +854,9 @@ static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, 
 
     // Set 'keywordprg' to ":help" if an empty
     // value was passed to :set by the user.
-    // Misuse errbuf[] for the resulting string.
     if (varp == (char *)&p_kp && (*arg == NUL || *arg == ' ')) {
-      STRCPY(errbuf, ":help");
       save_arg = arg;
-      arg = errbuf;
+      arg = ":help";
     } else if (varp == (char *)&p_bs && ascii_isdigit(**(char_u **)varp)) {
       // Convert 'backspace' number to string, for
       // adding, prepending and removing string.
@@ -936,7 +934,7 @@ static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, 
     // are not removed, and keep backslash at start, for "\\machine\path",
     // but do remove it for "\\\\machine\\path".
     // The reverse is found in ExpandOldSetting().
-    while (*arg && !ascii_iswhite(*arg)) {
+    while (*arg != NUL && !ascii_iswhite(*arg)) {
       if (*arg == '\\' && arg[1] != NUL
 #ifdef BACKSLASH_IN_FILENAME
           && !((flags & P_EXPAND)
@@ -1062,8 +1060,8 @@ static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, 
       }
     }
 
-    if (save_arg != NULL) {  // number for 'whichwrap'
-      arg = save_arg;
+    if (save_arg != NULL) {
+      arg = save_arg;  // arg was temporarily changed, restore it
     }
   }
 

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1209,4 +1209,18 @@ func Test_switchbuf_reset()
   only!
 endfunc
 
+" :set empty string for global 'keywordprg' falls back to ":help"
+func Test_keywordprg_empty()
+  let k = &keywordprg
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  set keywordprg=
+  call assert_equal(':help', &keywordprg)
+  set keywordprg=man
+  call assert_equal('man', &keywordprg)
+  call assert_equal("\n  keywordprg=:help", execute('set kp= kp?'))
+  let &keywordprg = k
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0540: assigning stack variable to argument confuses Coverity

Problem:    Assigning stack variable to argument confuses Coverity.
Solution:   Use a local pointer, also makes the code simpler.
https://github.com/vim/vim/commit/6f98114e4a5db3917c4f9d2fec09e11b4b0d0be5


#### vim-patch:9.0.0544: minor issues with setting a string option

Problem:    Minor issues with setting a string option.
Solution:   Adjust the code, add a test. (closes vim/vim#11192)
https://github.com/vim/vim/commit/fcba86c0316dc0d6341078b50e7967206a1627a0