### PR TITLE
feat(treesitter): support self injection

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -752,7 +752,7 @@ end
 function LanguageTree:_get_injection(match, metadata)
   local ranges = {} ---@type Range6[]
   local combined = metadata['injection.combined'] ~= nil
-  local lang = metadata['injection.language'] --[[@as string?]]
+  local lang = metadata['injection.self'] ~= nil and self:lang() or metadata['injection.language'] --[[@as string?]]
   local include_children = metadata['injection.include-children'] ~= nil
 
   for id, node in pairs(match) do


### PR DESCRIPTION
See https://github.com/nvim-treesitter/nvim-treesitter/pull/3573#pullrequestreview-1132968510 for the motivation.

This seems to work and I'll try to add some actual tests later to make sure it does.

#### Example usage:

`c/injections.scm`
```scheme
;; preproc_arg gets injected as c
(preproc_arg) @self
```

`cpp/injections.scm`
```scheme
; inherits: c
;; preproc_arg gets injected as cpp
```