### PR TITLE
vim-patch:9.0.{0656,0661}: 'fillchars' "lastline"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2148,6 +2148,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When neither "lastline" nor "truncate" is included, a last line that
 	doesn't fit is replaced with "@" lines.
 
+	The "@" character can be changed by setting the "lastline" item in
+	'fillchars'.  The character is highlighted with |hl-NonText|.
+
 						*'eadirection'* *'ead'*
 'eadirection' 'ead'	string	(default "both")
 			global
@@ -2483,6 +2486,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  diff		'-'		deleted lines of the 'diff' option
 	  msgsep	' '		message separator 'display'
 	  eob		'~'		empty lines at the end of a buffer
+	  lastline	'@'		'display' contains lastline/truncate
 
 	Any one that is omitted will fall back to the default.  For "stl" and
 	"stlnc" the space will be used when there is highlighting, '^' or '='
@@ -2520,6 +2524,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  fold		Folded			|hl-Folded|
 	  diff		DiffDelete		|hl-DiffDelete|
 	  eob		EndOfBuffer		|hl-EndOfBuffer|
+	  lastline	NonText			|hl-NonText|
 
 		*'fixendofline'* *'fixeol'* *'nofixendofline'* *'nofixeol'*
 'fixendofline' 'fixeol'	boolean	(default on)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1168,6 +1168,7 @@ struct window_S {
     int diff;
     int msgsep;
     int eob;
+    int lastline;
   } w_p_fcs_chars;
 
   // "w_topline", "w_leftcol" and "w_skipcol" specify the offsets for

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1921,24 +1921,27 @@ win_update_start:
       wp->w_filler_rows = wp->w_grid.rows - srow;
     } else if (dy_flags & DY_TRUNCATE) {      // 'display' has "truncate"
       int scr_row = wp->w_grid.rows - 1;
+      int symbol = wp->w_p_fcs_chars.lastline;
+      char fillbuf[12];  // 2 characters of 6 bytes
+      int charlen = utf_char2bytes(symbol, &fillbuf[0]);
+      utf_char2bytes(symbol, &fillbuf[charlen]);
 
       // Last line isn't finished: Display "@@@" in the last screen line.
-      grid_puts_len(&wp->w_grid, "@@", MIN(wp->w_grid.cols, 2), scr_row, 0, at_attr);
-
-      grid_fill(&wp->w_grid, scr_row, scr_row + 1, 2, wp->w_grid.cols,
-                '@', ' ', at_attr);
+      grid_puts_len(&wp->w_grid, fillbuf, MIN(wp->w_grid.cols, 2) * charlen, scr_row, 0, at_attr);
+      grid_fill(&wp->w_grid, scr_row, scr_row + 1, 2, wp->w_grid.cols, symbol, ' ', at_attr);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else if (dy_flags & DY_LASTLINE) {      // 'display' has "lastline"
       int start_col = wp->w_grid.cols - 3;
+      int symbol = wp->w_p_fcs_chars.lastline;
 
       // Last line isn't finished: Display "@@@" at the end.
       grid_fill(&wp->w_grid, wp->w_grid.rows - 1, wp->w_grid.rows,
-                MAX(start_col, 0), wp->w_grid.cols, '@', '@', at_attr);
+                MAX(start_col, 0), wp->w_grid.cols, symbol, symbol, at_attr);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else {
-      win_draw_end(wp, '@', ' ', true, srow, wp->w_grid.rows, HLF_AT);
+      win_draw_end(wp, wp->w_p_fcs_chars.lastline, ' ', true, srow, wp->w_grid.rows, HLF_AT);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1328,6 +1328,7 @@ char *set_chars_option(win_T *wp, char **varp, bool apply)
     { &wp->w_p_fcs_chars.diff,       "diff",      '-' },
     { &wp->w_p_fcs_chars.msgsep,     "msgsep",    ' ' },
     { &wp->w_p_fcs_chars.eob,        "eob",       '~' },
+    { &wp->w_p_fcs_chars.lastline,   "lastline",  '@' },
   };
 
   struct chars_tab lcs_tab[] = {

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -435,6 +435,10 @@ func Run_Test_display_lastline(euro)
   call term_sendkeys(buf, ":3split\<CR>")
   call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}5', {})
 
+  call term_sendkeys(buf, ":close\<CR>")
+  call term_sendkeys(buf, ":2vsplit\<CR>")
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}6', {})
+
   call StopVimInTerminal(buf)
 endfunc
 

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -407,30 +407,45 @@ func Test_display_linebreak_breakat()
   let &breakat=_breakat
 endfunc
 
-func Test_display_lastline()
-  CheckScreendump
-
+func Run_Test_display_lastline(euro)
   let lines =<< trim END
-      call setline(1, ['aaa', 'b'->repeat(100)])
+      call setline(1, ['aaa', 'b'->repeat(200)])
       set display=truncate
+
       vsplit
       100wincmd <
   END
-  call writefile(lines, 'XdispLastline')
+  if a:euro != ''
+    let lines[2] = 'set fillchars=vert:\|,lastline:€'
+  endif
+  call writefile(lines, 'XdispLastline', 'D')
   let buf = RunVimInTerminal('-S XdispLastline', #{rows: 10})
-  call VerifyScreenDump(buf, 'Test_display_lastline_1', {})
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}1', {})
 
   call term_sendkeys(buf, ":set display=lastline\<CR>")
-  call VerifyScreenDump(buf, 'Test_display_lastline_2', {})
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}2', {})
 
   call term_sendkeys(buf, ":100wincmd >\<CR>")
-  call VerifyScreenDump(buf, 'Test_display_lastline_3', {})
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}3', {})
 
   call term_sendkeys(buf, ":set display=truncate\<CR>")
-  call VerifyScreenDump(buf, 'Test_display_lastline_4', {})
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}4', {})
+
+  call term_sendkeys(buf, ":close\<CR>")
+  call term_sendkeys(buf, ":3split\<CR>")
+  call VerifyScreenDump(buf, $'Test_display_lastline_{a:euro}5', {})
 
   call StopVimInTerminal(buf)
-  call delete('XdispLastline')
+endfunc
+
+func Test_display_lastline()
+  CheckScreendump
+
+  call Run_Test_display_lastline('')
+  call Run_Test_display_lastline('euro_')
+
+  call assert_fails(':set fillchars=lastline:', 'E474:')
+  call assert_fails(':set fillchars=lastline:〇', 'E474:')
 endfunc
 
 

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -9,6 +9,7 @@ local command = helpers.command
 describe('display', function()
   before_each(clear)
 
+  -- oldtest: Test_display_scroll_at_topline()
   it('scroll when modified at topline vim-patch:8.2.1488', function()
     local screen = Screen.new(20, 4)
     screen:attach()
@@ -26,6 +27,7 @@ describe('display', function()
     ]])
   end)
 
+  -- oldtest: Test_display_scroll_update_visual()
   it('scrolling when modified at topline in Visual mode vim-patch:8.2.4626', function()
     local screen = Screen.new(60, 8)
     screen:attach()
@@ -56,8 +58,8 @@ describe('display', function()
     ]])
   end)
 
-  it('@@@ in the last line shows correctly in a narrow window vim-patch:8.2.4718', function()
-    local screen = Screen.new(60, 10)
+  local function run_test_display_lastline(euro)
+    local screen = Screen.new(75, 10)
     screen:set_default_attr_ids({
       [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
       [2] = {bold = true, reverse = true},  -- StatusLine
@@ -65,39 +67,71 @@ describe('display', function()
     })
     screen:attach()
     exec([[
-      call setline(1, ['aaa', 'b'->repeat(100)])
+      call setline(1, ['aaa', 'b'->repeat(200)])
       set display=truncate
+
       vsplit
       100wincmd <
     ]])
-    screen:expect([[
-      ^a│aaa                                                       |
-      a│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
-      a│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                |
-      b│{1:~                                                         }|
-      b│{1:~                                                         }|
-      b│{1:~                                                         }|
-      b│{1:~                                                         }|
-      {1:@}│{1:~                                                         }|
-      {2:< }{3:[No Name] [+]                                             }|
-                                                                  |
-    ]])
+    local fillchar = '@'
+    if euro then
+      command('set fillchars=lastline:€')
+      fillchar = '€'
+    end
+    screen:expect((([[
+      ^a│aaa                                                                      |
+      a│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      a│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      b│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                   |
+      b│{1:~                                                                        }|
+      b│{1:~                                                                        }|
+      b│{1:~                                                                        }|
+      {1:@}│{1:~                                                                        }|
+      {2:< }{3:[No Name] [+]                                                            }|
+                                                                                 |
+    ]]):gsub('@', fillchar)))
+
     command('set display=lastline')
     screen:expect_unchanged()
+
     command('100wincmd >')
-    screen:expect([[
-      ^aaa                                                       │a|
-      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb│a|
-      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                │a|
-      {1:~                                                         }│b|
-      {1:~                                                         }│b|
-      {1:~                                                         }│b|
-      {1:~                                                         }│b|
-      {1:~                                                         }│{1:@}|
-      {2:[No Name] [+]                                              }{3:<}|
-                                                                  |
-    ]])
+    screen:expect((([[
+      ^aaa                                                                      │a|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb│a|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb│a|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                   │b|
+      {1:~                                                                        }│b|
+      {1:~                                                                        }│b|
+      {1:~                                                                        }│b|
+      {1:~                                                                        }│{1:@}|
+      {2:[No Name] [+]                                                             }{3:<}|
+                                                                                 |
+    ]]):gsub('@', fillchar)))
+
     command('set display=truncate')
     screen:expect_unchanged()
+
+    command('close')
+    command('3split')
+    screen:expect((([[
+      ^aaa                                                                        |
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      {1:@@@                                                                        }|
+      {2:[No Name] [+]                                                              }|
+      aaa                                                                        |
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                         |
+      {3:[No Name] [+]                                                              }|
+                                                                                 |
+    ]]):gsub('@', fillchar)))
+  end
+
+  -- oldtest: Test_display_lastline()
+  it('display "lastline" works correctly', function()
+    run_test_display_lastline()
+  end)
+  it('display "lastline" works correctly with multibyte fillchar', function()
+    run_test_display_lastline(true)
   end)
 end)

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -125,6 +125,21 @@ describe('display', function()
       {3:[No Name] [+]                                                              }|
                                                                                  |
     ]]):gsub('@', fillchar)))
+
+    command('close')
+    command('2vsplit')
+    screen:expect((([[
+      ^aa│aaa                                                                     |
+      a │bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bb│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bb│bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb                |
+      bb│{1:~                                                                       }|
+      bb│{1:~                                                                       }|
+      bb│{1:~                                                                       }|
+      {1:@@}│{1:~                                                                       }|
+      {2:<  }{3:[No Name] [+]                                                           }|
+                                                                                 |
+    ]]):gsub('@', fillchar)))
   end
 
   -- oldtest: Test_display_lastline()


### PR DESCRIPTION
Close #19908

#### vim-patch:9.0.0656: cannot specify another character to use instead of '@'

Problem:    Cannot specify another character to use instead of '@' at the end
            of the window.
Solution:   Add "lastline" to 'fillchars'. (Martin Tournoij, closes vim/vim#11264)
https://github.com/vim/vim/commit/4ba5f1dab656103e8f4a4505452d1816b9e83c1e

Use latest code in drawscreen.c instead.


#### vim-patch:9.0.0661: multi-byte "lastline" in 'fillchars' does not work properly

Problem:    Multi-byte "lastline" item in 'fillchars' does not work properly
            when the window is two columns wide.
Solution:   Compute the text length correctly. (closes vim/vim#11280)
https://github.com/vim/vim/commit/18b3500b8c517e44c23197e558aa36aed1c6916c