### PR TITLE
vim-patch:7.4.{1081,1097},8.2.{0401,0418}: eval tests

### DIFF
--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -88,6 +88,7 @@ func Test_blob_get_range()
   call assert_equal(0z0011223344, b[:])
   call assert_equal(0z0011223344, b[:-1])
   call assert_equal(0z, b[5:6])
+  call assert_equal(0z0011, b[-10:1])
 endfunc
 
 func Test_blob_get()

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -854,7 +854,7 @@ func Test_cmdline_complete_bang()
   endif
 endfunc
 
-funct Test_cmdline_complete_languages()
+func Test_cmdline_complete_languages()
   let lang = substitute(execute('language time'), '.*"\(.*\)"$', '\1', '')
   call assert_equal(lang, v:lc_time)
 
@@ -891,10 +891,8 @@ endfunc
 
 func Test_cmdline_complete_env_variable()
   let $X_VIM_TEST_COMPLETE_ENV = 'foo'
-
   call feedkeys(":edit $X_VIM_TEST_COMPLETE_E\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('"edit $X_VIM_TEST_COMPLETE_ENV', @:)
-
   unlet $X_VIM_TEST_COMPLETE_ENV
 endfunc
 
@@ -1074,17 +1072,13 @@ func Test_cmdline_complete_various()
   call feedkeys(":e `a1b2c\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"e `a1b2c', @:)
 
-  " completion for the expression register
-  call feedkeys(":\"\<C-R>=float2\t\"\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"float2nr("', @=)
-
   " completion for :language command with an invalid argument
   call feedkeys(":language dummy \t\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"language dummy \t", @:)
 
   " completion for commands after a :global command
-  call feedkeys(":g/a\\xb/call float2\t\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"g/a\xb/call float2nr(', @:)
+  call feedkeys(":g/a\\xb/clearj\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"g/a\xb/clearjumps', @:)
 
   " completion with ambiguous user defined commands
   com TCmd1 echo 'TCmd1'
@@ -1097,20 +1091,6 @@ func Test_cmdline_complete_various()
   " completion after a range followed by a pipe (|) character
   call feedkeys(":1,10 | chist\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"1,10 | chistory', @:)
-
-  " completion for window local variables
-  let w:wvar1 = 10
-  let w:wvar2 = 10
-  call feedkeys(":echo w:wvar\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"echo w:wvar1 w:wvar2', @:)
-  unlet w:wvar1 w:wvar2
-
-  " completion for tab local variables
-  let t:tvar1 = 10
-  let t:tvar2 = 10
-  call feedkeys(":echo t:tvar\<C-A>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"echo t:tvar1 t:tvar2', @:)
-  unlet t:tvar1 t:tvar2
 endfunc
 
 func Test_cmdline_write_alternatefile()

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1077,6 +1077,40 @@ func Test_cmdline_complete_various()
   " completion for the expression register
   call feedkeys(":\"\<C-R>=float2\t\"\<C-B>\"\<CR>", 'xt')
   call assert_equal('"float2nr("', @=)
+
+  " completion for :language command with an invalid argument
+  call feedkeys(":language dummy \t\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"language dummy \t", @:)
+
+  " completion for commands after a :global command
+  call feedkeys(":g/a\\xb/call float2\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"g/a\xb/call float2nr(', @:)
+
+  " completion with ambiguous user defined commands
+  com TCmd1 echo 'TCmd1'
+  com TCmd2 echo 'TCmd2'
+  call feedkeys(":TCmd \t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"TCmd ', @:)
+  delcom TCmd1
+  delcom TCmd2
+
+  " completion after a range followed by a pipe (|) character
+  call feedkeys(":1,10 | chist\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"1,10 | chistory', @:)
+
+  " completion for window local variables
+  let w:wvar1 = 10
+  let w:wvar2 = 10
+  call feedkeys(":echo w:wvar\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"echo w:wvar1 w:wvar2', @:)
+  unlet w:wvar1 w:wvar2
+
+  " completion for tab local variables
+  let t:tvar1 = 10
+  let t:tvar2 = 10
+  call feedkeys(":echo t:tvar\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"echo t:tvar1 t:tvar2', @:)
+  unlet t:tvar1 t:tvar2
 endfunc
 
 func Test_cmdline_write_alternatefile()
@@ -1682,16 +1716,16 @@ func Test_wildmode()
   " Test for wildmode=longest with 'fileignorecase' set
   set wildmode=longest
   set fileignorecase
-  argadd AA AAA AAAA
-  call feedkeys(":buffer \t\<C-B>\"\<CR>", 'xt')
-  call assert_equal('"buffer AA', @:)
+  argadd AAA AAAA AAAAA
+  call feedkeys(":buffer a\t\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"buffer AAA', @:)
   set fileignorecase&
 
   " Test for listing files with wildmode=list
   set wildmode=list
   let g:Sline = ''
   call feedkeys(":b A\t\t\<F2>\<C-B>\"\<CR>", 'xt')
-  call assert_equal('AA    AAA   AAAA', g:Sline)
+  call assert_equal('AAA    AAAA   AAAAA', g:Sline)
   call assert_equal('"b A', @:)
 
   %argdelete

--- a/src/nvim/testdir/test_const.vim
+++ b/src/nvim/testdir/test_const.vim
@@ -231,6 +231,14 @@ func Test_const_with_special_variables()
     call assert_fails('const &filetype = "vim"', 'E996:')
     call assert_fails('const &l:filetype = "vim"', 'E996:')
     call assert_fails('const &g:encoding = "utf-8"', 'E996:')
+
+    call assert_fails('const [a, $CONST_FOO] = [369, "abc"]', 'E996:')
+    call assert_equal(369, a)
+    call assert_equal(v:null, getenv("CONST_FOO"))
+
+    call assert_fails('const [b; $CONST_FOO] = [246, 2, "abc"]', 'E996:')
+    call assert_equal(246, b)
+    call assert_equal(v:null, getenv("CONST_FOO"))
 endfunc
 
 func Test_const_with_eval_name()
@@ -274,3 +282,5 @@ func Test_lock_depth_is_2()
     const d2 = #{a: 0, b: lvar, c: 4}
     let d2.b[1] = 'd'
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -1198,6 +1198,33 @@ func Test_diff_maintains_change_mark()
   delfunc DiffMaintainsChangeMark
 endfunc
 
+" Test for 'patchexpr'
+func Test_patchexpr()
+  let g:patch_args = []
+  func TPatch()
+    call add(g:patch_args, readfile(v:fname_in))
+    call add(g:patch_args, readfile(v:fname_diff))
+    call writefile(['output file'], v:fname_out)
+  endfunc
+  set patchexpr=TPatch()
+
+  call writefile(['input file'], 'Xinput')
+  call writefile(['diff file'], 'Xdiff')
+  %bwipe!
+  edit Xinput
+  diffpatch Xdiff
+  call assert_equal('output file', getline(1))
+  call assert_equal('Xinput.new', bufname())
+  call assert_equal(2, winnr('$'))
+  call assert_true(&diff)
+
+  call delete('Xinput')
+  call delete('Xdiff')
+  set patchexpr&
+  delfunc TPatch
+  %bwipe!
+endfunc
+
 func Test_diff_rnu()
   CheckScreendump
 

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -479,12 +479,21 @@ endfunc
 func Test_redir_cmd()
   call assert_fails('redir @@', 'E475:')
   call assert_fails('redir abc', 'E475:')
+  call assert_fails('redir => 1abc', 'E474:')
+  call assert_fails('redir => a b', 'E488:')
+  call assert_fails('redir => abc[1]', 'E475:')
+  let b=0zFF
+  call assert_fails('redir =>> b', 'E734:')
+  unlet b
+
   if has('unix')
+    " Redirecting to a directory name
     call mkdir('Xdir')
     call assert_fails('redir > Xdir', 'E17:')
     call delete('Xdir', 'd')
   endif
   if !has('bsd')
+    " Redirecting to a read-only file
     call writefile([], 'Xfile')
     call setfperm('Xfile', 'r--r--r--')
     call assert_fails('redir! > Xfile', 'E190:')

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -804,6 +804,10 @@ func Test_getbufvar()
   call assert_equal(0, getbufvar(bnr, '&autoindent'))
   call assert_equal(0, getbufvar(bnr, '&autoindent', 1))
 
+  " Set and get a buffer-local variable
+  call setbufvar(bnr, 'bufvar_test', ['one', 'two'])
+  call assert_equal(['one', 'two'], getbufvar(bnr, 'bufvar_test'))
+
   " Open new window with forced option values
   set fileformats=unix,dos
   new ++ff=dos ++bin ++enc=iso-8859-2
@@ -1633,6 +1637,10 @@ func Test_func_sandbox()
 
   call assert_fails('call Fsandbox()', 'E48:')
   delfunc Fsandbox
+
+  " From a sandbox try to set a predefined variable (which cannot be modified
+  " from a sandbox)
+  call assert_fails('sandbox let v:lnum = 10', 'E794:')
 endfunc
 
 func EditAnotherFile()
@@ -2142,14 +2150,6 @@ func Test_range()
 
   " sort()
   call assert_equal([0, 1, 2, 3, 4, 5], sort(range(5, 0, -1)))
-
-  " 'spellsuggest'
-  func MySuggest()
-    return range(3)
-  endfunc
-  set spell spellsuggest=expr:MySuggest()
-  call assert_equal([], spellsuggest('baord', 3))
-  set nospell spellsuggest&
 
   " string()
   call assert_equal('[0, 1, 2, 3, 4]', string(range(5)))

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1199,6 +1199,7 @@ func Test_col()
   norm gg4|mx6|mY2|
   call assert_equal(2, col('.'))
   call assert_equal(7, col('$'))
+  call assert_equal(2, col('v'))
   call assert_equal(4, col("'x"))
   call assert_equal(6, col("'Y"))
   call assert_equal(2, [1, 2]->col())
@@ -1209,6 +1210,19 @@ func Test_col()
   call assert_equal(0, col([2, '$']))
   call assert_equal(0, col([1, 100]))
   call assert_equal(0, col([1]))
+
+  " test for getting the visual start column
+  func T()
+    let g:Vcol = col('v')
+    return ''
+  endfunc
+  let g:Vcol = 0
+  xmap <expr> <F2> T()
+  exe "normal gg3|ve\<F2>"
+  call assert_equal(3, g:Vcol)
+  xunmap <F2>
+  delfunc T
+
   bw!
 endfunc
 

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -63,6 +63,7 @@ function Test_lambda_fails()
   call assert_equal(3, {a, b -> a + b}(1, 2))
   call assert_fails('echo {a, a -> a + a}(1, 2)', 'E853:')
   call assert_fails('echo {a, b -> a + b)}(1, 2)', 'E15:')
+  echo assert_fails('echo 10->{a -> a + 2}', 'E107:')
 endfunc
 
 func Test_not_lambda()

--- a/src/nvim/testdir/test_let.vim
+++ b/src/nvim/testdir/test_let.vim
@@ -25,9 +25,62 @@ func Test_let()
   let s = "\na                     #1\nb                     #2"
   call assert_equal(s, out)
 
+  " Test for displaying a string variable
+  let s = 'vim'
+  let out = execute('let s')
+  let s = "\ns                      vim"
+  call assert_equal(s, out)
+
+  " Test for displaying a list variable
+  let l = [1, 2]
+  let out = execute('let l')
+  let s = "\nl                     [1, 2]"
+  call assert_equal(s, out)
+
+  " Test for displaying a dict variable
+  let d = {'k' : 'v'}
+  let out = execute('let d')
+  let s = "\nd                     {'k': 'v'}"
+  call assert_equal(s, out)
+
+  " Test for displaying a function reference variable
+  let F = function('min')
+  let out = execute('let F')
+  let s = "\nF                     *min()"
+  call assert_equal(s, out)
+
   let x = 0
   if 0 | let x = 1 | endif
   call assert_equal(0, x)
+
+  " Display a list item using an out of range index
+  let l = [10]
+  call assert_fails('let l[1]', 'E684:')
+
+  " List special variable dictionaries
+  let g:Test_Global_Var = 5
+  call assert_match("\nTest_Global_Var       #5", execute('let g:'))
+  unlet g:Test_Global_Var
+
+  let b:Test_Buf_Var = 8
+  call assert_match("\nb:Test_Buf_Var        #8", execute('let b:'))
+  unlet b:Test_Buf_Var
+
+  let w:Test_Win_Var = 'foo'
+  call assert_equal("\nw:Test_Win_Var         foo", execute('let w:'))
+  unlet w:Test_Win_Var
+
+  let t:Test_Tab_Var = 'bar'
+  call assert_equal("\nt:Test_Tab_Var         bar", execute('let t:'))
+  unlet t:Test_Tab_Var
+
+  let s:Test_Script_Var = [7]
+  call assert_match("\ns:Test_Script_Var     \\[7]", execute('let s:'))
+  unlet s:Test_Script_Var
+
+  let l:Test_Local_Var = {'k' : 5}
+  call assert_match("\nl:Test_Local_Var      {'k': 5}", execute('let l:'))
+  call assert_match("v:errors              []", execute('let v:'))
 endfunc
 
 func s:set_arg1(a) abort
@@ -201,16 +254,45 @@ func Test_let_option_error()
   let &fillchars = _w
 endfunc
 
+" Errors with the :let statement
 func Test_let_errors()
   let s = 'abcd'
   call assert_fails('let s[1] = 5', 'E689:')
 
   let l = [1, 2, 3]
   call assert_fails('let l[:] = 5', 'E709:')
+
+  call assert_fails('let x:lnum=5', 'E488:')
+  call assert_fails('let v:=5', 'E461:')
+  call assert_fails('let [a]', 'E474:')
+  call assert_fails('let [a, b] = [', 'E697:')
+  call assert_fails('let [a, b] = [10, 20', 'E696:')
+  call assert_fails('let [a, b] = 10', 'E714:')
+  call assert_fails('let [a, , b] = [10, 20]', 'E475:')
+  call assert_fails('let [a, b&] = [10, 20]', 'E475:')
+  call assert_fails('let $ = 10', 'E475:')
+  call assert_fails('let $FOO[1] = "abc"', 'E18:')
+  call assert_fails('let &buftype[1] = "nofile"', 'E18:')
+  let s = "var"
+  let var = 1
+  call assert_fails('let {s}.1 = 2', 'E18:')
+
+  " This test works only when the language is English
+  if v:lang == "C" || v:lang =~ '^[Ee]n'
+    call assert_fails('let [a ; b;] = [10, 20]',
+          \ 'Double ; in list of variables')
+  endif
 endfunc
 
 func Test_let_heredoc_fails()
   call assert_fails('let v =<< marker', 'E991:')
+  try
+    exe "let v =<< TEXT | abc | TEXT"
+    call assert_report('No exception thrown')
+  catch /E488:/
+  catch
+    call assert_report("Caught exception: " .. v:exception)
+  endtry
 
   let text =<< trim END
   func WrongSyntax()
@@ -243,6 +325,10 @@ func Test_let_heredoc_fails()
   call writefile(text, 'XheredocBadMarker')
   call assert_fails('source XheredocBadMarker', 'E221:')
   call delete('XheredocBadMarker')
+
+  call writefile(['let v =<< TEXT', 'abc'], 'XheredocMissingMarker')
+  call assert_fails('source XheredocMissingMarker', 'E990:')
+  call delete('XheredocMissingMarker')
 endfunc
 
 func Test_let_heredoc_trim_no_indent_marker()
@@ -361,3 +447,5 @@ E
 END
   call assert_equal(['     x', '     \y', '     z'], [a, b, c])
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_let.vim
+++ b/src/nvim/testdir/test_let.vim
@@ -276,6 +276,17 @@ func Test_let_errors()
   let s = "var"
   let var = 1
   call assert_fails('let {s}.1 = 2', 'E18:')
+  call assert_fails('let a[1] = 5', 'E121:')
+  let l = [[1,2]]
+  call assert_fails('let l[:][0] = [5]', 'E708:')
+  let d = {'k' : 4}
+  call assert_fails('let d.# = 5', 'E713:')
+  call assert_fails('let d.m += 5', 'E734:')
+  let l = [1, 2]
+  call assert_fails('let l[2] = 0', 'E684:')
+  call assert_fails('let l[0:1] = [1, 2, 3]', 'E710:')
+  call assert_fails('let l[-2:-3] = [3, 4]', 'E684:')
+  call assert_fails('let l[0:4] = [5, 6]', 'E711:')
 
   " This test works only when the language is English
   if v:lang == "C" || v:lang =~ '^[Ee]n'

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -31,6 +31,7 @@ func Test_list_slice()
   call assert_equal([1, 'as''d', [1, 2, function('strlen')]], l[:-2])
   call assert_equal([1, 'as''d', [1, 2, function('strlen')], {'a': 1}], l[0:8])
   call assert_equal([], l[8:-1])
+  call assert_equal([], l[0:-10])
 endfunc
 
 " List identity
@@ -104,6 +105,8 @@ func Test_list_range_assign()
   let l = [0]
   let l[:] = [1, 2]
   call assert_equal([1, 2], l)
+  let l[-4:-1] = [5, 6]
+  call assert_equal([5, 6], l)
 endfunc
 
 " Test removing items in list
@@ -709,6 +712,12 @@ func Test_listdict_compare()
   call assert_true(d == d)
   call assert_false(l != deepcopy(l))
   call assert_false(d != deepcopy(d))
+
+  " comparison errors
+  call assert_fails('echo [1, 2] =~ {}', 'E691:')
+  call assert_fails('echo [1, 2] =~ [1, 2]', 'E692:')
+  call assert_fails('echo {} =~ 5', 'E735:')
+  call assert_fails('echo {} =~ {}', 'E736:')
 endfunc
 
   " compare complex recursively linked list and dict
@@ -920,6 +929,19 @@ func Test_deep_nested_dict()
   " call assert_fails('let x = execute("echo deep_dict")', 'E724:')
   call test_garbagecollect_now()
   unlet deep_dict
+endfunc
+
+" List and dict indexing tests
+func Test_listdict_index()
+  call assert_fails('echo function("min")[0]', 'E695:')
+  call assert_fails('echo v:true[0]', 'E909:')
+  let d = {'k' : 10}
+  call assert_fails('echo d.', 'E15:')
+  call assert_fails('echo d[1:2]', 'E719:')
+  call assert_fails("let v = [4, 6][{-> 1}]", 'E729:')
+  call assert_fails("let v = range(5)[2:[]]", 'E730:')
+  call assert_fails("let v = range(5)[2:{-> 2}(]", 'E116:')
+  call assert_fails("let v = range(5)[2:3", 'E111:')
 endfunc
 
 " Test for a null list

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -574,6 +574,18 @@ func Test_let_lock_list()
   unlet l
 endfunc
 
+" Locking part of the list
+func Test_let_lock_list_items()
+  let l = [1, 2, 3, 4]
+  lockvar l[2:]
+  call assert_equal(0, islocked('l[0]'))
+  call assert_equal(1, islocked('l[2]'))
+  call assert_equal(1, islocked('l[3]'))
+  call assert_fails('let l[2] = 10', 'E741:')
+  call assert_fails('let l[3] = 20', 'E741:')
+  unlet l
+endfunc
+
 " lockvar/islocked() triggering script autoloading
 func Test_lockvar_script_autoload()
   let old_rtp = &rtp
@@ -870,6 +882,46 @@ func Test_scope_dict()
   call s:check_scope_dict('v', v:true)
 endfunc
 
+" Test for deep nesting of lists (> 100)
+func Test_deep_nested_list()
+  let deep_list = []
+  let l = deep_list
+  for i in range(102)
+    let newlist = []
+    call add(l, newlist)
+    let l = newlist
+  endfor
+  call add(l, 102)
+
+  call assert_fails('let m = deepcopy(deep_list)', 'E698:')
+  call assert_fails('lockvar 110 deep_list', 'E743:')
+  call assert_fails('unlockvar 110 deep_list', 'E743:')
+  " Nvim implements :echo very differently
+  " call assert_fails('let x = execute("echo deep_list")', 'E724:')
+  call test_garbagecollect_now()
+  unlet deep_list
+endfunc
+
+" Test for deep nesting of dicts (> 100)
+func Test_deep_nested_dict()
+  let deep_dict = {}
+  let d = deep_dict
+  for i in range(102)
+    let newdict = {}
+    let d.k = newdict
+    let d = newdict
+  endfor
+  let d.k = 'v'
+
+  call assert_fails('let m = deepcopy(deep_dict)', 'E698:')
+  call assert_fails('lockvar 110 deep_dict', 'E743:')
+  call assert_fails('unlockvar 110 deep_dict', 'E743:')
+  " Nvim implements :echo very differently
+  " call assert_fails('let x = execute("echo deep_dict")', 'E724:')
+  call test_garbagecollect_now()
+  unlet deep_dict
+endfunc
+
 " Test for a null list
 func Test_null_list()
   let l = v:_null_list
@@ -906,3 +958,5 @@ func Test_null_list()
   call assert_equal(1, islocked('l'))
   unlockvar l
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -91,6 +91,15 @@ func Test_setpos()
   call assert_equal([0, 1, 21341234, 0], getpos("'a"))
   call assert_equal(4, virtcol("'a"))
 
+  " Test with invalid buffer number, line number and column number
+  call cursor(2, 2)
+  call setpos('.', [-1, 1, 1, 0])
+  call assert_equal([2, 2], [line('.'), col('.')])
+  call setpos('.', [0, -1, 1, 0])
+  call assert_equal([2, 2], [line('.'), col('.')])
+  call setpos('.', [0, 1, -1, 0])
+  call assert_equal([2, 2], [line('.'), col('.')])
+
   bwipe!
   call win_gotoid(twowin)
   bwipe!

--- a/src/nvim/testdir/test_method.vim
+++ b/src/nvim/testdir/test_method.vim
@@ -35,6 +35,7 @@ func Test_list_method()
   call assert_equal(v:t_list, l->type())
   call assert_equal([1, 2, 3], [1, 1, 2, 3, 3]->uniq())
   call assert_fails('eval l->values()', 'E715:')
+  call assert_fails('echo []->len', 'E107:')
 endfunc
 
 func Test_dict_method()

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -514,6 +514,7 @@ func Test_normal10_expand()
 
   " Test expand(`=...`) i.e. backticks expression expansion
   call assert_equal('5', expand('`=2+3`'))
+  call assert_equal('3.14', expand('`=3.14`'))
 
   " clean up
   bw!

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -474,6 +474,35 @@ func Test_spellsuggest_option_expr()
   bwipe!
 endfunc
 
+" Test for 'spellsuggest' expr errrors
+func Test_spellsuggest_expr_errors()
+  " 'spellsuggest'
+  func MySuggest()
+    return range(3)
+  endfunc
+  set spell spellsuggest=expr:MySuggest()
+  call assert_equal([], spellsuggest('baord', 3))
+
+  " Test for 'spellsuggest' expression returning a non-list value
+  func! MySuggest2()
+    return 'good'
+  endfunc
+  set spellsuggest=expr:MySuggest2()
+  call assert_equal([], spellsuggest('baord'))
+
+  " Test for 'spellsuggest' expression returning a list with dict values
+  func! MySuggest3()
+    return [[{}, {}]]
+  endfunc
+  set spellsuggest=expr:MySuggest3()
+  call assert_fails("call spellsuggest('baord')", 'E728:')
+
+  set nospell spellsuggest&
+  delfunc MySuggest
+  delfunc MySuggest2
+  delfunc MySuggest3
+endfunc
+
 func Test_spellsuggest_timeout()
   set spellsuggest=timeout:30
   set spellsuggest=timeout:-123

--- a/src/nvim/testdir/test_unlet.vim
+++ b/src/nvim/testdir/test_unlet.vim
@@ -20,6 +20,7 @@ endfunc
 
 func Test_unlet_fails()
   call assert_fails('unlet v:["count"]', 'E46:')
+  call assert_fails('unlet $', 'E475:')
 endfunc
 
 func Test_unlet_env()
@@ -55,3 +56,5 @@ func Test_unlet_complete()
   call feedkeys(":unlet $FOO\t\n", 'tx')
   call assert_true(!exists('$FOOBAR') || empty($FOOBAR))
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_unlet.vim
+++ b/src/nvim/testdir/test_unlet.vim
@@ -21,6 +21,12 @@ endfunc
 func Test_unlet_fails()
   call assert_fails('unlet v:["count"]', 'E46:')
   call assert_fails('unlet $', 'E475:')
+  let v = {}
+  call assert_fails('unlet v[:]', 'E719:')
+  let l = []
+  call assert_fails("unlet l['k'", 'E111:')
+  let d = {'k' : 1}
+  call assert_fails("unlet d.k2", 'E716:')
 endfunc
 
 func Test_unlet_env()

--- a/src/nvim/testdir/test_unlet.vim
+++ b/src/nvim/testdir/test_unlet.vim
@@ -7,6 +7,12 @@ func Test_read_only()
   catch
     call assert_true(v:exception =~ ':E795:')
   endtry
+  try
+    " this caused a crash
+    unlet v:errmsg
+  catch
+    call assert_true(v:exception =~ ':E795:')
+  endtry
 endfunc
 
 func Test_existing()

--- a/src/nvim/testdir/test_unlet.vim
+++ b/src/nvim/testdir/test_unlet.vim
@@ -1,18 +1,9 @@
 " Tests for :unlet
 
 func Test_read_only()
-  try
-    " this caused a crash
-    unlet v:count
-  catch
-    call assert_true(v:exception =~ ':E795:')
-  endtry
-  try
-    " this caused a crash
-    unlet v:errmsg
-  catch
-    call assert_true(v:exception =~ ':E795:')
-  endtry
+  " these caused a crash
+  call assert_fails('unlet v:count', 'E795:')
+  call assert_fails('unlet v:errmsg', 'E795:')
 endfunc
 
 func Test_existing()
@@ -24,11 +15,7 @@ endfunc
 
 func Test_not_existing()
   unlet! does_not_exist
-  try
-    unlet does_not_exist
-  catch
-    call assert_true(v:exception =~ ':E108:')
-  endtry
+  call assert_fails('unlet does_not_exist', 'E108:')
 endfunc
 
 func Test_unlet_fails()

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -87,6 +87,9 @@ func Test_user_func()
   call assert_fails("call extend(g:, {'max': function('min')})", 'E704')
   call assert_equal(3, max([1, 2, 3]))
 
+  " Try to overwrite an user defined function with a function reference
+  call assert_fails("let Expr1 = function('min')", 'E705:')
+
   " Regression: the first line below used to throw ?E110: Missing ')'?
   " Second is here just to prove that this line is correct when not skipping
   " rhs of &&.

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -617,6 +617,27 @@ func Test_command_list()
   call assert_equal("\nNo user-defined commands found", execute('command'))
 endfunc
 
+" Test for a custom user completion returning the wrong value type
+func Test_usercmd_custom()
+  func T1(a, c, p)
+    return "a\nb\n"
+  endfunc
+  command -nargs=* -complete=customlist,T1 TCmd1
+  call feedkeys(":T1 \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"T1 ', @:)
+  delcommand TCmd1
+  delfunc T1
+
+  func T2(a, c, p)
+    return ['a', 'b', 'c']
+  endfunc
+  command -nargs=* -complete=customlist,T2 TCmd2
+  call feedkeys(":T2 \<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"T2 ', @:)
+  delcommand TCmd2
+  delfunc T2
+endfunc
+
 func Test_delcommand_buffer()
   command Global echo 'global'
   command -buffer OneBuffer echo 'one'

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1656,6 +1656,8 @@ func Test_compound_assignment_operators()
       call assert_equal(4.2, x)
       call assert_fails('let x %= 0.5', 'E734')
       call assert_fails('let x .= "f"', 'E734')
+      let x = !3.14
+      call assert_equal(0.0, x)
     endif
 
     " Test for environment variable
@@ -1940,6 +1942,20 @@ func Test_sfile_in_function()
   endfunc
   call Xfunc()
   delfunc Xfunc
+endfunc
+
+" Test for errors in converting to float from various types         {{{1
+func Test_float_conversion_errors()
+  if has('float')
+    call assert_fails('let x = 4.0 % 2.0', 'E804')
+    call assert_fails('echo 1.1[0]', 'E806')
+    call assert_fails('echo sort([function("min"), 1], "f")', 'E891:')
+    call assert_fails('echo 3.2 == "vim"', 'E892:')
+    call assert_fails('echo sort([[], 1], "f")', 'E893:')
+    call assert_fails('echo sort([{}, 1], "f")', 'E894:')
+    call assert_fails('echo 3.2 == v:true', 'E362:')
+    " call assert_fails('echo 3.2 == v:none', 'E907:')
+  endif
 endfunc
 
 func Test_for_over_string()

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1542,6 +1542,9 @@ func Test_delfunction_force()
     endfunc
     delfunc! Xtest
     delfunc! Xtest
+
+    " Try deleting the current function
+    call assert_fails('delfunc Test_delfunction_force', 'E131:')
 endfunc
 
 " Test using bang after user command				    {{{1

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -592,6 +592,11 @@ func Test_window_contents()
   call assert_equal(59, line("w0"))
   call assert_equal('59 ', s3)
 
+  %d
+  call setline(1, ['one', 'two', 'three'])
+  call assert_equal(1, line('w0'))
+  call assert_equal(3, line('w$'))
+
   bwipeout!
   call test_garbagecollect_now()
 endfunc


### PR DESCRIPTION
#### vim-patch:7.4.1081

Problem:    No test for what previously caused a crash.
Solution:   Add test for unletting errmsg.

https://github.com/vim/vim/commit/254b105b755d9736ece5f7f28db92acaf3e7bf76

Use v:errmsg instead of errmsg.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:7.4.1097

Problem:    Looking up the alloc ID for tests fails.
Solution:   Fix the line computation.  Use assert_fails() for unlet test.

https://github.com/vim/vim/commit/065ee9aebf9abe08ae8c0dba7d05cbdcc423c8e0

Use v:count and v:errmsg instead of count and errmsg.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0401: not enough test coverage for evalvars.c

Problem:    Not enough test coverage for evalvars.c.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5804)

https://github.com/vim/vim/commit/8dfcce3a78ccb520cc9d09081f998091494c50bf

Assert E475 instead of E474 in :redir test because a later patch changed
the error number.

Comment out the test for :echo with a deeply nested container as Nvim
implements :echo very differently.


#### vim-patch:8.2.0418: code in eval.c not sufficiently covered by tests

Problem:    Code in eval.c not sufficiently covered by tests.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5815)

https://github.com/vim/vim/commit/8b633135106dda8605463b780573c45b00c22afe

Nvim does not have v:none, so comment out test for it.