### PR TITLE
ci(stylua): explicitly set the version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
         uses: JohnnyMorganz/stylua-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
           args: --check runtime/
 
       - if: "!cancelled()"


### PR DESCRIPTION
This will silence the warning about needing to pin the version in the
Summary Page.