### PR TITLE
build: remove python linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
             automake \
             build-essential \
             cmake \
-            flake8 \
             gettext \
             libluajit-5.1-dev \
             libmsgpack-dev \
@@ -105,10 +104,6 @@ jobs:
       - if: "!cancelled()"
         name: lintlua
         run: make lintlua
-
-      - if: "!cancelled()"
-        name: lintpy
-        run: make lintpy
 
       - if: "!cancelled()"
         name: lintsh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'python' ]
+        language: [ 'cpp' ]
 
     steps:
     - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -608,7 +608,6 @@ endif()
 #
 find_program(LUACHECK_PRG luacheck)
 find_program(STYLUA_PRG stylua)
-find_program(FLAKE8_PRG flake8)
 find_program(UNCRUSTIFY_PRG uncrustify)
 find_program(SHELLCHECK_PRG shellcheck)
 
@@ -635,14 +634,6 @@ add_custom_target(lintlua)
 add_dependencies(lintlua lintlua-luacheck lintlua-stylua)
 
 include(InstallHelpers)
-add_glob_targets(
-  TARGET lintpy
-  COMMAND ${FLAKE8_PRG}
-  FLAGS --max-line-length 100
-  GLOB_DIRS contrib scripts src test
-  GLOB_PAT *.py
-  TOUCH_STRATEGY SINGLE
-  )
 
 add_glob_targets(
   TARGET lintsh
@@ -658,7 +649,7 @@ add_custom_target(lintcommit
 add_dependencies(lintcommit nvim)
 
 add_custom_target(lint)
-add_dependencies(lint check-single-includes lintc lintlua lintpy lintsh lintcommit lintuncrustify)
+add_dependencies(lint check-single-includes lintc lintlua lintsh lintcommit lintuncrustify)
 
 #
 # Format

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ src/nvim/testdir/%.vim: phony_force
 functionaltest functionaltest-lua unittest benchmark: | nvim
 	$(BUILD_TOOL) -C build $@
 
-lintlua lintsh lintpy lintuncrustify lintc lintcfull check-single-includes generated-sources lintcommit lint formatc formatlua format: | build/.ran-cmake
+lintlua lintsh lintuncrustify lintc lintcfull check-single-includes generated-sources lintcommit lint formatc formatlua format: | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@
 
 test: functionaltest unittest
@@ -166,4 +166,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test lintlua lintpy lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix lintcommit formatc formatlua format
+.PHONY: test lintlua lintsh functionaltest unittest lint lintc clean distclean nvim libnvim cmake deps install appimage checkprefix lintcommit formatc formatlua format


### PR DESCRIPTION
This includes both the `lintpy` make target and for CI. We're actively
trying to reduce our python usage, so this only seems to give warnings
for unimportant things such as exceeding the line after deleting python
code.