### PR TITLE
fix(dist): update neovim-qt, win32tools.zip

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -183,9 +183,9 @@ set(LUV_SHA256 f8c69908e17ec8ab370253d1508e23deaecfc0c4752d2efb77e427e579501104)
 set(LUA_COMPAT53_URL https://github.com/keplerproject/lua-compat-5.3/archive/v0.9.tar.gz)
 set(LUA_COMPAT53_SHA256 ad05540d2d96a48725bb79a1def35cf6652a4e2ec26376e2617c8ce2baa6f416)
 
-# cat.exe curl.exe curl-ca-bundle.crt tee.exe xxd.exe
-set(WINTOOLS_URL https://github.com/neovim/deps/raw/db6981d3d86c9eb78656883b72a7e493b06d31fb/opt/win32tools.zip)
-set(WINTOOLS_SHA256 8344cac77fd37e60bb3ac29b0507f5bad29ad710644671bad370910fd16e43cf)
+# cat.exe curl.exe curl-ca-bundle.crt diff.exe tee.exe xxd.exe
+set(WINTOOLS_URL https://github.com/neovim/deps/raw/c1e7dd8de9e1b18d11dcfa0a192cd029262e5303/opt/win32tools.zip)
+set(WINTOOLS_SHA256 3c4c490a3d392ceeb1347cb77cc821a31900b688a2189276d3a1131a3f21daf1)
 
 set(WINGUI_URL https://github.com/equalsraf/neovim-qt/releases/download/v0.2.17/neovim-qt.zip)
 set(WINGUI_SHA256 502e386eef677c2c2e0c11d8cbb27f3e12b4d96818369417e8da4129c4580c25)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -490,6 +490,7 @@ if(WIN32)
   foreach(DEP_FILE IN ITEMS
                       curl-ca-bundle.crt
                       curl.exe
+                      diff.exe
                       tee.exe
                       win32yank.exe
                       xxd.exe
@@ -531,6 +532,8 @@ if(WIN32)
                       translations/qt_uk.qm
                       D3Dcompiler_47.dll
                       libEGL.dll
+                      libgcc_s_seh-1.dll
+                      libGLESv2.dll
                       libstdc++-6.dll
                       libwinpthread-1.dll
                       nvim-qt.exe


### PR DESCRIPTION
- fix regression by #20411
  - `diff.exe` is required for non-default 'diffopt' (diffopt=filler, diffopt=context, …)
  - the names of some required nvim-qt DLLs changed