### PR TITLE
build(deps): specify C++ compiler for msgpack

### DIFF
--- a/cmake.deps/cmake/BuildMsgpack.cmake
+++ b/cmake.deps/cmake/BuildMsgpack.cmake
@@ -8,12 +8,28 @@ set(MSGPACK_CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/msgpack
   -DCMAKE_GENERATOR=${CMAKE_GENERATOR})
 
 if(MSVC)
+  # The msgpack project has a dependency on C++ compiler.
+  # The string `MSGPACK_CXX_COMPILER` is used to specify the C++ compiler.
+  # If the C++ compiler has been been specified, that one is used, and
+  # `MSGPACK_CXX_COMPILER` is set to "-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}".
+  # Otherwise, if LLVM/clang-cl is used as the C compiler, it shall also be used
+  # as the C++ compiler for consistency, and `MSGPACK_CXX_COMPILER` # is set to
+  # "-DCMAKE_CXX_COMPILER=${CMAKE_C_COMPILER}".
+  # Otherwise, `MSGPACK_CXX_COMPILER` remains an empty string, which shall not
+  # break other builds.
+  set(MSGPACK_CXX_COMPILER)
+  if(CMAKE_CXX_COMPILER)
+    set(MSGPACK_CXX_COMPILER -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+  elseif(CMAKE_C_COMPILER_ID MATCHES "Clang")
+    set(MSGPACK_CXX_COMPILER -DCMAKE_CXX_COMPILER=${CMAKE_C_COMPILER})
+  endif()
   # Same as Unix without fPIC
   set(MSGPACK_CONFIGURE_COMMAND ${CMAKE_COMMAND} ${DEPS_BUILD_DIR}/src/msgpack
     -DMSGPACK_BUILD_TESTS=OFF
     -DMSGPACK_BUILD_EXAMPLES=OFF
     -DCMAKE_INSTALL_PREFIX=${DEPS_INSTALL_DIR}
     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    ${MSGPACK_CXX_COMPILER}
     -DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}
     ${BUILD_TYPE_STRING}
     # Make sure we use the same generator, otherwise we may


### PR DESCRIPTION
There is an issue to build neovim 0.8 in Windows.

Version: NVIM v0.8.0
Build type: Release
Compilers: MSVC/cl 19.33.31630 x64, LLVM/clang-cl 15.0.2 x64
Windows: 10 21H2 19044.2006

Dependencies build command:
~~~cmd
pushd neovim\cmake.deps
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl
cmake --build Release
popd
~~~

Neovim build command:
~~~cmd
pushd neovim
md Release
cmake -S. -BRelease -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-cl --DDEPS_PREFIX="cmake.deps/Release/usr"
cmake --build Release
popd
~~~


### Problem:
The "msgpack" project has a dependency on C++ compiler.
If LLVM/clang-cl is used as the C compiler, it shall also be used as the C++ compiler for consistency.
However, the C++ compiler for "msgpack" is not configured in "BuildMsgpack.cmake".
And cmake would use LLVM/clang++ (the GNU frontend) as the C++ compiler, which is inconsistent with LLVM/clang-cl (the MSVC frontend).

![msgpack-cxx](https://user-images.githubusercontent.com/1460232/195024345-0837d06e-db18-43f4-af0d-bc54c2eaf378.png)

### Solution:
Specify C++ compiler for msgpack if LLVM/clang-cl is used as the C compiler.
