### PR TITLE
vim-patch:8.2.{2653,4234}

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -43,7 +43,7 @@
 static char e_string_required_for_argument_nr[]
   = N_("E1174: String required for argument %d");
 static char e_non_empty_string_required_for_argument_nr[]
-  = N_("E1142: Non-empty string required for argument %d");
+  = N_("E1175: Non-empty string required for argument %d");
 static char e_number_required_for_argument_nr[]
   = N_("E1210: Number required for argument %d");
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -997,8 +997,6 @@ EXTERN char e_luv_api_disabled[] INIT(= N_("E5560: %s must not be called in a lu
 EXTERN char e_floatonly[] INIT(= N_("E5601: Cannot close window, only floating window would remain"));
 EXTERN char e_floatexchange[] INIT(= N_("E5602: Cannot exchange or rotate float"));
 
-EXTERN char e_non_empty_string_required[] INIT(= N_("E1142: Non-empty string required"));
-
 EXTERN char e_cannot_define_autocommands_for_all_events[] INIT(= N_("E1155: Cannot define autocommands for ALL events"));
 
 EXTERN char e_resulting_text_too_long[] INIT(= N_("E1240: Resulting text too long"));

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -2206,6 +2206,12 @@ func Test_range()
   call assert_equal([0, 1, 2, 3, 4], uniq(range(5)))
 endfunc
 
+func Test_garbagecollect_now_fails()
+  let v:testing = 0
+  call assert_fails('call test_garbagecollect_now()', 'E1142:')
+  let v:testing = 1
+endfunc
+
 " Test for the eval() function
 func Test_eval()
   call assert_fails("call eval('5 a')", 'E488:')

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -14,6 +14,9 @@
 # include "testing.c.generated.h"
 #endif
 
+static char e_calling_test_garbagecollect_now_while_v_testing_is_not_set[]
+  = N_("E1142: Calling test_garbagecollect_now() while v:testing is not set");
+
 /// Prepare "gap" for an assert error and add the sourcing position.
 static void prepare_assert_error(garray_T *gap)
 {
@@ -614,7 +617,11 @@ void f_test_garbagecollect_now(typval_T *argvars, typval_T *rettv, EvalFuncData 
 {
   // This is dangerous, any Lists and Dicts used internally may be freed
   // while still in use.
-  garbage_collect(true);
+  if (!get_vim_var_nr(VV_TESTING)) {
+    emsg(_(e_calling_test_garbagecollect_now_while_v_testing_is_not_set));
+  } else {
+    garbage_collect(true);
+  }
 }
 
 /// "test_write_list_log()" function

--- a/test/functional/vimscript/exepath_spec.lua
+++ b/test/functional/vimscript/exepath_spec.lua
@@ -23,7 +23,7 @@ describe('exepath()', function()
     for _, input in ipairs({'v:null', 'v:true', 'v:false', '{}', '[]'}) do
       eq('Vim(call):E1174: String required for argument 1', exc_exec('call exepath('..input..')'))
     end
-    eq('Vim(call):E1142: Non-empty string required for argument 1', exc_exec('call exepath("")'))
+    eq('Vim(call):E1175: Non-empty string required for argument 1', exc_exec('call exepath("")'))
     command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
     for _, input in ipairs({'v:null', 'v:true', 'v:false'}) do
       eq('Vim(call):E1174: String required for argument 1', exc_exec('call exepath('..input..')'))


### PR DESCRIPTION
#### vim-patch:8.2.2653: build failure

Problem:    Build failure.
Solution:   Add missing changes.

https://github.com/vim/vim/commit/3a0f092ac0dbdd4ce71f9c4abe020e89f13df36c

Omit E1176: only applicable to Vim9 script.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4234: test_garbagecollect_now() does not check v:testing

Problem:    test_garbagecollect_now() does not check v:testing as documented.
Solution:   Give an error if v:testing is not set.

https://github.com/vim/vim/commit/b3d83980d2ac0f7a25314270416f17af874ca269

Co-authored-by: Bram Moolenaar <Bram@vim.org>