### PR TITLE
ci(release): remove unnecessary matrix strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,12 +131,7 @@ jobs:
       DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
       DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}
       CMAKE_BUILD_TYPE: "RelWithDebInfo"
-    strategy:
-      matrix:
-        include:
-          - config: MSVC_64
-            archive: nvim-win64
-    name: windows (${{ matrix.config }})
+    name: windows (MSVC_64)
     steps:
       - uses: actions/checkout@v3
         with:
@@ -147,10 +142,10 @@ jobs:
         run: .\ci\build.ps1 -Package
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.archive }}
+          name: nvim-win64
           path: |
-            build/${{ matrix.archive }}.msi
-            build/${{ matrix.archive }}.zip
+            build/nvim-win64.msi
+            build/nvim-win64.zip
           retention-days: 1
 
   publish:


### PR DESCRIPTION
We only have one Windows release job, so the matrix setup isn't needed.
