### PR TITLE
fix(powershell): incorrect length allocation for ":%w !" commands

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1381,7 +1381,7 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
                                   : 0;
 
   if (itmp != NULL) {
-    len += is_pwsh  ? strlen(itmp) + sizeof("& { Get-Content " " | & " " }") - 1
+    len += is_pwsh  ? strlen(itmp) + sizeof("& { Get-Content " " | & " " }") - 1 + 6  // +6: #20530
                     : strlen(itmp) + sizeof(" { " " < " " } ") - 1;
   }
   if (otmp != NULL) {

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -660,4 +660,33 @@ describe('shell :!', function()
         1]])
     end
   end)
+
+  it(':{range}! without redirecting to buffer', function()
+    local screen = Screen.new(500, 10)
+    screen:attach()
+    insert([[
+      3
+      1
+      4
+      2]])
+    feed(':4verbose %w !sort<cr>')
+    if is_os('win') then
+      screen:expect{
+        any=[[Executing command: .?sort %< .*]]
+      }
+    else
+      screen:expect{
+        any=[[Executing command: .?%(sort%) %< .*]]
+
+      }
+    end
+    feed('<CR>')
+    helpers.set_shell_powershell(true)
+    feed(':4verbose %w !sort<cr>')
+    screen:expect{
+      any=[[Executing command: .?& { Get%-Content .* | & sort }]]
+    }
+    feed('<CR>')
+    helpers.expect_exit(command, 'qall!')
+  end)
 end)


### PR DESCRIPTION
The calculation of `len` in [`make_filter_cmd`][1] for powershell falls short by one character for the following ex command:

```
:%w !sort
```

This command satisfies these conditions:

- [`itmp`][2] is not null
- [`otmp`][3] is null


__NOTE__ that other shells circumvent this bug only because of `len` allocation for six extra characters: a pair of curly braces and four spaces (L1553):

https://github.com/neovim/neovim/blob/cfdb4cbada8c65aa57e69776bcc0f7b8b298317a/src/nvim/ex_cmds.c#L1551-L1554

If allocation for these six characters are removed, then bash also faces the same bug.

I couldn't find where these six characters were being used in the shell command for other shells, so I didn't include them in calculating `len` for powershell in my PR #19438.



[1]: https://github.com/neovim/neovim/blob/cfdb4cbada8c/src/nvim/ex_cmds.c#L1534
[2]: https://github.com/neovim/neovim/blob/cfdb4cbada8c/src/nvim/ex_cmds.c#L1531
[3]: https://github.com/neovim/neovim/blob/cfdb4cbada8c/src/nvim/ex_cmds.c#L1532