### PR TITLE
fix(lsp/window_showDocument): correctly handle external resources

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -519,15 +519,15 @@ M['window/showDocument'] = function(_, result, ctx, _)
     -- TODO(lvimuser): ask the user for confirmation
     local cmd
     if vim.fn.has('win32') == 1 then
-      cmd = { 'cmd.exe', '/c', 'start', '""', vim.fn.shellescape(uri) }
+      cmd = { 'cmd.exe', '/c', 'start', '""', uri }
     elseif vim.fn.has('macunix') == 1 then
-      cmd = { 'open', vim.fn.shellescape(uri) }
+      cmd = { 'open', uri }
     else
-      cmd = { 'xdg-open', vim.fn.shellescape(uri) }
+      cmd = { 'xdg-open', uri }
     end
 
     local ret = vim.fn.system(cmd)
-    if vim.v.shellerror ~= 0 then
+    if vim.v.shell_error ~= 0 then
       return {
         success = false,
         error = {


### PR DESCRIPTION
- since cmd is a list, it runs directly ('no shell') and we shouldn't escape.
- typo: shellerror -> shell_error

Ref:
```
system({cmd} [, {input}])				*system()* *E677*
		Gets the output of {cmd} as a |string| (|systemlist()| returns
		a |List|) and sets |v:shell_error| to the error code.
		{cmd} is treated as in |jobstart()|:
		If {cmd} is a List it runs directly (no 'shell').
		If {cmd} is a String it runs in the 'shell'
```
---

Follow up to https://github.com/neovim/neovim/pull/19977.

For Windows, doesn't seem to matter whether we escape or not; opted not to for consistency.