### PR TITLE
vim-patch:9.0.0786: user command does not get number from :tab modifier

### DIFF
--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -79,6 +79,19 @@ function Test_cmdmods()
   call assert_equal('silent!', g:mods)
   tab MyCmd
   call assert_equal('tab', g:mods)
+  0tab MyCmd
+  call assert_equal('0tab', g:mods)
+  tab split
+  tab MyCmd
+  call assert_equal('tab', g:mods)
+  1tab MyCmd
+  call assert_equal('1tab', g:mods)
+  tabprev
+  tab MyCmd
+  call assert_equal('tab', g:mods)
+  2tab MyCmd
+  call assert_equal('2tab', g:mods)
+  2tabclose
   topleft MyCmd
   call assert_equal('topleft', g:mods)
   to MyCmd

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1236,8 +1236,18 @@ size_t add_win_cmd_modifers(char *buf, const cmdmod_T *cmod, bool *multi_mods)
 
   // :tab
   if (cmod->cmod_tab > 0) {
-    result += add_cmd_modifier(buf, "tab", multi_mods);
+    int tabnr = cmod->cmod_tab - 1;
+    if (tabnr == tabpage_index(curtab)) {
+      // For compatibility, don't add a tabpage number if it is the same
+      // as the default number for :tab.
+      result += add_cmd_modifier(buf, "tab", multi_mods);
+    } else {
+      char tab_buf[NUMBUFLEN + 3];
+      snprintf(tab_buf, sizeof(tab_buf), "%dtab", tabnr);
+      result += add_cmd_modifier(buf, tab_buf, multi_mods);
+    }
   }
+
   // :topleft
   if (cmod->cmod_split & WSP_TOP) {
     result += add_cmd_modifier(buf, "topleft", multi_mods);
@@ -1307,7 +1317,7 @@ size_t uc_mods(char *buf, const cmdmod_T *cmod, bool quote)
       result += add_cmd_modifier(buf, "verbose", &multi_mods);
     } else {
       char verbose_buf[NUMBUFLEN];
-      snprintf(verbose_buf, NUMBUFLEN, "%dverbose", verbose_value);
+      snprintf(verbose_buf, sizeof(verbose_buf), "%dverbose", verbose_value);
       result += add_cmd_modifier(buf, verbose_buf, &multi_mods);
     }
   }


### PR DESCRIPTION
#### vim-patch:9.0.0786: user command does not get number from :tab modifier

Problem:    User command does not get number from :tab modifier.
Solution:   Include the number. (closes vim/vim#11393)
https://github.com/vim/vim/commit/208567e9d744ef7b89bed1f62e951ae4ee2f6f5f