### PR TITLE
docs: swap CursorLineFold and CursorLineSign

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5201,10 +5201,10 @@ LineNrBelow	Line number for when the 'relativenumber'
 							*hl-CursorLineNr*
 CursorLineNr	Like LineNr when 'cursorline' is set and 'cursorlineopt'
 		contains "number" or is "both", for the cursor line.
-							*hl-CursorLineSign*
-CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
 							*hl-CursorLineFold*
 CursorLineFold	Like FoldColumn when 'cursorline' is set for the cursor line.
+							*hl-CursorLineSign*
+CursorLineSign	Like SignColumn when 'cursorline' is set for the cursor line.
 							*hl-MatchParen*
 MatchParen	Character under the cursor or just before it, if it
 		is a paired bracket, and its match. |pi_paren.txt|


### PR DESCRIPTION
`SignColumn` comes after `FoldColumn`, so `CursorLineSign` must come after `CursorLineFold`