### PR TITLE
added tape extension

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -989,6 +989,7 @@ local extension = {
   swift = 'swift',
   svh = 'systemverilog',
   sv = 'systemverilog',
+  tape = 'vhs',
   tak = 'tak',
   task = 'taskedit',
   tm = 'tcl',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -612,6 +612,7 @@ let s:filename_checks = {
     \ 'verilogams': ['file.va', 'file.vams'],
     \ 'vgrindefs': ['vgrindefs'],
     \ 'vhdl': ['file.hdl', 'file.vhd', 'file.vhdl', 'file.vbe', 'file.vst', 'file.vhdl_123', 'file.vho', 'some.vhdl_1', 'some.vhdl_1-file'],
+    \ 'vhs': ['file.tape'],
     \ 'vim': ['file.vim', 'file.vba', '.exrc', '_exrc', 'some-vimrc', 'some-vimrc-file', 'vimrc', 'vimrc-file'],
     \ 'viminfo': ['.viminfo', '_viminfo'],
     \ 'vmasm': ['file.mar'],


### PR DESCRIPTION
[VHS](https://github.com/charmbracelet/vhs) is a tool that generates terminal gifs from code, like asciicinema, but with actual gifs as result, and instead of recoding it, you generate them from code.

`.tape` is the extension of those files.

I already PR the treesitter stuff, check https://github.com/nvim-treesitter/nvim-treesitter/pull/3726

This registers `.tape` files to the `vhs` filetype.
