### PR TITLE
docs: mark cmdheight=0 and vim.ui_attach as experimental

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -978,6 +978,12 @@ vim.ui_attach({ns}, {options}, {callback})                *vim.ui_attach()*
     {callback} receives event name plus additional parameters. See |ui-popupmenu|
     and the sections below for event format for respective events.
 
+    WARNING: This api is considered experimental.  Usability will vary for
+    different screen elements. In particular `ext_messages` behavior is subject
+    to further changes and usability improvements.  This is expected to be
+    used to handle messages when setting 'cmdheight' to zero (which is
+    likewise experimental).
+
     Example (stub for a |ui-popupmenu| implementation): >
 
       ns = vim.api.nvim_create_namespace('my_fancy_pum')

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1338,9 +1338,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	When 'cmdheight' is zero, there is no command-line unless it is being
 	used.  The command-line will cover the last line of the screen when
-	shown. Some informative messages will not be displayed, any other
-	messages will cause the |hit-enter| prompt.  Expect some other
-	unexpected behavior too.
+	shown.
+
+	WARNING: `cmdheight=0` is considered experimental. Except some
+	unwanted behaviour. Some 'shortmess' flags and similar
+	mechanism might fail to take effect, causing unwanted hit-enter
+	prompts.  Some informative messages, both from Nvim itself and
+	plugins, will not be displayed.
 
 						*'cmdwinheight'* *'cwh'*
 'cmdwinheight' 'cwh'	number	(default 7)


### PR DESCRIPTION
These will require further work for user experience out of the box during the 0.9 cycle.