### PR TITLE
vim-patch:9.0.0713: <amatch> of MenuPopup event is expanded like a file name

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1743,17 +1743,18 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     sfname = xstrdup(fname);
     // Don't try expanding the following events.
     if (event == EVENT_CMDLINECHANGED || event == EVENT_CMDLINEENTER
-        || event == EVENT_CMDLINELEAVE || event == EVENT_CMDWINENTER
-        || event == EVENT_CMDWINLEAVE || event == EVENT_CMDUNDEFINED
+        || event == EVENT_CMDLINELEAVE || event == EVENT_CMDUNDEFINED
+        || event == EVENT_CMDWINENTER || event == EVENT_CMDWINLEAVE
         || event == EVENT_COLORSCHEME || event == EVENT_COLORSCHEMEPRE
         || event == EVENT_DIRCHANGED || event == EVENT_DIRCHANGEDPRE
         || event == EVENT_FILETYPE || event == EVENT_FUNCUNDEFINED
-        || event == EVENT_MODECHANGED || event == EVENT_OPTIONSET
-        || event == EVENT_QUICKFIXCMDPOST || event == EVENT_QUICKFIXCMDPRE
-        || event == EVENT_REMOTEREPLY || event == EVENT_SPELLFILEMISSING
-        || event == EVENT_SYNTAX || event == EVENT_SIGNAL
-        || event == EVENT_TABCLOSED || event == EVENT_USER
-        || event == EVENT_WINCLOSED || event == EVENT_WINSCROLLED) {
+        || event == EVENT_MENUPOPUP || event == EVENT_MODECHANGED
+        || event == EVENT_OPTIONSET || event == EVENT_QUICKFIXCMDPOST
+        || event == EVENT_QUICKFIXCMDPRE || event == EVENT_REMOTEREPLY
+        || event == EVENT_SIGNAL || event == EVENT_SPELLFILEMISSING
+        || event == EVENT_SYNTAX || event == EVENT_TABCLOSED
+        || event == EVENT_USER || event == EVENT_WINCLOSED
+        || event == EVENT_WINSCROLLED) {
       fname = xstrdup(fname);
     } else {
       fname = FullName_save(fname, false);

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -481,6 +481,35 @@ func Test_popup_menu()
   unmenu PopUp
 endfunc
 
+" Test for MenuPopup autocommand
+func Test_autocmd_MenuPopup()
+  CheckNotGui
+
+  set mouse=a
+  set mousemodel=popup
+  aunmenu *
+  autocmd MenuPopup * exe printf(
+    \ 'anoremenu PopUp.Foo <Cmd>let g:res = ["%s", "%s"]<CR>',
+    \ expand('<afile>'), expand('<amatch>'))
+
+  call feedkeys("\<RightMouse>\<Down>\<CR>", 'tnix')
+  call assert_equal(['n', 'n'], g:res)
+
+  call feedkeys("v\<RightMouse>\<Down>\<CR>\<Esc>", 'tnix')
+  call assert_equal(['v', 'v'], g:res)
+
+  call feedkeys("gh\<RightMouse>\<Down>\<CR>\<Esc>", 'tnix')
+  call assert_equal(['s', 's'], g:res)
+
+  call feedkeys("i\<RightMouse>\<Down>\<CR>\<Esc>", 'tnix')
+  call assert_equal(['i', 'i'], g:res)
+
+  autocmd! MenuPopup
+  aunmenu PopUp.Foo
+  unlet g:res
+  set mouse& mousemodel&
+endfunc
+
 " Test for listing the menus using the :menu command
 func Test_show_menus()
   " In the GUI, tear-off menu items are present in the output below


### PR DESCRIPTION
#### vim-patch:9.0.0713: \<amatch\> of MenuPopup event is expanded like a file name

Problem:    \<amatch\> of MenuPopup event is expanded like a file name.
Solution:   Do not expand \<amatch\> for MenuPopup. (closes vim/vim#11328)
https://github.com/vim/vim/commit/c601d988b6b1a672f71e3d61f4aaa4f7742a3a21