### PR TITLE
build: fix incorrect clang-tidy identifier rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -36,19 +36,20 @@ Checks: >
   -readability-suspicious-call-argument,
 
 CheckOptions:
-  readability-identifier-naming.ClassMemberCase: lower_case
-  readability-identifier-naming.ClassMemberSuffix: _
-  readability-identifier-naming.FunctionCase: lower_case
-  readability-identifier-naming.GlobalConstantCase: CamelCase
-  readability-identifier-naming.GlobalConstantPrefix: k
-  readability-identifier-naming.MemberConstantCase: CamelCase
-  readability-identifier-naming.MemberConstantPrefix: k
-  readability-identifier-naming.NamespaceCase: lower_case
-  readability-identifier-naming.StaticConstantCase: CamelCase
-  readability-identifier-naming.StaticConstantPrefix: k
-  readability-identifier-naming.StructCase: CamelCase
-  readability-identifier-naming.TemplateParameterCase: CamelCase
-  readability-identifier-naming.VariableCase: lower_case
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
 
 WarningsAsErrors: ''
 


### PR DESCRIPTION
Also remove identifier rules that are C++ only.
