### PR TITLE
refactor(typval): changes to `tv_copy`

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3931,8 +3931,7 @@ static void partial_free(partial_T *pt)
 
 // TODO(ZyX-I): Move to eval/typval.h
 
-/// Unreference a closure: decrement the reference count and free it when it
-/// becomes zero.
+/// Unreference a closure: decrement the reference count and free it when it becomes zero.
 void partial_unref(partial_T *pt)
 {
   if (pt != NULL && --pt->pt_refcount <= 0) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -649,7 +649,7 @@ static void cleanup_function_call(funccall_T *fc)
 
     // Make a copy of the a: variables, since we didn't do that above.
     TV_DICT_ITER(&fc->l_avars, di, {
-      tv_copy(&di->di_tv, &di->di_tv);
+      tv_increment_refcount(&di->di_tv);
     });
   }
 
@@ -661,7 +661,7 @@ static void cleanup_function_call(funccall_T *fc)
 
     // Make a copy of the a:000 items, since we didn't do that above.
     TV_LIST_ITER(&fc->l_varlist, li, {
-      tv_copy(TV_LIST_ITEM_TV(li), TV_LIST_ITEM_TV(li));
+      tv_increment_refcount(TV_LIST_ITEM_TV(li));
     });
   }
 
@@ -977,7 +977,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     if (addlocal) {
       // Named arguments can be accessed without the "a:" prefix in lambda
       // expressions. Add to the l: dict.
-      tv_copy(&v->di_tv, &v->di_tv);
+      tv_increment_refcount(&v->di_tv);
       tv_dict_add(&fc->l_vars, v);
     } else {
       tv_dict_add(&fc->l_avars, v);


### PR DESCRIPTION
`tv_copy` will no longer increment refcount when the source and destination are same. Instead, places which utilize this behavior of `tv_copy` will now use the new `tv_increment_refcount` function, which increases explicitness and makes the intent clearer.