### PR TITLE
fix: restore original cursor position after :redrawstatus

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -504,6 +504,14 @@ handle_T ui_cursor_grid(void)
   return cursor_grid_handle;
 }
 
+static bool ui_should_reset_cursor(void)
+{
+  // Do not reset the cursor in modes in which the cursor should be placed outside of its window
+  bool no_reset = State == MODE_CMDLINE || State == MODE_HITRETURN || State == MODE_ASKMORE
+                  || State == MODE_SETWSIZE || State == MODE_EXTERNCMD || State == MODE_CONFIRM;
+  return !no_reset;
+}
+
 void ui_flush(void)
 {
   if (!ui_active()) {
@@ -515,6 +523,10 @@ void ui_flush(void)
   msg_scroll_flush();
 
   if (pending_cursor_update) {
+    // Reset the cursor to its position in the window to avoid sending incorrect position to the UI
+    if (ui_should_reset_cursor()) {
+      setcursor();
+    }
     ui_call_grid_cursor_goto(cursor_grid_handle, cursor_row, cursor_col);
     pending_cursor_update = false;
   }


### PR DESCRIPTION
Related issues: https://github.com/neovide/neovide/issues/1434, https://github.com/neovide/neovide/issues/890, https://github.com/neovim/neovim/issues/11806.

### The problem

Cursor frequently jumps to statusline/tabline/winbar and back to its position in the window. This is especially noticeable in Neovide due to its (cool) cursor animations, but this is not specifically related to Neovide - it happens in the terminal too, but is less visible (more like flickering). 

### Context

I've been debugging this for some time now and I think I found what was the problem. First I thought that it's an issue with Neovide, but following https://github.com/neovide/neovide/issues/1434#issuecomment-1200238282 it looked like Neovim is sending cursor goto commands, so I moved on to debugging Neovim. I attached with GDB and after some time found the following functions on which I put breakpoints: 
* [ui_grid_cursor_goto](https://github.com/jedrzejboczar/neovim/blob/edf3b684056acca4e586fe860b055b414a8e750b/src/nvim/ui.c#L465) - updates current grid position
* ui_call_grid_cursor_goto - sends position to UI (`ui_events_call.generated.h:194`)

When updating the screen the general pattern is: several `ui_grid_cursor_goto()` followed by `ui_call_grid_cursor_goto()`. From what I understand, Neovim does the redrawing by moving the cursor all around the screen and calling the drawing functions while the cursor is placed at drawing position. And after such a sequence the cursor is meant to go back to its original position before `ui_call_grid_cursor_goto()`. 

However, sometimes the cursor position was being changed to statusline just before sending position to UI. This way UI was receiving a single incorrect position, which in the next update was re-set to the correct one - thus the jumping. From stack traces I found that this position change happened due to evaluation of `:redrawstatus!` command, in my case this was from [lsp-status redraw_callback](https://github.com/nvim-lua/lsp-status.nvim/blob/54f48eb5017632d81d0fd40112065f1d062d0629/lua/lsp-status/redraw.lua#L9).

### Solution

I tried a few approaches, but the simplest one is to call `setcursor()` in `ex_redrawstatus`/`ex_redrawtabline`. This resets the cursor just before `ui_flash()` (which actually [sends the position update to UI](https://github.com/jedrzejboczar/neovim/blob/edf3b684056acca4e586fe860b055b414a8e750b/src/nvim/ui.c#L518)). I don't know if this is the best solution so I would appreciate any suggestions from someone who better understands this screen drawing code.

### Reproduction

I tried to narrow down the issue to a minimal case. In my use case this always happened when opening Lua files and sumneko_lua was  reporting "loading workspace" progress. When trying to reproduce the problem in a minimal config, I noticed that it's necessary to have a slow statusline (statusline generation taking considerable amount of time). In my case the following config causes the issue reliably (starting Neovim with `--clean -u minimal-config.lua`):
```lua
-- Trigger :redrawstatus in regular interval to simulate what lsp-status.nvim
-- does when e.g. sumneko_lua is loading workspace.
local interval = 100

local iter = 0
local timer = vim.loop.new_timer()
timer:start(interval, interval, vim.schedule_wrap(function()
    print(iter)
    iter = iter + 1
    vim.cmd('redrawstatus!')
end))

-- Some computation to introduce delay
local function fib(n)
    local a, b
    a, b = 0, 1
    for _ = 1, n do
        a, b = b, a + b
    end
    return a
end

-- Statusline that takes some time to compute
function _G.statusline()
    local n = math.random(1000 * 1000, 10000 * 1000)
    fib(n)
    -- return 'MyStatusline (' .. iter .. ')'
    return 'MyStatusline'
end

vim.opt.statusline = '%{%v:lua.statusline()%}'
-- vim.opt.winbar = '%{%v:lua.statusline()%}'
```
But small changes to the code may cause the issue to not appear, e.g. removing `print(iter)`. I don't really know why this `print` is necessary to reproduce in this demo. 

Here is a video showing the issue. With changes from this PR applied, cursor jumping doesn't happen.

https://user-images.githubusercontent.com/16623787/194943331-c990c850-1402-45ca-b0ea-82c16cd9446a.mp4


