### PR TITLE
ci: use default clang for asan and tsan jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,11 +213,11 @@ jobs:
       matrix:
         include:
           - flavor: asan
-            cc: clang-13
+            cc: clang
             runner: ubuntu-22.04
             os: linux
           - flavor: tsan
-            cc: clang-13
+            cc: clang
             runner: ubuntu-22.04
             os: linux
           - flavor: uchar
@@ -273,14 +273,6 @@ jobs:
             echo "Unexpected CMake version: $cmake_version"
             exit 1
           }
-
-      - name: Install new clang
-        if: matrix.flavor == 'asan' || matrix.flavor == 'tsan'
-        run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod a+x llvm.sh
-          sudo ./llvm.sh 13
-          rm llvm.sh
 
       - name: Install brew packages
         if: matrix.os == 'osx'

--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -30,7 +30,7 @@ case "$FLAVOR" in
     BUILD_FLAGS="$BUILD_FLAGS -DPREFER_LUA=ON"
     cat <<EOF >> "$GITHUB_ENV"
 CLANG_SANITIZER=ASAN_UBSAN
-SYMBOLIZER=asan_symbolize-13
+SYMBOLIZER=asan_symbolize
 ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan:intercept_tls_get_addr=0
 UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan
 EOF


### PR DESCRIPTION
Also remove step for installing clang-13 since it's not needed anymore.