### PR TITLE
vim-patch:9.0.0706: :help in a narrow window always opens at the top

### DIFF
--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -149,7 +149,7 @@ void ex_help(exarg_T *eap)
       n = WSP_HELP;
       if (cmdmod.cmod_split == 0 && curwin->w_width != Columns
           && curwin->w_width < 80) {
-        n |= WSP_TOP;
+        n |= p_sb ? WSP_BOT : WSP_TOP;
       }
       if (win_split(0, n) == FAIL) {
         goto erret;


### PR DESCRIPTION
#### vim-patch:9.0.0706: :help in a narrow window always opens at the top

Problem:    :help in a narrow window always opens at the top.
Solution:   Respect 'splitbelow'.
https://github.com/vim/vim/commit/28f7e701b7857cfc5ab5531ee7ac26e2542ad662