### PR TITLE
revert: "ci(commitlint): use pull_request_target to avoid "skip ci""

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,8 +1,6 @@
 name: "Commit Linter"
 on:
-  # Only pull_request and push honor [skip ci].  Since this workflow must pass
-  # to merge a PR, it can't be skipped, so use pull_request_target
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
@@ -10,6 +8,8 @@ jobs:
   lint-commits:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This reverts commit d7e2229b41748e84f525ee44cee19be81382ceab.

This workflow isn't required to pass to merge a PR any more. Using
pull_request_target to bypass the required check when using [skip ci] is
therefore no longer needed.
