### PR TITLE
vim-patch:8.2.{2060,3626}

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -779,7 +779,7 @@ void au_event_restore(char *old_ei)
 // :autocmd * *.c               show all autocommands for *.c files.
 //
 // Mostly a {group} argument can optionally appear before <event>.
-void do_autocmd(char *arg_in, int forceit)
+void do_autocmd(exarg_T *eap, char *arg_in, int forceit)
 {
   char *arg = arg_in;
   char *envpat = NULL;
@@ -790,6 +790,7 @@ void do_autocmd(char *arg_in, int forceit)
   int group;
 
   if (*arg == '|') {
+    eap->nextcmd = arg + 1;
     arg = "";
     group = AUGROUP_ALL;  // no argument, use all groups
   } else {
@@ -806,6 +807,7 @@ void do_autocmd(char *arg_in, int forceit)
 
   pat = skipwhite(pat);
   if (*pat == '|') {
+    eap->nextcmd = pat + 1;
     pat = "";
     cmd = "";
   } else {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4231,7 +4231,7 @@ static void ex_autocmd(exarg_T *eap)
     secure = 2;
     eap->errmsg = _(e_curdir);
   } else if (eap->cmdidx == CMD_autocmd) {
-    do_autocmd(eap->arg, eap->forceit);
+    do_autocmd(eap, eap->arg, eap->forceit);
   } else {
     do_augroup(eap->arg, eap->forceit);
   }

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -481,17 +481,20 @@ endfunc
 func Test_early_bar()
   " test that a bar is recognized before the {event}
   call s:AddAnAutocmd()
-  augroup vimBarTest | au! | augroup END
+  augroup vimBarTest | au! | let done = 77 | augroup END
   call assert_equal(1, len(split(execute('au vimBarTest'), "\n")))
+  call assert_equal(77, done)
 
   call s:AddAnAutocmd()
-  augroup vimBarTest| au!| augroup END
+  augroup vimBarTest| au!| let done = 88 | augroup END
   call assert_equal(1, len(split(execute('au vimBarTest'), "\n")))
+  call assert_equal(88, done)
 
   " test that a bar is recognized after the {event}
   call s:AddAnAutocmd()
-  augroup vimBarTest| au!BufReadCmd| augroup END
+  augroup vimBarTest| au!BufReadCmd| let done = 99 | augroup END
   call assert_equal(1, len(split(execute('au vimBarTest'), "\n")))
+  call assert_equal(99, done)
 
   " test that a bar is recognized after the {group}
   call s:AddAnAutocmd()

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1975,9 +1975,7 @@ func Test_change_mark_in_autocmds()
 endfunc
 
 func Test_Filter_noshelltemp()
-  if !executable('cat')
-    return
-  endif
+  CheckExecutable cat
 
   enew!
   call setline(1, ['a', 'b', 'c', 'd'])

--- a/src/nvim/testdir/test_compiler.vim
+++ b/src/nvim/testdir/test_compiler.vim
@@ -1,9 +1,11 @@
 " Test the :compiler command
 
+source check.vim
+source shared.vim
+
 func Test_compiler()
-  if !executable('perl')
-    return
-  endif
+  CheckExecutable perl
+  CheckFeature quickfix
 
   " $LANG changes the output of Perl.
   if $LANG != ''

--- a/src/nvim/testdir/test_delete.vim
+++ b/src/nvim/testdir/test_delete.vim
@@ -1,5 +1,7 @@
 " Test for delete().
 
+source check.vim
+
 func Test_file_delete()
   split Xfile
   call setline(1, ['a', 'b'])
@@ -41,9 +43,7 @@ func Test_recursive_delete()
 endfunc
 
 func Test_symlink_delete()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   split Xfile
   call setline(1, ['a', 'b'])
   wq
@@ -56,9 +56,7 @@ func Test_symlink_delete()
 endfunc
 
 func Test_symlink_dir_delete()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   call mkdir('Xdir1')
   silent !ln -s Xdir1 Xlink
   call assert_true(isdirectory('Xdir1'))
@@ -70,9 +68,7 @@ func Test_symlink_dir_delete()
 endfunc
 
 func Test_symlink_recursive_delete()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   call mkdir('Xdir3')
   call mkdir('Xdir3/subdir')
   call mkdir('Xdir4')

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -621,9 +621,7 @@ func Test_diff_move_to()
 endfunc
 
 func Test_diffexpr()
-  if !executable('diff')
-    return
-  endif
+  CheckExecutable diff
 
   func DiffExpr()
     " Prepend some text to check diff type detection

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -95,9 +95,7 @@ func Test_indent_fold2()
 endfunc
 
 func Test_manual_fold_with_filter()
-  if !executable('cat')
-    return
-  endif
+  CheckExecutable cat
   for type in ['manual', 'marker']
     exe 'set foldmethod=' . type
     new


### PR DESCRIPTION
#### vim-patch:8.2.2060: check for features implemented with "if"

Problem:    Check for features implemented with "if".
Solution:   Use the Check commands. (Ken Takata, closes vim/vim#7383)

https://github.com/vim/vim/commit/aeb313f355cd67638e3c611354ce401d86f56afe

Cherry-pick test_compiler.vim changes from patch 8.1.2373.


#### vim-patch:8.2.3626: "au! event" cannot be followed by another command

Problem:    "au!" and "au! event" cannot be followed by another command as
            documented.
Solution:   When a bar is found set nextcmd.

https://github.com/vim/vim/commit/b8e642f7ace5382b4dacb7a8effd86f22b828cc1

Cherry-pick do_autocmd() "eap" argument from patch 8.2.3268.

Co-authored-by: Bram Moolenaar <Bram@vim.org>