### PR TITLE
vim-patch:8.2.2592: code coverage could be improved

### DIFF
--- a/src/nvim/testdir/test_fileformat.vim
+++ b/src/nvim/testdir/test_fileformat.vim
@@ -31,6 +31,15 @@ func Test_fileformat_autocommand()
   bw!
 endfunc
 
+func Test_fileformat_nomodifiable()
+  new
+  setlocal nomodifiable
+
+  call assert_fails('set fileformat=latin1', 'E21:')
+
+  bw
+endfunc
+
 " Convert the contents of a file into a literal string
 func s:file2str(fname)
   let b = readfile(a:fname, 'B')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -3399,6 +3399,13 @@ func Test_normal_delete_cmd()
   " delete to a readonly register
   call setline(1, ['abcd'])
   call assert_beeps('normal ":d2l')
+
+  " D and d with 'nomodifiable'
+  call setline(1, ['abcd'])
+  setlocal nomodifiable
+  call assert_fails('normal D', 'E21:')
+  call assert_fails('normal d$', 'E21:')
+
   close!
 endfunc
 

--- a/src/nvim/testdir/test_sleep.vim
+++ b/src/nvim/testdir/test_sleep.vim
@@ -21,6 +21,7 @@ func! Test_sleep_bang()
   call s:assert_takes_longer('sl 50m', 50)
   call s:assert_takes_longer('sl! 50m', 50)
   call s:assert_takes_longer('1sleep', 1000)
+  call s:assert_takes_longer('normal 1gs', 1000)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_textformat.vim
+++ b/src/nvim/testdir/test_textformat.vim
@@ -1044,6 +1044,22 @@ func Test_empty_matchpairs()
   bwipe!
 endfunc
 
+func Test_mps_error()
+  let encoding_save = &encoding
+
+  " for e in ['utf-8', 'latin1']
+  for e in ['utf-8']
+    exe 'set encoding=' .. e
+
+    call assert_fails('set mps=<:', 'E474:', e)
+    call assert_fails('set mps=:>', 'E474:', e)
+    call assert_fails('set mps=<>', 'E474:', e)
+    call assert_fails('set mps=<:>_', 'E474:', e)
+  endfor
+
+  let &encoding = encoding_save
+endfunc
+
 " Test for ra on multi-byte characters
 func Test_ra_multibyte()
   new

--- a/src/nvim/testdir/test_viminfo.vim
+++ b/src/nvim/testdir/test_viminfo.vim
@@ -18,4 +18,9 @@ func Test_viminfo_option_error()
   call assert_fails('set viminfo=%10', 'E528:')
 endfunc
 
+func Test_viminfo_oldfiles_newfile()
+  let v:oldfiles = v:_null_list
+  call assert_equal("\nNo old files", execute('oldfiles'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.2592: code coverage could be improved

Problem:    Code coverage could be improved.
Solution:   Add a few more tests. (Dominique Pellé, closes vim/vim#7957)

https://github.com/vim/vim/commit/6fd367a97c8653a2d734a38252c7d68d4b2ebaa7

Test case in test_viminfo.vim is applicable.