### PR TITLE
vim-patch:8.2.{4466,4467}: running filetype test leaves file behind

### DIFF
--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -933,6 +933,7 @@ func Test_d_file()
   bwipe!
 
   filetype off
+  call delete('Xfile.d')
 endfunc
 
 func Test_dat_file()

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -932,6 +932,7 @@ func Test_d_file()
   call assert_equal('d', &filetype)
   bwipe!
 
+  " clean up
   filetype off
   call delete('Xfile.d')
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.4466: MS-Windows: illegal memory access in installer

Problem:    MS-Windows: illegal memory access in installer when using
            "create-directories" as the final argument.
Solution:   Check the argument count. (Cam Sinclair, closes vim/vim#9844)
https://github.com/vim/vim/commit/5c6edf41f9beffea21ce45d658822cc4c0745fdb


#### vim-patch:8.2.4467: running filetype test leaves file behind

Problem:    Running filetype test leaves file behind.
Solution:   Delete the file.
https://github.com/vim/vim/commit/0e71b7d4ce3e1210150ce772e1af6956057a71ed