### PR TITLE
feat(autocmds): add SearchPost event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -844,6 +844,12 @@ RemoteReply			When a reply from a Vim that functions as
 				Note that even if an autocommand is defined,
 				the reply should be read with remote_read()
 				to consume it.
+							*SearchPost*
+SearchPost			After making a search using |/|, |?|, |*|,
+				|#|, |n| or |N|.
+				Sets these |v:event| keys:
+				    startpos
+				    endpos
 							*SearchWrapped*
 SearchWrapped			After making a search with |n| or |N| if the
 				search wraps around the document back to

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -81,6 +81,7 @@ return {
     'RecordingEnter',         -- when starting to record a macro
     'RecordingLeave',         -- just before a macro stops recording
     'RemoteReply',            -- upon string reception from a remote vim
+    'SearchPost',             -- after the search
     'SearchWrapped',          -- after the search wrapped around
     'SessionLoadPost',        -- after loading a session file
     'ShellCmdPost',           -- after ":!cmd"

--- a/test/functional/autocmd/searchpost_spec.lua
+++ b/test/functional/autocmd/searchpost_spec.lua
@@ -1,0 +1,55 @@
+local helpers = require('test.functional.helpers')(after_each)
+local clear, eval, eq = helpers.clear, helpers.eval, helpers.eq
+local feed, command, curbufmeths = helpers.feed, helpers.command, helpers.curbufmeths
+
+describe('SearchPost', function()
+  before_each(function()
+    clear()
+
+    command('let g:count = 0')
+    command('autocmd SearchPost * let g:event = copy(v:event)')
+    command('autocmd SearchPost * let g:count += 1')
+
+    curbufmeths.set_lines(0, -1, true, {
+      'foo\0bar',
+      'baz text',
+    })
+  end)
+
+  it('is executed after search and should provide positions', function()
+    feed('/foo<CR>')
+    eq({
+      startpos = { 1, 0 },
+      endpos = { 1, 2 }
+    }, eval('g:event'))
+    eq(1, eval('g:count'))
+
+    feed('/foo/e+5<CR>')
+    eq({
+      startpos = { 1, 0 },
+      endpos = { 1, 2 }
+    }, eval('g:event'))
+    eq(2, eval('g:count'))
+
+    feed('/foo/s+2<CR>')
+    eq({
+      startpos = { 1, 0 },
+      endpos = { 1, 2 }
+    }, eval('g:event'))
+    eq(3, eval('g:count'))
+
+    feed('G<CR>?foo.bar<CR>')
+    eq({
+      startpos = { 1, 0 },
+      endpos = { 1, 6 }
+    }, eval('g:event'))
+    eq(4, eval('g:count'))
+
+    feed('G<CR>?.bar\\nbaz<CR>/e-2')
+    eq({
+      startpos = { 1, 3 },
+      endpos = { 2, 2 }
+    }, eval('g:event'))
+    eq(5, eval('g:count'))
+  end)
+end)


### PR DESCRIPTION
Problem:
Extra highlighting after jumping to search result currently requires adding mappings that override N, n, #, * and expr mapping <CR> for / and ?.

This is brittle.

Solution:
We can provide users with an autocommand event similar TextYankPost that provides them with start and end position of the match.

Mostly to greatly simplify https://github.com/ivyl/bling.nvim