### PR TITLE
vim-patch:9.0.0678: using exclamation marks on :function

### DIFF
--- a/src/nvim/testdir/script_util.vim
+++ b/src/nvim/testdir/script_util.vim
@@ -48,7 +48,7 @@ endfunc
 " delete it afterwards.  However, if an exception is thrown the file may remain,
 " the caller should call DeleteTheScript() afterwards.
 let s:script_name = ''
-function! ExecAsScript(funcname)
+func ExecAsScript(funcname)
     " Make a script from the function passed as argument.
     let s:script_name = MakeScript(a:funcname)
 
@@ -56,9 +56,9 @@ function! ExecAsScript(funcname)
     exec "source" s:script_name
     call delete(s:script_name)
     let s:script_name = ''
-endfunction
+endfunc
 
-function! DeleteTheScript()
+func DeleteTheScript()
     if s:script_name
 	call delete(s:script_name)
 	let s:script_name = ''

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -3,26 +3,26 @@
 source check.vim
 source screendump.vim
 
-function! s:screen_attr(lnum) abort
+func s:screen_attr(lnum) abort
   return map(range(1, 8), 'screenattr(a:lnum, v:val)')
-endfunction
+endfunc
 
-function! s:test_windows(h, w) abort
+func s:test_windows(h, w) abort
   call NewWindow(a:h, a:w)
-endfunction
+endfunc
 
-function! s:close_windows() abort
+func s:close_windows() abort
   call CloseWindow()
-endfunction
+endfunc
 
-function! s:new_hi() abort
+func s:new_hi() abort
   redir => save_hi
   silent! hi CursorLineNr
   redir END
   let save_hi = join(split(substitute(save_hi, '\s*xxx\s*', ' ', ''), "\n"), '')
   exe 'hi' save_hi 'ctermbg=0 guibg=Black'
   return save_hi
-endfunction
+endfunc
 
 func Test_cursorline_highlight1()
   let save_hi = s:new_hi()

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -1129,15 +1129,15 @@ func Test_CompleteChanged()
 
   autocmd! AAAAA_Group
   set complete& completeopt&
-  delfunc! OnPumchange
+  delfunc! OnPumChange
   bw!
 endfunc
 
-function! GetPumPosition()
+func GetPumPosition()
   call assert_true( pumvisible() )
   let g:pum_pos = pum_getpos()
   return ''
-endfunction
+endfunc
 
 func Test_pum_getpos()
   new

--- a/src/nvim/testdir/test_prompt_buffer.vim
+++ b/src/nvim/testdir/test_prompt_buffer.vim
@@ -223,7 +223,7 @@ func Test_prompt_buffer_getbufinfo()
   %bwipe!
 endfunc
 
-function! Test_prompt_while_writing_to_hidden_buffer()
+func Test_prompt_while_writing_to_hidden_buffer()
   throw 'skipped: TODO'
   call CanTestPromptBuffer()
   CheckUnix

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -756,23 +756,23 @@ endfunc
 
 XpathINIT
 
-function! NULL()
+func NULL()
     Xpath 'a'
     return 0
-endfunction
+endfunc
 
-function! ZERO()
+func ZERO()
     Xpath 'b'
     return 0
-endfunction
+endfunc
 
-function! F0()
+func! F0()
     Xpath 'c'
-endfunction
+endfunc
 
-function! F1(arg)
+func! F1(arg)
     Xpath 'e'
-endfunction
+endfunc
 
 let V0 = 1
 
@@ -1370,10 +1370,10 @@ endfunc
 " Test 95:  lines of :append, :change, :insert			    {{{1
 "-------------------------------------------------------------------------------
 
-function! DefineFunction(name, body)
+func DefineFunction(name, body)
     let func = join(['function! ' . a:name . '()'] + a:body + ['endfunction'], "\n")
     exec func
-endfunction
+endfunc
 
 func Test_script_lines()
     " :append

--- a/src/nvim/testdir/view_util.vim
+++ b/src/nvim/testdir/view_util.vim
@@ -19,7 +19,7 @@ endfunc
 " Get text on the screen, including composing characters.
 " ScreenLines(lnum, width) or
 " ScreenLines([start, end], width)
-function! ScreenLines(lnum, width) abort
+func ScreenLines(lnum, width) abort
   redraw!
   if type(a:lnum) == v:t_list
     let start = a:lnum[0]
@@ -33,9 +33,9 @@ function! ScreenLines(lnum, width) abort
     let lines += [join(map(range(1, a:width), 'screenstring(l, v:val)'), '')]
   endfor
   return lines
-endfunction
+endfunc
 
-function! ScreenAttrs(lnum, width) abort
+func ScreenAttrs(lnum, width) abort
   redraw!
   if type(a:lnum) == v:t_list
     let start = a:lnum[0]
@@ -49,16 +49,16 @@ function! ScreenAttrs(lnum, width) abort
     let attrs += [map(range(1, a:width), 'screenattr(l, v:val)')]
   endfor
   return attrs
-endfunction
+endfunc
 
-function! NewWindow(height, width) abort
+func NewWindow(height, width) abort
   exe a:height . 'new'
   exe a:width . 'vsp'
   set winfixwidth winfixheight
   redraw!
-endfunction
+endfunc
 
-function! CloseWindow() abort
+func CloseWindow() abort
   bw!
   redraw!
-endfunction
+endfunc


### PR DESCRIPTION
#### vim-patch:9.0.0678: using exclamation marks on :function

Problem:    Using exclamation marks on :function.
Solution:   Use :func and :endfunc as usual.
https://github.com/vim/vim/commit/97f0eb169bf805c372b13c6bc9a03da2e75e3354

Add a missing change from patch 8.1.1875.