### PR TITLE
vim-patch:8.2.{3665,3705,3712,3725},9.0.{0246,0389}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -320,7 +320,15 @@ or a function reference or a lambda function.  Examples:
 	set opfunc=MyOpFunc
 	set opfunc=function('MyOpFunc')
 	set opfunc=funcref('MyOpFunc')
-	let &opfunc = "{t -> MyOpFunc(t)}"
+	set opfunc={a\ ->\ MyOpFunc(a)}
+	" set using a funcref variable
+	let Fn = function('MyTagFunc')
+	let &tagfunc = string(Fn)
+	" set using a lambda expression
+	let &tagfunc = "{t -> MyTagFunc(t)}"
+	" set using a variable with lambda expression
+	let L = {a, b, c -> MyTagFunc(a, b , c)}
+	let &tagfunc = string(L)
 <
 
 Setting the filetype

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -314,8 +314,8 @@ Note: In the future more global options can be made |global-local|.  Using
 
 						*option-value-function*
 Some options ('completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
-'operatorfunc', 'quickfixtextfunc' and 'tagfunc') are set to a function name
-or a function reference or a lambda function.  Examples:
+'operatorfunc', 'quickfixtextfunc', 'tagfunc' and 'thesaurusfunc') are set to
+a function name or a function reference or a lambda function.  Examples:
 >
 	set opfunc=MyOpFunc
 	set opfunc=function('MyOpFunc')
@@ -1454,7 +1454,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option specifies a function to be used for Insert mode completion
 	with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
 	See |complete-functions| for an explanation of how the function is
-	invoked and what it should return.
+	invoked and what it should return.  The value can be the name of a
+	function, a |lambda| or a |Funcref|. See |option-value-function| for
+	more information.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
@@ -4421,7 +4423,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option specifies a function to be used for Insert mode omni
 	completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
 	See |complete-functions| for an explanation of how the function is
-	invoked and what it should return.
+	invoked and what it should return.  The value can be the name of a
+	function, a |lambda| or a |Funcref|. See |option-value-function| for
+	more information.
 	This option is usually set by a filetype plugin:
 	|:filetype-plugin-on|
 	This option cannot be set from a |modeline| or in the |sandbox|, for
@@ -6576,6 +6580,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global or local to buffer |global-local|
 	This option specifies a function to be used for thesaurus completion
 	with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
+	The value can be the name of a function, a |lambda| or a |Funcref|.
+	See |option-value-function| for more information.
 
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -318,9 +318,9 @@ Some options ('completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
 or a function reference or a lambda function.  Examples:
 >
 	set opfunc=MyOpFunc
-	set opfunc=function("MyOpFunc")
-	set opfunc=funcref("MyOpFunc")
-	set opfunc={t\ ->\ MyOpFunc(t)}
+	set opfunc=function('MyOpFunc')
+	set opfunc=funcref('MyOpFunc')
+	let &opfunc = "{t -> MyOpFunc(t)}"
 <
 
 Setting the filetype
@@ -6443,7 +6443,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option specifies a function to be used to perform tag searches.
 	The function gets the tag pattern and should return a List of matching
 	tags.  See |tag-function| for an explanation of how to write the
-	function and an example.
+	function and an example.  The value can be the name of a function, a
+	|lambda| or a |Funcref|. See |option-value-function| for more
+	information.
 
 						*'taglength'* *'tl'*
 'taglength' 'tl'	number	(default 0)

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -909,6 +909,8 @@ If the function returns |v:null| instead of a List, a standard tag lookup will
 be performed instead.
 
 It is not allowed to change the tagstack from inside 'tagfunc'.  *E986* 
+It is not allowed to close a window or change window from inside 'tagfunc'.
+*E1299*
 
 The following is a hypothetical example of a function used for 'tagfunc'.  It
 uses the output of |taglist()| to generate the result: a list of tags in the

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1971,8 +1971,11 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_cinw);
   clear_string_option(&buf->b_p_cpt);
   clear_string_option(&buf->b_p_cfu);
+  callback_free(&buf->b_cfu_cb);
   clear_string_option(&buf->b_p_ofu);
+  callback_free(&buf->b_ofu_cb);
   clear_string_option(&buf->b_p_tsrfu);
+  callback_free(&buf->b_tsrfu_cb);
   clear_string_option(&buf->b_p_gp);
   clear_string_option(&buf->b_p_mp);
   clear_string_option(&buf->b_p_efm);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1981,6 +1981,7 @@ void free_buf_options(buf_T *buf, int free_p_ff)
   clear_string_option(&buf->b_p_tags);
   clear_string_option(&buf->b_p_tc);
   clear_string_option(&buf->b_p_tfu);
+  callback_free(&buf->b_tfu_cb);
   clear_string_option(&buf->b_p_dict);
   clear_string_option(&buf->b_p_tsr);
   clear_string_option(&buf->b_p_qe);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -675,7 +675,9 @@ struct file_buffer {
   char *b_p_csl;                ///< 'completeslash'
 #endif
   char *b_p_cfu;                ///< 'completefunc'
+  Callback b_cfu_cb;            ///< 'completefunc' callback
   char *b_p_ofu;                ///< 'omnifunc'
+  Callback b_ofu_cb;            ///< 'omnifunc' callback
   char *b_p_tfu;                ///< 'tagfunc'
   Callback b_tfu_cb;            ///< 'tagfunc' callback
   int b_p_eof;                  ///< 'endoffile'
@@ -749,6 +751,7 @@ struct file_buffer {
   char *b_p_dict;               ///< 'dictionary' local value
   char *b_p_tsr;                ///< 'thesaurus' local value
   char *b_p_tsrfu;              ///< 'thesaurusfunc' local value
+  Callback b_tsrfu_cb;          ///< 'thesaurusfunc' callback
   long b_p_ul;                  ///< 'undolevels' local value
   int b_p_udf;                  ///< 'undofile'
   char *b_p_lw;                 ///< 'lispwords' local value

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -677,6 +677,7 @@ struct file_buffer {
   char *b_p_cfu;                ///< 'completefunc'
   char *b_p_ofu;                ///< 'omnifunc'
   char *b_p_tfu;                ///< 'tagfunc'
+  Callback b_tfu_cb;            ///< 'tagfunc' callback
   int b_p_eof;                  ///< 'endoffile'
   int b_p_eol;                  ///< 'endofline'
   int b_p_fixeol;               ///< 'fixendofline'

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1110,25 +1110,7 @@ fail:
 
   return ret;
 }
-/// Call Vim script function and return the result as a number
-///
-/// @param[in]  func  Function name.
-/// @param[in]  argc  Number of arguments.
-/// @param[in]  argv  Array with typval_T arguments.
-///
-/// @return -1 when calling function fails, result of function otherwise.
-varnumber_T call_func_retnr(const char *func, int argc, typval_T *argv)
-  FUNC_ATTR_NONNULL_ALL
-{
-  typval_T rettv;
 
-  if (call_vim_function((char *)func, argc, argv, &rettv) == FAIL) {
-    return -1;
-  }
-  varnumber_T retval = tv_get_number_chk(&rettv, NULL);
-  tv_clear(&rettv);
-  return retval;
-}
 /// Call Vim script function and return the result as a string
 ///
 /// @param[in]  func  Function name.
@@ -1151,6 +1133,7 @@ char *call_func_retstr(const char *const func, int argc, typval_T *argv)
   tv_clear(&rettv);
   return retval;
 }
+
 /// Call Vim script function and return the result as a List
 ///
 /// @param[in]  func  Function name.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5029,9 +5029,8 @@ void common_function(typval_T *argvars, typval_T *rettv, bool is_funcref)
 
   if ((use_string && vim_strchr(s, AUTOLOAD_CHAR) == NULL) || is_funcref) {
     name = s;
-    trans_name = (char *)trans_function_name(&name, false,
-                                             TFN_INT | TFN_QUIET | TFN_NO_AUTOLOAD
-                                             | TFN_NO_DEREF, NULL, NULL);
+    trans_name = save_function_name(&name, false,
+                                    TFN_INT | TFN_QUIET | TFN_NO_AUTOLOAD | TFN_NO_DEREF, NULL);
     if (*name != NUL) {
       s = NULL;
     }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1886,6 +1886,27 @@ theend:
   return (char_u *)name;
 }
 
+/// Call trans_function_name(), except that a lambda is returned as-is.
+/// Returns the name in allocated memory.
+char *save_function_name(char **name, bool skip, int flags, funcdict_T *fudi)
+{
+  char *p = *name;
+  char *saved;
+
+  if (strncmp(p, "<lambda>", 8) == 0) {
+    p += 8;
+    (void)getdigits(&p, false, 0);
+    saved = xstrndup(*name, (size_t)(p - *name));
+    if (fudi != NULL) {
+      CLEAR_POINTER(fudi);
+    }
+  } else {
+    saved = (char *)trans_function_name(&p, skip, flags, fudi, NULL);
+  }
+  *name = p;
+  return saved;
+}
+
 #define MAX_FUNC_NESTING 50
 
 /// List functions.
@@ -2000,14 +2021,7 @@ void ex_function(exarg_T *eap)
   // s:func      script-local function name
   // g:func      global function name, same as "func"
   p = eap->arg;
-  if (strncmp(p, "<lambda>", 8) == 0) {
-    p += 8;
-    (void)getdigits(&p, false, 0);
-    name = xstrndup(eap->arg, (size_t)(p - eap->arg));
-    CLEAR_FIELD(fudi);
-  } else {
-    name = (char *)trans_function_name(&p, eap->skip, TFN_NO_AUTOLOAD, &fudi, NULL);
-  }
+  name = save_function_name(&p, eap->skip, TFN_NO_AUTOLOAD, &fudi);
   paren = (vim_strchr(p, '(') != NULL);
   if (name == NULL && (fudi.fd_dict == NULL || !paren) && !eap->skip) {
     // Return on an invalid expression in braces, unless the expression

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1393,6 +1393,24 @@ func_call_skip_call:
   return r;
 }
 
+/// call the 'callback' function and return the result as a number.
+/// Returns -1 when calling the function fails.  Uses argv[0] to argv[argc - 1]
+/// for the function arguments. argv[argc] should have type VAR_UNKNOWN.
+///
+/// @param argcount  number of "argvars"
+/// @param argvars   vars for arguments, must have "argcount" PLUS ONE elements!
+varnumber_T callback_call_retnr(Callback *callback, int argcount, typval_T *argvars)
+{
+  typval_T rettv;
+  if (!callback_call(callback, argcount, argvars, &rettv)) {
+    return -1;
+  }
+
+  varnumber_T retval = tv_get_number_chk(&rettv, NULL);
+  tv_clear(&rettv);
+  return retval;
+}
+
 /// Give an error message for the result of a function.
 /// Nothing if "error" is FCERR_NONE.
 static void user_func_error(int error, const char_u *name)

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2239,10 +2239,10 @@ static char_u *get_complete_funcname(int type)
   }
 }
 
-/// Execute user defined complete function 'completefunc' or 'omnifunc', and
-/// get matches in "matches".
+/// Execute user defined complete function 'completefunc', 'omnifunc' or
+/// 'thesaurusfunc', and get matches in "matches".
 ///
-/// @param type  CTRL_X_OMNI or CTRL_X_FUNCTION
+/// @param type  either CTRL_X_OMNI or CTRL_X_FUNCTION or CTRL_X_THESAURUS
 static void expand_by_function(int type, char_u *base)
 {
   list_T *matchlist = NULL;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -51,6 +51,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
+#include "nvim/insexpand.h"
 #include "nvim/keycodes.h"
 #include "nvim/locale.h"
 #include "nvim/macros.h"
@@ -4381,11 +4382,13 @@ void buf_copy_options(buf_T *buf, int flags)
 #endif
       buf->b_p_cfu = xstrdup(p_cfu);
       COPY_OPT_SCTX(buf, BV_CFU);
+      set_buflocal_cfu_callback(buf);
       buf->b_p_ofu = xstrdup(p_ofu);
       COPY_OPT_SCTX(buf, BV_OFU);
+      set_buflocal_ofu_callback(buf);
       buf->b_p_tfu = xstrdup(p_tfu);
       COPY_OPT_SCTX(buf, BV_TFU);
-      buf_set_tfu_callback(buf);
+      set_buflocal_tfu_callback(buf);
       buf->b_p_sts = p_sts;
       COPY_OPT_SCTX(buf, BV_STS);
       buf->b_p_sts_nopaste = p_sts_nopaste;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -78,6 +78,7 @@
 #include "nvim/spellsuggest.h"
 #include "nvim/strings.h"
 #include "nvim/syntax.h"
+#include "nvim/tag.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
 #include "nvim/undo.h"
@@ -577,6 +578,7 @@ void free_all_options(void)
     }
   }
   free_operatorfunc_option();
+  free_tagfunc_option();
 }
 #endif
 
@@ -4383,6 +4385,7 @@ void buf_copy_options(buf_T *buf, int flags)
       COPY_OPT_SCTX(buf, BV_OFU);
       buf->b_p_tfu = xstrdup(p_tfu);
       COPY_OPT_SCTX(buf, BV_TFU);
+      buf_set_tfu_callback(buf);
       buf->b_p_sts = p_sts;
       COPY_OPT_SCTX(buf, BV_STS);
       buf->b_p_sts_nopaste = p_sts_nopaste;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -38,6 +38,7 @@
 #include "nvim/spellfile.h"
 #include "nvim/spellsuggest.h"
 #include "nvim/strings.h"
+#include "nvim/tag.h"
 #include "nvim/ui.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"
@@ -1478,6 +1479,10 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
   } else if (varp == &p_qftf) {  // 'quickfixtextfunc'
     if (qf_process_qftf_option() == FAIL) {
+      errmsg = e_invarg;
+    }
+  } else if (gvarp == &p_tfu) {  // 'tagfunc'
+    if (set_tagfunc_option() == FAIL) {
       errmsg = e_invarg;
     }
   } else {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1473,6 +1473,18 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
         }
       }
     }
+  } else if (gvarp == &p_cfu) {  // 'completefunc'
+    if (set_completefunc_option() == FAIL) {
+      errmsg = e_invarg;
+    }
+  } else if (gvarp == &p_ofu) {  // 'omnifunc'
+    if (set_omnifunc_option() == FAIL) {
+      errmsg = e_invarg;
+    }
+  } else if (gvarp == &p_tsrfu) {  // 'thesaurusfunc'
+    if (set_thesaurusfunc_option() == FAIL) {
+      errmsg = e_invarg;
+    }
   } else if (varp == &p_opfunc) {  // 'operatorfunc'
     if (set_operatorfunc_option() == FAIL) {
       errmsg = e_invarg;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -106,6 +106,8 @@ static char_u *recurmsg
   = (char_u *)N_("E986: cannot modify the tag stack within tagfunc");
 static char_u *tfu_inv_ret_msg
   = (char_u *)N_("E987: invalid return value from tagfunc");
+static char e_window_unexpectedly_close_while_searching_for_tags[]
+  = N_("E1299: Window unexpectedly closed while searching for tags");
 
 static char *tagmatchname = NULL;   // name of last used tag
 
@@ -499,6 +501,15 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
           && new_num_matches < max_num_matches) {
         max_num_matches = MAXCOL;  // If less than max_num_matches
                                    // found: all matches found.
+      }
+
+      // A tag function may do anything, which may cause various
+      // information to become invalid.  At least check for the tagstack
+      // to still be the same.
+      if (tagstack != curwin->w_tagstack) {
+        emsg(_(e_window_unexpectedly_close_while_searching_for_tags));
+        FreeWild(new_num_matches, new_matches);
+        break;
       }
 
       // If there already were some matches for the same name, move them

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -199,6 +199,7 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
   int skip_msg = false;
   char_u *buf_ffname = (char_u *)curbuf->b_ffname;  // name for priority computation
   int use_tfu = 1;
+  char *tofree = NULL;
 
   // remember the matches for the last used tag
   static int num_matches = 0;
@@ -450,7 +451,10 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
 
     // When desired match not found yet, try to find it (and others).
     if (use_tagstack) {
-      name = tagstack[tagstackidx].tagname;
+      // make a copy, the tagstack may change in 'tagfunc'
+      name = xstrdup(tagstack[tagstackidx].tagname);
+      xfree(tofree);
+      tofree = name;
     } else if (g_do_tagpreview != 0) {
       name = ptag_entry.tagname;
     } else {
@@ -681,6 +685,7 @@ end_do_tag:
   }
   postponed_split = 0;          // don't split next time
   g_do_tagpreview = 0;          // don't do tag preview next time
+  xfree(tofree);
 }
 
 // List all the matching tags.

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -149,7 +149,7 @@ void free_tagfunc_option(void)
 
 /// Copy the global 'tagfunc' callback function to the buffer-local 'tagfunc'
 /// callback for 'buf'.
-void buf_set_tfu_callback(buf_T *buf)
+void set_buflocal_tfu_callback(buf_T *buf)
 {
   callback_free(&buf->b_tfu_cb);
   if (tfu_cb.data.funcref != NULL && *tfu_cb.data.funcref != NUL) {

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -496,6 +496,13 @@ func Test_function_with_funcref()
   call assert_fails("call function('foo()')", 'E475:')
   call assert_fails("call function('foo()')", 'foo()')
   call assert_fails("function('')", 'E129:')
+
+  let Len = {s -> strlen(s)}
+  call assert_equal(6, Len('foobar'))
+  let name = string(Len)
+  " can evaluate "function('<lambda>99')"
+  call execute('let Ref = ' .. name)
+  call assert_equal(4, Ref('text'))
 endfunc
 
 func Test_funcref()

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -117,4 +117,54 @@ func Test_tagfunc_settagstack()
   delfunc Mytagfunc2
 endfunc
 
+" Test for different ways of setting the 'tagfunc' option
+func Test_tagfunc_callback()
+  " Test for using a function()
+  func MytagFunc1(pat, flags, info)
+    let g:MytagFunc1_args = [a:pat, a:flags, a:info]
+    return v:null
+  endfunc
+  let g:MytagFunc1_args = []
+  set tagfunc=function('MytagFunc1')
+  call assert_fails('tag abc', 'E433:')
+  call assert_equal(['abc', '', {}], g:MytagFunc1_args)
+
+  " Test for using a funcref()
+  new
+  func MytagFunc2(pat, flags, info)
+    let g:MytagFunc2_args = [a:pat, a:flags, a:info]
+    return v:null
+  endfunc
+  let g:MytagFunc2_args = []
+  set tagfunc=funcref('MytagFunc2')
+  call assert_fails('tag def', 'E433:')
+  call assert_equal(['def', '', {}], g:MytagFunc2_args)
+
+  " Test for using a lambda function
+  new
+  func MytagFunc3(pat, flags, info)
+    let g:MytagFunc3_args = [a:pat, a:flags, a:info]
+    return v:null
+  endfunc
+  let g:MytagFunc3_args = []
+  let &tagfunc= '{a, b, c -> MytagFunc3(a, b, c)}'
+  call assert_fails('tag ghi', 'E433:')
+  call assert_equal(['ghi', '', {}], g:MytagFunc3_args)
+
+  " Test for clearing the 'tagfunc' option
+  set tagfunc=''
+  set tagfunc&
+
+  call assert_fails("set tagfunc=function('abc')", "E700:")
+  call assert_fails("set tagfunc=funcref('abc')", "E700:")
+  let &tagfunc = "{a -> 'abc'}"
+  call assert_fails("echo taglist('a')", "E987:")
+
+  " cleanup
+  delfunc MytagFunc1
+  delfunc MytagFunc2
+  delfunc MytagFunc3
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -285,4 +285,17 @@ func Test_tagfunc_wipes_buffer()
   set tagfunc=
 endfunc
 
+func Test_tagfunc_closes_window()
+  split any
+  func MytagfuncClose(pat, flags, info)
+    close
+    return [{'name' : 'mytag', 'filename' : 'Xtest', 'cmd' : '1'}]
+  endfunc
+  set tagfunc=MytagfuncClose
+  call assert_fails('tag xyz', 'E1299:')
+
+  set tagfunc=
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -273,4 +273,16 @@ func Test_tagfunc_callback()
   %bw!
 endfunc
 
+func Test_tagfunc_wipes_buffer()
+  func g:Tag0unc0(t,f,o)
+   bwipe
+  endfunc
+  set tagfunc=g:Tag0unc0
+  new
+  cal assert_fails('tag 0', 'E987:')
+
+  delfunc g:Tag0unc0
+  set tagfunc=
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -117,6 +117,12 @@ func Test_tagfunc_settagstack()
   delfunc Mytagfunc2
 endfunc
 
+" Script local tagfunc callback function
+func s:ScriptLocalTagFunc(pat, flags, info)
+  let g:ScriptLocalFuncArgs = [a:pat, a:flags, a:info]
+  return v:null
+endfunc
+
 " Test for different ways of setting the 'tagfunc' option
 func Test_tagfunc_callback()
   " Test for using a function()
@@ -159,6 +165,21 @@ func Test_tagfunc_callback()
   call assert_equal(['a14', '', {}], g:MytagFunc2_args)
   call assert_fails('let &tagfunc = Fn', 'E729:')
 
+  " Test for using a script local function
+  set tagfunc=<SID>ScriptLocalTagFunc
+  new | only
+  let g:ScriptLocalFuncArgs = []
+  call assert_fails('tag a15', 'E433:')
+  call assert_equal(['a15', '', {}], g:ScriptLocalFuncArgs)
+
+  " Test for using a script local funcref variable
+  let Fn = function("s:ScriptLocalTagFunc")
+  let &tagfunc= string(Fn)
+  new | only
+  let g:ScriptLocalFuncArgs = []
+  call assert_fails('tag a16', 'E433:')
+  call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
+
   " Test for using a lambda function
   func MytagFunc3(pat, flags, info)
     let g:MytagFunc3_args = [a:pat, a:flags, a:info]
@@ -167,30 +188,30 @@ func Test_tagfunc_callback()
   set tagfunc={a,\ b,\ c\ ->\ MytagFunc3(a,\ b,\ c)}
   new | only
   let g:MytagFunc3_args = []
-  call assert_fails('tag a15', 'E433:')
-  call assert_equal(['a15', '', {}], g:MytagFunc3_args)
+  call assert_fails('tag a17', 'E433:')
+  call assert_equal(['a17', '', {}], g:MytagFunc3_args)
 
   " Set 'tagfunc' to a lambda expression
   let &tagfunc = '{a, b, c -> MytagFunc3(a, b, c)}'
   new | only
   let g:MytagFunc3_args = []
-  call assert_fails('tag a16', 'E433:')
-  call assert_equal(['a16', '', {}], g:MytagFunc3_args)
+  call assert_fails('tag a18', 'E433:')
+  call assert_equal(['a18', '', {}], g:MytagFunc3_args)
 
   " Set 'tagfunc' to a variable with a lambda expression
   let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
   let &tagfunc = string(Lambda)
   new | only
   let g:MytagFunc3_args = []
-  call assert_fails("tag a17", "E433:")
-  call assert_equal(['a17', '', {}], g:MytagFunc3_args)
+  call assert_fails("tag a19", "E433:")
+  call assert_equal(['a19', '', {}], g:MytagFunc3_args)
   call assert_fails('let &tagfunc = Lambda', 'E729:')
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
   let &tagfunc = string(Lambda)
   new | only
-  call assert_fails("tag a17", "E987:")
+  call assert_fails("tag a20", "E987:")
 
   " Test for clearing the 'tagfunc' option
   set tagfunc=''


### PR DESCRIPTION
#### vim-patch:8.2.3665: cannot use a lambda for 'tagfunc'

Problem:    Cannot use a lambda for 'tagfunc'.
Solution:   Use 'tagfunc' like 'opfunc'. (Yegappan Lakshmanan, closes vim/vim#9204)
https://github.com/vim/vim/commit/19916a8c8920b6a1fd737ffa6d4e363fc7a96319

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3705: cannot pass a lambda name to function() or funcref()

Problem:    Cannot pass a lambda name to function() or funcref(). (Yegappan
            Lakshmanan)
Solution:   Handle a lambda name differently.

https://github.com/vim/vim/commit/eba3b7f6645c8f856132b4c06a009a3b0a44e21c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3712: cannot use Vim9 lambda for 'tagfunc'

Problem:    Cannot use Vim9 lambda for 'tagfunc'.
Solution:   Make it work, add more tests. (Yegappan Lakshmanan, closes vim/vim#9250)
https://github.com/vim/vim/commit/05e59e3a9ffddbf93c7af02cd2ba1d0f822d4625

Omit Vim9 script in code and comment out in tests.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3725: cannot use a lambda for 'completefunc' and 'omnifunc'

Problem:    Cannot use a lambda for 'completefunc' and 'omnifunc'.
Solution:   Implement lambda support. (Yegappan Lakshmanan, closes vim/vim#9257)
https://github.com/vim/vim/commit/8658c759f05b317707d56e3b65a5ef63930c7498

Comment out Vim9 script in tests.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0246: using freed memory when 'tagfunc' deletes the buffer

Problem:    Using freed memory when 'tagfunc' deletes the buffer.
Solution:   Make a copy of the tag name.

https://github.com/vim/vim/commit/adce965162dd89bf29ee0e5baf53652e7515762c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0389: crash when 'tagfunc' closes the window

Problem:    Crash when 'tagfunc' closes the window.
Solution:   Bail out when the window was closed.

https://github.com/vim/vim/commit/ccfde4d028e891a41e3548323c3d47b06fb0b83e

Add docs for E1299 from Vim runtime.

Co-authored-by: Bram Moolenaar <Bram@vim.org>