### PR TITLE
fix(man): handle absolute paths as `:Man` targets

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -283,6 +283,14 @@ local function get_path(sect, name, silent)
     return
   end
 
+  -- `man -w /some/path` will return `/some/path` for any existent file, which
+  -- stops us from actually determining if a path has a corresponding man file.
+  -- Since `:Man /some/path/to/man/file` isn't supported anyway, we should just
+  -- error out here if we detect this is the case.
+  if sect == '' and #results == 1 and results[1] == name then
+    return
+  end
+
   -- find any that match the specified name
   local namematches = vim.tbl_filter(function(v)
     return fn.fnamemodify(v, ':t'):match(name)


### PR DESCRIPTION
Previously, attempting to provide `:Man` with an absolute path as the name would cause neovim to return the following error:

```
Error detected while processing command line:
/usr/local/share/nvim/runtime/lua/man.lua:690: /usr/local/share/nvim/runtime/lua/man.lua:683: Vim:E426: tag not found: nil(nil)
Press ENTER or type command to continue
```

..because it would try to validate the existence of a man page for the provided name by executing `man -w /some/path` which (on at least some Linux machines [0]) returns `/some/path` instead of the path to the nroff files that would be formatted to satisfy the man(1) lookup.

While man pages are not normally named after absolute paths, users shouldn't be blamed for trying. Given such a name/path, neovim would **not** complain that the path didn't have a corresponding man file but would error out when trying to call the tag function for the null-propagated name-and-section `nil(nil)`. (The same underlying error existed before this function was ported to lua, but did not exhibit the lua-specific `nil(nil)` name; instead a tag lookup for `()` would fail and error out.)

With this patch, we detect the case where `man -w ...` returns the same value as the provided name to not only prevent invoking the tag function for a non-existent/malformed name+sect but also to properly report the non-existence of a man page for the provided lookup (the absolute path).

While man(1) can be used to directly read an nroff-formatted document via `man /path/to/nroff.doc`, `:Man /path/to/nroff.doc` never supported this behavior so no functionality is lost in case the provided path _was_ an nroff file.

[0]: `man -w /absolute/path` returning `/absolute/path` observed on an Ubuntu 18.04 installation.