### PR TITLE
refactor(treesitter)!: rename x_position => x_pos

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -251,6 +251,12 @@ Use existing common {action} names if possible:
     list    Get all things
     set     Set a thing (or group of things)
 
+Use existing common {thing} names if possible:
+    buf     Buffer
+    pos     Position
+    tab     Tabpage
+    win     Window
+
 Use consistent names for {thing} in all API functions. E.g. a buffer is called
 "buf" everywhere, not "buffer" in some places and "buf" in others.
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -434,8 +434,7 @@ get_captures_at_cursor({winnr})                     *get_captures_at_cursor()*
     Return: ~
         string[] List of capture names
 
-                                                  *get_captures_at_position()*
-get_captures_at_position({bufnr}, {row}, {col})
+get_captures_at_pos({bufnr}, {row}, {col})             *get_captures_at_pos()*
     Returns a list of highlight captures at the given position
 
     Each capture is represented by a table containing the capture name as a
@@ -460,8 +459,7 @@ get_node_at_cursor({winnr})                             *get_node_at_cursor()*
     Return: ~
         (string) Name of node under the cursor
 
-                                                      *get_node_at_position()*
-get_node_at_position({bufnr}, {row}, {col}, {opts})
+get_node_at_pos({bufnr}, {row}, {col}, {opts})             *get_node_at_pos()*
     Returns the smallest named node at the given position
 
     Parameters: ~

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -202,7 +202,7 @@ end
 ---@param col number Position column
 ---
 ---@return table[] List of captures `{ capture = "capture name", metadata = { ... } }`
-function M.get_captures_at_position(bufnr, row, col)
+function M.get_captures_at_pos(bufnr, row, col)
   if bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
@@ -258,7 +258,7 @@ function M.get_captures_at_cursor(winnr)
   local bufnr = a.nvim_win_get_buf(winnr)
   local cursor = a.nvim_win_get_cursor(winnr)
 
-  local data = M.get_captures_at_position(bufnr, cursor[1] - 1, cursor[2])
+  local data = M.get_captures_at_pos(bufnr, cursor[1] - 1, cursor[2])
 
   local captures = {}
 
@@ -278,7 +278,7 @@ end
 ---             - ignore_injections boolean Ignore injected languages (default true)
 ---
 ---@return userdata |tsnode| under the cursor
-function M.get_node_at_position(bufnr, row, col, opts)
+function M.get_node_at_pos(bufnr, row, col, opts)
   if bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
@@ -302,8 +302,7 @@ function M.get_node_at_cursor(winnr)
   local bufnr = a.nvim_win_get_buf(winnr)
   local cursor = a.nvim_win_get_cursor(winnr)
 
-  return M.get_node_at_position(bufnr, cursor[1] - 1, cursor[2], { ignore_injections = false })
-    :type()
+  return M.get_node_at_pos(bufnr, cursor[1] - 1, cursor[2], { ignore_injections = false }):type()
 end
 
 --- Starts treesitter highlighting for a buffer

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -295,14 +295,16 @@ annotation_map = {
 # or if `cond()` is callable and returns True.
 def debug_this(o, cond=True):
     name = ''
+    if cond is False:
+        return
     if not isinstance(o, str):
         try:
             name = o.nodeName
             o = o.toprettyxml(indent='  ', newl='\n')
         except Exception:
             pass
-    if ((callable(cond) and cond())
-            or (not callable(cond) and cond)
+    if (cond is True
+            or (callable(cond) and cond())
             or (not callable(cond) and cond in o)):
         raise RuntimeError('xxx: {}\n{}'.format(name, o))
 
@@ -887,7 +889,7 @@ def extract_from_xml(filename, target, width, fmt_vimhelp):
 def fmt_doxygen_xml_as_vimhelp(filename, target):
     """Entrypoint for generating Vim :help from from Doxygen XML.
 
-    Returns 3 items:
+    Returns 2 items:
       1. Vim help text for functions found in `filename`.
       2. Vim help text for deprecated functions.
     """
@@ -1094,7 +1096,11 @@ def main(config, args):
                         fn_map_full.update(fn_map)
 
         if len(sections) == 0:
-            fail(f'no sections for target: {target}')
+            if target == 'lua':
+                fail(f'no sections for target: {target} (this usually means'
+                     + ' "luajit" was not found by scripts/lua2dox_filter)')
+            else:
+                fail(f'no sections for target: {target}')
         if len(sections) > len(CONFIG[target]['section_order']):
             raise RuntimeError(
                 'found new modules "{}"; update the "section_order" map'.format(

--- a/scripts/lua2dox_filter
+++ b/scripts/lua2dox_filter
@@ -37,6 +37,10 @@ test_executable(){
 ##! \brief sets the lua interpreter
 set_lua(){
 	if test -z "${EXE}"; then
+		test_executable '.deps/usr/bin/luajit'
+	fi
+
+	if test -z "${EXE}"; then
 		test_executable 'luajit'
 	fi
 
@@ -73,7 +77,8 @@ do_readlink(){
 set_lua
 if test -z "${EXE}"
 then
-	echo "no lua interpreter available"
+	echo "no lua interpreter found"
+	exit 1
 else
 	BASENAME=`basename "$0"`
 	do_readlink "$0"

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -607,7 +607,7 @@ describe('treesitter highlighting', function()
     eq({
       {capture='Error', metadata = { priority='101' }};
       {capture='type', metadata = { } };
-    }, exec_lua [[ return vim.treesitter.get_captures_at_position(0, 0, 2) ]])
+    }, exec_lua [[ return vim.treesitter.get_captures_at_pos(0, 0, 2) ]])
     end)
 
   it("allows to use captures with dots (don't use fallback when specialization of foo exists)", function()


### PR DESCRIPTION
"pos" has a long precedent as "position" in vim, and there is no reason to use a verbose name here.