### PR TITLE
vim-patch:9.0.0665: setting 'cmdheight' has no effect if last window was resized

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2468,7 +2468,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
     // if p_ch changed value, change the command line height
     // Only compute the new window layout when startup has been
     // completed. Otherwise the frame sizes may be wrong.
-    if (p_ch != old_value && full_screen) {
+    if ((p_ch != old_value || topframe->fr_height != Rows - p_ch) && full_screen) {
       command_height();
     }
   } else if (pp == &p_uc) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -186,8 +186,15 @@ func Test_changing_cmdheight()
 
   let lines =<< trim END
       set cmdheight=1 laststatus=2
+      func EchoTwo()
+        set laststatus=2
+        set cmdheight=5
+        echo 'foo'
+        echo 'bar'
+        set cmdheight=1
+      endfunc
   END
-  call writefile(lines, 'XTest_cmdheight')
+  call writefile(lines, 'XTest_cmdheight', 'D')
 
   let buf = RunVimInTerminal('-S XTest_cmdheight', {'rows': 8})
   call term_sendkeys(buf, ":resize -3\<CR>")
@@ -205,14 +212,17 @@ func Test_changing_cmdheight()
   call term_sendkeys(buf, ":set cmdheight-=2\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_4', {})
 
-  " reducing window size and then setting cmdheight
+  " reducing window size and then setting cmdheight 
   call term_sendkeys(buf, ":resize -1\<CR>")
   call term_sendkeys(buf, ":set cmdheight=1\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_5', {})
 
+  " setting 'cmdheight' works after outputting two messages
+  call term_sendkeys(buf, ":call EchoTwo()\<CR>")
+  call VerifyScreenDump(buf, 'Test_changing_cmdheight_6', {})
+
   " clean up
   call StopVimInTerminal(buf)
-  call delete('XTest_cmdheight')
 endfunc
 
 func Test_map_completion()

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6263,7 +6263,7 @@ void win_comp_scroll(win_T *wp)
   }
 }
 
-// command_height: called whenever p_ch has been changed
+/// command_height: called whenever p_ch has been changed.
 void command_height(void)
 {
   int h;
@@ -6274,6 +6274,9 @@ void command_height(void)
   // GUI starts up, we can't be sure in what order things happen.  And when
   // p_ch was changed in another tab page.
   curtab->tp_ch_used = p_ch;
+
+  // Update cmdline_row to what it should be: just below the last window.
+  cmdline_row = topframe->fr_height;
 
   // If cmdline_row is smaller than what it is supposed to be for 'cmdheight'
   // then set old_p_ch to what it would be, so that the windows get resized

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -172,6 +172,47 @@ describe('cmdline', function()
                                     |
     ]])
   end)
+
+  it("setting 'cmdheight' works after outputting two messages vim-patch:9.0.0665", function()
+    local screen = Screen.new(60, 8)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, reverse = true},  -- StatusLine
+    })
+    screen:attach()
+    exec([[
+      set cmdheight=1 laststatus=2
+      func EchoTwo()
+        set laststatus=2
+        set cmdheight=5
+        echo 'foo'
+        echo 'bar'
+        set cmdheight=1
+      endfunc
+    ]])
+    feed(':call EchoTwo()')
+    screen:expect([[
+                                                                  |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {1:[No Name]                                                   }|
+      :call EchoTwo()^                                             |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                                            |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {1:[No Name]                                                   }|
+                                                                  |
+    ]])
+  end)
 end)
 
 describe('cmdwin', function()


### PR DESCRIPTION
Fix #20486

#### vim-patch:9.0.0665: setting 'cmdheight' has no effect if last window was resized

Problem:    Setting 'cmdheight' has no effect if last window was resized.
Solution:   Do apply 'cmdheight' when told to.  Use the frame height instead
            of the cmdline_row.
https://github.com/vim/vim/commit/0816f473ab2f6cf7d8311c0f97371cada7f20d18
