### PR TITLE
vim-patch:9.0.0738: cannot suppress completion "scanning" messages

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5557,6 +5557,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  c	don't give |ins-completion-menu| messages.  For example,
 		"-- XXX completion (YYY)", "match 1 of 2", "The only match",
 		"Pattern not found", "Back at original", etc.
+	  C	don't give messages while scanning for ins-completion items,
+		for instance "scanning tags"
 	  q	use "recording" instead of "recording @a"
 	  F	don't give the file info when editing a file, like `:silent`
 		was used for the command

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1433,7 +1433,7 @@ static void ins_compl_files(int count, char **files, int thesaurus, int flags, r
 
   for (i = 0; i < count && !got_int && !compl_interrupted; i++) {
     fp = os_fopen(files[i], "r");  // open dictionary file
-    if (flags != DICT_EXACT) {
+    if (flags != DICT_EXACT && !shortmess(SHM_COMPLETIONSCAN)) {
       msg_hist_off = true;  // reset in msg_trunc_attr()
       vim_snprintf((char *)IObuff, IOSIZE,
                    _("Scanning dictionary: %s"), files[i]);
@@ -2759,14 +2759,16 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
       st->dict = (char_u *)st->ins_buf->b_fname;
       st->dict_f = DICT_EXACT;
     }
-    msg_hist_off = true;  // reset in msg_trunc_attr()
-    vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
-                 st->ins_buf->b_fname == NULL
-                 ? buf_spname(st->ins_buf)
-                 : st->ins_buf->b_sfname == NULL
-                 ? st->ins_buf->b_fname
-                 : st->ins_buf->b_sfname);
-    (void)msg_trunc_attr((char *)IObuff, true, HL_ATTR(HLF_R));
+    if (!shortmess(SHM_COMPLETIONSCAN)) {
+      msg_hist_off = true;  // reset in msg_trunc_attr()
+      vim_snprintf((char *)IObuff, IOSIZE, _("Scanning: %s"),
+                   st->ins_buf->b_fname == NULL
+                   ? buf_spname(st->ins_buf)
+                   : st->ins_buf->b_sfname == NULL
+                   ? st->ins_buf->b_fname
+                   : st->ins_buf->b_sfname);
+      (void)msg_trunc_attr((char *)IObuff, true, HL_ATTR(HLF_R));
+    }
   } else if (*st->e_cpt == NUL) {
     status = INS_COMPL_CPT_END;
   } else {
@@ -2787,10 +2789,12 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
     } else if (*st->e_cpt == 'd') {
       compl_type = CTRL_X_PATH_DEFINES;
     } else if (*st->e_cpt == ']' || *st->e_cpt == 't') {
-      msg_hist_off = true;  // reset in msg_trunc_attr()
       compl_type = CTRL_X_TAGS;
-      vim_snprintf((char *)IObuff, IOSIZE, "%s", _("Scanning tags."));
-      (void)msg_trunc_attr((char *)IObuff, true, HL_ATTR(HLF_R));
+      if (!shortmess(SHM_COMPLETIONSCAN)) {
+        msg_hist_off = true;  // reset in msg_trunc_attr()
+        vim_snprintf((char *)IObuff, IOSIZE, "%s", _("Scanning tags."));
+        (void)msg_trunc_attr((char *)IObuff, true, HL_ATTR(HLF_R));
+      }
     } else {
       compl_type = -1;
     }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -239,7 +239,7 @@ enum {
   SHM_MOD            = 'm',  ///< Modified.
   SHM_FILE           = 'f',  ///< (file 1 of 2)
   SHM_LAST           = 'i',  ///< Last line incomplete.
-  SHM_TEXT           = 'x',  ///< Tx instead of textmode.
+  SHM_TEXT           = 'x',  ///< tx instead of textmode.
   SHM_LINES          = 'l',  ///< "L" instead of "lines".
   SHM_NEW            = 'n',  ///< "[New]" instead of "[New file]".
   SHM_WRI            = 'w',  ///< "[w]" instead of "written".
@@ -253,9 +253,10 @@ enum {
   SHM_ATTENTION      = 'A',  ///< No ATTENTION messages.
   SHM_INTRO          = 'I',  ///< Intro messages.
   SHM_COMPLETIONMENU = 'c',  ///< Completion menu messages.
+  SHM_COMPLETIONSCAN = 'C',  ///< Completion scanning messages.
   SHM_RECORDING      = 'q',  ///< Short recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
-  SHM_SEARCHCOUNT    = 'S',  ///< Search sats: '[1/10]'
+  SHM_SEARCHCOUNT    = 'S',  ///< Search stats: '[1/10]'
 };
 /// Represented by 'a' flag.
 #define SHM_ALL_ABBREVIATIONS ((char[]) { \

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -118,7 +118,8 @@ static char *(p_rdb_values[]) = { "compositor", "nothrottle", "invalid", "nodelt
 static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW,
                           SHM_WRI, SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL,
                           SHM_OVER, SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO,
-                          SHM_COMPLETIONMENU, SHM_RECORDING, SHM_FILEINFO, SHM_SEARCHCOUNT, 0, };
+                          SHM_COMPLETIONMENU, SHM_COMPLETIONSCAN, SHM_RECORDING, SHM_FILEINFO,
+                          SHM_SEARCHCOUNT, 0, };
 
 /// After setting various option values: recompute variables that depend on
 /// option values.


### PR DESCRIPTION
#### vim-patch:9.0.0738: cannot suppress completion "scanning" messages

Problem:    Cannot suppress completion "scanning" messages.
Solution:   Add the "C" flag in 'shortmess'. (Bjorn Linse, closes vim/vim#11354)
https://github.com/vim/vim/commit/91ccbad5ded8bcf2cc93a873ff2c3179b0c548c7