### PR TITLE
vim-patch:9.0.0265: no good reason why the "gf" command isn't in the tiny version

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4702,8 +4702,7 @@ void set_context_in_set_cmd(expand_T *xp, char_u *arg, int opt_flags)
         || p == (char_u *)&p_cdpath
         || p == (char_u *)&p_vdir) {
       xp->xp_context = EXPAND_DIRECTORIES;
-      if (p == (char_u *)&p_path
-          || p == (char_u *)&p_cdpath) {
+      if (p == (char_u *)&p_path || p == (char_u *)&p_cdpath) {
         xp->xp_backslash = XP_BS_THREE;
       } else {
         xp->xp_backslash = XP_BS_ONE;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -895,7 +895,6 @@ endfunc
 
 " Test for the default CDPATH option
 func Test_opt_default_cdpath()
-  CheckFeature file_in_path
   let after =<< trim [CODE]
     call assert_equal(',/path/to/dir1,/path/to/dir2', &cdpath)
     call writefile(v:errors, 'Xtestout')

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -585,6 +585,7 @@ wingotofile:
       cmdmod.cmod_tab = tabpage_index(curtab) + 1;
       nchar = xchar;
       goto wingotofile;
+
     case 't':                       // CTRL-W gt: go to next tab page
       goto_tabpage((int)Prenum);
       break;


### PR DESCRIPTION
#### vim-patch:9.0.0265: no good reason why the "gf" command isn't in the tiny version

Problem:    No good reason why the "gf" command is not in the tiny version.
Solution:   Graduate the file_in_path feature.

https://github.com/vim/vim/commit/f80f40a55ccff0a4331c5fbd1ac446511f622ed0

Co-authored-by: Bram Moolenaar <Bram@vim.org>