### PR TITLE
vim-patch:9.0.0550: crash when closing a tabpage and buffer is NULL

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4696,7 +4696,6 @@ void tabpage_close(int forceit)
 void tabpage_close_other(tabpage_T *tp, int forceit)
 {
   int done = 0;
-  int h = tabline_height();
   char prev_idx[NUMBUFLEN];
 
   // Limit to 1000 windows, autocommands may add a window while we close
@@ -4711,11 +4710,6 @@ void tabpage_close_other(tabpage_T *tp, int forceit)
     if (!valid_tabpage(tp) || tp->tp_lastwin == wp) {
       break;
     }
-  }
-
-  redraw_tabline = true;
-  if (h != tabline_height()) {
-    win_new_screen_rows();
   }
 }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -447,6 +447,26 @@ func Test_WinClosed_throws_with_tabs()
   augroup! test-WinClosed
 endfunc
 
+" This used to trigger WinClosed twice for the same window, and the window's
+" buffer was NULL in the second autocommand.
+func Test_WinClosed_switch_tab()
+  edit Xa
+  split Xb
+  split Xc
+  tab split
+  new
+  augroup test-WinClosed
+    autocmd WinClosed * tabprev | bwipe!
+  augroup END
+  close
+  " Check that the tabline has been fully removed
+  call assert_equal([1, 1], win_screenpos(0))
+
+  autocmd! test-WinClosed
+  augroup! test-WinClosed
+  %bwipe!
+endfunc
+
 func s:AddAnAutocmd()
   augroup vimBarTest
     au BufReadCmd * echo 'hello'

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -4,6 +4,7 @@ local assert_alive = helpers.assert_alive
 local feed, clear, nvim = helpers.feed, helpers.clear, helpers.nvim
 local poke_eventloop = helpers.poke_eventloop
 local eval, feed_command, source = helpers.eval, helpers.feed_command, helpers.source
+local pcall_err = helpers.pcall_err
 local eq, neq = helpers.eq, helpers.neq
 local meths = helpers.meths
 local retry = helpers.retry
@@ -338,6 +339,11 @@ describe(':terminal buffer', function()
       {3:-- TERMINAL --}                                    |
     ]]}
     eq('t', funcs.mode(1))
+  end)
+
+  it('writing to an existing file with :w fails #13549', function()
+    eq('Vim(write):E13: File exists (add ! to override)',
+       pcall_err(command, 'write test/functional/fixtures/tty-test.c'))
   end)
 end)
 


### PR DESCRIPTION
Fix #20285
Fix #20290

#### vim-patch:9.0.0550: crash when closing a tabpage and buffer is NULL

Problem:    Crash when closing a tabpage and buffer is NULL.
Solution:   Adjust how autocommands are triggered when closing a window.
            (closes vim/vim#11198)
https://github.com/vim/vim/commit/62de54b48d6354d4622ec0b21ffa4cf3cf312505