### PR TITLE
fix(filetype): don't pass empty string to detect

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -170,7 +170,7 @@ local extension = {
     return require('vim.filetype.detect').bindzone(bufnr, 'dcl')
   end,
   db = function(path, bufnr)
-    return require('vim.filetype.detect').bindzone(bufnr, '')
+    return require('vim.filetype.detect').bindzone(bufnr)
   end,
   bicep = 'bicep',
   bb = 'bitbake',


### PR DESCRIPTION
Problem: `*.db` files use empty string as default filetype, which is
inconsistent with the rest of the code which uses `nil` instead.
Solution: don't pass a default empty string

Fixes #20763
