### PR TITLE
vim-patch:8.2.{2837,3839}: various tests

### DIFF
--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -683,6 +683,12 @@ func Test_sandbox()
   sandbox call Sandbox_tests()
 endfunc
 
+func Test_command_not_implemented_E319()
+  if !has('mzscheme')
+    call assert_fails('mzscheme', 'E319:')
+  endif
+endfunc
+
 func Test_not_break_expression_register()
   call setreg('=', '1+1')
   if 0

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1018,7 +1018,9 @@ func Test_charidx()
   call assert_equal(2, charidx(a, 4))
   call assert_equal(3, charidx(a, 7))
   call assert_equal(-1, charidx(a, 8))
+  call assert_equal(-1, charidx(a, -1))
   call assert_equal(-1, charidx('', 0))
+  call assert_equal(-1, charidx(v:_null_string, 0))
 
   " count composing characters
   call assert_equal(0, charidx(a, 0, 1))

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1116,6 +1116,35 @@ func Test_opt_reset_scroll()
   call delete('Xscroll')
 endfunc
 
+" Check that VIM_POSIX env variable influences default value of 'cpo' and 'shm'
+func Test_VIM_POSIX()
+  throw 'Skipped: Nvim does not support $VIM_POSIX'
+  let saved_VIM_POSIX = getenv("VIM_POSIX")
+
+  call setenv('VIM_POSIX', "1")
+  let after =<< trim [CODE]
+    call writefile([&cpo, &shm], 'X_VIM_POSIX')
+    qall
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\.;',
+          \            'AS'], readfile('X_VIM_POSIX'))
+  endif
+
+  call setenv('VIM_POSIX', v:null)
+  let after =<< trim [CODE]
+    call writefile([&cpo, &shm], 'X_VIM_POSIX')
+    qall
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>;',
+          \            'S'], readfile('X_VIM_POSIX'))
+  endif
+
+  call delete('X_VIM_POSIX')
+  call setenv('VIM_POSIX', saved_VIM_POSIX)
+endfunc
+
 " Test for setting an option to a Vi or Vim default
 func Test_opt_default()
   throw 'Skipped: Nvim has different defaults'

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -620,6 +620,12 @@ func Test_invalid_args()
   endfor
 
   if has('gui_gtk')
+    let out = split(system(GetVimCommand() .. ' --socketid'), "\n")
+    call assert_equal(1, v:shell_error)
+    call assert_match('^VIM - Vi IMproved .* (.*)$',          out[0])
+    call assert_equal('Argument missing after: "--socketid"', out[1])
+    call assert_equal('More info with: "vim -h"',             out[2])
+
     for opt in ['--socketid x', '--socketid 0xg']
       let out = split(system(GetVimCommand() .. ' ' .. opt), "\n")
       call assert_equal(1, v:shell_error)
@@ -627,6 +633,7 @@ func Test_invalid_args()
       call assert_equal('Invalid argument for: "--socketid"', out[1])
       call assert_equal('More info with: "vim -h"',           out[2])
     endfor
+
   endif
 endfunc
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -113,6 +113,9 @@ func Test_syntime()
   let a = execute('syntime report')
   call assert_equal("\nNo Syntax items defined for this buffer", a)
 
+  let a = execute('syntime clear')
+  call assert_equal("\nNo Syntax items defined for this buffer", a)
+
   view samples/memfile_test.c
   setfiletype cpp
   redraw

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -666,6 +666,24 @@ func Test_syntax_c()
   call delete('Xtest.c')
 endfun
 
+" Test \z(...) along with \z1
+func Test_syn_zsub()
+  new
+  syntax on
+  call setline(1,  'xxx start foo xxx not end foo xxx end foo xxx')
+  let l:expected = '    ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ    '
+
+  for l:re in [0, 1, 2]
+    " Example taken from :help :syn-ext-match
+    syntax region Z start="start \z(\I\i*\)" skip="not end \z1" end="end \z1"
+    eval AssertHighlightGroups(1, 1, l:expected, 1, 'regexp=' .. l:re)
+    syntax clear Z
+  endfor
+
+  set re&
+  bw!
+endfunc
+
 " Using \z() in a region with NFA failing should not crash.
 func Test_syn_wrong_z_one()
   new


### PR DESCRIPTION
#### vim-patch:8.2.2837: various code lines not covered by tests

Problem:    Various code lines not covered by tests.
Solution:   Add test cases. (Dominique Pellé, closes vim/vim#8178)

https://github.com/vim/vim/commit/6d37e8e3baafba460bd2d051170d213c1ba9a523

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>


#### vim-patch:8.2.3839: using \z() with \z1 not tested for syntax highlighting

Problem:    Using \z() with \z1 not tested for syntax highlighting.
Solution:   Add a test. (Dominique Pellé, closes vim/vim#9365)

https://github.com/vim/vim/commit/354b23a9f87fd8c5aec457d88320a0a5bce4b985

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>