### PR TITLE
fix(intro): do not show patch version in :help news line

### DIFF
--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2228,8 +2228,8 @@ void intro_message(int colon)
     N_("type  :q<Enter>               to exit         "),
     N_("type  :help<Enter>            for help        "),
     "",
-    N_("type :help news<Enter> to see changes in")
-    " v" STR(NVIM_VERSION_MAJOR) "." STR(NVIM_VERSION_MINOR) "." STR(NVIM_VERSION_PATCH),
+    N_("type  :help news<Enter> to see changes in")
+    " v" STR(NVIM_VERSION_MAJOR) "." STR(NVIM_VERSION_MINOR),
     "",
     N_("Help poor children in Uganda!"),
     N_("type  :help iccf<Enter>       for information "),

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1273,7 +1273,7 @@ describe('ui/ext_messages', function()
       {1:~                }type  :q{5:<Enter>}               to exit         {1:                 }|
       {1:~                }type  :help{5:<Enter>}            for help        {1:                 }|
       {1:~                                                                               }|
-      {1:~               }type :help news{5:<Enter>} to see changes in v{MATCH:.*}|
+      {1:~                }type  :help news{5:<Enter>} to see changes in v{MATCH:%d+%.%d+}|
       {1:~                                                                               }|
       {MATCH:.*}|
       {MATCH:.*}|
@@ -1329,7 +1329,7 @@ describe('ui/ext_messages', function()
                        type  :q{5:<Enter>}               to exit                          |
                        type  :help{5:<Enter>}            for help                         |
                                                                                       |
-                      type :help news{5:<Enter>} to see changes in {MATCH:.*}|
+                       type  :help news{5:<Enter>} to see changes in v{MATCH:%d+%.%d+}|
                                                                                       |
       {MATCH:.*}|
       {MATCH:.*}|


### PR DESCRIPTION
Because maintenance releases share the same news.txt as the last
non-maintenance release.
