### PR TITLE
docs(dev-style): remove rule about variable declarations

### DIFF
--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -181,19 +181,6 @@ Use `bool` to represent boolean values. >
     int loaded = 1;  // BAD: loaded should have type bool.
 
 
-Variable declarations ~
-
-Multiple, simple variable declarations can be declared on the same line given
-that there are no initializations. A simple variable declaration is one that
-is not a pointer or array. >
-
-    int i, j, k;    // Allowed
-
-Use only one initialization per line. >
-
-    int i, j = 1;   // BAD
-
-
 Conditions ~
 
 Don't use "yoda-conditions". Use at most one assignment per condition. >

--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -183,9 +183,15 @@ Use `bool` to represent boolean values. >
 
 Variable declarations ~
 
-Declare only one variable per line. >
+Multiple, simple variable declarations can be declared on the same line given
+that there are no initializations. A simple variable declaration is one that
+is not a pointer or array. >
 
-    int i, j = 1
+    int i, j, k;    // Allowed
+
+Use only one initialization per line. >
+
+    int i, j = 1;   // BAD
 
 
 Conditions ~


### PR DESCRIPTION
~~Apply fixes to violations detected by clang-tidy to conform with Neovim's style guide~~

Update style guide for variable declaration as per suggestion in https://github.com/neovim/neovim/pull/20446#issuecomment-1265905231

```help
Multiple, simple variable declarations can be declared on the same line given
that there are no initializations. A simple variable declaration is one that
is not a pointer or array. >
    int i, j, k;    // Allowed
    
Use only one initialization per line. >
    int i, j = 1;   // BAD
```

ref: [DCL04-C. Do not declare more than one variable per declaration](https://wiki.sei.cmu.edu/confluence/display/c/DCL04-C.+Do+not+declare+more+than+one+variable+per+declaration)
