### PR TITLE
fix: compiler warnings from clang 15

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -159,7 +159,7 @@ list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 if(NOT MSVC)
   # xdiff, mpack, lua-cjson: inlined external project, we don't maintain it. #9306
   set_source_files_properties(
-    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion")
+    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion -Wno-strict-prototypes")
 endif()
 
 if(NOT "${MIN_LOG_LEVEL}" MATCHES "^$")

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1249,14 +1249,12 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
         item_compare_func_ptr = item_compare_keeping_zero;
       }
 
-      int idx = 0;
       for (listitem_T *li = TV_LIST_ITEM_NEXT(l, tv_list_first(l))
            ; li != NULL;) {
         listitem_T *const prev_li = TV_LIST_ITEM_PREV(l, li);
         if (item_compare_func_ptr(&prev_li, &li) == 0) {
           li = tv_list_item_remove(l, li);
         } else {
-          idx++;
           li = TV_LIST_ITEM_NEXT(l, li);
         }
         if (info.item_compare_func_err) {  // -V547

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -83,7 +83,6 @@ int get_keystroke(MultiQueue *events)
   int len = 0;
   int n;
   int save_mapped_ctrl_c = mapped_ctrl_c;
-  int waited = 0;
 
   mapped_ctrl_c = 0;        // mappings are not used here
   for (;;) {
@@ -110,10 +109,8 @@ int get_keystroke(MultiQueue *events)
       // Replace zero and K_SPECIAL by a special key code.
       n = fix_input_buffer(buf + len, n);
       len += n;
-      waited = 0;
-    } else if (len > 0) {
-      waited++;             // keep track of the waiting time
     }
+
     if (n > 0) {  // found a termcode: adjust length
       len = n;
     }


### PR DESCRIPTION
Add -Wno-strict-prototypes flag to external dependencies to suppress
cjson warnings. These needs to be fixed upstream first.