### PR TITLE
vim-patch:8.2.{0162,0163}

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1320,6 +1320,9 @@ func Test_balloon_show()
 
   " This won't do anything but must not crash either.
   call balloon_show('hi!')
+  if !has('gui_running')
+    call balloon_show(range(3))
+  endif
 endfunc
 
 func Test_shellescape()

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -2038,15 +2038,10 @@ func Test_range()
   call assert_equal(1, index(range(1, 5), 2))
 
   " inputlist()
-  " call test_feedinput("1\<CR>")
-  call nvim_input('1<CR>')
-  call assert_equal(1, inputlist(range(10)))
-  " call test_feedinput("1\<CR>")
-  call nvim_input('1<CR>')
-  call assert_equal(1, inputlist(range(3, 10)))
-
-  " call assert_equal('[0,1,2,3]', json_encode(range(4)))
-  call assert_equal('[0, 1, 2, 3]', json_encode(range(4)))
+  call feedkeys(":let result = inputlist(range(10))\<CR>1\<CR>", 'x')
+  call assert_equal(1, result)
+  call feedkeys(":let result = inputlist(range(3, 10))\<CR>1\<CR>", 'x')
+  call assert_equal(1, result)
 
   " insert()
   call assert_equal([42, 1, 2, 3, 4, 5], insert(range(1, 5), 42))
@@ -2058,6 +2053,10 @@ func Test_range()
 
   " join()
   call assert_equal('0 1 2 3 4', join(range(5)))
+
+  " json_encode()
+  " call assert_equal('[0,1,2,3]', json_encode(range(4)))
+  call assert_equal('[0, 1, 2, 3]', json_encode(range(4)))
 
   " len()
   call assert_equal(0, len(range(0)))


### PR DESCRIPTION
#### vim-patch:8.2.0162: balloon test fails in the GUI

Problem:    Balloon test fails in the GUI.
Solution:   Skip test in the GUI.

https://github.com/vim/vim/commit/7d8ea0b24191d64155fcf9e8d2d2eefff91ae549

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0163: test hangs on MS-Windows console

Problem:    Test hangs on MS-Windows console.
Solution:   use feedkeys() instead of test_feedinput(). (Ken Takata)

https://github.com/vim/vim/commit/272ca95fc3d21ae1e2626a7aec38a6990e88ad6b

Co-authored-by: Bram Moolenaar <Bram@vim.org>