### PR TITLE
vim-patch:9.0.{partial:0737,0754}: lisp indent fixes

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1814,17 +1814,15 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
     vreplace_mode = 0;
   }
 
-  // May do lisp indenting.
   if (!p_paste
       && leader == NULL
       && curbuf->b_p_lisp
       && curbuf->b_p_ai) {
+    // do lisp indenting
     fixthisline(get_lisp_indent);
     ai_col = (colnr_T)getwhitecols_curline();
-  }
-
-  // May do indenting after opening a new line.
-  if (do_cindent) {
+  } else if (do_cindent) {
+    // do 'cindent' or 'indentexpr' indenting
     do_c_expr_indent();
     ai_col = (colnr_T)getwhitecols_curline();
   }

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1138,7 +1138,7 @@ static int lisp_match(char_u *p)
     (void)copy_option_part(&word, (char *)buf, LSIZE, ",");
     len = (int)STRLEN(buf);
 
-    if ((STRNCMP(buf, p, len) == 0) && (p[len] == ' ')) {
+    if ((STRNCMP(buf, p, len) == 0) && ascii_iswhite_or_nul(p[len])) {
       return true;
     }
   }

--- a/src/nvim/testdir/test_alot.vim
+++ b/src/nvim/testdir/test_alot.vim
@@ -15,7 +15,6 @@ source test_fnamemodify.vim
 source test_ga.vim
 source test_glob2regpat.vim
 source test_global.vim
-source test_lispwords.vim
 source test_move.vim
 source test_put.vim
 source test_reltime.vim

--- a/src/nvim/testdir/test_lispindent.vim
+++ b/src/nvim/testdir/test_lispindent.vim
@@ -91,6 +91,17 @@ func Test_lispindent_negative()
   call assert_equal(-1, lispindent(-1))
 endfunc
 
+func Test_lispindent_with_indentexpr()
+  enew
+  setl ai lisp nocin indentexpr=11
+  exe "normal a(x\<CR>1\<CR>2)\<Esc>"
+  let expected = ['(x', '  1', '  2)']
+  call assert_equal(expected, getline(1, 3))
+  normal 1G=G
+  call assert_equal(expected, getline(1, 3))
+  bwipe!
+endfunc
+
 func Test_lisp_indent_works()
   " This was reading beyond the end of the line
   new

--- a/src/nvim/testdir/test_lispindent.vim
+++ b/src/nvim/testdir/test_lispindent.vim
@@ -86,6 +86,11 @@ func Test_lisp_indent()
   set nolisp
 endfunc
 
+func Test_lispindent_negative()
+  " in legacy script there is no error
+  call assert_equal(-1, lispindent(-1))
+endfunc
+
 func Test_lisp_indent_works()
   " This was reading beyond the end of the line
   new


### PR DESCRIPTION
#### vim-patch:partial:9.0.0737: Lisp word only recognized when a space follows

Problem:    Lisp word only recognized when a space follows.
Solution:   Also match a word at the end of a line.  Rename the test.  Use a
            compiled function to avoid backslashes.
https://github.com/vim/vim/commit/d26c5805bcbd630dab0478c2d22503a6e32a83c1

Keep the old Test_lisp_indent().


#### vim-patch:9.0.0754: 'indentexpr' overrules lisp indenting in one situation

Problem:    'indentexpr' overrules lisp indenting in one situation.
Solution:   Add "else" to keep the lisp indent. (issue vim/vim#11327)
https://github.com/vim/vim/commit/a79b35b5781ae770334cec781d17fec3875f8108