### PR TITLE
ci(windows): build dependencies with Ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,9 +327,8 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 45
     env:
-      DEPS_BUILD_DIR: ${{ format('{0}/nvim-deps', github.workspace) }}
-      DEPS_PREFIX: ${{ format('{0}/nvim-deps/usr', github.workspace) }}
-      CMAKE_BUILD_TYPE: "RelWithDebInfo"
+      DEPS_BUILD_DIR: ${{ github.workspace }}/nvim-deps
+      DEPS_PREFIX: ${{ github.workspace }}/nvim-deps/usr
     name: windows (MSVC_64)
     steps:
       - uses: actions/checkout@v3
@@ -337,7 +336,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ${{ env.DEPS_BUILD_DIR }}
-          key: ${{ hashFiles('cmake.deps\**') }}
+          key: windows-${{ hashFiles('cmake.deps/**', 'ci/build.ps1') }}
 
       - name: Build deps
         run: .\ci\build.ps1 -BuildDeps
@@ -346,7 +345,6 @@ jobs:
         run: .\ci\build.ps1 -Build
 
       - name: Install test deps
-        continue-on-error: false
         run: .\ci\build.ps1 -EnsureTestDeps
 
       - if: "!cancelled()"


### PR DESCRIPTION
This will save around a minute of CI time for each run. Also clean up
build.ps1 by removing unnecessary code.