### PR TITLE
build: generate compilation database for older cmake versions

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -451,6 +451,10 @@ set_target_properties(nvim
   PROPERTIES
   EXPORT_COMPILE_COMMANDS ON)
 
+if(${CMAKE_VERSION} VERSION_LESS 3.20)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 target_link_libraries(nvim ${NVIM_EXEC_LINK_LIBRARIES})
 install_helper(TARGETS nvim)
 if(MSVC)


### PR DESCRIPTION
Fall back to the older method of setting CMAKE_EXPORT_COMPILE_COMMANDS
for cmake versions less than 3.20. This isn't recommended as it's not
possible to exclude targets from generating a compilation database,
which may cause some tools like clang-tidy to do unnecessary work. But
having an unoptimized compilation database is still useful enough that
it's worth having.
