### PR TITLE
fix(treesitter): link text hl-groups by default

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -380,6 +380,8 @@ The following captures are linked by default to standard |group-name|s:
     @text.uri          Underlined
     @text.underline    Underlined
     @text.todo         Todo
+    @text.emphasis     Underlined
+    @text.strong       Todo
 
     @comment           Comment
     @punctuation       Delimiter

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -191,6 +191,8 @@ static const char *highlight_init_both[] = {
   "default link @text.uri Underlined",
   "default link @text.underline Underlined",
   "default link @text.todo Todo",
+  "default link @text.emphasis Underlined",
+  "default link @text.strong Todo",
 
   // Miscs
   "default link @comment Comment",


### PR DESCRIPTION
### Description

Link more `@text` captures to highlight groups by default.

These are currently used in: {rst, markdown (inline), html, latext}

and potentially vimdoc (?)
