### PR TITLE
feat(docs): format parameter list as a list

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -545,9 +545,9 @@ nvim__get_runtime({pat}, {all}, {*opts})                 *nvim__get_runtime()*
         |api-fast|
 
     Parameters: ~
-        {pat}   pattern of files to search for
-        {all}   whether to return all matches or only the first
-        {opts}  is_lua: only search lua subdirs
+      • {pat}   pattern of files to search for
+      • {all}   whether to return all matches or only the first
+      • {opts}  is_lua: only search lua subdirs
 
     Return: ~
         list of absolute paths to the found files
@@ -559,7 +559,7 @@ nvim__id({obj})                                                   *nvim__id()*
     in plugins.
 
     Parameters: ~
-        {obj}  Object to return.
+      • {obj}  Object to return.
 
     Return: ~
         its argument.
@@ -571,7 +571,7 @@ nvim__id_array({arr})                                       *nvim__id_array()*
     in plugins.
 
     Parameters: ~
-        {arr}  Array to return.
+      • {arr}  Array to return.
 
     Return: ~
         its argument.
@@ -583,7 +583,7 @@ nvim__id_dictionary({dct})                             *nvim__id_dictionary()*
     in plugins.
 
     Parameters: ~
-        {dct}  Dictionary to return.
+      • {dct}  Dictionary to return.
 
     Return: ~
         its argument.
@@ -595,7 +595,7 @@ nvim__id_float({flt})                                       *nvim__id_float()*
     in plugins.
 
     Parameters: ~
-        {flt}  Value to return.
+      • {flt}  Value to return.
 
     Return: ~
         its argument.
@@ -625,7 +625,7 @@ nvim_call_atomic({calls})                                 *nvim_call_atomic()*
         |RPC| only
 
     Parameters: ~
-        {calls}  an array of calls, where each call is described by an array
+      • {calls}  an array of calls, where each call is described by an array
                  with two elements: the request name, and an array of
                  arguments.
 
@@ -652,15 +652,15 @@ nvim_chan_send({chan}, {data})                              *nvim_chan_send()*
         |vim.api| only
 
     Parameters: ~
-        {chan}  id of the channel
-        {data}  data to write. 8-bit clean: can contain NUL bytes.
+      • {chan}  id of the channel
+      • {data}  data to write. 8-bit clean: can contain NUL bytes.
 
 nvim_create_buf({listed}, {scratch})                       *nvim_create_buf()*
     Creates a new, empty, unnamed buffer.
 
     Parameters: ~
-        {listed}   Sets 'buflisted'
-        {scratch}  Creates a "throwaway" |scratch-buffer| for temporary work
+      • {listed}   Sets 'buflisted'
+      • {scratch}  Creates a "throwaway" |scratch-buffer| for temporary work
                    (always 'nomodified'). Also sets 'nomodeline' on the
                    buffer.
 
@@ -691,7 +691,7 @@ nvim_del_mark({name})                                        *nvim_del_mark()*
         fails with error if a lowercase or buffer local named mark is used.
 
     Parameters: ~
-        {name}  Mark name
+      • {name}  Mark name
 
     Return: ~
         true if the mark was deleted, else false.
@@ -704,31 +704,31 @@ nvim_del_var({name})                                          *nvim_del_var()*
     Removes a global (g:) variable.
 
     Parameters: ~
-        {name}  Variable name
+      • {name}  Variable name
 
 nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
     Echo a message.
 
     Parameters: ~
-        {chunks}   A list of [text, hl_group] arrays, each representing a text
+      • {chunks}   A list of [text, hl_group] arrays, each representing a text
                    chunk with specified highlight. `hl_group` element can be
                    omitted for no highlight.
-        {history}  if true, add to |message-history|.
-        {opts}     Optional parameters. Reserved for future use.
+      • {history}  if true, add to |message-history|.
+      • {opts}     Optional parameters. Reserved for future use.
 
 nvim_err_write({str})                                       *nvim_err_write()*
     Writes a message to the Vim error buffer. Does not append "\n", the
     message is buffered (won't display) until a linefeed is written.
 
     Parameters: ~
-        {str}  Message
+      • {str}  Message
 
 nvim_err_writeln({str})                                   *nvim_err_writeln()*
     Writes a message to the Vim error buffer. Appends "\n", so the buffer is
     flushed (and displayed).
 
     Parameters: ~
-        {str}  Message
+      • {str}  Message
 
     See also: ~
         nvim_err_write()
@@ -740,8 +740,8 @@ nvim_eval_statusline({str}, {*opts})                  *nvim_eval_statusline()*
         |api-fast|
 
     Parameters: ~
-        {str}   Statusline string (see 'statusline').
-        {opts}  Optional parameters.
+      • {str}   Statusline string (see 'statusline').
+      • {opts}  Optional parameters.
                 • winid: (number) |window-ID| of the window to use as context
                   for statusline.
                 • maxwidth: (number) Maximum width of statusline.
@@ -776,8 +776,8 @@ nvim_exec_lua({code}, {args})                                *nvim_exec_lua()*
         |RPC| only
 
     Parameters: ~
-        {code}  Lua code to execute
-        {args}  Arguments to the code
+      • {code}  Lua code to execute
+      • {args}  Arguments to the code
 
     Return: ~
         Return value of Lua code if present or NIL.
@@ -798,9 +798,9 @@ nvim_feedkeys({keys}, {mode}, {escape_ks})                   *nvim_feedkeys()*
 <
 
     Parameters: ~
-        {keys}       to be typed
-        {mode}       behavior flags, see |feedkeys()|
-        {escape_ks}  If true, escape K_SPECIAL bytes in `keys` This should be
+      • {keys}       to be typed
+      • {mode}       behavior flags, see |feedkeys()|
+      • {escape_ks}  If true, escape K_SPECIAL bytes in `keys` This should be
                      false if you already used |nvim_replace_termcodes()|, and
                      true otherwise.
 
@@ -854,7 +854,7 @@ nvim_get_color_by_name({name})                      *nvim_get_color_by_name()*
 <
 
     Parameters: ~
-        {name}  Color name or "#rrggbb" string
+      • {name}  Color name or "#rrggbb" string
 
     Return: ~
         24-bit RGB value, or -1 for invalid argument.
@@ -872,7 +872,7 @@ nvim_get_context({*opts})                                 *nvim_get_context()*
     Gets a map of the current editor state.
 
     Parameters: ~
-        {opts}  Optional parameters.
+      • {opts}  Optional parameters.
                 • types: List of |context-types| ("regs", "jumps", "bufs",
                   "gvars", …) to gather, or empty for "all".
 
@@ -907,8 +907,8 @@ nvim_get_hl_by_id({hl_id}, {rgb})                        *nvim_get_hl_by_id()*
     Gets a highlight definition by id. |hlID()|
 
     Parameters: ~
-        {hl_id}  Highlight id as returned by |hlID()|
-        {rgb}    Export RGB colors
+      • {hl_id}  Highlight id as returned by |hlID()|
+      • {rgb}    Export RGB colors
 
     Return: ~
         Highlight definition map
@@ -920,8 +920,8 @@ nvim_get_hl_by_name({name}, {rgb})                     *nvim_get_hl_by_name()*
     Gets a highlight definition by name.
 
     Parameters: ~
-        {name}  Highlight group name
-        {rgb}   Export RGB colors
+      • {name}  Highlight group name
+      • {rgb}   Export RGB colors
 
     Return: ~
         Highlight definition map
@@ -938,7 +938,7 @@ nvim_get_keymap({mode})                                    *nvim_get_keymap()*
     Gets a list of global (non-buffer-local) |mapping| definitions.
 
     Parameters: ~
-        {mode}  Mode short-name ("n", "i", "v", ...)
+      • {mode}  Mode short-name ("n", "i", "v", ...)
 
     Return: ~
         Array of |maparg()|-like dictionaries describing mappings. The
@@ -954,8 +954,8 @@ nvim_get_mark({name}, {opts})                                *nvim_get_mark()*
         fails with error if a lowercase or buffer local named mark is used.
 
     Parameters: ~
-        {name}  Mark name
-        {opts}  Optional parameters. Reserved for future use.
+      • {name}  Mark name
+      • {opts}  Optional parameters. Reserved for future use.
 
     Return: ~
         4-tuple (row, col, buffer, buffername), (0, 0, 0, '') if the mark is
@@ -1001,8 +1001,8 @@ nvim_get_runtime_file({name}, {all})                 *nvim_get_runtime_file()*
         |api-fast|
 
     Parameters: ~
-        {name}  pattern of files to search for
-        {all}   whether to return all matches or only the first
+      • {name}  pattern of files to search for
+      • {all}   whether to return all matches or only the first
 
     Return: ~
         list of absolute paths to the found files
@@ -1011,7 +1011,7 @@ nvim_get_var({name})                                          *nvim_get_var()*
     Gets a global (g:) variable.
 
     Parameters: ~
-        {name}  Variable name
+      • {name}  Variable name
 
     Return: ~
         Variable value
@@ -1020,7 +1020,7 @@ nvim_get_vvar({name})                                        *nvim_get_vvar()*
     Gets a v: variable.
 
     Parameters: ~
-        {name}  Variable name
+      • {name}  Variable name
 
     Return: ~
         Variable value
@@ -1044,7 +1044,7 @@ nvim_input({keys})                                              *nvim_input()*
         |api-fast|
 
     Parameters: ~
-        {keys}  to be typed
+      • {keys}  to be typed
 
     Return: ~
         Number of bytes actually written (can be fewer than requested if the
@@ -1068,18 +1068,18 @@ nvim_input_mouse({button}, {action}, {modifier}, {grid}, {row}, {col})
         |api-fast|
 
     Parameters: ~
-        {button}    Mouse button: one of "left", "right", "middle", "wheel",
+      • {button}    Mouse button: one of "left", "right", "middle", "wheel",
                     "move".
-        {action}    For ordinary buttons, one of "press", "drag", "release".
+      • {action}    For ordinary buttons, one of "press", "drag", "release".
                     For the wheel, one of "up", "down", "left", "right".
                     Ignored for "move".
-        {modifier}  String of modifiers each represented by a single char. The
+      • {modifier}  String of modifiers each represented by a single char. The
                     same specifiers are used as for a key press, except that
                     the "-" separator is optional, so "C-A-", "c-a" and "CA"
                     can all be used to specify Ctrl+Alt+click.
-        {grid}      Grid number if the client uses |ui-multigrid|, else 0.
-        {row}       Mouse row-position (zero-based, like redraw events)
-        {col}       Mouse column-position (zero-based, like redraw events)
+      • {grid}      Grid number if the client uses |ui-multigrid|, else 0.
+      • {row}       Mouse row-position (zero-based, like redraw events)
+      • {col}       Mouse column-position (zero-based, like redraw events)
 
 nvim_list_bufs()                                            *nvim_list_bufs()*
     Gets the current list of buffer handles
@@ -1130,7 +1130,7 @@ nvim_load_context({dict})                                *nvim_load_context()*
     Sets the current editor state from the given |context| map.
 
     Parameters: ~
-        {dict}  |Context| map.
+      • {dict}  |Context| map.
 
 nvim_notify({msg}, {log_level}, {opts})                        *nvim_notify()*
     Notify the user with a message
@@ -1139,9 +1139,9 @@ nvim_notify({msg}, {log_level}, {opts})                        *nvim_notify()*
     echo area but can be overridden to trigger desktop notifications.
 
     Parameters: ~
-        {msg}        Message to display to the user
-        {log_level}  The log level
-        {opts}       Reserved for future use.
+      • {msg}        Message to display to the user
+      • {log_level}  The log level
+      • {opts}       Reserved for future use.
 
 nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
     Open a terminal instance in a buffer
@@ -1159,8 +1159,8 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
     virtual terminal having the intended size.
 
     Parameters: ~
-        {buffer}  the buffer to use (expected to be empty)
-        {opts}    Optional parameters.
+      • {buffer}  the buffer to use (expected to be empty)
+      • {opts}    Optional parameters.
                   • on_input: lua callback for input sent, i e keypresses in
                     terminal mode. Note: keypresses are sent raw as they would
                     be to the pty master end. For instance, a carriage return
@@ -1176,7 +1176,7 @@ nvim_out_write({str})                                       *nvim_out_write()*
     message is buffered (won't display) until a linefeed is written.
 
     Parameters: ~
-        {str}  Message
+      • {str}  Message
 
 nvim_paste({data}, {crlf}, {phase})                             *nvim_paste()*
     Pastes at cursor, in any mode.
@@ -1193,9 +1193,9 @@ nvim_paste({data}, {crlf}, {phase})                             *nvim_paste()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {data}   Multiline input. May be binary (containing NUL bytes).
-        {crlf}   Also break lines at CR and CRLF.
-        {phase}  -1: paste in a single call (i.e. without streaming). To
+      • {data}   Multiline input. May be binary (containing NUL bytes).
+      • {crlf}   Also break lines at CR and CRLF.
+      • {phase}  -1: paste in a single call (i.e. without streaming). To
                  "stream" a paste, call `nvim_paste` sequentially with these `phase` values:
                  • 1: starts the paste (exactly once)
                  • 2: continues the paste (zero or more times)
@@ -1215,15 +1215,15 @@ nvim_put({lines}, {type}, {after}, {follow})                      *nvim_put()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {lines}   |readfile()|-style list of lines. |channel-lines|
-        {type}    Edit behavior: any |getregtype()| result, or:
+      • {lines}   |readfile()|-style list of lines. |channel-lines|
+      • {type}    Edit behavior: any |getregtype()| result, or:
                   • "b" |blockwise-visual| mode (may include width, e.g. "b3")
                   • "c" |charwise| mode
                   • "l" |linewise| mode
                   • "" guess by contents, see |setreg()|
-        {after}   If true insert after cursor (like |p|), or before (like
+      • {after}   If true insert after cursor (like |p|), or before (like
                   |P|).
-        {follow}  If true place cursor at end of inserted text.
+      • {follow}  If true place cursor at end of inserted text.
 
                                                     *nvim_replace_termcodes()*
 nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
@@ -1231,10 +1231,10 @@ nvim_replace_termcodes({str}, {from_part}, {do_lt}, {special})
     the internal representation.
 
     Parameters: ~
-        {str}        String to be converted.
-        {from_part}  Legacy Vim parameter. Usually true.
-        {do_lt}      Also translate <lt>. Ignored if `special` is false.
-        {special}    Replace |keycodes|, e.g. <CR> becomes a "\r" char.
+      • {str}        String to be converted.
+      • {from_part}  Legacy Vim parameter. Usually true.
+      • {do_lt}      Also translate <lt>. Ignored if `special` is false.
+      • {special}    Replace |keycodes|, e.g. <CR> becomes a "\r" char.
 
     See also: ~
         replace_termcodes
@@ -1250,12 +1250,12 @@ nvim_select_popupmenu_item({item}, {insert}, {finish}, {opts})
     ensure the mapping doesn't end completion mode.
 
     Parameters: ~
-        {item}    Index (zero-based) of the item to select. Value of -1
+      • {item}    Index (zero-based) of the item to select. Value of -1
                   selects nothing and restores the original text.
-        {insert}  Whether the selection should be inserted in the buffer.
-        {finish}  Finish the completion and dismiss the popupmenu. Implies
+      • {insert}  Whether the selection should be inserted in the buffer.
+      • {finish}  Finish the completion and dismiss the popupmenu. Implies
                   `insert`.
-        {opts}    Optional parameters. Reserved for future use.
+      • {opts}    Optional parameters. Reserved for future use.
 
                                                       *nvim_set_client_info()*
 nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
@@ -1277,8 +1277,8 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
         |RPC| only
 
     Parameters: ~
-        {name}        Short name for the connected client
-        {version}     Dictionary describing the version, with these (optional)
+      • {name}        Short name for the connected client
+      • {version}     Dictionary describing the version, with these (optional)
                       keys:
                       • "major" major version (defaults to 0 if not set, for
                         no release yet)
@@ -1287,7 +1287,7 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
                       • "prerelease" string describing a prerelease, like
                         "dev" or "beta1"
                       • "commit" hash or similar identifier of commit
-        {type}        Must be one of the following values. Client libraries
+      • {type}        Must be one of the following values. Client libraries
                       should default to "remote" unless overridden by the
                       user.
                       • "remote" remote client connected to Nvim.
@@ -1296,7 +1296,7 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
                         example, IDE/editor implementing a vim mode).
                       • "host" plugin host, typically started by nvim
                       • "plugin" single plugin, started by nvim
-        {methods}     Builtin methods in the client. For a host, this does not
+      • {methods}     Builtin methods in the client. For a host, this does not
                       include plugin methods which will be discovered later.
                       The key should be the method name, the values are dicts
                       with these (optional) keys (more keys may be added in
@@ -1308,7 +1308,7 @@ nvim_set_client_info({name}, {version}, {type}, {methods}, {attributes})
                       • "nargs" Number of arguments. Could be a single integer
                         or an array of two integers, minimum and maximum
                         inclusive.
-        {attributes}  Arbitrary string:string map of informal client
+      • {attributes}  Arbitrary string:string map of informal client
                       properties. Suggested keys:
                       • "website": Client homepage URL (e.g. GitHub
                         repository)
@@ -1324,13 +1324,13 @@ nvim_set_current_buf({buffer})                        *nvim_set_current_buf()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {buffer}  Buffer handle
+      • {buffer}  Buffer handle
 
 nvim_set_current_dir({dir})                           *nvim_set_current_dir()*
     Changes the global working directory.
 
     Parameters: ~
-        {dir}  Directory path
+      • {dir}  Directory path
 
 nvim_set_current_line({line})                        *nvim_set_current_line()*
     Sets the current line.
@@ -1339,7 +1339,7 @@ nvim_set_current_line({line})                        *nvim_set_current_line()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {line}  Line contents
+      • {line}  Line contents
 
 nvim_set_current_tabpage({tabpage})               *nvim_set_current_tabpage()*
     Sets the current tabpage.
@@ -1348,7 +1348,7 @@ nvim_set_current_tabpage({tabpage})               *nvim_set_current_tabpage()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {tabpage}  Tabpage handle
+      • {tabpage}  Tabpage handle
 
 nvim_set_current_win({window})                        *nvim_set_current_win()*
     Sets the current window.
@@ -1357,7 +1357,7 @@ nvim_set_current_win({window})                        *nvim_set_current_win()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {window}  Window handle
+      • {window}  Window handle
 
 nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
     Sets a highlight group.
@@ -1375,10 +1375,10 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
         using these values results in an error.
 
     Parameters: ~
-        {ns_id}  Namespace id for this highlight |nvim_create_namespace()|.
+      • {ns_id}  Namespace id for this highlight |nvim_create_namespace()|.
                  Use 0 to set a highlight group globally |:highlight|.
-        {name}   Highlight group name, e.g. "ErrorMsg"
-        {val}    Highlight definition map, accepts the following keys:
+      • {name}   Highlight group name, e.g. "ErrorMsg"
+      • {val}    Highlight definition map, accepts the following keys:
                  • fg (or foreground): color name or "#RRGGBB", see note.
                  • bg (or background): color name or "#RRGGBB", see note.
                  • sp (or special): color name or "#RRGGBB"
@@ -1408,7 +1408,7 @@ nvim_set_hl_ns({ns_id})                                     *nvim_set_hl_ns()*
     see |nvim_win_set_hl_ns()|.
 
     Parameters: ~
-        {ns_id}  the namespace to use
+      • {ns_id}  the namespace to use
 
 nvim_set_hl_ns_fast({ns_id})                           *nvim_set_hl_ns_fast()*
     Set active namespace for highlights while redrawing.
@@ -1421,7 +1421,7 @@ nvim_set_hl_ns_fast({ns_id})                           *nvim_set_hl_ns_fast()*
         |api-fast|
 
     Parameters: ~
-        {ns_id}  the namespace to activate
+      • {ns_id}  the namespace to activate
 
 nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
     Sets a global |mapping| for the given mode.
@@ -1440,11 +1440,11 @@ nvim_set_keymap({mode}, {lhs}, {rhs}, {*opts})             *nvim_set_keymap()*
 <
 
     Parameters: ~
-        {mode}  Mode short-name (map command prefix: "n", "i", "v", "x", …) or
+      • {mode}  Mode short-name (map command prefix: "n", "i", "v", "x", …) or
                 "!" for |:map!|, or empty string for |:map|.
-        {lhs}   Left-hand-side |{lhs}| of the mapping.
-        {rhs}   Right-hand-side |{rhs}| of the mapping.
-        {opts}  Optional parameters map: keys are |:map-arguments|, values are
+      • {lhs}   Left-hand-side |{lhs}| of the mapping.
+      • {rhs}   Right-hand-side |{rhs}| of the mapping.
+      • {opts}  Optional parameters map: keys are |:map-arguments|, values are
                 booleans (default false). Accepts all |:map-arguments| as keys
                 excluding |<buffer>| but including |:noremap| and "desc".
                 Unknown key is an error. "desc" can be used to give a
@@ -1459,22 +1459,22 @@ nvim_set_var({name}, {value})                                 *nvim_set_var()*
     Sets a global (g:) variable.
 
     Parameters: ~
-        {name}   Variable name
-        {value}  Variable value
+      • {name}   Variable name
+      • {value}  Variable value
 
 nvim_set_vvar({name}, {value})                               *nvim_set_vvar()*
     Sets a v: variable, if it is not readonly.
 
     Parameters: ~
-        {name}   Variable name
-        {value}  Variable value
+      • {name}   Variable name
+      • {value}  Variable value
 
 nvim_strwidth({text})                                        *nvim_strwidth()*
     Calculates the number of display cells occupied by `text`. Control
     characters including <Tab> count as one cell.
 
     Parameters: ~
-        {text}  Some text
+      • {text}  Some text
 
     Return: ~
         Number of cells
@@ -1486,7 +1486,7 @@ nvim_subscribe({event})                                     *nvim_subscribe()*
         |RPC| only
 
     Parameters: ~
-        {event}  Event type string
+      • {event}  Event type string
 
 nvim_unsubscribe({event})                                 *nvim_unsubscribe()*
     Unsubscribes to event broadcasts.
@@ -1495,7 +1495,7 @@ nvim_unsubscribe({event})                                 *nvim_unsubscribe()*
         |RPC| only
 
     Parameters: ~
-        {event}  Event type string
+      • {event}  Event type string
 
 
 ==============================================================================
@@ -1508,9 +1508,9 @@ nvim_call_dict_function({dict}, {fn}, {args})
     On execution error: fails with VimL error, updates v:errmsg.
 
     Parameters: ~
-        {dict}  Dictionary, or String evaluating to a VimL |self| dict
-        {fn}    Name of the function defined on the VimL dict
-        {args}  Function arguments packed in an Array
+      • {dict}  Dictionary, or String evaluating to a VimL |self| dict
+      • {fn}    Name of the function defined on the VimL dict
+      • {args}  Function arguments packed in an Array
 
     Return: ~
         Result of the function call
@@ -1521,8 +1521,8 @@ nvim_call_function({fn}, {args})                        *nvim_call_function()*
     On execution error: fails with VimL error, updates v:errmsg.
 
     Parameters: ~
-        {fn}    Function to call
-        {args}  Function arguments packed in an Array
+      • {fn}    Function to call
+      • {args}  Function arguments packed in an Array
 
     Return: ~
         Result of the function call
@@ -1539,7 +1539,7 @@ nvim_command({command})                                       *nvim_command()*
     |nvim_parse_cmd()| in conjunction with |nvim_cmd()|.
 
     Parameters: ~
-        {command}  Ex command string
+      • {command}  Ex command string
 
 nvim_eval({expr})                                                *nvim_eval()*
     Evaluates a VimL |expression|. Dictionaries and Lists are recursively
@@ -1548,7 +1548,7 @@ nvim_eval({expr})                                                *nvim_eval()*
     On execution error: fails with VimL error, updates v:errmsg.
 
     Parameters: ~
-        {expr}  VimL expression string
+      • {expr}  VimL expression string
 
     Return: ~
         Evaluation result or expanded object
@@ -1563,8 +1563,8 @@ nvim_exec({src}, {output})                                       *nvim_exec()*
     On execution error: fails with VimL error, updates v:errmsg.
 
     Parameters: ~
-        {src}     Vimscript code
-        {output}  Capture and return all (non-error, non-shell |:!|) output
+      • {src}     Vimscript code
+      • {output}  Capture and return all (non-error, non-shell |:!|) output
 
     Return: ~
         Output (non-error, non-shell |:!|) if `output` is true, else empty
@@ -1583,8 +1583,8 @@ nvim_parse_expression({expr}, {flags}, {highlight})
         |api-fast|
 
     Parameters: ~
-        {expr}       Expression to parse. Always treated as a single line.
-        {flags}      Flags:
+      • {expr}       Expression to parse. Always treated as a single line.
+      • {flags}      Flags:
                      • "m" if multiple expressions in a row are allowed (only
                        the first one will be parsed),
                      • "E" if EOC tokens are not allowed (determines whether
@@ -1596,7 +1596,7 @@ nvim_parse_expression({expr}, {flags}, {highlight})
                      • "E" to parse like for "<C-r>=".
                      • empty string for ":call".
                      • "lm" to parse for ":let".
-        {highlight}  If true, return value will also include "highlight" key
+      • {highlight}  If true, return value will also include "highlight" key
                      containing array of 4-tuples (arrays) (Integer, Integer,
                      Integer, String), where first three numbers define the
                      highlighted region and represent line, starting column
@@ -1664,7 +1664,7 @@ nvim_buf_create_user_command({buffer}, {name}, {command}, {*opts})
     Create a new user command |user-commands| in the given buffer.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer.
+      • {buffer}  Buffer handle, or 0 for current buffer.
 
     See also: ~
         nvim_create_user_command
@@ -1677,15 +1677,15 @@ nvim_buf_del_user_command({buffer}, {name})
     |nvim_buf_create_user_command()| can be deleted with this function.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer.
-        {name}    Name of the command to delete.
+      • {buffer}  Buffer handle, or 0 for current buffer.
+      • {name}    Name of the command to delete.
 
 nvim_buf_get_commands({buffer}, {*opts})             *nvim_buf_get_commands()*
     Gets a map of buffer-local |user-commands|.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {opts}    Optional parameters. Currently not used.
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {opts}    Optional parameters. Currently not used.
 
     Return: ~
         Map of maps describing commands.
@@ -1708,11 +1708,11 @@ nvim_cmd({*cmd}, {*opts})                                         *nvim_cmd()*
     On execution error: fails with VimL error, updates v:errmsg.
 
     Parameters: ~
-        {cmd}   Command to execute. Must be a Dictionary that can contain the
+      • {cmd}   Command to execute. Must be a Dictionary that can contain the
                 same values as the return value of |nvim_parse_cmd()| except
                 "addr", "nargs" and "nextcmd" which are ignored if provided.
                 All values except for "cmd" are optional.
-        {opts}  Optional parameters.
+      • {opts}  Optional parameters.
                 • output: (boolean, default false) Whether to return command
                   output.
 
@@ -1740,9 +1740,9 @@ nvim_create_user_command({name}, {command}, {*opts})
 <
 
     Parameters: ~
-        {name}     Name of the new user command. Must begin with an uppercase
+      • {name}     Name of the new user command. Must begin with an uppercase
                    letter.
-        {command}  Replacement command to execute when this user command is
+      • {command}  Replacement command to execute when this user command is
                    executed. When called from Lua, the command can also be a
                    Lua function. The function is called with a single table
                    argument that contains the following keys:
@@ -1765,7 +1765,7 @@ nvim_create_user_command({name}, {command}, {*opts})
                    • smods: (table) Command modifiers in a structured format.
                      Has the same structure as the "mods" key of
                      |nvim_parse_cmd()|.
-        {opts}     Optional command attributes. See |command-attributes| for
+      • {opts}     Optional command attributes. See |command-attributes| for
                    more details. To use boolean attributes (such as
                    |:command-bang| or |:command-bar|) set the value to "true".
                    In addition to the string options listed in
@@ -1783,7 +1783,7 @@ nvim_del_user_command({name})                        *nvim_del_user_command()*
     Delete a user-defined command.
 
     Parameters: ~
-        {name}  Name of the command to delete.
+      • {name}  Name of the command to delete.
 
 nvim_get_commands({*opts})                               *nvim_get_commands()*
     Gets a map of global (non-buffer-local) Ex commands.
@@ -1791,7 +1791,7 @@ nvim_get_commands({*opts})                               *nvim_get_commands()*
     Currently only |user-commands| are supported, not builtin Ex commands.
 
     Parameters: ~
-        {opts}  Optional parameters. Currently only supports {"builtin":false}
+      • {opts}  Optional parameters. Currently only supports {"builtin":false}
 
     Return: ~
         Map of maps describing commands.
@@ -1805,8 +1805,8 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
         |api-fast|
 
     Parameters: ~
-        {str}   Command line string to parse. Cannot contain "\n".
-        {opts}  Optional parameters. Reserved for future use.
+      • {str}   Command line string to parse. Cannot contain "\n".
+      • {opts}  Optional parameters. Reserved for future use.
 
     Return: ~
         Dictionary containing command information, with these keys:
@@ -1874,8 +1874,8 @@ nvim_buf_get_option({buffer}, {name})                  *nvim_buf_get_option()*
     Gets a buffer option value
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Option name
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Option name
 
     Return: ~
         Option value
@@ -1885,9 +1885,9 @@ nvim_buf_set_option({buffer}, {name}, {value})         *nvim_buf_set_option()*
     (only works if there's a global fallback)
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Option name
-        {value}   Option value
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Option name
+      • {value}   Option value
 
 nvim_get_all_options_info()                      *nvim_get_all_options_info()*
     Gets the option information for all options.
@@ -1902,7 +1902,7 @@ nvim_get_option({name})                                    *nvim_get_option()*
     Gets the global value of an option.
 
     Parameters: ~
-        {name}  Option name
+      • {name}  Option name
 
     Return: ~
         Option value (global)
@@ -1925,7 +1925,7 @@ nvim_get_option_info({name})                          *nvim_get_option_info()*
     • flaglist: List of single char flags
 
     Parameters: ~
-        {name}  Option name
+      • {name}  Option name
 
     Return: ~
         Option Information
@@ -1937,8 +1937,8 @@ nvim_get_option_value({name}, {*opts})               *nvim_get_option_value()*
     current buffer or window, unless "buf" or "win" is set in {opts}.
 
     Parameters: ~
-        {name}  Option name
-        {opts}  Optional parameters
+      • {name}  Option name
+      • {opts}  Optional parameters
                 • scope: One of "global" or "local". Analogous to |:setglobal|
                   and |:setlocal|, respectively.
                 • win: |window-ID|. Used for getting window local options.
@@ -1952,8 +1952,8 @@ nvim_set_option({name}, {value})                           *nvim_set_option()*
     Sets the global value of an option.
 
     Parameters: ~
-        {name}   Option name
-        {value}  New option value
+      • {name}   Option name
+      • {value}  New option value
 
                                                      *nvim_set_option_value()*
 nvim_set_option_value({name}, {value}, {*opts})
@@ -1964,9 +1964,9 @@ nvim_set_option_value({name}, {value}, {*opts})
     Note the options {win} and {buf} cannot be used together.
 
     Parameters: ~
-        {name}   Option name
-        {value}  New option value
-        {opts}   Optional parameters
+      • {name}   Option name
+      • {value}  New option value
+      • {opts}   Optional parameters
                  • scope: One of "global" or "local". Analogous to
                    |:setglobal| and |:setlocal|, respectively.
                  • win: |window-ID|. Used for setting window local option.
@@ -1976,8 +1976,8 @@ nvim_win_get_option({window}, {name})                  *nvim_win_get_option()*
     Gets a window option value
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {name}    Option name
+      • {window}  Window handle, or 0 for current window
+      • {name}    Option name
 
     Return: ~
         Option value
@@ -1987,9 +1987,9 @@ nvim_win_set_option({window}, {name}, {value})         *nvim_win_set_option()*
     (only works if there's a global fallback)
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {name}    Option name
-        {value}   Option value
+      • {window}  Window handle, or 0 for current window
+      • {name}    Option name
+      • {value}   Option value
 
 
 ==============================================================================
@@ -2020,13 +2020,13 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
 <
 
     Parameters: ~
-        {buffer}       Buffer handle, or 0 for current buffer
-        {send_buffer}  True if the initial notification should contain the
+      • {buffer}       Buffer handle, or 0 for current buffer
+      • {send_buffer}  True if the initial notification should contain the
                        whole buffer: first notification will be
                        `nvim_buf_lines_event`. Else the first notification
                        will be `nvim_buf_changedtick_event`. Not for Lua
                        callbacks.
-        {opts}         Optional parameters.
+      • {opts}         Optional parameters.
                        • on_lines: Lua callback invoked on change. Return `true` to detach. Args:
                          • the string "lines"
                          • buffer handle
@@ -2100,8 +2100,8 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
         |vim.api| only
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {fun}     Function to call inside the buffer (currently lua callable
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {fun}     Function to call inside the buffer (currently lua callable
                   only)
 
     Return: ~
@@ -2112,7 +2112,7 @@ nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
     Unmaps a buffer-local |mapping| for the given mode.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     See also: ~
         |nvim_del_keymap()|
@@ -2125,8 +2125,8 @@ nvim_buf_del_mark({buffer}, {name})                      *nvim_buf_del_mark()*
         buffer it will return false.
 
     Parameters: ~
-        {buffer}  Buffer to set the mark on
-        {name}    Mark name
+      • {buffer}  Buffer to set the mark on
+      • {name}    Mark name
 
     Return: ~
         true if the mark was deleted, else false.
@@ -2139,8 +2139,8 @@ nvim_buf_del_var({buffer}, {name})                        *nvim_buf_del_var()*
     Removes a buffer-scoped (b:) variable
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Variable name
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Variable name
 
 nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
     Deletes the buffer. See |:bwipeout|
@@ -2149,8 +2149,8 @@ nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {opts}    Optional parameters. Keys:
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {opts}    Optional parameters. Keys:
                   • force: Force deletion and ignore unsaved changes.
                   • unload: Unloaded only, do not delete. See |:bunload|
 
@@ -2161,7 +2161,7 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
         |RPC| only
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         False if detach failed (because the buffer isn't loaded); otherwise
@@ -2175,7 +2175,7 @@ nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
     Gets a changed tick of a buffer
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         `b:changedtick` value.
@@ -2184,8 +2184,8 @@ nvim_buf_get_keymap({buffer}, {mode})                  *nvim_buf_get_keymap()*
     Gets a list of buffer-local |mapping| definitions.
 
     Parameters: ~
-        {mode}    Mode short-name ("n", "i", "v", ...)
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {mode}    Mode short-name ("n", "i", "v", ...)
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         Array of |maparg()|-like dictionaries describing mappings. The
@@ -2203,10 +2203,10 @@ nvim_buf_get_lines({buffer}, {start}, {end}, {strict_indexing})
     `strict_indexing` is set.
 
     Parameters: ~
-        {buffer}           Buffer handle, or 0 for current buffer
-        {start}            First line index
-        {end}              Last line index, exclusive
-        {strict_indexing}  Whether out-of-bounds should be an error.
+      • {buffer}           Buffer handle, or 0 for current buffer
+      • {start}            First line index
+      • {end}              Last line index, exclusive
+      • {strict_indexing}  Whether out-of-bounds should be an error.
 
     Return: ~
         Array of lines, or empty array for unloaded buffer.
@@ -2218,8 +2218,8 @@ nvim_buf_get_mark({buffer}, {name})                      *nvim_buf_get_mark()*
     Marks are (1,0)-indexed. |api-indexing|
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Mark name
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Mark name
 
     Return: ~
         (row, col) tuple, (0, 0) if the mark is not set, or is an
@@ -2233,7 +2233,7 @@ nvim_buf_get_name({buffer})                              *nvim_buf_get_name()*
     Gets the full file name for the buffer
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         Buffer name
@@ -2250,8 +2250,8 @@ nvim_buf_get_offset({buffer}, {index})                 *nvim_buf_get_offset()*
     for unloaded buffer.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {index}   Line index
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {index}   Line index
 
     Return: ~
         Integer byte offset, or -1 for unloaded buffer.
@@ -2270,12 +2270,12 @@ nvim_buf_get_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     Prefer |nvim_buf_get_lines()| when retrieving entire lines.
 
     Parameters: ~
-        {buffer}     Buffer handle, or 0 for current buffer
-        {start_row}  First line index
-        {start_col}  Starting column (byte offset) on first line
-        {end_row}    Last line index, inclusive
-        {end_col}    Ending column (byte offset) on last line, exclusive
-        {opts}       Optional parameters. Currently unused.
+      • {buffer}     Buffer handle, or 0 for current buffer
+      • {start_row}  First line index
+      • {start_col}  Starting column (byte offset) on first line
+      • {end_row}    Last line index, inclusive
+      • {end_col}    Ending column (byte offset) on last line, exclusive
+      • {opts}       Optional parameters. Currently unused.
 
     Return: ~
         Array of lines, or empty array for unloaded buffer.
@@ -2284,8 +2284,8 @@ nvim_buf_get_var({buffer}, {name})                        *nvim_buf_get_var()*
     Gets a buffer-scoped (b:) variable.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Variable name
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Variable name
 
     Return: ~
         Variable value
@@ -2295,7 +2295,7 @@ nvim_buf_is_loaded({buffer})                            *nvim_buf_is_loaded()*
     about unloaded buffers.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         true if the buffer is valid and loaded, false otherwise.
@@ -2308,7 +2308,7 @@ nvim_buf_is_valid({buffer})                              *nvim_buf_is_valid()*
         for more info about unloaded buffers.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         true if the buffer is valid, false otherwise.
@@ -2317,7 +2317,7 @@ nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
     Returns the number of lines in the given buffer.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     Return: ~
         Line count, or 0 for unloaded buffer. |api-buffer|
@@ -2327,7 +2327,7 @@ nvim_buf_set_keymap({buffer}, {mode}, {lhs}, {rhs}, {*opts})
     Sets a buffer-local |mapping| for the given mode.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
+      • {buffer}  Buffer handle, or 0 for current buffer
 
     See also: ~
         |nvim_set_keymap()|
@@ -2350,11 +2350,11 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
         not allowed when |textlock| is active
 
     Parameters: ~
-        {buffer}           Buffer handle, or 0 for current buffer
-        {start}            First line index
-        {end}              Last line index, exclusive
-        {strict_indexing}  Whether out-of-bounds should be an error.
-        {replacement}      Array of lines to use as replacement
+      • {buffer}           Buffer handle, or 0 for current buffer
+      • {start}            First line index
+      • {end}              Last line index, exclusive
+      • {strict_indexing}  Whether out-of-bounds should be an error.
+      • {replacement}      Array of lines to use as replacement
 
                                                          *nvim_buf_set_mark()*
 nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
@@ -2367,11 +2367,11 @@ nvim_buf_set_mark({buffer}, {name}, {line}, {col}, {opts})
         Passing 0 as line deletes the mark
 
     Parameters: ~
-        {buffer}  Buffer to set the mark on
-        {name}    Mark name
-        {line}    Line number
-        {col}     Column/row number
-        {opts}    Optional parameters. Reserved for future use.
+      • {buffer}  Buffer to set the mark on
+      • {name}    Mark name
+      • {line}    Line number
+      • {col}     Column/row number
+      • {opts}    Optional parameters. Reserved for future use.
 
     Return: ~
         true if the mark was set, else false.
@@ -2384,8 +2384,8 @@ nvim_buf_set_name({buffer}, {name})                      *nvim_buf_set_name()*
     Sets the full file name for a buffer
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Buffer name
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Buffer name
 
                                                          *nvim_buf_set_text()*
 nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
@@ -2407,20 +2407,20 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     lines.
 
     Parameters: ~
-        {buffer}       Buffer handle, or 0 for current buffer
-        {start_row}    First line index
-        {start_col}    Starting column (byte offset) on first line
-        {end_row}      Last line index, inclusive
-        {end_col}      Ending column (byte offset) on last line, exclusive
-        {replacement}  Array of lines to use as replacement
+      • {buffer}       Buffer handle, or 0 for current buffer
+      • {start_row}    First line index
+      • {start_col}    Starting column (byte offset) on first line
+      • {end_row}      Last line index, inclusive
+      • {end_col}      Ending column (byte offset) on last line, exclusive
+      • {replacement}  Array of lines to use as replacement
 
 nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
     Sets a buffer-scoped (b:) variable
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {name}    Variable name
-        {value}   Variable value
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {name}    Variable name
+      • {value}   Variable value
 
 
 ==============================================================================
@@ -2451,12 +2451,12 @@ nvim_buf_add_highlight({buffer}, {ns_id}, {hl_group}, {line}, {col_start},
     |nvim_create_namespace()| to create a new empty namespace.
 
     Parameters: ~
-        {buffer}     Buffer handle, or 0 for current buffer
-        {ns_id}      namespace to use or -1 for ungrouped highlight
-        {hl_group}   Name of the highlight group to use
-        {line}       Line to highlight (zero-indexed)
-        {col_start}  Start of (byte-indexed) column range to highlight
-        {col_end}    End of (byte-indexed) column range to highlight, or -1 to
+      • {buffer}     Buffer handle, or 0 for current buffer
+      • {ns_id}      namespace to use or -1 for ungrouped highlight
+      • {hl_group}   Name of the highlight group to use
+      • {line}       Line to highlight (zero-indexed)
+      • {col_start}  Start of (byte-indexed) column range to highlight
+      • {col_end}    End of (byte-indexed) column range to highlight, or -1 to
                      highlight to end of line
 
     Return: ~
@@ -2471,19 +2471,19 @@ nvim_buf_clear_namespace({buffer}, {ns_id}, {line_start}, {line_end})
     buffer, specify line_start=0 and line_end=-1.
 
     Parameters: ~
-        {buffer}      Buffer handle, or 0 for current buffer
-        {ns_id}       Namespace to clear, or -1 to clear all namespaces.
-        {line_start}  Start of range of lines to clear
-        {line_end}    End of range of lines to clear (exclusive) or -1 to
+      • {buffer}      Buffer handle, or 0 for current buffer
+      • {ns_id}       Namespace to clear, or -1 to clear all namespaces.
+      • {line_start}  Start of range of lines to clear
+      • {line_end}    End of range of lines to clear (exclusive) or -1 to
                       clear to end of buffer.
 
 nvim_buf_del_extmark({buffer}, {ns_id}, {id})         *nvim_buf_del_extmark()*
     Removes an extmark.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {ns_id}   Namespace id from |nvim_create_namespace()|
-        {id}      Extmark id
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {ns_id}   Namespace id from |nvim_create_namespace()|
+      • {id}      Extmark id
 
     Return: ~
         true if the extmark was found, else false
@@ -2493,10 +2493,10 @@ nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {opts})
     Gets the position (0-indexed) of an extmark.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {ns_id}   Namespace id from |nvim_create_namespace()|
-        {id}      Extmark id
-        {opts}    Optional parameters. Keys:
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {ns_id}   Namespace id from |nvim_create_namespace()|
+      • {id}      Extmark id
+      • {opts}    Optional parameters. Keys:
                   • details: Whether to include the details dict
 
     Return: ~
@@ -2535,14 +2535,14 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
 <
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {ns_id}   Namespace id from |nvim_create_namespace()|
-        {start}   Start of range: a 0-indexed (row, col) or valid extmark id
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {ns_id}   Namespace id from |nvim_create_namespace()|
+      • {start}   Start of range: a 0-indexed (row, col) or valid extmark id
                   (whose position defines the bound). |api-indexing|
-        {end}     End of range (inclusive): a 0-indexed (row, col) or valid
+      • {end}     End of range (inclusive): a 0-indexed (row, col) or valid
                   extmark id (whose position defines the bound).
                   |api-indexing|
-        {opts}    Optional parameters. Keys:
+      • {opts}    Optional parameters. Keys:
                   • limit: Maximum number of marks to return
                   • details Whether to include the details dict
 
@@ -2563,11 +2563,11 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {*opts})
     range of text, and also to associate virtual text to the mark.
 
     Parameters: ~
-        {buffer}  Buffer handle, or 0 for current buffer
-        {ns_id}   Namespace id from |nvim_create_namespace()|
-        {line}    Line where to place the mark, 0-based. |api-indexing|
-        {col}     Column where to place the mark, 0-based. |api-indexing|
-        {opts}    Optional parameters.
+      • {buffer}  Buffer handle, or 0 for current buffer
+      • {ns_id}   Namespace id from |nvim_create_namespace()|
+      • {line}    Line where to place the mark, 0-based. |api-indexing|
+      • {col}     Column where to place the mark, 0-based. |api-indexing|
+      • {opts}    Optional parameters.
                   • id : id of the extmark to edit.
                   • end_row : ending line of the mark, 0-based inclusive.
                   • end_col : ending col of the mark, 0-based exclusive.
@@ -2674,7 +2674,7 @@ nvim_create_namespace({name})                        *nvim_create_namespace()*
     new, anonymous namespace is created.
 
     Parameters: ~
-        {name}  Namespace name or empty string
+      • {name}  Namespace name or empty string
 
     Return: ~
         Namespace id
@@ -2717,8 +2717,8 @@ nvim_set_decoration_provider({ns_id}, {*opts})
         |vim.api| only
 
     Parameters: ~
-        {ns_id}  Namespace id from |nvim_create_namespace()|
-        {opts}   Table of callbacks:
+      • {ns_id}  Namespace id from |nvim_create_namespace()|
+      • {opts}   Table of callbacks:
                  • on_start: called first on each screen redraw ["start",
                    tick]
                  • on_buf: called for each buffer being redrawn (before window
@@ -2741,8 +2741,8 @@ nvim_win_call({window}, {fun})                               *nvim_win_call()*
         |vim.api| only
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {fun}     Function to call inside the window (currently lua callable
+      • {window}  Window handle, or 0 for current window
+      • {fun}     Function to call inside the window (currently lua callable
                   only)
 
     Return: ~
@@ -2760,8 +2760,8 @@ nvim_win_close({window}, {force})                           *nvim_win_close()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {force}   Behave like `:close!` The last window of a buffer with
+      • {window}  Window handle, or 0 for current window
+      • {force}   Behave like `:close!` The last window of a buffer with
                   unwritten changes can be closed. The buffer will become
                   hidden, even if 'hidden' is not set.
 
@@ -2769,14 +2769,14 @@ nvim_win_del_var({window}, {name})                        *nvim_win_del_var()*
     Removes a window-scoped (w:) variable
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {name}    Variable name
+      • {window}  Window handle, or 0 for current window
+      • {name}    Variable name
 
 nvim_win_get_buf({window})                                *nvim_win_get_buf()*
     Gets the current buffer in a window
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Buffer handle
@@ -2785,7 +2785,7 @@ nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
     Gets the (1,0)-indexed cursor position in the window. |api-indexing|
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         (row, col) tuple
@@ -2794,7 +2794,7 @@ nvim_win_get_height({window})                          *nvim_win_get_height()*
     Gets the window height
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Height as a count of rows
@@ -2803,7 +2803,7 @@ nvim_win_get_number({window})                          *nvim_win_get_number()*
     Gets the window number
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Window number
@@ -2812,7 +2812,7 @@ nvim_win_get_position({window})                      *nvim_win_get_position()*
     Gets the window position in display cells. First position is zero.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         (row, col) tuple with the window position
@@ -2821,7 +2821,7 @@ nvim_win_get_tabpage({window})                        *nvim_win_get_tabpage()*
     Gets the window tabpage
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Tabpage that contains the window
@@ -2830,8 +2830,8 @@ nvim_win_get_var({window}, {name})                        *nvim_win_get_var()*
     Gets a window-scoped (w:) variable
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {name}    Variable name
+      • {window}  Window handle, or 0 for current window
+      • {name}    Variable name
 
     Return: ~
         Variable value
@@ -2840,7 +2840,7 @@ nvim_win_get_width({window})                            *nvim_win_get_width()*
     Gets the window width
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Width as a count of columns
@@ -2857,13 +2857,13 @@ nvim_win_hide({window})                                      *nvim_win_hide()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
 nvim_win_is_valid({window})                              *nvim_win_is_valid()*
     Checks if a window is valid
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         true if the window is valid, false otherwise
@@ -2875,23 +2875,23 @@ nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {buffer}  Buffer handle
+      • {window}  Window handle, or 0 for current window
+      • {buffer}  Buffer handle
 
 nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
     Sets the (1,0)-indexed cursor position in the window. |api-indexing| This
     scrolls the window even if it is not the current one.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {pos}     (row, col) tuple representing the new position
+      • {window}  Window handle, or 0 for current window
+      • {pos}     (row, col) tuple representing the new position
 
 nvim_win_set_height({window}, {height})                *nvim_win_set_height()*
     Sets the window height.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {height}  Height as a count of rows
+      • {window}  Window handle, or 0 for current window
+      • {height}  Height as a count of rows
 
 nvim_win_set_hl_ns({window}, {ns_id})                   *nvim_win_set_hl_ns()*
     Set highlight namespace for a window. This will use highlights defined in
@@ -2900,23 +2900,23 @@ nvim_win_set_hl_ns({window}, {ns_id})                   *nvim_win_set_hl_ns()*
     This takes precedence over the 'winhighlight' option.
 
     Parameters: ~
-        {ns_id}  the namespace to use
+      • {ns_id}  the namespace to use
 
 nvim_win_set_var({window}, {name}, {value})               *nvim_win_set_var()*
     Sets a window-scoped (w:) variable
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {name}    Variable name
-        {value}   Variable value
+      • {window}  Window handle, or 0 for current window
+      • {name}    Variable name
+      • {value}   Variable value
 
 nvim_win_set_width({window}, {width})                   *nvim_win_set_width()*
     Sets the window width. This will only succeed if the screen is split
     vertically.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {width}   Width as a count of columns
+      • {window}  Window handle, or 0 for current window
+      • {width}   Width as a count of columns
 
 
 ==============================================================================
@@ -2961,9 +2961,9 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
         not allowed when |textlock| is active
 
     Parameters: ~
-        {buffer}  Buffer to display, or 0 for current buffer
-        {enter}   Enter the window (make it the current window)
-        {config}  Map defining the window configuration. Keys:
+      • {buffer}  Buffer to display, or 0 for current buffer
+      • {enter}   Enter the window (make it the current window)
+      • {config}  Map defining the window configuration. Keys:
                   • relative: Sets the window layout to "floating", placed at
                     (row,col) coordinates relative to:
                     • "editor" The global editor grid
@@ -3064,7 +3064,7 @@ nvim_win_get_config({window})                          *nvim_win_get_config()*
     `relative` is empty for normal windows.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
+      • {window}  Window handle, or 0 for current window
 
     Return: ~
         Map defining the window configuration, see |nvim_open_win()|
@@ -3077,8 +3077,8 @@ nvim_win_set_config({window}, {*config})               *nvim_win_set_config()*
     changed. `row`/`col` and `relative` must be reconfigured together.
 
     Parameters: ~
-        {window}  Window handle, or 0 for current window
-        {config}  Map defining the window configuration, see |nvim_open_win()|
+      • {window}  Window handle, or 0 for current window
+      • {config}  Map defining the window configuration, see |nvim_open_win()|
 
     See also: ~
         |nvim_open_win()|
@@ -3091,14 +3091,14 @@ nvim_tabpage_del_var({tabpage}, {name})               *nvim_tabpage_del_var()*
     Removes a tab-scoped (t:) variable
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
-        {name}     Variable name
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {name}     Variable name
 
 nvim_tabpage_get_number({tabpage})                 *nvim_tabpage_get_number()*
     Gets the tabpage number
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
 
     Return: ~
         Tabpage number
@@ -3107,8 +3107,8 @@ nvim_tabpage_get_var({tabpage}, {name})               *nvim_tabpage_get_var()*
     Gets a tab-scoped (t:) variable
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
-        {name}     Variable name
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {name}     Variable name
 
     Return: ~
         Variable value
@@ -3117,7 +3117,7 @@ nvim_tabpage_get_win({tabpage})                       *nvim_tabpage_get_win()*
     Gets the current window in a tabpage
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
 
     Return: ~
         Window handle
@@ -3126,7 +3126,7 @@ nvim_tabpage_is_valid({tabpage})                     *nvim_tabpage_is_valid()*
     Checks if a tabpage is valid
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
 
     Return: ~
         true if the tabpage is valid, false otherwise
@@ -3135,7 +3135,7 @@ nvim_tabpage_list_wins({tabpage})                   *nvim_tabpage_list_wins()*
     Gets the windows in a tabpage
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
 
     Return: ~
         List of windows in `tabpage`
@@ -3145,9 +3145,9 @@ nvim_tabpage_set_var({tabpage}, {name}, {value})
     Sets a tab-scoped (t:) variable
 
     Parameters: ~
-        {tabpage}  Tabpage handle, or 0 for current tabpage
-        {name}     Variable name
-        {value}    Variable value
+      • {tabpage}  Tabpage handle, or 0 for current tabpage
+      • {name}     Variable name
+      • {value}    Variable value
 
 
 ==============================================================================
@@ -3158,7 +3158,7 @@ nvim_clear_autocmds({*opts})                           *nvim_clear_autocmds()*
     particular autocmd, see |nvim_del_autocmd()|.
 
     Parameters: ~
-        {opts}  Parameters
+      • {opts}  Parameters
                 • event: (string|table) Examples:
                   • event: "pat1"
                   • event: { "pat1" }
@@ -3190,8 +3190,8 @@ nvim_create_augroup({name}, {*opts})                   *nvim_create_augroup()*
 <
 
     Parameters: ~
-        {name}  String: The name of the group
-        {opts}  Dictionary Parameters
+      • {name}  String: The name of the group
+      • {opts}  Dictionary Parameters
                 • clear (bool) optional: defaults to true. Clear existing
                   commands if the group already exists |autocmd-groups|.
 
@@ -3254,9 +3254,9 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
 <
 
     Parameters: ~
-        {event}  (string|array) The event or events to register this
+      • {event}  (string|array) The event or events to register this
                  autocommand
-        {opts}   Dictionary of autocommand options:
+      • {opts}   Dictionary of autocommand options:
                  • group (string|integer) optional: the autocommand group name
                    or id to match against.
                  • pattern (string|array) optional: pattern or patterns to
@@ -3307,7 +3307,7 @@ nvim_del_augroup_by_id({id})                        *nvim_del_augroup_by_id()*
     This group will no longer exist.
 
     Parameters: ~
-        {id}  Integer The id of the group.
+      • {id}  Integer The id of the group.
 
     See also: ~
         |nvim_del_augroup_by_name()|
@@ -3321,7 +3321,7 @@ nvim_del_augroup_by_name({name})                  *nvim_del_augroup_by_name()*
     This group will no longer exist.
 
     Parameters: ~
-        {name}  String The name of the group.
+      • {name}  String The name of the group.
 
     See also: ~
         |autocmd-groups|
@@ -3332,7 +3332,7 @@ nvim_del_autocmd({id})                                    *nvim_del_autocmd()*
     NOTE: Only autocommands created via the API have an id.
 
     Parameters: ~
-        {id}  Integer The id returned by nvim_create_autocmd
+      • {id}  Integer The id returned by nvim_create_autocmd
 
     See also: ~
         |nvim_create_autocmd()|
@@ -3342,8 +3342,8 @@ nvim_exec_autocmds({event}, {*opts})                    *nvim_exec_autocmds()*
     |autocmd-execute|.
 
     Parameters: ~
-        {event}  (String|Array) The event or events to execute
-        {opts}   Dictionary of autocommand options:
+      • {event}  (String|Array) The event or events to execute
+      • {opts}   Dictionary of autocommand options:
                  • group (string|integer) optional: the autocommand group name
                    or id to match against. |autocmd-groups|.
                  • pattern (string|array) optional: defaults to "*"
@@ -3379,7 +3379,7 @@ nvim_get_autocmds({*opts})                               *nvim_get_autocmds()*
     autocommands that match any combination of them.
 
     Parameters: ~
-        {opts}  Dictionary with at least one of the following:
+      • {opts}  Dictionary with at least one of the following:
                 • group (string|integer): the autocommand group name or id to
                   match against.
                 • event (string|array): event or events to match against
@@ -3428,9 +3428,9 @@ nvim_ui_attach({width}, {height}, {options})                *nvim_ui_attach()*
         |RPC| only
 
     Parameters: ~
-        {width}    Requested screen columns
-        {height}   Requested screen rows
-        {options}  |ui-option| map
+      • {width}    Requested screen columns
+      • {height}   Requested screen rows
+      • {options}  |ui-option| map
 
 nvim_ui_detach()                                            *nvim_ui_detach()*
     Deactivates UI events on the channel.
@@ -3456,10 +3456,10 @@ nvim_ui_pum_set_bounds({width}, {height}, {row}, {col})
         |RPC| only
 
     Parameters: ~
-        {width}   Popupmenu width.
-        {height}  Popupmenu height.
-        {row}     Popupmenu row.
-        {col}     Popupmenu height.
+      • {width}   Popupmenu width.
+      • {height}  Popupmenu height.
+      • {row}     Popupmenu row.
+      • {col}     Popupmenu height.
 
 nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
     Tells Nvim the number of elements displaying in the popupmenu, to decide
@@ -3469,7 +3469,7 @@ nvim_ui_pum_set_height({height})                    *nvim_ui_pum_set_height()*
         |RPC| only
 
     Parameters: ~
-        {height}  Popupmenu height, must be greater than zero.
+      • {height}  Popupmenu height, must be greater than zero.
 
 nvim_ui_set_option({name}, {value})                     *nvim_ui_set_option()*
     TODO: Documentation
@@ -3494,8 +3494,8 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
         |RPC| only
 
     Parameters: ~
-        {grid}    The handle of the grid to be changed.
-        {width}   The new requested width.
-        {height}  The new requested height.
+      • {grid}    The handle of the grid to be changed.
+      • {width}   The new requested width.
+      • {height}  The new requested height.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -342,7 +342,7 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
           any of the above.
 
     Parameters: ~
-        {opts}       (table|nil) When omitted or "nil", retrieve the current
+      • {opts}       (table|nil) When omitted or "nil", retrieve the current
                      configuration. Otherwise, a configuration table with the
                      following keys:
                      • underline: (default true) Use underline for
@@ -397,32 +397,32 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                        severities are displayed before lower severities (e.g.
                        ERROR is displayed before WARN). Options:
                        • reverse: (boolean) Reverse sort order
-        {namespace}  (number|nil) Update the options for the given namespace.
+      • {namespace}  (number|nil) Update the options for the given namespace.
                      When omitted, update the global diagnostic options.
 
 disable({bufnr}, {namespace})                       *vim.diagnostic.disable()*
     Disable diagnostics in the given buffer.
 
     Parameters: ~
-        {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
+      • {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
                      omitted, disable diagnostics in all buffers.
-        {namespace}  (number|nil) Only disable diagnostics for the given
+      • {namespace}  (number|nil) Only disable diagnostics for the given
                      namespace.
 
 enable({bufnr}, {namespace})                         *vim.diagnostic.enable()*
     Enable diagnostics in the given buffer.
 
     Parameters: ~
-        {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
+      • {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
                      omitted, enable diagnostics in all buffers.
-        {namespace}  (number|nil) Only enable diagnostics for the given
+      • {namespace}  (number|nil) Only enable diagnostics for the given
                      namespace.
 
 fromqflist({list})                               *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.
 
     Parameters: ~
-        {list}  (table) A list of quickfix items from |getqflist()| or
+      • {list}  (table) A list of quickfix items from |getqflist()| or
                 |getloclist()|.
 
     Return: ~
@@ -432,9 +432,9 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
     Get current diagnostics.
 
     Parameters: ~
-        {bufnr}  (number|nil) Buffer number to get diagnostics from. Use 0 for
+      • {bufnr}  (number|nil) Buffer number to get diagnostics from. Use 0 for
                  current buffer or nil for all buffers.
-        {opts}   (table|nil) A table with the following keys:
+      • {opts}   (table|nil) A table with the following keys:
                  • namespace: (number) Limit diagnostics to the given
                    namespace.
                  • lnum: (number) Limit diagnostics to the given line number.
@@ -447,7 +447,7 @@ get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
     Get namespace metadata.
 
     Parameters: ~
-        {namespace}  (number) Diagnostic namespace
+      • {namespace}  (number) Diagnostic namespace
 
     Return: ~
         (table) Namespace metadata
@@ -462,7 +462,7 @@ get_next({opts})                                   *vim.diagnostic.get_next()*
     Get the next diagnostic closest to the cursor position.
 
     Parameters: ~
-        {opts}  (table) See |vim.diagnostic.goto_next()|
+      • {opts}  (table) See |vim.diagnostic.goto_next()|
 
     Return: ~
         (table) Next diagnostic
@@ -471,7 +471,7 @@ get_next_pos({opts})                           *vim.diagnostic.get_next_pos()*
     Return the position of the next diagnostic in the current buffer.
 
     Parameters: ~
-        {opts}  (table) See |vim.diagnostic.goto_next()|
+      • {opts}  (table) See |vim.diagnostic.goto_next()|
 
     Return: ~
         (table) Next diagnostic position as a (row, col) tuple.
@@ -480,7 +480,7 @@ get_prev({opts})                                   *vim.diagnostic.get_prev()*
     Get the previous diagnostic closest to the cursor position.
 
     Parameters: ~
-        {opts}  (table) See |vim.diagnostic.goto_next()|
+      • {opts}  (table) See |vim.diagnostic.goto_next()|
 
     Return: ~
         (table) Previous diagnostic
@@ -489,7 +489,7 @@ get_prev_pos({opts})                           *vim.diagnostic.get_prev_pos()*
     Return the position of the previous diagnostic in the current buffer.
 
     Parameters: ~
-        {opts}  (table) See |vim.diagnostic.goto_next()|
+      • {opts}  (table) See |vim.diagnostic.goto_next()|
 
     Return: ~
         (table) Previous diagnostic position as a (row, col) tuple.
@@ -498,7 +498,7 @@ goto_next({opts})                                 *vim.diagnostic.goto_next()*
     Move to the next diagnostic.
 
     Parameters: ~
-        {opts}  (table|nil) Configuration table with the following keys:
+      • {opts}  (table|nil) Configuration table with the following keys:
                 • namespace: (number) Only consider diagnostics from the given
                   namespace.
                 • cursor_position: (cursor position) Cursor position as a
@@ -519,7 +519,7 @@ goto_prev({opts})                                 *vim.diagnostic.goto_prev()*
     Move to the previous diagnostic in the current buffer.
 
     Parameters: ~
-        {opts}  (table) See |vim.diagnostic.goto_next()|
+      • {opts}  (table) See |vim.diagnostic.goto_next()|
 
 hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
     Hide currently displayed diagnostics.
@@ -532,9 +532,9 @@ hide({namespace}, {bufnr})                             *vim.diagnostic.hide()*
     |vim.diagnostic.disable()|.
 
     Parameters: ~
-        {namespace}  (number|nil) Diagnostic namespace. When omitted, hide
+      • {namespace}  (number|nil) Diagnostic namespace. When omitted, hide
                      diagnostics from all namespaces.
-        {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
+      • {bufnr}      (number|nil) Buffer number, or 0 for current buffer. When
                      omitted, hide diagnostics in all buffers.
 
                                                       *vim.diagnostic.match()*
@@ -555,13 +555,13 @@ match({str}, {pat}, {groups}, {severity_map}, {defaults})
 <
 
     Parameters: ~
-        {str}           (string) String to parse diagnostics from.
-        {pat}           (string) Lua pattern with capture groups.
-        {groups}        (table) List of fields in a |diagnostic-structure| to
+      • {str}           (string) String to parse diagnostics from.
+      • {pat}           (string) Lua pattern with capture groups.
+      • {groups}        (table) List of fields in a |diagnostic-structure| to
                         associate with captures from {pat}.
-        {severity_map}  (table) A table mapping the severity field from
+      • {severity_map}  (table) A table mapping the severity field from
                         {groups} with an item from |vim.diagnostic.severity|.
-        {defaults}      (table|nil) Table of default values for any fields not
+      • {defaults}      (table|nil) Table of default values for any fields not
                         listed in {groups}. When omitted, numeric values
                         default to 0 and "severity" defaults to ERROR.
 
@@ -573,7 +573,7 @@ open_float({opts}, {...})                        *vim.diagnostic.open_float()*
     Show diagnostics in a floating window.
 
     Parameters: ~
-        {opts}  (table|nil) Configuration table with the same keys as
+      • {opts}  (table|nil) Configuration table with the same keys as
                 |vim.lsp.util.open_floating_preview()| in addition to the
                 following:
                 • bufnr: (number) Buffer number to show diagnostics from.
@@ -631,27 +631,27 @@ reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
     re-displayed, use |vim.diagnostic.hide()|.
 
     Parameters: ~
-        {namespace}  (number|nil) Diagnostic namespace. When omitted, remove
+      • {namespace}  (number|nil) Diagnostic namespace. When omitted, remove
                      diagnostics from all namespaces.
-        {bufnr}      (number|nil) Remove diagnostics for the given buffer.
+      • {bufnr}      (number|nil) Remove diagnostics for the given buffer.
                      When omitted, diagnostics are removed for all buffers.
 
 set({namespace}, {bufnr}, {diagnostics}, {opts})        *vim.diagnostic.set()*
     Set diagnostics for the given namespace and buffer.
 
     Parameters: ~
-        {namespace}    (number) The diagnostic namespace
-        {bufnr}        (number) Buffer number
-        {diagnostics}  (table) A list of diagnostic items
+      • {namespace}    (number) The diagnostic namespace
+      • {bufnr}        (number) Buffer number
+      • {diagnostics}  (table) A list of diagnostic items
                        |diagnostic-structure|
-        {opts}         (table|nil) Display options to pass to
+      • {opts}         (table|nil) Display options to pass to
                        |vim.diagnostic.show()|
 
 setloclist({opts})                               *vim.diagnostic.setloclist()*
     Add buffer diagnostics to the location list.
 
     Parameters: ~
-        {opts}  (table|nil) Configuration table with the following keys:
+      • {opts}  (table|nil) Configuration table with the following keys:
                 • namespace: (number) Only add diagnostics from the given
                   namespace.
                 • winnr: (number, default 0) Window number to set location
@@ -666,7 +666,7 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
     Add all diagnostics to the quickfix list.
 
     Parameters: ~
-        {opts}  (table|nil) Configuration table with the following keys:
+      • {opts}  (table|nil) Configuration table with the following keys:
                 • namespace: (number) Only add diagnostics from the given
                   namespace.
                 • open: (boolean, default true) Open quickfix list after
@@ -680,17 +680,17 @@ show({namespace}, {bufnr}, {diagnostics}, {opts})
     Display diagnostics for the given namespace and buffer.
 
     Parameters: ~
-        {namespace}    (number|nil) Diagnostic namespace. When omitted, show
+      • {namespace}    (number|nil) Diagnostic namespace. When omitted, show
                        diagnostics from all namespaces.
-        {bufnr}        (number|nil) Buffer number, or 0 for current buffer.
+      • {bufnr}        (number|nil) Buffer number, or 0 for current buffer.
                        When omitted, show diagnostics in all buffers.
-        {diagnostics}  (table|nil) The diagnostics to display. When omitted,
+      • {diagnostics}  (table|nil) The diagnostics to display. When omitted,
                        use the saved diagnostics for the given namespace and
                        buffer. This can be used to display a list of
                        diagnostics without saving them or to display only a
                        subset of diagnostics. May not be used when {namespace}
                        or {bufnr} is nil.
-        {opts}         (table|nil) Display options. See
+      • {opts}         (table|nil) Display options. See
                        |vim.diagnostic.config()|.
 
 toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
@@ -698,7 +698,7 @@ toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
     passed to |setqflist()| or |setloclist()|.
 
     Parameters: ~
-        {diagnostics}  (table) List of diagnostics |diagnostic-structure|.
+      • {diagnostics}  (table) List of diagnostics |diagnostic-structure|.
 
     Return: ~
         array of quickfix list items |setqflist-what|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -539,8 +539,8 @@ buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*
     Without calling this, the server won't be notified of changes to a buffer.
 
     Parameters: ~
-        {bufnr}      (number) Buffer handle, or 0 for current
-        {client_id}  (number) Client id
+      • {bufnr}      (number) Buffer handle, or 0 for current
+      • {client_id}  (number) Client id
 
 buf_detach_client({bufnr}, {client_id})          *vim.lsp.buf_detach_client()*
     Detaches client from the specified buffer. Note: While the server is
@@ -548,23 +548,23 @@ buf_detach_client({bufnr}, {client_id})          *vim.lsp.buf_detach_client()*
     send notifications should it ignore this notification.
 
     Parameters: ~
-        {bufnr}      (number) Buffer handle, or 0 for current
-        {client_id}  (number) Client id
+      • {bufnr}      (number) Buffer handle, or 0 for current
+      • {client_id}  (number) Client id
 
 buf_is_attached({bufnr}, {client_id})              *vim.lsp.buf_is_attached()*
     Checks if a buffer is attached for a particular client.
 
     Parameters: ~
-        {bufnr}      (number) Buffer handle, or 0 for current
-        {client_id}  (number) the client id
+      • {bufnr}      (number) Buffer handle, or 0 for current
+      • {client_id}  (number) the client id
 
 buf_notify({bufnr}, {method}, {params})                 *vim.lsp.buf_notify()*
     Send a notification to a server
 
     Parameters: ~
-        {bufnr}   [number] (optional): The number of the buffer
-        {method}  [string]: Name of the request method
-        {params}  [string]: Arguments to send to the server
+      • {bufnr}   [number] (optional): The number of the buffer
+      • {method}  [string]: Name of the request method
+      • {params}  [string]: Arguments to send to the server
 
     Return: ~
         true if any client returns true; false otherwise
@@ -576,10 +576,10 @@ buf_request_all({bufnr}, {method}, {params}, {callback})
     |vim.lsp.buf_request()| but the return result and callback are different.
 
     Parameters: ~
-        {bufnr}     (number) Buffer handle, or 0 for current.
-        {method}    (string) LSP method name
-        {params}    (optional, table) Parameters to send to the server
-        {callback}  (function) The callback to call when all requests are
+      • {bufnr}     (number) Buffer handle, or 0 for current.
+      • {method}    (string) LSP method name
+      • {params}    (optional, table) Parameters to send to the server
+      • {callback}  (function) The callback to call when all requests are
                     finished.
 
     Return: ~
@@ -595,10 +595,10 @@ buf_request_sync({bufnr}, {method}, {params}, {timeout_ms})
     result is different. Wait maximum of {timeout_ms} (default 1000) ms.
 
     Parameters: ~
-        {bufnr}       (number) Buffer handle, or 0 for current.
-        {method}      (string) LSP method name
-        {params}      (optional, table) Parameters to send to the server
-        {timeout_ms}  (optional, number, default=1000) Maximum time in
+      • {bufnr}       (number) Buffer handle, or 0 for current.
+      • {method}      (string) LSP method name
+      • {params}      (optional, table) Parameters to send to the server
+      • {timeout_ms}  (optional, number, default=1000) Maximum time in
                       milliseconds to wait for a result.
 
     Return: ~
@@ -666,7 +666,7 @@ client_is_stopped({client_id})                   *vim.lsp.client_is_stopped()*
     Checks whether a client is stopped.
 
     Parameters: ~
-        {client_id}  (Number)
+      • {client_id}  (Number)
 
     Return: ~
         true if client is stopped, false otherwise.
@@ -676,8 +676,8 @@ for_each_buffer_client({bufnr}, {fn})
     Invokes a function for each LSP client attached to a buffer.
 
     Parameters: ~
-        {bufnr}  (number) Buffer number
-        {fn}     (function) Function to run on each client attached to buffer
+      • {bufnr}  (number) Buffer number
+      • {fn}     (function) Function to run on each client attached to buffer
                  {bufnr}. The function takes the client, client ID, and buffer
                  number as arguments. Example: >
 
@@ -696,7 +696,7 @@ formatexpr({opts})                                      *vim.lsp.formatexpr()*
     'v:lua.vim.lsp.formatexpr(#{timeout_ms:250})')`.
 
     Parameters: ~
-        {opts}  (table) options for customizing the formatting expression
+      • {opts}  (table) options for customizing the formatting expression
                 which takes the following optional keys:
                 • timeout_ms (default 500ms). The timeout period for the
                   formatting request.
@@ -705,7 +705,7 @@ get_active_clients({filter})                    *vim.lsp.get_active_clients()*
     Get active clients.
 
     Parameters: ~
-        {filter}  (table|nil) A table with key-value pairs used to filter the
+      • {filter}  (table|nil) A table with key-value pairs used to filter the
                   returned clients. The available keys are:
                   • id (number): Only return clients with the given id
                   • bufnr (number): Only return clients attached to this
@@ -720,7 +720,7 @@ get_buffers_by_client_id({client_id})
     Returns list of buffers attached to client_id.
 
     Parameters: ~
-        {client_id}  (number) client id
+      • {client_id}  (number) client id
 
     Return: ~
         list of buffer ids
@@ -730,7 +730,7 @@ get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
     not yet be fully initialized.
 
     Parameters: ~
-        {client_id}  (number) client id
+      • {client_id}  (number) client id
 
     Return: ~
         |vim.lsp.client| object, or nil
@@ -745,8 +745,8 @@ omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
     Implements 'omnifunc' compatible LSP completion.
 
     Parameters: ~
-        {findstart}  0 or 1, decides behavior
-        {base}       If findstart=0, text to match against
+      • {findstart}  0 or 1, decides behavior
+      • {base}       If findstart=0, text to match against
 
     Return: ~
         (number) Decided by {findstart}:
@@ -768,7 +768,7 @@ set_log_level({level})                               *vim.lsp.set_log_level()*
     Use `lsp.log_levels` for reverse lookup.
 
     Parameters: ~
-        {level}  [number|string] the case insensitive level name or number
+      • {level}  [number|string] the case insensitive level name or number
 
     See also: ~
         |vim.lsp.log_levels|
@@ -818,9 +818,9 @@ start({config}, {opts})                                      *vim.lsp.start()*
     `ftplugin/<filetype_name>.lua` (See |ftplugin-name|)
 
     Parameters: ~
-        {config}  (table) Same configuration as documented in
+      • {config}  (table) Same configuration as documented in
                   |vim.lsp.start_client()|
-        {opts}    nil|table Optional keyword arguments:
+      • {opts}    nil|table Optional keyword arguments:
                   • reuse_client (fun(client: client, config: table): boolean)
                     Predicate used to decide if a client should be re-used.
                     Used on all running clients. The default implementation
@@ -837,7 +837,7 @@ start_client({config})                                *vim.lsp.start_client()*
     The following parameters describe fields in the {config} table.
 
     Parameters: ~
-        {cmd}                (table|string|fun(dispatchers: table):table)
+      • {cmd}                (table|string|fun(dispatchers: table):table)
                              command string or list treated like |jobstart()|.
                              The command must launch the language server
                              process. `cmd` can also be a function that
@@ -848,26 +848,26 @@ start_client({config})                                *vim.lsp.start_client()*
                              |vim.lsp.rpc.notify()| For TCP there is a
                              built-in rpc client factory:
                              |vim.lsp.rpc.connect()|
-        {cmd_cwd}            (string, default=|getcwd()|) Directory to launch
+      • {cmd_cwd}            (string, default=|getcwd()|) Directory to launch
                              the `cmd` process. Not related to `root_dir`.
-        {cmd_env}            (table) Environment flags to pass to the LSP on
+      • {cmd_env}            (table) Environment flags to pass to the LSP on
                              spawn. Can be specified using keys like a map or
                              as a list with `k=v` pairs or both. Non-string values are coerced to
                              string. Example: >
 
      { "PRODUCTION=true"; "TEST=123"; PORT = 8080; HOST = "0.0.0.0"; }
 <
-        {detached}           (boolean, default true) Daemonize the server
+      • {detached}           (boolean, default true) Daemonize the server
                              process so that it runs in a separate process
                              group from Nvim. Nvim will shutdown the process
                              on exit, but if Nvim fails to exit cleanly this
                              could leave behind orphaned server processes.
-        {workspace_folders}  (table) List of workspace folders passed to the
+      • {workspace_folders}  (table) List of workspace folders passed to the
                              language server. For backwards compatibility
                              rootUri and rootPath will be derived from the
                              first workspace folder in this list. See
                              `workspaceFolders` in the LSP spec.
-        {capabilities}       Map overriding the default capabilities defined
+      • {capabilities}       Map overriding the default capabilities defined
                              by |vim.lsp.protocol.make_client_capabilities()|,
                              passed to the language server on initialization.
                              Hint: use make_client_capabilities() and modify
@@ -875,44 +875,44 @@ start_client({config})                                *vim.lsp.start_client()*
                              • Note: To send an empty dictionary use
                                `{[vim.type_idx]=vim.types.dictionary}`, else
                                it will be encoded as an array.
-        {handlers}           Map of language server method names to
+      • {handlers}           Map of language server method names to
                              |lsp-handler|
-        {settings}           Map with language server specific settings. These
+      • {settings}           Map with language server specific settings. These
                              are returned to the language server if requested
                              via `workspace/configuration`. Keys are
                              case-sensitive.
-        {commands}           (table) Table that maps string of clientside
+      • {commands}           (table) Table that maps string of clientside
                              commands to user-defined functions. Commands
                              passed to start_client take precedence over the
                              global command registry. Each key must be a
                              unique command name, and the value is a function
                              which is called if any LSP action (code action,
                              code lenses, ...) triggers the command.
-        {init_options}       Values to pass in the initialization request as
+      • {init_options}       Values to pass in the initialization request as
                              `initializationOptions`. See `initialize` in the
                              LSP spec.
-        {name}               (string, default=client-id) Name in log messages.
-        {get_language_id}    function(bufnr, filetype) -> language ID as
+      • {name}               (string, default=client-id) Name in log messages.
+      • {get_language_id}    function(bufnr, filetype) -> language ID as
                              string. Defaults to the filetype.
-        {offset_encoding}    (default="utf-16") One of "utf-8", "utf-16", or
+      • {offset_encoding}    (default="utf-16") One of "utf-8", "utf-16", or
                              "utf-32" which is the encoding that the LSP
                              server expects. Client does not verify this is
                              correct.
-        {on_error}           Callback with parameters (code, ...), invoked
+      • {on_error}           Callback with parameters (code, ...), invoked
                              when the client operation throws an error. `code`
                              is a number describing the error. Other arguments
                              may be passed depending on the error kind. See
                              `vim.lsp.rpc.client_errors` for possible errors.
                              Use `vim.lsp.rpc.client_errors[code]` to get
                              human-friendly name.
-        {before_init}        Callback with parameters (initialize_params,
+      • {before_init}        Callback with parameters (initialize_params,
                              config) invoked before the LSP "initialize"
                              phase, where `params` contains the parameters
                              being sent to the server and `config` is the
                              config that was passed to
                              |vim.lsp.start_client()|. You can use this to
                              modify parameters before they are sent.
-        {on_init}            Callback (client, initialize_result) invoked
+      • {on_init}            Callback (client, initialize_result) invoked
                              after LSP "initialize", where `result` is a table
                              of `capabilities` and anything else the server
                              may send. For example, clangd sends
@@ -925,19 +925,19 @@ start_client({config})                                *vim.lsp.start_client()*
                              make this assumption. A
                              `workspace/didChangeConfiguration` notification
                              should be sent to the server during on_init.
-        {on_exit}            Callback (code, signal, client_id) invoked on
+      • {on_exit}            Callback (code, signal, client_id) invoked on
                              client exit.
                              • code: exit code of the process
                              • signal: number describing the signal used to
                                terminate (if any)
                              • client_id: client handle
-        {on_attach}          Callback (client, bufnr) invoked when client
+      • {on_attach}          Callback (client, bufnr) invoked when client
                              attaches to a buffer.
-        {trace}              "off" | "messages" | "verbose" | nil passed
+      • {trace}              "off" | "messages" | "verbose" | nil passed
                              directly to the language server in the initialize
                              request. Invalid/empty values will default to
                              "off"
-        {flags}              A table with flags for the client. The current
+      • {flags}              A table with flags for the client. The current
                              (experimental) flags are:
                              • allow_incremental_sync (bool, default true):
                                Allow using incremental sync for buffer edits
@@ -951,7 +951,7 @@ start_client({config})                                *vim.lsp.start_client()*
                                sending kill -15. If set to false, nvim exits
                                immediately after sending the "shutdown"
                                request to the server.
-        {root_dir}           (string) Directory where the LSP server will base
+      • {root_dir}           (string) Directory where the LSP server will base
                              its workspaceFolders, rootUri, and rootPath on
                              initialization.
 
@@ -974,8 +974,8 @@ stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
     for this client, then force-shutdown is attempted.
 
     Parameters: ~
-        {client_id}  client id or |vim.lsp.client| object, or list thereof
-        {force}      (boolean) (optional) shutdown forcefully
+      • {client_id}  client id or |vim.lsp.client| object, or list thereof
+      • {force}      (boolean) (optional) shutdown forcefully
 
 tagfunc({...})                                             *vim.lsp.tagfunc()*
     Provides an interface between the built-in client and 'tagfunc'.
@@ -986,8 +986,8 @@ tagfunc({...})                                             *vim.lsp.tagfunc()*
     LSP servers, falls back to using built-in tags.
 
     Parameters: ~
-        {pattern}  Pattern used to find a workspace symbol
-        {flags}    See |tag-function|
+      • {pattern}  Pattern used to find a workspace symbol
+      • {flags}    See |tag-function|
 
     Return: ~
         A list of matching tags
@@ -996,8 +996,8 @@ with({handler}, {override_config})                            *vim.lsp.with()*
     Function to manage overriding defaults for LSP handlers.
 
     Parameters: ~
-        {handler}          (function) See |lsp-handler|
-        {override_config}  (table) Table containing the keys to override
+      • {handler}          (function) See |lsp-handler|
+      • {override_config}  (table) Table containing the keys to override
                            behavior of the {handler}
 
 
@@ -1016,7 +1016,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
     Selects a code action available at the current cursor position.
 
     Parameters: ~
-        {options}  (table|nil) Optional table which holds the following
+      • {options}  (table|nil) Optional table which holds the following
                    optional fields:
                    • context: (table|nil) Corresponds to `CodeActionContext` of the LSP specification:
                      • diagnostics (table|nil): LSP`Diagnostic[]` . Inferred from the current position if not provided.
@@ -1043,7 +1043,7 @@ completion({context})                               *vim.lsp.buf.completion()*
     called in Insert mode.
 
     Parameters: ~
-        {context}  (context support not yet implemented) Additional
+      • {context}  (context support not yet implemented) Additional
                    information about the context in which a completion was
                    triggered (how it was triggered, and by which trigger
                    character, if applicable)
@@ -1058,7 +1058,7 @@ declaration({options})                             *vim.lsp.buf.declaration()*
         |vim.lsp.buf.definition()| instead.
 
     Parameters: ~
-        {options}  (table|nil) additional options
+      • {options}  (table|nil) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1068,7 +1068,7 @@ definition({options})                               *vim.lsp.buf.definition()*
     Jumps to the definition of the symbol under the cursor.
 
     Parameters: ~
-        {options}  (table|nil) additional options
+      • {options}  (table|nil) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1093,7 +1093,7 @@ document_symbol({options})                     *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the quickfix window.
 
     Parameters: ~
-        {options}  (table|nil) additional options
+      • {options}  (table|nil) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1101,7 +1101,7 @@ execute_command({command_params})              *vim.lsp.buf.execute_command()*
     Executes an LSP server command.
 
     Parameters: ~
-        {command_params}  (table) A valid `ExecuteCommandParams` object
+      • {command_params}  (table) A valid `ExecuteCommandParams` object
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand
@@ -1111,7 +1111,7 @@ format({options})                                       *vim.lsp.buf.format()*
     server clients.
 
     Parameters: ~
-        {options}  table|nil Optional table which holds the following optional
+      • {options}  table|nil Optional table which holds the following optional
                    fields:
                    • formatting_options (table|nil): Can be used to specify
                      FormattingOptions. Some unspecified options will be
@@ -1154,7 +1154,7 @@ implementation({options})                       *vim.lsp.buf.implementation()*
     quickfix window.
 
     Parameters: ~
-        {options}  (table|nil) additional options
+      • {options}  (table|nil) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1176,8 +1176,8 @@ references({context}, {options})                    *vim.lsp.buf.references()*
     window.
 
     Parameters: ~
-        {context}  (table) Context for the request
-        {options}  (table|nil) additional options
+      • {context}  (table) Context for the request
+      • {options}  (table|nil) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1193,9 +1193,9 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
     Renames all references to the symbol under the cursor.
 
     Parameters: ~
-        {new_name}  (string|nil) If not provided, the user will be prompted
+      • {new_name}  (string|nil) If not provided, the user will be prompted
                     for a new name using |vim.ui.input()|.
-        {options}   (table|nil) additional options
+      • {options}   (table|nil) additional options
                     • filter (function|nil): Predicate used to filter clients.
                       Receives a client as argument and must return a boolean.
                       Clients matching the predicate are included.
@@ -1217,7 +1217,7 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
 
     Parameters: ~
-        {options}  (table|nil) additional options
+      • {options}  (table|nil) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1231,8 +1231,8 @@ workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
     string means no filtering is done.
 
     Parameters: ~
-        {query}    (string, optional)
-        {options}  (table|nil) additional options
+      • {query}    (string, optional)
+      • {options}  (table|nil) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1245,7 +1245,7 @@ get_namespace({client_id})                *vim.lsp.diagnostic.get_namespace()*
     |vim.diagnostic|.
 
     Parameters: ~
-        {client_id}  (number) The id of the LSP client
+      • {client_id}  (number) The id of the LSP client
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
 on_publish_diagnostics({_}, {result}, {ctx}, {config})
@@ -1274,7 +1274,7 @@ on_publish_diagnostics({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-        {config}  (table) Configuration table (see |vim.diagnostic.config()|).
+      • {config}  (table) Configuration table (see |vim.diagnostic.config()|).
 
 
 ==============================================================================
@@ -1284,15 +1284,15 @@ display({lenses}, {bufnr}, {client_id})           *vim.lsp.codelens.display()*
     Display the lenses using virtual text
 
     Parameters: ~
-        {lenses}     (table) of lenses to display (`CodeLens[] | null`)
-        {bufnr}      (number)
-        {client_id}  (number)
+      • {lenses}     (table) of lenses to display (`CodeLens[] | null`)
+      • {bufnr}      (number)
+      • {client_id}  (number)
 
 get({bufnr})                                          *vim.lsp.codelens.get()*
     Return all lenses for the given buffer
 
     Parameters: ~
-        {bufnr}  (number) Buffer number. 0 can be used for the current buffer.
+      • {bufnr}  (number) Buffer number. 0 can be used for the current buffer.
 
     Return: ~
         (table) (`CodeLens[]`)
@@ -1316,9 +1316,9 @@ save({lenses}, {bufnr}, {client_id})                 *vim.lsp.codelens.save()*
     Store lenses for a specific buffer and client
 
     Parameters: ~
-        {lenses}     (table) of lenses to store (`CodeLens[] | null`)
-        {bufnr}      (number)
-        {client_id}  (number)
+      • {lenses}     (table) of lenses to store (`CodeLens[] | null`)
+      • {bufnr}      (number)
+      • {client_id}  (number)
 
 
 ==============================================================================
@@ -1336,7 +1336,7 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
 <
 
     Parameters: ~
-        {config}  (table) Configuration table.
+      • {config}  (table) Configuration table.
                   • border: (default=nil)
                     • Add borders to the floating window
                     • See |nvim_open_win()|
@@ -1355,7 +1355,7 @@ signature_help({_}, {result}, {ctx}, {config})
 <
 
     Parameters: ~
-        {config}  (table) Configuration table.
+      • {config}  (table) Configuration table.
                   • border: (default=nil)
                     • Add borders to the floating window
                     • See |nvim_open_win()|
@@ -1370,8 +1370,8 @@ apply_text_document_edit({text_document_edit}, {index}, {offset_encoding})
     document.
 
     Parameters: ~
-        {text_document_edit}  table: a `TextDocumentEdit` object
-        {index}               number: Optional index of the edit, if from a
+      • {text_document_edit}  table: a `TextDocumentEdit` object
+      • {index}               number: Optional index of the edit, if from a
                               list of edits (or nil, if not from a list)
 
     See also: ~
@@ -1382,9 +1382,9 @@ apply_text_edits({text_edits}, {bufnr}, {offset_encoding})
     Applies a list of text edits to a buffer.
 
     Parameters: ~
-        {text_edits}       (table) list of `TextEdit` objects
-        {bufnr}            (number) Buffer id
-        {offset_encoding}  (string) utf-8|utf-16|utf-32
+      • {text_edits}       (table) list of `TextEdit` objects
+      • {bufnr}            (number) Buffer id
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textEdit
@@ -1394,24 +1394,24 @@ apply_workspace_edit({workspace_edit}, {offset_encoding})
     Applies a `WorkspaceEdit`.
 
     Parameters: ~
-        {workspace_edit}   (table) `WorkspaceEdit`
-        {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
+      • {workspace_edit}   (table) `WorkspaceEdit`
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
 
 buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
     Removes document highlights from a buffer.
 
     Parameters: ~
-        {bufnr}  (number) Buffer id
+      • {bufnr}  (number) Buffer id
 
                                      *vim.lsp.util.buf_highlight_references()*
 buf_highlight_references({bufnr}, {references}, {offset_encoding})
     Shows a list of document highlights for a certain buffer.
 
     Parameters: ~
-        {bufnr}            (number) Buffer id
-        {references}       (table) List of `DocumentHighlight` objects to
+      • {bufnr}            (number) Buffer id
+      • {references}       (table) List of `DocumentHighlight` objects to
                            highlight
-        {offset_encoding}  (string) One of "utf-8", "utf-16", "utf-32".
+      • {offset_encoding}  (string) One of "utf-8", "utf-16", "utf-32".
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#documentHighlight
@@ -1421,10 +1421,10 @@ character_offset({buf}, {row}, {col}, {offset_encoding})
     Returns the UTF-32 and UTF-16 offsets for a position in a certain buffer.
 
     Parameters: ~
-        {buf}              (number) buffer number (0 for current)
-        {row}              0-indexed line
-        {col}              0-indexed byte offset in line
-        {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
+      • {buf}              (number) buffer number (0 for current)
+      • {row}              0-indexed line
+      • {col}              0-indexed byte offset in line
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of `buf`
 
     Return: ~
@@ -1439,8 +1439,8 @@ convert_input_to_markdown_lines({input}, {contents})
     `textDocument/signatureHelp`, and potentially others.
 
     Parameters: ~
-        {input}     (`MarkedString` | `MarkedString[]` | `MarkupContent`)
-        {contents}  (table, optional, default `{}`) List of strings to extend
+      • {input}     (`MarkedString` | `MarkedString[]` | `MarkupContent`)
+      • {contents}  (table, optional, default `{}`) List of strings to extend
                     with converted lines
 
     Return: ~
@@ -1454,10 +1454,10 @@ convert_signature_help_to_markdown_lines({signature_help}, {ft}, {triggers})
     Converts `textDocument/SignatureHelp` response to markdown lines.
 
     Parameters: ~
-        {signature_help}  Response of `textDocument/SignatureHelp`
-        {ft}              optional filetype that will be use as the `lang` for
+      • {signature_help}  Response of `textDocument/SignatureHelp`
+      • {ft}              optional filetype that will be use as the `lang` for
                           the label markdown code block
-        {triggers}        optional list of trigger characters from the lsp
+      • {triggers}        optional list of trigger characters from the lsp
                           server. used to better determine parameter offsets
 
     Return: ~
@@ -1471,7 +1471,7 @@ extract_completion_items({result})
     Can be used to extract the completion items from a `textDocument/completion` request, which may return one of `CompletionItem[]` , `CompletionList` or null.
 
     Parameters: ~
-        {result}  (table) The result of a `textDocument/completion` request
+      • {result}  (table) The result of a `textDocument/completion` request
 
     Return: ~
         (table) List of completion items
@@ -1483,7 +1483,7 @@ get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
     Returns indentation size.
 
     Parameters: ~
-        {bufnr}  (number|nil): Buffer handle, defaults to current
+      • {bufnr}  (number|nil): Buffer handle, defaults to current
 
     Return: ~
         (number) indentation size
@@ -1496,9 +1496,9 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
     Jumps to a location.
 
     Parameters: ~
-        {location}         (table) (`Location`|`LocationLink`)
-        {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
-        {reuse_win}        (boolean) Jump to existing window if buffer is
+      • {location}         (table) (`Location`|`LocationLink`)
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32 (required)
+      • {reuse_win}        (boolean) Jump to existing window if buffer is
                            already opened.
 
     Return: ~
@@ -1513,8 +1513,8 @@ locations_to_items({locations}, {offset_encoding})
     |setloclist()|.
 
     Parameters: ~
-        {locations}        (table) list of `Location`s or `LocationLink`s
-        {offset_encoding}  (string) offset_encoding for locations
+      • {locations}        (table) list of `Location`s or `LocationLink`s
+      • {offset_encoding}  (string) offset_encoding for locations
                            utf-8|utf-16|utf-32
 
     Return: ~
@@ -1524,8 +1524,8 @@ lookup_section({settings}, {section})          *vim.lsp.util.lookup_section()*
     Helper function to return nested values in language server settings
 
     Parameters: ~
-        {settings}  a table of language server settings
-        {section}   a string indicating the field of the settings table
+      • {settings}  a table of language server settings
+      • {section}   a string indicating the field of the settings table
 
     Return: ~
         (table or string) The value of settings accessed via section
@@ -1536,9 +1536,9 @@ make_floating_popup_options({width}, {height}, {opts})
     table can be passed to |nvim_open_win()|.
 
     Parameters: ~
-        {width}   (number) window width (in character cells)
-        {height}  (number) window height (in character cells)
-        {opts}    (table, optional)
+      • {width}   (number) window width (in character cells)
+      • {height}  (number) window height (in character cells)
+      • {opts}    (table, optional)
                   • offset_x (number) offset to add to `col`
                   • offset_y (number) offset to add to `row`
                   • border (string or table) override `border`
@@ -1554,7 +1554,7 @@ make_formatting_params({options})
     cursor position.
 
     Parameters: ~
-        {options}  (table|nil) with valid `FormattingOptions` entries
+      • {options}  (table|nil) with valid `FormattingOptions` entries
 
     Return: ~
         `DocumentFormattingParams` object
@@ -1568,13 +1568,13 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
     similar to |vim.lsp.util.make_range_params()|.
 
     Parameters: ~
-        {start_pos}        number[]|nil {row, col} mark-indexed position.
+      • {start_pos}        number[]|nil {row, col} mark-indexed position.
                            Defaults to the start of the last visual selection.
-        {end_pos}          number[]|nil {row, col} mark-indexed position.
+      • {end_pos}          number[]|nil {row, col} mark-indexed position.
                            Defaults to the end of the last visual selection.
-        {bufnr}            (number|nil) buffer handle or 0 for current,
+      • {bufnr}            (number|nil) buffer handle or 0 for current,
                            defaults to current
-        {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
+      • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
                            `offset_encoding` of first client of `bufnr`
 
     Return: ~
@@ -1587,9 +1587,9 @@ make_position_params({window}, {offset_encoding})
     cursor position.
 
     Parameters: ~
-        {window}           number|nil: window handle or 0 for current,
+      • {window}           number|nil: window handle or 0 for current,
                            defaults to current
-        {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
 
@@ -1607,9 +1607,9 @@ make_range_params({window}, {offset_encoding})
     `textDocument/rangeFormatting`.
 
     Parameters: ~
-        {window}           number|nil: window handle or 0 for current,
+      • {window}           number|nil: window handle or 0 for current,
                            defaults to current
-        {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
+      • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
 
@@ -1622,7 +1622,7 @@ make_text_document_params({bufnr})
     Creates a `TextDocumentIdentifier` object for the current buffer.
 
     Parameters: ~
-        {bufnr}  number|nil: Buffer handle, defaults to current
+      • {bufnr}  number|nil: Buffer handle, defaults to current
 
     Return: ~
         `TextDocumentIdentifier`
@@ -1635,17 +1635,17 @@ make_workspace_params({added}, {removed})
     Create the workspace params
 
     Parameters: ~
-        {added}    
-        {removed}
+      • {added}    
+      • {removed}
 
                                         *vim.lsp.util.open_floating_preview()*
 open_floating_preview({contents}, {syntax}, {opts})
     Shows contents in a floating window.
 
     Parameters: ~
-        {contents}  (table) of lines to show in window
-        {syntax}    (string) of syntax to set for opened buffer
-        {opts}      (table) with optional fields (additional keys are passed
+      • {contents}  (table) of lines to show in window
+      • {syntax}    (string) of syntax to set for opened buffer
+      • {opts}      (table) with optional fields (additional keys are passed
                     on to |nvim_open_win()|)
                     • height: (number) height of floating window
                     • width: (number) width of floating window
@@ -1674,7 +1674,7 @@ parse_snippet({input})                          *vim.lsp.util.parse_snippet()*
     Parses snippets in a completion entry.
 
     Parameters: ~
-        {input}  (string) unparsed snippet
+      • {input}  (string) unparsed snippet
 
     Return: ~
         (string) parsed snippet
@@ -1688,7 +1688,7 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
       definition)
 
     Parameters: ~
-        {location}  a single `Location` or `LocationLink`
+      • {location}  a single `Location` or `LocationLink`
 
     Return: ~
         (bufnr,winnr) buffer and window number of floating window or nil
@@ -1697,7 +1697,7 @@ rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Rename old_fname to new_fname
 
     Parameters: ~
-        {opts}  (table)
+      • {opts}  (table)
 
 set_lines({lines}, {A}, {B}, {new_lines})           *vim.lsp.util.set_lines()*
     Replaces text in a range with new text.
@@ -1705,10 +1705,10 @@ set_lines({lines}, {A}, {B}, {new_lines})           *vim.lsp.util.set_lines()*
     CAUTION: Changes in-place!
 
     Parameters: ~
-        {lines}      (table) Original list of strings
-        {A}          (table) Start position; a 2-tuple of {line, col} numbers
-        {B}          (table) End position; a 2-tuple of {line, col} numbers
-        {new_lines}  A list of strings to replace the original
+      • {lines}      (table) Original list of strings
+      • {A}          (table) Start position; a 2-tuple of {line, col} numbers
+      • {B}          (table) End position; a 2-tuple of {line, col} numbers
+      • {new_lines}  A list of strings to replace the original
 
     Return: ~
         (table) The modified {lines} object
@@ -1726,8 +1726,8 @@ stylize_markdown({bufnr}, {contents}, {opts})
     `open_floating_preview` instead
 
     Parameters: ~
-        {contents}  (table) of lines to show in window
-        {opts}      dictionary with optional fields
+      • {contents}  (table) of lines to show in window
+      • {opts}      dictionary with optional fields
                     • height of floating window
                     • width of floating window
                     • wrap_at character to wrap at for computing height
@@ -1744,7 +1744,7 @@ symbols_to_items({symbols}, {bufnr})         *vim.lsp.util.symbols_to_items()*
     Converts symbols to quickfix list items.
 
     Parameters: ~
-        {symbols}  DocumentSymbol[] or SymbolInformation[]
+      • {symbols}  DocumentSymbol[] or SymbolInformation[]
 
               *vim.lsp.util.text_document_completion_list_to_complete_items()*
 text_document_completion_list_to_complete_items({result}, {prefix})
@@ -1752,10 +1752,10 @@ text_document_completion_list_to_complete_items({result}, {prefix})
     vim-compatible |complete-items|.
 
     Parameters: ~
-        {result}  The result of a `textDocument/completion` call, e.g. from
+      • {result}  The result of a `textDocument/completion` call, e.g. from
                   |vim.lsp.buf.completion()|, which may be one of
                   `CompletionItem[]`, `CompletionList` or `null`
-        {prefix}  (string) the prefix to filter the completion items
+      • {prefix}  (string) the prefix to filter the completion items
 
     Return: ~
         { matches = complete-items table, incomplete = bool }
@@ -1767,7 +1767,7 @@ trim_empty_lines({lines})                    *vim.lsp.util.trim_empty_lines()*
     Removes empty lines from the beginning and end.
 
     Parameters: ~
-        {lines}  (table) list of lines to trim
+      • {lines}  (table) list of lines to trim
 
     Return: ~
         (table) trimmed list of lines
@@ -1780,7 +1780,7 @@ try_trim_markdown_code_blocks({lines})
     CAUTION: Modifies the input in-place!
 
     Parameters: ~
-        {lines}  (table) list of lines
+      • {lines}  (table) list of lines
 
     Return: ~
         (string) filetype or "markdown" if it was unchanged.
@@ -1805,20 +1805,20 @@ set_format_func({handle})                      *vim.lsp.log.set_format_func()*
     Sets formatting function used to format logs
 
     Parameters: ~
-        {handle}  (function) function to apply to logging arguments, pass
+      • {handle}  (function) function to apply to logging arguments, pass
                   vim.inspect for multi-line formatting
 
 set_level({level})                                   *vim.lsp.log.set_level()*
     Sets the current log level.
 
     Parameters: ~
-        {level}  (string or number) One of `vim.lsp.log.levels`
+      • {level}  (string or number) One of `vim.lsp.log.levels`
 
 should_log({level})                                 *vim.lsp.log.should_log()*
     Checks whether the level is sufficient for logging.
 
     Parameters: ~
-        {level}  (number) log level
+      • {level}  (number) log level
 
     Return: ~
         (bool) true if would log, false if not
@@ -1832,8 +1832,8 @@ connect({host}, {port})                                *vim.lsp.rpc.connect()*
     and port
 
     Parameters: ~
-        {host}  (string)
-        {port}  (number)
+      • {host}  (string)
+      • {port}  (number)
 
     Return: ~
         (function)
@@ -1842,7 +1842,7 @@ format_rpc_error({err})                       *vim.lsp.rpc.format_rpc_error()*
     Constructs an error message from an LSP error object.
 
     Parameters: ~
-        {err}  (table) The error object
+      • {err}  (table) The error object
 
     Return: ~
         (string) The formatted error message
@@ -1851,8 +1851,8 @@ notify({method}, {params})                              *vim.lsp.rpc.notify()*
     Sends a notification to the LSP server.
 
     Parameters: ~
-        {method}  (string) The invoked LSP method
-        {params}  (table|nil): Parameters for the invoked LSP method
+      • {method}  (string) The invoked LSP method
+      • {params}  (table|nil): Parameters for the invoked LSP method
 
     Return: ~
         (bool) `true` if notification could be sent, `false` if not
@@ -1862,11 +1862,11 @@ request({method}, {params}, {callback}, {notify_reply_callback})
     Sends a request to the LSP server and runs {callback} upon response.
 
     Parameters: ~
-        {method}                 (string) The invoked LSP method
-        {params}                 (table|nil) Parameters for the invoked LSP
+      • {method}                 (string) The invoked LSP method
+      • {params}                 (table|nil) Parameters for the invoked LSP
                                  method
-        {callback}               (function) Callback to invoke
-        {notify_reply_callback}  (function|nil) Callback to invoke as soon as
+      • {callback}               (function) Callback to invoke
+      • {notify_reply_callback}  (function|nil) Callback to invoke as soon as
                                  a request is no longer pending
 
     Return: ~
@@ -1878,10 +1878,10 @@ rpc_response_error({code}, {message}, {data})
     Creates an RPC response object/table.
 
     Parameters: ~
-        {code}     (number) RPC error code defined in
+      • {code}     (number) RPC error code defined in
                    `vim.lsp.protocol.ErrorCodes`
-        {message}  (string|nil) arbitrary message to send to server
-        {data}     any|nil arbitrary data to send to server
+      • {message}  (string|nil) arbitrary message to send to server
+      • {data}     any|nil arbitrary data to send to server
 
                                                          *vim.lsp.rpc.start()*
 start({cmd}, {cmd_args}, {dispatchers}, {extra_spawn_params})
@@ -1891,16 +1891,16 @@ start({cmd}, {cmd_args}, {dispatchers}, {extra_spawn_params})
     |vim.lsp.rpc.connect()|
 
     Parameters: ~
-        {cmd}                 (string) Command to start the LSP server.
-        {cmd_args}            (table) List of additional string arguments to
+      • {cmd}                 (string) Command to start the LSP server.
+      • {cmd_args}            (table) List of additional string arguments to
                               pass to {cmd}.
-        {dispatchers}         (table|nil) Dispatchers for LSP message types.
+      • {dispatchers}         (table|nil) Dispatchers for LSP message types.
                               Valid dispatcher names are:
                               • `"notification"`
                               • `"server_request"`
                               • `"on_error"`
                               • `"on_exit"`
-        {extra_spawn_params}  (table|nil) Additional context for the LSP
+      • {extra_spawn_params}  (table|nil) Additional context for the LSP
                               server process. May contain:
                               • {cwd} (string) Working directory for the LSP
                                 server process
@@ -1924,14 +1924,14 @@ compute_diff({___MissingCloseParenHere___})
     Returns the range table for the difference between prev and curr lines
 
     Parameters: ~
-        {prev_lines}       (table) list of lines
-        {curr_lines}       (table) list of lines
-        {firstline}        (number) line to begin search for first difference
-        {lastline}         (number) line to begin search in old_lines for last
+      • {prev_lines}       (table) list of lines
+      • {curr_lines}       (table) list of lines
+      • {firstline}        (number) line to begin search for first difference
+      • {lastline}         (number) line to begin search in old_lines for last
                            difference
-        {new_lastline}     (number) line to begin search in new_lines for last
+      • {new_lastline}     (number) line to begin search in new_lines for last
                            difference
-        {offset_encoding}  (string) encoding requested by language server
+      • {offset_encoding}  (string) encoding requested by language server
 
     Return: ~
         (table) TextDocumentContentChangeEvent see https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#textDocumentContentChangeEvent
@@ -1950,7 +1950,7 @@ resolve_capabilities({server_capabilities})
     Creates a normalized object describing LSP server capabilities.
 
     Parameters: ~
-        {server_capabilities}  (table) Table of capabilities supported by the
+      • {server_capabilities}  (table) Table of capabilities supported by the
                                server
 
     Return: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1395,7 +1395,7 @@ cmd({command})                                                     *vim.cmd()*
 <
 
     Parameters: ~
-        {command}  string|table Command(s) to execute. If a string, executes
+      • {command}  string|table Command(s) to execute. If a string, executes
                    multiple lines of Vim script at once. In this case, it is
                    an alias to |nvim_exec()|, where `output` is set to false.
                    Thus it works identical to |:source|. If a table, executes
@@ -1416,8 +1416,8 @@ defer_fn({fn}, {timeout})                                     *vim.defer_fn()*
     are safe to call.
 
     Parameters: ~
-        {fn}       Callback to call once `timeout` expires
-        {timeout}  Number of milliseconds to wait before calling `fn`
+      • {fn}       Callback to call once `timeout` expires
+      • {timeout}  Number of milliseconds to wait before calling `fn`
 
     Return: ~
         timer luv timer object
@@ -1427,13 +1427,13 @@ deprecate({name}, {alternative}, {version}, {plugin}, {backtrace})
     Display a deprecation notification to the user.
 
     Parameters: ~
-        {name}         string Deprecated function.
-        {alternative}  (string|nil) Preferred alternative function.
-        {version}      string Version in which the deprecated function will be
+      • {name}         string Deprecated function.
+      • {alternative}  (string|nil) Preferred alternative function.
+      • {version}      string Version in which the deprecated function will be
                        removed.
-        {plugin}       string|nil Plugin name that the function will be
+      • {plugin}       string|nil Plugin name that the function will be
                        removed from. Defaults to "Nvim".
-        {backtrace}    boolean|nil Prints backtrace. Defaults to true.
+      • {backtrace}    boolean|nil Prints backtrace. Defaults to true.
 
 inspect({object}, {options})                                   *vim.inspect()*
     Return a human-readable representation of the given object.
@@ -1450,9 +1450,9 @@ notify({msg}, {level}, {opts})                                  *vim.notify()*
     writes to |:messages|.
 
     Parameters: ~
-        {msg}    (string) Content of the notification to show to the user.
-        {level}  (number|nil) One of the values from |vim.log.levels|.
-        {opts}   (table|nil) Optional parameters. Unused by default.
+      • {msg}    (string) Content of the notification to show to the user.
+      • {level}  (number|nil) One of the values from |vim.log.levels|.
+      • {opts}   (table|nil) Optional parameters. Unused by default.
 
 notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
     Display a notification only one time.
@@ -1461,9 +1461,9 @@ notify_once({msg}, {level}, {opts})                        *vim.notify_once()*
     display a notification.
 
     Parameters: ~
-        {msg}    (string) Content of the notification to show to the user.
-        {level}  (number|nil) One of the values from |vim.log.levels|.
-        {opts}   (table|nil) Optional parameters. Unused by default.
+      • {msg}    (string) Content of the notification to show to the user.
+      • {level}  (number|nil) One of the values from |vim.log.levels|.
+      • {opts}   (table|nil) Optional parameters. Unused by default.
 
     Return: ~
         (boolean) true if message was displayed, else false
@@ -1482,11 +1482,11 @@ on_key({fn}, {ns_id})                                           *vim.on_key()*
         {fn} will receive the keys after mappings have been evaluated
 
     Parameters: ~
-        {fn}     function: Callback function. It should take one string
+      • {fn}     function: Callback function. It should take one string
                  argument. On each key press, Nvim passes the key char to
                  fn(). |i_CTRL-V| If {fn} is nil, it removes the callback for
                  the associated {ns_id}
-        {ns_id}  number? Namespace ID. If nil or 0, generates and returns a
+      • {ns_id}  number? Namespace ID. If nil or 0, generates and returns a
                  new |nvim_create_namespace()| id.
 
     Return: ~
@@ -1514,8 +1514,8 @@ paste({lines}, {phase})                                          *vim.paste()*
 <
 
     Parameters: ~
-        {lines}  |readfile()|-style list of lines to paste. |channel-lines|
-        {phase}  -1: "non-streaming" paste: the call contains all lines. If
+      • {lines}  |readfile()|-style list of lines to paste. |channel-lines|
+      • {phase}  -1: "non-streaming" paste: the call contains all lines. If
                  paste is "streamed", `phase` indicates the stream state:
                  • 1: starts the paste (exactly once)
                  • 2: continues the paste (zero or more times)
@@ -1544,11 +1544,11 @@ region({bufnr}, {pos1}, {pos2}, {regtype}, {inclusive})         *vim.region()*
     points
 
     Parameters: ~
-        {bufnr}      (number) of buffer
-        {pos1}       (line, column) tuple marking beginning of region
-        {pos2}       (line, column) tuple marking end of region
-        {regtype}    type of selection, see |setreg()|
-        {inclusive}  (boolean) indicating whether the selection is
+      • {bufnr}      (number) of buffer
+      • {pos1}       (line, column) tuple marking beginning of region
+      • {pos2}       (line, column) tuple marking end of region
+      • {regtype}    type of selection, see |setreg()|
+      • {inclusive}  (boolean) indicating whether the selection is
                      end-inclusive
 
     Return: ~
@@ -1571,8 +1571,8 @@ deep_equal({a}, {b})                                        *vim.deep_equal()*
     Tables are compared recursively unless they both provide the `eq` metamethod. All other types are compared using the equality `==` operator.
 
     Parameters: ~
-        {a}  any First value
-        {b}  any Second value
+      • {a}  any First value
+      • {b}  any Second value
 
     Return: ~
         (boolean) `true` if values are equals, else `false`
@@ -1585,7 +1585,7 @@ deepcopy({orig})                                              *vim.deepcopy()*
     not copied and will throw an error.
 
     Parameters: ~
-        {orig}  (table) Table to copy
+      • {orig}  (table) Table to copy
 
     Return: ~
         (table) Table of copied keys and (nested) values.
@@ -1606,7 +1606,7 @@ defaulttable({create})                                    *vim.defaulttable()*
 <
 
     Parameters: ~
-        {create}  (function|nil) The function called to create a missing
+      • {create}  (function|nil) The function called to create a missing
                   value.
 
     Return: ~
@@ -1616,8 +1616,8 @@ endswith({s}, {suffix})                                       *vim.endswith()*
     Tests if `s` ends with `suffix`.
 
     Parameters: ~
-        {s}       (string) String
-        {suffix}  (string) Suffix to match
+      • {s}       (string) String
+      • {suffix}  (string) Suffix to match
 
     Return: ~
         (boolean) `true` if `suffix` is a suffix of `s`
@@ -1626,9 +1626,9 @@ gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
     Splits a string at each instance of a separator.
 
     Parameters: ~
-        {s}      (string) String to split
-        {sep}    (string) Separator or pattern
-        {plain}  (boolean) If `true` use `sep` literally (passed to
+      • {s}      (string) String to split
+      • {sep}    (string) Separator or pattern
+      • {plain}  (boolean) If `true` use `sep` literally (passed to
                  string.find)
 
     Return: ~
@@ -1643,7 +1643,7 @@ is_callable({f})                                           *vim.is_callable()*
     Returns true if object `f` can be called as a function.
 
     Parameters: ~
-        {f}  any Any object
+      • {f}  any Any object
 
     Return: ~
         (boolean) `true` if `f` is callable, else `false`
@@ -1654,10 +1654,10 @@ list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
     NOTE: This mutates dst!
 
     Parameters: ~
-        {dst}     (table) List which will be modified and appended to
-        {src}     (table) List from which values will be inserted
-        {start}   (number) Start index on src. Defaults to 1
-        {finish}  (number) Final index on src. Defaults to `#src`
+      • {dst}     (table) List which will be modified and appended to
+      • {src}     (table) List from which values will be inserted
+      • {start}   (number) Start index on src. Defaults to 1
+      • {finish}  (number) Final index on src. Defaults to `#src`
 
     Return: ~
         (table) dst
@@ -1670,9 +1670,9 @@ list_slice({list}, {start}, {finish})                       *vim.list_slice()*
     (inclusive)
 
     Parameters: ~
-        {list}    (table) Table
-        {start}   (number) Start range of slice
-        {finish}  (number) End range of slice
+      • {list}    (table) Table
+      • {start}   (number) Start range of slice
+      • {finish}  (number) End range of slice
 
     Return: ~
         (table) Copy of table sliced from start to finish (inclusive)
@@ -1681,7 +1681,7 @@ pesc({s})                                                         *vim.pesc()*
     Escapes magic chars in |lua-patterns|.
 
     Parameters: ~
-        {s}  (string) String to escape
+      • {s}  (string) String to escape
 
     Return: ~
         (string) %-escaped pattern string
@@ -1701,9 +1701,9 @@ split({s}, {sep}, {kwargs})                                      *vim.split()*
 <
 
     Parameters: ~
-        {s}       (string) String to split
-        {sep}     (string) Separator or pattern
-        {kwargs}  (table) Keyword arguments:
+      • {s}       (string) String to split
+      • {sep}     (string) Separator or pattern
+      • {kwargs}  (table) Keyword arguments:
                   • plain: (boolean) If `true` use `sep` literally (passed to
                     string.find)
                   • trimempty: (boolean) If `true` remove empty items from the
@@ -1719,8 +1719,8 @@ startswith({s}, {prefix})                                   *vim.startswith()*
     Tests if `s` starts with `prefix`.
 
     Parameters: ~
-        {s}       (string) String
-        {prefix}  (string) Prefix to match
+      • {s}       (string) String
+      • {prefix}  (string) Prefix to match
 
     Return: ~
         (boolean) `true` if `prefix` is a prefix of `s`
@@ -1732,7 +1732,7 @@ tbl_add_reverse_lookup({o})                     *vim.tbl_add_reverse_lookup()*
     Note that this modifies the input.
 
     Parameters: ~
-        {o}  (table) Table to add the reverse to
+      • {o}  (table) Table to add the reverse to
 
     Return: ~
         (table) o
@@ -1741,8 +1741,8 @@ tbl_contains({t}, {value})                                *vim.tbl_contains()*
     Checks if a list-like (vector) table contains `value`.
 
     Parameters: ~
-        {t}      (table) Table to check
-        {value}  any Value to compare
+      • {t}      (table) Table to check
+      • {value}  any Value to compare
 
     Return: ~
         (boolean) `true` if `t` contains `value`
@@ -1756,7 +1756,7 @@ tbl_count({t})                                               *vim.tbl_count()*
 <
 
     Parameters: ~
-        {t}  (table) Table
+      • {t}  (table) Table
 
     Return: ~
         (number) Number of non-nil values in table
@@ -1768,12 +1768,12 @@ tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
     Merges recursively two or more map-like tables.
 
     Parameters: ~
-        {behavior}  (string) Decides what to do if a key is found in more than
+      • {behavior}  (string) Decides what to do if a key is found in more than
                     one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
-        {...}       (table) Two or more map-like tables
+      • {...}       (table) Two or more map-like tables
 
     Return: ~
         (table) Merged table
@@ -1785,12 +1785,12 @@ tbl_extend({behavior}, {...})                               *vim.tbl_extend()*
     Merges two or more map-like tables.
 
     Parameters: ~
-        {behavior}  (string) Decides what to do if a key is found in more than
+      • {behavior}  (string) Decides what to do if a key is found in more than
                     one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
-        {...}       (table) Two or more map-like tables
+      • {...}       (table) Two or more map-like tables
 
     Return: ~
         (table) Merged table
@@ -1802,8 +1802,8 @@ tbl_filter({func}, {t})                                     *vim.tbl_filter()*
     Filter a table using a predicate function
 
     Parameters: ~
-        {func}  function|table Function or callable table
-        {t}     (table) Table
+      • {func}  function|table Function or callable table
+      • {t}     (table) Table
 
     Return: ~
         (table) Table of filtered values
@@ -1813,7 +1813,7 @@ tbl_flatten({t})                                           *vim.tbl_flatten()*
     "unrolled" and appended to the result.
 
     Parameters: ~
-        {t}  (table) List-like table
+      • {t}  (table) List-like table
 
     Return: ~
         (table) Flattened copy of the given list-like table
@@ -1832,8 +1832,8 @@ tbl_get({o}, {...})                                            *vim.tbl_get()*
 <
 
     Parameters: ~
-        {o}    (table) Table to index
-        {...}  (string) Optional strings (0 or more, variadic) via which to
+      • {o}    (table) Table to index
+      • {...}  (string) Optional strings (0 or more, variadic) via which to
                index the table
 
     Return: ~
@@ -1843,7 +1843,7 @@ tbl_isempty({t})                                           *vim.tbl_isempty()*
     Checks if a table is empty.
 
     Parameters: ~
-        {t}  (table) Table to check
+      • {t}  (table) Table to check
 
     Return: ~
         (boolean) `true` if `t` is empty
@@ -1859,7 +1859,7 @@ tbl_islist({t})                                             *vim.tbl_islist()*
     for example from |rpcrequest()| or |vim.fn|.
 
     Parameters: ~
-        {t}  (table) Table
+      • {t}  (table) Table
 
     Return: ~
         (boolean) `true` if array-like table, else `false`
@@ -1869,7 +1869,7 @@ tbl_keys({t})                                                 *vim.tbl_keys()*
     return table of keys is not guaranteed.
 
     Parameters: ~
-        {t}  (table) Table
+      • {t}  (table) Table
 
     Return: ~
         (table) List of keys
@@ -1881,8 +1881,8 @@ tbl_map({func}, {t})                                           *vim.tbl_map()*
     Apply a function to all values of a table.
 
     Parameters: ~
-        {func}  function|table Function or callable table
-        {t}     (table) Table
+      • {func}  function|table Function or callable table
+      • {t}     (table) Table
 
     Return: ~
         (table) Table of transformed values
@@ -1892,7 +1892,7 @@ tbl_values({t})                                             *vim.tbl_values()*
     return table of values is not guaranteed.
 
     Parameters: ~
-        {t}  (table) Table
+      • {t}  (table) Table
 
     Return: ~
         (table) List of values
@@ -1901,7 +1901,7 @@ trim({s})                                                         *vim.trim()*
     Trim whitespace (Lua pattern "%s") from both sides of a string.
 
     Parameters: ~
-        {s}  (string) String to trim
+      • {s}  (string) String to trim
 
     Return: ~
         (string) String with whitespace removed from its beginning and end
@@ -1946,7 +1946,7 @@ validate({opt})                                               *vim.validate()*
 <
 
     Parameters: ~
-        {opt}  (table) Names of parameters to validate. Each key is a
+      • {opt}  (table) Names of parameters to validate. Each key is a
                parameter name; each value is a tuple in one of these forms:
                1. (arg_value, type_name, optional)
                   • arg_value: argument value
@@ -1971,7 +1971,7 @@ uri_from_bufnr({bufnr})                                 *vim.uri_from_bufnr()*
     Get a URI from a bufnr
 
     Parameters: ~
-        {bufnr}  (number)
+      • {bufnr}  (number)
 
     Return: ~
         (string) URI
@@ -1980,7 +1980,7 @@ uri_from_fname({path})                                  *vim.uri_from_fname()*
     Get a URI from a file path.
 
     Parameters: ~
-        {path}  (string) Path to file
+      • {path}  (string) Path to file
 
     Return: ~
         (string) URI
@@ -1990,7 +1990,7 @@ uri_to_bufnr({uri})                                       *vim.uri_to_bufnr()*
     the uri already exists.
 
     Parameters: ~
-        {uri}  (string)
+      • {uri}  (string)
 
     Return: ~
         (number) bufnr
@@ -1999,7 +1999,7 @@ uri_to_fname({uri})                                       *vim.uri_to_fname()*
     Get a filename from a URI
 
     Parameters: ~
-        {uri}  (string)
+      • {uri}  (string)
 
     Return: ~
         (string) filename or unchanged URI for non-file URIs
@@ -2019,7 +2019,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
 <
 
     Parameters: ~
-        {opts}        (table) Additional options. See |input()|
+      • {opts}        (table) Additional options. See |input()|
                       • prompt (string|nil) Text of the prompt
                       • default (string|nil) Default reply to the input
                       • completion (string|nil) Specifies type of completion
@@ -2028,7 +2028,7 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                         "-complete=" argument. See |:command-completion|
                       • highlight (function) Function that will be used for
                         highlighting user inputs.
-        {on_confirm}  (function) ((input|nil) -> ()) Called once the user
+      • {on_confirm}  (function) ((input|nil) -> ()) Called once the user
                       confirms or abort the input. `input` is what the user
                       typed. `nil` if the user aborted the dialog.
 
@@ -2052,8 +2052,8 @@ select({items}, {opts}, {on_choice})                         *vim.ui.select()*
 <
 
     Parameters: ~
-        {items}      (table) Arbitrary items
-        {opts}       (table) Additional options
+      • {items}      (table) Arbitrary items
+      • {opts}       (table) Additional options
                      • prompt (string|nil) Text of the prompt. Defaults to
                        `Select one of:`
                      • format_item (function item -> text) Function to format
@@ -2063,7 +2063,7 @@ select({items}, {opts}, {on_choice})                         *vim.ui.select()*
                        item shape. Plugins reimplementing `vim.ui.select` may
                        wish to use this to infer the structure or semantics of
                        `items`, or the context in which select() was called.
-        {on_choice}  (function) ((item|nil, idx|nil) -> ()) Called once the
+      • {on_choice}  (function) ((item|nil, idx|nil) -> ()) Called once the
                      user made a choice. `idx` is the 1-based index of `item`
                      within `items`. `nil` if the user aborted the dialog.
 
@@ -2157,7 +2157,7 @@ add({filetypes})                                          *vim.filetype.add()*
 <
 
     Parameters: ~
-        {filetypes}  (table) A table containing new filetype maps (see
+      • {filetypes}  (table) A table containing new filetype maps (see
                      example).
 
 match({args})                                           *vim.filetype.match()*
@@ -2192,7 +2192,7 @@ match({args})                                           *vim.filetype.match()*
 <
 
     Parameters: ~
-        {args}  (table) Table specifying which matching strategy to use.
+      • {args}  (table) Table specifying which matching strategy to use.
                 Accepted keys are:
                 • buf (number): Buffer number to use for matching. Mutually
                   exclusive with {contents}
@@ -2226,7 +2226,7 @@ del({modes}, {lhs}, {opts})                                 *vim.keymap.del()*
 <
 
     Parameters: ~
-        {opts}  (table|nil) A table of optional arguments:
+      • {opts}  (table|nil) A table of optional arguments:
                 • buffer: (number or boolean) Remove a mapping from the given
                   buffer. When "true" or 0, use the current buffer.
 
@@ -2266,12 +2266,12 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
 <
 
     Parameters: ~
-        {mode}  string|table Same mode short names as |nvim_set_keymap()|. Can
+      • {mode}  string|table Same mode short names as |nvim_set_keymap()|. Can
                 also be list of modes to create mapping on multiple modes.
-        {lhs}   (string) Left-hand side |{lhs}| of the mapping.
-        {rhs}   string|function Right-hand side |{rhs}| of the mapping. Can
+      • {lhs}   (string) Left-hand side |{lhs}| of the mapping.
+      • {rhs}   string|function Right-hand side |{rhs}| of the mapping. Can
                 also be a Lua function.
-        {opts}  (table|nil) A table of |:map-arguments|.
+      • {opts}  (table|nil) A table of |:map-arguments|.
                 • Accepts options accepted by the {opts} parameter in
                   |nvim_set_keymap()|, with the following notable differences:
                   • replace_keycodes: Defaults to `true` if "expr" is `true`.
@@ -2297,7 +2297,7 @@ basename({file})                                           *vim.fs.basename()*
     Return the basename of the given file or directory
 
     Parameters: ~
-        {file}  (string) File or directory
+      • {file}  (string) File or directory
 
     Return: ~
         (string) Basename of {file}
@@ -2306,7 +2306,7 @@ dir({path})                                                     *vim.fs.dir()*
     Return an iterator over the files and directories located in {path}
 
     Parameters: ~
-        {path}  (string) An absolute or relative path to the directory to
+      • {path}  (string) An absolute or relative path to the directory to
                 iterate over. The path is first normalized
                 |vim.fs.normalize()|.
 
@@ -2319,7 +2319,7 @@ dirname({file})                                             *vim.fs.dirname()*
     Return the parent directory of the given file or directory
 
     Parameters: ~
-        {file}  (string) File or directory
+      • {file}  (string) File or directory
 
     Return: ~
         (string) Parent directory of {file}
@@ -2337,11 +2337,11 @@ find({names}, {opts})                                          *vim.fs.find()*
     specifying {type} to be "file" or "directory", respectively.
 
     Parameters: ~
-        {names}  (string|table|fun(name: string): boolean) Names of the files
+      • {names}  (string|table|fun(name: string): boolean) Names of the files
                  and directories to find. Must be base names, paths and globs
                  are not supported. If a function it is called per file and
                  dir within the traversed directories to test if they match.
-        {opts}   (table) Optional keyword arguments:
+      • {opts}   (table) Optional keyword arguments:
                  • path (string): Path to begin searching from. If omitted,
                    the current working directory is used.
                  • upward (boolean, default false): If true, search upward
@@ -2378,7 +2378,7 @@ normalize({path})                                         *vim.fs.normalize()*
 <
 
     Parameters: ~
-        {path}  (string) Path to normalize
+      • {path}  (string) Path to normalize
 
     Return: ~
         (string) Normalized path
@@ -2402,7 +2402,7 @@ parents({start})                                            *vim.fs.parents()*
 <
 
     Parameters: ~
-        {start}  (string) Initial file or directory.
+      • {start}  (string) Initial file or directory.
 
     Return: ~
         (function) Iterator

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -429,7 +429,7 @@ get_captures_at_cursor({winnr})                     *get_captures_at_cursor()*
     Returns a list of highlight capture names under the cursor
 
     Parameters: ~
-        {winnr}  (number|nil) Window handle or 0 for current window (default)
+      • {winnr}  (number|nil) Window handle or 0 for current window (default)
 
     Return: ~
         string[] List of capture names
@@ -442,9 +442,9 @@ get_captures_at_pos({bufnr}, {row}, {col})             *get_captures_at_pos()*
     if none are defined).
 
     Parameters: ~
-        {bufnr}  (number) Buffer number (0 for current buffer)
-        {row}    (number) Position row
-        {col}    (number) Position column
+      • {bufnr}  (number) Buffer number (0 for current buffer)
+      • {row}    (number) Position row
+      • {col}    (number) Position column
 
     Return: ~
         table[] List of captures `{ capture = "capture name", metadata = { ...
@@ -454,7 +454,7 @@ get_node_at_cursor({winnr})                             *get_node_at_cursor()*
     Returns the smallest named node under the cursor
 
     Parameters: ~
-        {winnr}  (number|nil) Window handle or 0 for current window (default)
+      • {winnr}  (number|nil) Window handle or 0 for current window (default)
 
     Return: ~
         (string) Name of node under the cursor
@@ -463,10 +463,10 @@ get_node_at_pos({bufnr}, {row}, {col}, {opts})             *get_node_at_pos()*
     Returns the smallest named node at the given position
 
     Parameters: ~
-        {bufnr}  (number) Buffer number (0 for current buffer)
-        {row}    (number) Position row
-        {col}    (number) Position column
-        {opts}   (table) Optional keyword arguments:
+      • {bufnr}  (number) Buffer number (0 for current buffer)
+      • {row}    (number) Position row
+      • {col}    (number) Position column
+      • {opts}   (table) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
 
@@ -477,7 +477,7 @@ get_node_range({node_or_range})                             *get_node_range()*
     Returns the node's range or an unpacked range table
 
     Parameters: ~
-        {node_or_range}  (userdata|table) |tsnode| or table of positions
+      • {node_or_range}  (userdata|table) |tsnode| or table of positions
 
     Return: ~
         (table) `{ start_row, start_col, end_row, end_col }`
@@ -489,11 +489,11 @@ get_parser({bufnr}, {lang}, {opts})                             *get_parser()*
     If needed, this will create the parser.
 
     Parameters: ~
-        {bufnr}  (number|nil) Buffer the parser should be tied to (default:
+      • {bufnr}  (number|nil) Buffer the parser should be tied to (default:
                  current buffer)
-        {lang}   (string|nil) Filetype of this parser (default: buffer
+      • {lang}   (string|nil) Filetype of this parser (default: buffer
                  filetype)
-        {opts}   (table|nil) Options to pass to the created language tree
+      • {opts}   (table|nil) Options to pass to the created language tree
 
     Return: ~
         LanguageTree |LanguageTree| object to use for parsing
@@ -502,9 +502,9 @@ get_string_parser({str}, {lang}, {opts})                 *get_string_parser()*
     Returns a string parser
 
     Parameters: ~
-        {str}   (string) Text to parse
-        {lang}  (string) Language of this string
-        {opts}  (table|nil) Options to pass to the created language tree
+      • {str}   (string) Text to parse
+      • {lang}  (string) Language of this string
+      • {opts}  (table|nil) Options to pass to the created language tree
 
     Return: ~
         LanguageTree |LanguageTree| object to use for parsing
@@ -513,8 +513,8 @@ is_ancestor({dest}, {source})                                  *is_ancestor()*
     Determines whether a node is the ancestor of another
 
     Parameters: ~
-        {dest}    userdata Possible ancestor |tsnode|
-        {source}  userdata Possible descendant |tsnode|
+      • {dest}    userdata Possible ancestor |tsnode|
+      • {source}  userdata Possible descendant |tsnode|
 
     Return: ~
         (boolean) True if {dest} is an ancestor of {source}
@@ -523,9 +523,9 @@ is_in_node_range({node}, {line}, {col})                   *is_in_node_range()*
     Determines whether (line, col) position is in node range
 
     Parameters: ~
-        {node}  userdata |tsnode| defining the range
-        {line}  (number) Line (0-based)
-        {col}   (number) Column (0-based)
+      • {node}  userdata |tsnode| defining the range
+      • {line}  (number) Line (0-based)
+      • {col}   (number) Column (0-based)
 
     Return: ~
         (boolean) True if the position is in node range
@@ -534,8 +534,8 @@ node_contains({node}, {range})                               *node_contains()*
     Determines if a node contains a range
 
     Parameters: ~
-        {node}   userdata |tsnode|
-        {range}  (table)
+      • {node}   userdata |tsnode|
+      • {range}  (table)
 
     Return: ~
         (boolean) True if the {node} contains the {range}
@@ -560,16 +560,16 @@ start({bufnr}, {lang})                                               *start()*
 <
 
     Parameters: ~
-        {bufnr}  (number|nil) Buffer to be highlighted (default: current
+      • {bufnr}  (number|nil) Buffer to be highlighted (default: current
                  buffer)
-        {lang}   (string|nil) Language of the parser (default: buffer
+      • {lang}   (string|nil) Language of the parser (default: buffer
                  filetype)
 
 stop({bufnr})                                                         *stop()*
     Stops treesitter highlighting for a buffer
 
     Parameters: ~
-        {bufnr}  (number|nil) Buffer to stop highlighting (default: current
+      • {bufnr}  (number|nil) Buffer to stop highlighting (default: current
                  buffer)
 
 
@@ -583,7 +583,7 @@ inspect_language({lang})                                  *inspect_language()*
     names, ...
 
     Parameters: ~
-        {lang}  (string) Language
+      • {lang}  (string) Language
 
     Return: ~
         (table)
@@ -596,11 +596,11 @@ require_language({lang}, {path}, {silent}, {symbol_name})
     {path}
 
     Parameters: ~
-        {lang}         (string) Language the parser should parse
-        {path}         (string|nil) Optional path the parser is located at
-        {silent}       (boolean|nil) Don't throw an error if language not
+      • {lang}         (string) Language the parser should parse
+      • {path}         (string|nil) Optional path the parser is located at
+      • {silent}       (boolean|nil) Don't throw an error if language not
                        found
-        {symbol_name}  (string|nil) Internal symbol name for the language to
+      • {symbol_name}  (string|nil) Internal symbol name for the language to
                        load
 
     Return: ~
@@ -619,26 +619,26 @@ add_directive({name}, {handler}, {force})                    *add_directive()*
     `metadata[capture_id].key = value`
 
     Parameters: ~
-        {name}     (string) Name of the directive, without leading #
-        {handler}  function(match:string, pattern:string, bufnr:number,
+      • {name}     (string) Name of the directive, without leading #
+      • {handler}  function(match:string, pattern:string, bufnr:number,
                    predicate:function, metadata:table)
 
 add_predicate({name}, {handler}, {force})                    *add_predicate()*
     Adds a new predicate to be used in queries
 
     Parameters: ~
-        {name}     (string) Name of the predicate, without leading #
-        {handler}  function(match:string, pattern:string, bufnr:number,
+      • {name}     (string) Name of the predicate, without leading #
+      • {handler}  function(match:string, pattern:string, bufnr:number,
                    predicate:function)
 
 get_node_text({node}, {source}, {opts})                      *get_node_text()*
     Gets the text corresponding to a given node
 
     Parameters: ~
-        {node}    userdata |tsnode|
-        {source}  (number|string) Buffer or string from which the {node} is
+      • {node}    userdata |tsnode|
+      • {source}  (number|string) Buffer or string from which the {node} is
                   extracted
-        {opts}    (table|nil) Optional parameters.
+      • {opts}    (table|nil) Optional parameters.
                   • concat: (boolean) Concatenate result in a string (default
                     true)
 
@@ -649,8 +649,8 @@ get_query({lang}, {query_name})                                  *get_query()*
     Returns the runtime query {query_name} for {lang}.
 
     Parameters: ~
-        {lang}        (string) Language to use for the query
-        {query_name}  (string) Name of the query (e.g. "highlights")
+      • {lang}        (string) Language to use for the query
+      • {query_name}  (string) Name of the query (e.g. "highlights")
 
     Return: ~
         Query Parsed query
@@ -660,9 +660,9 @@ get_query_files({lang}, {query_name}, {is_included})
     Gets the list of files used to make up a query
 
     Parameters: ~
-        {lang}         (string) Language to get query for
-        {query_name}   (string) Name of the query to load (e.g., "highlights")
-        {is_included}  (boolean|nil) Internal parameter, most of the time left
+      • {lang}         (string) Language to get query for
+      • {query_name}   (string) Name of the query to load (e.g., "highlights")
+      • {is_included}  (boolean|nil) Internal parameter, most of the time left
                        as `nil`
 
     Return: ~
@@ -694,8 +694,8 @@ parse_query({lang}, {query})                                   *parse_query()*
     • `info.patterns` contains information about predicates.
 
     Parameters: ~
-        {lang}   (string) Language to use for the query
-        {query}  (string) Query in s-expr syntax
+      • {lang}   (string) Language to use for the query
+      • {query}  (string) Query in s-expr syntax
 
     Return: ~
         Query Parsed query
@@ -726,11 +726,11 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-        {node}    userdata |tsnode| under which the search will occur
-        {source}  (number|string) Source buffer or string to extract text from
-        {start}   (number) Starting line for the search
-        {stop}    (number) Stopping line for the search (end-exclusive)
-        {self}
+      • {node}    userdata |tsnode| under which the search will occur
+      • {source}  (number|string) Source buffer or string to extract text from
+      • {start}   (number) Starting line for the search
+      • {stop}    (number) Stopping line for the search (end-exclusive)
+      • {self}
 
     Return: ~
         (number) capture Matching capture id
@@ -761,11 +761,11 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-        {node}    userdata |tsnode| under which the search will occur
-        {source}  (number|string) Source buffer or string to search
-        {start}   (number) Starting line for the search
-        {stop}    (number) Stopping line for the search (end-exclusive)
-        {self}
+      • {node}    userdata |tsnode| under which the search will occur
+      • {source}  (number|string) Source buffer or string to search
+      • {start}   (number) Starting line for the search
+      • {stop}    (number) Stopping line for the search (end-exclusive)
+      • {self}
 
     Return: ~
         (number) pattern id
@@ -779,9 +779,9 @@ set_query({lang}, {query_name}, {text})                          *set_query()*
     by plugins.
 
     Parameters: ~
-        {lang}        (string) Language to use for the query
-        {query_name}  (string) Name of the query (e.g., "highlights")
-        {text}        (string) Query text (unparsed).
+      • {lang}        (string) Language to use for the query
+      • {query_name}  (string) Name of the query (e.g., "highlights")
+      • {text}        (string) Query text (unparsed).
 
 
 ==============================================================================
@@ -791,8 +791,8 @@ new({tree}, {opts})                                        *highlighter.new()*
     Creates a new highlighter using
 
     Parameters: ~
-        {tree}  LanguageTree |LanguageTree| parser object to use for highlighting
-        {opts}  (table|nil) Configuration of the highlighter:
+      • {tree}  LanguageTree |LanguageTree| parser object to use for highlighting
+      • {opts}  (table|nil) Configuration of the highlighter:
                 • queries table overwrite queries used by the highlighter
 
     Return: ~
@@ -802,7 +802,7 @@ TSHighlighter:destroy({self})                        *TSHighlighter:destroy()*
     Removes all internal references to the highlighter
 
     Parameters: ~
-        {self}
+      • {self}
 
 
 ==============================================================================
@@ -812,14 +812,14 @@ LanguageTree:children({self})                        *LanguageTree:children()*
     Returns a map of language to child tree.
 
     Parameters: ~
-        {self}
+      • {self}
 
 LanguageTree:contains({self}, {range})               *LanguageTree:contains()*
     Determines whether {range} is contained in the |LanguageTree|.
 
     Parameters: ~
-        {range}  (table) `{ start_line, start_col, end_line, end_col }`
-        {self}
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {self}
 
     Return: ~
         (boolean)
@@ -832,17 +832,17 @@ LanguageTree:destroy({self})                          *LanguageTree:destroy()*
     Note: This DOES NOT remove this tree from a parent. Instead, `remove_child` must be called on the parent to remove it.
 
     Parameters: ~
-        {self}
+      • {self}
 
                                                *LanguageTree:for_each_child()*
 LanguageTree:for_each_child({self}, {fn}, {include_self})
     Invokes the callback for each |LanguageTree| and its children recursively
 
     Parameters: ~
-        {fn}            function(tree: LanguageTree, lang: string)
-        {include_self}  (boolean) Whether to include the invoking tree in the
+      • {fn}            function(tree: LanguageTree, lang: string)
+      • {include_self}  (boolean) Whether to include the invoking tree in the
                         results
-        {self}
+      • {self}
 
 LanguageTree:for_each_tree({self}, {fn})        *LanguageTree:for_each_tree()*
     Invokes the callback for each |LanguageTree| recursively.
@@ -850,40 +850,40 @@ LanguageTree:for_each_tree({self}, {fn})        *LanguageTree:for_each_tree()*
     Note: This includes the invoking tree's child trees as well.
 
     Parameters: ~
-        {fn}    function(tree: TSTree, languageTree: LanguageTree)
-        {self}
+      • {fn}    function(tree: TSTree, languageTree: LanguageTree)
+      • {self}
 
 LanguageTree:included_regions({self})        *LanguageTree:included_regions()*
     Gets the set of included regions
 
     Parameters: ~
-        {self}
+      • {self}
 
 LanguageTree:invalidate({self}, {reload})          *LanguageTree:invalidate()*
     Invalidates this parser and all its children
 
     Parameters: ~
-        {self}
+      • {self}
 
 LanguageTree:is_valid({self})                        *LanguageTree:is_valid()*
     Determines whether this tree is valid. If the tree is invalid, call `parse()` . This will return the updated tree.
 
     Parameters: ~
-        {self}
+      • {self}
 
 LanguageTree:lang({self})                                *LanguageTree:lang()*
     Gets the language of this tree node.
 
     Parameters: ~
-        {self}
+      • {self}
 
                                            *LanguageTree:language_for_range()*
 LanguageTree:language_for_range({self}, {range})
     Gets the appropriate language that contains {range}.
 
     Parameters: ~
-        {range}  (table) `{ start_line, start_col, end_line, end_col }`
-        {self}
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {self}
 
     Return: ~
         LanguageTree Managing {range}
@@ -893,11 +893,11 @@ LanguageTree:named_node_for_range({self}, {range}, {opts})
     Gets the smallest named node that contains {range}.
 
     Parameters: ~
-        {range}  (table) `{ start_line, start_col, end_line, end_col }`
-        {opts}   (table|nil) Optional keyword arguments:
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
-        {self}
+      • {self}
 
     Return: ~
         userdata|nil Found |tsnode|
@@ -908,7 +908,7 @@ LanguageTree:parse({self})                              *LanguageTree:parse()*
     determine if any child languages should be created.
 
     Parameters: ~
-        {self}
+      • {self}
 
     Return: ~
         userdata[] Table of parsed |tstree|
@@ -918,7 +918,7 @@ LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
     Registers callbacks for the |LanguageTree|.
 
     Parameters: ~
-        {cbs}   (table) An |nvim_buf_attach()|-like table argument with the
+      • {cbs}   (table) An |nvim_buf_attach()|-like table argument with the
                 following handlers:
                 • `on_bytes` : see |nvim_buf_attach()|, but this will be called after the parsers callback.
                 • `on_changedtree` : a callback that will be called every time
@@ -929,24 +929,24 @@ LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
                   tree.
                 • `on_child_removed` : emitted when a child is removed from
                   the tree.
-        {self}
+      • {self}
 
 LanguageTree:source({self})                            *LanguageTree:source()*
     Returns the source content of the language tree (bufnr or string).
 
     Parameters: ~
-        {self}
+      • {self}
 
                                                *LanguageTree:tree_for_range()*
 LanguageTree:tree_for_range({self}, {range}, {opts})
     Gets the tree that contains {range}.
 
     Parameters: ~
-        {range}  (table) `{ start_line, start_col, end_line, end_col }`
-        {opts}   (table|nil) Optional keyword arguments:
+      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
-        {self}
+      • {self}
 
     Return: ~
         userdata|nil Contained |tstree|
@@ -956,7 +956,7 @@ LanguageTree:trees({self})                              *LanguageTree:trees()*
     languages.
 
     Parameters: ~
-        {self}
+      • {self}
 
 new({source}, {lang}, {opts})                             *languagetree.new()*
     A |LanguageTree| holds the treesitter parser for a given language {lang}
@@ -964,9 +964,9 @@ new({source}, {lang}, {opts})                             *languagetree.new()*
     may contain child languages themselves, hence the name).
 
     Parameters: ~
-        {source}  (number|string) Buffer or a string of text to parse
-        {lang}    (string) Root language this tree represents
-        {opts}    (table|nil) Optional keyword arguments:
+      • {source}  (number|string) Buffer or a string of text to parse
+      • {lang}    (string) Root language this tree represents
+      • {opts}    (table|nil) Optional keyword arguments:
                   • injections table Mapping language to injection query
                     strings. This is useful for overriding the built-in
                     runtime file searching for the injection language query

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -673,7 +673,7 @@ def fmt_node_as_vimhelp(parent, width=text_width - indentation, indent='',
         max_name_len = max_name(m.keys()) + 4
         out = ''
         for name, desc in m.items():
-            name = '    {}'.format('{{{}}}'.format(name).ljust(max_name_len))
+            name = '  • {}'.format('{{{}}}'.format(name).ljust(max_name_len))
             out += '{}{}\n'.format(name, desc)
         return out.rstrip()
 


### PR DESCRIPTION
Problem:
The {foo} parameters listed in `:help api` and similar generated docs, are intended to be a "list" but they aren't prefixed with a list symbol. This prevents parsers from understanding the list, which forces generators like `gen_help_html.lua` to use hard-wrapped/preformatted layout instead of a soft-wrapped "flow" layout.

Solution:
Modify gen_vimdoc.py to prefix {foo} parameters with a "•" symbol.