### PR TITLE
build: always ignore user's cmake preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /venv/
 compile_commands.json
 /.luarc.json
+CMakeUserPresets.json
 
 # IDEs
 /.vs/
@@ -73,5 +74,3 @@ tags
 
 # vim patches
 /vim-*.patch
-
-/CMakeUserPresets.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /venv/
 compile_commands.json
 /.luarc.json
-CMakeUserPresets.json
 
 # IDEs
 /.vs/
@@ -74,3 +73,5 @@ tags
 
 # vim patches
 /vim-*.patch
+
+CMakeUserPresets.json


### PR DESCRIPTION
Add a new rule to ignore `CMakeUserPresets.txt` in all sub-directories.

#### How Has This Been Tested?

A basic preset can be defined in `cmake.deps/CMakeUsersPresets.json`

```json
{
  "version": 3,
  "configurePresets": [
    {
      "name": "deps",
      "displayName": "deps preset",
      "binaryDir": "${sourceParentDir}/.deps",
      "cacheVariables": {
        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
        "USE_BUNDLED_MSGPACK": false
      }
    }
  ],
  "buildPresets": [
    {
      "name": "deps",
      "configurePreset": "deps"
    }
  ]
}
```

However, using cmake 23+ allows using presets v5 which adds an in `include` key:
- we include the main `CMakePresets.json` (any valid preset file works)
- now we can inhert any preset and re-use the same variables (e.g. `CMAKE_BUILD_TYPE`)

```json
{
  "version": 5,
  "include": [
    "../CMakePresets.json"
  ],
  "configurePresets": [
    {
      "name": "deps",
      "displayName": "deps preset",
      "binaryDir": "${sourceParentDir}/.deps",
      "inherits": [
        "windows-default"
      ]
    }
  ],
  "buildPresets": [
    {
      "name": "deps",
      "configurePreset": "deps"
    }
  ]
}
```
