### PR TITLE
ci(vim-patch): add original author as co-author

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -120,9 +120,9 @@ get_vim_sources() {
 
 commit_message() {
   if [[ -n "$vim_tag" ]]; then
-    printf '%s\n%s' "${vim_message}" "${vim_commit_url}"
+    printf '%s\n\n%s\n\n%s' "${vim_message}" "${vim_commit_url}" "${vim_coauthor}"
   else
-    printf 'vim-patch:%s\n\n%s\n%s' "$vim_version" "$vim_message" "$vim_commit_url"
+    printf 'vim-patch:%s\n\n%s\n\n%s\n\n%s' "$vim_version" "$vim_message" "$vim_commit_url" "$vim_coauthor"
   fi
 }
 
@@ -175,6 +175,7 @@ assign_commit_details() {
   vim_commit_url="https://github.com/vim/vim/commit/${vim_commit}"
   vim_message="$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty='format:%B' "${vim_commit}" \
       | sed -e 's/\(#[0-9]\{1,\}\)/vim\/vim\1/g')"
+  vim_coauthor="$(git -C "${VIM_SOURCE_DIR}" log -1 --pretty='format:Co-authored-by: %an <%ae>' "${vim_commit}")"
   if [[ ${munge_commit_line} == "true" ]]; then
     # Remove first line of commit message.
     vim_message="$(echo "${vim_message}" | sed -e '1s/^patch /vim-patch:/')"


### PR DESCRIPTION
This is a suggestion. The original author would appear on the commit (with their GitHub account if they have one).

Example:

```
vim-patch:9.0.0806: 'langmap' works differently when there are modifiers

Problem:    'langmap' works differently when there are modifiers.
Solution:   Only apply 'langmap' to a character where modifiers have no
            effect. (closes vim/vim#11395, closes vim/vim#11404)

https://github.com/vim/vim/commit/49660f5139d3fd55326a54eadf6bb31a3ffec2bf

Co-authored-by: zeertzjq <zeertzjq@outlook.com>
```

Diff:

```diff
diff --git a/before.txt b/after.txt
index c21714b31..b12e4b1b7 100644
--- a/before.txt
+++ b/after.txt
@@ -3,4 +3,7 @@ vim-patch:9.0.0806: 'langmap' works differently when there are modifiers
 Problem:    'langmap' works differently when there are modifiers.
 Solution:   Only apply 'langmap' to a character where modifiers have no
             effect. (closes vim/vim#11395, closes vim/vim#11404)
+
 https://github.com/vim/vim/commit/49660f5139d3fd55326a54eadf6bb31a3ffec2bf
+
+Co-authored-by: zeertzjq <zeertzjq@outlook.com>
```

Reference: https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors