### PR TITLE
docs: update vimdoc parser

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -203,8 +203,8 @@ set(TREESITTER_LUA_SHA256 564594fe0ffd2f2fb3578a15019b723e1bc94ac82cb6a0103a6b3b
 set(TREESITTER_VIM_URL https://github.com/vigoux/tree-sitter-viml/archive/v0.2.0.tar.gz)
 set(TREESITTER_VIM_SHA256 608dcc31a7948cb66ae7f45494620e2e9face1af75598205541f80d782ec4501)
 
-set(TREESITTER_HELP_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v1.2.2.tar.gz)
-set(TREESITTER_HELP_SHA256 d33b9447dae04f19e1ac50c94b78e305574c07f942791f70aea96fe266447c18)
+set(TREESITTER_HELP_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v1.2.3.tar.gz)
+set(TREESITTER_HELP_SHA256 e0a0d1c6c142b0096bb9ca22acd7e7ad3b205fbe68c26e6bfbbe03632c04db08)
 
 set(TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.20.7.tar.gz)
 set(TREESITTER_SHA256 b355e968ec2d0241bbd96748e00a9038f83968f85d822ecb9940cbe4c42e182e)

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4,7 +4,7 @@
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
-Builtin functions				*builtin-functions*
+Builtin functions		*vimscript-functions* *builtin-functions*
 
 For functions grouped by what they are used for see |function-list|.
 

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -441,13 +441,13 @@ steps to make a numbered list.
 SHIFTING LINES LEFT OR RIGHT				*shift-left-right*
 
 							*<*
-<{motion}		Shift {motion} lines one 'shiftwidth' leftwards.
+ <{motion}		Shift {motion} lines one 'shiftwidth' leftwards.
 
 			If the 'shiftwidth' option is set to zero, the amount
 			of indent is calculated at the first non-blank
 			character in the line.
 							*<<*
-<<			Shift [count] lines one 'shiftwidth' leftwards.
+ <<			Shift [count] lines one 'shiftwidth' leftwards.
 
 							*v_<*
 {Visual}[count]<	Shift the highlighted lines [count] 'shiftwidth'

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -4,7 +4,7 @@
 		  VIM REFERENCE MANUAL	  by Bram Moolenaar
 
 
-Expression evaluation			*expression* *expr* *E15* *eval*
+Expression evaluation		*vimscript* *expression* *expr* *E15* *eval*
 
 Using expressions is introduced in chapter 41 of the user manual |usr_41.txt|.
 

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -1,6 +1,6 @@
 *help.txt*	Nvim
 
-			VIM - main help file
+				 NVIM - help
 									 k
       Move around:  Use the cursor keys, or "h" to go left,	       h   l
 		    "j" to go down, "k" to go up, "l" to go right.	 j
@@ -37,170 +37,153 @@ Get specific help:  It is possible to go directly to whatever you want help
 
 Vim stands for Vi IMproved.  Most of Vim was made by Bram Moolenaar, but only
 through the help of many others.  See |credits|.
+
+==============================================================================
+NVIM DOCUMENTATION
+
 ------------------------------------------------------------------------------
-						*doc-file-list* *Q_ct*
-BASIC:
-|quickref|	Overview of the most common commands you will use
-|tutor|		30-minute interactive course for beginners
-|copying|	About copyrights
-|iccf|		Helping poor children in Uganda
-|sponsor|	Sponsor Vim development, become a registered Vim user
-|www|		Vim on the World Wide Web
-|bugs|		Where to send bug reports
+ABOUT NVIM				*reference_toc* *doc-file-list* *Q_ct*
 
-USER MANUAL: These files explain how to accomplish an editing task.
+|news|			News since the previous release
+|nvim|			Transitioning from Vim
+|vim-differences|	Nvim compared to Vim
+|user-manual|		User manual: How to accomplish editing tasks.
+|quickref|		Overview of common commands
+|tutor|			30-minute interactive course for beginners
+|copying|		About copyrights
+|iccf|			Helping poor children in Uganda
+|sponsor|		Sponsor Vim development, become a registered Vim user
+|www|			Vim on the World Wide Web
+|bugs|			Where to send bug reports
+|support|		Supported platforms
 
-|usr_toc.txt|	Table Of Contents
+------------------------------------------------------------------------------
+GENERAL
 
-Getting Started ~
-|usr_01.txt|  About the manuals
-|usr_02.txt|  The first steps in Vim
-|usr_03.txt|  Moving around
-|usr_04.txt|  Making small changes
-|usr_05.txt|  Set your settings
-|usr_06.txt|  Using syntax highlighting
-|usr_07.txt|  Editing more than one file
-|usr_08.txt|  Splitting windows
-|usr_09.txt|  Using the GUI
-|usr_10.txt|  Making big changes
-|usr_11.txt|  Recovering from a crash
-|usr_12.txt|  Clever tricks
+|intro.txt|		Introduction to Vim; notation used in help files
+|helphelp|		Using the :help files
+|index|			Index of all commands
+|tips|			Various tips on using Vim
+|message.txt|		(Error) messages and explanations
+|uganda.txt|		Vim distribution and what to do with your money
 
-Editing Effectively ~
-|usr_20.txt|  Typing command-line commands quickly
-|usr_21.txt|  Go away and come back
-|usr_22.txt|  Finding the file to edit
-|usr_23.txt|  Editing other files
-|usr_24.txt|  Inserting quickly
-|usr_25.txt|  Editing formatted text
-|usr_26.txt|  Repeating
-|usr_27.txt|  Search commands and patterns
-|usr_28.txt|  Folding
-|usr_29.txt|  Moving through programs
-|usr_30.txt|  Editing programs
-|usr_31.txt|  Exploiting the GUI
-|usr_32.txt|  The undo tree
+------------------------------------------------------------------------------
+BASIC EDITING
 
-Tuning Vim ~
-|usr_40.txt|  Make new commands
-|usr_41.txt|  Write a Vim script
-|usr_42.txt|  Add new menus
-|usr_43.txt|  Using filetypes
-|usr_44.txt|  Your own syntax highlighted
-|usr_45.txt|  Select your language
+|starting|		Starting Vim, Vim command arguments, initialisation
+|edit-files|		Editing and writing files
+|motion.txt|		Commands for moving around
+|scrolling|		Scrolling the text in the window
+|insert.txt|		Insert and Replace mode
+|change.txt|		Deleting and replacing text
+|undo-redo|		Undo and Redo
+|repeat.txt|		Repeating commands, Vim scripts and debugging
+|visual-mode|		Using Visual mode (selecting text)
+|various|		Various other commands
+|crash-recovery|	Recovering from a crash
 
+------------------------------------------------------------------------------
+ADVANCED EDITING
 
-REFERENCE MANUAL: These files explain every detail of Vim.	*reference_toc*
+|cmdline|		Command-line editing
+|options|		Description of all options
+|pattern-searches|	Vim regexp patterns and search commands
+|key-mapping|		Key mapping (shortcuts), abbreviations
+|tags|			Tags and special searches
+|windows|		Commands for using windows and buffers
+|tabpage|		Commands for using tabpages
+|spell|			Spell checking
+|diff|			Comparing files
+|folding|		Hide (fold) ranges of lines
+|terminal|		Embedded terminal emulator
 
-General subjects ~
-|intro.txt|	general introduction to Vim; notation used in help files
-|nvim.txt|	Transitioning from Vim
-|help.txt|	overview and quick reference (this file)
-|helphelp.txt|	about using the help files
-|index.txt|	alphabetical index of all commands
-|tips.txt|	various tips on using Vim
-|message.txt|	(error) messages and explanations
-|develop.txt|	development of Nvim
-|debug.txt|	debugging Vim itself
-|uganda.txt|	Vim distribution conditions and what to do with your money
+------------------------------------------------------------------------------
+API (EXTENSIBILITY/SCRIPTING/PLUGINS)
 
-Basic editing ~
-|starting.txt|	starting Vim, Vim command arguments, initialisation
-|editing.txt|	editing and writing files
-|motion.txt|	commands for moving around
-|scroll.txt|	scrolling the text in the window
-|insert.txt|	Insert and Replace mode
-|change.txt|	deleting and replacing text
-|undo.txt|	Undo and Redo
-|repeat.txt|	repeating commands, Vim scripts and debugging
-|visual.txt|	using the Visual mode (selecting a text area)
-|various.txt|	various remaining commands
-|recover.txt|	recovering from a crash
+|api|			Nvim API via RPC, Lua and VimL
+|ui|			Nvim UI protocol
+|lua|			Lua API
+|luaref|		Lua reference manual
+|luvref|		Luv (|vim.loop|) reference manual
+|autocmd|		Event handlers
+|job-control|		Spawn and control multiple processes
+|channel|		Nvim asynchronous IO
+|vimscript|		Vimscript reference
+|vimscript-functions|	Vimscript functions
+|testing.txt|		Vimscript testing functions
+|remote-plugin|		Nvim remote plugins
 
-Advanced editing ~
-|cmdline.txt|	Command-line editing
-|options.txt|	description of all options
-|pattern.txt|	regexp patterns and search commands
-|map.txt|	key mapping and abbreviations
-|tagsrch.txt|	tags and special searches
-|windows.txt|	commands for using multiple windows and buffers
-|tabpage.txt|	commands for using multiple tab pages
-|spell.txt|	spell checking
-|diff.txt|	working with two to eight versions of the same file
-|autocmd.txt|	automatically executing commands on an event
-|eval.txt|	expression evaluation, conditional commands
-|builtin.txt|	builtin functions
-|userfunc.txt|	defining user functions
-|fold.txt|	hide (fold) ranges of lines
-|lua.txt|	Lua API
-|api.txt|	Nvim API via RPC, Lua and VimL
+------------------------------------------------------------------------------
+PROGRAMMING LANGUAGE SUPPORT
 
-Special issues ~
-|testing.txt|	    testing Vim and Vim scripts
-|print.txt|	    printing
-|remote_plugin.txt|   Nvim support for remote plugins
+|lsp|			Language Server Protocol (LSP)
+|diagnostic-api|	Diagnostic framework
+|treesitter|		Incremental syntax parsing
+|indent.txt|      	automatic indenting for C and other languages
+|syntax|		syntax highlighting
+|filetype|		Settings for specific types of files
+|quickfix|		Commands for a quick edit-compile-fix cycle
+|ft_ada.txt|      	Ada filetype plugin
+|ft_ps1.txt|      	PowerShell filetype plugin
+|ft_raku.txt|     	Raku filetype plugin
+|ft_rust.txt|     	Rust filetype plugin
+|ft_sql.txt|      	SQL filetype plugin
 
-Programming language support ~
-|indent.txt|       automatic indenting for C and other languages
-|lsp.txt|          Language Server Protocol (LSP)
-|treesitter.txt|   tree-sitter library for incremental parsing of buffers
-|diagnostic.txt|   Diagnostic framework
-|syntax.txt|       syntax highlighting
-|filetype.txt|     settings done specifically for a type of file
-|quickfix.txt|     commands for a quick edit-compile-fix cycle
-|provider.txt|     Built-in remote plugin hosts
-|ft_ada.txt|       Ada (the programming language) support
-|ft_ps1.txt|       Filetype plugin for Windows PowerShell
-|ft_raku.txt|      Filetype plugin for Raku
-|ft_rust.txt|      Filetype plugin for Rust
-|ft_sql.txt|       about the SQL filetype plugin
+------------------------------------------------------------------------------
+UI
 
-Language support ~
-|digraph.txt|	list of available digraphs
-|mbyte.txt|	multibyte text support
-|mlang.txt|	non-English language support
-|rileft.txt|	right-to-left editing mode
-|arabic.txt|	Arabic language support and editing
-|hebrew.txt|	Hebrew language support and editing
-|russian.txt|	Russian language support and editing
+|tui|			Builtin UI
+|gui|			External (graphical) UIs
+|signs|			Signs displayed as window decorations (the "gutter")
 
-GUI ~
-|gui.txt|	Graphical User Interface (GUI)
+------------------------------------------------------------------------------
+LANGUAGE SUPPORT
 
-Interfaces ~
-|if_perl.txt|	Perl interface
-|if_pyth.txt|	Python interface
-|if_ruby.txt|	Ruby interface
-|sign.txt|	debugging signs
+|digraph|		List of available digraphs
+|mbyte.txt|		Multibyte text support
+|mlang.txt|		Non-English language support
+|rileft.txt|		Right-to-left editing mode
+|arabic.txt|		Arabic language support and editing
+|hebrew.txt|		Hebrew language support and editing
+|russian.txt|		Russian language support and editing
 
-Versions ~
-|vim_diff.txt|	Main differences between Nvim and Vim
-|vi_diff.txt|	Main differences between Vim and Vi
-|deprecated.txt|  Deprecated items that have been or will be removed
+------------------------------------------------------------------------------
+INTEROP
 
-Other ~
-|news.txt|		News and notable changes in the latest release
-|terminal_emulator.txt|	Terminal buffers
-|term.txt|		Terminal UI
-|ui.txt|		Nvim UI protocol
-|channel.txt|		Nvim asynchronous IO
-|dev_style.txt|		Nvim style guide
-|job_control.txt|	Spawn and control multiple processes
-|luaref.txt|		Lua reference manual
-|luvref.txt|		Luv (|vim.loop|) reference manual
-|support.txt|		Supported platforms
+|provider|		Builtin remote plugin hosts
+|if_perl|		Perl interface
+|if_pyth|		Python interface
+|if_ruby|		Ruby interface
+
+------------------------------------------------------------------------------
+VERSIONS
+
+|deprecated|		Deprecated features that will be removed
+|vi-differences|	Differences between Vim and Vi
+
+------------------------------------------------------------------------------
+DEVELOPING NVIM
+
+|dev|			Development of Nvim
+|dev-style|		Development style guidelines
+|debug.txt|		Debugging Vim itself
+
+------------------------------------------------------------------------------
+OTHER
+
+|print.txt|		For your briefcase and fax machine
 
 						*standard-plugin-list*
 Standard plugins ~
-|matchit.txt|      Extended |%| matching
-|pi_gzip.txt|      Reading and writing compressed files
-|pi_health.txt|    Healthcheck framework
-|pi_msgpack.txt|   msgpack utilities
-|pi_netrw.txt|     Reading and writing files over a network
-|pi_paren.txt|     Highlight matching parens
-|pi_spec.txt|      Filetype plugin to work with rpm spec files
-|pi_tar.txt|       Tar file explorer
-|pi_zip.txt|       Zip archive explorer
+|matchit.txt|		Extended |%| matching
+|pi_gzip.txt|      	Reading and writing compressed files
+|pi_health.txt|    	Healthcheck framework
+|pi_msgpack.txt|   	msgpack utilities
+|pi_netrw.txt|     	Reading and writing files over a network
+|pi_paren.txt|     	Highlight matching parens
+|pi_spec.txt|      	Filetype plugin to work with rpm spec files
+|pi_tar.txt|       	Tar file explorer
+|pi_zip.txt|       	Zip archive explorer
 
 LOCAL ADDITIONS:				*local-additions*
 
@@ -213,8 +196,8 @@ CTRL-T, CTRL-O, g<RightMouse>, or <C-RightMouse> to go back to where you were.
 Note that tags are within | characters, but when highlighting is enabled these
 characters are hidden.  That makes it easier to read a command.
 
-Anyway, you can use CTRL-] on any word, also when it is not within |, and Vim
-will try to find help for it.  Especially for options in single quotes, e.g.
+You can use CTRL-] on any word (even if it is not within "|") and Nvim will
+try to find help for it.  Especially for options in single quotes, e.g.
 'hlsearch'.
 
 ------------------------------------------------------------------------------

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -60,7 +60,7 @@ ABOUT NVIM				*reference_toc* *doc-file-list* *Q_ct*
 ------------------------------------------------------------------------------
 GENERAL
 
-|intro.txt|		Introduction to Vim; notation used in help files
+|intro|			Introduction to Vim; notation used in help files
 |helphelp|		Using the :help files
 |index|			Index of all commands
 |tips|			Various tips on using Vim

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -20,8 +20,7 @@ For a list of Vim variables see |vim-variable|.
 1. Insert mode						*insert-index*
 
 tag		char		action in Insert mode	~
------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |i_CTRL-@|	CTRL-@		insert previously inserted text and stop
 				insert
 |i_CTRL-A|	CTRL-A		insert previously inserted text
@@ -184,8 +183,7 @@ SECTION	 a section that possibly starts with '}' instead of '{'
 note: 1 = cursor movement command; 2 = can be undone/redone
 
 tag		char	      note action in Normal mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 		CTRL-@		   not used
 |CTRL-A|	CTRL-A		2  add N to number at/after cursor
 |CTRL-B|	CTRL-B		1  scroll N screens Backwards
@@ -470,8 +468,7 @@ tag		char	      note action in Normal mode	~
 These can be used after an operator or in Visual mode to select an object.
 
 tag		command		   action in op-pending and Visual mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |v_aquote|	a"		   double quoted string
 |v_a'|		a'		   single quoted string
 |v_a(|		a(		   same as ab
@@ -513,8 +510,7 @@ tag		command		   action in op-pending and Visual mode	~
 2.2 Window commands						*CTRL-W*
 
 tag		command		   action in Normal mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |CTRL-W_CTRL-B|	CTRL-W CTRL-B	   same as "CTRL-W b"
 |CTRL-W_CTRL-C|	CTRL-W CTRL-C	   same as "CTRL-W c"
 |CTRL-W_CTRL-D|	CTRL-W CTRL-D	   same as "CTRL-W d"
@@ -612,8 +608,7 @@ tag		command		   action in Normal mode	~
 2.3 Square bracket commands					*[* *]*
 
 tag		char	      note action in Normal mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |[_CTRL-D|	[ CTRL-D	   jump to first #define found in current and
 				   included files matching the word under the
 				   cursor, start searching at beginning of
@@ -703,8 +698,7 @@ tag		char	      note action in Normal mode	~
 2.4 Commands starting with 'g'						*g*
 
 tag		char	      note action in Normal mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 g_CTRL-A	g CTRL-A	   dump a memory profile
 |g_CTRL-G|	g CTRL-G	   show information about current cursor
 				   position
@@ -807,8 +801,7 @@ g_CTRL-A	g CTRL-A	   dump a memory profile
 2.5 Commands starting with 'z'						*z*
 
 tag		char	      note action in Normal mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |z<CR>|		z<CR>		   redraw, cursor line to top of window,
 				   cursor on first non-blank
 |zN<CR>|	z{height}<CR>	   redraw, make window {height} lines high
@@ -882,8 +875,7 @@ tag		char	      note action in Normal mode	~
 These can be used after an operator, but before a {motion} has been entered.
 
 tag		char		action in Operator-pending mode	~
------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |o_v|		v		force operator to work charwise
 |o_V|		V		force operator to work linewise
 |o_CTRL-V|	CTRL-V		force operator to work blockwise
@@ -895,8 +887,7 @@ Most commands in Visual mode are the same as in Normal mode.  The ones listed
 here are those that are different.
 
 tag		command	      note action in Visual mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |v_CTRL-\_CTRL-N| CTRL-\ CTRL-N	   stop Visual mode
 |v_CTRL-\_CTRL-G| CTRL-\ CTRL-G	   go to Normal mode
 |v_CTRL-A|	CTRL-A		2  add N to number in highlighted text
@@ -1016,8 +1007,7 @@ Normal characters are inserted at the current cursor position.
 file names, tags, commands etc. as appropriate.
 
 tag		command		action in Command-line editing mode	~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 		CTRL-@		not used
 |c_CTRL-A|	CTRL-A		do completion on the pattern in front of the
 				cursor and insert all matches
@@ -1127,8 +1117,7 @@ mentioning any arguments.  The optional part of the command name is inside [].
 The commands are sorted on the non-optional part of their name.
 
 tag		command		action ~
-------------------------------------------------------------------------------
-
+------------------------------------------------------------------------------ ~
 |:|		:		nothing
 |:range|	:{range}	go to last line in {range}
 |:!|		:!		filter lines or execute an external command

--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -3,7 +3,7 @@
 
                     LUV REFERENCE MANUAL
 
-
+								      *luvref*
 This file documents the Lua bindings for the LibUV library which is used for
 Nvim's event-loop and is accessible from Lua via |vim.loop| (e.g., |uv.version()|
 is exposed as `vim.loop.version()`).

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -440,9 +440,9 @@ se[t]			the string "set " or "se " (note the space); When
 :			a colon
 [text]			any text or empty
 
-Examples:
-   /* vim: set ai tw=75: */ ~
-   /* Vim: set ai tw=75: */ ~
+Examples: >
+   /* vim: set ai tw=75: */
+   /* Vim: set ai tw=75: */
 
 The white space before {vi:|vim:|Vim:|ex:} is required.  This minimizes the
 chance that a normal word like "lex:" is caught.  There is one exception:
@@ -479,10 +479,10 @@ number can be specified where "vim:" or "Vim:" is used:
 	vim={vers}:	version {vers}
 	vim>{vers}:	version after {vers}
 {vers} is 700 for Vim 7.0 (hundred times the major version plus minor).
-For example, to use a modeline only for Vim 7.0:
-	/* vim700: set foldmethod=marker */ ~
-To use a modeline for Vim after version 7.2:
-	/* vim>702: set cole=2: */ ~
+For example, to use a modeline only for Vim 7.0: >
+	/* vim700: set foldmethod=marker */
+To use a modeline for Vim after version 7.2: >
+	/* vim>702: set cole=2: */
 There can be no blanks between "vim" and the ":".
 The modeline is ignored if {vers} does not fit in an integer.
 
@@ -491,16 +491,16 @@ The number of lines that are checked can be set with the 'modelines' option.
 If 'modeline' is off or 'modelines' is 0 no lines are checked.
 
 Note that for the first form all of the rest of the line is used, thus a line
-like:
-   /* vi:ts=4: */ ~
-will give an error message for the trailing "*/".  This line is OK:
-   /* vi:set ts=4: */ ~
+like: >
+   /* vi:ts=4: */
+will give an error message for the trailing "*/".  This line is OK: >
+   /* vi:set ts=4: */
 
 If an error is detected the rest of the line is skipped.
 
 If you want to include a ':' in a set command precede it with a '\'.  The
-backslash in front of the ':' will be removed.  Example:
-   /* vi:set fillchars=stl\:^,vert\:\|: */ ~
+backslash in front of the ':' will be removed.  Example: >
+   /* vi:set fillchars=stl\:^,vert\:\|: */
 This sets the 'fillchars' option to "stl:^,vert:\|".  Only a single backslash
 before the ':' is removed.  Thus to include "\:" you have to specify "\\:".
 							*E992*
@@ -1872,9 +1872,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		^\(#\s*define\|[a-z]*\s*const\s*[a-z]*\)
 <	You can also use "\ze" just before the name and continue the pattern
 	to check what is following.  E.g. for Javascript, if a function is
-	defined with "func_name = function(args)": >
+	defined with `func_name = function(args)`: >
 		^\s*\ze\i\+\s*=\s*function(
-<	If the function is defined with "func_name : function() {...": >
+<	If the function is defined with `func_name : function() {...`: >
 	        ^\s*\ze\i\+\s*[:]\s*(*function\s*(
 <	When using the ":set" command, you need to double the backslashes!
 	To avoid that use `:let` with a single quote string: >
@@ -2406,13 +2406,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	this use the ":filetype on" command. |:filetype|
 	Setting this option to a different value is most useful in a modeline,
 	for a file for which the file type is not automatically recognized.
-	Example, for in an IDL file:
-		/* vim: set filetype=idl : */ ~
-	|FileType| |filetypes|
+	Example, for in an IDL file: >
+		/* vim: set filetype=idl : */
+<	|FileType| |filetypes|
 	When a dot appears in the value then this separates two filetype
-	names.  Example:
-		/* vim: set filetype=c.doxygen : */ ~
-	This will use the "c" filetype first, then the "doxygen" filetype.
+	names.  Example: >
+		/* vim: set filetype=c.doxygen : */
+<	This will use the "c" filetype first, then the "doxygen" filetype.
 	This works both for filetype plugins and for syntax files.  More than
 	one dot may appear.
 	This option is not copied to another buffer, independent of the 's' or
@@ -5685,7 +5685,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   "number"	display signs in the 'number' column. If the number
 			column is not present, then behaves like "auto".
 
-	Note regarding 'orphaned signs': with signcolumn numbers higher than
+	Note regarding "orphaned signs": with signcolumn numbers higher than
 	1, deleting lines will also remove the associated signs automatically,
 	in contrast to the default Vim behavior of keeping and grouping them.
 	This is done in order for the signcolumn appearance not appear weird
@@ -6263,12 +6263,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Otherwise this option does not always reflect the current syntax (the
 	b:current_syntax variable does).
 	This option is most useful in a modeline, for a file which syntax is
-	not automatically recognized.  Example, in an IDL file:
-		/* vim: set syntax=idl : */ ~
-	When a dot appears in the value then this separates two filetype
-	names.  Example:
-		/* vim: set syntax=c.doxygen : */ ~
-	This will use the "c" syntax first, then the "doxygen" syntax.
+	not automatically recognized.  Example, in an IDL file: >
+		/* vim: set syntax=idl : */
+<	When a dot appears in the value then this separates two filetype
+	names.  Example: >
+		/* vim: set syntax=c.doxygen : */
+<	This will use the "c" syntax first, then the "doxygen" syntax.
 	Note that the second one must be prepared to be loaded as an addition,
 	otherwise it will be skipped.  More than one dot may appear.
 	To switch off syntax highlighting for the current file, use: >

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -4,7 +4,7 @@
                             NVIM REFERENCE MANUAL
 
 
-Support
+Support                                                              *support*
 
                                       Type |gO| to see the table of contents.
 

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -519,7 +519,7 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
       return text
     end
     local s = ('%s<a href="%s#%s">%s</a>'):format(ws(), helppage, url_encode(tagname), html_esc(tagname))
-    if node_name == 'taglink' and opt.old then
+    if opt.old and node_name == 'taglink' then
       s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
     end
     return s
@@ -528,7 +528,7 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
       return text
     end
     local s = ('%s<code>%s</code>'):format(ws(), trimmed)
-    if node_name == 'codespan' and opt.old then
+    if opt.old and node_name == 'codespan' then
       s = fix_tab_after_conceal(s, node_text(root:next_sibling()))
     end
     return s

--- a/test/functional/lua/help_spec.lua
+++ b/test/functional/lua/help_spec.lua
@@ -19,11 +19,11 @@ describe(':help docs', function()
     local rv = exec_lua([[return require('scripts.gen_help_html').validate('./build/runtime/doc')]])
     -- Check that we actually found helpfiles.
     ok(rv.helpfiles > 100, '>100 :help files', rv.helpfiles)
-    eq({}, rv.invalid_links, 'found invalid :help tag links')
-    eq({}, rv.invalid_urls, 'found invalid URLs in :help docs')
+    eq({}, rv.invalid_links, 'invalid tags in :help docs')
+    eq({}, rv.invalid_urls, 'invalid URLs in :help docs')
     -- Check that parse errors did not increase wildly.
     -- TODO: Fix all parse errors in :help files.
-    ok(rv.err_count < 350, '<350 parse errors', rv.err_count)
+    ok(rv.err_count < 250, '<250 parse errors', rv.err_count)
   end)
 
   it('gen_help_html.lua generates HTML', function()
@@ -44,7 +44,7 @@ describe(':help docs', function()
       tmpdir
     )
     eq(4, #rv.helpfiles)
-    ok(rv.err_count < 25, '<25 parse errors', rv.err_count)
-    eq({}, rv.invalid_links, 'found invalid :help tag links')
+    eq(0, rv.err_count, 'parse errors in :help docs')
+    eq({}, rv.invalid_links, 'invalid tags in :help docs')
   end)
 end)


### PR DESCRIPTION
Remove the user-manual ToC from help.txt, because:
1. it duplicates usr_toc.txt
2. it is not what most readers are looking for in the main help page.

fix https://github.com/neovim/tree-sitter-vimdoc/issues/49
fix https://github.com/neovim/tree-sitter-vimdoc/issues/50
fix https://github.com/neovim/tree-sitter-vimdoc/issues/51