### PR TITLE
vim-patch:8.2.2316: Vim9: cannot list a lambda function

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1983,7 +1983,14 @@ void ex_function(exarg_T *eap)
   // s:func      script-local function name
   // g:func      global function name, same as "func"
   p = eap->arg;
-  name = (char *)trans_function_name(&p, eap->skip, TFN_NO_AUTOLOAD, &fudi, NULL);
+  if (strncmp(p, "<lambda>", 8) == 0) {
+    p += 8;
+    (void)getdigits(&p, false, 0);
+    name = xstrndup(eap->arg, (size_t)(p - eap->arg));
+    CLEAR_FIELD(fudi);
+  } else {
+    name = (char *)trans_function_name(&p, eap->skip, TFN_NO_AUTOLOAD, &fudi, NULL);
+  }
   paren = (vim_strchr(p, '(') != NULL);
   if (name == NULL && (fudi.fd_dict == NULL || !paren) && !eap->skip) {
     // Return on an invalid expression in braces, unless the expression

--- a/test/functional/vimscript/eval_spec.lua
+++ b/test/functional/vimscript/eval_spec.lua
@@ -17,6 +17,7 @@ local clear = helpers.clear
 local eq = helpers.eq
 local exc_exec = helpers.exc_exec
 local exec = helpers.exec
+local exec_capture = helpers.exec_capture
 local eval = helpers.eval
 local command = helpers.command
 local write_file = helpers.write_file
@@ -245,5 +246,18 @@ describe("uncaught exception", function()
     command('set runtimepath+=. | let result = ""')
     eq('throw1', exc_exec('try | runtime! throw*.vim | endtry'))
     eq('123', eval('result'))
+  end)
+end)
+
+describe('lambda function', function()
+  before_each(clear)
+
+  it('can be shown using :function followed by <lambda> #20466', function()
+    command('let A = {-> 1}')
+    local num = exec_capture('echo A'):match("function%('<lambda>(%d+)'%)")
+    eq(([[
+   function <lambda>%s(...)
+1  return 1
+   endfunction]]):format(num), exec_capture(('function <lambda>%s'):format(num)))
   end)
 end)


### PR DESCRIPTION
Fix #20466

#### vim-patch:8.2.2316: Vim9: cannot list a lambda function

Problem:    Vim9: cannot list a lambda function.
Solution:   Support the \<lambda>9 notation, like :disassemble.
https://github.com/vim/vim/commit/b657198cb30765468451d7f68fce49b5b4000c5d