### PR TITLE
fix(diagnostic): edit global_diagnostic_options directly when ns not nil

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -661,7 +661,11 @@ function M.config(opts, namespace)
   end
 
   for k, v in pairs(opts) do
-    t[k] = v
+    if namespace then
+      global_diagnostic_options[k] = v
+    else
+      t[k] = v
+    end
   end
 
   if namespace then


### PR DESCRIPTION
In case the namespace parameter is not nil, variable t won't have the same reference as global_diagnostic_options. As a result line 1251 (of this commit) would not have access to the configuration provided by user and it would resort to the default value of global_diagnostic_options.