### PR TITLE
vim-patch:9fbdbb814f4a

### DIFF
--- a/runtime/compiler/hare.vim
+++ b/runtime/compiler/hare.vim
@@ -1,0 +1,31 @@
+" Vim compiler file
+" Compiler: Hare Compiler
+" Maintainer: Amelia Clarke <me@rsaihe.dev>
+" Last Change: 2022-09-21
+
+if exists("g:current_compiler")
+  finish
+endif
+let g:current_compiler = "hare"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+if exists(':CompilerSet') != 2
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+if filereadable("Makefile") || filereadable("makefile")
+  CompilerSet makeprg=make
+else
+  CompilerSet makeprg=hare\ build
+endif
+
+CompilerSet errorformat=
+  \Error\ %f:%l:%c:\ %m,
+  \Syntax\ error:\ %.%#\ at\ %f:%l:%c\\,\ %m,
+  \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+" vim: tabstop=2 shiftwidth=2 expandtab

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1660,7 +1660,8 @@ The valid escape sequences are
 If the first two characters of an escape sequence are "q-" (for example,
 <q-args>) then the value is quoted in such a way as to make it a valid value
 for use in an expression.  This uses the argument as one single value.
-When there is no argument <q-args> is an empty string.
+When there is no argument <q-args> is an empty string.  See the
+|q-args-example| below.
 							*<f-args>*
 To allow commands to pass their arguments on to a user-defined function, there
 is a special form <f-args> ("function args").  This splits the command
@@ -1670,7 +1671,7 @@ See the Mycmd example below.  If no arguments are given <f-args> is removed.
    To embed whitespace into an argument of <f-args>, prepend a backslash.
 <f-args> replaces every pair of backslashes (\\) with one backslash.  A
 backslash followed by a character other than white space or a backslash
-remains unmodified.  Overview:
+remains unmodified.  Also see |f-args-example| below.  Overview:
 
 	command		   <f-args> ~
 	XX ab		   "ab"
@@ -1684,7 +1685,8 @@ remains unmodified.  Overview:
 	XX a\\\\b	   'a\\b'
 	XX a\\\\ b	   'a\\', 'b'
 
-Examples >
+
+Examples for user commands: >
 
    " Delete everything after here to the end
    :com Ddel +,$d
@@ -1700,7 +1702,8 @@ Examples >
    " Count the number of lines in the range
    :com! -range -nargs=0 Lines  echo <line2> - <line1> + 1 "lines"
 
-   " Call a user function (example of <f-args>)
+<						*f-args-example*
+Call a user function (example of <f-args>) >
    :com -nargs=* Mycmd call Myfunc(<f-args>)
 
 When executed as: >
@@ -1708,7 +1711,8 @@ When executed as: >
 This will invoke: >
 	:call Myfunc("arg1","arg2")
 
-   :" A more substantial example
+<						*q-args-example* 
+A more substantial example: >
    :function Allargs(command)
    :   let i = 0
    :   while i < argc()

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1172,7 +1172,7 @@ g;			Go to [count] older position in change list.
 			(not a motion command)
 
 							*g,* *E663*
-g,			Go to [count] newer cursor position in change list.
+g,			Go to [count] newer position in change list.
 			Just like |g;| but in the opposite direction.
 			(not a motion command)
 

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -83,7 +83,7 @@ pattern and do not match another pattern: >
 This first finds all lines containing "found", but only executes {cmd} when
 there is no match for "notfound".
 
-Any Ex command can be used, see |ex-cmd-index|. To execute a Normal mode
+Any Ex command can be used, see |ex-cmd-index|.  To execute a Normal mode
 command, you can use the `:normal` command: >
 	:g/pat/normal {commands}
 Make sure that {commands} ends with a whole command, otherwise Vim will wait

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -83,7 +83,8 @@ pattern and do not match another pattern: >
 This first finds all lines containing "found", but only executes {cmd} when
 there is no match for "notfound".
 
-To execute a non-Ex command, you can use the `:normal` command: >
+Any Ex command can be used, see |ex-cmd-index|. To execute a Normal mode
+command, you can use the `:normal` command: >
 	:g/pat/normal {commands}
 Make sure that {commands} ends with a whole command, otherwise Vim will wait
 for you to type the rest of the command for each match.  The screen will not

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3118,7 +3118,7 @@ The default is to use the twice sh_minlines.  Set it to a smaller number to
 speed up displaying.  The disadvantage is that highlight errors may appear.
 
 syntax/sh.vim tries to flag certain problems as errors; usually things like
-extra "]"s, "done"s, "fi"s, etc.  If you find the error handling problematic
+unmatched "]"s, "done"s, "fi"s, etc.  If you find the error handling problematic
 for your purposes, you may suppress such error highlighting by putting
 the following line in your .vimrc: >
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3118,7 +3118,7 @@ The default is to use the twice sh_minlines.  Set it to a smaller number to
 speed up displaying.  The disadvantage is that highlight errors may appear.
 
 syntax/sh.vim tries to flag certain problems as errors; usually things like
-unmatched "]"s, "done"s, "fi"s, etc.  If you find the error handling problematic
+unmatched "]", "done", "fi", etc.  If you find the error handling problematic
 for your purposes, you may suppress such error highlighting by putting
 the following line in your .vimrc: >
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -34,8 +34,6 @@ CTRL-L			Clears and redraws the screen.  The redraw may happen
 			window, or all status lines and window bars if "!" is
 			included. Useful if 'statusline' or 'winbar' includes
 			an item that doesn't cause automatic updating.
-			If the command line is being edited the redraw is
-			postponed until later.
 
 						*:redrawt* *:redrawtabline*
 :redrawt[abline]	Redraw the tabline.  Useful to update the tabline when

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -34,6 +34,8 @@ CTRL-L			Clears and redraws the screen.  The redraw may happen
 			window, or all status lines and window bars if "!" is
 			included. Useful if 'statusline' or 'winbar' includes
 			an item that doesn't cause automatic updating.
+			If the command line is being edited the redraw is
+			postponed until later.
 
 						*:redrawt* *:redrawtabline*
 :redrawt[abline]	Redraw the tabline.  Useful to update the tabline when

--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1,7 +1,7 @@
 " Vim support file to detect file types
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Sep 11
+" Last Change:	2022 Sep 27
 
 " Only run this if enabled
 if !exists("do_legacy_filetype")

--- a/runtime/ftplugin/chatito.vim
+++ b/runtime/ftplugin/chatito.vim
@@ -1,0 +1,15 @@
+" Vim filetype plugin
+" Language:	Chatito
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 19
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:#,:// commentstring=#\ %s
+" indent of 4 spaces is mandated by the spec
+setlocal expandtab softtabstop=4 shiftwidth=4
+
+let b:undo_ftplugin = 'setl com< cms< et< sts< sw<'

--- a/runtime/ftplugin/elixir.vim
+++ b/runtime/ftplugin/elixir.vim
@@ -1,7 +1,7 @@
 " Elixir filetype plugin
 " Language: Elixir
 " Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
-" Last Change: 2022 August 10
+" Last Change: 2022 Sep 20
 
 if exists("b:did_ftplugin")
   finish
@@ -23,7 +23,11 @@ if exists('loaded_matchit') && !exists('b:match_words')
         \ ',{:},\[:\],(:)'
 endif
 
+setlocal shiftwidth=2 softtabstop=2 expandtab iskeyword+=!,?
+setlocal comments=:#
 setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = 'setlocal sw< sts< et< isk< com< cms<'
 
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/runtime/ftplugin/gyp.vim
+++ b/runtime/ftplugin/gyp.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 27
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t
+setlocal commentstring=#\ %s comments=b:#,fb:-
+
+let b:undo_ftplugin = 'setlocal fo< cms< com<'

--- a/runtime/ftplugin/hare.vim
+++ b/runtime/ftplugin/hare.vim
@@ -1,0 +1,27 @@
+" Vim filetype plugin
+" Language: Hare
+" Maintainer: Amelia Clarke <me@rsaihe.dev>
+" Previous Maintainer: Drew DeVault <sir@cmpwn.com>
+" Last Updated: 2022-09-21
+
+" Only do this when not done yet for this buffer
+if exists('b:did_ftplugin')
+  finish
+endif
+
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
+setlocal noexpandtab
+setlocal tabstop=8
+setlocal shiftwidth=0
+setlocal softtabstop=0
+setlocal textwidth=80
+setlocal commentstring=//\ %s
+
+" Set 'formatoptions' to break comment lines but not other lines,
+" and insert the comment leader when hitting <CR> or using "o".
+setlocal fo-=t fo+=croql
+
+compiler hare
+" vim: tabstop=2 shiftwidth=2 expandtab

--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -1,0 +1,16 @@
+" Elixir filetype plugin
+" Language: HEEx
+" Maintainer:	Mitchell Hanberg <vimNOSPAM@mitchellhanberg.com>
+" Last Change: 2022 Sep 21
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal shiftwidth=2 softtabstop=2 expandtab
+
+setlocal comments=:<%!--
+setlocal commentstring=<%!--\ %s\ --%>
+
+let b:undo_ftplugin = 'set sw< sts< et< com< cms<'

--- a/runtime/indent/chatito.vim
+++ b/runtime/indent/chatito.vim
@@ -1,0 +1,32 @@
+" Vim indent file
+" Language:	Chatito
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 20
+
+if exists('b:did_indent')
+    finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=GetChatitoIndent()
+setlocal indentkeys=o,O,*<Return>,0#,!^F
+
+let b:undo_indent = 'setl inde< indk<'
+
+if exists('*GetChatitoIndent')
+    finish
+endif
+
+function GetChatitoIndent()
+    let l:prev = v:lnum - 1
+    if getline(prevnonblank(l:prev)) =~# '^[~%@]\['
+        " shift indent after definitions
+        return shiftwidth()
+    elseif getline(l:prev) !~# '^\s*$'
+        " maintain indent in sentences
+        return indent(l:prev)
+    else
+        " reset indent after a blank line
+        return 0
+    end
+endfunction

--- a/runtime/indent/gyp.vim
+++ b/runtime/indent/gyp.vim
@@ -1,0 +1,7 @@
+" Vim indent file
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Last Change:	2022 Sep 27
+
+" JSON indent works well
+runtime! indent/json.vim

--- a/runtime/indent/hare.vim
+++ b/runtime/indent/hare.vim
@@ -1,0 +1,138 @@
+" Vim indent file
+" Language: Hare
+" Maintainer: Amelia Clarke <me@rsaihe.dev>
+" Last Change: 2022 Sep 22
+
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+if !has("cindent") || !has("eval")
+  finish
+endif
+
+setlocal cindent
+
+" L0 -> don't deindent labels
+" (s -> use one indent after a trailing (
+" m1 -> if ) starts a line, indent it the same as its matching (
+" ks -> add an extra indent to extra lines in an if expression or for expression
+" j1 -> indent code inside {} one level when in parentheses
+" J1 -> see j1
+" *0 -> don't search for unclosed block comments
+" #1 -> don't deindent lines that begin with #
+setlocal cinoptions=L0,(s,m1,ks,j1,J1,*0,#1
+
+" Controls which keys reindent the current line.
+" 0{     -> { at beginning of line
+" 0}     -> } at beginning of line
+" 0)     -> ) at beginning of line
+" 0]     -> ] at beginning of line
+" !^F    -> <C-f> (not inserted)
+" o      -> <CR> or `o` command
+" O      -> `O` command
+" e      -> else
+" 0=case -> case
+setlocal indentkeys=0{,0},0),0],!^F,o,O,e,0=case
+
+setlocal cinwords=if,else,for,switch,match
+
+setlocal indentexpr=GetHareIndent()
+
+function! FloorCindent(lnum)
+  return cindent(a:lnum) / shiftwidth() * shiftwidth()
+endfunction
+
+function! GetHareIndent()
+  let line = getline(v:lnum)
+  let prevlnum = prevnonblank(v:lnum - 1)
+  let prevline = getline(prevlnum)
+  let prevprevline = getline(prevnonblank(prevlnum - 1))
+
+  " This is all very hacky and imperfect, but it's tough to do much better when
+  " working with regex-based indenting rules.
+
+  " If the previous line ended with =, indent by one shiftwidth.
+  if prevline =~# '\v\=\s*(//.*)?$'
+    return indent(prevlnum) + shiftwidth()
+  endif
+
+  " If the previous line ended in a semicolon and the line before that ended
+  " with =, deindent by one shiftwidth.
+  if prevline =~# '\v;\s*(//.*)?$' && prevprevline =~# '\v\=\s*(//.*)?$'
+    return indent(prevlnum) - shiftwidth()
+  endif
+
+  " TODO: The following edge-case is still indented incorrectly:
+  " case =>
+  "         if (foo) {
+  "                 bar;
+  "         };
+  " | // cursor is incorrectly deindented by one shiftwidth.
+  "
+  " This only happens if the {} block is the first statement in the case body.
+  " If `case` is typed, the case will also be incorrectly deindented by one
+  " shiftwidth. Are you having fun yet?
+
+  " Deindent cases.
+  if line =~# '\v^\s*case'
+    " If the previous line was also a case, don't do any special indenting.
+    if prevline =~# '\v^\s*case'
+      return indent(prevlnum)
+    end
+
+    " If the previous line was a multiline case, deindent by one shiftwidth.
+    if prevline =~# '\v\=\>\s*(//.*)?$'
+      return indent(prevlnum) - shiftwidth()
+    endif
+
+    " If the previous line started a block, deindent by one shiftwidth.
+    " This handles the first case in a switch/match block.
+    if prevline =~# '\v\{\s*(//.*)?$'
+      return FloorCindent(v:lnum) - shiftwidth()
+    end
+
+    " If the previous line ended in a semicolon and the line before that wasn't
+    " a case, deindent by one shiftwidth.
+    if prevline =~# '\v;\s*(//.*)?$' && prevprevline !~# '\v\=\>\s*(//.*)?$'
+      return FloorCindent(v:lnum) - shiftwidth()
+    end
+
+    let l:indent = FloorCindent(v:lnum)
+
+    " If a normal cindent would indent the same amount as the previous line,
+    " deindent by one shiftwidth. This fixes some issues with `case let` blocks.
+    if l:indent == indent(prevlnum)
+      return l:indent - shiftwidth()
+    endif
+
+    " Otherwise, do a normal cindent.
+    return l:indent
+  endif
+
+  " Don't indent an extra shiftwidth for cases which span multiple lines.
+  if prevline =~# '\v\=\>\s*(//.*)?$' && prevline !~# '\v^\s*case\W'
+    return indent(prevlnum)
+  endif
+
+  " Indent the body of a case.
+  " If the previous line ended in a semicolon and the line before that was a
+  " case, don't do any special indenting.
+  if prevline =~# '\v;\s*(//.*)?$' && prevprevline =~# '\v\=\>\s*(//.*)?$' && line !~# '\v^\s*}'
+    return indent(prevlnum)
+  endif
+
+  let l:indent = FloorCindent(v:lnum)
+
+  " If the previous line was a case and a normal cindent wouldn't indent, indent
+  " an extra shiftwidth.
+  if prevline =~# '\v\=\>\s*(//.*)?$' && l:indent == indent(prevlnum)
+    return l:indent + shiftwidth()
+  endif
+
+  " If everything above is false, do a normal cindent.
+  return l:indent
+endfunction
+
+" vim: tabstop=2 shiftwidth=2 expandtab

--- a/runtime/indent/solidity.vim
+++ b/runtime/indent/solidity.vim
@@ -1,0 +1,442 @@
+" Vim indent file
+" Language: 		Solidity
+" Acknowledgement: 	Based off of vim-javascript
+" Maintainer: 		Cothi (jiungdev@gmail.com)
+" Original Author: 	tomlion (https://github.com/tomlion/vim-solidity)
+" Last Changed: 	2022 Sep 27
+"
+" 0. Initialization {{{1
+" =================
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal nosmartindent
+
+" Now, set up our indentation expression and keys that trigger it.
+setlocal indentexpr=GetSolidityIndent()
+setlocal indentkeys=0{,0},0),0],0\,,!^F,o,O,e
+
+" Only define the function once.
+if exists("*GetSolidityIndent")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" 1. Variables {{{1
+" ============
+
+let s:js_keywords = '^\s*\(break\|case\|catch\|continue\|debugger\|default\|delete\|do\|else\|finally\|for\|function\|if\|in\|instanceof\|new\|return\|switch\|this\|throw\|try\|typeof\|var\|void\|while\|with\)'
+
+" Regex of syntax group names that are or delimit string or are comments.
+let s:syng_strcom = 'string\|regex\|comment\c'
+
+" Regex of syntax group names that are strings.
+let s:syng_string = 'regex\c'
+
+" Regex of syntax group names that are strings or documentation.
+let s:syng_multiline = 'comment\c'
+
+" Regex of syntax group names that are line comment.
+let s:syng_linecom = 'linecomment\c'
+
+" Expression used to check whether we should skip a match with searchpair().
+let s:skip_expr = "synIDattr(synID(line('.'),col('.'),1),'name') =~ '".s:syng_strcom."'"
+
+let s:line_term = '\s*\%(\%(\/\/\).*\)\=$'
+
+" Regex that defines continuation lines, not including (, {, or [.
+let s:continuation_regex = '\%([\\*+/.:]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)' . s:line_term
+
+" Regex that defines continuation lines.
+" TODO: this needs to deal with if ...: and so on
+let s:msl_regex = '\%([\\*+/.:([]\|\%(<%\)\@<![=-]\|\W[|&?]\|||\|&&\)' . s:line_term
+
+let s:one_line_scope_regex = '\<\%(if\|else\|for\|while\)\>[^{;]*' . s:line_term
+
+" Regex that defines blocks.
+let s:block_regex = '\%([{[]\)\s*\%(|\%([*@]\=\h\w*,\=\s*\)\%(,\s*[*@]\=\h\w*\)*|\)\=' . s:line_term
+
+let s:var_stmt = '^\s*var'
+
+let s:comma_first = '^\s*,'
+let s:comma_last = ',\s*$'
+
+let s:ternary = '^\s\+[?|:]'
+let s:ternary_q = '^\s\+?'
+
+" 2. Auxiliary Functions {{{1
+" ======================
+
+" Check if the character at lnum:col is inside a string, comment, or is ascii.
+function s:IsInStringOrComment(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_strcom
+endfunction
+
+" Check if the character at lnum:col is inside a string.
+function s:IsInString(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_string
+endfunction
+
+" Check if the character at lnum:col is inside a multi-line comment.
+function s:IsInMultilineComment(lnum, col)
+  return !s:IsLineComment(a:lnum, a:col) && synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_multiline
+endfunction
+
+" Check if the character at lnum:col is a line comment.
+function s:IsLineComment(lnum, col)
+  return synIDattr(synID(a:lnum, a:col, 1), 'name') =~ s:syng_linecom
+endfunction
+
+" Find line above 'lnum' that isn't empty, in a comment, or in a string.
+function s:PrevNonBlankNonString(lnum)
+  let in_block = 0
+  let lnum = prevnonblank(a:lnum)
+  while lnum > 0
+    " Go in and out of blocks comments as necessary.
+    " If the line isn't empty (with opt. comment) or in a string, end search.
+    let line = getline(lnum)
+    if line =~ '/\*'
+      if in_block
+        let in_block = 0
+      else
+        break
+      endif
+    elseif !in_block && line =~ '\*/'
+      let in_block = 1
+    elseif !in_block && line !~ '^\s*\%(//\).*$' && !(s:IsInStringOrComment(lnum, 1) && s:IsInStringOrComment(lnum, strlen(line)))
+      break
+    endif
+    let lnum = prevnonblank(lnum - 1)
+  endwhile
+  return lnum
+endfunction
+
+" Find line above 'lnum' that started the continuation 'lnum' may be part of.
+function s:GetMSL(lnum, in_one_line_scope)
+  " Start on the line we're at and use its indent.
+  let msl = a:lnum
+  let lnum = s:PrevNonBlankNonString(a:lnum - 1)
+  while lnum > 0
+    " If we have a continuation line, or we're in a string, use line as MSL.
+    " Otherwise, terminate search as we have found our MSL already.
+    let line = getline(lnum)
+    let col = match(line, s:msl_regex) + 1
+    if (col > 0 && !s:IsInStringOrComment(lnum, col)) || s:IsInString(lnum, strlen(line))
+      let msl = lnum
+    else
+      " Don't use lines that are part of a one line scope as msl unless the
+      " flag in_one_line_scope is set to 1
+      "
+      if a:in_one_line_scope
+        break
+      end
+      let msl_one_line = s:Match(lnum, s:one_line_scope_regex)
+      if msl_one_line == 0
+        break
+      endif
+    endif
+    let lnum = s:PrevNonBlankNonString(lnum - 1)
+  endwhile
+  return msl
+endfunction
+
+function s:RemoveTrailingComments(content)
+  let single = '\/\/\(.*\)\s*$'
+  let multi = '\/\*\(.*\)\*\/\s*$'
+  return substitute(substitute(a:content, single, '', ''), multi, '', '')
+endfunction
+
+" Find if the string is inside var statement (but not the first string)
+function s:InMultiVarStatement(lnum)
+  let lnum = s:PrevNonBlankNonString(a:lnum - 1)
+
+"  let type = synIDattr(synID(lnum, indent(lnum) + 1, 0), 'name')
+
+  " loop through previous expressions to find a var statement
+  while lnum > 0
+    let line = getline(lnum)
+
+    " if the line is a js keyword
+    if (line =~ s:js_keywords)
+      " check if the line is a var stmt
+      " if the line has a comma first or comma last then we can assume that we
+      " are in a multiple var statement
+      if (line =~ s:var_stmt)
+        return lnum
+      endif
+
+      " other js keywords, not a var
+      return 0
+    endif
+
+    let lnum = s:PrevNonBlankNonString(lnum - 1)
+  endwhile
+
+  " beginning of program, not a var
+  return 0
+endfunction
+
+" Find line above with beginning of the var statement or returns 0 if it's not
+" this statement
+function s:GetVarIndent(lnum)
+  let lvar = s:InMultiVarStatement(a:lnum)
+  let prev_lnum = s:PrevNonBlankNonString(a:lnum - 1)
+
+  if lvar
+    let line = s:RemoveTrailingComments(getline(prev_lnum))
+
+    " if the previous line doesn't end in a comma, return to regular indent
+    if (line !~ s:comma_last)
+      return indent(prev_lnum) - &sw
+    else
+      return indent(lvar) + &sw
+    endif
+  endif
+
+  return -1
+endfunction
+
+
+" Check if line 'lnum' has more opening brackets than closing ones.
+function s:LineHasOpeningBrackets(lnum)
+  let open_0 = 0
+  let open_2 = 0
+  let open_4 = 0
+  let line = getline(a:lnum)
+  let pos = match(line, '[][(){}]', 0)
+  while pos != -1
+    if !s:IsInStringOrComment(a:lnum, pos + 1)
+      let idx = stridx('(){}[]', line[pos])
+      if idx % 2 == 0
+        let open_{idx} = open_{idx} + 1
+      else
+        let open_{idx - 1} = open_{idx - 1} - 1
+      endif
+    endif
+    let pos = match(line, '[][(){}]', pos + 1)
+  endwhile
+  return (open_0 > 0) . (open_2 > 0) . (open_4 > 0)
+endfunction
+
+function s:Match(lnum, regex)
+  let col = match(getline(a:lnum), a:regex) + 1
+  return col > 0 && !s:IsInStringOrComment(a:lnum, col) ? col : 0
+endfunction
+
+function s:IndentWithContinuation(lnum, ind, width)
+  " Set up variables to use and search for MSL to the previous line.
+  let p_lnum = a:lnum
+  let lnum = s:GetMSL(a:lnum, 1)
+  let line = getline(lnum)
+
+  " If the previous line wasn't a MSL and is continuation return its indent.
+  " TODO: the || s:IsInString() thing worries me a bit.
+  if p_lnum != lnum
+    if s:Match(p_lnum,s:continuation_regex)||s:IsInString(p_lnum,strlen(line))
+      return a:ind
+    endif
+  endif
+
+  " Set up more variables now that we know we aren't continuation bound.
+  let msl_ind = indent(lnum)
+
+  " If the previous line ended with [*+/.-=], start a continuation that
+  " indents an extra level.
+  if s:Match(lnum, s:continuation_regex)
+    if lnum == p_lnum
+      return msl_ind + a:width
+    else
+      return msl_ind
+    endif
+  endif
+
+  return a:ind
+endfunction
+
+function s:InOneLineScope(lnum)
+  let msl = s:GetMSL(a:lnum, 1)
+  if msl > 0 && s:Match(msl, s:one_line_scope_regex)
+    return msl
+  endif
+  return 0
+endfunction
+
+function s:ExitingOneLineScope(lnum)
+  let msl = s:GetMSL(a:lnum, 1)
+  if msl > 0
+    " if the current line is in a one line scope ..
+    if s:Match(msl, s:one_line_scope_regex)
+      return 0
+    else
+      let prev_msl = s:GetMSL(msl - 1, 1)
+      if s:Match(prev_msl, s:one_line_scope_regex)
+        return prev_msl
+      endif
+    endif
+  endif
+  return 0
+endfunction
+
+" 3. GetSolidityIndent Function {{{1
+" =========================
+
+function GetSolidityIndent()
+  " 3.1. Setup {{{2
+  " ----------
+
+  " Set up variables for restoring position in file.  Could use v:lnum here.
+  let vcol = col('.')
+
+  " 3.2. Work on the current line {{{2
+  " -----------------------------
+
+  let ind = -1
+  " Get the current line.
+  let line = getline(v:lnum)
+  " previous nonblank line number
+  let prevline = prevnonblank(v:lnum - 1)
+
+  " If we got a closing bracket on an empty line, find its match and indent
+  " according to it.  For parentheses we indent to its column - 1, for the
+  " others we indent to the containing line's MSL's level.  Return -1 if fail.
+  let col = matchend(line, '^\s*[],})]')
+  if col > 0 && !s:IsInStringOrComment(v:lnum, col)
+    call cursor(v:lnum, col)
+
+    let lvar = s:InMultiVarStatement(v:lnum)
+    if lvar
+      let prevline_contents = s:RemoveTrailingComments(getline(prevline))
+
+      " check for comma first
+      if (line[col - 1] =~ ',')
+        " if the previous line ends in comma or semicolon don't indent
+        if (prevline_contents =~ '[;,]\s*$')
+          return indent(s:GetMSL(line('.'), 0))
+        " get previous line indent, if it's comma first return prevline indent
+        elseif (prevline_contents =~ s:comma_first)
+          return indent(prevline)
+        " otherwise we indent 1 level
+        else
+          return indent(lvar) + &sw
+        endif
+      endif
+    endif
+
+
+    let bs = strpart('(){}[]', stridx(')}]', line[col - 1]) * 2, 2)
+    if searchpair(escape(bs[0], '\['), '', bs[1], 'bW', s:skip_expr) > 0
+      if line[col-1]==')' && col('.') != col('$') - 1
+        let ind = virtcol('.')-1
+      else
+        let ind = indent(s:GetMSL(line('.'), 0))
+      endif
+    endif
+    return ind
+  endif
+
+  " If the line is comma first, dedent 1 level
+  if (getline(prevline) =~ s:comma_first)
+    return indent(prevline) - &sw
+  endif
+
+  if (line =~ s:ternary)
+    if (getline(prevline) =~ s:ternary_q)
+      return indent(prevline)
+    else
+      return indent(prevline) + &sw
+    endif
+  endif
+
+  " If we are in a multi-line comment, cindent does the right thing.
+  if s:IsInMultilineComment(v:lnum, 1) && !s:IsLineComment(v:lnum, 1)
+    return cindent(v:lnum)
+  endif
+
+  " Check for multiple var assignments
+"  let var_indent = s:GetVarIndent(v:lnum)
+"  if var_indent >= 0
+"    return var_indent
+"  endif
+
+  " 3.3. Work on the previous line. {{{2
+  " -------------------------------
+
+  " If the line is empty and the previous nonblank line was a multi-line
+  " comment, use that comment's indent. Deduct one char to account for the
+  " space in ' */'.
+  if line =~ '^\s*$' && s:IsInMultilineComment(prevline, 1)
+    return indent(prevline) - 1
+  endif
+
+  " Find a non-blank, non-multi-line string line above the current line.
+  let lnum = s:PrevNonBlankNonString(v:lnum - 1)
+
+  " If the line is empty and inside a string, use the previous line.
+  if line =~ '^\s*$' && lnum != prevline
+    return indent(prevnonblank(v:lnum))
+  endif
+
+  " At the start of the file use zero indent.
+  if lnum == 0
+    return 0
+  endif
+
+  " Set up variables for current line.
+  let line = getline(lnum)
+  let ind = indent(lnum)
+
+  " If the previous line ended with a block opening, add a level of indent.
+  if s:Match(lnum, s:block_regex)
+    return indent(s:GetMSL(lnum, 0)) + &sw
+  endif
+
+  " If the previous line contained an opening bracket, and we are still in it,
+  " add indent depending on the bracket type.
+  if line =~ '[[({]'
+    let counts = s:LineHasOpeningBrackets(lnum)
+    if counts[0] == '1' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
+      if col('.') + 1 == col('$')
+        return ind + &sw
+      else
+        return virtcol('.')
+      endif
+    elseif counts[1] == '1' || counts[2] == '1'
+      return ind + &sw
+    else
+      call cursor(v:lnum, vcol)
+    end
+  endif
+
+  " 3.4. Work on the MSL line. {{{2
+  " --------------------------
+
+  let ind_con = ind
+  let ind = s:IndentWithContinuation(lnum, ind_con, &sw)
+
+  " }}}2
+  "
+  "
+  let ols = s:InOneLineScope(lnum)
+  if ols > 0
+    let ind = ind + &sw
+  else
+    let ols = s:ExitingOneLineScope(lnum)
+    while ols > 0 && ind > 0
+      let ind = ind - &sw
+      let ols = s:InOneLineScope(ols - 1)
+    endwhile
+  endif
+
+  return ind
+endfunction
+
+" }}}1
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/indent/vue.vim
+++ b/runtime/indent/vue.vim
@@ -1,0 +1,12 @@
+" Vim indent file placeholder
+" Language:	Vue
+" Maintainer:	None, please volunteer if you have a real Vue indent script
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+   finish
+endif
+let b:did_indent = 1
+
+" Html comes closest
+runtime! indent/html.vim

--- a/runtime/syntax/chatito.vim
+++ b/runtime/syntax/chatito.vim
@@ -1,0 +1,62 @@
+" Vim syntax file
+" Language:	Chatito
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Filenames:	*.chatito
+" Last Change:	2022 Sep 19
+
+if exists('b:current_syntax')
+    finish
+endif
+
+" Comment
+syn keyword chatitoTodo contained TODO FIXME XXX
+syn match chatitoComment /^#.*/ contains=chatitoTodo,@Spell
+syn match chatitoComment +^//.*+ contains=chatitoTodo,@Spell
+
+" Import
+syn match chatitoImport /^import \+.*$/ transparent contains=chatitoImportKeyword,chatitoImportFile
+syn keyword chatitoImportKeyword import contained nextgroup=chatitoImportFile
+syn match chatitoImportFile /.*$/ contained skipwhite
+
+" Intent
+syn match chatitoIntent /^%\[[^\]?]\+\]\((.\+)\)\=$/ contains=chatitoArgs
+
+" Slot
+syn match chatitoSlot /^@\[[^\]?#]\+\(#[^\]?#]\+\)\=\]\((.\+)\)\=$/ contains=chatitoArgs,chatitoVariation
+syn match chatitoSlot /@\[[^\]?#]\+\(#[^\]?#]\+\)\=?\=\]/ contained contains=chatitoOpt,chatitoVariation
+
+" Alias
+syn match chatitoAlias /^\~\[[^\]?]\+\]\=$/
+syn match chatitoAlias /\~\[[^\]?]\+?\=\]/ contained contains=chatitoOpt
+
+" Probability
+syn match chatitoProbability /\*\[\d\+\(\.\d\+\)\=%\=\]/ contained
+
+" Optional
+syn match chatitoOpt '?' contained
+
+" Arguments
+syn match chatitoArgs /(.\+)/ contained
+
+" Variation
+syn match chatitoVariation /#[^\]?#]\+/ contained
+
+" Value
+syn match chatitoValue /^ \{4\}\zs.\+$/ contains=chatitoProbability,chatitoSlot,chatitoAlias,@Spell
+
+" Errors
+syn match chatitoError /^\t/
+
+hi def link chatitoAlias String
+hi def link chatitoArgs Special
+hi def link chatitoComment Comment
+hi def link chatitoError Error
+hi def link chatitoImportKeyword Include
+hi def link chatitoIntent Statement
+hi def link chatitoOpt SpecialChar
+hi def link chatitoProbability Number
+hi def link chatitoSlot Identifier
+hi def link chatitoTodo Todo
+hi def link chatitoVariation Special
+
+let b:current_syntax = 'chatito'

--- a/runtime/syntax/desktop.vim
+++ b/runtime/syntax/desktop.vim
@@ -3,7 +3,7 @@
 " Filenames: *.desktop, *.directory
 " Maintainer: Eisuke Kawashima ( e.kawaschima+vim AT gmail.com )
 " Previous Maintainer: Mikolaj Machowski ( mikmach AT wp DOT pl )
-" Last Change: 2020-06-11
+" Last Change: 2022 Sep 22
 " Version Info: desktop.vim 1.5
 " References:
 " - https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-1.5.html (2020-04-27)
@@ -60,10 +60,10 @@ syn match dtLocaleSuffix
 
 " Boolean Value {{{2
 syn match   dtBoolean
-      \ /^\%(DBusActivatable\|Hidden\|NoDisplay\|PrefersNonDefaultGPU\|StartupNotify\|Terminal\)\s*=\s*\%(true\|false\)/
+      \ /^\%(DBusActivatable\|Hidden\|NoDisplay\|PrefersNonDefaultGPU\|SingleMainWindow\|StartupNotify\|Terminal\)\s*=\s*\%(true\|false\)/
       \ contains=dtBooleanKey,dtDelim,dtBooleanValue transparent
 syn keyword dtBooleanKey
-      \ DBusActivatable Hidden NoDisplay PrefersNonDefaultGPU StartupNotify Terminal
+      \ DBusActivatable Hidden NoDisplay PrefersNonDefaultGPU SingleMainWindow StartupNotify Terminal
       \ contained nextgroup=dtDelim
 
 if s:desktop_enable_kde

--- a/runtime/syntax/gyp.vim
+++ b/runtime/syntax/gyp.vim
@@ -1,0 +1,49 @@
+" Vim syntax file
+" Language:	GYP
+" Maintainer:	ObserverOfTime <chronobserver@disroot.org>
+" Filenames:	*.gyp,*.gypi
+" Last Change:	2022 Sep 27
+
+if !exists('g:main_syntax')
+  if exists('b:current_syntax') && b:current_syntax ==# 'gyp'
+    finish
+  endif
+  let g:main_syntax = 'gyp'
+endif
+
+" Based on JSON syntax
+runtime! syntax/json.vim
+
+" Single quotes are allowed
+syn clear jsonStringSQError
+
+syn match jsonKeywordMatch /'\([^']\|\\\'\)\+'[[:blank:]\r\n]*\:/ contains=jsonKeyword
+if has('conceal') && (!exists('g:vim_json_conceal') || g:vim_json_conceal==1)
+   syn region  jsonKeyword matchgroup=jsonQuote start=/'/  end=/'\ze[[:blank:]\r\n]*\:/ concealends contained
+else
+   syn region  jsonKeyword matchgroup=jsonQuote start=/'/  end=/'\ze[[:blank:]\r\n]*\:/ contained
+endif
+
+syn match  jsonStringMatch /'\([^']\|\\\'\)\+'\ze[[:blank:]\r\n]*[,}\]]/ contains=jsonString
+if has('conceal') && (!exists('g:vim_json_conceal') || g:vim_json_conceal==1)
+    syn region  jsonString oneline matchgroup=jsonQuote start=/'/  skip=/\\\\\|\\'/  end=/'/ concealends contains=jsonEscape contained
+else
+    syn region  jsonString oneline matchgroup=jsonQuote start=/'/  skip=/\\\\\|\\'/  end=/'/ contains=jsonEscape contained
+endif
+
+" Trailing commas are allowed
+if !exists('g:vim_json_warnings') || g:vim_json_warnings==1
+    syn clear jsonTrailingCommaError
+endif
+
+" Python-style comments are allowed
+syn match   jsonComment  /#.*$/ contains=jsonTodo,@Spell
+syn keyword jsonTodo     FIXME NOTE TODO XXX TBD contained
+
+hi def link jsonComment Comment
+hi def link jsonTodo    Todo
+
+let b:current_syntax = 'gyp'
+if g:main_syntax ==# 'gyp'
+  unlet g:main_syntax
+endif

--- a/runtime/syntax/hare.vim
+++ b/runtime/syntax/hare.vim
@@ -1,0 +1,133 @@
+" PRELUDE {{{1
+" Vim syntax file
+" Language: Hare
+" Maintainer: Amelia Clarke <me@rsaihe.dev>
+" Last Change: 2022-09-21
+
+if exists("b:current_syntax")
+  finish
+endif
+let b:current_syntax = "hare"
+
+" SYNTAX {{{1
+syn case match
+
+" KEYWORDS {{{2
+syn keyword hareConditional if else match switch
+syn keyword hareKeyword break continue return yield
+syn keyword hareKeyword defer
+syn keyword hareKeyword fn
+syn keyword hareKeyword let
+syn keyword hareLabel case
+syn keyword hareOperator as is
+syn keyword hareRepeat for
+syn keyword hareStorageClass const def export nullable static
+syn keyword hareStructure enum struct union
+syn keyword hareTypedef type
+
+" C ABI.
+syn keyword hareKeyword vastart vaarg vaend
+
+" BUILTINS {{{2
+syn keyword hareBuiltin abort
+syn keyword hareBuiltin alloc free
+syn keyword hareBuiltin append delete insert
+syn keyword hareBuiltin assert
+syn keyword hareBuiltin len offset
+
+" TYPES {{{2
+syn keyword hareType bool
+syn keyword hareType char str
+syn keyword hareType f32 f64
+syn keyword hareType u8 u16 u32 u64 i8 i16 i32 i64
+syn keyword hareType uint int
+syn keyword hareType rune
+syn keyword hareType uintptr
+syn keyword hareType void
+
+" C ABI.
+syn keyword hareType valist
+
+" LITERALS {{{2
+syn keyword hareBoolean true false
+syn keyword hareNull null
+
+" Number literals.
+syn match hareNumber "\v(\.@1<!|\.\.)\zs<\d+([Ee][+-]?\d+)?(z|[iu](8|16|32|64)?)?>" display
+syn match hareNumber "\v(\.@1<!|\.\.)\zs<0b[01]+(z|[iu](8|16|32|64)?)?>" display
+syn match hareNumber "\v(\.@1<!|\.\.)\zs<0o\o+(z|[iu](8|16|32|64)?)?>" display
+syn match hareNumber "\v(\.@1<!|\.\.)\zs<0x\x+(z|[iu](8|16|32|64)?)?>" display
+
+" Floating-point number literals.
+syn match hareFloat "\v<\d+\.\d+([Ee][+-]?\d+)?(f32|f64)?>" display
+syn match hareFloat "\v<\d+([Ee][+-]?\d+)?(f32|f64)>" display
+
+" String and rune literals.
+syn match hareEscape "\\[\\'"0abfnrtv]" contained display
+syn match hareEscape "\v\\(x\x{2}|u\x{4}|U\x{8})" contained display
+syn match hareFormat "\v\{\d*(\%\d*|(:[ 0+-]?\d*(\.\d+)?[Xbox]?))?}" contained display
+syn match hareFormat "\({{\|}}\)" contained display
+syn region hareRune start="'" end="'\|$" skip="\\'" contains=hareEscape display extend
+syn region hareString start=+"+ end=+"\|$+ skip=+\\"+ contains=hareEscape,hareFormat display extend
+syn region hareString start="`" end="`\|$" contains=hareFormat display
+
+" MISCELLANEOUS {{{2
+syn keyword hareTodo FIXME TODO XXX contained
+
+" Attributes.
+syn match hareAttribute "@[a-z]*"
+
+" Blocks.
+syn region hareBlock start="{" end="}" fold transparent
+
+" Comments.
+syn region hareComment start="//" end="$" contains=hareCommentDoc,hareTodo,@Spell display keepend
+syn region hareCommentDoc start="\[\[" end="]]\|\ze\_s" contained display
+
+" The size keyword can be either a builtin or a type.
+syn match hareBuiltin "\v<size>\ze(\_s*//.*\_$)*\_s*\(" contains=hareComment
+syn match hareType "\v<size>((\_s*//.*\_$)*\_s*\()@!" contains=hareComment
+
+" Trailing whitespace.
+syn match hareSpaceError "\v\s+$" display excludenl
+syn match hareSpaceError "\v\zs +\ze\t" display
+
+" Use statement.
+syn region hareUse start="\v^\s*\zsuse>" end=";" contains=hareComment display
+
+syn match hareErrorAssertion "\v(^([^/]|//@!)*\)\_s*)@<=!\=@!"
+syn match hareQuestionMark "?"
+
+" DEFAULT HIGHLIGHTING {{{1
+hi def link hareAttribute Keyword
+hi def link hareBoolean Boolean
+hi def link hareBuiltin Function
+hi def link hareComment Comment
+hi def link hareCommentDoc SpecialComment
+hi def link hareConditional Conditional
+hi def link hareEscape SpecialChar
+hi def link hareFloat Float
+hi def link hareFormat SpecialChar
+hi def link hareKeyword Keyword
+hi def link hareLabel Label
+hi def link hareNull Constant
+hi def link hareNumber Number
+hi def link hareOperator Operator
+hi def link hareQuestionMark Special
+hi def link hareRepeat Repeat
+hi def link hareRune Character
+hi def link hareStorageClass StorageClass
+hi def link hareString String
+hi def link hareStructure Structure
+hi def link hareTodo Todo
+hi def link hareType Type
+hi def link hareTypedef Typedef
+hi def link hareUse PreProc
+
+hi def link hareSpaceError Error
+autocmd InsertEnter * hi link hareSpaceError NONE
+autocmd InsertLeave * hi link hareSpaceError Error
+
+hi def hareErrorAssertion ctermfg=red cterm=bold guifg=red gui=bold
+
+" vim: tabstop=8 shiftwidth=2 expandtab

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	Bram Moolenaar (Bram@vim.org)
-" Last Change:	2021 Jun 13
+" Last Change:	2022 Sep 26
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -39,6 +39,7 @@ syn match helpVim		"VIM REFERENCE.*"
 syn match helpVim		"NVIM REFERENCE.*"
 syn match helpOption		"'[a-z]\{2,\}'"
 syn match helpOption		"'t_..'"
+syn match helpNormal		"'ab'"
 syn match helpCommand		"`[^` \t]\+`"hs=s+1,he=e-1 contains=helpBacktick
 syn match helpCommand		"\(^\|[^a-z"[]\)\zs`[^`]\+`\ze\([^a-z\t."']\|$\)"hs=s+1,he=e-1 contains=helpBacktick
 syn match helpHeader		"\s*\zs.\{-}\ze\s\=\~$" nextgroup=helpIgnore

--- a/runtime/syntax/hlsplaylist.vim
+++ b/runtime/syntax/hlsplaylist.vim
@@ -1,0 +1,120 @@
+" Vim syntax file
+" Language: HLS Playlist
+" Maintainer: Benoît Ryder <benoit@ryder.fr>
+" Latest Revision: 2022-09-23
+
+if exists("b:current_syntax")
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" Comment line
+syn match  hlsplaylistComment  "^#\(EXT\)\@!.*$"
+" Segment URL
+syn match  hlsplaylistUrl      "^[^#].*$"
+
+" Unknown tags, assume an attribute list or nothing
+syn match  hlsplaylistTagUnknown    "^#EXT[^:]*$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagUnknown    start="^#EXT[^:]*\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Basic Tags
+syn match  hlsplaylistTagHeader     "^#EXTM3U$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-VERSION\ze:"  end="$" keepend contains=hlsplaylistValueInt
+
+" Media or Multivariant Playlist Tags
+syn match  hlsplaylistTagHeader     "^#EXT-X-INDEPENDENT-SEGMENTS$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagDelimiter  start="^#EXT-X-START\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-DEFINE\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Media Playlist Tags
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-TARGETDURATION\ze:"  end="$" keepend contains=hlsplaylistValueFloat
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-MEDIA-SEQUENCE\ze:"  end="$" keepend contains=hlsplaylistValueInt
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-DISCONTINUITY-SEQUENCE\ze:"  end="$" keepend contains=hlsplaylistValueInt
+syn match  hlsplaylistTagDelimiter  "^#EXT-X-ENDLIST$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-PLAYLIST-TYPE\ze:"  end="$" keepend contains=hlsplaylistAttributeEnum
+syn match  hlsplaylistTagStandard   "^#EXT-X-I-FRAME-ONLY$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-PART-INF\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagHeader     start="^#EXT-X-SERVER-CONTROL\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Media Segment Tags
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXTINF\ze:"  end="$" keepend contains=hlsplaylistValueFloat,hlsplaylistExtInfDesc
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-BYTERANGE\ze:"  end="$" keepend contains=hlsplaylistValueInt
+syn match  hlsplaylistTagDelimiter  "^#EXT-X-DISCONTINUITY$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-KEY\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-MAP\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-PROGRAM-DATE-TIME\ze:"  end="$" keepend contains=hlsplaylistValueDateTime
+syn match  hlsplaylistTagDelimiter  "^#EXT-X-GAP$"
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-BITRATE\ze:"  end="$" keepend contains=hlsplaylistValueFloat
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXT-X-PART\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Media Metadata Tags
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-DATERANGE\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-SKIP\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXT-X-PRELOAD-HINT\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXT-X-RENDITION-REPORT\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Multivariant Playlist Tags
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-MEDIA\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXT-X-STREAM-INF\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStatement  start="^#EXT-X-I-FRAME-STREAM-INF\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-SESSION-DATA\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-SESSION-KEY\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+syn region hlsplaylistTagLine matchgroup=hlsplaylistTagStandard   start="^#EXT-X-CONTENT-STEERING\ze:"  end="$" keepend contains=hlsplaylistAttributeList
+
+" Attributes
+syn region hlsplaylistAttributeList  start=":" end="$" keepend contained
+  \ contains=hlsplaylistAttributeName,hlsplaylistAttributeInt,hlsplaylistAttributeHex,hlsplaylistAttributeFloat,hlsplaylistAttributeString,hlsplaylistAttributeEnum,hlsplaylistAttributeResolution,hlsplaylistAttributeUri
+" Common attributes
+syn match  hlsplaylistAttributeName        "[A-Za-z-]\+\ze=" contained
+syn match  hlsplaylistAttributeEnum        "=\zs[A-Za-z][A-Za-z0-9-_]*" contained
+syn match  hlsplaylistAttributeString      +=\zs"[^"]*"+ contained
+syn match  hlsplaylistAttributeInt         "=\zs\d\+" contained
+syn match  hlsplaylistAttributeFloat       "=\zs-\?\d*\.\d*" contained
+syn match  hlsplaylistAttributeHex         "=\zs0[xX]\d*" contained
+syn match  hlsplaylistAttributeResolution  "=\zs\d\+x\d\+" contained
+" Allow different highligting for URI attributes
+syn region hlsplaylistAttributeUri matchgroup=hlsplaylistAttributeName    start="\zsURI\ze" end="\(,\|$\)" contained contains=hlsplaylistUriQuotes
+syn region hlsplaylistUriQuotes    matchgroup=hlsplaylistAttributeString  start=+"+ end=+"+ keepend contained contains=hlsplaylistUriValue
+syn match  hlsplaylistUriValue             /[^" ]\+/ contained
+" Individual values
+syn match  hlsplaylistValueInt             "[0-9]\+" contained
+syn match  hlsplaylistValueFloat           "\(\d\+\|\d*\.\d*\)" contained
+syn match  hlsplaylistExtInfDesc           ",\zs.*$" contained
+syn match  hlsplaylistValueDateTime        "\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\(\.\d*\)\?\(Z\|\d\d:\?\d\d\)$" contained
+
+
+" Define default highlighting
+
+hi def link hlsplaylistComment  Comment
+hi def link hlsplaylistUrl      NONE
+
+hi def link hlsplaylistTagHeader     Special
+hi def link hlsplaylistTagStandard   Define
+hi def link hlsplaylistTagDelimiter  Delimiter
+hi def link hlsplaylistTagStatement  Statement
+hi def link hlsplaylistTagUnknown    Special
+
+hi def link hlsplaylistUriQuotes            String
+hi def link hlsplaylistUriValue             Underlined
+hi def link hlsplaylistAttributeQuotes      String
+hi def link hlsplaylistAttributeName        Identifier
+hi def link hlsplaylistAttributeInt         Number
+hi def link hlsplaylistAttributeHex         Number
+hi def link hlsplaylistAttributeFloat       Float
+hi def link hlsplaylistAttributeString      String
+hi def link hlsplaylistAttributeEnum        Constant
+hi def link hlsplaylistAttributeResolution  Constant
+hi def link hlsplaylistValueInt             Number
+hi def link hlsplaylistValueFloat           Float
+hi def link hlsplaylistExtInfDesc           String
+hi def link hlsplaylistValueDateTime        Constant
+
+
+let b:current_syntax = "hlsplaylist"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sts=2 sw=2 et

--- a/runtime/syntax/plsql.vim
+++ b/runtime/syntax/plsql.vim
@@ -4,8 +4,11 @@
 " Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
 " Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
 " URL: https://github.com/lee-lindley/vim_plsql_syntax
-" Last Change: Aug 21, 2022   
-" History  Lee Lindley (lee dot lindley at gmail dot com)
+" Last Change: Sep 19, 2022   
+" History  Carsten Czarski (carsten dot czarski at oracle com)
+"               add handling for typical SQL*Plus commands (rem, start, host, set, etc)
+"               add error highlight for non-breaking space
+"          Lee Lindley (lee dot lindley at gmail dot com)
 "               use get with default 0 instead of exists per Bram suggestion
 "               make procedure folding optional
 "               updated to 19c keywords. refined quoting. 
@@ -54,7 +57,12 @@ syn case ignore
 
 syn match   plsqlGarbage "[^ \t()]"
 syn match   plsqlIdentifier "[a-z][a-z0-9$_#]*"
+syn match   plsqlSqlPlusDefine "&&\?[a-z][a-z0-9$_#]*\.\?"
 syn match   plsqlHostIdentifier ":[a-z][a-z0-9$_#]*"
+
+" The Non-Breaking is often accidentally typed (Mac User: Opt+Space, after typing the "|",  Opt+7);
+" error highlight for these avoids running into annoying compiler errors.
+syn match   plsqlIllegalSpace "[\xa0]"
 
 " When wanted, highlight the trailing whitespace.
 if get(g:,"plsql_space_errors",0) == 1
@@ -79,7 +87,6 @@ syn match   plsqlOperator "\<IS\\_s\+\(NOT\_s\+\)\?NULL\>"
 "
 " conditional compilation Preprocessor directives and sqlplus define sigil
 syn match plsqlPseudo "$[$a-z][a-z0-9$_#]*"
-syn match plsqlPseudo "&"
 
 syn match plsqlReserved "\<\(CREATE\|THEN\|UPDATE\|INSERT\|SET\)\>"
 syn match plsqlKeyword "\<\(REPLACE\|PACKAGE\|FUNCTION\|PROCEDURE\|TYPE|BODY\|WHEN\|MATCHED\)\>"
@@ -150,7 +157,7 @@ syn keyword plsqlKeyword DATA_SECURITY_REWRITE_LIMIT DATA_VALIDATE DATE_MODE DAY
 syn keyword plsqlKeyword DBMS_STATS DBSTR2UTF8 DBTIMEZONE DB_ROLE_CHANGE DB_UNIQUE_NAME DB_VERSION
 syn keyword plsqlKeyword DDL DEALLOCATE DEBUG DEBUGGER DECLARE DECODE DECOMPOSE DECOMPRESS DECORRELATE
 syn keyword plsqlKeyword DECR DECREMENT DECRYPT DEDUPLICATE DEFAULTS DEFAULT_COLLATION DEFAULT_PDB_HINT
-syn keyword plsqlKeyword DEFERRABLE DEFERRED DEFINE DEFINED DEFINER DEFINITION DEGREE DELAY DELEGATE
+syn keyword plsqlKeyword DEFERRABLE DEFERRED DEFINED DEFINER DEFINITION DEGREE DELAY DELEGATE
 syn keyword plsqlKeyword DELETEXML DELETE_ALL DEMAND DENORM_AV DENSE_RANK DENSE_RANKM DEPENDENT DEPTH
 syn keyword plsqlKeyword DEQUEUE DEREF DEREF_NO_REWRITE DESCENDANT DESCRIPTION DESTROY DETACHED DETERMINED
 syn keyword plsqlKeyword DETERMINES DETERMINISTIC DG_GATHER_STATS DIAGNOSTICS DICTIONARY DIGEST DIMENSION
@@ -189,7 +196,7 @@ syn keyword plsqlKeyword HELP HEXTORAW HEXTOREF HIDDEN HIDE HIERARCHICAL HIERARC
 syn keyword plsqlKeyword HIER_CAPTION HIER_CHILDREN HIER_CHILD_COUNT HIER_COLUMN HIER_CONDITION HIER_DEPTH
 syn keyword plsqlKeyword HIER_DESCRIPTION HIER_HAS_CHILDREN HIER_LAG HIER_LEAD HIER_LEVEL HIER_MEMBER_NAME
 syn keyword plsqlKeyword HIER_MEMBER_UNIQUE_NAME HIER_ORDER HIER_PARENT HIER_WINDOW HIGH HINTSET_BEGIN
-syn keyword plsqlKeyword HINTSET_END HOST HOT HOUR HOURS HTTP HWM_BROKERED HYBRID ID IDENTIFIER IDENTITY
+syn keyword plsqlKeyword HINTSET_END HOT HOUR HOURS HTTP HWM_BROKERED HYBRID ID IDENTIFIER IDENTITY
 syn keyword plsqlKeyword IDGENERATORS IDLE IDLE_TIME IGNORE IGNORE_OPTIM_EMBEDDED_HINTS IGNORE_ROW_ON_DUPKEY_INDEX
 syn keyword plsqlKeyword IGNORE_WHERE_CLAUSE ILM IMMEDIATE IMMUTABLE IMPACT IMPORT INACTIVE INACTIVE_ACCOUNT_TIME
 syn keyword plsqlKeyword INCLUDE INCLUDES INCLUDE_VERSION INCLUDING INCOMING INCR INCREMENT INCREMENTAL
@@ -342,7 +349,7 @@ syn keyword plsqlKeyword SELF SEMIJOIN SEMIJOIN_DRIVER SEMI_TO_INNER SENSITIVE S
 syn keyword plsqlKeyword SERIAL SERIALIZABLE SERVERERROR SERVICE SERVICES SERVICE_NAME_CONVERT SESSION
 syn keyword plsqlKeyword SESSIONS_PER_USER SESSIONTIMEZONE SESSIONTZNAME SESSION_CACHED_CURSORS SETS
 syn keyword plsqlKeyword SETTINGS SET_GBY_PUSHDOWN SET_TO_JOIN SEVERE SHARD SHARDED SHARDS SHARDSPACE
-syn keyword plsqlKeyword SHARD_CHUNK_ID SHARED SHARED_POOL SHARE_OF SHARING SHD$COL$MAP SHELFLIFE SHOW
+syn keyword plsqlKeyword SHARD_CHUNK_ID SHARED SHARED_POOL SHARE_OF SHARING SHD$COL$MAP SHELFLIFE 
 syn keyword plsqlKeyword SHRINK SHUTDOWN SIBLING SIBLINGS SID SIGN SIGNAL_COMPONENT SIGNAL_FUNCTION
 syn keyword plsqlKeyword SIGNATURE SIMPLE SIN SINGLE SINGLETASK SINH SITE SKEWNESS_POP SKEWNESS_SAMP
 syn keyword plsqlKeyword SKIP SKIP_EXT_OPTIMIZER SKIP_PROXY SKIP_UNQ_UNUSABLE_IDX SKIP_UNUSABLE_INDEXES
@@ -445,7 +452,7 @@ syn keyword plsqlKeyword VECTOR_READ_TRACE VECTOR_TRANSFORM VECTOR_TRANSFORM_DIM
 syn keyword plsqlKeyword VERIFIER VERIFY VERSION VERSIONING VERSIONS VERSIONS_ENDSCN VERSIONS_ENDTIME
 syn keyword plsqlKeyword VERSIONS_OPERATION VERSIONS_STARTSCN VERSIONS_STARTTIME VERSIONS_XID VIEWS
 syn keyword plsqlKeyword VIOLATION VIRTUAL VISIBILITY VISIBLE VOLUME VSIZE WAIT WALLET WEEK WEEKS WELLFORMED
-syn keyword plsqlKeyword WHENEVER WHITESPACE WIDTH_BUCKET WINDOW WITHIN WITHOUT WITH_EXPRESSION
+syn keyword plsqlKeyword WHITESPACE WIDTH_BUCKET WINDOW WITHIN WITHOUT WITH_EXPRESSION
 syn keyword plsqlKeyword WITH_PLSQL WORK WRAPPED WRAPPER WRITE XDB_FASTPATH_INSERT XID XML XML2OBJECT
 syn keyword plsqlKeyword XMLATTRIBUTES XMLCAST XMLCDATA XMLCOLATTVAL XMLCOMMENT XMLCONCAT XMLDIFF XMLELEMENT
 syn keyword plsqlKeyword XMLEXISTS XMLEXISTS2 XMLFOREST XMLINDEX_REWRITE XMLINDEX_REWRITE_IN_SELECT
@@ -468,13 +475,13 @@ syn keyword plsqlReserved MINUS MODE NOCOMPRESS NOWAIT NUMBER_BASE OCICOLL OCIDA
 syn keyword plsqlReserved OCIDURATION OCIINTERVAL OCILOBLOCATOR OCINUMBER OCIRAW OCIREF OCIREFCURSOR
 syn keyword plsqlReserved OCIROWID OCISTRING OCITYPE OF ON OPTION ORACLE ORADATA ORDER ORLANY ORLVARY
 syn keyword plsqlReserved OUT OVERRIDING PARALLEL_ENABLE PARAMETER PASCAL PCTFREE PIPE PIPELINED POLYMORPHIC
-syn keyword plsqlReserved PRAGMA PRIOR PUBLIC RAISE RECORD RELIES_ON REM RENAME RESOURCE RESULT REVOKE ROWID 
+syn keyword plsqlReserved PRAGMA PRIOR PUBLIC RAISE RECORD RELIES_ON RENAME RESOURCE RESULT REVOKE ROWID 
 syn keyword plsqlReserved SB1 SB2 
 syn match plsqlReserved "\<SELECT\>"
 syn keyword plsqlReserved SEPARATE SHARE SHORT SIZE SIZE_T SPARSE SQLCODE SQLDATA
 syn keyword plsqlReserved SQLNAME SQLSTATE STANDARD START STORED STRUCT STYLE SYNONYM TABLE TDO
 syn keyword plsqlReserved TRANSACTIONAL TRIGGER UB1 UB4 UNION UNIQUE UNSIGNED UNTRUSTED VALIST
-syn keyword plsqlReserved VALUES VARIABLE VIEW VOID WHERE WITH
+syn keyword plsqlReserved VALUES VIEW VOID WHERE WITH
 
 " PL/SQL and SQL functions.
 syn keyword plsqlFunction ABS ACOS ADD_MONTHS APPROX_COUNT APPROX_COUNT_DISTINCT APPROX_COUNT_DISTINCT_AGG
@@ -584,18 +591,18 @@ syn match plsqlEND "\<END\>"
 syn match plsqlISAS "\<\(IS\|AS\)\>"
 
 " Various types of comments.
-syntax region plsqlCommentL start="--" skip="\\$" end="$" keepend extend contains=@plsqlCommentGroup,plsqlSpaceError
+syntax region plsqlCommentL start="--" skip="\\$" end="$" keepend extend contains=@plsqlCommentGroup,plsqlSpaceError,plsqlIllegalSpace,plsqlSqlplusDefine
 if get(g:,"plsql_fold",0) == 1
     syntax region plsqlComment
         \ start="/\*" end="\*/"
         \ extend
-        \ contains=@plsqlCommentGroup,plsqlSpaceError
+        \ contains=@plsqlCommentGroup,plsqlSpaceError,plsqlIllegalSpace,plsqlSqlplusDefine
         \ fold
 else
     syntax region plsqlComment
         \ start="/\*" end="\*/"
         \ extend
-        \ contains=@plsqlCommentGroup,plsqlSpaceError
+        \ contains=@plsqlCommentGroup,plsqlSpaceError,plsqlIllegalSpace,plsqlSqlplusDefine
 endif
 syn cluster plsqlCommentAll contains=plsqlCommentL,plsqlComment
 
@@ -618,23 +625,23 @@ syn match   plsqlFloatLiteral contained "\.\(\d\+\([eE][+-]\?\d\+\)\?\)[fd]\?"
 " double quoted strings in SQL are database object names. Should be a subgroup of Normal.
 " We will use Character group as a proxy for that so color can be chosen close to Normal
 syn region plsqlQuotedIdentifier	matchgroup=plsqlOperator start=+n\?"+     end=+"+ keepend extend
-syn cluster plsqlIdentifiers contains=plsqlIdentifier,plsqlQuotedIdentifier
+syn cluster plsqlIdentifiers contains=plsqlIdentifier,plsqlQuotedIdentifier,plsqlSqlPlusDefine
 
 " quoted string literals
 if get(g:,"plsql_fold",0) == 1
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?'+  skip=+''+    end=+'+ fold keepend extend
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\z([^[(<{]\)+    end=+\z1'+ fold keepend extend
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'<+   end=+>'+ fold keepend extend
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'{+   end=+}'+ fold keepend extend
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'(+   end=+)'+ fold keepend extend
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\[+  end=+]'+ fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?'+  skip=+''+    end=+'+ contains=plsqlSqlplusDefine fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\z([^[(<{]\)+    end=+\z1'+ contains=plsqlSqlplusDefine fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'<+   end=+>'+ contains=plsqlSqlplusDefine fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'{+   end=+}'+ contains=plsqlSqlplusDefine fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'(+   end=+)'+ contains=plsqlSqlplusDefine fold keepend extend
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\[+  end=+]'+ contains=plsqlSqlplusDefine fold keepend extend
 else
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?'+  skip=+''+    end=+'+ 
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\z([^[(<{]\)+    end=+\z1'+ 
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'<+   end=+>'+ 
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'{+   end=+}'+ 
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'(+   end=+)'+ 
-    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\[+  end=+]'+ 
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?'+  skip=+''+    end=+'+ contains=plsqlSqlplusDefine
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\z([^[(<{]\)+    end=+\z1'+ contains=plsqlSqlplusDefine
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'<+   end=+>'+ contains=plsqlSqlplusDefine
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'{+   end=+}'+ contains=plsqlSqlplusDefine
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'(+   end=+)'+ contains=plsqlSqlplusDefine
+    syn region plsqlStringLiteral	matchgroup=plsqlOperator start=+n\?q'\[+  end=+]'+ contains=plsqlSqlplusDefine
 endif
 
 syn keyword plsqlBooleanLiteral TRUE FALSE 
@@ -681,6 +688,10 @@ syn match plsqlConditional "\<\(ELSIF\|IF\|ELSE\)\>"
 syn match plsqlConditional "\<END\>\_s\+\<IF\>"
 syn match plsqlCase "\<END\>\_s\+\<CASE\>"
 syn match plsqlCase "\<CASE\>"
+
+syn region plsqlSqlPlusCommentL start="^\(REM\)\( \|$\)" skip="\\$" end="$" keepend extend contains=@plsqlCommentGroup,plsqlSpaceError,plsqlIllegalSpace
+syn region plsqlSqlPlusCommand  start="^\(SET\|DEFINE\|PROMPT\|ACCEPT\|EXEC\|HOST\|SHOW\|VAR\|VARIABLE\|COL\|WHENEVER\|TIMING\)\( \|$\)" skip="\\$" end="$" keepend extend
+syn region plsqlSqlPlusRunFile  start="^\(@\|@@\)" skip="\\$" end="$" keepend extend
 
 if get(g:,"plsql_fold",0) == 1
     setlocal foldmethod=syntax
@@ -826,6 +837,13 @@ hi def link plsqlComment2String     String
 hi def link plsqlTrigger	        Function
 hi def link plsqlTypeAttribute      StorageClass
 hi def link plsqlTodo		        Todo
+
+hi def link plsqlIllegalSpace       Error
+hi def link plsqlSqlPlusDefine      PreProc
+hi def link plsqlSqlPlusCommand     PreProc
+hi def link plsqlSqlPlusRunFile     Include
+hi def link plsqlSqlPlusCommentL    Comment
+
 " to be able to change them after loading, need override whether defined or not
 if get(g:,"plsql_legacy_sql_keywords",0) == 1
     hi link plsqlSQLKeyword         Function

--- a/runtime/syntax/solidity.vim
+++ b/runtime/syntax/solidity.vim
@@ -1,0 +1,173 @@
+" Vim syntax file
+" Language: 		Solidity
+" Maintainer: 		Cothi (jiungdev@gmail.com)
+" Original Author: 	tomlion (https://github.com/tomlion/vim-solidity/blob/master/syntax/solidity.vim)
+" Last Changed: 	2022 Sep 27
+"
+" Additional contributors:
+"       Modified by thesis (https://github.com/thesis/vim-solidity/blob/main/indent/solidity.vim)
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" keyword
+syn keyword solKeyword           abstract anonymous as break calldata case catch constant constructor continue default switch revert require
+syn keyword solKeyword           ecrecover addmod mulmod keccak256
+syn keyword solKeyword           delete do else emit enum external final for function if immutable import in indexed inline
+syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure override virtual
+syn keyword solKeyword           relocatable return returns static storage struct throw try type typeof using
+syn keyword solKeyword           var view while
+
+syn keyword solConstant          true false wei szabo finney ether seconds minutes hours days weeks years now
+syn keyword solConstant          abi block blockhash msg tx this super selfdestruct
+
+syn keyword solBuiltinType       mapping address bool
+syn keyword solBuiltinType       int int8 int16 int24 int32 int40 int48 int56 int64 int72 int80 int88 int96 int104 int112 int120 int128 int136 int144 int152 int160 int168 int178 int184 int192 int200 int208 int216 int224 int232 int240 int248 int256
+syn keyword solBuiltinType       uint uint8 uint16 uint24 uint32 uint40 uint48 uint56 uint64 uint72 uint80 uint88 uint96 uint104 uint112 uint120 uint128 uint136 uint144 uint152 uint160 uint168 uint178 uint184 uint192 uint200 uint208 uint216 uint224 uint232 uint240 uint248 uint256
+syn keyword solBuiltinType       fixed
+syn keyword solBuiltinType       fixed0x8 fixed0x16 fixed0x24 fixed0x32 fixed0x40 fixed0x48 fixed0x56 fixed0x64 fixed0x72 fixed0x80 fixed0x88 fixed0x96 fixed0x104 fixed0x112 fixed0x120 fixed0x128 fixed0x136 fixed0x144 fixed0x152 fixed0x160 fixed0x168 fixed0x178 fixed0x184 fixed0x192 fixed0x200 fixed0x208 fixed0x216 fixed0x224 fixed0x232 fixed0x240 fixed0x248 fixed0x256
+syn keyword solBuiltinType       fixed8x8 fixed8x16 fixed8x24 fixed8x32 fixed8x40 fixed8x48 fixed8x56 fixed8x64 fixed8x72 fixed8x80 fixed8x88 fixed8x96 fixed8x104 fixed8x112 fixed8x120 fixed8x128 fixed8x136 fixed8x144 fixed8x152 fixed8x160 fixed8x168 fixed8x178 fixed8x184 fixed8x192 fixed8x200 fixed8x208 fixed8x216 fixed8x224 fixed8x232 fixed8x240 fixed8x248
+syn keyword solBuiltinType       fixed16x8 fixed16x16 fixed16x24 fixed16x32 fixed16x40 fixed16x48 fixed16x56 fixed16x64 fixed16x72 fixed16x80 fixed16x88 fixed16x96 fixed16x104 fixed16x112 fixed16x120 fixed16x128 fixed16x136 fixed16x144 fixed16x152 fixed16x160 fixed16x168 fixed16x178 fixed16x184 fixed16x192 fixed16x200 fixed16x208 fixed16x216 fixed16x224 fixed16x232 fixed16x240
+syn keyword solBuiltinType       fixed24x8 fixed24x16 fixed24x24 fixed24x32 fixed24x40 fixed24x48 fixed24x56 fixed24x64 fixed24x72 fixed24x80 fixed24x88 fixed24x96 fixed24x104 fixed24x112 fixed24x120 fixed24x128 fixed24x136 fixed24x144 fixed24x152 fixed24x160 fixed24x168 fixed24x178 fixed24x184 fixed24x192 fixed24x200 fixed24x208 fixed24x216 fixed24x224 fixed24x232
+syn keyword solBuiltinType       fixed32x8 fixed32x16 fixed32x24 fixed32x32 fixed32x40 fixed32x48 fixed32x56 fixed32x64 fixed32x72 fixed32x80 fixed32x88 fixed32x96 fixed32x104 fixed32x112 fixed32x120 fixed32x128 fixed32x136 fixed32x144 fixed32x152 fixed32x160 fixed32x168 fixed32x178 fixed32x184 fixed32x192 fixed32x200 fixed32x208 fixed32x216 fixed32x224
+syn keyword solBuiltinType       fixed40x8 fixed40x16 fixed40x24 fixed40x32 fixed40x40 fixed40x48 fixed40x56 fixed40x64 fixed40x72 fixed40x80 fixed40x88 fixed40x96 fixed40x104 fixed40x112 fixed40x120 fixed40x128 fixed40x136 fixed40x144 fixed40x152 fixed40x160 fixed40x168 fixed40x178 fixed40x184 fixed40x192 fixed40x200 fixed40x208 fixed40x216
+syn keyword solBuiltinType       fixed48x8 fixed48x16 fixed48x24 fixed48x32 fixed48x40 fixed48x48 fixed48x56 fixed48x64 fixed48x72 fixed48x80 fixed48x88 fixed48x96 fixed48x104 fixed48x112 fixed48x120 fixed48x128 fixed48x136 fixed48x144 fixed48x152 fixed48x160 fixed48x168 fixed48x178 fixed48x184 fixed48x192 fixed48x200 fixed48x208
+syn keyword solBuiltinType       fixed56x8 fixed56x16 fixed56x24 fixed56x32 fixed56x40 fixed56x48 fixed56x56 fixed56x64 fixed56x72 fixed56x80 fixed56x88 fixed56x96 fixed56x104 fixed56x112 fixed56x120 fixed56x128 fixed56x136 fixed56x144 fixed56x152 fixed56x160 fixed56x168 fixed56x178 fixed56x184 fixed56x192 fixed56x200
+syn keyword solBuiltinType       fixed64x8 fixed64x16 fixed64x24 fixed64x32 fixed64x40 fixed64x48 fixed64x56 fixed64x64 fixed64x72 fixed64x80 fixed64x88 fixed64x96 fixed64x104 fixed64x112 fixed64x120 fixed64x128 fixed64x136 fixed64x144 fixed64x152 fixed64x160 fixed64x168 fixed64x178 fixed64x184 fixed64x192
+syn keyword solBuiltinType       fixed72x8 fixed72x16 fixed72x24 fixed72x32 fixed72x40 fixed72x48 fixed72x56 fixed72x64 fixed72x72 fixed72x80 fixed72x88 fixed72x96 fixed72x104 fixed72x112 fixed72x120 fixed72x128 fixed72x136 fixed72x144 fixed72x152 fixed72x160 fixed72x168 fixed72x178 fixed72x184
+syn keyword solBuiltinType       fixed80x8 fixed80x16 fixed80x24 fixed80x32 fixed80x40 fixed80x48 fixed80x56 fixed80x64 fixed80x72 fixed80x80 fixed80x88 fixed80x96 fixed80x104 fixed80x112 fixed80x120 fixed80x128 fixed80x136 fixed80x144 fixed80x152 fixed80x160 fixed80x168 fixed80x178
+syn keyword solBuiltinType       fixed88x8 fixed88x16 fixed88x24 fixed88x32 fixed88x40 fixed88x48 fixed88x56 fixed88x64 fixed88x72 fixed88x80 fixed88x88 fixed88x96 fixed88x104 fixed88x112 fixed88x120 fixed88x128 fixed88x136 fixed88x144 fixed88x152 fixed88x160 fixed88x168
+syn keyword solBuiltinType       fixed96x8 fixed96x16 fixed96x24 fixed96x32 fixed96x40 fixed96x48 fixed96x56 fixed96x64 fixed96x72 fixed96x80 fixed96x88 fixed96x96 fixed96x104 fixed96x112 fixed96x120 fixed96x128 fixed96x136 fixed96x144 fixed96x152 fixed96x160
+syn keyword solBuiltinType       fixed104x8 fixed104x16 fixed104x24 fixed104x32 fixed104x40 fixed104x48 fixed104x56 fixed104x64 fixed104x72 fixed104x80 fixed104x88 fixed104x96 fixed104x104 fixed104x112 fixed104x120 fixed104x128 fixed104x136 fixed104x144 fixed104x152
+syn keyword solBuiltinType       fixed112x8 fixed112x16 fixed112x24 fixed112x32 fixed112x40 fixed112x48 fixed112x56 fixed112x64 fixed112x72 fixed112x80 fixed112x88 fixed112x96 fixed112x104 fixed112x112 fixed112x120 fixed112x128 fixed112x136 fixed112x144
+syn keyword solBuiltinType       fixed120x8 fixed120x16 fixed120x24 fixed120x32 fixed120x40 fixed120x48 fixed120x56 fixed120x64 fixed120x72 fixed120x80 fixed120x88 fixed120x96 fixed120x104 fixed120x112 fixed120x120 fixed120x128 fixed120x136
+syn keyword solBuiltinType       fixed128x8 fixed128x16 fixed128x24 fixed128x32 fixed128x40 fixed128x48 fixed128x56 fixed128x64 fixed128x72 fixed128x80 fixed128x88 fixed128x96 fixed128x104 fixed128x112 fixed128x120 fixed128x128
+syn keyword solBuiltinType       fixed136x8 fixed136x16 fixed136x24 fixed136x32 fixed136x40 fixed136x48 fixed136x56 fixed136x64 fixed136x72 fixed136x80 fixed136x88 fixed136x96 fixed136x104 fixed136x112 fixed136x120
+syn keyword solBuiltinType       fixed144x8 fixed144x16 fixed144x24 fixed144x32 fixed144x40 fixed144x48 fixed144x56 fixed144x64 fixed144x72 fixed144x80 fixed144x88 fixed144x96 fixed144x104 fixed144x112
+syn keyword solBuiltinType       fixed152x8 fixed152x16 fixed152x24 fixed152x32 fixed152x40 fixed152x48 fixed152x56 fixed152x64 fixed152x72 fixed152x80 fixed152x88 fixed152x96 fixed152x104
+syn keyword solBuiltinType       fixed160x8 fixed160x16 fixed160x24 fixed160x32 fixed160x40 fixed160x48 fixed160x56 fixed160x64 fixed160x72 fixed160x80 fixed160x88 fixed160x96
+syn keyword solBuiltinType       fixed168x8 fixed168x16 fixed168x24 fixed168x32 fixed168x40 fixed168x48 fixed168x56 fixed168x64 fixed168x72 fixed168x80 fixed168x88
+syn keyword solBuiltinType       fixed176x8 fixed176x16 fixed176x24 fixed176x32 fixed176x40 fixed176x48 fixed176x56 fixed176x64 fixed176x72 fixed176x80
+syn keyword solBuiltinType       fixed184x8 fixed184x16 fixed184x24 fixed184x32 fixed184x40 fixed184x48 fixed184x56 fixed184x64 fixed184x72
+syn keyword solBuiltinType       fixed192x8 fixed192x16 fixed192x24 fixed192x32 fixed192x40 fixed192x48 fixed192x56 fixed192x64
+syn keyword solBuiltinType       fixed200x8 fixed200x16 fixed200x24 fixed200x32 fixed200x40 fixed200x48 fixed200x56
+syn keyword solBuiltinType       fixed208x8 fixed208x16 fixed208x24 fixed208x32 fixed208x40 fixed208x48
+syn keyword solBuiltinType       fixed216x8 fixed216x16 fixed216x24 fixed216x32 fixed216x40
+syn keyword solBuiltinType       fixed224x8 fixed224x16 fixed224x24 fixed224x32
+syn keyword solBuiltinType       fixed232x8 fixed232x16 fixed232x24
+syn keyword solBuiltinType       fixed240x8 fixed240x16
+syn keyword solBuiltinType       fixed248x8
+syn keyword solBuiltinType       ufixed
+syn keyword solBuiltinType       ufixed0x8 ufixed0x16 ufixed0x24 ufixed0x32 ufixed0x40 ufixed0x48 ufixed0x56 ufixed0x64 ufixed0x72 ufixed0x80 ufixed0x88 ufixed0x96 ufixed0x104 ufixed0x112 ufixed0x120 ufixed0x128 ufixed0x136 ufixed0x144 ufixed0x152 ufixed0x160 ufixed0x168 ufixed0x178 ufixed0x184 ufixed0x192 ufixed0x200 ufixed0x208 ufixed0x216 ufixed0x224 ufixed0x232 ufixed0x240 ufixed0x248 ufixed0x256
+syn keyword solBuiltinType       ufixed8x8 ufixed8x16 ufixed8x24 ufixed8x32 ufixed8x40 ufixed8x48 ufixed8x56 ufixed8x64 ufixed8x72 ufixed8x80 ufixed8x88 ufixed8x96 ufixed8x104 ufixed8x112 ufixed8x120 ufixed8x128 ufixed8x136 ufixed8x144 ufixed8x152 ufixed8x160 ufixed8x168 ufixed8x178 ufixed8x184 ufixed8x192 ufixed8x200 ufixed8x208 ufixed8x216 ufixed8x224 ufixed8x232 ufixed8x240 ufixed8x248
+syn keyword solBuiltinType       ufixed16x8 ufixed16x16 ufixed16x24 ufixed16x32 ufixed16x40 ufixed16x48 ufixed16x56 ufixed16x64 ufixed16x72 ufixed16x80 ufixed16x88 ufixed16x96 ufixed16x104 ufixed16x112 ufixed16x120 ufixed16x128 ufixed16x136 ufixed16x144 ufixed16x152 ufixed16x160 ufixed16x168 ufixed16x178 ufixed16x184 ufixed16x192 ufixed16x200 ufixed16x208 ufixed16x216 ufixed16x224 ufixed16x232 ufixed16x240
+syn keyword solBuiltinType       ufixed24x8 ufixed24x16 ufixed24x24 ufixed24x32 ufixed24x40 ufixed24x48 ufixed24x56 ufixed24x64 ufixed24x72 ufixed24x80 ufixed24x88 ufixed24x96 ufixed24x104 ufixed24x112 ufixed24x120 ufixed24x128 ufixed24x136 ufixed24x144 ufixed24x152 ufixed24x160 ufixed24x168 ufixed24x178 ufixed24x184 ufixed24x192 ufixed24x200 ufixed24x208 ufixed24x216 ufixed24x224 ufixed24x232
+syn keyword solBuiltinType       ufixed32x8 ufixed32x16 ufixed32x24 ufixed32x32 ufixed32x40 ufixed32x48 ufixed32x56 ufixed32x64 ufixed32x72 ufixed32x80 ufixed32x88 ufixed32x96 ufixed32x104 ufixed32x112 ufixed32x120 ufixed32x128 ufixed32x136 ufixed32x144 ufixed32x152 ufixed32x160 ufixed32x168 ufixed32x178 ufixed32x184 ufixed32x192 ufixed32x200 ufixed32x208 ufixed32x216 ufixed32x224
+syn keyword solBuiltinType       ufixed40x8 ufixed40x16 ufixed40x24 ufixed40x32 ufixed40x40 ufixed40x48 ufixed40x56 ufixed40x64 ufixed40x72 ufixed40x80 ufixed40x88 ufixed40x96 ufixed40x104 ufixed40x112 ufixed40x120 ufixed40x128 ufixed40x136 ufixed40x144 ufixed40x152 ufixed40x160 ufixed40x168 ufixed40x178 ufixed40x184 ufixed40x192 ufixed40x200 ufixed40x208 ufixed40x216
+syn keyword solBuiltinType       ufixed48x8 ufixed48x16 ufixed48x24 ufixed48x32 ufixed48x40 ufixed48x48 ufixed48x56 ufixed48x64 ufixed48x72 ufixed48x80 ufixed48x88 ufixed48x96 ufixed48x104 ufixed48x112 ufixed48x120 ufixed48x128 ufixed48x136 ufixed48x144 ufixed48x152 ufixed48x160 ufixed48x168 ufixed48x178 ufixed48x184 ufixed48x192 ufixed48x200 ufixed48x208
+syn keyword solBuiltinType       ufixed56x8 ufixed56x16 ufixed56x24 ufixed56x32 ufixed56x40 ufixed56x48 ufixed56x56 ufixed56x64 ufixed56x72 ufixed56x80 ufixed56x88 ufixed56x96 ufixed56x104 ufixed56x112 ufixed56x120 ufixed56x128 ufixed56x136 ufixed56x144 ufixed56x152 ufixed56x160 ufixed56x168 ufixed56x178 ufixed56x184 ufixed56x192 ufixed56x200
+syn keyword solBuiltinType       ufixed64x8 ufixed64x16 ufixed64x24 ufixed64x32 ufixed64x40 ufixed64x48 ufixed64x56 ufixed64x64 ufixed64x72 ufixed64x80 ufixed64x88 ufixed64x96 ufixed64x104 ufixed64x112 ufixed64x120 ufixed64x128 ufixed64x136 ufixed64x144 ufixed64x152 ufixed64x160 ufixed64x168 ufixed64x178 ufixed64x184 ufixed64x192
+syn keyword solBuiltinType       ufixed72x8 ufixed72x16 ufixed72x24 ufixed72x32 ufixed72x40 ufixed72x48 ufixed72x56 ufixed72x64 ufixed72x72 ufixed72x80 ufixed72x88 ufixed72x96 ufixed72x104 ufixed72x112 ufixed72x120 ufixed72x128 ufixed72x136 ufixed72x144 ufixed72x152 ufixed72x160 ufixed72x168 ufixed72x178 ufixed72x184
+syn keyword solBuiltinType       ufixed80x8 ufixed80x16 ufixed80x24 ufixed80x32 ufixed80x40 ufixed80x48 ufixed80x56 ufixed80x64 ufixed80x72 ufixed80x80 ufixed80x88 ufixed80x96 ufixed80x104 ufixed80x112 ufixed80x120 ufixed80x128 ufixed80x136 ufixed80x144 ufixed80x152 ufixed80x160 ufixed80x168 ufixed80x178
+syn keyword solBuiltinType       ufixed88x8 ufixed88x16 ufixed88x24 ufixed88x32 ufixed88x40 ufixed88x48 ufixed88x56 ufixed88x64 ufixed88x72 ufixed88x80 ufixed88x88 ufixed88x96 ufixed88x104 ufixed88x112 ufixed88x120 ufixed88x128 ufixed88x136 ufixed88x144 ufixed88x152 ufixed88x160 ufixed88x168
+syn keyword solBuiltinType       ufixed96x8 ufixed96x16 ufixed96x24 ufixed96x32 ufixed96x40 ufixed96x48 ufixed96x56 ufixed96x64 ufixed96x72 ufixed96x80 ufixed96x88 ufixed96x96 ufixed96x104 ufixed96x112 ufixed96x120 ufixed96x128 ufixed96x136 ufixed96x144 ufixed96x152 ufixed96x160
+syn keyword solBuiltinType       ufixed104x8 ufixed104x16 ufixed104x24 ufixed104x32 ufixed104x40 ufixed104x48 ufixed104x56 ufixed104x64 ufixed104x72 ufixed104x80 ufixed104x88 ufixed104x96 ufixed104x104 ufixed104x112 ufixed104x120 ufixed104x128 ufixed104x136 ufixed104x144 ufixed104x152
+syn keyword solBuiltinType       ufixed112x8 ufixed112x16 ufixed112x24 ufixed112x32 ufixed112x40 ufixed112x48 ufixed112x56 ufixed112x64 ufixed112x72 ufixed112x80 ufixed112x88 ufixed112x96 ufixed112x104 ufixed112x112 ufixed112x120 ufixed112x128 ufixed112x136 ufixed112x144
+syn keyword solBuiltinType       ufixed120x8 ufixed120x16 ufixed120x24 ufixed120x32 ufixed120x40 ufixed120x48 ufixed120x56 ufixed120x64 ufixed120x72 ufixed120x80 ufixed120x88 ufixed120x96 ufixed120x104 ufixed120x112 ufixed120x120 ufixed120x128 ufixed120x136
+syn keyword solBuiltinType       ufixed128x8 ufixed128x16 ufixed128x24 ufixed128x32 ufixed128x40 ufixed128x48 ufixed128x56 ufixed128x64 ufixed128x72 ufixed128x80 ufixed128x88 ufixed128x96 ufixed128x104 ufixed128x112 ufixed128x120 ufixed128x128
+syn keyword solBuiltinType       ufixed136x8 ufixed136x16 ufixed136x24 ufixed136x32 ufixed136x40 ufixed136x48 ufixed136x56 ufixed136x64 ufixed136x72 ufixed136x80 ufixed136x88 ufixed136x96 ufixed136x104 ufixed136x112 ufixed136x120
+syn keyword solBuiltinType       ufixed144x8 ufixed144x16 ufixed144x24 ufixed144x32 ufixed144x40 ufixed144x48 ufixed144x56 ufixed144x64 ufixed144x72 ufixed144x80 ufixed144x88 ufixed144x96 ufixed144x104 ufixed144x112
+syn keyword solBuiltinType       ufixed152x8 ufixed152x16 ufixed152x24 ufixed152x32 ufixed152x40 ufixed152x48 ufixed152x56 ufixed152x64 ufixed152x72 ufixed152x80 ufixed152x88 ufixed152x96 ufixed152x104
+syn keyword solBuiltinType       ufixed160x8 ufixed160x16 ufixed160x24 ufixed160x32 ufixed160x40 ufixed160x48 ufixed160x56 ufixed160x64 ufixed160x72 ufixed160x80 ufixed160x88 ufixed160x96
+syn keyword solBuiltinType       ufixed168x8 ufixed168x16 ufixed168x24 ufixed168x32 ufixed168x40 ufixed168x48 ufixed168x56 ufixed168x64 ufixed168x72 ufixed168x80 ufixed168x88
+syn keyword solBuiltinType       ufixed176x8 ufixed176x16 ufixed176x24 ufixed176x32 ufixed176x40 ufixed176x48 ufixed176x56 ufixed176x64 ufixed176x72 ufixed176x80
+syn keyword solBuiltinType       ufixed184x8 ufixed184x16 ufixed184x24 ufixed184x32 ufixed184x40 ufixed184x48 ufixed184x56 ufixed184x64 ufixed184x72
+syn keyword solBuiltinType       ufixed192x8 ufixed192x16 ufixed192x24 ufixed192x32 ufixed192x40 ufixed192x48 ufixed192x56 ufixed192x64
+syn keyword solBuiltinType       ufixed200x8 ufixed200x16 ufixed200x24 ufixed200x32 ufixed200x40 ufixed200x48 ufixed200x56
+syn keyword solBuiltinType       ufixed208x8 ufixed208x16 ufixed208x24 ufixed208x32 ufixed208x40 ufixed208x48
+syn keyword solBuiltinType       ufixed216x8 ufixed216x16 ufixed216x24 ufixed216x32 ufixed216x40
+syn keyword solBuiltinType       ufixed224x8 ufixed224x16 ufixed224x24 ufixed224x32
+syn keyword solBuiltinType       ufixed232x8 ufixed232x16 ufixed232x24
+syn keyword solBuiltinType       ufixed240x8 ufixed240x16
+syn keyword solBuiltinType       ufixed248x8
+syn keyword solBuiltinType       string string1 string2 string3 string4 string5 string6 string7 string8 string9 string10 string11 string12 string13 string14 string15 string16 string17 string18 string19 string20 string21 string22 string23 string24 string25 string26 string27 string28 string29 string30 string31 string32
+syn keyword solBuiltinType       byte bytes bytes1 bytes2 bytes3 bytes4 bytes5 bytes6 bytes7 bytes8 bytes9 bytes10 bytes11 bytes12 bytes13 bytes14 bytes15 bytes16 bytes17 bytes18 bytes19 bytes20 bytes21 bytes22 bytes23 bytes24 bytes25 bytes26 bytes27 bytes28 bytes29 bytes30 bytes31 bytes32
+
+hi def link solKeyword           Keyword
+hi def link solConstant          Constant
+hi def link solBuiltinType       Type
+hi def link solBuiltinFunction   Keyword
+
+syn match   solOperator          /\(!\||\|&\|+\|-\|<\|>\|=\|%\|\/\|*\|\~\|\^\)/
+syn match   solNumber            /\<-\=\d\+L\=\>\|\<0[xX]\x\+\>/
+syn match   solFloat             /\<-\=\%(\d\+\.\d\+\|\d\+\.\|\.\d\+\)\%([eE][+-]\=\d\+\)\=\>/
+
+syn region  solString            start=+"+  skip=+\\\\\|\\$"\|\\"+  end=+"+
+syn region  solString            start=+'+  skip=+\\\\\|\\$'\|\\'+  end=+'+
+
+hi def link solOperator          Operator
+hi def link solNumber            Number
+hi def link solFloat             Float
+hi def link solString            String
+
+" Function
+syn match   solFunction          /\<function\>/ nextgroup=solFuncName,solFuncArgs skipwhite
+syn match   solFuncName          contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solFuncArgs skipwhite
+
+syn region  solFuncArgs          contained matchgroup=solFuncParens start='(' end=')' contains=solFuncArgCommas,solBuiltinType nextgroup=solModifierName,solFuncReturns,solFuncBody keepend skipwhite skipempty
+syn match   solModifierName      contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solModifierArgs,solModifierName skipwhite
+syn region  solModifierArgs      contained matchgroup=solFuncParens start='(' end=')' contains=solFuncArgCommas nextgroup=solModifierName,solFuncReturns,solFuncBody skipwhite
+syn region  solFuncReturns       contained matchgroup=solFuncParens nextgroup=solFuncBody start='(' end=')' contains=solFuncArgCommas,solBuiltinType skipwhite
+
+syn match   solFuncArgCommas     contained ','
+syn region  solFuncBody          start="{" end="}" fold transparent
+
+hi def link solFunction          Type
+hi def link solFuncName          Function
+hi def link solModifierName      Function
+
+" Yul blocks
+syn match   yul                  /\<assembly\>/ skipwhite skipempty nextgroup=yulBody
+syn region  yulBody              contained start='{' end='}' fold contains=yulAssemblyOp,solNumber,yulVarDeclaration,solLineComment,solComment skipwhite skipempty
+syn keyword yulAssemblyOp        contained stop add sub mul div sdiv mod smod exp not lt gt slt sgt eq iszero and or xor byte shl shr sar addmod mulmod signextend keccak256 pc pop mload mstore mstore8 sload sstore msize gas address balance selfbalance caller callvalue calldataload calldatasize calldatacopy codesize codecopy extcodesize extcodecopy returndatasize returndatacopy extcodehash create create2 call callcode delegatecall staticcall return revert selfdestruct invalid log0 log1 log2 log3 log4 chainid basefee origin gasprice blockhash coinbase timestamp number difficulty gaslimit
+syn keyword yulVarDeclaration    contained let
+
+hi def link yul                 Keyword
+hi def link yulVarDeclaration   Keyword
+hi def link yulAssemblyOp       Keyword
+
+" Contract
+syn match   solContract          /\<\%(contract\|library\|interface\)\>/ nextgroup=solContractName skipwhite
+syn match   solContractName      contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solContractParent skipwhite
+syn region  solContractParent    contained start='is' end='{' contains=solContractName,solContractNoise,solContractCommas skipwhite skipempty
+syn match   solContractNoise     contained 'is' containedin=solContractParent
+syn match   solContractCommas    contained ','
+
+hi def link solContract          Type
+hi def link solContractName      Function
+
+" Event
+syn match   solEvent             /\<event\>/ nextgroup=solEventName,solEventArgs skipwhite
+syn match   solEventName         contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solEventArgs skipwhite
+syn region  solEventArgs         contained matchgroup=solFuncParens start='(' end=')' contains=solEventArgCommas,solBuiltinType,solEventArgSpecial skipwhite skipempty
+syn match   solEventArgCommas    contained ','
+syn match   solEventArgSpecial   contained 'indexed'
+
+hi def link solEvent             Type
+hi def link solEventName         Function
+hi def link solEventArgSpecial   Label
+
+" Comment
+syn keyword solCommentTodo       TODO FIXME XXX TBD contained
+syn match solNatSpec             contained /@title\|@author\|@notice\|@dev\|@param\|@inheritdoc\|@return/
+syn region  solLineComment       start=+\/\/+ end=+$+ contains=solCommentTodo,solNatSpec,@Spell
+syn region  solLineComment       start=+^\s*\/\/+ skip=+\n\s*\/\/+ end=+$+ contains=solCommentTodo,solNatSpec,@Spell fold
+syn region  solComment           start="/\*"  end="\*/" contains=solCommentTodo,solNatSpec,@Spell fold
+
+hi def link solCommentTodo       Todo
+hi def link solNatSpec           Label
+hi def link solLineComment       Comment
+hi def link solComment           Comment
+
+let b:current_syntax = "solidity"

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -368,7 +368,7 @@ syn match	vimSetMod	contained	"&vim\=\|[!&?<]\|all&"
 " Let: {{{2
 " ===
 syn keyword	vimLet	let	unl[et]	skipwhite nextgroup=vimVar,vimFuncVar,vimLetHereDoc
-VimFoldh syn region vimLetHereDoc matchgroup=vimLetHereDocStart start='=<<\s\+\%(trim\|eval\>\)\=\s*\z(\L\S*\)' matchgroup=vimLetHereDocStop end='^\s*\z1\s*$'
+VimFoldh syn region vimLetHereDoc matchgroup=vimLetHereDocStart start='=<<\s\+\%(trim\s\+\)\=\%(eval\s\+\)\=\z(\L\S*\)' matchgroup=vimLetHereDocStop end='^\s*\z1\s*$'
 
 " Abbreviations: {{{2
 " =============


### PR DESCRIPTION
Update runtime files
https://github.com/vim/vim/commit/9fbdbb814f4ad67a14979aba4a6a49800c2f1a99

Skip ftplugin/vim.vim (vim9script change)
Drop indent/vim.vim and autoload/dist/vimindent.vim (vim9script rewrite)

Also skip for now doc changes that look dependent on patches (let me know if some of them are still applicable).