### PR TITLE
refactor: replace unnecessary helper functions in optionstr.c

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3659,7 +3659,6 @@ static int eval_index(char **arg, typval_T *rettv, int evaluate, int verbose)
 int get_option_tv(const char **const arg, typval_T *const rettv, const bool evaluate)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  bool working = (**arg == '+');  // has("+option")
   int opt_flags;
 
   // Isolate the option name and find its value.
@@ -3704,10 +3703,6 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
       rettv->v_type = VAR_STRING;
       rettv->vval.v_string = stringval;
     }
-  } else if (working && (opt_type == gov_hidden_bool
-                         || opt_type == gov_hidden_number
-                         || opt_type == gov_hidden_string)) {
-    ret = FAIL;
   }
 
   *option_end = c;                  // put back for error messages

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1938,9 +1938,14 @@ static void f_exists(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       xfree(exp);
     }
   } else if (*p == '&' || *p == '+') {  // Option.
-    n = (get_option_tv(&p, NULL, true) == OK);
-    if (*skipwhite(p) != NUL) {
-      n = false;  // Trailing garbage.
+    bool working = (*p == '+');  // whether option needs to be working
+    int opt_flags;
+
+    if (find_option_end(&p, &opt_flags) != NULL) {
+      int opt_idx = findoption(p);
+      n = (opt_idx >= 0 && (!working || get_varp_scope(get_option(opt_idx), opt_flags) != NULL));
+    } else {
+      n = false;
     }
   } else if (*p == '*') {  // Internal or user defined function.
     n = function_exists(p + 1, false);

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -990,4 +990,41 @@ typedef struct {
   uint64_t channel_id;     /// Only used when script_id is SID_API_CLIENT.
 } LastSet;
 
+// WV_ and BV_ values get typecasted to this for the "indir" field
+typedef enum {
+  PV_NONE = 0,
+  PV_MAXVAL = 0xffff,  // to avoid warnings for value out of range
+} idopt_T;
+
+typedef struct vimoption {
+  char *fullname;        // full option name
+  char *shortname;       // permissible abbreviation
+  uint32_t flags;               // see below
+  char_u *var;             // global option: pointer to variable;
+                           // window-local option: VAR_WIN;
+                           // buffer-local option: global value
+  idopt_T indir;                // global option: PV_NONE;
+                                // local option: indirect option index
+  char *def_val;         // default values for variable (neovim!!)
+  LastSet last_set;             // script in which the option was last set
+} vimoption_T;
+
+// The options that are local to a window or buffer have "indir" set to one of
+// these values.  Special values:
+// PV_NONE: global option.
+// PV_WIN is added: window-local option
+// PV_BUF is added: buffer-local option
+// PV_BOTH is added: global option which also has a local value.
+#define PV_BOTH 0x1000
+#define PV_WIN  0x2000
+#define PV_BUF  0x4000
+#define PV_MASK 0x0fff
+#define OPT_WIN(x)  (idopt_T)(PV_WIN + (int)(x))
+#define OPT_BUF(x)  (idopt_T)(PV_BUF + (int)(x))
+#define OPT_BOTH(x) (idopt_T)(PV_BOTH + (int)(x))
+
+// Options local to a window have a value local to a buffer and global to all
+// buffers.  Indicate this by setting "var" to VAR_WIN.
+#define VAR_WIN ((char_u *)-1)
+
 #endif  // NVIM_OPTION_DEFS_H


### PR DESCRIPTION
Replaces unnecessary helper functions in `optionstr.c` such as `get_option_flags()`, `get_option_fullname()`, `set_option_flag()`, `is_global_option()`, etc. with a single `get_option()` helper function that allows direct access to the `options` array.

Also refactors `f_exists()` to use `get_varp_scope` instead of using `get_option_tv`. This opens up the path for removing `getoptions_T` altogether later down the line since the hidden option logic is no longer needed.