### PR TITLE
vim-patch:8.2.{1395,3407}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1444,7 +1444,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
         }
         wrong = ((lp->ll_dict->dv_scope == VAR_DEF_SCOPE
                   && tv_is_func(*rettv)
-                  && !var_check_func_name((const char *)key, lp->ll_di == NULL))
+                  && var_wrong_func_name((const char *)key, lp->ll_di == NULL))
                  || !valid_varname((const char *)key));
         if (len != -1) {
           key[len] = prevval;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2436,7 +2436,7 @@ void tv_dict_extend(dict_T *const d1, dict_T *const d2, const char *const action
       // Check the key to be valid when adding to any scope.
       if (d1->dv_scope == VAR_DEF_SCOPE
           && tv_is_func(di2->di_tv)
-          && !var_check_func_name((const char *)di2->di_key, di1 == NULL)) {
+          && var_wrong_func_name((const char *)di2->di_key, di1 == NULL)) {
         break;
       }
       if (!valid_varname((const char *)di2->di_key)) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1841,6 +1841,7 @@ dictitem_T *tv_dict_item_alloc_len(const char *const key, const size_t key_len)
   di->di_key[key_len] = NUL;
   di->di_flags = DI_FLAGS_ALLOC;
   di->di_tv.v_lock = VAR_UNLOCKED;
+  di->di_tv.v_type = VAR_UNKNOWN;
   return di;
 }
 

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1257,7 +1257,7 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
     v = find_var_in_scoped_ht(name, name_len, true);
   }
 
-  if (tv_is_func(*tv) && !var_check_func_name(name, v == NULL)) {
+  if (tv_is_func(*tv) && var_wrong_func_name(name, v == NULL)) {
     return;
   }
 
@@ -1445,9 +1445,9 @@ bool var_check_fixed(const int flags, const char *name, size_t name_len)
 /// @param[in]  name  Possible function/funcref name.
 /// @param[in]  new_var  True if it is a name for a variable.
 ///
-/// @return false in case of error, true in case of success. Also gives an
+/// @return false in case of success, true in case of failure. Also gives an
 ///         error message if appropriate.
-bool var_check_func_name(const char *const name, const bool new_var)
+bool var_wrong_func_name(const char *const name, const bool new_var)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   // Allow for w: b: s: and t:.
@@ -1455,16 +1455,16 @@ bool var_check_func_name(const char *const name, const bool new_var)
       && !ASCII_ISUPPER((name[0] != NUL && name[1] == ':')
                         ? name[2] : name[0])) {
     semsg(_("E704: Funcref variable name must start with a capital: %s"), name);
-    return false;
+    return true;
   }
   // Don't allow hiding a function.  When "v" is not NULL we might be
   // assigning another function to the same var, the type is checked
   // below.
   if (new_var && function_exists(name, false)) {
     semsg(_("E705: Variable name conflicts with existing function: %s"), name);
-    return false;
+    return true;
   }
-  return true;
+  return false;
 }
 
 // TODO(ZyX-I): move to eval/expressions


### PR DESCRIPTION
#### vim-patch:8.2.1395: Vim9: no error if declaring a funcref with lower case letter

Problem:    Vim9: no error if declaring a funcref with a lower case letter.
Solution:   Check the name after the type is inferred. Fix confusing name.

https://github.com/vim/vim/commit/98b4f145eb89405021e23a4a37db51d60a75a1d0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3407: using uninitialized memory with "let g:['bar'] = 2"

Problem:    Using uninitialized memory with "let g:['bar'] = 2".
Solution:   Initialize v_type of a new dict item.

https://github.com/vim/vim/commit/3b318513561b5862944769188ae4af6b70311838

Co-authored-by: Bram Moolenaar <Bram@vim.org>