### PR TITLE
fix(vim.ui.input): return empty string when inputs nothing

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1976,7 +1976,8 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                         highlighting user inputs.
       • {on_confirm}  (function) ((input|nil) -> ()) Called once the user
                       confirms or abort the input. `input` is what the user
-                      typed. `nil` if the user aborted the dialog.
+                      typed (it might be an empty string if nothing was
+                      entered), or `nil` if the user aborted the dialog.
 
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
     Prompts the user to pick a single item from a collection of entries

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -73,7 +73,8 @@ end
 ---               user inputs.
 ---@param on_confirm function ((input|nil) -> ())
 ---               Called once the user confirms or abort the input.
----               `input` is what the user typed.
+---               `input` is what the user typed (it might be
+---               an empty string if nothing was entered), or
 ---               `nil` if the user aborted the dialog.
 ---
 --- Example:
@@ -88,11 +89,17 @@ function M.input(opts, on_confirm)
   })
 
   opts = (opts and not vim.tbl_isempty(opts)) and opts or vim.empty_dict()
+
+  -- Note that vim.fn.input({}) returns an empty string when cancelled.
+  -- vim.ui.input() should distinguish aborting from entering an empty string.
+  local _canceled = vim.NIL
+  opts = vim.tbl_extend('keep', opts, { cancelreturn = _canceled })
+
   local input = vim.fn.input(opts)
-  if #input > 0 then
-    on_confirm(input)
-  else
+  if input == _canceled then
     on_confirm(nil)
+  else
+    on_confirm(input)
   end
 end
 

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -83,5 +83,61 @@ describe('vim.ui', function()
       feed('abcdefg<cr>')
       eq('abcdefg', exec_lua('return result'))
     end)
+
+    it('can input empty text #18144', function()
+      feed(':lua vim.ui.input({}, function(input) result = input end)<cr>')
+      feed('<cr>')
+      eq('', exec_lua('return result'))
+    end)
+
+    it('can input empty text with cancelreturn opt #18144', function()
+      feed(':lua vim.ui.input({ cancelreturn = "CANCEL" }, function(input) result = input end)<cr>')
+      feed('<cr>')
+      eq('', exec_lua('return result'))
+    end)
+
+    it('can return nil when aborted with ESC #18144', function()
+      feed(':lua result = "on_confirm not called"<cr>')
+      feed(':lua vim.ui.input({}, function(input) result = input end)<cr>')
+      feed('Inputted Text<esc>')
+      -- Note: When `result == nil`, exec_lua('returns result') returns vim.NIL
+      eq(true, exec_lua('return (nil == result)'))
+    end)
+
+    it('can return opts.cacelreturn when aborted with ESC with cancelreturn opt #18144', function()
+      feed(':lua result = "on_confirm not called"<cr>')
+      feed(':lua vim.ui.input({ cancelreturn = "CANCEL" }, function(input) result = input end)<cr>')
+      feed('Inputted Text<esc>')
+      eq('CANCEL', exec_lua('return result'))
+    end)
+
+    it('does not call on_confirm when interrupted with Ctrl-C #18144', function()
+      feed(':lua result = "on_confirm not called"<cr>')
+      eq('on_confirm not called', exec_lua('return result'))
+      feed(':lua vim.ui.input({}, function(input) result = input end)<cr>')
+      feed('Inputted Text<c-c>')
+      -- Ctrl-C would make vim.ui.input() throw, so `result = input` won't be executed
+      eq('on_confirm not called', exec_lua('return result'))
+    end)
+
+    it('does not call on_confirm when interrupted with cancelreturn opt #18144', function()
+      feed(':lua result = "on_confirm not called"<cr>')
+      eq('on_confirm not called', exec_lua('return result'))
+      feed(':lua vim.ui.input({ cancelreturn = "CANCEL" }, function(input) result = input end)<cr>')
+      feed('Inputted Text<c-c>')
+      -- Ctrl-C would make vim.ui.input() throw, so `result = input` won't be executed
+      -- Note that the control flow logic is slightly different from the behavior with ESC
+      eq('on_confirm not called', exec_lua('return result'))
+    end)
+
+    it('can return the identical object when an arbitrary opts.cancelreturn object is given', function()
+      feed(':lua fn = function() return 42 end<CR>')
+      eq(42, exec_lua('return fn()'))
+      feed(':lua vim.ui.input({ cancelreturn = fn }, function(input) result = input end)<cr>')
+      feed('cancel<esc>')
+      eq(true, exec_lua('return (result == fn)'))
+      eq(42, exec_lua('return result()'))
+    end)
+
   end)
 end)

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -120,16 +120,6 @@ describe('vim.ui', function()
       eq('on_confirm not called', exec_lua('return result'))
     end)
 
-    it('does not call on_confirm when interrupted with cancelreturn opt #18144', function()
-      feed(':lua result = "on_confirm not called"<cr>')
-      eq('on_confirm not called', exec_lua('return result'))
-      feed(':lua vim.ui.input({ cancelreturn = "CANCEL" }, function(input) result = input end)<cr>')
-      feed('Inputted Text<c-c>')
-      -- Ctrl-C would make vim.ui.input() throw, so `result = input` won't be executed
-      -- Note that the control flow logic is slightly different from the behavior with ESC
-      eq('on_confirm not called', exec_lua('return result'))
-    end)
-
     it('can return the identical object when an arbitrary opts.cancelreturn object is given', function()
       feed(':lua fn = function() return 42 end<CR>')
       eq(42, exec_lua('return fn()'))


### PR DESCRIPTION
The previous behavior of `vim.ui.input()` when typing <CR> with no text
input (with an intention of having the empty string as input)
was to execute `on_confirm(nil)`.

Inputting an empty string now should correctly execute `on_confirm('')`.
This should be clearly distinguished from cancelling or aborting the
input UI, in which case `on_confirm(nil)` is executed as before.

Fixes #18144.