### PR TITLE
refactor(uncrustify): improved formatting rules

### DIFF
--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -782,55 +782,6 @@ example, `"\uFEFF"`, is the Unicode zero-width no-break space character, which
 would be invisible if included in the source as straight UTF-8.
 
 
-Function Declarations and Definitions ~
-
-Return type on the same line as function name, parameters on the same line if
-they fit.
-
-Functions look like this: >
-
-    ReturnType function_name(Type par_name1, Type par_name2)
-    {
-      do_something();
-      ...
-    }
-
-If you have too much text to fit on one line: >
-
-    ReturnType really_long_function_name(Type par_name1, Type par_name2,
-                                         Type par_name3)
-    {
-      do_something();
-      ...
-    }
-
-or if you cannot fit even the first parameter (but only then): >
-
-    ReturnType really_really_really_long_function_name(
-        Type par_name1,  // 4 space indent
-        Type par_name2,
-        Type par_name3)
-    {
-      do_something();  // 2 space indent
-      ...
-    }
-
-Some points to note:
-
-- The open parenthesis is always on the same line as the function name.
-- There is never a space between the function name and the open parenthesis.
-- There is never a space between the parentheses and the parameters.
-- The open curly brace is always on the next line.
-- The close curly brace is always on the last line by itself.
-- There should be a space between the close parenthesis and the open curly
-  brace.
-- All parameters should be named, with identical names in the declaration and
-  implementation.
-- All parameters should be aligned if possible.
-- Default indentation is 2 spaces.
-- Wrapped parameters have a 4 space indent.
-
-
 Function Calls ~
 
 On one line if it fits; otherwise, wrap arguments at the parenthesis.
@@ -889,18 +840,6 @@ no name, assume a zero-length name. >
           interiorwrappinglist2 } };
 
 
-Conditionals ~
-
-Don't use spaces inside parentheses. >
-
-    if (condition) {  // no spaces inside parentheses
-      ...  // 2 space indent.
-    } else if (...) {  // The else goes on the same line as the closing brace.
-      ...
-    } else {
-      ...
-    }
-
 Loops and Switch Statements ~
 
 Annotate non-trivial fall-through between cases.
@@ -920,39 +859,6 @@ execute, simply `assert`: >
       default:
         assert(false);
     }
-
-Pointer Expressions ~
-
-No spaces around period or arrow. Pointer operators do not have trailing
-spaces.
-
-The following are examples of correctly-formatted pointer and reference
-expressions: >
-
-    x = *p;
-    p = &x;
-    x = r.y;
-    x = r->y;
-
-Note that:
-
-    - There are no spaces around the period or arrow when accessing a member.
-    - Pointer operators have no space after the * or &.
-
-Boolean Expressions ~
-
-When you have a boolean expression that is longer than the standard line
-length, keep operators at the start of the line. >
-
-    if (this_one_thing > this_other_thing
-        && a_third_thing == a_fourth_thing
-        && yet_another && last_one) {
-      ...
-    }
-
-Also note that you should always use the punctuation operators, such as `&&`
-and `~`, rather than the word operators, such as `and` and `compl`.
-
 
 Return Values ~
 
@@ -1001,8 +907,6 @@ Use of horizontal whitespace depends on location.
         x = -5;           // No spaces separating unary operators and their
         x++;              // arguments.
         if (x && !y)
-          ...
-        i = (int)d;       // No spaces after a cast operator.
 <
 
 Vertical Whitespace ~

--- a/src/nvim/api/private/dispatch.h
+++ b/src/nvim/api/private/dispatch.h
@@ -3,10 +3,7 @@
 
 #include "nvim/api/private/defs.h"
 
-typedef Object (*ApiDispatchWrapper)(uint64_t channel_id,
-                                     Array args,
-                                     Arena *arena,
-                                     Error *error);
+typedef Object (*ApiDispatchWrapper)(uint64_t channel_id, Array args, Arena *arena, Error *error);
 
 /// The rpc_method_handlers table, used in msgpack_rpc_dispatch(), stores
 /// functions of this type.

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -69,11 +69,10 @@ void scroll(Integer count)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
 // Second revision of the grid protocol, used with ext_linegrid ui option
-void default_colors_set(Integer rgb_fg, Integer rgb_bg, Integer rgb_sp,
-                        Integer cterm_fg, Integer cterm_bg)
+void default_colors_set(Integer rgb_fg, Integer rgb_bg, Integer rgb_sp, Integer cterm_fg,
+                        Integer cterm_bg)
   FUNC_API_SINCE(4) FUNC_API_REMOTE_IMPL;
-void hl_attr_define(Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs,
-                    Array info)
+void hl_attr_define(Integer id, HlAttrs rgb_attrs, HlAttrs cterm_attrs, Array info)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_BRIDGE_IMPL;
 void hl_group_set(String name, Integer id)
   FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL;
@@ -85,8 +84,8 @@ void grid_cursor_goto(Integer grid, Integer row, Integer col)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
 void grid_line(Integer grid, Integer row, Integer col_start, Array data)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_ONLY FUNC_API_CLIENT_IMPL;
-void grid_scroll(Integer grid, Integer top, Integer bot,
-                 Integer left, Integer right, Integer rows, Integer cols)
+void grid_scroll(Integer grid, Integer top, Integer bot, Integer left, Integer right, Integer rows,
+                 Integer cols)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
 void grid_destroy(Integer grid)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
@@ -94,20 +93,18 @@ void grid_destroy(Integer grid)
 // For performance and simplicity, we use the dense screen representation
 // in internal code, such as compositor and TUI. The remote_ui module will
 // translate this in to the public grid_line format.
-void raw_line(Integer grid, Integer row, Integer startcol,
-              Integer endcol, Integer clearcol, Integer clearattr,
-              LineFlags flags, const schar_T *chunk, const sattr_T *attrs)
+void raw_line(Integer grid, Integer row, Integer startcol, Integer endcol, Integer clearcol,
+              Integer clearattr, LineFlags flags, const schar_T *chunk, const sattr_T *attrs)
   FUNC_API_NOEXPORT FUNC_API_COMPOSITOR_IMPL;
 
 void event(char *name, Array args)
   FUNC_API_NOEXPORT FUNC_API_COMPOSITOR_IMPL;
 
-void win_pos(Integer grid, Window win, Integer startrow,
-             Integer startcol, Integer width, Integer height)
+void win_pos(Integer grid, Window win, Integer startrow, Integer startcol, Integer width,
+             Integer height)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid,
-                   Float anchor_row, Float anchor_col, Boolean focusable,
-                   Integer zindex)
+void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid, Float anchor_row,
+                   Float anchor_col, Boolean focusable, Integer zindex)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_external_pos(Integer grid, Window win)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
@@ -118,29 +115,25 @@ void win_close(Integer grid)
 void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
   FUNC_API_SINCE(6) FUNC_API_BRIDGE_IMPL FUNC_API_COMPOSITOR_IMPL;
 
-void win_viewport(Integer grid, Window win, Integer topline,
-                  Integer botline, Integer curline, Integer curcol,
-                  Integer line_count)
+void win_viewport(Integer grid, Window win, Integer topline, Integer botline, Integer curline,
+                  Integer curcol, Integer line_count)
   FUNC_API_SINCE(7) FUNC_API_BRIDGE_IMPL;
 
-void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id,
-                 Integer row, Integer col)
+void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id, Integer row, Integer col)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
 
-void popupmenu_show(Array items, Integer selected,
-                    Integer row, Integer col, Integer grid)
+void popupmenu_show(Array items, Integer selected, Integer row, Integer col, Integer grid)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void popupmenu_hide(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void popupmenu_select(Integer selected)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
-void tabline_update(Tabpage current, Array tabs,
-                    Buffer current_buffer, Array buffers)
+void tabline_update(Tabpage current, Array tabs, Buffer current_buffer, Array buffers)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
-void cmdline_show(Array content, Integer pos, String firstc, String prompt,
-                  Integer indent, Integer level)
+void cmdline_show(Array content, Integer pos, String firstc, String prompt, Integer indent,
+                  Integer level)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void cmdline_pos(Integer pos, Integer level)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -439,8 +439,7 @@ static int insert_check(VimState *state)
     s->mincol = curwin->w_wcol;
     validate_cursor_col();
 
-    if (
-        curwin->w_wcol < s->mincol - tabstop_at(get_nolist_virtcol(),
+    if (curwin->w_wcol < s->mincol - tabstop_at(get_nolist_virtcol(),
                                                 curbuf->b_p_ts,
                                                 curbuf->b_p_vts_array)
         && curwin->w_wrow == curwin->w_winrow

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -43,10 +43,8 @@ static inline ListLog *list_log_new(const size_t size)
   return ret;
 }
 
-static inline void list_log(const list_T *const l,
-                            const listitem_T *const li1,
-                            const listitem_T *const li2,
-                            const char *const action)
+static inline void list_log(const list_T *const l, const listitem_T *const li1,
+                            const listitem_T *const li2, const char *const action)
   REAL_FATTR_ALWAYS_INLINE;
 
 /// Add new entry to log
@@ -488,8 +486,7 @@ extern bool tv_in_free_unref_items;
     } \
   })
 
-static inline bool tv_get_float_chk(const typval_T *tv,
-                                    float_T *ret_f)
+static inline bool tv_get_float_chk(const typval_T *tv, float_T *ret_f)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the float value

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -16,8 +16,7 @@ typedef struct stream Stream;
 /// @param count Number of bytes that was read.
 /// @param data User-defined data
 /// @param eof If the stream reached EOF.
-typedef void (*stream_read_cb)(Stream *stream, RBuffer *buf, size_t count,
-                               void *data, bool eof);
+typedef void (*stream_read_cb)(Stream *stream, RBuffer *buf, size_t count, void *data, bool eof);
 
 /// Type of function called when the Stream has information about a write
 /// request.

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1413,8 +1413,7 @@ char_u *find_file_in_path_option(char_u *ptr, size_t len, int options, int first
         // When the file doesn't exist, try adding parts of 'suffixesadd'.
         buf = (char *)suffixes;
         for (;;) {
-          if (
-              (os_path_exists(NameBuff)
+          if ((os_path_exists(NameBuff)
                && (find_what == FINDFILE_BOTH
                    || ((find_what == FINDFILE_DIR)
                        == os_isdir(NameBuff))))) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6518,8 +6518,7 @@ static void n_opencmd(cmdarg_T *cap)
     if (u_save((linenr_T)(curwin->w_cursor.lnum -
                           (cap->cmdchar == 'O' ? 1 : 0)),
                (linenr_T)(curwin->w_cursor.lnum +
-                          (cap->cmdchar == 'o' ? 1 : 0))
-               )
+                          (cap->cmdchar == 'o' ? 1 : 0)))
         && open_line(cap->cmdchar == 'O' ? BACKWARD : FORWARD,
                      has_format_option(FO_OPEN_COMS) ? OPENLINE_DO_COM : 0,
                      0, NULL)) {

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1557,6 +1557,18 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
   (sd_default_values[(entry).type].data.attr == (entry).data.attr)
 #define ONE_IF_NOT_DEFAULT(entry, attr) \
   ((size_t)(!CHECK_DEFAULT(entry, attr)))
+
+#define PACK_BOOL(entry, name, attr) \
+  do { \
+    if (!CHECK_DEFAULT(entry, search_pattern.attr)) { \
+      PACK_STATIC_STR(name); \
+      if (sd_default_values[(entry).type].data.search_pattern.attr) { \
+        msgpack_pack_false(spacker); \
+      } else { \
+        msgpack_pack_true(spacker); \
+      } \
+    } \
+  } while (0)
   switch (entry.type) {
   case kSDItemMissing:
     abort();
@@ -1640,17 +1652,6 @@ static ShaDaWriteResult shada_pack_entry(msgpack_packer *const packer, ShadaEntr
     msgpack_pack_map(spacker, map_size);
     PACK_STATIC_STR(SEARCH_KEY_PAT);
     PACK_BIN(cstr_as_string(entry.data.search_pattern.pat));
-#define PACK_BOOL(entry, name, attr) \
-  do { \
-    if (!CHECK_DEFAULT(entry, search_pattern.attr)) { \
-      PACK_STATIC_STR(name); \
-      if (sd_default_values[(entry).type].data.search_pattern.attr) { \
-        msgpack_pack_false(spacker); \
-      } else { \
-        msgpack_pack_true(spacker); \
-      } \
-    } \
-  } while (0)
     PACK_BOOL(entry, SEARCH_KEY_MAGIC, magic);
     PACK_BOOL(entry, SEARCH_KEY_IS_LAST_USED, is_last_used);
     PACK_BOOL(entry, SEARCH_KEY_SMARTCASE, smartcase);
@@ -1957,6 +1958,28 @@ static const char *shada_format_entry(const ShadaEntry entry)
   ret[0] = 0;
   vim_snprintf(S_LEN(ret), "%s", "[ ] ts=%" PRIu64 " ");
   //                         ^ Space for `can_free_entry`
+#define FORMAT_MARK_ENTRY(entry_name, name_fmt, name_fmt_arg) \
+  do { \
+    typval_T ad_tv = { \
+      .v_type = VAR_DICT, \
+      .vval.v_dict = entry.data.filemark.additional_data \
+    }; \
+    size_t ad_len; \
+    char *const ad = encode_tv2string(&ad_tv, &ad_len); \
+    vim_snprintf_add(S_LEN(ret), \
+                     entry_name " {" name_fmt " file=[%zu]\"%.512s\", " \
+                     "pos={l=%" PRIdLINENR ",c=%" PRIdCOLNR ",a=%" PRIdCOLNR "}, " \
+                     "ad={%p:[%zu]%.64s} }", \
+                     name_fmt_arg, \
+                     strlen(entry.data.filemark.fname), \
+                     entry.data.filemark.fname, \
+                     entry.data.filemark.mark.lnum, \
+                     entry.data.filemark.mark.col, \
+                     entry.data.filemark.mark.coladd, \
+                     (void *)entry.data.filemark.additional_data, \
+                     ad_len, \
+                     ad); \
+  } while (0)
   switch (entry.type) {
   case kSDItemMissing:
     vim_snprintf_add(S_LEN(ret), "Missing");
@@ -1985,28 +2008,6 @@ static const char *shada_format_entry(const ShadaEntry entry)
   case kSDItemVariable:
     vim_snprintf_add(S_LEN(ret), "Variable { TODO }");
     break;
-#define FORMAT_MARK_ENTRY(entry_name, name_fmt, name_fmt_arg) \
-  do { \
-    typval_T ad_tv = { \
-      .v_type = VAR_DICT, \
-      .vval.v_dict = entry.data.filemark.additional_data \
-    }; \
-    size_t ad_len; \
-    char *const ad = encode_tv2string(&ad_tv, &ad_len); \
-    vim_snprintf_add(S_LEN(ret), \
-                     entry_name " {" name_fmt " file=[%zu]\"%.512s\", " \
-                     "pos={l=%" PRIdLINENR ",c=%" PRIdCOLNR ",a=%" PRIdCOLNR "}, " \
-                     "ad={%p:[%zu]%.64s} }", \
-                     name_fmt_arg, \
-                     strlen(entry.data.filemark.fname), \
-                     entry.data.filemark.fname, \
-                     entry.data.filemark.mark.lnum, \
-                     entry.data.filemark.mark.col, \
-                     entry.data.filemark.mark.coladd, \
-                     (void *)entry.data.filemark.additional_data, \
-                     ad_len, \
-                     ad); \
-  } while (0)
   case kSDItemGlobalMark:
     FORMAT_MARK_ENTRY("GlobalMark", " name='%c',", entry.data.filemark.name);
     break;
@@ -2055,6 +2056,32 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
   ShaDaWriteResult ret = kSDWriteSuccessfull;
   ShadaEntry entry;
   ShaDaReadResult srni_ret;
+
+#define COMPARE_WITH_ENTRY(wms_entry_, entry) \
+  do { \
+    PossiblyFreedShadaEntry *const wms_entry = (wms_entry_); \
+    if (wms_entry->data.type != kSDItemMissing) { \
+      if (wms_entry->data.timestamp >= (entry).timestamp) { \
+        shada_free_shada_entry(&(entry)); \
+        break; \
+      } \
+      if (wms_entry->can_free_entry) { \
+        shada_free_shada_entry(&wms_entry->data); \
+      } \
+    } \
+    *wms_entry = pfs_entry; \
+  } while (0)
+
+#define FREE_POSSIBLY_FREED_SHADA_ENTRY(entry) \
+  do { \
+    if ((entry).can_free_entry) { \
+      shada_free_shada_entry(&(entry).data); \
+    } \
+  } while (0)
+
+#define SDE_TO_PFSDE(entry) \
+  ((PossiblyFreedShadaEntry) { .can_free_entry = true, .data = (entry) })
+
   while ((srni_ret = shada_read_next_item(sd_reader, &entry, srni_flags,
                                           max_kbyte))
          != kSDReadStatusFinished) {
@@ -2072,20 +2099,6 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
     case kSDReadStatusMalformed:
       continue;
     }
-#define COMPARE_WITH_ENTRY(wms_entry_, entry) \
-  do { \
-    PossiblyFreedShadaEntry *const wms_entry = (wms_entry_); \
-    if (wms_entry->data.type != kSDItemMissing) { \
-      if (wms_entry->data.timestamp >= (entry).timestamp) { \
-        shada_free_shada_entry(&(entry)); \
-        break; \
-      } \
-      if (wms_entry->can_free_entry) { \
-        shada_free_shada_entry(&wms_entry->data); \
-      } \
-    } \
-    *wms_entry = pfs_entry; \
-  } while (0)
     const PossiblyFreedShadaEntry pfs_entry = {
       .can_free_entry = true,
       .data = entry,
@@ -2225,14 +2238,6 @@ static inline ShaDaWriteResult shada_read_when_writing(ShaDaReadDef *const sd_re
           *wms_entry = pfs_entry;
         }
       } else {
-#define FREE_POSSIBLY_FREED_SHADA_ENTRY(entry) \
-  do { \
-    if ((entry).can_free_entry) { \
-      shada_free_shada_entry(&(entry).data); \
-    } \
-  } while (0)
-#define SDE_TO_PFSDE(entry) \
-  ((PossiblyFreedShadaEntry) { .can_free_entry = true, .data = (entry) })
 #define AFTERFREE_DUMMY(entry)
 #define DUMMY_IDX_ADJ(i)
         MERGE_JUMPS(filemarks->changes_size, filemarks->changes,

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -252,8 +252,7 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
 
       new_tag = true;
     } else {
-      if (
-          g_do_tagpreview != 0 ? ptag_entry.tagname == NULL :
+      if (g_do_tagpreview != 0 ? ptag_entry.tagname == NULL :
           tagstacklen == 0) {
         // empty stack
         emsg(_(e_tagstack));

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -2120,6 +2120,22 @@ viml_pexpr_parse_process_token:
     assert(kv_size(pt_stack));
     const ExprASTParseType cur_pt = kv_last(pt_stack);
     assert(lambda_node == NULL || cur_pt == kEPTLambdaArguments);
+#define SIMPLE_UB_OP(op) \
+  case kExprLex##op: { \
+      if (want_node == kENodeValue) { \
+        /* Value level: assume unary operator. */ \
+        NEW_NODE_WITH_CUR_POS(cur_node, kExprNodeUnary##op); \
+        *top_node_p = cur_node; \
+        kvi_push(ast_stack, &cur_node->children); \
+        HL_CUR_TOKEN(Unary##op); \
+      } else { \
+        NEW_NODE_WITH_CUR_POS(cur_node, kExprNodeBinary##op); \
+        ADD_OP_NODE(cur_node); \
+        HL_CUR_TOKEN(Binary##op); \
+      } \
+      want_node = kENodeValue; \
+      break; \
+  }
     switch (tok_type) {
     case kExprLexMissing:
     case kExprLexSpacing:
@@ -2141,22 +2157,6 @@ viml_pexpr_parse_process_token:
       HL_CUR_TOKEN(Register);
       break;
     }
-#define SIMPLE_UB_OP(op) \
-  case kExprLex##op: { \
-      if (want_node == kENodeValue) { \
-        /* Value level: assume unary operator. */ \
-        NEW_NODE_WITH_CUR_POS(cur_node, kExprNodeUnary##op); \
-        *top_node_p = cur_node; \
-        kvi_push(ast_stack, &cur_node->children); \
-        HL_CUR_TOKEN(Unary##op); \
-      } else { \
-        NEW_NODE_WITH_CUR_POS(cur_node, kExprNodeBinary##op); \
-        ADD_OP_NODE(cur_node); \
-        HL_CUR_TOKEN(Binary##op); \
-      } \
-      want_node = kENodeValue; \
-      break; \
-  }
       SIMPLE_UB_OP(Plus)
       SIMPLE_UB_OP(Minus)
 #undef SIMPLE_UB_OP

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -1714,7 +1714,7 @@ nl_try_brace                    = ignore   # ignore/add/remove/force/not_defined
 nl_getset_brace                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'for' and '{'.
-nl_for_brace                    = ignore   # ignore/add/remove/force/not_defined
+nl_for_brace                    = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the '{' of a 'catch' statement, as in
 # 'catch (decl) <here> {'.
@@ -1738,7 +1738,7 @@ nl_brace_square                 = ignore   # ignore/add/remove/force/not_defined
 nl_brace_fparen                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'while' and '{'.
-nl_while_brace                  = ignore   # ignore/add/remove/force/not_defined
+nl_while_brace                  = remove   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between 'scope (x)' and '{'.
 nl_scope_brace                  = ignore   # ignore/add/remove/force/not_defined
@@ -1763,7 +1763,7 @@ nl_do_brace                     = remove   # ignore/add/remove/force/not_defined
 nl_brace_while                  = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'switch' and '{'.
-nl_switch_brace                 = ignore   # ignore/add/remove/force/not_defined
+nl_switch_brace                 = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'synchronized' and '{'.
 nl_synchronized_brace           = ignore   # ignore/add/remove/force/not_defined
@@ -1777,7 +1777,7 @@ nl_multi_line_cond              = false    # true/false
 
 # Add a newline after '(' if an if/for/while/switch condition spans multiple
 # lines
-nl_multi_line_sparen_open       = ignore   # ignore/add/remove/force/not_defined
+nl_multi_line_sparen_open       = remove   # ignore/add/remove/force/not_defined
 
 # Add a newline before ')' if an if/for/while/switch condition spans multiple
 # lines. Overrides nl_before_if_closing_paren if both are specified.
@@ -1908,7 +1908,7 @@ nl_func_paren_empty             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between a function name and the opening '(' in the
 # definition.
-nl_func_def_paren               = ignore   # ignore/add/remove/force/not_defined
+nl_func_def_paren               = remove   # ignore/add/remove/force/not_defined
 
 # Overrides nl_func_def_paren for functions with no parameters.
 nl_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
@@ -1941,7 +1941,7 @@ nl_func_decl_start_multi_line   = false    # true/false
 nl_func_def_start_multi_line    = false    # true/false
 
 # Add or remove newline after each ',' in a function declaration.
-nl_func_decl_args               = ignore   # ignore/add/remove/force/not_defined
+nl_func_decl_args               = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline after each ',' in a function definition.
 nl_func_def_args                = remove   # ignore/add/remove/force/not_defined
@@ -1958,7 +1958,7 @@ nl_func_decl_args_multi_line    = false    # true/false
 nl_func_def_args_multi_line     = false    # true/false
 
 # Add or remove newline before the ')' in a function declaration.
-nl_func_decl_end                = ignore   # ignore/add/remove/force/not_defined
+nl_func_decl_end                = remove   # ignore/add/remove/force/not_defined
 
 # Add or remove newline before the ')' in a function definition.
 nl_func_def_end                 = remove   # ignore/add/remove/force/not_defined
@@ -1991,7 +1991,7 @@ nl_func_call_empty              = ignore   # ignore/add/remove/force/not_defined
 nl_func_call_start              = remove   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline before ')' in a function call.
-nl_func_call_end                = ignore   # ignore/add/remove/force/not_defined
+nl_func_call_end                = remove   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after '(' in a function call if '(' and ')' are in
 # different lines.
@@ -3515,5 +3515,5 @@ set QUESTION                     REAL_FATTR_CONST
 set QUESTION                     REAL_FATTR_NONNULL_ALL
 set QUESTION                     REAL_FATTR_PURE
 set QUESTION                     REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 102
+# option(s) with 'not default' value: 110
 #


### PR DESCRIPTION
- refactor(uncrustify): move macros definitions to enable formatting

Uncrustify struggles to format function-like macros which are defined in
deeply nested areas of the code. Un-nesting them unblocks useful
formatting rules from uncrustify.

- refactor(uncrustify): improved formatting rules

- docs(dev-style): remove rules covered by uncrustify

There's no reason for contributors to learn rules that can be automated
away.