### PR TITLE
feat: add args.client for LspAttach callback

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -89,7 +89,7 @@ calls behind capability checks:
 >
     vim.api.nvim_create_autocmd('LspAttach', {
       callback = function(args)
-        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        local client = args.client
         if client.server_capabilities.hoverProvider then
           vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = args.buf })
         end
@@ -492,7 +492,7 @@ callback in the "data" table. Example: >
     vim.api.nvim_create_autocmd("LspAttach", {
       callback = function(args)
         local bufnr = args.buf
-        local client = vim.lsp.get_client_by_id(args.data.client_id)
+        local client = args.client
         if client.server_capabilities.completionProvider then
           vim.bo[bufnr].omnifunc = "v:lua.vim.lsp.omnifunc"
         end

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1522,6 +1522,7 @@ function lsp.start_client(config)
     nvim_exec_autocmds('LspAttach', {
       buffer = bufnr,
       modeline = false,
+      client = client,
       data = { client_id = client.id },
     })
 


### PR DESCRIPTION
Many LSP modules ([aerial](https://github.com/stevearc/aerial.nvim), [navic](https://github.com/SmiteshP/nvim-navic), [lsp-format](https://github.com/lukas-reineke/lsp-format.nvim)) need client as `on_attach` function argument.
It is convenient that returns `args.client` for users.

```lua
callback = function(args)
  -- local client = vim.lsp.get_client_by_id(args.data.client_id)
  local client = args.client
  require('aerial').on_attach(client, args.buf)
end,
```