### PR TITLE
fix(completion): set pum_size even if ext_popupmenu is used

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -264,12 +264,15 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       pum_row = above_row;
       pum_height = pum_win_row - above_row;
     }
+
+    pum_array = array;
+    // Set "pum_size" before returning so that pum_set_event_info() gets the correct size.
+    pum_size = size;
+
     if (pum_external) {
       return;
     }
 
-    pum_array = array;
-    pum_size = size;
     pum_compute_size();
     int max_width = pum_base_width;
 

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1128,6 +1128,49 @@ describe('completion', function()
       call cursor(4, 1)
     ]])
 
+    -- v:event.size should be set with ext_popupmenu #20646
+    screen:set_option('ext_popupmenu', true)
+    feed('Sf<C-N>')
+    screen:expect({grid = [[
+      foo                                                         |
+      bar                                                         |
+      foobar                                                      |
+      f^                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {3:-- Keyword completion (^N^P) }{5:Back at original}               |
+    ]], popupmenu = {
+      anchor = { 1, 3, 0 },
+      items = { { "foo", "", "", "" }, { "foobar", "", "", "" } },
+      pos = -1
+    }})
+    eq({completed_item = {}, width = 0,
+      height = 2, size = 2,
+      col = 0, row = 4, scrollbar = false},
+      eval('g:event'))
+    feed('oob')
+    screen:expect({grid = [[
+      foo                                                         |
+      bar                                                         |
+      foobar                                                      |
+      foob^                                                        |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {3:-- Keyword completion (^N^P) }{5:Back at original}               |
+    ]], popupmenu = {
+      anchor = { 1, 3, 0 },
+      items = { { "foobar", "", "", "" } },
+      pos = -1
+    }})
+    eq({completed_item = {}, width = 0,
+      height = 1, size = 1,
+      col = 0, row = 4, scrollbar = false},
+      eval('g:event'))
+    feed('<Esc>')
+    screen:set_option('ext_popupmenu', false)
+
     feed('Sf<C-N>')
     screen:expect([[
       foo                                                         |


### PR DESCRIPTION
Fix #20646

This allows CompleteChanged event to get the correct `v:event.size`.
It should be harmless and more consistent to also set `pum_array`.
