### PR TITLE
feat(profile): add "NVIM IDLE" to --startuptime

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -110,7 +110,10 @@ argument.
 		This can be used to find out where time is spent while loading
 		your |config|, plugins and opening the first file.
 		When {fname} already exists new messages are appended.
-
+		If your profiler script needs to know when to quit, use:
+>
+		nvim --startuptime nvim.log +'set ut=0 | au CursorHold * qa!'
+<
 							*-+*
 +[num]		The cursor will be positioned on line "num" for the first
 		file being edited.  If "num" is missing, the cursor will be

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -95,7 +95,7 @@ typedef struct normal_state {
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
 
-bool first_redraw = false;
+bool did_first_redraw = false;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.c.generated.h"
@@ -1384,8 +1384,8 @@ static int normal_check(VimState *state)
     do_redraw = false;
 
     // Measure the first screen update in --startuptime
-    if (time_fd != NULL && !first_redraw) {
-      first_redraw = true;
+    if (time_fd != NULL && !did_first_redraw) {
+      did_first_redraw = true;
       TIME_MSG("first screen update");
     }
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1381,13 +1381,11 @@ static int normal_check(VimState *state)
     normal_redraw(s);
     do_redraw = false;
 
-    // Now that we have drawn the first screen all the startup stuff
-    // has been done, close any file for startup messages.
-    if (time_fd != NULL) {
+    // Measure the first screen update in --startuptime
+    static bool first = true;
+    if (time_fd != NULL && first) {
+      first = false;
       TIME_MSG("first screen update");
-      TIME_MSG("--- NVIM STARTED ---");
-      fclose(time_fd);
-      time_fd = NULL;
     }
   }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -95,6 +95,8 @@ typedef struct normal_state {
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
 
+bool first_redraw = false;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.c.generated.h"
 #endif
@@ -1382,9 +1384,8 @@ static int normal_check(VimState *state)
     do_redraw = false;
 
     // Measure the first screen update in --startuptime
-    static bool first = true;
-    if (time_fd != NULL && first) {
-      first = false;
+    if (time_fd != NULL && !first_redraw) {
+      first_redraw = true;
       TIME_MSG("first screen update");
     }
   }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1387,6 +1387,8 @@ static int normal_check(VimState *state)
     if (time_fd != NULL && !did_first_redraw) {
       did_first_redraw = true;
       TIME_MSG("first screen update");
+      TIME_MSG("--- NVIM STARTED ---");
+      fflush(time_fd);
     }
   }
 

--- a/src/nvim/normal.h
+++ b/src/nvim/normal.h
@@ -72,6 +72,8 @@ typedef struct cmdarg_S {
 #define CA_COMMAND_BUSY     1   // skip restarting edit() once
 #define CA_NO_ADJ_OP_END    2   // don't adjust operator end
 
+extern bool first_redraw;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.h.generated.h"
 #endif

--- a/src/nvim/normal.h
+++ b/src/nvim/normal.h
@@ -72,7 +72,7 @@ typedef struct cmdarg_S {
 #define CA_COMMAND_BUSY     1   // skip restarting edit() once
 #define CA_NO_ADJ_OP_END    2   // don't adjust operator end
 
-extern bool first_redraw;
+extern bool did_first_redraw;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "normal.h.generated.h"

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -65,11 +65,11 @@ getkey:
       // Flush screen updates before blocking
       ui_flush();
 
-      // Ready for user input. Skip everything before the first screen update to prevent
+      // Entered idle state. Skip everything before the first screen update to prevent
       // closing the startup log file when prompt() is called in VimEnter autocommand.
       if (time_fd != NULL && did_first_redraw) {
         TIME_MSG("--- NVIM STARTED ---");
-        // Now that we are listening for user input, close any file for startup messages.
+        // Now that we are idle, close any file for startup messages.
         fclose(time_fd);
         time_fd = NULL;
       }

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -13,6 +13,7 @@
 #include "nvim/lib/kvec.h"
 #include "nvim/log.h"
 #include "nvim/main.h"
+#include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/os/input.h"
@@ -64,8 +65,9 @@ getkey:
       // Flush screen updates before blocking
       ui_flush();
 
-      // Skip everything before VimEnter event, like calling prompt() in init.vim
-      if (time_fd != NULL && get_vim_var_nr(VV_VIM_DID_ENTER)) {
+      // Skip everything before the first screen update to prevent closing
+      // the startup log file when prompt() is called in VimEnter autocommand.
+      if (time_fd != NULL && first_redraw) {
         TIME_MSG("ready for user input");
         TIME_MSG("--- NVIM STARTED ---");
         // Now that we are listening for user input, close any file for startup messages.

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -66,7 +66,7 @@ getkey:
       ui_flush();
 
       // Entered idle state. Skip everything before the first screen update to prevent
-      // closing the startup log file when prompt() is called in VimEnter autocommand.
+      // closing the startup log file when input() is called in VimEnter autocommand.
       if (time_fd != NULL && did_first_redraw) {
         TIME_MSG("--- NVIM IDLE ---");
         // Now that we are idle, close any file for startup messages.

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -65,10 +65,9 @@ getkey:
       // Flush screen updates before blocking
       ui_flush();
 
-      // Skip everything before the first screen update to prevent closing
-      // the startup log file when prompt() is called in VimEnter autocommand.
-      if (time_fd != NULL && first_redraw) {
-        TIME_MSG("ready for user input");
+      // Ready for user input. Skip everything before the first screen update to prevent
+      // closing the startup log file when prompt() is called in VimEnter autocommand.
+      if (time_fd != NULL && did_first_redraw) {
         TIME_MSG("--- NVIM STARTED ---");
         // Now that we are listening for user input, close any file for startup messages.
         fclose(time_fd);

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -16,6 +16,7 @@
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/os/input.h"
+#include "nvim/profile.h"
 #include "nvim/state.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
@@ -62,6 +63,15 @@ getkey:
       }
       // Flush screen updates before blocking
       ui_flush();
+
+      // Now that we are listening for user input, close any file for startup messages.
+      if (time_fd != NULL) {
+        TIME_MSG("ready for user input");
+        TIME_MSG("--- NVIM STARTED ---");
+        fclose(time_fd);
+        time_fd = NULL;
+      }
+
       // Call `os_inchar` directly to block for events or user input without
       // consuming anything from `input_buffer`(os/input.c) or calling the
       // mapping engine.

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -68,7 +68,7 @@ getkey:
       // Entered idle state. Skip everything before the first screen update to prevent
       // closing the startup log file when prompt() is called in VimEnter autocommand.
       if (time_fd != NULL && did_first_redraw) {
-        TIME_MSG("--- NVIM STARTED ---");
+        TIME_MSG("--- NVIM IDLE ---");
         // Now that we are idle, close any file for startup messages.
         fclose(time_fd);
         time_fd = NULL;

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -64,10 +64,11 @@ getkey:
       // Flush screen updates before blocking
       ui_flush();
 
-      // Now that we are listening for user input, close any file for startup messages.
-      if (time_fd != NULL) {
+      // Skip everything before VimEnter event, like calling prompt() in init.vim
+      if (time_fd != NULL && get_vim_var_nr(VV_VIM_DID_ENTER)) {
         TIME_MSG("ready for user input");
         TIME_MSG("--- NVIM STARTED ---");
+        // Now that we are listening for user input, close any file for startup messages.
         fclose(time_fd);
         time_fd = NULL;
       }


### PR DESCRIPTION
Profile startup time until neovim starts listening for user input. This includes some of the first processed events.

One caveat with this is that startup time profiling plugins won't have any reliable way of knowing when to close neovim after running it with `--startuptime`. I think this could be solved by adding a new event, like maybe `ProfileDone`, `ProfileWritten`, `VimReady`?