### PR TITLE
refactor: fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,3 @@
----
-
 Checks: >
   -*,
 
@@ -16,8 +14,6 @@ Checks: >
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-macro-parentheses,
-  -bugprone-misplaced-widening-cast,
-  -bugprone-narrowing-conversions,
   -bugprone-narrowing-conversions,
   -bugprone-not-null-terminated-result,
   -bugprone-reserved-identifier,
@@ -32,6 +28,7 @@ Checks: >
   -misc-unused-parameters,
   -modernize-macro-to-enum,
   -performance-no-int-to-ptr,
+  -readability-avoid-const-params-in-decls,
   -readability-braces-around-statements,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,
@@ -43,8 +40,3 @@ Checks: >
   -readability-redundant-declaration,
   -readability-redundant-function-ptr-dereference,
   -readability-suspicious-call-argument,
-
-WarningsAsErrors: ''
-
-HeaderFilterRegex: "(src/[cjson|klib|mpack|unicode|xdiff]/).*\\.h$"
-...

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -833,9 +833,8 @@ uint32_t src2ns(Integer *src_id)
   }
   if (*src_id < 0) {
     return (((uint32_t)1) << 31) - 1;
-  } else {
-    return (uint32_t)(*src_id);
   }
+  return (uint32_t)(*src_id);
 }
 
 /// Adds a highlight to buffer.

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -110,15 +110,14 @@ Window nvim_tabpage_get_win(Tabpage tabpage, Error *err)
 
   if (tab == curtab) {
     return nvim_get_current_win();
-  } else {
-    FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
-      if (wp == tab->tp_curwin) {
-        return wp->handle;
-      }
-    }
-    // There should always be a current window for a tabpage
-    abort();
   }
+  FOR_ALL_WINDOWS_IN_TAB(wp, tab) {
+    if (wp == tab->tp_curwin) {
+      return wp->handle;
+    }
+  }
+  // There should always be a current window for a tabpage
+  abort();
 }
 
 /// Gets the tabpage number

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -532,7 +532,7 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, E
       kv_drop(ast_conv_stack, 1);
     } else {
       if (cur_item.ret_node_p->type == kObjectTypeNil) {
-        size_t items_size = (size_t)(3  // "type", "start" and "len"
+        size_t items_size = (size_t)(3  // "type", "start" and "len"  // NOLINT(bugprone-misplaced-widening-cast)
                                      + (node->children != NULL)  // "children"
                                      + (node->type == kExprNodeOption
                                         || node->type == kExprNodePlainIdentifier)  // "scope"

--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -27,70 +27,72 @@
 #include "nvim/vim.h"
 
 // Unicode values for Arabic characters.
-#define a_HAMZA                         0x0621
-#define a_ALEF_MADDA                    0x0622
-#define a_ALEF_HAMZA_ABOVE              0x0623
-#define a_WAW_HAMZA                     0x0624
-#define a_ALEF_HAMZA_BELOW              0x0625
-#define a_YEH_HAMZA                     0x0626
-#define a_ALEF                          0x0627
-#define a_BEH                           0x0628
-#define a_TEH_MARBUTA                   0x0629
-#define a_TEH                           0x062a
-#define a_THEH                          0x062b
-#define a_JEEM                          0x062c
-#define a_HAH                           0x062d
-#define a_KHAH                          0x062e
-#define a_DAL                           0x062f
-#define a_THAL                          0x0630
-#define a_REH                           0x0631
-#define a_ZAIN                          0x0632
-#define a_SEEN                          0x0633
-#define a_SHEEN                         0x0634
-#define a_SAD                           0x0635
-#define a_DAD                           0x0636
-#define a_TAH                           0x0637
-#define a_ZAH                           0x0638
-#define a_AIN                           0x0639
-#define a_GHAIN                         0x063a
-#define a_TATWEEL                       0x0640
-#define a_FEH                           0x0641
-#define a_QAF                           0x0642
-#define a_KAF                           0x0643
-#define a_LAM                           0x0644
-#define a_MEEM                          0x0645
-#define a_NOON                          0x0646
-#define a_HEH                           0x0647
-#define a_WAW                           0x0648
-#define a_ALEF_MAKSURA                  0x0649
-#define a_YEH                           0x064a
-#define a_FATHATAN                      0x064b
-#define a_DAMMATAN                      0x064c
-#define a_KASRATAN                      0x064d
-#define a_FATHA                         0x064e
-#define a_DAMMA                         0x064f
-#define a_KASRA                         0x0650
-#define a_SHADDA                        0x0651
-#define a_SUKUN                         0x0652
-#define a_MADDA_ABOVE                   0x0653
-#define a_HAMZA_ABOVE                   0x0654
-#define a_HAMZA_BELOW                   0x0655
+enum {
+  a_HAMZA = 0x0621,
+  a_ALEF_MADDA = 0x0622,
+  a_ALEF_HAMZA_ABOVE = 0x0623,
+  a_WAW_HAMZA = 0x0624,
+  a_ALEF_HAMZA_BELOW = 0x0625,
+  a_YEH_HAMZA = 0x0626,
+  a_ALEF = 0x0627,
+  a_BEH = 0x0628,
+  a_TEH_MARBUTA = 0x0629,
+  a_TEH = 0x062a,
+  a_THEH = 0x062b,
+  a_JEEM = 0x062c,
+  a_HAH = 0x062d,
+  a_KHAH = 0x062e,
+  a_DAL = 0x062f,
+  a_THAL = 0x0630,
+  a_REH = 0x0631,
+  a_ZAIN = 0x0632,
+  a_SEEN = 0x0633,
+  a_SHEEN = 0x0634,
+  a_SAD = 0x0635,
+  a_DAD = 0x0636,
+  a_TAH = 0x0637,
+  a_ZAH = 0x0638,
+  a_AIN = 0x0639,
+  a_GHAIN = 0x063a,
+  a_TATWEEL = 0x0640,
+  a_FEH = 0x0641,
+  a_QAF = 0x0642,
+  a_KAF = 0x0643,
+  a_LAM = 0x0644,
+  a_MEEM = 0x0645,
+  a_NOON = 0x0646,
+  a_HEH = 0x0647,
+  a_WAW = 0x0648,
+  a_ALEF_MAKSURA = 0x0649,
+  a_YEH = 0x064a,
+  a_FATHATAN = 0x064b,
+  a_DAMMATAN = 0x064c,
+  a_KASRATAN = 0x064d,
+  a_FATHA = 0x064e,
+  a_DAMMA = 0x064f,
+  a_KASRA = 0x0650,
+  a_SHADDA = 0x0651,
+  a_SUKUN = 0x0652,
+  a_MADDA_ABOVE = 0x0653,
+  a_HAMZA_ABOVE = 0x0654,
+  a_HAMZA_BELOW = 0x0655,
 
-#define a_PEH                           0x067e
-#define a_TCHEH                         0x0686
-#define a_JEH                           0x0698
-#define a_FKAF                          0x06a9
-#define a_GAF                           0x06af
-#define a_FYEH                          0x06cc
+  a_PEH = 0x067e,
+  a_TCHEH = 0x0686,
+  a_JEH = 0x0698,
+  a_FKAF = 0x06a9,
+  a_GAF = 0x06af,
+  a_FYEH = 0x06cc,
 
-#define a_s_LAM_ALEF_MADDA_ABOVE        0xfef5
-#define a_f_LAM_ALEF_MADDA_ABOVE        0xfef6
-#define a_s_LAM_ALEF_HAMZA_ABOVE        0xfef7
-#define a_f_LAM_ALEF_HAMZA_ABOVE        0xfef8
-#define a_s_LAM_ALEF_HAMZA_BELOW        0xfef9
-#define a_f_LAM_ALEF_HAMZA_BELOW        0xfefa
-#define a_s_LAM_ALEF                    0xfefb
-#define a_f_LAM_ALEF                    0xfefc
+  a_s_LAM_ALEF_MADDA_ABOVE = 0xfef5,
+  a_f_LAM_ALEF_MADDA_ABOVE = 0xfef6,
+  a_s_LAM_ALEF_HAMZA_ABOVE = 0xfef7,
+  a_f_LAM_ALEF_HAMZA_ABOVE = 0xfef8,
+  a_s_LAM_ALEF_HAMZA_BELOW = 0xfef9,
+  a_f_LAM_ALEF_HAMZA_BELOW = 0xfefa,
+  a_s_LAM_ALEF = 0xfefb,
+  a_f_LAM_ALEF = 0xfefc,
+};
 
 static struct achar {
   unsigned c;

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -169,13 +169,12 @@ Decoration get_decor(mtkey_t mark)
 {
   if (mark.decor_full) {
     return *mark.decor_full;
-  } else {
-    Decoration fake = DECORATION_INIT;
-    fake.hl_id = mark.hl_id;
-    fake.priority = mark.priority;
-    fake.hl_eol = (mark.flags & MT_FLAG_HL_EOL);
-    return fake;
   }
+  Decoration fake = DECORATION_INIT;
+  fake.hl_id = mark.hl_id;
+  fake.priority = mark.priority;
+  fake.hl_eol = (mark.flags & MT_FLAG_HL_EOL);
+  return fake;
 }
 
 /// @return true if decor has a virtual position (virtual text or ui_watched)

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1133,37 +1133,36 @@ static int diff_file(diffio_T *dio)
   // Use xdiff for generating the diff.
   if (dio->dio_internal) {
     return diff_file_internal(dio);
-  } else {
-    const size_t len = (strlen(tmp_orig) + strlen(tmp_new) + strlen(tmp_diff)
-                        + strlen(p_srr) + 27);
-    char *const cmd = xmalloc(len);
-
-    // We don't want $DIFF_OPTIONS to get in the way.
-    if (os_getenv("DIFF_OPTIONS")) {
-      os_unsetenv("DIFF_OPTIONS");
-    }
-
-    // Build the diff command and execute it.  Always use -a, binary
-    // differences are of no use.  Ignore errors, diff returns
-    // non-zero when differences have been found.
-    vim_snprintf(cmd, len, "diff %s%s%s%s%s%s%s%s %s",
-                 diff_a_works == kFalse ? "" : "-a ",
-                 "",
-                 (diff_flags & DIFF_IWHITE) ? "-b " : "",
-                 (diff_flags & DIFF_IWHITEALL) ? "-w " : "",
-                 (diff_flags & DIFF_IWHITEEOL) ? "-Z " : "",
-                 (diff_flags & DIFF_IBLANK) ? "-B " : "",
-                 (diff_flags & DIFF_ICASE) ? "-i " : "",
-                 tmp_orig, tmp_new);
-    append_redir(cmd, len, p_srr, tmp_diff);
-    block_autocmds();  // Avoid ShellCmdPost stuff
-    (void)call_shell((char_u *)cmd,
-                     kShellOptFilter | kShellOptSilent | kShellOptDoOut,
-                     NULL);
-    unblock_autocmds();
-    xfree(cmd);
-    return OK;
   }
+  const size_t len = (strlen(tmp_orig) + strlen(tmp_new) + strlen(tmp_diff)
+                      + strlen(p_srr) + 27);
+  char *const cmd = xmalloc(len);
+
+  // We don't want $DIFF_OPTIONS to get in the way.
+  if (os_getenv("DIFF_OPTIONS")) {
+    os_unsetenv("DIFF_OPTIONS");
+  }
+
+  // Build the diff command and execute it.  Always use -a, binary
+  // differences are of no use.  Ignore errors, diff returns
+  // non-zero when differences have been found.
+  vim_snprintf(cmd, len, "diff %s%s%s%s%s%s%s%s %s",
+               diff_a_works == kFalse ? "" : "-a ",
+               "",
+               (diff_flags & DIFF_IWHITE) ? "-b " : "",
+               (diff_flags & DIFF_IWHITEALL) ? "-w " : "",
+               (diff_flags & DIFF_IWHITEEOL) ? "-Z " : "",
+               (diff_flags & DIFF_IBLANK) ? "-B " : "",
+               (diff_flags & DIFF_ICASE) ? "-i " : "",
+               tmp_orig, tmp_new);
+  append_redir(cmd, len, p_srr, tmp_diff);
+  block_autocmds();  // Avoid ShellCmdPost stuff
+  (void)call_shell((char_u *)cmd,
+                   kShellOptFilter | kShellOptSilent | kShellOptDoOut,
+                   NULL);
+  unblock_autocmds();
+  xfree(cmd);
+  return OK;
 }
 
 /// Create a new version of a file from the current buffer and a diff file.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -87,10 +87,12 @@ typedef struct insert_state {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "edit.c.generated.h"
 #endif
-#define BACKSPACE_CHAR              1
-#define BACKSPACE_WORD              2
-#define BACKSPACE_WORD_NOT_SPACE    3
-#define BACKSPACE_LINE              4
+enum {
+  BACKSPACE_CHAR = 1,
+  BACKSPACE_WORD = 2,
+  BACKSPACE_WORD_NOT_SPACE = 3,
+  BACKSPACE_LINE = 4,
+};
 
 /// Set when doing something for completion that may call edit() recursively,
 /// which is not allowed.
@@ -1227,9 +1229,8 @@ bool edit(int cmdchar, bool startln, long count)
       restart_edit = 'i';
       force_restart_edit = true;
       return false;
-    } else {
-      return terminal_enter();
     }
+    return terminal_enter();
   }
 
   // Don't allow inserting in the sandbox.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1942,11 +1942,10 @@ bool next_for_item(void *fi_void, char *arg)
   listitem_T *item = fi->fi_lw.lw_item;
   if (item == NULL) {
     return false;
-  } else {
-    fi->fi_lw.lw_item = TV_LIST_ITEM_NEXT(fi->fi_list, item);
-    return (ex_let_vars(arg, TV_LIST_ITEM_TV(item), true,
-                        fi->fi_semicolon, fi->fi_varcount, false, NULL) == OK);
   }
+  fi->fi_lw.lw_item = TV_LIST_ITEM_NEXT(fi->fi_list, item);
+  return (ex_let_vars(arg, TV_LIST_ITEM_TV(item), true,
+                      fi->fi_semicolon, fi->fi_varcount, false, NULL) == OK);
 }
 
 // TODO(ZyX-I): move to eval/ex_cmds
@@ -7172,9 +7171,8 @@ int check_luafunc_name(const char *const str, const bool paren)
   const char *const p = skip_luafunc_name(str);
   if (*p != (paren ? '(' : NUL)) {
     return 0;
-  } else {
-    return (int)(p - str);
   }
+  return (int)(p - str);
 }
 
 /// Handle:
@@ -7920,9 +7918,8 @@ static var_flavour_T var_flavour(char *varname)
       }
     }
     return VAR_FLAVOUR_SHADA;
-  } else {
-    return VAR_FLAVOUR_DEFAULT;
   }
+  return VAR_FLAVOUR_DEFAULT;
 }
 
 /// Iterate over global variables

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -284,13 +284,12 @@ typval_T decode_string(const char *const s, const size_t len, const TriState has
       }
     }
     return tv;
-  } else {
-    return (typval_T) {
-      .v_type = VAR_STRING,
-      .v_lock = VAR_UNLOCKED,
-      .vval = { .v_string = ((s == NULL || s_allocated) ? (char *)s : xmemdupz(s, len)) },
-    };
   }
+  return (typval_T) {
+    .v_type = VAR_STRING,
+    .v_lock = VAR_UNLOCKED,
+    .vval = { .v_string = ((s == NULL || s_allocated) ? (char *)s : xmemdupz(s, len)) },
+  };
 }
 
 /// Parse JSON double-quoted string

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5238,10 +5238,9 @@ static void f_mkdir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         xfree(failed_dir);
         rettv->vval.v_number = FAIL;
         return;
-      } else {
-        rettv->vval.v_number = OK;
-        return;
       }
+      rettv->vval.v_number = OK;
+      return;
     }
   }
   rettv->vval.v_number = vim_mkdir_emsg(dir, prot);
@@ -7483,9 +7482,8 @@ static void f_serverstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (argvars[0].v_type != VAR_STRING) {
       emsg(_(e_invarg));
       return;
-    } else {
-      address = xstrdup(tv_get_string(argvars));
     }
+    address = xstrdup(tv_get_string(argvars));
   } else {
     address = server_address_new(NULL);
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1747,9 +1747,8 @@ static bool tv_dict_watcher_matches(DictWatcher *watcher, const char *const key)
   const size_t len = watcher->key_pattern_len;
   if (len && watcher->key_pattern[len - 1] == '*') {
     return strncmp(key, watcher->key_pattern, len - 1) == 0;
-  } else {
-    return strcmp(key, watcher->key_pattern) == 0;
   }
+  return strcmp(key, watcher->key_pattern) == 0;
 }
 
 /// Send a change notification to all dictionary watchers that match given key

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2019,9 +2019,8 @@ void ex_function(exarg_T *eap)
       }
       xfree(fudi.fd_newkey);
       return;
-    } else {
-      eap->skip = true;
     }
+    eap->skip = true;
   }
 
   // An error in a function call during evaluation of an expression in magic

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -380,9 +380,8 @@ const char *skip_var_list(const char *arg, int *var_count, int *semicolon)
       }
     }
     return p + 1;
-  } else {
-    return skip_var_one((char *)arg);
   }
+  return skip_var_one((char *)arg);
 }
 
 /// Skip one (assignable) variable name, including @r, $VAR, &option, d.key,
@@ -884,9 +883,8 @@ static int do_unlet_var(lval_T *lp, char *name_end, exarg_T *eap, int deep FUNC_
       lp->ll_n1++;
       if (lp->ll_li == NULL || (!lp->ll_empty2 && lp->ll_n2 < lp->ll_n1)) {
         break;
-      } else {
-        last_li = lp->ll_li;
       }
+      last_li = lp->ll_li;
     }
     tv_list_remove_items(lp->ll_list, first_li, last_li);
   } else {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2137,9 +2137,8 @@ static int check_readonly(int *forceit, buf_T *buf)
         // Set forceit, to force the writing of a readonly file
         *forceit = true;
         return false;
-      } else {
-        return true;
       }
+      return true;
     } else if (buf->b_p_ro) {
       emsg(_(e_readonly));
     } else {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4357,9 +4357,8 @@ char *check_nextcmd(char *p)
 
   if (*s == '|' || *s == '\n') {
     return s + 1;
-  } else {
-    return NULL;
   }
+  return NULL;
 }
 
 /// - if there are more files to edit
@@ -4758,9 +4757,8 @@ static void ex_only(exarg_T *eap)
     for (wp = firstwin; --wnr > 0;) {
       if (wp->w_next == NULL) {
         break;
-      } else {
-        wp = wp->w_next;
       }
+      wp = wp->w_next;
     }
   } else {
     wp = curwin;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -72,15 +72,17 @@
 #endif
 
 #define HAS_BW_FLAGS
-#define FIO_LATIN1     0x01    // convert Latin1
-#define FIO_UTF8       0x02    // convert UTF-8
-#define FIO_UCS2       0x04    // convert UCS-2
-#define FIO_UCS4       0x08    // convert UCS-4
-#define FIO_UTF16      0x10    // convert UTF-16
-#define FIO_ENDIAN_L   0x80    // little endian
-#define FIO_NOCONVERT  0x2000  // skip encoding conversion
-#define FIO_UCSBOM     0x4000  // check for BOM at start of file
-#define FIO_ALL        (-1)    // allow all formats
+enum {
+  FIO_LATIN1 = 0x01,       // convert Latin1
+  FIO_UTF8 = 0x02,         // convert UTF-8
+  FIO_UCS2 = 0x04,         // convert UCS-2
+  FIO_UCS4 = 0x08,         // convert UCS-4
+  FIO_UTF16 = 0x10,        // convert UTF-16
+  FIO_ENDIAN_L = 0x80,     // little endian
+  FIO_NOCONVERT = 0x2000,  // skip encoding conversion
+  FIO_UCSBOM = 0x4000,     // check for BOM at start of file
+  FIO_ALL = -1,            // allow all formats
+};
 
 // When converting, a read() or write() may leave some bytes to be converted
 // for the next call.  The value is guessed...
@@ -498,18 +500,17 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
         return FAIL;
       }
       return OK;                  // a new file is not an error
-    } else {
-      filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]") :
-#if defined(UNIX) && defined(EOVERFLOW)
-                                // libuv only returns -errno
-                                // in Unix and in Windows
-                                // open() does not set
-                                // EOVERFLOW
-                                (fd == -EOVERFLOW) ? _("[File too big]") :
-#endif
-                                _("[Permission Denied]")), 0);
-      curbuf->b_p_ro = true;                  // must use "w!" now
     }
+    filemess(curbuf, sfname, ((fd == UV_EFBIG) ? _("[File too big]") :
+#if defined(UNIX) && defined(EOVERFLOW)
+                              // libuv only returns -errno
+                              // in Unix and in Windows
+                              // open() does not set
+                              // EOVERFLOW
+                              (fd == -EOVERFLOW) ? _("[File too big]") :
+#endif
+                              _("[Permission Denied]")), 0);
+    curbuf->b_p_ro = true;                  // must use "w!" now
 
     return FAIL;
   }
@@ -5232,10 +5233,9 @@ static void vim_mktempdir(void)
     if (vim_settempdir(path)) {
       // Successfully created and set temporary directory so stop trying.
       break;
-    } else {
-      // Couldn't set `vim_tempdir` to `path` so remove created directory.
-      os_rmdir(path);
     }
+    // Couldn't set `vim_tempdir` to `path` so remove created directory.
+    os_rmdir(path);
   }
   (void)umask(umask_save);
 }

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -57,9 +57,11 @@ typedef struct {
                                 // folds too
 } fold_T;
 
-#define FD_OPEN         0       // fold is open (nested ones can be closed)
-#define FD_CLOSED       1       // fold is closed
-#define FD_LEVEL        2       // depends on 'foldlevel' (nested folds too)
+enum {
+  FD_OPEN = 0,    // fold is open (nested ones can be closed)
+  FD_CLOSED = 1,  // fold is closed
+  FD_LEVEL = 2,   // depends on 'foldlevel' (nested folds too)
+};
 
 #define MAX_LEVEL       20      // maximum fold depth
 
@@ -1772,7 +1774,7 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
     }
   }
   if (text == NULL) {
-    unsigned long count = (unsigned long)(lnume - lnum + 1);
+    unsigned long count = (unsigned long)(lnume - lnum + 1);  // NOLINT(bugprone-misplaced-widening-cast)
 
     vim_snprintf(buf, FOLD_TEXT_LEN,
                  NGETTEXT("+--%3ld line folded",
@@ -3115,7 +3117,7 @@ static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
       return FAIL;
     }
     if (fprintf(fd, "%" PRId64 ",%" PRId64 "fold",
-                (int64_t)(fp->fd_top + off),
+                (int64_t)fp->fd_top + off,
                 (int64_t)(fp->fd_top + off + fp->fd_len - 1)) < 0
         || put_eol(fd) == FAIL) {
       return FAIL;
@@ -3136,7 +3138,7 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
     if (fp->fd_flags != FD_LEVEL) {
       if (!GA_EMPTY(&fp->fd_nested)) {
         // open nested folds while this fold is open
-        if (fprintf(fd, "%" PRId64, (int64_t)(fp->fd_top + off)) < 0
+        if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
             || put_eol(fd) == FAIL
             || put_line(fd, "normal! zo") == FAIL) {
           return FAIL;

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -122,8 +122,10 @@ static const uint32_t cterm_color_16[16] = {
 
 static int current_syn_id;
 
-#define PRCOLOR_BLACK 0
-#define PRCOLOR_WHITE 0xffffff
+enum {
+  PRCOLOR_BLACK = 0,
+  PRCOLOR_WHITE = 0xffffff,
+};
 
 static TriState curr_italic;
 static TriState curr_bold;
@@ -132,13 +134,15 @@ static uint32_t curr_bg;
 static uint32_t curr_fg;
 static int page_count;
 
-#define OPT_MBFONT_USECOURIER  0
-#define OPT_MBFONT_ASCII       1
-#define OPT_MBFONT_REGULAR     2
-#define OPT_MBFONT_BOLD        3
-#define OPT_MBFONT_OBLIQUE     4
-#define OPT_MBFONT_BOLDOBLIQUE 5
-#define OPT_MBFONT_NUM_OPTIONS 6
+enum {
+  OPT_MBFONT_USECOURIER = 0,
+  OPT_MBFONT_ASCII = 1,
+  OPT_MBFONT_REGULAR = 2,
+  OPT_MBFONT_BOLD = 3,
+  OPT_MBFONT_OBLIQUE = 4,
+  OPT_MBFONT_BOLDOBLIQUE = 5,
+  OPT_MBFONT_NUM_OPTIONS = 6,
+};
 
 static option_table_T mbfont_opts[OPT_MBFONT_NUM_OPTIONS] = {
   { "c",       false, 0, NULL, 0, false },
@@ -938,8 +942,10 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
 // Some of these documents can be found in PDF form on Adobe's web site -
 // http://www.adobe.com
 
-#define PRT_PS_DEFAULT_DPI          (72)    // Default user space resolution
-#define PRT_PS_DEFAULT_FONTSIZE     (10)
+enum {
+  PRT_PS_DEFAULT_DPI = 72,  // Default user space resolution
+  PRT_PS_DEFAULT_FONTSIZE = 10,
+};
 
 #define PRT_MEDIASIZE_LEN  ARRAY_SIZE(prt_mediasize)
 
@@ -960,10 +966,12 @@ static struct prt_mediasize_S prt_mediasize[] = {
   { "tabloid",         792.0, 1224.0 }
 };
 
-#define PRT_PS_FONT_ROMAN       (0)
-#define PRT_PS_FONT_BOLD        (1)
-#define PRT_PS_FONT_OBLIQUE     (2)
-#define PRT_PS_FONT_BOLDOBLIQUE (3)
+enum {
+  PRT_PS_FONT_ROMAN = 0,
+  PRT_PS_FONT_BOLD = 1,
+  PRT_PS_FONT_OBLIQUE = 2,
+  PRT_PS_FONT_BOLDOBLIQUE = 3,
+};
 
 // Standard font metrics for Courier family
 static struct prt_ps_font_S prt_ps_courier_font = {
@@ -984,14 +992,16 @@ static struct prt_ps_font_S prt_ps_mb_font = {
 // Pointer to current font set being used
 static struct prt_ps_font_S *prt_ps_font;
 
-#define CS_JIS_C_1978   (0x01)
-#define CS_JIS_X_1983   (0x02)
-#define CS_JIS_X_1990   (0x04)
-#define CS_NEC          (0x08)
-#define CS_MSWINDOWS    (0x10)
-#define CS_CP932        (0x20)
-#define CS_KANJITALK6   (0x40)
-#define CS_KANJITALK7   (0x80)
+enum {
+  CS_JIS_C_1978 = 0x01,
+  CS_JIS_X_1983 = 0x02,
+  CS_JIS_X_1990 = 0x04,
+  CS_NEC = 0x08,
+  CS_MSWINDOWS = 0x10,
+  CS_CP932 = 0x20,
+  CS_KANJITALK6 = 0x40,
+  CS_KANJITALK7 = 0x80,
+};
 
 // Japanese encodings and charsets
 static struct prt_ps_encoding_S j_encodings[] = {
@@ -1015,13 +1025,15 @@ static struct prt_ps_charset_S j_charsets[] = {
   { "KANJITALK7",  "90pv",     CS_KANJITALK7 }
 };
 
-#define CS_GB_2312_80       (0x01)
-#define CS_GBT_12345_90     (0x02)
-#define CS_GBK2K            (0x04)
-#define CS_SC_MAC           (0x08)
-#define CS_GBT_90_MAC       (0x10)
-#define CS_GBK              (0x20)
-#define CS_SC_ISO10646      (0x40)
+enum {
+  CS_GB_2312_80 = 0x01,
+  CS_GBT_12345_90 = 0x02,
+  CS_GBK2K = 0x04,
+  CS_SC_MAC = 0x08,
+  CS_GBT_90_MAC = 0x10,
+  CS_GBK = 0x20,
+  CS_SC_ISO10646 = 0x40,
+};
 
 // Simplified Chinese encodings and charsets
 static struct prt_ps_encoding_S sc_encodings[] = {
@@ -1043,19 +1055,21 @@ static struct prt_ps_charset_S sc_charsets[] = {
   { "ISO10646",    "UniGB",    CS_SC_ISO10646 }
 };
 
-#define CS_CNS_PLANE_1      (0x01)
-#define CS_CNS_PLANE_2      (0x02)
-#define CS_CNS_PLANE_1_2    (0x04)
-#define CS_B5               (0x08)
-#define CS_ETEN             (0x10)
-#define CS_HK_GCCS          (0x20)
-#define CS_HK_SCS           (0x40)
-#define CS_HK_SCS_ETEN      (0x80)
-#define CS_MTHKL            (0x100)
-#define CS_MTHKS            (0x200)
-#define CS_DLHKL            (0x400)
-#define CS_DLHKS            (0x800)
-#define CS_TC_ISO10646      (0x1000)
+enum {
+  CS_CNS_PLANE_1 = 0x01,
+  CS_CNS_PLANE_2 = 0x02,
+  CS_CNS_PLANE_1_2 = 0x04,
+  CS_B5 = 0x08,
+  CS_ETEN = 0x10,
+  CS_HK_GCCS = 0x20,
+  CS_HK_SCS = 0x40,
+  CS_HK_SCS_ETEN = 0x80,
+  CS_MTHKL = 0x100,
+  CS_MTHKS = 0x200,
+  CS_DLHKL = 0x400,
+  CS_DLHKS = 0x800,
+  CS_TC_ISO10646 = 0x1000,
+};
 
 // Traditional Chinese encodings and charsets
 static struct prt_ps_encoding_S tc_encodings[] = {
@@ -1087,10 +1101,12 @@ static struct prt_ps_charset_S tc_charsets[] = {
   { "ISO10646",    "UniCNS",   CS_TC_ISO10646 }
 };
 
-#define CS_KR_X_1992        (0x01)
-#define CS_KR_MAC           (0x02)
-#define CS_KR_X_1992_MS     (0x04)
-#define CS_KR_ISO10646      (0x08)
+enum {
+  CS_KR_X_1992 = 0x01,
+  CS_KR_MAC = 0x02,
+  CS_KR_X_1992_MS = 0x04,
+  CS_KR_ISO10646 = 0x08,
+};
 
 // Korean encodings and charsets
 static struct prt_ps_encoding_S k_encodings[] = {
@@ -1169,10 +1185,12 @@ static struct prt_ps_mbfont_S prt_ps_mbfonts[] = {
 
 // Data for table based DSC comment recognition, easy to extend if VIM needs to
 // read more comments.
-#define PRT_DSC_MISC_TYPE           (-1)
-#define PRT_DSC_TITLE_TYPE          (1)
-#define PRT_DSC_VERSION_TYPE        (2)
-#define PRT_DSC_ENDCOMMENTS_TYPE    (3)
+enum {
+  PRT_DSC_MISC_TYPE = -1,
+  PRT_DSC_TITLE_TYPE = 1,
+  PRT_DSC_VERSION_TYPE = 2,
+  PRT_DSC_ENDCOMMENTS_TYPE = 3,
+};
 
 #define PRT_DSC_TITLE               "%%Title:"
 #define PRT_DSC_VERSION             "%%Version:"

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -141,10 +141,9 @@ int hl_get_syn_attr(int ns_id, int idx, HlAttrs at_en)
       || at_en.rgb_ae_attr != 0 || ns_id != 0) {
     return get_attr_entry((HlEntry){ .attr = at_en, .kind = kHlSyntax,
                                      .id1 = idx, .id2 = ns_id });
-  } else {
-    // If all the fields are cleared, clear the attr field back to default value
-    return 0;
   }
+  // If all the fields are cleared, clear the attr field back to default value
+  return 0;
 }
 
 void ns_hl_def(NS ns_id, int hl_id, HlAttrs attrs, int link_id, Dict(highlight) *dict)
@@ -238,12 +237,11 @@ int ns_get_hl(NS *ns_hl, int hl_id, bool link, bool nodefault)
   if (link) {
     if (it.attr_id >= 0) {
       return 0;
-    } else {
-      if (it.link_global) {
-        *ns_hl = 0;
-      }
-      return it.link_id;
     }
+    if (it.link_global) {
+      *ns_hl = 0;
+    }
+    return it.link_id;
   } else {
     return it.attr_id;
   }

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -23,9 +23,11 @@
 
 /// \addtogroup SG_SET
 /// @{
-#define SG_CTERM        2       // cterm has been set
-#define SG_GUI          4       // gui has been set
-#define SG_LINK         8       // link has been set
+enum {
+  SG_CTERM = 2,  // cterm has been set
+  SG_GUI = 4,    // gui has been set
+  SG_LINK = 8,   // link has been set
+};
 /// @}
 
 #define MAX_SYN_NAME 200
@@ -1729,9 +1731,8 @@ int syn_name2id(const char *name)
   if (name[0] == '@') {
     // if we look up @aaa.bbb, we have to consider @aaa as well
     return syn_check_group(name, strlen(name));
-  } else {
-    return syn_name2id_len(name, strlen(name));
   }
+  return syn_name2id_len(name, strlen(name));
 }
 
 /// Lookup a highlight group name and return its ID.

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -896,9 +896,8 @@ int inindent(int extra)
 
   if (col >= curwin->w_cursor.col + extra) {
     return true;
-  } else {
-    return false;
   }
+  return false;
 }
 
 /// @return  true if the conditions are OK for smart indenting.

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -458,9 +458,8 @@ bool cin_iscase(const char_u *s, bool strict)
         // JS etc.
         if (strict) {
           return false;                 // stop at string
-        } else {
-          return true;
         }
+        return true;
       }
     }
     return false;
@@ -2877,14 +2876,13 @@ int get_c_indent(void)
               // Line below current line is the one that starts a
               // (possibly broken) line ending in a comma.
               break;
-            } else {
-              amount = get_indent();
-              if (curwin->w_cursor.lnum - 1 == ourscope) {
-                // line above is start of the scope, thus current
-                // line is the one that stars a (possibly broken)
-                // line ending in a comma.
-                break;
-              }
+            }
+            amount = get_indent();
+            if (curwin->w_cursor.lnum - 1 == ourscope) {
+              // line above is start of the scope, thus current
+              // line is the one that stars a (possibly broken)
+              // line ending in a comma.
+              break;
             }
           }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -55,24 +55,26 @@
 
 #define CTRL_X_WANT_IDENT       0x100
 
-#define CTRL_X_NORMAL           0  ///< CTRL-N CTRL-P completion, default
-#define CTRL_X_NOT_DEFINED_YET  1
-#define CTRL_X_SCROLL           2
-#define CTRL_X_WHOLE_LINE       3
-#define CTRL_X_FILES            4
-#define CTRL_X_TAGS             (5 + CTRL_X_WANT_IDENT)
-#define CTRL_X_PATH_PATTERNS    (6 + CTRL_X_WANT_IDENT)
-#define CTRL_X_PATH_DEFINES     (7 + CTRL_X_WANT_IDENT)
-#define CTRL_X_FINISHED         8
-#define CTRL_X_DICTIONARY       (9 + CTRL_X_WANT_IDENT)
-#define CTRL_X_THESAURUS        (10 + CTRL_X_WANT_IDENT)
-#define CTRL_X_CMDLINE          11
-#define CTRL_X_FUNCTION         12
-#define CTRL_X_OMNI             13
-#define CTRL_X_SPELL            14
-#define CTRL_X_LOCAL_MSG        15  ///< only used in "ctrl_x_msgs"
-#define CTRL_X_EVAL             16  ///< for builtin function complete()
-#define CTRL_X_CMDLINE_CTRL_X   17  ///< CTRL-X typed in CTRL_X_CMDLINE
+enum {
+  CTRL_X_NORMAL = 0,  ///< CTRL-N CTRL-P completion, default
+  CTRL_X_NOT_DEFINED_YET = 1,
+  CTRL_X_SCROLL = 2,
+  CTRL_X_WHOLE_LINE = 3,
+  CTRL_X_FILES = 4,
+  CTRL_X_TAGS = (5 + CTRL_X_WANT_IDENT),
+  CTRL_X_PATH_PATTERNS = (6 + CTRL_X_WANT_IDENT),
+  CTRL_X_PATH_DEFINES = (7 + CTRL_X_WANT_IDENT),
+  CTRL_X_FINISHED = 8,
+  CTRL_X_DICTIONARY = (9 + CTRL_X_WANT_IDENT),
+  CTRL_X_THESAURUS = (10 + CTRL_X_WANT_IDENT),
+  CTRL_X_CMDLINE = 11,
+  CTRL_X_FUNCTION = 12,
+  CTRL_X_OMNI = 13,
+  CTRL_X_SPELL = 14,
+  CTRL_X_LOCAL_MSG = 15,       ///< only used in "ctrl_x_msgs"
+  CTRL_X_EVAL = 16,            ///< for builtin function complete()
+  CTRL_X_CMDLINE_CTRL_X = 17,  ///< CTRL-X typed in CTRL_X_CMDLINE
+};
 
 #define CTRL_X_MSG(i) ctrl_x_msgs[(i) & ~CTRL_X_WANT_IDENT]
 

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -906,9 +906,8 @@ Float nlua_pop_Float(lua_State *lstate, Error *err)
   lua_pop(lstate, 1);
   if (table_props.type != kObjectTypeFloat) {
     return 0;
-  } else {
-    return (Float)table_props.val;
   }
+  return (Float)table_props.val;
 }
 
 /// Convert lua table to array without determining whether it is array

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -378,15 +378,14 @@ int nlua_setvar(lua_State *lstate)
     if (di == NULL) {
       // Doesn't exist, nothing to do
       return 0;
-    } else {
-      // Notify watchers
-      if (watched) {
-        tv_dict_watcher_notify(dict, key.data, NULL, &di->di_tv);
-      }
-
-      // Delete the entry
-      tv_dict_item_remove(dict, di);
     }
+    // Notify watchers
+    if (watched) {
+      tv_dict_watcher_notify(dict, key.data, NULL, &di->di_tv);
+    }
+
+    // Delete the entry
+    tv_dict_item_remove(dict, di);
   } else {
     // Update the key
     typval_T tv;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -88,16 +88,20 @@
 #include "nvim/api/extmark.h"
 
 // values for "window_layout"
-#define WIN_HOR     1       // "-o" horizontally split windows
-#define WIN_VER     2       // "-O" vertically split windows
-#define WIN_TABS    3       // "-p" windows on tab pages
+enum {
+  WIN_HOR = 1,   // "-o" horizontally split windows
+  WIN_VER = 2,   // "-O" vertically split windows
+  WIN_TABS = 3,  // "-p" windows on tab pages
+};
 
 // Values for edit_type.
-#define EDIT_NONE   0       // no edit type yet
-#define EDIT_FILE   1       // file name argument[s] given, use argument list
-#define EDIT_STDIN  2       // read file from stdin
-#define EDIT_TAG    3       // tag name argument given, use tagname
-#define EDIT_QF     4       // start in quickfix mode
+enum {
+  EDIT_NONE = 0,   // no edit type yet
+  EDIT_FILE = 1,   // file name argument[s] given, use argument list
+  EDIT_STDIN = 2,  // read file from stdin
+  EDIT_TAG = 3,    // tag name argument given, use tagname
+  EDIT_QF = 4,     // start in quickfix mode
+};
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "main.c.generated.h"

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1479,9 +1479,8 @@ const void *mark_jumplist_iter(const void *const iter, const win_T *const win, x
   *fm = *iter_mark;
   if (iter_mark == &(win->w_jumplist[win->w_jumplistlen - 1])) {
     return NULL;
-  } else {
-    return iter_mark + 1;
   }
+  return iter_mark + 1;
 }
 
 /// Iterate over global marks

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -805,17 +805,17 @@ bool get_prevcol_hl_flag(win_T *wp, match_T *search_hl, long curcol)
                                 || (prevcol > (long)search_hl->startcol
                                     && search_hl->endcol == MAXCOL))) {
     return true;
-  } else {
-    cur = wp->w_match_head;
-    while (cur != NULL) {
-      if (!cur->mit_hl.is_addpos && (prevcol == (long)cur->mit_hl.startcol
-                                     || (prevcol > (long)cur->mit_hl.startcol
-                                         && cur->mit_hl.endcol == MAXCOL))) {
-        return true;
-      }
-      cur = cur->mit_next;
-    }
   }
+  cur = wp->w_match_head;
+  while (cur != NULL) {
+    if (!cur->mit_hl.is_addpos && (prevcol == (long)cur->mit_hl.startcol
+                                   || (prevcol > (long)cur->mit_hl.startcol
+                                       && cur->mit_hl.endcol == MAXCOL))) {
+      return true;
+    }
+    cur = cur->mit_next;
+  }
+
   return false;
 }
 

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1186,9 +1186,8 @@ static int utf_convert(int a, const convertStruct *const table, size_t n_items)
       && a <= table[start].rangeEnd
       && (a - table[start].rangeStart) % table[start].step == 0) {
     return a + table[start].offset;
-  } else {
-    return a;
   }
+  return a;
 }
 
 // Return the folded-case equivalent of "a", which is a UCS-4 character.  Uses

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -815,8 +815,10 @@ static bool mf_do_open(memfile_T *mfp, char *fname, int flags)
 /// The number of buckets in the hashtable is increased by a factor of
 /// MHT_GROWTH_FACTOR when the average number of items per bucket
 /// exceeds 2 ^ MHT_LOG_LOAD_FACTOR.
-#define MHT_LOG_LOAD_FACTOR 6
-#define MHT_GROWTH_FACTOR   2   // must be a power of two
+enum {
+  MHT_LOG_LOAD_FACTOR = 6,
+  MHT_GROWTH_FACTOR = 2,  // must be a power of two
+};
 
 /// Initialize an empty hash table.
 static void mf_hash_init(mf_hashtab_T *mht)

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -83,10 +83,12 @@ typedef struct pointer_block PTR_BL;        // contents of a pointer block
 typedef struct data_block DATA_BL;          // contents of a data block
 typedef struct pointer_entry PTR_EN;        // block/line-count pair
 
-#define DATA_ID        (('d' << 8) + 'a')   // data block id
-#define PTR_ID         (('p' << 8) + 't')   // pointer block id
-#define BLOCK0_ID0     'b'                  // block 0 id 0
-#define BLOCK0_ID1     '0'                  // block 0 id 1
+enum {
+  DATA_ID = (('d' << 8) + 'a'),  // data block id
+  PTR_ID = (('p' << 8) + 't'),   // pointer block id
+  BLOCK0_ID0 = 'b',              // block 0 id 0
+  BLOCK0_ID1 = '0',              // block 0 id 1
+};
 
 // pointer to a block, used in a pointer block
 struct pointer_entry {
@@ -134,18 +136,22 @@ struct data_block {
 #define INDEX_SIZE  (sizeof(unsigned))      // size of one db_index entry
 #define HEADER_SIZE (sizeof(DATA_BL) - INDEX_SIZE)  // size of data block header
 
-#define B0_FNAME_SIZE_ORG       900     // what it was in older versions
-#define B0_FNAME_SIZE_NOCRYPT   898     // 2 bytes used for other things
-#define B0_FNAME_SIZE_CRYPT     890     // 10 bytes used for other things
-#define B0_UNAME_SIZE           40
-#define B0_HNAME_SIZE           40
+enum {
+  B0_FNAME_SIZE_ORG = 900,      // what it was in older versions
+  B0_FNAME_SIZE_NOCRYPT = 898,  // 2 bytes used for other things
+  B0_FNAME_SIZE_CRYPT = 890,    // 10 bytes used for other things
+  B0_UNAME_SIZE = 40,
+  B0_HNAME_SIZE = 40,
+};
 // Restrict the numbers to 32 bits, otherwise most compilers will complain.
 // This won't detect a 64 bit machine that only swaps a byte in the top 32
 // bits, but that is crazy anyway.
-#define B0_MAGIC_LONG   0x30313233L
-#define B0_MAGIC_INT    0x20212223L
-#define B0_MAGIC_SHORT  0x10111213L
-#define B0_MAGIC_CHAR   0x55
+enum {
+  B0_MAGIC_LONG = 0x30313233L,
+  B0_MAGIC_INT = 0x20212223L,
+  B0_MAGIC_SHORT = 0x10111213L,
+  B0_MAGIC_CHAR = 0x55,
+};
 
 // Block zero holds all info about the swap file.
 //
@@ -205,10 +211,12 @@ struct block0 {
 static linenr_T lowest_marked = 0;
 
 // arguments for ml_find_line()
-#define ML_DELETE       0x11        // delete line
-#define ML_INSERT       0x12        // insert line
-#define ML_FIND         0x13        // just find the line
-#define ML_FLUSH        0x02        // flush locked block
+enum {
+  ML_DELETE = 0x11,  // delete line
+  ML_INSERT = 0x12,  // insert line
+  ML_FIND = 0x13,    // just find the line
+  ML_FLUSH = 0x02,   // flush locked block
+};
 #define ML_SIMPLE(x)    ((x) & 0x10)  // DEL, INS or FIND
 
 // argument for ml_upd_block0()
@@ -271,7 +279,7 @@ int ml_open(buf_T *buf)
   b0p->b0_id[0] = BLOCK0_ID0;
   b0p->b0_id[1] = BLOCK0_ID1;
   b0p->b0_magic_long = B0_MAGIC_LONG;
-  b0p->b0_magic_int = (int)B0_MAGIC_INT;
+  b0p->b0_magic_int = B0_MAGIC_INT;
   b0p->b0_magic_short = (int16_t)B0_MAGIC_SHORT;
   b0p->b0_magic_char = B0_MAGIC_CHAR;
   xstrlcpy(xstpcpy((char *)b0p->b0_version, "VIM "), Version, 6);
@@ -3375,7 +3383,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
 static int b0_magic_wrong(ZERO_BL *b0p)
 {
   return b0p->b0_magic_long != B0_MAGIC_LONG
-         || b0p->b0_magic_int != (int)B0_MAGIC_INT
+         || b0p->b0_magic_int != B0_MAGIC_INT
          || b0p->b0_magic_short != (int16_t)B0_MAGIC_SHORT
          || b0p->b0_magic_char != B0_MAGIC_CHAR;
 }
@@ -3525,8 +3533,10 @@ void ml_setflags(buf_T *buf)
   }
 }
 
-#define MLCS_MAXL 800   // max no of lines in chunk
-#define MLCS_MINL 400   // should be half of MLCS_MAXL
+enum {
+  MLCS_MAXL = 800,  // max no of lines in chunk
+  MLCS_MINL = 400,  // should be half of MLCS_MAXL
+};
 
 /// Keep information for finding byte offset of a line
 ///

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -439,9 +439,8 @@ char *xstrdupnul(const char *const str)
 {
   if (str == NULL) {
     return xmallocz(0);
-  } else {
-    return xstrdup(str);
   }
+  return xstrdup(str);
 }
 
 /// A version of memchr that starts the search at `src + len`.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -59,8 +59,10 @@ struct msgchunk_S {
 };
 
 // Magic chars used in confirm dialog strings
-#define DLG_BUTTON_SEP  '\n'
-#define DLG_HOTKEY_CHAR '&'
+enum {
+  DLG_BUTTON_SEP = '\n',
+  DLG_HOTKEY_CHAR = '&',
+};
 
 static int confirm_msg_used = false;            // displaying confirm_msg
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1179,17 +1179,15 @@ retnomove:
       // Don't use start_arrow() if we're in the same window
       if (curwin == old_curwin) {
         return IN_STATUS_LINE;
-      } else {
-        return IN_STATUS_LINE | CURSOR_MOVED;
       }
+      return IN_STATUS_LINE | CURSOR_MOVED;
     }
     if (sep_line_offset) {                          // In (or below) status line
       // Don't use start_arrow() if we're in the same window
       if (curwin == old_curwin) {
         return IN_SEP_LINE;
-      } else {
-        return IN_SEP_LINE | CURSOR_MOVED;
       }
+      return IN_SEP_LINE | CURSOR_MOVED;
     }
 
     curwin->w_cursor.lnum = curwin->w_topline;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4299,9 +4299,8 @@ static void nv_brackets(cmdarg_T *cap)
                         cap->nchar == 's', false, NULL) == 0) {
         clearopbeep(cap->oap);
         break;
-      } else {
-        curwin->w_set_curswant = true;
       }
+      curwin->w_set_curswant = true;
     }
     if (cap->oap->op_type == OP_NOP && (fdo_flags & FDO_SEARCH) && KeyTyped) {
       foldOpenCursor();

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2950,15 +2950,13 @@ int get_option_value_strict(char *name, int64_t *numval, char **stringval, int o
     if (p->indir & PV_WIN) {
       if (opt_type == SREQ_BUF) {
         return 0;  // Requested buffer-local, not window-local option
-      } else {
-        rv |= SOPT_WIN;
       }
+      rv |= SOPT_WIN;
     } else if (p->indir & PV_BUF) {
       if (opt_type == SREQ_WIN) {
         return 0;  // Requested window-local, not buffer-local option
-      } else {
-        rv |= SOPT_BUF;
       }
+      rv |= SOPT_BUF;
     }
   }
 
@@ -2969,9 +2967,8 @@ int get_option_value_strict(char *name, int64_t *numval, char **stringval, int o
   if (opt_type == SREQ_GLOBAL) {
     if (p->var == VAR_WIN) {
       return 0;
-    } else {
-      varp = p->var;
     }
+    varp = p->var;
   } else {
     if (opt_type == SREQ_BUF) {
       // Special case: 'modified' is b_changed, but we also want to
@@ -3094,9 +3091,8 @@ char *set_option_value(const char *const name, const long number, const char *co
       }
       if (flags & P_NUM) {
         return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
-      } else {
-        return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
       }
+      return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
     }
   }
   return NULL;

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -837,10 +837,9 @@ const void *vim_env_iter(const char delim, const char *const val, const void *co
   if (dirend == NULL) {
     *len = strlen(varval);
     return NULL;
-  } else {
-    *len = (size_t)(dirend - varval);
-    return dirend + 1;
   }
+  *len = (size_t)(dirend - varval);
+  return dirend + 1;
 }
 
 /// Iterates $PATH-like delimited list `val` in reverse order.
@@ -870,11 +869,10 @@ const void *vim_env_iter_rev(const char delim, const char *const val, const void
     *len = varlen;
     *dir = val;
     return NULL;
-  } else {
-    *dir = colon + 1;
-    *len = (size_t)(varend - colon);
-    return colon - 1;
   }
+  *dir = colon + 1;
+  *len = (size_t)(varend - colon);
+  return colon - 1;
 }
 
 /// @param[out] exe_name should be at least MAXPATHL in size

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -121,9 +121,8 @@ bool os_isrealdir(const char *name)
   fs_loop_unlock();
   if (S_ISLNK(request.statbuf.st_mode)) {
     return false;
-  } else {
-    return S_ISDIR(request.statbuf.st_mode);
   }
+  return S_ISDIR(request.statbuf.st_mode);
 }
 
 /// Check if the given path exists and is a directory.
@@ -249,9 +248,8 @@ bool os_can_exe(const char *name, char **abspath, bool use_path)
         && is_executable(name, abspath)) {
 #endif
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   return is_executable_in_path(name, abspath);
@@ -756,9 +754,8 @@ int32_t os_getperm(const char *name)
   int stat_result = os_stat(name, &statbuf);
   if (stat_result == kLibuvSuccess) {
     return (int32_t)statbuf.st_mode;
-  } else {
-    return stat_result;
   }
+  return stat_result;
 }
 
 /// Set the permission of a file.

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -469,9 +469,8 @@ static InbufPollResult inbuf_poll(int ms, MultiQueue *events)
 
   if (input_ready(events)) {
     return kInputAvail;
-  } else {
-    return input_eof ? kInputEof : kInputNone;
   }
+  return input_eof ? kInputEof : kInputNone;
 }
 
 void input_done(void)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -33,8 +33,10 @@
 #include "nvim/vim.h"
 #include "nvim/window.h"
 
-#define URL_SLASH       1               // path_is_url() has found ":/"
-#define URL_BACKSLASH   2               // path_is_url() has found ":\\"
+enum {
+  URL_SLASH = 1,      // path_is_url() has found ":/"
+  URL_BACKSLASH = 2,  // path_is_url() has found ":\\"
+};
 
 #ifdef gen_expand_wildcards
 # undef gen_expand_wildcards

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -238,9 +238,8 @@ int win_chartabsize(win_T *wp, char *p, colnr_T col)
   buf_T *buf = wp->w_buffer;
   if (*p == TAB && (!wp->w_p_list || wp->w_p_lcs_chars.tab1)) {
     return tabstop_padding(col, buf->b_p_ts, buf->b_p_vts_array);
-  } else {
-    return ptr2cells(p);
   }
+  return ptr2cells(p);
 }
 
 /// Return the number of characters the string 's' will take on the screen,

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -762,12 +762,11 @@ static bool pum_set_selected(int n, int repeat)
             if (e == NULL) {
               ml_append(lnum++, (char *)p, 0, false);
               break;
-            } else {
-              *e = NUL;
-              ml_append(lnum++, (char *)p, (int)(e - p + 1), false);
-              *e = '\n';
-              p = e + 1;
             }
+            *e = NUL;
+            ml_append(lnum++, (char *)p, (int)(e - p + 1), false);
+            *e = '\n';
+            p = e + 1;
           }
 
           // Increase the height of the preview window to show the

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2153,12 +2153,11 @@ static char *qf_push_dir(char *dirbuf, struct dir_stack_T **stackptr, bool is_fi
 
   if ((*stackptr)->dirname != NULL) {
     return (*stackptr)->dirname;
-  } else {
-    ds_ptr = *stackptr;
-    *stackptr = (*stackptr)->next;
-    xfree(ds_ptr);
-    return NULL;
   }
+  ds_ptr = *stackptr;
+  *stackptr = (*stackptr)->next;
+  xfree(ds_ptr);
+  return NULL;
 }
 
 // pop dirbuf from the directory stack and return previous directory or NULL if
@@ -2706,11 +2705,10 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit, int
     if (!can_abandon(curbuf, forceit)) {
       no_write_message();
       return FAIL;
-    } else {
-      retval = do_ecmd(qf_ptr->qf_fnum, NULL, NULL, NULL, (linenr_T)1,
-                       ECMD_HIDE + ECMD_SET_HELP,
-                       prev_winid == curwin->handle ? curwin : NULL);
     }
+    retval = do_ecmd(qf_ptr->qf_fnum, NULL, NULL, NULL, (linenr_T)1,
+                     ECMD_HIDE + ECMD_SET_HELP,
+                     prev_winid == curwin->handle ? curwin : NULL);
   } else {
     retval = buflist_getfile(qf_ptr->qf_fnum, (linenr_T)1,
                              GETF_SETMARK | GETF_SWITCH, forceit);
@@ -5140,11 +5138,10 @@ static bool vgr_qflist_valid(win_T *wp, qf_info_T *qi, unsigned qfid, char *titl
       // An autocmd has freed the location list
       emsg(_(e_current_location_list_was_changed));
       return false;
-    } else {
-      // Quickfix list is not found, create a new one.
-      qf_new_list(qi, title);
-      return true;
     }
+    // Quickfix list is not found, create a new one.
+    qf_new_list(qi, title);
+    return true;
   }
   if (qf_restore_list(qi, qfid) == FAIL) {
     return false;

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -3017,10 +3017,9 @@ shada_write_file_open: {}
           assert(sd_reader.close != NULL);
           sd_reader.close(&sd_reader);
           return FAIL;
-        } else {
-          (*wp)++;
-          goto shada_write_file_open;
         }
+        (*wp)++;
+        goto shada_write_file_open;
       } else {
         semsg(_(SERR "System error while opening temporary ShaDa file %s "
                 "for writing: %s"), tempname, os_strerror(error));
@@ -3257,13 +3256,12 @@ static ShaDaReadResult fread_len(ShaDaReadDef *const sd_reader, char *const buff
       semsg(_(SERR "System error while reading ShaDa file: %s"),
             sd_reader->error);
       return kSDReadStatusReadError;
-    } else {
-      semsg(_(RCERR "Error while reading ShaDa file: "
-              "last entry specified that it occupies %" PRIu64 " bytes, "
-              "but file ended earlier"),
-            (uint64_t)length);
-      return kSDReadStatusNotShaDa;
     }
+    semsg(_(RCERR "Error while reading ShaDa file: "
+            "last entry specified that it occupies %" PRIu64 " bytes, "
+            "but file ended earlier"),
+          (uint64_t)length);
+    return kSDReadStatusNotShaDa;
   }
   return kSDReadStatusSuccess;
 }
@@ -3576,16 +3574,15 @@ shada_read_next_item_start:
         entry->type = kSDItemMissing;
       }
       return spm_ret;
-    } else {
-      entry->data.unknown_item.contents = xmalloc(length);
-      const ShaDaReadResult fl_ret =
-        fread_len(sd_reader, entry->data.unknown_item.contents, length);
-      if (fl_ret != kSDReadStatusSuccess) {
-        shada_free_shada_entry(entry);
-        entry->type = kSDItemMissing;
-      }
-      return fl_ret;
     }
+    entry->data.unknown_item.contents = xmalloc(length);
+    const ShaDaReadResult fl_ret =
+      fread_len(sd_reader, entry->data.unknown_item.contents, length);
+    if (fl_ret != kSDReadStatusSuccess) {
+      shada_free_shada_entry(entry);
+      entry->type = kSDItemMissing;
+    }
+    return fl_ret;
   }
 
   msgpack_unpacked unpacked;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -112,11 +112,13 @@
 #include "nvim/vim.h"             // for curwin, strlen, STRLCPY, STRNCMP
 
 // Result values.  Lower number is accepted over higher one.
-#define SP_BANNED       (-1)
-#define SP_RARE         0
-#define SP_OK           1
-#define SP_LOCAL        2
-#define SP_BAD          3
+enum {
+  SP_BANNED = -1,
+  SP_RARE = 0,
+  SP_OK = 1,
+  SP_LOCAL = 2,
+  SP_BAD = 3,
+};
 
 // First language that is loaded, start of the linked list of loaded
 // languages.

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -258,50 +258,55 @@
 
 // Special byte values for <byte>.  Some are only used in the tree for
 // postponed prefixes, some only in the other trees.  This is a bit messy...
-#define BY_NOFLAGS      0       // end of word without flags or region; for
-                                // postponed prefix: no <pflags>
-#define BY_INDEX        1       // child is shared, index follows
-#define BY_FLAGS        2       // end of word, <flags> byte follows; for
-                                // postponed prefix: <pflags> follows
-#define BY_FLAGS2       3       // end of word, <flags> and <flags2> bytes
-                                // follow; never used in prefix tree
-#define BY_SPECIAL  BY_FLAGS2   // highest special byte value
+enum {
+  BY_NOFLAGS = 0,  // end of word without flags or region; for postponed prefix: no <pflags>
+  BY_INDEX = 1,    // child is shared, index follows
+  BY_FLAGS = 2,    // end of word, <flags> byte follows; for postponed prefix: <pflags> follows
+  BY_FLAGS2 = 3,   // end of word, <flags> and <flags2> bytes follow; never used in prefix tree
+  BY_SPECIAL = BY_FLAGS2,  // highest special byte value
+};
 
 #define ZERO_FLAG   65009       // used when flag is zero: "0"
 
 // Flags used in .spl file for soundsalike flags.
-#define SAL_F0LLOWUP            1
-#define SAL_COLLAPSE            2
-#define SAL_REM_ACCENTS         4
+enum {
+  SAL_F0LLOWUP = 1,
+  SAL_COLLAPSE = 2,
+  SAL_REM_ACCENTS = 4,
+};
 
 #define VIMSPELLMAGIC "VIMspell"  // string at start of Vim spell file
 #define VIMSPELLMAGICL (sizeof(VIMSPELLMAGIC) - 1)
 #define VIMSPELLVERSION 50
 
 // Section IDs.  Only renumber them when VIMSPELLVERSION changes!
-#define SN_REGION       0       // <regionname> section
-#define SN_CHARFLAGS    1       // charflags section
-#define SN_MIDWORD      2       // <midword> section
-#define SN_PREFCOND     3       // <prefcond> section
-#define SN_REP          4       // REP items section
-#define SN_SAL          5       // SAL items section
-#define SN_SOFO         6       // soundfolding section
-#define SN_MAP          7       // MAP items section
-#define SN_COMPOUND     8       // compound words section
-#define SN_SYLLABLE     9       // syllable section
-#define SN_NOBREAK      10      // NOBREAK section
-#define SN_SUGFILE      11      // timestamp for .sug file
-#define SN_REPSAL       12      // REPSAL items section
-#define SN_WORDS        13      // common words
-#define SN_NOSPLITSUGS  14      // don't split word for suggestions
-#define SN_INFO         15      // info section
-#define SN_NOCOMPOUNDSUGS 16    // don't compound for suggestions
-#define SN_END          255     // end of sections
+enum {
+  SN_REGION = 0,           // <regionname> section
+  SN_CHARFLAGS = 1,        // charflags section
+  SN_MIDWORD = 2,          // <midword> section
+  SN_PREFCOND = 3,         // <prefcond> section
+  SN_REP = 4,              // REP items section
+  SN_SAL = 5,              // SAL items section
+  SN_SOFO = 6,             // soundfolding section
+  SN_MAP = 7,              // MAP items section
+  SN_COMPOUND = 8,         // compound words section
+  SN_SYLLABLE = 9,         // syllable section
+  SN_NOBREAK = 10,         // NOBREAK section
+  SN_SUGFILE = 11,         // timestamp for .sug file
+  SN_REPSAL = 12,          // REPSAL items section
+  SN_WORDS = 13,           // common words
+  SN_NOSPLITSUGS = 14,     // don't split word for suggestions
+  SN_INFO = 15,            // info section
+  SN_NOCOMPOUNDSUGS = 16,  // don't compound for suggestions
+  SN_END = 255,            // end of sections
+};
 
 #define SNF_REQUIRED    1       // <sectionflags>: required section
 
-#define CF_WORD         0x01
-#define CF_UPPER        0x02
+enum {
+  CF_WORD = 0x01,
+  CF_UPPER = 0x02,
+};
 
 static char *e_spell_trunc = N_("E758: Truncated spell file");
 static char *e_illegal_character_in_word = N_("E1280: Illegal character in word");

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -91,45 +91,55 @@ typedef struct {
 #define SUG_MAX_COUNT(su)       (SUG_CLEAN_COUNT(su) + 50)
 
 // score for various changes
-#define SCORE_SPLIT     149     // split bad word
-#define SCORE_SPLIT_NO  249     // split bad word with NOSPLITSUGS
-#define SCORE_ICASE     52      // slightly different case
-#define SCORE_REGION    200     // word is for different region
-#define SCORE_RARE      180     // rare word
-#define SCORE_SWAP      75      // swap two characters
-#define SCORE_SWAP3     110     // swap two characters in three
-#define SCORE_REP       65      // REP replacement
-#define SCORE_SUBST     93      // substitute a character
-#define SCORE_SIMILAR   33      // substitute a similar character
-#define SCORE_SUBCOMP   33      // substitute a composing character
-#define SCORE_DEL       94      // delete a character
-#define SCORE_DELDUP    66      // delete a duplicated character
-#define SCORE_DELCOMP   28      // delete a composing character
-#define SCORE_INS       96      // insert a character
-#define SCORE_INSDUP    67      // insert a duplicate character
-#define SCORE_INSCOMP   30      // insert a composing character
-#define SCORE_NONWORD   103     // change non-word to word char
+enum {
+  SCORE_SPLIT = 149,     // split bad word
+  SCORE_SPLIT_NO = 249,  // split bad word with NOSPLITSUGS
+  SCORE_ICASE = 52,      // slightly different case
+  SCORE_REGION = 200,    // word is for different region
+  SCORE_RARE = 180,      // rare word
+  SCORE_SWAP = 75,       // swap two characters
+  SCORE_SWAP3 = 110,     // swap two characters in three
+  SCORE_REP = 65,        // REP replacement
+  SCORE_SUBST = 93,      // substitute a character
+  SCORE_SIMILAR = 33,    // substitute a similar character
+  SCORE_SUBCOMP = 33,    // substitute a composing character
+  SCORE_DEL = 94,        // delete a character
+  SCORE_DELDUP = 66,     // delete a duplicated character
+  SCORE_DELCOMP = 28,    // delete a composing character
+  SCORE_INS = 96,        // insert a character
+  SCORE_INSDUP = 67,     // insert a duplicate character
+  SCORE_INSCOMP = 30,    // insert a composing character
+  SCORE_NONWORD = 103,   // change non-word to word char
+};
 
-#define SCORE_FILE      30      // suggestion from a file
-#define SCORE_MAXINIT   350     // Initial maximum score: higher == slower.
-                                // 350 allows for about three changes.
+enum {
+  SCORE_FILE = 30,      // suggestion from a file
+  SCORE_MAXINIT = 350,  // Initial maximum score: higher == slower.
+                        // 350 allows for about three changes.
+};
 
-#define SCORE_COMMON1   30      // subtracted for words seen before
-#define SCORE_COMMON2   40      // subtracted for words often seen
-#define SCORE_COMMON3   50      // subtracted for words very often seen
-#define SCORE_THRES2    10      // word count threshold for COMMON2
-#define SCORE_THRES3    100     // word count threshold for COMMON3
+enum {
+  SCORE_COMMON1 = 30,  // subtracted for words seen before
+  SCORE_COMMON2 = 40,  // subtracted for words often seen
+  SCORE_COMMON3 = 50,  // subtracted for words very often seen
+  SCORE_THRES2 = 10,   // word count threshold for COMMON2
+  SCORE_THRES3 = 100,  // word count threshold for COMMON3
+};
 
 // When trying changed soundfold words it becomes slow when trying more than
 // two changes.  With less than two changes it's slightly faster but we miss a
 // few good suggestions.  In rare cases we need to try three of four changes.
-#define SCORE_SFMAX1    200     // maximum score for first try
-#define SCORE_SFMAX2    300     // maximum score for second try
-#define SCORE_SFMAX3    400     // maximum score for third try
+enum {
+  SCORE_SFMAX1 = 200,  // maximum score for first try
+  SCORE_SFMAX2 = 300,  // maximum score for second try
+  SCORE_SFMAX3 = 400,  // maximum score for third try
+};
 
 #define SCORE_BIG       (SCORE_INS * 3)  // big difference
-#define SCORE_MAXMAX    999999           // accept any score
-#define SCORE_LIMITMAX  350              // for spell_edit_score_limit()
+enum {
+  SCORE_MAXMAX = 999999,  // accept any score
+  SCORE_LIMITMAX = 350,   // for spell_edit_score_limit()
+};
 
 // for spell_edit_score_limit() we need to know the minimum value of
 // SCORE_ICASE, SCORE_SWAP, SCORE_DEL, SCORE_SIMILAR and SCORE_INS
@@ -186,19 +196,25 @@ typedef struct trystate_S {
 } trystate_T;
 
 // values for ts_isdiff
-#define DIFF_NONE       0       // no different byte (yet)
-#define DIFF_YES        1       // different byte found
-#define DIFF_INSERT     2       // inserting character
+enum {
+  DIFF_NONE = 0,    // no different byte (yet)
+  DIFF_YES = 1,     // different byte found
+  DIFF_INSERT = 2,  // inserting character
+};
 
 // values for ts_flags
-#define TSF_PREFIXOK    1       // already checked that prefix is OK
-#define TSF_DIDSPLIT    2       // tried split at this point
-#define TSF_DIDDEL      4       // did a delete, "ts_delidx" has index
+enum {
+  TSF_PREFIXOK = 1,  // already checked that prefix is OK
+  TSF_DIDSPLIT = 2,  // tried split at this point
+  TSF_DIDDEL = 4,    // did a delete, "ts_delidx" has index
+};
 
 // special values ts_prefixdepth
-#define PFD_NOPREFIX    0xff    // not using prefixes
-#define PFD_PREFIXTREE  0xfe    // walking through the prefix tree
-#define PFD_NOTSPECIAL  0xfd    // highest value that's not special
+enum {
+  PFD_NOPREFIX = 0xff,    // not using prefixes
+  PFD_PREFIXTREE = 0xfe,  // walking through the prefix tree
+  PFD_NOTSPECIAL = 0xfd,  // highest value that's not special
+};
 
 static long spell_suggest_timeout = 5000;
 
@@ -341,9 +357,11 @@ static int bytes2offset(char_u **pp)
 }
 
 // values for sps_flags
-#define SPS_BEST    1
-#define SPS_FAST    2
-#define SPS_DOUBLE  4
+enum {
+  SPS_BEST = 1,
+  SPS_FAST = 2,
+  SPS_DOUBLE = 4,
+};
 
 static int sps_flags = SPS_BEST;  ///< flags from 'spellsuggest'
 static int sps_limit = 9999;      ///< max nr of suggestions given

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -604,10 +604,9 @@ static const void *tv_ptr(const typval_T *const tvs, int *const idxp)
   if (tvs[idx].v_type == VAR_UNKNOWN) {
     emsg(_(e_printf));
     return NULL;
-  } else {
-    (*idxp)++;
-    return tvs[idx].vval.v_string;
   }
+  (*idxp)++;
+  return tvs[idx].vval.v_string;
 }
 
 /// Get float argument from idxp entry in tvs

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3123,22 +3123,20 @@ static void syn_cmd_clear(exarg_T *eap, int syncing)
         if (id == 0) {
           semsg(_("E391: No such syntax cluster: %s"), arg);
           break;
-        } else {
-          // We can't physically delete a cluster without changing
-          // the IDs of other clusters, so we do the next best thing
-          // and make it empty.
-          int scl_id = id - SYNID_CLUSTER;
-
-          XFREE_CLEAR(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
         }
+        // We can't physically delete a cluster without changing
+        // the IDs of other clusters, so we do the next best thing
+        // and make it empty.
+        int scl_id = id - SYNID_CLUSTER;
+
+        XFREE_CLEAR(SYN_CLSTR(curwin->w_s)[scl_id].scl_list);
       } else {
         id = syn_name2id_len(arg, (size_t)(arg_end - arg));
         if (id == 0) {
           semsg(_(e_nogroup), arg);
           break;
-        } else {
-          syn_clear_one(id, syncing);
         }
+        syn_clear_one(id, syncing);
       }
       arg = skipwhite(arg_end);
     }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -81,14 +81,16 @@ typedef struct {
 // ht_match[] is used to find duplicates, ga_match[] to keep them in sequence.
 // At the end, the matches from ga_match[] are concatenated, to make a list
 // sorted on priority.
-#define MT_ST_CUR       0               // static match in current file
-#define MT_GL_CUR       1               // global match in current file
-#define MT_GL_OTH       2               // global match in other file
-#define MT_ST_OTH       3               // static match in other file
-#define MT_IC_OFF       4               // add for icase match
-#define MT_RE_OFF       8               // add for regexp match
-#define MT_MASK         7               // mask for printing priority
-#define MT_COUNT        16
+enum {
+  MT_ST_CUR = 0,  // static match in current file
+  MT_GL_CUR = 1,  // global match in current file
+  MT_GL_OTH = 2,  // global match in other file
+  MT_ST_OTH = 3,  // static match in other file
+  MT_IC_OFF = 4,  // add for icase match
+  MT_RE_OFF = 8,  // add for regexp match
+  MT_MASK = 7,    // mask for printing priority
+  MT_COUNT = 16,
+};
 
 static char *mt_names[MT_COUNT/2] =
 { "FSC", "F C", "F  ", "FS ", " SC", "  C", "   ", " S " };
@@ -1595,9 +1597,8 @@ int find_tags(char *pat, int *num_matches, char ***matchesp, int flags, int minc
                                               - search_info.low_offset) / 2);
           if (offset == search_info.curr_offset) {
             break;              // End the binary search without a match.
-          } else {
-            search_info.curr_offset = offset;
           }
+          search_info.curr_offset = offset;
         } else if (state == TS_SKIP_BACK) {
           // Skipping back (after a match during binary search).
           search_info.curr_offset -= lbuf_size * 2;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -324,15 +324,14 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
       && map_has(KittyKey, cstr_t)(&kitty_key_map, (KittyKey)key->code.codepoint)) {
     handle_kitty_key_protocol(input, key);
     return;
-  } else {
-    while (*ptr) {
-      if (*ptr == '<') {
-        len += (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
-      } else {
-        buf[len++] = *ptr;
-      }
-      ptr++;
+  }
+  while (*ptr) {
+    if (*ptr == '<') {
+      len += (size_t)snprintf(buf + len, sizeof(buf) - len, "<lt>");
+    } else {
+      buf[len++] = *ptr;
     }
+    ptr++;
   }
 
   tinput_enqueue(input, buf, len);
@@ -355,21 +354,20 @@ static void forward_modified_utf8(TermInput *input, TermKeyKey *key)
                                      (KittyKey)key->code.codepoint)) {
       handle_kitty_key_protocol(input, key);
       return;
-    } else {
-      // Termkey doesn't include the S- modifier for ASCII characters (e.g.,
-      // ctrl-shift-l is <C-L> instead of <C-S-L>.  Vim, on the other hand,
-      // treats <C-L> and <C-l> the same, requiring the S- modifier.
-      len = termkey_strfkey(input->tk, buf, sizeof(buf), key, TERMKEY_FORMAT_VIM);
-      if ((key->modifiers & TERMKEY_KEYMOD_CTRL)
-          && !(key->modifiers & TERMKEY_KEYMOD_SHIFT)
-          && ASCII_ISUPPER(key->code.codepoint)) {
-        assert(len <= 62);
-        // Make room for the S-
-        memmove(buf + 3, buf + 1, len - 1);
-        buf[1] = 'S';
-        buf[2] = '-';
-        len += 2;
-      }
+    }
+    // Termkey doesn't include the S- modifier for ASCII characters (e.g.,
+    // ctrl-shift-l is <C-L> instead of <C-S-L>.  Vim, on the other hand,
+    // treats <C-L> and <C-l> the same, requiring the S- modifier.
+    len = termkey_strfkey(input->tk, buf, sizeof(buf), key, TERMKEY_FORMAT_VIM);
+    if ((key->modifiers & TERMKEY_KEYMOD_CTRL)
+        && !(key->modifiers & TERMKEY_KEYMOD_SHIFT)
+        && ASCII_ISUPPER(key->code.codepoint)) {
+      assert(len <= 62);
+      // Make room for the S-
+      memmove(buf + 3, buf + 1, len - 1);
+      buf[1] = 'S';
+      buf[2] = '-';
+      len += 2;
     }
   }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1651,9 +1651,8 @@ static void out(void *ctx, const char *str, size_t len)
       // Called by unibi_format(): avoid flush_buf() halfway an escape sequence.
       data->overflow = true;
       return;
-    } else {
-      flush_buf(ui);
     }
+    flush_buf(ui);
   }
 
   memcpy(data->buf + data->bufpos, str, len);

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2713,9 +2713,8 @@ void ex_undojoin(exarg_T *eap)
   }
   if (get_undolevel(curbuf) < 0) {
     return;                 // no entries, nothing to do
-  } else {
-    curbuf->b_u_synced = false;  // Append next change to last entry
   }
+  curbuf->b_u_synced = false;  // Append next change to last entry
 }
 
 /// Called after writing or reloading the file and setting b_changed to false.

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -343,9 +343,8 @@ static char *get_command_complete(int arg)
 {
   if (arg >= (int)(ARRAY_SIZE(command_complete))) {
     return NULL;
-  } else {
-    return (char *)command_complete[arg];
   }
+  return (char *)command_complete[arg];
 }
 
 /// Function given to ExpandGeneric() to obtain the list of values for -complete.
@@ -357,9 +356,8 @@ char *get_user_cmd_complete(expand_T *xp, int idx)
   char *cmd_compl = get_command_complete(idx);
   if (cmd_compl == NULL) {
     return "";
-  } else {
-    return cmd_compl;
   }
+  return cmd_compl;
 }
 
 int cmdcomplete_str_to_type(const char *complete_str)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -270,9 +270,8 @@ newwindow:
         for (wp = firstwin; --Prenum > 0;) {
           if (wp->w_next == NULL) {
             break;
-          } else {
-            wp = wp->w_next;
           }
+          wp = wp->w_next;
         }
       } else {
         if (nchar == 'W') {  // go to previous window
@@ -872,9 +871,8 @@ int win_fdccol_count(win_T *wp)
     const int fdccol = fdc[4] == ':' ? fdc[5] - '0' : 1;
     int needed_fdccols = getDeepestNesting(wp);
     return MIN(fdccol, needed_fdccols);
-  } else {
-    return fdc[0] - '0';
   }
+  return fdc[0] - '0';
 }
 
 void ui_ext_win_position(win_T *wp, bool validate)
@@ -4869,12 +4867,11 @@ win_T *buf_jump_open_win(buf_T *buf)
   if (curwin->w_buffer == buf) {
     win_enter(curwin, false);
     return curwin;
-  } else {
-    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-      if (wp->w_buffer == buf) {
-        win_enter(wp, false);
-        return wp;
-      }
+  }
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_buffer == buf) {
+      win_enter(wp, false);
+      return wp;
     }
   }
 
@@ -6642,12 +6639,11 @@ static bool resize_frame_for_winbar(frame_T *fr)
   if (fp == NULL || fp == fr) {
     emsg(_(e_noroom));
     return false;
-  } else {
-    frame_new_height(fp, fp->fr_height - 1, false, false);
-    win_new_height(wp, wp->w_height + 1);
-    frame_fix_height(wp);
-    (void)win_comp_pos();
   }
+  frame_new_height(fp, fp->fr_height - 1, false, false);
+  win_new_height(wp, wp->w_height + 1);
+  frame_fix_height(wp);
+  (void)win_comp_pos();
 
   return true;
 }


### PR DESCRIPTION
Enable and fix bugprone-misplaced-widening-cast warning.

Fix some modernize-macro-to-enum and readability-else-after-return
warnings, but don't enable them. While the warnings can be useful, they
are in general too noisy to enable.