### PR TITLE
docs: sync `pumheight` between options and quickref

### DIFF
--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -827,7 +827,7 @@ Short explanation of each option:		*option-list*
 'printmbcharset'  'pmbcs'   CJK character set to be used for :hardcopy
 'printmbfont'	  'pmbfn'   font names to be used for CJK output of :hardcopy
 'printoptions'	  'popt'    controls the format of :hardcopy output
-'pumheight'	  'ph'	    maximum height of the popup menu
+'pumheight'	  'ph'	    maximum number of items to show in the popup menu
 'pumwidth'	  'pw'	    minimum width of the popup menu
 'pyxversion'	  'pyx'	    Python version used for pyx* commands
 'quoteescape'	  'qe'	    escape characters used in a string


### PR DESCRIPTION
In order to keep the description in the options in sync with what the quick reference states.

`/runtim/doc/options.txt`

```text
Maximum number of items to show in the popup menu
([ins-completion-menu](https://neovim.io/doc/user/insert.html#ins-completion-menu)). Zero means "use available screen space".
```