### PR TITLE
fix(decoration): redraw correctly when re-using ids

### DIFF
--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -112,6 +112,7 @@ void extmark_set(buf_T *buf, uint32_t ns_id, uint32_t *idp, int row, colnr_T col
           marktree_revise(buf->b_marktree, itr, decor_level, old_mark);
           goto revised;
         }
+        decor_remove(buf, old_mark.pos.row, old_mark.pos.row, old_mark.decor_full);
         marktree_del_itr(buf->b_marktree, itr, false);
       }
     } else {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2085,4 +2085,39 @@ describe('decorations: virt_text', function()
     ]]}
   end)
 
+  it('redraws correctly when re-using extmark ids', function()
+    command 'normal 5ohello'
+
+    screen:expect{grid=[[
+                                                        |
+      hello                                             |
+      hello                                             |
+      hello                                             |
+      hello                                             |
+      hell^o                                             |
+      {3:~                                                 }|
+      {3:~                                                 }|
+      {3:~                                                 }|
+                                                        |
+    ]]}
+
+    local ns = meths.create_namespace('ns')
+    for row = 1, 5 do
+      meths.buf_set_extmark(0, ns, row, 0, { id = 1, virt_text = {{'world', 'Normal'}} })
+    end
+
+    screen:expect{grid=[[
+                                                        |
+      hello                                             |
+      hello                                             |
+      hello                                             |
+      hello                                             |
+      hell^o world                                       |
+      {3:~                                                 }|
+      {3:~                                                 }|
+      {3:~                                                 }|
+                                                        |
+    ]]}
+  end)
+
 end)


### PR DESCRIPTION
00cfc1d (from #20249) reduced the amount of unnecessary redraws. This
surfaced an issue where if and extmark with a specific ID is
repositioned to a different row, the decorations from the old row were
not redrawn and removed. This change fixes that by redrawing the
old row.
