### PR TITLE
feat(fs): add vim.fs.realpath()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2257,9 +2257,10 @@ dir({path})                                                     *vim.fs.dir()*
                 |vim.fs.normalize()|.
 
     Return: ~
-        Iterator over files and directories in {path}. Each iteration yields
-        two values: name and type. Each "name" is the basename of the file or
-        directory relative to {path}. Type is one of "file" or "directory".
+        (function) Iterator over files and directories in {path}. Each
+        iteration yields two values: name and type. Each "name" is the
+        basename of the file or directory relative to {path}. Type is one of
+        "file" or "directory".
 
 dirname({file})                                             *vim.fs.dirname()*
     Return the parent directory of the given file or directory
@@ -2352,5 +2353,15 @@ parents({start})                                            *vim.fs.parents()*
 
     Return: ~
         (function) Iterator
+
+realpath({path})                                           *vim.fs.realpath()*
+    Convert a path to an absolute path without symlinks.
+
+    Parameters: ~
+      • {path}  (string) Path to convert to an absolute path
+
+    Return: ~
+        (string|nil) Absolute path, or nil if the file or directory does not
+        exist.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -55,9 +55,10 @@ end
 ---
 ---@param path (string) An absolute or relative path to the directory to iterate
 ---            over. The path is first normalized |vim.fs.normalize()|.
----@return Iterator over files and directories in {path}. Each iteration yields
----        two values: name and type. Each "name" is the basename of the file or
----        directory relative to {path}. Type is one of "file" or "directory".
+---@return (function) Iterator over files and directories in {path}. Each
+---        iteration yields two values: name and type. Each "name" is the
+---        basename of the file or directory relative to {path}. Type is one of
+---        "file" or "directory".
 function M.dir(path)
   return function(fs)
     return vim.loop.fs_scandir_next(fs)
@@ -228,6 +229,15 @@ end
 function M.normalize(path)
   vim.validate({ path = { path, 's' } })
   return (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))
+end
+
+--- Convert a path to an absolute path without symlinks.
+---
+---@param path (string) Path to convert to an absolute path
+---@return (string|nil) Absolute path, or nil if the file or directory does not
+---        exist.
+function M.realpath(path)
+  return vim.loop.fs_realpath(path)
 end
 
 return M


### PR DESCRIPTION
realpath() converts a relative path into an absolute path, while also resolving symlinks. This requires the given file or directory to actually exist. If it does not exist, this function returns nil.
