### PR TITLE
vim-patch:8.2.{0433,0644,0866,0958}: various tests

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7080,8 +7080,8 @@ setloclist({nr}, {list} [, {action} [, {what}]])		*setloclist()*
 			GetLoclist()->setloclist(winnr)
 
 setmatches({list} [, {win}])				*setmatches()*
-		Restores a list of matches saved by |getmatches() for the
-		current window|.  Returns 0 if successful, otherwise -1.  All
+		Restores a list of matches saved by |getmatches()| for the
+		current window.  Returns 0 if successful, otherwise -1.  All
 		current matches are cleared before the list is restored.  See
 		example for |getmatches()|.
 		If {win} is specified, use the window with this number or

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -1,5 +1,6 @@
 " Test argument list commands
 
+source check.vim
 source shared.vim
 source term_util.vim
 
@@ -552,9 +553,7 @@ endfunc
 
 " Test for quitting Vim with unedited files in the argument list
 func Test_quit_with_arglist()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
   call term_sendkeys(buf, ":set nomore\n")
   call term_sendkeys(buf, ":args a b c\n")

--- a/src/nvim/testdir/test_backup.vim
+++ b/src/nvim/testdir/test_backup.vim
@@ -1,5 +1,7 @@
 " Tests for the backup function
 
+source check.vim
+
 func Test_backup()
   set backup backupdir=. backupskip=
   new
@@ -56,3 +58,19 @@ func Test_backup2_backupcopy()
   call delete(f)
   set backup&vim backupdir&vim backupcopy&vim backupskip&vim
 endfunc
+
+" Test for using a non-existing directory as a backup directory
+func Test_non_existing_backupdir()
+  throw 'Skipped: Nvim auto-creates backup directory'
+  CheckNotBSD
+  let save_backup = &backupdir
+  set backupdir=./non_existing_dir
+  call writefile(['line1'], 'Xfile')
+  new Xfile
+  " TODO: write doesn't fail in Cirrus FreeBSD CI test
+  call assert_fails('write', 'E510:')
+  let &backupdir = save_backup
+  call delete('Xfile')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -26,6 +26,7 @@ func Test_setbufline_getbufline()
   call assert_equal(['d'], getbufline(b, 4))
   call assert_equal(['e'], getbufline(b, 5))
   call assert_equal([], getbufline(b, 6))
+  call assert_equal([], getbufline(b, 2, 1))
   exe "bwipe! " . b
 endfunc
 

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -182,6 +182,7 @@ func Test_client_server()
     endif
   endtry
 
+  call assert_fails('call remote_startserver([])', 'E730:')
   call assert_fails("let x = remote_peek([])", 'E730:')
   call assert_fails("let x = remote_read('vim10')", 'E277:')
   call assert_fails("call server2client('abc', 'xyz')", 'E258:')

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -195,8 +195,6 @@ func Test_edit_long_file_name()
 
   call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
 
-  call term_sendkeys(buf, ":q\<cr>")
-
   " clean up
   call StopVimInTerminal(buf)
   call delete(longName)

--- a/src/nvim/testdir/test_ex_mode.vim
+++ b/src/nvim/testdir/test_ex_mode.vim
@@ -97,7 +97,6 @@ func Test_Ex_substitute()
   call term_sendkeys(buf, ":vi\<CR>")
   call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)
 
-  call term_sendkeys(buf, ":q!\n")
   call StopVimInTerminal(buf)
 endfunc
 

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -528,6 +528,7 @@ func Test_setmatches()
   endif
   eval set->setmatches()
   call assert_equal(exp, getmatches())
+  call assert_fails('let m = setmatches([], [])', 'E957:')
 endfunc
 
 func Test_empty_concatenate()

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -29,6 +29,8 @@ func Test_has()
     call assert_equal(0, and(has('ttyout'), 0))
     call assert_equal(1, has('multi_byte_encoding'))
   endif
+  call assert_equal(1, has('vcon', 1))
+  call assert_equal(1, has('mouse_gpm_enabled', 1))
 
   call assert_equal(0, has('nonexistent'))
   call assert_equal(0, has('nonexistent', 1))
@@ -1331,12 +1333,15 @@ endfunc
 
 " Test for the inputdialog() function
 func Test_inputdialog()
-  CheckNotGui
-
-  call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<CR>", 'xt')
-  call assert_equal('xx', v)
-  call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<Esc>", 'xt')
-  call assert_equal('yy', v)
+  if has('gui_running')
+    call assert_fails('let v=inputdialog([], "xx")', 'E730:')
+    call assert_fails('let v=inputdialog("Q", [])', 'E730:')
+  else
+    call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<CR>", 'xt')
+    call assert_equal('xx', v)
+    call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<Esc>", 'xt')
+    call assert_equal('yy', v)
+  endif
 endfunc
 
 " Test for inputlist()
@@ -1387,6 +1392,7 @@ func Test_balloon_show()
   call balloon_show('hi!')
   if !has('gui_running')
     call balloon_show(range(3))
+    call balloon_show([])
   endif
 endfunc
 
@@ -2271,6 +2277,9 @@ func Test_range()
   call assert_fails('let x=range(2, 8, 0)', 'E726:')
   call assert_fails('let x=range(3, 1)', 'E727:')
   call assert_fails('let x=range(1, 3, -2)', 'E727:')
+  call assert_fails('let x=range([])', 'E745:')
+  call assert_fails('let x=range(1, [])', 'E745:')
+  call assert_fails('let x=range(1, 4, [])', 'E745:')
 endfunc
 
 func Test_garbagecollect_now_fails()

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -160,12 +160,14 @@ endfunc
 func Test_matchadd_error()
   call clearmatches()
   " Nvim: not an error anymore:
+  " call assert_fails("call matchadd('GroupDoesNotExist', 'X')", 'E28:')
   call matchadd('GroupDoesNotExist', 'X')
   call assert_equal([{'group': 'GroupDoesNotExist', 'pattern': 'X', 'priority': 10, 'id': 1206}], getmatches())
   call assert_fails("call matchadd('Search', '\\(')", 'E475:')
   call assert_fails("call matchadd('Search', 'XXX', 1, 123, 1)", 'E715:')
   call assert_fails("call matchadd('Error', 'XXX', 1, 3)", 'E798:')
   call assert_fails("call matchadd('Error', 'XXX', 1, 0)", 'E799:')
+  call assert_fails("call matchadd('Error', 'XXX', [], 0)", 'E745:')
 endfunc
 
 func Test_matchaddpos()
@@ -305,7 +307,10 @@ func Test_matchaddpos_error()
   call assert_fails("call matchaddpos('Error', [1], 1, 123, 1)", 'E715:')
   call assert_fails("call matchaddpos('Error', [1], 1, 5, {'window':12345})", 'E957:')
   " Why doesn't the following error have an error code E...?
+  " call assert_fails("call matchaddpos('Error', [{}])", 'E290:')
   call assert_fails("call matchaddpos('Error', [{}])", 'E5031:')
+  call assert_equal(-1, matchaddpos('Error', v:_null_list))
+  call assert_fails("call matchaddpos('Error', [1], [], 1)", 'E745:')
 endfunc
 
 func OtherWindowCommon()
@@ -361,6 +366,5 @@ func Test_matchadd_other_window()
   call StopVimInTerminal(buf)
   call delete('XscriptMatchCommon')
 endfunc
-
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -343,9 +343,7 @@ func Test_matchdelete_error()
 endfunc
 
 func Test_matchclear_other_window()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
   let buf = OtherWindowCommon()
   call term_sendkeys(buf, ":call clearmatches(winid)\<CR>")
   call VerifyScreenDump(buf, 'Test_matchclear_1', {})
@@ -355,9 +353,7 @@ func Test_matchclear_other_window()
 endfunc
 
 func Test_matchadd_other_window()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
   let buf = OtherWindowCommon()
   call term_sendkeys(buf, ":call matchadd('Search', 'Hello', 1, -1, #{window: winid})\<CR>")
   call term_sendkeys(buf, ":\<CR>")

--- a/src/nvim/testdir/test_menu.vim
+++ b/src/nvim/testdir/test_menu.vim
@@ -252,6 +252,7 @@ func Test_menu_info()
   nmenu Test.abc  <Nop>
   call assert_equal('<Nop>', menu_info('Test.abc').rhs)
   call assert_fails('call menu_info([])', 'E730:')
+  call assert_fails('call menu_info("", [])', 'E730:')
   nunmenu Test
 
   " Test for defining menus in different modes

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -285,7 +285,9 @@ func Test_get_register()
 
   " Test for inserting a multi-line register in the command line
   call feedkeys(":\<C-R>r\<Esc>", 'xt')
-  call assert_equal("a\rb", histget(':', -1))  " Modified because of #6137
+  " Nvim: no trailing CR because of #6137
+  " call assert_equal("a\rb\r", histget(':', -1))
+  call assert_equal("a\rb", histget(':', -1))
 
   call assert_fails('let r = getreg("=", [])', 'E745:')
   call assert_fails('let r = getreg("=", 1, [])', 'E745:')

--- a/src/nvim/testdir/test_reltime.vim
+++ b/src/nvim/testdir/test_reltime.vim
@@ -24,4 +24,8 @@ func Test_reltime()
   call assert_true(reltimefloat(differs) < 0.1)
   call assert_true(reltimefloat(differs) > 0.0)
 
+  call assert_equal(0, reltime({}))
+  call assert_equal(0, reltime({}, {}))
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -897,9 +897,7 @@ func Test_incsearch_cmdline_modifier()
 endfunc
 
 func Test_incsearch_scrolling()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
   call assert_equal(0, &scrolloff)
   call writefile([
 	\ 'let dots = repeat(".", 120)',

--- a/src/nvim/testdir/test_signals.vim
+++ b/src/nvim/testdir/test_signals.vim
@@ -53,7 +53,7 @@ endfunc
 " Test signal PWR, which should update the swap file.
 func Test_signal_PWR()
   if !HasSignal('PWR')
-    return
+    throw 'Skipped: PWR signal not supported'
   endif
 
   " Set a very large 'updatetime' and 'updatecount', so that we can be sure
@@ -77,6 +77,35 @@ func Test_signal_PWR()
 
   bwipe!
   set updatetime& updatecount&
+endfunc
+
+" Test signal INT. Handler sets got_int. It should be like typing CTRL-C.
+func Test_signal_INT()
+  if !HasSignal('INT')
+    throw 'Skipped: INT signal not supported'
+  endif
+
+  " Skip the rest of the test when running with valgrind as signal INT is not
+  " received somehow by Vim when running with valgrind.
+  let cmd = GetVimCommand()
+  if cmd =~ 'valgrind'
+    throw 'Skipped: cannot test signal INT with valgrind'
+  endif
+
+  if !CanRunVimInTerminal()
+    throw 'Skipped: cannot run vim in terminal'
+  endif
+  let buf = RunVimInTerminal('', {'rows': 6})
+  let pid_vim = term_getjob(buf)->job_info().process
+
+  " Check that an endless loop in Vim is interrupted by signal INT.
+  call term_sendkeys(buf, ":while 1 | endwhile\n")
+  call WaitForAssert({-> assert_equal(':while 1 | endwhile', term_getline(buf, 6))})
+  exe 'silent !kill -s INT ' .. pid_vim
+  call term_sendkeys(buf, ":call setline(1, 'INTERUPTED')\n")
+  call WaitForAssert({-> assert_equal('INTERUPTED', term_getline(buf, 1))})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " Test a deadly signal.

--- a/src/nvim/testdir/test_signals.vim
+++ b/src/nvim/testdir/test_signals.vim
@@ -81,6 +81,7 @@ endfunc
 
 " Test signal INT. Handler sets got_int. It should be like typing CTRL-C.
 func Test_signal_INT()
+  CheckRunVimInTerminal
   if !HasSignal('INT')
     throw 'Skipped: INT signal not supported'
   endif
@@ -92,9 +93,6 @@ func Test_signal_INT()
     throw 'Skipped: cannot test signal INT with valgrind'
   endif
 
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
   let buf = RunVimInTerminal('', {'rows': 6})
   let pid_vim = term_getjob(buf)->job_info().process
 
@@ -121,9 +119,7 @@ func Test_deadly_signal_TERM()
   if !HasSignal('TERM')
     throw 'Skipped: TERM signal not supported'
   endif
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
   let cmd = GetVimCommand()
   if cmd =~ 'valgrind'
     throw 'Skipped: cannot test signal TERM with valgrind'

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -1741,9 +1741,7 @@ endfunc
 
 " Test for correct cursor position after the sign column appears or disappears.
 func Test_sign_cursor_position()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
 
   let lines =<< trim END
 	call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -809,9 +809,7 @@ func Test_issue_3969()
 endfunc
 
 func Test_start_with_tabs()
-  if !CanRunVimInTerminal()
-    return
-  endif
+  CheckRunVimInTerminal
 
   let buf = RunVimInTerminal('-p a b c', {})
   call VerifyScreenDump(buf, 'Test_start_with_tabs', {})
@@ -968,9 +966,7 @@ endfunc
 
 " Test for specifying a non-existing vimrc file using "-u"
 func Test_missing_vimrc()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
   let after =<< trim [CODE]
     call assert_match('^E282:', v:errmsg)
     call writefile(v:errors, 'Xtestout')

--- a/src/nvim/testdir/test_startup_utf8.vim
+++ b/src/nvim/testdir/test_startup_utf8.vim
@@ -63,9 +63,7 @@ func Test_read_fifo_utf8()
 endfunc
 
 func Test_detect_ambiwidth()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run Vim in a terminal window'
-  endif
+  CheckRunVimInTerminal
 
   " Use the title termcap entries to output the escape sequence.
   call writefile([

--- a/src/nvim/testdir/test_syntax.vim
+++ b/src/nvim/testdir/test_syntax.vim
@@ -631,9 +631,7 @@ endfunc
 
 " Check highlighting for a small piece of C code with a screen dump.
 func Test_syntax_c()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
   call writefile([
 	\ '/* comment line at the top */',
 	\ 'int main(int argc, char **argv) { // another comment',

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -591,9 +591,7 @@ func Test_tabs()
 endfunc
 
 func Test_tabpage_cmdheight()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot make screendumps'
-  endif
+  CheckRunVimInTerminal
   call writefile([
         \ 'set laststatus=2',
         \ 'set cmdheight=2',

--- a/src/nvim/testdir/test_timers.vim
+++ b/src/nvim/testdir/test_timers.vim
@@ -304,9 +304,7 @@ func Test_timer_ex_mode()
 endfunc
 
 func Test_timer_restore_count()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run Vim in a terminal window'
-  endif
+  CheckRunVimInTerminal
   " Check that v:count is saved and restored, not changed by a timer.
   call writefile([
         \ 'nnoremap <expr><silent> L v:count ? v:count . "l" : "l"',

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -1707,9 +1707,7 @@ endfunc
 
 " Test for deep nesting of if/for/while/try statements              {{{1
 func Test_deep_nest()
-  if !CanRunVimInTerminal()
-    throw 'Skipped: cannot run vim in terminal'
-  endif
+  CheckRunVimInTerminal
 
   let lines =<< trim [SCRIPT]
     " Deep nesting of if ... endif

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -501,10 +501,13 @@ func Test_win_screenpos()
   call assert_equal([1, 32], win_screenpos(2))
   call assert_equal([12, 1], win_screenpos(3))
   call assert_equal([0, 0], win_screenpos(4))
+  call assert_fails('let l = win_screenpos([])', 'E745:')
   only
 endfunc
 
 func Test_window_jump_tag()
+  CheckFeature quickfix
+
   help
   /iccf
   call assert_match('^|iccf|',  getline('.'))
@@ -734,6 +737,7 @@ func Test_relative_cursor_position_in_one_line_window()
 
   only!
   bwipe!
+  call assert_fails('call winrestview(v:_null_dict)', 'E474:')
 endfunc
 
 func Test_relative_cursor_position_after_move_and_resize()
@@ -910,6 +914,10 @@ func Test_winnr()
   call assert_fails("echo winnr('ll')", 'E15:')
   call assert_fails("echo winnr('5')", 'E15:')
   call assert_equal(4, winnr('0h'))
+  call assert_fails("let w = winnr([])", 'E730:')
+  call assert_equal('unknown', win_gettype(-1))
+  call assert_equal(-1, winheight(-1))
+  call assert_equal(-1, winwidth(-1))
 
   tabnew
   call assert_equal(8, tabpagewinnr(1, 'j'))
@@ -930,9 +938,12 @@ func Test_winrestview()
   call assert_equal(view, winsaveview())
 
   bwipe!
+  call assert_fails('call winrestview(v:_null_dict)', 'E474:')
 endfunc
 
 func Test_win_splitmove()
+  CheckFeature quickfix
+
   edit a
   leftabove split b
   leftabove vsplit c
@@ -958,6 +969,7 @@ func Test_win_splitmove()
   call assert_equal(bufname(winbufnr(2)), 'b')
   call assert_equal(bufname(winbufnr(3)), 'a')
   call assert_equal(bufname(winbufnr(4)), 'd')
+  call assert_fails('call win_splitmove(winnr(), winnr("k"), v:_null_dict)', 'E474:')
   only | bd
 
   call assert_fails('call win_splitmove(winnr(), 123)', 'E957:')

--- a/src/nvim/testdir/test_window_id.vim
+++ b/src/nvim/testdir/test_window_id.vim
@@ -1,5 +1,7 @@
 " Test using the window ID.
 
+source check.vim
+
 func Test_win_getid()
   edit one
   let id1 = win_getid()
@@ -90,10 +92,16 @@ func Test_win_getid()
   split
   call assert_equal(sort([id5, win_getid()]), sort(win_findbuf(bufnr5)))
 
+  call assert_fails('let w = win_getid([])', 'E745:')
+  call assert_equal(0, win_getid(-1))
+  call assert_equal(-1, win_getid(1, -1))
+
   only!
 endfunc
 
 func Test_win_getid_curtab()
+  CheckFeature quickfix
+
   tabedit X
   tabfirst
   copen
@@ -127,4 +135,8 @@ func Test_winlayout()
   let w2 = win_getid()
   call assert_equal(['leaf', w2], 2->winlayout())
   tabclose
+
+  call assert_equal([], winlayout(-1))
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -260,6 +260,13 @@ func Test_write_errors()
   close
 
   call delete('Xfile')
+
+  " Nvim treats NULL list/blob more like empty list/blob
+  " call writefile(v:_null_list, 'Xfile')
+  " call assert_false(filereadable('Xfile'))
+  " call writefile(v:_null_blob, 'Xfile')
+  " call assert_false(filereadable('Xfile'))
+  call assert_fails('call writefile([], "")', 'E482:')
 endfunc
 
 " Test for writing a file using invalid file encoding

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -267,6 +267,138 @@ func Test_write_errors()
   " call writefile(v:_null_blob, 'Xfile')
   " call assert_false(filereadable('Xfile'))
   call assert_fails('call writefile([], "")', 'E482:')
+
+  " very long file name
+  let long_fname = repeat('n', 5000)
+  call assert_fails('exe "w " .. long_fname', 'E75:')
+  call assert_fails('call writefile([], long_fname)', 'E482:')
+endfunc
+
+" Test for writing to a file which is modified after Vim read it
+func Test_write_file_mtime()
+  CheckEnglish
+  CheckRunVimInTerminal
+
+  " First read the file into a buffer
+  call writefile(["Line1", "Line2"], 'Xfile')
+  let old_ftime = getftime('Xfile')
+  let buf = RunVimInTerminal('Xfile', #{rows : 10})
+  call term_wait(buf)
+  call term_sendkeys(buf, ":set noswapfile\<CR>")
+  call term_wait(buf)
+
+  " Modify the file directly.  Make sure the file modification time is
+  " different. Note that on Linux/Unix, the file is considered modified
+  " outside, only if the difference is 2 seconds or more
+  sleep 1
+  call writefile(["Line3", "Line4"], 'Xfile')
+  let new_ftime = getftime('Xfile')
+  while new_ftime - old_ftime < 2
+    sleep 100m
+    call writefile(["Line3", "Line4"], 'Xfile')
+    let new_ftime = getftime('Xfile')
+  endwhile
+
+  " Try to overwrite the file and check for the prompt
+  call term_sendkeys(buf, ":w\<CR>")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_equal("WARNING: The file has been changed since reading it!!!", term_getline(buf, 9))})
+  call assert_equal("Do you really want to write to it (y/n)?",
+        \ term_getline(buf, 10))
+  call term_sendkeys(buf, "n\<CR>")
+  call term_wait(buf)
+  call assert_equal(new_ftime, getftime('Xfile'))
+  call term_sendkeys(buf, ":w\<CR>")
+  call term_wait(buf)
+  call term_sendkeys(buf, "y\<CR>")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_equal('Line2', readfile('Xfile')[1])})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xfile')
+endfunc
+
+" Test for an autocmd unloading a buffer during a write command
+func Test_write_autocmd_unloadbuf_lockmark()
+  augroup WriteTest
+    autocmd BufWritePre Xfile enew | write
+  augroup END
+  e Xfile
+  call assert_fails('lockmarks write', 'E203:')
+  augroup WriteTest
+    au!
+  augroup END
+  augroup! WriteTest
+endfunc
+
+" Test for writing a buffer with 'acwrite' but without autocmds
+func Test_write_acwrite_error()
+  new Xfile
+  call setline(1, ['line1', 'line2', 'line3'])
+  set buftype=acwrite
+  call assert_fails('write', 'E676:')
+  call assert_fails('1,2write!', 'E676:')
+  call assert_fails('w >>', 'E676:')
+  close!
+endfunc
+
+" Test for adding and removing lines from an autocmd when writing a buffer
+func Test_write_autocmd_add_remove_lines()
+  new Xfile
+  call setline(1, ['aaa', 'bbb', 'ccc', 'ddd'])
+
+  " Autocmd deleting lines from the file when writing a partial file
+  augroup WriteTest2
+    au!
+    autocmd FileWritePre Xfile 1,2d
+  augroup END
+  call assert_fails('2,3w!', 'E204:')
+
+  " Autocmd adding lines to a file when writing a partial file
+  augroup WriteTest2
+    au!
+    autocmd FileWritePre Xfile call append(0, ['xxx', 'yyy'])
+  augroup END
+  %d
+  call setline(1, ['aaa', 'bbb', 'ccc', 'ddd'])
+  1,2w!
+  call assert_equal(['xxx', 'yyy', 'aaa', 'bbb'], readfile('Xfile'))
+
+  " Autocmd deleting lines from the file when writing the whole file
+  augroup WriteTest2
+    au!
+    autocmd BufWritePre Xfile 1,2d
+  augroup END
+  %d
+  call setline(1, ['aaa', 'bbb', 'ccc', 'ddd'])
+  w
+  call assert_equal(['ccc', 'ddd'], readfile('Xfile'))
+
+  augroup WriteTest2
+    au!
+  augroup END
+  augroup! WriteTest2
+
+  close!
+  call delete('Xfile')
+endfunc
+
+" Test for writing to a readonly file
+func Test_write_readonly()
+  " In Cirrus-CI, the freebsd tests are run under a root account. So this test
+  " doesn't fail.
+  CheckNotBSD
+  call writefile([], 'Xfile')
+  call setfperm('Xfile', "r--------")
+  edit Xfile
+  set noreadonly
+  call assert_fails('write', 'E505:')
+  let save_cpo = &cpo
+  set cpo+=W
+  call assert_fails('write!', 'E504:')
+  let &cpo = save_cpo
+  call delete('Xfile')
 endfunc
 
 " Test for writing a file using invalid file encoding


### PR DESCRIPTION
#### vim-patch:8.2.0433: INT signal not properly tested

Problem:    INT signal not properly tested.
Solution:   Add a test.  Also clean up some unnecessary lines. (Dominique
            Pelle, closes vim/vim#5828)

https://github.com/vim/vim/commit/bad8804cdd739a5a7321b8411ad7fd4f45741b54


#### vim-patch:8.2.0644: insufficient testing for invalid function arguments

Problem:    Insufficient testing for invalid function arguments.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5988)

https://github.com/vim/vim/commit/99fa721944dda9d07c53c907c33466728df5c271

Omit test_listener.vim: changed again in patch 8.2.1183.
Omit test_textprop.vim: changed again in patch 8.2.1183.
Cherry-pick quickfix feature checks from patch 8.1.2373.
Omit Test_saveas() change: duplicate and removed in patch 8.2.0866.


#### vim-patch:8.2.0866: not enough tests for buffer writing

Problem:    Not enough tests for buffer writing.
Solution:   Add more tests. Use CheckRunVimInTerminal in more places.
            (Yegappan Lakshmanan, closes vim/vim#6167)

https://github.com/vim/vim/commit/494e9069cb32620f7688a7cb128a3feff827639e


#### vim-patch:8.2.0958: not sufficient testing for buffer writing

Problem:    Not sufficient testing for buffer writing.
Solution:   Add a few tests. (Yegappan Lakshmanan, closes vim/vim#6238)

https://github.com/vim/vim/commit/1de5f7c81d5e78fb4d612134bd2dfa6ee9183fae

Co-authored-by: Bram Moolenaar <Bram@vim.org>