### PR TITLE
vim-patch:9.0.0583: only recognizing .m3u8 files is inconsistent

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -845,8 +845,8 @@ au BufNewFile,BufRead *.hex,*.h32		setf hex
 " Hjson
 au BufNewFile,BufRead *.hjson			setf hjson
 
-" HLS Playlist
-au BufNewFile,BufRead *.m3u8			setf hlsplaylist
+" HLS Playlist (or another form of playlist)
+au BufNewFile,BufRead *.m3u,*.m3u8		setf hlsplaylist
 
 " Hollywood
 au BufRead,BufNewFile *.hws			setf hollywood

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -473,6 +473,7 @@ local extension = {
   hex = 'hex',
   ['h32'] = 'hex',
   hjson = 'hjson',
+  m3u = 'hlsplaylist',
   m3u8 = 'hlsplaylist',
   hog = 'hog',
   hws = 'hollywood',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -255,7 +255,7 @@ let s:filename_checks = {
     \ 'hex': ['file.hex', 'file.h32'],
     \ 'hgcommit': ['hg-editor-file.txt'],
     \ 'hjson': ['file.hjson'],
-    \ 'hlsplaylist': ['file.m3u8'],
+    \ 'hlsplaylist': ['file.m3u', 'file.m3u8'],
     \ 'hog': ['file.hog', 'snort.conf', 'vision.conf'],
     \ 'hollywood': ['file.hws'],
     \ 'hoon': ['file.hoon'],


### PR DESCRIPTION
Problem:    Only recognizing .m3u8 files is inconsistent.
Solution:   Also matc .m3u files. (issue vim/vim#11204)
https://github.com/vim/vim/commit/b9725bc7f6427654eb4e35874034b0ec1b6b96b3