### PR TITLE
vim-patch:9.0.0765: with a Visual block a put command column may go negative

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3370,6 +3370,9 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
     // adjust '] mark
     curbuf->b_op_end.lnum = curwin->w_cursor.lnum - 1;
     curbuf->b_op_end.col = bd.textcol + (colnr_T)totlen - 1;
+    if (curbuf->b_op_end.col < 0) {
+      curbuf->b_op_end.col = 0;
+    }
     curbuf->b_op_end.coladd = 0;
     if (flags & PUT_CURSEND) {
       colnr_T len;

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -474,6 +474,18 @@ func Test_visual_block_put()
   bw!
 endfunc
 
+func Test_visual_block_put_invalid()
+  enew!
+  behave mswin
+  norm yy
+  norm v)Ps/^/	
+  " this was causing the column to become negative
+  silent norm ggv)P
+
+  bwipe!
+  behave xterm
+endfunc
+
 " Visual modes (v V CTRL-V) followed by an operator; count; repeating
 func Test_visual_mode_op()
   new


### PR DESCRIPTION
#### vim-patch:9.0.0765: with a Visual block a put command column may go negative

Problem:    With a Visual block a put command column may go negative.
Solution:   Check that the column does not become negative.
https://github.com/vim/vim/commit/36343ae0fb7247e060abfd35fb8e4337b33abb4b