### PR TITLE
vim-patch:9.0.0771: cannot always tell the difference beween tex and …

### DIFF
--- a/runtime/autoload/dist/ft.vim
+++ b/runtime/autoload/dist/ft.vim
@@ -145,7 +145,7 @@ func dist#ft#FTcls()
     return
   endif
 
-  if getline(1) =~ '^%'
+  if getline(1) =~ '^\v%(\%|\\)'
     setf tex
   elseif getline(1)[0] == '#' && getline(1) =~ 'rexx'
     setf rexx

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -181,7 +181,7 @@ function M.cls(bufnr)
     return vim.g.filetype_cls
   end
   local line = getlines(bufnr, 1)
-  if line:find('^%%') then
+  if line:find('^[%%\\]') then
     return 'tex'
   elseif line:find('^#') and line:lower():find('rexx') then
     return 'rexx'

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1768,6 +1768,11 @@ func Test_cls_file()
   call assert_equal('tex', &filetype)
   bwipe!
 
+  call writefile(['\NeedsTeXFormat{LaTeX2e}'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('tex', &filetype)
+  bwipe!
+
   " Rexx
 
   call writefile(['# rexx'], 'Xfile.cls')


### PR DESCRIPTION
…rexx files

Problem:    Cannot always tell the difference beween tex and rexx files.
Solution:   Recognize tex by a leading backslash. (Martin Tournoij,
            closes vim/vim#11380)
https://github.com/vim/vim/commit/bd053f894b0d7652928201faa68c53d1ce2acdc5