### PR TITLE
vim-patch:8.2.2542: highlight of char beyond line end is not correct

### DIFF
--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -644,7 +644,35 @@ end)
 
 describe('Search highlight', function()
   before_each(clear)
-  it('Search highlight is combined with Visual highlight vim-patch:8.2.2797', function()
+
+  -- oldtest: Test_hlsearch_dump()
+  it('beyond line end vim-patch:8.2.2542', function()
+    local screen = Screen.new(50, 6)
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [2] = {background = Screen.colors.Yellow},  -- Search
+      [3] = {background = Screen.colors.Grey90},  -- CursorLine
+    })
+    screen:attach()
+    exec([[
+      set hlsearch noincsearch cursorline
+      call setline(1, ["xxx", "xxx", "xxx"])
+      /.*
+      2
+    ]])
+    feed([[/\_.*<CR>]])
+    screen:expect([[
+      {2:xxx }                                              |
+      {2:xxx }                                              |
+      {2:^xxx }{3:                                              }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      /\_.*                                             |
+    ]])
+  end)
+
+  -- oldtest: Test_hlsearch_and_visual()
+  it('is combined with Visual highlight vim-patch:8.2.2797', function()
     local screen = Screen.new(40, 6)
     screen:set_default_attr_ids({
       [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -221,10 +221,10 @@ describe('search highlighting', function()
       feed('gg/foo\\nbar<CR>')
       screen:expect([[
         one                                     |
-        {2:^foo}                                     |
+        {2:^foo }                                    |
         {2:bar}                                     |
         baz                                     |
-        {1:foo}                                     |
+        {1:foo }                                    |
         {1:bar}                                     |
         /foo\nbar                               |
       ]])
@@ -232,20 +232,20 @@ describe('search highlighting', function()
       feed('gg/efg\\nhij<CR>')
       screen:expect([[
         ---                                     |
-        abcd{2:^efg}                                 |
+        abcd{2:^efg }                                |
         {2:hij}kl                                   |
         ---                                     |
-        abcd{1:efg}                                 |
+        abcd{1:efg }                                |
         {1:hij}kl                                   |
         /efg\nhij                               |
       ]])
       feed('n')
       screen:expect([[
         ---                                     |
-        abcd{1:efg}                                 |
+        abcd{1:efg }                                |
         {1:hij}kl                                   |
         ---                                     |
-        abcd{2:^efg}                                 |
+        abcd{2:^efg }                                |
         {2:hij}kl                                   |
         /efg\nhij                               |
       ]])
@@ -548,9 +548,9 @@ describe('search highlighting', function()
     feed('/line\\na<cr>')
     screen:expect([[
                                               |
-      a  repeated {2:^line}                        |
-      {2:a}  repeated {2:line}                        |
-      {2:a}  repeated {2:line}                        |
+      a  repeated {2:^line }                       |
+      {2:a}  repeated {2:line }                       |
+      {2:a}  repeated {2:line }                       |
       {2:a}  repeated line                        |
       {1:~                                       }|
       {4:search hit BOTTOM, continuing at TOP}    |
@@ -560,9 +560,9 @@ describe('search highlighting', function()
     feed('4Grb')
     screen:expect([[
                                               |
-      a  repeated {2:line}                        |
+      a  repeated {2:line }                       |
       {2:a}  repeated line                        |
-      ^b  repeated {2:line}                        |
+      ^b  repeated {2:line }                       |
       {2:a}  repeated line                        |
       {1:~                                       }|
       {4:search hit BOTTOM, continuing at TOP}    |


### PR DESCRIPTION
#### vim-patch:8.2.2542: highlight of char beyond line end is not correct

Problem:    Highlight of char beyond line end is not correct. (Chuan Wei Foo)
Solution:   Fix counting NUL as one cell.  Draw one more character if the EOL
            is part of the match.
https://github.com/vim/vim/commit/41f0895c6e3c7b921e3c102ad42be52b1be48018

Reorder test_search.vim to match Vim.