### PR TITLE
fix(runtime): properly rely on t_Co for colorschemes

### DIFF
--- a/runtime/colors/blue.vim
+++ b/runtime/colors/blue.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'blue'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#cd0000', '#00cd00', '#cdcd00', '#0000ee', '#cd00cd', '#00cdcd', '#e5e5e5', '#7f7f7f', '#ff0000', '#00ff00', '#ffff00', '#5c5cff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/darkblue.vim
+++ b/runtime/colors/darkblue.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'darkblue'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#8b0000', '#90f020', '#ffa500', '#00008b', '#8b008b', '#008b8b', '#c0c0c0', '#808080', '#ffa0a0', '#90f020', '#ffff60', '#0030ff', '#ff00ff', '#90fff0', '#ffffff']

--- a/runtime/colors/delek.vim
+++ b/runtime/colors/delek.vim
@@ -13,7 +13,7 @@ set background=light
 hi clear
 let g:colors_name = 'delek'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#ffffff', '#0000ff', '#00cd00', '#cd00cd', '#008b8b', '#0000ff', '#ff1493', '#bcbcbc', '#ee0000', '#0000ff', '#00cd00', '#cd00cd', '#008b8b', '#0000ff', '#ff1493', '#000000']

--- a/runtime/colors/desert.vim
+++ b/runtime/colors/desert.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'desert'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#7f7f8c', '#cd5c5c', '#9acd32', '#bdb76b', '#75a0ff', '#eeee00', '#cd853f', '#666666', '#8a7f7f', '#ff0000', '#89fb98', '#f0e68c', '#6dceeb', '#ffde9b', '#ffa0a0', '#c2bfa5']

--- a/runtime/colors/elflord.vim
+++ b/runtime/colors/elflord.vim
@@ -12,7 +12,7 @@ set background=dark
 hi clear
 let g:colors_name = 'elflord'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 hi! link Terminal Normal
 hi! link Boolean Constant

--- a/runtime/colors/evening.vim
+++ b/runtime/colors/evening.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'evening'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#cd0000', '#00cd00', '#cdcd00', '#0087ff', '#cd00cd', '#00cdcd', '#e5e5e5', '#7f7f7f', '#ff0000', '#00ff00', '#ffff00', '#5c5cff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/habamax.vim
+++ b/runtime/colors/habamax.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'habamax'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#1c1c1c', '#d75f5f', '#87af87', '#afaf87', '#5f87af', '#af87af', '#5f8787', '#9e9e9e', '#767676', '#d7875f', '#afd7af', '#d7d787', '#87afd7', '#d7afd7', '#87afaf', '#bcbcbc']

--- a/runtime/colors/industry.vim
+++ b/runtime/colors/industry.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'industry'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#303030', '#870000', '#5fd75f', '#afaf00', '#87afff', '#af00af', '#00afaf', '#6c6c6c', '#444444', '#ff0000', '#00ff00', '#ffff00', '#005fff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/koehler.vim
+++ b/runtime/colors/koehler.vim
@@ -12,7 +12,7 @@ set background=dark
 hi clear
 let g:colors_name = 'koehler'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 hi! link Terminal Normal
 hi! link Boolean Constant

--- a/runtime/colors/lunaperche.vim
+++ b/runtime/colors/lunaperche.vim
@@ -11,7 +11,7 @@
 hi clear
 let g:colors_name = 'lunaperche'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 hi! link helpVim Title
 hi! link helpHeader Title

--- a/runtime/colors/morning.vim
+++ b/runtime/colors/morning.vim
@@ -13,7 +13,7 @@ set background=light
 hi clear
 let g:colors_name = 'morning'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#e4e4e4', '#a52a2a', '#ff00ff', '#6a0dad', '#008787', '#2e8b57', '#6a5acd', '#bcbcbc', '#0000ff', '#a52a2a', '#ff00ff', '#6a0dad', '#008787', '#2e8b57', '#6a5acd', '#000000']

--- a/runtime/colors/murphy.vim
+++ b/runtime/colors/murphy.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'murphy'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#303030', '#ffa700', '#005f00', '#ffd7af', '#87afff', '#ffafaf', '#00afaf', '#bcbcbc', '#444444', '#ff0000', '#00875f', '#ffff00', '#005fff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/pablo.vim
+++ b/runtime/colors/pablo.vim
@@ -12,7 +12,7 @@ set background=dark
 hi clear
 let g:colors_name = 'pablo'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#cd0000', '#00cd00', '#cdcd00', '#0000ee', '#cd00cd', '#00cdcd', '#e5e5e5', '#7f7f7f', '#ff0000', '#00ff00', '#ffff00', '#5c5cff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/peachpuff.vim
+++ b/runtime/colors/peachpuff.vim
@@ -13,7 +13,7 @@ set background=light
 hi clear
 let g:colors_name = 'peachpuff'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#ffdab9', '#a52a2a', '#c00058', '#cd00cd', '#008b8b', '#2e8b57', '#6a5acd', '#737373', '#406090', '#a52a2a', '#c00058', '#cd00cd', '#008b8b', '#2e8b57', '#6a5acd', '#000000']

--- a/runtime/colors/quiet.vim
+++ b/runtime/colors/quiet.vim
@@ -11,7 +11,7 @@
 hi clear
 let g:colors_name = 'quiet'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 hi! link Terminal Normal
 hi! link StatusLineTerm StatusLine

--- a/runtime/colors/ron.vim
+++ b/runtime/colors/ron.vim
@@ -12,7 +12,7 @@ set background=dark
 hi clear
 let g:colors_name = 'ron'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 hi! link Terminal Normal
 hi! link Boolean Constant

--- a/runtime/colors/shine.vim
+++ b/runtime/colors/shine.vim
@@ -13,7 +13,7 @@ set background=light
 hi clear
 let g:colors_name = 'shine'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#8b0000', '#006400', '#ffff00', '#00008b', '#6a0dad', '#008b8b', '#dadada', '#767676', '#ffafaf', '#90ee90', '#ffff60', '#add8e6', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/slate.vim
+++ b/runtime/colors/slate.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'slate'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#cd0000', '#00cd00', '#cdcd00', '#0000ee', '#cd00cd', '#00cdcd', '#e5e5e5', '#7f7f7f', '#ff0000', '#00ff00', '#ffff00', '#5c5cff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/torte.vim
+++ b/runtime/colors/torte.vim
@@ -13,7 +13,7 @@ set background=dark
 hi clear
 let g:colors_name = 'torte'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#000000', '#cd0000', '#00cd00', '#cdcd00', '#0000ee', '#cd00cd', '#00cdcd', '#e5e5e5', '#7f7f7f', '#ff0000', '#00ff00', '#ffff00', '#5c5cff', '#ff00ff', '#00ffff', '#ffffff']

--- a/runtime/colors/zellner.vim
+++ b/runtime/colors/zellner.vim
@@ -13,7 +13,7 @@ set background=light
 hi clear
 let g:colors_name = 'zellner'
 
-let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ? &t_Co : 0) : -1
+let s:t_Co = &t_Co
 
 if (has('termguicolors') && &termguicolors) || has('gui_running')
   let g:terminal_ansi_colors = ['#ffffff', '#a52a2a', '#ff00ff', '#a020f0', '#0000ff', '#0000ff', '#ff00ff', '#a9a9a9', '#ff0000', '#a52a2a', '#ff00ff', '#a020f0', '#0000ff', '#0000ff', '#ff00ff', '#000000']


### PR DESCRIPTION
Problem: check for available colors failed
Solution: simply trust t_Co, which is always available

Fixes #20597 