### PR TITLE
vim-patch:9.0.{0620,0622}: matchaddpos() can only add up to 8 matches

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5010,7 +5010,7 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		respectively.  3 is reserved for use by the |matchparen|
 		plugin.
 		If the {id} argument is not specified or -1, |matchadd()|
-		automatically chooses a free ID.
+		automatically chooses a free ID, which is at least 1000.
 
 		The optional {dict} argument allows for further custom
 		values. Currently this is used to specify a match specific

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5068,8 +5068,6 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])
 		ignored, as well as entries with negative column numbers and
 		lengths.
 
-		The maximum number of positions in {pos} is 8.
-
 		Returns -1 on error.
 
 		Example: >

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -984,9 +984,6 @@ typedef struct {
   proftime_T tm;        // for a time limit
 } match_T;
 
-/// number of positions supported by matchaddpos()
-#define MAXPOSMATCH 8
-
 /// Same as lpos_T, but with additional field len.
 typedef struct {
   linenr_T lnum;   ///< line number
@@ -994,29 +991,28 @@ typedef struct {
   int len;    ///< length: 0 - to the end of line
 } llpos_T;
 
-/// posmatch_T provides an array for storing match items for matchaddpos()
-/// function.
-typedef struct posmatch posmatch_T;
-struct posmatch {
-  llpos_T pos[MAXPOSMATCH];   ///< array of positions
-  int cur;                ///< internal position counter
-  linenr_T toplnum;            ///< top buffer line
-  linenr_T botlnum;            ///< bottom buffer line
-};
-
-// matchitem_T provides a linked list for storing match items for ":match" and
-// the match functions.
+/// matchitem_T provides a linked list for storing match items for ":match",
+/// matchadd() and matchaddpos().
 typedef struct matchitem matchitem_T;
 struct matchitem {
-  matchitem_T *next;
-  int id;                   ///< match ID
-  int priority;             ///< match priority
-  char *pattern;            ///< pattern to highlight
-  regmmatch_T match;        ///< regexp program for pattern
-  posmatch_T pos;           ///< position matches
-  match_T hl;               ///< struct for doing the actual highlighting
-  int hlg_id;               ///< highlight group ID
-  int conceal_char;         ///< cchar for Conceal highlighting
+  matchitem_T *mit_next;
+  int mit_id;              ///< match ID
+  int mit_priority;        ///< match priority
+
+  // Either a pattern is defined (mit_pattern is not NUL) or a list of
+  // positions is given (mit_pos is not NULL and mit_pos_count > 0).
+  char *mit_pattern;       ///< pattern to highlight
+  regmmatch_T mit_match;   ///< regexp program for pattern
+
+  llpos_T *mit_pos_array;  ///< array of positions
+  int mit_pos_count;       ///< nr of entries in mit_pos
+  int mit_pos_cur;         ///< internal position counter
+  linenr_T mit_toplnum;    ///< top buffer line
+  linenr_T mit_botlnum;    ///< bottom buffer line
+
+  match_T mit_hl;          ///< struct for doing the actual highlighting
+  int mit_hlg_id;          ///< highlight group ID
+  int mit_conceal_char;    ///< cchar for Conceal highlighting
 };
 
 typedef int FloatAnchor;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1126,12 +1126,12 @@ win_update_start:
       } else {
         const matchitem_T *cur = wp->w_match_head;
         while (cur != NULL) {
-          if (cur->match.regprog != NULL
-              && re_multiline(cur->match.regprog)) {
+          if (cur->mit_match.regprog != NULL
+              && re_multiline(cur->mit_match.regprog)) {
             top_to_mod = true;
             break;
           }
-          cur = cur->next;
+          cur = cur->mit_next;
         }
       }
     }

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -36,8 +36,8 @@ function Test_match()
   let m1 = matchadd("MyGroup1", "TODO")
   let m2 = matchadd("MyGroup2", "FIXME", 42)
   let m3 = matchadd("MyGroup3", "XXX", 60, 17)
-  let ans = [{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 4},
-        \    {'group': 'MyGroup2', 'pattern': 'FIXME', 'priority': 42, 'id': 5},
+  let ans = [{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1000},
+        \    {'group': 'MyGroup2', 'pattern': 'FIXME', 'priority': 42, 'id': 1001},
         \    {'group': 'MyGroup3', 'pattern': 'XXX', 'priority': 60, 'id': 17}]
   call assert_equal(ans, getmatches())
 
@@ -118,7 +118,7 @@ function Test_match()
   call clearmatches()
 
   call setline(1, 'abcdΣabcdef')
-  eval "MyGroup1"->matchaddpos([[1, 4, 2], [1, 9, 2]])
+  eval "MyGroup1"->matchaddpos([[1, 4, 2], [1, 9, 2]], 10, 42)
   1
   redraw!
   let v1 = screenattr(1, 1)
@@ -129,7 +129,7 @@ function Test_match()
   let v8 = screenattr(1, 8)
   let v9 = screenattr(1, 9)
   let v10 = screenattr(1, 10)
-  call assert_equal([{'group': 'MyGroup1', 'id': 11, 'priority': 10, 'pos1': [1, 4, 2], 'pos2': [1, 9, 2]}], getmatches())
+  call assert_equal([{'group': 'MyGroup1', 'id': 42, 'priority': 10, 'pos1': [1, 4, 2], 'pos2': [1, 9, 2]}], getmatches())
   call assert_notequal(v1, v4)
   call assert_equal(v5, v4)
   call assert_equal(v6, v1)
@@ -143,7 +143,7 @@ function Test_match()
   let m=getmatches()
   call clearmatches()
   call setmatches(m)
-  call assert_equal([{'group': 'MyGroup1', 'id': 11, 'priority': 10, 'pos1': [1, 4, 2], 'pos2': [1,9, 2]}, {'group': 'MyGroup1', 'pattern': '\%2lmatchadd', 'priority': 10, 'id': 12}], getmatches())
+  call assert_equal([{'group': 'MyGroup1', 'id': 42, 'priority': 10, 'pos1': [1, 4, 2], 'pos2': [1,9, 2]}, {'group': 'MyGroup1', 'pattern': '\%2lmatchadd', 'priority': 10, 'id': 1106}], getmatches())
 
   highlight MyGroup1 NONE
   highlight MyGroup2 NONE
@@ -161,7 +161,7 @@ func Test_matchadd_error()
   call clearmatches()
   " Nvim: not an error anymore:
   call matchadd('GroupDoesNotExist', 'X')
-  call assert_equal([{'group': 'GroupDoesNotExist', 'pattern': 'X', 'priority': 10, 'id': 13}], getmatches())
+  call assert_equal([{'group': 'GroupDoesNotExist', 'pattern': 'X', 'priority': 10, 'id': 1206}], getmatches())
   call assert_fails("call matchadd('Search', '\\(')", 'E475:')
   call assert_fails("call matchadd('Search', 'XXX', 1, 123, 1)", 'E715:')
   call assert_fails("call matchadd('Error', 'XXX', 1, 3)", 'E798:')
@@ -253,8 +253,8 @@ func Test_matchaddpos_otherwin()
 
   let savematches = getmatches(winid)
   let expect = [
-        \ {'group': 'Search', 'pattern': '4', 'priority': 10, 'id': 4},
-        \ {'group': 'Error', 'id': 5, 'priority': 10, 'pos1': [1, 2, 1], 'pos2': [2, 2, 1]},
+        \ {'group': 'Search', 'pattern': '4', 'priority': 10, 'id': 1000},
+        \ {'group': 'Error', 'id': 1001, 'priority': 10, 'pos1': [1, 2, 1], 'pos2': [2, 2, 1]},
         \]
   call assert_equal(expect, savematches)
 

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -2,6 +2,7 @@
 " matchaddpos(), matcharg(), matchdelete(), and setmatches().
 
 source screendump.vim
+source check.vim
 
 function Test_match()
   highlight MyGroup1 term=bold ctermbg=red guibg=red
@@ -217,6 +218,21 @@ func Test_matchaddpos()
   call clearmatches()
   syntax off
   set hlsearch&
+endfunc
+
+" Add 12 match positions (previously the limit was 8 positions).
+func Test_matchaddpos_dump()
+  CheckScreendump
+
+  let lines =<< trim END
+      call setline(1, ['1234567890123']->repeat(14))
+      call matchaddpos('Search', range(1, 12)->map({i, v -> [v, v]}))
+  END
+  call writefile(lines, 'Xmatchaddpos', 'D')
+  let buf = RunVimInTerminal('-S Xmatchaddpos', #{rows: 14})
+  call VerifyScreenDump(buf, 'Test_matchaddpos_1', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_matchaddpos_otherwin()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4981,8 +4981,7 @@ static win_T *win_alloc(win_T *after, bool hidden)
 
   foldInitWin(new_wp);
   unblock_autocmds();
-  new_wp->w_match_head = NULL;
-  new_wp->w_next_match_id = 4;
+  new_wp->w_next_match_id = 1000;  // up to 1000 can be picked by the user
   return new_wp;
 }
 

--- a/test/functional/legacy/063_match_and_matchadd_spec.lua
+++ b/test/functional/legacy/063_match_and_matchadd_spec.lua
@@ -3,10 +3,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 
-local eval, clear, command = helpers.eval, helpers.clear, helpers.command
-local eq, neq = helpers.eq, helpers.neq
+local clear, command = helpers.clear, helpers.command
 local insert = helpers.insert
-local pcall_err = helpers.pcall_err
 
 describe('063: Test for ":match", "matchadd()" and related functions', function()
   setup(clear)
@@ -19,105 +17,9 @@ describe('063: Test for ":match", "matchadd()" and related functions', function(
       [1] = {background = Screen.colors.Red},
     })
 
-    -- Check that "matcharg()" returns the correct group and pattern if a match
-    -- is defined.
     command("highlight MyGroup1 term=bold ctermbg=red guibg=red")
     command("highlight MyGroup2 term=italic ctermbg=green guibg=green")
     command("highlight MyGroup3 term=underline ctermbg=blue guibg=blue")
-    command("match MyGroup1 /TODO/")
-    command("2match MyGroup2 /FIXME/")
-    command("3match MyGroup3 /XXX/")
-    eq({'MyGroup1', 'TODO'}, eval('matcharg(1)'))
-    eq({'MyGroup2', 'FIXME'}, eval('matcharg(2)'))
-    eq({'MyGroup3', 'XXX'}, eval('matcharg(3)'))
-
-    -- Check that "matcharg()" returns an empty list if the argument is not 1,
-    -- 2 or 3 (only 0 and 4 are tested).
-    eq({}, eval('matcharg(0)'))
-    eq({}, eval('matcharg(4)'))
-
-    -- Check that "matcharg()" returns ['', ''] if a match is not defined.
-    command("match")
-    command("2match")
-    command("3match")
-    eq({'', ''}, eval('matcharg(1)'))
-    eq({'', ''}, eval('matcharg(2)'))
-    eq({'', ''}, eval('matcharg(3)'))
-
-    -- Check that "matchadd()" and "getmatches()" agree on added matches and
-    -- that default values apply.
-    command("let m1 = matchadd('MyGroup1', 'TODO')")
-    command("let m2 = matchadd('MyGroup2', 'FIXME', 42)")
-    command("let m3 = matchadd('MyGroup3', 'XXX', 60, 17)")
-    eq({{group = 'MyGroup1', pattern = 'TODO', priority = 10, id = 4},
-        {group = 'MyGroup2', pattern = 'FIXME', priority = 42, id = 5},
-        {group = 'MyGroup3', pattern = 'XXX', priority = 60, id = 17}},
-      eval('getmatches()'))
-
-    -- Check that "matchdelete()" deletes the matches defined in the previous
-    -- test correctly.
-    command("call matchdelete(m1)")
-    command("call matchdelete(m2)")
-    command("call matchdelete(m3)")
-    eq({}, eval('getmatches()'))
-
-    --- Check that "matchdelete()" returns 0 if successful and otherwise -1.
-    command("let m = matchadd('MyGroup1', 'TODO')")
-    eq(0, eval('matchdelete(m)'))
-
-    -- matchdelete throws error and returns -1 on failure
-    neq(true, pcall(function() eval('matchdelete(42)') end))
-    eq('Vim(let):E803: ID not found: 42', pcall_err(command, 'let r2 = matchdelete(42)'))
-
-    -- Check that "clearmatches()" clears all matches defined by ":match" and
-    -- "matchadd()".
-    command("let m1 = matchadd('MyGroup1', 'TODO')")
-    command("let m2 = matchadd('MyGroup2', 'FIXME', 42)")
-    command("let m3 = matchadd('MyGroup3', 'XXX', 60, 17)")
-    command("match MyGroup1 /COFFEE/")
-    command("2match MyGroup2 /HUMPPA/")
-    command("3match MyGroup3 /VIM/")
-    command("call clearmatches()")
-    eq({}, eval('getmatches()'))
-
-    -- Check that "setmatches()" restores a list of matches saved by
-    -- "getmatches()" without changes. (Matches with equal priority must also
-    -- remain in the same order.)
-    command("let m1 = matchadd('MyGroup1', 'TODO')")
-    command("let m2 = matchadd('MyGroup2', 'FIXME', 42)")
-    command("let m3 = matchadd('MyGroup3', 'XXX', 60, 17)")
-    command("match MyGroup1 /COFFEE/")
-    command("2match MyGroup2 /HUMPPA/")
-    command("3match MyGroup3 /VIM/")
-    command("let ml = getmatches()")
-    local ml = eval("ml")
-    command("call clearmatches()")
-    command("call setmatches(ml)")
-    eq(ml, eval('getmatches()'))
-
-    -- Check that "setmatches()" can correctly restore the matches from matchaddpos()
-    command("call clearmatches()")
-    command("call setmatches(ml)")
-    eq(ml, eval('getmatches()'))
-
-    -- Check that "setmatches()" will not add two matches with the same ID. The
-    -- expected behaviour (for now) is to add the first match but not the
-    -- second and to return -1.
-    eq('Vim(let):E801: ID already taken: 1',
-       pcall_err(command, "let r1 = setmatches([{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1}, {'group': 'MyGroup2', 'pattern': 'FIXME', 'priority': 10, 'id': 1}])"))
-    eq({{group = 'MyGroup1', pattern = 'TODO', priority = 10, id = 1}}, eval('getmatches()'))
-
-    -- Check that "setmatches()" returns 0 if successful and otherwise -1.
-    -- (A range of valid and invalid input values are tried out to generate the
-    -- return values.)
-    eq(0,eval("setmatches([])"))
-    eq(0,eval("setmatches([{'group': 'MyGroup1', 'pattern': 'TODO', 'priority': 10, 'id': 1}])"))
-    command("call clearmatches()")
-    eq('Vim(let):E714: List required', pcall_err(command, 'let rf1 = setmatches(0)'))
-    eq('Vim(let):E474: List item 0 is either not a dictionary or an empty one',
-       pcall_err(command, 'let rf2 = setmatches([0])'))
-    eq('Vim(let):E474: List item 0 is missing one of the required keys',
-       pcall_err(command, "let rf3 = setmatches([{'wrong key': 'wrong value'}])"))
 
     -- Check that "matchaddpos()" positions matches correctly
     insert('abcdefghijklmnopq')

--- a/test/functional/legacy/match_spec.lua
+++ b/test/functional/legacy/match_spec.lua
@@ -1,0 +1,38 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local exec = helpers.exec
+
+before_each(clear)
+
+describe('matchaddpos()', function()
+  -- oldtest: Test_matchaddpos_dump()
+  it('can add more than 8 match positions vim-patch:9.0.0620', function()
+    local screen = Screen.new(60, 14)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Yellow},  -- Search
+    })
+    screen:attach()
+    exec([[
+      call setline(1, ['1234567890123']->repeat(14))
+      call matchaddpos('Search', range(1, 12)->map({i, v -> [v, v]}))
+    ]])
+    screen:expect([[
+      {1:^1}234567890123                                               |
+      1{1:2}34567890123                                               |
+      12{1:3}4567890123                                               |
+      123{1:4}567890123                                               |
+      1234{1:5}67890123                                               |
+      12345{1:6}7890123                                               |
+      123456{1:7}890123                                               |
+      1234567{1:8}90123                                               |
+      12345678{1:9}0123                                               |
+      123456789{1:0}123                                               |
+      1234567890{1:1}23                                               |
+      12345678901{1:2}3                                               |
+      1234567890123                                               |
+                                                                  |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:9.0.0620: matchaddpos() can only add up to 8 matches

Problem:    matchaddpos() can only add up to 8 matches.
Solution:   Allocate the array of positions.
https://github.com/vim/vim/commit/50faf02f43d7f1a56ec2023028fca7c72dbce83e


#### vim-patch:9.0.0622: matchaddpos() can get slow when adding many matches

Problem:    matchaddpos() can get slow when adding many matches.
Solution:   Update the next available match ID when manually picking an ID and
            remove check if the available ID can be used. (idea by Rick Howe)
https://github.com/vim/vim/commit/9f573a8df02d9f699a43d2afbd1d2841d700b9ad