### PR TITLE
build(clint.py): remove rules for braces

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1404,7 +1404,9 @@ struct window_S {
 };
 
 /// Macros defined in Vim, but not in Neovim
+// uncrustify:off
 #define CHANGEDTICK(buf) \
   (=== Include buffer.h & use buf_(get|set|inc) _changedtick ===)
+// uncrustify:on
 
 #endif  // NVIM_BUFFER_DEFS_H

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -19,8 +19,7 @@
 #endif
 
 /// Handling of cursor and mouse pointer shapes in various modes.
-cursorentry_T shape_table[SHAPE_IDX_COUNT] =
-{
+cursorentry_T shape_table[SHAPE_IDX_COUNT] = {
   // Values are set by 'guicursor' and 'mouseshape'.
   // Adjust the SHAPE_IDX_ defines when changing this!
   { "normal", 0, 0, 0, 700L, 400L, 250L, 0, 0, "n", SHAPE_CURSOR + SHAPE_MOUSE },

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -52,7 +52,6 @@ static garray_T user_digraphs = { 0, 0, (int)sizeof(digr_T), 10, NULL };
 /// Note: Characters marked with XX are not included literally, because some
 /// compilers cannot handle them (Amiga SAS/C is the most picky one).
 static digr_T digraphdefault[] =
-
 // digraphs for Unicode from RFC1345
 // (also work for ISO-8859-1 aka latin1)
 {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -133,8 +133,7 @@ static struct vimvar {
   char *vv_name;  ///< Name of the variable, without v:.
   TV_DICTITEM_STRUCT(VIMVAR_KEY_LEN + 1) vv_di;  ///< Value and name for key (max 16 chars).
   char vv_flags;  ///< Flags: #VV_COMPAT, #VV_RO, #VV_RO_SBX.
-} vimvars[] =
-{
+} vimvars[] = {
   // VV_ tails differing from upcased string literals:
   // VV_CC_FROM "charconvert_from"
   // VV_CC_TO "charconvert_to"

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3595,13 +3595,13 @@ bool tv_check_str_or_nr(const typval_T *const tv)
 #define FUNC_ERROR "E703: Using a Funcref as a Number"
 
 static const char *const num_errors[] = {
-  [VAR_PARTIAL]=N_(FUNC_ERROR),
-  [VAR_FUNC]=N_(FUNC_ERROR),
-  [VAR_LIST]=N_("E745: Using a List as a Number"),
-  [VAR_DICT]=N_("E728: Using a Dictionary as a Number"),
-  [VAR_FLOAT]=N_("E805: Using a Float as a Number"),
-  [VAR_BLOB]=N_("E974: Using a Blob as a Number"),
-  [VAR_UNKNOWN]=N_("E685: using an invalid value as a Number"),
+  [VAR_PARTIAL]= N_(FUNC_ERROR),
+  [VAR_FUNC]= N_(FUNC_ERROR),
+  [VAR_LIST]= N_("E745: Using a List as a Number"),
+  [VAR_DICT]= N_("E728: Using a Dictionary as a Number"),
+  [VAR_FLOAT]= N_("E805: Using a Float as a Number"),
+  [VAR_BLOB]= N_("E974: Using a Blob as a Number"),
+  [VAR_UNKNOWN]= N_("E685: using an invalid value as a Number"),
 };
 
 #undef FUNC_ERROR
@@ -3640,13 +3640,13 @@ bool tv_check_num(const typval_T *const tv)
 #define FUNC_ERROR "E729: using Funcref as a String"
 
 static const char *const str_errors[] = {
-  [VAR_PARTIAL]=N_(FUNC_ERROR),
-  [VAR_FUNC]=N_(FUNC_ERROR),
-  [VAR_LIST]=N_("E730: using List as a String"),
-  [VAR_DICT]=N_("E731: using Dictionary as a String"),
-  [VAR_FLOAT]=((const char *)e_float_as_string),
-  [VAR_BLOB]=N_("E976: using Blob as a String"),
-  [VAR_UNKNOWN]=N_("E908: using an invalid value as a String"),
+  [VAR_PARTIAL]= N_(FUNC_ERROR),
+  [VAR_FUNC]= N_(FUNC_ERROR),
+  [VAR_LIST]= N_("E730: using List as a String"),
+  [VAR_DICT]= N_("E731: using Dictionary as a String"),
+  [VAR_FLOAT]= ((const char *)e_float_as_string),
+  [VAR_BLOB]= N_("E976: using Blob as a String"),
+  [VAR_UNKNOWN]= N_("E908: using an invalid value as a String"),
 };
 
 #undef FUNC_ERROR

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -998,7 +998,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
       listitem_T *li = &fc->l_listitems[ai];
 
       *TV_LIST_ITEM_TV(li) = argvars[i];
-      TV_LIST_ITEM_TV(li)->v_lock =  VAR_FIXED;
+      TV_LIST_ITEM_TV(li)->v_lock = VAR_FIXED;
       tv_list_append(&fc->l_varlist, li);
     }
   }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -1083,7 +1083,7 @@ void ex_endwhile(exarg_T *eap)
       }
       // Try to find the matching ":while" and report what's missing.
       for (idx = cstack->cs_idx; idx > 0; idx--) {
-        fl =  cstack->cs_flags[idx];
+        fl = cstack->cs_flags[idx];
         if ((fl & CSF_TRY) && !(fl & CSF_FINALLY)) {
           // Give up at a try conditional not in its finally clause.
           // Ignore the ":endwhile"/":endfor".

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1083,7 +1083,7 @@ static int foldLevelWin(win_T *wp, linenr_T lnum)
 {
   fold_T *fp;
   linenr_T lnum_rel = lnum;
-  int level =  0;
+  int level = 0;
 
   // Recursively search for a fold that contains "lnum".
   garray_T *gap = &wp->w_folds;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -613,7 +613,7 @@ EXTERN int State INIT(= MODE_NORMAL);
 EXTERN bool debug_mode INIT(= false);
 EXTERN bool finish_op INIT(= false);    // true while an operator is pending
 EXTERN long opcount INIT(= 0);          // count for pending operator
-EXTERN int motion_force INIT(=0);       // motion force for pending operator
+EXTERN int motion_force INIT(= 0);       // motion force for pending operator
 
 // Ex Mode (Q) state
 EXTERN bool exmode_active INIT(= false);  // true if Ex mode is active
@@ -621,7 +621,7 @@ EXTERN bool exmode_active INIT(= false);  // true if Ex mode is active
 /// Flag set when normal_check() should return 0 when entering Ex mode.
 EXTERN bool pending_exmode_active INIT(= false);
 
-EXTERN bool ex_no_reprint INIT(=false);   // No need to print after z or p.
+EXTERN bool ex_no_reprint INIT(= false);   // No need to print after z or p.
 
 // 'inccommand' command preview state
 EXTERN bool cmdpreview INIT(= false);

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -140,8 +140,7 @@ static int page_count;
 #define OPT_MBFONT_BOLDOBLIQUE 5
 #define OPT_MBFONT_NUM_OPTIONS 6
 
-static option_table_T mbfont_opts[OPT_MBFONT_NUM_OPTIONS] =
-{
+static option_table_T mbfont_opts[OPT_MBFONT_NUM_OPTIONS] = {
   { "c",       false, 0, NULL, 0, false },
   { "a",       false, 0, NULL, 0, false },
   { "r",       false, 0, NULL, 0, false },
@@ -208,8 +207,7 @@ typedef enum {
 } PrtResourceType;
 
 // String versions of PS resource types
-static const char *const prt_resource_types[] =
-{
+static const char *const prt_resource_types[] = {
   [PRT_RESOURCE_TYPE_PROCSET] = "procset",
   [PRT_RESOURCE_TYPE_ENCODING] = "encoding",
   [PRT_RESOURCE_TYPE_CMAP] = "cmap",
@@ -945,8 +943,7 @@ static colnr_T hardcopy_line(prt_settings_T *psettings, int page_line, prt_pos_T
 
 #define PRT_MEDIASIZE_LEN  ARRAY_SIZE(prt_mediasize)
 
-static struct prt_mediasize_S prt_mediasize[] =
-{
+static struct prt_mediasize_S prt_mediasize[] = {
   { "A4",              595.0,  842.0 },
   { "letter",          612.0,  792.0 },
   { "10x14",           720.0, 1008.0 },
@@ -969,8 +966,7 @@ static struct prt_mediasize_S prt_mediasize[] =
 #define PRT_PS_FONT_BOLDOBLIQUE (3)
 
 // Standard font metrics for Courier family
-static struct prt_ps_font_S prt_ps_courier_font =
-{
+static struct prt_ps_font_S prt_ps_courier_font = {
   600,
   -100, 50,
   -250, 805,
@@ -978,8 +974,7 @@ static struct prt_ps_font_S prt_ps_courier_font =
 };
 
 // Generic font metrics for multi-byte fonts
-static struct prt_ps_font_S prt_ps_mb_font =
-{
+static struct prt_ps_font_S prt_ps_mb_font = {
   1000,
   -100, 50,
   -250, 805,
@@ -999,8 +994,7 @@ static struct prt_ps_font_S *prt_ps_font;
 #define CS_KANJITALK7   (0x80)
 
 // Japanese encodings and charsets
-static struct prt_ps_encoding_S j_encodings[] =
-{
+static struct prt_ps_encoding_S j_encodings[] = {
   { "iso-2022-jp", NULL,       (CS_JIS_C_1978|CS_JIS_X_1983|CS_JIS_X_1990|
                                 CS_NEC) },
   { "euc-jp",      "EUC",      (CS_JIS_C_1978|CS_JIS_X_1983|CS_JIS_X_1990) },
@@ -1010,8 +1004,7 @@ static struct prt_ps_encoding_S j_encodings[] =
   { "ucs-2",       "UCS2",     CS_JIS_X_1990 },
   { "utf-8",       "UTF8",    CS_JIS_X_1990 }
 };
-static struct prt_ps_charset_S j_charsets[] =
-{
+static struct prt_ps_charset_S j_charsets[] = {
   { "JIS_C_1978",  "78",       CS_JIS_C_1978 },
   { "JIS_X_1983",  NULL,       CS_JIS_X_1983 },
   { "JIS_X_1990",  "Hojo",     CS_JIS_X_1990 },
@@ -1031,8 +1024,7 @@ static struct prt_ps_charset_S j_charsets[] =
 #define CS_SC_ISO10646      (0x40)
 
 // Simplified Chinese encodings and charsets
-static struct prt_ps_encoding_S sc_encodings[] =
-{
+static struct prt_ps_encoding_S sc_encodings[] = {
   { "iso-2022",    NULL,       (CS_GB_2312_80|CS_GBT_12345_90) },
   { "gb18030",     NULL,       CS_GBK2K },
   { "euc-cn",      "EUC",      (CS_GB_2312_80|CS_GBT_12345_90|CS_SC_MAC|
@@ -1041,8 +1033,7 @@ static struct prt_ps_encoding_S sc_encodings[] =
   { "ucs-2",       "UCS2",     CS_SC_ISO10646 },
   { "utf-8",       "UTF8",     CS_SC_ISO10646 }
 };
-static struct prt_ps_charset_S sc_charsets[] =
-{
+static struct prt_ps_charset_S sc_charsets[] = {
   { "GB_2312-80",  "GB",       CS_GB_2312_80 },
   { "GBT_12345-90", "GBT",      CS_GBT_12345_90 },
   { "MAC",         "GBpc",     CS_SC_MAC },
@@ -1067,8 +1058,7 @@ static struct prt_ps_charset_S sc_charsets[] =
 #define CS_TC_ISO10646      (0x1000)
 
 // Traditional Chinese encodings and charsets
-static struct prt_ps_encoding_S tc_encodings[] =
-{
+static struct prt_ps_encoding_S tc_encodings[] = {
   { "iso-2022",    NULL,       (CS_CNS_PLANE_1|CS_CNS_PLANE_2) },
   { "euc-tw",      "EUC",      CS_CNS_PLANE_1_2 },
   { "big5",        "B5",       (CS_B5|CS_ETEN|CS_HK_GCCS|CS_HK_SCS|
@@ -1080,8 +1070,7 @@ static struct prt_ps_encoding_S tc_encodings[] =
   { "utf-16",      "UTF16",    CS_TC_ISO10646 },
   { "utf-32",      "UTF32",    CS_TC_ISO10646 }
 };
-static struct prt_ps_charset_S tc_charsets[] =
-{
+static struct prt_ps_charset_S tc_charsets[] = {
   { "CNS_1992_1",  "CNS1",     CS_CNS_PLANE_1 },
   { "CNS_1992_2",  "CNS2",     CS_CNS_PLANE_2 },
   { "CNS_1993",    "CNS",      CS_CNS_PLANE_1_2 },
@@ -1104,8 +1093,7 @@ static struct prt_ps_charset_S tc_charsets[] =
 #define CS_KR_ISO10646      (0x08)
 
 // Korean encodings and charsets
-static struct prt_ps_encoding_S k_encodings[] =
-{
+static struct prt_ps_encoding_S k_encodings[] = {
   { "iso-2022-kr", NULL,       CS_KR_X_1992 },
   { "euc-kr",      "EUC",      (CS_KR_X_1992|CS_KR_MAC) },
   { "johab",       "Johab",    CS_KR_X_1992 },
@@ -1115,8 +1103,7 @@ static struct prt_ps_encoding_S k_encodings[] =
   { "ucs-2",       "UCS2",     CS_KR_ISO10646 },
   { "utf-8",       "UTF8",     CS_KR_ISO10646 }
 };
-static struct prt_ps_charset_S k_charsets[] =
-{
+static struct prt_ps_charset_S k_charsets[] = {
   { "KS_X_1992",   "KSC",      CS_KR_X_1992 },
   { "CP1361",      "KSC",      CS_KR_X_1992 },
   { "MAC",         "KSCpc",    CS_KR_MAC },
@@ -1126,8 +1113,7 @@ static struct prt_ps_charset_S k_charsets[] =
   { "ISO10646",    "UniKS",    CS_KR_ISO10646 }
 };
 
-static struct prt_ps_mbfont_S prt_ps_mbfonts[] =
-{
+static struct prt_ps_mbfont_S prt_ps_mbfonts[] = {
   {
     ARRAY_SIZE(j_encodings),
     j_encodings,
@@ -1193,8 +1179,7 @@ static struct prt_ps_mbfont_S prt_ps_mbfonts[] =
 #define PRT_DSC_ENDCOMMENTS         "%%EndComments:"
 
 #define SIZEOF_CSTR(s)      (sizeof(s) - 1)
-static struct prt_dsc_comment_S prt_dsc_table[] =
-{
+static struct prt_dsc_comment_S prt_dsc_table[] = {
   { PRT_DSC_TITLE,       SIZEOF_CSTR(PRT_DSC_TITLE),     PRT_DSC_TITLE_TYPE },
   { PRT_DSC_VERSION,     SIZEOF_CSTR(PRT_DSC_VERSION),
     PRT_DSC_VERSION_TYPE },

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -77,8 +77,7 @@
 #define CTRL_X_MSG(i) ctrl_x_msgs[(i) & ~CTRL_X_WANT_IDENT]
 
 /// Message for CTRL-X mode, index is ctrl_x_mode.
-static char *ctrl_x_msgs[] =
-{
+static char *ctrl_x_msgs[] = {
   N_(" Keyword completion (^N^P)"),  // CTRL_X_NORMAL, ^P/^N compl.
   N_(" ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"),
   NULL,  // CTRL_X_SCROLL: depends on state

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -46,8 +46,7 @@ static const struct modmasktable {
 
 #define MOD_KEYS_ENTRY_SIZE 5
 
-static char_u modifier_keys_table[] =
-{
+static char_u modifier_keys_table[] = {
   //  mod mask      with modifier               without modifier
   MOD_MASK_SHIFT, '&', '9',                   '@', '1',         // begin
   MOD_MASK_SHIFT, '&', '0',                   '@', '2',         // cancel
@@ -347,8 +346,7 @@ static struct mousetable {
   int button;                 // Which mouse button is it?
   bool is_click;              // Is it a mouse button click event?
   bool is_drag;               // Is it a mouse drag event?
-} mouse_table[] =
-{
+} mouse_table[] = {
   { KE_LEFTMOUSE,        MOUSE_LEFT,     true,   false },
   { KE_LEFTDRAG,         MOUSE_LEFT,     false,  true },
   { KE_LEFTRELEASE,      MOUSE_LEFT,     false,  false },

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -400,7 +400,7 @@ static int nlua_wait(lua_State *lstate)
 
   bool fast_only = false;
   if (lua_top >= 4) {
-    fast_only =  lua_toboolean(lstate, 4);
+    fast_only = lua_toboolean(lstate, 4);
   }
 
   MultiQueue *loop_events = fast_only || in_fast_callback > 0

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -136,8 +136,7 @@ const uint8_t utf8len_tab_zero[] = {
 // "iso-8859-n" is handled by enc_canonize() directly.
 static struct
 {   const char *name;   int prop;              int codepage; }
-enc_canon_table[] =
-{
+enc_canon_table[] = {
 #define IDX_LATIN_1     0
   { "latin1",          ENC_8BIT + ENC_LATIN1,  1252 },
 #define IDX_ISO_2       1
@@ -270,8 +269,7 @@ enc_canon_table[] =
 // Aliases for encoding names.
 static struct
 {   const char *name; int canon; }
-enc_alias_table[] =
-{
+enc_alias_table[] = {
   { "ansi",            IDX_LATIN_1 },
   { "iso-8859-1",      IDX_LATIN_1 },
   { "latin2",          IDX_ISO_2 },
@@ -1024,8 +1022,7 @@ bool utf_printable(int c)
 {
   // Sorted list of non-overlapping intervals.
   // 0xd800-0xdfff is reserved for UTF-16, actually illegal.
-  static struct interval nonprint[] =
-  {
+  static struct interval nonprint[] = {
     { 0x070f, 0x070f }, { 0x180b, 0x180e }, { 0x200b, 0x200f }, { 0x202a, 0x202e },
     { 0x2060, 0x206f }, { 0xd800, 0xdfff }, { 0xfeff, 0xfeff }, { 0xfff9, 0xfffb },
     { 0xfffe, 0xffff }

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -39,7 +39,7 @@ extern MemRealloc mem_realloc;
 extern bool entered_free_all_mem;
 #endif
 
-EXTERN size_t arena_alloc_count INIT(=0);
+EXTERN size_t arena_alloc_count INIT(= 0);
 
 typedef struct consumed_blk {
   struct consumed_blk *prev;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -145,8 +145,7 @@ static const struct nv_cmd {
   nv_func_T cmd_func;           ///< function for this command
   uint16_t cmd_flags;           ///< NV_ flags
   int16_t cmd_arg;              ///< value for ca.arg
-} nv_cmds[] =
-{
+} nv_cmds[] = {
   { NUL,       nv_error,       0,                      0 },
   { Ctrl_A,    nv_addsub,      0,                      0 },
   { Ctrl_B,    nv_page,        NV_STS,                 BACKWARD },
@@ -5748,7 +5747,7 @@ static void nv_pcmark(cmdarg_T *cap)
       fm = get_changelist(curbuf, curwin, (int)cap->count1);
     } else {
       fm = get_jumplist(curwin, (int)cap->count1);
-      flags |=  KMarkNoContext | kMarkJumpList;
+      flags |= KMarkNoContext | kMarkJumpList;
     }
     // Changelist and jumplist have their own error messages. Therefore avoid
     // calling nv_mark_move_to() when not found to avoid incorrect error

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -95,8 +95,7 @@ struct block_def {
 // The names of operators.
 // IMPORTANT: Index must correspond with defines in vim.h!!!
 // The third field indicates whether the operator always works on lines.
-static char opchars[][3] =
-{
+static char opchars[][3] = {
   { NUL, NUL, 0 },                       // OP_NOP
   { 'd', NUL, OPF_CHANGE },              // OP_DELETE
   { 'y', NUL, 0 },                       // OP_YANK

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -337,8 +337,7 @@ static const size_t LINE_MAXLEN = 4096;
 static struct fmtpattern {
   char convchar;
   char *pattern;
-} fmt_pat[FMT_PATTERNS] =
-{
+} fmt_pat[FMT_PATTERNS] = {
   { 'f', ".\\+" },      // only used when at end
   { 'n', "\\d\\+" },    // 1
   { 'l', "\\d\\+" },    // 2
@@ -7066,7 +7065,7 @@ static void hgr_search_in_rtp(qf_list_T *qfl, regmatch_T *p_regmatch, const char
 void ex_helpgrep(exarg_T *eap)
 {
   qf_info_T *qi = &ql_info;
-  char *au_name =  NULL;
+  char *au_name = NULL;
 
   switch (eap->cmdidx) {
   case CMD_helpgrep:

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -181,8 +181,7 @@ static int backslash_trans(int c)
 /// recognized.  Otherwise "pp" is advanced to after the item.
 static int get_char_class(char **pp)
 {
-  static const char *(class_names[]) =
-  {
+  static const char *(class_names[]) = {
     "alnum:]",
 #define CLASS_ALNUM 0
     "alpha:]",
@@ -1328,8 +1327,7 @@ typedef struct {
 } decomp_T;
 
 // 0xfb20 - 0xfb4f
-static decomp_T decomp_table[0xfb4f - 0xfb20 + 1] =
-{
+static decomp_T decomp_table[0xfb4f - 0xfb20 + 1] = {
   { 0x5e2, 0, 0 },          // 0xfb20       alt ayin
   { 0x5d0, 0, 0 },          // 0xfb21       alt alef
   { 0x5d3, 0, 0 },          // 0xfb22       alt dalet
@@ -2276,16 +2274,14 @@ list_T *reg_submatch_list(int no)
 # include "nvim/regexp_nfa.c"
 #endif
 
-static regengine_T bt_regengine =
-{
+static regengine_T bt_regengine = {
   bt_regcomp,
   bt_regfree,
   bt_regexec_nl,
   bt_regexec_multi,
 };
 
-static regengine_T nfa_regengine =
-{
+static regengine_T nfa_regengine = {
   nfa_regcomp,
   nfa_regfree,
   nfa_regexec_nl,

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -80,8 +80,7 @@
 // one for other searches.  last_idx points to the one that was used the last
 // time.
 
-static struct spat spats[2] =
-{
+static struct spat spats[2] = {
   // Last used search pattern
   [0] = { NULL, true, false, 0, { '/', false, false, 0L }, NULL },
   // Last used substitute pattern

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1476,7 +1476,7 @@ static char *shada_filename(const char *file)
       file = p_shadafile;
     } else {
       if ((file = (char *)find_shada_parameter('n')) == NULL || *file == NUL) {
-        file =  shada_get_default_file();
+        file = shada_get_default_file();
       }
       // XXX It used to be one level lower, so that whatever is in
       //     `p_shadafile` was expanded. I intentionally moved it here

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1041,7 +1041,7 @@ int vim_vsnprintf_typval(char *str, size_t str_m, const char *fmt, va_list ap, t
             break;
           }
           if (arg > 0) {
-            arg_sign =  1;
+            arg_sign = 1;
           } else if (arg < 0) {
             arg_sign = -1;
           }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3344,8 +3344,7 @@ static int last_matchgroup;
 static void syn_list_one(const int id, const bool syncing, const bool link_only)
 {
   bool did_header = false;
-  static struct name_list namelist1[] =
-  {
+  static struct name_list namelist1[] = {
     { HL_DISPLAY, "display" },
     { HL_CONTAINED, "contained" },
     { HL_ONELINE, "oneline" },
@@ -3358,8 +3357,7 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
     { HL_CONCEALENDS, "concealends" },
     { 0, NULL }
   };
-  static struct name_list namelist2[] =
-  {
+  static struct name_list namelist2[] = {
     { HL_SKIPWHITE, "skipwhite" },
     { HL_SKIPNL, "skipnl" },
     { HL_SKIPEMPTY, "skipempty" },
@@ -5238,8 +5236,7 @@ struct subcommand {
   void (*func)(exarg_T *, int);              // function to call
 };
 
-static struct subcommand subcommands[] =
-{
+static struct subcommand subcommands[] = {
   { "case",      syn_cmd_case },
   { "clear",     syn_cmd_clear },
   { "cluster",   syn_cmd_cluster },

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -36,8 +36,7 @@ static char e_no_such_user_defined_command_in_current_buffer_str[]
 
 /// List of names for completion for ":command" with the EXPAND_ flag.
 /// Must be alphabetical for completion.
-static const char *command_complete[] =
-{
+static const char *command_complete[] = {
   [EXPAND_ARGLIST] = "arglist",
   [EXPAND_AUGROUP] = "augroup",
   [EXPAND_BEHAVE] = "behave",
@@ -86,8 +85,7 @@ static struct {
   cmd_addr_T expand;
   char *name;
   char *shortname;
-} addr_type_complete[] =
-{
+} addr_type_complete[] = {
   { ADDR_ARGUMENTS, "arguments", "arg" },
   { ADDR_LINES, "lines", "line" },
   { ADDR_LOADED_BUFFERS, "loaded_buffers", "load" },

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -125,7 +125,7 @@ sp_before_assign                = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space after assignment operator '=', '+=', etc.
 #
 # Overrides sp_assign.
-sp_after_assign                 = ignore   # ignore/add/remove/force/not_defined
+sp_after_assign                 = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'enum {'.
 #
@@ -1642,7 +1642,7 @@ nl_end_of_file                  = force    # ignore/add/remove/force/not_defined
 nl_end_of_file_min              = 1        # unsigned number
 
 # Add or remove newline between '=' and '{'.
-nl_assign_brace                 = ignore   # ignore/add/remove/force/not_defined
+nl_assign_brace                 = remove   # ignore/add/remove/force/not_defined
 
 # (D) Add or remove newline between '=' and '['.
 nl_assign_square                = ignore   # ignore/add/remove/force/not_defined
@@ -3515,5 +3515,5 @@ set QUESTION                     REAL_FATTR_CONST
 set QUESTION                     REAL_FATTR_NONNULL_ALL
 set QUESTION                     REAL_FATTR_PURE
 set QUESTION                     REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 110
+# option(s) with 'not default' value: 112
 #


### PR DESCRIPTION
Uncrustify is the source of truth where possible.
Remove any redundant checks from clint.py.
See also https://github.com/neovim/neovim/pull/18563