### PR TITLE
vim-patch:9.0.0670: no space for command line when there is a tabline

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2468,7 +2468,9 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
     // if p_ch changed value, change the command line height
     // Only compute the new window layout when startup has been
     // completed. Otherwise the frame sizes may be wrong.
-    if ((p_ch != old_value || topframe->fr_height != Rows - p_ch) && full_screen) {
+    if ((p_ch != old_value
+         || tabline_height() + topframe->fr_height != Rows - p_ch)
+        && full_screen) {
       command_height();
     }
   } else if (pp == &p_uc) {

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -225,6 +225,16 @@ func Test_changing_cmdheight()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_cmdheight_tabline()
+  CheckScreendump
+
+  let buf = RunVimInTerminal('-c "set ls=2" -c "set stal=2" -c "set cmdheight=1"', {'rows': 6})
+  call VerifyScreenDump(buf, 'Test_cmdheight_tabline_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_map_completion()
   if !has('cmdline_compl')
     return

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4300,7 +4300,7 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, bool trigger_enter_a
   // When cmdheight is changed in a tab page with '<C-w>-', cmdline_row is
   // changed but p_ch and tp_ch_used are not changed. Thus we also need to
   // check cmdline_row.
-  if ((row < cmdline_row) && (cmdline_row <= Rows - p_ch)) {
+  if (row < cmdline_row && cmdline_row <= Rows - p_ch) {
     clear_cmdline = true;
   }
 
@@ -6409,7 +6409,7 @@ void command_height(void)
   curtab->tp_ch_used = p_ch;
 
   // Update cmdline_row to what it should be: just below the last window.
-  cmdline_row = topframe->fr_height;
+  cmdline_row = topframe->fr_height + tabline_height();
 
   // If cmdline_row is smaller than what it is supposed to be for 'cmdheight'
   // then set old_p_ch to what it would be, so that the windows get resized

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -5,6 +5,7 @@ local command = helpers.command
 local feed = helpers.feed
 local feed_command = helpers.feed_command
 local exec = helpers.exec
+local meths = helpers.meths
 local pesc = helpers.pesc
 
 describe('cmdline', function()
@@ -205,6 +206,31 @@ describe('cmdline', function()
     screen:expect([[
       ^                                                            |
       {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {1:[No Name]                                                   }|
+                                                                  |
+    ]])
+  end)
+
+  -- oldtest: Test_cmdheight_tabline()
+  it("changing 'cmdheight' when there is a tabline", function()
+    local screen = Screen.new(60, 8)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {bold = true, reverse = true},  -- StatusLine
+      [2] = {bold = true},  -- TabLineSel
+      [3] = {reverse = true},  -- TabLineFill
+    })
+    screen:attach()
+    meths.set_option('laststatus', 2)
+    meths.set_option('showtabline', 2)
+    meths.set_option('cmdheight', 1)
+    screen:expect([[
+      {2: [No Name] }{3:                                                 }|
+      ^                                                            |
       {0:~                                                           }|
       {0:~                                                           }|
       {0:~                                                           }|


### PR DESCRIPTION
#### vim-patch:9.0.0670: no space for command line when there is a tabline

Problem:    No space for command line when there is a tabline.
Solution:   Correct computation of where the command line should be.
https://github.com/vim/vim/commit/c9f5f73206272ccad0aa536854debc5f9781978a