### PR TITLE
feat: disable press_enter messages when cmdheight = 0

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -849,7 +849,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool init
   // If the line is too long, clear it, so ruler and shown command do
   // not get printed in the middle of it.
   msg_check();
-  if (p_ch == 0 && !ui_has(kUIMessages)) {
+  if (p_ch == 0 && !ui_has(kUIMessages) && !msg_didout) {
     if (must_redraw < UPD_VALID) {
       must_redraw = UPD_VALID;
     }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1396,16 +1396,14 @@ void msg_start(void)
     msg_clr_eos();
   }
 
+  bool cmdheight_check = p_ch == 0 && !ui_has(kUIMessages);
+
   // if cmdheight=0, we need to scroll in the first line of msg_grid upon the screen
-  if (p_ch == 0 && !ui_has(kUIMessages)) {
+  if (cmdheight_check && !msg_scrolled) {
     msg_grid_validate();
-
-    if (!msg_scrolled) {
-      msg_scroll_up(false, true);
-      cmdline_row = Rows - 1;
-    }
-
+    msg_scroll_up(false, true);
     msg_scrolled++;
+    cmdline_row = Rows - 1;
   }
 
   if (!msg_scroll && full_screen) {     // overwrite last message
@@ -1415,6 +1413,10 @@ void msg_start(void)
     msg_putchar('\n');
     did_return = true;
     cmdline_row = msg_row;
+  } else if (cmdheight_check) {
+    msg_row = Rows - 1;
+    cmdline_row = msg_row;
+    need_wait_return = true;
   }
   if (!msg_didany || lines_left < 0) {
     msg_starthere();

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1397,11 +1397,15 @@ void msg_start(void)
   }
 
   // if cmdheight=0, we need to scroll in the first line of msg_grid upon the screen
-  if (p_ch == 0 && !ui_has(kUIMessages) && !msg_scrolled) {
+  if (p_ch == 0 && !ui_has(kUIMessages)) {
     msg_grid_validate();
-    msg_scroll_up(false, true);
+
+    if (!msg_scrolled) {
+      msg_scroll_up(false, true);
+      cmdline_row = Rows - 1;
+    }
+
     msg_scrolled++;
-    cmdline_row = Rows - 1;
   }
 
   if (!msg_scroll && full_screen) {     // overwrite last message

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1306,6 +1306,7 @@ static void hit_return_msg(void)
     msg_puts(_("Interrupt: "));
   }
 
+  msg_puts_attr(_("Press ENTER or type command to continue"), HL_ATTR(HLF_R));
   if (!msg_use_printf()) {
     msg_clr_eos();
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1407,7 +1407,7 @@ void msg_start(void)
   if (!msg_scroll && full_screen) {     // overwrite last message
     msg_row = cmdline_row;
     msg_col = cmdmsg_rl ? Columns - 1 : 0;
-  } else if (msg_didout || (p_ch == 0 && !ui_has(kUIMessages) && !did_emsg)) {  // start message on next line
+  } else if (msg_didout) {  // start message on next line
     msg_putchar('\n');
     did_return = true;
     cmdline_row = msg_row;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1291,6 +1291,10 @@ void wait_return(int redraw)
 /// Write the hit-return prompt.
 static void hit_return_msg(void)
 {
+  if (p_ch <= 0) {
+    return;
+  }
+
   int save_p_more = p_more;
 
   p_more = false;       // don't want to see this message when scrolling back
@@ -1302,7 +1306,6 @@ static void hit_return_msg(void)
     msg_puts(_("Interrupt: "));
   }
 
-  msg_puts_attr(_("Press ENTER or type command to continue"), HL_ATTR(HLF_R));
   if (!msg_use_printf()) {
     msg_clr_eos();
   }
@@ -1403,7 +1406,7 @@ void msg_start(void)
   if (!msg_scroll && full_screen) {     // overwrite last message
     msg_row = cmdline_row;
     msg_col = cmdmsg_rl ? Columns - 1 : 0;
-  } else if (msg_didout || (p_ch == 0 && !ui_has(kUIMessages))) {  // start message on next line
+  } else if (msg_didout || (p_ch == 0 && !ui_has(kUIMessages) && !did_emsg)) {  // start message on next line
     msg_putchar('\n');
     did_return = true;
     cmdline_row = msg_row;

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -474,11 +474,11 @@ func Test_cmdheight_zero()
   redraw!
 
   echo 'test echo'
-  call assert_equal(116, screenchar(&lines + 1, 1))
+  call assert_equal(116, screenchar(&lines, 1))
   redraw!
 
   echomsg 'test echomsg'
-  call assert_equal(116, screenchar(&lines + 1, 1))
+  call assert_equal(116, screenchar(&lines, 1))
   redraw!
 
   call feedkeys(":ls\<CR>", "xt")

--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -474,11 +474,11 @@ func Test_cmdheight_zero()
   redraw!
 
   echo 'test echo'
-  call assert_equal(116, screenchar(&lines, 1))
+  call assert_equal(116, screenchar(&lines + 1, 1))
   redraw!
 
   echomsg 'test echomsg'
-  call assert_equal(116, screenchar(&lines, 1))
+  call assert_equal(116, screenchar(&lines + 1, 1))
   redraw!
 
   call feedkeys(":ls\<CR>", "xt")

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1062,7 +1062,7 @@ describe('cmdheight=0', function()
       {1:~                        }|
       {1:~                        }|
       {1:~                        }|
-      {1:~                        }|
+      :                        |
     ]], showmode={}}
     eq(0, eval('&cmdheight'))
   end)
@@ -1073,8 +1073,8 @@ describe('cmdheight=0', function()
     screen:expect{grid=[[
                                |
       {1:~                        }|
-      {2:                         }|
-      :call input("foo >")     |
+      {1:~                        }|
+      {1:~                        }|
       foo >^                    |
     ]]}
     eq(0, eval('&cmdheight'))
@@ -1084,7 +1084,7 @@ describe('cmdheight=0', function()
       {1:~                        }|
       {1:~                        }|
       {1:~                        }|
-      {1:~                        }|
+      foo >                    |
     ]], showmode={}}
     eq(0, eval('&cmdheight'))
   end)
@@ -1093,11 +1093,11 @@ describe('cmdheight=0', function()
     command("set cmdheight=0 noruler laststatus=3 winbar=foo")
     feed(':split<CR>')
     screen:expect{grid=[[
-      {2:                         }|
-      :split                   |
-      {4:E36: Not enough room}     |
-      {5:Press ENTER or type comma}|
-      {5:nd to continue}^           |
+      {3:foo                      }|
+                               |
+      {1:~                        }|
+      {1:~                        }|
+      {4:E36: Not enough room}^     |
     ]]}
     feed('<CR>')
     screen:expect{grid=[[

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -90,9 +90,6 @@ describe('ui/ext_messages', function()
       }, {
         content = { { "1" } },
         kind = "echo"
-      }, {
-        content = { { "Press ENTER or type command to continue", 4 } },
-        kind = "return_prompt"
     } }}
     feed('<cr><cr>')
 
@@ -173,10 +170,7 @@ describe('ui/ext_messages', function()
       }, {
         content = { { "E605: Exception not caught: foo", 2 } },
         kind = ""
-      }, {
-        content = { { "Press ENTER or type command to continue", 4 } },
-        kind = "return_prompt"
-      } }
+      }}
     }
 
     -- kind=quickfix after :cnext
@@ -236,10 +230,8 @@ describe('ui/ext_messages', function()
       }, {
         content = {{ "fail", 2 }},
         kind = "echoerr"
-      }, {
-        content = {{ "Press ENTER or type command to continue", 4 }},
-        kind = "return_prompt"
-    }}}
+      }
+    }}
 
     feed(':echoerr "extrafail"<cr>')
     screen:expect{grid=[[
@@ -252,15 +244,10 @@ describe('ui/ext_messages', function()
         content = { { "bork", 2 } },
         kind = "echoerr"
       }, {
-        content = { { "fail", 2 } },
-        kind = "echoerr"
-      }, {
         content = { { "extrafail", 2 } },
         kind = "echoerr"
-      }, {
-        content = { { "Press ENTER or type command to continue", 4 } },
-        kind = "return_prompt"
-    }}}
+      },
+    }}
 
     feed('<cr>')
     screen:expect{grid=[[
@@ -311,10 +298,8 @@ describe('ui/ext_messages', function()
       {kind="echoerr", content={{"fail", 2}}},
       {kind="echoerr", content={{"extrafail", 2}}},
       {kind="echoerr", content={{"problem", 2}}}
-    }, messages={{
-      content = {{ "Press ENTER or type command to continue", 4 }},
-      kind = "return_prompt"
-    }}}
+    }, messages={
+    }}
 
     feed '<cr>'
     screen:expect{grid=[[
@@ -381,7 +366,6 @@ describe('ui/ext_messages', function()
     ]], messages={
       {content = {{ "x                     #1" }}, kind = ""},
       {content = {{ "y                     #2" }}, kind = ""},
-      {content = {{ "Press ENTER or type command to continue", 4 }}, kind = "return_prompt"}
     }}
   end)
 
@@ -472,10 +456,8 @@ describe('ui/ext_messages', function()
       content = {{ "stuff" }},
       kind = "echomsg",
     }}, showmode={{ "-- INSERT --", 3 }},
-      messages={{
-        content = {{ "Press ENTER or type command to continue", 4}},
-        kind = "return_prompt"
-    }}}
+      messages={}
+    }
   end)
 
   it('&showmode with macro-recording message', function()
@@ -706,10 +688,8 @@ describe('ui/ext_messages', function()
       {kind="", content={{"Type  :qa  and press <Enter> to exit Nvim"}}},
       {kind="echoerr", content={{"bork", 2}}},
       {kind="emsg", content={{"E117: Unknown function: nosuchfunction", 2}}}
-    }, messages={{
-      content = {{ "Press ENTER or type command to continue", 4}},
-      kind = "return_prompt"
-    }}}
+    }, messages={}
+    }
   end)
 
   it('implies ext_cmdline and ignores cmdheight', function()
@@ -891,7 +871,6 @@ stack traceback:
       {1:~                        }|
       {1:~                        }|
     ]], messages={
-      { content = { { "Press ENTER or type command to continue", 4 } }, kind = "return_prompt" }
     }, msg_history={
       { content = { { "wow, ", 7 }, { "such\n\nvery ", 2 }, { "color", 10 } }, kind = "echomsg" }
     }}
@@ -1338,9 +1317,7 @@ describe('ui/ext_messages', function()
                                                                                       |
                                                                                       |
                                                                                       |
-    ]], messages={
-      {content = { { "Press ENTER or type command to continue", 4 } }, kind = "return_prompt" }
-    }}
+    ]], messages={}}
   end)
 
   it('supports global statusline', function()
@@ -2005,12 +1982,12 @@ aliquip ex ea commodo consequat.]])
     screen:expect{grid=[[
                                          |
       {1:~                                  }|
+      {1:~                                  }|
+      {1:~                                  }|
       {12:                                   }|
       :ls                                |
         1 %a   "[No Name]"               |
-           line 1                        |
-      {4:Press ENTER or type command to cont}|
-      {4:inue}^                               |
+           line 1^                        |
     ]]}
 
     feed('<cr>')
@@ -2029,12 +2006,12 @@ aliquip ex ea commodo consequat.]])
     screen:expect{grid=[[
                                          |
       {1:~                                  }|
+      {1:~                                  }|
       {12:                                   }|
       :ls                                |
         1 %a   "[No Name]"               |
-           line 1                        |
-      {4:Press ENTER or type command to cont}|
-      {4:inue}^                               |
+           line 1^                        |
+                                         |
     ]]}
 
     feed('<cr>')


### PR DESCRIPTION
Fix #20380

It improves `cmdheight=0` behavior.
The command line redraw is executed when no messages.

NOTE:  It is not perfect solution.  The echoed text will be overwritten by redraw.
I think it is trade off.