### PR TITLE
vim-patch:8.2.{0531,0534,0606,1113}: various tests

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -179,4 +179,4 @@ newtestssilent: $(NEW_TESTS_RES)
 	@echo "[OLDTEST] Running" $*
 	@rm -rf $*.failed test.ok $(RM_ON_RUN)
 	@mkdir -p $(TMPDIR)
-	@/bin/sh runnvim.sh $(ROOT) $(NVIM_PRG) $* $(RUN_VIMTEST) $(NO_INITS) -u NONE -S runtest.vim $*.vim
+	@/bin/sh runnvim.sh $(ROOT) $(NVIM_PRG) $* $(RUN_VIMTEST) $(NO_INITS) -u NONE --cmd "set shortmess-=F" -S runtest.vim $*.vim

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -147,7 +147,7 @@ func Test_client_server()
 
     " Edit files in separate tab pages
     call system(cmd .. ' --remote-tab Xfile1 Xfile2 Xfile3')
-    call assert_equal('3', remote_expr(name, 'tabpagenr("$")'))
+    call WaitForAssert({-> assert_equal('3', remote_expr(name, 'tabpagenr("$")'))})
     call assert_equal('Xfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
     eval name->remote_send(":%bw!\<CR>")
 

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -87,4 +87,10 @@ func Test_source_autocmd_sfile()
   call delete('Xscript.vim')
 endfunc
 
+func Test_source_error()
+  call assert_fails('scriptencoding utf-8', 'E167:')
+  call assert_fails('finish', 'E168:')
+  " call assert_fails('scriptversion 2', 'E984:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -363,6 +363,64 @@ func Test_syntax_invalid_arg()
   call assert_fails('syntax sync x', 'E404:')
   call assert_fails('syntax keyword Abc a[', 'E789:')
   call assert_fails('syntax keyword Abc a[bc]d', 'E890:')
+
+  let caught_393 = 0
+  try
+    syntax keyword cMyItem grouphere G1
+  catch /E393:/
+    let caught_393 = 1
+  endtry
+  call assert_equal(1, caught_393)
+
+  let caught_394 = 0
+  try
+    syntax sync match Abc grouphere MyItem "abc"'
+  catch /E394:/
+    let caught_394 = 1
+  endtry
+  call assert_equal(1, caught_394)
+
+  " Test for too many \z\( and unmatched \z\(
+  " Not able to use assert_fails() here because both E50:/E879: and E475:
+  " messages are emitted.
+  set regexpengine=1
+  let caught_52 = 0
+  try
+    syntax region MyRegion start='\z\(' end='\*/'
+  catch /E52:/
+    let caught_52 = 1
+  endtry
+  call assert_equal(1, caught_52)
+
+  let caught_50 = 0
+  try
+    let cmd = "syntax region MyRegion start='"
+    let cmd ..= repeat("\\z\\(.\\)", 10) .. "' end='\*/'"
+    exe cmd
+  catch /E50:/
+    let caught_50 = 1
+  endtry
+  call assert_equal(1, caught_50)
+
+  set regexpengine=2
+  let caught_54 = 0
+  try
+    syntax region MyRegion start='\z\(' end='\*/'
+  catch /E54:/
+    let caught_54 = 1
+  endtry
+  call assert_equal(1, caught_54)
+
+  let caught_879 = 0
+  try
+    let cmd = "syntax region MyRegion start='"
+    let cmd ..= repeat("\\z\\(.\\)", 10) .. "' end='\*/'"
+    exe cmd
+  catch /E879:/
+    let caught_879 = 1
+  endtry
+  call assert_equal(1, caught_879)
+  set regexpengine&
 endfunc
 
 func Test_syn_sync()

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -225,6 +225,17 @@ func Test_endfunction_trailing()
   delfunc Xtest
   set verbose=0
 
+  func Xtest(a1, a2)
+    echo a:a1 .. a:a2
+  endfunc
+  set verbose=15
+  redir @a
+  call Xtest(123, repeat('x', 100))
+  redir END
+  call assert_match('calling Xtest(123, ''xxxxxxx.*x\.\.\.x.*xxxx'')', getreg('a'))
+  delfunc Xtest
+  set verbose=0
+
   function Foo()
     echo 'hello'
   endfunction | echo 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -3,6 +3,9 @@
 " Also test that a builtin function cannot be replaced.
 " Also test for regression when calling arbitrary expression.
 
+source check.vim
+source shared.vim
+
 func Table(title, ...)
   let ret = a:title
   let idx = 1
@@ -83,6 +86,7 @@ func Test_user_func()
   normal o[(one again
   call assert_equal('1. one again', getline('.'))
 
+  " Try to overwrite a function in the global (g:) scope
   call assert_equal(3, max([1, 2, 3]))
   call assert_fails("call extend(g:, {'max': function('min')})", 'E704')
   call assert_equal(3, max([1, 2, 3]))
@@ -176,6 +180,258 @@ endfunc
 " Test for listing user-defined functions
 func Test_function_list()
   call assert_fails("function Xabc", 'E123:')
+endfunc
+
+" Test for <sfile>, <slnum> in a function
+func Test_sfile_in_function()
+  func Xfunc()
+    call assert_match('..Test_sfile_in_function\[5]..Xfunc', expand('<sfile>'))
+    call assert_equal('2', expand('<slnum>'))
+  endfunc
+  call Xfunc()
+  delfunc Xfunc
+endfunc
+
+" Test trailing text after :endfunction				    {{{1
+func Test_endfunction_trailing()
+  call assert_false(exists('*Xtest'))
+
+  exe "func Xtest()\necho 'hello'\nendfunc\nlet done = 'yes'"
+  call assert_true(exists('*Xtest'))
+  call assert_equal('yes', done)
+  delfunc Xtest
+  unlet done
+
+  exe "func Xtest()\necho 'hello'\nendfunc|let done = 'yes'"
+  call assert_true(exists('*Xtest'))
+  call assert_equal('yes', done)
+  delfunc Xtest
+  unlet done
+
+  " trailing line break
+  exe "func Xtest()\necho 'hello'\nendfunc\n"
+  call assert_true(exists('*Xtest'))
+  delfunc Xtest
+
+  set verbose=1
+  exe "func Xtest()\necho 'hello'\nendfunc \" garbage"
+  call assert_notmatch('W22:', split(execute('1messages'), "\n")[0])
+  call assert_true(exists('*Xtest'))
+  delfunc Xtest
+
+  exe "func Xtest()\necho 'hello'\nendfunc garbage"
+  call assert_match('W22:', split(execute('1messages'), "\n")[0])
+  call assert_true(exists('*Xtest'))
+  delfunc Xtest
+  set verbose=0
+
+  function Foo()
+    echo 'hello'
+  endfunction | echo 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+  delfunc Foo
+endfunc
+
+func Test_delfunction_force()
+  delfunc! Xtest
+  delfunc! Xtest
+  func Xtest()
+    echo 'nothing'
+  endfunc
+  delfunc! Xtest
+  delfunc! Xtest
+
+  " Try deleting the current function
+  call assert_fails('delfunc Test_delfunction_force', 'E131:')
+endfunc
+
+func Test_function_defined_line()
+  CheckNotGui
+
+  let lines =<< trim [CODE]
+  " F1
+  func F1()
+    " F2
+    func F2()
+      "
+      "
+      "
+      return
+    endfunc
+    " F3
+    execute "func F3()\n\n\n\nreturn\nendfunc"
+    " F4
+    execute "func F4()\n
+                \\n
+                \\n
+                \\n
+                \return\n
+                \endfunc"
+  endfunc
+  " F5
+  execute "func F5()\n\n\n\nreturn\nendfunc"
+  " F6
+  execute "func F6()\n
+              \\n
+              \\n
+              \\n
+              \return\n
+              \endfunc"
+  call F1()
+  verbose func F1
+  verbose func F2
+  verbose func F3
+  verbose func F4
+  verbose func F5
+  verbose func F6
+  qall!
+  [CODE]
+
+  call writefile(lines, 'Xtest.vim')
+  let res = system(GetVimCommandClean() .. ' -es -X -S Xtest.vim')
+  call assert_equal(0, v:shell_error)
+
+  let m = matchstr(res, 'function F1()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 2$', m)
+
+  let m = matchstr(res, 'function F2()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 4$', m)
+
+  let m = matchstr(res, 'function F3()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 11$', m)
+
+  let m = matchstr(res, 'function F4()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 13$', m)
+
+  let m = matchstr(res, 'function F5()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 21$', m)
+
+  let m = matchstr(res, 'function F6()[^[:print:]]*[[:print:]]*')
+  call assert_match(' line 23$', m)
+
+  call delete('Xtest.vim')
+endfunc
+
+" Test for defining a function reference in the global scope
+func Test_add_funcref_to_global_scope()
+  let x = g:
+  let caught_E862 = 0
+  try
+    func x.Xfunc()
+      return 1
+    endfunc
+  catch /E862:/
+    let caught_E862 = 1
+  endtry
+  call assert_equal(1, caught_E862)
+endfunc
+
+func Test_funccall_garbage_collect()
+  func Func(x, ...)
+    call add(a:x, a:000)
+  endfunc
+  call Func([], [])
+  " Must not crash cause by invalid freeing
+  call test_garbagecollect_now()
+  call assert_true(v:true)
+  delfunc Func
+endfunc
+
+" Test for script-local function
+func <SID>DoLast()
+  call append(line('$'), "last line")
+endfunc
+
+func s:DoNothing()
+  call append(line('$'), "nothing line")
+endfunc
+
+func Test_script_local_func()
+  set nocp nomore viminfo+=nviminfo
+  new
+  nnoremap <buffer> _x	:call <SID>DoNothing()<bar>call <SID>DoLast()<bar>delfunc <SID>DoNothing<bar>delfunc <SID>DoLast<cr>
+
+  normal _x
+  call assert_equal('nothing line', getline(2))
+  call assert_equal('last line', getline(3))
+  close!
+
+  " Try to call a script local function in global scope
+  let lines =<< trim [CODE]
+    :call assert_fails('call s:Xfunc()', 'E81:')
+    :call assert_fails('let x = call("<SID>Xfunc", [])', 'E120:')
+    :call writefile(v:errors, 'Xresult')
+    :qall
+
+  [CODE]
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '-s Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xresult')
+  call delete('Xscript')
+endfunc
+
+" Test for errors in defining new functions
+func Test_func_def_error()
+  call assert_fails('func Xfunc abc ()', 'E124:')
+  call assert_fails('func Xfunc(', 'E125:')
+  call assert_fails('func xfunc()', 'E128:')
+
+  " Try to redefine a function that is in use
+  let caught_E127 = 0
+  try
+    func! Test_func_def_error()
+    endfunc
+  catch /E127:/
+    let caught_E127 = 1
+  endtry
+  call assert_equal(1, caught_E127)
+
+  " Try to define a function in a dict twice
+  let d = {}
+  let lines =<< trim END
+    func d.F1()
+      return 1
+    endfunc
+  END
+  let l = join(lines, "\n") . "\n"
+  exe l
+  call assert_fails('exe l', 'E717:')
+
+  " Define an autoload function with an incorrect file name
+  call writefile(['func foo#Bar()', 'return 1', 'endfunc'], 'Xscript')
+  call assert_fails('source Xscript', 'E746:')
+  call delete('Xscript')
+endfunc
+
+" Test for deleting a function
+func Test_del_func()
+  call assert_fails('delfunction Xabc', 'E130:')
+  let d = {'a' : 10}
+  call assert_fails('delfunc d.a', 'E718:')
+endfunc
+
+" Test for calling return outside of a function
+func Test_return_outside_func()
+  call writefile(['return 10'], 'Xscript')
+  call assert_fails('source Xscript', 'E133:')
+  call delete('Xscript')
+endfunc
+
+" Test for errors in calling a function
+func Test_func_arg_error()
+  " Too many arguments
+  call assert_fails("call call('min', range(1,20))", 'E118:')
+  call assert_fails("call call('min', range(1,21))", 'E699:')
+  call assert_fails('echo min(0,1,2,3,4,5,6,7,8,9,1,2,3,4,5,6,7,8,9,0,1)',
+        \ 'E740:')
+
+  " Missing dict argument
+  func Xfunc() dict
+    return 1
+  endfunc
+  call assert_fails('call Xfunc()', 'E725:')
+  delfunc Xfunc
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.0531: various errors not tested

Problem:    Various errors not tested.
Solution:   Add tests. (Yegappan Lakshmanan, closes vim/vim#5895)

https://github.com/vim/vim/commit/476a613135bdc94e61c1dce8a9cbb4ab0b6dc2d1

Need to remove "F" flag from 'shortmess' as early as possible.


#### vim-patch:8.2.0534: client-server test fails under valgrind

Problem:    Client-server test fails under valgrind.
Solution:   Use WaitForAssert().

https://github.com/vim/vim/commit/25d57009520f0e590920b9f953b1cbbb358e72a2

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0606: several syntax HL errors not checked

Problem:    Several syntax HL errors not checked.
Solution:   Add tests. (Yegappan Lakshmanan, closes vim/vim#5954)

https://github.com/vim/vim/commit/fbf2122cf920a89274ffbefaaeb6c5eeacf5187b


#### vim-patch:8.2.1113: no test for verbose output of :call

Problem:    No test for verbose output of :call.
Solution:   Add a test.

https://github.com/vim/vim/commit/a0d072ef8203b225bd46bcd826cb3d2e3c3b941a

Co-authored-by: Bram Moolenaar <Bram@vim.org>