### PR TITLE
fix(docs-html): gen_help_html mishandles tab alignment

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -369,6 +369,18 @@ local function visit_validate(root, level, lang_tree, opt, stats)
   end
 end
 
+-- Fix tab alignment issues caused by concealed characters like |, `, * in tags
+-- and code blocks.
+local function fix_tab_after_conceal(text, next_node_text)
+  -- Vim tabs take into account the two concealed characters even though they
+  -- are invisible, so we need to add back in the two spaces if this is
+  -- followed by a tab to make the tab alignment to match Vim's behavior.
+  if string.sub(next_node_text,1,1) == '\t' then
+    text = text .. '  '
+  end
+  return text
+end
+
 -- Generates HTML from node `root` recursively.
 local function visit_node(root, level, lang_tree, headings, opt, stats)
   level = level or 0
@@ -485,12 +497,20 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     if ignored then
       return text
     end
-    return ('%s<a href="%s#%s">%s</a>'):format(ws(), helppage, url_encode(tagname), html_esc(tagname))
+    local s = ('%s<a href="%s#%s">%s</a>'):format(ws(), helppage, url_encode(tagname), html_esc(tagname))
+    if node_name == 'taglink' and opt.old then
+      s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
+    end
+    return s
   elseif vim.tbl_contains({'codespan', 'keycode'}, node_name) then
     if root:has_error() then
       return text
     end
-    return ('%s<code>%s</code>'):format(ws(), trimmed)
+    local s = ('%s<code>%s</code>'):format(ws(), trimmed)
+    if node_name == 'codespan' and opt.old then
+      s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
+    end
+    return s
   elseif node_name == 'argument' then
     return ('%s<code>{%s}</code>'):format(ws(), text)
   elseif node_name == 'codeblock' then
@@ -512,6 +532,10 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     end
     local el = in_heading and 'span' or 'code'
     local s = ('%s<a name="%s"></a><%s class="%s">%s</%s>'):format(ws(), url_encode(tagname), el, cssclass, trimmed, el)
+    if opt.old then
+        s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
+    end
+
     if in_heading and prev ~= 'tag' then
       -- Start the <span> container for tags in a heading.
       -- This makes "justify-content:space-between" right-align the tags.


### PR DESCRIPTION
The gen_help_html.lua script is a useful tool to generate structured HTML pages from the vim docs, but it has an issue of not properly handling tab characters under certain circumstances.

In Vim, sometimes the metadata is hidden using conceal, e.g. `*some_tag_definition*`, `|some_tag_link|`, and \`some_code_block\`. For convenience, Vim hides the '*' / '|' / '`' characters to make it more readable, but those characters still count when a tab character follows it. So if you have a tag of say 6 characters long, those two concealed characters would lead to the tab character after it starting at character 8, therefore aligned to one further tab length away. The gen_help_html doesn't account for that which is what leads to a lot of formatting errors in the generated output.

This commit fixes that by manually adding two spaces after each concealed tag, if it's followed by a tab char.