### PR TITLE
build(deps): require libtermkey version 0.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -498,7 +498,7 @@ if(FEAT_TUI)
     add_definitions(-DNVIM_UNIBI_HAS_VAR_FROM)
   endif()
 
-  find_package(LibTermkey 0.18 REQUIRED)
+  find_package(LibTermkey 0.22 REQUIRED)
   include_directories(SYSTEM ${LIBTERMKEY_INCLUDE_DIRS})
 endif()
 

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -159,14 +159,10 @@ void tinput_init(TermInput *input, Loop *loop)
     term = "";  // termkey_new_abstract assumes non-null (#2745)
   }
 
-#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
   input->tk = termkey_new_abstract(term,
                                    TERMKEY_FLAG_UTF8 | TERMKEY_FLAG_NOSTART);
   termkey_hook_terminfo_getstr(input->tk, input->tk_ti_hook_fn, NULL);
   termkey_start(input->tk);
-#else
-  input->tk = termkey_new_abstract(term, TERMKEY_FLAG_UTF8);
-#endif
 
   int curflags = termkey_get_canonflags(input->tk);
   termkey_set_canonflags(input->tk, curflags | TERMKEY_CANON_DELBS);

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -26,9 +26,7 @@ typedef struct term_input {
   ExtkeysType extkeys_type;
   long ttimeoutlen;
   TermKey *tk;
-#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
   TermKey_Terminfo_Getstr_Hook *tk_ti_hook_fn;  ///< libtermkey terminfo hook
-#endif
   TimeWatcher timer_handle;
   Loop *loop;
   Stream read_stream;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -485,9 +485,7 @@ static void tui_main(UIBridgeData *bridge, UI *ui)
   // TODO(bfredl): zero hl is empty, send this explicitly?
   kv_push(data->attrs, HLATTRS_INIT);
 
-#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
   data->input.tk_ti_hook_fn = tui_tk_ti_getstr;
-#endif
   tinput_init(&data->input, &tui_loop);
   tui_terminal_start(ui);
 
@@ -2278,7 +2276,6 @@ static void flush_buf(UI *ui)
   data->overflow = false;
 }
 
-#if TERMKEY_VERSION_MAJOR > 0 || TERMKEY_VERSION_MINOR > 18
 /// Try to get "kbs" code from stty because "the terminfo kbs entry is extremely
 /// unreliable." (Vim, Bash, and tmux also do this.)
 ///
@@ -2287,14 +2284,14 @@ static void flush_buf(UI *ui)
 static const char *tui_get_stty_erase(void)
 {
   static char stty_erase[2] = { 0 };
-# if defined(HAVE_TERMIOS_H)
+#if defined(HAVE_TERMIOS_H)
   struct termios t;
   if (tcgetattr(input_global_fd(), &t) != -1) {
     stty_erase[0] = (char)t.c_cc[VERASE];
     stty_erase[1] = '\0';
     DLOG("stty/termios:erase=%s", stty_erase);
   }
-# endif
+#endif
   return stty_erase;
 }
 
@@ -2328,4 +2325,3 @@ static const char *tui_tk_ti_getstr(const char *name, const char *value, void *d
 
   return value;
 }
-#endif


### PR DESCRIPTION
Reduces #ifdef code.