### PR TITLE
ci(backport): bump to version 0.0.8

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
-        uses: zeebe-io/backport-action@v0.0.7
+        uses: zeebe-io/backport-action@v0.0.8
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}

--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -57,8 +57,7 @@ has a major bug:
 
 The neovim repository includes a backport [github action](https://github.com/zeebe-io/backport-action).
 In order to trigger the action, a PR must be labeled with a label matching the
-form `backport release-0.X`. Note, the PR must have a description in the issue body,
-or the backport will fail.
+form `backport release-0.X`.
 
 Third-party dependencies
 --------------


### PR DESCRIPTION
Primary bug fix is allowing backports with empty PR description.
