### PR TITLE
vim-patch:8.2.{2570,2623,2627,4495}: tests fail when run as root

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -90,15 +90,6 @@ func CheckUnix()
   endif
 endfunc
 
-" Command to check for not running on a BSD system.
-" TODO: using this checks should not be needed
-command CheckNotBSD call CheckNotBSD()
-func CheckNotBSD()
-  if has('bsd')
-    throw 'Skipped: does not work on BSD'
-  endif
-endfunc
-
 " Command to check that making screendumps is supported.
 " Caller must source screendump.vim
 command CheckScreendump call CheckScreendump()

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1834,9 +1834,10 @@ func Test_edit_charconvert()
 endfunc
 
 " Test for editing a file without read permission
-" NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_edit_file_no_read_perm()
   CheckUnix
+  CheckNotRoot
+
   call writefile(['one', 'two'], 'Xfile')
   call setfperm('Xfile', '-w-------')
   new

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -1834,6 +1834,7 @@ func Test_edit_charconvert()
 endfunc
 
 " Test for editing a file without read permission
+" NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_edit_file_no_read_perm()
   CheckUnix
   call writefile(['one', 'two'], 'Xfile')

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -493,13 +493,6 @@ func Test_redir_cmd()
     call assert_fails('redir > Xdir', 'E17:')
     call delete('Xdir', 'd')
   endif
-  if !has('bsd')
-    " Redirecting to a read-only file
-    call writefile([], 'Xfile')
-    call setfperm('Xfile', 'r--r--r--')
-    call assert_fails('redir! > Xfile', 'E190:')
-    call delete('Xfile')
-  endif
 
   " Test for redirecting to a register
   redir @q> | echon 'clean ' | redir END
@@ -510,6 +503,17 @@ func Test_redir_cmd()
   redir => color | echon 'blue ' | redir END
   redir =>> color | echon 'sky' | redir END
   call assert_equal('blue sky', color)
+endfunc
+
+func Test_redir_cmd_readonly()
+  CheckNotRoot
+  CheckNotBSD
+
+  " Redirecting to a read-only file
+  call writefile([], 'Xfile')
+  call setfperm('Xfile', 'r--r--r--')
+  call assert_fails('redir! > Xfile', 'E190:')
+  call delete('Xfile')
 endfunc
 
 " Test for the :filetype command

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -476,6 +476,7 @@ func Test_winsize_cmd()
 endfunc
 
 " Test for the :redir command
+" NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_redir_cmd()
   call assert_fails('redir @@', 'E475:')
   call assert_fails('redir abc', 'E475:')

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -507,7 +507,6 @@ endfunc
 
 func Test_redir_cmd_readonly()
   CheckNotRoot
-  CheckNotBSD
 
   " Redirecting to a read-only file
   call writefile([], 'Xfile')

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -1,5 +1,7 @@
 " Tests for :help
 
+source check.vim
+
 func Test_help_restore_snapshot()
   help
   set buftype=
@@ -112,33 +114,38 @@ func Test_helptag_cmd()
   call assert_equal(["help-tags\ttags\t1"], readfile('Xdir/tags'))
   call delete('Xdir/tags')
 
-  " The following tests fail on FreeBSD for some reason
-  if has('unix') && !has('bsd')
-    " Read-only tags file
-    call mkdir('Xdir/doc', 'p')
-    call writefile([''], 'Xdir/doc/tags')
-    call writefile([], 'Xdir/doc/sample.txt')
-    call setfperm('Xdir/doc/tags', 'r-xr--r--')
-    call assert_fails('helptags Xdir/doc', 'E152:', getfperm('Xdir/doc/tags'))
-
-    let rtp = &rtp
-    let &rtp = 'Xdir'
-    helptags ALL
-    let &rtp = rtp
-
-    call delete('Xdir/doc/tags')
-
-    " No permission to read the help file
-    call setfperm('Xdir/a/doc/sample.txt', '-w-------')
-    call assert_fails('helptags Xdir', 'E153:', getfperm('Xdir/a/doc/sample.txt'))
-    call delete('Xdir/a/doc/sample.txt')
-    call delete('Xdir/tags')
-  endif
-
   " Duplicate tags in the help file
   call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xdir/a/doc/sample.txt')
   call assert_fails('helptags Xdir', 'E154:')
 
+  call delete('Xdir', 'rf')
+endfunc
+
+func Test_helptag_cmd_readonly()
+  CheckUnix
+  CheckNotRoot
+  " The following tests fail on FreeBSD for some reason
+  CheckNotBSD
+
+  " Read-only tags file
+  call mkdir('Xdir/doc', 'p')
+  call writefile([''], 'Xdir/doc/tags')
+  call writefile([], 'Xdir/doc/sample.txt')
+  call setfperm('Xdir/doc/tags', 'r-xr--r--')
+  call assert_fails('helptags Xdir/doc', 'E152:', getfperm('Xdir/doc/tags'))
+
+  let rtp = &rtp
+  let &rtp = 'Xdir'
+  helptags ALL
+  let &rtp = rtp
+
+  call delete('Xdir/doc/tags')
+
+  " No permission to read the help file
+  call mkdir('Xdir/b/doc', 'p')
+  call writefile([], 'Xdir/b/doc/sample.txt')
+  call setfperm('Xdir/b/doc/sample.txt', '-w-------')
+  call assert_fails('helptags Xdir', 'E153:', getfperm('Xdir/b/doc/sample.txt'))
   call delete('Xdir', 'rf')
 endfunc
 

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -124,8 +124,6 @@ endfunc
 func Test_helptag_cmd_readonly()
   CheckUnix
   CheckNotRoot
-  " The following tests fail on FreeBSD for some reason
-  CheckNotBSD
 
   " Read-only tags file
   call mkdir('Xdir/doc', 'p')

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -149,7 +149,7 @@ endfunc
 
 " Test for setting the 'helpheight' option in the help window
 func Test_help_window_height()
-  let &cmdheight = &lines - 24
+  let &cmdheight = &lines - 23
   set helpheight=10
   help
   set helpheight=14

--- a/src/nvim/testdir/test_help.vim
+++ b/src/nvim/testdir/test_help.vim
@@ -98,6 +98,7 @@ func Test_help_completion()
 endfunc
 
 " Test for the :helptags command
+" NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_helptag_cmd()
   call mkdir('Xdir/a/doc', 'p')
 

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -419,6 +419,7 @@ func Test_patchmode()
 endfunc
 
 " Test for writing to a file in a readonly directory
+" NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_write_readonly_dir()
   " On MS-Windows, modifying files in a read-only directory is allowed.
   CheckUnix

--- a/src/nvim/testdir/test_writefile.vim
+++ b/src/nvim/testdir/test_writefile.vim
@@ -423,6 +423,9 @@ endfunc
 func Test_write_readonly_dir()
   " On MS-Windows, modifying files in a read-only directory is allowed.
   CheckUnix
+  " Root can do it too.
+  CheckNotRoot
+
   call mkdir('Xdir')
   call writefile(['one'], 'Xdir/Xfile1')
   call setfperm('Xdir', 'r-xr--r--')


### PR DESCRIPTION
#### vim-patch:8.2.2570: tests fail when run as root

Problem:    Tests fail when run as root.
Solution:   Add a comment mentioning the expected failure. (issue vim/vim#7919)

https://github.com/vim/vim/commit/f9a65505d1d93f3e67e5b8646bde3bbc44c70f7d

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2623: some tests fail when run as root

Problem:    Some tests fail when run as root.
Solution:   Use CheckNotRoot.

https://github.com/vim/vim/commit/17709e280ac5ba234b04641cde88d38e3522cedf

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2627: no need to check for BSD after checking for not root

Problem:    No need to check for BSD after checking for not root.
Solution:   Remove CheckNotBSD. (Ozaki Kiichi, closes vim/vim#7989)

https://github.com/vim/vim/commit/4355894869355c185e7810e67d52802453576e81


#### vim-patch:8.2.4495: help test fails in 24 line terminal

Problem:    Help test fails in 24 line terminal.
Solution:   Use up to 23 lines for text.

https://github.com/vim/vim/commit/e4e1a1e1c8a2bc6efd806e379b5fc80998318830

Co-authored-by: Bram Moolenaar <Bram@vim.org>