### PR TITLE
fix(build): close uv handles on a different define

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -170,6 +170,10 @@ if(DEBUG OR CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)
   add_definitions(-DEXITFREE)
 endif()
 
+if(CLANG_ASAN_UBSAN OR CLANG_MSAN OR CLANG_TSAN)
+  add_definitions(-DNOT_CLOSE_UV)
+endif()
+
 get_directory_property(gen_cdefs COMPILE_DEFINITIONS)
 foreach(gen_cdef ${gen_cdefs} DO_NOT_DEFINE_EMPTY_ATTRIBUTES)
   if(NOT ${gen_cdef} MATCHES "INCLUDE_GENERATED_DECLARATIONS")

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -131,7 +131,7 @@ void loop_on_put(MultiQueue *queue, void *data)
   uv_stop(&loop->uv);
 }
 
-#if !defined(EXITFREE)
+#if !defined(NOT_CLOSE_UV)
 static void loop_walk_cb(uv_handle_t *handle, void *arg)
 {
   if (!uv_is_closing(handle)) {
@@ -172,7 +172,7 @@ bool loop_close(Loop *loop, bool wait)
       log_uv_handles(&loop->uv);
       break;
     }
-#if defined(EXITFREE)
+#if defined(NOT_CLOSE_UV)
     (void)didstop;
 #else
     if (!didstop) {


### PR DESCRIPTION
    Previously if EXITFREE was defined, then uv handles were not closed.
    This was done to better detect memory leaks.

    However, now EXITFREE is always defined for debug builds which makes
    them pretty annoying to use since not closing the handles causes a lag
    on exit.

    This change adds a new define, NOT_UV_CLOSE, which when defined will not
    close the uv handles when exiting. This is automatically set when
    sanitizers are enabled.

Alternative to #18582
Fixes #18670

### Motivation

Debug builds are the quickest build type to build since it omits optimizations (e.g. LTO). This makes debug builds a preferred choice for testing plugins under CI, however the additional lag makes running individual tests in plugins very slow.