### PR TITLE
fix: setting tabline option not redrawing tabline

### DIFF
--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -30,6 +30,7 @@ local type_flags={
 
 local redraw_flags={
   statuslines='P_RSTAT',
+  tabline = 'P_RTABL',
   current_window='P_RWIN',
   current_window_only='P_RWINONLY',
   current_buffer='P_RBUF',

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2648,6 +2648,10 @@ void check_redraw(uint32_t flags)
     status_redraw_all();
   }
 
+  if ((flags & P_RTABL) || all) {  // mark tablines dirty
+    redraw_tabline = true;
+  }
+
   if ((flags & P_RBUF) || (flags & P_RWIN) || all) {
     changed_window_setting();
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -24,6 +24,7 @@
 #define P_NO_MKRC      0x200U       ///< don't include in :mkvimrc output
 
 // when option changed, what to display:
+#define P_RTABL        0x800U       ///< redraw tabline
 #define P_RSTAT        0x1000U      ///< redraw status lines
 #define P_RWIN         0x2000U      ///< redraw current window and recompute text
 #define P_RBUF         0x4000U      ///< redraw current buffer and recompute text

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -19,7 +19,7 @@
 -- types: bool, number, string
 -- lists: (nil), comma, onecomma, flags, flagscomma
 -- scopes: global, buffer, window
--- redraw options: statuslines, current_window, curent_window_only,
+-- redraw options: statuslines, tabline, current_window, curent_window_only,
 --                 current_buffer, all_windows, curswant
 -- defaults: {condition=#if condition, if_true=default, if_false=default}
 -- #if condition:
@@ -2407,7 +2407,7 @@ return {
       short_desc=N_("custom format for the console tab pages line"),
       type='string', scope={'global'},
       modelineexpr=true,
-      redraw={'statuslines'},
+      redraw={'tabline'},
       varname='p_tal',
       defaults={if_true=""}
     },

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -84,3 +84,39 @@ describe('ui/ext_tabline', function()
     end}
   end)
 end)
+
+describe("tabline", function()
+  local screen
+
+  before_each(function()
+    clear()
+    screen = Screen.new(42, 5)
+    screen:attach()
+  end)
+
+  it('redraws when tabline option is set', function()
+    command('set tabline=asdf')
+    command('set showtabline=2')
+    screen:expect{grid=[[
+      {1:asdf                                      }|
+      ^                                          |
+      {2:~                                         }|
+      {2:~                                         }|
+                                                |
+    ]], attr_ids={
+      [1] = {reverse = true};
+      [2] = {bold = true, foreground = Screen.colors.Blue1};
+    }}
+    command('set tabline=jkl')
+    screen:expect{grid=[[
+      {1:jkl                                       }|
+      ^                                          |
+      {2:~                                         }|
+      {2:~                                         }|
+                                                |
+    ]], attr_ids={
+      [1] = {reverse = true};
+      [2] = {bold = true, foreground = Screen.colors.Blue};
+    }}
+  end)
+end)


### PR DESCRIPTION
With #20374 tabline option is marked with 'statuslines' redraw flag. But 'statuslines' doesn't redraw tabline. As a result tabline no longer gets redrawn when tabline option is set.

This fixes the issue by adding a new redraw flag P_RTAL to redraw tabline.

@bfredl @zeertzjq