### PR TITLE
refactor: clang-tidy fixes to silence clangd warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,54 +2,47 @@
 
 Checks: >
   -*,
+
   bugprone-*,
-  cert-env33-c,
-  cert-err34-c,
-  cert-flp30-c,
-  cert-msc30-c,
-  clang-analyzer-*,
-  clang-diagnostics-*,
   google-*,
   misc-*,
-  misc-non-copyable-objects,
-  misc-static-assert,
+  modernize-*,
   performance-*,
   portability-*,
   readability-*,
+
   -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-macro-parentheses,
+  -bugprone-misplaced-widening-cast,
   -bugprone-narrowing-conversions,
+  -bugprone-narrowing-conversions,
+  -bugprone-not-null-terminated-result,
+  -bugprone-reserved-identifier,
   -bugprone-sizeof-expression,
+  -bugprone-suspicious-include,
+  -bugprone-suspicious-memory-comparison,
   -bugprone-unused-return-value,
-  -clang-analyzer-security.insecureAPI.strcpy,
+  -google-readability-braces-around-statements,
   -google-readability-function-size,
+  -misc-misplaced-const,
   -misc-no-recursion,
   -misc-unused-parameters,
+  -modernize-macro-to-enum,
   -performance-no-int-to-ptr,
+  -readability-braces-around-statements,
   -readability-else-after-return,
-  -readability-function-*,
+  -readability-function-cognitive-complexity,
+  -readability-function-size,
   -readability-identifier-length,
   -readability-isolate-declaration,
   -readability-magic-numbers,
+  -readability-misleading-indentation,
+  -readability-redundant-declaration,
   -readability-redundant-function-ptr-dereference,
   -readability-suspicious-call-argument,
-
-CheckOptions:
-  - key: readability-identifier-naming.FunctionCase
-    value: lower_case
-  - key: readability-identifier-naming.GlobalConstantCase
-    value: CamelCase
-  - key: readability-identifier-naming.GlobalConstantPrefix
-    value: k
-  - key: readability-identifier-naming.StaticConstantCase
-    value: CamelCase
-  - key: readability-identifier-naming.StaticConstantPrefix
-    value: k
-  - key: readability-identifier-naming.StructCase
-    value: CamelCase
-  - key: readability-identifier-naming.VariableCase
-    value: lower_case
 
 WarningsAsErrors: ''
 

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -48,7 +48,7 @@ typedef enum {
 /// Internal call from lua code
 #define LUA_INTERNAL_CALL (VIML_INTERNAL_CALL + 1)
 
-static inline bool is_internal_call(const uint64_t channel_id)
+static inline bool is_internal_call(uint64_t channel_id)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
 
 /// Check whether call is internal

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -845,7 +845,7 @@ static void remote_ui_raw_line(UI *ui, Integer grid, Integer row, Integer startc
     for (size_t i = 0; i < ncells; i++) {
       repeat++;
       if (i == ncells - 1 || attrs[i] != attrs[i + 1]
-          || strcmp(chunk[i], chunk[i + 1])) {
+          || strcmp(chunk[i], chunk[i + 1]) != 0) {
         if (UI_BUF_SIZE - BUF_POS(data) < 2 * (1 + 2 + sizeof(schar_T) + 5 + 5)) {
           // close to overflowing the redraw buffer. finish this event,
           // flush, and start a new "grid_line" event at the current position.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1012,7 +1012,7 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   return (Integer)chan->id;
 }
 
-static void term_write(char *buf, size_t size, void *data)
+static void term_write(char *buf, size_t size, void *data)  // NOLINT(readability-non-const-parameter)
 {
   Channel *chan = data;
   LuaRef cb = chan->stream.internal.cb;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2125,7 +2125,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
   bool use_tabline = false;
   bool highlights = false;
 
-  if (str.size < 2 || memcmp(str.data, "%!", 2)) {
+  if (str.size < 2 || memcmp(str.data, "%!", 2) != 0) {
     const char *const errmsg = check_stl_option(str.data);
     if (errmsg) {
       api_set_error(err, kErrorTypeValidation, "%s", errmsg);

--- a/src/nvim/ascii.h
+++ b/src/nvim/ascii.h
@@ -84,31 +84,31 @@
 # define PATHSEPSTR     "/"
 #endif
 
-static inline bool ascii_iswhite(int)
+static inline bool ascii_iswhite(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_iswhite_or_nul(int)
+static inline bool ascii_iswhite_or_nul(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_isdigit(int)
+static inline bool ascii_isdigit(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_isxdigit(int)
+static inline bool ascii_isxdigit(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_isident(int)
+static inline bool ascii_isident(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_isbdigit(int)
+static inline bool ascii_isbdigit(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 
-static inline bool ascii_isspace(int)
+static inline bool ascii_isspace(int c)
   REAL_FATTR_CONST
   REAL_FATTR_ALWAYS_INLINE;
 

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -69,8 +69,8 @@ EXTERN char *msg_qflist INIT(= N_("[Quickfix List]"));
 # include "buffer.h.generated.h"
 #endif
 
-static inline void buf_set_changedtick(buf_T *const buf,
-                                       const varnumber_T changedtick)
+static inline void buf_set_changedtick(buf_T *buf,
+                                       varnumber_T changedtick)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
 
 /// Set b:changedtick, also checking b: for consistency in debug build
@@ -102,7 +102,7 @@ static inline void buf_set_changedtick(buf_T *const buf, const varnumber_T chang
   }
 }
 
-static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
+static inline varnumber_T buf_get_changedtick(const buf_T *buf)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE
   REAL_FATTR_WARN_UNUSED_RESULT;
 
@@ -116,7 +116,7 @@ static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
   return buf->changedtick_di.di_tv.vval.v_number;
 }
 
-static inline void buf_inc_changedtick(buf_T *const buf)
+static inline void buf_inc_changedtick(buf_T *buf)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
 
 /// Increment b:changedtick value

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1880,7 +1880,7 @@ void set_cmd_context(expand_T *xp, char_u *str, int len, int col, int use_ccline
 /// @param col  position of cursor
 /// @param matchcount  return: nr of matches
 /// @param matches  return: array of pointers to matches
-int expand_cmdline(expand_T *xp, char_u *str, int col, int *matchcount, char ***matches)
+int expand_cmdline(expand_T *xp, const char_u *str, int col, int *matchcount, char ***matches)
 {
   char_u *file_str = NULL;
   int options = WILD_ADD_SLASH|WILD_SILENT;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2212,7 +2212,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
       // flag to indicate whether prevcol equals startcol of search_hl or
       // one of the matches
       bool prevcol_hl_flag = get_prevcol_hl_flag(wp, &screen_search_hl,
-                                                 (long)(ptr - line) - 1);
+                                                 (long)(ptr - line) - 1);  // NOLINT(google-readability-casting)
 
       // Invert at least one char, used for Visual and empty line or
       // highlight match at end of line. If it's beyond the last
@@ -2248,7 +2248,10 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
         if (area_attr == 0 && !has_fold) {
           // Use attributes from match with highest priority among
           // 'search_hl' and the match list.
-          get_search_match_hl(wp, &screen_search_hl, (long)(ptr - line), &char_attr);
+          get_search_match_hl(wp,
+                              &screen_search_hl,
+                              (long)(ptr - line),  // NOLINT(google-readability-casting)
+                              &char_attr);
         }
 
         int eol_attr = char_attr;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -489,7 +489,7 @@ void eval_clear(void)
 
 /// Set an internal variable to a string value. Creates the variable if it does
 /// not already exist.
-void set_internal_string_var(const char *name, char *value)
+void set_internal_string_var(const char *name, char *value)  // NOLINT(readability-non-const-parameter)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   typval_T tv = {
@@ -8311,7 +8311,7 @@ repeat:
 /// "flags" can be "g" to do a global substitute.
 ///
 /// @return  an allocated string, NULL for error.
-char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, char *flags)
+char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char *flags)
 {
   int sublen;
   regmatch_T regmatch;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4225,11 +4225,11 @@ bool garbage_collect(bool testing)
 
   // history items (ShaDa additional elements)
   if (p_hi) {
-    for (uint8_t i = 0; i < HIST_COUNT; i++) {
+    for (HistoryType i = 0; i < HIST_COUNT; i++) {
       const void *iter = NULL;
       do {
         histentry_T hist;
-        iter = hist_iter(iter, i, false, &hist);
+        iter = hist_iter(iter, (uint8_t)i, false, &hist);
         if (hist.hisstr != NULL) {
           ABORTING(set_ref_list)(hist.additional_elements, copyID);
         }

--- a/src/nvim/eval/encode.h
+++ b/src/nvim/eval/encode.h
@@ -15,9 +15,9 @@
 /// @param[in]  objname  Object name, used for error message.
 ///
 /// @return OK in case of success, FAIL otherwise.
-int encode_vim_to_msgpack(msgpack_packer *const packer,
-                          typval_T *const tv,
-                          const char *const objname);
+int encode_vim_to_msgpack(msgpack_packer *packer,
+                          typval_T *tv,
+                          const char *objname);
 
 /// Convert VimL value to :echo output
 ///
@@ -26,9 +26,9 @@ int encode_vim_to_msgpack(msgpack_packer *const packer,
 /// @param[in]  objname  Object name, used for error message.
 ///
 /// @return OK in case of success, FAIL otherwise.
-int encode_vim_to_echo(garray_T *const packer,
-                       typval_T *const tv,
-                       const char *const objname);
+int encode_vim_to_echo(garray_T *packer,
+                       typval_T *tv,
+                       const char *objname);
 
 /// Structure defining state for read_from_list()
 typedef struct {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5866,8 +5866,8 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   char buf[(IOSIZE/256) * 256];    // rounded to avoid odd + 1
   int io_size = sizeof(buf);
   char *prev = NULL;               // previously read bytes, if any
-  long prevlen  = 0;               // length of data in prev
-  long prevsize = 0;               // size of prev buffer
+  ptrdiff_t prevlen  = 0;               // length of data in prev
+  ptrdiff_t prevsize = 0;               // size of prev buffer
   long maxline  = MAXLNUM;
 
   if (argvars[1].v_type != VAR_UNKNOWN) {
@@ -6022,17 +6022,17 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         // small, to avoid repeatedly 'allocing' large and
         // 'reallocing' small.
         if (prevsize == 0) {
-          prevsize = (long)(p - start);
+          prevsize = p - start;
         } else {
-          long grow50pc = (prevsize * 3) / 2;
-          long growmin  = (long)((p - start) * 2 + prevlen);
+          ptrdiff_t grow50pc = (prevsize * 3) / 2;
+          ptrdiff_t growmin  = (p - start) * 2 + prevlen;
           prevsize = grow50pc > growmin ? grow50pc : growmin;
         }
         prev = xrealloc(prev, (size_t)prevsize);
       }
       // Add the line part to end of "prev".
       memmove(prev + prevlen, start, (size_t)(p - start));
-      prevlen += (long)(p - start);
+      prevlen += p - start;
     }
   }   // while
 

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1361,7 +1361,7 @@ void tv_list_reverse(list_T *const l)
 ///               true list will not be modified. Must be initialized to false
 ///               by the caller.
 void tv_list_item_sort(list_T *const l, ListSortItem *const ptrs,
-                       const ListSorter item_compare_func, bool *errp)
+                       const ListSorter item_compare_func, const bool *errp)
   FUNC_ATTR_NONNULL_ARG(3, 4)
 {
   const int len = tv_list_len(l);

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -90,7 +90,7 @@ static inline void list_log(const list_T *const l, const listitem_T *const li1,
 #define TV_DICT_HI2DI(hi) \
   ((dictitem_T *)((hi)->hi_key - offsetof(dictitem_T, di_key)))
 
-static inline void tv_list_ref(list_T *const l)
+static inline void tv_list_ref(list_T *l)
   REAL_FATTR_ALWAYS_INLINE;
 
 /// Increase reference count for a given list
@@ -106,7 +106,7 @@ static inline void tv_list_ref(list_T *const l)
   l->lv_refcount++;
 }
 
-static inline void tv_list_set_ret(typval_T *const tv, list_T *const l)
+static inline void tv_list_set_ret(typval_T *tv, list_T *l)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
 
 /// Set a list as the return value.  Increments the reference count.
@@ -120,7 +120,7 @@ static inline void tv_list_set_ret(typval_T *const tv, list_T *const l)
   tv_list_ref(l);
 }
 
-static inline VarLockStatus tv_list_locked(const list_T *const l)
+static inline VarLockStatus tv_list_locked(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get list lock status
@@ -163,7 +163,7 @@ static inline void tv_list_set_copyid(list_T *const l, const int copyid)
   l->lv_copyID = copyid;
 }
 
-static inline int tv_list_len(const list_T *const l)
+static inline int tv_list_len(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the number of items in a list
@@ -178,7 +178,7 @@ static inline int tv_list_len(const list_T *const l)
   return l->lv_len;
 }
 
-static inline int tv_list_copyid(const list_T *const l)
+static inline int tv_list_copyid(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Get list copyID
@@ -191,7 +191,7 @@ static inline int tv_list_copyid(const list_T *const l)
   return l->lv_copyID;
 }
 
-static inline list_T *tv_list_latest_copy(const list_T *const l)
+static inline list_T *tv_list_latest_copy(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Get latest list copy
@@ -206,7 +206,7 @@ static inline list_T *tv_list_latest_copy(const list_T *const l)
   return l->lv_copylist;
 }
 
-static inline int tv_list_uidx(const list_T *const l, int n)
+static inline int tv_list_uidx(const list_T *l, int n)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Normalize index: that is, return either -1 or non-negative index
@@ -229,7 +229,7 @@ static inline int tv_list_uidx(const list_T *const l, int n)
   return n;
 }
 
-static inline bool tv_list_has_watchers(const list_T *const l)
+static inline bool tv_list_has_watchers(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Check whether list has watchers
@@ -244,7 +244,7 @@ static inline bool tv_list_has_watchers(const list_T *const l)
   return l && l->lv_watch;
 }
 
-static inline listitem_T *tv_list_first(const list_T *const l)
+static inline listitem_T *tv_list_first(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get first list item
@@ -262,7 +262,7 @@ static inline listitem_T *tv_list_first(const list_T *const l)
   return l->lv_first;
 }
 
-static inline listitem_T *tv_list_last(const list_T *const l)
+static inline listitem_T *tv_list_last(const list_T *l)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get last list item
@@ -280,7 +280,7 @@ static inline listitem_T *tv_list_last(const list_T *const l)
   return l->lv_last;
 }
 
-static inline void tv_dict_set_ret(typval_T *const tv, dict_T *const d)
+static inline void tv_dict_set_ret(typval_T *tv, dict_T *d)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
 
 /// Set a dictionary as the return value
@@ -296,7 +296,7 @@ static inline void tv_dict_set_ret(typval_T *const tv, dict_T *const d)
   }
 }
 
-static inline long tv_dict_len(const dict_T *const d)
+static inline long tv_dict_len(const dict_T *d)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the number of items in a Dictionary
@@ -310,7 +310,7 @@ static inline long tv_dict_len(const dict_T *const d)
   return (long)d->dv_hashtab.ht_used;
 }
 
-static inline bool tv_dict_is_watched(const dict_T *const d)
+static inline bool tv_dict_is_watched(const dict_T *d)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Check if dictionary is watched
@@ -323,7 +323,7 @@ static inline bool tv_dict_is_watched(const dict_T *const d)
   return d && !QUEUE_EMPTY(&d->watchers);
 }
 
-static inline void tv_blob_set_ret(typval_T *const tv, blob_T *const b)
+static inline void tv_blob_set_ret(typval_T *tv, blob_T *b)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
 
 /// Set a blob as the return value.
@@ -341,7 +341,7 @@ static inline void tv_blob_set_ret(typval_T *const tv, blob_T *const b)
   }
 }
 
-static inline int tv_blob_len(const blob_T *const b)
+static inline int tv_blob_len(const blob_T *b)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the length of the data in the blob, in bytes.
@@ -355,7 +355,7 @@ static inline int tv_blob_len(const blob_T *const b)
   return b->bv_ga.ga_len;
 }
 
-static inline char_u tv_blob_get(const blob_T *const b, int idx)
+static inline char_u tv_blob_get(const blob_T *b, int idx)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the byte at index `idx` in the blob.
@@ -369,7 +369,7 @@ static inline char_u tv_blob_get(const blob_T *const b, int idx)
   return ((char_u *)b->bv_ga.ga_data)[idx];
 }
 
-static inline void tv_blob_set(blob_T *const b, int idx, char_u c)
+static inline void tv_blob_set(blob_T *b, int idx, char_u c)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Store the byte `c` at index `idx` in the blob.
@@ -488,8 +488,8 @@ extern bool tv_in_free_unref_items;
     } \
   })
 
-static inline bool tv_get_float_chk(const typval_T *const tv,
-                                    float_T *const ret_f)
+static inline bool tv_get_float_chk(const typval_T *tv,
+                                    float_T *ret_f)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the float value
@@ -527,7 +527,7 @@ static inline DictWatcher *tv_dict_watcher_node_data(QUEUE *q)
   return QUEUE_DATA(q, DictWatcher, node);
 }
 
-static inline bool tv_is_func(const typval_T tv)
+static inline bool tv_is_func(typval_T tv)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST;
 
 /// Check whether given typval_T contains a function

--- a/src/nvim/eval/typval_encode.h
+++ b/src/nvim/eval/typval_encode.h
@@ -71,7 +71,7 @@ typedef kvec_withinit_t(MPConvStackVal, 8) MPConvStack;
 #define _mp_pop kv_pop
 #define _mp_last kv_last
 
-static inline size_t tv_strlen(const typval_T *const tv)
+static inline size_t tv_strlen(const typval_T *tv)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT
   REAL_FATTR_NONNULL_ALL;
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1193,7 +1193,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
 /// For the first we only count the name stored in func_hashtab as a reference,
 /// using function() does not count as a reference, because the function is
 /// looked up by name.
-static bool func_name_refcount(char_u *name)
+static bool func_name_refcount(const char_u *name)
 {
   return isdigit(*name) || *name == '<';
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3239,7 +3239,7 @@ void sub_set_replacement(SubReplacementString sub)
 /// @param[in]  save Save pattern to options, history
 ///
 /// @returns true if :substitute can be replaced with a join command
-static bool sub_joining_lines(exarg_T *eap, char *pat, char *sub, char *cmd, bool save)
+static bool sub_joining_lines(exarg_T *eap, char *pat, const char *sub, const char *cmd, bool save)
   FUNC_ATTR_NONNULL_ARG(1, 3, 4)
 {
   // TODO(vim): find a generic solution to make line-joining operations more

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5654,7 +5654,7 @@ void do_sleep(long msec)
 {
   ui_flush();  // flush before waiting
   for (long left = msec; !got_int && left > 0; left -= 1000L) {
-    int next = left > 1000l ? 1000 : (int)left;
+    int next = left > 1000L ? 1000 : (int)left;
     LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, (int)next, got_int);
     os_breakcheck();
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7266,7 +7266,7 @@ static void ex_terminal(exarg_T *eap)
 
 void verify_command(char *cmd)
 {
-  if (strcmp("smile", cmd)) {
+  if (strcmp("smile", cmd) != 0) {
     return;  // acceptable non-existing command
   }
   msg(" #xxn`          #xnxx`        ,+x@##@Mz;`        .xxx"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1059,7 +1059,7 @@ static int current_tab_nr(tabpage_T *tab)
 #define LAST_TAB_NR current_tab_nr(NULL)
 
 /// Figure out the address type for ":wincmd".
-static void get_wincmd_addr_type(char *arg, exarg_T *eap)
+static void get_wincmd_addr_type(const char *arg, exarg_T *eap)
 {
   switch (*arg) {
   case 'S':
@@ -2837,7 +2837,7 @@ theend:
 /// @param pp   start of command
 /// @param cmd  name of command
 /// @param len  required length
-bool checkforcmd(char **pp, char *cmd, int len)
+bool checkforcmd(char **pp, const char *cmd, int len)
 {
   int i;
 
@@ -6559,7 +6559,7 @@ static void ex_tag(exarg_T *eap)
   ex_tag_cmd(eap, cmdnames[eap->cmdidx].cmd_name);
 }
 
-static void ex_tag_cmd(exarg_T *eap, char *name)
+static void ex_tag_cmd(exarg_T *eap, const char *name)
 {
   int cmd;
 
@@ -6685,8 +6685,8 @@ ssize_t find_cmdline_var(const char_u *src, size_t *usedlen)
 /// @return          an allocated string if a valid match was found.
 ///                  Returns NULL if no match was found.  "usedlen" then still contains the
 ///                  number of characters to skip.
-char_u *eval_vars(char_u *src, char_u *srcstart, size_t *usedlen, linenr_T *lnump, char **errormsg,
-                  int *escaped, bool empty_is_error)
+char_u *eval_vars(char_u *src, const char_u *srcstart, size_t *usedlen, linenr_T *lnump,
+                  char **errormsg, int *escaped, bool empty_is_error)
 {
   char *result;
   char *resultbuf = NULL;

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -240,7 +240,7 @@ static int ses_arglist(FILE *fd, char *cmd, garray_T *gap, int fullname, unsigne
 }
 
 /// @return  the buffer name for `buf`.
-static char *ses_get_fname(buf_T *buf, unsigned *flagp)
+static char *ses_get_fname(buf_T *buf, const unsigned *flagp)
 {
   // Use the short file name if the current directory is known at the time
   // the session file will be sourced.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1933,7 +1933,7 @@ bool is_dev_fd_file(char *fname)
 /// @param linecnt  line count before reading more bytes
 /// @param p        start of more bytes read
 /// @param endp     end of more bytes read
-static linenr_T readfile_linenr(linenr_T linecnt, char_u *p, char_u *endp)
+static linenr_T readfile_linenr(linenr_T linecnt, char_u *p, const char_u *endp)
 {
   char_u *s;
   linenr_T lnum;
@@ -4097,7 +4097,7 @@ static int get_fio_flags(const char_u *name)
 ///
 /// @return  the name of the encoding and set "*lenp" to the length or,
 ///          NULL when no BOM found.
-static char_u *check_for_bom(char_u *p, long size, int *lenp, int flags)
+static char_u *check_for_bom(const char_u *p, long size, int *lenp, int flags)
 {
   char *name = NULL;
   int len = 2;

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -509,7 +509,7 @@ void AppendToRedobuffLit(const char *str, int len)
       s--;
     }
     if (s > start) {
-      add_buff(&redobuff, start, (long)(s - start));
+      add_buff(&redobuff, start, s - start);
     }
 
     if (*s == NUL || (len >= 0 && s - str >= len)) {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1886,7 +1886,7 @@ static int check_simplify_modifier(int max_offset)
 /// - When there is no match yet, return map_result_nomatch, need to get more
 ///   typeahead.
 /// - On failure (out of memory) return map_result_fail.
-static int handle_mapping(int *keylenp, bool *timedout, int *mapdepth)
+static int handle_mapping(int *keylenp, const bool *timedout, int *mapdepth)
 {
   mapblock_T *mp = NULL;
   mapblock_T *mp2;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -1741,7 +1741,7 @@ static bool prt_check_resource(const struct prt_ps_resource_S *resource, const c
   FUNC_ATTR_NONNULL_ALL
 {
   // Version number m.n should match, the revision number does not matter
-  if (STRNCMP(resource->version, version, strlen(version))) {
+  if (STRNCMP(resource->version, version, strlen(version)) != 0) {
     semsg(_("E621: \"%s\" resource file has wrong version"),
           resource->name);
     return false;

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -101,7 +101,7 @@ bool tabstop_set(char *var, long **array)
 /// Calculate the number of screen spaces a tab will occupy.
 /// If "vts" is set then the tab widths are taken from that array,
 /// otherwise the value of ts is used.
-int tabstop_padding(colnr_T col, long ts_arg, long *vts)
+int tabstop_padding(colnr_T col, long ts_arg, const long *vts)
 {
   long ts = ts_arg == 0 ? 8 : ts_arg;
   colnr_T tabcol = 0;
@@ -129,7 +129,7 @@ int tabstop_padding(colnr_T col, long ts_arg, long *vts)
 }
 
 /// Find the size of the tab that covers a particular column.
-int tabstop_at(colnr_T col, long ts, long *vts)
+int tabstop_at(colnr_T col, long ts, const long *vts)
 {
   colnr_T tabcol = 0;
   int t;
@@ -178,7 +178,7 @@ colnr_T tabstop_start(colnr_T col, long ts, long *vts)
 
 /// Find the number of tabs and spaces necessary to get from one column
 /// to another.
-void tabstop_fromto(colnr_T start_col, colnr_T end_col, long ts_arg, long *vts, int *ntabs,
+void tabstop_fromto(colnr_T start_col, colnr_T end_col, long ts_arg, const long *vts, int *ntabs,
                     int *nspcs)
 {
   int spaces = end_col - start_col;
@@ -242,7 +242,7 @@ void tabstop_fromto(colnr_T start_col, colnr_T end_col, long ts_arg, long *vts, 
 }
 
 /// See if two tabstop arrays contain the same values.
-bool tabstop_eq(long *ts1, long *ts2)
+bool tabstop_eq(const long *ts1, const long *ts2)
 {
   int t;
 
@@ -266,7 +266,7 @@ bool tabstop_eq(long *ts1, long *ts2)
 }
 
 /// Copy a tabstop array, allocating space for the new array.
-int *tabstop_copy(long *oldts)
+int *tabstop_copy(const long *oldts)
 {
   long *newts;
   int t;

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -572,7 +572,7 @@ bool ins_compl_accept_char(int c)
 
 /// Get the completed text by inferring the case of the originally typed text.
 /// If the result is in allocated memory "tofree" is set to it.
-static char_u *ins_compl_infercase_gettext(char_u *str, int char_len, int compl_char_len,
+static char_u *ins_compl_infercase_gettext(const char_u *str, int char_len, int compl_char_len,
                                            int min_len, char **tofree)
 {
   bool has_lower = false;
@@ -1378,7 +1378,8 @@ theend:
 /// skipping the word at 'skip_word'.
 ///
 /// @return  OK on success.
-static int thesaurus_add_words_in_line(char *fname, char_u **buf_arg, int dir, char_u *skip_word)
+static int thesaurus_add_words_in_line(char *fname, char_u **buf_arg, int dir,
+                                       const char_u *skip_word)
 {
   int status = OK;
 

--- a/src/nvim/locale.c
+++ b/src/nvim/locale.c
@@ -42,7 +42,7 @@ static char *get_locale_val(int what)
 
 /// @return  true when "lang" starts with a valid language name.
 ///          Rejects NULL, empty string, "C", "C.UTF-8" and others.
-static bool is_valid_mess_lang(char *lang)
+static bool is_valid_mess_lang(const char *lang)
 {
   return lang != NULL && ASCII_ISALPHA(lang[0]) && ASCII_ISALPHA(lang[1]);
 }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1350,7 +1350,7 @@ int ExpandMappings(regmatch_T *regmatch, int *num_file, char ***file)
     char **ptr3 = ptr1 + count;
 
     while (ptr2 < ptr3) {
-      if (strcmp(*ptr1, *ptr2)) {
+      if (strcmp(*ptr1, *ptr2) != 0) {
         *++ptr1 = *ptr2++;
       } else {
         xfree(*ptr2++);

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -78,12 +78,13 @@ static inline int mark_local_index(const char name)
                    : -1))));
 }
 
-static inline bool lt(pos_T, pos_T) REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
-static inline bool equalpos(pos_T, pos_T)
+static inline bool lt(pos_T a, pos_T b)
   REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
-static inline bool ltoreq(pos_T, pos_T)
+static inline bool equalpos(pos_T a, pos_T b)
   REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
-static inline void clearpos(pos_T *)
+static inline bool ltoreq(pos_T a, pos_T b)
+  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
+static inline void clearpos(pos_T *a)
   REAL_FATTR_ALWAYS_INLINE;
 
 /// Return true if position a is before (less than) position b.

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2301,7 +2301,7 @@ void *my_iconv_open(char_u *to, char_u *from)
 // sequence and set "*unconvlenp" to the length of it.
 // Returns the converted string in allocated memory.  NULL for an error.
 // If resultlenp is not NULL, sets it to the result length in bytes.
-static char_u *iconv_string(const vimconv_T *const vcp, char_u *str, size_t slen,
+static char_u *iconv_string(const vimconv_T *const vcp, const char_u *str, size_t slen,
                             size_t *unconvlenp, size_t *resultlenp)
 {
   const char *from;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -437,7 +437,7 @@ void ml_open_file(buf_T *buf)
   if (buf->b_spell) {
     char *fname = vim_tempname();
     if (fname != NULL) {
-      (void)mf_open_file(mfp, (char *)fname);           // consumes fname!
+      (void)mf_open_file(mfp, fname);           // consumes fname!
     }
     buf->b_may_swap = false;
     return;
@@ -1193,7 +1193,7 @@ int recover_names(char_u *fname, int list, int nr, char **fname_out)
     // Isolate a directory name from *dirp and put it in dir_name (we know
     // it is large enough, so use 31000 for length).
     // Advance dirp to next directory name.
-    (void)copy_option_part(&dirp, (char *)dir_name, 31000, ",");
+    (void)copy_option_part(&dirp, dir_name, 31000, ",");
 
     if (dir_name[0] == '.' && dir_name[1] == NUL) {     // check current dir
       if (fname == NULL) {
@@ -1208,24 +1208,24 @@ int recover_names(char_u *fname, int list, int nr, char **fname_out)
       }
     } else {                      // check directory dir_name
       if (fname == NULL) {
-        names[0] = concat_fnames((char *)dir_name, "*.sw?", true);
+        names[0] = concat_fnames(dir_name, "*.sw?", true);
         // For Unix names starting with a dot are special.  MS-Windows
         // supports this too, on some file systems.
-        names[1] = concat_fnames((char *)dir_name, ".*.sw?", true);
-        names[2] = concat_fnames((char *)dir_name, ".sw?", true);
+        names[1] = concat_fnames(dir_name, ".*.sw?", true);
+        names[2] = concat_fnames(dir_name, ".sw?", true);
         num_names = 3;
       } else {
         int len = (int)STRLEN(dir_name);
         p = dir_name + len;
-        if (after_pathsep((char *)dir_name, (char *)p)
+        if (after_pathsep(dir_name, p)
             && len > 1
             && p[-1] == p[-2]) {
           // Ends with '//', Use Full path for swap name
-          tail = (char_u *)make_percent_swname((char *)dir_name,
+          tail = (char_u *)make_percent_swname(dir_name,
                                                (char *)fname_res);
         } else {
           tail = (char_u *)path_tail((char *)fname_res);
-          tail = (char_u *)concat_fnames((char *)dir_name, (char *)tail, true);
+          tail = (char_u *)concat_fnames(dir_name, (char *)tail, true);
         }
         num_names = recov_file_names(names, (char *)tail, false);
         xfree(tail);
@@ -1262,7 +1262,7 @@ int recover_names(char_u *fname, int list, int nr, char **fname_out)
       for (int i = 0; i < num_files; i++) {
         // Do not expand wildcards, on Windows would try to expand
         // "%tmp%" in "%tmp%file"
-        if (path_full_compare((char *)p, files[i], true, false) & kEqualFiles) {
+        if (path_full_compare(p, files[i], true, false) & kEqualFiles) {
           // Remove the name from files[i].  Move further entries
           // down.  When the array becomes empty free it here, since
           // FreeWild() won't be called below.
@@ -1292,7 +1292,7 @@ int recover_names(char_u *fname, int list, int nr, char **fname_out)
         }
       } else {
         msg_puts(_("   In directory "));
-        msg_home_replace((char *)dir_name);
+        msg_home_replace(dir_name);
         msg_puts(":\n");
       }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -3485,7 +3485,7 @@ static void long_to_char(long n, char_u *s)
   s[3] = (char_u)(n & 0xff);
 }
 
-static long char_to_long(char_u *s)
+static long char_to_long(const char_u *s)
 {
   long retval;
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -318,7 +318,7 @@ bool msg_attr_keep(const char *s, int attr, bool keep, bool multiline)
       || (*s != '<'
           && last_msg_hist != NULL
           && last_msg_hist->msg != NULL
-          && strcmp(s, last_msg_hist->msg))) {
+          && strcmp(s, last_msg_hist->msg) != 0)) {
     add_msg_hist(s, -1, attr, multiline);
   }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3066,7 +3066,7 @@ static void nv_gd(oparg_T *oap, int nchar, int thisblock)
 
 /// @return true if line[offset] is not inside a C-style comment or string,
 ///         false otherwise.
-static bool is_ident(char_u *line, int offset)
+static bool is_ident(const char_u *line, int offset)
 {
   bool incomment = false;
   int instring = 0;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3256,7 +3256,7 @@ static void showoptions(int all, int opt_flags)
 }
 
 /// Return true if option "p" has its default value.
-static int optval_default(vimoption_T *p, char_u *varp)
+static int optval_default(vimoption_T *p, const char_u *varp)
 {
   if (varp == NULL) {
     return true;            // hidden option is always at default
@@ -4889,7 +4889,7 @@ static void option_value2string(vimoption_T *opp, int opt_flags)
 /// Return true if "varp" points to 'wildchar' or 'wildcharm' and it can be
 /// printed as a keyname.
 /// "*wcp" is set to the value of the option if it's 'wildchar' or 'wildcharm'.
-static int wc_use_keyname(char_u *varp, long *wcp)
+static int wc_use_keyname(const char_u *varp, long *wcp)
 {
   if (((long *)varp == &p_wc) || ((long *)varp == &p_wcm)) {
     *wcp = *(long *)varp;

--- a/src/nvim/os/fileio.h
+++ b/src/nvim/os/fileio.h
@@ -37,7 +37,7 @@ typedef enum {
                            ///< EAGAIN was encountered.
 } FileOpenFlags;
 
-static inline bool file_eof(const FileDescriptor *const fp)
+static inline bool file_eof(const FileDescriptor *fp)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Check whether end of file was encountered
@@ -51,7 +51,7 @@ static inline bool file_eof(const FileDescriptor *const fp)
   return fp->eof && rbuffer_size(fp->rv) == 0;
 }
 
-static inline int file_fd(const FileDescriptor *const fp)
+static inline int file_fd(const FileDescriptor *fp)
   REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Return the file descriptor associated with the FileDescriptor structure

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -67,7 +67,7 @@ void os_delay(uint64_t ms, bool ignoreinput)
     }
     LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, (int)ms, got_int);
   } else {
-    os_microdelay(ms * 1000u, ignoreinput);
+    os_microdelay(ms * 1000U, ignoreinput);
   }
 }
 
@@ -80,10 +80,10 @@ void os_delay(uint64_t ms, bool ignoreinput)
 ///                    If false, waiting is aborted on any input.
 void os_microdelay(uint64_t us, bool ignoreinput)
 {
-  uint64_t elapsed = 0u;
+  uint64_t elapsed = 0U;
   uint64_t base = uv_hrtime();
   // Convert microseconds to nanoseconds, or UINT64_MAX on overflow.
-  const uint64_t ns = (us < UINT64_MAX / 1000u) ? us * 1000u : UINT64_MAX;
+  const uint64_t ns = (us < UINT64_MAX / 1000U) ? us * 1000U : UINT64_MAX;
 
   uv_mutex_lock(&delay_mutex);
 
@@ -92,7 +92,7 @@ void os_microdelay(uint64_t us, bool ignoreinput)
     // Else we check for input in ~100ms intervals.
     const uint64_t ns_delta = ignoreinput
                               ? ns - elapsed
-                              : MIN(ns - elapsed, 100000000u);  // 100ms
+                              : MIN(ns - elapsed, 100000000U);  // 100ms
 
     const int rv = uv_cond_timedwait(&delay_cond, &delay_mutex, ns_delta);
     if (0 != rv && UV_ETIMEDOUT != rv) {

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -398,7 +398,7 @@ bool prof_def_func(void)
 /// Print the count and times for one function or function line.
 ///
 /// @param prefer_self  when equal print only self time
-static void prof_func_line(FILE *fd, int count, proftime_T *total, proftime_T *self,
+static void prof_func_line(FILE *fd, int count, const proftime_T *total, const proftime_T *self,
                            bool prefer_self)
 {
   if (count > 0) {
@@ -684,7 +684,7 @@ void script_prof_save(proftime_T *tm)
 }
 
 /// Count time spent in children after invoking another script or function.
-void script_prof_restore(proftime_T *tm)
+void script_prof_restore(const proftime_T *tm)
 {
   scriptitem_T *si;
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -563,7 +563,7 @@ static size_t efm_regpat_bufsz(char *efm)
 }
 
 /// Return the length of a 'errorformat' option part (separated by ",").
-static int efm_option_part_len(char *efm)
+static int efm_option_part_len(const char *efm)
 {
   int len;
 
@@ -5257,7 +5257,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
 
 /// Jump to the first match and update the directory.
 static void vgr_jump_to_match(qf_info_T *qi, int forceit, bool *redraw_for_dummy,
-                              buf_T *first_match_buf, char *target_dir)
+                              buf_T *first_match_buf, char *target_dir)  // NOLINT(readability-non-const-parameter)
 {
   buf_T *buf = curbuf;
   qf_jump(qi, 0, 0, forceit);

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -343,7 +343,7 @@ RuntimeSearchPath copy_runtime_search_path(const RuntimeSearchPath src)
   return dst;
 }
 
-void runtime_search_path_unref(RuntimeSearchPath path, int *ref)
+void runtime_search_path_unref(RuntimeSearchPath path, const int *ref)
   FUNC_ATTR_NONNULL_ALL
 {
   if (*ref) {

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -339,7 +339,7 @@ bool sha256_self_test(void)
       }
     }
 
-    if (memcmp(output, sha_self_test_vector[i], SHA256_BUFFER_SIZE)) {
+    if (memcmp(output, sha_self_test_vector[i], SHA256_BUFFER_SIZE) != 0) {
       failures = true;
       output[sizeof(output) - 1] = '\0';
 

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1151,8 +1151,8 @@ static void shada_read(ShaDaReadDef *const sd_reader, const int flags)
   }
   HistoryMergerState hms[HIST_COUNT];
   if (srni_flags & kSDReadHistory) {
-    for (uint8_t i = 0; i < HIST_COUNT; i++) {
-      hms_init(&hms[i], i, (size_t)p_hi, true, true);
+    for (HistoryType i = 0; i < HIST_COUNT; i++) {
+      hms_init(&hms[i], (uint8_t)i, (size_t)p_hi, true, true);
     }
   }
   ShadaEntry cur_entry;
@@ -1416,12 +1416,12 @@ shada_read_main_cycle_end:
   //          memory for the history string itself and separator character which
   //          may be assigned right away.
   if (srni_flags & kSDReadHistory) {
-    for (uint8_t i = 0; i < HIST_COUNT; i++) {
+    for (HistoryType i = 0; i < HIST_COUNT; i++) {
       hms_insert_whole_neovim_history(&hms[i]);
       clr_history(i);
       int *new_hisidx;
       int *new_hisnum;
-      histentry_T *hist = hist_get_array(i, &new_hisidx, &new_hisnum);
+      histentry_T *hist = hist_get_array((uint8_t)i, &new_hisidx, &new_hisnum);
       if (hist != NULL) {
         hms_to_he_array(&hms[i], hist, new_hisidx, new_hisnum);
       }
@@ -2511,7 +2511,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
   bool dump_history = false;
 
   // Initialize history merger
-  for (uint8_t i = 0; i < HIST_COUNT; i++) {
+  for (HistoryType i = 0; i < HIST_COUNT; i++) {
     long num_saved = get_shada_parameter(hist_type2char(i));
     if (num_saved == -1) {
       num_saved = p_hi;
@@ -2519,7 +2519,7 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
     if (num_saved > 0) {
       dump_history = true;
       dump_one_history[i] = true;
-      hms_init(&wms->hms[i], i, (size_t)num_saved, sd_reader != NULL, false);
+      hms_init(&wms->hms[i], (uint8_t)i, (size_t)num_saved, sd_reader != NULL, false);
     } else {
       dump_one_history[i] = false;
     }

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -1271,7 +1271,7 @@ static void sign_place_cmd(buf_T *buf, linenr_T lnum, char *sign_name, int id, c
 }
 
 /// ":sign unplace" command
-static void sign_unplace_cmd(buf_T *buf, linenr_T lnum, char *sign_name, int id, char *group)
+static void sign_unplace_cmd(buf_T *buf, linenr_T lnum, const char *sign_name, int id, char *group)
 {
   if (lnum >= 0 || sign_name != NULL || (group != NULL && *group == '\0')) {
     emsg(_(e_invarg));
@@ -1328,7 +1328,7 @@ static void sign_unplace_cmd(buf_T *buf, linenr_T lnum, char *sign_name, int id,
 ///   :sign jump {id} buffer={nr}
 ///   :sign jump {id} group={group} file={fname}
 ///   :sign jump {id} group={group} buffer={nr}
-static void sign_jump_cmd(buf_T *buf, linenr_T lnum, char *sign_name, int id, char *group)
+static void sign_jump_cmd(buf_T *buf, linenr_T lnum, const char *sign_name, int id, char *group)
 {
   if (sign_name == NULL && group == NULL && id == -1) {
     emsg(_(e_argreq));

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -960,7 +960,7 @@ bool can_compound(slang_T *slang, const char_u *word, const char_u *flags)
 // compound rule.  This is used to stop trying a compound if the flags
 // collected so far can't possibly match any compound rule.
 // Caller must check that slang->sl_comprules is not NULL.
-bool match_compoundrule(slang_T *slang, char_u *compflags)
+bool match_compoundrule(slang_T *slang, const char_u *compflags)
 {
   // loop over all the COMPOUNDRULE entries
   for (char_u *p = slang->sl_comprules; *p != NUL; p++) {
@@ -2184,7 +2184,7 @@ static void use_midword(slang_T *lp, win_T *wp)
 // Find the region "region[2]" in "rp" (points to "sl_regions").
 // Each region is simply stored as the two characters of its name.
 // Returns the index if found (first is 0), REGION_ALL if not found.
-static int find_region(char_u *rp, char_u *region)
+static int find_region(const char_u *rp, const char_u *region)
 {
   int i;
 
@@ -2209,7 +2209,7 @@ static int find_region(char_u *rp, char_u *region)
 /// @param[in]  end  End of word or NULL for NUL delimited string
 ///
 /// @returns  Case type of word
-int captype(char_u *word, char_u *end)
+int captype(char_u *word, const char_u *end)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char_u *p;
@@ -2814,7 +2814,7 @@ static void spell_soundfold_sofo(slang_T *slang, char_u *inword, char_u *res)
 
 // Turn "inword" into its sound-a-like equivalent in "res[MAXWLEN]".
 // Multi-byte version of spell_soundfold().
-static void spell_soundfold_wsal(slang_T *slang, char_u *inword, char_u *res)
+static void spell_soundfold_wsal(slang_T *slang, const char_u *inword, char_u *res)
 {
   salitem_T *smp = (salitem_T *)slang->sl_sal.ga_data;
   int word[MAXWLEN] = { 0 };

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -819,7 +819,7 @@ endOK:
 
 // Fill in the wordcount fields for a trie.
 // Returns the total number of words.
-static void tree_count_words(char_u *byts, idx_T *idxs)
+static void tree_count_words(const char_u *byts, idx_T *idxs)
 {
   int depth;
   idx_T arridx[MAXWLEN];
@@ -3962,8 +3962,8 @@ static int store_word(spellinfo_T *spin, char_u *word, int flags, int region, co
 // When "flags" < 0 we are adding to the prefix tree where "flags" is used for
 // "rare" and "region" is the condition nr.
 // Returns FAIL when out of memory.
-static int tree_add_word(spellinfo_T *spin, char_u *word, wordnode_T *root, int flags, int region,
-                         int affixID)
+static int tree_add_word(spellinfo_T *spin, const char_u *word, wordnode_T *root, int flags,
+                         int region, int affixID)
 {
   wordnode_T *node = root;
   wordnode_T *np;
@@ -5742,7 +5742,7 @@ static void init_spellfile(void)
 /// Set the spell character tables from strings in the .spl file.
 ///
 /// @param cnt  length of "flags"
-static void set_spell_charflags(char_u *flags, int cnt, char_u *fol)
+static void set_spell_charflags(const char_u *flags, int cnt, char_u *fol)
 {
   // We build the new tables here first, so that we can compare with the
   // previous one.

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2171,18 +2171,14 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char_u *fname)
         midword = (char_u *)getroom_save(spin, (char_u *)items[1]);
       } else if (is_aff_rule(items, itemcnt, "TRY", 2)) {
         // ignored, we look in the tree for what chars may appear
-      }
-      // TODO: remove "RAR" later
-      else if ((is_aff_rule(items, itemcnt, "RAR", 2)
-                || is_aff_rule(items, itemcnt, "RARE", 2))
-               && aff->af_rare == 0) {
+      } else if ((is_aff_rule(items, itemcnt, "RAR", 2)  // TODO(vim): remove "RAR" later
+                  || is_aff_rule(items, itemcnt, "RARE", 2))
+                 && aff->af_rare == 0) {
         aff->af_rare = affitem2flag(aff->af_flagtype, (char_u *)items[1],
                                     fname, lnum);
-      }
-      // TODO: remove "KEP" later
-      else if ((is_aff_rule(items, itemcnt, "KEP", 2)
-                || is_aff_rule(items, itemcnt, "KEEPCASE", 2))
-               && aff->af_keepcase == 0) {
+      } else if ((is_aff_rule(items, itemcnt, "KEP", 2)  // TODO(vim): remove "KEP" later
+                  || is_aff_rule(items, itemcnt, "KEEPCASE", 2))
+                 && aff->af_keepcase == 0) {
         aff->af_keepcase = affitem2flag(aff->af_flagtype, (char_u *)items[1],
                                         fname, lnum);
       } else if ((is_aff_rule(items, itemcnt, "BAD", 2)

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -3530,7 +3530,7 @@ static int soundalike_score(char *goodstart, char *badstart)
 /// The implementation of the algorithm comes from Aspell editdist.cpp,
 /// edit_distance().  It has been converted from C++ to C and modified to
 /// support multi-byte characters.
-static int spell_edit_score(slang_T *slang, char_u *badword, char_u *goodword)
+static int spell_edit_score(slang_T *slang, const char_u *badword, const char_u *goodword)
 {
   int *cnt;
   int j, i;
@@ -3635,7 +3635,8 @@ static int spell_edit_score_limit(slang_T *slang, char_u *badword, char_u *goodw
 
 /// Multi-byte version of spell_edit_score_limit().
 /// Keep it in sync with the above!
-static int spell_edit_score_limit_w(slang_T *slang, char_u *badword, char_u *goodword, int limit)
+static int spell_edit_score_limit_w(slang_T *slang, const char_u *badword, const char_u *goodword,
+                                    int limit)
 {
   limitscore_T stack[10];               // allow for over 3 * 2 edits
   int stackidx;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -829,7 +829,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
       //       so `vim_strsize` will work.
       char *t = stl_items[stl_groupitems[groupdepth]].start;
       *out_p = NUL;
-      long group_len = vim_strsize(t);
+      ptrdiff_t group_len = vim_strsize(t);
 
       // If the group contained internal items
       // and the group did not have a minimum width,
@@ -915,7 +915,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
         }
         // If the group is shorter than the minimum width, add padding characters.
       } else if (abs(stl_items[stl_groupitems[groupdepth]].minwid) > group_len) {
-        long min_group_width = stl_items[stl_groupitems[groupdepth]].minwid;
+        ptrdiff_t min_group_width = stl_items[stl_groupitems[groupdepth]].minwid;
         // If the group is left-aligned, add characters to the right.
         if (min_group_width < 0) {
           min_group_width = 0 - min_group_width;
@@ -929,7 +929,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, int use_san
           group_len = (min_group_width - group_len) * utf_char2len(fillchar);
           memmove(t + group_len, t, (size_t)(out_p - t));
           if (out_p + group_len >= (out_end_p + 1)) {
-            group_len = (long)(out_end_p - out_p);
+            group_len = out_end_p - out_p;
           }
           out_p += group_len;
           // }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5304,7 +5304,7 @@ void ex_ownsyntax(exarg_T *eap)
     curwin->w_s = xcalloc(1, sizeof(synblock_T));
     hash_init(&curwin->w_s->b_keywtab);
     hash_init(&curwin->w_s->b_keywtab_ic);
-    // TODO: Keep the spell checking as it was. NOLINT(readability/todo)
+    // TODO(vim): Keep the spell checking as it was.
     curwin->w_p_spell = false;  // No spell checking
     // make sure option values are "empty_option" instead of NULL
     clear_string_option(&curwin->w_s->b_p_spc);

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1495,7 +1495,7 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
 
     // Try tag file names from tags option one by one.
     for (first_file = true;
-         get_tagfname(&tn, first_file, (char *)tag_fname) == OK;
+         get_tagfname(&tn, first_file, tag_fname) == OK;
          first_file = false) {
       // A file that doesn't exist is silently ignored.  Only when not a
       // single file is found, an error message is given (further on).
@@ -1553,7 +1553,7 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
         }
       }
 
-      if ((fp = os_fopen((char *)tag_fname, "r")) == NULL) {
+      if ((fp = os_fopen(tag_fname, "r")) == NULL) {
         continue;
       }
 
@@ -1647,7 +1647,7 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
           // skip empty and blank lines
           do {
             eof = vim_fgets((char_u *)lbuf, lbuf_size, fp);
-          } while (!eof && vim_isblankline((char *)lbuf));
+          } while (!eof && vim_isblankline(lbuf));
 
           if (eof) {
             break;                                  // end of file
@@ -1953,7 +1953,7 @@ parse_line:
 
           // Decide in which array to store this match.
           is_current = test_for_current((char *)tagp.fname, (char *)tagp.fname_end,
-                                        (char *)tag_fname,
+                                        tag_fname,
                                         buf_ffname);
           is_static = test_for_static(&tagp);
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -643,8 +643,6 @@ end_do_tag:
   }
   postponed_split = 0;          // don't split next time
   g_do_tagpreview = 0;          // don't do tag preview next time
-
-  return;
 }
 
 // List all the matching tags.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -428,7 +428,7 @@ bool terminal_enter(void)
   long save_w_p_so = curwin->w_p_so;
   long save_w_p_siso = curwin->w_p_siso;
   if (curwin->w_p_cul && curwin->w_p_culopt_flags & CULOPT_NBR) {
-    if (strcmp(curwin->w_p_culopt, "number")) {
+    if (strcmp(curwin->w_p_culopt, "number") != 0) {
       save_w_p_culopt = curwin->w_p_culopt;
       curwin->w_p_culopt = xstrdup("number");
     }

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -229,7 +229,7 @@ bool findpar(bool *pincl, int dir, long count, int what, bool both)
 }
 
 /// check if the string 's' is a nroff macro that is in option 'opt'
-static bool inmacro(char_u *opt, char_u *s)
+static bool inmacro(char_u *opt, const char_u *s)
 {
   char_u *macro;
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -322,7 +322,7 @@ void vim_beep(unsigned val)
 
       // Only beep up to three times per half a second,
       // otherwise a sequence of beeps would freeze Vim.
-      if (start_time == 0 || os_hrtime() - start_time > 500000000u) {
+      if (start_time == 0 || os_hrtime() - start_time > 500000000U) {
         beeps = 0;
         start_time = os_hrtime();
       }
@@ -452,7 +452,7 @@ void ui_line(ScreenGrid *grid, int row, int startcol, int endcol, int clearcol, 
                              MIN(clearcol, (int)grid->cols - 1));
     ui_call_flush();
     uint64_t wd = (uint64_t)labs(p_wd);
-    os_microdelay(wd * 1000u, true);
+    os_microdelay(wd * 1000U, true);
     pending_cursor_update = true;  // restore the cursor later
   }
 }

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -505,7 +505,7 @@ static void debug_delay(Integer lines)
   ui_call_flush();
   uint64_t wd = (uint64_t)labs(p_wd);
   uint64_t factor = (uint64_t)MAX(MIN(lines, 5), 1);
-  os_microdelay(factor * wd * 1000u, true);
+  os_microdelay(factor * wd * 1000U, true);
 }
 
 static void compose_area(Integer startrow, Integer endrow, Integer startcol, Integer endcol)

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1077,7 +1077,7 @@ bool uc_split_args_iter(const char *arg, size_t arglen, size_t *end, char *buf, 
 }
 
 /// split and quote args for <f-args>
-static char *uc_split_args(char *arg, char **args, size_t *arglens, size_t argc, size_t *lenp)
+static char *uc_split_args(char *arg, char **args, const size_t *arglens, size_t argc, size_t *lenp)
 {
   char *buf;
   char *p;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -34,7 +34,7 @@
   "." STR(NVIM_VERSION_MINOR) "." STR(NVIM_VERSION_PATCH) \
   NVIM_VERSION_PRERELEASE
 #endif
-#define NVIM_VERSION_LONG "NVIM " NVIM_VERSION_MEDIUM
+#define NVIM_VERSION_LONG "NVIM " NVIM_VERSION_MEDIUM  // NOLINT(bugprone-suspicious-missing-comma)
 
 char *Version = VIM_VERSION_SHORT;
 char *longVersion = NVIM_VERSION_LONG;
@@ -2218,7 +2218,7 @@ void intro_message(int colon)
   int sponsor;
   char *p;
   static char *(lines[]) = {
-    N_(NVIM_VERSION_LONG),  // NOLINT(bugprone-suspicious-missing-comma)
+    N_(NVIM_VERSION_LONG),
     "",
     N_("Nvim is open source and freely distributable"),
     N_("https://neovim.io/#chat"),

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2239,7 +2239,7 @@ void intro_message(int colon)
   size_t lines_size = ARRAY_SIZE(lines);
   assert(lines_size <= LONG_MAX);
 
-  blanklines = Rows - ((long)lines_size - 1l);
+  blanklines = Rows - ((long)lines_size - 1L);
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2218,7 +2218,7 @@ void intro_message(int colon)
   int sponsor;
   char *p;
   static char *(lines[]) = {
-    N_(NVIM_VERSION_LONG),
+    N_(NVIM_VERSION_LONG),  // NOLINT(bugprone-suspicious-missing-comma)
     "",
     N_("Nvim is open source and freely distributable"),
     N_("https://neovim.io/#chat"),

--- a/src/nvim/viml/parser/parser.h
+++ b/src/nvim/viml/parser/parser.h
@@ -202,7 +202,7 @@ static inline void viml_parser_advance(ParserState *const pstate, const size_t l
 
 static inline void viml_parser_highlight(ParserState *pstate,
                                          ParserPosition start,
-                                         size_t end_col,
+                                         size_t len,
                                          const char *group)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 

--- a/src/nvim/viml/parser/parser.h
+++ b/src/nvim/viml/parser/parser.h
@@ -81,8 +81,8 @@ typedef struct {
   bool can_continuate;
 } ParserState;
 
-static inline void viml_parser_init(ParserState *const ret_pstate, const ParserLineGetter get_line,
-                                    void *const cookie, ParserHighlight *const colors)
+static inline void viml_parser_init(ParserState *ret_pstate, ParserLineGetter get_line,
+                                    void *cookie, ParserHighlight *colors)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1, 2);
 
 /// Initialize a new parser state instance
@@ -109,7 +109,7 @@ static inline void viml_parser_init(ParserState *const ret_pstate, const ParserL
   kvi_init(ret_pstate->stack);
 }
 
-static inline void viml_parser_destroy(ParserState *const pstate)
+static inline void viml_parser_destroy(ParserState *pstate)
   REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE;
 
 /// Free all memory allocated by the parser on heap
@@ -127,8 +127,8 @@ static inline void viml_parser_destroy(ParserState *const pstate)
   kvi_destroy(pstate->stack);
 }
 
-static inline void viml_preader_get_line(ParserInputReader *const preader,
-                                         ParserLine *const ret_pline)
+static inline void viml_preader_get_line(ParserInputReader *preader,
+                                         ParserLine *ret_pline)
   REAL_FATTR_NONNULL_ALL;
 
 /// Get one line from ParserInputReader
@@ -152,8 +152,8 @@ static inline void viml_preader_get_line(ParserInputReader *const preader,
   *ret_pline = pline;
 }
 
-static inline bool viml_parser_get_remaining_line(ParserState *const pstate,
-                                                  ParserLine *const ret_pline)
+static inline bool viml_parser_get_remaining_line(ParserState *pstate,
+                                                  ParserLine *ret_pline)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Get currently parsed line, shifted to pstate->pos.col
@@ -178,8 +178,8 @@ static inline bool viml_parser_get_remaining_line(ParserState *const pstate,
   return ret_pline->data != NULL;
 }
 
-static inline void viml_parser_advance(ParserState *const pstate,
-                                       const size_t len)
+static inline void viml_parser_advance(ParserState *pstate,
+                                       size_t len)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Advance position by a given number of bytes
@@ -200,10 +200,10 @@ static inline void viml_parser_advance(ParserState *const pstate, const size_t l
   }
 }
 
-static inline void viml_parser_highlight(ParserState *const pstate,
-                                         const ParserPosition start,
-                                         const size_t end_col,
-                                         const char *const group)
+static inline void viml_parser_highlight(ParserState *pstate,
+                                         ParserPosition start,
+                                         size_t end_col,
+                                         const char *group)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Record highlighting of some region of text

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -785,7 +785,7 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
   bool change_border = (fconfig.border != wp->w_float_config.border
                         || memcmp(fconfig.border_hl_ids,
                                   wp->w_float_config.border_hl_ids,
-                                  sizeof fconfig.border_hl_ids));
+                                  sizeof fconfig.border_hl_ids) != 0);
 
   wp->w_float_config = fconfig;
 


### PR DESCRIPTION
- refactor: readability-uppercase-literal-suffix

- refactor: readability-named-parameter

- refactor: bugprone-suspicious-string-compare

- refactor: google-readability-casting

- refactor: readability-redundant-control-flow

- refactor: bugprone-too-small-loop-variable

- refactor: readability-non-const-parameter

- refactor: readability-avoid-const-params-in-decls

- refactor: google-readability-todo

- refactor: readability-inconsistent-declaration-parameter-name

- refactor: bugprone-suspicious-missing-comma

- refactor: remove noisy or slow warnings