### PR TITLE
vim-patch:9.0.0700: there is no real need for a "big" build

### DIFF
--- a/src/nvim/testdir/test_regexp_utf8.vim
+++ b/src/nvim/testdir/test_regexp_utf8.vim
@@ -258,8 +258,7 @@ func Test_multibyte_chars()
   "  When there is no match use only the first two items.
   let tl = []
 
-  " Multi-byte character tests. These will fail unless vim is compiled
-  " with Multibyte (FEAT_MBYTE) or BIG/HUGE features.
+  " Multi-byte character tests.
   call add(tl, [2, '[[:alpha:][=a=]]\+', '879 aiaãâaiuvna ', 'aiaãâaiuvna'])
   call add(tl, [2, '[[=a=]]\+', 'ddaãâbcd', 'aãâ'])								" equivalence classes
   call add(tl, [2, '[^ม ]\+', 'มม oijasoifjos ifjoisj f osij j มมมมม abcd', 'oijasoifjos'])


### PR DESCRIPTION
#### vim-patch:9.0.0700: there is no real need for a "big" build

Problem:    There is no real need for a "big" build.
Solution:   Move common features to "normal" build, less often used features
            to the "huge" build. (Martin Tournoij, closes vim/vim#11283)
https://github.com/vim/vim/commit/25f3a146a0e4c731b8608f4cfbbfdf7a71b2d05e