### PR TITLE
Un-deprecate 'exrc' option

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -128,10 +128,6 @@ NORMAL COMMANDS
 OPTIONS
 - *cpo-<* *:menu-<special>* *:menu-special* *:map-<special>* *:map-special*
   `<>` notation is always enabled.
-- *'exrc'* *'ex'*	Security risk: downloaded files could include
-			a malicious .nvimrc or .exrc file. See 'secure'.
-			Recommended alternative: define an autocommand in your
-			|vimrc| to set options for a matching directory.
 - 'gdefault'		Enables the |:substitute| flag 'g' by default.
 - *'fe'*		'fenc'+'enc' before Vim 6.0; no longer used.
 - *'highlight'* *'hl'*	Names of builtin |highlight-groups| cannot be changed.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -784,6 +784,15 @@ vim.empty_dict()                                            *vim.empty_dict()*
     Note: If numeric keys are present in the table, Nvim ignores the metatable
     marker and converts the dict to a list/array anyway.
 
+vim.readsecure({path})                                      *vim.readsecure()*
+    Read the file at {path}, prompting the user if the file should be trusted.
+    The user is given the option to mark the file as trusted, blacklist the
+    file, view the file contents in a buffer, or do nothing. If the user
+    chooses to trust or blacklist the file, this decision is saved by writing
+    the full file path and the SHA256 hash of the file contents to a "trust
+    database" at $XDG_STATE_HOME/nvim/trust. Further calls to this function
+    with a matching content hash will not re-prompt the user.
+
 vim.rpcnotify({channel}, {method} [, {args}...])             *vim.rpcnotify()*
     Sends {event} to {channel} via |RPC| and returns immediately. If {channel}
     is 0, the event is broadcast to all channels.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2246,6 +2246,24 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option is reset when the 'paste' option is set and restored when
 	the 'paste' option is reset.
 
+					*'exrc'* *'ex'* *'noexrc'* *'noex'*
+'exrc' 'ex'		boolean (default off)
+			global
+	Enables the reading of .nvimrc and .exrc files in the current
+	directory.
+
+	When a .nvimrc or .exrc file is found in the current directory, the
+	user is prompted whether or not to trust the file. The file contents
+	are only sourced if the user indicates the file should be trusted. The
+	user's decision is remembered by writing the full file path of the
+	file along with the SHA256 hash of its contents to a "trust database"
+	at $XDG_STATE_HOME/nvim/trust.
+
+	See also |vim.readsecure()|.
+
+	This option cannot be set from a |modeline| or in the |sandbox|, for
+	security reasons.
+
 				*'fileencoding'* *'fenc'* *E213*
 'fileencoding' 'fenc'	string (default: "")
 			local to buffer

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -416,6 +416,8 @@ Options:
   'jumpoptions' "view" tries to restore the |mark-view| when moving through
   the |jumplist|, |changelist|, |alternate-file| or using |mark-motions|.
   'shortmess' the "F" flag does not affect output from autocommands
+  'exrc' searches for ".nvimrc" or ".exrc" files and users are prompted to
+         choose if the file is trusted
 
 Shell:
   Shell output (|:!|, |:make|, …) is always routed through the UI, so it

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1987,7 +1987,12 @@ static void source_startup_scripts(const mparm_T *const parmp)
 #endif
       secure = p_secure;
 
-      if (do_source(VIMRC_FILE, true, DOSO_VIMRC) == FAIL) {
+      size_t dummy;
+      char *init_str = read_secure(VIMRC_FILE, &dummy);
+      if (init_str) {
+        do_source_str(init_str, VIMRC_FILE);
+        xfree(init_str);
+      } else {
 #if defined(UNIX)
         // if ".exrc" is not owned by user set 'secure' mode
         if (!os_file_owned(EXRC_FILE)) {
@@ -1996,7 +2001,11 @@ static void source_startup_scripts(const mparm_T *const parmp)
           secure = 0;
         }
 #endif
-        (void)do_source(EXRC_FILE, false, DOSO_NONE);
+        init_str = read_secure(EXRC_FILE, &dummy);
+        if (init_str) {
+          do_source_str(init_str, EXRC_FILE);
+          xfree(init_str);
+        }
       }
     }
     if (secure == 2) {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -5,9 +5,12 @@
 ///
 /// Management of runtime files (including packages)
 
+#include "nvim/api/buffer.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/vim.h"
 #include "nvim/ascii.h"
 #include "nvim/autocmd.h"
+#include "nvim/buffer.h"
 #include "nvim/charset.h"
 #include "nvim/cmdexpand.h"
 #include "nvim/debugger.h"
@@ -24,6 +27,7 @@
 #include "nvim/os/os.h"
 #include "nvim/profile.h"
 #include "nvim/runtime.h"
+#include "nvim/sha256.h"
 #include "nvim/vim.h"
 
 /// Structure used to store info for each sourced file.
@@ -1839,6 +1843,218 @@ static void cmd_source_buffer(const exarg_T *const eap)
                             ":source (no file)");
   }
   ga_clear(&ga);
+}
+
+/// Read a file, prompting the user if the file should be trusted or not.
+///
+/// Maintain a "trust database" at stdpath('state')/trust containing a sequence
+/// of [hash, path] pairs. A path can be marked as blacklisted by using a '!'
+/// character for the hash.
+///
+/// @param path[in] Path to file
+/// @param len[out] Pointer which is populated with the length of the returned contents without the
+///                 trailing NUL byte.
+///
+/// @return A pointer to file contents if the file should be trusted, or NULL
+///         otherwise. Caller owns returned memory.
+char *read_secure(const char *path, size_t *len)
+  FUNC_ATTR_NONNULL_ALL
+{
+  ssize_t fsize = 0;
+  char *contents = NULL;
+
+  // Exit early if file can't be read
+  FILE *fp = fopen(path, "r");
+  if (!fp) {
+    return NULL;
+  }
+
+  PMap(cstr_t) file_hashes = MAP_INIT;
+  char *fullpath = os_realpath(path, NULL);
+  char *trustdb = stdpaths_user_state_subpath("trust", 0, false);
+  FILE *trust_fp = os_fopen(trustdb, "r");
+  if (trust_fp) {
+    // Pre-allocate space for file path, 64 char hash, one space, one newline, and one null byte
+    int size = MAXPATHL + 64 + 3;
+    char *line = xcalloc((size_t)size, sizeof(char));
+    while (fgets(line, size, trust_fp) != NULL) {
+      char *s = line;
+      char *h = strsep(&s, " \n");
+      char *p = strsep(&s, "\n");
+      if (h == NULL || p == NULL) {
+        // Malformed line
+        continue;
+      }
+
+      // The trust database should not contain multiple entries for the same file, but if it does
+      // avoid making a duplicate copy of the file path (which would leak memory) and assume that
+      // the first hash read for the file is the "real" one.
+      if (!pmap_has(cstr_t)(&file_hashes, p)) {
+        (void)pmap_put(cstr_t)(&file_hashes, xstrdup(p), xstrdup(h));
+      }
+    }
+
+    xfree(line);
+    fclose(trust_fp);
+  }
+
+  const char *curhash = pmap_get(cstr_t)(&file_hashes, fullpath);
+  if (curhash != NULL && strcmp(curhash, "!") == 0) {
+    // File is blacklisted
+    goto out;
+  }
+
+  fseek(fp, 0, SEEK_END);
+  fsize = ftell(fp);
+  fseek(fp, 0, SEEK_SET);
+  assert(fsize >= 0);
+
+  contents = xcalloc((size_t)fsize, sizeof(char));
+  if (fread(contents, sizeof(char), (size_t)fsize, fp) != (size_t)fsize) {
+    XFREE_CLEAR(contents);
+    goto out;
+  }
+
+  const char *hash = sha256_bytes((uint8_t *)contents, (size_t)fsize, NULL, 0);
+  if (curhash && strcmp(curhash, hash) == 0) {
+    // File is trusted
+    goto out;
+  }
+
+  // File does not yet exist in trust database or hash did not match
+  // Prompt user for action
+  snprintf(IObuff, IOSIZE, "%s is untrusted", fullpath);
+  int choice = do_dialog(VIM_QUESTION, NULL, IObuff, "&ignore\n&view\n&blacklist\n&trust", 1, NULL,
+                         false);
+  switch (choice) {
+  case 0:
+  case 1:
+    // Cancelled or ignored
+    XFREE_CLEAR(contents);
+    goto out;
+  case 2: {
+    // View
+    Error err = ERROR_INIT;
+    Buffer buf = nvim_create_buf(false, true, &err);
+    if (ERROR_SET(&err)) {
+      XFREE_CLEAR(contents);
+      goto out;
+    }
+
+    nvim_buf_set_name(buf, cstr_as_string(fullpath), &err);
+    if (ERROR_SET(&err)) {
+      XFREE_CLEAR(contents);
+      goto out;
+    }
+
+    if (do_buffer(DOBUF_SPLIT, DOBUF_FIRST, FORWARD, buf, false) == FAIL) {
+      XFREE_CLEAR(contents);
+      goto out;
+    }
+
+    if (contents[fsize - 1] == '\n') {
+      contents[fsize - 1] = '\0';
+    }
+
+    Array lines = ARRAY_DICT_INIT;
+    char *str = contents;
+    char *line = NULL;
+    while ((line = strsep(&str, "\n")) != NULL) {
+      ADD(lines, CSTR_TO_OBJ(line));
+    }
+
+    nvim_buf_set_lines(INTERNAL_CALL_MASK, 0, 0, 1, false, lines, &err);
+    api_free_array(lines);
+    if (ERROR_SET(&err)) {
+      XFREE_CLEAR(contents);
+      goto out;
+    }
+
+    set_option_value_give_err("filetype", 0, "vim", OPT_LOCAL);
+    set_option_value_give_err("readonly", 1, NULL, OPT_LOCAL);
+    set_option_value_give_err("modifiable", 0, NULL, OPT_LOCAL);
+
+    XFREE_CLEAR(contents);
+    goto out;
+  }
+  case 3: {
+    // Blacklist
+
+    // Only duplicate the file path if it does not already exist in the map
+    char **k = (char **)pmap_ref(cstr_t)(&file_hashes, fullpath, false);
+    if (k == NULL) {
+      k = (char **)pmap_ref(cstr_t)(&file_hashes, xstrdup(fullpath), true);
+    }
+
+    *k = xstrdup("!");
+
+    XFREE_CLEAR(contents);
+    break;
+  }
+  case 4: {
+    // Trust
+
+    // Only duplicate the file path if it does not already exist in the map
+    char **k = (char **)pmap_ref(cstr_t)(&file_hashes, fullpath, false);
+    if (k == NULL) {
+      k = (char **)pmap_ref(cstr_t)(&file_hashes, xstrdup(fullpath), true);
+    }
+
+    *k = xstrdup(hash);
+
+    break;
+  }
+  case 5:
+    // Unreachable
+    assert(false);
+    XFREE_CLEAR(contents);
+    goto out;
+  }
+
+  trust_fp = os_fopen(trustdb, "w");
+  if (!trust_fp) {
+    semsg("Failed to open trust database %s\n", trustdb);
+    if (contents) {
+      XFREE_CLEAR(contents);
+    }
+    goto out;
+  }
+
+  {
+    const char *p;
+    char *h;
+    map_foreach(&file_hashes, p, h, {
+      fprintf(trust_fp, "%s %s\n", h, p);
+    })
+  }
+
+out:
+  xfree(fullpath);
+  xfree(trustdb);
+  fclose(fp);
+
+  if (trust_fp) {
+    fclose(trust_fp);
+  }
+
+  {
+    const char *p;
+    char *h;
+    map_foreach(&file_hashes, p, h, {
+      xfree((void *)p);
+      xfree(h);
+    })
+  }
+  pmap_destroy(cstr_t)(&file_hashes);
+
+  if (contents != NULL) {
+    // Subtract one for trailing null byte
+    *len = (size_t)fsize;
+  } else {
+    *len = 0;
+  }
+
+  return contents;
 }
 
 /// Executes lines in `src` as Ex commands.

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -1024,6 +1024,7 @@ endfunc
 
 " Test for using the 'exrc' option
 func Test_exrc()
+  throw 'skipped: Nvim requires exrc file to be trusted'
   let after =<< trim [CODE]
     call assert_equal(1, &exrc)
     call assert_equal(1, &secure)

--- a/test/functional/lua/readsecure_spec.lua
+++ b/test/functional/lua/readsecure_spec.lua
@@ -1,0 +1,169 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+
+local eq = helpers.eq
+local clear = helpers.clear
+local command = helpers.command
+local pathsep = helpers.get_pathsep()
+local curbufmeths = helpers.curbufmeths
+local exec_lua = helpers.exec_lua
+local feed_command = helpers.feed_command
+local feed = helpers.feed
+local funcs = helpers.funcs
+local pcall_err = helpers.pcall_err
+
+describe('vim.readsecure', function()
+  local xstate = 'Xstate'
+
+  setup(function()
+    helpers.mkdir_p(xstate .. pathsep .. 'nvim')
+  end)
+
+  teardown(function()
+    helpers.rmdir(xstate)
+  end)
+
+  before_each(function()
+    helpers.write_file('Xfile', [[
+      let g:foobar = 42
+    ]])
+    clear{env={XDG_STATE_HOME=xstate}}
+  end)
+
+  after_each(function()
+    os.remove('Xfile')
+    helpers.rmdir(xstate)
+  end)
+
+  it('works', function()
+    local screen = Screen.new(80, 8)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [1] = {bold = true, foreground = Screen.colors.Blue1},
+      [2] = {bold = true, reverse = true},
+      [3] = {bold = true, foreground = Screen.colors.SeaGreen},
+      [4] = {reverse = true},
+    })
+
+    local cwd = funcs.getcwd()
+
+    -- Need to use feed_command instead of exec_lua because of the confirmation prompt
+    feed_command([[lua vim.readsecure('Xfile')]])
+    screen:expect{grid=[[
+                                                                                      |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {2:                                                                                }|
+      :lua vim.readsecure('Xfile')                                                    |
+      {3:]] .. cwd .. pathsep .. [[Xfile is untrusted}{MATCH:%s+}|
+      {3:[i]gnore, (v)iew, (b)lacklist, (t)rust: }^                                        |
+    ]]}
+    feed('b')
+    screen:expect{grid=[[
+      ^                                                                                |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+                                                                                      |
+    ]]}
+
+    local trust = helpers.read_file(funcs.stdpath('state') .. pathsep .. 'trust')
+    eq(string.format('! %s\n', cwd .. pathsep .. 'Xfile'), trust)
+    eq(helpers.NIL, exec_lua([[vim.readsecure('Xfile')]]))
+
+    os.remove(funcs.stdpath('state') .. pathsep .. 'trust')
+
+    feed_command([[lua vim.readsecure('Xfile')]])
+    screen:expect{grid=[[
+                                                                                      |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {2:                                                                                }|
+      :lua vim.readsecure('Xfile')                                                    |
+      {3:]] .. cwd .. pathsep .. [[Xfile is untrusted}{MATCH:%s+}|
+      {3:[i]gnore, (v)iew, (b)lacklist, (t)rust: }^                                        |
+    ]]}
+    feed('t')
+    screen:expect{grid=[[
+      ^                                                                                |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+                                                                                      |
+    ]]}
+
+    local hash = funcs.sha256(helpers.read_file('Xfile'))
+    trust = helpers.read_file(funcs.stdpath('state') .. pathsep .. 'trust')
+    eq(string.format('%s %s\n', hash, cwd .. pathsep .. 'Xfile'), trust)
+    eq(helpers.NIL, exec_lua([[vim.readsecure('Xfile')]]))
+
+    os.remove(funcs.stdpath('state') .. pathsep .. 'trust')
+
+    feed_command([[lua vim.readsecure('Xfile')]])
+    screen:expect{grid=[[
+                                                                                      |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {2:                                                                                }|
+      :lua vim.readsecure('Xfile')                                                    |
+      {3:]] .. cwd .. pathsep .. [[Xfile is untrusted}{MATCH:%s+}|
+      {3:[i]gnore, (v)iew, (b)lacklist, (t)rust: }^                                        |
+    ]]}
+    feed('i')
+    screen:expect{grid=[[
+      ^                                                                                |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+                                                                                      |
+    ]]}
+
+    -- Trust database is not updated
+    trust = helpers.read_file(funcs.stdpath('state') .. pathsep .. 'trust')
+    eq(nil, trust)
+
+    feed_command([[lua vim.readsecure('Xfile')]])
+    screen:expect{grid=[[
+                                                                                      |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {2:                                                                                }|
+      :lua vim.readsecure('Xfile')                                                    |
+      {3:]] .. cwd .. pathsep .. [[Xfile is untrusted}{MATCH:%s+}|
+      {3:[i]gnore, (v)iew, (b)lacklist, (t)rust: }^                                        |
+    ]]}
+    feed('v')
+    screen:expect{grid=[[
+      ^  let g:foobar = 42                                                             |
+      {1:~                                                                               }|
+      {1:~                                                                               }|
+      {2:]] .. cwd .. pathsep .. [[Xfile [RO]{MATCH:%s+}|
+                                                                                      |
+      {1:~                                                                               }|
+      {4:[No Name]                                                                       }|
+                                                                                      |
+    ]]}
+
+    -- Trust database is not updated
+    trust = helpers.read_file(funcs.stdpath('state') .. pathsep .. 'trust')
+    eq(nil, trust)
+
+    -- Cannot write file
+    pcall_err(command, 'write')
+    eq(false, curbufmeths.get_option('modifiable'))
+  end)
+end)
+


### PR DESCRIPTION
Un-deprecate the 'exrc' option by introducing a new `read_secure` function that prompts the user whether the `.nvimrc` or `.exrc` file found in the current directory should be trusted and only sources the file if the user indicates that it is. The user's decision is persisted in a "trust database" at `$XDG_STATE_HOME/nvim/trust`.

The format of the "trust database" is shamelessly cribbed from https://github.com/ii14/exrc.vim.

A Lua interface to the `read_secure()` function is provided at `vim.readsecure()` to expose this functionality to plugins.

TODO:

- [x] Tests

Closes #20911.