### PR TITLE
vim-patch:9.0.{0816,0819}: CTRL-Z at end of file is always dropped

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2135,6 +2135,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	See 'fileencoding' to control file-content encoding.
 
+			*'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
+'endoffile' 'eof'	boolean	(default on)
+			local to buffer
+	Indicates that a CTRL-Z character was found at the end of the file
+	when reading it.  Normally only happens when 'fileformat' is "dos".
+	When writing a file and this option is off and the 'binary' option
+	is on, or 'fixeol' option is off, no CTRL-Z will be written at the
+	end of the file.
+
 			*'endofline'* *'eol'* *'noendofline'* *'noeol'*
 'endofline' 'eol'	boolean	(default on)
 			local to buffer
@@ -2490,7 +2499,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'fixendofline' 'fixeol'	boolean	(default on)
 			local to buffer
 	When writing a file and this option is on, <EOL> at the end of file
-	will be restored if missing. Turn this option off if you want to
+	will be restored if missing.  Turn this option off if you want to
 	preserve the situation from the original file.
 	When the 'binary' option is set the value of this option doesn't
 	matter.

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -689,6 +689,7 @@ Short explanation of each option:		*option-list*
 'display'	  'dy'	    list of flags for how to display text
 'eadirection'	  'ead'     in which direction 'equalalways' works
 'encoding'	  'enc'     encoding used internally
+'endoffile'	  'eof'     write CTRL-Z at end of the file
 'endofline'	  'eol'     write <EOL> for last line in file
 'equalalways'	  'ea'	    windows are automatically made the same size
 'equalprg'	  'ep'	    external program to use for "=" command

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Oct 15
+" Last Change:	2022 Oct 28
 
 " If there already is an option window, jump to that one.
 let buf = bufnr('option-window')
@@ -956,6 +956,9 @@ call <SID>BinOptionL("bin")
 call <SID>AddOption("endofline", gettext("last line in the file has an end-of-line"))
 call append("$", "\t" .. s:local_to_buffer)
 call <SID>BinOptionL("eol")
+call <SID>AddOption("endoffile", gettext("last line in the file followed by CTRL-Z"))
+call append("$", "\t" .. s:local_to_buffer)
+call <SID>BinOptionL("eof")
 call <SID>AddOption("fixendofline", gettext("fixes missing end-of-line at end of text file"))
 call append("$", "\t" .. s:local_to_buffer)
 call <SID>BinOptionL("fixeol")

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -689,6 +689,8 @@ void buf_clear_file(buf_T *buf)
 {
   buf->b_ml.ml_line_count = 1;
   unchanged(buf, true, true);
+  buf->b_p_eof = false;
+  buf->b_start_eof = false;
   buf->b_p_eol = true;
   buf->b_start_eol = true;
   buf->b_p_bomb = false;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -794,6 +794,7 @@ struct file_buffer {
   linenr_T b_no_eol_lnum;       // non-zero lnum when last line of next binary
                                 // write should not have an end-of-line
 
+  int b_start_eof;              // last line had eof (CTRL-Z) when it was read
   int b_start_eol;              // last line had eol when it was read
   int b_start_ffc;              // first char of 'ff' when edit started
   char *b_start_fenc;           // 'fileencoding' when edit started or NULL

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -675,6 +675,7 @@ struct file_buffer {
   char *b_p_cfu;                ///< 'completefunc'
   char *b_p_ofu;                ///< 'omnifunc'
   char *b_p_tfu;                ///< 'tagfunc'
+  int b_p_eof;                  ///< 'endoffile'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'
   int b_p_et;                   ///< 'expandtab'

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -539,6 +539,7 @@ void unchanged(buf_T *buf, int ff, bool always_inc_changedtick)
 void save_file_ff(buf_T *buf)
 {
   buf->b_start_ffc = (unsigned char)(*buf->b_p_ff);
+  buf->b_start_eof = buf->b_p_eof;
   buf->b_start_eol = buf->b_p_eol;
   buf->b_start_bomb = buf->b_p_bomb;
 
@@ -573,7 +574,8 @@ bool file_ff_differs(buf_T *buf, bool ignore_empty)
   if (buf->b_start_ffc != *buf->b_p_ff) {
     return true;
   }
-  if ((buf->b_p_bin || !buf->b_p_fixeol) && buf->b_start_eol != buf->b_p_eol) {
+  if ((buf->b_p_bin || !buf->b_p_fixeol)
+      && (buf->b_start_eof != buf->b_p_eof || buf->b_start_eol != buf->b_p_eol)) {
     return true;
   }
   if (!buf->b_p_bin && buf->b_start_bomb != buf->b_p_bomb) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -524,8 +524,9 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     // Don't change 'eol' if reading from buffer as it will already be
     // correctly set when reading stdin.
     if (!read_buffer) {
-      curbuf->b_p_eol = true;
       curbuf->b_p_eof = false;
+      curbuf->b_start_eof = false;
+      curbuf->b_p_eol = true;
       curbuf->b_start_eol = true;
     }
     curbuf->b_p_bomb = false;
@@ -1629,13 +1630,16 @@ failed:
   if (!error
       && !got_int
       && linerest != 0
+      // TODO(vim): should we handle CTRL-Z differently here for 'endoffile'?
       && !(!curbuf->b_p_bin
-           && fileformat == EOL_DOS)) {
+           && fileformat == EOL_DOS
+           && *line_start == Ctrl_Z
+           && ptr == line_start + 1)) {
     // remember for when writing
     if (set_options) {
       curbuf->b_p_eol = false;
       if (*line_start == Ctrl_Z && ptr == line_start + 1) {
-        curbuf->b_p_eof = false;
+        curbuf->b_p_eof = true;
       }
     }
     *ptr = NUL;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3978,6 +3978,8 @@ static char_u *get_varp(vimoption_T *p)
     return (char_u *)&(curbuf->b_p_cfu);
   case PV_OFU:
     return (char_u *)&(curbuf->b_p_ofu);
+  case PV_EOF:
+    return (char_u *)&(curbuf->b_p_eof);
   case PV_EOL:
     return (char_u *)&(curbuf->b_p_eol);
   case PV_FIXEOL:

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -497,6 +497,7 @@ EXTERN char_u *p_ef;            // 'errorfile'
 EXTERN char *p_efm;             // 'errorformat'
 EXTERN char *p_gefm;            // 'grepformat'
 EXTERN char *p_gp;              // 'grepprg'
+EXTERN int p_eof;               ///< 'endoffile'
 EXTERN int p_eol;               ///< 'endofline'
 EXTERN char *p_ei;              // 'eventignore'
 EXTERN int p_et;                ///< 'expandtab'
@@ -858,6 +859,7 @@ enum {
   BV_CFU,
   BV_DEF,
   BV_INC,
+  BV_EOF,
   BV_EOL,
   BV_FIXEOL,
   BV_EP,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -641,6 +641,15 @@ return {
       defaults={if_true=macros('ENC_DFLT')}
     },
     {
+      full_name='endoffile', abbreviation='eof',
+      short_desc=N_("write CTRL-Z for last line in file"),
+      type='bool', scope={'buffer'},
+      no_mkrc=true,
+      redraw={'statuslines'},
+      varname='p_eof',
+      defaults={if_true=true}
+    },
+    {
       full_name='endofline', abbreviation='eol',
       short_desc=N_("write <EOL> for last line in file"),
       type='bool', scope={'buffer'},

--- a/src/nvim/testdir/test_fixeol.vim
+++ b/src/nvim/testdir/test_fixeol.vim
@@ -34,10 +34,10 @@ func Test_fixeol()
   w >>XXTestEol
   w >>XXTestNoEol
 
-  call assert_equal(['with eol', 'END'], readfile('XXEol'))
-  call assert_equal(['without eolEND'], readfile('XXNoEol'))
-  call assert_equal(['with eol', 'stays eol', 'END'], readfile('XXTestEol'))
-  call assert_equal(['without eol', 'stays withoutEND'],
+  call assert_equal(['with eol or eof', 'END'], readfile('XXEol'))
+  call assert_equal(['without eol or eofEND'], readfile('XXNoEol'))
+  call assert_equal(['with eol or eof', 'stays eol', 'END'], readfile('XXTestEol'))
+  call assert_equal(['without eol or eof', 'stays withoutEND'],
 	      \ readfile('XXTestNoEol'))
 
   call delete('XXEol')

--- a/src/nvim/testdir/test_fixeol.vim
+++ b/src/nvim/testdir/test_fixeol.vim
@@ -1,16 +1,17 @@
-" Tests for 'fixeol' and 'eol'
+" Tests for 'fixeol', 'eof' and 'eol'
+
 func Test_fixeol()
   " first write two test files – with and without trailing EOL
   " use Unix fileformat for consistency
   set ff=unix
   enew!
-  call setline('.', 'with eol')
+  call setline('.', 'with eol or eof')
   w! XXEol
   enew!
-  set noeol nofixeol
-  call setline('.', 'without eol')
+  set noeof noeol nofixeol
+  call setline('.', 'without eol or eof')
   w! XXNoEol
-  set eol fixeol
+  set eol eof fixeol
   bwipe XXEol XXNoEol
 
   " try editing files with 'fixeol' disabled
@@ -43,6 +44,8 @@ func Test_fixeol()
   call delete('XXNoEol')
   call delete('XXTestEol')
   call delete('XXTestNoEol')
-  set ff& fixeol& eol&
+  set ff& fixeol& eof& eol&
   enew!
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0816: CTRL-Z at end of file is always dropped

Problem:    CTRL-Z at end of file is always dropped.
Solution:   Add the 'endoffile' option, like the 'endofline' option.
            (closes vim/vim#11408)

Cherry-pick test_fixeol.vim changes from patch 8.2.1432.
Cherry-pick 'endoffile' changes from latest Vim runtime update.

https://github.com/vim/vim/commit/fb0cf2357e0c85bbfd9f9178705ad8d77b6b3b4e

vim-patch:f0b567e32a46

Revert unintended Makefile change

https://github.com/vim/vim/commit/f0b567e32a462fe838170a202919d18b53eff987

vim-patch:72c8e3c070b3

Fix wrong struct access for member.

https://github.com/vim/vim/commit/72c8e3c070b30f82bc0d203a62c168e43a13e99b

vim-patch:3f68a4136eb9

Add missing entry for the 'endoffile' option.

https://github.com/vim/vim/commit/3f68a4136eb99840d739af5133ab31948f273f63

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0819: still a build error, tests are failing

Problem:    Still a build error, tests are failing.
Solution:   Correct recent changes. Add missing init for 'eof'.

https://github.com/vim/vim/commit/1577537f109d97a975fda9a899cacfb598617767

vim-patch:1577537f109d

Co-authored-by: Bram Moolenaar <Bram@vim.org>