### PR TITLE
fix(highlight): link more treesitter groups by default

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -372,6 +372,59 @@ instance, to highlight comments differently per language: >
     hi @comment.lua @guifg=DarkBlue
     hi link @comment.doc.java String
 <
+The following captures are linked by default to standard |group-name|s:
+>
+    @text.literal      Comment
+    @text.reference    Identifier
+    @text.title        Title
+    @text.uri          Underlined
+    @text.underline    Underlined
+    @text.todo         Todo
+
+    @comment           Comment
+    @punctuation       Delimiter
+
+    @constant          Constant
+    @constant.builtin  Special
+    @constant.macro    Define
+    @define            Define
+    @macro             Macro
+    @string            String
+    @string.escape     SpecialChar
+    @string.special    SpecialChar
+    @character         Character
+    @character.special SpecialChar
+    @number            Number
+    @boolean           Boolean
+    @float             Float
+
+    @function          Function
+    @function.builtin  Special
+    @function.macro    Macro
+    @parameter         Identifier
+    @method            Function
+    @field             Identifier
+    @property          Identifier
+    @constructor       Special
+
+    @conditional       Conditional
+    @repeat            Repeat
+    @label             Label
+    @operator          Operator
+    @keyword           Keyword
+    @exception         Exception
+
+    @variable          Identifier
+    @type              Type
+    @type.definition   Typedef
+    @storageclass      StorageClass
+    @structure         Structure
+    @namespace         Identifier
+    @include           Include
+    @preproc           PreProc
+    @debug             Debug
+    @tag               Tag
+<
                                                   *treesitter-highlight-spell*
 The special `@spell` capture can be used to indicate that a node should be
 spell checked by Nvim's builtin |spell| checker. For example, the following

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -98,8 +98,6 @@ enum {
 
 // The default highlight groups.  These are compiled-in for fast startup and
 // they still work when the runtime files can't be found.
-//
-// When making changes here, also change runtime/colors/default.vim!
 
 static const char *highlight_init_both[] = {
   "Conceal      ctermbg=DarkGrey ctermfg=LightGrey guibg=DarkGrey guifg=LightGrey",
@@ -186,9 +184,13 @@ static const char *highlight_init_both[] = {
   "default link DiagnosticSignInfo DiagnosticInfo",
   "default link DiagnosticSignHint DiagnosticHint",
 
+  // Text
+  "default link @text.literal Comment",
+  "default link @text.reference Identifier",
+  "default link @text.title Title",
+  "default link @text.uri Underlined",
   "default link @text.underline Underlined",
-  "default link @todo Todo",
-  "default link @debug Debug",
+  "default link @text.todo Todo",
 
   // Miscs
   "default link @comment Comment",
@@ -202,6 +204,7 @@ static const char *highlight_init_both[] = {
   "default link @macro Macro",
   "default link @string String",
   "default link @string.escape SpecialChar",
+  "default link @string.special SpecialChar",
   "default link @character Character",
   "default link @character.special SpecialChar",
   "default link @number Number",
@@ -226,12 +229,16 @@ static const char *highlight_init_both[] = {
   "default link @keyword Keyword",
   "default link @exception Exception",
 
+  "default link @variable Identifier",
   "default link @type Type",
   "default link @type.definition Typedef",
   "default link @storageclass StorageClass",
   "default link @structure Structure",
+  "default link @namespace Identifier",
   "default link @include Include",
   "default link @preproc PreProc",
+  "default link @debug Debug",
+  "default link @tag Tag",
   NULL
 };
 


### PR DESCRIPTION
Add groups that are used by `vimdoc` parser  (targets align with corresponding links in `syntax/help.vim`) as well as `@tag`.

I'd be open to add more links; a good rule of thumb should be 
1. if there's an obvious standard group, add a link (like `@tag` -> `Tag`) -- I don't think there's any missing now?
2. if it's used in one of the bundled highlight queries -- only glaring omission is `@variable` (that could be linked to `Identifier` if that is not too noisy?) and `@namespace`; the rest use fallbacks.

(This mitigates a regression in nvim-treesitter after removing the obsolete `TS*` highlight groups.)

@justinmk 