### PR TITLE
ci: add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *' # Run every day at 01:30
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v6
+        with:
+          days-before-close: 30
+          days-before-stale: -1
+          stale-issue-label: needs:response
+          stale-pr-label: needs:response
+          close-issue-message: "This issue has been closed since a request for
+            information has not been answered for 30 days. It can be reopened
+            when the requested information is provided."
+          close-pr-message: "This PR has been closed since a request for
+            changes has not been answered for 30 days. It can be reopened when
+            the requested changes are provided."


### PR DESCRIPTION
Stale strategy is to never automatically stale anything. Only mark stale
issues or PRs if they get the `needs:response` label. In that case close
after 30 days if there hasn't been any activity.