### PR TITLE
test: introduce helper function skip

### DIFF
--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -7,6 +7,7 @@ local exec_lua = helpers.exec_lua
 local retry = helpers.retry
 local isCI = helpers.isCI
 local assert_alive = helpers.assert_alive
+local skip = helpers.skip
 
 describe('notify', function()
   local channel
@@ -78,13 +79,7 @@ describe('notify', function()
   end)
 
   it('cancels stale events on channel close', function()
-    if isCI() then
-      pending('hangs on CI #14083 #15251')
-      return
-    elseif helpers.skip_fragile(pending) then
-      return
-    end
-    if helpers.pending_win32(pending) then return end
+    skip(isCI(), 'hangs on CI #14083 #15251')
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
     local catpath = eval('exepath("cat")')
     eq({id=catchan, argv={catpath}, stream='job', mode='rpc', client = {}}, exec_lua ([[

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -250,7 +250,7 @@ describe('server -> client', function()
       pcall(funcs.jobstop, jobid)
     end)
 
-    if helpers.pending_win32(pending) then return end
+    if helpers.skip(helpers.iswin()) then return end
 
     it('rpc and text stderr can be combined', function()
       local status, rv = pcall(funcs.rpcrequest, jobid, 'poll')

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -30,6 +30,7 @@ local exec_lua = helpers.exec_lua
 local exc_exec = helpers.exc_exec
 local insert = helpers.insert
 local expect_exit = helpers.expect_exit
+local skip = helpers.skip
 
 local pcall_err = helpers.pcall_err
 local format_string = helpers.format_string
@@ -2729,7 +2730,7 @@ describe('API', function()
       eq({}, meths.get_runtime_file("foobarlang/", true))
     end)
     it('can handle bad patterns', function()
-      if helpers.pending_win32(pending) then return end
+      skip(iswin())
 
       eq("Vim:E220: Missing }.", pcall_err(meths.get_runtime_file, "{", false))
 

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -6,7 +6,7 @@ local nvim_prog = helpers.nvim_prog
 local feed_command = helpers.feed_command
 local feed_data = thelpers.feed_data
 
-if helpers.pending_win32(pending) then return end
+if helpers.skip(helpers.iswin()) then return end
 
 describe('autoread TUI FocusGained/FocusLost', function()
   local f1 = 'xtest-foo'

--- a/test/functional/autocmd/signal_spec.lua
+++ b/test/functional/autocmd/signal_spec.lua
@@ -5,11 +5,10 @@ local command = helpers.command
 local eq = helpers.eq
 local funcs = helpers.funcs
 local next_msg = helpers.next_msg
+local iswin = helpers.iswin
+local skip = helpers.skip
 
-if helpers.pending_win32(pending) then
-  -- Only applies to POSIX systems.
-  return
-end
+if skip(iswin(), 'Only applies to POSIX systems') then return end
 
 local function posix_kill(signame, pid)
   os.execute('kill -s '..signame..' -- '..pid..' >/dev/null')

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -11,6 +11,7 @@ local feed = helpers.feed
 local pcall_err = helpers.pcall_err
 local assert_alive = helpers.assert_alive
 local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe('autocmd TermClose', function()
   before_each(function()
@@ -55,7 +56,7 @@ describe('autocmd TermClose', function()
   end)
 
   it('kills job trapping SIGTERM', function()
-    if iswin() then return end
+    skip(iswin())
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" TERM && echo 1 && sleep 60', { ]]
@@ -75,7 +76,7 @@ describe('autocmd TermClose', function()
   end)
 
   it('kills PTY job trapping SIGHUP and SIGTERM', function()
-    if iswin() then return end
+    skip(iswin())
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" HUP TERM && echo 1 && sleep 60', { ]]

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -12,6 +12,8 @@ local retry = helpers.retry
 local expect_twostreams = helpers.expect_twostreams
 local assert_alive = helpers.assert_alive
 local pcall_err = helpers.pcall_err
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe('channels', function()
   local init = [[
@@ -145,7 +147,7 @@ describe('channels', function()
   end
 
   it('can use stdio channel with pty', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     source([[
       let g:job_opts = {
       \ 'on_stdout': function('OnEvent'),
@@ -199,7 +201,7 @@ describe('channels', function()
 
 
   it('stdio channel can use rpc and stderr simultaneously', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     source([[
       let g:job_opts = {
       \ 'on_stderr': function('OnEvent'),

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -28,6 +28,7 @@ local write_file = helpers.write_file
 local Screen = require('test.functional.ui.screen')
 local feed_command = helpers.feed_command
 local isCI = helpers.isCI
+local skip = helpers.skip
 
 describe('fileio', function()
   before_each(function()
@@ -89,9 +90,7 @@ describe('fileio', function()
   end)
 
   it('backup #9709', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     clear({ args={ '-i', 'Xtest_startup_shada',
                    '--cmd', 'set directory=Xtest_startup_swapdir' } })
 
@@ -111,9 +110,7 @@ describe('fileio', function()
   end)
 
   it('backup with full path #11214', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     clear()
     mkdir('Xtest_backupdir')
     command('set backup')
@@ -135,9 +132,7 @@ describe('fileio', function()
   end)
 
   it('backup symlinked files #11349', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     clear()
 
     local initial_content = 'foo'
@@ -159,9 +154,7 @@ describe('fileio', function()
 
 
   it('backup symlinked files in first avialable backupdir #11349', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     clear()
 
     local initial_content = 'foo'
@@ -306,9 +299,7 @@ describe('tmpdir', function()
     end)
 
     -- "…/nvim.<user>/" has wrong permissions:
-    if iswin() then
-      return  -- TODO(justinmk): need setfperm/getfperm on Windows. #8244
-    end
+    skip(iswin(), 'TODO(justinmk): need setfperm/getfperm on Windows. #8244')
     os.remove(testlog)
     os.remove(tmproot)
     mkdir(tmproot)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -23,6 +23,7 @@ local expect_msg_seq = helpers.expect_msg_seq
 local pcall_err = helpers.pcall_err
 local matches = helpers.matches
 local Screen = require('test.functional.ui.screen')
+local skip = helpers.skip
 
 describe('jobs', function()
   local channel
@@ -87,7 +88,7 @@ describe('jobs', function()
   end)
 
   it('append environment with pty #env', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     nvim('command', "let $VAR = 'abc'")
     nvim('command', "let $TOTO = 'goodbye world'")
     nvim('command', "let g:job_opts.pty = v:true")
@@ -225,7 +226,7 @@ describe('jobs', function()
   end)
 
   it('error on non-executable `cwd`', function()
-    if iswin() then return end  -- N/A for Windows
+    skip(iswin(), 'Not applicable for Windows')
 
     local dir = 'Xtest_not_executable_dir'
     mkdir(dir)
@@ -805,7 +806,7 @@ describe('jobs', function()
     end)
 
     it('can be called recursively', function()
-      if helpers.pending_win32(pending) then return end  -- TODO: Need `cat`.
+      skip(iswin(), "TODO: Need `cat`")
       source([[
       let g:opts = {}
       let g:counter = 0
@@ -1027,7 +1028,7 @@ describe('jobs', function()
   end)
 
   describe('running tty-test program', function()
-    if helpers.pending_win32(pending) then return end
+    if skip(iswin()) then return end
     local function next_chunk()
       local rv
       while true do
@@ -1124,7 +1125,7 @@ describe("pty process teardown", function()
   end)
 
   it("does not prevent/delay exit. #4798 #4900", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     -- Use a nested nvim (in :term) to test without --headless.
     feed_command(":terminal '"..helpers.nvim_prog
       .."' -u NONE -i NONE --cmd '"..nvim_set.."' "

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -9,6 +9,8 @@ local clear = helpers.clear
 local funcs = helpers.funcs
 local nvim_prog_abs = helpers.nvim_prog_abs
 local write_file = helpers.write_file
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe('Command-line option', function()
   describe('-s', function()
@@ -49,7 +51,7 @@ describe('Command-line option', function()
       eq(#('100500\n'), attrs.size)
     end)
     it('does not crash after reading from stdin in non-headless mode', function()
-      if helpers.pending_win32(pending) then return end
+      skip(iswin())
       local screen = Screen.new(40, 8)
       screen:attach()
       local args = {

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -9,6 +9,8 @@ local clear = helpers.clear
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local pathsep = helpers.get_pathsep()
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 -- These directories will be created for testing
 local directories = {
@@ -279,9 +281,7 @@ describe("getcwd()", function ()
   end)
 
   it("returns empty string if working directory does not exist", function()
-    if helpers.iswin() then
-      return
-    end
+    skip(iswin())
     command("cd "..directories.global)
     command("call delete('../"..directories.global.."', 'd')")
     eq("", helpers.eval("getcwd()"))

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -14,6 +14,7 @@ local pesc = helpers.pesc
 local rmdir = helpers.rmdir
 local sleep = helpers.sleep
 local meths = helpers.meths
+local skip = helpers.skip
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -194,10 +195,7 @@ describe(':mksession', function()
   end)
 
   it('restores CWD for :terminal buffer at root directory #16988', function()
-    if iswin() then
-      pending('N/A for Windows')
-      return
-    end
+    skip(iswin(), 'N/A for Windows')
 
     local screen
     local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -10,6 +10,7 @@ local funcs = helpers.funcs
 local meths = helpers.meths
 local iswin = helpers.iswin
 local isCI = helpers.isCI
+local skip = helpers.skip
 
 local fname = 'Xtest-functional-ex_cmds-write'
 local fname_bak = fname .. '~'
@@ -56,9 +57,7 @@ describe(':write', function()
   end)
 
   it('&backupcopy=no replaces symlink with new file', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     command('set backupcopy=no')
     write_file('test_bkc_file.txt', 'content0')
     if iswin() then
@@ -122,9 +121,7 @@ describe(':write', function()
   end)
 
   it('errors out correctly', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     command('let $HOME=""')
     eq(funcs.fnamemodify('.', ':p:h'), funcs.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
@@ -155,8 +152,7 @@ describe(':write', function()
       eq(true, os.remove(fname_bak))
     end
     write_file(fname_bak, 'TTYX')
-    -- FIXME: exc_exec('write!') outputs 0 in Windows
-    if iswin() then return end
+    skip(iswin(), [[FIXME: exc_exec('write!') outputs 0 in Windows]])
     lfs.link(fname_bak .. ('/xxxxx'):rep(20), fname, true)
     eq('Vim(write):E166: Can\'t open linked file for writing',
        pcall_err(command, 'write!'))

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -763,13 +763,10 @@ function module.create_callindex(func)
   return table
 end
 
--- Helper to skip tests. Returns true in Windows systems.
--- pending_fn is pending() from busted
-function module.pending_win32(pending_fn)
-  if iswin() then
-    if pending_fn ~= nil then
-      pending_fn('FIXME: Windows', function() end)
-    end
+function module.skip(cond, reason)
+  if cond then
+    local pending = getfenv(2).pending
+    pending(reason or 'FIXME')
     return true
   else
     return false

--- a/test/functional/legacy/filechanged_spec.lua
+++ b/test/functional/legacy/filechanged_spec.lua
@@ -1,6 +1,8 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local call, eq, meths = helpers.call, helpers.eq, helpers.meths
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 local function expected_empty()
   eq({}, meths.get_vvar('errors'))
@@ -15,7 +17,7 @@ describe('file changed dialog', function()
   end)
 
   it('works', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     source([[
       func Test_file_changed_dialog()
         au! FileChangedShell

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -2,6 +2,8 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
+local iswin = helpers.iswin
+local skip = helpers.skip
 local write_file = require('test.helpers').write_file
 
 describe('URI methods', function()
@@ -167,7 +169,7 @@ describe('URI methods', function()
 
   describe('uri from bufnr', function()
     it('Windows paths should not be treated as uris', function()
-      if not helpers.iswin() then return end
+      skip(not iswin(), "Not applicable on non-Windows")
 
       local file = helpers.tmpname()
       write_file(file, 'Test content')

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -19,13 +19,15 @@ local read_file = require('test.helpers').read_file
 local write_file = require('test.helpers').write_file
 local isCI = helpers.isCI
 local meths = helpers.meths
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 -- Use these to get access to a coroutine so that I can run async tests and use
 -- yield.
 local run, stop = helpers.run, helpers.stop
 
 -- TODO(justinmk): hangs on Windows https://github.com/neovim/neovim/pull/11837
-if helpers.pending_win32(pending) then return end
+if skip(iswin()) then return end
 
 -- Fake LSP server.
 local fake_lsp_code = 'test/functional/fixtures/fake-lsp-server.lua'

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -9,6 +9,7 @@ local matches = helpers.matches
 local write_file = helpers.write_file
 local tmpname = helpers.tmpname
 local isCI = helpers.isCI
+local skip = helpers.skip
 
 clear()
 if funcs.executable('man') == 0 then
@@ -161,9 +162,7 @@ describe(':Man', function()
   end)
 
   it('reports non-existent man pages for absolute paths', function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
+    skip(isCI('cirrus'))
     local actual_file = tmpname()
     -- actual_file must be an absolute path to an existent file for us to test against it
     matches('^/.+', actual_file)

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -9,6 +9,8 @@ local curbufmeths = helpers.curbufmeths
 local insert = helpers.insert
 local expect = helpers.expect
 local feed = helpers.feed
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 do
   clear()
@@ -24,7 +26,7 @@ before_each(function()
 end)
 
 describe('legacy perl provider', function()
-  if helpers.pending_win32(pending) then return end
+  skip(iswin())
 
   it('feature test', function()
     eq(1, eval('has("perl")'))
@@ -68,7 +70,7 @@ describe('legacy perl provider', function()
 end)
 
 describe('perl provider', function()
-  if helpers.pending_win32(pending) then return end
+  skip(iswin())
   teardown(function ()
     os.remove('Xtest-perl-hello.pl')
     os.remove('Xtest-perl-hello-plugin.pl')

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -5,6 +5,8 @@ local meths, nvim_command, funcs, eq =
 local write_file, spawn, set_session, nvim_prog, exc_exec =
   helpers.write_file, helpers.spawn, helpers.set_session, helpers.nvim_prog,
   helpers.exc_exec
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 local lfs = require('lfs')
 local paths = require('test.cmakeconfig.paths')
@@ -248,7 +250,7 @@ describe('ShaDa support code', function()
   end)
 
   it('does not crash when ShaDa file directory is not writable', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
 
     funcs.mkdir(dirname, '', 0)
     eq(0, funcs.filewritable(dirname))

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -6,7 +6,7 @@ local feed_data = thelpers.feed_data
 local enter_altscreen = thelpers.enter_altscreen
 local exit_altscreen = thelpers.exit_altscreen
 
-if helpers.pending_win32(pending) then return end
+if helpers.skip(helpers.iswin()) then return end
 
 describe(':terminal altscreen', function()
   local screen

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -2,7 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local child_session = require('test.functional.terminal.helpers')
 local ok = helpers.ok
 
-if helpers.pending_win32(pending) then return end
+if helpers.skip(helpers.iswin()) then return end
 
 describe('api', function()
   local screen
@@ -67,4 +67,3 @@ describe('api', function()
     socket_session1:request("nvim_command", "qa!")
   end)
 end)
-

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -15,6 +15,8 @@ local matches = helpers.matches
 local exec_lua = helpers.exec_lua
 local sleep = helpers.sleep
 local funcs = helpers.funcs
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe(':terminal buffer', function()
   local screen
@@ -262,7 +264,7 @@ describe(':terminal buffer', function()
   end)
 
   it('it works with set rightleft #11438', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     local columns = eval('&columns')
     feed(string.rep('a', columns))
     command('set rightleft')

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -9,6 +9,8 @@ local matches = helpers.matches
 local feed_command = helpers.feed_command
 local hide_cursor = thelpers.hide_cursor
 local show_cursor = thelpers.show_cursor
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe(':terminal cursor', function()
   local screen
@@ -88,7 +90,7 @@ describe(':terminal cursor', function()
 
   describe('when invisible', function()
     it('is not highlighted and is detached from screen cursor', function()
-      if helpers.pending_win32(pending) then return end
+      skip(iswin())
       hide_cursor()
       screen:expect([[
         tty ready                                         |
@@ -361,7 +363,7 @@ describe('buffer cursor position is correct in terminal without number column', 
   end)
 
   describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
-    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+    if skip(iswin(), "Encoding problem?") then return end
 
     before_each(function()
       setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
@@ -444,7 +446,7 @@ describe('buffer cursor position is correct in terminal without number column', 
   end)
 
   describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+    skip(iswin(), "Encoding problem?")
 
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')
@@ -741,7 +743,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
   end)
 
   describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
-    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+    if skip(iswin(), "Encoding problem?") then return end
 
     before_each(function()
       setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
@@ -824,7 +826,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
   end)
 
   describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    if helpers.pending_win32(pending) then return end  -- These tests fail on Windows. Encoding problem?
+    skip(iswin(), "Encoding problem?")
 
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -36,7 +36,7 @@ describe(':edit term://*', function()
   end)
 
   it("runs TermOpen early enough to set buffer-local 'scrollback'", function()
-    if helpers.pending_win32(pending) then return end
+    if helpers.skip(helpers.iswin()) then return end
     local columns, lines = 20, 4
     local scr = get_screen(columns, lines)
     local rep = 97

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -11,6 +11,7 @@ local ok = helpers.ok
 local iswin = helpers.iswin
 local command = helpers.command
 local isCI = helpers.isCI
+local skip = helpers.skip
 
 describe(':terminal', function()
   local screen
@@ -46,10 +47,7 @@ describe(':terminal', function()
   end)
 
   it("reads output buffer on terminal reporting #4151", function()
-    if isCI('cirrus') then
-      pending('FIXME: cirrus')
-    end
-    if helpers.pending_win32(pending) then return end
+    skip(isCI('cirrus') or iswin())
     if iswin() then
       feed_command([[terminal powershell -NoProfile -NoLogo -Command Write-Host -NoNewline "\"$([char]27)[6n\""; Start-Sleep -Milliseconds 500 ]])
     else
@@ -146,7 +144,7 @@ describe(':terminal (with fake shell)', function()
   end
 
   it('with no argument, acts like termopen()', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     terminal_with_fake_shell()
     retry(nil, 4 * screen.timeout, function()
     screen:expect([[
@@ -170,7 +168,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("with no argument, but 'shell' has arguments, acts like termopen()", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
     terminal_with_fake_shell()
     screen:expect([[
@@ -182,7 +180,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('executes a given command through the shell', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell('echo hi')
     screen:expect([[
@@ -194,7 +192,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("executes a given command through the shell, when 'shell' has arguments", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell('echo hi')
@@ -207,7 +205,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('allows quotes and slashes', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell([[echo 'hello' \ "world"]])
     screen:expect([[
@@ -244,7 +242,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('works with :find', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     terminal_with_fake_shell()
     screen:expect([[
       ^ready $                                           |
@@ -263,7 +261,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('works with gf', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
     retry(nil, 4 * screen.timeout, function()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -7,6 +7,8 @@ local nvim_prog_abs = helpers.nvim_prog_abs
 local eq, eval = helpers.eq, helpers.eval
 local funcs = helpers.funcs
 local nvim_set = helpers.nvim_set
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe(':terminal highlight', function()
   local screen
@@ -58,7 +60,7 @@ describe(':terminal highlight', function()
       end)
 
       local function pass_attrs()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         screen:expect(sub([[
           tty ready                                         |
           {NUM:text}text{10: }                                         |
@@ -73,7 +75,7 @@ describe(':terminal highlight', function()
       it('will pass the corresponding attributes', pass_attrs)
 
       it('will pass the corresponding attributes on scrollback', function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         pass_attrs()
         local lines = {}
         for i = 1, 8 do
@@ -197,7 +199,7 @@ describe(':terminal highlight forwarding', function()
   end)
 
   it('will handle cterm and rgb attributes', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     thelpers.set_fg(3)
     thelpers.feed_data('text')
     thelpers.feed_termcode('[38:2:255:128:0m')
@@ -249,7 +251,7 @@ describe(':terminal highlight with custom palette', function()
   end)
 
   it('will use the custom color', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     thelpers.set_fg(3)
     thelpers.feed_data('text')
     thelpers.clear_attrs()

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -3,6 +3,8 @@ local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, eval = helpers.clear, helpers.eq, helpers.eval
 local feed, nvim, command = helpers.feed, helpers.nvim, helpers.command
 local feed_data = thelpers.feed_data
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 describe(':terminal mouse', function()
   local screen
@@ -66,7 +68,7 @@ describe(':terminal mouse', function()
     end)
 
     it('does not leave terminal mode on left-release', function()
-      if helpers.pending_win32(pending) then return end
+      skip(iswin())
       feed('<LeftRelease>')
       eq('t', eval('mode(1)'))
     end)
@@ -87,7 +89,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse press, drag and release to the program', function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         feed('<LeftMouse><1,2>')
         screen:expect([[
           line27                                            |
@@ -131,7 +133,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse scroll to the program', function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         feed('<ScrollWheelUp><0,0>')
         screen:expect([[
           line27                                            |
@@ -145,7 +147,7 @@ describe(':terminal mouse', function()
       end)
 
       it('dragging and scrolling do not interfere with each other', function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         feed('<LeftMouse><1,2>')
         screen:expect([[
           line27                                            |
@@ -199,7 +201,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse clicks to the program with the correct even if set nu', function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         command('set number')
         -- When the display area such as a number is clicked, it returns to the
         -- normal mode.
@@ -230,7 +232,7 @@ describe(':terminal mouse', function()
     end)
 
     describe('with a split window and other buffer', function()
-      if helpers.pending_win32(pending) then return end
+      skip(iswin())
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -15,6 +15,7 @@ local feed_data = thelpers.feed_data
 local pcall_err = helpers.pcall_err
 local exec_lua = helpers.exec_lua
 local assert_alive = helpers.assert_alive
+local skip = helpers.skip
 
 describe(':terminal scrollback', function()
   local screen
@@ -139,7 +140,7 @@ describe(':terminal scrollback', function()
 
 
     describe('and height decreased by 1', function()
-      if helpers.pending_win32(pending) then return end
+      if skip(iswin()) then return end
       local function will_hide_top_line()
         feed([[<C-\><C-N>]])
         screen:try_resize(screen._width - 2, screen._height - 1)
@@ -185,7 +186,7 @@ describe(':terminal scrollback', function()
     -- XXX: Can't test this reliably on Windows unless the cursor is _moved_
     --      by the resize. http://docs.libuv.org/en/v1.x/signal.html
     --      See also: https://github.com/rprichard/winpty/issues/110
-    if helpers.pending_win32(pending) then return end
+    if skip(iswin()) then return end
 
     describe('and the height is decreased by 2', function()
       before_each(function()
@@ -264,7 +265,7 @@ describe(':terminal scrollback', function()
       -- XXX: Can't test this reliably on Windows unless the cursor is _moved_
       --      by the resize. http://docs.libuv.org/en/v1.x/signal.html
       --      See also: https://github.com/rprichard/winpty/issues/110
-      if helpers.pending_win32(pending) then return end
+      if skip(iswin()) then return end
       local function pop_then_push()
         screen:try_resize(screen._width, screen._height + 1)
         screen:expect([[
@@ -346,7 +347,7 @@ end)
 
 describe(':terminal prints more lines than the screen height and exits', function()
   it('will push extra lines to scrollback', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     clear()
     local screen = Screen.new(30, 7)
     screen:attach({rgb=false})
@@ -606,7 +607,7 @@ describe("pending scrollback line handling", function()
   end)
 
   it("does not crash after nvim_buf_call #14891", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     exec_lua [[
       local a = vim.api
       local bufnr = a.nvim_create_buf(false, true)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -23,7 +23,7 @@ local read_file = helpers.read_file
 local funcs = helpers.funcs
 local meths = helpers.meths
 
-if helpers.pending_win32(pending) then return end
+if helpers.skip(helpers.iswin()) then return end
 
 describe('TUI', function()
   local screen

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -8,6 +8,7 @@ local command = helpers.command
 local retry = helpers.retry
 local eq = helpers.eq
 local eval = helpers.eval
+local skip = helpers.skip
 
 describe(':terminal window', function()
   local screen
@@ -18,7 +19,7 @@ describe(':terminal window', function()
   end)
 
   it('sets topline correctly #8556', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     -- Test has hardcoded assumptions of dimensions.
     eq(7, eval('&lines'))
     feed_data('\n\n\n')  -- Add blank lines.
@@ -54,9 +55,7 @@ describe(':terminal window', function()
         {3:-- TERMINAL --}                                    |
       ]])
 
-      if iswin() then
-        return  -- win: :terminal resize is unreliable #7007
-      end
+      skip(iswin(), 'win: :terminal resize is unreliable #7007')
 
       -- numberwidth=9
       feed([[<C-\><C-N>]])

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -5,6 +5,8 @@ local eq = helpers.eq
 local insert = helpers.insert
 local exec_lua = helpers.exec_lua
 local feed = helpers.feed
+local iswin = helpers.iswin
+local skip = helpers.skip
 
 before_each(clear)
 
@@ -12,7 +14,7 @@ describe('treesitter parser API', function()
   clear()
 
   it('parses buffer', function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
 
     insert([[
       int main() {
@@ -684,7 +686,7 @@ int x = INT_MAX;
       end)
 
       it("should not inject bad languages", function()
-        if helpers.pending_win32(pending) then return end
+        skip(iswin())
         exec_lua([=[
         vim.treesitter.add_directive("inject-bad!", function(match, _, _, pred, metadata)
           metadata.language = "{"

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -7,6 +7,7 @@ local meths = helpers.meths
 local iswin = helpers.iswin
 local testprg = helpers.testprg
 local thelpers = require('test.functional.terminal.helpers')
+local skip = helpers.skip
 
 describe('ext_hlstate detailed highlights', function()
   local screen
@@ -182,7 +183,7 @@ describe('ext_hlstate detailed highlights', function()
   end)
 
   it("work with :terminal", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
 
     screen:set_default_attr_ids({
       [1] = {{}, {{hi_name = "TermCursorNC", ui_name = "TermCursorNC", kind = "ui"}}},

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -13,6 +13,7 @@ local testprg = helpers.testprg
 local nvim_dir = helpers.nvim_dir
 local has_powershell = helpers.has_powershell
 local set_shell_powershell = helpers.set_shell_powershell
+local skip = helpers.skip
 
 describe("shell command :!", function()
   local screen
@@ -36,7 +37,7 @@ describe("shell command :!", function()
   end)
 
   it("displays output without LF/EOF. #4646 #4569 #3772", function()
-    if helpers.pending_win32(pending) then return end
+    skip(iswin())
     -- NOTE: We use a child nvim (within a :term buffer)
     --       to avoid triggering a UI flush.
     child_session.feed_data(":!printf foo; sleep 200\n")
@@ -52,9 +53,7 @@ describe("shell command :!", function()
   end)
 
   it("throttles shell-command output greater than ~10KB", function()
-    if 'openbsd' == helpers.uname() then
-      pending('FIXME #10804')
-    end
+    skip('openbsd' == helpers.uname(), 'FIXME #10804')
     child_session.feed_data((":!%s REP 30001 foo\n"):format(testprg('shell-test')))
 
     -- If we observe any line starting with a dot, then throttling occurred.
@@ -96,9 +95,7 @@ describe("shell command :!", function()
   end)
 
   it('handles control codes', function()
-    if iswin() then
-      pending('missing printf')
-    end
+    skip(iswin(), 'missing printf')
     local screen = Screen.new(50, 4)
     screen:set_default_attr_ids {
       [1] = {bold = true, reverse = true};


### PR DESCRIPTION
This is essentially a convenience wrapper around the `pending()`
function, similar to `skip_fragile()` but more general-purpose.

Also remove `pending_win32` function as it can be replaced by
`skip(iswin())`.