### PR TITLE
vim-patch:9.0.0692: PoE filter files are not recognized

### DIFF
--- a/runtime/filetype.vim
+++ b/runtime/filetype.vim
@@ -1392,6 +1392,9 @@ au BufNewFile,BufRead *.dpr,*.lpr			setf pascal
 " Free Pascal makefile definition file
 au BufNewFile,BufRead *.fpc				setf fpcmake
 
+" Path of Exile item filter
+au BufNewFile,BufRead *.filter				setf poefilter
+
 " PDF
 au BufNewFile,BufRead *.pdf				setf pdf
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -774,6 +774,7 @@ local extension = {
   po = 'po',
   pot = 'po',
   pod = 'pod',
+  filter = 'poefilter',
   pk = 'poke',
   ps = 'postscr',
   epsi = 'postscr',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -427,6 +427,7 @@ let s:filename_checks = {
     \ 'plsql': ['file.pls', 'file.plsql'],
     \ 'po': ['file.po', 'file.pot'],
     \ 'pod': ['file.pod'],
+    \ 'poefilter': ['file.filter'],
     \ 'poke': ['file.pk'],
     \ 'postscr': ['file.ps', 'file.pfa', 'file.afm', 'file.eps', 'file.epsf', 'file.epsi', 'file.ai'],
     \ 'pov': ['file.pov'],


### PR DESCRIPTION
Problem:    PoE filter files are not recognized.
Solution:   Add a pattern to detect PoE filter files. (closes vim/vim#11305)
https://github.com/vim/vim/commit/b7f52f5659c68b61ccc645ef866f8fd82361cd26