### PR TITLE
build(deps): disable shared library for libvterm.

### DIFF
--- a/cmake.deps/cmake/LibvtermCMakeLists.txt
+++ b/cmake.deps/cmake/LibvtermCMakeLists.txt
@@ -41,14 +41,6 @@ file(GLOB VTERM_SOURCES ${CMAKE_SOURCE_DIR}/src/*.c)
 add_library(vterm ${VTERM_SOURCES} ${TBL_FILES_HEADERS})
 install(TARGETS vterm ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-add_library(vterm-shared SHARED ${VTERM_SOURCES} ${TBL_FILES_HEADERS})
-set_target_properties(vterm-shared PROPERTIES
-  OUTPUT_NAME vterm
-  SOVERSION 0)
-install(TARGETS vterm-shared
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-
 install(FILES include/vterm.h include/vterm_keycodes.h
   DESTINATION include)
 


### PR DESCRIPTION
There is an issue to build neovim 0.8 under Windows.

Version: NVIM v0.8.0
Build type: Release
Compilers: MSVC/cl 19.33.31630 x64, LLVM/clang-cl 15.0.2 x64
Windows: 10 21H2 19044.2006

Dependencies build command:
~~~{batch shell}
pushd neovim\cmake.deps
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl
cmake --build Release
popd
~~~

Neovim build command:
~~~{batch shell}
pushd neovim
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl --DDEPS_PREFIX="cmake.deps/Release/usr"
cmake --build Release
popd
~~~

Note: `cl` can be used in replacement of `clang-cl`.


### Problem
Cannot build both static and share libraries for libvterm under Windows.
The static and shared library would have the same name "vterm.lib", thus there would be multiple rules to build the same target.

### Solution
Disable shared library for libvterm.