### PR TITLE
docs(undo): `Nvi` -> `Nvim`

### DIFF
--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -76,9 +76,9 @@ Examples	Vim way			Vi-compatible way	~
 "uu"		two times undo		no-op
 "u CTRL-R"	no-op			two times undo
 
-Rationale:  Nvi uses the "." command instead of CTRL-R.  Unfortunately, this
+Rationale:  Nvim uses the "." command instead of CTRL-R.  Unfortunately, this
 	    is not Vi compatible.  For example "dwdwu." in Vi deletes two
-	    words, in Nvi it does nothing.
+	    words, in Nvim it does nothing.
 
 ==============================================================================
 3. Undo blocks						*undo-blocks*


### PR DESCRIPTION
Fix spelling mistake in [undo.txt](https://github.com/neovim/neovim/blob/9a5ac065093b58cceb676700b988584931cef150/runtime/doc/undo.txt#L79-L81)