### PR TITLE
test(ui): add proper support for measuring redraw performance 

### DIFF
--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -79,11 +79,31 @@ describe('search stat', function()
       /foo                   [1/2]  |
     ]])
     feed('n')
-    poke_eventloop()
-    screen:expect_unchanged()
+    screen:expect([[
+      if                            |
+      {3:^+--  2 lines: foo·············}|
+      endif                         |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /foo                   [1/2]  |
+    ]])
     feed('n')
-    poke_eventloop()
-    screen:expect_unchanged()
+    screen:expect([[
+      if                            |
+      {3:^+--  2 lines: foo·············}|
+      endif                         |
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      /foo                   [1/2]  |
+    ]])
   end)
 
   it('is cleared by gd and gD vim-patch:8.2.3583', function()

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2885,6 +2885,24 @@ it(':substitute with inccommand during :terminal activity', function()
 
     feed('gg')
     feed(':%s/foo/ZZZ')
+    screen:expect{grid=[[
+      {12:ZZZ} bar baz                   |
+      bar baz fox                   |
+      bar {12:ZZZ} baz                   |
+      {15:~                             }|
+      {15:~                             }|
+      {15:~                             }|
+      {11:[No Name] [+]                 }|
+                                    |
+      {15:~                             }|
+      {10:term                          }|
+      |1| {12:ZZZ} bar baz               |
+      |3| bar {12:ZZZ} baz               |
+      {15:~                             }|
+      {10:[Preview]                     }|
+      :%s/foo/ZZZ^                   |
+    ]]}
+
     sleep(20)  -- Allow some terminal activity.
     helpers.poke_eventloop()
     screen:expect_unchanged()

--- a/test/functional/ui/redraw_perf_spec.lua
+++ b/test/functional/ui/redraw_perf_spec.lua
@@ -1,0 +1,90 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear, feed, command = helpers.clear, helpers.feed, helpers.command
+local eq = helpers.eq
+local insert = helpers.insert
+local meths = helpers.meths
+
+describe('redraw perf', function()
+  before_each(function()
+    clear()
+    command('set redrawdebug+=nodelta')
+    screen = Screen.new(40,10)
+    screen:set_default_attr_ids {
+      [0] = {bold=true, foreground=Screen.colors.Blue};
+    }
+    screen:track_redraws()
+    screen:attach()
+    screen:expect{grid=[[
+      + ^                                        |
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      +                                         |
+    ]]}
+  end)
+  it('when editing lines', function()
+    meths.buf_set_lines(0, 0, -1, true, {'aa', 'bb', 'cc'})
+    -- TODO: too many EOB lines!
+    screen:expect{grid=[[
+      + ^aa                                      |
+      + bb                                      |
+      + cc                                      |
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      -                                         |
+    ]]}
+
+    feed'rx'
+    screen:expect{grid=[[
+      + ^xa                                      |
+      - bb                                      |
+      - cc                                      |
+      - {0:~                                       }|
+      - {0:~                                       }|
+      - {0:~                                       }|
+      - {0:~                                       }|
+      - {0:~                                       }|
+      - {0:~                                       }|
+      -                                         |
+    ]]}
+
+    feed 'yyp'
+    -- TODO: too much!
+    screen:expect{grid=[[
+      - xa                                      |
+      + ^xa                                      |
+      + bb                                      |
+      + cc                                      |
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      + {0:~                                       }|
+      -                                         |
+    ]]}
+
+    feed 'dd'
+    screen:expect{grid=[[
+      - xa                                      |
+      + ^bb                                      |
+      s cc                                      |
+      s {0:~                                       }|
+      s {0:~                                       }|
+      s {0:~                                       }|
+      s {0:~                                       }|
+      s {0:~                                       }|
+      + {0:~                                       }|
+      -                                         |
+    ]]}
+  end)
+end)

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -22,6 +22,7 @@ describe('search highlighting', function()
       [3] = {reverse = true},
       [4] = {foreground = colors.Red}, -- Message
       [6] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGrey}, -- Folded
+      [7] = {reverse = true, bold = true};
     })
   end)
 
@@ -317,6 +318,16 @@ describe('search highlighting', function()
       bar foo baz
     ]])
     feed('/foo')
+    screen:expect{grid=[[
+        {3:foo} bar baz       │                   |
+        bar baz {2:foo}       │                   |
+        bar {2:foo} baz       │                   |
+                          │                   |
+      {1:~                   }│                   |
+      {7:[No Name] [+]        }{3:term               }|
+      /foo^                                    |
+    ]]}
+
     helpers.poke_eventloop()
     screen:expect_unchanged()
   end)

--- a/test/functional/ui/syntax_conceal_spec.lua
+++ b/test/functional/ui/syntax_conceal_spec.lua
@@ -907,6 +907,7 @@ describe('Screen', function()
   it('redraws not too much with conceallevel=1', function()
     command('set conceallevel=1')
     command('set redrawdebug+=nodelta')
+    screen:track_redraws()
 
     insert([[
     aaa
@@ -914,46 +915,38 @@ describe('Screen', function()
     ccc
     ]])
     screen:expect{grid=[[
-      aaa                                                  |
-      bbb                                                  |
-      ccc                                                  |
-      ^                                                     |
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-                                                           |
+      + aaa                                                  |
+      + bbb                                                  |
+      + ccc                                                  |
+      + ^                                                     |
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      +                                                      |
     ]]}
 
-    -- XXX: hack to get notifications, and check only a single line is
-    --      updated.  Could use next_msg() also.
-    local orig_handle_grid_line = screen._handle_grid_line
-    local grid_lines = {}
-    function screen._handle_grid_line(self, grid, row, col, items)
-      table.insert(grid_lines, {row, col, items})
-      orig_handle_grid_line(self, grid, row, col, items)
-    end
     feed('k')
     screen:expect{grid=[[
-      aaa                                                  |
-      bbb                                                  |
-      ^ccc                                                  |
-                                                           |
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-                                                           |
+      - aaa                                                  |
+      - bbb                                                  |
+      + ^ccc                                                  |
+      +                                                      |
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      -                                                      |
     ]]}
-    eq({{2, 0, {{'c', 0, 3}, {' ', 0, 50}}}, {3, 0, {{' ', 0, 53}}}}, grid_lines)
   end)
 
   it('K_EVENT should not cause extra redraws with concealcursor #13196', function()
     command('set conceallevel=1')
     command('set concealcursor=nv')
     command('set redrawdebug+=nodelta')
+    screen:track_redraws()
 
     insert([[
     aaa
@@ -961,44 +954,34 @@ describe('Screen', function()
     ccc
     ]])
     screen:expect{grid=[[
-      aaa                                                  |
-      bbb                                                  |
-      ccc                                                  |
-      ^                                                     |
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-                                                           |
+      + aaa                                                  |
+      + bbb                                                  |
+      + ccc                                                  |
+      + ^                                                     |
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      + {0:~                                                    }|
+      +                                                      |
     ]]}
 
-    -- XXX: hack to get notifications, and check only a single line is
-    --      updated.  Could use next_msg() also.
-    local orig_handle_grid_line = screen._handle_grid_line
-    local grid_lines = {}
-    function screen._handle_grid_line(self, grid, row, col, items)
-      table.insert(grid_lines, {row, col, items})
-      orig_handle_grid_line(self, grid, row, col, items)
-    end
     feed('k')
     screen:expect{grid=[[
-      aaa                                                  |
-      bbb                                                  |
-      ^ccc                                                  |
-                                                           |
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-      {0:~                                                    }|
-                                                           |
+      - aaa                                                  |
+      - bbb                                                  |
+      + ^ccc                                                  |
+      -                                                      |
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      - {0:~                                                    }|
+      -                                                      |
     ]]}
-    eq({{2, 0, {{'c', 0, 3}, {' ', 0, 50}}}}, grid_lines)
     grid_lines = {}
     poke_eventloop()  -- causes K_EVENT key
     screen:expect_unchanged()
-    eq({}, grid_lines) -- no redraw was done
   end)
 
   -- Copy of Test_cursor_column_in_concealed_line_after_window_scroll in


### PR DESCRIPTION
currently our screen test suite is very good at catching final redraw state errors. It cares very little about redraw performance tho (i e don't invalidate a larger region of the screen than necessary). Start with some basic verifying of VALID/SOME_VALID redraws working as intended