### PR TITLE
vim-patch:8.2.2343: Vim9: return type of readfile() is any

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -349,6 +349,7 @@ pyxeval({expr})			any	evaluate |python_x| expression
 rand([{expr}])			Number	get pseudo-random number
 range({expr} [, {max} [, {stride}]])
 				List	items from {expr} to {max}
+readblob({fname})		Blob	read a |Blob| from {fname}
 readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
@@ -6036,6 +6037,14 @@ rand([{expr}])						*rand()*
 		Can also be used as a |method|: >
 			seed->rand()
 <
+
+readblob({fname})					*readblob()*
+		Read file {fname} in binary mode and return a |Blob|.
+		When the file can't be opened an error message is given and
+		the result is an empty |Blob|.
+		Also see |readfile()| and |writefile()|.
+
+
 							*readdir()*
 readdir({directory} [, {expr}])
 		Return a list with file and directory names in {directory}.
@@ -6070,6 +6079,7 @@ readdir({directory} [, {expr}])
 		Can also be used as a |method|: >
 			GetDirName()->readdir()
 <
+
 							*readfile()*
 readfile({fname} [, {type} [, {max}]])
 		Read file {fname} and return a |List|, each line of the file
@@ -6081,8 +6091,6 @@ readfile({fname} [, {type} [, {max}]])
 		- When the last line ends in a NL an extra empty list item is
 		  added.
 		- No CR characters are removed.
-		When {type} contains "B" a |Blob| is returned with the binary
-		data of the file unmodified.
 		Otherwise:
 		- CR characters that appear before a NL are removed.
 		- Whether the last line ends in a NL or not does not matter.
@@ -6099,6 +6107,9 @@ readfile({fname} [, {type} [, {max}]])
 		Note that without {max} the whole file is read into memory.
 		Also note that there is no recognition of encoding.  Read a
 		file into a buffer if you need to.
+		Deprecated (use |readblob()| instead): When {type} contains
+		"B" a |Blob| is returned with the binary data of the file
+		unmodified.
 		When the file can't be opened an error message is given and
 		the result is an empty list.
 		Also see |writefile()|.
@@ -8907,7 +8918,12 @@ win_execute({id}, {command} [, {silent}])		*win_execute()*
 		have unexpected side effects.  Use |:noautocmd| if needed.
 		Example: >
 			call win_execute(winid, 'syntax enable')
-<
+<		Doing the same with `setwinvar()` would not trigger
+		autocommands and not actually show syntax highlighting.
+
+		When window {id} does not exist then no error is given and
+		an empty string is returned.
+
 		Can also be used as a |method|, the base is passed as the
 		second argument: >
 			GetCommand()->win_execute(winid)

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -818,6 +818,7 @@ System functions and manipulation of files:
 	setenv()		set an environment variable
 	hostname()		name of the system
 	readfile()		read a file into a List of lines
+	readblob()		read a file into a Blob
 	readdir()		get a List of file names in a directory
 	writefile()		write a List of lines or Blob into a file
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -291,6 +291,7 @@ return {
     perleval={args=1, base=1},
     rand={args={0, 1}, base=1},
     range={args={1, 3}, base=1},
+    readblob={args=1, base=1},
     readdir={args={1, 2}, base=1},
     readfile={args={1, 3}, base=1},
     reduce={args={2, 3}, base=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5872,11 +5872,11 @@ static void f_readdir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   ga_clear_strings(&ga);
 }
 
-/// "readfile()" function
-static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+/// "readfile()" or "readblob()" function
+static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_blob)
 {
   bool binary = false;
-  bool blob = false;
+  bool blob = always_blob;
   FILE *fd;
   char buf[(IOSIZE/256) * 256];    // rounded to avoid odd + 1
   int io_size = sizeof(buf);
@@ -6011,8 +6011,8 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
             int adjust_prevlen = 0;
 
             if (dest < buf) {  // -V782
-              adjust_prevlen = (int)(buf - dest);  // -V782
               // adjust_prevlen must be 1 or 2.
+              adjust_prevlen = (int)(buf - dest);  // -V782
               dest = buf;
             }
             if (readlen > p - buf + 1) {
@@ -6053,6 +6053,18 @@ static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   xfree(prev);
   fclose(fd);
+}
+
+/// "readblob()" function
+static void f_readblob(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  read_file_or_blob(argvars, rettv, true);
+}
+
+/// "readfile()" function
+static void f_readfile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  read_file_or_blob(argvars, rettv, false);
 }
 
 /// "getreginfo()" function

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -851,9 +851,7 @@ func Test_mksession_shortmess_with_A()
   edit Xtestfile
   write
   let fname = swapname('%')
-  " readblob() needs patch 8.2.2343
-  " let cont = readblob(fname)
-  let cont = readfile(fname, 'B')
+  let cont = readblob(fname)
   set sessionoptions-=options
   mksession Xtestsession
   bwipe!


### PR DESCRIPTION
#### vim-patch:8.2.2343: Vim9: return type of readfile() is any

Problem:    Vim9: return type of readfile() is any.
Solution:   Add readblob() so that readfile() can be expected to always
            return a list of strings.

https://github.com/vim/vim/commit/c423ad77ed763c11ba67729bbf63c1cf0915231f

Co-authored-by: Bram Moolenaar <Bram@vim.org>