### PR TITLE
vim-patch:9.0.0750: crash when popup closed in callback

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1753,7 +1753,7 @@ win_update_start:
         // Let the syntax stuff know we skipped a few lines.
         if (syntax_last_parsed != 0 && syntax_last_parsed + 1 < lnum
             && syntax_present(wp)) {
-          syntax_end_parsing(syntax_last_parsed + 1);
+          syntax_end_parsing(wp, syntax_last_parsed + 1);
         }
 
         // Display one line
@@ -1827,7 +1827,7 @@ win_update_start:
 
   // Let the syntax stuff know we stop parsing here.
   if (syntax_last_parsed != 0 && syntax_present(wp)) {
-    syntax_end_parsing(syntax_last_parsed + 1);
+    syntax_end_parsing(wp, syntax_last_parsed + 1);
   }
 
   // If we didn't hit the end of the file, and we didn't finish the last

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -1327,10 +1327,13 @@ static bool syn_stack_equal(synstate_T *sp)
 //          displayed line
 //          displayed line
 // lnum ->  line below window
-void syntax_end_parsing(linenr_T lnum)
+void syntax_end_parsing(win_T *wp, linenr_T lnum)
 {
   synstate_T *sp;
 
+  if (syn_block != wp->w_s) {
+    return;  // not the right window
+  }
   sp = syn_stack_find_entry(lnum);
   if (sp != NULL && sp->sst_lnum < lnum) {
     sp = sp->sst_next;


### PR DESCRIPTION
#### vim-patch:9.0.0750: crash when popup closed in callback

Problem:    Crash when popup closed in callback. (Maxim Kim)
Solution:   In syntax_end_parsing() check that syn_block is valid.
https://github.com/vim/vim/commit/0abd6cf62d65180dc2c40d67cd95f13b0691f7ea