### PR TITLE
feat(nvim_cmd)!: allow using first argument as count

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1697,7 +1697,13 @@ nvim_cmd({*cmd}, {*opts})                                         *nvim_cmd()*
     of a String. This allows for easier construction and manipulation of an Ex
     command. This also allows for things such as having spaces inside a
     command argument, expanding filenames in a command that otherwise doesn't
-    expand filenames, etc.
+    expand filenames, etc. Command arguments may also be Number, Boolean or
+    String.
+
+    The first argument may also be used instead of count for commands that
+    support it in order to make their usage simpler with |vim.cmd()|. For
+    example, instead of `vim.cmd.bdelete{ count = 2 }`, you may do
+    `vim.cmd.bdelete(2)`.
 
     On execution error: fails with VimL error, updates v:errmsg.
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1339,6 +1339,20 @@ static int parse_count(exarg_T *eap, char **errormsg, bool validate)
           || ascii_iswhite(*p))) {
     long n = getdigits_long(&eap->arg, false, -1);
     eap->arg = skipwhite(eap->arg);
+
+    if (eap->args != NULL) {
+      assert(eap->argc > 0 && eap->arg >= eap->args[0]);
+      // If eap->arg is still pointing to the first argument, just make eap->args[0] point to the
+      // same location. This is needed for usecases like vim.cmd.sleep('10m'). If eap->arg is
+      // pointing outside the first argument, shift arguments by 1.
+      if (eap->arg < eap->args[0] + eap->arglens[0]) {
+        eap->arglens[0] -= (size_t)(eap->arg - eap->args[0]);
+        eap->args[0] = eap->arg;
+      } else {
+        shift_cmd_args(eap);
+      }
+    }
+
     if (n <= 0 && (eap->argt & EX_ZEROR) == 0) {
       if (errormsg != NULL) {
         *errormsg = _(e_zerocount);
@@ -1512,6 +1526,30 @@ end:
   return retval;
 }
 
+// Shift Ex-command arguments to the right.
+static void shift_cmd_args(exarg_T *eap)
+{
+  assert(eap->args != NULL && eap->argc > 0);
+
+  char **oldargs = eap->args;
+  size_t *oldarglens = eap->arglens;
+
+  eap->argc--;
+  eap->args = eap->argc > 0 ? xcalloc(eap->argc, sizeof(char *)) : NULL;
+  eap->arglens = eap->argc > 0 ? xcalloc(eap->argc, sizeof(size_t)) : NULL;
+
+  for (size_t i = 0; i < eap->argc; i++) {
+    eap->args[i] = oldargs[i + 1];
+    eap->arglens[i] = oldarglens[i + 1];
+  }
+
+  // If there are no arguments, make eap->arg point to the end of string.
+  eap->arg = (eap->argc > 0 ? eap->args[0] : (oldargs[0] + oldarglens[0]));
+
+  xfree(oldargs);
+  xfree(oldarglens);
+}
+
 static int execute_cmd0(int *retv, exarg_T *eap, char **errormsg, bool preview)
 {
   // If filename expansion is enabled, expand filenames
@@ -1551,15 +1589,7 @@ static int execute_cmd0(int *retv, exarg_T *eap, char **errormsg, bool preview)
                                    eap->args[0] + eap->arglens[0],
                                    (eap->argt & EX_BUFUNL) != 0, false, false);
       eap->addr_count = 1;
-      // Shift each argument by 1
-      for (size_t i = 0; i < eap->argc - 1; i++) {
-        eap->args[i] = eap->args[i + 1];
-      }
-      // Make the last argument point to the NUL terminator at the end of string
-      eap->args[eap->argc - 1] = eap->args[eap->argc - 1] + eap->arglens[eap->argc - 1];
-      eap->argc -= 1;
-
-      eap->arg = eap->args[0];
+      shift_cmd_args(eap);
     }
     if (eap->line2 < 0) {  // failed
       return FAIL;
@@ -1656,6 +1686,11 @@ int execute_cmd(exarg_T *eap, CmdParseInfo *cmdinfo, bool preview)
     // at the end of a closed fold.
     (void)hasFolding(eap->line1, &eap->line1, NULL);
     (void)hasFolding(eap->line2, NULL, &eap->line2);
+  }
+
+  // Use first argument as count when possible
+  if (parse_count(eap, &errormsg, true) == FAIL) {
+    goto end;
   }
 
   // Execute the command

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1,6 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local lfs = require('lfs')
+local luv = require('luv')
 
 local fmt = string.format
 local assert_alive = helpers.assert_alive
@@ -3961,6 +3962,24 @@ describe('API', function()
         {0:~                                       }|
         15                                      |
       ]]}
+    end)
+    it('works with non-String args', function()
+      eq('2', meths.cmd({cmd = 'echo', args = {2}}, {output = true}))
+      eq('1', meths.cmd({cmd = 'echo', args = {true}}, {output = true}))
+    end)
+    describe('first argument as count', function()
+      before_each(clear)
+
+      it('works', function()
+        command('vsplit | enew')
+        meths.cmd({cmd = 'bdelete', args = {meths.get_current_buf()}}, {})
+        eq(1, meths.get_current_buf().id)
+      end)
+      it('works with :sleep using milliseconds', function()
+        local start = luv.now()
+        meths.cmd({cmd = 'sleep', args = {'100m'}}, {})
+        ok(luv.now() - start <= 300)
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
Allows `nvim_cmd` to use the first argument as count for applicable commands. Also adds support for non-String arguments to `nvim_cmd`.

For example: Previously you had to do `vim.cmd.bdelete{ count = 3 }` to delete buffer 3, now you can just do `vim.cmd.bdelete(3)`