### PR TITLE
vim-patch:9.0.{0822,0823,0824,0825}: window dragging fixes

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -9690,6 +9690,10 @@ static void f_win_move_separator(typval_T *argvars, typval_T *rettv, EvalFuncDat
   if (wp == NULL || wp->w_floating) {
     return;
   }
+  if (!win_valid(wp)) {
+    emsg(_(e_cannot_resize_window_in_another_tab_page));
+    return;
+  }
 
   int offset = (int)tv_get_number(&argvars[1]);
   win_drag_vsep_line(wp, offset);

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -227,6 +227,15 @@ static int get_fpos_of_mouse(pos_T *mpos)
   return IN_BUFFER;
 }
 
+static bool mouse_got_click = false;  ///< got a click some time back
+
+/// Reset the flag that a mouse click was seen.  To be called when switching tab
+/// page.
+void reset_mouse_got_click(void)
+{
+  mouse_got_click = false;
+}
+
 /// Do the appropriate action for the current mouse click in the current mode.
 /// Not used for Command-line mode.
 ///
@@ -268,8 +277,6 @@ static int get_fpos_of_mouse(pos_T *mpos)
 /// @return           true if start_arrow() should be called for edit mode.
 bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
 {
-  static bool got_click = false;        // got a click some time back
-
   int which_button;             // MOUSE_LEFT, _MIDDLE or _RIGHT
   bool is_click;                // If false it's a drag or release event
   bool is_drag;                 // If true it's a drag event
@@ -328,13 +335,13 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
 
   // Ignore drag and release events if we didn't get a click.
   if (is_click) {
-    got_click = true;
+    mouse_got_click = true;
   } else {
-    if (!got_click) {                   // didn't get click, ignore
+    if (!mouse_got_click) {             // didn't get click, ignore
       return false;
     }
-    if (!is_drag) {                     // release, reset got_click
-      got_click = false;
+    if (!is_drag) {                     // release, reset mouse_got_click
+      mouse_got_click = false;
       if (in_tab_line) {
         in_tab_line = false;
         return false;
@@ -351,7 +358,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       stuffnumReadbuff(count);
     }
     stuffcharReadbuff(Ctrl_T);
-    got_click = false;                  // ignore drag&release now
+    mouse_got_click = false;  // ignore drag&release now
     return false;
   }
 
@@ -574,7 +581,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
         ui_flush();  // Update before showing popup menu
       }
       show_popupmenu();
-      got_click = false;  // ignore release events
+      mouse_got_click = false;  // ignore release events
       return (jump_flags & CURSOR_MOVED) != 0;
     }
     if (which_button == MOUSE_LEFT
@@ -613,7 +620,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
 
   // If an operator is pending, ignore all drags and releases until the next mouse click.
   if (!is_drag && oap != NULL && oap->op_type != OP_NOP) {
-    got_click = false;
+    mouse_got_click = false;
     oap->motion_type = kMTCharWise;
   }
 
@@ -815,7 +822,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     } else {                                    // location list window
       do_cmdline_cmd(".ll");
     }
-    got_click = false;                  // ignore drag&release now
+    mouse_got_click = false;  // ignore drag&release now
   } else if ((mod_mask & MOD_MASK_CTRL)
              || (curbuf->b_help && (mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK)) {
     // Ctrl-Mouse click (or double click in a help window) jumps to the tag
@@ -824,7 +831,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
       stuffcharReadbuff(Ctrl_O);
     }
     stuffcharReadbuff(Ctrl_RSB);
-    got_click = false;                  // ignore drag&release now
+    mouse_got_click = false;  // ignore drag&release now
   } else if ((mod_mask & MOD_MASK_SHIFT)) {
     // Shift-Mouse click searches for the next occurrence of the word under
     // the mouse pointer

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1050,6 +1050,24 @@ func Test_mouse_drag_mapped_start_select()
   set mouse&
 endfunc
 
+func Test_mouse_drag_statusline()
+  set laststatus=2
+  set mouse=a
+  func ClickExpr()
+      call Ntest_setmouse(&lines - 1, 1)
+        return "\<LeftMouse>"
+  endfunc
+  func DragExpr()
+      call Ntest_setmouse(&lines - 2, 1)
+        return "\<LeftDrag>"
+  endfunc
+  nnoremap <expr> <F2> ClickExpr()
+  nnoremap <expr> <F3> DragExpr()
+
+  " this was causing a crash in win_drag_status_line()
+  call feedkeys("\<F2>:tabnew\<CR>\<F3>", 'tx')
+endfunc
+
 " Test for mapping <LeftDrag> in Insert mode
 func Test_mouse_drag_insert_map()
   set mouse=a

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -1054,18 +1054,24 @@ func Test_mouse_drag_statusline()
   set laststatus=2
   set mouse=a
   func ClickExpr()
-      call Ntest_setmouse(&lines - 1, 1)
-        return "\<LeftMouse>"
+    call Ntest_setmouse(&lines - 1, 1)
+    return "\<LeftMouse>"
   endfunc
   func DragExpr()
-      call Ntest_setmouse(&lines - 2, 1)
-        return "\<LeftDrag>"
+    call Ntest_setmouse(&lines - 2, 1)
+    return "\<LeftDrag>"
   endfunc
   nnoremap <expr> <F2> ClickExpr()
   nnoremap <expr> <F3> DragExpr()
 
   " this was causing a crash in win_drag_status_line()
   call feedkeys("\<F2>:tabnew\<CR>\<F3>", 'tx')
+
+  nunmap <F2>
+  nunmap <F3>
+  delfunc ClickExpr
+  delfunc DragExpr
+  set laststatus& mouse&
 endfunc
 
 " Test for mapping <LeftDrag> in Insert mode

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1393,17 +1393,20 @@ func Test_win_move_separator()
   call assert_equal(w0, winwidth(0))
   call assert_true(win_move_separator(0, -1))
   call assert_equal(w0, winwidth(0))
+
   " check that win_move_separator doesn't error with offsets beyond moving
   " possibility
   call assert_true(win_move_separator(id, 5000))
   call assert_true(winwidth(id) > w)
   call assert_true(win_move_separator(id, -5000))
   call assert_true(winwidth(id) < w)
+
   " check that win_move_separator returns false for an invalid window
   wincmd =
   let w = winwidth(0)
   call assert_false(win_move_separator(-1, 1))
   call assert_equal(w, winwidth(0))
+
   " check that win_move_separator returns false for a floating window
   let id = nvim_open_win(
         \ 0, 0, #{relative: 'editor', row: 2, col: 2, width: 5, height: 3})
@@ -1411,6 +1414,13 @@ func Test_win_move_separator()
   call assert_false(win_move_separator(id, 1))
   call assert_equal(w, winwidth(id))
   call nvim_win_close(id, 1)
+
+  " check that using another tabpage fails without crash
+  let id = win_getid()
+  tabnew
+  call assert_fails('call win_move_separator(id, -1)', 'E1308:')
+  tabclose
+
   %bwipe!
 endfunc
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4214,7 +4214,7 @@ static int leave_tabpage(buf_T *new_curbuf, bool trigger_leave_autocmds)
     }
   }
 
-  reset_mouse_got_click();
+  reset_dragwin();
   tp->tp_curwin = curwin;
   tp->tp_prevwin = prevwin;
   tp->tp_firstwin = firstwin;
@@ -4279,7 +4279,7 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, bool trigger_enter_a
 
   // If there was a click in a window, it won't be usable for a following
   // drag.
-  reset_mouse_got_click();
+  reset_dragwin();
 
   // The tabpage line may have appeared or disappeared, may need to resize the frames for that.
   // When the Vim window was resized or ROWS_AVAIL changed need to update frame sizes too.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4195,6 +4195,7 @@ static int leave_tabpage(buf_T *new_curbuf, bool trigger_leave_autocmds)
 {
   tabpage_T *tp = curtab;
 
+  reset_mouse_got_click();
   leaving_window(curwin);
   reset_VIsual_and_resel();     // stop Visual mode
   if (trigger_leave_autocmds) {
@@ -4392,6 +4393,7 @@ void goto_tabpage_tp(tabpage_T *tp, bool trigger_enter_autocmds, bool trigger_le
   // Don't repeat a message in another tab page.
   set_keep_msg(NULL, 0);
 
+  reset_mouse_got_click();
   skip_win_fix_scroll = true;
   if (tp != curtab && leave_tabpage(tp->tp_curwin->w_buffer,
                                     trigger_leave_autocmds) == OK) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4195,7 +4195,6 @@ static int leave_tabpage(buf_T *new_curbuf, bool trigger_leave_autocmds)
 {
   tabpage_T *tp = curtab;
 
-  reset_mouse_got_click();
   leaving_window(curwin);
   reset_VIsual_and_resel();     // stop Visual mode
   if (trigger_leave_autocmds) {
@@ -4214,6 +4213,8 @@ static int leave_tabpage(buf_T *new_curbuf, bool trigger_leave_autocmds)
       return FAIL;
     }
   }
+
+  reset_mouse_got_click();
   tp->tp_curwin = curwin;
   tp->tp_prevwin = prevwin;
   tp->tp_firstwin = firstwin;
@@ -4275,6 +4276,10 @@ static void enter_tabpage(tabpage_T *tp, buf_T *old_curbuf, bool trigger_enter_a
   if (row < cmdline_row && cmdline_row <= Rows - p_ch) {
     clear_cmdline = true;
   }
+
+  // If there was a click in a window, it won't be usable for a following
+  // drag.
+  reset_mouse_got_click();
 
   // The tabpage line may have appeared or disappeared, may need to resize the frames for that.
   // When the Vim window was resized or ROWS_AVAIL changed need to update frame sizes too.
@@ -4393,7 +4398,6 @@ void goto_tabpage_tp(tabpage_T *tp, bool trigger_enter_autocmds, bool trigger_le
   // Don't repeat a message in another tab page.
   set_keep_msg(NULL, 0);
 
-  reset_mouse_got_click();
   skip_win_fix_scroll = true;
   if (tp != curtab && leave_tabpage(tp->tp_curwin->w_buffer,
                                     trigger_leave_autocmds) == OK) {


### PR DESCRIPTION
Fix #20780

#### vim-patch:9.0.0822: crash when dragging the statusline with a mapping

Problem:    Crash when dragging the statusline with a mapping.
Solution:   Check for valid window pointer. (issue vim/vim#11427)

https://github.com/vim/vim/commit/8ab9ca93eea32b318235384720200771863ecaee

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0823: mouse drag test fails

Problem:    Mouse drag test fails.
Solution:   Only reset the mouse click flag when actually switching to another
            tab page.  Disable test that keeps failing.

https://github.com/vim/vim/commit/7a7db047dcb2336de5103e793345eb5a9d125900

Omit test_termcodes.vim change: reverted in patch 9.0.0825.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0824: crash when using win_move_separator() in other tab page

Problem:    Crash when using win_move_separator() in other tab page.
Solution:   Check for valid window in current tab page.
            (closes vim/vim#11479)

https://github.com/vim/vim/commit/873f41a0187e81a22aa4622fbf938de72a54abba


#### vim-patch:9.0.0825: cannot drag an entry in the tabpage line

Problem:    Cannot drag an entry in the tabpage line.
Solution:   Clear dragwin instead of got_click. (closes vim/vim#11483)

https://github.com/vim/vim/commit/8e0ccb6bc21a446e5c6375b7fdf200fb53a129da

Omit Test_term_mouse_drag_to_move_tab(): covered by ui/mouse_spec.lua.