### PR TITLE
vim-patch:partial:{3e79c97c18c5,9da17d7c5707,9.0.0753}

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1137,7 +1137,7 @@ tag		command		action ~
 |:&|		:&		repeat last ":substitute"
 |:star|		:*		execute contents of a register
 |:<|		:<		shift lines one 'shiftwidth' left
-|:=|		:=		print the cursor line number
+|:=|		:=		print the last line number
 |:>|		:>		shift lines one 'shiftwidth' right
 |:@|		:@		execute contents of a register
 |:@@|		:@@		repeat the previous ":@"

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1135,7 +1135,7 @@ tag		command		action ~
 |:!!|		:!!		repeat last ":!" command
 |:#|		:#		same as ":number"
 |:&|		:&		repeat last ":substitute"
-|:star|		:*		execute contents of a register
+|:star|		:*		use the last Visual area, like :'<,'>
 |:<|		:<		shift lines one 'shiftwidth' left
 |:=|		:=		print the last line number
 |:>|		:>		shift lines one 'shiftwidth' right
@@ -1329,6 +1329,7 @@ tag		command		action ~
 |:highlight|	:hi[ghlight]	specify highlighting methods
 |:hide|		:hid[e]		hide current buffer for a command
 |:history|	:his[tory]	print a history list
+|:horizontal|	:hor[izontal]	following window command work horizontally
 |:insert|	:i[nsert]	insert text
 |:iabbrev|	:ia[bbrev]	like ":abbrev" but for Insert mode
 |:iabclear|	:iabc[lear]	like ":abclear" but for Insert mode

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3688,12 +3688,13 @@ DEFINING CASE						*:syn-case* *E390*
 	items until the next ":syntax case" command are affected.
 
 :sy[ntax] case
-	Show either "syntax case match" or "syntax case ignore" (translated).
+	Show either "syntax case match" or "syntax case ignore".
 
 
 DEFINING FOLDLEVEL					*:syn-foldlevel*
 
-:sy[ntax] foldlevel [start | minimum]
+:sy[ntax] foldlevel start
+:sy[ntax] foldlevel minimum
 	This defines how the foldlevel of a line is computed when using
 	foldmethod=syntax (see |fold-syntax| and |:syn-fold|):
 
@@ -3706,11 +3707,14 @@ DEFINING FOLDLEVEL					*:syn-foldlevel*
 	may close and open horizontally within a line.
 
 :sy[ntax] foldlevel
-	Show either "syntax foldlevel start" or "syntax foldlevel minimum".
+	Show the current foldlevel method, either "syntax foldlevel start" or
+	"syntax foldlevel minimum".
 
 SPELL CHECKING						*:syn-spell*
 
-:sy[ntax] spell [toplevel | notoplevel | default]
+:sy[ntax] spell toplevel
+:sy[ntax] spell notoplevel
+:sy[ntax] spell default
 	This defines where spell checking is to be done for text that is not
 	in a syntax item:
 
@@ -3725,8 +3729,8 @@ SPELL CHECKING						*:syn-spell*
 	To activate spell checking the 'spell' option must be set.
 
 :sy[ntax] spell
-	Show either "syntax spell toplevel", "syntax spell notoplevel" or
-	"syntax spell default" (translated).
+	Show the current syntax spell checking method, either "syntax spell
+	toplevel", "syntax spell notoplevel" or "syntax spell default".
 
 
 SYNTAX ISKEYWORD SETTING				*:syn-iskeyword*
@@ -4324,7 +4328,7 @@ IMPLICIT CONCEAL					*:syn-conceal-implicit*
 	given explicitly.
 
 :sy[ntax] conceal
-	Show either "syntax conceal on" or "syntax conceal off" (translated).
+	Show either "syntax conceal on" or "syntax conceal off".
 
 ==============================================================================
 8. Syntax patterns				*:syn-pattern* *E401* *E402*

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -220,7 +220,7 @@ Canada:		Contact Kuwasha in Surrey, Canada.  They take care of the
 		forwards 100% of the money to the project in Uganda.  You can
 		send them a one time donation directly.
 		Please send me a note so that I know what has been donated
-		because of Vim.  Look on their for information about
+		because of Vim.  Look on their site for information about
 		sponsorship: https://www.kuwasha.net/
 		If you make a donation to Kuwasha you will receive a tax
 		receipt which can be submitted with your tax return.
@@ -245,7 +245,7 @@ Credit Card:	You can use PayPal to send money with a Credit card.  This is
 		The e-mail address for sending the money to is:
 		    Bram@iccf-holland.org
 
-Others:		Transfer to one of these accounts if possible:
+Others:		Transfer to this account if possible:
 		    ING bank: 	IBAN: NL95 INGB 0004 5487 74
 				Swift code: INGBNL2A
 		    under the name "stichting ICCF Holland", Amersfoort

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -166,10 +166,11 @@ households are stimulated to build a proper latrine.  I helped setting up a
 production site for cement slabs.  These are used to build a good latrine.
 They are sold below cost price.
 
-There is a small clinic at the project, which provides children and their
-family with medical help.  When needed, transport to a hospital is offered.
-Immunization programs are carried out and help is provided when an epidemic is
-breaking out (measles and cholera have been a problem).
+There is a clinic at the project, which provides children and their family
+medical help.  Since 2020 a maternity ward was added and 24/7 service is
+available.  When needed, transport to a hospital is offered.  Immunization
+programs are carried out and help is provided when an epidemic is breaking out
+(measles and cholera have been a problem).
 							*donate*
 Summer 1994 to summer 1995 I spent a whole year at the centre, working as a
 volunteer.  I have helped to expand the centre and worked in the area of water
@@ -211,44 +212,29 @@ Check the ICCF web site for the latest information!  See |iccf| for the URL.
 
 
 USA:		The methods mentioned below can be used.
-		Sending a check to the Nehemiah Group Outreach Society (NGOS)
-		is no longer possible, unfortunately. We are looking for
-		another way to get you an IRS tax receipt.
-		For sponsoring a child contact KCF in Canada (see below). US
-		checks can be sent to them to lower banking costs.
+		If you must send a check send it to our Canadian partner:
+		https://www.kuwasha.net/
 
-Canada:		Contact Kibaale Children's Fund (KCF) in Surrey, Canada.  They
-		take care of the Canadian sponsors for the children in
-		Kibaale.  KCF forwards 100% of the money to the project in
-		Uganda.  You can send them a one time donation directly.
+Canada:		Contact Kuwasha in Surrey, Canada.  They take care of the
+		Canadian sponsors for the children in Kibaale.  Kuwasha
+		forwards 100% of the money to the project in Uganda.  You can
+		send them a one time donation directly.
 		Please send me a note so that I know what has been donated
-		because of Vim.  Ask KCF for information about sponsorship.
-			Kibaale Children's Fund c/o Pacific Academy
-			10238-168 Street
-			Surrey, B.C. V4N 1Z4
-			Canada
-			Phone: 604-581-5353
-		If you make a donation to Kibaale Children's Fund (KCF) you
-		will receive a tax receipt which can be submitted with your
-		tax return.
+		because of Vim.  Look on their for information about
+		sponsorship: https://www.kuwasha.net/
+		If you make a donation to Kuwasha you will receive a tax
+		receipt which can be submitted with your tax return.
 
-Holland:	Transfer to the account of "Stichting ICCF Holland" in Lisse.
-		This will allow for tax deduction if you live in Holland.
-			Postbank, nr. 4548774
-			IBAN: NL95 INGB 0004 5487 74
+Holland:	Transfer to the account of "Stichting ICCF Holland" in
+		Amersfoort.  This will allow for tax deduction if you live in
+		Holland.  ING bank, IBAN: NL95 INGB 0004 5487 74
 
 Germany:	It is possible to make donations that allow for a tax return.
 		Check the ICCF web site for the latest information:
 			https://iccf-holland.org/germany.html
 
-World:		Use a postal money order.  That should be possible from any
-		country, mostly from the post office.  Use this name (which is
-		in my passport): "Abraham Moolenaar".  Use Euro for the
-		currency if possible.
-
-Europe:		Use a bank transfer if possible.  Your bank should have a form
-		that you can use for this.  See "Others" below for the swift
-		code and IBAN number.
+Europe:		Use a bank transfer if possible.  See "Others" below for the
+		swift code and IBAN number.
 		Any other method should work.  Ask for information about
 		sponsorship.
 
@@ -258,28 +244,12 @@ Credit Card:	You can use PayPal to send money with a Credit card.  This is
 		    https://www.paypal.com/en_US/mrb/pal=XAC62PML3GF8Q
 		The e-mail address for sending the money to is:
 		    Bram@iccf-holland.org
-		For amounts above 400 Euro ($500) sending a check is
-		preferred.
 
 Others:		Transfer to one of these accounts if possible:
-		    Postbank, account 4548774
-				Swift code: INGB NL 2A
-				IBAN: NL95 INGB 0004 5487 74
-			under the name "stichting ICCF Holland", Lisse
-		    If that doesn't work:
-		    Rabobank Lisse, account 3765.05.117
-				Swift code: RABO NL 2U
-			under the name "Bram Moolenaar", Lisse
-		Otherwise, send a check in euro or US dollars to the address
-		below.  Minimal amount: $70 (my bank does not accept smaller
-		amounts for foreign check, sorry)
+		    ING bank: 	IBAN: NL95 INGB 0004 5487 74
+				Swift code: INGBNL2A
+		    under the name "stichting ICCF Holland", Amersfoort
+		Checks are not accepted.
 
-Address to send checks to:
-			Bram Moolenaar
-			Finsterruetihof 1
-			8134 Adliswil
-			Switzerland
-
-This address is expected to be valid for a long time.
 
  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
#### vim-patch:partial:3e79c97c18c5

Update runtime files; use compiled functions
https://github.com/vim/vim/commit/3e79c97c18c50f97797ab13ed81c4011eba9aba0

Only port uganda.txt.


#### vim-patch:partial:9da17d7c5707

Update runtime files
https://github.com/vim/vim/commit/9da17d7c57071c306565da6a35c3704db1916b78

Only port index.txt, syntax.txt and uganda.txt.


#### vim-patch:partial:9.0.0753: some Ex commands are not in the help index

Problem:    Some Ex commands are not in the help index.
Solution:   Add the missing commands.  Add a script to check all Ex commands
            are in the help index. (Yee Cheng Chin, closes vim/vim#11371)
https://github.com/vim/vim/commit/b77bdce120d7e140d0d0bd535ec9febdef78993d

Only port index.txt docs for :star and :horizontal.