### PR TITLE
docs(api): pattern is not expanded for autocommands

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3267,6 +3267,12 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
       pattern = { "*.py", "*.pyi" }
 <
 
+    Note: The `pattern` is passed to callbacks and commands as a literal string; environment
+    variables like `$HOME` and `~` are not automatically expanded as they are by |:autocmd|. Instead,
+    |expand()| such variables explicitly: >
+      pattern = vim.fn.expand("~") .. "/some/path/*.py"
+<
+
     Example values for event: >
       "BufWritePre"
       {"CursorHold", "BufWritePre", "BufWritePost"}
@@ -3279,7 +3285,7 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
                  • group (string|integer) optional: the autocommand group name
                    or id to match against.
                  • pattern (string|array) optional: pattern or patterns to
-                   match against |autocmd-pattern|.
+                   match literally against |autocmd-pattern|.
                  • buffer (integer) optional: buffer number for buffer local
                    autocommands |autocmd-buflocal|. Cannot be used with
                    {pattern}.

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -401,6 +401,13 @@ cleanup:
 ///   pattern = { "*.py", "*.pyi" }
 /// </pre>
 ///
+/// Note: The `pattern` is passed to callbacks and commands as a literal string; environment
+/// variables like `$HOME` and `~` are not automatically expanded as they are by |:autocmd|.
+/// Instead, |expand()| such variables explicitly:
+/// <pre>
+///   pattern = vim.fn.expand("~") .. "/some/path/*.py"
+/// </pre>
+///
 /// Example values for event:
 /// <pre>
 ///   "BufWritePre"
@@ -411,7 +418,7 @@ cleanup:
 /// @param opts Dictionary of autocommand options:
 ///             - group (string|integer) optional: the autocommand group name or
 ///             id to match against.
-///             - pattern (string|array) optional: pattern or patterns to match
+///             - pattern (string|array) optional: pattern or patterns to match literally
 ///             against |autocmd-pattern|.
 ///             - buffer (integer) optional: buffer number for buffer local autocommands
 ///             |autocmd-buflocal|. Cannot be used with {pattern}.


### PR DESCRIPTION
Problem: Unlike `:autocmd`, `nvim_create_autocommand()` does not expand environment variables in the `pattern`, which is unexpected.

Solution: Add a note to the documentation explaining this and suggesting using `expand()` explicitly.

Closes #17744
