### PR TITLE
vim-patch:8.2.{2100,2726,2727}

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -48,6 +48,8 @@ static char *e_funcexts = N_("E122: Function %s already exists, add ! to replace
 static char *e_funcdict = N_("E717: Dictionary entry already exists");
 static char *e_funcref = N_("E718: Funcref required");
 static char *e_nofunc = N_("E130: Unknown function: %s");
+static char e_no_white_space_allowed_before_str_str[]
+  = N_("E1068: No white space allowed before '%s': %s");
 
 void func_init(void)
 {
@@ -148,6 +150,15 @@ static int get_function_args(char **argp, char_u endchar, garray_T *newargs, int
       } else if (any_default) {
         emsg(_("E989: Non-default argument follows default argument"));
         mustend = true;
+      }
+
+      if (ascii_iswhite(*p) && *skipwhite(p) == ',') {
+        // Be tolerant when skipping
+        if (!skip) {
+          semsg(_(e_no_white_space_allowed_before_str_str), ",", p);
+          goto err_ret;
+        }
+        p = skipwhite(p);
       }
       if (*p == ',') {
         p++;

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1865,6 +1865,7 @@ func Test_call()
   let mydict = {'data': [0, 1, 2, 3], 'len': function("Mylen")}
   eval mydict.len->call([], mydict)->assert_equal(4)
   call assert_fails("call call('Mylen', [], 0)", 'E715:')
+  call assert_fails('call foo', 'E107:')
 endfunc
 
 func Test_char2nr()

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -245,6 +245,11 @@ func Test_closure_counter()
   call assert_equal(2, l:F())
   call assert_equal(3, l:F())
   call assert_equal(4, l:F())
+
+  call assert_match("^\n   function <SNR>\\d\\+_bar() closure"
+  \              .. "\n1        let x += 1"
+  \              .. "\n2        return x"
+  \              .. "\n   endfunction$", execute('func s:bar'))
 endfunc
 
 func Test_closure_unlet()

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -126,7 +126,7 @@ func Test_lambda_closure_counter()
   endfunc
 
   let l:F = s:foo()
-  call garbagecollect()
+  call test_garbagecollect_now()
   call assert_equal(1, l:F())
   call assert_equal(2, l:F())
   call assert_equal(3, l:F())
@@ -209,9 +209,9 @@ func Test_lambda_circular_reference()
   endfunc
 
   call s:Foo()
-  call garbagecollect()
+  call test_garbagecollect_now()
   let i = 0 | while i < 10000 | call s:Foo() | let i+= 1 | endwhile
-  call garbagecollect()
+  call test_garbagecollect_now()
 endfunc
 
 func Test_lambda_combination()
@@ -240,7 +240,7 @@ func Test_closure_counter()
   endfunc
 
   let l:F = s:foo()
-  call garbagecollect()
+  call test_garbagecollect_now()
   call assert_equal(1, l:F())
   call assert_equal(2, l:F())
   call assert_equal(3, l:F())
@@ -258,7 +258,7 @@ func Test_closure_unlet()
   endfunc
 
   call assert_false(has_key(s:foo(), 'x'))
-  call garbagecollect()
+  call test_garbagecollect_now()
 endfunc
 
 func LambdaFoo()
@@ -295,7 +295,7 @@ func Test_named_function_closure()
   endfunc
   call Afoo()
   call assert_equal(14, s:Abar())
-  call garbagecollect()
+  call test_garbagecollect_now()
   call assert_equal(14, s:Abar())
 endfunc
 

--- a/src/nvim/testdir/test_signals.vim
+++ b/src/nvim/testdir/test_signals.vim
@@ -129,8 +129,7 @@ func Test_deadly_signal_TERM()
   call assert_equal(['foo'], getline(1, '$'))
 
   let result = readfile('XautoOut')
-  call assert_match('VimLeavePre triggered', result[0])
-  call assert_match('VimLeave triggered', result[1])
+  call assert_equal(["VimLeavePre triggered", "VimLeave triggered"], result)
 
   %bwipe!
   call delete('.Xsig_TERM.swp')

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -445,4 +445,36 @@ func Test_func_arg_error()
   delfunc Xfunc
 endfunc
 
+func Test_func_dict()
+  let mydict = {'a': 'b'}
+  function mydict.somefunc() dict
+    return len(self)
+  endfunc
+
+  call assert_equal("{'a': 'b', 'somefunc': function('2')}", string(mydict))
+  call assert_equal(2, mydict.somefunc())
+  call assert_match("^\n   function \\d\\\+() dict"
+  \              .. "\n1      return len(self)"
+  \              .. "\n   endfunction$", execute('func mydict.somefunc'))
+endfunc
+
+func Test_func_range()
+  new
+  call setline(1, range(1, 8))
+  func FuncRange() range
+    echo a:firstline
+    echo a:lastline
+  endfunc
+  3
+  call assert_equal("\n3\n3", execute('call FuncRange()'))
+  call assert_equal("\n4\n6", execute('4,6 call FuncRange()'))
+  call assert_equal("\n   function FuncRange() range"
+  \              .. "\n1      echo a:firstline"
+  \              .. "\n2      echo a:lastline"
+  \              .. "\n   endfunction",
+  \                 execute('function FuncRange'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -149,8 +149,8 @@ func Test_default_arg()
   call assert_equal(res.optional, 2)
   call assert_equal(res['0'], 1)
 
-  call assert_fails("call MakeBadFunc()", 'E989')
-  call assert_fails("fu F(a=1 ,) | endf", 'E475')
+  call assert_fails("call MakeBadFunc()", 'E989:')
+  call assert_fails("fu F(a=1 ,) | endf", 'E1068:')
 
   " Since neovim does not have v:none, the ability to use the default
   " argument with the intermediate argument set to v:none has been omitted.


### PR DESCRIPTION
#### vim-patch:8.2.2100: insufficient testing for function range and dict

Problem:    Insufficient testing for function range and dict.
Solution:   Add a few tests. (Dominique Pellé, closes vim/vim#7428)

https://github.com/vim/vim/commit/67322bf74a106b6476b093e75da87d61e2181b76


#### vim-patch:8.2.2726: confusing error message with white space before comma

Problem:    Confusing error message with white space before comma in the
            arguments of a function declaration.
Solution:   Give a specific error message.

https://github.com/vim/vim/commit/86cdb8a4bd1abff40b5f80c3c4149b33cbaab990

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2727: function test fails

Problem:    Function test fails.
Solution:   Adjust expected error number.

https://github.com/vim/vim/commit/e9b8b78e046b40b877c999432c4698edb3413d5d

Cherry-pick colons from patch 8.2.1593.

Co-authored-by: Bram Moolenaar <Bram@vim.org>