### PR TITLE
vim-patch:9.0.0835: the window title is not redrawn when 'endoffile' changes

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1975,14 +1975,12 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
   } else if ((int *)varp == &curbuf->b_p_ma) {
     // when 'modifiable' is changed, redraw the window title
     redraw_titles();
-  } else if ((int *)varp == &curbuf->b_p_eol) {
-    // when 'endofline' is changed, redraw the window title
-    redraw_titles();
-  } else if ((int *)varp == &curbuf->b_p_fixeol) {
-    // when 'fixeol' is changed, redraw the window title
-    redraw_titles();
-  } else if ((int *)varp == &curbuf->b_p_bomb) {
-    // when 'bomb' is changed, redraw the window title and tab page text
+  } else if ((int *)varp == &curbuf->b_p_eof
+             || (int *)varp == &curbuf->b_p_eol
+             || (int *)varp == &curbuf->b_p_fixeol
+             || (int *)varp == &curbuf->b_p_bomb) {
+    // redraw the window title and tab page text when 'endoffile', 'endofline',
+    // 'fixeol' or 'bomb' is changed
     redraw_titles();
   } else if ((int *)varp == &curbuf->b_p_bin) {
     // when 'bin' is set also set some other options


### PR DESCRIPTION
#### vim-patch:9.0.0835: the window title is not redrawn when 'endoffile' changes

Problem:    The window title is not redrawn when 'endoffile' changes.
Solution:   redraw the window title when 'endoffile' is changed. (Ken Takata,
            closes vim/vim#11488)

https://github.com/vim/vim/commit/845bbb72ed2da4b5fb2a503d91cfd6435df2f584

Co-authored-by: K.Takata <kentkt@csc.jp>