### PR TITLE
feat(checkhealth): report style/formatting

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -5,8 +5,13 @@ function! health#check(plugin_names) abort
         \ ? s:discover_healthchecks()
         \ : s:get_healthcheck(a:plugin_names)
 
-  " create scratch-buffer
-  execute 'tab sbuffer' nvim_create_buf(v:true, v:true)
+  " Create buffer and open in a tab, unless this is the default buffer when Nvim starts.
+  let emptybuf = (bufnr('$') == 1 && empty(getline(1)) && 1 == line('$'))
+  execute (emptybuf ? 'buffer' : 'tab sbuffer') nvim_create_buf(v:true, v:true)
+  if bufexists('health://')
+    bwipe health://
+  endif
+  file health://
   setfiletype checkhealth
 
   if empty(healthchecks)
@@ -38,7 +43,7 @@ function! health#check(plugin_names) abort
                 \ name, v:throwpoint, v:exception))
         endif
       endtry
-      let header = [name. ': ' . func, repeat('=', 72)]
+      let header = [repeat('=', 78), name .. ': ' .. func, '']
       " remove empty line after header from report_start
       let s:output = s:output[0] == '' ? s:output[1:] : s:output
       let s:output = header + s:output + ['']
@@ -47,8 +52,7 @@ function! health#check(plugin_names) abort
     endfor
   endif
 
-  " needed for plasticboy/vim-markdown, because it uses fdm=expr
-  normal! zR
+  " Clear the 'Running healthchecks...' message.
   redraw|echo ''
 endfunction
 
@@ -58,7 +62,7 @@ endfunction
 
 " Starts a new report.
 function! health#report_start(name) abort
-  call s:collect_output("\n## " . a:name)
+  call s:collect_output(printf("\n%s ~", a:name))
 endfunction
 
 " Indents lines *except* line 1 of a string if it contains newlines.
@@ -81,7 +85,7 @@ endfunction
 " Format a message for a specific report item.
 " a:1: Optional advice (string or list)
 function! s:format_report_message(status, msg, ...) abort " {{{
-  let output = '  - ' . a:status . ': ' . s:indent_after_line1(a:msg, 4)
+  let output = '- ' .. a:status .. (empty(a:status) ? '' : ' ') .. s:indent_after_line1(a:msg, 2)
 
   " Optional parameters
   if a:0 > 0
@@ -92,9 +96,9 @@ function! s:format_report_message(status, msg, ...) abort " {{{
 
     " Report each suggestion
     if !empty(advice)
-      let output .= "\n    - ADVICE:"
+      let output .= "\n  - ADVICE:"
       for suggestion in advice
-        let output .= "\n      - " . s:indent_after_line1(suggestion, 10)
+        let output .= "\n    - " . s:indent_after_line1(suggestion, 6)
       endfor
     endif
   endif
@@ -102,9 +106,9 @@ function! s:format_report_message(status, msg, ...) abort " {{{
   return s:help_to_link(output)
 endfunction " }}}
 
-" Use {msg} to report information in the current section
+" Reports a message as a listitem in the current section.
 function! health#report_info(msg) abort " {{{
-  call s:collect_output(s:format_report_message('INFO', a:msg))
+  call s:collect_output(s:format_report_message('', a:msg))
 endfunction " }}}
 
 " Reports a successful healthcheck.

--- a/runtime/ftplugin/checkhealth.vim
+++ b/runtime/ftplugin/checkhealth.vim
@@ -1,20 +1,18 @@
 " Vim filetype plugin
-" Language:     Neovim checkhealth buffer
-" Last Change:  2021 Dec 15
+" Language:     Nvim :checkhealth buffer
+" Last Change:  2022 Nov 10
 
 if exists("b:did_ftplugin")
   finish
 endif
 
-runtime! ftplugin/markdown.vim ftplugin/markdown_*.vim ftplugin/markdown/*.vim
+runtime! ftplugin/help.vim
 
 setlocal wrap breakindent linebreak
-setlocal conceallevel=2 concealcursor=nc
-setlocal keywordprg=:help
 let &l:iskeyword='!-~,^*,^|,^",192-255'
 
 if exists("b:undo_ftplugin")
-  let b:undo_ftplugin .= "|setl wrap< bri< lbr< cole< cocu< kp< isk<"
+  let b:undo_ftplugin .= "|setl wrap< bri< lbr< kp< isk<"
 else
-  let b:undo_ftplugin = "setl wrap< bri< lbr< cole< cocu< kp< isk<"
+  let b:undo_ftplugin = "setl wrap< bri< lbr< kp< isk<"
 endif

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -359,14 +359,12 @@ local function check_terminal()
           \                   ..'\%(conemu\|vtpcon\|win32con\)')))
       call health#report_error('command failed: '.cmd."\n".out)
     else
-      call health#report_info('key_backspace (kbs) terminfo entry: '
-            \ .(empty(kbs_entry) ? '? (not found)' : kbs_entry))
-      call health#report_info('key_dc (kdch1) terminfo entry: '
-            \ .(empty(kbs_entry) ? '? (not found)' : kdch1_entry))
+      call health#report_info(printf('key_backspace (kbs) terminfo entry: `%s`', (empty(kbs_entry) ? '? (not found)' : kbs_entry)))
+      call health#report_info(printf('key_dc (kdch1) terminfo entry: `%s`', (empty(kbs_entry) ? '? (not found)' : kdch1_entry)))
     endif
     for env_var in ['XTERM_VERSION', 'VTE_VERSION', 'TERM_PROGRAM', 'COLORTERM', 'SSH_TTY']
       if exists('$'.env_var)
-        call health#report_info(printf("$%s='%s'", env_var, eval('$'.env_var)))
+        call health#report_info(printf('$%s="%s"', env_var, eval('$'.env_var)))
       endif
     endfor
   endf

--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -1,26 +1,21 @@
 " Vim syntax file
-" Language:     Neovim checkhealth buffer
-" Last Change:  2021 Dec 15
+" Language:     Nvim :checkhealth buffer
+" Last Change:  2022 Nov 10
 
 if exists("b:current_syntax")
   finish
 endif
 
-runtime! syntax/markdown.vim
+runtime! syntax/help.vim
 unlet! b:current_syntax
 
 syn case match
 
-" We do not care about markdown syntax errors
-if hlexists('markdownError')
-  syn clear markdownError
-endif
-
-syn keyword healthError ERROR[:] containedin=markdownCodeBlock,mkdListItemLine
-syn keyword healthWarning WARNING[:] containedin=markdownCodeBlock,mkdListItemLine
-syn keyword healthSuccess OK[:] containedin=markdownCodeBlock,mkdListItemLine
-syn match healthHelp "|.\{-}|" containedin=markdownCodeBlock,mkdListItemLine contains=healthBar
-syn match healthBar  "|" contained conceal
+syn keyword healthError ERROR[:]
+syn keyword healthWarning WARNING[:]
+syn keyword healthSuccess OK[:]
+syn match helpSectionDelim "^======*\n.*$"
+syn match healthHeadingChar "=" conceal cchar=─ contained containedin=helpSectionDelim
 
 hi def link healthError Error
 hi def link healthWarning WarningMsg

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -29,7 +29,7 @@ describe(':checkhealth', function()
     -- Do this after startup, otherwise it just breaks $VIMRUNTIME.
     command("let $VIM='zub'")
     command("checkhealth nvim")
-    matches('ERROR: $VIM .* zub', curbuf_contents())
+    matches('ERROR $VIM .* zub', curbuf_contents())
   end)
   it('completions can be listed via getcompletion()', function()
     clear()
@@ -55,21 +55,22 @@ describe('health.vim', function()
       command("checkhealth full_render")
       helpers.expect([[
 
+      ==============================================================================
       full_render: health#full_render#check
-      ========================================================================
-      ## report 1
-        - OK: life is fine
-        - WARNING: no what installed
-          - ADVICE:
-            - pip what
-            - make what
 
-      ## report 2
-        - INFO: stuff is stable
-        - ERROR: why no hardcopy
-          - ADVICE:
-            - :help |:hardcopy|
-            - :help |:TOhtml|
+      report 1 ~
+      - OK life is fine
+      - WARNING no what installed
+        - ADVICE:
+          - pip what
+          - make what
+
+      report 2 ~
+      - stuff is stable
+      - ERROR why no hardcopy
+        - ADVICE:
+          - :help |:hardcopy|
+          - :help |:TOhtml|
       ]])
     end)
 
@@ -77,26 +78,29 @@ describe('health.vim', function()
       command("checkhealth success1 success2 test_plug")
       helpers.expect([[
 
+        ==============================================================================
         success1: health#success1#check
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
 
+        report 2 ~
+        - OK nothing to see here
+
+        ==============================================================================
         success2: health#success2#check
-        ========================================================================
-        ## another 1
-          - OK: ok
 
+        another 1 ~
+        - OK ok
+
+        ==============================================================================
         test_plug: require("test_plug.health").check()
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
+
+        report 2 ~
+        - OK nothing to see here
         ]])
     end)
 
@@ -106,13 +110,14 @@ describe('health.vim', function()
       -- and the Lua healthcheck is used instead.
       helpers.expect([[
 
+        ==============================================================================
         test_plug: require("test_plug.health").check()
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
+
+        report 2 ~
+        - OK nothing to see here
         ]])
     end)
 
@@ -120,13 +125,14 @@ describe('health.vim', function()
       command("checkhealth test_plug.submodule")
       helpers.expect([[
 
+        ==============================================================================
         test_plug.submodule: require("test_plug.submodule.health").check()
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
+
+        report 2 ~
+        - OK nothing to see here
         ]])
     end)
 
@@ -137,30 +143,34 @@ describe('health.vim', function()
       local received = table.concat(buf_lines, '\n', 1, #buf_lines - 5)
       local expected = helpers.dedent([[
 
+        ==============================================================================
         test_plug: require("test_plug.health").check()
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
 
+        report 2 ~
+        - OK nothing to see here
+
+        ==============================================================================
         test_plug.submodule: require("test_plug.submodule.health").check()
-        ========================================================================
-        ## report 1
-          - OK: everything is fine
 
-        ## report 2
-          - OK: nothing to see here
+        report 1 ~
+        - OK everything is fine
 
+        report 2 ~
+        - OK nothing to see here
+
+        ==============================================================================
         test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
-        ========================================================================
-          - ERROR: The healthcheck report for "test_plug.submodule_empty" plugin is empty.
 
+        - ERROR The healthcheck report for "test_plug.submodule_empty" plugin is empty.
+
+        ==============================================================================
         test_plug.submodule_failed: require("test_plug.submodule_failed.health").check()
-        ========================================================================
-          - ERROR: Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
-            function health#check, line 20]])
+
+        - ERROR Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
+          function health#check, line 25]])
       eq(expected, received)
     end)
 
@@ -168,11 +178,12 @@ describe('health.vim', function()
       command("checkhealth broken")
       helpers.expect([[
 
+        ==============================================================================
         broken: health#broken#check
-        ========================================================================
-          - ERROR: Failed to run healthcheck for "broken" plugin. Exception:
-            function health#check[20]..health#broken#check, line 1
-            caused an error
+
+        - ERROR Failed to run healthcheck for "broken" plugin. Exception:
+          function health#check[25]..health#broken#check, line 1
+          caused an error
         ]])
     end)
 
@@ -180,9 +191,10 @@ describe('health.vim', function()
       command("checkhealth test_plug.submodule_empty")
       helpers.expect([[
 
+      ==============================================================================
       test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
-      ========================================================================
-        - ERROR: The healthcheck report for "test_plug.submodule_empty" plugin is empty.
+
+      - ERROR The healthcheck report for "test_plug.submodule_empty" plugin is empty.
       ]])
     end)
 
@@ -197,38 +209,38 @@ describe('health.vim', function()
 
       local expected = global_helpers.dedent([[
 
+        ==============================================================================
         test_plug.submodule_failed: require("test_plug.submodule_failed.health").check()
-        ========================================================================
-          - ERROR: Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
-            function health#check, line 20]])
+
+        - ERROR Failed to run healthcheck for "test_plug.submodule_failed" plugin. Exception:
+          function health#check, line 25]])
       eq(expected, received)
     end)
 
     it("highlights OK, ERROR", function()
-      local screen = Screen.new(72, 10)
+      local screen = Screen.new(50, 12)
       screen:attach()
       screen:set_default_attr_ids({
         Ok = { foreground = Screen.colors.Grey3, background = 6291200 },
         Error = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
-        Heading = { bold=true, foreground=Screen.colors.Magenta },
-        Heading2 = { foreground = Screen.colors.SlateBlue },
-        Bar = { foreground = 0x6a0dad },
-        Bullet = { bold=true, foreground=Screen.colors.Brown },
+        Heading = { foreground = tonumber('0x6a0dad') },
+        Bar = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGrey },
       })
       command("checkhealth foo success1")
-      command("1tabclose")
-      command("set laststatus=0")
+      command("set nowrap laststatus=0")
       screen:expect{grid=[[
-        ^                                                                        |
-        {Heading:foo: }                                                                   |
-        {Bar:========================================================================}|
-        {Bullet:  -} {Error:ERROR}: No healthcheck found for "foo" plugin.                       |
-                                                                                |
-        {Heading:success1: health#success1#check}                                         |
-        {Bar:========================================================================}|
-        {Heading2:## }{Heading:report 1}                                                             |
-        {Bullet:  -} {Ok:OK}: everything is fine                                              |
-                                                                                |
+        ^                                                  |
+        {Bar:──────────────────────────────────────────────────}|
+        {Heading:foo: }                                             |
+                                                          |
+        - {Error:ERROR} No healthcheck found for "foo" plugin.    |
+                                                          |
+        {Bar:──────────────────────────────────────────────────}|
+        {Heading:success1: health#success1#check}                   |
+                                                          |
+        {Heading:report 1}                                          |
+        - {Ok:OK} everything is fine                           |
+                                                          |
       ]]}
     end)
 
@@ -237,9 +249,10 @@ describe('health.vim', function()
       -- luacheck: ignore 613
       helpers.expect([[
 
+        ==============================================================================
         non_existent_healthcheck: 
-        ========================================================================
-          - ERROR: No healthcheck found for "non_existent_healthcheck" plugin.
+
+        - ERROR No healthcheck found for "non_existent_healthcheck" plugin.
         ]])
     end)
 


### PR DESCRIPTION

<img width="805" alt="image" src="https://user-images.githubusercontent.com/1359421/201347540-205d4acb-6200-4407-998b-26f8b63ba30b.png">


- Use help syntax instead of markdown.
- Don't open new tab if we're on the first default empty buffer.
- Name the buffer `health://`
- Don't indent the first level of items.
- Don't print a status for "info" messages. The "INFO" status is noisy and redundant. These are just "neutral" messages.
- Drop the ":" after statuses. They are already UPPERCASE and highlighted.