### PR TITLE
vim-patch:9.0.0559: timer test may get stuck at hit-enter prompt

### DIFF
--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -349,11 +349,13 @@ func Test_nocatch_timer_garbage_collect()
     let a = {'foo', 'bar'}
   endfunc
   func FeedChar(id)
-    call feedkeys('x', 't')
+    call feedkeys(":\<CR>", 't')
   endfunc
   call timer_start(300, 'FeedChar')
   call timer_start(100, 'CauseAnError')
-  let x = getchar()
+  let x = getchar()   " wait for error in timer
+  let x = getchar(0)  " read any remaining chars
+  let x = getchar(0)
 
   set ut&
   call test_override('no_wait_return', 1)


### PR DESCRIPTION
#### vim-patch:9.0.0559: timer test may get stuck at hit-enter prompt

Problem:    Timer test may get stuck at hit-enter prompt.
Solution:   Feed some more characters.
https://github.com/vim/vim/commit/4ecf16bbf951f10fd32c918c9d8bc004b7f8f7c9