### PR TITLE
vim-patch:9.0.0621: filetype test leaves file behind

### DIFF
--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1251,7 +1251,7 @@ endfunc
 func Test_m_file()
   filetype on
 
-  call writefile(['looks like Matlab'], 'Xfile.m')
+  call writefile(['looks like Matlab'], 'Xfile.m', 'D')
   split Xfile.m
   call assert_equal('matlab', &filetype)
   bwipe!


### PR DESCRIPTION
Problem:    Filetype test leaves file behind.
Solution:   Add deferred delete flag to writefile(). (Dominique Pellé,
            closes vim/vim#11249)
https://github.com/vim/vim/commit/fc06cda8379031890ee8852cdca61eb8af8e1ba2

Leave no file behind!