### PR TITLE
fix(health): correct tmux rgb verification

### DIFF
--- a/runtime/autoload/health/nvim.vim
+++ b/runtime/autoload/health/nvim.vim
@@ -235,7 +235,7 @@ function! s:check_tmux() abort
   endif
 
   " check for RGB capabilities
-  let info = system(['tmux', 'server-info'])
+  let info = system(['tmux', 'show-messages', '-JT'])
   let has_tc = stridx(info, " Tc: (flag) true") != -1
   let has_rgb = stridx(info, " RGB: (flag) true") != -1
   if !has_tc && !has_rgb


### PR DESCRIPTION
Current RGB verification parses `tmux server-info`. Despite it being listed as a valid alias [here](https://github.com/tmux/tmux/blob/master/options-table.c#L234), `server-info` isn't recognized as a command in more recent versions.

Use the alias `tmux show-messages -JT` instead.

Fixes #20841 