### PR TITLE
fix(man.lua): set modifiable before writing page

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -457,7 +457,7 @@ local function get_page(path, silent)
 end
 
 local function put_page(page)
-  vim.bo.modified = true
+  vim.bo.modifiable = true
   vim.bo.readonly = false
   vim.bo.swapfile = false
 


### PR DESCRIPTION
Fix `nvim --clean +'h h' +'Man ls'`
![image](https://user-images.githubusercontent.com/17562139/199628382-9c173e0b-4647-4a1b-bd60-513fdb1d832e.png)
