### PR TITLE
feat(lsp): handle multi-root workspaces

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -533,6 +533,19 @@ Example: >
 ==============================================================================
 Lua module: vim.lsp                                                 *lsp-core*
 
+                                              *vim.lsp.add_workspace_folder()*
+add_workspace_folder({folder}, {filter})
+    Add the folder at path to the workspace folders to clients matching the
+    filter
+
+    Parameters: ~
+      • {folder}  string|table|nil will default to CWD
+      • {filter}  (table|nil) A table with key-value pairs used to filter
+                  clients
+
+    Return: ~
+        (boolean|nil) true if workspace was added
+
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*
     Implements the `textDocument/did…` notifications required to track a
     buffer for any language server.
@@ -742,6 +755,30 @@ get_log_path()                                        *vim.lsp.get_log_path()*
     Return: ~
         (String) Path to logfile.
 
+list_workspace_folders({filter})            *vim.lsp.list_workspace_folders()*
+    Registry for client side commands. This is an extension point for plugins
+    to handle custom commands which are not part of the core language server
+    protocol specification.
+
+    The registry is a table where the key is a unique command name, and the
+    value is a function which is called if any LSP action (code action, code
+    lenses, ...) triggers the command.
+
+    If a LSP response contains a command for which no matching entry is
+    available in this registry, the command will be executed via the LSP
+    server using `workspace/executeCommand`.
+
+    The first argument to the function will be the `Command`: Command title:
+    String command: String arguments?: any[]
+
+    The second argument is the `ctx` of |lsp-handler| List workspace folders for clients matching the filter
+
+    Parameters: ~
+      • {filter}  (table|nil) A table with key-value pairs to filter clients
+
+    Return: ~
+        (table|nil) list of `{ uri:string, name: string }`
+
 omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
     Implements 'omnifunc' compatible LSP completion.
 
@@ -758,6 +795,19 @@ omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
         |complete-functions|
         |complete-items|
         |CompleteDone|
+
+                                           *vim.lsp.remove_workspace_folder()*
+remove_workspace_folder({folder}, {filter})
+    Remove the folder at path from the workspace folders in clients matching
+    the filter
+
+    Parameters: ~
+      • {folder}  string|table|nil will default to CWD
+      • {filter}  (table|nil) A table with key-value pairs used to filter
+                  clients
+
+    Return: ~
+        (boolean|nil) true if workspace was removed
 
 set_log_level({level})                               *vim.lsp.set_log_level()*
     Sets the global log level for LSP logging.
@@ -823,6 +873,11 @@ start({config}, {opts})                                      *vim.lsp.start()*
                     Predicate used to decide if a client should be re-used.
                     Used on all running clients. The default implementation
                     re-uses a client if name and root_dir matches.
+                  • workspace_markers (table) list of search patterns used to
+                    determine the workspace root for the current buffer.
+                    Neither `/` nor `$HOME` are allowed!, and any pattern
+                    search that arrives at either will be rejected to prevent
+                    performance issues.
                   • bufnr (number) Buffer handle to attach to if starting or
                     re-using a client (0 for current).
 
@@ -1004,11 +1059,6 @@ with({handler}, {override_config})                            *vim.lsp.with()*
 ==============================================================================
 Lua module: vim.lsp.buf                                              *lsp-buf*
 
-                                          *vim.lsp.buf.add_workspace_folder()*
-add_workspace_folder({workspace_folder})
-    Add the folder at path to the workspace folders. If {path} is not
-    provided, the user will be prompted for a path using |input()|.
-
 clear_references()                            *vim.lsp.buf.clear_references()*
     Removes document highlights from current buffer.
 
@@ -1163,9 +1213,6 @@ incoming_calls()                                *vim.lsp.buf.incoming_calls()*
     window. If the symbol can resolve to multiple items, the user can pick one
     in the |inputlist()|.
 
-list_workspace_folders()                *vim.lsp.buf.list_workspace_folders()*
-    List workspace folders.
-
 outgoing_calls()                                *vim.lsp.buf.outgoing_calls()*
     Lists all the items that are called by the symbol under the cursor in the
     |quickfix| window. If the symbol can resolve to multiple items, the user
@@ -1183,11 +1230,6 @@ references({context}, {options})                    *vim.lsp.buf.references()*
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
-
-                                       *vim.lsp.buf.remove_workspace_folder()*
-remove_workspace_folder({workspace_folder})
-    Remove the folder at path from the workspace folders. If {path} is not
-    provided, the user will be prompted for a path using |input()|.
 
 rename({new_name}, {options})                           *vim.lsp.buf.rename()*
     Renames all references to the symbol under the cursor.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -952,7 +952,7 @@ function lsp.start(config, opts)
   for _, clients in ipairs({ uninitialized_clients, lsp.get_active_clients() }) do
     for _, client in pairs(clients) do
       if reuse_client(client, config, bufnr) then
-        local _ = log.info() and log.info('reusing found matching workspace for', client.name, 'for buffer', bufnr)
+        local _ = log.debug() and log.debug('reusing found matching workspace for', client.name, 'for buffer', bufnr)
         lsp.buf_attach_client(bufnr, client.id)
         return client.id
       end

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -821,10 +821,8 @@ local function resolve_workspace(markers, bufnr)
   bufnr = resolve_bufnr(bufnr)
   local bufname = vim.api.nvim_buf_get_name(bufnr)
   local buf_path = vim.fs.dirname(bufname)
-  local anchor = vim.fs.find(
-    markers,
-    { path = buf_path, stop = vim.loop.os_homedir(), upward = true }
-  )[1]
+  local anchor =
+    vim.fs.find(markers, { path = buf_path, stop = vim.loop.os_homedir(), upward = true })[1]
   if not anchor then
     return
   end
@@ -952,7 +950,8 @@ function lsp.start(config, opts)
   for _, clients in ipairs({ uninitialized_clients, lsp.get_active_clients() }) do
     for _, client in pairs(clients) do
       if reuse_client(client, config, bufnr) then
-        local _ = log.debug() and log.debug('reusing found matching workspace for', client.name, 'for buffer', bufnr)
+        local _ = log.debug()
+          and log.debug('reusing found matching workspace for', client.name, 'for buffer', bufnr)
         lsp.buf_attach_client(bufnr, client.id)
         return client.id
       end
@@ -1409,10 +1408,10 @@ function lsp.start_client(config)
 
       ---@param folder string|table
       client.add_workspace_folder = function(folder)
-        if type(folder) == "string" then
+        if type(folder) == 'string' then
           folder = {
-          uri = vim.uri_from_fname(folder),
-          name = folder,
+            uri = vim.uri_from_fname(folder),
+            name = folder,
           }
         end
         client.workspace_folders = client.workspace_folders or {}
@@ -1431,14 +1430,14 @@ function lsp.start_client(config)
 
       ---@param folder string|table
       client.remove_workspace_folder = function(folder)
-        if type(folder) == "string" then
+        if type(folder) == 'string' then
           folder = {
-          uri = vim.uri_from_fname(folder),
-          name = folder,
+            uri = vim.uri_from_fname(folder),
+            name = folder,
           }
         end
         client.workspace_folders = client.workspace_folders or {}
-        local params = { event = { added = { }, removed = {folder } } }
+        local params = { event = { added = {}, removed = { folder } } }
         for idx, entry in ipairs(client.workspace_folders) do
           if entry.uri == folder.uri then
             client.workspace_folders[idx] = nil
@@ -2447,7 +2446,7 @@ function lsp.list_workspace_folders(filter)
   local workspace_folders = {}
   for _, client in ipairs(lsp.get_active_clients(filter)) do
     for _, folder in ipairs(client.workspace_folders or {}) do
-      workspace_folders[client.name] =workspace_folders[client.name] or {}
+      workspace_folders[client.name] = workspace_folders[client.name] or {}
       table.insert(workspace_folders[client.name], folder)
     end
   end

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -460,78 +460,19 @@ function M.outgoing_calls()
   call_hierarchy('callHierarchy/outgoingCalls')
 end
 
---- List workspace folders.
----
+---@deprecated use |vim.lsp.list_workspace_folder| instead
 function M.list_workspace_folders()
-  local workspace_folders = {}
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
-    for _, folder in pairs(client.workspace_folders or {}) do
-      table.insert(workspace_folders, folder.name)
-    end
-  end
-  return workspace_folders
+  return vim.lsp.list_workspace_folders({ bufnr = 0 })
 end
 
---- Add the folder at path to the workspace folders. If {path} is
---- not provided, the user will be prompted for a path using |input()|.
+---@deprecated use |vim.lsp.add_workspace_folder| instead
 function M.add_workspace_folder(workspace_folder)
-  workspace_folder = workspace_folder
-    or npcall(vim.fn.input, 'Workspace Folder: ', vim.fn.expand('%:p:h'), 'dir')
-  api.nvim_command('redraw')
-  if not (workspace_folder and #workspace_folder > 0) then
-    return
-  end
-  if vim.fn.isdirectory(workspace_folder) == 0 then
-    print(workspace_folder, ' is not a valid directory')
-    return
-  end
-  local params = util.make_workspace_params(
-    { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } },
-    { {} }
-  )
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
-    local found = false
-    for _, folder in pairs(client.workspace_folders or {}) do
-      if folder.name == workspace_folder then
-        found = true
-        print(workspace_folder, 'is already part of this workspace')
-        break
-      end
-    end
-    if not found then
-      vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
-      if not client.workspace_folders then
-        client.workspace_folders = {}
-      end
-      table.insert(client.workspace_folders, params.event.added[1])
-    end
-  end
+  vim.lsp.add_workspace_folder(workspace_folder, { bufnr = 0 })
 end
 
---- Remove the folder at path from the workspace folders. If
---- {path} is not provided, the user will be prompted for
---- a path using |input()|.
+---@deprecated use |vim.lsp.remove_workspace_folder| instead
 function M.remove_workspace_folder(workspace_folder)
-  workspace_folder = workspace_folder
-    or npcall(vim.fn.input, 'Workspace Folder: ', vim.fn.expand('%:p:h'))
-  api.nvim_command('redraw')
-  if not (workspace_folder and #workspace_folder > 0) then
-    return
-  end
-  local params = util.make_workspace_params(
-    { {} },
-    { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } }
-  )
-  for _, client in pairs(vim.lsp.buf_get_clients()) do
-    for idx, folder in pairs(client.workspace_folders) do
-      if folder.name == workspace_folder then
-        vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
-        client.workspace_folders[idx] = nil
-        return
-      end
-    end
-  end
-  print(workspace_folder, 'is not currently part of the workspace')
+  vim.lsp.remove_workspace_folder(workspace_folder, { bufnr = 0 })
 end
 
 --- Lists all symbols in the current workspace in the quickfix window.


### PR DESCRIPTION
### Description

Extend `vim.lsp.start` to handle multi-root workspaces by utilizing "workspace_markers"

state diagram of this workflow

<p align="center">
	<img height="600" src="https://user-images.githubusercontent.com/59826753/197349124-4cc2faa4-2fcc-4afe-a825-2632a045716c.svg">
</p>

### How to test

create `ftplugin/lua.lua` and add the following
<details>
<summary>expand</summary>

```lua
local install_prefix = vim.fn.stdpath "data" .. "/mason/bin"
local bin_name = install_prefix .. "/" .. "lua-language-server"
local cmd = { bin_name }

local root_files = {
  ".luarc.json",
  ".luacheckrc",
  ".stylua.toml",
  "stylua.toml",
  "selene.toml",
  "lua/",
  ".git",
}

local config = {
  cmd = cmd,
  name = "sumneko_lua",
  filetypes = { "lua" },
  workspace_markers = root_files,
  single_file_support = true,
  -- log_level = vim.lsp.protocol.MessageType.Warning,
  settings = {
    Lua = {
      telemetry = { enable = false },
      library = {
        vim.fn.expand "$VIMRUNTIME",
      },
      runtime = {
        version = "LuaJIT",
        special = {
          reload = "require",
        },
      },
      diagnostics = {
        globals = { "vim", "packer_plugins" },
      },
      maxPreload = 5000,
      preloadFileSize = 10000,
    },
  },
  -- on_attach = require("user.lsp").common_on_attach,
  -- on_init = require("user.lsp").common_on_init,
  -- on_exit = require("user.lsp").common_on_exit,
  -- capabilities = require("user.lsp").common_capabilities(),
  flags = {
    debounce_text_changes = 150,
  },
}

vim.lsp.start(config, {})
```

</details>

now start neovim in your config folder for example, and then try to open different lua files:
- if the file is inside `vim.fn.stdpath("config")` then you won't notice anything new
- if the file is outside `vim.fn.stdpath("config")` then you will be prompted to add it to the
current workspace folders, see the chart above for the full workflow.


### Background

`vim.lsp.start()` can re-use a client, but is not sending `workspace/didChangeWorkspaceFolders`, this PR makes that possible

- previous work
  - https://github.com/neovim/neovim/pull/16369
  - https://github.com/neovim/neovim/pull/17149
- currently related work
  - https://github.com/neovim/neovim/pull/18839

### TODOs

- [ ] is `workspace_markers` a good name?
- [ ] should `workspace_markers` be a config key for `lsp.start_client` or leave it as an opt in `lsp.start`
for now?
- [ ] do we need a deprecation notice for `vim.lsp.buf.{add,remove,list}_workspace_folders`?
