### PR TITLE
vim-patch:9.0.0562: HSL playlist files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -845,6 +845,9 @@ au BufNewFile,BufRead *.hex,*.h32		setf hex
 " Hjson
 au BufNewFile,BufRead *.hjson			setf hjson
 
+" HLS Playlist
+au BufNewFile,BufRead *.m3u8			setf hlsplaylist
+
 " Hollywood
 au BufRead,BufNewFile *.hws			setf hollywood
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -473,6 +473,7 @@ local extension = {
   hex = 'hex',
   ['h32'] = 'hex',
   hjson = 'hjson',
+  m3u8 = 'hlsplaylist',
   hog = 'hog',
   hws = 'hollywood',
   hoon = 'hoon',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -255,6 +255,7 @@ let s:filename_checks = {
     \ 'hex': ['file.hex', 'file.h32'],
     \ 'hgcommit': ['hg-editor-file.txt'],
     \ 'hjson': ['file.hjson'],
+    \ 'hlsplaylist': ['file.m3u8'],
     \ 'hog': ['file.hog', 'snort.conf', 'vision.conf'],
     \ 'hollywood': ['file.hws'],
     \ 'hoon': ['file.hoon'],


### PR DESCRIPTION
Problem:    HSL playlist files are not recognized.
Solution:   Add a pattern to recognize HSL palylist files. (Benoît Ryder,
            closes vim/vim#11204)
https://github.com/vim/vim/commit/35fdd9a67d73d4750152c419d4193ebb6b6d6eee