### PR TITLE
fix: find multibyte file name in line

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -3002,9 +3002,9 @@ static void foldlevelMarker(fline_T *flp)
 
   // cache a few values for speed
   char *startmarker = flp->wp->w_p_fmr;
-  int cstart = (unsigned char)(*startmarker);
+  char cstart = *startmarker;
   startmarker++;
-  int cend = (unsigned char)(*foldendmarker);
+  char cend = *foldendmarker;
 
   // Default: no start found, next level is same as current level
   flp->start = 0;
@@ -3012,7 +3012,7 @@ static void foldlevelMarker(fline_T *flp)
 
   char *s = ml_get_buf(flp->wp->w_buffer, flp->lnum + flp->off, false);
   while (*s) {
-    if ((unsigned char)(*s) == cstart
+    if (*s == cstart
         && STRNCMP(s + 1, startmarker, foldstartmarkerlen - 1) == 0) {
       // found startmarker: set flp->lvl
       s += foldstartmarkerlen;
@@ -3032,7 +3032,7 @@ static void foldlevelMarker(fline_T *flp)
         flp->lvl_next++;
         flp->start++;
       }
-    } else if ((unsigned char)(*s) == cend
+    } else if (*s == cend
                && STRNCMP(s + 1, foldendmarker + 1, foldendmarkerlen - 1) == 0) {
       // found endmarker: set flp->lvl_next
       s += foldendmarkerlen;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6545,7 +6545,7 @@ char_u *file_name_in_line(char_u *line, int col, int options, long count, char_u
 
   // search forward for what could be the start of a file name
   ptr = (char *)line + col;
-  while (*ptr != NUL && !vim_isfilec(*ptr)) {
+  while (*ptr != NUL && !vim_isfilec((uint8_t)(*ptr))) {
     MB_PTR_ADV(ptr);
   }
   if (*ptr == NUL) {            // nothing found
@@ -6560,7 +6560,8 @@ char_u *file_name_in_line(char_u *line, int col, int options, long count, char_u
   while ((char_u *)ptr > line) {
     if ((len = (size_t)(utf_head_off((char *)line, ptr - 1))) > 0) {
       ptr -= len + 1;
-    } else if (vim_isfilec(ptr[-1]) || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
+    } else if (vim_isfilec((uint8_t)ptr[-1])
+               || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
       ptr--;
     } else {
       break;
@@ -6570,7 +6571,7 @@ char_u *file_name_in_line(char_u *line, int col, int options, long count, char_u
   // Search forward for the last char of the file name.
   // Also allow ":/" when ':' is not in 'isfname'.
   len = 0;
-  while (vim_isfilec(ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
+  while (vim_isfilec((uint8_t)ptr[len]) || (ptr[len] == '\\' && ptr[len + 1] == ' ')
          || ((options & FNAME_HYP) && path_is_url(ptr + len))
          || (is_url && vim_strchr(":?&=", ptr[len]) != NULL)) {
     // After type:// we also include :, ?, & and = as valid characters, so that

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -4,6 +4,8 @@ local eq = helpers.eq
 local eval = helpers.eval
 local command = helpers.command
 local iswin = helpers.iswin
+local insert = helpers.insert
+local feed = helpers.feed
 
 describe('path collapse', function()
   local targetdir
@@ -52,5 +54,17 @@ describe('path collapse', function()
     command('cd test')
     command('edit '..join_path('.', '..', targetdir, 'tty-test.c'))
     eq(expected_path, eval('expand("%:p")'))
+  end)
+end)
+
+describe('file search', function()
+  before_each(clear)
+
+  it('find multibyte file name in line #20517', function()
+    command('cd test/functional/fixtures')
+    insert('filename_with_unicode_ααα')
+    eq('', eval('expand("%")'))
+    feed('gf')
+    eq('filename_with_unicode_ααα', eval('expand("%:t")'))
   end)
 end)


### PR DESCRIPTION
And remove unnecessary unsigned casts in fold marker comparison.

Fix #20517
