### PR TITLE
build(deps): restore support for USE_EXISTING_SRC_DIR

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -66,6 +66,8 @@ else()
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." OFF)
 endif()
 
+option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
+
 find_package(Git)
 if(NOT Git_FOUND)
   message(FATAL_ERROR "Git is required to apply patches.")

--- a/cmake.deps/cmake/BuildGettext.cmake
+++ b/cmake.deps/cmake/BuildGettext.cmake
@@ -1,4 +1,7 @@
 if(MSVC)
+  if(USE_EXISTING_SRC_DIR)
+    unset(GETTEXT_URL)
+  endif()
   ExternalProject_Add(gettext
     URL ${GETTEXT_URL}
     URL_HASH SHA256=${GETTEXT_SHA256}

--- a/cmake.deps/cmake/BuildLibiconv.cmake
+++ b/cmake.deps/cmake/BuildLibiconv.cmake
@@ -1,4 +1,7 @@
 if(MSVC)
+  if(USE_EXISTING_SRC_DIR)
+    unset(LIBICONV_URL)
+  endif()
   ExternalProject_Add(libiconv
     URL ${LIBICONV_URL}
     URL_HASH SHA256=${LIBICONV_SHA256}

--- a/cmake.deps/cmake/BuildLibtermkey.cmake
+++ b/cmake.deps/cmake/BuildLibtermkey.cmake
@@ -22,6 +22,9 @@ else()
     CFLAGS=-fPIC LDFLAGS+=-static ${DEFAULT_MAKE_CFLAGS} install)
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LIBTERMKEY_URL)
+endif()
 ExternalProject_Add(libtermkey
   URL ${LIBTERMKEY_URL}
   URL_HASH SHA256=${LIBTERMKEY_SHA256}

--- a/cmake.deps/cmake/BuildLibuv.cmake
+++ b/cmake.deps/cmake/BuildLibuv.cmake
@@ -1,3 +1,6 @@
+if(USE_EXISTING_SRC_DIR)
+  unset(LIBUV_URL)
+endif()
 ExternalProject_Add(libuv
   URL ${LIBUV_URL}
   URL_HASH SHA256=${LIBUV_SHA256}

--- a/cmake.deps/cmake/BuildLibvterm.cmake
+++ b/cmake.deps/cmake/BuildLibvterm.cmake
@@ -24,6 +24,9 @@ else()
                                            install)
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LIBVTERM_URL)
+endif()
 ExternalProject_Add(libvterm
   URL ${LIBVTERM_URL}
   URL_HASH SHA256=${LIBVTERM_SHA256}

--- a/cmake.deps/cmake/BuildLua.cmake
+++ b/cmake.deps/cmake/BuildLua.cmake
@@ -42,6 +42,9 @@ set(LUA_INSTALL_TOP_ARG "INSTALL_TOP=${DEPS_INSTALL_DIR}")
 
 message(STATUS "Lua target is ${LUA_TARGET}")
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LUA_URL)
+endif()
 ExternalProject_Add(lua
   URL ${LUA_URL}
   URL_HASH SHA256=${LUA_SHA256}

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -15,6 +15,9 @@ function(BuildLuajit)
     set(_luajit_TARGET "luajit")
   endif()
 
+  if(USE_EXISTING_SRC_DIR)
+    unset(LUAJIT_URL)
+  endif()
   ExternalProject_Add(${_luajit_TARGET}
     URL ${LUAJIT_URL}
     URL_HASH SHA256=${LUAJIT_SHA256}

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -81,6 +81,9 @@ else()
   message(FATAL_ERROR "Trying to build luarocks in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LUAROCKS_URL)
+endif()
 ExternalProject_Add(luarocks
   URL ${LUAROCKS_URL}
   URL_HASH SHA256=${LUAROCKS_SHA256}

--- a/cmake.deps/cmake/BuildLuv.cmake
+++ b/cmake.deps/cmake/BuildLuv.cmake
@@ -55,6 +55,9 @@ else()
   endif()
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LUA_COMPAT53_URL)
+endif()
 ExternalProject_Add(lua-compat-5.3
   URL ${LUA_COMPAT53_URL}
   URL_HASH SHA256=${LUA_COMPAT53_SHA256}
@@ -64,6 +67,9 @@ ExternalProject_Add(lua-compat-5.3
   BUILD_COMMAND ""
   INSTALL_COMMAND "")
 
+if(USE_EXISTING_SRC_DIR)
+  unset(LUV_URL)
+endif()
 ExternalProject_Add(luv-static
   DEPENDS lua-compat-5.3
   URL ${LUV_URL}

--- a/cmake.deps/cmake/BuildMsgpack.cmake
+++ b/cmake.deps/cmake/BuildMsgpack.cmake
@@ -21,6 +21,9 @@ if(MSVC)
     -DCMAKE_GENERATOR=${CMAKE_GENERATOR})
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(MSGPACK_URL)
+endif()
 ExternalProject_Add(msgpack
   URL ${MSGPACK_URL}
   URL_HASH SHA256=${MSGPACK_SHA256}

--- a/cmake.deps/cmake/BuildTreesitter.cmake
+++ b/cmake.deps/cmake/BuildTreesitter.cmake
@@ -17,6 +17,9 @@ else()
     ${MAKE_PRG} CC=${DEPS_C_COMPILER} PREFIX=${DEPS_INSTALL_DIR} install)
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(TREESITTER_URL)
+endif()
 ExternalProject_Add(tree-sitter
   URL ${TREESITTER_URL}
   URL_HASH SHA256=${TREESITTER_SHA256}

--- a/cmake.deps/cmake/BuildTreesitterParsers.cmake
+++ b/cmake.deps/cmake/BuildTreesitterParsers.cmake
@@ -1,5 +1,8 @@
 function(BuildTSParser LANG TS_URL TS_SHA256 TS_CMAKE_FILE)
   set(NAME treesitter-${LANG})
+  if(USE_EXISTING_SRC_DIR)
+    unset(TS_URL)
+  endif()
   ExternalProject_Add(${NAME}
     URL ${TS_URL}
     URL_HASH SHA256=${TS_SHA256}

--- a/cmake.deps/cmake/BuildUnibilium.cmake
+++ b/cmake.deps/cmake/BuildUnibilium.cmake
@@ -16,6 +16,9 @@ else()
   set(UNIBILIUM_INSTALL_COMMAND ${MAKE_PRG} PREFIX=${DEPS_INSTALL_DIR} install)
 endif()
 
+if(USE_EXISTING_SRC_DIR)
+  unset(UNIBILIUM_URL)
+endif()
 ExternalProject_Add(unibilium
   URL ${UNIBILIUM_URL}
   URL_HASH SHA256=${UNIBILIUM_SHA256}

--- a/cmake.deps/cmake/GetBinaryDeps.cmake
+++ b/cmake.deps/cmake/GetBinaryDeps.cmake
@@ -22,6 +22,9 @@ function(GetBinaryDep)
     message(FATAL_ERROR "${URL_VARNAME} and ${HASH_VARNAME} must be set")
   endif()
 
+  if(USE_EXISTING_SRC_DIR)
+    unset(URL)
+  endif()
   ExternalProject_Add(${_gettool_TARGET}
     URL ${URL}
     URL_HASH SHA256=${HASH}


### PR DESCRIPTION
59d5f692f removed cmake.deps/cmake/DownloadAndExtractFile.cmake and support for USE_EXISTING_SRC_DIR.  The Ubuntu nightly PPA still relies on USE_EXISTING_SRC_DIR functionality since it can't access the network during the build.

Supplying an empty value for ExternalProject_Add()'s URL value appears to provide the needed mechanism to avoid re-downloading when the sources are already present.  This is undocumented behavior, though, so it may break in the future.

Now, if USE_EXISTING_SRC_DIR is set, the ExternalProject's URL variable is unset, preventing the download and erroring out if the source doesn't actually exist.