### PR TITLE
vim-patch:8.2.{partial:2881,3408}

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2704,6 +2704,13 @@ void ex_delfunction(exarg_T *eap)
     *p = NUL;
   }
 
+  if (isdigit(*name) && fudi.fd_dict == NULL) {
+    if (!eap->skip) {
+      semsg(_(e_invarg2), eap->arg);
+    }
+    xfree(name);
+    return;
+  }
   if (!eap->skip) {
     fp = find_func(name);
   }

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -423,6 +423,11 @@ func Test_del_func()
   func d.fn()
     return 1
   endfunc
+
+  " cannot delete the dict function by number
+  let nr = substitute(execute('echo d'), '.*function(''\(\d\+\)'').*', '\1', '')
+  call assert_fails('delfunction g:' .. nr, 'E475: Invalid argument: g:')
+
   delfunc d.fn
   call assert_equal({'a' : 10}, d)
 endfunc

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -420,6 +420,11 @@ func Test_del_func()
   call assert_fails('delfunction Xabc', 'E130:')
   let d = {'a' : 10}
   call assert_fails('delfunc d.a', 'E718:')
+  func d.fn()
+    return 1
+  endfunc
+  delfunc d.fn
+  call assert_equal({'a' : 10}, d)
 endfunc
 
 " Test for calling return outside of a function
@@ -451,11 +456,12 @@ func Test_func_dict()
     return len(self)
   endfunc
 
-  call assert_equal("{'a': 'b', 'somefunc': function('2')}", string(mydict))
+  call assert_equal("{'a': 'b', 'somefunc': function('3')}", string(mydict))
   call assert_equal(2, mydict.somefunc())
   call assert_match("^\n   function \\d\\\+() dict"
   \              .. "\n1      return len(self)"
   \              .. "\n   endfunction$", execute('func mydict.somefunc'))
+  call assert_fails('call mydict.nonexist()', 'E716:')
 endfunc
 
 func Test_func_range()


### PR DESCRIPTION
#### vim-patch:partial:8.2.2881: various pieces of code not covered by tests

Problem:    Various pieces of code not covered by tests.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8245)

https://github.com/vim/vim/commit/611728f80604dd56960e8c197e5749d203c8feb1

Only port the last two hunks of test_user_func.vim.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3408: can delete a numbered function

Problem:    Can delete a numbered function. (Naohiro Ono)
Solution:   Disallow deleting a numbered function.

https://github.com/vim/vim/commit/ddfc05100a29263a682dd96bb924dfde4354a654

Co-authored-by: Bram Moolenaar <Bram@vim.org>

Fix #18852