### PR TITLE
vim-patch:8.2.4735: quickfix tests can be a bit hard to read

### DIFF
--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -104,9 +104,15 @@ func XlistTests(cchar)
   call assert_true(v:errmsg ==# 'E42: No Errors')
 
   " Populate the list and then try
-  Xgetexpr ['non-error 1', 'Xtestfile1:1:3:Line1',
-		  \ 'non-error 2', 'Xtestfile2:2:2:Line2',
-		  \ 'non-error| 3', 'Xtestfile3:3:1:Line3']
+  let lines =<< trim END
+    non-error 1
+    Xtestfile1:1:3:Line1
+    non-error 2
+    Xtestfile2:2:2:Line2
+    non-error| 3
+    Xtestfile3:3:1:Line3
+  END
+  Xgetexpr lines
 
   " List only valid entries
   let l = split(execute('Xlist', ''), "\n")
@@ -272,8 +278,12 @@ func XwindowTests(cchar)
   call assert_true(winnr('$') == 1)
 
   " Create a list with valid entries
-  Xgetexpr ['Xtestfile1:1:3:Line1', 'Xtestfile2:2:2:Line2',
-		  \ 'Xtestfile3:3:1:Line3']
+  let lines =<< trim END
+    Xtestfile1:1:3:Line1
+    Xtestfile2:2:2:Line2
+    Xtestfile3:3:1:Line3
+  END
+  Xgetexpr lines
 
   " Open the window
   Xwindow
@@ -336,8 +346,12 @@ func XwindowTests(cchar)
   if a:cchar == 'c'
       " Opening the quickfix window in multiple tab pages should reuse the
       " quickfix buffer
-      Xgetexpr ['Xtestfile1:1:3:Line1', 'Xtestfile2:2:2:Line2',
-		  \ 'Xtestfile3:3:1:Line3']
+      let lines =<< trim END
+        Xtestfile1:1:3:Line1
+        Xtestfile2:2:2:Line2
+        Xtestfile3:3:1:Line3
+      END
+      Xgetexpr lines
       Xopen
       let qfbufnum = bufnr('%')
       tabnew
@@ -372,14 +386,16 @@ func Test_copenHeight_tabline()
   set tabline& showtabline&
 endfunc
 
-
 " Tests for the :cfile, :lfile, :caddfile, :laddfile, :cgetfile and :lgetfile
 " commands.
 func XfileTests(cchar)
   call s:setup_commands(a:cchar)
 
-  call writefile(['Xtestfile1:700:10:Line 700',
-	\ 'Xtestfile2:800:15:Line 800'], 'Xqftestfile1')
+  let lines =<< trim END
+    Xtestfile1:700:10:Line 700
+    Xtestfile2:800:15:Line 800
+  END
+  call writefile(lines, 'Xqftestfile1')
 
   enew!
   Xfile Xqftestfile1
@@ -403,8 +419,11 @@ func XfileTests(cchar)
   call assert_true(len(l) == 3 &&
 	\ l[2].lnum == 900 && l[2].col == 30 && l[2].text ==# 'Line 900')
 
-  call writefile(['Xtestfile1:222:77:Line 222',
-	\ 'Xtestfile2:333:88:Line 333'], 'Xqftestfile1')
+  let lines =<< trim END
+    Xtestfile1:222:77:Line 222
+    Xtestfile2:333:88:Line 333
+  END
+  call writefile(lines, 'Xqftestfile1')
 
   enew!
   Xgetfile Xqftestfile1
@@ -434,8 +453,11 @@ func XbufferTests(cchar)
   call s:setup_commands(a:cchar)
 
   enew!
-  silent! call setline(1, ['Xtestfile7:700:10:Line 700',
-	\ 'Xtestfile8:800:15:Line 800'])
+  let lines =<< trim END
+    Xtestfile7:700:10:Line 700
+    Xtestfile8:800:15:Line 800
+  END
+  silent! call setline(1, lines)
   Xbuffer!
   let l = g:Xgetlist()
   call assert_true(len(l) == 2 &&
@@ -443,8 +465,11 @@ func XbufferTests(cchar)
 	\ l[1].lnum == 800 && l[1].col == 15 && l[1].text ==# 'Line 800')
 
   enew!
-  silent! call setline(1, ['Xtestfile9:900:55:Line 900',
-	\ 'Xtestfile10:950:66:Line 950'])
+  let lines =<< trim END
+    Xtestfile9:900:55:Line 900
+    Xtestfile10:950:66:Line 950
+  END
+  silent! call setline(1, lines)
   Xgetbuffer
   let l = g:Xgetlist()
   call assert_true(len(l) == 2 &&
@@ -452,8 +477,11 @@ func XbufferTests(cchar)
 	\ l[1].lnum == 950 && l[1].col == 66 && l[1].text ==# 'Line 950')
 
   enew!
-  silent! call setline(1, ['Xtestfile11:700:20:Line 700',
-	\ 'Xtestfile12:750:25:Line 750'])
+  let lines =<< trim END
+    Xtestfile11:700:20:Line 700
+    Xtestfile12:750:25:Line 750
+  END
+  silent! call setline(1, lines)
   Xaddbuffer
   let l = g:Xgetlist()
   call assert_true(len(l) == 4 &&
@@ -523,12 +551,15 @@ func Xtest_browse(cchar)
   call s:create_test_file('Xqftestfile1')
   call s:create_test_file('Xqftestfile2')
 
-  Xgetexpr ['Xqftestfile1:5:Line5',
-		\ 'Xqftestfile1:6:Line6',
-		\ 'Xqftestfile2:10:Line10',
-		\ 'Xqftestfile2:11:Line11',
-		\ 'RegularLine1',
-		\ 'RegularLine2']
+  let lines =<< trim END
+    Xqftestfile1:5:Line5
+    Xqftestfile1:6:Line6
+    Xqftestfile2:10:Line10
+    Xqftestfile2:11:Line11
+    RegularLine1
+    RegularLine2
+  END
+  Xgetexpr lines
 
   Xfirst
   call assert_fails('-5Xcc', 'E16:')
@@ -578,10 +609,13 @@ func Xtest_browse(cchar)
   call assert_equal(5, line('.'))
 
   " Jumping to an error from the error window using cc command
-  Xgetexpr ['Xqftestfile1:5:Line5',
-		\ 'Xqftestfile1:6:Line6',
-		\ 'Xqftestfile2:10:Line10',
-		\ 'Xqftestfile2:11:Line11']
+  let lines =<< trim END
+    Xqftestfile1:5:Line5
+    Xqftestfile1:6:Line6
+    Xqftestfile2:10:Line10
+    Xqftestfile2:11:Line11
+  END
+  Xgetexpr lines
   Xopen
   10Xcc
   call assert_equal(11, line('.'))
@@ -1109,20 +1143,21 @@ func s:dir_stack_tests(cchar)
   let save_efm=&efm
   set efm=%DEntering\ dir\ '%f',%f:%l:%m,%XLeaving\ dir\ '%f'
 
-  let lines = ["Entering dir 'dir1/a'",
-		\ 'habits2.txt:1:Nine Healthy Habits',
-		\ "Entering dir 'b'",
-		\ 'habits3.txt:2:0 Hours of television',
-		\ 'habits2.txt:7:5 Small meals',
-		\ "Entering dir 'dir1/c'",
-		\ 'habits4.txt:3:1 Hour of exercise',
-		\ "Leaving dir 'dir1/c'",
-		\ "Leaving dir 'dir1/a'",
-		\ 'habits1.txt:4:2 Liters of water',
-		\ "Entering dir 'dir2'",
-		\ 'habits5.txt:5:3 Cups of hot green tea',
-		\ "Leaving dir 'dir2'"
-		\]
+  let lines =<< trim END
+    Entering dir 'dir1/a'
+    habits2.txt:1:Nine Healthy Habits
+    Entering dir 'b'
+    habits3.txt:2:0 Hours of television
+    habits2.txt:7:5 Small meals
+    Entering dir 'dir1/c'
+    habits4.txt:3:1 Hour of exercise
+    Leaving dir 'dir1/c'
+    Leaving dir 'dir1/a'
+    habits1.txt:4:2 Liters of water
+    Entering dir 'dir2'
+    habits5.txt:5:3 Cups of hot green tea
+    Leaving dir 'dir2'
+  END
 
   Xexpr ""
   for l in lines
@@ -1156,19 +1191,19 @@ func Test_efm_dirstack()
   call mkdir('dir1/c')
   call mkdir('dir2')
 
-  let lines = ["Nine Healthy Habits",
-		\ "0 Hours of television",
-		\ "1 Hour of exercise",
-		\ "2 Liters of water",
-		\ "3 Cups of hot green tea",
-		\ "4 Short mental breaks",
-		\ "5 Small meals",
-		\ "6 AM wake up time",
-		\ "7 Minutes of laughter",
-		\ "8 Hours of sleep (at least)",
-		\ "9 PM end of the day and off to bed"
-		\ ]
-
+  let lines =<< trim END
+    Nine Healthy Habits
+    0 Hours of television
+    1 Hour of exercise
+    2 Liters of water
+    3 Cups of hot green tea
+    4 Short mental breaks
+    5 Small meals
+    6 AM wake up time
+    7 Minutes of laughter
+    8 Hours of sleep (at least)
+    9 PM end of the day and off to bed
+  END
   call writefile(lines, 'habits1.txt')
   call writefile(lines, 'dir1/a/habits2.txt')
   call writefile(lines, 'dir1/a/b/habits3.txt')
@@ -1194,7 +1229,13 @@ func Xefm_ignore_continuations(cchar)
 	\ '%-Wignored %m %l,' .
 	\ '%+Cmore ignored %m %l,' .
 	\ '%Zignored end'
-  Xgetexpr ['ignored warning 1', 'more ignored continuation 2', 'ignored end', 'error resync 4']
+  let lines =<< trim END
+    ignored warning 1
+    more ignored continuation 2
+    ignored end
+    error resync 4
+  END
+  Xgetexpr lines
   let l = map(g:Xgetlist(), '[v:val.text, v:val.valid, v:val.lnum, v:val.type]')
   call assert_equal([['resync', 1, 4, 'E']], l)
 
@@ -1438,8 +1479,14 @@ func Test_efm_error_type()
 
   " error type
   set efm=%f:%l:%t:%m
-  cexpr ["Xfile1:10:E:msg1", "Xfile1:20:W:msg2", "Xfile1:30:I:msg3",
-        \ "Xfile1:40:N:msg4", "Xfile1:50:R:msg5"]
+  let lines =<< trim END
+    Xfile1:10:E:msg1
+    Xfile1:20:W:msg2
+    Xfile1:30:I:msg3
+    Xfile1:40:N:msg4
+    Xfile1:50:R:msg5
+  END
+  cexpr lines
   let output = split(execute('clist'), "\n")
   call assert_equal([
         \ ' 1 Xfile1:10 error: msg1',
@@ -1450,8 +1497,14 @@ func Test_efm_error_type()
 
   " error type and a error number
   set efm=%f:%l:%t:%n:%m
-  cexpr ["Xfile1:10:E:2:msg1", "Xfile1:20:W:4:msg2", "Xfile1:30:I:6:msg3",
-        \ "Xfile1:40:N:8:msg4", "Xfile1:50:R:3:msg5"]
+  let lines =<< trim END
+    Xfile1:10:E:2:msg1
+    Xfile1:20:W:4:msg2
+    Xfile1:30:I:6:msg3
+    Xfile1:40:N:8:msg4
+    Xfile1:50:R:3:msg5
+  END
+  cexpr lines
   let output = split(execute('clist'), "\n")
   call assert_equal([
         \ ' 1 Xfile1:10 error   2: msg1',
@@ -1476,8 +1529,13 @@ func Test_efm_end_lnum_col()
 
   " multiple lines
   set efm=%A%n)%m,%Z%f:%l-%e:%c-%k
-  cexpr ["1)msg1", "Xfile1:14-24:1-2",
-        \ "2)msg2", "Xfile1:24-34:3-4"]
+  let lines =<< trim END
+    1)msg1
+    Xfile1:14-24:1-2
+    2)msg2
+    Xfile1:24-34:3-4
+  END
+  cexpr lines
   let output = split(execute('clist'), "\n")
   call assert_equal([
         \ ' 1 Xfile1:14-24 col 1-2 error   1: msg1',
@@ -1887,12 +1945,12 @@ func Test_cgetfile_on_long_lines()
   " Problematic values if the line is longer than 4096 bytes.  Then 1024 bytes
   " are read at a time.
   for len in [4078, 4079, 4080, 5102, 5103, 5104, 6126, 6127, 6128, 7150, 7151, 7152]
-    let lines = [
-      \ '/tmp/file1:1:1:aaa',
-      \ '/tmp/file2:1:1:%s',
-      \ '/tmp/file3:1:1:bbb',
-      \ '/tmp/file4:1:1:ccc',
-      \ ]
+    let lines =<< trim END
+      /tmp/file1:1:1:aaa
+      /tmp/file2:1:1:%s
+      /tmp/file3:1:1:bbb
+      /tmp/file4:1:1:ccc
+    END
     let lines[1] = substitute(lines[1], '%s', repeat('x', len), '')
     call writefile(lines, 'Xcqetfile.txt')
     cgetfile Xcqetfile.txt
@@ -1919,12 +1977,15 @@ func Test_switchbuf()
   let file1_winid = win_getid()
   new Xqftestfile2
   let file2_winid = win_getid()
-  cgetexpr ['Xqftestfile1:5:Line5',
-		\ 'Xqftestfile1:6:Line6',
-		\ 'Xqftestfile2:10:Line10',
-		\ 'Xqftestfile2:11:Line11',
-		\ 'Xqftestfile3:15:Line15',
-		\ 'Xqftestfile3:16:Line16']
+  let lines =<< trim END
+    Xqftestfile1:5:Line5
+    Xqftestfile1:6:Line6
+    Xqftestfile2:10:Line10
+    Xqftestfile2:11:Line11
+    Xqftestfile3:15:Line15
+    Xqftestfile3:16:Line16
+  END
+  cgetexpr lines
 
   new
   let winid = win_getid()
@@ -2586,21 +2647,23 @@ func Test_Autocmd()
   silent! cexpr non_existing_func()
   silent! caddexpr non_existing_func()
   silent! cgetexpr non_existing_func()
-  let l = ['precexpr',
-        \ 'postcexpr',
-        \ 'precaddexpr',
-        \ 'postcaddexpr',
-        \ 'precgetexpr',
-        \ 'postcgetexpr',
-        \ 'precexpr',
-        \ 'postcexpr',
-        \ 'precaddexpr',
-        \ 'postcaddexpr',
-        \ 'precgetexpr',
-        \ 'postcgetexpr',
-        \ 'precexpr',
-        \ 'precaddexpr',
-        \ 'precgetexpr']
+  let l =<< trim END
+    precexpr
+    postcexpr
+    precaddexpr
+    postcaddexpr
+    precgetexpr
+    postcgetexpr
+    precexpr
+    postcexpr
+    precaddexpr
+    postcaddexpr
+    precgetexpr
+    postcgetexpr
+    precexpr
+    precaddexpr
+    precgetexpr
+  END
   call assert_equal(l, g:acmds)
 
   let g:acmds = []
@@ -2618,15 +2681,17 @@ func Test_Autocmd()
   exe 'silent! cgetbuffer ' . bnum
   exe 'silent! caddbuffer ' . bnum
   enew!
-  let l = ['precbuffer',
-      \ 'postcbuffer',
-      \ 'precgetbuffer',
-      \ 'postcgetbuffer',
-      \ 'precaddbuffer',
-      \ 'postcaddbuffer',
-      \ 'precbuffer',
-      \ 'precgetbuffer',
-      \ 'precaddbuffer']
+  let l =<< trim END
+    precbuffer
+    postcbuffer
+    precgetbuffer
+    postcgetbuffer
+    precaddbuffer
+    postcaddbuffer
+    precbuffer
+    precgetbuffer
+    precaddbuffer
+  END
   call assert_equal(l, g:acmds)
 
   call writefile(['Xtest:1:Line1'], 'Xtest')
@@ -2641,24 +2706,26 @@ func Test_Autocmd()
   silent! cfile do_not_exist
   silent! caddfile do_not_exist
   silent! cgetfile do_not_exist
-  let l = ['precfile',
-        \ 'postcfile',
-        \ 'precaddfile',
-        \ 'postcaddfile',
-        \ 'precgetfile',
-        \ 'postcgetfile',
-        \ 'precfile',
-        \ 'postcfile',
-        \ 'precaddfile',
-        \ 'postcaddfile',
-        \ 'precgetfile',
-        \ 'postcgetfile',
-        \ 'precfile',
-        \ 'postcfile',
-        \ 'precaddfile',
-        \ 'postcaddfile',
-        \ 'precgetfile',
-        \ 'postcgetfile']
+  let l =<< trim END
+    precfile
+    postcfile
+    precaddfile
+    postcaddfile
+    precgetfile
+    postcgetfile
+    precfile
+    postcfile
+    precaddfile
+    postcaddfile
+    precgetfile
+    postcgetfile
+    precfile
+    postcfile
+    precaddfile
+    postcaddfile
+    precgetfile
+    postcgetfile
+  END
   call assert_equal(l, g:acmds)
 
   let g:acmds = []
@@ -2671,20 +2738,22 @@ func Test_Autocmd()
   set makeprg=
   silent! make
   set makeprg&
-  let l = ['prehelpgrep',
-        \ 'posthelpgrep',
-        \ 'prehelpgrep',
-        \ 'posthelpgrep',
-        \ 'previmgrep',
-        \ 'postvimgrep',
-        \ 'previmgrepadd',
-        \ 'postvimgrepadd',
-        \ 'previmgrep',
-        \ 'postvimgrep',
-        \ 'previmgrepadd',
-        \ 'postvimgrepadd',
-        \ 'premake',
-        \ 'postmake']
+  let l =<< trim END
+    prehelpgrep
+    posthelpgrep
+    prehelpgrep
+    posthelpgrep
+    previmgrep
+    postvimgrep
+    previmgrepadd
+    postvimgrepadd
+    previmgrep
+    postvimgrep
+    previmgrepadd
+    postvimgrepadd
+    premake
+    postmake
+  END
   call assert_equal(l, g:acmds)
 
   if has('unix')
@@ -2704,22 +2773,24 @@ func Test_Autocmd()
     silent lgrep Grep_Autocmd_Text test_quickfix.vim
     silent lgrepadd GrepAdd_Autocmd_Text test_quickfix.vim
     set grepprg&vim
-    let l = ['pregrep',
-		\ 'postgrep',
-		\ 'pregrepadd',
-		\ 'postgrepadd',
-		\ 'pregrep',
-		\ 'postgrep',
-		\ 'pregrepadd',
-		\ 'postgrepadd',
-		\ 'pregrep',
-		\ 'postgrep',
-		\ 'pregrepadd',
-		\ 'postgrepadd',
-		\ 'prelgrep',
-		\ 'postlgrep',
-		\ 'prelgrepadd',
-		\ 'postlgrepadd']
+    let l =<< trim END
+      pregrep
+      postgrep
+      pregrepadd
+      postgrepadd
+      pregrep
+      postgrep
+      pregrepadd
+      postgrepadd
+      pregrep
+      postgrep
+      pregrepadd
+      postgrepadd
+      prelgrep
+      postlgrep
+      prelgrepadd
+      postlgrepadd
+    END
     call assert_equal(l, g:acmds)
   endif
 
@@ -2878,11 +2949,11 @@ func Test_cwindow_highlight()
   CheckScreendump
 
   let lines =<< trim END
-	call setline(1, ['some', 'text', 'with', 'matches'])
-	write XCwindow
-	vimgrep e XCwindow
-	redraw
-	cwindow 4
+    call setline(1, ['some', 'text', 'with', 'matches'])
+    write XCwindow
+    vimgrep e XCwindow
+    redraw
+    cwindow 4
   END
   call writefile(lines, 'XtestCwindow')
   let buf = RunVimInTerminal('-S XtestCwindow', #{rows: 12})
@@ -2899,10 +2970,13 @@ endfunc
 func XvimgrepTests(cchar)
   call s:setup_commands(a:cchar)
 
-  call writefile(['Editor:VIM vim',
-	      \ 'Editor:Emacs EmAcS',
-	      \ 'Editor:Notepad NOTEPAD'], 'Xtestfile1')
-  call writefile(['Linux', 'MacOS', 'MS-Windows'], 'Xtestfile2')
+  let lines =<< trim END
+    Editor:VIM vim
+    Editor:Emacs EmAcS
+    Editor:Notepad NOTEPAD
+  END
+  call writefile(lines, 'Xtestfile1')
+  call writefile(['Linux', 'macOS', 'MS-Windows'], 'Xtestfile2')
 
   " Error cases
   call assert_fails('Xvimgrep /abc *', 'E682:')
@@ -2916,7 +2990,7 @@ func XvimgrepTests(cchar)
 
   Xexpr ""
   Xvimgrepadd Notepad Xtestfile1
-  Xvimgrepadd MacOS Xtestfile2
+  Xvimgrepadd macOS Xtestfile2
   let l = g:Xgetlist()
   call assert_equal(2, len(l))
   call assert_equal('Editor:Notepad NOTEPAD', l[0].text)
@@ -3412,14 +3486,15 @@ func Xmultifilestack_tests(cchar)
   " error line ends with a file stack.
   let efm_val = 'Error\ l%l\ in\ %f,'
   let efm_val .= '%-P%>(%f%r,Error\ l%l\ in\ %m,%-Q)%r'
-  let l = g:Xgetlist({'lines' : [
-              \ '(one.txt',
-              \ 'Error l4 in one.txt',
-              \ ') (two.txt',
-              \ 'Error l6 in two.txt',
-              \ ')',
-              \ 'Error l8 in one.txt'
-              \ ], 'efm' : efm_val})
+  let lines =<< trim END
+    (one.txt
+    Error l4 in one.txt
+    ) (two.txt
+    Error l6 in two.txt
+    )
+    Error l8 in one.txt
+  END
+  let l = g:Xgetlist({'lines': lines, 'efm' : efm_val})
   call assert_equal(3, len(l.items))
   call assert_equal('one.txt', bufname(l.items[0].bufnr))
   call assert_equal(4, l.items[0].lnum)
@@ -3697,7 +3772,15 @@ func Xqfjump_tests(cchar)
     call g:Xsetlist([], 'f')
     setlocal buftype=nofile
     new
-    call g:Xsetlist([], ' ', {'lines' : ['F1:1:1:Line1', 'F1:2:2:Line2', 'F2:1:1:Line1', 'F2:2:2:Line2', 'F3:1:1:Line1', 'F3:2:2:Line2']})
+    let lines =<< trim END
+      F1:1:1:Line1
+      F1:2:2:Line2
+      F2:1:1:Line1
+      F2:2:2:Line2
+      F3:1:1:Line1
+      F3:2:2:Line2
+    END
+    call g:Xsetlist([], ' ', {'lines': lines})
     Xopen
     let winid = win_getid()
     wincmd p
@@ -4929,9 +5012,20 @@ func Xtest_below(cchar)
   endif
 
   " Test for lines with multiple quickfix entries
-  Xexpr ["X1:5:L5", "X2:5:1:L5_1", "X2:5:2:L5_2", "X2:5:3:L5_3",
-	      \ "X2:10:1:L10_1", "X2:10:2:L10_2", "X2:10:3:L10_3",
-	      \ "X2:15:1:L15_1", "X2:15:2:L15_2", "X2:15:3:L15_3", "X3:3:L3"]
+  let lines =<< trim END
+    X1:5:L5
+    X2:5:1:L5_1
+    X2:5:2:L5_2
+    X2:5:3:L5_3
+    X2:10:1:L10_1
+    X2:10:2:L10_2
+    X2:10:3:L10_3
+    X2:15:1:L15_1
+    X2:15:2:L15_2
+    X2:15:3:L15_3
+    X3:3:L3
+  END
+  Xexpr lines
   edit +1 X2
   Xbelow 2
   call assert_equal(['X2', 10, 1], [@%, line('.'), col('.')])
@@ -4995,33 +5089,32 @@ func Test_cbelow()
 endfunc
 
 func Test_quickfix_count()
-  let commands = [
-	\ 'cNext',
-	\ 'cNfile',
-	\ 'cabove',
-	\ 'cbelow',
-	\ 'cfirst',
-	\ 'clast',
-	\ 'cnewer',
-	\ 'cnext',
-	\ 'cnfile',
-	\ 'colder',
-	\ 'cprevious',
-	\ 'crewind',
-	\
-	\ 'lNext',
-	\ 'lNfile',
-	\ 'labove',
-	\ 'lbelow',
-	\ 'lfirst',
-	\ 'llast',
-	\ 'lnewer',
-	\ 'lnext',
-	\ 'lnfile',
-	\ 'lolder',
-	\ 'lprevious',
-	\ 'lrewind',
-	\ ]
+  let commands =<< trim END
+    cNext
+    cNfile
+    cabove
+    cbelow
+    cfirst
+    clast
+    cnewer
+    cnext
+    cnfile
+    colder
+    cprevious
+    crewind
+    lNext
+    lNfile
+    labove
+    lbelow
+    lfirst
+    llast
+    lnewer
+    lnext
+    lnfile
+    lolder
+    lprevious
+    lrewind
+  END
   for cmd in commands
     call assert_fails('-1' .. cmd, 'E16:')
     call assert_fails('.' .. cmd, 'E16:')
@@ -5662,9 +5755,12 @@ func Test_locationlist_open_in_newtab()
 
   %bwipe!
 
-  lgetexpr ['Xqftestfile1:5:Line5',
-		\ 'Xqftestfile2:10:Line10',
-		\ 'Xqftestfile3:16:Line16']
+  let lines =<< trim END
+    Xqftestfile1:5:Line5
+    Xqftestfile2:10:Line10
+    Xqftestfile3:16:Line16
+  END
+  lgetexpr lines
 
   silent! llast
   call assert_equal(1, tabpagenr('$'))


### PR DESCRIPTION
#### vim-patch:8.2.4735: quickfix tests can be a bit hard to read

Problem:    Quickfix tests can be a bit hard to read.
Solution:   Use heredoc instead of strings and line continuation. (Yegappan
            Lakshmanan, closes vim/vim#10145)
https://github.com/vim/vim/commit/4a7724a4406f639edd3f93f3542626811cf56719

Cherry-pick a typo fix from patch 8.2.3637.