### PR TITLE
vim-patch:9.0.0422: not enough testing of the :all command

### DIFF
--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -610,4 +610,130 @@ func Test_clear_arglist_in_all()
   au! *
 endfunc
 
+" Test for the :all command
+func Test_all_command()
+  %argdelete
+
+  " :all command should not close windows with files in the argument list,
+  " but can rearrange the windows.
+  args Xargnew1 Xargnew2
+  %bw!
+  edit Xargold1
+  split Xargnew1
+  let Xargnew1_winid = win_getid()
+  split Xargold2
+  split Xargnew2
+  let Xargnew2_winid = win_getid()
+  split Xargold3
+  all
+  call assert_equal(2, winnr('$'))
+  call assert_equal([Xargnew1_winid, Xargnew2_winid],
+        \ [win_getid(1), win_getid(2)])
+  call assert_equal([bufnr('Xargnew1'), bufnr('Xargnew2')],
+        \ [winbufnr(1), winbufnr(2)])
+
+  " :all command should close windows for files which are not in the
+  " argument list in the current tab page.
+  %bw!
+  edit Xargold1
+  split Xargold2
+  tabedit Xargold3
+  split Xargold4
+  tabedit Xargold5
+  tabfirst
+  all
+  call assert_equal(3, tabpagenr('$'))
+  call assert_equal([bufnr('Xargnew1'), bufnr('Xargnew2')], tabpagebuflist(1))
+  call assert_equal([bufnr('Xargold4'), bufnr('Xargold3')], tabpagebuflist(2))
+  call assert_equal([bufnr('Xargold5')], tabpagebuflist(3))
+
+  " :tab all command should close windows for files which are not in the
+  " argument list across all the tab pages.
+  %bw!
+  edit Xargold1
+  split Xargold2
+  tabedit Xargold3
+  split Xargold4
+  tabedit Xargold5
+  tabfirst
+  args Xargnew1 Xargnew2
+  tab all
+  call assert_equal(2, tabpagenr('$'))
+  call assert_equal([bufnr('Xargnew1')], tabpagebuflist(1))
+  call assert_equal([bufnr('Xargnew2')], tabpagebuflist(2))
+
+  " If a count is specified, then :all should open only that many windows.
+  %bw!
+  args Xargnew1 Xargnew2 Xargnew3 Xargnew4 Xargnew5
+  all 3
+  call assert_equal(3, winnr('$'))
+  call assert_equal([bufnr('Xargnew1'), bufnr('Xargnew2'), bufnr('Xargnew3')],
+        \ [winbufnr(1), winbufnr(2), winbufnr(3)])
+
+  " The :all command should not open more than 'tabpagemax' tab pages.
+  " If there are more files, then they should be opened in the last tab page.
+  %bw!
+  set tabpagemax=3
+  tab all
+  call assert_equal(3, tabpagenr('$'))
+  call assert_equal([bufnr('Xargnew1')], tabpagebuflist(1))
+  call assert_equal([bufnr('Xargnew2')], tabpagebuflist(2))
+  call assert_equal([bufnr('Xargnew3'), bufnr('Xargnew4'), bufnr('Xargnew5')],
+        \ tabpagebuflist(3))
+  set tabpagemax&
+
+  " Without the 'hidden' option, modified buffers should not be closed.
+  args Xargnew1 Xargnew2
+  %bw!
+  edit Xargtemp1
+  call setline(1, 'temp buffer 1')
+  split Xargtemp2
+  call setline(1, 'temp buffer 2')
+  all
+  call assert_equal(4, winnr('$'))
+  call assert_equal([bufnr('Xargtemp2'), bufnr('Xargtemp1'), bufnr('Xargnew1'),
+        \ bufnr('Xargnew2')],
+        \ [winbufnr(1), winbufnr(2), winbufnr(3), winbufnr(4)])
+
+  " With the 'hidden' option set, both modified and unmodified buffers in
+  " closed windows should be hidden.
+  set hidden
+  all
+  call assert_equal(2, winnr('$'))
+  call assert_equal([bufnr('Xargnew1'), bufnr('Xargnew2')],
+        \ [winbufnr(1), winbufnr(2)])
+  call assert_equal([1, 1, 0, 0], [getbufinfo('Xargtemp1')[0].hidden,
+        \ getbufinfo('Xargtemp2')[0].hidden,
+        \ getbufinfo('Xargnew1')[0].hidden,
+        \ getbufinfo('Xargnew2')[0].hidden])
+  set nohidden
+
+  " When 'winheight' is set to a large value, :all should open only one
+  " window.
+  args Xargnew1 Xargnew2 Xargnew3 Xargnew4 Xargnew5
+  %bw!
+  set winheight=9999
+  call assert_fails('all', 'E36:')
+  call assert_equal([1, bufnr('Xargnew1')], [winnr('$'), winbufnr(1)])
+  set winheight&
+
+  " When 'winwidth' is set to a large value, :vert all should open only one
+  " window.
+  %bw!
+  set winwidth=9999
+  call assert_fails('vert all', 'E36:')
+  call assert_equal([1, bufnr('Xargnew1')], [winnr('$'), winbufnr(1)])
+  set winwidth&
+
+  " empty argument list tests
+  %bw!
+  %argdelete
+  call assert_equal('', execute('args'))
+  all
+  call assert_equal(1, winnr('$'))
+
+  %argdelete
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0422: not enough testing of the :all command

Problem:    Not enough testing of the :all command.
Solution:   Add more testing. (Yegappan Lakshmanan, closes vim/vim#11091)
https://github.com/vim/vim/commit/0dc2fd307ffc223cf010d1fdea6e3d5c4524d43c