### PR TITLE
revert: "build: remove unnecessary policy related code"

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -1,6 +1,13 @@
 # Set LC_ALL to meet expectations of some locale-sensitive tests.
 set(ENV{LC_ALL} "en_US.UTF-8")
 
+if(POLICY CMP0012)
+  # Avoid policy warning due to CI=true. This is needed even if the main
+  # project has already set this policy as policy settings are reset when using
+  # the cmake script mode (-P).
+  cmake_policy(SET CMP0012 NEW)
+endif()
+
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
 set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)


### PR DESCRIPTION
This partially reverts commit 42aeb5c5b18af1362362a2e6bdf10a2a4ec70f0f.

Setting cmake policies is normally not required as
cmake_minimum_required automatically sets these. One exception is cmake
script mode (-P) since it automatically resets all policy changes.

Closes: https://github.com/neovim/neovim/issues/20286
