### PR TITLE
ci(backport): bump version to v0

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
-        uses: zeebe-io/backport-action@v0.0.8
+        uses: zeebe-io/backport-action@v0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_workspace: ${{ github.workspace }}


### PR DESCRIPTION
backport-action now uses "v0" tag to point to the latest stable version.
This helps us avoid having to manually bump the version to get bug
fixes.
