### PR TITLE
fix(cmdline): don't send invalid cursor with incsearch and cmdheight=0

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1399,13 +1399,15 @@ void msg_start(void)
     msg_clr_eos();
   }
 
+  // if cmdheight=0, we need to scroll in the first line of msg_grid upon the screen
+  if (p_ch == 0 && !ui_has(kUIMessages) && !msg_scrolled) {
+    msg_grid_validate();
+    msg_scroll_up(false, true);
+    msg_scrolled++;
+    cmdline_row = Rows - 1;
+  }
+
   if (!msg_scroll && full_screen) {     // overwrite last message
-    if (cmdline_row >= Rows && !ui_has(kUIMessages)) {
-      msg_grid_validate();
-      msg_scroll_up(false, true);
-      msg_scrolled++;
-      cmdline_row = Rows - 1;
-    }
     msg_row = cmdline_row;
     msg_col = cmdmsg_rl ? Columns - 1 : 0;
   } else if (msg_didout || (p_ch == 0 && !ui_has(kUIMessages))) {  // start message on next line

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1196,4 +1196,46 @@ describe('cmdheight=0', function()
       {1:~                        }|
     ]]}
   end)
+
+  it('with multigrid', function()
+    clear{args={'--cmd', 'set cmdheight=0'}}
+    screen:attach{ext_multigrid=true}
+    screen:expect{grid=[[
+    ## grid 1
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [2:-------------------------]|
+    ## grid 2
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ## grid 3
+    ]], win_viewport={
+      [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1};
+    }}
+
+    feed '/p'
+    screen:expect{grid=[[
+    ## grid 1
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [2:-------------------------]|
+      [3:-------------------------]|
+    ## grid 2
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ## grid 3
+      /p^                       |
+    ]], win_viewport={
+      [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1};
+    }}
+  end)
 end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -769,6 +769,7 @@ end
 
 function Screen:_handle_grid_cursor_goto(grid, row, col)
   self._cursor.grid = grid
+  assert(row >= 0 and col >= 0)
   self._cursor.row = row + 1
   self._cursor.col = col + 1
 end


### PR DESCRIPTION
fixes #20306