### PR TITLE
vim-patch:8.2.0448: various functions not properly tested

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7261,6 +7261,7 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 							*setreg()*
 setreg({regname}, {value} [, {options}])
 		Set the register {regname} to {value}.
+		If {regname} is "" or "@", the unnamed register '"' is used.
 		The {regname} argument is a string.
 
 		{value} may be any value returned by |getreg()| or

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -4,6 +4,9 @@ source term_util.vim
 " Command to check for the presence of a feature.
 command -nargs=1 CheckFeature call CheckFeature(<f-args>)
 func CheckFeature(name)
+  " if !has(a:name, 1)
+  "   throw 'Checking for non-existent feature ' .. a:name
+  " endif
   if !has(a:name)
     throw 'Skipped: ' .. a:name .. ' feature missing'
   endif

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -300,6 +300,8 @@ func Test_blob_index()
   call assert_equal(3, 0z11110111->index(0x11, 2))
   call assert_equal(2, index(0z11111111, 0x11, -2))
   call assert_equal(3, index(0z11110111, 0x11, -2))
+  call assert_equal(0, index(0z11110111, 0x11, -10))
+  call assert_fails("echo index(0z11110111, 0x11, [])", 'E745:')
 
   call assert_fails('call index("asdf", 0)', 'E897:')
 endfunc

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -421,6 +421,7 @@ func Test_breakindent11()
   let width = strlen(text[1:]) + indent(2) + strlen(&sbr) * 3 " text wraps 3 times
   call assert_equal(width, strdisplaywidth(text))
   call s:close_windows('set sbr=')
+  call assert_equal(4, strdisplaywidth("\t", 4))
 endfunc
 
 func Test_breakindent11_vartabs()

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -89,6 +89,13 @@ func Test_complete_wildmenu()
   call assert_equal('"e Xtestfile3 Xtestfile4', @:)
   cd -
 
+  cnoremap <expr> <F2> wildmenumode()
+  call feedkeys(":cd Xdir\<Tab>\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"cd Xdir1/0', @:)
+  call feedkeys(":e Xdir1/\<Tab>\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"e Xdir1/Xdir2/1', @:)
+  cunmap <F2>
+
   " cleanup
   %bwipe
   call delete('Xdir1/Xdir2/Xtestfile4')

--- a/src/nvim/testdir/test_exists.vim
+++ b/src/nvim/testdir/test_exists.vim
@@ -68,6 +68,10 @@ func Test_exists()
   " Existing environment variable
   let $EDITOR_NAME = 'Vim Editor'
   call assert_equal(1, exists('$EDITOR_NAME'))
+  if has('unix')
+    " ${name} environment variables are supported only on Unix-like systems
+    call assert_equal(1, exists('${VIM}'))
+  endif
   " Non-existing environment variable
   call assert_equal(0, exists('$NON_ENV_VAR'))
 
@@ -323,3 +327,5 @@ endfunc
 func Test_exists_funcarg()
   call FuncArg_Tests("arg1", "arg2")
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_expand_func.vim
+++ b/src/nvim/testdir/test_expand_func.vim
@@ -139,6 +139,7 @@ func Test_expand_wildignore()
   call assert_equal('test_expand_func.vim', expand('test_expand_func.vim', 1))
   call assert_equal(['test_expand_func.vim'],
         \ expand('test_expand_func.vim', 1, 1))
+  call assert_fails("call expand('*', [])", 'E745:')
   set wildignore&
 endfunc
 

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -65,6 +65,8 @@ func Test_strgetchar()
   call assert_equal(-1, strgetchar('axb', -1))
   call assert_equal(-1, strgetchar('axb', 3))
   call assert_equal(-1, strgetchar('', 0))
+  call assert_fails("let c=strgetchar([], 1)", 'E730:')
+  call assert_fails("let c=strgetchar('axb', [])", 'E745:')
 endfunc
 
 func Test_strcharpart()
@@ -502,6 +504,9 @@ func Test_substitute_expr()
   endfunc
   " recursive call works
   call assert_equal('-y-x-', substitute('xxx', 'x\(.\)x', {-> '-' . Recurse() . '-' . submatch(1) . '-'}, ''))
+
+  call assert_fails("let s=submatch([])", 'E745:')
+  call assert_fails("let s=submatch(2, [])", 'E745:')
 endfunc
 
 func Test_invalid_submatch()

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -341,6 +341,7 @@ func Test_dict_deepcopy()
   let l[1] = l2
   let l3 = deepcopy(l2)
   call assert_true(l3[1] is l3[2])
+  call assert_fails("call deepcopy([1, 2], 2)", 'E474:')
 endfunc
 
 " Locked variables
@@ -420,6 +421,11 @@ func Test_list_locked_var()
       call assert_equal(expected[depth][u][1], ps)
     endfor
   endfor
+  call assert_fails("let x=islocked('a b')", 'E488:')
+  let mylist = [1, 2, 3]
+  call assert_fails("let x = islocked('mylist[1:2]')", 'E786:')
+  let mydict = {'k' : 'v'}
+  call assert_fails("let x = islocked('mydict.a')", 'E716:')
 endfunc
 
 " Unletting locked variables
@@ -736,6 +742,8 @@ func Test_str_split()
   call assert_equal(['aa', '', 'bb', 'cc', ''], split('aa,,bb, cc,', ',\s*', 1))
   call assert_equal(['a', 'b', 'c'], split('abc', '\zs'))
   call assert_equal(['', 'a', '', 'b', '', 'c', ''], split('abc', '\zs', 1))
+  call assert_fails("call split('abc', [])", 'E730:')
+  call assert_fails("call split('abc', 'b', [])", 'E745:')
 endfunc
 
 " compare recursively linked list and dict

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -100,6 +100,8 @@ func Test_setpos()
   call setpos('.', [0, 1, -1, 0])
   call assert_equal([2, 2], [line('.'), col('.')])
 
+  call assert_fails("call setpos('ab', [0, 1, 1, 0])", 'E474:')
+
   bwipe!
   call win_gotoid(twowin)
   bwipe!

--- a/src/nvim/testdir/test_partial.vim
+++ b/src/nvim/testdir/test_partial.vim
@@ -82,6 +82,9 @@ func Test_partial_dict()
 
   let dict = {"tr": function('tr', ['hello', 'h', 'H'])}
   call assert_equal("Hello", dict.tr())
+
+  call assert_fails("let F=function('setloclist', 10)", "E923:")
+  call assert_fails("let F=function('setloclist', [], [])", "E922:")
 endfunc
 
 func Test_partial_implicit()
@@ -354,3 +357,5 @@ func Test_compare_partials()
   call assert_true(F1 isnot# F1d1)  " Partial /= non-partial
   call assert_true(d1.f1 isnot# d1.f1)  " handle_subscript creates new partial each time
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -263,8 +263,16 @@ func Test_get_register()
   call assert_equal('', getreg("\<C-F>"))
   call assert_equal('', getreg("\<C-W>"))
   call assert_equal('', getreg("\<C-L>"))
+  " Change the last used register to '"' for the next test
+  normal! ""yy
+  let @" = 'happy'
+  call assert_equal('happy', getreg())
+  call assert_equal('happy', getreg(''))
 
   call assert_equal('', getregtype('!'))
+  call assert_fails('echo getregtype([])', 'E730:')
+  call assert_equal('v', getregtype())
+  call assert_equal('v', getregtype(''))
 
   " Test for inserting an invalid register content
   call assert_beeps('exe "normal i\<C-R>!"')
@@ -348,6 +356,12 @@ func Test_set_register()
   call assert_equal('abcabc', getline(1))
   normal 0".gP
   call assert_equal('abcabcabc', getline(1))
+
+  let @"=''
+  call setreg('', '1')
+  call assert_equal('1', @")
+  call setreg('@', '2')
+  call assert_equal('2', @")
 
   enew!
 endfunc

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -1430,3 +1430,5 @@ let g:test_data_aff_sal = [
       \"SAL ZZ-                  _",
       \"SAL Z                    S",
       \ ]
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -453,6 +453,11 @@ func Test_substitute_errors()
   setl nomodifiable
   call assert_fails('s/foo/bar/', 'E21:')
 
+  call assert_fails("let s=substitute([], 'a', 'A', 'g')", 'E730:')
+  call assert_fails("let s=substitute('abcda', [], 'A', 'g')", 'E730:')
+  call assert_fails("let s=substitute('abcda', 'a', [], 'g')", 'E730:')
+  call assert_fails("let s=substitute('abcda', 'a', 'A', [])", 'E730:')
+
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -623,6 +623,8 @@ func Test_synstack_synIDtrans()
   call assert_equal(['cComment', 'cTodo'], map(synstack(line("."), col(".")), 'synIDattr(v:val, "name")'))
   call assert_equal(['Comment', 'Todo'],   map(synstack(line("."), col(".")), 'synIDattr(synIDtrans(v:val), "name")'))
 
+  call assert_fails("let n=synIDtrans([])", 'E745:')
+
   syn clear
   bw!
 endfunc

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -36,6 +36,8 @@ func Test_taglist()
   call assert_equal('d', cmd[0]['kind'])
   call assert_equal('call cursor(3, 4)', cmd[0]['cmd'])
 
+  call assert_fails("let l=taglist([])", 'E730:')
+
   call delete('Xtags')
   set tags&
   bwipe

--- a/src/nvim/testdir/test_utf8.vim
+++ b/src/nvim/testdir/test_utf8.vim
@@ -21,6 +21,8 @@ func Test_strchars()
     call assert_equal(exp[i][1], inp[i]->strchars(0))
     call assert_equal(exp[i][2], strchars(inp[i], 1))
   endfor
+  call assert_fails("let v=strchars('abc', [])", 'E474:')
+  call assert_fails("let v=strchars('abc', 2)", 'E474:')
 endfunc
 
 " Test for customlist completion

--- a/src/nvim/testdir/test_vartabs.vim
+++ b/src/nvim/testdir/test_vartabs.vim
@@ -379,6 +379,8 @@ func Test_vartabs_shiftwidth()
   let lines = ScreenLines([1, 3], winwidth(0))
   call s:compare_lines(expect4, lines)
 
+  call assert_fails('call shiftwidth([])', 'E745:')
+
   " cleanup
   bw!
   bw!

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -542,6 +542,7 @@ func Test_window_newtab()
   call assert_equal(2, tabpagenr('$'))
   call assert_equal(['Xb', 'Xa'], map(tabpagebuflist(1), 'bufname(v:val)'))
   call assert_equal(['Xc'      ], map(2->tabpagebuflist(), 'bufname(v:val)'))
+  call assert_equal(['Xc'      ], map(tabpagebuflist(), 'bufname(v:val)'))
 
   %bw!
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.0448: various functions not properly tested

Problem:    Various functions not properly tested.
Solution:   Add more tests, especially for failures. (Yegappan Lakshmanan,
            closes vim/vim#5843)

https://github.com/vim/vim/commit/0e05de46226eb4e5ea580beefa71831f92d613d3

Cherry-pick test changes from patch 8.2.0427 and skip Test_has().
Cherry-pick Test_complete_wildmenu() change from patch 8.2.4339.