### PR TITLE
vim-patch:8.2.{3735,3751,3756,3758,3788,3792}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -315,7 +315,8 @@ Note: In the future more global options can be made |global-local|.  Using
 						*option-value-function*
 Some options ('completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
 'operatorfunc', 'quickfixtextfunc', 'tagfunc' and 'thesaurusfunc') are set to
-a function name or a function reference or a lambda function.  Examples:
+a function name or a function reference or a lambda function.  When using a
+lambda it will be converted to the name, e.g. "<lambda>123".  Examples:
 >
 	set opfunc=MyOpFunc
 	set opfunc=function('MyOpFunc')
@@ -325,10 +326,10 @@ a function name or a function reference or a lambda function.  Examples:
 	let Fn = function('MyTagFunc')
 	let &tagfunc = string(Fn)
 	" set using a lambda expression
-	let &tagfunc = "{t -> MyTagFunc(t)}"
+	let &tagfunc = {t -> MyTagFunc(t)}
 	" set using a variable with lambda expression
 	let L = {a, b, c -> MyTagFunc(a, b , c)}
-	let &tagfunc = string(L)
+	let &tagfunc = L
 <
 
 Setting the filetype

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -313,10 +313,10 @@ Note: In the future more global options can be made |global-local|.  Using
 
 
 						*option-value-function*
-Some options ('completefunc', 'imactivatefunc', 'imstatusfunc', 'omnifunc',
-'operatorfunc', 'quickfixtextfunc', 'tagfunc' and 'thesaurusfunc') are set to
-a function name or a function reference or a lambda function.  When using a
-lambda it will be converted to the name, e.g. "<lambda>123".  Examples:
+Some options ('completefunc', 'omnifunc', 'operatorfunc', 'quickfixtextfunc',
+'tagfunc' and 'thesaurusfunc') are set to a function name or a function
+reference or a lambda function.  When using a lambda it will be converted to
+the name, e.g. "<lambda>123".  Examples:
 >
 	set opfunc=MyOpFunc
 	set opfunc=function('MyOpFunc')

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -487,7 +487,7 @@ static getoption_T access_option_value(char *key, long *numval, char **stringval
                                        bool get, Error *err)
 {
   if (get) {
-    return get_option_value(key, numval, stringval, opt_flags);
+    return get_option_value(key, numval, stringval, NULL, opt_flags);
   } else {
     char *errmsg;
     if ((errmsg = set_option_value(key, *numval, *stringval, opt_flags))) {

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -131,7 +131,7 @@ bool ctx_restore(Context *ctx, const int flags)
   }
 
   char *op_shada;
-  get_option_value("shada", NULL, &op_shada, OPT_GLOBAL);
+  get_option_value("shada", NULL, &op_shada, NULL, OPT_GLOBAL);
   set_option_value("shada", 0L, "!,'100,%", OPT_GLOBAL);
 
   if (flags & kCtxRegs) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3689,10 +3689,10 @@ static int eval_index(char **arg, typval_T *rettv, int evaluate, int verbose)
 int get_option_tv(const char **const arg, typval_T *const rettv, const bool evaluate)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  int opt_flags;
+  int scope;
 
   // Isolate the option name and find its value.
-  char *option_end = (char *)find_option_end(arg, &opt_flags);
+  char *option_end = (char *)find_option_end(arg, &scope);
   if (option_end == NULL) {
     if (rettv != NULL) {
       semsg(_("E112: Option name missing: %s"), *arg);
@@ -3712,7 +3712,7 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
   char c = *option_end;
   *option_end = NUL;
   getoption_T opt_type = get_option_value(*arg, &numval,
-                                          rettv == NULL ? NULL : &stringval, opt_flags);
+                                          rettv == NULL ? NULL : &stringval, NULL, scope);
 
   if (opt_type == gov_unknown) {
     if (rettv != NULL) {
@@ -7794,19 +7794,19 @@ void ex_execute(exarg_T *eap)
 ///
 /// @return  NULL when no option name found.  Otherwise pointer to the char
 ///          after the option name.
-const char *find_option_end(const char **const arg, int *const opt_flags)
+const char *find_option_end(const char **const arg, int *const scope)
 {
   const char *p = *arg;
 
   p++;
   if (*p == 'g' && p[1] == ':') {
-    *opt_flags = OPT_GLOBAL;
+    *scope = OPT_GLOBAL;
     p += 2;
   } else if (*p == 'l' && p[1] == ':') {
-    *opt_flags = OPT_LOCAL;
+    *scope = OPT_LOCAL;
     p += 2;
   } else {
-    *opt_flags = 0;
+    *scope = 0;
   }
 
   if (!ASCII_ISALPHA(*p)) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5860,6 +5860,7 @@ bool callback_from_typval(Callback *const callback, typval_T *const arg)
   return true;
 }
 
+/// @return  whether the callback could be called.
 bool callback_call(Callback *const callback, const int argcount_in, typval_T *const argvars_in,
                    typval_T *const rettv)
   FUNC_ATTR_NONNULL_ALL
@@ -8705,9 +8706,9 @@ bool invoke_prompt_interrupt(void)
   argv[0].v_type = VAR_UNKNOWN;
 
   got_int = false;  // don't skip executing commands
-  callback_call(&curbuf->b_prompt_interrupt, 0, argv, &rettv);
+  int ret = callback_call(&curbuf->b_prompt_interrupt, 0, argv, &rettv);
   tv_clear(&rettv);
-  return true;
+  return ret != FAIL;
 }
 
 /// Compare "typ1" and "typ2".  Put the result in "typ1".

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1394,7 +1394,7 @@ func_call_skip_call:
 }
 
 /// call the 'callback' function and return the result as a number.
-/// Returns -1 when calling the function fails.  Uses argv[0] to argv[argc - 1]
+/// Returns -2 when calling the function fails.  Uses argv[0] to argv[argc - 1]
 /// for the function arguments. argv[argc] should have type VAR_UNKNOWN.
 ///
 /// @param argcount  number of "argvars"
@@ -1403,7 +1403,7 @@ varnumber_T callback_call_retnr(Callback *callback, int argcount, typval_T *argv
 {
   typval_T rettv;
   if (!callback_call(callback, argcount, argvars, &rettv)) {
-    return -1;
+    return -2;
   }
 
   varnumber_T retval = tv_get_number_chk(&rettv, NULL);

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -29,14 +29,14 @@ local type_flags={
 }
 
 local redraw_flags={
+  ui_option='P_UI_OPTION',
+  tabline='P_RTABL',
   statuslines='P_RSTAT',
-  tabline = 'P_RTABL',
   current_window='P_RWIN',
   current_window_only='P_RWINONLY',
   current_buffer='P_RBUF',
   all_windows='P_RALL',
   curswant='P_CURSWANT',
-  ui_option='P_UI_OPTION',
 }
 
 local list_flags={
@@ -78,6 +78,7 @@ local get_flags = function(o)
     {'deny_in_modelines', 'P_NO_ML'},
     {'deny_duplicates', 'P_NODUP'},
     {'modelineexpr', 'P_MLE'},
+    {'func'}
   }) do
     local key_name = flag_desc[1]
     local def_name = flag_desc[2] or ('P_' .. key_name:upper())

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2299,6 +2299,17 @@ int set_thesaurusfunc_option(void)
   return retval;
 }
 
+/// Mark the global 'completefunc' 'omnifunc' and 'thesaurusfunc' callbacks with
+/// "copyID" so that they are not garbage collected.
+bool set_ref_in_insexpand_funcs(int copyID)
+{
+  bool abort = set_ref_in_callback(&cfu_cb, copyID, NULL, NULL);
+  abort = abort || set_ref_in_callback(&ofu_cb, copyID, NULL, NULL);
+  abort = abort || set_ref_in_callback(&tsrfu_cb, copyID, NULL, NULL);
+
+  return abort;
+}
+
 /// Get the user-defined completion function name for completion "type"
 static char_u *get_complete_funcname(int type)
 {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2233,7 +2233,7 @@ static Callback tsrfu_cb;  ///< 'thesaurusfunc' callback function
 static void copy_global_to_buflocal_cb(Callback *globcb, Callback *bufcb)
 {
   callback_free(bufcb);
-  if (globcb->data.funcref != NULL && *globcb->data.funcref != NUL) {
+  if (globcb->type != kCallbackNone) {
     callback_copy(bufcb, globcb);
   }
 }
@@ -2290,11 +2290,9 @@ int set_thesaurusfunc_option(void)
 
   if (*curbuf->b_p_tsrfu != NUL) {
     // buffer-local option set
-    callback_free(&curbuf->b_tsrfu_cb);
     retval = option_set_callback_func(curbuf->b_p_tsrfu, &curbuf->b_tsrfu_cb);
   } else {
     // global option set
-    callback_free(&tsrfu_cb);
     retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
   }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5606,6 +5606,13 @@ void free_operatorfunc_option(void)
 }
 #endif
 
+/// Mark the global 'operatorfunc' callback with "copyID" so that it is not
+/// garbage collected.
+bool set_ref_in_opfunc(int copyID)
+{
+  return set_ref_in_callback(&opfunc_cb, copyID, NULL, NULL);
+}
+
 /// Handle the "g@" operator: call 'operatorfunc'.
 static void op_function(const oparg_T *oap)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5193,7 +5193,7 @@ int option_set_callback_func(char *optval, Callback *optcb)
   }
 
   Callback cb;
-  if (!callback_from_typval(&cb, tv)) {
+  if (!callback_from_typval(&cb, tv) || cb.type == kCallbackNone) {
     tv_free(tv);
     return FAIL;
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -24,6 +24,7 @@
 #define P_NO_MKRC      0x200U       ///< don't include in :mkvimrc output
 
 // when option changed, what to display:
+#define P_UI_OPTION    0x400U       ///< send option to remote UI
 #define P_RTABL        0x800U       ///< redraw tabline
 #define P_RSTAT        0x1000U      ///< redraw status lines
 #define P_RWIN         0x2000U      ///< redraw current window and recompute text
@@ -50,9 +51,9 @@
 #define P_NDNAME       0x8000000U   ///< only normal dir name chars allowed
 #define P_RWINONLY     0x10000000U  ///< only redraw current window
 #define P_MLE          0x20000000U  ///< under control of 'modelineexpr'
+#define P_FUNC         0x40000000U  ///< accept a function reference or a lambda
 
-#define P_NO_DEF_EXP   0x40000000U  ///< Do not expand default value.
-#define P_UI_OPTION    0x80000000U  ///< send option to remote ui
+#define P_NO_DEF_EXP   0x80000000U  ///< Do not expand default value.
 
 /// Flags for option-setting functions
 ///

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10,6 +10,7 @@
 --    secure=nil, gettext=nil, noglob=nil, normal_fname_chars=nil,
 --    pri_mkrc=nil, deny_in_modelines=nil, normal_dname_chars=nil,
 --    modelineexpr=nil,
+--    func=nil,
 --    expand=nil, nodefault=nil, no_mkrc=nil,
 --    alloced=nil,
 --    save_pv_indir=nil,
@@ -455,6 +456,7 @@ return {
       type='string', scope={'buffer'},
       secure=true,
       alloced=true,
+      func=true,
       varname='p_cfu',
       defaults={if_true=""}
     },
@@ -1638,6 +1640,7 @@ return {
       type='string', scope={'buffer'},
       secure=true,
       alloced=true,
+      func=true,
       varname='p_ofu',
       defaults={if_true=""}
     },
@@ -1653,6 +1656,7 @@ return {
       short_desc=N_("function to be called for |g@| operator"),
       type='string', scope={'global'},
       secure=true,
+      func=true,
       varname='p_opfunc',
       defaults={if_true=""}
     },
@@ -1835,6 +1839,8 @@ return {
       full_name='quickfixtextfunc', abbreviation='qftf',
       short_desc=N_("customize the quickfix window"),
       type='string', scope={'global'},
+      secure=true,
+      func=true,
       varname='p_qftf',
       defaults={if_true=""}
     },
@@ -2408,6 +2414,8 @@ return {
       full_name='tagfunc', abbreviation='tfu',
       short_desc=N_("function used to perform tag searches"),
       type='string', scope={'buffer'},
+      secure=true,
+      func=true,
       varname='p_tfu',
       defaults={if_true=""}
     },
@@ -2538,6 +2546,7 @@ return {
       type='string', scope={'global', 'buffer'},
       secure=true,
       alloced=true,
+      func=true,
       varname='p_tsrfu',
       defaults={if_true=""}
     },

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3145,7 +3145,7 @@ void ex_spelldump(exarg_T *eap)
   }
   char *spl;
   long dummy;
-  (void)get_option_value("spl", &dummy, &spl, OPT_LOCAL);
+  (void)get_option_value("spl", &dummy, &spl, NULL, OPT_LOCAL);
 
   // Create a new empty buffer in a new window.
   do_cmdline_cmd("new");

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -149,6 +149,13 @@ void free_tagfunc_option(void)
 }
 #endif
 
+/// Mark the global 'tagfunc' callback with "copyID" so that it is not garbage
+/// collected.
+bool set_ref_in_tagfunc(int copyID)
+{
+  return set_ref_in_callback(&tfu_cb, copyID, NULL, NULL);
+}
+
 /// Copy the global 'tagfunc' callback function to the buffer-local 'tagfunc'
 /// callback for 'buf'.
 void set_buflocal_tfu_callback(buf_T *buf)

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -154,7 +154,7 @@ void free_tagfunc_option(void)
 void set_buflocal_tfu_callback(buf_T *buf)
 {
   callback_free(&buf->b_tfu_cb);
-  if (tfu_cb.data.funcref != NULL && *tfu_cb.data.funcref != NUL) {
+  if (tfu_cb.type != kCallbackNone) {
     callback_copy(&buf->b_tfu_cb, &tfu_cb);
   }
 }
@@ -1153,7 +1153,7 @@ static int find_tagfunc_tags(char_u *pat, garray_T *ga, int *match_count, int fl
     }
   }
 
-  if (*curbuf->b_p_tfu == NUL) {
+  if (*curbuf->b_p_tfu == NUL || curbuf->b_tfu_cb.type == kCallbackNone) {
     return FAIL;
   }
 

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1,5 +1,8 @@
+" Test for insert completion
+
 source screendump.vim
 source check.vim
+source vim9.vim
 
 " Test for insert expansion
 func Test_ins_complete()
@@ -1292,154 +1295,179 @@ func Test_completefunc_callback()
     return a:findstart ? 0 : []
   endfunc
 
-  " Test for using a function()
-  set completefunc=function('MycompleteFunc1',[10])
-  new | only
-  call setline(1, 'one')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MycompleteFunc1_args)
-  bw!
+  let lines =<< trim END
+    #" Test for using a function()
+    set completefunc=function('g:MycompleteFunc1',\ [10])
+    new | only
+    call setline(1, 'one')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MycompleteFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'completefunc'
-  let Fn = function('MycompleteFunc1', [11])
-  let &completefunc = Fn
-  new | only
-  call setline(1, 'two')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MycompleteFunc1_args)
-  bw!
+    #" Using a funcref variable to set 'completefunc'
+    VAR Fn = function('g:MycompleteFunc1', [11])
+    LET &completefunc = Fn
+    new | only
+    call setline(1, 'two')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MycompleteFunc1_args)
+    bw!
 
-  " Using string(funcref_variable) to set 'completefunc'
-  let Fn = function('MycompleteFunc1', [12])
-  let &completefunc = string(Fn)
-  new | only
-  call setline(1, 'two')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MycompleteFunc1_args)
-  bw!
+    #" Using string(funcref_variable) to set 'completefunc'
+    LET Fn = function('g:MycompleteFunc1', [12])
+    LET &completefunc = string(Fn)
+    new | only
+    call setline(1, 'two')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MycompleteFunc1_args)
+    bw!
 
-  " Test for using a funcref()
-  set completefunc=funcref('MycompleteFunc1',\ [13])
-  new | only
-  call setline(1, 'three')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MycompleteFunc1_args)
-  bw!
+    #" Test for using a funcref()
+    set completefunc=funcref('g:MycompleteFunc1',\ [13])
+    new | only
+    call setline(1, 'three')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MycompleteFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'completefunc'
-  let Fn = funcref('MycompleteFunc1', [14])
-  let &completefunc = Fn
-  new | only
-  call setline(1, 'four')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MycompleteFunc1_args)
-  bw!
+    #" Using a funcref variable to set 'completefunc'
+    LET Fn = funcref('g:MycompleteFunc1', [14])
+    LET &completefunc = Fn
+    new | only
+    call setline(1, 'four')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MycompleteFunc1_args)
+    bw!
 
-  " Using a string(funcref_variable) to set 'completefunc'
-  let Fn = funcref('MycompleteFunc1', [15])
-  let &completefunc = string(Fn)
-  new | only
-  call setline(1, 'four')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MycompleteFunc1_args)
-  bw!
+    #" Using a string(funcref_variable) to set 'completefunc'
+    LET Fn = funcref('g:MycompleteFunc1', [15])
+    LET &completefunc = string(Fn)
+    new | only
+    call setline(1, 'four')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MycompleteFunc1_args)
+    bw!
 
-  " Test for using a lambda function
-  set completefunc={a,\ b\ ->\ MycompleteFunc1(16,\ a,\ b)}
-  new | only
-  call setline(1, 'five')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MycompleteFunc1_args)
-  bw!
+    #" Test for using a lambda function with set
+    VAR optval = "LSTART a, b LMIDDLE MycompleteFunc1(16, a, b) LEND"
+    LET optval = substitute(optval, ' ', '\\ ', 'g')
+    exe "set completefunc=" .. optval
+    new | only
+    call setline(1, 'five')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MycompleteFunc1_args)
+    bw!
 
-  " Set 'completefunc' to a lambda expression
-  let &completefunc = {a, b -> MycompleteFunc1(17, a, b)}
-  new | only
-  call setline(1, 'six')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MycompleteFunc1_args)
-  bw!
+    #" Set 'completefunc' to a lambda expression
+    LET &completefunc = LSTART a, b LMIDDLE MycompleteFunc1(17, a, b) LEND
+    new | only
+    call setline(1, 'six')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MycompleteFunc1_args)
+    bw!
 
-  " Set 'completefunc' to string(lambda_expression)
-  let &completefunc = '{a, b -> MycompleteFunc1(18, a, b)}'
-  new | only
-  call setline(1, 'six')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MycompleteFunc1_args)
-  bw!
+    #" Set 'completefunc' to string(lambda_expression)
+    LET &completefunc = 'LSTART a, b LMIDDLE MycompleteFunc1(18, a, b) LEND'
+    new | only
+    call setline(1, 'six')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MycompleteFunc1_args)
+    bw!
 
-  " Set 'completefunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MycompleteFunc1(19, a, b)}
-  let &completefunc = Lambda
-  new | only
-  call setline(1, 'seven')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MycompleteFunc1_args)
-  bw!
+    #" Set 'completefunc' to a variable with a lambda expression
+    VAR Lambda = LSTART a, b LMIDDLE MycompleteFunc1(19, a, b) LEND
+    LET &completefunc = Lambda
+    new | only
+    call setline(1, 'seven')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MycompleteFunc1_args)
+    bw!
 
-  " Set 'completefunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MycompleteFunc1(20, a, b)}
-  let &completefunc = string(Lambda)
-  new | only
-  call setline(1, 'seven')
-  let g:MycompleteFunc1_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MycompleteFunc1_args)
-  bw!
+    #" Set 'completefunc' to a string(variable with a lambda expression)
+    LET Lambda = LSTART a, b LMIDDLE MycompleteFunc1(20, a, b) LEND
+    LET &completefunc = string(Lambda)
+    new | only
+    call setline(1, 'seven')
+    LET g:MycompleteFunc1_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MycompleteFunc1_args)
+    bw!
 
-  " Test for using a lambda function with incorrect return value
-  let Lambda = {s -> strlen(s)}
-  let &completefunc = Lambda
-  new | only
-  call setline(1, 'eight')
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  bw!
+    #" Test for using a lambda function with incorrect return value
+    LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
+    LET &completefunc = Lambda
+    new | only
+    call setline(1, 'eight')
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    bw!
 
-  " Test for clearing the 'completefunc' option
-  set completefunc=''
-  set completefunc&
+    #" Test for clearing the 'completefunc' option
+    set completefunc=''
+    set completefunc&
+    call assert_fails("set completefunc=function('abc')", "E700:")
+    call assert_fails("set completefunc=funcref('abc')", "E700:")
 
-  call assert_fails("set completefunc=function('abc')", "E700:")
-  call assert_fails("set completefunc=funcref('abc')", "E700:")
+    #" set 'completefunc' to a non-existing function
+    func MycompleteFunc2(findstart, base)
+      call add(g:MycompleteFunc2_args, [a:findstart, a:base])
+      return a:findstart ? 0 : []
+    endfunc
+    set completefunc=MycompleteFunc2
+    call setline(1, 'five')
+    call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
+    call assert_fails("LET &completefunc = function('NonExistingFunc')", 'E700:')
+    LET g:MycompleteFunc2_args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
+    bw!
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let &completefunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set completefunc=(a,\ b)\ =>\ g:MycompleteFunc1(21,\ a,\ b)
+  " set completefunc=(a,\ b)\ =>\ MycompleteFunc1(21,\ a,\ b)
   new | only
   let g:MycompleteFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E117:')
   call assert_equal([], g:MycompleteFunc1_args)
 
-  " set 'completefunc' to a non-existing function
-  func MycompleteFunc2(findstart, base)
-    call add(g:MycompleteFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
+  " set 'completefunc' to a partial with dict. This used to cause a crash.
+  func SetCompleteFunc()
+    let params = {'complete': function('g:DictCompleteFunc')}
+    let &completefunc = params.complete
   endfunc
-  set completefunc=MycompleteFunc2
-  call setline(1, 'five')
-  call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
-  call assert_fails("let &completefunc = function('NonExistingFunc')", 'E700:')
-  let g:MycompleteFunc2_args = []
-  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
-  bw!
+  func g:DictCompleteFunc(_) dict
+  endfunc
+  call SetCompleteFunc()
+  new
+  call SetCompleteFunc()
+  bw
+  call test_garbagecollect_now()
+  new
+  set completefunc=
+  wincmd w
+  set completefunc=
+  %bw!
+  delfunc g:DictCompleteFunc
+  delfunc SetCompleteFunc
 
   " Vim9 tests
   let lines =<< trim END
     vim9script
 
-    # Test for using function()
+    # Test for using a def function with completefunc
     def Vim9CompleteFunc(val: number, findstart: number, base: string): any
       add(g:Vim9completeFuncArgs, [val, findstart, base])
       return findstart ? 0 : []
@@ -1450,44 +1478,6 @@ func Test_completefunc_callback()
     g:Vim9completeFuncArgs = []
     feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
     assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9completeFuncArgs)
-    bw!
-
-    # Test for using a lambda
-    &completefunc = (a, b) => Vim9CompleteFunc(61, a, b)
-    new | only
-    setline(1, 'two')
-    g:Vim9completeFuncArgs = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9completeFuncArgs)
-    bw!
-
-    # Test for using a string(lambda)
-    &completefunc = '(a, b) => Vim9CompleteFunc(62, a, b)'
-    new | only
-    setline(1, 'two')
-    g:Vim9completeFuncArgs = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9completeFuncArgs)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => Vim9CompleteFunc(63, a, b)
-    &completefunc = Fn
-    new | only
-    setline(1, 'three')
-    g:Vim9completeFuncArgs = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9completeFuncArgs)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    Fn = (a, b) => Vim9CompleteFunc(64, a, b)
-    &completefunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:Vim9completeFuncArgs = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9completeFuncArgs)
     bw!
   END
   " call CheckScriptSuccess(lines)
@@ -1506,154 +1496,179 @@ func Test_omnifunc_callback()
     return a:findstart ? 0 : []
   endfunc
 
-  " Test for using a function()
-  set omnifunc=function('MyomniFunc1',[10])
-  new | only
-  call setline(1, 'one')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MyomniFunc1_args)
-  bw!
+  let lines =<< trim END
+    #" Test for using a function()
+    set omnifunc=function('g:MyomniFunc1',\ [10])
+    new | only
+    call setline(1, 'one')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MyomniFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'omnifunc'
-  let Fn = function('MyomniFunc1', [11])
-  let &omnifunc = Fn
-  new | only
-  call setline(1, 'two')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MyomniFunc1_args)
-  bw!
+    #" Using a funcref variable to set 'omnifunc'
+    VAR Fn = function('g:MyomniFunc1', [11])
+    LET &omnifunc = Fn
+    new | only
+    call setline(1, 'two')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MyomniFunc1_args)
+    bw!
 
-  " Using a string(funcref_variable) to set 'omnifunc'
-  let Fn = function('MyomniFunc1', [12])
-  let &omnifunc = string(Fn)
-  new | only
-  call setline(1, 'two')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MyomniFunc1_args)
-  bw!
+    #" Using a string(funcref_variable) to set 'omnifunc'
+    LET Fn = function('g:MyomniFunc1', [12])
+    LET &omnifunc = string(Fn)
+    new | only
+    call setline(1, 'two')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MyomniFunc1_args)
+    bw!
 
-  " Test for using a funcref()
-  set omnifunc=funcref('MyomniFunc1',\ [13])
-  new | only
-  call setline(1, 'three')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MyomniFunc1_args)
-  bw!
+    #" Test for using a funcref()
+    set omnifunc=funcref('g:MyomniFunc1',\ [13])
+    new | only
+    call setline(1, 'three')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MyomniFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'omnifunc'
-  let Fn = funcref('MyomniFunc1', [14])
-  let &omnifunc = Fn
-  new | only
-  call setline(1, 'four')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MyomniFunc1_args)
-  bw!
+    #" Use let to set 'omnifunc' to a funcref
+    LET Fn = funcref('g:MyomniFunc1', [14])
+    LET &omnifunc = Fn
+    new | only
+    call setline(1, 'four')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MyomniFunc1_args)
+    bw!
 
-  " Using a string(funcref_variable) to set 'omnifunc'
-  let Fn = funcref('MyomniFunc1', [15])
-  let &omnifunc = string(Fn)
-  new | only
-  call setline(1, 'four')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MyomniFunc1_args)
-  bw!
+    #" Using a string(funcref) to set 'omnifunc'
+    LET Fn = funcref("g:MyomniFunc1", [15])
+    LET &omnifunc = string(Fn)
+    new | only
+    call setline(1, 'four')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MyomniFunc1_args)
+    bw!
 
-  " Test for using a lambda function
-  set omnifunc={a,\ b\ ->\ MyomniFunc1(16,\ a,\ b)}
-  new | only
-  call setline(1, 'five')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MyomniFunc1_args)
-  bw!
+    #" Test for using a lambda function with set
+    VAR optval = "LSTART a, b LMIDDLE MyomniFunc1(16, a, b) LEND"
+    LET optval = substitute(optval, ' ', '\\ ', 'g')
+    exe "set omnifunc=" .. optval
+    new | only
+    call setline(1, 'five')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MyomniFunc1_args)
+    bw!
 
-  " Set 'omnifunc' to a lambda expression
-  let &omnifunc = {a, b -> MyomniFunc1(17, a, b)}
-  new | only
-  call setline(1, 'six')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MyomniFunc1_args)
-  bw!
+    #" Set 'omnifunc' to a lambda expression
+    LET &omnifunc = LSTART a, b LMIDDLE MyomniFunc1(17, a, b) LEND
+    new | only
+    call setline(1, 'six')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MyomniFunc1_args)
+    bw!
 
-  " Set 'omnifunc' to a string(lambda_expression)
-  let &omnifunc = '{a, b -> MyomniFunc1(18, a, b)}'
-  new | only
-  call setline(1, 'six')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MyomniFunc1_args)
-  bw!
+    #" Set 'omnifunc' to a string(lambda_expression)
+    LET &omnifunc = 'LSTART a, b LMIDDLE MyomniFunc1(18, a, b) LEND'
+    new | only
+    call setline(1, 'six')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MyomniFunc1_args)
+    bw!
 
-  " Set 'omnifunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MyomniFunc1(19, a, b)}
-  let &omnifunc = Lambda
-  new | only
-  call setline(1, 'seven')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MyomniFunc1_args)
-  bw!
+    #" Set 'omnifunc' to a variable with a lambda expression
+    VAR Lambda = LSTART a, b LMIDDLE MyomniFunc1(19, a, b) LEND
+    LET &omnifunc = Lambda
+    new | only
+    call setline(1, 'seven')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MyomniFunc1_args)
+    bw!
 
-  " Set 'omnifunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MyomniFunc1(20, a, b)}
-  let &omnifunc = string(Lambda)
-  new | only
-  call setline(1, 'seven')
-  let g:MyomniFunc1_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MyomniFunc1_args)
-  bw!
+    #" Set 'omnifunc' to a string(variable with a lambda expression)
+    LET Lambda = LSTART a, b LMIDDLE MyomniFunc1(20, a, b) LEND
+    LET &omnifunc = string(Lambda)
+    new | only
+    call setline(1, 'seven')
+    LET g:MyomniFunc1_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MyomniFunc1_args)
+    bw!
 
-  " Test for using a lambda function with incorrect return value
-  let Lambda = {s -> strlen(s)}
-  let &omnifunc = Lambda
-  new | only
-  call setline(1, 'eight')
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  bw!
+    #" Test for using a lambda function with incorrect return value
+    LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
+    LET &omnifunc = Lambda
+    new | only
+    call setline(1, 'eight')
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    bw!
 
-  " Test for clearing the 'omnifunc' option
-  set omnifunc=''
-  set omnifunc&
+    #" Test for clearing the 'omnifunc' option
+    set omnifunc=''
+    set omnifunc&
+    call assert_fails("set omnifunc=function('abc')", "E700:")
+    call assert_fails("set omnifunc=funcref('abc')", "E700:")
 
-  call assert_fails("set omnifunc=function('abc')", "E700:")
-  call assert_fails("set omnifunc=funcref('abc')", "E700:")
+    #" set 'omnifunc' to a non-existing function
+    func MyomniFunc2(findstart, base)
+      call add(g:MyomniFunc2_args, [a:findstart, a:base])
+      return a:findstart ? 0 : []
+    endfunc
+    set omnifunc=MyomniFunc2
+    call setline(1, 'nine')
+    call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
+    call assert_fails("LET &omnifunc = function('NonExistingFunc')", 'E700:')
+    LET g:MyomniFunc2_args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
+    bw!
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let &omnifunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set omnifunc=(a,\ b)\ =>\ g:MyomniFunc1(21,\ a,\ b)
+  " set omnifunc=(a,\ b)\ =>\ MyomniFunc1(21,\ a,\ b)
   new | only
   let g:MyomniFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E117:')
   call assert_equal([], g:MyomniFunc1_args)
 
-  " set 'omnifunc' to a non-existing function
-  func MyomniFunc2(findstart, base)
-    call add(g:MyomniFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
+  " set 'omnifunc' to a partial with dict. This used to cause a crash.
+  func SetOmniFunc()
+    let params = {'omni': function('g:DictOmniFunc')}
+    let &omnifunc = params.omni
   endfunc
-  set omnifunc=MyomniFunc2
-  call setline(1, 'nine')
-  call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
-  call assert_fails("let &omnifunc = function('NonExistingFunc')", 'E700:')
-  let g:MyomniFunc2_args = []
-  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
-  bw!
+  func g:DictOmniFunc(_) dict
+  endfunc
+  call SetOmniFunc()
+  new
+  call SetOmniFunc()
+  bw
+  call test_garbagecollect_now()
+  new
+  set omnifunc=
+  wincmd w
+  set omnifunc=
+  %bw!
+  delfunc g:DictOmniFunc
+  delfunc SetOmniFunc
 
   " Vim9 tests
   let lines =<< trim END
     vim9script
 
-    # Test for using function()
+    # Test for using a def function with omnifunc
     def Vim9omniFunc(val: number, findstart: number, base: string): any
       add(g:Vim9omniFunc_Args, [val, findstart, base])
       return findstart ? 0 : []
@@ -1664,44 +1679,6 @@ func Test_omnifunc_callback()
     g:Vim9omniFunc_Args = []
     feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
     assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9omniFunc_Args)
-    bw!
-
-    # Test for using a lambda
-    &omnifunc = (a, b) => Vim9omniFunc(61, a, b)
-    new | only
-    setline(1, 'two')
-    g:Vim9omniFunc_Args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9omniFunc_Args)
-    bw!
-
-    # Test for using a string(lambda)
-    &omnifunc = '(a, b) => Vim9omniFunc(62, a, b)'
-    new | only
-    setline(1, 'two')
-    g:Vim9omniFunc_Args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9omniFunc_Args)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => Vim9omniFunc(63, a, b)
-    &omnifunc = Fn
-    new | only
-    setline(1, 'three')
-    g:Vim9omniFunc_Args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9omniFunc_Args)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    Fn = (a, b) => Vim9omniFunc(64, a, b)
-    &omnifunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:Vim9omniFunc_Args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9omniFunc_Args)
     bw!
   END
   " call CheckScriptSuccess(lines)
@@ -1720,178 +1697,215 @@ func Test_thesaurusfunc_callback()
     return a:findstart ? 0 : []
   endfunc
 
-  " Test for using a function()
-  set thesaurusfunc=function('MytsrFunc1',[10])
-  new | only
-  call setline(1, 'one')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MytsrFunc1_args)
-  bw!
+  let lines =<< trim END
+    #" Test for using a function()
+    set thesaurusfunc=function('g:MytsrFunc1',\ [10])
+    new | only
+    call setline(1, 'one')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MytsrFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'thesaurusfunc'
-  let Fn = function('MytsrFunc1', [11])
-  let &thesaurusfunc = Fn
-  new | only
-  call setline(1, 'two')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MytsrFunc1_args)
-  bw!
+    #" Using a funcref variable to set 'thesaurusfunc'
+    VAR Fn = function('g:MytsrFunc1', [11])
+    LET &thesaurusfunc = Fn
+    new | only
+    call setline(1, 'two')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MytsrFunc1_args)
+    bw!
 
-  " Using a string(funcref_variable) to set 'thesaurusfunc'
-  let Fn = function('MytsrFunc1', [12])
-  let &thesaurusfunc = string(Fn)
-  new | only
-  call setline(1, 'two')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MytsrFunc1_args)
-  bw!
+    #" Using a string(funcref_variable) to set 'thesaurusfunc'
+    LET Fn = function('g:MytsrFunc1', [12])
+    LET &thesaurusfunc = string(Fn)
+    new | only
+    call setline(1, 'two')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MytsrFunc1_args)
+    bw!
 
-  " Test for using a funcref()
-  set thesaurusfunc=funcref('MytsrFunc1',[13])
-  new | only
-  call setline(1, 'three')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MytsrFunc1_args)
-  bw!
+    #" Test for using a funcref()
+    set thesaurusfunc=funcref('g:MytsrFunc1',\ [13])
+    new | only
+    call setline(1, 'three')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MytsrFunc1_args)
+    bw!
 
-  " Using a funcref variable to set 'thesaurusfunc'
-  let Fn = funcref('MytsrFunc1', [14])
-  let &thesaurusfunc = Fn
-  new | only
-  call setline(1, 'four')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MytsrFunc1_args)
-  bw!
+    #" Using a funcref variable to set 'thesaurusfunc'
+    LET Fn = funcref('g:MytsrFunc1', [14])
+    LET &thesaurusfunc = Fn
+    new | only
+    call setline(1, 'four')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MytsrFunc1_args)
+    bw!
 
-  " Using a string(funcref_variable) to set 'thesaurusfunc'
-  let Fn = funcref('MytsrFunc1', [15])
-  let &thesaurusfunc = string(Fn)
-  new | only
-  call setline(1, 'four')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MytsrFunc1_args)
-  bw!
+    #" Using a string(funcref_variable) to set 'thesaurusfunc'
+    LET Fn = funcref('g:MytsrFunc1', [15])
+    LET &thesaurusfunc = string(Fn)
+    new | only
+    call setline(1, 'four')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MytsrFunc1_args)
+    bw!
 
-  " Test for using a lambda function
-  set thesaurusfunc={a,\ b\ ->\ MytsrFunc1(16,\ a,\ b)}
-  new | only
-  call setline(1, 'five')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MytsrFunc1_args)
-  bw!
+    #" Test for using a lambda function
+    VAR optval = "LSTART a, b LMIDDLE MytsrFunc1(16, a, b) LEND"
+    LET optval = substitute(optval, ' ', '\\ ', 'g')
+    exe "set thesaurusfunc=" .. optval
+    new | only
+    call setline(1, 'five')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MytsrFunc1_args)
+    bw!
 
-  " Set 'thesaurusfunc' to a lambda expression
-  let &thesaurusfunc = {a, b -> MytsrFunc1(17, a, b)}
-  new | only
-  call setline(1, 'six')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MytsrFunc1_args)
-  bw!
+    #" Test for using a lambda function with set
+    LET &thesaurusfunc = LSTART a, b LMIDDLE MytsrFunc1(17, a, b) LEND
+    new | only
+    call setline(1, 'six')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MytsrFunc1_args)
+    bw!
 
-  " Set 'thesaurusfunc' to a string(lambda expression)
-  let &thesaurusfunc = '{a, b -> MytsrFunc1(18, a, b)}'
-  new | only
-  call setline(1, 'six')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MytsrFunc1_args)
-  bw!
+    #" Set 'thesaurusfunc' to a string(lambda expression)
+    LET &thesaurusfunc = 'LSTART a, b LMIDDLE MytsrFunc1(18, a, b) LEND'
+    new | only
+    call setline(1, 'six')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MytsrFunc1_args)
+    bw!
 
-  " Set 'thesaurusfunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MytsrFunc1(19, a, b)}
-  let &thesaurusfunc = Lambda
-  new | only
-  call setline(1, 'seven')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MytsrFunc1_args)
-  bw!
+    #" Set 'thesaurusfunc' to a variable with a lambda expression
+    VAR Lambda = LSTART a, b LMIDDLE MytsrFunc1(19, a, b) LEND
+    LET &thesaurusfunc = Lambda
+    new | only
+    call setline(1, 'seven')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MytsrFunc1_args)
+    bw!
 
-  " Set 'thesaurusfunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MytsrFunc1(20, a, b)}
-  let &thesaurusfunc = string(Lambda)
-  new | only
-  call setline(1, 'seven')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MytsrFunc1_args)
-  bw!
+    #" Set 'thesaurusfunc' to a string(variable with a lambda expression)
+    LET Lambda = LSTART a, b LMIDDLE MytsrFunc1(20, a, b) LEND
+    LET &thesaurusfunc = string(Lambda)
+    new | only
+    call setline(1, 'seven')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MytsrFunc1_args)
+    bw!
 
-  " Test for using a lambda function with incorrect return value
-  let Lambda = {s -> strlen(s)}
-  let &thesaurusfunc = Lambda
-  new | only
-  call setline(1, 'eight')
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  bw!
+    #" Test for using a lambda function with incorrect return value
+    LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
+    LET &thesaurusfunc = Lambda
+    new | only
+    call setline(1, 'eight')
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    bw!
 
-  " Test for clearing the 'thesaurusfunc' option
-  set thesaurusfunc=''
-  set thesaurusfunc&
+    #" Test for clearing the 'thesaurusfunc' option
+    set thesaurusfunc=''
+    set thesaurusfunc&
+    call assert_fails("set thesaurusfunc=function('abc')", "E700:")
+    call assert_fails("set thesaurusfunc=funcref('abc')", "E700:")
 
-  call assert_fails("set thesaurusfunc=function('abc')", "E700:")
-  call assert_fails("set thesaurusfunc=funcref('abc')", "E700:")
+    #" set 'thesaurusfunc' to a non-existing function
+    func MytsrFunc2(findstart, base)
+      call add(g:MytsrFunc2_args, [a:findstart, a:base])
+      return a:findstart ? 0 : ['sunday']
+    endfunc
+    set thesaurusfunc=MytsrFunc2
+    call setline(1, 'ten')
+    call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
+    call assert_fails("LET &thesaurusfunc = function('NonExistingFunc')", 'E700:')
+    LET g:MytsrFunc2_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
+    bw!
+
+    #" Use a buffer-local value and a global value
+    set thesaurusfunc&
+    setlocal thesaurusfunc=function('g:MytsrFunc1',\ [22])
+    call setline(1, 'sun')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
+    call assert_equal('sun', getline(1))
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
+    new
+    call setline(1, 'sun')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
+    call assert_equal('sun', getline(1))
+    call assert_equal([], g:MytsrFunc1_args)
+    set thesaurusfunc=function('g:MytsrFunc1',\ [23])
+    wincmd w
+    call setline(1, 'sun')
+    LET g:MytsrFunc1_args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
+    call assert_equal('sun', getline(1))
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
+    :%bw!
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let &thesaurusfunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set thesaurusfunc=(a,\ b)\ =>\ g:MytsrFunc1(21,\ a,\ b)
+  " set thesaurusfunc=(a,\ b)\ =>\ MytsrFunc1(21,\ a,\ b)
   new | only
   let g:MytsrFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")', 'E117:')
   call assert_equal([], g:MytsrFunc1_args)
   bw!
 
-  " Use a buffer-local value and a global value
-  set thesaurusfunc&
-  setlocal thesaurusfunc=function('MytsrFunc1',[22])
-  call setline(1, 'sun')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
-  call assert_equal('sun', getline(1))
-  call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
-  new
-  call setline(1, 'sun')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
-  call assert_equal('sun', getline(1))
-  call assert_equal([], g:MytsrFunc1_args)
-  set thesaurusfunc=function('MytsrFunc1',[23])
-  wincmd w
-  call setline(1, 'sun')
-  let g:MytsrFunc1_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
-  call assert_equal('sun', getline(1))
-  call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
-  %bw!
-
-  " set 'thesaurusfunc' to a non-existing function
-  func MytsrFunc2(findstart, base)
-    call add(g:MytsrFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : ['sunday']
+  " set 'thesaurusfunc' to a partial with dict. This used to cause a crash.
+  func SetTsrFunc()
+    let params = {'thesaurus': function('g:DictTsrFunc')}
+    let &thesaurusfunc = params.thesaurus
   endfunc
-  set thesaurusfunc=MytsrFunc2
-  call setline(1, 'ten')
-  call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
-  call assert_fails("let &thesaurusfunc = function('NonExistingFunc')", 'E700:')
-  let g:MytsrFunc2_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
+  func g:DictTsrFunc(_) dict
+  endfunc
+  call SetTsrFunc()
+  new
+  call SetTsrFunc()
+  bw
+  call test_garbagecollect_now()
+  new
+  set thesaurusfunc=
+  wincmd w
+  %bw!
+  delfunc SetTsrFunc
+
+  " set buffer-local 'thesaurusfunc' to a partial with dict. This used to
+  " cause a crash.
+  func SetLocalTsrFunc()
+    let params = {'thesaurus': function('g:DictTsrFunc')}
+    let &l:thesaurusfunc = params.thesaurus
+  endfunc
+  call SetLocalTsrFunc()
+  call test_garbagecollect_now()
+  call SetLocalTsrFunc()
+  set thesaurusfunc=
   bw!
+  delfunc g:DictTsrFunc
+  delfunc SetLocalTsrFunc
 
   " Vim9 tests
   let lines =<< trim END
     vim9script
 
-    # Test for using function()
+    # Test for using a def function with thesaurusfunc
     def Vim9tsrFunc(val: number, findstart: number, base: string): any
       add(g:Vim9tsrFunc_Args, [val, findstart, base])
       return findstart ? 0 : []
@@ -1902,44 +1916,6 @@ func Test_thesaurusfunc_callback()
     g:Vim9tsrFunc_Args = []
     feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
     assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9tsrFunc_Args)
-    bw!
-
-    # Test for using a lambda
-    &thesaurusfunc = (a, b) => Vim9tsrFunc(61, a, b)
-    new | only
-    setline(1, 'two')
-    g:Vim9tsrFunc_Args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9tsrFunc_Args)
-    bw!
-
-    # Test for using a string(lambda)
-    &thesaurusfunc = '(a, b) => Vim9tsrFunc(62, a, b)'
-    new | only
-    setline(1, 'two')
-    g:Vim9tsrFunc_Args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9tsrFunc_Args)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => Vim9tsrFunc(63, a, b)
-    &thesaurusfunc = Fn
-    new | only
-    setline(1, 'three')
-    g:Vim9tsrFunc_Args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9tsrFunc_Args)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    Fn = (a, b) => Vim9tsrFunc(64, a, b)
-    &thesaurusfunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:Vim9tsrFunc_Args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9tsrFunc_Args)
     bw!
   END
   " call CheckScriptSuccess(lines)

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1491,6 +1491,15 @@ func Test_completefunc_callback()
   " call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E117:')
   " call assert_equal([], g:MycompleteFunc2_args)
 
+  " set 'completefunc' to a non-existing function
+  set completefunc=MycompleteFunc2
+  call setline(1, 'five')
+  call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &completefunc = function('NonExistingFunc')", 'E700:')
+  let g:MycompleteFunc2_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
+
   " cleanup
   delfunc MycompleteFunc1
   delfunc MycompleteFunc2
@@ -1701,6 +1710,15 @@ func Test_omnifunc_callback()
   " let g:MyomniFunc2_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E117:')
   " call assert_equal([], g:MyomniFunc2_args)
+
+  " set 'omnifunc' to a non-existing function
+  set omnifunc=MyomniFunc2
+  call setline(1, 'nine')
+  call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &omnifunc = function('NonExistingFunc')", 'E700:')
+  let g:MyomniFunc2_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
 
   " cleanup
   delfunc MyomniFunc1
@@ -1939,6 +1957,16 @@ func Test_thesaurusfunc_callback()
   call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
   call assert_equal('sunday', getline(1))
   call assert_equal([[1, ''], [0, 'sun']], g:MytsrFunc4_args)
+  %bw!
+
+  " set 'thesaurusfunc' to a non-existing function
+  set thesaurusfunc=MytsrFunc2
+  call setline(1, 'ten')
+  call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &thesaurusfunc = function('NonExistingFunc')", 'E700:')
+  let g:MytsrFunc2_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
 
   " cleanup
   set thesaurusfunc&

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1290,123 +1290,136 @@ endfunc
 
 " Test for different ways of setting the 'completefunc' option
 func Test_completefunc_callback()
-  func MycompleteFunc1(val, findstart, base)
-    call add(g:MycompleteFunc1_args, [a:val, a:findstart, a:base])
+  func CompleteFunc1(callnr, findstart, base)
+    call add(g:CompleteFunc1Args, [a:callnr, a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
+  func CompleteFunc2(findstart, base)
+    call add(g:CompleteFunc2Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
 
   let lines =<< trim END
-    #" Test for using a function()
-    set completefunc=function('g:MycompleteFunc1',\ [10])
-    new | only
-    call setline(1, 'one')
-    LET g:MycompleteFunc1_args = []
+    #" Test for using a function name
+    LET &completefunc = 'g:CompleteFunc2'
+    new
+    call setline(1, 'zero')
+    LET g:CompleteFunc2Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MycompleteFunc1_args)
+    call assert_equal([[1, ''], [0, 'zero']], g:CompleteFunc2Args)
+    bw!
+
+    #" Test for using a function()
+    set completefunc=function('g:CompleteFunc1',\ [10])
+    new
+    call setline(1, 'one')
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:CompleteFunc1Args)
     bw!
 
     #" Using a funcref variable to set 'completefunc'
-    VAR Fn = function('g:MycompleteFunc1', [11])
+    VAR Fn = function('g:CompleteFunc1', [11])
     LET &completefunc = Fn
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MycompleteFunc1_args)
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:CompleteFunc1Args)
     bw!
 
     #" Using string(funcref_variable) to set 'completefunc'
-    LET Fn = function('g:MycompleteFunc1', [12])
+    LET Fn = function('g:CompleteFunc1', [12])
     LET &completefunc = string(Fn)
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MycompleteFunc1_args)
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:CompleteFunc1Args)
     bw!
 
     #" Test for using a funcref()
-    set completefunc=funcref('g:MycompleteFunc1',\ [13])
-    new | only
+    set completefunc=funcref('g:CompleteFunc1',\ [13])
+    new
     call setline(1, 'three')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MycompleteFunc1_args)
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:CompleteFunc1Args)
     bw!
 
     #" Using a funcref variable to set 'completefunc'
-    LET Fn = funcref('g:MycompleteFunc1', [14])
+    LET Fn = funcref('g:CompleteFunc1', [14])
     LET &completefunc = Fn
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MycompleteFunc1_args)
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:CompleteFunc1Args)
     bw!
 
     #" Using a string(funcref_variable) to set 'completefunc'
-    LET Fn = funcref('g:MycompleteFunc1', [15])
+    LET Fn = funcref('g:CompleteFunc1', [15])
     LET &completefunc = string(Fn)
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MycompleteFunc1_args)
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:CompleteFunc1Args)
     bw!
 
     #" Test for using a lambda function with set
-    VAR optval = "LSTART a, b LMIDDLE MycompleteFunc1(16, a, b) LEND"
+    VAR optval = "LSTART a, b LMIDDLE CompleteFunc1(16, a, b) LEND"
     LET optval = substitute(optval, ' ', '\\ ', 'g')
     exe "set completefunc=" .. optval
-    new | only
+    new
     call setline(1, 'five')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MycompleteFunc1_args)
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:CompleteFunc1Args)
     bw!
 
     #" Set 'completefunc' to a lambda expression
-    LET &completefunc = LSTART a, b LMIDDLE MycompleteFunc1(17, a, b) LEND
-    new | only
+    LET &completefunc = LSTART a, b LMIDDLE CompleteFunc1(17, a, b) LEND
+    new
     call setline(1, 'six')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MycompleteFunc1_args)
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:CompleteFunc1Args)
     bw!
 
     #" Set 'completefunc' to string(lambda_expression)
-    LET &completefunc = 'LSTART a, b LMIDDLE MycompleteFunc1(18, a, b) LEND'
-    new | only
+    LET &completefunc = 'LSTART a, b LMIDDLE CompleteFunc1(18, a, b) LEND'
+    new
     call setline(1, 'six')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MycompleteFunc1_args)
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:CompleteFunc1Args)
     bw!
 
     #" Set 'completefunc' to a variable with a lambda expression
-    VAR Lambda = LSTART a, b LMIDDLE MycompleteFunc1(19, a, b) LEND
+    VAR Lambda = LSTART a, b LMIDDLE CompleteFunc1(19, a, b) LEND
     LET &completefunc = Lambda
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MycompleteFunc1_args)
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:CompleteFunc1Args)
     bw!
 
     #" Set 'completefunc' to a string(variable with a lambda expression)
-    LET Lambda = LSTART a, b LMIDDLE MycompleteFunc1(20, a, b) LEND
+    LET Lambda = LSTART a, b LMIDDLE CompleteFunc1(20, a, b) LEND
     LET &completefunc = string(Lambda)
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MycompleteFunc1_args = []
+    LET g:CompleteFunc1Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MycompleteFunc1_args)
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:CompleteFunc1Args)
     bw!
 
     #" Test for using a lambda function with incorrect return value
     LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
     LET &completefunc = Lambda
-    new | only
+    new
     call setline(1, 'eight')
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
     bw!
@@ -1418,17 +1431,13 @@ func Test_completefunc_callback()
     call assert_fails("set completefunc=funcref('abc')", "E700:")
 
     #" set 'completefunc' to a non-existing function
-    func MycompleteFunc2(findstart, base)
-      call add(g:MycompleteFunc2_args, [a:findstart, a:base])
-      return a:findstart ? 0 : []
-    endfunc
-    set completefunc=MycompleteFunc2
+    set completefunc=CompleteFunc2
     call setline(1, 'five')
     call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
     call assert_fails("LET &completefunc = function('NonExistingFunc')", 'E700:')
-    LET g:MycompleteFunc2_args = []
+    LET g:CompleteFunc2Args = []
     call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
+    call assert_equal([[1, ''], [0, 'five']], g:CompleteFunc2Args)
     bw!
   END
   call CheckLegacyAndVim9Success(lines)
@@ -1437,11 +1446,11 @@ func Test_completefunc_callback()
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set completefunc=(a,\ b)\ =>\ MycompleteFunc1(21,\ a,\ b)
+  " set completefunc=(a,\ b)\ =>\ CompleteFunc1(21,\ a,\ b)
   new | only
-  let g:MycompleteFunc1_args = []
+  let g:CompleteFunc1Args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E117:')
-  call assert_equal([], g:MycompleteFunc1_args)
+  call assert_equal([], g:CompleteFunc1Args)
 
   " set 'completefunc' to a partial with dict. This used to cause a crash.
   func SetCompleteFunc()
@@ -1483,131 +1492,145 @@ func Test_completefunc_callback()
   " call CheckScriptSuccess(lines)
 
   " cleanup
-  delfunc MycompleteFunc1
-  delfunc MycompleteFunc2
   set completefunc&
+  delfunc CompleteFunc1
+  delfunc CompleteFunc2
+  unlet g:CompleteFunc1Args g:CompleteFunc2Args
   %bw!
 endfunc
 
 " Test for different ways of setting the 'omnifunc' option
 func Test_omnifunc_callback()
-  func MyomniFunc1(val, findstart, base)
-    call add(g:MyomniFunc1_args, [a:val, a:findstart, a:base])
+  func OmniFunc1(callnr, findstart, base)
+    call add(g:OmniFunc1Args, [a:callnr, a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
+  func OmniFunc2(findstart, base)
+    call add(g:OmniFunc2Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
 
   let lines =<< trim END
-    #" Test for using a function()
-    set omnifunc=function('g:MyomniFunc1',\ [10])
-    new | only
-    call setline(1, 'one')
-    LET g:MyomniFunc1_args = []
+    #" Test for using a function name
+    LET &omnifunc = 'g:OmniFunc2'
+    new
+    call setline(1, 'zero')
+    LET g:OmniFunc2Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MyomniFunc1_args)
+    call assert_equal([[1, ''], [0, 'zero']], g:OmniFunc2Args)
+    bw!
+
+    #" Test for using a function()
+    set omnifunc=function('g:OmniFunc1',\ [10])
+    new
+    call setline(1, 'one')
+    LET g:OmniFunc1Args = []
+    call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:OmniFunc1Args)
     bw!
 
     #" Using a funcref variable to set 'omnifunc'
-    VAR Fn = function('g:MyomniFunc1', [11])
+    VAR Fn = function('g:OmniFunc1', [11])
     LET &omnifunc = Fn
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MyomniFunc1_args)
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:OmniFunc1Args)
     bw!
 
     #" Using a string(funcref_variable) to set 'omnifunc'
-    LET Fn = function('g:MyomniFunc1', [12])
+    LET Fn = function('g:OmniFunc1', [12])
     LET &omnifunc = string(Fn)
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MyomniFunc1_args)
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:OmniFunc1Args)
     bw!
 
     #" Test for using a funcref()
-    set omnifunc=funcref('g:MyomniFunc1',\ [13])
-    new | only
+    set omnifunc=funcref('g:OmniFunc1',\ [13])
+    new
     call setline(1, 'three')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MyomniFunc1_args)
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:OmniFunc1Args)
     bw!
 
     #" Use let to set 'omnifunc' to a funcref
-    LET Fn = funcref('g:MyomniFunc1', [14])
+    LET Fn = funcref('g:OmniFunc1', [14])
     LET &omnifunc = Fn
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MyomniFunc1_args)
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:OmniFunc1Args)
     bw!
 
     #" Using a string(funcref) to set 'omnifunc'
-    LET Fn = funcref("g:MyomniFunc1", [15])
+    LET Fn = funcref("g:OmniFunc1", [15])
     LET &omnifunc = string(Fn)
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MyomniFunc1_args)
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:OmniFunc1Args)
     bw!
 
     #" Test for using a lambda function with set
-    VAR optval = "LSTART a, b LMIDDLE MyomniFunc1(16, a, b) LEND"
+    VAR optval = "LSTART a, b LMIDDLE OmniFunc1(16, a, b) LEND"
     LET optval = substitute(optval, ' ', '\\ ', 'g')
     exe "set omnifunc=" .. optval
-    new | only
+    new
     call setline(1, 'five')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MyomniFunc1_args)
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:OmniFunc1Args)
     bw!
 
     #" Set 'omnifunc' to a lambda expression
-    LET &omnifunc = LSTART a, b LMIDDLE MyomniFunc1(17, a, b) LEND
-    new | only
+    LET &omnifunc = LSTART a, b LMIDDLE OmniFunc1(17, a, b) LEND
+    new
     call setline(1, 'six')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MyomniFunc1_args)
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:OmniFunc1Args)
     bw!
 
     #" Set 'omnifunc' to a string(lambda_expression)
-    LET &omnifunc = 'LSTART a, b LMIDDLE MyomniFunc1(18, a, b) LEND'
-    new | only
+    LET &omnifunc = 'LSTART a, b LMIDDLE OmniFunc1(18, a, b) LEND'
+    new
     call setline(1, 'six')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MyomniFunc1_args)
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:OmniFunc1Args)
     bw!
 
     #" Set 'omnifunc' to a variable with a lambda expression
-    VAR Lambda = LSTART a, b LMIDDLE MyomniFunc1(19, a, b) LEND
+    VAR Lambda = LSTART a, b LMIDDLE OmniFunc1(19, a, b) LEND
     LET &omnifunc = Lambda
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MyomniFunc1_args)
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:OmniFunc1Args)
     bw!
 
     #" Set 'omnifunc' to a string(variable with a lambda expression)
-    LET Lambda = LSTART a, b LMIDDLE MyomniFunc1(20, a, b) LEND
+    LET Lambda = LSTART a, b LMIDDLE OmniFunc1(20, a, b) LEND
     LET &omnifunc = string(Lambda)
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MyomniFunc1_args = []
+    LET g:OmniFunc1Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MyomniFunc1_args)
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:OmniFunc1Args)
     bw!
 
     #" Test for using a lambda function with incorrect return value
     LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
     LET &omnifunc = Lambda
-    new | only
+    new
     call setline(1, 'eight')
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
     bw!
@@ -1619,17 +1642,13 @@ func Test_omnifunc_callback()
     call assert_fails("set omnifunc=funcref('abc')", "E700:")
 
     #" set 'omnifunc' to a non-existing function
-    func MyomniFunc2(findstart, base)
-      call add(g:MyomniFunc2_args, [a:findstart, a:base])
-      return a:findstart ? 0 : []
-    endfunc
-    set omnifunc=MyomniFunc2
+    set omnifunc=OmniFunc2
     call setline(1, 'nine')
     call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
     call assert_fails("LET &omnifunc = function('NonExistingFunc')", 'E700:')
-    LET g:MyomniFunc2_args = []
+    LET g:OmniFunc2Args = []
     call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
+    call assert_equal([[1, ''], [0, 'nine']], g:OmniFunc2Args)
     bw!
   END
   call CheckLegacyAndVim9Success(lines)
@@ -1638,11 +1657,11 @@ func Test_omnifunc_callback()
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set omnifunc=(a,\ b)\ =>\ MyomniFunc1(21,\ a,\ b)
+  " set omnifunc=(a,\ b)\ =>\ OmniFunc1(21,\ a,\ b)
   new | only
-  let g:MyomniFunc1_args = []
+  let g:OmniFunc1Args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E117:')
-  call assert_equal([], g:MyomniFunc1_args)
+  call assert_equal([], g:OmniFunc1Args)
 
   " set 'omnifunc' to a partial with dict. This used to cause a crash.
   func SetOmniFunc()
@@ -1684,131 +1703,145 @@ func Test_omnifunc_callback()
   " call CheckScriptSuccess(lines)
 
   " cleanup
-  delfunc MyomniFunc1
-  delfunc MyomniFunc2
   set omnifunc&
+  delfunc OmniFunc1
+  delfunc OmniFunc2
+  unlet g:OmniFunc1Args g:OmniFunc2Args
   %bw!
 endfunc
 
 " Test for different ways of setting the 'thesaurusfunc' option
 func Test_thesaurusfunc_callback()
-  func MytsrFunc1(val, findstart, base)
-    call add(g:MytsrFunc1_args, [a:val, a:findstart, a:base])
+  func TsrFunc1(callnr, findstart, base)
+    call add(g:TsrFunc1Args, [a:callnr, a:findstart, a:base])
     return a:findstart ? 0 : []
+  endfunc
+  func TsrFunc2(findstart, base)
+    call add(g:TsrFunc2Args, [a:findstart, a:base])
+    return a:findstart ? 0 : ['sunday']
   endfunc
 
   let lines =<< trim END
-    #" Test for using a function()
-    set thesaurusfunc=function('g:MytsrFunc1',\ [10])
-    new | only
-    call setline(1, 'one')
-    LET g:MytsrFunc1_args = []
+    #" Test for using a function name
+    LET &thesaurusfunc = 'g:TsrFunc2'
+    new
+    call setline(1, 'zero')
+    LET g:TsrFunc2Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MytsrFunc1_args)
+    call assert_equal([[1, ''], [0, 'zero']], g:TsrFunc2Args)
+    bw!
+
+    #" Test for using a function()
+    set thesaurusfunc=function('g:TsrFunc1',\ [10])
+    new
+    call setline(1, 'one')
+    LET g:TsrFunc1Args = []
+    call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:TsrFunc1Args)
     bw!
 
     #" Using a funcref variable to set 'thesaurusfunc'
-    VAR Fn = function('g:MytsrFunc1', [11])
+    VAR Fn = function('g:TsrFunc1', [11])
     LET &thesaurusfunc = Fn
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MytsrFunc1_args)
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:TsrFunc1Args)
     bw!
 
     #" Using a string(funcref_variable) to set 'thesaurusfunc'
-    LET Fn = function('g:MytsrFunc1', [12])
+    LET Fn = function('g:TsrFunc1', [12])
     LET &thesaurusfunc = string(Fn)
-    new | only
+    new
     call setline(1, 'two')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MytsrFunc1_args)
+    call assert_equal([[12, 1, ''], [12, 0, 'two']], g:TsrFunc1Args)
     bw!
 
     #" Test for using a funcref()
-    set thesaurusfunc=funcref('g:MytsrFunc1',\ [13])
-    new | only
+    set thesaurusfunc=funcref('g:TsrFunc1',\ [13])
+    new
     call setline(1, 'three')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MytsrFunc1_args)
+    call assert_equal([[13, 1, ''], [13, 0, 'three']], g:TsrFunc1Args)
     bw!
 
     #" Using a funcref variable to set 'thesaurusfunc'
-    LET Fn = funcref('g:MytsrFunc1', [14])
+    LET Fn = funcref('g:TsrFunc1', [14])
     LET &thesaurusfunc = Fn
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MytsrFunc1_args)
+    call assert_equal([[14, 1, ''], [14, 0, 'four']], g:TsrFunc1Args)
     bw!
 
     #" Using a string(funcref_variable) to set 'thesaurusfunc'
-    LET Fn = funcref('g:MytsrFunc1', [15])
+    LET Fn = funcref('g:TsrFunc1', [15])
     LET &thesaurusfunc = string(Fn)
-    new | only
+    new
     call setline(1, 'four')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MytsrFunc1_args)
+    call assert_equal([[15, 1, ''], [15, 0, 'four']], g:TsrFunc1Args)
     bw!
 
     #" Test for using a lambda function
-    VAR optval = "LSTART a, b LMIDDLE MytsrFunc1(16, a, b) LEND"
+    VAR optval = "LSTART a, b LMIDDLE TsrFunc1(16, a, b) LEND"
     LET optval = substitute(optval, ' ', '\\ ', 'g')
     exe "set thesaurusfunc=" .. optval
-    new | only
+    new
     call setline(1, 'five')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MytsrFunc1_args)
+    call assert_equal([[16, 1, ''], [16, 0, 'five']], g:TsrFunc1Args)
     bw!
 
     #" Test for using a lambda function with set
-    LET &thesaurusfunc = LSTART a, b LMIDDLE MytsrFunc1(17, a, b) LEND
-    new | only
+    LET &thesaurusfunc = LSTART a, b LMIDDLE TsrFunc1(17, a, b) LEND
+    new
     call setline(1, 'six')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MytsrFunc1_args)
+    call assert_equal([[17, 1, ''], [17, 0, 'six']], g:TsrFunc1Args)
     bw!
 
     #" Set 'thesaurusfunc' to a string(lambda expression)
-    LET &thesaurusfunc = 'LSTART a, b LMIDDLE MytsrFunc1(18, a, b) LEND'
-    new | only
+    LET &thesaurusfunc = 'LSTART a, b LMIDDLE TsrFunc1(18, a, b) LEND'
+    new
     call setline(1, 'six')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MytsrFunc1_args)
+    call assert_equal([[18, 1, ''], [18, 0, 'six']], g:TsrFunc1Args)
     bw!
 
     #" Set 'thesaurusfunc' to a variable with a lambda expression
-    VAR Lambda = LSTART a, b LMIDDLE MytsrFunc1(19, a, b) LEND
+    VAR Lambda = LSTART a, b LMIDDLE TsrFunc1(19, a, b) LEND
     LET &thesaurusfunc = Lambda
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MytsrFunc1_args)
+    call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:TsrFunc1Args)
     bw!
 
     #" Set 'thesaurusfunc' to a string(variable with a lambda expression)
-    LET Lambda = LSTART a, b LMIDDLE MytsrFunc1(20, a, b) LEND
+    LET Lambda = LSTART a, b LMIDDLE TsrFunc1(20, a, b) LEND
     LET &thesaurusfunc = string(Lambda)
-    new | only
+    new
     call setline(1, 'seven')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MytsrFunc1_args)
+    call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:TsrFunc1Args)
     bw!
 
     #" Test for using a lambda function with incorrect return value
     LET Lambda = LSTART a, b LMIDDLE strlen(a) LEND
     LET &thesaurusfunc = Lambda
-    new | only
+    new
     call setline(1, 'eight')
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
     bw!
@@ -1820,40 +1853,36 @@ func Test_thesaurusfunc_callback()
     call assert_fails("set thesaurusfunc=funcref('abc')", "E700:")
 
     #" set 'thesaurusfunc' to a non-existing function
-    func MytsrFunc2(findstart, base)
-      call add(g:MytsrFunc2_args, [a:findstart, a:base])
-      return a:findstart ? 0 : ['sunday']
-    endfunc
-    set thesaurusfunc=MytsrFunc2
+    set thesaurusfunc=TsrFunc2
     call setline(1, 'ten')
     call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
     call assert_fails("LET &thesaurusfunc = function('NonExistingFunc')", 'E700:')
-    LET g:MytsrFunc2_args = []
+    LET g:TsrFunc2Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
+    call assert_equal([[1, ''], [0, 'ten']], g:TsrFunc2Args)
     bw!
 
     #" Use a buffer-local value and a global value
     set thesaurusfunc&
-    setlocal thesaurusfunc=function('g:MytsrFunc1',\ [22])
+    setlocal thesaurusfunc=function('g:TsrFunc1',\ [22])
     call setline(1, 'sun')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
     call assert_equal('sun', getline(1))
-    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:TsrFunc1Args)
     new
     call setline(1, 'sun')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
     call assert_equal('sun', getline(1))
-    call assert_equal([], g:MytsrFunc1_args)
-    set thesaurusfunc=function('g:MytsrFunc1',\ [23])
+    call assert_equal([], g:TsrFunc1Args)
+    set thesaurusfunc=function('g:TsrFunc1',\ [23])
     wincmd w
     call setline(1, 'sun')
-    LET g:MytsrFunc1_args = []
+    LET g:TsrFunc1Args = []
     call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
     call assert_equal('sun', getline(1))
-    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
+    call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:TsrFunc1Args)
     :%bw!
   END
   call CheckLegacyAndVim9Success(lines)
@@ -1862,11 +1891,11 @@ func Test_thesaurusfunc_callback()
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set thesaurusfunc=(a,\ b)\ =>\ MytsrFunc1(21,\ a,\ b)
+  " set thesaurusfunc=(a,\ b)\ =>\ TsrFunc1(21,\ a,\ b)
   new | only
-  let g:MytsrFunc1_args = []
+  let g:TsrFunc1Args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")', 'E117:')
-  call assert_equal([], g:MytsrFunc1_args)
+  call assert_equal([], g:TsrFunc1Args)
   bw!
 
   " set 'thesaurusfunc' to a partial with dict. This used to cause a crash.
@@ -1922,8 +1951,9 @@ func Test_thesaurusfunc_callback()
 
   " cleanup
   set thesaurusfunc&
-  delfunc MytsrFunc1
-  delfunc MytsrFunc2
+  delfunc TsrFunc1
+  delfunc TsrFunc2
+  unlet g:TsrFunc1Args g:TsrFunc2Args
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1340,7 +1340,7 @@ func Test_completefunc_callback()
     call add(g:MycompleteFunc3_args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set completefunc={a,\ b,\ ->\ MycompleteFunc3(a,\ b,)}
+  set completefunc={a,\ b\ ->\ MycompleteFunc3(a,\ b)}
   new | only
   call setline(1, 'five')
   let g:MycompleteFunc3_args = []
@@ -1403,26 +1403,29 @@ func Test_completefunc_callback()
     bw!
 
     # Test for using a lambda
-    def MycompleteFunc2(findstart: number, base: string): any
-      add(g:MycompleteFunc2_args, [findstart, base])
+    def LambdaComplete1(findstart: number, base: string): any
+      add(g:LambdaComplete1_args, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &completefunc = '(a, b) => MycompleteFunc2(a, b)'
+    &completefunc = '(a, b) => LambdaComplete1(a, b)'
     new | only
     setline(1, 'two')
-    g:MycompleteFunc2_args = []
+    g:LambdaComplete1_args = []
     feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc2_args)
+    assert_equal([[1, ''], [0, 'two']], g:LambdaComplete1_args)
     bw!
 
     # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => MycompleteFunc2(a, b)
+    var Fn: func = (findstart, base) => {
+            add(g:LambdaComplete2_args, [findstart, base])
+            return findstart ? 0 : []
+        }
     &completefunc = string(Fn)
     new | only
     setline(1, 'three')
-    g:MycompleteFunc2_args = []
+    g:LambdaComplete2_args = []
     feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:MycompleteFunc2_args)
+    assert_equal([[1, ''], [0, 'three']], g:LambdaComplete2_args)
     bw!
   END
   " call CheckScriptSuccess(lines)
@@ -1497,7 +1500,7 @@ func Test_omnifunc_callback()
     call add(g:MyomniFunc3_args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set omnifunc={a,\ b,\ ->\ MyomniFunc3(a,\ b,)}
+  set omnifunc={a,\ b\ ->\ MyomniFunc3(a,\ b)}
   new | only
   call setline(1, 'five')
   let g:MyomniFunc3_args = []
@@ -1654,7 +1657,7 @@ func Test_thesaurusfunc_callback()
     call add(g:MytsrFunc3_args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set thesaurusfunc={a,\ b,\ ->\ MytsrFunc3(a,\ b,)}
+  set thesaurusfunc={a,\ b\ ->\ MytsrFunc3(a,\ b)}
   new | only
   call setline(1, 'five')
   let g:MytsrFunc3_args = []

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1287,121 +1287,114 @@ endfunc
 
 " Test for different ways of setting the 'completefunc' option
 func Test_completefunc_callback()
-  " Test for using a function()
-  func MycompleteFunc1(findstart, base)
-    call add(g:MycompleteFunc1_args, [a:findstart, a:base])
+  func MycompleteFunc1(val, findstart, base)
+    call add(g:MycompleteFunc1_args, [a:val, a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set completefunc=function('MycompleteFunc1')
+
+  " Test for using a function()
+  set completefunc=function('MycompleteFunc1',[10])
   new | only
   call setline(1, 'one')
   let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'one']], g:MycompleteFunc1_args)
+  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MycompleteFunc1_args)
   bw!
 
   " Using a funcref variable to set 'completefunc'
-  let Fn = function('MycompleteFunc1')
+  let Fn = function('MycompleteFunc1', [11])
   let &completefunc = Fn
   new | only
   call setline(1, 'two')
   let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
+  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MycompleteFunc1_args)
   bw!
 
   " Using string(funcref_variable) to set 'completefunc'
-  let Fn = function('MycompleteFunc1')
+  let Fn = function('MycompleteFunc1', [12])
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
+  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MycompleteFunc1_args)
   bw!
 
   " Test for using a funcref()
-  func MycompleteFunc2(findstart, base)
-    call add(g:MycompleteFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set completefunc=funcref('MycompleteFunc2')
+  set completefunc=funcref('MycompleteFunc1',\ [13])
   new | only
   call setline(1, 'three')
-  let g:MycompleteFunc2_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'three']], g:MycompleteFunc2_args)
+  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MycompleteFunc1_args)
   bw!
 
   " Using a funcref variable to set 'completefunc'
-  let Fn = funcref('MycompleteFunc2')
+  let Fn = funcref('MycompleteFunc1', [14])
   let &completefunc = Fn
   new | only
   call setline(1, 'four')
-  let g:MycompleteFunc2_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
+  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MycompleteFunc1_args)
   bw!
 
   " Using a string(funcref_variable) to set 'completefunc'
-  let Fn = funcref('MycompleteFunc2')
+  let Fn = funcref('MycompleteFunc1', [15])
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'four')
-  let g:MycompleteFunc2_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
+  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MycompleteFunc1_args)
   bw!
 
   " Test for using a lambda function
-  func MycompleteFunc3(findstart, base)
-    call add(g:MycompleteFunc3_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set completefunc={a,\ b\ ->\ MycompleteFunc3(a,\ b)}
+  set completefunc={a,\ b\ ->\ MycompleteFunc1(16,\ a,\ b)}
   new | only
   call setline(1, 'five')
-  let g:MycompleteFunc3_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc3_args)
+  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MycompleteFunc1_args)
   bw!
 
   " Set 'completefunc' to a lambda expression
-  let &completefunc = {a, b -> MycompleteFunc3(a, b)}
+  let &completefunc = {a, b -> MycompleteFunc1(17, a, b)}
   new | only
   call setline(1, 'six')
-  let g:MycompleteFunc3_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MycompleteFunc3_args)
+  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MycompleteFunc1_args)
   bw!
 
   " Set 'completefunc' to string(lambda_expression)
-  let &completefunc = '{a, b -> MycompleteFunc3(a, b)}'
+  let &completefunc = '{a, b -> MycompleteFunc1(18, a, b)}'
   new | only
   call setline(1, 'six')
-  let g:MycompleteFunc3_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MycompleteFunc3_args)
+  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MycompleteFunc1_args)
   bw!
 
   " Set 'completefunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MycompleteFunc3(a, b)}
+  let Lambda = {a, b -> MycompleteFunc1(19, a, b)}
   let &completefunc = Lambda
   new | only
   call setline(1, 'seven')
-  let g:MycompleteFunc3_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
+  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MycompleteFunc1_args)
   bw!
 
   " Set 'completefunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MycompleteFunc3(a, b)}
+  let Lambda = {a, b -> MycompleteFunc1(20, a, b)}
   let &completefunc = string(Lambda)
   new | only
   call setline(1, 'seven')
-  let g:MycompleteFunc3_args = []
+  let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
+  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MycompleteFunc1_args)
   bw!
 
   " Test for using a lambda function with incorrect return value
@@ -1421,77 +1414,18 @@ func Test_completefunc_callback()
   let &completefunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
 
-  " Vim9 tests
-  let lines =<< trim END
-    vim9script
-
-    # Test for using function()
-    def MycompleteFunc1(findstart: number, base: string): any
-      add(g:MycompleteFunc1_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    set completefunc=function('MycompleteFunc1')
-    new | only
-    setline(1, 'one')
-    g:MycompleteFunc1_args = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'one']], g:MycompleteFunc1_args)
-    bw!
-
-    # Test for using a lambda
-    def LambdaComplete1(findstart: number, base: string): any
-      add(g:LambdaComplete1_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    &completefunc = (a, b) => LambdaComplete1(a, b)
-    new | only
-    setline(1, 'two')
-    g:LambdaComplete1_args = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:LambdaComplete1_args)
-    bw!
-
-    # Test for using a string(lambda)
-    &completefunc = '(a, b) => LambdaComplete1(a, b)'
-    new | only
-    setline(1, 'two')
-    g:LambdaComplete1_args = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:LambdaComplete1_args)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (findstart, base) => {
-            add(g:LambdaComplete2_args, [findstart, base])
-            return findstart ? 0 : []
-        }
-    &completefunc = Fn
-    new | only
-    setline(1, 'three')
-    g:LambdaComplete2_args = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:LambdaComplete2_args)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    &completefunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:LambdaComplete2_args = []
-    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:LambdaComplete2_args)
-    bw!
-  END
-  " call CheckScriptSuccess(lines)
-
   " Using Vim9 lambda expression in legacy context should fail
-  " set completefunc=(a,\ b)\ =>\ g:MycompleteFunc2(a,\ b)
-  " new | only
-  " let g:MycompleteFunc2_args = []
+  " set completefunc=(a,\ b)\ =>\ g:MycompleteFunc1(21,\ a,\ b)
+  new | only
+  let g:MycompleteFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-U>\<Esc>", "x")', 'E117:')
-  " call assert_equal([], g:MycompleteFunc2_args)
+  call assert_equal([], g:MycompleteFunc1_args)
 
   " set 'completefunc' to a non-existing function
+  func MycompleteFunc2(findstart, base)
+    call add(g:MycompleteFunc2_args, [a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
   set completefunc=MycompleteFunc2
   call setline(1, 'five')
   call assert_fails("set completefunc=function('NonExistingFunc')", 'E700:')
@@ -1499,132 +1433,182 @@ func Test_completefunc_callback()
   let g:MycompleteFunc2_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'five']], g:MycompleteFunc2_args)
+  bw!
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def Vim9CompleteFunc(val: number, findstart: number, base: string): any
+      add(g:Vim9completeFuncArgs, [val, findstart, base])
+      return findstart ? 0 : []
+    enddef
+    set completefunc=function('Vim9CompleteFunc',\ [60])
+    new | only
+    setline(1, 'one')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9completeFuncArgs)
+    bw!
+
+    # Test for using a lambda
+    &completefunc = (a, b) => Vim9CompleteFunc(61, a, b)
+    new | only
+    setline(1, 'two')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9completeFuncArgs)
+    bw!
+
+    # Test for using a string(lambda)
+    &completefunc = '(a, b) => Vim9CompleteFunc(62, a, b)'
+    new | only
+    setline(1, 'two')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9completeFuncArgs)
+    bw!
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a, b) => Vim9CompleteFunc(63, a, b)
+    &completefunc = Fn
+    new | only
+    setline(1, 'three')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9completeFuncArgs)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
+    Fn = (a, b) => Vim9CompleteFunc(64, a, b)
+    &completefunc = string(Fn)
+    new | only
+    setline(1, 'three')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9completeFuncArgs)
+    bw!
+  END
+  " call CheckScriptSuccess(lines)
 
   " cleanup
   delfunc MycompleteFunc1
   delfunc MycompleteFunc2
-  delfunc MycompleteFunc3
   set completefunc&
   %bw!
 endfunc
 
 " Test for different ways of setting the 'omnifunc' option
 func Test_omnifunc_callback()
-  " Test for using a function()
-  func MyomniFunc1(findstart, base)
-    call add(g:MyomniFunc1_args, [a:findstart, a:base])
+  func MyomniFunc1(val, findstart, base)
+    call add(g:MyomniFunc1_args, [a:val, a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set omnifunc=function('MyomniFunc1')
+
+  " Test for using a function()
+  set omnifunc=function('MyomniFunc1',[10])
   new | only
   call setline(1, 'one')
   let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'one']], g:MyomniFunc1_args)
+  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MyomniFunc1_args)
   bw!
 
   " Using a funcref variable to set 'omnifunc'
-  let Fn = function('MyomniFunc1')
+  let Fn = function('MyomniFunc1', [11])
   let &omnifunc = Fn
   new | only
   call setline(1, 'two')
   let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
+  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MyomniFunc1_args)
   bw!
 
   " Using a string(funcref_variable) to set 'omnifunc'
-  let Fn = function('MyomniFunc1')
+  let Fn = function('MyomniFunc1', [12])
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
+  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MyomniFunc1_args)
   bw!
 
   " Test for using a funcref()
-  func MyomniFunc2(findstart, base)
-    call add(g:MyomniFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set omnifunc=funcref('MyomniFunc2')
+  set omnifunc=funcref('MyomniFunc1',\ [13])
   new | only
   call setline(1, 'three')
-  let g:MyomniFunc2_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'three']], g:MyomniFunc2_args)
+  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MyomniFunc1_args)
   bw!
 
   " Using a funcref variable to set 'omnifunc'
-  let Fn = funcref('MyomniFunc2')
+  let Fn = funcref('MyomniFunc1', [14])
   let &omnifunc = Fn
   new | only
   call setline(1, 'four')
-  let g:MyomniFunc2_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
+  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MyomniFunc1_args)
   bw!
 
   " Using a string(funcref_variable) to set 'omnifunc'
-  let Fn = funcref('MyomniFunc2')
+  let Fn = funcref('MyomniFunc1', [15])
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'four')
-  let g:MyomniFunc2_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
+  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MyomniFunc1_args)
   bw!
 
   " Test for using a lambda function
-  func MyomniFunc3(findstart, base)
-    call add(g:MyomniFunc3_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set omnifunc={a,\ b\ ->\ MyomniFunc3(a,\ b)}
+  set omnifunc={a,\ b\ ->\ MyomniFunc1(16,\ a,\ b)}
   new | only
   call setline(1, 'five')
-  let g:MyomniFunc3_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'five']], g:MyomniFunc3_args)
+  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MyomniFunc1_args)
   bw!
 
   " Set 'omnifunc' to a lambda expression
-  let &omnifunc = {a, b -> MyomniFunc3(a, b)}
+  let &omnifunc = {a, b -> MyomniFunc1(17, a, b)}
   new | only
   call setline(1, 'six')
-  let g:MyomniFunc3_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MyomniFunc3_args)
+  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MyomniFunc1_args)
   bw!
 
   " Set 'omnifunc' to a string(lambda_expression)
-  let &omnifunc = '{a, b -> MyomniFunc3(a, b)}'
+  let &omnifunc = '{a, b -> MyomniFunc1(18, a, b)}'
   new | only
   call setline(1, 'six')
-  let g:MyomniFunc3_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MyomniFunc3_args)
+  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MyomniFunc1_args)
   bw!
 
   " Set 'omnifunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MyomniFunc3(a, b)}
+  let Lambda = {a, b -> MyomniFunc1(19, a, b)}
   let &omnifunc = Lambda
   new | only
   call setline(1, 'seven')
-  let g:MyomniFunc3_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
+  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MyomniFunc1_args)
   bw!
 
   " Set 'omnifunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MyomniFunc3(a, b)}
+  let Lambda = {a, b -> MyomniFunc1(20, a, b)}
   let &omnifunc = string(Lambda)
   new | only
   call setline(1, 'seven')
-  let g:MyomniFunc3_args = []
+  let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
+  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MyomniFunc1_args)
   bw!
 
   " Test for using a lambda function with incorrect return value
@@ -1644,74 +1628,18 @@ func Test_omnifunc_callback()
   let &omnifunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
 
-  " Vim9 tests
-  let lines =<< trim END
-    vim9script
-
-    # Test for using function()
-    def MyomniFunc1(findstart: number, base: string): any
-      add(g:MyomniFunc1_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    set omnifunc=function('MyomniFunc1')
-    new | only
-    setline(1, 'one')
-    g:MyomniFunc1_args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'one']], g:MyomniFunc1_args)
-    bw!
-
-    # Test for using a lambda
-    def MyomniFunc2(findstart: number, base: string): any
-      add(g:MyomniFunc2_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    &omnifunc = (a, b) => MyomniFunc2(a, b)
-    new | only
-    setline(1, 'two')
-    g:MyomniFunc2_args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:MyomniFunc2_args)
-    bw!
-
-    # Test for using a string(lambda)
-    &omnifunc = '(a, b) => MyomniFunc2(a, b)'
-    new | only
-    setline(1, 'two')
-    g:MyomniFunc2_args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:MyomniFunc2_args)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => MyomniFunc2(a, b)
-    &omnifunc = Fn
-    new | only
-    setline(1, 'three')
-    g:MyomniFunc2_args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:MyomniFunc2_args)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    &omnifunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:MyomniFunc2_args = []
-    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:MyomniFunc2_args)
-    bw!
-  END
-  " call CheckScriptSuccess(lines)
-
   " Using Vim9 lambda expression in legacy context should fail
-  " set omnifunc=(a,\ b)\ =>\ g:MyomniFunc2(a,\ b)
-  " new | only
-  " let g:MyomniFunc2_args = []
+  " set omnifunc=(a,\ b)\ =>\ g:MyomniFunc1(21,\ a,\ b)
+  new | only
+  let g:MyomniFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-O>\<Esc>", "x")', 'E117:')
-  " call assert_equal([], g:MyomniFunc2_args)
+  call assert_equal([], g:MyomniFunc1_args)
 
   " set 'omnifunc' to a non-existing function
+  func MyomniFunc2(findstart, base)
+    call add(g:MyomniFunc2_args, [a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
   set omnifunc=MyomniFunc2
   call setline(1, 'nine')
   call assert_fails("set omnifunc=function('NonExistingFunc')", 'E700:')
@@ -1719,132 +1647,182 @@ func Test_omnifunc_callback()
   let g:MyomniFunc2_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'nine']], g:MyomniFunc2_args)
+  bw!
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def Vim9omniFunc(val: number, findstart: number, base: string): any
+      add(g:Vim9omniFunc_Args, [val, findstart, base])
+      return findstart ? 0 : []
+    enddef
+    set omnifunc=function('Vim9omniFunc',\ [60])
+    new | only
+    setline(1, 'one')
+    g:Vim9omniFunc_Args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9omniFunc_Args)
+    bw!
+
+    # Test for using a lambda
+    &omnifunc = (a, b) => Vim9omniFunc(61, a, b)
+    new | only
+    setline(1, 'two')
+    g:Vim9omniFunc_Args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9omniFunc_Args)
+    bw!
+
+    # Test for using a string(lambda)
+    &omnifunc = '(a, b) => Vim9omniFunc(62, a, b)'
+    new | only
+    setline(1, 'two')
+    g:Vim9omniFunc_Args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9omniFunc_Args)
+    bw!
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a, b) => Vim9omniFunc(63, a, b)
+    &omnifunc = Fn
+    new | only
+    setline(1, 'three')
+    g:Vim9omniFunc_Args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9omniFunc_Args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
+    Fn = (a, b) => Vim9omniFunc(64, a, b)
+    &omnifunc = string(Fn)
+    new | only
+    setline(1, 'three')
+    g:Vim9omniFunc_Args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9omniFunc_Args)
+    bw!
+  END
+  " call CheckScriptSuccess(lines)
 
   " cleanup
   delfunc MyomniFunc1
   delfunc MyomniFunc2
-  delfunc MyomniFunc3
   set omnifunc&
   %bw!
 endfunc
 
 " Test for different ways of setting the 'thesaurusfunc' option
 func Test_thesaurusfunc_callback()
-  " Test for using a function()
-  func MytsrFunc1(findstart, base)
-    call add(g:MytsrFunc1_args, [a:findstart, a:base])
+  func MytsrFunc1(val, findstart, base)
+    call add(g:MytsrFunc1_args, [a:val, a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set thesaurusfunc=function('MytsrFunc1')
+
+  " Test for using a function()
+  set thesaurusfunc=function('MytsrFunc1',[10])
   new | only
   call setline(1, 'one')
   let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'one']], g:MytsrFunc1_args)
+  call assert_equal([[10, 1, ''], [10, 0, 'one']], g:MytsrFunc1_args)
   bw!
 
   " Using a funcref variable to set 'thesaurusfunc'
-  let Fn = function('MytsrFunc1')
+  let Fn = function('MytsrFunc1', [11])
   let &thesaurusfunc = Fn
   new | only
   call setline(1, 'two')
   let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
+  call assert_equal([[11, 1, ''], [11, 0, 'two']], g:MytsrFunc1_args)
   bw!
 
   " Using a string(funcref_variable) to set 'thesaurusfunc'
-  let Fn = function('MytsrFunc1')
+  let Fn = function('MytsrFunc1', [12])
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
+  call assert_equal([[12, 1, ''], [12, 0, 'two']], g:MytsrFunc1_args)
   bw!
 
   " Test for using a funcref()
-  func MytsrFunc2(findstart, base)
-    call add(g:MytsrFunc2_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set thesaurusfunc=funcref('MytsrFunc2')
+  set thesaurusfunc=funcref('MytsrFunc1',[13])
   new | only
   call setline(1, 'three')
-  let g:MytsrFunc2_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'three']], g:MytsrFunc2_args)
+  call assert_equal([[13, 1, ''], [13, 0, 'three']], g:MytsrFunc1_args)
   bw!
 
   " Using a funcref variable to set 'thesaurusfunc'
-  let Fn = funcref('MytsrFunc2')
+  let Fn = funcref('MytsrFunc1', [14])
   let &thesaurusfunc = Fn
   new | only
   call setline(1, 'four')
-  let g:MytsrFunc2_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
+  call assert_equal([[14, 1, ''], [14, 0, 'four']], g:MytsrFunc1_args)
   bw!
 
   " Using a string(funcref_variable) to set 'thesaurusfunc'
-  let Fn = funcref('MytsrFunc2')
+  let Fn = funcref('MytsrFunc1', [15])
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'four')
-  let g:MytsrFunc2_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
+  call assert_equal([[15, 1, ''], [15, 0, 'four']], g:MytsrFunc1_args)
   bw!
 
   " Test for using a lambda function
-  func MytsrFunc3(findstart, base)
-    call add(g:MytsrFunc3_args, [a:findstart, a:base])
-    return a:findstart ? 0 : []
-  endfunc
-  set thesaurusfunc={a,\ b\ ->\ MytsrFunc3(a,\ b)}
+  set thesaurusfunc={a,\ b\ ->\ MytsrFunc1(16,\ a,\ b)}
   new | only
   call setline(1, 'five')
-  let g:MytsrFunc3_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'five']], g:MytsrFunc3_args)
+  call assert_equal([[16, 1, ''], [16, 0, 'five']], g:MytsrFunc1_args)
   bw!
 
   " Set 'thesaurusfunc' to a lambda expression
-  let &thesaurusfunc = {a, b -> MytsrFunc3(a, b)}
+  let &thesaurusfunc = {a, b -> MytsrFunc1(17, a, b)}
   new | only
   call setline(1, 'six')
-  let g:MytsrFunc3_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MytsrFunc3_args)
+  call assert_equal([[17, 1, ''], [17, 0, 'six']], g:MytsrFunc1_args)
   bw!
 
   " Set 'thesaurusfunc' to a string(lambda expression)
-  let &thesaurusfunc = '{a, b -> MytsrFunc3(a, b)}'
+  let &thesaurusfunc = '{a, b -> MytsrFunc1(18, a, b)}'
   new | only
   call setline(1, 'six')
-  let g:MytsrFunc3_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'six']], g:MytsrFunc3_args)
+  call assert_equal([[18, 1, ''], [18, 0, 'six']], g:MytsrFunc1_args)
   bw!
 
   " Set 'thesaurusfunc' to a variable with a lambda expression
-  let Lambda = {a, b -> MytsrFunc3(a, b)}
+  let Lambda = {a, b -> MytsrFunc1(19, a, b)}
   let &thesaurusfunc = Lambda
   new | only
   call setline(1, 'seven')
-  let g:MytsrFunc3_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
+  call assert_equal([[19, 1, ''], [19, 0, 'seven']], g:MytsrFunc1_args)
   bw!
 
   " Set 'thesaurusfunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b -> MytsrFunc3(a, b)}
+  let Lambda = {a, b -> MytsrFunc1(20, a, b)}
   let &thesaurusfunc = string(Lambda)
   new | only
   call setline(1, 'seven')
-  let g:MytsrFunc3_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-  call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
+  call assert_equal([[20, 1, ''], [20, 0, 'seven']], g:MytsrFunc1_args)
   bw!
 
   " Test for using a lambda function with incorrect return value
@@ -1864,102 +1842,42 @@ func Test_thesaurusfunc_callback()
   let &thesaurusfunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
 
-  " Vim9 tests
-  let lines =<< trim END
-    vim9script
-
-    # Test for using function()
-    def MytsrFunc1(findstart: number, base: string): any
-      add(g:MytsrFunc1_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    set thesaurusfunc=function('MytsrFunc1')
-    new | only
-    setline(1, 'one')
-    g:MytsrFunc1_args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'one']], g:MytsrFunc1_args)
-    bw!
-
-    # Test for using a lambda
-    def MytsrFunc2(findstart: number, base: string): any
-      add(g:MytsrFunc2_args, [findstart, base])
-      return findstart ? 0 : []
-    enddef
-    &thesaurusfunc = (a, b) => MytsrFunc2(a, b)
-    new | only
-    setline(1, 'two')
-    g:MytsrFunc2_args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:MytsrFunc2_args)
-    bw!
-
-    # Test for using a string(lambda)
-    &thesaurusfunc = '(a, b) => MytsrFunc2(a, b)'
-    new | only
-    setline(1, 'two')
-    g:MytsrFunc2_args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'two']], g:MytsrFunc2_args)
-    bw!
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b) => MytsrFunc2(a, b)
-    &thesaurusfunc = Fn
-    new | only
-    setline(1, 'three')
-    g:MytsrFunc2_args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:MytsrFunc2_args)
-    bw!
-
-    # Test for using a string(variable with a lambda expression)
-    &thesaurusfunc = string(Fn)
-    new | only
-    setline(1, 'three')
-    g:MytsrFunc2_args = []
-    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
-    assert_equal([[1, ''], [0, 'three']], g:MytsrFunc2_args)
-    bw!
-  END
-  " call CheckScriptSuccess(lines)
-
   " Using Vim9 lambda expression in legacy context should fail
-  " set thesaurusfunc=(a,\ b)\ =>\ g:MytsrFunc2(a,\ b)
-  " new | only
-  " let g:MytsrFunc2_args = []
+  " set thesaurusfunc=(a,\ b)\ =>\ g:MytsrFunc1(21,\ a,\ b)
+  new | only
+  let g:MytsrFunc1_args = []
   " call assert_fails('call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")', 'E117:')
-  " call assert_equal([], g:MytsrFunc2_args)
-  " bw!
+  call assert_equal([], g:MytsrFunc1_args)
+  bw!
 
   " Use a buffer-local value and a global value
-  func MytsrFunc4(findstart, base)
-    call add(g:MytsrFunc4_args, [a:findstart, a:base])
-    return a:findstart ? 0 : ['sunday']
-  endfunc
   set thesaurusfunc&
-  setlocal thesaurusfunc=function('MytsrFunc4')
+  setlocal thesaurusfunc=function('MytsrFunc1',[22])
   call setline(1, 'sun')
-  let g:MytsrFunc4_args = []
-  call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
-  call assert_equal('sunday', getline(1))
-  call assert_equal([[1, ''], [0, 'sun']], g:MytsrFunc4_args)
-  new
-  call setline(1, 'sun')
-  let g:MytsrFunc4_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
   call assert_equal('sun', getline(1))
-  call assert_equal([], g:MytsrFunc4_args)
-  set thesaurusfunc=function('MytsrFunc1')
+  call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
+  new
+  call setline(1, 'sun')
+  let g:MytsrFunc1_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
+  call assert_equal('sun', getline(1))
+  call assert_equal([], g:MytsrFunc1_args)
+  set thesaurusfunc=function('MytsrFunc1',[23])
   wincmd w
   call setline(1, 'sun')
-  let g:MytsrFunc4_args = []
+  let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
-  call assert_equal('sunday', getline(1))
-  call assert_equal([[1, ''], [0, 'sun']], g:MytsrFunc4_args)
+  call assert_equal('sun', getline(1))
+  call assert_equal([[22, 1, ''], [22, 0, 'sun']], g:MytsrFunc1_args)
   %bw!
 
   " set 'thesaurusfunc' to a non-existing function
+  func MytsrFunc2(findstart, base)
+    call add(g:MytsrFunc2_args, [a:findstart, a:base])
+    return a:findstart ? 0 : ['sunday']
+  endfunc
   set thesaurusfunc=MytsrFunc2
   call setline(1, 'ten')
   call assert_fails("set thesaurusfunc=function('NonExistingFunc')", 'E700:')
@@ -1967,13 +1885,69 @@ func Test_thesaurusfunc_callback()
   let g:MytsrFunc2_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'ten']], g:MytsrFunc2_args)
+  bw!
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def Vim9tsrFunc(val: number, findstart: number, base: string): any
+      add(g:Vim9tsrFunc_Args, [val, findstart, base])
+      return findstart ? 0 : []
+    enddef
+    set thesaurusfunc=function('Vim9tsrFunc',\ [60])
+    new | only
+    setline(1, 'one')
+    g:Vim9tsrFunc_Args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9tsrFunc_Args)
+    bw!
+
+    # Test for using a lambda
+    &thesaurusfunc = (a, b) => Vim9tsrFunc(61, a, b)
+    new | only
+    setline(1, 'two')
+    g:Vim9tsrFunc_Args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[61, 1, ''], [61, 0, 'two']], g:Vim9tsrFunc_Args)
+    bw!
+
+    # Test for using a string(lambda)
+    &thesaurusfunc = '(a, b) => Vim9tsrFunc(62, a, b)'
+    new | only
+    setline(1, 'two')
+    g:Vim9tsrFunc_Args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[62, 1, ''], [62, 0, 'two']], g:Vim9tsrFunc_Args)
+    bw!
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a, b) => Vim9tsrFunc(63, a, b)
+    &thesaurusfunc = Fn
+    new | only
+    setline(1, 'three')
+    g:Vim9tsrFunc_Args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[63, 1, ''], [63, 0, 'three']], g:Vim9tsrFunc_Args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
+    Fn = (a, b) => Vim9tsrFunc(64, a, b)
+    &thesaurusfunc = string(Fn)
+    new | only
+    setline(1, 'three')
+    g:Vim9tsrFunc_Args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[64, 1, ''], [64, 0, 'three']], g:Vim9tsrFunc_Args)
+    bw!
+  END
+  " call CheckScriptSuccess(lines)
 
   " cleanup
   set thesaurusfunc&
   delfunc MytsrFunc1
   delfunc MytsrFunc2
-  delfunc MytsrFunc3
-  delfunc MytsrFunc4
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_ins_complete.vim
+++ b/src/nvim/testdir/test_ins_complete.vim
@@ -1302,13 +1302,22 @@ func Test_completefunc_callback()
 
   " Using a funcref variable to set 'completefunc'
   let Fn = function('MycompleteFunc1')
+  let &completefunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MycompleteFunc1_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
+  bw!
+
+  " Using string(funcref_variable) to set 'completefunc'
+  let Fn = function('MycompleteFunc1')
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MycompleteFunc1_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MycompleteFunc1_args)
-  call assert_fails('let &completefunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -1326,13 +1335,22 @@ func Test_completefunc_callback()
 
   " Using a funcref variable to set 'completefunc'
   let Fn = funcref('MycompleteFunc2')
+  let &completefunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MycompleteFunc2_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'completefunc'
+  let Fn = funcref('MycompleteFunc2')
   let &completefunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MycompleteFunc2_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MycompleteFunc2_args)
-  call assert_fails('let &completefunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -1349,6 +1367,15 @@ func Test_completefunc_callback()
   bw!
 
   " Set 'completefunc' to a lambda expression
+  let &completefunc = {a, b -> MycompleteFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MycompleteFunc3_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MycompleteFunc3_args)
+  bw!
+
+  " Set 'completefunc' to string(lambda_expression)
   let &completefunc = '{a, b -> MycompleteFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -1359,18 +1386,27 @@ func Test_completefunc_callback()
 
   " Set 'completefunc' to a variable with a lambda expression
   let Lambda = {a, b -> MycompleteFunc3(a, b)}
+  let &completefunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MycompleteFunc3_args = []
+  call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
+  bw!
+
+  " Set 'completefunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MycompleteFunc3(a, b)}
   let &completefunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MycompleteFunc3_args = []
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MycompleteFunc3_args)
-  call assert_fails('let &completefunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &completefunc = string(Lambda)
+  let &completefunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
@@ -1382,7 +1418,7 @@ func Test_completefunc_callback()
 
   call assert_fails("set completefunc=function('abc')", "E700:")
   call assert_fails("set completefunc=funcref('abc')", "E700:")
-  let &completefunc = "{a -> 'abc'}"
+  let &completefunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
 
   " Vim9 tests
@@ -1407,6 +1443,15 @@ func Test_completefunc_callback()
       add(g:LambdaComplete1_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &completefunc = (a, b) => LambdaComplete1(a, b)
+    new | only
+    setline(1, 'two')
+    g:LambdaComplete1_args = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:LambdaComplete1_args)
+    bw!
+
+    # Test for using a string(lambda)
     &completefunc = '(a, b) => LambdaComplete1(a, b)'
     new | only
     setline(1, 'two')
@@ -1420,6 +1465,15 @@ func Test_completefunc_callback()
             add(g:LambdaComplete2_args, [findstart, base])
             return findstart ? 0 : []
         }
+    &completefunc = Fn
+    new | only
+    setline(1, 'three')
+    g:LambdaComplete2_args = []
+    feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:LambdaComplete2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &completefunc = string(Fn)
     new | only
     setline(1, 'three')
@@ -1462,13 +1516,22 @@ func Test_omnifunc_callback()
 
   " Using a funcref variable to set 'omnifunc'
   let Fn = function('MyomniFunc1')
+  let &omnifunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MyomniFunc1_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'omnifunc'
+  let Fn = function('MyomniFunc1')
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MyomniFunc1_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MyomniFunc1_args)
-  call assert_fails('let &omnifunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -1486,13 +1549,22 @@ func Test_omnifunc_callback()
 
   " Using a funcref variable to set 'omnifunc'
   let Fn = funcref('MyomniFunc2')
+  let &omnifunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MyomniFunc2_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'omnifunc'
+  let Fn = funcref('MyomniFunc2')
   let &omnifunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MyomniFunc2_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MyomniFunc2_args)
-  call assert_fails('let &omnifunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -1509,6 +1581,15 @@ func Test_omnifunc_callback()
   bw!
 
   " Set 'omnifunc' to a lambda expression
+  let &omnifunc = {a, b -> MyomniFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MyomniFunc3_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MyomniFunc3_args)
+  bw!
+
+  " Set 'omnifunc' to a string(lambda_expression)
   let &omnifunc = '{a, b -> MyomniFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -1519,18 +1600,27 @@ func Test_omnifunc_callback()
 
   " Set 'omnifunc' to a variable with a lambda expression
   let Lambda = {a, b -> MyomniFunc3(a, b)}
+  let &omnifunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MyomniFunc3_args = []
+  call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
+  bw!
+
+  " Set 'omnifunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MyomniFunc3(a, b)}
   let &omnifunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MyomniFunc3_args = []
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MyomniFunc3_args)
-  call assert_fails('let &omnifunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &omnifunc = string(Lambda)
+  let &omnifunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
@@ -1542,7 +1632,7 @@ func Test_omnifunc_callback()
 
   call assert_fails("set omnifunc=function('abc')", "E700:")
   call assert_fails("set omnifunc=funcref('abc')", "E700:")
-  let &omnifunc = "{a -> 'abc'}"
+  let &omnifunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
 
   " Vim9 tests
@@ -1567,6 +1657,15 @@ func Test_omnifunc_callback()
       add(g:MyomniFunc2_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &omnifunc = (a, b) => MyomniFunc2(a, b)
+    new | only
+    setline(1, 'two')
+    g:MyomniFunc2_args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:MyomniFunc2_args)
+    bw!
+
+    # Test for using a string(lambda)
     &omnifunc = '(a, b) => MyomniFunc2(a, b)'
     new | only
     setline(1, 'two')
@@ -1577,6 +1676,15 @@ func Test_omnifunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b) => MyomniFunc2(a, b)
+    &omnifunc = Fn
+    new | only
+    setline(1, 'three')
+    g:MyomniFunc2_args = []
+    feedkeys("A\<C-X>\<C-O>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:MyomniFunc2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &omnifunc = string(Fn)
     new | only
     setline(1, 'three')
@@ -1619,13 +1727,22 @@ func Test_thesaurusfunc_callback()
 
   " Using a funcref variable to set 'thesaurusfunc'
   let Fn = function('MytsrFunc1')
+  let &thesaurusfunc = Fn
+  new | only
+  call setline(1, 'two')
+  let g:MytsrFunc1_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'thesaurusfunc'
+  let Fn = function('MytsrFunc1')
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'two')
   let g:MytsrFunc1_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'two']], g:MytsrFunc1_args)
-  call assert_fails('let &thesaurusfunc = Fn', 'E729:')
   bw!
 
   " Test for using a funcref()
@@ -1643,13 +1760,22 @@ func Test_thesaurusfunc_callback()
 
   " Using a funcref variable to set 'thesaurusfunc'
   let Fn = funcref('MytsrFunc2')
+  let &thesaurusfunc = Fn
+  new | only
+  call setline(1, 'four')
+  let g:MytsrFunc2_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
+  bw!
+
+  " Using a string(funcref_variable) to set 'thesaurusfunc'
+  let Fn = funcref('MytsrFunc2')
   let &thesaurusfunc = string(Fn)
   new | only
   call setline(1, 'four')
   let g:MytsrFunc2_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'four']], g:MytsrFunc2_args)
-  call assert_fails('let &thesaurusfunc = Fn', 'E729:')
   bw!
 
   " Test for using a lambda function
@@ -1666,6 +1792,15 @@ func Test_thesaurusfunc_callback()
   bw!
 
   " Set 'thesaurusfunc' to a lambda expression
+  let &thesaurusfunc = {a, b -> MytsrFunc3(a, b)}
+  new | only
+  call setline(1, 'six')
+  let g:MytsrFunc3_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'six']], g:MytsrFunc3_args)
+  bw!
+
+  " Set 'thesaurusfunc' to a string(lambda expression)
   let &thesaurusfunc = '{a, b -> MytsrFunc3(a, b)}'
   new | only
   call setline(1, 'six')
@@ -1676,18 +1811,27 @@ func Test_thesaurusfunc_callback()
 
   " Set 'thesaurusfunc' to a variable with a lambda expression
   let Lambda = {a, b -> MytsrFunc3(a, b)}
+  let &thesaurusfunc = Lambda
+  new | only
+  call setline(1, 'seven')
+  let g:MytsrFunc3_args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
+  bw!
+
+  " Set 'thesaurusfunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b -> MytsrFunc3(a, b)}
   let &thesaurusfunc = string(Lambda)
   new | only
   call setline(1, 'seven')
   let g:MytsrFunc3_args = []
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'seven']], g:MytsrFunc3_args)
-  call assert_fails('let &thesaurusfunc = Lambda', 'E729:')
   bw!
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
-  let &thesaurusfunc = string(Lambda)
+  let &thesaurusfunc = Lambda
   new | only
   call setline(1, 'eight')
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
@@ -1699,7 +1843,7 @@ func Test_thesaurusfunc_callback()
 
   call assert_fails("set thesaurusfunc=function('abc')", "E700:")
   call assert_fails("set thesaurusfunc=funcref('abc')", "E700:")
-  let &thesaurusfunc = "{a -> 'abc'}"
+  let &thesaurusfunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
 
   " Vim9 tests
@@ -1724,6 +1868,15 @@ func Test_thesaurusfunc_callback()
       add(g:MytsrFunc2_args, [findstart, base])
       return findstart ? 0 : []
     enddef
+    &thesaurusfunc = (a, b) => MytsrFunc2(a, b)
+    new | only
+    setline(1, 'two')
+    g:MytsrFunc2_args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:MytsrFunc2_args)
+    bw!
+
+    # Test for using a string(lambda)
     &thesaurusfunc = '(a, b) => MytsrFunc2(a, b)'
     new | only
     setline(1, 'two')
@@ -1734,6 +1887,15 @@ func Test_thesaurusfunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b) => MytsrFunc2(a, b)
+    &thesaurusfunc = Fn
+    new | only
+    setline(1, 'three')
+    g:MytsrFunc2_args = []
+    feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:MytsrFunc2_args)
+    bw!
+
+    # Test for using a string(variable with a lambda expression)
     &thesaurusfunc = string(Fn)
     new | only
     setline(1, 'three')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -460,110 +460,120 @@ endfunc
 " Test for different ways of setting the 'operatorfunc' option
 func Test_opfunc_callback()
   new
-  func MyopFunc(val, type)
-    let g:OpFuncArgs = [a:val, a:type]
+  func OpFunc1(callnr, type)
+    let g:OpFunc1Args = [a:callnr, a:type]
+  endfunc
+  func OpFunc2(type)
+    let g:OpFunc2Args = [a:type]
   endfunc
 
   let lines =<< trim END
-    #" Test for using a function()
-    set opfunc=function('g:MyopFunc',\ [10])
-    LET g:OpFuncArgs = []
+    #" Test for using a function name
+    LET &opfunc = 'g:OpFunc2'
+    LET g:OpFunc2Args = []
     normal! g@l
-    call assert_equal([10, 'char'], g:OpFuncArgs)
+    call assert_equal(['char'], g:OpFunc2Args)
+
+    #" Test for using a function()
+    set opfunc=function('g:OpFunc1',\ [10])
+    LET g:OpFunc1Args = []
+    normal! g@l
+    call assert_equal([10, 'char'], g:OpFunc1Args)
 
     #" Using a funcref variable to set 'operatorfunc'
-    VAR Fn = function('g:MyopFunc', [11])
+    VAR Fn = function('g:OpFunc1', [11])
     LET &opfunc = Fn
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([11, 'char'], g:OpFuncArgs)
+    call assert_equal([11, 'char'], g:OpFunc1Args)
 
     #" Using a string(funcref_variable) to set 'operatorfunc'
-    LET Fn = function('g:MyopFunc', [12])
+    LET Fn = function('g:OpFunc1', [12])
     LET &operatorfunc = string(Fn)
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([12, 'char'], g:OpFuncArgs)
+    call assert_equal([12, 'char'], g:OpFunc1Args)
 
     #" Test for using a funcref()
-    set operatorfunc=funcref('g:MyopFunc',\ [13])
-    LET g:OpFuncArgs = []
+    set operatorfunc=funcref('g:OpFunc1',\ [13])
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([13, 'char'], g:OpFuncArgs)
+    call assert_equal([13, 'char'], g:OpFunc1Args)
 
     #" Using a funcref variable to set 'operatorfunc'
-    LET Fn = funcref('g:MyopFunc', [14])
+    LET Fn = funcref('g:OpFunc1', [14])
     LET &opfunc = Fn
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([14, 'char'], g:OpFuncArgs)
+    call assert_equal([14, 'char'], g:OpFunc1Args)
 
     #" Using a string(funcref_variable) to set 'operatorfunc'
-    LET Fn = funcref('g:MyopFunc', [15])
+    LET Fn = funcref('g:OpFunc1', [15])
     LET &opfunc = string(Fn)
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([15, 'char'], g:OpFuncArgs)
+    call assert_equal([15, 'char'], g:OpFunc1Args)
 
     #" Test for using a lambda function using set
-    VAR optval = "LSTART a LMIDDLE MyopFunc(16, a) LEND"
+    VAR optval = "LSTART a LMIDDLE OpFunc1(16, a) LEND"
     LET optval = substitute(optval, ' ', '\\ ', 'g')
     exe "set opfunc=" .. optval
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([16, 'char'], g:OpFuncArgs)
+    call assert_equal([16, 'char'], g:OpFunc1Args)
 
     #" Test for using a lambda function using LET
-    LET &opfunc = LSTART a LMIDDLE MyopFunc(17, a) LEND
-    LET g:OpFuncArgs = []
+    LET &opfunc = LSTART a LMIDDLE OpFunc1(17, a) LEND
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([17, 'char'], g:OpFuncArgs)
+    call assert_equal([17, 'char'], g:OpFunc1Args)
 
     #" Set 'operatorfunc' to a string(lambda expression)
-    LET &opfunc = 'LSTART a LMIDDLE MyopFunc(18, a) LEND'
-    LET g:OpFuncArgs = []
+    LET &opfunc = 'LSTART a LMIDDLE OpFunc1(18, a) LEND'
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([18, 'char'], g:OpFuncArgs)
+    call assert_equal([18, 'char'], g:OpFunc1Args)
 
     #" Set 'operatorfunc' to a variable with a lambda expression
-    VAR Lambda = LSTART a LMIDDLE MyopFunc(19, a) LEND
+    VAR Lambda = LSTART a LMIDDLE OpFunc1(19, a) LEND
     LET &opfunc = Lambda
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([19, 'char'], g:OpFuncArgs)
+    call assert_equal([19, 'char'], g:OpFunc1Args)
 
     #" Set 'operatorfunc' to a string(variable with a lambda expression)
-    LET Lambda = LSTART a LMIDDLE MyopFunc(20, a) LEND
+    LET Lambda = LSTART a LMIDDLE OpFunc1(20, a) LEND
     LET &opfunc = string(Lambda)
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([20, 'char'], g:OpFuncArgs)
+    call assert_equal([20, 'char'], g:OpFunc1Args)
 
     #" Try to use 'operatorfunc' after the function is deleted
-    func g:TmpOpFunc(type)
-      LET g:OpFuncArgs = [21, a:type]
+    func g:TmpOpFunc1(type)
+      let g:TmpOpFunc1Args = [21, a:type]
     endfunc
-    LET &opfunc = function('g:TmpOpFunc')
-    delfunc g:TmpOpFunc
+    LET &opfunc = function('g:TmpOpFunc1')
+    delfunc g:TmpOpFunc1
     call test_garbagecollect_now()
-    LET g:OpFuncArgs = []
+    LET g:TmpOpFunc1Args = []
     call assert_fails('normal! g@l', 'E117:')
-    call assert_equal([], g:OpFuncArgs)
+    call assert_equal([], g:TmpOpFunc1Args)
 
     #" Try to use a function with two arguments for 'operatorfunc'
-    func MyopFunc2(x, y)
-      LET g:OpFuncArgs = [a:x, a:y]
+    func g:TmpOpFunc2(x, y)
+      let g:TmpOpFunc2Args = [a:x, a:y]
     endfunc
-    set opfunc=MyopFunc2
-    LET g:OpFuncArgs = []
+    set opfunc=TmpOpFunc2
+    LET g:TmpOpFunc2Args = []
     call assert_fails('normal! g@l', 'E119:')
-    call assert_equal([], g:OpFuncArgs)
+    call assert_equal([], g:TmpOpFunc2Args)
+    delfunc TmpOpFunc2
 
     #" Try to use a lambda function with two arguments for 'operatorfunc'
-    LET &opfunc = LSTART a, b LMIDDLE MyopFunc(22, b) LEND
-    LET g:OpFuncArgs = []
+    LET &opfunc = LSTART a, b LMIDDLE OpFunc1(22, b) LEND
+    LET g:OpFunc1Args = []
     call assert_fails('normal! g@l', 'E119:')
-    call assert_equal([], g:OpFuncArgs)
+    call assert_equal([], g:OpFunc1Args)
 
     #" Test for clearing the 'operatorfunc' option
     set opfunc=''
@@ -572,20 +582,20 @@ func Test_opfunc_callback()
     call assert_fails("set opfunc=funcref('abc')", "E700:")
 
     #" set 'operatorfunc' to a non-existing function
-    LET &opfunc = function('g:MyopFunc', [23])
+    LET &opfunc = function('g:OpFunc1', [23])
     call assert_fails("set opfunc=function('NonExistingFunc')", 'E700:')
     call assert_fails("LET &opfunc = function('NonExistingFunc')", 'E700:')
-    LET g:OpFuncArgs = []
+    LET g:OpFunc1Args = []
     normal! g@l
-    call assert_equal([23, 'char'], g:OpFuncArgs)
+    call assert_equal([23, 'char'], g:OpFunc1Args)
   END
   call CheckTransLegacySuccess(lines)
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set opfunc=(a)\ =>\ MyopFunc(24,\ a)
-  let g:OpFuncArgs = []
+  " set opfunc=(a)\ =>\ OpFunc1(24,\ a)
+  let g:OpFunc1Args = []
   " call assert_fails('normal! g@l', 'E117:')
-  call assert_equal([], g:OpFuncArgs)
+  call assert_equal([], g:OpFunc1Args)
 
   " set 'operatorfunc' to a partial with dict. This used to cause a crash.
   func SetOpFunc()
@@ -606,20 +616,20 @@ func Test_opfunc_callback()
 
     # Test for using a def function with opfunc
     def g:Vim9opFunc(val: number, type: string): void
-      g:OpFuncArgs = [val, type]
+      g:OpFunc1Args = [val, type]
     enddef
     set opfunc=function('g:Vim9opFunc',\ [60])
-    g:OpFuncArgs = []
+    g:OpFunc1Args = []
     normal! g@l
-    assert_equal([60, 'char'], g:OpFuncArgs)
+    assert_equal([60, 'char'], g:OpFunc1Args)
   END
   " call CheckScriptSuccess(lines)
 
   " cleanup
   set opfunc&
-  delfunc MyopFunc
-  delfunc MyopFunc2
-  unlet g:OpFuncArgs
+  delfunc OpFunc1
+  delfunc OpFunc2
+  unlet g:OpFunc1Args g:OpFunc2Args
   %bw!
 endfunc
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -3,6 +3,7 @@
 source shared.vim
 source check.vim
 source view_util.vim
+source vim9.vim
 source screendump.vim
 
 func Setup_NewWindow()
@@ -463,110 +464,122 @@ func Test_opfunc_callback()
     let g:OpFuncArgs = [a:val, a:type]
   endfunc
 
-  " Test for using a function()
-  set opfunc=function('MyopFunc',\ [11])
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([11, 'char'], g:OpFuncArgs)
+  let lines =<< trim END
+    #" Test for using a function()
+    set opfunc=function('g:MyopFunc',\ [10])
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([10, 'char'], g:OpFuncArgs)
 
-  " Using a funcref variable to set 'operatorfunc'
-  let Fn = function('MyopFunc', [12])
-  let &opfunc = Fn
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([12, 'char'], g:OpFuncArgs)
+    #" Using a funcref variable to set 'operatorfunc'
+    VAR Fn = function('g:MyopFunc', [11])
+    LET &opfunc = Fn
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([11, 'char'], g:OpFuncArgs)
 
-  " Using a string(funcref_variable) to set 'operatorfunc'
-  let Fn = function('MyopFunc', [13])
-  let &operatorfunc = string(Fn)
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([13, 'char'], g:OpFuncArgs)
+    #" Using a string(funcref_variable) to set 'operatorfunc'
+    LET Fn = function('g:MyopFunc', [12])
+    LET &operatorfunc = string(Fn)
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([12, 'char'], g:OpFuncArgs)
 
-  " Test for using a funcref()
-  set operatorfunc=funcref('MyopFunc',\ [14])
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([14, 'char'], g:OpFuncArgs)
+    #" Test for using a funcref()
+    set operatorfunc=funcref('g:MyopFunc',\ [13])
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([13, 'char'], g:OpFuncArgs)
 
-  " Using a funcref variable to set 'operatorfunc'
-  let Fn = funcref('MyopFunc', [15])
-  let &opfunc = Fn
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([15, 'char'], g:OpFuncArgs)
+    #" Using a funcref variable to set 'operatorfunc'
+    LET Fn = funcref('g:MyopFunc', [14])
+    LET &opfunc = Fn
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([14, 'char'], g:OpFuncArgs)
 
-  " Using a string(funcref_variable) to set 'operatorfunc'
-  let Fn = funcref('MyopFunc', [16])
-  let &opfunc = string(Fn)
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([16, 'char'], g:OpFuncArgs)
+    #" Using a string(funcref_variable) to set 'operatorfunc'
+    LET Fn = funcref('g:MyopFunc', [15])
+    LET &opfunc = string(Fn)
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([15, 'char'], g:OpFuncArgs)
 
-  " Test for using a lambda function using set
-  set opfunc={a\ ->\ MyopFunc(17,\ a)}
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([17, 'char'], g:OpFuncArgs)
+    #" Test for using a lambda function using set
+    VAR optval = "LSTART a LMIDDLE MyopFunc(16, a) LEND"
+    LET optval = substitute(optval, ' ', '\\ ', 'g')
+    exe "set opfunc=" .. optval
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([16, 'char'], g:OpFuncArgs)
 
-  " Test for using a lambda function using let
-  let &opfunc = {a -> MyopFunc(18, a)}
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([18, 'char'], g:OpFuncArgs)
+    #" Test for using a lambda function using LET
+    LET &opfunc = LSTART a LMIDDLE MyopFunc(17, a) LEND
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([17, 'char'], g:OpFuncArgs)
 
-  " Set 'operatorfunc' to a string(lambda expression)
-  let &opfunc = '{a -> MyopFunc(19, a)}'
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([19, 'char'], g:OpFuncArgs)
+    #" Set 'operatorfunc' to a string(lambda expression)
+    LET &opfunc = 'LSTART a LMIDDLE MyopFunc(18, a) LEND'
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([18, 'char'], g:OpFuncArgs)
 
-  " Set 'operatorfunc' to a variable with a lambda expression
-  let Lambda = {a -> MyopFunc(20, a)}
-  let &opfunc = Lambda
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([20, 'char'], g:OpFuncArgs)
+    #" Set 'operatorfunc' to a variable with a lambda expression
+    VAR Lambda = LSTART a LMIDDLE MyopFunc(19, a) LEND
+    LET &opfunc = Lambda
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([19, 'char'], g:OpFuncArgs)
 
-  " Set 'operatorfunc' to a string(variable with a lambda expression)
-  let Lambda = {a -> MyopFunc(21, a)}
-  let &opfunc = string(Lambda)
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([21, 'char'], g:OpFuncArgs)
+    #" Set 'operatorfunc' to a string(variable with a lambda expression)
+    LET Lambda = LSTART a LMIDDLE MyopFunc(20, a) LEND
+    LET &opfunc = string(Lambda)
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([20, 'char'], g:OpFuncArgs)
 
-  " Try to use 'operatorfunc' after the function is deleted
-  func TmpOpFunc(type)
-    let g:OpFuncArgs = [22, a:type]
-  endfunc
-  let &opfunc = function('TmpOpFunc')
-  delfunc TmpOpFunc
-  call test_garbagecollect_now()
-  let g:OpFuncArgs = []
-  call assert_fails('normal! g@l', 'E117:')
-  call assert_equal([], g:OpFuncArgs)
+    #" Try to use 'operatorfunc' after the function is deleted
+    func g:TmpOpFunc(type)
+      LET g:OpFuncArgs = [21, a:type]
+    endfunc
+    LET &opfunc = function('g:TmpOpFunc')
+    delfunc g:TmpOpFunc
+    call test_garbagecollect_now()
+    LET g:OpFuncArgs = []
+    call assert_fails('normal! g@l', 'E117:')
+    call assert_equal([], g:OpFuncArgs)
 
-  " Try to use a function with two arguments for 'operatorfunc'
-  func! MyopFunc2(x, y)
-    let g:OpFuncArgs = [a:x, a:y]
-  endfunc
-  set opfunc=MyopFunc2
-  let g:OpFuncArgs = []
-  call assert_fails('normal! g@l', 'E119:')
-  call assert_equal([], g:OpFuncArgs)
+    #" Try to use a function with two arguments for 'operatorfunc'
+    func MyopFunc2(x, y)
+      LET g:OpFuncArgs = [a:x, a:y]
+    endfunc
+    set opfunc=MyopFunc2
+    LET g:OpFuncArgs = []
+    call assert_fails('normal! g@l', 'E119:')
+    call assert_equal([], g:OpFuncArgs)
 
-  " Try to use a lambda function with two arguments for 'operatorfunc'
-  let &opfunc = {a, b -> MyopFunc(23, b)}
-  let g:OpFuncArgs = []
-  call assert_fails('normal! g@l', 'E119:')
-  call assert_equal([], g:OpFuncArgs)
+    #" Try to use a lambda function with two arguments for 'operatorfunc'
+    LET &opfunc = LSTART a, b LMIDDLE MyopFunc(22, b) LEND
+    LET g:OpFuncArgs = []
+    call assert_fails('normal! g@l', 'E119:')
+    call assert_equal([], g:OpFuncArgs)
 
-  " Test for clearing the 'operatorfunc' option
-  set opfunc=''
-  set opfunc&
+    #" Test for clearing the 'operatorfunc' option
+    set opfunc=''
+    set opfunc&
+    call assert_fails("set opfunc=function('abc')", "E700:")
+    call assert_fails("set opfunc=funcref('abc')", "E700:")
 
-  call assert_fails("set opfunc=function('abc')", "E700:")
-  call assert_fails("set opfunc=funcref('abc')", "E700:")
+    #" set 'operatorfunc' to a non-existing function
+    LET &opfunc = function('g:MyopFunc', [23])
+    call assert_fails("set opfunc=function('NonExistingFunc')", 'E700:')
+    call assert_fails("LET &opfunc = function('NonExistingFunc')", 'E700:')
+    LET g:OpFuncArgs = []
+    normal! g@l
+    call assert_equal([23, 'char'], g:OpFuncArgs)
+  END
+  call CheckTransLegacySuccess(lines)
 
   " Using Vim9 lambda expression in legacy context should fail
   " set opfunc=(a)\ =>\ MyopFunc(24,\ a)
@@ -574,19 +587,24 @@ func Test_opfunc_callback()
   " call assert_fails('normal! g@l', 'E117:')
   call assert_equal([], g:OpFuncArgs)
 
-  " set 'operatorfunc' to a non-existing function
-  let &opfunc = function('MyopFunc', [25])
-  call assert_fails("set opfunc=function('NonExistingFunc')", 'E700:')
-  call assert_fails("let &opfunc = function('NonExistingFunc')", 'E700:')
-  let g:OpFuncArgs = []
-  normal! g@l
-  call assert_equal([25, 'char'], g:OpFuncArgs)
+  " set 'operatorfunc' to a partial with dict. This used to cause a crash.
+  func SetOpFunc()
+    let operator = {'execute': function('OperatorExecute')}
+    let &opfunc = operator.execute
+  endfunc
+  func OperatorExecute(_) dict
+  endfunc
+  call SetOpFunc()
+  call test_garbagecollect_now()
+  set operatorfunc=
+  delfunc SetOpFunc
+  delfunc OperatorExecute
 
   " Vim9 tests
   let lines =<< trim END
     vim9script
 
-    # Test for using function()
+    # Test for using a def function with opfunc
     def g:Vim9opFunc(val: number, type: string): void
       g:OpFuncArgs = [val, type]
     enddef
@@ -594,33 +612,6 @@ func Test_opfunc_callback()
     g:OpFuncArgs = []
     normal! g@l
     assert_equal([60, 'char'], g:OpFuncArgs)
-
-    # Test for using a lambda
-    &opfunc = (a) => Vim9opFunc(61, a)
-    g:OpFuncArgs = []
-    normal! g@l
-    assert_equal([61, 'char'], g:OpFuncArgs)
-
-    # Test for using a string(lambda)
-    &opfunc = '(a) => Vim9opFunc(62, a)'
-    g:OpFuncArgs = []
-    normal! g@l
-    assert_equal([62, 'char'], g:OpFuncArgs)
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a) => Vim9opFunc(63, a)
-    &opfunc = Fn
-    g:OpFuncArgs = []
-    normal! g@l
-    assert_equal([63, 'char'], g:OpFuncArgs)
-
-    # Test for using a string(variable with a lambda expression)
-    Fn = (a) => Vim9opFunc(64, a)
-    &opfunc = string(Fn)
-    g:OpFuncArgs = []
-    normal! g@l
-    assert_equal([64, 'char'], g:OpFuncArgs)
-    bw!
   END
   " call CheckScriptSuccess(lines)
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -388,70 +388,6 @@ func Test_normal09a_operatorfunc()
   norm V10j,,
   call assert_equal(22, g:a)
 
-  " Use a lambda function for 'opfunc'
-  unmap <buffer> ,,
-  call cursor(1, 1)
-  let g:a=0
-  nmap <buffer><silent> ,, :set opfunc={type\ ->\ CountSpaces(type)}<CR>g@
-  vmap <buffer><silent> ,, :<C-U>call CountSpaces(visualmode(), 1)<CR>
-  50
-  norm V2j,,
-  call assert_equal(6, g:a)
-  norm V,,
-  call assert_equal(2, g:a)
-  norm ,,l
-  call assert_equal(0, g:a)
-  50
-  exe "norm 0\<c-v>10j2l,,"
-  call assert_equal(11, g:a)
-  50
-  norm V10j,,
-  call assert_equal(22, g:a)
-
-  " use a partial function for 'opfunc'
-  let g:OpVal = 0
-  func! Test_opfunc1(x, y, type)
-    let g:OpVal =  a:x + a:y
-  endfunc
-  set opfunc=function('Test_opfunc1',\ [5,\ 7])
-  normal! g@l
-  call assert_equal(12, g:OpVal)
-  " delete the function and try to use g@
-  delfunc Test_opfunc1
-  call test_garbagecollect_now()
-  call assert_fails('normal! g@l', 'E117:')
-  set opfunc=
-
-  " use a funcref for 'opfunc'
-  let g:OpVal = 0
-  func! Test_opfunc2(x, y, type)
-    let g:OpVal =  a:x + a:y
-  endfunc
-  set opfunc=funcref('Test_opfunc2',\ [4,\ 3])
-  normal! g@l
-  call assert_equal(7, g:OpVal)
-  " delete the function and try to use g@
-  delfunc Test_opfunc2
-  call test_garbagecollect_now()
-  call assert_fails('normal! g@l', 'E933:')
-  set opfunc=
-
-  " Try to use a function with two arguments for 'operatorfunc'
-  let g:OpVal = 0
-  func! Test_opfunc3(x, y)
-    let g:OpVal = 4
-  endfunc
-  set opfunc=Test_opfunc3
-  call assert_fails('normal! g@l', 'E119:')
-  call assert_equal(0, g:OpVal)
-  set opfunc=
-  delfunc Test_opfunc3
-  unlet g:OpVal
-
-  " Try to use a lambda function with two arguments for 'operatorfunc'
-  set opfunc={x,\ y\ ->\ 'done'}
-  call assert_fails('normal! g@l', 'E119:')
-
   " clean up
   unmap <buffer> ,,
   set opfunc=
@@ -518,6 +454,182 @@ func Test_normal09c_operatorfunc()
   call assert_equal(['_____', '_____', '_____', '_____', '______'], getline(1, '$'))
   bwipe!
   set operatorfunc=
+endfunc
+
+" Test for different ways of setting the 'operatorfunc' option
+func Test_opfunc_callback()
+  new
+  func MyopFunc(val, type)
+    let g:OpFuncArgs = [a:val, a:type]
+  endfunc
+
+  " Test for using a function()
+  set opfunc=function('MyopFunc',\ [11])
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([11, 'char'], g:OpFuncArgs)
+
+  " Using a funcref variable to set 'operatorfunc'
+  let Fn = function('MyopFunc', [12])
+  let &opfunc = Fn
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([12, 'char'], g:OpFuncArgs)
+
+  " Using a string(funcref_variable) to set 'operatorfunc'
+  let Fn = function('MyopFunc', [13])
+  let &operatorfunc = string(Fn)
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([13, 'char'], g:OpFuncArgs)
+
+  " Test for using a funcref()
+  set operatorfunc=funcref('MyopFunc',\ [14])
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([14, 'char'], g:OpFuncArgs)
+
+  " Using a funcref variable to set 'operatorfunc'
+  let Fn = funcref('MyopFunc', [15])
+  let &opfunc = Fn
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([15, 'char'], g:OpFuncArgs)
+
+  " Using a string(funcref_variable) to set 'operatorfunc'
+  let Fn = funcref('MyopFunc', [16])
+  let &opfunc = string(Fn)
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([16, 'char'], g:OpFuncArgs)
+
+  " Test for using a lambda function using set
+  set opfunc={a\ ->\ MyopFunc(17,\ a)}
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([17, 'char'], g:OpFuncArgs)
+
+  " Test for using a lambda function using let
+  let &opfunc = {a -> MyopFunc(18, a)}
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([18, 'char'], g:OpFuncArgs)
+
+  " Set 'operatorfunc' to a string(lambda expression)
+  let &opfunc = '{a -> MyopFunc(19, a)}'
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([19, 'char'], g:OpFuncArgs)
+
+  " Set 'operatorfunc' to a variable with a lambda expression
+  let Lambda = {a -> MyopFunc(20, a)}
+  let &opfunc = Lambda
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([20, 'char'], g:OpFuncArgs)
+
+  " Set 'operatorfunc' to a string(variable with a lambda expression)
+  let Lambda = {a -> MyopFunc(21, a)}
+  let &opfunc = string(Lambda)
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([21, 'char'], g:OpFuncArgs)
+
+  " Try to use 'operatorfunc' after the function is deleted
+  func TmpOpFunc(type)
+    let g:OpFuncArgs = [22, a:type]
+  endfunc
+  let &opfunc = function('TmpOpFunc')
+  delfunc TmpOpFunc
+  call test_garbagecollect_now()
+  let g:OpFuncArgs = []
+  call assert_fails('normal! g@l', 'E117:')
+  call assert_equal([], g:OpFuncArgs)
+
+  " Try to use a function with two arguments for 'operatorfunc'
+  func! MyopFunc2(x, y)
+    let g:OpFuncArgs = [a:x, a:y]
+  endfunc
+  set opfunc=MyopFunc2
+  let g:OpFuncArgs = []
+  call assert_fails('normal! g@l', 'E119:')
+  call assert_equal([], g:OpFuncArgs)
+
+  " Try to use a lambda function with two arguments for 'operatorfunc'
+  let &opfunc = {a, b -> MyopFunc(23, b)}
+  let g:OpFuncArgs = []
+  call assert_fails('normal! g@l', 'E119:')
+  call assert_equal([], g:OpFuncArgs)
+
+  " Test for clearing the 'operatorfunc' option
+  set opfunc=''
+  set opfunc&
+
+  call assert_fails("set opfunc=function('abc')", "E700:")
+  call assert_fails("set opfunc=funcref('abc')", "E700:")
+
+  " Using Vim9 lambda expression in legacy context should fail
+  " set opfunc=(a)\ =>\ MyopFunc(24,\ a)
+  let g:OpFuncArgs = []
+  " call assert_fails('normal! g@l', 'E117:')
+  call assert_equal([], g:OpFuncArgs)
+
+  " set 'operatorfunc' to a non-existing function
+  let &opfunc = function('MyopFunc', [25])
+  call assert_fails("set opfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &opfunc = function('NonExistingFunc')", 'E700:')
+  let g:OpFuncArgs = []
+  normal! g@l
+  call assert_equal([25, 'char'], g:OpFuncArgs)
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def g:Vim9opFunc(val: number, type: string): void
+      g:OpFuncArgs = [val, type]
+    enddef
+    set opfunc=function('g:Vim9opFunc',\ [60])
+    g:OpFuncArgs = []
+    normal! g@l
+    assert_equal([60, 'char'], g:OpFuncArgs)
+
+    # Test for using a lambda
+    &opfunc = (a) => Vim9opFunc(61, a)
+    g:OpFuncArgs = []
+    normal! g@l
+    assert_equal([61, 'char'], g:OpFuncArgs)
+
+    # Test for using a string(lambda)
+    &opfunc = '(a) => Vim9opFunc(62, a)'
+    g:OpFuncArgs = []
+    normal! g@l
+    assert_equal([62, 'char'], g:OpFuncArgs)
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a) => Vim9opFunc(63, a)
+    &opfunc = Fn
+    g:OpFuncArgs = []
+    normal! g@l
+    assert_equal([63, 'char'], g:OpFuncArgs)
+
+    # Test for using a string(variable with a lambda expression)
+    Fn = (a) => Vim9opFunc(64, a)
+    &opfunc = string(Fn)
+    g:OpFuncArgs = []
+    normal! g@l
+    assert_equal([64, 'char'], g:OpFuncArgs)
+    bw!
+  END
+  " call CheckScriptSuccess(lines)
+
+  " cleanup
+  set opfunc&
+  delfunc MyopFunc
+  delfunc MyopFunc2
+  unlet g:OpFuncArgs
+  %bw!
 endfunc
 
 func Test_normal10_expand()

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -5695,6 +5695,13 @@ func Test_qftextfunc_callback()
   let lines =<< trim END
     set efm=%f:%l:%c:%m
 
+    #" Test for using a function name
+    LET &qftf = 'g:Tqfexpr'
+    cexpr "F0:0:0:L0"
+    copen
+    call assert_equal('F0-L0C0-L0', getline(1))
+    cclose
+
     #" Test for using a function()
     set qftf=function('g:Tqfexpr')
     cexpr "F1:1:1:L1"

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -1,5 +1,7 @@
 " Test 'tagfunc'
 
+source vim9.vim
+
 func TagFunc(pat, flag, info)
   let g:tagfunc_args = [a:pat, a:flag, a:info]
   let tags = []
@@ -130,55 +132,121 @@ func Test_tagfunc_callback()
     return v:null
   endfunc
 
-  " Test for using a function()
-  set tagfunc=function('MytagFunc1',[10])
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a11', 'E433:')
-  call assert_equal([10, 'a11', '', {}], g:MytagFunc1_args)
+  let lines =<< trim END
+    #" Test for using a function()
+    set tagfunc=function('g:MytagFunc1',\ [10])
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a11', 'E433:')
+    call assert_equal([10, 'a11', '', {}], g:MytagFunc1_args)
 
-  " Using a funcref variable to set 'tagfunc'
-  let Fn = function('MytagFunc1', [11])
-  let &tagfunc = Fn
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a12', 'E433:')
-  call assert_equal([11, 'a12', '', {}], g:MytagFunc1_args)
+    #" Using a funcref variable to set 'tagfunc'
+    VAR Fn = function('g:MytagFunc1', [11])
+    LET &tagfunc = Fn
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a12', 'E433:')
+    call assert_equal([11, 'a12', '', {}], g:MytagFunc1_args)
 
-  " Using a string(funcref_variable) to set 'tagfunc'
-  let Fn = function('MytagFunc1', [12])
-  let &tagfunc = string(Fn)
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a12', 'E433:')
-  call assert_equal([12, 'a12', '', {}], g:MytagFunc1_args)
+    #" Using a string(funcref_variable) to set 'tagfunc'
+    LET Fn = function('g:MytagFunc1', [12])
+    LET &tagfunc = string(Fn)
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a12', 'E433:')
+    call assert_equal([12, 'a12', '', {}], g:MytagFunc1_args)
 
-  " Test for using a funcref()
-  func MytagFunc2(pat, flags, info)
-    let g:MytagFunc2_args = [a:pat, a:flags, a:info]
-    return v:null
-  endfunc
-  set tagfunc=funcref('MytagFunc1',[13])
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a13', 'E433:')
-  call assert_equal([13, 'a13', '', {}], g:MytagFunc1_args)
+    #" Test for using a funcref()
+    set tagfunc=funcref('g:MytagFunc1',\ [13])
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a13', 'E433:')
+    call assert_equal([13, 'a13', '', {}], g:MytagFunc1_args)
 
-  " Using a funcref variable to set 'tagfunc'
-  let Fn = funcref('MytagFunc1', [14])
-  let &tagfunc = Fn
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a14', 'E433:')
-  call assert_equal([14, 'a14', '', {}], g:MytagFunc1_args)
+    #" Using a funcref variable to set 'tagfunc'
+    LET Fn = funcref('g:MytagFunc1', [14])
+    LET &tagfunc = Fn
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a14', 'E433:')
+    call assert_equal([14, 'a14', '', {}], g:MytagFunc1_args)
 
-  " Using a string(funcref_variable) to set 'tagfunc'
-  let Fn = funcref('MytagFunc1', [15])
-  let &tagfunc = string(Fn)
+    #" Using a string(funcref_variable) to set 'tagfunc'
+    LET Fn = funcref('g:MytagFunc1', [15])
+    LET &tagfunc = string(Fn)
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a14', 'E433:')
+    call assert_equal([15, 'a14', '', {}], g:MytagFunc1_args)
+
+    #" Test for using a lambda function
+    VAR optval = "LSTART a, b, c LMIDDLE MytagFunc1(16, a, b, c) LEND"
+    LET optval = substitute(optval, ' ', '\\ ', 'g')
+    exe "set tagfunc=" .. optval
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a17', 'E433:')
+    call assert_equal([16, 'a17', '', {}], g:MytagFunc1_args)
+
+    #" Set 'tagfunc' to a lambda expression
+    LET &tagfunc = LSTART a, b, c LMIDDLE MytagFunc1(17, a, b, c) LEND
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a18', 'E433:')
+    call assert_equal([17, 'a18', '', {}], g:MytagFunc1_args)
+
+    #" Set 'tagfunc' to a string(lambda expression)
+    LET &tagfunc = 'LSTART a, b, c LMIDDLE MytagFunc1(18, a, b, c) LEND'
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails('tag a18', 'E433:')
+    call assert_equal([18, 'a18', '', {}], g:MytagFunc1_args)
+
+    #" Set 'tagfunc' to a variable with a lambda expression
+    VAR Lambda = LSTART a, b, c LMIDDLE MytagFunc1(19, a, b, c) LEND
+    LET &tagfunc = Lambda
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails("tag a19", "E433:")
+    call assert_equal([19, 'a19', '', {}], g:MytagFunc1_args)
+
+    #" Set 'tagfunc' to a string(variable with a lambda expression)
+    LET Lambda = LSTART a, b, c LMIDDLE MytagFunc1(20, a, b, c) LEND
+    LET &tagfunc = string(Lambda)
+    new | only
+    LET g:MytagFunc1_args = []
+    call assert_fails("tag a19", "E433:")
+    call assert_equal([20, 'a19', '', {}], g:MytagFunc1_args)
+
+    #" Test for using a lambda function with incorrect return value
+    LET Lambda = LSTART a, b, c LMIDDLE strlen(a) LEND
+    LET &tagfunc = string(Lambda)
+    new | only
+    call assert_fails("tag a20", "E987:")
+
+    #" Test for clearing the 'tagfunc' option
+    set tagfunc=''
+    set tagfunc&
+    call assert_fails("set tagfunc=function('abc')", "E700:")
+    call assert_fails("set tagfunc=funcref('abc')", "E700:")
+
+    #" set 'tagfunc' to a non-existing function
+    LET &tagfunc = function('g:MytagFunc1', [21])
+    call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
+    call assert_fails("LET &tagfunc = function('NonExistingFunc')", 'E700:')
+    call assert_fails("tag axb123", 'E426:')
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let &tagfunc = "{a -> 'abc'}"
+  call assert_fails("echo taglist('a')", "E987:")
+
+  " Using Vim9 lambda expression in legacy context should fail
+  " set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc1(21,\ a,\ b,\ c)
   new | only
   let g:MytagFunc1_args = []
-  call assert_fails('tag a14', 'E433:')
-  call assert_equal([15, 'a14', '', {}], g:MytagFunc1_args)
+  " call assert_fails("tag a17", "E117:")
+  call assert_equal([], g:MytagFunc1_args)
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
@@ -203,70 +271,25 @@ func Test_tagfunc_callback()
   call assert_fails('tag a16', 'E433:')
   call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
 
-  " Test for using a lambda function
-  set tagfunc={a,\ b,\ c\ ->\ MytagFunc1(16,\ a,\ b,\ c)}
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a17', 'E433:')
-  call assert_equal([16, 'a17', '', {}], g:MytagFunc1_args)
-
-  " Set 'tagfunc' to a lambda expression
-  let &tagfunc = {a, b, c -> MytagFunc1(17, a, b, c)}
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a18', 'E433:')
-  call assert_equal([17, 'a18', '', {}], g:MytagFunc1_args)
-
-  " Set 'tagfunc' to a string(lambda expression)
-  let &tagfunc = '{a, b, c -> MytagFunc1(18, a, b, c)}'
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails('tag a18', 'E433:')
-  call assert_equal([18, 'a18', '', {}], g:MytagFunc1_args)
-
-  " Set 'tagfunc' to a variable with a lambda expression
-  let Lambda = {a, b, c -> MytagFunc1(19, a, b, c)}
-  let &tagfunc = Lambda
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails("tag a19", "E433:")
-  call assert_equal([19, 'a19', '', {}], g:MytagFunc1_args)
-
-  " Set 'tagfunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b, c -> MytagFunc1(20, a, b, c)}
-  let &tagfunc = string(Lambda)
-  new | only
-  let g:MytagFunc1_args = []
-  call assert_fails("tag a19", "E433:")
-  call assert_equal([20, 'a19', '', {}], g:MytagFunc1_args)
-
-  " Test for using a lambda function with incorrect return value
-  let Lambda = {s -> strlen(s)}
-  let &tagfunc = string(Lambda)
-  new | only
-  call assert_fails("tag a20", "E987:")
-
-  " Test for clearing the 'tagfunc' option
-  set tagfunc=''
-  set tagfunc&
-
-  call assert_fails("set tagfunc=function('abc')", "E700:")
-  call assert_fails("set tagfunc=funcref('abc')", "E700:")
-  let &tagfunc = "{a -> 'abc'}"
-  call assert_fails("echo taglist('a')", "E987:")
-
-  " Using Vim9 lambda expression in legacy context should fail
-  " set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc1(21,\ a,\ b,\ c)
-  new | only
-  let g:MytagFunc1_args = []
-  " call assert_fails("tag a17", "E117:")
-  call assert_equal([], g:MytagFunc1_args)
-
-  " set 'tagfunc' to a non-existing function
-  call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
-  call assert_fails("let &tagfunc = function('NonExistingFunc')", 'E700:')
-  call assert_fails("tag axb123", 'E426:')
-  bw!
+  " set 'tagfunc' to a partial with dict. This used to cause a crash.
+  func SetTagFunc()
+    let params = {'tagfn': function('g:DictTagFunc')}
+    let &tagfunc = params.tagfn
+  endfunc
+  func g:DictTagFunc(_) dict
+  endfunc
+  call SetTagFunc()
+  new
+  call SetTagFunc()
+  bw
+  call test_garbagecollect_now()
+  new
+  set tagfunc=
+  wincmd w
+  set tagfunc=
+  :%bw!
+  delfunc g:DictTagFunc
+  delfunc SetTagFunc
 
   " Vim9 tests
   let lines =<< trim END
@@ -282,42 +305,11 @@ func Test_tagfunc_callback()
     g:Vim9tagFuncArgs = []
     assert_fails('tag a10', 'E433:')
     assert_equal([60, 'a10', '', {}], g:Vim9tagFuncArgs)
-
-    # Test for using a lambda
-    &tagfunc = (a, b, c) => MytagFunc1(61, a, b, c)
-    new | only
-    g:MytagFunc1_args = []
-    assert_fails('tag a20', 'E433:')
-    assert_equal([61, 'a20', '', {}], g:MytagFunc1_args)
-
-    # Test for using a string(lambda)
-    &tagfunc = '(a, b, c) => MytagFunc1(62, a, b, c)'
-    new | only
-    g:MytagFunc1_args = []
-    assert_fails('tag a20', 'E433:')
-    assert_equal([62, 'a20', '', {}], g:MytagFunc1_args)
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b, c) => MytagFunc1(63, a, b, c)
-    &tagfunc = Fn
-    new | only
-    g:MytagFunc1_args = []
-    assert_fails('tag a30', 'E433:')
-    assert_equal([63, 'a30', '', {}], g:MytagFunc1_args)
-
-    # Test for using a variable with a lambda expression
-    Fn = (a, b, c) => MytagFunc1(64, a, b, c)
-    &tagfunc = string(Fn)
-    new | only
-    g:MytagFunc1_args = []
-    assert_fails('tag a30', 'E433:')
-    assert_equal([64, 'a30', '', {}], g:MytagFunc1_args)
   END
   " call CheckScriptSuccess(lines)
 
   " cleanup
   delfunc MytagFunc1
-  delfunc MytagFunc2
   set tagfunc&
   %bw!
 endfunc

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -127,102 +127,126 @@ endfunc
 
 " Test for different ways of setting the 'tagfunc' option
 func Test_tagfunc_callback()
-  func MytagFunc1(val, pat, flags, info)
-    let g:MytagFunc1_args = [a:val, a:pat, a:flags, a:info]
+  func TagFunc1(callnr, pat, flags, info)
+    let g:TagFunc1Args = [a:callnr, a:pat, a:flags, a:info]
+    return v:null
+  endfunc
+  func TagFunc2(pat, flags, info)
+    let g:TagFunc2Args = [a:pat, a:flags, a:info]
     return v:null
   endfunc
 
   let lines =<< trim END
+    #" Test for using a function name
+    LET &tagfunc = 'g:TagFunc2'
+    new
+    LET g:TagFunc2Args = []
+    call assert_fails('tag a10', 'E433:')
+    call assert_equal(['a10', '', {}], g:TagFunc2Args)
+    bw!
+
     #" Test for using a function()
-    set tagfunc=function('g:MytagFunc1',\ [10])
-    new | only
-    LET g:MytagFunc1_args = []
+    set tagfunc=function('g:TagFunc1',\ [10])
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a11', 'E433:')
-    call assert_equal([10, 'a11', '', {}], g:MytagFunc1_args)
+    call assert_equal([10, 'a11', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Using a funcref variable to set 'tagfunc'
-    VAR Fn = function('g:MytagFunc1', [11])
+    VAR Fn = function('g:TagFunc1', [11])
     LET &tagfunc = Fn
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a12', 'E433:')
-    call assert_equal([11, 'a12', '', {}], g:MytagFunc1_args)
+    call assert_equal([11, 'a12', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Using a string(funcref_variable) to set 'tagfunc'
-    LET Fn = function('g:MytagFunc1', [12])
+    LET Fn = function('g:TagFunc1', [12])
     LET &tagfunc = string(Fn)
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a12', 'E433:')
-    call assert_equal([12, 'a12', '', {}], g:MytagFunc1_args)
+    call assert_equal([12, 'a12', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Test for using a funcref()
-    set tagfunc=funcref('g:MytagFunc1',\ [13])
-    new | only
-    LET g:MytagFunc1_args = []
+    set tagfunc=funcref('g:TagFunc1',\ [13])
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a13', 'E433:')
-    call assert_equal([13, 'a13', '', {}], g:MytagFunc1_args)
+    call assert_equal([13, 'a13', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Using a funcref variable to set 'tagfunc'
-    LET Fn = funcref('g:MytagFunc1', [14])
+    LET Fn = funcref('g:TagFunc1', [14])
     LET &tagfunc = Fn
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a14', 'E433:')
-    call assert_equal([14, 'a14', '', {}], g:MytagFunc1_args)
+    call assert_equal([14, 'a14', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Using a string(funcref_variable) to set 'tagfunc'
-    LET Fn = funcref('g:MytagFunc1', [15])
+    LET Fn = funcref('g:TagFunc1', [15])
     LET &tagfunc = string(Fn)
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a14', 'E433:')
-    call assert_equal([15, 'a14', '', {}], g:MytagFunc1_args)
+    call assert_equal([15, 'a14', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Test for using a lambda function
-    VAR optval = "LSTART a, b, c LMIDDLE MytagFunc1(16, a, b, c) LEND"
+    VAR optval = "LSTART a, b, c LMIDDLE TagFunc1(16, a, b, c) LEND"
     LET optval = substitute(optval, ' ', '\\ ', 'g')
     exe "set tagfunc=" .. optval
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a17', 'E433:')
-    call assert_equal([16, 'a17', '', {}], g:MytagFunc1_args)
+    call assert_equal([16, 'a17', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Set 'tagfunc' to a lambda expression
-    LET &tagfunc = LSTART a, b, c LMIDDLE MytagFunc1(17, a, b, c) LEND
-    new | only
-    LET g:MytagFunc1_args = []
+    LET &tagfunc = LSTART a, b, c LMIDDLE TagFunc1(17, a, b, c) LEND
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a18', 'E433:')
-    call assert_equal([17, 'a18', '', {}], g:MytagFunc1_args)
+    call assert_equal([17, 'a18', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Set 'tagfunc' to a string(lambda expression)
-    LET &tagfunc = 'LSTART a, b, c LMIDDLE MytagFunc1(18, a, b, c) LEND'
-    new | only
-    LET g:MytagFunc1_args = []
+    LET &tagfunc = 'LSTART a, b, c LMIDDLE TagFunc1(18, a, b, c) LEND'
+    new
+    LET g:TagFunc1Args = []
     call assert_fails('tag a18', 'E433:')
-    call assert_equal([18, 'a18', '', {}], g:MytagFunc1_args)
+    call assert_equal([18, 'a18', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Set 'tagfunc' to a variable with a lambda expression
-    VAR Lambda = LSTART a, b, c LMIDDLE MytagFunc1(19, a, b, c) LEND
+    VAR Lambda = LSTART a, b, c LMIDDLE TagFunc1(19, a, b, c) LEND
     LET &tagfunc = Lambda
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails("tag a19", "E433:")
-    call assert_equal([19, 'a19', '', {}], g:MytagFunc1_args)
+    call assert_equal([19, 'a19', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Set 'tagfunc' to a string(variable with a lambda expression)
-    LET Lambda = LSTART a, b, c LMIDDLE MytagFunc1(20, a, b, c) LEND
+    LET Lambda = LSTART a, b, c LMIDDLE TagFunc1(20, a, b, c) LEND
     LET &tagfunc = string(Lambda)
-    new | only
-    LET g:MytagFunc1_args = []
+    new
+    LET g:TagFunc1Args = []
     call assert_fails("tag a19", "E433:")
-    call assert_equal([20, 'a19', '', {}], g:MytagFunc1_args)
+    call assert_equal([20, 'a19', '', {}], g:TagFunc1Args)
+    bw!
 
     #" Test for using a lambda function with incorrect return value
     LET Lambda = LSTART a, b, c LMIDDLE strlen(a) LEND
     LET &tagfunc = string(Lambda)
-    new | only
+    new
     call assert_fails("tag a20", "E987:")
+    bw!
 
     #" Test for clearing the 'tagfunc' option
     set tagfunc=''
@@ -231,10 +255,13 @@ func Test_tagfunc_callback()
     call assert_fails("set tagfunc=funcref('abc')", "E700:")
 
     #" set 'tagfunc' to a non-existing function
-    LET &tagfunc = function('g:MytagFunc1', [21])
+    LET &tagfunc = function('g:TagFunc2', [21])
+    LET g:TagFunc2Args = []
     call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
     call assert_fails("LET &tagfunc = function('NonExistingFunc')", 'E700:')
     call assert_fails("tag axb123", 'E426:')
+    call assert_equal([], g:TagFunc2Args)
+    bw!
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -242,11 +269,11 @@ func Test_tagfunc_callback()
   call assert_fails("echo taglist('a')", "E987:")
 
   " Using Vim9 lambda expression in legacy context should fail
-  " set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc1(21,\ a,\ b,\ c)
+  " set tagfunc=(a,\ b,\ c)\ =>\ g:TagFunc1(21,\ a,\ b,\ c)
   new | only
-  let g:MytagFunc1_args = []
+  let g:TagFunc1Args = []
   " call assert_fails("tag a17", "E117:")
-  call assert_equal([], g:MytagFunc1_args)
+  call assert_equal([], g:TagFunc1Args)
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
@@ -309,7 +336,8 @@ func Test_tagfunc_callback()
   " call CheckScriptSuccess(lines)
 
   " cleanup
-  delfunc MytagFunc1
+  delfunc TagFunc1
+  delfunc TagFunc2
   set tagfunc&
   %bw!
 endfunc

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -138,12 +138,19 @@ func Test_tagfunc_callback()
 
   " Using a funcref variable to set 'tagfunc'
   let Fn = function('MytagFunc1')
+  let &tagfunc = Fn
+  new | only
+  let g:MytagFunc1_args = []
+  call assert_fails('tag a12', 'E433:')
+  call assert_equal(['a12', '', {}], g:MytagFunc1_args)
+
+  " Using a string(funcref_variable) to set 'tagfunc'
+  let Fn = function('MytagFunc1')
   let &tagfunc = string(Fn)
   new | only
   let g:MytagFunc1_args = []
   call assert_fails('tag a12', 'E433:')
   call assert_equal(['a12', '', {}], g:MytagFunc1_args)
-  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a funcref()
   func MytagFunc2(pat, flags, info)
@@ -158,12 +165,19 @@ func Test_tagfunc_callback()
 
   " Using a funcref variable to set 'tagfunc'
   let Fn = funcref('MytagFunc2')
+  let &tagfunc = Fn
+  new | only
+  let g:MytagFunc2_args = []
+  call assert_fails('tag a14', 'E433:')
+  call assert_equal(['a14', '', {}], g:MytagFunc2_args)
+
+  " Using a string(funcref_variable) to set 'tagfunc'
+  let Fn = funcref('MytagFunc2')
   let &tagfunc = string(Fn)
   new | only
   let g:MytagFunc2_args = []
   call assert_fails('tag a14', 'E433:')
   call assert_equal(['a14', '', {}], g:MytagFunc2_args)
-  call assert_fails('let &tagfunc = Fn', 'E729:')
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
@@ -173,6 +187,14 @@ func Test_tagfunc_callback()
   call assert_equal(['a15', '', {}], g:ScriptLocalFuncArgs)
 
   " Test for using a script local funcref variable
+  let Fn = function("s:ScriptLocalTagFunc")
+  let &tagfunc= Fn
+  new | only
+  let g:ScriptLocalFuncArgs = []
+  call assert_fails('tag a16', 'E433:')
+  call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
+
+  " Test for using a string(script local funcref variable)
   let Fn = function("s:ScriptLocalTagFunc")
   let &tagfunc= string(Fn)
   new | only
@@ -192,6 +214,13 @@ func Test_tagfunc_callback()
   call assert_equal(['a17', '', {}], g:MytagFunc3_args)
 
   " Set 'tagfunc' to a lambda expression
+  let &tagfunc = {a, b, c -> MytagFunc3(a, b, c)}
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails('tag a18', 'E433:')
+  call assert_equal(['a18', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a string(lambda expression)
   let &tagfunc = '{a, b, c -> MytagFunc3(a, b, c)}'
   new | only
   let g:MytagFunc3_args = []
@@ -200,12 +229,19 @@ func Test_tagfunc_callback()
 
   " Set 'tagfunc' to a variable with a lambda expression
   let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
+  let &tagfunc = Lambda
+  new | only
+  let g:MytagFunc3_args = []
+  call assert_fails("tag a19", "E433:")
+  call assert_equal(['a19', '', {}], g:MytagFunc3_args)
+
+  " Set 'tagfunc' to a string(variable with a lambda expression)
+  let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
   let &tagfunc = string(Lambda)
   new | only
   let g:MytagFunc3_args = []
   call assert_fails("tag a19", "E433:")
   call assert_equal(['a19', '', {}], g:MytagFunc3_args)
-  call assert_fails('let &tagfunc = Lambda', 'E729:')
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
@@ -242,6 +278,13 @@ func Test_tagfunc_callback()
       g:MytagFunc2_args = [pat, flags, info]
       return null
     enddef
+    &tagfunc = (a, b, c) => MytagFunc2(a, b, c)
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a20', 'E433:')
+    assert_equal(['a20', '', {}], g:MytagFunc2_args)
+
+    # Test for using a string(lambda)
     &tagfunc = '(a, b, c) => MytagFunc2(a, b, c)'
     new | only
     g:MytagFunc2_args = []
@@ -250,6 +293,13 @@ func Test_tagfunc_callback()
 
     # Test for using a variable with a lambda expression
     var Fn: func = (a, b, c) => MytagFunc2(a, b, c)
+    &tagfunc = Fn
+    new | only
+    g:MytagFunc2_args = []
+    assert_fails('tag a30', 'E433:')
+    assert_equal(['a30', '', {}], g:MytagFunc2_args)
+
+    # Test for using a variable with a lambda expression
     &tagfunc = string(Fn)
     new | only
     g:MytagFunc2_args = []

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -125,59 +125,60 @@ endfunc
 
 " Test for different ways of setting the 'tagfunc' option
 func Test_tagfunc_callback()
-  " Test for using a function()
-  func MytagFunc1(pat, flags, info)
-    let g:MytagFunc1_args = [a:pat, a:flags, a:info]
+  func MytagFunc1(val, pat, flags, info)
+    let g:MytagFunc1_args = [a:val, a:pat, a:flags, a:info]
     return v:null
   endfunc
-  set tagfunc=function('MytagFunc1')
+
+  " Test for using a function()
+  set tagfunc=function('MytagFunc1',[10])
   new | only
   let g:MytagFunc1_args = []
   call assert_fails('tag a11', 'E433:')
-  call assert_equal(['a11', '', {}], g:MytagFunc1_args)
+  call assert_equal([10, 'a11', '', {}], g:MytagFunc1_args)
 
   " Using a funcref variable to set 'tagfunc'
-  let Fn = function('MytagFunc1')
+  let Fn = function('MytagFunc1', [11])
   let &tagfunc = Fn
   new | only
   let g:MytagFunc1_args = []
   call assert_fails('tag a12', 'E433:')
-  call assert_equal(['a12', '', {}], g:MytagFunc1_args)
+  call assert_equal([11, 'a12', '', {}], g:MytagFunc1_args)
 
   " Using a string(funcref_variable) to set 'tagfunc'
-  let Fn = function('MytagFunc1')
+  let Fn = function('MytagFunc1', [12])
   let &tagfunc = string(Fn)
   new | only
   let g:MytagFunc1_args = []
   call assert_fails('tag a12', 'E433:')
-  call assert_equal(['a12', '', {}], g:MytagFunc1_args)
+  call assert_equal([12, 'a12', '', {}], g:MytagFunc1_args)
 
   " Test for using a funcref()
   func MytagFunc2(pat, flags, info)
     let g:MytagFunc2_args = [a:pat, a:flags, a:info]
     return v:null
   endfunc
-  set tagfunc=funcref('MytagFunc2')
+  set tagfunc=funcref('MytagFunc1',[13])
   new | only
-  let g:MytagFunc2_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a13', 'E433:')
-  call assert_equal(['a13', '', {}], g:MytagFunc2_args)
+  call assert_equal([13, 'a13', '', {}], g:MytagFunc1_args)
 
   " Using a funcref variable to set 'tagfunc'
-  let Fn = funcref('MytagFunc2')
+  let Fn = funcref('MytagFunc1', [14])
   let &tagfunc = Fn
   new | only
-  let g:MytagFunc2_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a14', 'E433:')
-  call assert_equal(['a14', '', {}], g:MytagFunc2_args)
+  call assert_equal([14, 'a14', '', {}], g:MytagFunc1_args)
 
   " Using a string(funcref_variable) to set 'tagfunc'
-  let Fn = funcref('MytagFunc2')
+  let Fn = funcref('MytagFunc1', [15])
   let &tagfunc = string(Fn)
   new | only
-  let g:MytagFunc2_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a14', 'E433:')
-  call assert_equal(['a14', '', {}], g:MytagFunc2_args)
+  call assert_equal([15, 'a14', '', {}], g:MytagFunc1_args)
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
@@ -203,45 +204,41 @@ func Test_tagfunc_callback()
   call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
 
   " Test for using a lambda function
-  func MytagFunc3(pat, flags, info)
-    let g:MytagFunc3_args = [a:pat, a:flags, a:info]
-    return v:null
-  endfunc
-  set tagfunc={a,\ b,\ c\ ->\ MytagFunc3(a,\ b,\ c)}
+  set tagfunc={a,\ b,\ c\ ->\ MytagFunc1(16,\ a,\ b,\ c)}
   new | only
-  let g:MytagFunc3_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a17', 'E433:')
-  call assert_equal(['a17', '', {}], g:MytagFunc3_args)
+  call assert_equal([16, 'a17', '', {}], g:MytagFunc1_args)
 
   " Set 'tagfunc' to a lambda expression
-  let &tagfunc = {a, b, c -> MytagFunc3(a, b, c)}
+  let &tagfunc = {a, b, c -> MytagFunc1(17, a, b, c)}
   new | only
-  let g:MytagFunc3_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a18', 'E433:')
-  call assert_equal(['a18', '', {}], g:MytagFunc3_args)
+  call assert_equal([17, 'a18', '', {}], g:MytagFunc1_args)
 
   " Set 'tagfunc' to a string(lambda expression)
-  let &tagfunc = '{a, b, c -> MytagFunc3(a, b, c)}'
+  let &tagfunc = '{a, b, c -> MytagFunc1(18, a, b, c)}'
   new | only
-  let g:MytagFunc3_args = []
+  let g:MytagFunc1_args = []
   call assert_fails('tag a18', 'E433:')
-  call assert_equal(['a18', '', {}], g:MytagFunc3_args)
+  call assert_equal([18, 'a18', '', {}], g:MytagFunc1_args)
 
   " Set 'tagfunc' to a variable with a lambda expression
-  let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
+  let Lambda = {a, b, c -> MytagFunc1(19, a, b, c)}
   let &tagfunc = Lambda
   new | only
-  let g:MytagFunc3_args = []
+  let g:MytagFunc1_args = []
   call assert_fails("tag a19", "E433:")
-  call assert_equal(['a19', '', {}], g:MytagFunc3_args)
+  call assert_equal([19, 'a19', '', {}], g:MytagFunc1_args)
 
   " Set 'tagfunc' to a string(variable with a lambda expression)
-  let Lambda = {a, b, c -> MytagFunc3(a, b, c)}
+  let Lambda = {a, b, c -> MytagFunc1(20, a, b, c)}
   let &tagfunc = string(Lambda)
   new | only
-  let g:MytagFunc3_args = []
+  let g:MytagFunc1_args = []
   call assert_fails("tag a19", "E433:")
-  call assert_equal(['a19', '', {}], g:MytagFunc3_args)
+  call assert_equal([20, 'a19', '', {}], g:MytagFunc1_args)
 
   " Test for using a lambda function with incorrect return value
   let Lambda = {s -> strlen(s)}
@@ -258,72 +255,69 @@ func Test_tagfunc_callback()
   let &tagfunc = "{a -> 'abc'}"
   call assert_fails("echo taglist('a')", "E987:")
 
-  " Vim9 tests
-  let lines =<< trim END
-    vim9script
-
-    # Test for using function()
-    def MytagFunc1(pat: string, flags: string, info: dict<any>): any
-      g:MytagFunc1_args = [pat, flags, info]
-      return null
-    enddef
-    set tagfunc=function('MytagFunc1')
-    new | only
-    g:MytagFunc1_args = []
-    assert_fails('tag a10', 'E433:')
-    assert_equal(['a10', '', {}], g:MytagFunc1_args)
-
-    # Test for using a lambda
-    def MytagFunc2(pat: string, flags: string, info: dict<any>): any
-      g:MytagFunc2_args = [pat, flags, info]
-      return null
-    enddef
-    &tagfunc = (a, b, c) => MytagFunc2(a, b, c)
-    new | only
-    g:MytagFunc2_args = []
-    assert_fails('tag a20', 'E433:')
-    assert_equal(['a20', '', {}], g:MytagFunc2_args)
-
-    # Test for using a string(lambda)
-    &tagfunc = '(a, b, c) => MytagFunc2(a, b, c)'
-    new | only
-    g:MytagFunc2_args = []
-    assert_fails('tag a20', 'E433:')
-    assert_equal(['a20', '', {}], g:MytagFunc2_args)
-
-    # Test for using a variable with a lambda expression
-    var Fn: func = (a, b, c) => MytagFunc2(a, b, c)
-    &tagfunc = Fn
-    new | only
-    g:MytagFunc2_args = []
-    assert_fails('tag a30', 'E433:')
-    assert_equal(['a30', '', {}], g:MytagFunc2_args)
-
-    # Test for using a variable with a lambda expression
-    &tagfunc = string(Fn)
-    new | only
-    g:MytagFunc2_args = []
-    assert_fails('tag a30', 'E433:')
-    assert_equal(['a30', '', {}], g:MytagFunc2_args)
-  END
-  " call CheckScriptSuccess(lines)
-
   " Using Vim9 lambda expression in legacy context should fail
-  " set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc2(a,\ b,\ c)
-  " new | only
-  " let g:MytagFunc3_args = []
+  " set tagfunc=(a,\ b,\ c)\ =>\ g:MytagFunc1(21,\ a,\ b,\ c)
+  new | only
+  let g:MytagFunc1_args = []
   " call assert_fails("tag a17", "E117:")
-  " call assert_equal([], g:MytagFunc3_args)
+  call assert_equal([], g:MytagFunc1_args)
 
   " set 'tagfunc' to a non-existing function
   call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
   call assert_fails("let &tagfunc = function('NonExistingFunc')", 'E700:')
   call assert_fails("tag axb123", 'E426:')
+  bw!
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    # Test for using function()
+    def Vim9tagFunc(val: number, pat: string, flags: string, info: dict<any>): any
+      g:Vim9tagFuncArgs = [val, pat, flags, info]
+      return null
+    enddef
+    set tagfunc=function('Vim9tagFunc',\ [60])
+    new | only
+    g:Vim9tagFuncArgs = []
+    assert_fails('tag a10', 'E433:')
+    assert_equal([60, 'a10', '', {}], g:Vim9tagFuncArgs)
+
+    # Test for using a lambda
+    &tagfunc = (a, b, c) => MytagFunc1(61, a, b, c)
+    new | only
+    g:MytagFunc1_args = []
+    assert_fails('tag a20', 'E433:')
+    assert_equal([61, 'a20', '', {}], g:MytagFunc1_args)
+
+    # Test for using a string(lambda)
+    &tagfunc = '(a, b, c) => MytagFunc1(62, a, b, c)'
+    new | only
+    g:MytagFunc1_args = []
+    assert_fails('tag a20', 'E433:')
+    assert_equal([62, 'a20', '', {}], g:MytagFunc1_args)
+
+    # Test for using a variable with a lambda expression
+    var Fn: func = (a, b, c) => MytagFunc1(63, a, b, c)
+    &tagfunc = Fn
+    new | only
+    g:MytagFunc1_args = []
+    assert_fails('tag a30', 'E433:')
+    assert_equal([63, 'a30', '', {}], g:MytagFunc1_args)
+
+    # Test for using a variable with a lambda expression
+    Fn = (a, b, c) => MytagFunc1(64, a, b, c)
+    &tagfunc = string(Fn)
+    new | only
+    g:MytagFunc1_args = []
+    assert_fails('tag a30', 'E433:')
+    assert_equal([64, 'a30', '', {}], g:MytagFunc1_args)
+  END
+  " call CheckScriptSuccess(lines)
 
   " cleanup
   delfunc MytagFunc1
   delfunc MytagFunc2
-  delfunc MytagFunc3
   set tagfunc&
   %bw!
 endfunc

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -315,6 +315,11 @@ func Test_tagfunc_callback()
   " call assert_fails("tag a17", "E117:")
   " call assert_equal([], g:MytagFunc3_args)
 
+  " set 'tagfunc' to a non-existing function
+  call assert_fails("set tagfunc=function('NonExistingFunc')", 'E700:')
+  call assert_fails("let &tagfunc = function('NonExistingFunc')", 'E700:')
+  call assert_fails("tag axb123", 'E426:')
+
   " cleanup
   delfunc MytagFunc1
   delfunc MytagFunc2

--- a/src/nvim/testdir/vim9.vim
+++ b/src/nvim/testdir/vim9.vim
@@ -1,0 +1,80 @@
+
+" Use a different file name for each run.
+let s:sequence = 1
+
+" Check that "lines" inside a legacy function has no error.
+func CheckLegacySuccess(lines)
+  let cwd = getcwd()
+  let fname = 'XlegacySuccess' .. s:sequence
+  let s:sequence += 1
+  call writefile(['func Func()'] + a:lines + ['endfunc'], fname)
+  try
+    exe 'so ' .. fname
+    call Func()
+  finally
+    delfunc! Func
+    call chdir(cwd)
+    call delete(fname)
+  endtry
+endfunc
+
+" Check that "lines" inside a legacy function results in the expected error
+func CheckLegacyFailure(lines, error)
+  let cwd = getcwd()
+  let fname = 'XlegacyFails' .. s:sequence
+  let s:sequence += 1
+  call writefile(['func Func()'] + a:lines + ['endfunc', 'call Func()'], fname)
+  try
+    call assert_fails('so ' .. fname, a:error)
+  finally
+    delfunc! Func
+    call chdir(cwd)
+    call delete(fname)
+  endtry
+endfunc
+
+" Execute "lines" in a legacy function, translated as in
+" CheckLegacyAndVim9Success()
+func CheckTransLegacySuccess(lines)
+  let legacylines = a:lines->deepcopy()->map({_, v ->
+                              \ v->substitute('\<VAR\>', 'let', 'g')
+                              \  ->substitute('\<LET\>', 'let', 'g')
+                              \  ->substitute('\<LSTART\>', '{', 'g')
+                              \  ->substitute('\<LMIDDLE\>', '->', 'g')
+                              \  ->substitute('\<LEND\>', '}', 'g')
+                              \  ->substitute('\<TRUE\>', '1', 'g')
+                              \  ->substitute('\<FALSE\>', '0', 'g')
+                              \  ->substitute('#"', ' "', 'g')
+                              \ })
+  call CheckLegacySuccess(legacylines)
+endfunc
+
+" Execute "lines" in a legacy function
+" Use 'VAR' for a declaration.
+" Use 'LET' for an assignment
+" Use ' #"' for a comment
+" Use LSTART arg LMIDDLE expr LEND for lambda
+" Use 'TRUE' for 1
+" Use 'FALSE' for 0
+func CheckLegacyAndVim9Success(lines)
+  call CheckTransLegacySuccess(a:lines)
+endfunc
+
+" Execute "lines" in a legacy function
+" Use 'VAR' for a declaration.
+" Use 'LET' for an assignment
+" Use ' #"' for a comment
+func CheckLegacyAndVim9Failure(lines, error)
+  if type(a:error) == type('string')
+    let legacyError = error
+  else
+    let legacyError = error[0]
+  endif
+
+  let legacylines = a:lines->deepcopy()->map({_, v ->
+                              \ v->substitute('\<VAR\>', 'let', 'g')
+                              \  ->substitute('\<LET\>', 'let', 'g')
+                              \  ->substitute('#"', ' "', 'g')
+                              \ })
+  call CheckLegacyFailure(legacylines, legacyError)
+endfunc


### PR DESCRIPTION
#### vim-patch:8.2.3735: cannot use a lambda for 'imactivatefunc'

Problem:    Cannot use a lambda for 'imactivatefunc'.
Solution:   Add lambda support for 'imactivatefunc' and 'imstatusfunc'.
            (Yegappan Lakshmanan, closes vim/vim#9275)

https://github.com/vim/vim/commit/7645da568c5e3b4ee339a2e99c3b3af790619787

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3751: cannot assign a lambda to an option that takes a function

Problem:    Cannot assign a lambda to an option that takes a function.
Solution:   Automatically convert the lambda to a string. (Yegappan
            Lakshmanan, closes vim/vim#9286)

https://github.com/vim/vim/commit/6409553b6e3b4de4e1d72b8ee5445595214581ff

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3756: might crash when callback is not valid

Problem:    might crash when callback is not valid.
Solution:   Check for valid callback. (Yegappan Lakshmanan, closes vim/vim#9293)

https://github.com/vim/vim/commit/4dc24eb5adbcc76838fae1e900936dd230209d96

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3758: options that take a function insufficiently tested

Problem:    Options that take a function insufficiently tested.
Solution:   Add additional tests and enhance existing tests. (Yegappan
            Lakshmanan, closes vim/vim#9298)

https://github.com/vim/vim/commit/2172bff36417ddd90653531edc65897411c83b3f

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3788: lambda for option that is a function may be freed

Problem:    Lambda for option that is a function may be garbage collected.
Solution:   Set a reference in the funcref. (Yegappan Lakshmanan,
            closes vim/vim#9330)

https://github.com/vim/vim/commit/6ae8fae8696623b527c7fb22567f6a3705b2f0dd

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3792: setting *func options insufficiently tested

Problem:    Setting *func options insufficiently tested.
Solution:   Impove tests. (Yegappan Lakshmanan, closes vim/vim#9337)

https://github.com/vim/vim/commit/04ef1fb13d200f770952e670357dddadb6210dd4

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>