### PR TITLE
vim-patch:9.0.0657: too many #ifdefs

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -1024,7 +1024,8 @@ static void do_arg_all(int count, int forceit, int keep_tabs)
     return;
   }
   if (ARGCOUNT <= 0) {
-    // Don't give an error message.  We don't want it when the ":all" command is in the .vimrc.
+    // Don't give an error message.  We don't want it when the ":all"
+    // command is in the .vimrc.
     return;
   }
   setpcmark();

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1740,9 +1740,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     }
 
     // click in a tab selects that tab page
-    if (is_click
-        && cmdwin_type == 0
-        && mouse_col < Columns) {
+    if (is_click && cmdwin_type == 0 && mouse_col < Columns) {
       in_tab_line = true;
       c1 = tab_page_click_defs[mouse_col].tabnr;
       switch (tab_page_click_defs[mouse_col].type) {
@@ -6918,10 +6916,7 @@ static void nv_esc(cmdarg_T *cap)
                && cap->oap->regname == 0);
 
   if (cap->arg) {               // true for CTRL-C
-    if (restart_edit == 0
-        && cmdwin_type == 0
-        && !VIsual_active
-        && no_reason) {
+    if (restart_edit == 0 && cmdwin_type == 0 && !VIsual_active && no_reason) {
       if (anyBufIsChanged()) {
         msg(_("Type  :qa!  and press <Enter> to abandon all changes"
               " and exit Nvim"));


### PR DESCRIPTION
#### vim-patch:9.0.0657: too many #ifdefs

Problem:    Too many #ifdefs.
Solution:   Graduate the +cmdwin feature.  Now the tiny and small builds are
            equal, drop the small build.  (Martin Tournoij, closes vim/vim#11268)
https://github.com/vim/vim/commit/7904fa420eb577274c4c3711295240100167d495

Accidentally forgot to mark as ported:

vim-patch:9.0.0471: no test for what patch 9.0.0469 fixes

Problem:    No test for what patch 9.0.0469 fixes.
Solution:   Add a test. (closes vim/vim#11140)
https://github.com/vim/vim/commit/12167d8b84c4a99751d9928f1a9a59c90b14931f