### PR TITLE
vim-patch:9.0.{0697,0702}: cursor in wrong position with 'linebreak'

### DIFF
--- a/src/nvim/testdir/test_listlbr.vim
+++ b/src/nvim/testdir/test_listlbr.vim
@@ -7,6 +7,7 @@ CheckOption linebreak
 CheckFeature conceal
 
 source view_util.vim
+source screendump.vim
 
 function s:screen_lines(lnum, width) abort
   return ScreenLines(a:lnum, a:width)
@@ -131,6 +132,26 @@ func Test_linebreak_with_visual_operations()
   call assert_equal('BBBb', @@)
 
   call s:close_windows()
+endfunc
+
+func Test_linebreak_reset_restore()
+  CheckScreendump
+
+  let lines =<< trim END
+      vim9script
+      &linebreak = true
+      &showcmd = true
+      &showmode = false
+      ('a'->repeat(&columns - 10) .. ' ' .. 'b'->repeat(10) .. ' c')->setline(1)
+  END
+  call writefile(lines, 'XlbrResetRestore', 'D')
+  let buf = RunVimInTerminal('-S XlbrResetRestore', {'rows': 8})
+
+  call term_sendkeys(buf, '$v$s')
+  call VerifyScreenDump(buf, 'Test_linebreak_reset_restore_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_virtual_block()

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1492,37 +1492,4 @@ func Test_switch_buffer_ends_visual_mode()
   exe 'bwipe!' buf2
 endfunc
 
-" Test that cursor is drawn at correct position after an operator in Visual
-" mode when 'linebreak' and 'showcmd' are enabled.
-func Test_visual_operator_with_linebreak()
-  CheckRunVimInTerminal
-
-  let lines =<< trim END
-    set linebreak showcmd noshowmode
-    call setline(1, repeat('a', &columns - 10) .. ' bbbbbbbbbb c')
-  END
-  call writefile(lines, 'XTest_visual_op_linebreak', 'D')
-
-  let buf = RunVimInTerminal('-S XTest_visual_op_linebreak', {'rows': 6})
-
-  call term_sendkeys(buf, '$v$')
-  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
-  call term_sendkeys(buf, 'zo')
-  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
-
-  call term_sendkeys(buf, "$\<C-V>$")
-  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
-  call term_sendkeys(buf, 'I')
-  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
-
-  call term_sendkeys(buf, "\<Esc>$v$")
-  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
-  call term_sendkeys(buf, 's')
-  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
-
-  " clean up
-  call term_sendkeys(buf, "\<Esc>")
-  call StopVimInTerminal(buf)
-endfunc
-
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1492,5 +1492,37 @@ func Test_switch_buffer_ends_visual_mode()
   exe 'bwipe!' buf2
 endfunc
 
+" Test that cursor is drawn at correct position after an operator in Visual
+" mode when 'linebreak' and 'showcmd' are enabled.
+func Test_visual_operator_with_linebreak()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set linebreak showcmd noshowmode
+    call setline(1, repeat('a', &columns - 10) .. ' bbbbbbbbbb c')
+  END
+  call writefile(lines, 'XTest_visual_op_linebreak', 'D')
+
+  let buf = RunVimInTerminal('-S XTest_visual_op_linebreak', {'rows': 6})
+
+  call term_sendkeys(buf, '$v$')
+  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
+  call term_sendkeys(buf, 'zo')
+  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
+
+  call term_sendkeys(buf, "$\<C-V>$")
+  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
+  call term_sendkeys(buf, 'I')
+  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
+
+  call term_sendkeys(buf, "\<Esc>$v$")
+  call WaitForAssert({-> assert_equal(13, term_getcursor(buf)[1])})
+  call term_sendkeys(buf, 's')
+  call WaitForAssert({-> assert_equal(12, term_getcursor(buf)[1])})
+
+  " clean up
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/listlbr_spec.lua
+++ b/test/functional/legacy/listlbr_spec.lua
@@ -1,11 +1,12 @@
 -- Test for linebreak and list option (non-utf8)
 
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local feed, insert, source = helpers.feed, helpers.insert, helpers.source
 local clear, feed_command, expect = helpers.clear, helpers.feed_command, helpers.expect
 
 describe('listlbr', function()
-  setup(clear)
+  before_each(clear)
 
   -- luacheck: ignore 621 (Indentation)
   -- luacheck: ignore 611 (Line contains only whitespaces)
@@ -194,5 +195,98 @@ describe('listlbr', function()
       aaaaaaaaaaaaaaaaaaaa
       aa>-----a-$         
       ~                   ]])
+  end)
+
+  -- oldtest: Test_linebreak_reset_restore()
+  it('cursor position is drawn correctly after operator', function()
+    local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.LightGrey},  -- Visual
+      [2] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+    })
+    screen:attach()
+
+    -- f_wincol() calls validate_cursor()
+    source([[
+      set linebreak showcmd noshowmode formatexpr=wincol()-wincol()
+      call setline(1, repeat('a', &columns - 10) .. ' bbbbbbbbbb c')
+    ]])
+
+    feed('$v$')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb {1:c}^                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+                                                       2          |
+    ]])
+    feed('zo')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb ^c                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                                         |
+    ]])
+
+    feed('$v$')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb {1:c}^                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                              2          |
+    ]])
+    feed('gq')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb ^c                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                                         |
+    ]])
+
+    feed('$<C-V>$')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb {1:c}^                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                              1x2        |
+    ]])
+    feed('I')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb ^c                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                                         |
+    ]])
+
+    feed('<Esc>$v$')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb {1:c}^                                                |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                              2          |
+    ]])
+    feed('s')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa          |
+      bbbbbbbbbb ^                                                 |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {2:E490: No fold found}                                         |
+    ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:9.0.0697: cursor in wrong position with Visual substitute

Problem:    Cursor in wrong position with Visual substitute.
Solution:   When restoring 'linebreak' mark the virtual column as invalid.
            (closes vim/vim#11311)
https://github.com/vim/vim/commit/16dab41537ae206f4cab676ad53edbae5fd5fb45

N/A patches for version.c:

vim-patch:9.0.0699: tiny build fails

Problem:    Tiny build fails.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/bf499c0e6f30a94fe062f83ea0190f93178d0d74


#### vim-patch:9.0.0702: incomplete testing cursor position with 'linebreak' set

Problem:    Incomplete testing cursor position after change with 'linebreak'
            set.
Solution:   Add a test and move test cases together. (closes vim/vim#11313)
https://github.com/vim/vim/commit/30c0c467d6cc2a7af960ccb9002b50115b0e55cf