### PR TITLE
feat(api): add command name to Lua command callback opts

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1757,6 +1757,7 @@ nvim_create_user_command({name}, {command}, {*opts})
                    executed. When called from Lua, the command can also be a
                    Lua function. The function is called with a single table
                    argument that contains the following keys:
+                   • name: (string) Command name
                    • args: (string) The args passed to the command, if any
                      |<args>|
                    • fargs: (table) The args split by unescaped whitespace

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -884,6 +884,7 @@ static void build_cmdline_str(char **cmdlinep, exarg_T *eap, CmdParseInfo *cmdin
 /// @param  command Replacement command to execute when this user command is executed. When called
 ///                 from Lua, the command can also be a Lua function. The function is called with a
 ///                 single table argument that contains the following keys:
+///                 - name: (string) Command name
 ///                 - args: (string) The args passed to the command, if any |<args>|
 ///                 - fargs: (table) The args split by unescaped whitespace (when more than one
 ///                 argument is allowed), if any |<f-args>|

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1985,6 +1985,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   nlua_pushref(lstate, preview ? cmd->uc_preview_luaref : cmd->uc_luaref);
 
   lua_newtable(lstate);
+  lua_pushstring(lstate, cmd->uc_name);
+  lua_setfield(lstate, -2, "name");
+
   lua_pushboolean(lstate, eap->forceit == 1);
   lua_setfield(lstate, -2, "bang");
 

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -114,6 +114,7 @@ describe('nvim_create_user_command', function()
     ]]
 
     eq({
+      name = "CommandWithLuaCallback",
       args = [[this\  is    a\ test]],
       fargs = {"this ", "is", "a test"},
       bang = false,
@@ -150,6 +151,7 @@ describe('nvim_create_user_command', function()
     ]=])
 
     eq({
+      name = "CommandWithLuaCallback",
       args = [[this   includes\ a backslash: \\]],
       fargs = {"this", "includes a", "backslash:", "\\"},
       bang = false,
@@ -186,6 +188,7 @@ describe('nvim_create_user_command', function()
     ]=])
 
     eq({
+      name = "CommandWithLuaCallback",
       args = "a\\b",
       fargs = {"a\\b"},
       bang = false,
@@ -222,6 +225,7 @@ describe('nvim_create_user_command', function()
     ]=])
 
     eq({
+      name = "CommandWithLuaCallback",
       args = 'h\tey ',
       fargs = {[[h]], [[ey]]},
       bang = true,
@@ -258,6 +262,7 @@ describe('nvim_create_user_command', function()
     ]=])
 
     eq({
+      name = "CommandWithLuaCallback",
       args = "h",
       fargs = {"h"},
       bang = false,
@@ -294,6 +299,7 @@ describe('nvim_create_user_command', function()
     ]])
 
     eq({
+      name = "CommandWithLuaCallback",
       args = "",
       fargs = {},  -- fargs works without args
       bang = false,
@@ -342,6 +348,7 @@ describe('nvim_create_user_command', function()
     ]]
 
     eq({
+      name = "CommandWithOneOrNoArg",
       args = "hello I'm one argument",
       fargs = {"hello I'm one argument"},  -- Doesn't split args
       bang = false,
@@ -379,6 +386,7 @@ describe('nvim_create_user_command', function()
 
     -- f-args is an empty table if no args were passed
     eq({
+      name = "CommandWithOneOrNoArg",
       args = "",
       fargs = {},
       bang = false,
@@ -427,6 +435,7 @@ describe('nvim_create_user_command', function()
       })
     ]]
     eq({
+      name = "CommandWithNoArgs",
       args = "",
       fargs = {},
       bang = false,
@@ -463,6 +472,7 @@ describe('nvim_create_user_command', function()
     ]])
     -- register can be specified
     eq({
+      name = "CommandWithNoArgs",
       args = "",
       fargs = {},
       bang = false,


### PR DESCRIPTION
Adds a `name` key to the opts dict passed to Lua command callbacks created using `nvim_create_user_command()`. This is useful for when multiple commands use the same callback.

Note that this kind of behavior is not as strange as one might think, even some internal Neovim commands reuse the same internal C function, differing their behavior by checking the command name. `substitute`, `smagic` and `snomagic` are examples of that.

This will also be useful for generalized Lua command preview functions that can preview a wide range of commands, in which case knowing the command name is necessary for the preview function to actually be able to execute the command that it's supposed to preview.