### PR TITLE
vim-patch:9.0.0826: if 'endofline' is set CTRL-Z may be written in a wrong place

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -545,6 +545,44 @@ Before editing binary, executable or Vim script files you should set the
 option.  This will avoid the use of 'fileformat'.  Without this you risk that
 single <NL> characters are unexpectedly replaced with <CR><NL>.
 
+END OF LINE AND END OF FILE				*eol-and-eof*
+
+Vim has several options to control the file format:
+	'fileformat'	the <EOL> style: Unix, DOS, Mac
+	'endofline'	whether the last line ends with a <EOL>
+	'endoffile'	whether the file ends with a CTRL-Z
+	'fixendofline'	whether to fix eol and eof
+
+The first three values are normally detected automatically when reading the
+file and are used when writing the text to a file.  While editing the buffer
+it looks like every line has a line ending and the CTRL-Z isn't there (an
+exception is when 'binary' is set, it works differently then).
+
+The 'fixendofline' option can be used to choose what to write.  You can also
+change the option values to write the file differently than how it was read.
+
+Here are some examples how to use them.
+
+If you want files in Unix format (every line NL terminated): >
+	setl ff=unix fixeol
+You should probably do this on any Unix-like system.  Also modern MS-Windows
+systems tend to work well with this.  It is recommended to always use this
+format for Vim scripts.
+
+If you want to use an old MS-DOS file in a modern environment, fixing line
+endings and dropping CTRL-Z, but keeping the <CR><NL> style <EOL>: >
+	setl ff=dos fixeol
+This is useful for many MS-Windows programs, they regularly expect the
+<CR><NL> line endings.
+
+If you want to drop the final <EOL> and add a final CTRL-Z (e.g. for an old
+system like CP/M): >
+	setl ff=dos nofixeol noeol eof
+
+If you want to preserve the fileformat exactly as-is, including any final
+<EOL> and final CTRL-Z: >
+	setl nofixeol
+
 ==============================================================================
 3. The argument list				*argument-list* *arglist*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2143,6 +2143,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When writing a file and this option is off and the 'binary' option
 	is on, or 'fixeol' option is off, no CTRL-Z will be written at the
 	end of the file.
+	See |eol-and-eof| for example settings.
 
 			*'endofline'* *'eol'* *'noendofline'* *'noeol'*
 'endofline' 'eol'	boolean	(default on)
@@ -2158,6 +2159,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	to remember the presence of a <EOL> for the last line in the file, so
 	that when you write the file the situation from the original file can
 	be kept.  But you can change it if you want to.
+	See |eol-and-eof| for example settings.
 
 			     *'equalalways'* *'ea'* *'noequalalways'* *'noea'*
 'equalalways' 'ea'	boolean	(default on)
@@ -2504,6 +2506,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the 'binary' option is set the value of this option doesn't
 	matter.
 	See the 'endofline' option.
+	See |eol-and-eof| for example settings.
 
 						*'foldclose'* *'fcl'*
 'foldclose' 'fcl'	string (default "")

--- a/src/nvim/testdir/test_fixeol.vim
+++ b/src/nvim/testdir/test_fixeol.vim
@@ -48,4 +48,71 @@ func Test_fixeol()
   enew!
 endfunc
 
+func Test_eof()
+  let data = 0z68656c6c6f.0d0a.776f726c64   " "hello\r\nworld"
+
+  " 1. Eol, Eof
+  " read
+  call writefile(data + 0z0d0a.1a, 'XXEolEof')
+  e! XXEolEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([1, 1], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z0d0a.1a, readblob('XXEolEof'))
+
+  " 2. NoEol, Eof
+  " read
+  call writefile(data + 0z1a, 'XXNoEolEof')
+  e! XXNoEolEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([0, 1], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXNoEolEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z1a, readblob('XXNoEolEof'))
+
+  " 3. Eol, NoEof
+  " read
+  call writefile(data + 0z0d0a, 'XXEolNoEof')
+  e! XXEolNoEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([1, 0], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolNoEof'))
+  set nofixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXEolNoEof'))
+
+  " 4. NoEol, NoEof
+  " read
+  call writefile(data, 'XXNoEolNoEof')
+  e! XXNoEolNoEof
+  call assert_equal(['hello', 'world'], getline(1, 2))
+  call assert_equal([0, 0], [&eol, &eof])
+  " write
+  set fixeol
+  w!
+  call assert_equal(data + 0z0d0a, readblob('XXNoEolNoEof'))
+  set nofixeol
+  w!
+  call assert_equal(data, readblob('XXNoEolNoEof'))
+
+  call delete('XXEolEof')
+  call delete('XXNoEolEof')
+  call delete('XXEolNoEof')
+  call delete('XXNoEolNoEof')
+  set ff& fixeol& eof& eol&
+  enew!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0826: if 'endofline' is set CTRL-Z may be written in a wrong place

Problem:    If 'endofline' is set the CTRL-Z may be written in the wrong
            place.
Solution:   Write CTRL-Z at the end of the file.  Update the help to explain
            the possibilities better. (Ken Takata, closes vim/vim#11486)

https://github.com/vim/vim/commit/3af982196b1b973e953c35351961f2a96fe34172

Co-authored-by: K.Takata <kentkt@csc.jp>