### PR TITLE
fix: cmdline flicker when cmdheight = 0

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -434,9 +434,11 @@ int update_screen(void)
     // UPD_CLEAR is already handled
     if (type == UPD_NOT_VALID && !ui_has(kUIMultigrid) && msg_scrolled) {
       was_invalidated = ui_comp_set_screen_valid(false);
-      for (int i = valid; i < Rows - p_ch; i++) {
-        grid_clear_line(&default_grid, default_grid.line_offset[i],
-                        Columns, false);
+      if (p_ch > 0) {
+        for (int i = valid; i < Rows - p_ch; i++) {
+          grid_clear_line(&default_grid, default_grid.line_offset[i],
+                          Columns, false);
+        }
       }
       FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp->w_floating) {


### PR DESCRIPTION
I have fixed the screen flicker when `cmdheight=0`.

I don't know the clear is really needed.

@bfredl Can you check it?