### PR TITLE
feat(lua): add `vim.bufcall` and `vim.wincall`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1078,6 +1078,22 @@ vim.env                                                              *vim.env*
         print(vim.env.TERM)
 <
 
+vim.bufcall({bufnr}, {func}, {...})                             *vim.bufcall()*
+    Invokes {func} with the current buffer set to {bufnr}.
+    Equivalent to: >
+        vim.api.nvim_buf_call(bufnr, function()
+          func(...)
+        end)
+<
+
+vim.wincall({winid}, {func}, {...})                             *vim.wincall()*
+    Invokes {func} with the current window set to {winid}.
+    Equivalent to: >
+        vim.api.nvim_win_call(winid, function()
+          func(...)
+        end)
+<
+
                                                                  *lua-options*
                                                              *lua-vim-options*
                                                                  *lua-vim-set*

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -538,3 +538,16 @@ end
 vim.opt = create_option_accessor()
 vim.opt_local = create_option_accessor('local')
 vim.opt_global = create_option_accessor('global')
+
+local function ctxcall(ctxcaller)
+  return function(handle, fn, ...)
+    local args = { ... }
+    local nargs = select('#', ...)
+    return ctxcaller(handle, function()
+      return fn(unpack(args, 1, nargs))
+    end)
+  end
+end
+
+vim.bufcall = ctxcall(a.nvim_buf_call)
+vim.wincall = ctxcall(a.nvim_win_call)


### PR DESCRIPTION
Ergonomic wrappers for `nvim_buf_call` and `nvim_win_call`

Motivated from https://github.com/nvim-treesitter/nvim-treesitter-context/pull/170 which has:

```lua
vim.api.nvim_win_call(winid, function()
  vim.fn.winrestview({leftcol = leftcol})
end)
```

Can now be written as:

```lua
vim.wincall(winid, vim.fn.winrestview, {leftcol = leftcol})
```

which is much more similar to std functions like `pcall` etc.
