### PR TITLE
vim-patch:8.2.{1465,2184,2670,2671},9.0.{0712,partial:0715}

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1294,6 +1294,9 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
   } else if ((argvars[0].v_type == VAR_NUMBER || argvars[0].v_type == VAR_STRING)
              && (argvars[1].v_type == VAR_NUMBER || argvars[1].v_type == VAR_STRING)) {
     line = tv_get_lnum(argvars);
+    if (line < 0) {
+      semsg(_(e_invarg2), tv_get_string(&argvars[0]));
+    }
     col = (long)tv_get_number_chk(&argvars[1], NULL);
     if (charcol) {
       col = buf_charidx_to_byteidx(curbuf, (linenr_T)line, (int)col) + 1;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1270,7 +1270,7 @@ static void f_ctxsize(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// Otherwise use the column number as a byte offset.
 static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
 {
-  long line, col;
+  long lnum, col;
   long coladd = 0;
   bool set_curswant = true;
 
@@ -1284,7 +1284,7 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
       return;
     }
 
-    line = pos.lnum;
+    lnum = pos.lnum;
     col = pos.col;
     coladd = pos.coladd;
     if (curswant >= 0) {
@@ -1293,13 +1293,15 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
     }
   } else if ((argvars[0].v_type == VAR_NUMBER || argvars[0].v_type == VAR_STRING)
              && (argvars[1].v_type == VAR_NUMBER || argvars[1].v_type == VAR_STRING)) {
-    line = tv_get_lnum(argvars);
-    if (line < 0) {
+    lnum = tv_get_lnum(argvars);
+    if (lnum < 0) {
       semsg(_(e_invarg2), tv_get_string(&argvars[0]));
+    } else if (lnum == 0) {
+      lnum = curwin->w_cursor.lnum;
     }
     col = (long)tv_get_number_chk(&argvars[1], NULL);
     if (charcol) {
-      col = buf_charidx_to_byteidx(curbuf, (linenr_T)line, (int)col) + 1;
+      col = buf_charidx_to_byteidx(curbuf, (linenr_T)lnum, (int)col) + 1;
     }
     if (argvars[2].v_type != VAR_UNKNOWN) {
       coladd = (long)tv_get_number_chk(&argvars[2], NULL);
@@ -1308,11 +1310,11 @@ static void set_cursorpos(typval_T *argvars, typval_T *rettv, bool charcol)
     emsg(_(e_invarg));
     return;
   }
-  if (line < 0 || col < 0 || coladd < 0) {
+  if (lnum < 0 || col < 0 || coladd < 0) {
     return;  // type error; errmsg already given
   }
-  if (line > 0) {
-    curwin->w_cursor.lnum = (linenr_T)line;
+  if (lnum > 0) {
+    curwin->w_cursor.lnum = (linenr_T)lnum;
   }
   if (col > 0) {
     curwin->w_cursor.col = (colnr_T)col - 1;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3750,8 +3750,9 @@ varnumber_T tv_get_number_chk(const typval_T *const tv, bool *const ret_error)
 linenr_T tv_get_lnum(const typval_T *const tv)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  const int did_emsg_before = did_emsg;
   linenr_T lnum = (linenr_T)tv_get_number_chk(tv, NULL);
-  if (lnum <= 0 && tv->v_type != VAR_NUMBER) {
+  if (lnum <= 0 && did_emsg_before == did_emsg && tv->v_type != VAR_NUMBER) {
     int fnum;
     // No valid number, try using same function as line() does.
     pos_T *const fp = var2fpos(tv, true, &fnum, false);

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3751,8 +3751,9 @@ linenr_T tv_get_lnum(const typval_T *const tv)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   linenr_T lnum = (linenr_T)tv_get_number_chk(tv, NULL);
-  if (lnum <= 0) {  // No valid number, try using same function as line() does.
+  if (lnum <= 0 && tv->v_type != VAR_NUMBER) {
     int fnum;
+    // No valid number, try using same function as line() does.
     pos_T *const fp = var2fpos(tv, true, &fnum, false);
     if (fp != NULL) {
       lnum = fp->lnum;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3751,7 +3751,7 @@ linenr_T tv_get_lnum(const typval_T *const tv)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   linenr_T lnum = (linenr_T)tv_get_number_chk(tv, NULL);
-  if (lnum == 0) {  // No valid number, try using same function as line() does.
+  if (lnum <= 0) {  // No valid number, try using same function as line() does.
     int fnum;
     pos_T *const fp = var2fpos(tv, true, &fnum, false);
     if (fp != NULL) {

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -199,7 +199,7 @@ EXTERN dict_T vimvardict;                   // Dictionary with v: variables
 EXTERN dict_T globvardict;                  // Dictionary with g: variables
 /// g: value
 #define globvarht globvardict.dv_hashtab
-EXTERN bool did_emsg;                       // set by emsg() when the message
+EXTERN int did_emsg;                        // set by emsg() when the message
                                             // is displayed or thrown
 EXTERN bool called_vim_beep;                // set if vim_beep() is called
 EXTERN bool did_emsg_syntax;                // did_emsg set because of a

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -658,7 +658,7 @@ static bool emsg_multiline(const char *s, bool multiline)
     // interrupt message).
     if (cause_errthrow(s, severe, &ignore)) {
       if (!ignore) {
-        did_emsg = true;
+        did_emsg++;
       }
       return true;
     }
@@ -721,7 +721,7 @@ static bool emsg_multiline(const char *s, bool multiline)
     } else {
       flush_buffers(FLUSH_MINIMAL);  // flush internal buffers
     }
-    did_emsg = true;               // flag for DoOneCmd()
+    did_emsg++;               // flag for DoOneCmd()
   }
 
   emsg_on_display = true;     // remember there is an error message

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -32,7 +32,7 @@ func Test_move_cursor()
   call cursor(1, 1, 1)
   call assert_equal([1, 1, 1], getcurpos()[1:3])
 
-  call assert_equal(-1, cursor(-1, -1))
+  call assert_fails('call cursor(-1, -1)', 'E475:')
 
   quit!
 endfunc

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -353,8 +353,14 @@ func Test_setcursorcharpos()
   normal G
   call setcursorcharpos([1, 1])
   call assert_equal([1, 1], [line('.'), col('.')])
+
   call setcursorcharpos([2, 7, 0])
   call assert_equal([2, 9], [line('.'), col('.')])
+  call setcursorcharpos([0, 7, 0])
+  call assert_equal([2, 9], [line('.'), col('.')])
+  call setcursorcharpos(0, 7, 0)
+  call assert_equal([2, 9], [line('.'), col('.')])
+
   call setcursorcharpos(3, 4)
   call assert_equal([3, 1], [line('.'), col('.')])
   call setcursorcharpos([3, 1])


### PR DESCRIPTION
#### vim-patch:8.2.2184: Vim9: no error when using "2" for a line number

Problem:    Vim9: no error when using "2" for a line number.
Solution:   Give an error message if the line number is invalid.
https://github.com/vim/vim/commit/9a963377b4811e4e0419ec8825856ff4b01331ac

N/A patches for version.c:

vim-patch:8.2.1465: Vim9: subscript not handled properly

Problem:    Vim9: subscript not handled properly.
Solution:   Adjust error message.  Remove dead code.  Disallow string to
            number conversion in scripts.
https://github.com/vim/vim/commit/56acb0943ede35cd9d2f6667cde2442819ccbf59


#### vim-patch:8.2.2671: error for line number in legacy script

Problem:    Error for line number in legacy script.
Solution:   Check for number type.
https://github.com/vim/vim/commit/f6bdd82c7e2076dbacb764a5d288189d61c68451

N/A patches for version.c:

vim-patch:8.2.2670: Vim9: error for append(0, text)

Problem:    Vim9: error for append(0, text).
Solution:   Check for negative number.
https://github.com/vim/vim/commit/b2ac7d0663ef31a335c50c6afca042ed9ace5059


#### vim-patch:9.0.0712: wrong column when calling setcursorcharpos() with zero lnum

Problem:    Wrong column when calling setcursorcharpos() with zero lnum.
Solution:   Set the line number before calling buf_charidx_to_byteidx().
https://github.com/vim/vim/commit/79f234499b6692cc16970b7455bc9b002242632f


#### vim-patch:partial:9.0.0715: wrong argument for append() gives two error messages

Problem:    Wrong argument for append() gives two error messages.
Solution:   When getting an error for a number argument don't try using it as
            a string.
https://github.com/vim/vim/commit/801cd35e7e3b21e519e12a1610ee1d721e40893e

Skip test as it depends on too many previous patches.