### PR TITLE
fix: 'scroll' is not set correctly for floats with 'splitkeep'

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6119,7 +6119,6 @@ void win_fix_scroll(int resize)
       invalidate_botline_win(wp);
       validate_botline(wp);
     }
-    win_comp_scroll(wp);
     wp->w_prev_height = wp->w_height;
     wp->w_prev_winrow = wp->w_winrow;
   }
@@ -6292,7 +6291,6 @@ void scroll_to_fraction(win_T *wp, int prev_height)
     wp->w_prev_fraction_row = wp->w_wrow;
   }
 
-  win_comp_scroll(wp);
   redraw_later(wp, UPD_SOME_VALID);
   wp->w_redr_status = true;
   invalidate_botline_win(wp);
@@ -6327,6 +6325,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
     }
     wp->w_skipcol = 0;
     wp->w_height_inner = height;
+    win_comp_scroll(wp);
 
     // There is no point in adjusting the scroll position when exiting.  Some
     // values might be invalid.

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -430,6 +430,13 @@ describe('float window', function()
     assert_alive()
   end)
 
+  it("'scroll' is computed correctly when opening float with splitkeep=screen #20684", function()
+    meths.set_option('splitkeep', 'screen')
+    local float_opts = {relative = 'editor', row = 1, col = 1, width = 10, height = 10}
+    local float_win = meths.open_win(0, true, float_opts)
+    eq(5, meths.win_get_option(float_win, 'scroll'))
+  end)
+
   describe('with only one tabpage,', function()
     local float_opts = {relative = 'editor', row = 1, col = 1, width = 1, height = 1}
     local old_buf, old_win


### PR DESCRIPTION
Problem:	'scroll' is not set correctly for floats when 'splitkeep' != cursor.
Solution:	Compute 'scroll' when window size is set (Fix https://github.com/neovim/neovim/issues/20684).

If this needs extra tests I could add it later but float/splitkeep permutations should now share the same code path as the existing `'scroll'` tests.