### PR TITLE
vim-patch:8.2.{0968,0976,1022,1810,2901}: various tests

### DIFF
--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -252,6 +252,7 @@ func Test_blob_func_remove()
   call assert_fails("call remove(b, 3, 2)", 'E979:')
   call assert_fails("call remove(1, 0)", 'E896:')
   call assert_fails("call remove(b, b)", 'E974:')
+  call assert_fails("call remove(b, 1, [])", 'E745:')
   call assert_fails("call remove(v:_null_blob, 1, 2)", 'E979:')
 
   " Translated from v8.2.3284

--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -68,30 +68,6 @@ func Test_cd_minus()
   call delete('Xresult')
 endfunc
 
-func Test_cd_with_cpo_chdir()
-  e Xfoo
-  call setline(1, 'foo')
-  let path = getcwd()
-  " set cpo+=.
-
-  " :cd should fail when buffer is modified and 'cpo' contains dot.
-  " call assert_fails('cd ..', 'E747:')
-  call assert_equal(path, getcwd())
-
-  " :cd with exclamation mark should succeed.
-  cd! ..
-  call assert_notequal(path, getcwd())
-
-  " :cd should succeed when buffer has been written.
-  w!
-  exe 'cd ' .. fnameescape(path)
-  call assert_equal(path, getcwd())
-
-  call delete('Xfoo')
-  set cpo&
-  bw!
-endfunc
-
 " Test for chdir()
 func Test_chdir_func()
   let topdir = getcwd()

--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -51,7 +51,7 @@ func Test_csearch_virtualedit()
   normal! tb
   call assert_equal([0, 1, 2, 6], getpos('.'))
   set virtualedit&
-  close!
+  bw!
 endfunc
 
 " Test for character search failure in latin1 encoding
@@ -65,7 +65,34 @@ func Test_charsearch_latin1()
   call assert_beeps('normal $Fz')
   call assert_beeps('normal $Tx')
   let &encoding = save_enc
-  close!
+  bw!
+endfunc
+
+" Test for using character search to find a multibyte character with composing
+" characters.
+func Test_charsearch_composing_char()
+  new
+  call setline(1, "one two thq\u0328\u0301r\u0328\u0301ree")
+  call feedkeys("fr\u0328\u0301", 'xt')
+  call assert_equal([0, 1, 16, 0, 12], getcurpos())
+
+  " use character search with a multi-byte character followed by a
+  " non-composing character
+  call setline(1, "abc deȉf ghi")
+  call feedkeys("ggcf\u0209\u0210", 'xt')
+  call assert_equal("\u0210f ghi", getline(1))
+  bw!
+endfunc
+
+" Test for character search with 'hkmap'
+func Test_charsearch_hkmap()
+  new
+  set hkmap
+  call setline(1, "ùðáâ÷ëòéïçìêöî")
+  call feedkeys("fë", 'xt')
+  call assert_equal([0, 1, 11, 0, 6], getcurpos())
+  set hkmap&
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -43,36 +43,6 @@ func Test_charsearch()
   enew!
 endfunc
 
-" Test for t,f,F,T movement commands and 'cpo-;' setting
-func Test_search_cmds()
-  enew!
-  call append(0, ["aaa two three four", "    zzz", "yyy   ",
-	      \ "bbb yee yoo four", "ccc two three four",
-	      \ "ddd yee yoo four"])
-  set cpo-=;
-  1
-  normal! 0tt;D
-  2
-  normal! 0fz;D
-  3
-  normal! $Fy;D
-  4
-  normal! $Ty;D
-  set cpo+=;
-  5
-  normal! 0tt;;D
-  6
-  normal! $Ty;;D
-
-  call assert_equal('aaa two', getline(1))
-  call assert_equal('    z', getline(2))
-  call assert_equal('y', getline(3))
-  call assert_equal('bbb y', getline(4))
-  call assert_equal('ccc', getline(5))
-  call assert_equal('ddd yee y', getline(6))
-  enew!
-endfunc
-
 " Test for character search in virtual edit mode with <Tab>
 func Test_csearch_virtualedit()
   new

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -167,6 +167,7 @@ func Test_cpo_E()
   call assert_beeps('normal "ayl')
   " change an empty line
   call assert_beeps('normal lcTa')
+  call assert_beeps('normal 0c0')
   " delete an empty line
   call assert_beeps('normal D')
   call assert_beeps('normal dl')

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -1,0 +1,631 @@
+" Test for various 'cpoptions' (cpo) flags
+
+source check.vim
+source view_util.vim
+
+" Test for the 'a' flag in 'cpo'. Reading a file should set the alternate
+" file name.
+func Test_cpo_a()
+  let save_cpo = &cpo
+  call writefile(['one'], 'Xfile')
+  " Wipe out all the buffers, so that the alternate file is empty
+  edit Xfoo | %bw
+  set cpo-=a
+  new
+  read Xfile
+  call assert_equal('', @#)
+  %d
+  set cpo+=a
+  read Xfile
+  call assert_equal('Xfile', @#)
+  close!
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'A' flag in 'cpo'. Writing a file should set the alternate
+" file name.
+func Test_cpo_A()
+  let save_cpo = &cpo
+  " Wipe out all the buffers, so that the alternate file is empty
+  edit Xfoo | %bw
+  set cpo-=A
+  new Xfile1
+  write Xfile2
+  call assert_equal('', @#)
+  %bw
+  call delete('Xfile2')
+  new Xfile1
+  set cpo+=A
+  write Xfile2
+  call assert_equal('Xfile2', @#)
+  close!
+  call delete('Xfile2')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'b' flag in 'cpo'. "\|" at the end of a map command is
+" recognized as the end of the map.
+func Test_cpo_b()
+  let save_cpo = &cpo
+  set cpo+=b
+  nnoremap <F5> :pwd\<CR>\|let i = 1
+  call assert_equal(':pwd\<CR>\', maparg('<F5>'))
+  nunmap <F5>
+  exe "nnoremap <F5> :pwd\<C-V>|let i = 1"
+  call assert_equal(':pwd|let i = 1', maparg('<F5>'))
+  nunmap <F5>
+  set cpo-=b
+  nnoremap <F5> :pwd\<CR>\|let i = 1
+  call assert_equal(':pwd\<CR>|let i = 1', maparg('<F5>'))
+  let &cpo = save_cpo
+  nunmap <F5>
+endfunc
+
+" Test for the 'c' flag in 'cpo'.
+func Test_cpo_c()
+  let save_cpo = &cpo
+  set cpo+=c
+  new
+  call setline(1, ' abababababab')
+  exe "normal gg/abab\<CR>"
+  call assert_equal(3, searchcount().total)
+  set cpo-=c
+  exe "normal gg/abab\<CR>"
+  call assert_equal(5, searchcount().total)
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'C' flag in 'cpo' (line continuation)
+func Test_cpo_C()
+  let save_cpo = &cpo
+  call writefile(['let l = [', '\ 1,', '\ 2]'], 'Xfile')
+  set cpo-=C
+  source Xfile
+  call assert_equal([1, 2], g:l)
+  set cpo+=C
+  call assert_fails('source Xfile', 'E10:')
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'd' flag in 'cpo' (tags relative to the current file)
+func Test_cpo_d()
+  let save_cpo = &cpo
+  call mkdir('Xdir')
+  call writefile(["one\tXfile1\t/^one$/"], 'tags')
+  call writefile(["two\tXfile2\t/^two$/"], 'Xdir/tags')
+  set tags=./tags
+  set cpo-=d
+  edit Xdir/Xfile
+  call assert_equal('two', taglist('.*')[0].name)
+  set cpo+=d
+  call assert_equal('one', taglist('.*')[0].name)
+  %bw!
+  call delete('tags')
+  call delete('Xdir', 'rf')
+  set tags&
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'D' flag in 'cpo' (digraph after a r, f or t)
+func Test_cpo_D()
+  CheckFeature digraphs
+  let save_cpo = &cpo
+  new
+  set cpo-=D
+  call setline(1, 'abcdefgh|')
+  exe "norm! 1gg0f\<c-k>!!"
+  call assert_equal(9, col('.'))
+  set cpo+=D
+  exe "norm! 1gg0f\<c-k>!!"
+  call assert_equal(1, col('.'))
+  set cpo-=D
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'e' flag in 'cpo'
+func Test_cpo_e()
+  let save_cpo = &cpo
+  let @a='let i = 45'
+  set cpo+=e
+  call feedkeys(":@a\<CR>", 'xt')
+  call assert_equal(45, i)
+  set cpo-=e
+  call feedkeys(":@a\<CR>6\<CR>", 'xt')
+  call assert_equal(456, i)
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'E' flag in 'cpo' with yank, change, delete, etc. operators
+func Test_cpo_E()
+  new
+  call setline(1, '')
+  set cpo+=E
+  " yank an empty line
+  call assert_beeps('normal "ayl')
+  " change an empty line
+  call assert_beeps('normal lcTa')
+  " delete an empty line
+  call assert_beeps('normal D')
+  call assert_beeps('normal dl')
+  call assert_equal('', getline(1))
+  " change case of an empty line
+  call assert_beeps('normal gul')
+  call assert_beeps('normal gUl')
+  " replace a character
+  call assert_beeps('normal vrx')
+  " increment and decrement
+  call assert_beeps('exe "normal v\<C-A>"')
+  call assert_beeps('exe "normal v\<C-X>"')
+  set cpo-=E
+  close!
+endfunc
+
+" Test for the 'f' flag in 'cpo' (read in an empty buffer sets the file name)
+func Test_cpo_f()
+  let save_cpo = &cpo
+  new
+  set cpo-=f
+  read test_cpoptions.vim
+  call assert_equal('', @%)
+  %d
+  set cpo+=f
+  read test_cpoptions.vim
+  call assert_equal('test_cpoptions.vim', @%)
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'F' flag in 'cpo' (write in an empty buffer sets the file name)
+func Test_cpo_F()
+  let save_cpo = &cpo
+  new
+  set cpo-=F
+  write Xfile
+  call assert_equal('', @%)
+  call delete('Xfile')
+  set cpo+=F
+  write Xfile
+  call assert_equal('Xfile', @%)
+  close!
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'g' flag in 'cpo' (jump to line 1 when re-editing a file)
+func Test_cpo_g()
+  throw 'Skipped: Nvim does not support cpoptions flag "g"'
+  let save_cpo = &cpo
+  new test_cpoptions.vim
+  set cpo-=g
+  normal 20G
+  edit
+  call assert_equal(20, line('.'))
+  set cpo+=g
+  edit
+  call assert_equal(1, line('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for inserting text in a line with only spaces ('H' flag in 'cpoptions')
+func Test_cpo_H()
+  throw 'Skipped: Nvim does not support cpoptions flag "H"'
+  let save_cpo = &cpo
+  new
+  set cpo-=H
+  call setline(1, '    ')
+  normal! Ia
+  call assert_equal('    a', getline(1))
+  set cpo+=H
+  call setline(1, '    ')
+  normal! Ia
+  call assert_equal('   a ', getline(1))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'I' flag in 'cpo' (deleting autoindent when using arrow keys)
+func Test_cpo_I()
+  let save_cpo = &cpo
+  new
+  setlocal autoindent
+  set cpo+=I
+  exe "normal i    one\<CR>\<Up>"
+  call assert_equal('    ', getline(2))
+  set cpo-=I
+  %d
+  exe "normal i    one\<CR>\<Up>"
+  call assert_equal('', getline(2))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'J' flag in 'cpo' (two spaces after a sentence)
+func Test_cpo_J()
+  let save_cpo = &cpo
+  new
+  set cpo-=J
+  call setline(1, 'one. two!  three? four."''  five.)]')
+  normal 0
+  for colnr in [6, 12, 19, 28, 34]
+    normal )
+    call assert_equal(colnr, col('.'))
+  endfor
+  for colnr in [28, 19, 12, 6, 1]
+    normal (
+    call assert_equal(colnr, col('.'))
+  endfor
+  set cpo+=J
+  normal 0
+  for colnr in [12, 28, 34]
+    normal )
+    call assert_equal(colnr, col('.'))
+  endfor
+  for colnr in [28, 12, 1]
+    normal (
+    call assert_equal(colnr, col('.'))
+  endfor
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" TODO: Add a test for 'k' in 'cpo'
+
+" TODO: Add a test for 'K' in 'cpo'
+
+" Test for the 'l' flag in 'cpo' (backslash in a [] range)
+func Test_cpo_l()
+  let save_cpo = &cpo
+  new
+  call setline(1, ['', "a\tc" .. '\t'])
+  set cpo-=l
+  exe 'normal gg/[\t]' .. "\<CR>"
+  call assert_equal([2, 8], [col('.'), virtcol('.')])
+  set cpo+=l
+  exe 'normal gg/[\t]' .. "\<CR>"
+  call assert_equal([4, 10], [col('.'), virtcol('.')])
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for inserting tab in virtual replace mode ('L' flag in 'cpoptions')
+func Test_cpo_L()
+  let save_cpo = &cpo
+  new
+  set cpo-=L
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>ijklmnopqr", getline(1))
+  set cpo+=L
+  set list
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>cdefghijklmnopqr", getline(1))
+  set nolist
+  call setline(1, 'abcdefghijklmnopqr')
+  exe "normal 0gR\<Tab>"
+  call assert_equal("\<Tab>ijklmnopqr", getline(1))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" TODO: This test doesn't work.
+
+" Test for the 'M' flag in 'cpo' (% with escape parenthesis)
+func Test_cpo_M()
+  let save_cpo = &cpo
+  new
+  call setline(1, ['( \( )', '\( ( \)'])
+
+  set cpo-=M
+  call cursor(1, 1)
+  normal %
+  call assert_equal(6, col('.'))
+  call cursor(1, 4)
+  call assert_beeps('normal %')
+  call cursor(2, 2)
+  normal %
+  call assert_equal(7, col('.'))
+  call cursor(2, 4)
+  call assert_beeps('normal %')
+
+  set cpo+=M
+  call cursor(1, 4)
+  normal %
+  call assert_equal(6, col('.'))
+  call cursor(1, 1)
+  call assert_beeps('normal %')
+  call cursor(2, 4)
+  normal %
+  call assert_equal(7, col('.'))
+  call cursor(2, 1)
+  call assert_beeps('normal %')
+
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'n' flag in 'cpo' (using number column for wrapped lines)
+func Test_cpo_n()
+  let save_cpo = &cpo
+  new
+  call setline(1, repeat('a', &columns))
+  setlocal number
+  set cpo-=n
+  redraw!
+  call assert_equal('    aaaa', Screenline(2))
+  set cpo+=n
+  redraw!
+  call assert_equal('aaaa', Screenline(2))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'o' flag in 'cpo' (line offset to search command)
+func Test_cpo_o()
+  let save_cpo = &cpo
+  new
+  call setline(1, ['', 'one', 'two', 'three', 'one', 'two', 'three'])
+  set cpo-=o
+  exe "normal /one/+2\<CR>"
+  normal n
+  call assert_equal(7, line('.'))
+  set cpo+=o
+  exe "normal /one/+2\<CR>"
+  normal n
+  call assert_equal(5, line('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'O' flag in 'cpo' (overwriting an existing file)
+func Test_cpo_O()
+  let save_cpo = &cpo
+  new Xfile
+  call setline(1, 'one')
+  call writefile(['two'], 'Xfile')
+  set cpo-=O
+  call assert_fails('write', 'E13:')
+  set cpo+=O
+  write
+  call assert_equal(['one'], readfile('Xfile'))
+  close!
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'P' flag in 'cpo' (appending to a file sets the current file
+" name)
+func Test_cpo_P()
+  let save_cpo = &cpo
+  call writefile([], 'Xfile')
+  new
+  call setline(1, 'one')
+  set cpo+=F
+  set cpo-=P
+  write >> Xfile
+  call assert_equal('', @%)
+  set cpo+=P
+  write >> Xfile
+  call assert_equal('Xfile', @%)
+  close!
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'q' flag in 'cpo' (joining multiple lines)
+func Test_cpo_q()
+  let save_cpo = &cpo
+  new
+  call setline(1, ['one', 'two', 'three', 'four', 'five'])
+  set cpo-=q
+  normal gg4J
+  call assert_equal(14, col('.'))
+  %d
+  call setline(1, ['one', 'two', 'three', 'four', 'five'])
+  set cpo+=q
+  normal gg4J
+  call assert_equal(4, col('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'r' flag in 'cpo' (redo command with a search motion)
+func Test_cpo_r()
+  let save_cpo = &cpo
+  new
+  call setline(1, repeat(['one two three four'], 2))
+  set cpo-=r
+  exe "normal ggc/two\<CR>abc "
+  let @/ = 'three'
+  normal 2G.
+  call assert_equal('abc two three four', getline(2))
+  %d
+  call setline(1, repeat(['one two three four'], 2))
+  set cpo+=r
+  exe "normal ggc/two\<CR>abc "
+  let @/ = 'three'
+  normal 2G.
+  call assert_equal('abc three four', getline(2))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'R' flag in 'cpo' (clear marks after a filter command)
+func Test_cpo_R()
+  CheckUnix
+  let save_cpo = &cpo
+  new
+  call setline(1, ['three', 'one', 'two'])
+  set cpo-=R
+  3mark r
+  %!sort
+  call assert_equal(3, line("'r"))
+  %d
+  call setline(1, ['three', 'one', 'two'])
+  set cpo+=R
+  3mark r
+  %!sort
+  call assert_equal(0, line("'r"))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'S' flag in 'cpo' (copying buffer options)
+func Test_cpo_S()
+  let save_cpo = &cpo
+  new Xfile1
+  set noautoindent
+  new Xfile2
+  set cpo-=S
+  set autoindent
+  wincmd p
+  call assert_equal(0, &autoindent)
+  wincmd p
+  call assert_equal(1, &autoindent)
+  set cpo+=S
+  wincmd p
+  call assert_equal(1, &autoindent)
+  set noautoindent
+  wincmd p
+  call assert_equal(0, &autoindent)
+  wincmd t
+  close!
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'u' flag in 'cpo' (Vi-compatible undo)
+func Test_cpo_u()
+  let save_cpo = &cpo
+  new
+  set cpo-=u
+  exe "normal iabc\<C-G>udef\<C-G>ughi"
+  normal uu
+  call assert_equal('abc', getline(1))
+  %d
+  set cpo+=u
+  exe "normal iabc\<C-G>udef\<C-G>ughi"
+  normal uu
+  call assert_equal('abcdefghi', getline(1))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'x' flag in 'cpo' (Esc on command-line executes command)
+func Test_cpo_x()
+  let save_cpo = &cpo
+  set cpo-=x
+  let i = 1
+  call feedkeys(":let i=10\<Esc>", 'xt')
+  call assert_equal(1, i)
+  set cpo+=x
+  call feedkeys(":let i=10\<Esc>", 'xt')
+  call assert_equal(10, i)
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'X' flag in 'cpo' ('R' with a count)
+func Test_cpo_X()
+  let save_cpo = &cpo
+  new
+  call setline(1, 'aaaaaa')
+  set cpo-=X
+  normal gg4Rx
+  call assert_equal('xxxxaa', getline(1))
+  normal ggRy
+  normal 4.
+  call assert_equal('yyyyaa', getline(1))
+  call setline(1, 'aaaaaa')
+  set cpo+=X
+  normal gg4Rx
+  call assert_equal('xxxxaaaaa', getline(1))
+  normal ggRy
+  normal 4.
+  call assert_equal('yyyyxxxaaaaa', getline(1))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'y' flag in 'cpo' (repeating a yank command)
+func Test_cpo_y()
+  let save_cpo = &cpo
+  new
+  call setline(1, ['one', 'two'])
+  set cpo-=y
+  normal ggyy
+  normal 2G.
+  call assert_equal("one\n", @")
+  %d
+  call setline(1, ['one', 'two'])
+  set cpo+=y
+  normal ggyy
+  normal 2G.
+  call assert_equal("two\n", @")
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'Z' flag in 'cpo' (write! resets 'readonly')
+func Test_cpo_Z()
+  let save_cpo = &cpo
+  call writefile([], 'Xfile')
+  new Xfile
+  setlocal readonly
+  set cpo-=Z
+  write!
+  call assert_equal(0, &readonly)
+  set cpo+=Z
+  setlocal readonly
+  write!
+  call assert_equal(1, &readonly)
+  close!
+  call delete('Xfile')
+  let &cpo = save_cpo
+endfunc
+
+" Test for cursor movement with '-' in 'cpoptions'
+func Test_cpo_minus()
+  throw 'Skipped: Nvim does not support cpoptions flag "-"'
+  new
+  call setline(1, ['foo', 'bar', 'baz'])
+  let save_cpo = &cpo
+  set cpo+=-
+  call assert_beeps('normal 10j')
+  call assert_equal(1, line('.'))
+  normal G
+  call assert_beeps('normal 10k')
+  call assert_equal(3, line('.'))
+  call assert_fails(10, 'E16:')
+  let &cpo = save_cpo
+  close!
+endfunc
+
+" Test for displaying dollar when changing text ('$' flag in 'cpoptions')
+func Test_cpo_dollar()
+  throw 'Skipped: use test/functional/legacy/cpoptions_spec.lua'
+  new
+  let g:Line = ''
+  func SaveFirstLine()
+    let g:Line = Screenline(1)
+    return ''
+  endfunc
+  inoremap <expr> <buffer> <F2> SaveFirstLine()
+  call test_override('redraw_flag', 1)
+  set cpo+=$
+  call setline(1, 'one two three')
+  redraw!
+  exe "normal c2w\<F2>vim"
+  call assert_equal('one tw$ three', g:Line)
+  call assert_equal('vim three', getline(1))
+  set cpo-=$
+  call test_override('ALL', 0)
+  delfunc SaveFirstLine
+  %bw!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -1,6 +1,7 @@
-" Test for various 'cpoptions' (cpo) flags
+" Test for the various 'cpoptions' (cpo) flags
 
 source check.vim
+source shared.vim
 source view_util.vim
 
 " Test for the 'a' flag in 'cpo'. Reading a file should set the alternate
@@ -60,6 +61,24 @@ func Test_cpo_b()
   call assert_equal(':pwd\<CR>|let i = 1', maparg('<F5>'))
   let &cpo = save_cpo
   nunmap <F5>
+endfunc
+
+" Test for the 'B' flag in 'cpo'. A backslash in mappings, abbreviations, user
+" commands and menu commands has no special meaning.
+func Test_cpo_B()
+  let save_cpo = &cpo
+  new
+  set cpo-=B
+  iabbr <buffer> abc ab\<BS>d
+  exe "normal iabc "
+  call assert_equal('ab<BS>d ', getline(1))
+  %d
+  set cpo+=B
+  iabbr <buffer> abc ab\<BS>d
+  exe "normal iabc "
+  call assert_equal('abd ', getline(1))
+  close!
+  let &cpo = save_cpo
 endfunc
 
 " Test for the 'c' flag in 'cpo'.
@@ -228,6 +247,8 @@ func Test_cpo_H()
   let &cpo = save_cpo
 endfunc
 
+" TODO: Add a test for the 'i' flag in 'cpo'
+
 " Test for the 'I' flag in 'cpo' (deleting autoindent when using arrow keys)
 func Test_cpo_I()
   let save_cpo = &cpo
@@ -243,6 +264,8 @@ func Test_cpo_I()
   close!
   let &cpo = save_cpo
 endfunc
+
+" Test for the 'j' flag in 'cpo' is in the test_join.vim file.
 
 " Test for the 'J' flag in 'cpo' (two spaces after a sentence)
 func Test_cpo_J()
@@ -273,9 +296,9 @@ func Test_cpo_J()
   let &cpo = save_cpo
 endfunc
 
-" TODO: Add a test for 'k' in 'cpo'
+" TODO: Add a test for the 'k' flag in 'cpo'
 
-" TODO: Add a test for 'K' in 'cpo'
+" TODO: Add a test for the 'K' flag in 'cpo'
 
 " Test for the 'l' flag in 'cpo' (backslash in a [] range)
 func Test_cpo_l()
@@ -313,7 +336,7 @@ func Test_cpo_L()
   let &cpo = save_cpo
 endfunc
 
-" TODO: This test doesn't work.
+" TODO: Add a test for the 'm' flag in 'cpo'
 
 " Test for the 'M' flag in 'cpo' (% with escape parenthesis)
 func Test_cpo_M()
@@ -398,6 +421,8 @@ func Test_cpo_O()
   let &cpo = save_cpo
 endfunc
 
+" Test for the 'p' flag in 'cpo' is in the test_lispwords.vim file.
+
 " Test for the 'P' flag in 'cpo' (appending to a file sets the current file
 " name)
 func Test_cpo_P()
@@ -475,6 +500,8 @@ func Test_cpo_R()
   let &cpo = save_cpo
 endfunc
 
+" TODO: Add a test for the 's' flag in 'cpo'
+
 " Test for the 'S' flag in 'cpo' (copying buffer options)
 func Test_cpo_S()
   let save_cpo = &cpo
@@ -499,6 +526,8 @@ func Test_cpo_S()
   let &cpo = save_cpo
 endfunc
 
+" Test for the 't' flag in 'cpo' is in the test_tagjump.vim file.
+
 " Test for the 'u' flag in 'cpo' (Vi-compatible undo)
 func Test_cpo_u()
   let save_cpo = &cpo
@@ -515,6 +544,33 @@ func Test_cpo_u()
   close!
   let &cpo = save_cpo
 endfunc
+
+" TODO: Add a test for the 'v' flag in 'cpo' (backspace doesn't remove
+" characters from the screen)
+
+" Test for the 'w' flag in 'cpo' ('cw' on a blank character changes only one
+" character)
+func Test_cpo_w()
+  throw 'Skipped: Nvim does not support cpoptions flag "w"'
+  let save_cpo = &cpo
+  new
+  set cpo+=w
+  call setline(1, 'here      are   some words')
+  norm! 1gg0elcwZZZ
+  call assert_equal('hereZZZ     are   some words', getline('.'))
+  norm! 1gg2elcWYYY
+  call assert_equal('hereZZZ     areYYY  some words', getline('.'))
+  set cpo-=w
+  call setline(1, 'here      are   some words')
+  norm! 1gg0elcwZZZ
+  call assert_equal('hereZZZare   some words', getline('.'))
+  norm! 1gg2elcWYYY
+  call assert_equal('hereZZZare   someYYYwords', getline('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the 'W' flag in 'cpo' is in the test_writefile.vim file
 
 " Test for the 'x' flag in 'cpo' (Esc on command-line executes command)
 func Test_cpo_x()
@@ -588,22 +644,7 @@ func Test_cpo_Z()
   let &cpo = save_cpo
 endfunc
 
-" Test for cursor movement with '-' in 'cpoptions'
-func Test_cpo_minus()
-  throw 'Skipped: Nvim does not support cpoptions flag "-"'
-  new
-  call setline(1, ['foo', 'bar', 'baz'])
-  let save_cpo = &cpo
-  set cpo+=-
-  call assert_beeps('normal 10j')
-  call assert_equal(1, line('.'))
-  normal G
-  call assert_beeps('normal 10k')
-  call assert_equal(3, line('.'))
-  call assert_fails(10, 'E16:')
-  let &cpo = save_cpo
-  close!
-endfunc
+" Test for the '!' flag in 'cpo' is in the test_normal.vim file
 
 " Test for displaying dollar when changing text ('$' flag in 'cpoptions')
 func Test_cpo_dollar()
@@ -626,6 +667,252 @@ func Test_cpo_dollar()
   call test_override('ALL', 0)
   delfunc SaveFirstLine
   %bw!
+endfunc
+
+" Test for the '%' flag in 'cpo' (parenthesis matching inside strings)
+func Test_cpo_percent()
+  let save_cpo = &cpo
+  new
+  call setline(1, '    if (strcmp("ab)cd(", s))')
+  set cpo-=%
+  normal 8|%
+  call assert_equal(28, col('.'))
+  normal 15|%
+  call assert_equal(27, col('.'))
+  normal 27|%
+  call assert_equal(15, col('.'))
+  call assert_beeps("normal 19|%")
+  call assert_beeps("normal 22|%")
+  set cpo+=%
+  normal 8|%
+  call assert_equal(28, col('.'))
+  normal 15|%
+  call assert_equal(19, col('.'))
+  normal 27|%
+  call assert_equal(22, col('.'))
+  normal 19|%
+  call assert_equal(15, col('.'))
+  normal 22|%
+  call assert_equal(27, col('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for cursor movement with '-' in 'cpoptions'
+func Test_cpo_minus()
+  throw 'Skipped: Nvim does not support cpoptions flag "-"'
+  new
+  call setline(1, ['foo', 'bar', 'baz'])
+  let save_cpo = &cpo
+  set cpo+=-
+  call assert_beeps('normal 10j')
+  call assert_equal(1, line('.'))
+  normal G
+  call assert_beeps('normal 10k')
+  call assert_equal(3, line('.'))
+  call assert_fails(10, 'E16:')
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '+' flag in 'cpo' ('write file' command resets the 'modified'
+" flag)
+func Test_cpo_plus()
+  let save_cpo = &cpo
+  call writefile([], 'Xfile')
+  new Xfile
+  call setline(1, 'foo')
+  write X1
+  call assert_equal(1, &modified)
+  set cpo+=+
+  write X2
+  call assert_equal(0, &modified)
+  close!
+  call delete('Xfile')
+  call delete('X1')
+  call delete('X2')
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '*' flag in 'cpo' (':*' is same as ':@')
+func Test_cpo_star()
+  throw 'Skipped: Nvim does not support cpoptions flag "*"'
+  let save_cpo = &cpo
+  let x = 0
+  new
+  set cpo-=*
+  let @a = 'let x += 1'
+  call assert_fails('*a', 'E20:')
+  set cpo+=*
+  *a
+  call assert_equal(1, x)
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '<' flag in 'cpo' is in the test_mapping.vim file
+
+" Test for the '>' flag in 'cpo' (use a new line when appending to a register)
+func Test_cpo_gt()
+  let save_cpo = &cpo
+  new
+  call setline(1, 'one two')
+  set cpo-=>
+  let @r = ''
+  normal gg"Rye
+  normal "Rye
+  call assert_equal("oneone", @r)
+  set cpo+=>
+  let @r = ''
+  normal gg"Rye
+  normal "Rye
+  call assert_equal("\none\none", @r)
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the ';' flag in 'cpo'
+" Test for t,f,F,T movement commands and 'cpo-;' setting
+func Test_cpo_semicolon()
+  let save_cpo = &cpo
+  new
+  call append(0, ["aaa two three four", "    zzz", "yyy   ",
+	      \ "bbb yee yoo four", "ccc two three four",
+	      \ "ddd yee yoo four"])
+  set cpo-=;
+  1
+  normal! 0tt;D
+  2
+  normal! 0fz;D
+  3
+  normal! $Fy;D
+  4
+  normal! $Ty;D
+  set cpo+=;
+  5
+  normal! 0tt;;D
+  6
+  normal! $Ty;;D
+
+  call assert_equal('aaa two', getline(1))
+  call assert_equal('    z', getline(2))
+  call assert_equal('y', getline(3))
+  call assert_equal('bbb y', getline(4))
+  call assert_equal('ccc', getline(5))
+  call assert_equal('ddd yee y', getline(6))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '#' flag in 'cpo' (count before 'D', 'o' and 'O' operators)
+func Test_cpo_hash()
+  throw 'Skipped: Nvim does not support cpoptions flag "#"'
+  let save_cpo = &cpo
+  new
+  set cpo-=#
+  call setline(1, ['one', 'two', 'three'])
+  normal gg2D
+  call assert_equal(['three'], getline(1, '$'))
+  normal gg2ofour
+  call assert_equal(['three', 'four', 'four'], getline(1, '$'))
+  normal gg2Otwo
+  call assert_equal(['two', 'two', 'three', 'four', 'four'], getline(1, '$'))
+  %d
+  set cpo+=#
+  call setline(1, ['one', 'two', 'three'])
+  normal gg2D
+  call assert_equal(['', 'two', 'three'], getline(1, '$'))
+  normal gg2oone
+  call assert_equal(['', 'one', 'two', 'three'], getline(1, '$'))
+  normal gg2Ozero
+  call assert_equal(['zero', '', 'one', 'two', 'three'], getline(1, '$'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '&' flag in 'cpo'. The swap file is kept when a buffer is still
+" loaded and ':preserve' is used.
+func Test_cpo_ampersand()
+  throw 'Skipped: Nvim does not support cpoptions flag "&"'
+  call writefile(['one'], 'Xfile')
+  let after =<< trim [CODE]
+    set cpo+=&
+    preserve
+    qall
+  [CODE]
+  if RunVim([], after, 'Xfile')
+    call assert_equal(1, filereadable('.Xfile.swp'))
+    call delete('.Xfile.swp')
+  endif
+  call delete('Xfile')
+endfunc
+
+" Test for the '\' flag in 'cpo' (backslash in a [] range in a search pattern)
+func Test_cpo_backslash()
+  throw 'Skipped: Nvim does not support cpoptions flag "\"'
+  let save_cpo = &cpo
+  new
+  call setline(1, ['', " \\-string"])
+  set cpo-=\
+  exe 'normal gg/[ \-]' .. "\<CR>n"
+  call assert_equal(3, col('.'))
+  set cpo+=\
+  exe 'normal gg/[ \-]' .. "\<CR>n"
+  call assert_equal(2, col('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '/' flag in 'cpo' is in the test_substitute.vim file
+
+" Test for the '{' flag in 'cpo' (the "{" and "}" commands stop at a {
+" character at the start of a line)
+func Test_cpo_brace()
+  throw 'Skipped: Nvim does not support cpoptions flag "{"'
+  let save_cpo = &cpo
+  new
+  call setline(1, ['', '{', '    int i;', '}', ''])
+  set cpo-={
+  normal gg}
+  call assert_equal(5, line('.'))
+  normal G{
+  call assert_equal(1, line('.'))
+  set cpo+={
+  normal gg}
+  call assert_equal(2, line('.'))
+  normal G{
+  call assert_equal(2, line('.'))
+  close!
+  let &cpo = save_cpo
+endfunc
+
+" Test for the '.' flag in 'cpo' (:cd command fails if the current buffer is
+" modified)
+func Test_cpo_dot()
+  throw 'Skipped: Nvim does not support cpoptions flag "."'
+  let save_cpo = &cpo
+  new Xfoo
+  call setline(1, 'foo')
+  let save_dir = getcwd()
+  set cpo+=.
+
+  " :cd should fail when buffer is modified and 'cpo' contains dot.
+  call assert_fails('cd ..', 'E747:')
+  call assert_equal(save_dir, getcwd())
+
+  " :cd with exclamation mark should succeed.
+  cd! ..
+  call assert_notequal(save_dir, getcwd())
+
+  " :cd should succeed when buffer has been written.
+  w!
+  exe 'cd ' .. fnameescape(save_dir)
+  call assert_equal(save_dir, getcwd())
+
+  call delete('Xfoo')
+  set cpo&
+  close!
+  let &cpo = save_cpo
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -248,6 +248,7 @@ func Test_cpo_H()
 endfunc
 
 " TODO: Add a test for the 'i' flag in 'cpo'
+" Interrupting the reading of a file will leave it modified.
 
 " Test for the 'I' flag in 'cpo' (deleting autoindent when using arrow keys)
 func Test_cpo_I()
@@ -296,9 +297,12 @@ func Test_cpo_J()
   let &cpo = save_cpo
 endfunc
 
-" TODO: Add a test for the 'k' flag in 'cpo'
+" TODO: Add a test for the 'k' flag in 'cpo'.
+" Disable the recognition of raw key codes in mappings, abbreviations, and the
+" "to" part of menu commands.
 
-" TODO: Add a test for the 'K' flag in 'cpo'
+" TODO: Add a test for the 'K' flag in 'cpo'.
+" Don't wait for a key code to complete when it is halfway a mapping.
 
 " Test for the 'l' flag in 'cpo' (backslash in a [] range)
 func Test_cpo_l()
@@ -336,7 +340,9 @@ func Test_cpo_L()
   let &cpo = save_cpo
 endfunc
 
-" TODO: Add a test for the 'm' flag in 'cpo'
+" TODO: Add a test for the 'm' flag in 'cpo'.
+" When included, a showmatch will always wait half a second.  When not
+" included, a showmatch will wait half a second or until a character is typed.
 
 " Test for the 'M' flag in 'cpo' (% with escape parenthesis)
 func Test_cpo_M()
@@ -500,7 +506,9 @@ func Test_cpo_R()
   let &cpo = save_cpo
 endfunc
 
-" TODO: Add a test for the 's' flag in 'cpo'
+" TODO: Add a test for the 's' flag in 'cpo'.
+" Set buffer options when entering the buffer for the first time.  If not
+" present the options are set when the buffer is created.
 
 " Test for the 'S' flag in 'cpo' (copying buffer options)
 func Test_cpo_S()
@@ -545,8 +553,8 @@ func Test_cpo_u()
   let &cpo = save_cpo
 endfunc
 
-" TODO: Add a test for the 'v' flag in 'cpo' (backspace doesn't remove
-" characters from the screen)
+" TODO: Add a test for the 'v' flag in 'cpo'.
+" Backspaced characters remain visible on the screen in Insert mode.
 
 " Test for the 'w' flag in 'cpo' ('cw' on a blank character changes only one
 " character)

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1724,40 +1724,6 @@ func Test_edit_illegal_filename()
   close!
 endfunc
 
-" Test for inserting text in a line with only spaces ('H' flag in 'cpoptions')
-func Test_edit_cpo_H()
-  throw 'Skipped: Nvim does not support cpoptions flag "H"'
-  new
-  call setline(1, '    ')
-  normal! Ia
-  call assert_equal('    a', getline(1))
-  set cpo+=H
-  call setline(1, '    ')
-  normal! Ia
-  call assert_equal('   a ', getline(1))
-  set cpo-=H
-  close!
-endfunc
-
-" Test for inserting tab in virtual replace mode ('L' flag in 'cpoptions')
-func Test_edit_cpo_L()
-  new
-  call setline(1, 'abcdefghijklmnopqr')
-  exe "normal 0gR\<Tab>"
-  call assert_equal("\<Tab>ijklmnopqr", getline(1))
-  set cpo+=L
-  set list
-  call setline(1, 'abcdefghijklmnopqr')
-  exe "normal 0gR\<Tab>"
-  call assert_equal("\<Tab>cdefghijklmnopqr", getline(1))
-  set nolist
-  call setline(1, 'abcdefghijklmnopqr')
-  exe "normal 0gR\<Tab>"
-  call assert_equal("\<Tab>ijklmnopqr", getline(1))
-  set cpo-=L
-  %bw!
-endfunc
-
 " Test for editing a directory
 func Test_edit_is_a_directory()
   CheckEnglish

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1433,9 +1433,7 @@ endfunc
 
 func Test_edit_rightleft()
   " Cursor in rightleft mode moves differently
-  if !exists("+rightleft")
-    return
-  endif
+  CheckFeature rightleft
   call NewWindow(10, 20)
   call setline(1, ['abc', 'def', 'ghi'])
   call cursor(1, 2)
@@ -1480,6 +1478,13 @@ func Test_edit_rightleft()
         \"                 ihg",
         \"                   ~"]
   call assert_equal(join(expect, "\n"), join(lines, "\n"))
+  %d _
+  " call test_override('redraw_flag', 1)
+  " call test_override('char_avail', 1)
+  call feedkeys("a\<C-V>x41", "xt")
+  redraw!
+  call assert_equal(repeat(' ', 19) .. 'A', Screenline(1))
+  " call test_override('ALL', 0)
   set norightleft
   bw!
 endfunc
@@ -1866,6 +1871,107 @@ func Test_edit_insertmode_ex_edit()
   " clean up
   call StopVimInTerminal(buf)
   call delete('Xtest_edit_insertmode_ex_edit')
+endfunc
+
+" Pressing escape in 'insertmode' should beep
+func Test_edit_insertmode_esc_beeps()
+  throw "Skipped: Nvim does not support 'insertmode'"
+  new
+  set insertmode
+  call assert_beeps("call feedkeys(\"one\<Esc>\", 'xt')")
+  set insertmode&
+  " unsupported CTRL-G command should beep in insert mode.
+  call assert_beeps("normal i\<C-G>l")
+  close!
+endfunc
+
+" Test for 'hkmap' and 'hkmapp'
+func Test_edit_hkmap()
+  CheckFeature rightleft
+  if has('win32') && !has('gui')
+    " Test fails on the MS-Windows terminal version
+    return
+  endif
+  new
+
+  set revins hkmap
+  let str = 'abcdefghijklmnopqrstuvwxyz'
+  let str ..= 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  let str ..= '`/'',.;'
+  call feedkeys('i' .. str, 'xt')
+  let expected = "óõú,.;"
+  let expected ..= "ZYXWVUTSRQPONMLKJIHGFEDCBA"
+  let expected ..= "æèñ'äåàãø/ôíîöêìçïéòë÷âáðù"
+  call assert_equal(expected, getline(1))
+
+  %d
+  set revins hkmap hkmapp
+  let str = 'abcdefghijklmnopqrstuvwxyz'
+  let str ..= 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  call feedkeys('i' .. str, 'xt')
+  let expected = "õYXWVUTSRQóOïíLKJIHGFEDêBA"
+  let expected ..= "öòXùåèúæø'ôñðîì÷çéäâóǟãëáà"
+  call assert_equal(expected, getline(1))
+
+  set revins& hkmap& hkmapp&
+  close!
+endfunc
+
+" Test for 'allowrevins' and using CTRL-_ in insert mode
+func Test_edit_allowrevins()
+  CheckFeature rightleft
+  new
+  set allowrevins
+  call feedkeys("iABC\<C-_>DEF\<C-_>GHI", 'xt')
+  call assert_equal('ABCFEDGHI', getline(1))
+  set allowrevins&
+  close!
+endfunc
+
+" Test for inserting a register in insert mode using CTRL-R
+func Test_edit_insert_reg()
+  throw 'Skipped: use test/functional/legacy/edit_spec.lua'
+  new
+  let g:Line = ''
+  func SaveFirstLine()
+    let g:Line = Screenline(1)
+    return 'r'
+  endfunc
+  inoremap <expr> <buffer> <F2> SaveFirstLine()
+  call test_override('redraw_flag', 1)
+  call test_override('char_avail', 1)
+  let @r = 'sample'
+  call feedkeys("a\<C-R>=SaveFirstLine()\<CR>", "xt")
+  call assert_equal('"', g:Line)
+  call test_override('ALL', 0)
+  close!
+endfunc
+
+" When a character is inserted at the last position of the last line in a
+" window, the window contents should be scrolled one line up. If the top line
+" is part of a fold, then the entire fold should be scrolled up.
+func Test_edit_lastline_scroll()
+  new
+  let h = winheight(0)
+  let lines = ['one', 'two', 'three']
+  let lines += repeat(['vim'], h - 4)
+  call setline(1, lines)
+  call setline(h, repeat('x', winwidth(0) - 1))
+  call feedkeys("GAx", 'xt')
+  redraw!
+  call assert_equal(h - 1, winline())
+  call assert_equal(2, line('w0'))
+
+  " scroll with a fold
+  1,2fold
+  normal gg
+  call setline(h + 1, repeat('x', winwidth(0) - 1))
+  call feedkeys("GAx", 'xt')
+  redraw!
+  call assert_equal(h - 1, winline())
+  call assert_equal(3, line('w0'))
+
+  close!
 endfunc
 
 func Test_edit_browse()

--- a/src/nvim/testdir/test_increment.vim
+++ b/src/nvim/testdir/test_increment.vim
@@ -877,4 +877,21 @@ func Test_normal_increment_with_virtualedit()
   set virtualedit&
 endfunc
 
+" Test for incrementing a signed hexadecimal and octal number
+func Test_normal_increment_signed_hexoct_nr()
+  new
+  " negative sign before a hex number should be ignored
+  call setline(1, ["-0x9"])
+  exe "norm \<C-A>"
+  call assert_equal(["-0xa"], getline(1, '$'))
+  exe "norm \<C-X>"
+  call assert_equal(["-0x9"], getline(1, '$'))
+  call setline(1, ["-007"])
+  exe "norm \<C-A>"
+  call assert_equal(["-010"], getline(1, '$'))
+  exe "norm \<C-X>"
+  call assert_equal(["-007"], getline(1, '$'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2644,7 +2644,6 @@ endfunc
 " Test for cw cW ce
 func Test_normal39_cw()
   " Test for cw and cW on whitespace
-  " and cpo+=w setting
   new
   set tw=0
   call append(0, 'here      are   some words')
@@ -2652,14 +2651,6 @@ func Test_normal39_cw()
   call assert_equal('hereZZZare   some words', getline('.'))
   norm! 1gg0elcWYYY
   call assert_equal('hereZZZareYYYsome words', getline('.'))
-  " Nvim: no "w" flag in 'cpoptions'.
-  " set cpo+=w
-  " call setline(1, 'here      are   some words')
-  " norm! 1gg0elcwZZZ
-  " call assert_equal('hereZZZ     are   some words', getline('.'))
-  " norm! 1gg2elcWYYY
-  " call assert_equal('hereZZZ     areYYY  some words', getline('.'))
-  set cpo-=w
   norm! 2gg0cwfoo
   call assert_equal('foo', getline('.'))
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2125,6 +2125,16 @@ func Test_normal30_changecase()
   call assert_equal(['aaaaaa', 'AAAAaa'], getline(1, 2))
   set whichwrap&
 
+  " try changing the case with a double byte encoding (DBCS)
+  %bw!
+  let enc = &enc
+  " set encoding=cp932
+  call setline(1, "\u8470")
+  normal ~
+  normal gU$gu$gUgUg~g~gugu
+  call assert_equal("\u8470", getline(1))
+  let &encoding = enc
+
   " clean up
   bw!
 endfunc
@@ -3497,6 +3507,27 @@ func Test_normal_percent_jump()
   call assert_equal(50, line('.'))
   call assert_equal(-1, foldclosedend(50))
   close!
+endfunc
+
+" Test for << and >> commands to shift text by 'shiftwidth'
+func Test_normal_shift_rightleft()
+  new
+  call setline(1, ['one', '', "\t", '  two', "\tthree", '      four'])
+  set shiftwidth=2 tabstop=8
+  normal gg6>>
+  call assert_equal(['  one', '', "\t  ", '    two', "\t  three", "\tfour"],
+        \ getline(1, '$'))
+  normal ggVG2>>
+  call assert_equal(['      one', '', "\t      ", "\ttwo",
+        \ "\t      three", "\t    four"], getline(1, '$'))
+  normal gg6<<
+  call assert_equal(['    one', '', "\t    ", '      two', "\t    three",
+        \ "\t  four"], getline(1, '$'))
+  normal ggVG2<<
+  call assert_equal(['one', '', "\t", '  two', "\tthree", '      four'],
+        \ getline(1, '$'))
+  set shiftwidth& tabstop&
+  bw!
 endfunc
 
 " Some commands like yy, cc, dd, >>, << and !! accept a count after

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2931,20 +2931,6 @@ func Test_normal52_rl()
   bw!
 endfunc
 
-func Test_normal53_digraph()
-  CheckFeature digraphs
-  new
-  call setline(1, 'abcdefgh|')
-  exe "norm! 1gg0f\<c-k>!!"
-  call assert_equal(9, col('.'))
-  set cpo+=D
-  exe "norm! 1gg0f\<c-k>!!"
-  call assert_equal(1, col('.'))
-
-  set cpo-=D
-  bw!
-endfunc
-
 func Test_normal54_Ctrl_bsl()
   new
   call setline(1, 'abcdefghijklmn')
@@ -3265,46 +3251,6 @@ func Test_normal_gk_gj()
   set cpoptions& number& numberwidth& wrap&
 endfunc
 
-" Test for cursor movement with '-' in 'cpoptions'
-func Test_normal_cpo_minus()
-  throw 'Skipped: Nvim does not support cpoptions flag "-"'
-  new
-  call setline(1, ['foo', 'bar', 'baz'])
-  let save_cpo = &cpo
-  set cpo+=-
-  call assert_beeps('normal 10j')
-  call assert_equal(1, line('.'))
-  normal G
-  call assert_beeps('normal 10k')
-  call assert_equal(3, line('.'))
-  call assert_fails(10, 'E16:')
-  let &cpo = save_cpo
-  close!
-endfunc
-
-" Test for displaying dollar when changing text ('$' flag in 'cpoptions')
-func Test_normal_cpo_dollar()
-  throw 'Skipped: use test/functional/legacy/cpoptions_spec.lua'
-  new
-  let g:Line = ''
-  func SaveFirstLine()
-    let g:Line = Screenline(1)
-    return ''
-  endfunc
-  inoremap <expr> <buffer> <F2> SaveFirstLine()
-  call test_override('redraw_flag', 1)
-  set cpo+=$
-  call setline(1, 'one two three')
-  redraw!
-  exe "normal c2w\<F2>vim"
-  call assert_equal('one tw$ three', g:Line)
-  call assert_equal('vim three', getline(1))
-  set cpo-=$
-  call test_override('ALL', 0)
-  delfunc SaveFirstLine
-  %bw!
-endfunc
-
 " Test for using : to run a multi-line Ex command in operator pending mode
 func Test_normal_yank_with_excmd()
   new
@@ -3384,31 +3330,6 @@ func Test_normal_delete_cmd()
   " delete to a readonly register
   call setline(1, ['abcd'])
   call assert_beeps('normal ":d2l')
-  close!
-endfunc
-
-" Test for the 'E' flag in 'cpo' with yank, change, delete, etc. operators
-func Test_empty_region_error()
-  new
-  call setline(1, '')
-  set cpo+=E
-  " yank an empty line
-  call assert_beeps('normal "ayl')
-  " change an empty line
-  call assert_beeps('normal lcTa')
-  " delete an empty line
-  call assert_beeps('normal D')
-  call assert_beeps('normal dl')
-  call assert_equal('', getline(1))
-  " change case of an empty line
-  call assert_beeps('normal gul')
-  call assert_beeps('normal gUl')
-  " replace a character
-  call assert_beeps('normal vrx')
-  " increment and decrement
-  call assert_beeps('exe "normal v\<C-A>"')
-  call assert_beeps('exe "normal v\<C-X>"')
-  set cpo-=E
   close!
 endfunc
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -120,6 +120,39 @@ func Test_normal01_keymodel()
   call feedkeys("Vkk\<Up>yy", 'tx')
   call assert_equal(['47', '48', '49', '50'], getreg(0, 0, 1))
 
+  " Test for using special keys to start visual selection
+  %d
+  call setline(1, ['red fox tail', 'red fox tail', 'red fox tail'])
+  set keymodel=startsel
+  " Test for <S-PageUp> and <S-PageDown>
+  call cursor(1, 1)
+  call feedkeys("\<S-PageDown>y", 'xt')
+  call assert_equal([0, 1, 1, 0], getpos("'<"))
+  call assert_equal([0, 3, 1, 0], getpos("'>"))
+  call feedkeys("Gz\<CR>8|\<S-PageUp>y", 'xt')
+  call assert_equal([0, 2, 1, 0], getpos("'<"))
+  call assert_equal([0, 3, 8, 0], getpos("'>"))
+  " Test for <S-C-Home> and <S-C-End>
+  call cursor(2, 12)
+  call feedkeys("\<S-C-Home>y", 'xt')
+  call assert_equal([0, 1, 1, 0], getpos("'<"))
+  call assert_equal([0, 2, 12, 0], getpos("'>"))
+  call cursor(1, 4)
+  call feedkeys("\<S-C-End>y", 'xt')
+  call assert_equal([0, 1, 4, 0], getpos("'<"))
+  call assert_equal([0, 3, 13, 0], getpos("'>"))
+  " Test for <S-C-Left> and <S-C-Right>
+  call cursor(2, 5)
+  call feedkeys("\<S-C-Right>y", 'xt')
+  call assert_equal([0, 2, 5, 0], getpos("'<"))
+  call assert_equal([0, 2, 9, 0], getpos("'>"))
+  call cursor(2, 9)
+  call feedkeys("\<S-C-Left>y", 'xt')
+  call assert_equal([0, 2, 5, 0], getpos("'<"))
+  call assert_equal([0, 2, 9, 0], getpos("'>"))
+
+  set keymodel&
+
   " clean up
   bw!
 endfunc
@@ -509,6 +542,14 @@ func Test_normal10_expand()
     call assert_equal(expected[i], expand('<cexpr>'), 'i == ' . i)
   endfor
 
+  " Test for <cexpr> in state.val and ptr->val
+  call setline(1, 'x = state.val;')
+  call cursor(1, 10)
+  call assert_equal('state.val', expand('<cexpr>'))
+  call setline(1, 'x = ptr->val;')
+  call cursor(1, 9)
+  call assert_equal('ptr->val', expand('<cexpr>'))
+
   if executable('echo')
     " Test expand(`...`) i.e. backticks command expansion.
     " MS-Windows has a trailing space.
@@ -520,6 +561,19 @@ func Test_normal10_expand()
   call assert_equal('3.14', expand('`=3.14`'))
 
   " clean up
+  bw!
+endfunc
+
+" Test for expand() in latin1 encoding
+func Test_normal_expand_latin1()
+  new
+  let save_enc = &encoding
+  " set encoding=latin1
+  call setline(1, 'val = item->color;')
+  call cursor(1, 11)
+  call assert_equal('color', expand("<cword>"))
+  call assert_equal('item->color', expand("<cexpr>"))
+  let &encoding = save_enc
   bw!
 endfunc
 
@@ -547,6 +601,13 @@ func Test_normal11_showcmd()
   redraw!
   call assert_match('1-3$', Screenline(&lines))
   call feedkeys("v", 'xt')
+  " test for visually selecting the end of line
+  call setline(1, ["foobar"])
+  call feedkeys("$vl", 'xt')
+  redraw!
+  call assert_match('2$', Screenline(&lines))
+  call feedkeys("y", 'xt')
+  call assert_equal("r\n", @")
   bw!
 endfunc
 
@@ -2160,6 +2221,13 @@ func Test_normal31_r_cmd()
   call setline(1, ["a\tb", "c\td", "e\tf"])
   normal gglvjjrx
   call assert_equal(['axx', 'xxx', 'xxf'], getline(1, '$'))
+
+  " replace with a multibyte character (with multiple composing characters)
+  %d
+  new
+  call setline(1, 'aaa')
+  exe "normal $ra\u0328\u0301"
+  call assert_equal("aaa\u0328\u0301", getline(1))
 
   " clean up
   set noautoindent

--- a/src/nvim/testdir/test_selectmode.vim
+++ b/src/nvim/testdir/test_selectmode.vim
@@ -34,6 +34,9 @@ func Test_selectmode_start()
   set selectmode=cmd
   call feedkeys('gvabc', 'xt')
   call assert_equal('abctdef', getline(1))
+  " arrow keys without shift should not start selection
+  call feedkeys("A\<Home>\<Right>\<Left>ro", 'xt')
+  call assert_equal('roabctdef', getline(1))
   set selectmode= keymodel=
   bw!
 endfunc

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -623,6 +623,17 @@ func Test_tabpage_close_cmdwin()
   tabonly
 endfunc
 
+" Pressing <C-PageUp> in insert mode should go to the previous tab page
+" and <C-PageDown> should go to the next tab page
+func Test_tabpage_Ctrl_Pageup()
+  tabnew
+  call feedkeys("i\<C-PageUp>", 'xt')
+  call assert_equal(1, tabpagenr())
+  call feedkeys("i\<C-PageDown>", 'xt')
+  call assert_equal(2, tabpagenr())
+  %bw!
+endfunc
+
 " Return the terminal key code for selecting a tab page from the tabline. This
 " sequence contains the following codes: a CSI (0x9b), KS_TABLINE (0xf0),
 " KS_FILLER (0x58) and then the tab page number.

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1096,6 +1096,20 @@ func Test_fo_a_w()
   call feedkeys("iabc abc a abc\<Esc>k0weade", 'xt')
   call assert_equal(['abc abcde ', 'a abc'], getline(1, '$'))
 
+  " when a line ends with space, it is not broken up.
+  %d
+  call feedkeys("ione two to    ", 'xt')
+  call assert_equal('one two to    ', getline(1))
+
+  " when a line ends with spaces and backspace is used in the next line, the
+  " last space in the previous line should be removed.
+  %d
+  set backspace=indent,eol,start
+  call setline(1, ['one    ', 'two'])
+  exe "normal 2Gi\<BS>"
+  call assert_equal(['one   two'], getline(1, '$'))
+  set backspace&
+
   " Test for 'a', 'w' and '1' options.
   setlocal textwidth=0
   setlocal fo=1aw

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -80,6 +80,10 @@ func Test_edit_change()
   call setline(1, "\t⒌")
   normal Cx
   call assert_equal('x', getline(1))
+  " Do a visual block change
+  call setline(1, ['a', 'b', 'c'])
+  exe "normal gg3l\<C-V>2jcx"
+  call assert_equal(['a  x', 'b  x', 'c  x'], getline(1, '$'))
   bwipe!
   set virtualedit=
 endfunc
@@ -289,6 +293,16 @@ func Test_replace_after_eol()
   call append(0, '"r"')
   normal gg$5lrxa
   call assert_equal('"r"    x', getline(1))
+  " visual block replace
+  %d _
+  call setline(1, ['a', '', 'b'])
+  exe "normal 2l\<C-V>2jrx"
+  call assert_equal(['a x', '  x', 'b x'], getline(1, '$'))
+  " visual characterwise selection replace after eol
+  %d _
+  call setline(1, 'a')
+  normal 4lv2lrx
+  call assert_equal('a   xxx', getline(1))
   bwipe!
   set virtualedit=
 endfunc
@@ -373,6 +387,19 @@ func Test_ve_backspace()
   set backspace&
   set virtualedit&
   close!
+endfunc
+
+" Test for delete (x) on EOL character and after EOL
+func Test_delete_past_eol()
+  new
+  call setline(1, "ab")
+  set virtualedit=all
+  exe "normal 2lx"
+  call assert_equal('ab', getline(1))
+  exe "normal 10lx"
+  call assert_equal('ab', getline(1))
+  set virtualedit&
+  bw!
 endfunc
 
 " After calling s:TryVirtualeditReplace(), line 1 will contain one of these

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -357,6 +357,24 @@ func Test_delete_break_tab()
   close!
 endfunc
 
+" Test for using <BS>, <C-W> and <C-U> in virtual edit mode
+" to erase character, word and line.
+func Test_ve_backspace()
+  new
+  call setline(1, 'sample')
+  set virtualedit=all
+  set backspace=indent,eol,start
+  exe "normal 15|i\<BS>\<BS>"
+  call assert_equal([0, 1, 7, 5], getpos('.'))
+  exe "normal 15|i\<C-W>"
+  call assert_equal([0, 1, 6, 0], getpos('.'))
+  exe "normal 15|i\<C-U>"
+  call assert_equal([0, 1, 1, 0], getpos('.'))
+  set backspace&
+  set virtualedit&
+  close!
+endfunc
+
 " After calling s:TryVirtualeditReplace(), line 1 will contain one of these
 " two strings, depending on whether virtual editing is on or off.
 let s:result_ve_on  = 'a      x'

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -225,6 +225,15 @@ func Test_virtual_replace()
   exe "normal iabcdefghijklmnopqrst\<Esc>0gRAB\tIJKLMNO\tQR"
   call assert_equal(['AB......CDEFGHI.Jkl',
 	      \ 'AB	IJKLMNO	QRst'], getline(12, 13))
+
+  " Test inserting Tab with 'noexpandtab' and 'softabstop' set to 4
+  %d
+  call setline(1, 'aaaaaaaaaaaaa')
+  set softtabstop=4
+  exe "normal gggR\<Tab>\<Tab>x"
+  call assert_equal("\txaaaa", getline(1))
+  set softtabstop&
+
   enew!
   set noai bs&vim
   if exists('save_t_kD')

--- a/test/functional/legacy/digraph_spec.lua
+++ b/test/functional/legacy/digraph_spec.lua
@@ -1,0 +1,46 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local feed = helpers.feed
+
+before_each(clear)
+
+describe('digraph', function()
+  -- oldtest: Test_entering_digraph()
+  it('characters displayed on the screen', function()
+    local screen = Screen.new(10, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
+      [2] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+    feed('i<C-K>')
+    screen:expect([[
+      {1:^?}           |
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {2:-- INSERT -} |
+    ]])
+    feed('1')
+    screen:expect([[
+      {1:^1}           |
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {2:-- INSERT -} |
+    ]])
+    feed('2')
+    screen:expect([[
+      ½^           |
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {2:-- INSERT -} |
+    ]])
+  end)
+end)

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local command = helpers.command
 local expect = helpers.expect
@@ -7,20 +8,51 @@ local sleep = helpers.sleep
 
 before_each(clear)
 
--- oldtest: Test_autoindent_remove_indent()
-it('autoindent removes indent when Insert mode is stopped', function()
-  command('set autoindent')
-  -- leaving insert mode in a new line with indent added by autoindent, should
-  -- remove the indent.
-  feed('i<Tab>foo<CR><Esc>')
-  -- Need to delay for sometime, otherwise the code in getchar.c will not be
-  -- exercised.
-  sleep(50)
-  -- when a line is wrapped and the cursor is at the start of the second line,
-  -- leaving insert mode, should move the cursor back to the first line.
-  feed('o' .. ('x'):rep(20) .. '<Esc>')
-  -- Need to delay for sometime, otherwise the code in getchar.c will not be
-  -- exercised.
-  sleep(50)
-  expect('\tfoo\n\n' .. ('x'):rep(20))
+describe('edit', function()
+  -- oldtest: Test_autoindent_remove_indent()
+  it('autoindent removes indent when Insert mode is stopped', function()
+    command('set autoindent')
+    -- leaving insert mode in a new line with indent added by autoindent, should
+    -- remove the indent.
+    feed('i<Tab>foo<CR><Esc>')
+    -- Need to delay for sometime, otherwise the code in getchar.c will not be
+    -- exercised.
+    sleep(50)
+    -- when a line is wrapped and the cursor is at the start of the second line,
+    -- leaving insert mode, should move the cursor back to the first line.
+    feed('o' .. ('x'):rep(20) .. '<Esc>')
+    -- Need to delay for sometime, otherwise the code in getchar.c will not be
+    -- exercised.
+    sleep(50)
+    expect('\tfoo\n\n' .. ('x'):rep(20))
+  end)
+
+  -- oldtest: Test_edit_insert_reg()
+  it('inserting a register using CTRL-R', function()
+    local screen = Screen.new(10, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
+      [2] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+    feed('a<C-R>')
+    screen:expect([[
+      {1:^"}           |
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {2:-- INSERT -} |
+    ]])
+    feed('=')
+    screen:expect([[
+      {1:"}           |
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      {0:~           }|
+      =^           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.0968: no proper testing of the 'cpoptions' flags

Problem:    No proper testing of the 'cpoptions' flags.
Solution:   Add tests. (Yegappan Lakshmanan, closes vim/vim#6251)

https://github.com/vim/vim/commit/c9630d2658af9dcaa01913e899b201bfdef7b536


#### vim-patch:8.2.0976: some 'cpoptions' not tested

Problem:    Some 'cpoptions' not tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6253)

https://github.com/vim/vim/commit/df7df59d85e7e56a796912dc865488a75d3f0e53


#### vim-patch:8.2.1022: various parts of code not covered by tests

Problem:    Various parts of code not covered by tests.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#6300)

https://github.com/vim/vim/commit/845e0ee59430eac07e74b6cb92020e420d17953d

Omit test_iminsert.vim: the commit that created this file was N/A.
Omit test_viminfo.vim: the added tests are N/A.


#### vim-patch:8.2.1810: some code in normal.c not covered by tests

Problem:    Some code in normal.c not covered by tests.
Solution:   Add normal mode tests. (Yegappan Lakshmanan, closes vim/vim#7086)

https://github.com/vim/vim/commit/d7e5e9430ae192c76f1f03c3ac53fae823d94c33


#### vim-patch:8.2.2901: some operators not fully tested

Problem:    Some operators not fully tested.
Solution:   Add a few test cases. (Yegappan Lakshmanan, closes vim/vim#8282)

https://github.com/vim/vim/commit/3e72dcad8b752a42b6eaf71213e3f5d534175256