### PR TITLE
vim-patch:8.2.{3252,3919,5027}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -654,9 +654,10 @@ appendbufline({buf}, {lnum}, {text})			*appendbufline()*
 
 		For the use of {buf}, see |bufname()|.
 
-		{lnum} is used like with |append()|.  Note that using |line()|
-		would use the current buffer, not the one appending to.
-		Use "$" to append at the end of the buffer.
+		{lnum} is the line number to append below.  Note that using
+		|line()| would use the current buffer, not the one appending
+		to.  Use "$" to append at the end of the buffer.  Other string
+		values are not supported.
 
 		On success 0 is returned, on failure 1 is returned.
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5200,6 +5200,7 @@ linenr_T tv_get_lnum_buf(const typval_T *const tv, const buf_T *const buf)
   if (tv->v_type == VAR_STRING
       && tv->vval.v_string != NULL
       && tv->vval.v_string[0] == '$'
+      && tv->vval.v_string[1] == NUL
       && buf != NULL) {
     return buf->b_ml.ml_line_count;
   }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -370,16 +370,22 @@ static void f_append(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   set_buffer_lines(curbuf, lnum, true, &argvars[1], rettv);
 }
 
-/// "appendbufline(buf, lnum, string/list)" function
-static void f_appendbufline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+/// Set or append lines to a buffer.
+static void buf_set_append_line(typval_T *argvars, typval_T *rettv, bool append)
 {
   buf_T *const buf = tv_get_buf(&argvars[0], false);
   if (buf == NULL) {
     rettv->vval.v_number = 1;  // FAIL
   } else {
     const linenr_T lnum = tv_get_lnum_buf(&argvars[1], buf);
-    set_buffer_lines(buf, lnum, true, &argvars[2], rettv);
+    set_buffer_lines(buf, lnum, append, &argvars[2], rettv);
   }
+}
+
+/// "appendbufline(buf, lnum, string/list)" function
+static void f_appendbufline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  buf_set_append_line(argvars, rettv, true);
 }
 
 /// "atan2()" function
@@ -7501,16 +7507,7 @@ static void f_serverstop(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "setbufline()" function
 static void f_setbufline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  linenr_T lnum;
-  buf_T *buf;
-
-  buf = tv_get_buf(&argvars[0], false);
-  if (buf == NULL) {
-    rettv->vval.v_number = 1;  // FAIL
-  } else {
-    lnum = tv_get_lnum_buf(&argvars[1], buf);
-    set_buffer_lines(buf, lnum, false, &argvars[2], rettv);
-  }
+  buf_set_append_line(argvars, rettv, false);
 }
 
 /// Set the cursor or mark position.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -726,7 +726,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
   if (cstack.cs_idx >= 0) {
     // If a sourced file or executed function ran to its end, report the
     // unclosed conditional.
-    if (!got_int && !did_throw
+    if (!got_int && !did_throw && !aborting()
         && ((getline_equal(fgetline, cookie, getsourceline)
              && !source_finished(fgetline, cookie))
             || (getline_equal(fgetline, cookie, get_func_line)

--- a/src/nvim/testdir/test_trycatch.vim
+++ b/src/nvim/testdir/test_trycatch.vim
@@ -2221,6 +2221,23 @@ func Test_user_command_throw_in_function_call()
   unlet g:caught
 endfunc
 
+" Test that after reporting an uncaught exception there is no error for a
+" missing :endif
+func Test_after_exception_no_endif_error()
+  function Throw()
+    throw "Failure"
+  endfunction
+
+  function Foo()
+    if 1
+      call Throw()
+    endif
+  endfunction
+  call assert_fails('call Foo()', ['E605:', 'E605:'])
+  delfunc Throw
+  delfunc Foo
+endfunc
+
 " Test for using throw in a called function with following endtry    {{{1
 func Test_user_command_function_call_with_endtry()
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:8.2.3252: duplicated code for adding buffer lines

Problem:    Duplicated code for adding buffer lines.
Solution:   Move code to a common function.  Also move map functions to map.c.
            (Yegappan Lakshmanan, closes vim/vim#8665)

https://github.com/vim/vim/commit/4a15504e911bc90a29d862862f0b7a46d8acd12a

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3919: Vim9: wrong argument for append() results in two errors

Problem:    Vim9: wrong argument for append() results in two errors.
Solution:   Check did_emsg.  Also for setline().  Adjust the help for
            appendbufline().

https://github.com/vim/vim/commit/8b6256f6ec075cca40341e61ebc9f538b4902dd1

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.5027: error for missing :endif when an exception was thrown

Problem:    Error for missing :endif when an exception was thrown. (Dani
            Dickstein)
Solution:   Do not give an error when aborting.

https://github.com/vim/vim/commit/bf79a4e48d09a5ae08645592885d54230fed30b8

Co-authored-by: Bram Moolenaar <Bram@vim.org>

Close #20878