### PR TITLE
fix(path): don't remove trailing slash when getting absolute path

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -2362,16 +2362,9 @@ static int path_to_absolute(const char *fname, char *buf, size_t len, int force)
     }
 #endif
     if (p != NULL) {
-      // relative to root
-      if (p == fname) {
-        // only one path component
-        relative_directory[0] = PATHSEP;
-        relative_directory[1] = NUL;
-      } else {
-        assert(p >= fname);
-        memcpy(relative_directory, fname, (size_t)(p - fname));
-        relative_directory[p - fname] = NUL;
-      }
+      assert(p >= fname);
+      memcpy(relative_directory, fname, (size_t)(p - fname + 1));
+      relative_directory[p - fname + 1] = NUL;
       end_of_path = p + 1;
     } else {
       relative_directory[0] = NUL;

--- a/test/unit/path_spec.lua
+++ b/test/unit/path_spec.lua
@@ -504,6 +504,16 @@ describe('path.c', function()
       eq(OK, result)
     end)
 
+    itp('does not remove trailing slash from non-existing relative directory #20847', function()
+      local expected = lfs.currentdir() .. '/non_existing_dir/'
+      local filename = 'non_existing_dir/'
+      local buflen = get_buf_len(expected, filename)
+      local do_expand = 1
+      local buf, result = vim_FullName(filename, buflen, do_expand)
+      eq(expected, ffi.string(buf))
+      eq(OK, result)
+    end)
+
     itp('expands "./" to the current directory #7117', function()
       local expected = lfs.currentdir() .. '/unit-test-directory/test.file'
       local filename = './unit-test-directory/test.file'


### PR DESCRIPTION
Fix #20847

Before Vim patch 8.2.3468 relative_directory is never used in the
resulting path name, so whether it has a trailing slash didn't matter.
Now path_full_dir_name() appends a non-existing relative directory to
the current directory name, so the trailing slash needs to be kept.
