### PR TITLE
fix(messages): don't set cmdline_row when messages have scrolled

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -196,7 +196,7 @@ void msg_grid_validate(void)
     msg_grid_set_pos(max_rows, false);
   }
 
-  if (msg_grid.chars && cmdline_row < msg_grid_pos) {
+  if (msg_grid.chars && !msg_scrolled && cmdline_row < msg_grid_pos) {
     // TODO(bfredl): this should already be the case, but fails in some
     // "batched" executions where compute_cmdrow() use stale positions or
     // something.

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1236,6 +1236,34 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
       bar^                                                         |
     ]])
   end)
+
+  it('consecutive calls to win_move_statusline() work after multiline message #21014',function()
+    async_meths.exec([[
+      echo "\n"
+      call win_move_statusline(0, -4)
+      call win_move_statusline(0, 4)
+    ]], false)
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {3:                                                            }|
+                                                                  |
+      {4:Press ENTER or type command to continue}^                     |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]])
+    eq(1, meths.get_option('cmdheight'))
+  end)
 end)
 
 it('calling screenstring() after redrawing between messages without UI #20999', function()


### PR DESCRIPTION
Fix #21014

When 'cmdheight' is changed while messages have scrolled, the position
of msg_grid is not moved up, so cmdline_row should not be set based on
the position of msg_grid.
