### PR TITLE
refactor: explicitly convert HANDLE to intptr_t for _open_osfhandle()

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1683,7 +1683,7 @@ failed:
       HANDLE conin = CreateFile("CONIN$", GENERIC_READ | GENERIC_WRITE,
                                 FILE_SHARE_READ, (LPSECURITY_ATTRIBUTES)NULL,
                                 OPEN_EXISTING, 0, (HANDLE)NULL);
-      vim_ignored = _open_osfhandle(conin, _O_RDONLY);
+      vim_ignored = _open_osfhandle((intptr_t)conin, _O_RDONLY);
 #endif
     }
   }


### PR DESCRIPTION
There is an issue to build neovim 0.8 by `LLVM/clang-cl` in Windows.

Version: NVIM v0.8.0
Build type: Release
Compilers: MSVC/cl 19.33.31630 x64, LLVM/clang-cl 15.0.2 x64
Windows: 10 21H2 19044.2006

Dependencies build command:
~~~cmd
pushd neovim\cmake.deps
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl
cmake --build Release
popd
~~~

Neovim build command:
~~~cmd
pushd neovim
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl --DDEPS_PREFIX="cmake.deps/Release/usr"
cmake --build Release
popd
~~~

### Problem:
The first parameter of `_open_osfhandle()` is an `intptr_t`; however, a `HANDLE` is passed.
The official documentation of [_open_osfhandle](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle) suggests to cast the `HANDLE` to `intptr_t`.
MSVC/cl is able to perform an implicit type cast.
However, LLVM/clang-cl will generate an compilation error.

### Solution:
Explicitly convert `HANDLE` to `intptr_t` for `_open_osfhandle()`.

Edit: Here is the figure that shows the error reported by LLVM/clang-cl.
![conin-type](https://user-images.githubusercontent.com/1460232/194989262-b0a2e668-d18e-4245-a806-7b31806a7eac.png)