### PR TITLE
vim-patch:8.1.0342,9.0.{0614,0616}: SpellFileMissing autocmd may delete buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -93,7 +93,6 @@
 #endif
 
 static char *e_auabort = N_("E855: Autocommands caused command to abort");
-static char *e_buflocked = N_("E937: Attempt to delete a buffer that is in use");
 
 // Number of times free_buffer() was called.
 static int buf_free_count = 0;
@@ -401,6 +400,27 @@ bool buf_valid(buf_T *buf)
   return false;
 }
 
+/// Return true when buffer "buf" can be unloaded.
+/// Give an error message and return false when the buffer is locked or the
+/// screen is being redrawn and the buffer is in a window.
+static bool can_unload_buffer(buf_T *buf)
+{
+  bool can_unload = !buf->b_locked;
+
+  if (can_unload && updating_screen) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (wp->w_buffer == buf) {
+        can_unload = false;
+        break;
+      }
+    }
+  }
+  if (!can_unload) {
+    emsg(_("E937: Attempt to delete a buffer that is in use"));
+  }
+  return can_unload;
+}
+
 /// Close the link to a buffer.
 ///
 /// @param win    If not NULL, set b_last_cursor.
@@ -458,8 +478,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
 
   // Disallow deleting the buffer when it is locked (already being closed or
   // halfway a command that relies on it). Unloading is allowed.
-  if (buf->b_locked > 0 && (del_buf || wipe_buf)) {
-    emsg(_(e_buflocked));
+  if ((del_buf || wipe_buf) && !can_unload_buffer(buf)) {
     return false;
   }
 
@@ -1206,8 +1225,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
   if (unload) {
     int forward;
     bufref_T bufref;
-    if (buf->b_locked) {
-      emsg(_(e_buflocked));
+    if (!can_unload_buffer(buf)) {
       return FAIL;
     }
     set_bufref(&bufref, buf);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -93,6 +93,8 @@
 #endif
 
 static char *e_auabort = N_("E855: Autocommands caused command to abort");
+static char e_attempt_to_delete_buffer_that_is_in_use_str[]
+  = N_("E937: Attempt to delete a buffer that is in use: %s");
 
 // Number of times free_buffer() was called.
 static int buf_free_count = 0;
@@ -416,7 +418,9 @@ static bool can_unload_buffer(buf_T *buf)
     }
   }
   if (!can_unload) {
-    emsg(_("E937: Attempt to delete a buffer that is in use"));
+    char *fname = buf->b_fname != NULL ? buf->b_fname : buf->b_ffname;
+    semsg(_(e_attempt_to_delete_buffer_that_is_in_use_str),
+          fname != NULL ? fname : "[No Name]");
   }
   return can_unload;
 }

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1511,6 +1511,10 @@ static void spell_load_lang(char_u *lang)
   sl.sl_slang = NULL;
   sl.sl_nobreak = false;
 
+  // Disallow deleting the current buffer.  Autocommands can do weird things
+  // and cause "lang" to be freed.
+  curbuf->b_locked++;
+
   // We may retry when no spell file is found for the language, an
   // autocommand may load it then.
   for (int round = 1; round <= 2; round++) {
@@ -1553,6 +1557,8 @@ static void spell_load_lang(char_u *lang)
     STRCPY(fname_enc + strlen(fname_enc) - 3, "add.spl");
     do_in_runtimepath((char *)fname_enc, DIP_ALL, spell_load_cb, &sl);
   }
+
+  curbuf->b_locked--;
 }
 
 // Return the encoding used for spell checking: Use 'encoding', except that we

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2752,6 +2752,16 @@ func Test_FileType_spell()
   setglobal spellfile=
 endfunc
 
+" this was wiping out the current buffer and using freed memory
+func Test_SpellFileMissing_bwipe()
+  next 0
+  au SpellFileMissing 0 bwipe
+  call assert_fails('set spell spelllang=0', 'E937:')
+
+  au! SpellFileMissing
+  bwipe
+endfunc
+
 " Test closing a window or editing another buffer from a FileChangedRO handler
 " in a readonly buffer
 func Test_FileChangedRO_winclose()

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -147,7 +147,7 @@ func Test_spell_file_missing()
   augroup TestSpellFileMissing
     autocmd! SpellFileMissing * bwipe
   augroup END
-  call assert_fails('set spell spelllang=ab_cd', 'E797:')
+  call assert_fails('set spell spelllang=ab_cd', 'E937:')
 
   " clean up
   augroup TestSpellFileMissing

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -5,6 +5,7 @@ local clear, command, nvim, testprg =
   helpers.clear, helpers.command, helpers.nvim, helpers.testprg
 local eval, eq, neq, retry =
   helpers.eval, helpers.eq, helpers.neq, helpers.retry
+local matches = helpers.matches
 local ok = helpers.ok
 local feed = helpers.feed
 local pcall_err = helpers.pcall_err
@@ -22,7 +23,8 @@ describe('autocmd TermClose', function()
   local function test_termclose_delete_own_buf()
     command('autocmd TermClose * bdelete!')
     command('terminal')
-    eq('Vim(bdelete):E937: Attempt to delete a buffer that is in use', pcall_err(command, 'bdelete!'))
+    matches('^Vim%(bdelete%):E937: Attempt to delete a buffer that is in use: term://',
+            pcall_err(command, 'bdelete!'))
     assert_alive()
   end
 


### PR DESCRIPTION
#### vim-patch:8.1.0342: crash when a callback deletes a window that is being used

Problem:    Crash when a callback deletes a window that is being used.
Solution:   Do not unload a buffer that is being displayed while redrawing the
            screen. Also avoid invoking callbacks while redrawing.
            (closes vim/vim#2107)
https://github.com/vim/vim/commit/94f01956a583223dafe24135489d0ab1100ab0ad

Omit parse_queued_messages(): N/A.
Cherry-pick a break statement from patch 8.1.0425.


#### vim-patch:9.0.0614: SpellFileMissing autocmd may delete buffer

Problem:    SpellFileMissing autocmd may delete buffer.
Solution:   Disallow deleting the current buffer to avoid using freed memory.
https://github.com/vim/vim/commit/ef976323e770315b5fca544efb6b2faa25674d15


#### vim-patch:9.0.0616: spell test fails because error message changed

Problem:    Spell test fails because error message changed.
Solution:   Adjust expected error message.
https://github.com/vim/vim/commit/371951d0c34d4f44b50ad8bc8d30a4ef7effade6