### PR TITLE
vim-patch:9.0.0747: too many #ifdefs

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1132,6 +1132,7 @@ static int normal_execute(VimState *state, int key)
   if (s->need_flushbuf) {
     ui_flush();
   }
+
   if (s->ca.cmdchar != K_IGNORE && s->ca.cmdchar != K_EVENT) {
     did_cursorhold = false;
   }
@@ -3513,6 +3514,7 @@ static bool nv_z_get_count(cmdarg_T *cap, int *nchar_arg)
     no_mapping--;
     allow_keys--;
     (void)add_to_showcmd(nchar);
+
     if (nchar == K_DEL || nchar == K_KDEL) {
       n /= 10;
     } else if (ascii_isdigit(nchar)) {
@@ -3553,6 +3555,7 @@ static int nv_zg_zw(cmdarg_T *cap, int nchar)
     no_mapping--;
     allow_keys--;
     (void)add_to_showcmd(nchar);
+
     if (vim_strchr("gGwW", nchar) == NULL) {
       clearopbeep(cap->oap);
       return OK;

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -860,6 +860,7 @@ int showmode(void)
   if (redrawing() && last->w_status_height == 0 && global_stl_height() == 0) {
     win_redr_ruler(last, true);
   }
+
   redraw_cmdline = false;
   redraw_mode = false;
   clear_cmdline = false;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -554,6 +554,7 @@ wingotofile:
     no_mapping--;
     allow_keys--;
     (void)add_to_showcmd(xchar);
+
     switch (xchar) {
     case '}':
       xchar = Ctrl_RSB;


### PR DESCRIPTION
#### vim-patch:9.0.0747: too many #ifdefs

Problem:    Too many #ifdefs.
Solution:   Gradudate the +cmdline_info feature. (Martin Tournoij,
            closes vim/vim#11330)
https://github.com/vim/vim/commit/ba43e76fcd5b2da57dbaa4d9a555793fe8ac344e