### PR TITLE
vim-patch:9.0.0727: help in the repository differs from patched version too much

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1519,9 +1519,10 @@ cursor({list})
 		|setcursorcharpos()|.
 
 		Does not change the jumplist.
+		{lnum} is used like with |getline()|, except that if {lnum} is
+		zero, the cursor will stay in the current line.
 		If {lnum} is greater than the number of lines in the buffer,
 		the cursor will be positioned at the last line in the buffer.
-		If {lnum} is zero, the cursor will stay in the current line.
 		If {col} is greater than the number of bytes in the line,
 		the cursor will be positioned at the last character in the
 		line.


### PR DESCRIPTION
#### vim-patch:9.0.0727: help in the repository differs from patched version too much

Problem:    Help in the repository differs from patched version too much.
Solution:   Make a patch for a few help files.
https://github.com/vim/vim/commit/7c6cd443757348aa987eed87506549ab6b2079fe