### PR TITLE
perf(redraw): remove redraw panic in insert-mode completion

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -95,7 +95,6 @@ typedef enum {
 # include "drawscreen.c.generated.h"
 #endif
 
-static bool redraw_popupmenu = false;
 static bool msg_grid_invalid = false;
 static bool resizing_autocmd = false;
 
@@ -209,7 +208,6 @@ void screenclear(void)
   redraw_all_later(UPD_NOT_VALID);
   redraw_cmdline = true;
   redraw_tabline = true;
-  redraw_popupmenu = true;
   pum_invalidate();
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_floating) {
@@ -339,7 +337,6 @@ void screen_resize(int width, int height)
         do_check_scrollbind(true);
       }
       if (State & MODE_CMDLINE) {
-        redraw_popupmenu = false;
         update_screen();
         redrawcmdline();
         if (pum_drawn()) {
@@ -348,11 +345,7 @@ void screen_resize(int width, int height)
       } else {
         update_topline(curwin);
         if (pum_drawn()) {
-          // TODO(bfredl): ins_compl_show_pum wants to redraw the screen first.
-          // For now make sure the nested update_screen() won't redraw the
-          // pum at the old position. Try to untangle this later.
-          redraw_popupmenu = false;
-          ins_compl_show_pum();
+          must_redraw_pum = true;
         }
         update_screen();
         if (redrawing()) {
@@ -591,9 +584,13 @@ int update_screen(void)
   end_search_hl();
 
   // May need to redraw the popup menu.
-  if (pum_drawn() && must_redraw_pum) {
+  if (must_redraw_pum) {
     win_check_ns_hl(curwin);
-    pum_redraw();
+    if (State & MODE_INSERT) {
+      ins_compl_redraw_pum();
+    } else {
+      pum_redraw();
+    }
   }
 
   win_check_ns_hl(NULL);
@@ -2002,6 +1999,13 @@ void redraw_curbuf_later(int type)
 {
   redraw_buf_later(curbuf, type);
 }
+
+void redraw_pum_later(void)
+{
+  must_redraw_pum = true;
+  redraw_later(curwin, UPD_VALID);
+}
+
 
 void redraw_buf_later(buf_T *buf, int type)
 {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1251,6 +1251,13 @@ void ins_compl_show_pum(void)
   // part of the screen would be updated.  We do need to redraw here.
   dollar_vcol = -1;
 
+  // Update the screen before drawing the popup menu over it.
+  // TODO(bfredl): pum_display() needs to be
+  // separated into two parts. We should just configure
+  // what is to be drawn here. Then the contents of the pum will be put to
+  // screen in update_screen(), after reallocating/drawing all windows
+  update_screen();
+
   // Compute the screen column of the start of the completed text.
   // Use the cursor to get all wrapping and other settings right.
   const colnr_T col = curwin->w_cursor.col;

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -903,7 +903,6 @@ static void ins_compl_longest_match(compl_T *match)
     had_match = (curwin->w_cursor.col > compl_col);
     ins_compl_delete();
     ins_bytes(compl_leader + get_compl_len());
-    ins_redraw(false);
 
     // When the match isn't there (to avoid matching itself) remove it
     // again after redrawing.
@@ -937,7 +936,6 @@ static void ins_compl_longest_match(compl_T *match)
     had_match = (curwin->w_cursor.col > compl_col);
     ins_compl_delete();
     ins_bytes(compl_leader + get_compl_len());
-    ins_redraw(false);
 
     // When the match isn't there (to avoid matching itself) remove it
     // again after redrawing.
@@ -1226,9 +1224,6 @@ void ins_compl_show_pum(void)
 
   // Dirty hard-coded hack: remove any matchparen highlighting.
   do_cmdline_cmd("if exists('g:loaded_matchparen')|3match none|endif");
-
-  // Update the screen before drawing the popup menu over it.
-  update_screen();
 
   int cur = -1;
   bool array_changed = false;
@@ -1648,8 +1643,7 @@ int ins_compl_bs(void)
     ins_compl_restart();
   }
 
-  // ins_compl_restart() calls update_screen() which may invalidate the pointer
-  // TODO(bfredl): get rid of random update_screen() calls deep inside completion logic
+  // ins_compl_restart() may call update_screen() which may invalidate the pointer
   line = get_cursor_line_ptr();
 
   xfree(compl_leader);
@@ -1756,10 +1750,6 @@ void ins_compl_addleader(int c)
 /// BS or a key was typed while still searching for matches.
 static void ins_compl_restart(void)
 {
-  // update screen before restart.
-  // so if complete is blocked,
-  // will stay to the last popup menu and reduce flicker
-  update_screen();  // TODO(bfredl): no.
   ins_compl_free();
   compl_started = false;
   compl_matches = 0;
@@ -2048,6 +2038,7 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
   if (c == Ctrl_C && cmdwin_type != 0) {
     // Avoid the popup menu remains displayed when leaving the
     // command line window.
+    // TODO: too early! why not redraw screen without cmdwin  later?
     update_screen();
   }
 
@@ -3536,9 +3527,6 @@ static int ins_compl_next(bool allow_get_expansion, int count, bool insert_match
   }
 
   if (!allow_get_expansion) {
-    // redraw to show the user what was inserted
-    update_screen();  // TODO(bfredl): no!
-
     // display the updated popup menu
     ins_compl_show_pum();
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2280,7 +2280,7 @@ int ml_replace(linenr_T lnum, char *line, bool copy)
 /// Do not use it after calling ml_replace().
 ///
 /// Check: The caller of this function should probably also call
-/// changed_lines(), unless update_screen(UPD_NOT_VALID) is used.
+/// changed_lines(), unless redraw_later(UPD_NOT_VALID) is used.
 ///
 /// @return  FAIL for failure, OK otherwise
 int ml_replace_buf(buf_T *buf, linenr_T lnum, char *line, bool copy)


### PR DESCRIPTION
- order of showing the pum and updating curwin is irrelevant in nvim
- no need to ins_redraw() in the middle of calculating longest match