### PR TITLE
vim-patch:9.0.0788: ModeChanged autocmd not executed when Visual ends with CTRL-C

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -37,6 +37,9 @@
 /// Functions calculating vertical size of text when displayed inside a window.
 /// Calls horizontal size functions defined below.
 
+/// Return the number of window lines occupied by buffer line "lnum".
+/// Includes any filler lines.
+///
 /// @param winheight when true limit to window height
 int plines_win(win_T *wp, linenr_T lnum, bool winheight)
 {
@@ -71,6 +74,9 @@ bool win_may_fill(win_T *wp)
   return (wp->w_p_diff && diffopt_filler()) || wp->w_buffer->b_virt_line_blocks;
 }
 
+/// Return the number of window lines occupied by buffer line "lnum".
+/// Does not include filler lines.
+///
 /// @param winheight when true limit to window height
 int plines_win_nofill(win_T *wp, linenr_T lnum, bool winheight)
 {

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -229,7 +229,9 @@ void get_mode(char *buf)
 /// Fires a ModeChanged autocmd if appropriate.
 void may_trigger_modechanged(void)
 {
-  if (!has_event(EVENT_MODECHANGED)) {
+  // Skip this when got_int is set, the autocommand will not be executed.
+  // Better trigger it next time.
+  if (!has_event(EVENT_MODECHANGED) || got_int) {
     return;
   }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -3198,19 +3198,29 @@ func Test_mode_changes()
     call assert_equal(5, g:nori_to_any)
   endif
 
-  if has('cmdwin')
-    let g:n_to_c = 0
-    au ModeChanged n:c let g:n_to_c += 1
-    let g:c_to_n = 0
-    au ModeChanged c:n let g:c_to_n += 1
-    let g:mode_seq += ['c', 'n', 'c', 'n']
-    call feedkeys("q:\<C-C>\<Esc>", 'tnix')
-    call assert_equal(len(g:mode_seq) - 1, g:index)
-    call assert_equal(2, g:n_to_c)
-    call assert_equal(2, g:c_to_n)
-    unlet g:n_to_c
-    unlet g:c_to_n
-  endif
+  let g:n_to_c = 0
+  au ModeChanged n:c let g:n_to_c += 1
+  let g:c_to_n = 0
+  au ModeChanged c:n let g:c_to_n += 1
+  let g:mode_seq += ['c', 'n', 'c', 'n']
+  call feedkeys("q:\<C-C>\<Esc>", 'tnix')
+  call assert_equal(len(g:mode_seq) - 1, g:index)
+  call assert_equal(2, g:n_to_c)
+  call assert_equal(2, g:c_to_n)
+  unlet g:n_to_c
+  unlet g:c_to_n
+
+  let g:n_to_v = 0
+  au ModeChanged n:v let g:n_to_v += 1
+  let g:v_to_n = 0
+  au ModeChanged v:n let g:v_to_n += 1
+  let g:mode_seq += ['v', 'n']
+  call feedkeys("v\<C-C>", 'tnix')
+  call assert_equal(len(g:mode_seq) - 1, g:index)
+  call assert_equal(1, g:n_to_v)
+  call assert_equal(1, g:v_to_n)
+  unlet g:n_to_v
+  unlet g:v_to_n
 
   au! ModeChanged
   delfunc TestMode


### PR DESCRIPTION
#### vim-patch:9.0.0788: ModeChanged autocmd not executed when Visual ends with CTRL-C

Problem:    ModeChanged autocmd not executed when Visual mode is ended with
            CTRL-C.
Solution:   Do not trigger the autocmd when got_int is set.
https://github.com/vim/vim/commit/61c4b04799bf114cadc3bbf212ae8b2ad22a6980

Cherry-pick removal of cmdwin feature check from patch 9.0.0663.