### PR TITLE
feat(lsp): lsp.start takes bufnr

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -825,6 +825,8 @@ start({config}, {opts})                                      *vim.lsp.start()*
                     Predicate used to decide if a client should be re-used.
                     Used on all running clients. The default implementation
                     re-uses a client if name and root_dir matches.
+                  • bufnr (number) Buffer handle to attach to if starting or
+                    re-using a client (0 for current).
 
     Return: ~
         (number|nil) client_id

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -860,6 +860,9 @@ end
 ---                            Used on all running clients.
 ---                            The default implementation re-uses a client if name
 ---                            and root_dir matches.
+---             - bufnr (number)
+---                     Buffer handle to attach to if starting or re-using a
+---                     client (0 for current).
 ---@return number|nil client_id
 function lsp.start(config, opts)
   opts = opts or {}
@@ -871,7 +874,10 @@ function lsp.start(config, opts)
   if not config.name and type(config.cmd) == 'table' then
     config.name = config.cmd[1] and vim.fs.basename(config.cmd[1]) or nil
   end
-  local bufnr = api.nvim_get_current_buf()
+  local bufnr = opts.bufnr
+  if bufnr == nil or bufnr == 0 then
+    bufnr = api.nvim_get_current_buf()
+  end
   for _, clients in ipairs({ uninitialized_clients, lsp.get_active_clients() }) do
     for _, client in pairs(clients) do
       if reuse_client(client, config) then


### PR DESCRIPTION
Motivation is mostly that `vim.lsp.start` provides some nice wrapping functionality around managing starting/attaching clients, however some things like determining the current project, etc. are things that might be done async. From this, the "current buffer" might change between when a `FileType` auto command is triggered versus when `vim.lsp.start` is called.

This change would allow the above use-case to be met.