### PR TITLE
ci: update which paths to ignore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
     paths-ignore:
-      - 'runtime/doc/*'
+      - 'contrib/**'
 
 # Cancel any in-progress CI runs for a PR if it is updated
 concurrency:


### PR DESCRIPTION
Skipping the CI on documentation-only changes is no longer appropriate
as we now rely on CI to test parts of documentation, e.g.
test/functional/lua/help_spec.lua.

Ignore changes in contrib/ as it's for non-essential user contributions
that we don't need to test.