### PR TITLE
dist(win): update neovim-qt, win32tools.zip

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -183,9 +183,9 @@ set(LUV_SHA256 f8c69908e17ec8ab370253d1508e23deaecfc0c4752d2efb77e427e579501104)
 set(LUA_COMPAT53_URL https://github.com/keplerproject/lua-compat-5.3/archive/v0.9.tar.gz)
 set(LUA_COMPAT53_SHA256 ad05540d2d96a48725bb79a1def35cf6652a4e2ec26376e2617c8ce2baa6f416)
 
-# cat.exe curl.exe curl-ca-bundle.crt diff.exe tee.exe xxd.exe
-set(WINTOOLS_URL https://github.com/neovim/deps/raw/d66e306abf5b846484b4f2adffd896bce7e065d2/opt/win32tools.zip)
-set(WINTOOLS_SHA256 2fb2f8d69070b3f16e029913fb95008e6be33893d77fc358012396c275a0fdb7)
+# cat.exe curl.exe curl-ca-bundle.crt tee.exe xxd.exe
+set(WINTOOLS_URL https://github.com/neovim/deps/raw/db6981d3d86c9eb78656883b72a7e493b06d31fb/opt/win32tools.zip)
+set(WINTOOLS_SHA256 8344cac77fd37e60bb3ac29b0507f5bad29ad710644671bad370910fd16e43cf)
 
 set(WINGUI_URL https://github.com/equalsraf/neovim-qt/releases/download/v0.2.16.1/neovim-qt.zip)
 set(WINGUI_SHA256 ddb4492db03da407703fb0ab271c4eb060250d1a7d71200e2b3b981cb0de59de)

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -187,8 +187,8 @@ set(LUA_COMPAT53_SHA256 ad05540d2d96a48725bb79a1def35cf6652a4e2ec26376e2617c8ce2
 set(WINTOOLS_URL https://github.com/neovim/deps/raw/db6981d3d86c9eb78656883b72a7e493b06d31fb/opt/win32tools.zip)
 set(WINTOOLS_SHA256 8344cac77fd37e60bb3ac29b0507f5bad29ad710644671bad370910fd16e43cf)
 
-set(WINGUI_URL https://github.com/equalsraf/neovim-qt/releases/download/v0.2.16.1/neovim-qt.zip)
-set(WINGUI_SHA256 ddb4492db03da407703fb0ab271c4eb060250d1a7d71200e2b3b981cb0de59de)
+set(WINGUI_URL https://github.com/equalsraf/neovim-qt/releases/download/v0.2.17/neovim-qt.zip)
+set(WINGUI_SHA256 502e386eef677c2c2e0c11d8cbb27f3e12b4d96818369417e8da4129c4580c25)
 
 set(WIN32YANK_X86_URL https://github.com/equalsraf/win32yank/releases/download/v0.0.4/win32yank-x86.zip)
 set(WIN32YANK_X86_SHA256 62f34e5a46c5d4a7b3f3b512e1ff7b77fedd432f42581cbe825233a996eed62c)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -531,8 +531,6 @@ if(WIN32)
                       translations/qt_uk.qm
                       D3Dcompiler_47.dll
                       libEGL.dll
-                      libgcc_s_dw2-1.dll
-                      libGLESV2.dll
                       libstdc++-6.dll
                       libwinpthread-1.dll
                       nvim-qt.exe

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -490,7 +490,6 @@ if(WIN32)
   foreach(DEP_FILE IN ITEMS
                       curl-ca-bundle.crt
                       curl.exe
-                      diff.exe
                       tee.exe
                       win32yank.exe
                       xxd.exe


### PR DESCRIPTION
- update neovim-qt
- updated curl.exe (+ ca bundle), tee.exe, xxd.exe
- removed diff.exe because `diffopt=internal` is now the default