### PR TITLE
build: copy each treesitter parser library individually

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -571,7 +571,10 @@ file(MAKE_DIRECTORY ${BINARY_LIB_DIR})
 
 # install treesitter parser if bundled
 if(EXISTS ${DEPS_PREFIX}/lib/nvim/parser)
-  file(COPY ${DEPS_PREFIX}/lib/nvim/parser DESTINATION ${BINARY_LIB_DIR})
+  glob_wrapper(TREESITTER_PARSERS ${DEPS_PREFIX}/lib/nvim/parser/*)
+  foreach(parser_lib ${TREESITTER_PARSERS})
+    file(COPY ${parser_lib} DESTINATION ${BINARY_LIB_DIR}/parser)
+  endforeach()
 endif()
 
 install(DIRECTORY ${BINARY_LIB_DIR}


### PR DESCRIPTION
Copying each .so file one by one, rather than the entire parser
directory, allows newer .so files to overwrite older .so files with the
same name. This is useful when bumping a parser version and rebuilding
neovim without needing to run `make distclean` beforehand.