### PR TITLE
[Backport release-0.8] build(nix): change the pkgs to final, add new version of libvterm

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -8,61 +8,63 @@
 
   outputs = { self, nixpkgs, flake-utils }:
     {
-      overlay = final: prev:
-        let
-          pkgs = nixpkgs.legacyPackages.${prev.system};
-        in
-        rec {
-          neovim = pkgs.neovim-unwrapped.overrideAttrs (oa: {
-            version = "master";
-            src = ../.;
-
-            buildInputs = oa.buildInputs ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
-              CoreServices
-            ]);
+      overlay = final: prev: rec {
+        neovim-unwrapped = prev.neovim-unwrapped.override ({
+          libvterm-neovim = prev.libvterm-neovim.overrideAttrs (old: {
+            version = "0.3";
+            src = builtins.fetchTarball {
+              url = "https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz";
+              sha256 = "0zg6sn5brwrnqaab883pdj0l2swk5askbbwbdam0zq55ikbrzgar";
+            };
           });
+        });
 
-          # a development binary to help debug issues
-          neovim-debug =
-            let
-              stdenv = if pkgs.stdenv.isLinux then pkgs.llvmPackages_latest.stdenv else pkgs.stdenv;
-            in
-            ((neovim.override {
-              lua = pkgs.luajit;
-              inherit stdenv;
-            }).overrideAttrs (oa: {
+        neovim = final.neovim-unwrapped.overrideAttrs (oa: {
+          version = "master";
+          src = ../.;
 
-              dontStrip = true;
-              NIX_CFLAGS_COMPILE = " -ggdb -Og";
+          buildInputs = oa.buildInputs
+            ++ final.lib.optionals final.stdenv.isDarwin
+            (with final.darwin.apple_sdk.frameworks; [ CoreServices ]);
+        });
 
-              cmakeBuildType = "Debug";
-              cmakeFlags = oa.cmakeFlags ++ [
-                "-DMIN_LOG_LEVEL=0"
-              ];
+        # a development binary to help debug issues
+        neovim-debug = let
+          stdenv = if final.stdenv.isLinux then
+            final.llvmPackages_latest.stdenv
+          else
+            final.stdenv;
+        in ((neovim.override {
+          lua = final.luajit;
+          inherit stdenv;
+        }).overrideAttrs (oa: {
 
-              disallowedReferences = [ ];
-            }));
+          dontStrip = true;
+          NIX_CFLAGS_COMPILE = " -ggdb -Og";
 
-          # for neovim developers, beware of the slow binary
-          neovim-developer =
-            let
-              lib = nixpkgs.lib;
-              luacheck = pkgs.luaPackages.luacheck;
-            in
-            (neovim-debug.override ({ doCheck = pkgs.stdenv.isLinux; })).overrideAttrs (oa: {
-              cmakeFlags = oa.cmakeFlags ++ [
-                "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
-                "-DMIN_LOG_LEVEL=0"
-                "-DENABLE_LTO=OFF"
-              ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
-                # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
-                # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
-                "-DCLANG_ASAN_UBSAN=ON"
-              ];
-            });
-        };
-    } //
-    flake-utils.lib.eachDefaultSystem (system:
+          cmakeBuildType = "Debug";
+          cmakeFlags = oa.cmakeFlags ++ [ "-DMIN_LOG_LEVEL=0" ];
+
+          disallowedReferences = [ ];
+        }));
+
+        # for neovim developers, beware of the slow binary
+        neovim-developer = let luacheck = final.luaPackages.luacheck;
+        in (neovim-debug.override ({
+          doCheck = final.stdenv.isLinux;
+        })).overrideAttrs (oa: {
+          cmakeFlags = oa.cmakeFlags ++ [
+            "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
+            "-DMIN_LOG_LEVEL=0"
+            "-DENABLE_LTO=OFF"
+          ] ++ final.lib.optionals final.stdenv.isLinux [
+            # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
+            # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
+            "-DCLANG_ASAN_UBSAN=ON"
+          ];
+        });
+      };
+    } // flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           overlays = [ self.overlay ];
@@ -75,26 +77,22 @@
           ps.msgpack
           ps.flake8 # for 'make pylint'
         ]);
-      in
-      rec {
-
+      in {
         packages = with pkgs; {
           default = neovim;
           inherit neovim neovim-debug neovim-developer;
         };
 
         checks = {
-          pylint = pkgs.runCommandNoCC "pylint"
-            {
-              nativeBuildInputs = [ pythonEnv ];
-              preferLocalBuild = true;
-            } "make -C ${./..} pylint > $out";
+          pylint = pkgs.runCommand "pylint" {
+            nativeBuildInputs = [ pythonEnv ];
+            preferLocalBuild = true;
+          } "make -C ${./..} pylint > $out";
 
-          shlint = pkgs.runCommandNoCC "shlint"
-            {
-              nativeBuildInputs = [ pkgs.shellcheck ];
-              preferLocalBuild = true;
-            } "make -C ${./..} shlint > $out";
+          shlint = pkgs.runCommand "shlint" {
+            nativeBuildInputs = [ pkgs.shellcheck ];
+            preferLocalBuild = true;
+          } "make -C ${./..} shlint > $out";
         };
 
         # kept for backwards-compatibility
@@ -103,17 +101,18 @@
         devShells = {
           default = pkgs.neovim-developer.overrideAttrs (oa: {
 
-            buildInputs = with pkgs; oa.buildInputs ++ [
-              cmake
-              lua.pkgs.luacheck
-              sumneko-lua-language-server
-              pythonEnv
-              include-what-you-use # for scripts/check-includes.py
-              jq # jq for scripts/vim-patch.sh -r
-              shellcheck # for `make shlint`
-              doxygen # for script/gen_vimdoc.py
-              clang-tools # for clangd to find the correct headers
-            ];
+            buildInputs = with pkgs;
+              oa.buildInputs ++ [
+                cmake
+                lua.pkgs.luacheck
+                sumneko-lua-language-server
+                pythonEnv
+                include-what-you-use # for scripts/check-includes.py
+                jq # jq for scripts/vim-patch.sh -r
+                shellcheck # for `make shlint`
+                doxygen # for script/gen_vimdoc.py
+                clang-tools # for clangd to find the correct headers
+              ];
 
             shellHook = oa.shellHook + ''
               export NVIM_PYTHON_LOG_LEVEL=DEBUG


### PR DESCRIPTION
Backport https://github.com/neovim/neovim/pull/20410 to `release-0.8`

Fixes build error in nix flake on release-0.8 branch

```
  REQUIRED PACKAGE NOT FOUND

  LIBVTERM 0.1.3 was found but version 0.3 is the minimum requirement.  This
  package is REQUIRED and you need to install it or adjust CMake
  configuration in order to continue building nvim.
```