### PR TITLE
vim-patch:8.2.1340: some tests fail on Cirrus CI and/or with FreeBSD

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -3079,32 +3079,37 @@ shada_write_file_nomerge: {}
     sd_reader.close(&sd_reader);
     bool did_remove = false;
     if (sw_ret == kSDWriteSuccessful) {
-#ifdef UNIX
-      // For Unix we check the owner of the file.  It's not very nice to
-      // overwrite a user’s viminfo file after a "su root", with a
-      // viminfo file that the user can't read.
       FileInfo old_info;
-      if (os_fileinfo(fname, &old_info)) {
-        if (getuid() == ROOT_UID) {
-          if (old_info.stat.st_uid != ROOT_UID
-              || old_info.stat.st_gid != getgid()) {
-            const uv_uid_t old_uid = (uv_uid_t)old_info.stat.st_uid;
-            const uv_gid_t old_gid = (uv_gid_t)old_info.stat.st_gid;
-            const int fchown_ret = os_fchown(file_fd(sd_writer.cookie),
-                                             old_uid, old_gid);
-            if (fchown_ret != 0) {
-              semsg(_(RNERR "Failed setting uid and gid for file %s: %s"),
-                    tempname, os_strerror(fchown_ret));
-              goto shada_write_file_did_not_remove;
-            }
+      if (!os_fileinfo(fname, &old_info)
+          || S_ISDIR(old_info.stat.st_mode)
+#ifdef UNIX
+          // For Unix we check the owner of the file.  It's not very nice
+          // to overwrite a user's viminfo file after a "su root", with a
+          // viminfo file that the user can't read.
+          || (getuid() != ROOT_UID
+              && !(old_info.stat.st_uid == getuid()
+                   ? (old_info.stat.st_mode & 0200)
+                   : (old_info.stat.st_gid == getgid()
+                      ? (old_info.stat.st_mode & 0020)
+                      : (old_info.stat.st_mode & 0002))))
+#endif
+          ) {
+        semsg(_("E137: ShaDa file is not writable: %s"), fname);
+        goto shada_write_file_did_not_remove;
+      }
+#ifdef UNIX
+      if (getuid() == ROOT_UID) {
+        if (old_info.stat.st_uid != ROOT_UID
+            || old_info.stat.st_gid != getgid()) {
+          const uv_uid_t old_uid = (uv_uid_t)old_info.stat.st_uid;
+          const uv_gid_t old_gid = (uv_gid_t)old_info.stat.st_gid;
+          const int fchown_ret = os_fchown(file_fd(sd_writer.cookie),
+                                           old_uid, old_gid);
+          if (fchown_ret != 0) {
+            semsg(_(RNERR "Failed setting uid and gid for file %s: %s"),
+                  tempname, os_strerror(fchown_ret));
+            goto shada_write_file_did_not_remove;
           }
-        } else if (!(old_info.stat.st_uid == getuid()
-                     ? (old_info.stat.st_mode & 0200)
-                     : (old_info.stat.st_gid == getgid()
-                        ? (old_info.stat.st_mode & 0020)
-                        : (old_info.stat.st_mode & 0002)))) {
-          semsg(_("E137: ShaDa file is not writable: %s"), fname);
-          goto shada_write_file_did_not_remove;
         }
       }
 #endif
@@ -3125,9 +3130,7 @@ shada_write_file_nomerge: {}
       }
     }
     if (!did_remove) {
-#ifdef UNIX
 shada_write_file_did_not_remove:
-#endif
       semsg(_(RNERR "Do not forget to remove %s or rename it manually to %s."),
             tempname, fname);
     }

--- a/src/nvim/testdir/test_backup.vim
+++ b/src/nvim/testdir/test_backup.vim
@@ -19,6 +19,22 @@ func Test_backup()
   call delete('Xbackup.txt~')
 endfunc
 
+func Test_backup_backupskip()
+  set backup backupdir=. backupskip=*.txt
+  new
+  call setline(1, ['line1', 'line2'])
+  :f Xbackup.txt
+  :w! Xbackup.txt
+  " backup file is only created after
+  " writing a second time (before overwriting)
+  :w! Xbackup.txt
+  call assert_false(filereadable('Xbackup.txt~'))
+  bw!
+  set backup&vim backupdir&vim backupskip&vim
+  call delete('Xbackup.txt')
+  call delete('Xbackup.txt~')
+endfunc
+
 func Test_backup2()
   set backup backupdir=.// backupskip=
   new
@@ -30,7 +46,7 @@ func Test_backup2()
   :w! Xbackup.txt
   sp *Xbackup.txt~
   call assert_equal(['line1', 'line2', 'line3'], getline(1,'$'))
-  let f=expand('%')
+  let f = expand('%')
   call assert_match('%testdir%Xbackup.txt\~', f)
   bw!
   bw!
@@ -50,7 +66,7 @@ func Test_backup2_backupcopy()
   :w! Xbackup.txt
   sp *Xbackup.txt~
   call assert_equal(['line1', 'line2', 'line3'], getline(1,'$'))
-  let f=expand('%')
+  let f = expand('%')
   call assert_match('%testdir%Xbackup.txt\~', f)
   bw!
   bw!
@@ -62,14 +78,11 @@ endfunc
 " Test for using a non-existing directory as a backup directory
 func Test_non_existing_backupdir()
   throw 'Skipped: Nvim auto-creates backup directory'
-  CheckNotBSD
-  let save_backup = &backupdir
-  set backupdir=./non_existing_dir
+  set backupdir=./non_existing_dir backupskip=
   call writefile(['line1'], 'Xfile')
   new Xfile
-  " TODO: write doesn't fail in Cirrus FreeBSD CI test
   call assert_fails('write', 'E510:')
-  let &backupdir = save_backup
+  set backupdir&vim backupskip&vim
   call delete('Xfile')
 endfunc
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1836,7 +1836,6 @@ endfunc
 " Test for editing a file without read permission
 func Test_edit_file_no_read_perm()
   CheckUnix
-  CheckNotBSD
   call writefile(['one', 'two'], 'Xfile')
   call setfperm('Xfile', '-w-------')
   new

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -136,9 +136,7 @@ func Test_writefile_sync_arg()
 endfunc
 
 func Test_writefile_sync_dev_stdout()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   if filewritable('/dev/stdout')
     " Just check that this doesn't cause an error.
     call writefile(['one'], '/dev/stdout', 's')
@@ -386,13 +384,10 @@ endfunc
 
 " Test for writing to a readonly file
 func Test_write_readonly()
-  " In Cirrus-CI, the freebsd tests are run under a root account. So this test
-  " doesn't fail.
-  CheckNotBSD
   call writefile([], 'Xfile')
   call setfperm('Xfile', "r--------")
   edit Xfile
-  set noreadonly
+  set noreadonly backupskip=
   call assert_fails('write', 'E505:')
   let save_cpo = &cpo
   set cpo+=W
@@ -401,37 +396,32 @@ func Test_write_readonly()
   call setline(1, ['line1'])
   write!
   call assert_equal(['line1'], readfile('Xfile'))
+  set backupskip&
   call delete('Xfile')
 endfunc
 
 " Test for 'patchmode'
 func Test_patchmode()
-  CheckNotBSD
   call writefile(['one'], 'Xfile')
-  set patchmode=.orig nobackup writebackup
+  set patchmode=.orig nobackup backupskip= writebackup
   new Xfile
   call setline(1, 'two')
   " first write should create the .orig file
   write
-  " TODO: Xfile.orig is not created in Cirrus FreeBSD CI test
   call assert_equal(['one'], readfile('Xfile.orig'))
   call setline(1, 'three')
   " subsequent writes should not create/modify the .orig file
   write
   call assert_equal(['one'], readfile('Xfile.orig'))
-  set patchmode& backup& writebackup&
+  set patchmode& backup& backupskip& writebackup&
   call delete('Xfile')
   call delete('Xfile.orig')
 endfunc
 
 " Test for writing to a file in a readonly directory
 func Test_write_readonly_dir()
-  if !has('unix') || has('bsd')
-    " On MS-Windows, modifying files in a read-only directory is allowed.
-    " In Cirrus-CI for Freebsd, tests are run under a root account where
-    " modifying files in a read-only directory are allowed.
-    return
-  endif
+  " On MS-Windows, modifying files in a read-only directory is allowed.
+  CheckUnix
   call mkdir('Xdir')
   call writefile(['one'], 'Xdir/Xfile1')
   call setfperm('Xdir', 'r-xr--r--')
@@ -441,12 +431,12 @@ func Test_write_readonly_dir()
   call assert_fails('write', 'E212:')
   " try to create a backup file in the directory
   edit! Xdir/Xfile1
-  set backupdir=./Xdir
+  set backupdir=./Xdir backupskip=
   set patchmode=.orig
   call assert_fails('write', 'E509:')
   call setfperm('Xdir', 'rwxr--r--')
   call delete('Xdir', 'rf')
-  set backupdir& patchmode&
+  set backupdir& backupskip& patchmode&
 endfunc
 
 " Test for writing a file using invalid file encoding


### PR DESCRIPTION
#### vim-patch:8.2.1340: some tests fail on Cirrus CI and/or with FreeBSD

Problem:    Some tests fail on Cirrus CI and/or with FreeBSD.
Solution:   Make 'backupskip' empty. Do not run tests as root. Check for
            directory when using viminfo. (Ozaki Kiichi, closes vim/vim#6596)

https://github.com/vim/vim/commit/b86abadf87bd0f85f800077171ec4b98aefff776