### PR TITLE
vim-patch:8.2.1919: assert_fails() setting emsg_silent changes normal execution

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1842,7 +1842,7 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
     pmap_put(handle_T)(&buffer_handles, buf->b_fnum, buf);
     if (top_file_num < 0) {  // wrap around (may cause duplicates)
       emsg(_("W14: Warning: List of file names overflow"));
-      if (emsg_silent == 0) {
+      if (emsg_silent == 0 && !in_assert_fails) {
         ui_flush();
         os_delay(3001L, true);  // make sure it is noticed
       }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -107,7 +107,7 @@ void changed(void)
       // Wait two seconds, to make sure the user reads this unexpected
       // message.  Since we could be anywhere, call wait_return() now,
       // and don't let the emsg() set msg_scroll.
-      if (need_wait_return && emsg_silent == 0) {
+      if (need_wait_return && emsg_silent == 0 && !in_assert_fails) {
         ui_flush();
         os_delay(2002L, true);
         wait_return(true);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -4946,7 +4946,7 @@ int buf_check_timestamp(buf_T *buf)
         }
         msg_clr_eos();
         (void)msg_end();
-        if (emsg_silent == 0) {
+        if (emsg_silent == 0 && !in_assert_fails) {
           ui_flush();
           // give the user some time to think about it
           os_delay(1004L, true);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -195,7 +195,6 @@ EXTERN int emsg_skip INIT(= 0);             // don't display errors for
 EXTERN bool emsg_severe INIT(= false);      // use message of next of several
                                             //  emsg() calls for throw
 // used by assert_fails()
-EXTERN bool emsg_assert_fails_used INIT(= false);
 EXTERN char *emsg_assert_fails_msg INIT(= NULL);
 EXTERN long emsg_assert_fails_lnum INIT(= 0);
 EXTERN char *emsg_assert_fails_context INIT(= NULL);
@@ -666,6 +665,8 @@ EXTERN int msg_silent INIT(= 0);         // don't print messages
 EXTERN int emsg_silent INIT(= 0);        // don't print error messages
 EXTERN bool emsg_noredir INIT(= false);  // don't redirect error messages
 EXTERN bool cmd_silent INIT(= false);    // don't echo the command line
+
+EXTERN bool in_assert_fails INIT(= false);  // assert_fails() active
 
 // Values for swap_exists_action: what to do when swap file already exists
 #define SEA_NONE        0       // don't use dialog

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -454,7 +454,7 @@ bool check_compl_option(bool dict_opt)
     msg_attr((dict_opt
               ? _("'dictionary' option is empty")
               : _("'thesaurus' option is empty")), HL_ATTR(HLF_E));
-    if (emsg_silent == 0) {
+    if (emsg_silent == 0 && !in_assert_fails) {
       vim_beep(BO_COMPL);
       setcursor();
       ui_flush();

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -664,7 +664,7 @@ static bool emsg_multiline(const char *s, bool multiline)
       return true;
     }
 
-    if (emsg_assert_fails_used && emsg_assert_fails_msg == NULL) {
+    if (in_assert_fails && emsg_assert_fails_msg == NULL) {
       emsg_assert_fails_msg = xstrdup(s);
       emsg_assert_fails_lnum = SOURCING_LNUM;
       xfree(emsg_assert_fails_context);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -611,6 +611,7 @@ static bool normal_need_redraw_mode_message(NormalState *s)
           && stuff_empty()
           && typebuf_typed()
           && emsg_silent == 0
+          && !in_assert_fails
           && !did_wait_return
           && s->oa.op_type == OP_NOP);
 }

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -572,7 +572,8 @@ void check_for_delay(bool check_msg_scroll)
 {
   if ((emsg_on_display || (check_msg_scroll && msg_scroll))
       && !did_wait_return
-      && emsg_silent == 0) {
+      && emsg_silent == 0
+      && !in_assert_fails) {
     ui_flush();
     os_delay(1006L, true);
     emsg_on_display = false;

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -175,7 +175,7 @@ func Test_autocmd_bufunload_avoiding_SEGV_01()
     exe 'autocmd BufUnload <buffer> ' . (lastbuf + 1) . 'bwipeout!'
   augroup END
 
-  call assert_fails('edit bb.txt', ['E937:', 'E517:'])
+  call assert_fails('edit bb.txt', 'E937:')
 
   autocmd! test_autocmd_bufunload
   augroup! test_autocmd_bufunload

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -779,7 +779,7 @@ func Test_expr_abbr()
   " invalid <expr> abbreviation
   abbr <expr> hte GetAbbr()
   call assert_fails('normal ihte ', 'E117:')
-  call assert_equal(' ', getline(1))
+  call assert_equal('', getline(1))
   unabbr <expr> hte
 
   close!

--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -359,7 +359,7 @@ func Test_completefunc_opens_new_window_one()
   /^one
   call assert_fails('call feedkeys("A\<C-X>\<C-U>\<C-N>\<Esc>", "x")', 'E565:')
   call assert_equal(winid, win_getid())
-  call assert_equal('oneDEF', getline(1))
+  call assert_equal('onedef', getline(1))
   q!
 endfunc
 
@@ -384,9 +384,7 @@ func Test_completefunc_opens_new_window_two()
   /^two
   call assert_fails('call feedkeys("A\<C-X>\<C-U>\<C-N>\<Esc>", "x")', 'E565:')
   call assert_equal(winid, win_getid())
-  " v8.2.1919 hasn't been ported yet
-  " call assert_equal('twodef', getline(1))
-  call assert_equal('twoDEF', getline(1))
+  call assert_equal('twodef', getline(1))
   q!
 endfunc
 

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -6,6 +6,8 @@
 #include "nvim/eval.h"
 #include "nvim/eval/encode.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/globals.h"
+#include "nvim/message.h"
 #include "nvim/os/os.h"
 #include "nvim/runtime.h"
 #include "nvim/testing.h"
@@ -491,8 +493,8 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   // trylevel must be zero for a ":throw" command to be considered failed
   trylevel = 0;
   suppress_errthrow = true;
-  emsg_silent = true;
-  emsg_assert_fails_used = true;
+  in_assert_fails = true;
+  no_wait_return++;
 
   do_cmdline_cmd(cmd);
   if (called_emsg == called_emsg_before) {
@@ -584,9 +586,14 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 theend:
   trylevel = save_trylevel;
   suppress_errthrow = false;
-  emsg_silent = false;
+  in_assert_fails = false;
+  did_emsg = false;
+  msg_col = 0;
+  no_wait_return--;
+  need_wait_return = false;
   emsg_on_display = false;
-  emsg_assert_fails_used = false;
+  msg_reset_scroll();
+  lines_left = Rows;
   XFREE_CLEAR(emsg_assert_fails_msg);
   set_vim_var_string(VV_ERRMSG, NULL, 0);
   if (wrong_arg_msg != NULL) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -315,7 +315,7 @@ void vim_beep(unsigned val)
 {
   called_vim_beep = true;
 
-  if (emsg_silent == 0) {
+  if (emsg_silent == 0 && !in_assert_fails) {
     if (!((bo_flags & val) || (bo_flags & BO_ALL))) {
       static int beeps = 0;
       static uint64_t start_time = 0;


### PR DESCRIPTION
#### vim-patch:8.2.1919: assert_fails() setting emsg_silent changes normal execution

Problem:    Assert_fails() setting emsg_silent changes normal execution.
Solution:   Use a separate flag in_assert_fails.

https://github.com/vim/vim/commit/28ee892ac4197421b3317f195512ca64cc56a5b4

Cherry-pick no_wait_return from patch 9.0.0846.

Co-authored-by: Bram Moolenaar <Bram@vim.org>