### PR TITLE
refactor(lsp): remove deprecated rootPath

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -863,10 +863,8 @@ start_client({config})                                *vim.lsp.start_client()*
                              on exit, but if Nvim fails to exit cleanly this
                              could leave behind orphaned server processes.
       • {workspace_folders}  (table) List of workspace folders passed to the
-                             language server. For backwards compatibility
-                             rootUri and rootPath will be derived from the
-                             first workspace folder in this list. See
-                             `workspaceFolders` in the LSP spec.
+                             language server. See `workspaceFolders` in the
+                             LSP spec.
       • {capabilities}       Map overriding the default capabilities defined
                              by |vim.lsp.protocol.make_client_capabilities()|,
                              passed to the language server on initialization.
@@ -951,9 +949,8 @@ start_client({config})                                *vim.lsp.start_client()*
                                sending kill -15. If set to false, nvim exits
                                immediately after sending the "shutdown"
                                request to the server.
-      • {root_dir}           (string) Directory where the LSP server will base
-                             its workspaceFolders, rootUri, and rootPath on
-                             initialization.
+      • {root_dir}           (string) Directory where the language server will
+                             base its workspaceFolders on initialization.
 
     Return: ~
         Client id. |vim.lsp.get_client_by_id()| Note: client may not be fully

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1268,8 +1268,6 @@ function lsp.start_client(config)
       client.initialized = true
       uninitialized_clients[client_id] = nil
       client.workspace_folders = workspace_folders
-      -- TODO(mjlbach): Backwards compatibility, to be removed in 0.7
-      client.workspaceFolders = client.workspace_folders
 
       -- These are the cleaned up capabilities we use for dynamically deciding
       -- when to send certain events to clients.


### PR DESCRIPTION
#### Description

Remove deprecated code in `lsp.lua`
- `rootPath` and `rootUri` have been deprecated since `3.6.0`, and there's no reason to keep propegating them to the servers
- cleanup unused `client.workspaceFolders`

ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
