### PR TITLE
vim-patch:9.0.0666: spacing-combining characters handled as composing

### DIFF
--- a/src/nvim/generators/gen_unicode_tables.lua
+++ b/src/nvim/generators/gen_unicode_tables.lua
@@ -153,7 +153,8 @@ local build_combining_table = function(ut_fp, dataprops)
   local start = -1
   local end_ = -1
   for _, p in ipairs(dataprops) do
-    if (({Mn=true, Mc=true, Me=true})[p[3]]) then
+    -- The 'Mc' property was removed, it does take up space.
+    if (({Mn=true, Me=true})[p[3]]) then
       local n = tonumber(p[1], 16)
       if start >= 0 and end_ + 1 == n then
         -- Continue with the same range.


### PR DESCRIPTION
#### vim-patch:9.0.0666: spacing-combining characters handled as composing

Problem:    Spacing-combining characters handled as composing, causing text to
            take more space than expected.
Solution:   Handle characters marked with "Mc" not as composing.
https://github.com/vim/vim/commit/7beaf6a720ddc7e2989c8831872bfb98ec78a65d