### PR TITLE
docs(news): add news.txt and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ Features
 - [XDG base directories](https://github.com/neovim/neovim/pull/3470) support
 - Compatible with most Vim plugins, including Ruby and Python plugins
 
-See [`:help nvim-features`][nvim-features] for the full list!
+See [`:help nvim-features`][nvim-features] for the full list, and `[:help
+news][nvim-news]` for noteworthy changes in the latest version!
 
 Install from package
 --------------------
@@ -116,6 +117,7 @@ Apache 2.0 license, except for contributions copied from Vim (identified by the
 
 [license-commit]: https://github.com/neovim/neovim/commit/b17d9691a24099c9210289f16afb1a498a89d803
 [nvim-features]: https://neovim.io/doc/user/vim_diff.html#nvim-features
+[nvim-news]: https://neovim.io/doc/user/news.html
 [Roadmap]: https://neovim.io/roadmap/
 [advanced UIs]: https://github.com/neovim/neovim/wiki/Related-projects#gui
 [Managed packages]: https://github.com/neovim/neovim/wiki/Installing-Neovim#install-from-package

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -1,0 +1,39 @@
+*news.txt*    Nvim
+
+
+			    NVIM REFERENCE MANUAL
+
+
+Notable changes in Nvim 0.9 from 0.8                                     *news*
+
+                                       Type |gO| to see the table of contents.
+
+==============================================================================
+BREAKING CHANGES                                                *news-breaking*
+
+The following changes may require adaptations in user config or plugins.
+
+==============================================================================
+NEW FEATURES                                                    *news-features*
+
+The following new APIs or features were added.
+
+==============================================================================
+CHANGED FEATURES                                                 *news-changes*
+
+The following changes to existing APIs or features add new behavior.
+
+==============================================================================
+REMOVED FEATURES                                                 *news-removed*
+
+The following deprecated functions or APIs were removed.
+
+==============================================================================
+DEPRECATIONS                                                *news-deprecations*
+
+The following functions are now deprecated and will be removed in the next
+release.
+
+
+
+ vim:tw=78:ts=8:sw=2:et:ft=help:norl:

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -44,6 +44,7 @@ local new_layout = {
   ['channel.txt'] = true,
   ['develop.txt'] = true,
   ['luaref.txt'] = true,
+  ['news.txt'] = true,
   ['nvim.txt'] = true,
   ['pi_health.txt'] = true,
   ['provider.txt'] = true,


### PR DESCRIPTION
Best get this in early...

Add a NEWS file to the docs that contains a list of noteworthy changes since the previous version (to be added to by each PR that introduces such a change).

The sections are very much open to discussion (could instead sort top-level by "modules" (API, Lua, LSP, treesitter, ...?)

Closes #19692 