### PR TITLE
fix(windows): consistent normalization in fs.find

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -119,7 +119,7 @@ function M.find(names, opts)
 
   ---@private
   local function add(match)
-    matches[#matches + 1] = match
+    matches[#matches + 1] = M.normalize(match)
     if #matches == limit then
       return true
     end

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -79,6 +79,15 @@ describe('vim.fs', function()
       ]], test_build_dir, nvim_prog_basename))
     end)
 
+    it('normalizes slashes correctly', function()
+      if not helpers.iswin() then return end
+      local repo_root = exec_lua([[
+        return vim.fs.find({".git"}, { upward = true, type = 'directory' })
+      ]])
+      assert.truthy(repo_root:match([[\\]]))
+      -- assert.falsy(repo_root:match([[\\]]))
+    end)
+
     it('accepts predicate as names', function()
       eq({test_build_dir}, exec_lua([[
         local dir = ...


### PR DESCRIPTION
fixes #20594

### How to test

run this command in the neovim repo root `:lua =vim.fs.find(".luacheckrc")`

before: `c:\\projects\\neovim/.luacheckrc`

with this PR: `c:/projects/neovim/.luacheckrc`