### PR TITLE
vim-patch:9.0.0739: mouse column not correctly used for popup_setpos

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -31,7 +31,9 @@
 static linenr_T orig_topline = 0;
 static int orig_topfill = 0;
 
-/// Translate window coordinates to buffer position without any side effects
+/// Translate window coordinates to buffer position without any side effects.
+/// Returns IN_BUFFER and sets "mpos->col" to the column when in buffer text.
+/// The column is one for the first column.
 int get_fpos_of_mouse(pos_T *mpos)
 {
   int grid = mouse_grid;
@@ -67,9 +69,6 @@ int get_fpos_of_mouse(pos_T *mpos)
 
   mpos->col = vcol2col(wp, mpos->lnum, col);
 
-  if (mpos->col > 0) {
-    mpos->col--;
-  }
   mpos->coladd = 0;
   return IN_BUFFER;
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1820,10 +1820,17 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
           } else if (get_fpos_of_mouse(&m_pos) != IN_BUFFER) {
             jump_flags = MOUSE_MAY_STOP_VIS;
           } else {
-            if ((lt(curwin->w_cursor, VIsual)
-                 && (lt(m_pos, curwin->w_cursor) || lt(VIsual, m_pos)))
-                || (lt(VIsual, curwin->w_cursor)
-                    && (lt(m_pos, VIsual) || lt(curwin->w_cursor, m_pos)))) {
+            if (VIsual_mode == 'V') {
+              if ((curwin->w_cursor.lnum <= VIsual.lnum
+                   && (m_pos.lnum < curwin->w_cursor.lnum || VIsual.lnum < m_pos.lnum))
+                  || (VIsual.lnum < curwin->w_cursor.lnum
+                      && (m_pos.lnum < VIsual.lnum || curwin->w_cursor.lnum < m_pos.lnum))) {
+                jump_flags = MOUSE_MAY_STOP_VIS;
+              }
+            } else if ((ltoreq(curwin->w_cursor, VIsual)
+                        && (lt(m_pos, curwin->w_cursor) || lt(VIsual, m_pos)))
+                       || (lt(VIsual, curwin->w_cursor)
+                           && (lt(m_pos, VIsual) || lt(curwin->w_cursor, m_pos)))) {
               jump_flags = MOUSE_MAY_STOP_VIS;
             } else if (VIsual_mode == Ctrl_V) {
               getvcols(curwin, &curwin->w_cursor, &VIsual, &leftcol, &rightcol);


### PR DESCRIPTION
#### vim-patch:9.0.0739: mouse column not correctly used for popup_setpos

Problem:    Mouse column not correctly used for popup_setpos.
Solution:   Adjust off-by-one error and handle Visual line selection properly.
            (Yee Cheng Chin, closes vim/vim#11356)
https://github.com/vim/vim/commit/17822c507c03d509037c9ee5eee5cfbb201b3f01

The test_termcodes.vim test cannot be used. Use a Lua test instead.