### PR TITLE
vim-patch:9.0.{0789,0790}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1224,6 +1224,11 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     }
     return FAIL;
   }
+  if ((action == DOBUF_GOTO || action == DOBUF_SPLIT) && (buf->b_flags & BF_DUMMY)) {
+    // disallow navigating to the dummy buffer
+    semsg(_(e_nobufnr), count);
+    return FAIL;
+  }
 
   // delete buffer "buf" from memory and/or the list
   if (unload) {

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -3280,7 +3280,8 @@ func Test_autocmd_split_dummy()
     lex 'Xtestfile2:4:4'
   endfunc
   call Xautocmd_changelist()
-  call assert_fails('call Xautocmd_changelist()', 'E86:')
+  " Should get E86, but it doesn't always happen (timing?)
+  silent! call Xautocmd_changelist()
 
   au! BufReadPre
   au! FileChangedShell

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -3269,4 +3269,24 @@ func Test_noname_autocmd()
   augroup! test_noname_autocmd_group
 endfunc
 
+func Test_autocmd_split_dummy()
+  " Autocommand trying to split a window containing a dummy buffer.
+  auto BufReadPre * exe "sbuf " .. expand("<abuf>") 
+  " Avoid the "W11" prompt
+  au FileChangedShell * let v:fcs_choice = 'reload'
+  func Xautocmd_changelist()
+    cal writefile(['Xtestfile2:4:4'], 'Xerr')
+    edit Xerr
+    lex 'Xtestfile2:4:4'
+  endfunc
+  call Xautocmd_changelist()
+  call assert_fails('call Xautocmd_changelist()', 'E86:')
+
+  au! BufReadPre
+  au! FileChangedShell
+  delfunc Xautocmd_changelist
+  bwipe! Xerr
+  call delete('Xerr')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0789: dummy buffer ends up in a window

Problem:    Dummy buffer ends up in a window.
Solution:   Disallow navigating to a dummy buffer.
https://github.com/vim/vim/commit/8f3c3c6cd044e3b5bf08dbfa3b3f04bb3f711bad


#### vim-patch:9.0.0790: test for dummy buffer does not always produce the E86 error

Problem:    Test for dummy buffer does not always produce the E86 error.
Solution:   Do not check if the error is produced.
https://github.com/vim/vim/commit/53c5c9f50ca68d3ed559eebb2c5f7d23f39a768c