### PR TITLE
fix(lua): fix architecture-dependent behavior in usercmd "reg"

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1811,7 +1811,7 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
           range items were specified.
         • count: (number) Any |<count>| that was supplied to the command. -1
           if command cannot take a count.
-        • reg: (number) The optional command |<register>|, if specified. Empty
+        • reg: (string) The optional command |<register>|, if specified. Empty
           string if not specified or if command cannot take a register.
         • bang: (boolean) Whether command contains a |<bang>| (!) modifier.
         • args: (array) Command arguments.

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -37,7 +37,7 @@
 ///                          specified and two elements if both range items were specified.
 ///         - count: (number) Any |<count>| that was supplied to the command. -1 if command cannot
 ///                           take a count.
-///         - reg: (number) The optional command |<register>|, if specified. Empty string if not
+///         - reg: (string) The optional command |<register>|, if specified. Empty string if not
 ///                         specified or if command cannot take a register.
 ///         - bang: (boolean) Whether command contains a |<bang>| (!) modifier.
 ///         - args: (array) Command arguments.
@@ -165,9 +165,7 @@ Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
     PUT(result, "count", INTEGER_OBJ(-1));
   }
 
-  char reg[2];
-  reg[0] = (char)ea.regname;
-  reg[1] = '\0';
+  char reg[2] = { (char)ea.regname, NUL };
   PUT(result, "reg", CSTR_TO_OBJ(reg));
 
   PUT(result, "bang", BOOLEAN_OBJ(ea.forceit));

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2036,7 +2036,8 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   }
   lua_setfield(lstate, -2, "fargs");
 
-  lua_pushstring(lstate, (const char *)&eap->regname);
+  char reg[2] = { (char)eap->regname, NUL };
+  lua_pushstring(lstate, reg);
   lua_setfield(lstate, -2, "reg");
 
   lua_pushinteger(lstate, eap->addr_count);

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -423,6 +423,7 @@ describe('nvim_create_user_command', function()
         nargs = 0,
         bang = true,
         count = 2,
+        register = true,
       })
     ]]
     eq({
@@ -458,6 +459,42 @@ describe('nvim_create_user_command', function()
       reg = "",
     }, exec_lua [[
       vim.cmd('CommandWithNoArgs')
+      return result
+    ]])
+    -- register can be specified
+    eq({
+      args = "",
+      fargs = {},
+      bang = false,
+      line1 = 1,
+      line2 = 1,
+      mods = "",
+      smods = {
+        browse = false,
+        confirm = false,
+        emsg_silent = false,
+        hide = false,
+        horizontal = false,
+        keepalt = false,
+        keepjumps = false,
+        keepmarks = false,
+        keeppatterns = false,
+        lockmarks = false,
+        noautocmd = false,
+        noswapfile = false,
+        sandbox = false,
+        silent = false,
+        split = "",
+        tab = -1,
+        unsilent = false,
+        verbose = -1,
+        vertical = false,
+      },
+      range = 0,
+      count = 2,
+      reg = "+",
+    }, exec_lua [[
+      vim.cmd('CommandWithNoArgs +')
       return result
     ]])
 


### PR DESCRIPTION
I don't think using an integer as a NUL-terminated string can work on
big-endian systems, at least.

This is also not tested. Add a test.

Also fix a mistake in the docs of nvim_parse_cmd.
