### PR TITLE
Replace vim.fn/vim.env in vim.fs

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -43,11 +43,11 @@ function M.dirname(file)
     return nil
   end
   vim.validate({ file = { file, 's' } })
-  if file:match('^%w:[\\/]?$') and iswin then
-    return file:gsub('\\', '/')
+  if iswin and file:match('^%w:[\\/]?$') then
+    return (file:gsub('\\', '/'))
   elseif not file:match('[\\/]') then
     return '.'
-  elseif file:match('^/[^/]+$') or file == '/' then
+  elseif file == '/' or file:match('^/[^/]+$') then
     return '/'
   end
   local dir = file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local iswin = package.config:sub(1,1) == '\\'
+local iswin = package.config:sub(1, 1) == '\\'
 
 --- Iterate over all the parents of the given file or directory.
 ---
@@ -43,12 +43,12 @@ function M.dirname(file)
     return nil
   end
   vim.validate({ file = { file, 's' } })
-  if not file:match('[\\/]') then
+  if file:match('^%w:[\\/]?$') and iswin then
+    return file:gsub('\\', '/')
+  elseif not file:match('[\\/]') then
     return '.'
   elseif file:match('^/[^/]+$') or file == '/' then
     return '/'
-  elseif file:match('^%w:[\\/]$') then
-    return iswin and file:gsub('\\', '/') or file:sub(1, 2)
   end
   local dir = file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')
   if iswin and dir:match('^%w:$') then
@@ -66,7 +66,7 @@ function M.basename(file)
     return nil
   end
   vim.validate({ file = { file, 's' } })
-  if iswin and file == '^%w:$' then
+  if iswin and file:match('^%w:[\\/]?$') then
     return ''
   end
   return file:match('[/\\]$') and '' or (file:match('[^\\/]*$'):gsub('\\', '/'))

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local iswin = package.config:sub(1, 1) == '\\'
+local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
 
 --- Iterate over all the parents of the given file or directory.
 ---

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local iswin = package.config:sub(1,1) == '\\'
+
 --- Iterate over all the parents of the given file or directory.
 ---
 --- Example:
@@ -43,12 +45,16 @@ function M.dirname(file)
   vim.validate({ file = { file, 's' } })
   if not file:match('[\\/]') then
     return '.'
-  elseif file == '/' or file:gsub('\\', '/'):match('^%w:$') then
-    return file
-  elseif file:match('^/[^/]+$') then
+  elseif file:match('^/[^/]+$') or file == '/' then
     return '/'
+  elseif file:match('^%w:[\\/]$') then
+    return iswin and file:gsub('\\', '/') or file:sub(1, 2)
   end
-  return file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')
+  local dir = file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')
+  if iswin and dir:match('^%w:$') then
+    return dir .. '/'
+  end
+  return (dir:gsub('\\', '/'))
 end
 
 --- Return the basename of the given file or directory
@@ -60,7 +66,10 @@ function M.basename(file)
     return nil
   end
   vim.validate({ file = { file, 's' } })
-  return file:match('[/\\]$') and '' or file:match('[^\\/]*$')
+  if iswin and file == '^%w:$' then
+    return ''
+  end
+  return file:match('[/\\]$') and '' or (file:match('[^\\/]*$'):gsub('\\', '/'))
 end
 
 --- Return an iterator over the files and directories located in {path}

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -40,6 +40,7 @@ function M.dirname(file)
   if file == nil then
     return nil
   end
+  vim.validate({ file = { file, 's' } })
   if not file:match('[\\/]') then
     return '.'
   elseif file == '/' or file:gsub('\\', '/'):match('^%w:$') then
@@ -55,7 +56,11 @@ end
 ---@param file (string) File or directory
 ---@return (string) Basename of {file}
 function M.basename(file)
-  return file:match('[/\\]$') and '' or file:match('[^\\/]+$')
+  if file == nil then
+    return nil
+  end
+  vim.validate({ file = { file, 's' } })
+  return file:match('[/\\]$') and '' or file:match('[^\\/]*$')
 end
 
 --- Return an iterator over the files and directories located in {path}

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -40,7 +40,14 @@ function M.dirname(file)
   if file == nil then
     return nil
   end
-  return vim.fn.fnamemodify(file, ':h')
+  if not file:match('[\\/]') then
+    return '.'
+  elseif file == '/' or file:gsub('\\', '/'):match('^%w:$') then
+    return file
+  elseif file:match('^/[^/]+$') then
+    return '/'
+  end
+  return file:match('[/\\]$') and file:sub(1, #file - 1) or file:match('^([/\\]?.+)[/\\]')
 end
 
 --- Return the basename of the given file or directory
@@ -48,7 +55,7 @@ end
 ---@param file (string) File or directory
 ---@return (string) Basename of {file}
 function M.basename(file)
-  return vim.fn.fnamemodify(file, ':t')
+  return file:match('[/\\]$') and '' or file:match('[^\\/]+$')
 end
 
 --- Return an iterator over the files and directories located in {path}
@@ -227,7 +234,12 @@ end
 ---@return (string) Normalized path
 function M.normalize(path)
   vim.validate({ path = { path, 's' } })
-  return (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))
+  return (
+    path
+      :gsub('^~/', vim.loop.os_homedir() .. '/')
+      :gsub('%$([%w_]+)', vim.loop.os_getenv)
+      :gsub('\\', '/')
+  )
 end
 
 return M

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -30,9 +30,19 @@ local test_basename_dirname_eq = {
   '/usr',
   'c:/usr',
   'c:/',
+  'c:',
   'c:/users/foo',
   'c:/users/foo/bar.lua',
   'c:/users/foo/bar/../',
+}
+
+local tests_windows_paths = {
+  'c:\\usr',
+  'c:\\',
+  'c:',
+  'c:\\users\\foo',
+  'c:\\users\\foo\\bar.lua',
+  'c:\\users\\foo\\bar\\..\\',
 }
 
 before_each(clear)
@@ -65,18 +75,25 @@ describe('vim.fs', function()
         return vim.fs.dirname(nvim_dir)
       ]], nvim_dir))
 
-      for _, path in ipairs(test_basename_dirname_eq) do
-        eq(
-          exec_lua([[
-            local path = ...
-            return vim.fn.fnamemodify(path,':h'):gsub('\\', '/')
-          ]], path),
-          exec_lua([[
-            local path = ...
-            return vim.fs.dirname(path)
-          ]], path),
-          path
-        )
+      local function test_paths(paths)
+        for _, path in ipairs(paths) do
+          eq(
+            exec_lua([[
+              local path = ...
+              return vim.fn.fnamemodify(path,':h'):gsub('\\', '/')
+            ]], path),
+            exec_lua([[
+              local path = ...
+              return vim.fs.dirname(path)
+            ]], path),
+            path
+          )
+        end
+      end
+
+      test_paths(test_basename_dirname_eq)
+      if iswin() then
+        test_paths(tests_windows_paths)
       end
     end)
   end)
@@ -88,18 +105,25 @@ describe('vim.fs', function()
         return vim.fs.basename(nvim_prog)
       ]], nvim_prog))
 
-      for _, path in ipairs(test_basename_dirname_eq) do
-        eq(
-          exec_lua([[
-            local path = ...
-            return vim.fn.fnamemodify(path,':t'):gsub('\\', '/')
-          ]], path),
-          exec_lua([[
-            local path = ...
-            return vim.fs.basename(path)
-          ]], path),
-          path
-        )
+      local function test_paths(paths)
+        for _, path in ipairs(paths) do
+          eq(
+            exec_lua([[
+              local path = ...
+              return vim.fn.fnamemodify(path,':t'):gsub('\\', '/')
+            ]], path),
+            exec_lua([[
+              local path = ...
+              return vim.fs.basename(path)
+            ]], path),
+            path
+          )
+        end
+      end
+
+      test_paths(test_basename_dirname_eq)
+      if iswin() then
+        test_paths(tests_windows_paths)
       end
     end)
   end)

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -17,6 +17,8 @@ local test_basename_dirname_eq = {
   '~/foo',
   '~/foo/bar.lua',
   'foo.lua',
+  ' ',
+  '',
   '.',
   '..',
   '../',

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -9,6 +9,7 @@ local nvim_dir = helpers.nvim_dir
 local test_build_dir = helpers.test_build_dir
 local iswin = helpers.iswin
 local nvim_prog = helpers.nvim_prog
+local is_os = helpers.is_os
 
 local nvim_prog_basename = iswin() and 'nvim.exe' or 'nvim'
 
@@ -70,8 +71,6 @@ describe('vim.fs', function()
 
   describe('dirname()', function()
     it('works', function()
-      local test_windows = vim.loop.os_uname().sysname == 'Windows_NT'
-
       eq(test_build_dir, exec_lua([[
         local nvim_dir = ...
         return vim.fs.dirname(nvim_dir)
@@ -94,7 +93,7 @@ describe('vim.fs', function()
       end
 
       test_paths(test_basename_dirname_eq)
-      if test_windows then
+      if is_os('win') then
         test_paths(tests_windows_paths)
       end
     end)
@@ -102,7 +101,6 @@ describe('vim.fs', function()
 
   describe('basename()', function()
     it('works', function()
-      local test_windows = vim.loop.os_uname().sysname == 'Windows_NT'
 
       eq(nvim_prog_basename, exec_lua([[
         local nvim_prog = ...
@@ -126,7 +124,7 @@ describe('vim.fs', function()
       end
 
       test_paths(test_basename_dirname_eq)
-      if test_windows then
+      if is_os('win') then
         test_paths(tests_windows_paths)
       end
     end)

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -12,6 +12,27 @@ local nvim_prog = helpers.nvim_prog
 
 local nvim_prog_basename = iswin() and 'nvim.exe' or 'nvim'
 
+local test_basename_dirname_eq = {
+  '~/foo/',
+  '~/foo',
+  '~/foo/bar.lua',
+  'foo.lua',
+  '.',
+  '..',
+  '../',
+  '~',
+  '/usr/bin',
+  '/usr/bin/gcc',
+  '/',
+  '/usr/',
+  '/usr',
+  'c:/usr',
+  'c:/',
+  'c:/users/foo',
+  'c:/users/foo/bar.lua',
+  'c:/users/foo/bar/../',
+}
+
 before_each(clear)
 
 describe('vim.fs', function()
@@ -41,6 +62,20 @@ describe('vim.fs', function()
         local nvim_dir = ...
         return vim.fs.dirname(nvim_dir)
       ]], nvim_dir))
+
+      for _, path in ipairs(test_basename_dirname_eq) do
+        eq(
+          exec_lua([[
+            local path = ...
+            return vim.fn.fnamemodify(path,':h'):gsub('\\', '/')
+          ]], path),
+          exec_lua([[
+            local path = ...
+            return vim.fs.dirname(path)
+          ]], path),
+          path
+        )
+      end
     end)
   end)
 
@@ -50,6 +85,20 @@ describe('vim.fs', function()
         local nvim_prog = ...
         return vim.fs.basename(nvim_prog)
       ]], nvim_prog))
+
+      for _, path in ipairs(test_basename_dirname_eq) do
+        eq(
+          exec_lua([[
+            local path = ...
+            return vim.fn.fnamemodify(path,':t'):gsub('\\', '/')
+          ]], path),
+          exec_lua([[
+            local path = ...
+            return vim.fs.basename(path)
+          ]], path),
+          path
+        )
+      end
     end)
   end)
 

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -70,6 +70,8 @@ describe('vim.fs', function()
 
   describe('dirname()', function()
     it('works', function()
+      local test_windows = package.config:sub(1, 1) == '\\'
+
       eq(test_build_dir, exec_lua([[
         local nvim_dir = ...
         return vim.fs.dirname(nvim_dir)
@@ -92,7 +94,7 @@ describe('vim.fs', function()
       end
 
       test_paths(test_basename_dirname_eq)
-      if iswin() then
+      if test_windows then
         test_paths(tests_windows_paths)
       end
     end)
@@ -100,6 +102,8 @@ describe('vim.fs', function()
 
   describe('basename()', function()
     it('works', function()
+      local test_windows = package.config:sub(1, 1) == '\\'
+
       eq(nvim_prog_basename, exec_lua([[
         local nvim_prog = ...
         return vim.fs.basename(nvim_prog)
@@ -122,7 +126,7 @@ describe('vim.fs', function()
       end
 
       test_paths(test_basename_dirname_eq)
-      if iswin() then
+      if test_windows then
         test_paths(tests_windows_paths)
       end
     end)

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -70,7 +70,7 @@ describe('vim.fs', function()
 
   describe('dirname()', function()
     it('works', function()
-      local test_windows = package.config:sub(1, 1) == '\\'
+      local test_windows = vim.loop.os_uname().sysname == 'Windows_NT'
 
       eq(test_build_dir, exec_lua([[
         local nvim_dir = ...
@@ -102,7 +102,7 @@ describe('vim.fs', function()
 
   describe('basename()', function()
     it('works', function()
-      local test_windows = package.config:sub(1, 1) == '\\'
+      local test_windows = vim.loop.os_uname().sysname == 'Windows_NT'
 
       eq(nvim_prog_basename, exec_lua([[
         local nvim_prog = ...


### PR DESCRIPTION
`vim.fs` functions like, `vim.fs.find`, could be useful in fast event contexts and inside uv threads,

Ex. Looking for files/dirs in slow FS or traversing deep repositories can hang the ui and can be delegated to background threads 

```lua
local function find_cpp_src(path)
    local fs = require 'vim.fs'

    local function filter(filename)
        return filename:match '.+%.cpp$' ~= nil
    end

    return vim.json.encode(fs.find(filter, { limit = math.huge, path = path }))
end

local function cb(results)
    if type(results) == type '' then
        vim.g.cpp_files = vim.json.decode(results)
    end
end

local work = vim.loop.new_work(find_cpp_src, cb)
work:queue '~/foo/'
```

Right now this is partially possible initializing `vim.env` and not using `basename/dirname` functions which include `vim.fs.find` going in upward direction