### PR TITLE
Add vim.fs.realpath() and use it in vim.fs.normalize()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2257,9 +2257,10 @@ dir({path})                                                     *vim.fs.dir()*
                 |vim.fs.normalize()|.
 
     Return: ~
-        Iterator over files and directories in {path}. Each iteration yields
-        two values: name and type. Each "name" is the basename of the file or
-        directory relative to {path}. Type is one of "file" or "directory".
+        (function) Iterator over files and directories in {path}. Each
+        iteration yields two values: name and type. Each "name" is the
+        basename of the file or directory relative to {path}. Type is one of
+        "file" or "directory".
 
 dirname({file})                                             *vim.fs.dirname()*
     Return the parent directory of the given file or directory
@@ -2352,5 +2353,15 @@ parents({start})                                            *vim.fs.parents()*
 
     Return: ~
         (function) Iterator
+
+realpath({path})                                           *vim.fs.realpath()*
+    Convert a path to an absolute path, resolving symlinks.
+
+    Parameters: ~
+      • {path}  (string) Path to convert to an absolute path
+
+    Return: ~
+        (string|nil) Absolute path, or nil if the file or directory does not
+        exist.
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2307,10 +2307,13 @@ find({names}, {opts})                                          *vim.fs.find()*
         (table) The paths of all matching files or directories
 
 normalize({path})                                         *vim.fs.normalize()*
-    Normalize a path to a standard format. A tilde (~) character at the
-    beginning of the path is expanded to the user's home directory and any
-    backslash (\) characters are converted to forward slashes (/). Environment
-    variables are also expanded.
+    Normalize a path to a standard format.
+
+    A tilde (~) character at the beginning of the path is expanded to the
+    user's home directory and any backslash (\) characters are converted to
+    forward slashes (/). Environment variables are expanded. If the given file
+    or directory exists, the path is also converted to an absolute path and
+    any symlinks are resolved.
 
     Example: >
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -39,6 +39,7 @@ NEW FEATURES                                                    *news-features*
 
 The following new APIs or features were added.
 
+• |vim.fs.realpath()| converts a relative path to an absolute path.
 • When using Nvim inside tmux 3.2 or later, the default clipboard provider
   will now copy to the system clipboard. |provider-clipboard|
 • 'splitkeep' option to control the scroll behavior of horizontal splits.
@@ -48,6 +49,9 @@ The following new APIs or features were added.
 CHANGED FEATURES                                                 *news-changes*
 
 The following changes to existing APIs or features add new behavior.
+
+• |vim.fs.normalize()| now converts relative paths to absolute paths if the
+  given file or directory exists.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -207,10 +207,13 @@ function M.find(names, opts)
   return matches
 end
 
---- Normalize a path to a standard format. A tilde (~) character at the
---- beginning of the path is expanded to the user's home directory and any
---- backslash (\\) characters are converted to forward slashes (/). Environment
---- variables are also expanded.
+--- Normalize a path to a standard format.
+---
+--- A tilde (~) character at the beginning of the path is expanded to the user's
+--- home directory and any backslash (\\) characters are converted to forward
+--- slashes (/). Environment variables are expanded. If the given file or
+--- directory exists, the path is also converted to an absolute path and any
+--- symlinks are resolved.
 ---
 --- Example:
 --- <pre>
@@ -228,7 +231,11 @@ end
 ---@return (string) Normalized path
 function M.normalize(path)
   vim.validate({ path = { path, 's' } })
-  return (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))
+  local p = (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))
+
+  -- Try to also convert the path to an absolute path with symlinks resolved, but if the path does
+  -- not yet exist simply return it as-is.
+  return M.realpath(p) or p
 end
 
 --- Convert a path to an absolute path, resolving symlinks.

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -55,9 +55,10 @@ end
 ---
 ---@param path (string) An absolute or relative path to the directory to iterate
 ---            over. The path is first normalized |vim.fs.normalize()|.
----@return Iterator over files and directories in {path}. Each iteration yields
----        two values: name and type. Each "name" is the basename of the file or
----        directory relative to {path}. Type is one of "file" or "directory".
+---@return (function) Iterator over files and directories in {path}. Each
+---        iteration yields two values: name and type. Each "name" is the
+---        basename of the file or directory relative to {path}. Type is one of
+---        "file" or "directory".
 function M.dir(path)
   return function(fs)
     return vim.loop.fs_scandir_next(fs)
@@ -228,6 +229,15 @@ end
 function M.normalize(path)
   vim.validate({ path = { path, 's' } })
   return (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))
+end
+
+--- Convert a path to an absolute path, resolving symlinks.
+---
+---@param path (string) Path to convert to an absolute path
+---@return (string|nil) Absolute path, or nil if the file or directory does not
+---        exist.
+function M.realpath(path)
+  return vim.loop.fs_realpath(path)
 end
 
 return M

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -9,6 +9,9 @@ local nvim_dir = helpers.nvim_dir
 local test_build_dir = helpers.test_build_dir
 local iswin = helpers.iswin
 local nvim_prog = helpers.nvim_prog
+local command = helpers.command
+local pathsep = helpers.get_pathsep()
+local funcs = helpers.funcs
 
 local nvim_prog_basename = iswin() and 'nvim.exe' or 'nvim'
 
@@ -113,6 +116,21 @@ describe('vim.fs', function()
         vim.env.XDG_CONFIG_HOME = ...
         return vim.fs.normalize('$XDG_CONFIG_HOME/nvim')
       ]], xdg_config_home))
+    end)
+    it('converts a relative path to an absolute path', function()
+      command('edit foo')
+      command('write')
+      eq(funcs.getcwd() .. pathsep .. 'foo', exec_lua [[ return vim.fs.normalize('foo') ]])
+      funcs.delete('foo')
+    end)
+    it('removes ./ and ../ from the path', function()
+      local path = table.concat({'bar', 'baz', 'foo'}, pathsep)
+      helpers.mkdir_p('bar' .. pathsep .. 'baz')
+      command('edit ' .. path)
+      command('write')
+      eq(funcs.getcwd() .. pathsep .. path, exec_lua [[ return vim.fs.normalize('./bar/baz/../../bar/baz/./foo') ]])
+      funcs.delete(path)
+      helpers.rmdir('bar')
     end)
   end)
 end)


### PR DESCRIPTION
Add `vim.fs.realpath()` (which is just a wrapper for `vim.loop.fs_realpath`) and use it in `vim.fs.normalize()`. `vim.fs.normalize()` can be used on files that do not exist. In these cases, `realpath()` returns nil, so `normalize()` returns the "unreal" path instead.
