### PR TITLE
vim-patch:8.1.1826,9.0.0019

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -39,6 +39,22 @@ func CheckFunction(name)
   endif
 endfunc
 
+" Command to check for the presence of an Ex command
+command -nargs=1 CheckCommand call CheckCommand(<f-args>)
+func CheckCommand(name)
+  if !exists(':' .. a:name)
+    throw 'Skipped: ' .. a:name .. ' command not supported'
+  endif
+endfunc
+
+" Command to check for the presence of a shell command
+command -nargs=1 CheckExecutable call CheckExecutable(<f-args>)
+func CheckExecutable(name)
+  if !executable(a:name)
+    throw 'Skipped: ' .. a:name .. ' program not executable'
+  endif
+endfunc
+
 " Command to check for the presence of python.  Argument should have been
 " obtained with PythonProg()
 func CheckPython(name)

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -4,9 +4,8 @@
 " while the test is run, the breakindent caching gets in its way.
 " It helps to change the tabstop setting and force a redraw (e.g. see
 " Test_breakindent08())
-if !exists('+breakindent')
-  throw 'Skipped: breakindent option not supported'
-endif
+source check.vim
+CheckOption breakindent
 
 source view_util.vim
 

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -2,6 +2,7 @@
 
 source shared.vim
 source screendump.vim
+source check.vim
 
 func Test_setbufline_getbufline()
   new
@@ -130,9 +131,8 @@ func Test_deletebufline()
 endfunc
 
 func Test_appendbufline_redraw()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckScreendump
+
   let lines =<< trim END
     new foo
     let winnr = 'foo'->bufwinnr()

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1,5 +1,6 @@
 " Test for folding
 
+source check.vim
 source view_util.vim
 source screendump.vim
 
@@ -727,9 +728,7 @@ func Test_fold_last_line_with_pagedown()
 endfunc
 
 func Test_folds_with_rnu()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckScreendump
 
   call writefile([
 	\ 'set fdm=marker rnu foldcolumn=2',

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1745,9 +1745,8 @@ endfunc
 func Test_confirm()
   " requires a UI to be active
   throw 'Skipped: use test/functional/vimscript/input_spec.lua'
-  if !has('unix') || has('gui_running')
-    return
-  endif
+  CheckUnix
+  CheckNotGui
 
   call feedkeys('o', 'L')
   let a = confirm('Press O to proceed')

--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -536,9 +536,7 @@ func Test_termguicolors()
 endfunc
 
 func Test_cursorline_after_yank()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckScreendump
 
   call writefile([
 	\ 'set cul rnu',
@@ -578,9 +576,7 @@ func Test_put_before_cursorline()
 endfunc
 
 func Test_cursorline_with_visualmode()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckScreendump
 
   call writefile([
 	\ 'set cul',

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -395,7 +395,9 @@ func Test_motionforce_omap()
 endfunc
 
 func Test_error_in_map_expr()
-  if !has('terminal') || (has('win32') && has('gui_running'))
+  " Unlike CheckRunVimInTerminal this does work in a win32 console
+  CheckFeature terminal
+  if has('win32') && has('gui_running')
     throw 'Skipped: cannot run Vim in a terminal window'
   endif
 

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -322,9 +322,8 @@ func OtherWindowCommon()
 endfunc
 
 func Test_matchdelete_other_window()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckScreendump
+
   let buf = OtherWindowCommon()
   call term_sendkeys(buf, ":call matchdelete(mid, winid)\<CR>")
   call VerifyScreenDump(buf, 'Test_matchdelete_1', {})

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -432,9 +432,8 @@ endfunc
 
 " Must be executed before other tests that set 'term'.
 func Test_000_term_option_verbose()
-  if has('nvim') || has('gui_running')
-    return
-  endif
+  throw "Skipped: Nvim does not support setting 'term'"
+  CheckNotGui
 
   call CheckWasNotSet('t_cm')
 

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -677,9 +677,9 @@ func Test_complete_CTRLN_startofbuffer()
 endfunc
 
 func Test_popup_and_window_resize()
-  if !has('terminal') || has('gui_running')
-    return
-  endif
+  CheckFeature terminal
+  CheckNotGui
+
   let h = winheight(0)
   if h < 15
     return
@@ -948,9 +948,9 @@ func Test_complete_o_tab()
 endfunc
 
 func Test_menu_only_exists_in_terminal()
-  if !exists(':tlmenu') || has('gui_running')
-    return
-  endif
+  CheckCommand tlmenu
+  CheckNotGui
+
   tlnoremenu  &Edit.&Paste<Tab>"+gP  <C-W>"+
   aunmenu *
   try

--- a/src/nvim/testdir/test_signals.vim
+++ b/src/nvim/testdir/test_signals.vim
@@ -16,8 +16,9 @@ endfunc
 " Test signal WINCH (window resize signal)
 func Test_signal_WINCH()
   throw 'skipped: Nvim cannot avoid terminal resize'
-  if has('gui_running') || !HasSignal('WINCH')
-    return
+  CheckNotGui
+  if !HasSignal('WINCH')
+    throw 'Skipped: WINCH signal not supported'
   endif
 
   " We do not actually want to change the size of the terminal.

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -267,10 +267,9 @@ endfunc
 
 " Test the -V[N] argument to set the 'verbose' option to [N]
 func Test_V_arg()
-  if has('gui_running')
-    " Can't catch the output of gvim.
-    return
-  endif
+  " Can't catch the output of gvim.
+  CheckNotGui
+
   let out = system(GetVimCommand() . ' --clean -es -X -V0 -c "set verbose?" -cq')
   call assert_equal("  verbose=0\n", out)
 
@@ -543,10 +542,9 @@ endfunc
 
 
 func Test_invalid_args()
-  if !has('unix') || has('gui_running')
-    " can't get output of Vim.
-    return
-  endif
+  " must be able to get the output of Vim.
+  CheckUnix
+  CheckNotGui
 
   for opt in ['-Y', '--does-not-exist']
     let out = split(system(GetVimCommand() .. ' ' .. opt), "\n")
@@ -747,10 +745,9 @@ func Test_progpath()
 endfunc
 
 func Test_silent_ex_mode()
-  if !has('unix') || has('gui_running')
-    " can't get output of Vim.
-    return
-  endif
+  " must be able to get the output of Vim.
+  CheckUnix
+  CheckNotGui
 
   " This caused an ml_get error.
   let out = system(GetVimCommand() . ' -u NONE -es -c''set verbose=1|h|exe "%norm\<c-y>\<c-d>"'' -c cq')
@@ -758,10 +755,9 @@ func Test_silent_ex_mode()
 endfunc
 
 func Test_default_term()
-  if !has('unix') || has('gui_running')
-    " can't get output of Vim.
-    return
-  endif
+  " must be able to get the output of Vim.
+  CheckUnix
+  CheckNotGui
 
   let save_term = $TERM
   let $TERM = 'unknownxxx'
@@ -794,6 +790,15 @@ func Test_zzz_startinsert()
     call assert_equal(['123456foobar'], lines)
   endif
   call delete('Xtestout')
+endfunc
+
+func Test_issue_3969()
+  " Can't catch the output of gvim.
+  CheckNotGui
+
+  " Check that message is not truncated.
+  let out = system(GetVimCommand() . ' -es -X -V1 -c "echon ''hello''" -cq')
+  call assert_equal('hello', out)
 endfunc
 
 func Test_start_with_tabs()

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -489,9 +489,8 @@ func Test_conceal()
 endfunc
 
 func Test_bg_detection()
-  if has('gui_running')
-    return
-  endif
+  CheckNotGui
+
   " auto-detection of &bg, make sure sure it isn't set anywhere before
   " this test
   hi Normal ctermbg=0

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -263,8 +263,9 @@ func Interrupt(timer)
 endfunc
 
 func Test_timer_peek_and_get_char()
-  CheckUnix
-  CheckGui
+  if !has('unix') && !has('gui_running')
+    throw 'Skipped: cannot feed low-level input'
+  endif
 
   call timer_start(0, 'FeedAndPeek')
   let intr = timer_start(100, 'Interrupt')
@@ -275,8 +276,9 @@ endfunc
 
 func Test_timer_getchar_zero()
   if has('win32') && !has('gui_running')
-    throw 'Skipped: cannot get low-level input'
+    throw 'Skipped: cannot feed low-level input'
   endif
+  CheckFunction reltimefloat
 
   " Measure the elapsed time to avoid a hang when it fails.
   let start = reltime()

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -263,9 +263,9 @@ func Interrupt(timer)
 endfunc
 
 func Test_timer_peek_and_get_char()
-  if !has('unix') && !has('gui_running')
-    return
-  endif
+  CheckUnix
+  CheckGui
+
   call timer_start(0, 'FeedAndPeek')
   let intr = timer_start(100, 'Interrupt')
   let c = getchar()
@@ -275,8 +275,7 @@ endfunc
 
 func Test_timer_getchar_zero()
   if has('win32') && !has('gui_running')
-    " Console: no low-level input
-    return
+    throw 'Skipped: cannot get low-level input'
   endif
 
   " Measure the elapsed time to avoid a hang when it fails.

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1747,10 +1747,7 @@ func Test_funccall_garbage_collect()
 endfunc
 
 func Test_function_defined_line()
-    if has('gui_running')
-        " Can't catch the output of gvim.
-        return
-    endif
+    CheckNotGui
 
     let lines =<< trim [CODE]
     " F1


### PR DESCRIPTION
#### vim-patch:8.1.1826: tests use hand coded feature and option checks

Problem:    Tests use hand coded feature and option checks.
Solution:   Use the commands from check.vim in more tests.

https://github.com/vim/vim/commit/8c5a278fc508da6dfe50e69b6ee734451aa4eafb

Omit Test_wincolor(): there are later patches that touch that function.
Omit test_memory_usage.vim: a Lua test is used for that file.
Cherry-pick Test_issue_3969() from patch 8.1.0969.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0019: timers test not run where possible

Problem:    Timers test not run where possible.
Solution:   Adjust platform checks. (closes vim/vim#10645)

https://github.com/vim/vim/commit/eb273cd7b036c35ae9070bd6352101914f273e71

Cherry-pick a line from patch 8.2.0183.