### PR TITLE
fix: properly configure luacheck and remove `local vim = ...` lines

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,6 +19,8 @@ cache = true
 ignore = {
   "631",  -- max_line_length
   "212/_.*",  -- unused argument, for vars with "_" prefix
+  "121", -- setting read-only global variable 'vim'
+  "122", -- setting read-only field of global variable 'vim'
 }
 
 -- Global objects defined by the C code

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -36,8 +36,6 @@
 --    - https://github.com/bakpakin/Fennel (pretty print, repl)
 --    - https://github.com/howl-editor/howl/tree/master/lib/howl/util
 
-local vim = assert(vim)
-
 -- These are for loading runtime modules lazily since they aren't available in
 -- the nvim binary as specified in executor.c
 for k, v in pairs({

--- a/runtime/lua/vim/_init_packages.lua
+++ b/runtime/lua/vim/_init_packages.lua
@@ -1,6 +1,3 @@
--- prevents luacheck from making lints for setting things on vim
-local vim = assert(vim)
-
 local pathtrails = {}
 vim._so_trails = {}
 for s in (package.cpath .. ';'):gmatch('[^;]*;') do

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -1,6 +1,3 @@
--- prevents luacheck from making lints for setting things on vim
-local vim = assert(vim)
-
 local a = vim.api
 
 -- TODO(tjdevries): Improve option metadata so that this doesn't have to be hardcoded.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -5,7 +5,6 @@ local protocol = require('vim.lsp.protocol')
 local util = require('vim.lsp.util')
 local sync = require('vim.lsp.sync')
 
-local vim = vim
 local api = vim.api
 local nvim_err_writeln, nvim_buf_get_lines, nvim_command, nvim_buf_get_option, nvim_exec_autocmds =
   api.nvim_err_writeln,

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1,4 +1,3 @@
-local vim = vim
 local api = vim.api
 local validate = vim.validate
 local util = require('vim.lsp.util')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -1,7 +1,6 @@
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
 local util = require('vim.lsp.util')
-local vim = vim
 local api = vim.api
 
 local M = {}

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -1,4 +1,3 @@
-local vim = vim
 local uv = vim.loop
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1,6 +1,5 @@
 local protocol = require('vim.lsp.protocol')
 local snippet = require('vim.lsp._snippet')
-local vim = vim
 local validate = vim.validate
 local api = vim.api
 local list_extend = vim.list_extend

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -6,7 +6,7 @@
 -- or the test suite. (Eventually the test suite will be run in a worker process,
 -- so this wouldn't be a separate case to consider)
 
-local vim = vim or {}
+vim = vim or {}
 
 --- Returns a deep copy of the given object. Non-table objects are copied as
 --- in a typical Lua assignment, whereas table objects are copied recursively.


### PR DESCRIPTION
Different lua files, currently had one of the lines below set at the top of the file:

- `local vim = vim or {}`
- `local vim = vim`
- `local vim = assert(vim)`

The only reason it was set as a **local** variable is to prevent **luacheck** errors `121` & `122`.

Setting it as a local confuses both **luacheck** (intended), but also `lua-language-server`.

For `sumneko`, this means a multi-second delay in completions for the global `vim` variable.

This PR, removes these lines and properly configures **luacheck** to ignore `121` & `122`.

In `shared.lua` it is set to `vim = vim or {}`, to ensure scripts that don't run in a Neovim env still work (some of the linters)

Result is fast completions and no luacheck errors.