### PR TITLE
vim-patch:9.0.0806: 'langmap' works differently when there are modifiers

### DIFF
--- a/src/nvim/testdir/test_langmap.vim
+++ b/src/nvim/testdir/test_langmap.vim
@@ -49,6 +49,41 @@ func Test_langmap()
   call feedkeys(';', 'tx')
   call assert_equal(5, col('.'))
 
+  set langmap=RL
+  let g:counter = 0
+  nnoremap L;L <Cmd>let g:counter += 1<CR>
+  nnoremap <C-L> <Cmd>throw 'This mapping shoud not be triggered'<CR>
+
+  " 'langmap' is applied to keys without modifiers when matching a mapping
+  call feedkeys('R;R', 'tx')
+  call assert_equal(1, g:counter)
+  nunmap L;L
+  unlet g:counter
+
+  delete
+  call assert_equal('', getline(1))
+  undo
+  call assert_equal('Hello World', getline(1))
+  " 'langmap' does not change Ctrl-R to Ctrl-L for consistency
+  call feedkeys("\<*C-R>", 'tx')
+  call assert_equal('', getline(1))
+
+  set langmap=6L
+  undo
+  setlocal bufhidden=hide
+  let oldbuf = bufnr()
+  enew
+  call assert_notequal(oldbuf, bufnr())
+  " 'langmap' does not change Ctrl-6 to Ctrl-L for consistency
+  " Ctrl-6 becomes Ctrl-^ after merging the Ctrl modifier
+  call feedkeys("\<*C-6>", 'tx')
+  call assert_equal(oldbuf, bufnr())
+  setlocal bufhidden&
+
+  nunmap <C-L>
+
   set langmap&
   quit!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #20705

#### vim-patch:9.0.0806: 'langmap' works differently when there are modifiers

Problem:    'langmap' works differently when there are modifiers.
Solution:   Only apply 'langmap' to a character where modifiers have no
            effect. (closes vim/vim#11404)
https://github.com/vim/vim/commit/49660f5139d3fd55326a54eadf6bb31a3ffec2bf