### PR TITLE
vim-patch:8.2.3713: MS-Windows: no error if vimgrep pattern is not matching

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -5325,10 +5325,8 @@ static int vgr_process_args(exarg_T *eap, vgr_args_T *args)
   }
 
   // Parse the list of arguments, wildcards have already been expanded.
-  if (get_arglist_exp(p, &args->fcount, &args->fnames, true) == FAIL) {
-    return FAIL;
-  }
-  if (args->fcount == 0) {
+  if (get_arglist_exp(p, &args->fcount, &args->fnames, true) == FAIL
+      || args->fcount == 0) {
     emsg(_(e_nomatch));
     return FAIL;
   }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -5801,6 +5801,21 @@ func Test_win_gettype()
   lclose
 endfunc
 
+fun Test_vimgrep_nomatch()
+  call XexprTests('c')
+  call g:Xsetlist([{'lnum':10,'text':'Line1'}])
+  copen
+  if has("win32")
+    call assert_fails('vimgrep foo *.zzz', 'E479:')
+    let expected = [{'lnum': 10, 'bufnr': 0, 'end_lnum': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': 0, 'module': '', 'type': '', 'end_col': 0, 'col': 0, 'text': 'Line1'}]
+  else
+    call assert_fails('vimgrep foo *.zzz', 'E480:')
+    let expected = []
+  endif
+  call assert_equal(expected, getqflist())
+  cclose
+endfunc
+
 " Test for opening the quickfix window in two tab pages and then closing one
 " of the quickfix windows. This should not make the quickfix buffer unlisted.
 " (github issue #9300).


### PR DESCRIPTION
#### vim-patch:8.2.3713: MS-Windows: no error if vimgrep pattern is not matching

Problem:    MS-Windows: No error message if vimgrep pattern is not matching.
Solution:   Give an error message. (Christian Brabandt, closes vim/vim#9245)

https://github.com/vim/vim/commit/0b226f60be5c30c32fb01fc0b6dc11286e7e2313

Co-authored-by: Christian Brabandt <cb@256bit.org>