### PR TITLE
vim-patch:9.0.{0567,0572}: 'completeopt' "longest" is not used for complete()

### DIFF
--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -704,8 +704,8 @@ endfunc
 
 " Test for using complete() with completeopt+=longest
 func Test_complete_with_longest()
-  inoremap <f3> <cmd>call complete(1, ["iaax", "iaay", "iaaz"])<cr>
   new
+  inoremap <buffer> <f3> <cmd>call complete(1, ["iaax", "iaay", "iaaz"])<cr>
 
   " default: insert first match
   set completeopt&
@@ -719,6 +719,7 @@ func Test_complete_with_longest()
   exe "normal Aa\<f3>\<esc>"
   call assert_equal('iaa', getline(1))
   set completeopt&
+  bwipe!
 endfunc
 
 
@@ -1276,7 +1277,7 @@ endfunc
 " A mapping is not used for the key after CTRL-X.
 func Test_no_mapping_for_ctrl_x_key()
   new
-  inoremap <C-K> <Cmd>let was_mapped = 'yes'<CR>
+  inoremap <buffer> <C-K> <Cmd>let was_mapped = 'yes'<CR>
   setlocal dictionary=README.txt
   call feedkeys("aexam\<C-X>\<C-K> ", 'xt')
   call assert_equal('example ', getline(1))

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -702,6 +702,26 @@ func Test_recursive_complete_func()
   bw!
 endfunc
 
+" Test for using complete() with completeopt+=longest
+func Test_complete_with_longest()
+  inoremap <f3> <cmd>call complete(1, ["iaax", "iaay", "iaaz"])<cr>
+  new
+
+  " default: insert first match
+  set completeopt&
+  call setline(1, ['i'])
+  exe "normal Aa\<f3>\<esc>"
+  call assert_equal('iaax', getline(1))
+
+  " with longest: insert longest prefix
+  set completeopt+=longest
+  call setline(1, ['i'])
+  exe "normal Aa\<f3>\<esc>"
+  call assert_equal('iaa', getline(1))
+  set completeopt&
+endfunc
+
+
 " Test for completing words following a completed word in a line
 func Test_complete_wrapscan()
   " complete words from another buffer


### PR DESCRIPTION
#### vim-patch:9.0.0567: 'completeopt' "longest" is not used for complete()

Problem:    'completeopt' "longest" is not used for complete().
Solution:   Also use "longest" for complete(). (Bjorn Linse, closes vim/vim#11206)
https://github.com/vim/vim/commit/87af60c91503e37c9144f8e48022b12994ce2c85


#### vim-patch:9.0.0572: insert complete tests leave a mapping behind

Problem:    Insert complete tests leave a mapping behind.
Solution:   Use a buffer-local mapping. (closes vim/vim#11211)
https://github.com/vim/vim/commit/75f4bafabdcc6bce5cf3e09fee29c634bf102c17