### PR TITLE
vim-patch:9.0.0843: VHS tape files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1057,6 +1057,7 @@ local extension = {
   hdl = 'vhdl',
   vho = 'vhdl',
   vbe = 'vhdl',
+  tape = 'vhs',
   vim = 'vim',
   vba = 'vim',
   mar = 'vmasm',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -612,6 +612,7 @@ let s:filename_checks = {
     \ 'verilogams': ['file.va', 'file.vams'],
     \ 'vgrindefs': ['vgrindefs'],
     \ 'vhdl': ['file.hdl', 'file.vhd', 'file.vhdl', 'file.vbe', 'file.vst', 'file.vhdl_123', 'file.vho', 'some.vhdl_1', 'some.vhdl_1-file'],
+    \ 'vhs': ['file.tape'],
     \ 'vim': ['file.vim', 'file.vba', '.exrc', '_exrc', 'some-vimrc', 'some-vimrc-file', 'vimrc', 'vimrc-file'],
     \ 'viminfo': ['.viminfo', '_viminfo'],
     \ 'vmasm': ['file.mar'],


### PR DESCRIPTION
Problem:    VHS tape files are not recognized.
Solution:   Add a filetype pattern. (Carlos Alexandro Becker, closes vim/vim#11452)

https://github.com/vim/vim/commit/1756f4b21837e8596241ecd668f4abbbab4bc7e5

Co-authored-by: Carlos A Becker <caarlos0@users.noreply.github.com>
