### PR TITLE
test: simplify platform detection

### DIFF
--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -3,12 +3,12 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
 local funcs = helpers.funcs
-local iswin = helpers.iswin
 local neq = helpers.neq
 local nvim_argv = helpers.nvim_argv
 local request = helpers.request
 local retry = helpers.retry
 local NIL = helpers.NIL
+local is_os = helpers.is_os
 
 describe('API', function()
   before_each(clear)
@@ -62,7 +62,7 @@ describe('API', function()
     it('returns process info', function()
       local pid = funcs.getpid()
       local pinfo = request('nvim_get_proc', pid)
-      eq((iswin() and 'nvim.exe' or 'nvim'), pinfo.name)
+      eq((is_os('win') and 'nvim.exe' or 'nvim'), pinfo.name)
       eq(pid, pinfo.pid)
       eq('number', type(pinfo.ppid))
       neq(pid, pinfo.ppid)

--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -5,7 +5,7 @@ local eq, clear, eval, command, nvim, next_msg =
 local meths = helpers.meths
 local exec_lua = helpers.exec_lua
 local retry = helpers.retry
-local isCI = helpers.isCI
+local is_ci = helpers.is_ci
 local assert_alive = helpers.assert_alive
 local skip = helpers.skip
 
@@ -79,7 +79,7 @@ describe('notify', function()
   end)
 
   it('cancels stale events on channel close', function()
-    skip(isCI(), 'hangs on CI #14083 #15251')
+    skip(is_ci(), 'hangs on CI #14083 #15251')
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
     local catpath = eval('exepath("cat")')
     eq({id=catchan, argv={catpath}, stream='job', mode='rpc', client = {}}, exec_lua ([[

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -250,7 +250,7 @@ describe('server -> client', function()
       pcall(funcs.jobstop, jobid)
     end)
 
-    if helpers.skip(helpers.iswin()) then return end
+    if helpers.skip(helpers.is_os('win')) then return end
 
     it('rpc and text stderr can be combined', function()
       local status, rv = pcall(funcs.rpcrequest, jobid, 'poll')

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -12,7 +12,6 @@ local exec = helpers.exec
 local eval = helpers.eval
 local expect = helpers.expect
 local funcs = helpers.funcs
-local iswin = helpers.iswin
 local meths = helpers.meths
 local matches = helpers.matches
 local pesc = helpers.pesc
@@ -400,7 +399,7 @@ describe('API', function()
     end)
 
     it('returns shell |:!| output', function()
-      local win_lf = iswin() and '\r' or ''
+      local win_lf = is_os('win') and '\r' or ''
       eq(':!echo foo\r\n\nfoo'..win_lf..'\n', nvim('command_output', [[!echo foo]]))
     end)
 
@@ -2125,7 +2124,7 @@ describe('API', function()
         pty='?',
       }
       local event = meths.get_var("opened_event")
-      if not iswin() then
+      if not is_os('win') then
         info.pty = event.info.pty
         neq(nil, string.match(info.pty, "^/dev/"))
       end
@@ -2141,7 +2140,7 @@ describe('API', function()
         stream = 'job',
         id = 4,
         argv = (
-          iswin() and {
+          is_os('win') and {
             eval('&shell'),
             '/s',
             '/c',
@@ -2163,7 +2162,7 @@ describe('API', function()
       -- :terminal with args + stopped process.
       eq(1, eval('jobstop(&channel)'))
       eval('jobwait([&channel], 1000)')  -- Wait.
-      expected2.pty = (iswin() and '?' or '')  -- pty stream was closed.
+      expected2.pty = (is_os('win') and '?' or '')  -- pty stream was closed.
       eq(expected2, eval('nvim_get_chan_info(&channel)'))
     end)
   end)
@@ -2724,7 +2723,7 @@ describe('API', function()
       eq({}, meths.get_runtime_file("foobarlang/", true))
     end)
     it('can handle bad patterns', function()
-      skip(iswin())
+      skip(is_os('win'))
 
       eq("Vim:E220: Missing }.", pcall_err(meths.get_runtime_file, "{", false))
 

--- a/test/functional/autocmd/dirchanged_spec.lua
+++ b/test/functional/autocmd/dirchanged_spec.lua
@@ -1,12 +1,12 @@
 local lfs = require('lfs')
-local h = require('test.functional.helpers')(after_each)
+local helpers = require('test.functional.helpers')(after_each)
 
-local clear = h.clear
-local command = h.command
-local eq = h.eq
-local eval = h.eval
-local request = h.request
-local iswin = h.iswin
+local clear = helpers.clear
+local command = helpers.command
+local eq = helpers.eq
+local eval = helpers.eval
+local request = helpers.request
+local is_os = helpers.is_os
 
 describe('autocmd DirChanged and DirChangedPre', function()
   local curdir = string.gsub(lfs.currentdir(), '\\', '/')
@@ -21,8 +21,8 @@ describe('autocmd DirChanged and DirChangedPre', function()
     curdir .. '\\XTEST-FUNCTIONAL-AUTOCMD-DIRCHANGED.DIR3',
   }
 
-  setup(function()    for _, dir in pairs(dirs) do h.mkdir(dir) end end)
-  teardown(function() for _, dir in pairs(dirs) do h.rmdir(dir) end end)
+  setup(function()    for _, dir in pairs(dirs) do helpers.mkdir(dir) end end)
+  teardown(function() for _, dir in pairs(dirs) do helpers.rmdir(dir) end end)
 
   before_each(function()
     clear()
@@ -159,7 +159,7 @@ describe('autocmd DirChanged and DirChangedPre', function()
     eq(1, eval('g:cdprecount'))
     eq(1, eval('g:cdcount'))
 
-    if iswin() then
+    if is_os('win') then
       command('lcd '..win_dirs[1])
       eq({}, eval('g:evpre'))
       eq({}, eval('g:ev'))
@@ -182,7 +182,7 @@ describe('autocmd DirChanged and DirChangedPre', function()
     eq(2, eval('g:cdprecount'))
     eq(2, eval('g:cdcount'))
 
-    if iswin() then
+    if is_os('win') then
       command('tcd '..win_dirs[2])
       eq({}, eval('g:evpre'))
       eq({}, eval('g:ev'))
@@ -204,7 +204,7 @@ describe('autocmd DirChanged and DirChangedPre', function()
     eq(3, eval('g:cdprecount'))
     eq(3, eval('g:cdcount'))
 
-    if iswin() then
+    if is_os('win') then
       command('cd '..win_dirs[3])
       eq({}, eval('g:evpre'))
       eq({}, eval('g:ev'))
@@ -229,7 +229,7 @@ describe('autocmd DirChanged and DirChangedPre', function()
     eq(4, eval('g:cdprecount'))
     eq(4, eval('g:cdcount'))
 
-    if iswin() then
+    if is_os('win') then
       command('split '..win_dirs[1]..'/baz')
       eq({}, eval('g:evpre'))
       eq({}, eval('g:ev'))
@@ -278,7 +278,7 @@ describe('autocmd DirChanged and DirChangedPre', function()
     eq(9, eval('g:cdprecount'))         -- same CWD, no DirChangedPre event
     eq(9, eval('g:cdcount'))            -- same CWD, no DirChanged event
 
-    if iswin() then
+    if is_os('win') then
       command('tabnew')                 -- tab 3
       eq(9, eval('g:cdprecount'))       -- same CWD, no DirChangedPre event
       eq(9, eval('g:cdcount'))          -- same CWD, no DirChanged event

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -6,7 +6,7 @@ local nvim_prog = helpers.nvim_prog
 local feed_command = helpers.feed_command
 local feed_data = thelpers.feed_data
 
-if helpers.skip(helpers.iswin()) then return end
+if helpers.skip(helpers.is_os('win')) then return end
 
 describe('autoread TUI FocusGained/FocusLost', function()
   local f1 = 'xtest-foo'

--- a/test/functional/autocmd/signal_spec.lua
+++ b/test/functional/autocmd/signal_spec.lua
@@ -5,10 +5,10 @@ local command = helpers.command
 local eq = helpers.eq
 local funcs = helpers.funcs
 local next_msg = helpers.next_msg
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
-if skip(iswin(), 'Only applies to POSIX systems') then return end
+if skip(is_os('win'), 'Only applies to POSIX systems') then return end
 
 local function posix_kill(signame, pid)
   os.execute('kill -s '..signame..' -- '..pid..' >/dev/null')

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -10,8 +10,8 @@ local ok = helpers.ok
 local feed = helpers.feed
 local pcall_err = helpers.pcall_err
 local assert_alive = helpers.assert_alive
-local iswin = helpers.iswin
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 describe('autocmd TermClose', function()
   before_each(function()
@@ -48,7 +48,7 @@ describe('autocmd TermClose', function()
   end)
 
   it('triggers when long-running terminal job gets stopped', function()
-    nvim('set_option', 'shell', iswin() and 'cmd.exe' or 'sh')
+    nvim('set_option', 'shell', is_os('win') and 'cmd.exe' or 'sh')
     command('autocmd TermClose * let g:test_termclose = 23')
     command('terminal')
     command('call jobstop(b:terminal_job_id)')
@@ -56,7 +56,7 @@ describe('autocmd TermClose', function()
   end)
 
   it('kills job trapping SIGTERM', function()
-    skip(iswin())
+    skip(is_os('win'))
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" TERM && echo 1 && sleep 60', { ]]
@@ -76,7 +76,7 @@ describe('autocmd TermClose', function()
   end)
 
   it('kills PTY job trapping SIGHUP and SIGTERM', function()
-    skip(iswin())
+    skip(is_os('win'))
     nvim('set_option', 'shell', 'sh')
     nvim('set_option', 'shellcmdflag', '-c')
     command([[ let g:test_job = jobstart('trap "" HUP TERM && echo 1 && sleep 60', { ]]

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -1,5 +1,4 @@
 local helpers = require('test.functional.helpers')(after_each)
-local uname = helpers.uname
 local clear, eq, eval, next_msg, ok, source = helpers.clear, helpers.eq,
    helpers.eval, helpers.next_msg, helpers.ok, helpers.source
 local command, funcs, meths = helpers.command, helpers.funcs, helpers.meths
@@ -12,7 +11,6 @@ local retry = helpers.retry
 local expect_twostreams = helpers.expect_twostreams
 local assert_alive = helpers.assert_alive
 local pcall_err = helpers.pcall_err
-local iswin = helpers.iswin
 local skip = helpers.skip
 
 describe('channels', function()
@@ -147,7 +145,7 @@ describe('channels', function()
   end
 
   it('can use stdio channel with pty', function()
-    skip(iswin())
+    skip(is_os('win'))
     source([[
       let g:job_opts = {
       \ 'on_stdout': function('OnEvent'),
@@ -180,8 +178,7 @@ describe('channels', function()
 
     command("call chansend(id, 'incomplet\004')")
 
-    local is_bsd = not not string.find(uname(), 'bsd')
-    local bsdlike = is_bsd or is_os('mac')
+    local bsdlike = is_os('bsd') or is_os('mac')
     local extra = bsdlike and "^D\008\008" or ""
     expect_twoline(id, "stdout",
                    "incomplet"..extra, "[1, ['incomplet'], 'stdin']", true)
@@ -201,7 +198,7 @@ describe('channels', function()
 
 
   it('stdio channel can use rpc and stderr simultaneously', function()
-    skip(iswin())
+    skip(is_os('win'))
     source([[
       let g:job_opts = {
       \ 'on_stderr': function('OnEvent'),

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -21,14 +21,14 @@ local read_file = helpers.read_file
 local tmpname = helpers.tmpname
 local trim = helpers.trim
 local currentdir = helpers.funcs.getcwd
-local iswin = helpers.iswin
 local assert_alive = helpers.assert_alive
 local expect_exit = helpers.expect_exit
 local write_file = helpers.write_file
 local Screen = require('test.functional.ui.screen')
 local feed_command = helpers.feed_command
-local isCI = helpers.isCI
 local skip = helpers.skip
+local is_os = helpers.is_os
+local is_ci = helpers.is_ci
 
 describe('fileio', function()
   before_each(function()
@@ -90,7 +90,7 @@ describe('fileio', function()
   end)
 
   it('backup #9709', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     clear({ args={ '-i', 'Xtest_startup_shada',
                    '--cmd', 'set directory=Xtest_startup_swapdir' } })
 
@@ -110,7 +110,7 @@ describe('fileio', function()
   end)
 
   it('backup with full path #11214', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     clear()
     mkdir('Xtest_backupdir')
     command('set backup')
@@ -123,7 +123,7 @@ describe('fileio', function()
 
     -- Backup filename = fullpath, separators replaced with "%".
     local backup_file_name = string.gsub(currentdir()..'/Xtest_startup_file1',
-      iswin() and '[:/\\]' or '/', '%%') .. '~'
+      is_os('win') and '[:/\\]' or '/', '%%') .. '~'
     local foo_contents = trim(read_file('Xtest_backupdir/'..backup_file_name))
     local foobar_contents = trim(read_file('Xtest_startup_file1'))
 
@@ -132,7 +132,7 @@ describe('fileio', function()
   end)
 
   it('backup symlinked files #11349', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     clear()
 
     local initial_content = 'foo'
@@ -154,7 +154,7 @@ describe('fileio', function()
 
 
   it('backup symlinked files in first avialable backupdir #11349', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     clear()
 
     local initial_content = 'foo'
@@ -299,7 +299,7 @@ describe('tmpdir', function()
     end)
 
     -- "…/nvim.<user>/" has wrong permissions:
-    skip(iswin(), 'TODO(justinmk): need setfperm/getfperm on Windows. #8244')
+    skip(is_os('win'), 'TODO(justinmk): need setfperm/getfperm on Windows. #8244')
     os.remove(testlog)
     os.remove(tmproot)
     mkdir(tmproot)

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -9,7 +9,7 @@ local clear = helpers.clear
 local funcs = helpers.funcs
 local nvim_prog_abs = helpers.nvim_prog_abs
 local write_file = helpers.write_file
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 describe('Command-line option', function()
@@ -51,7 +51,7 @@ describe('Command-line option', function()
       eq(#('100500\n'), attrs.size)
     end)
     it('does not crash after reading from stdin in non-headless mode', function()
-      skip(iswin())
+      skip(is_os('win'))
       local screen = Screen.new(40, 8)
       screen:attach()
       local args = {

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -3,16 +3,16 @@ local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
 local command = helpers.command
-local iswin = helpers.iswin
 local insert = helpers.insert
 local feed = helpers.feed
+local is_os = helpers.is_os
 
 describe('path collapse', function()
   local targetdir
   local expected_path
 
   local function join_path(...)
-    local pathsep = (iswin() and '\\' or '/')
+    local pathsep = (is_os('win') and '\\' or '/')
     return table.concat({...}, pathsep)
   end
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -20,11 +20,11 @@ local read_file = helpers.read_file
 local retry = helpers.retry
 local rmdir = helpers.rmdir
 local sleep = helpers.sleep
-local iswin = helpers.iswin
 local startswith = helpers.startswith
 local write_file = helpers.write_file
 local meths = helpers.meths
 local alter_slashes = helpers.alter_slashes
+local is_os = helpers.is_os
 
 local testfile = 'Xtest_startuptime'
 after_each(function()
@@ -79,7 +79,7 @@ describe('startup', function()
   it('in a TTY: has("ttyin")==1 has("ttyout")==1', function()
     local screen = Screen.new(25, 4)
     screen:attach()
-    if iswin() then
+    if is_os('win') then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
     end
     -- Running in :terminal
@@ -95,7 +95,7 @@ describe('startup', function()
     ]])
   end)
   it('output to pipe: has("ttyin")==1 has("ttyout")==0', function()
-    if iswin() then
+    if is_os('win') then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
     end
     -- Running in :terminal
@@ -111,7 +111,7 @@ describe('startup', function()
     end)
   end)
   it('input from pipe: has("ttyin")==0 has("ttyout")==1', function()
-    if iswin() then
+    if is_os('win') then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
     end
     -- Running in :terminal
@@ -130,7 +130,7 @@ describe('startup', function()
   it('input from pipe (implicit) #7679', function()
     local screen = Screen.new(25, 4)
     screen:attach()
-    if iswin() then
+    if is_os('win') then
       command([[set shellcmdflag=/s\ /c shellxquote=\"]])
     end
     -- Running in :terminal
@@ -665,7 +665,7 @@ describe('runtime:', function()
   end)
 
   it('loads plugin/*.lua from site packages', function()
-    local nvimdata = iswin() and "nvim-data" or "nvim"
+    local nvimdata = is_os('win') and "nvim-data" or "nvim"
     local plugin_path = table.concat({xdata, nvimdata, 'site', 'pack', 'xa', 'start', 'yb'}, pathsep)
     local plugin_folder_path = table.concat({plugin_path, 'plugin'}, pathsep)
     local plugin_after_path = table.concat({plugin_path, 'after', 'plugin'}, pathsep)

--- a/test/functional/ex_cmds/cd_spec.lua
+++ b/test/functional/ex_cmds/cd_spec.lua
@@ -9,8 +9,8 @@ local clear = helpers.clear
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local pathsep = helpers.get_pathsep()
-local iswin = helpers.iswin
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 -- These directories will be created for testing
 local directories = {
@@ -281,7 +281,7 @@ describe("getcwd()", function ()
   end)
 
   it("returns empty string if working directory does not exist", function()
-    skip(iswin())
+    skip(is_os('win'))
     command("cd "..directories.global)
     command("call delete('../"..directories.global.."', 'd')")
     eq("", helpers.eval("getcwd()"))

--- a/test/functional/ex_cmds/mksession_spec.lua
+++ b/test/functional/ex_cmds/mksession_spec.lua
@@ -5,7 +5,6 @@ local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local command = helpers.command
 local get_pathsep = helpers.get_pathsep
-local iswin = helpers.iswin
 local eq = helpers.eq
 local neq = helpers.neq
 local funcs = helpers.funcs
@@ -15,6 +14,7 @@ local rmdir = helpers.rmdir
 local sleep = helpers.sleep
 local meths = helpers.meths
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 local file_prefix = 'Xtest-functional-ex_cmds-mksession_spec'
 
@@ -178,7 +178,7 @@ describe(':mksession', function()
     command('cd ' .. cwd_dir)
     command('mksession ' .. session_path)
     command('%bwipeout!')
-    if iswin() then
+    if is_os('win') then
       sleep(100) -- Make sure all child processes have exited.
     end
 
@@ -189,13 +189,13 @@ describe(':mksession', function()
     local expected_cwd = cwd_dir .. '/' .. tab_dir
     matches('^term://' .. pesc(expected_cwd) .. '//%d+:', funcs.expand('%'))
     command('%bwipeout!')
-    if iswin() then
+    if is_os('win') then
       sleep(100) -- Make sure all child processes have exited.
     end
   end)
 
   it('restores CWD for :terminal buffer at root directory #16988', function()
-    skip(iswin(), 'N/A for Windows')
+    skip(is_os('win'), 'N/A for Windows')
 
     local screen
     local cwd_dir = funcs.fnamemodify('.', ':p:~'):gsub([[[\/]*$]], '')

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -14,9 +14,9 @@ local eval = helpers.eval
 local exec_capture = helpers.exec_capture
 local neq = helpers.neq
 local matches = helpers.matches
-local iswin = helpers.iswin
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
+local is_os = helpers.is_os
 
 describe(':source', function()
   before_each(function()
@@ -44,7 +44,7 @@ describe(':source', function()
   end)
 
   it("changing 'shellslash' changes the result of expand()", function()
-    if not iswin() then
+    if not is_os('win') then
       pending("'shellslash' only works on Windows")
       return
     end

--- a/test/functional/ex_cmds/write_spec.lua
+++ b/test/functional/ex_cmds/write_spec.lua
@@ -8,9 +8,9 @@ local command = helpers.command
 local feed_command = helpers.feed_command
 local funcs = helpers.funcs
 local meths = helpers.meths
-local iswin = helpers.iswin
-local isCI = helpers.isCI
 local skip = helpers.skip
+local is_os = helpers.is_os
+local is_ci = helpers.is_ci
 
 local fname = 'Xtest-functional-ex_cmds-write'
 local fname_bak = fname .. '~'
@@ -39,7 +39,7 @@ describe(':write', function()
   it('&backupcopy=auto preserves symlinks', function()
     command('set backupcopy=auto')
     write_file('test_bkc_file.txt', 'content0')
-    if iswin() then
+    if is_os('win') then
       command("silent !mklink test_bkc_link.txt test_bkc_file.txt")
     else
       command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
@@ -57,10 +57,10 @@ describe(':write', function()
   end)
 
   it('&backupcopy=no replaces symlink with new file', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     command('set backupcopy=no')
     write_file('test_bkc_file.txt', 'content0')
-    if iswin() then
+    if is_os('win') then
       command("silent !mklink test_bkc_link.txt test_bkc_file.txt")
     else
       command("silent !ln -s test_bkc_file.txt test_bkc_link.txt")
@@ -79,7 +79,7 @@ describe(':write', function()
 
   it("appends FIFO file", function()
     -- mkfifo creates read-only .lnk files on Windows
-    if iswin() or eval("executable('mkfifo')") == 0 then
+    if is_os('win') or eval("executable('mkfifo')") == 0 then
       pending('missing "mkfifo" command')
     end
 
@@ -112,7 +112,7 @@ describe(':write', function()
     eq(1, eval("filereadable('test/write/p_opt.txt')"))
 
     eq(('Vim(write):E32: No file name'), pcall_err(command, 'write ++p test_write/'))
-    if not iswin() then
+    if not is_os('win') then
       eq(('Vim(write):E17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
         pcall_err(command, 'write ++p .'))
       eq(('Vim(write):E17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
@@ -121,11 +121,11 @@ describe(':write', function()
   end)
 
   it('errors out correctly', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     command('let $HOME=""')
     eq(funcs.fnamemodify('.', ':p:h'), funcs.fnamemodify('.', ':p:h:~'))
     -- Message from check_overwrite
-    if not iswin() then
+    if not is_os('win') then
       eq(('Vim(write):E17: "'..funcs.fnamemodify('.', ':p:h')..'" is a directory'),
         pcall_err(command, 'write .'))
     end
@@ -144,7 +144,7 @@ describe(':write', function()
     funcs.setfperm(fname, 'r--------')
     eq('Vim(write):E505: "Xtest-functional-ex_cmds-write" is read-only (add ! to override)',
        pcall_err(command, 'write'))
-    if iswin() then
+    if is_os('win') then
       eq(0, os.execute('del /q/f ' .. fname))
       eq(0, os.execute('rd /q/s ' .. fname_bak))
     else
@@ -152,7 +152,7 @@ describe(':write', function()
       eq(true, os.remove(fname_bak))
     end
     write_file(fname_bak, 'TTYX')
-    skip(iswin(), [[FIXME: exc_exec('write!') outputs 0 in Windows]])
+    skip(is_os('win'), [[FIXME: exc_exec('write!') outputs 0 in Windows]])
     lfs.link(fname_bak .. ('/xxxxx'):rep(20), fname, true)
     eq('Vim(write):E166: Can\'t open linked file for writing',
        pcall_err(command, 'write!'))

--- a/test/functional/ex_cmds/wviminfo_spec.lua
+++ b/test/functional/ex_cmds/wviminfo_spec.lua
@@ -3,14 +3,14 @@ local lfs = require('lfs')
 local clear = helpers.clear
 local command, eq, neq, write_file =
   helpers.command, helpers.eq, helpers.neq, helpers.write_file
-local iswin = helpers.iswin
 local read_file = helpers.read_file
+local is_os = helpers.is_os
 
 describe(':wshada', function()
   local shada_file = 'wshada_test'
 
   before_each(function()
-    clear{args={'-i', iswin() and 'nul' or '/dev/null',
+    clear{args={'-i', is_os('win') and 'nul' or '/dev/null',
                 -- Need 'swapfile' for these tests.
                 '--cmd', 'set swapfile undodir=. directory=. viewdir=. backupdir=. belloff= noshowcmd noruler'},
           args_rm={'-n', '-i', '--cmd'}}

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -54,7 +54,6 @@ if module.nvim_dir == module.nvim_prog then
   module.nvim_dir = "."
 end
 
-local iswin = global_helpers.iswin
 local prepend_argv
 
 if os.getenv('VALGRIND') then
@@ -557,7 +556,7 @@ function module.source(code)
 end
 
 function module.has_powershell()
-  return module.eval('executable("'..(iswin() and 'powershell' or 'pwsh')..'")') == 1
+  return module.eval('executable("'..(is_os('win') and 'powershell' or 'pwsh')..'")') == 1
 end
 
 --- Sets Nvim shell to powershell.
@@ -570,9 +569,9 @@ function module.set_shell_powershell(fake)
   if not fake then
     assert(found)
   end
-  local shell = found and (iswin() and 'powershell' or 'pwsh') or module.testprg('pwsh-test')
+  local shell = found and (is_os('win') and 'powershell' or 'pwsh') or module.testprg('pwsh-test')
   local set_encoding = '[Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();'
-  local cmd = set_encoding..'Remove-Item -Force '..table.concat(iswin()
+  local cmd = set_encoding..'Remove-Item -Force '..table.concat(is_os('win')
     and {'alias:cat', 'alias:echo', 'alias:sleep', 'alias:sort'}
     or  {'alias:echo'}, ',')..';'
   module.exec([[
@@ -854,13 +853,13 @@ function module.exec_lua(code, ...)
 end
 
 function module.get_pathsep()
-  return iswin() and '\\' or '/'
+  return is_os('win') and '\\' or '/'
 end
 
 --- Gets the filesystem root dir, namely "/" or "C:/".
 function module.pathroot()
   local pathsep = package.config:sub(1,1)
-  return iswin() and (module.nvim_dir:sub(1,2)..pathsep) or '/'
+  return is_os('win') and (module.nvim_dir:sub(1,2)..pathsep) or '/'
 end
 
 --- Gets the full `…/build/bin/{name}` path of a test program produced by
@@ -868,7 +867,7 @@ end
 ---
 --- @param name (string) Name of the test program.
 function module.testprg(name)
-  local ext = module.iswin() and '.exe' or ''
+  local ext = module.is_os('win') and '.exe' or ''
   return ('%s/%s%s'):format(module.nvim_dir, name, ext)
 end
 
@@ -895,7 +894,7 @@ function module.missing_provider(provider)
 end
 
 function module.alter_slashes(obj)
-  if not iswin() then
+  if not is_os('win') then
     return obj
   end
   if type(obj) == 'string' then
@@ -913,7 +912,7 @@ function module.alter_slashes(obj)
 end
 
 local load_factor = 1
-if global_helpers.isCI() then
+if global_helpers.is_ci() then
   -- Compute load factor only once (but outside of any tests).
   module.clear()
   module.request('nvim_command', 'source src/nvim/testdir/load.vim')
@@ -946,14 +945,14 @@ end
 
 -- Kill process with given pid
 function module.os_kill(pid)
-  return os.execute((iswin()
+  return os.execute((is_os('win')
     and 'taskkill /f /t /pid '..pid..' > nul'
     or  'kill -9 '..pid..' > /dev/null'))
 end
 
 -- Create folder with non existing parents
 function module.mkdir_p(path)
-  return os.execute((iswin()
+  return os.execute((is_os('win')
     and 'mkdir '..path
     or 'mkdir -p '..path))
 end

--- a/test/functional/legacy/011_autocommands_spec.lua
+++ b/test/functional/legacy/011_autocommands_spec.lua
@@ -18,11 +18,11 @@ local clear, feed_command, expect, eq, neq, dedent, write_file, feed =
   helpers.clear, helpers.feed_command, helpers.expect, helpers.eq, helpers.neq,
   helpers.dedent, helpers.write_file, helpers.feed
 local command = helpers.command
-local iswin = helpers.iswin
 local read_file = helpers.read_file
+local is_os = helpers.is_os
 
 local function has_gzip()
-  local null = iswin() and 'nul' or '/dev/null'
+  local null = is_os('win') and 'nul' or '/dev/null'
   return os.execute('gzip --help >' .. null .. ' 2>&1') == 0
 end
 

--- a/test/functional/legacy/025_jump_tag_hidden_spec.lua
+++ b/test/functional/legacy/025_jump_tag_hidden_spec.lua
@@ -23,7 +23,7 @@ describe('jump to a tag with hidden set', function()
     feed_command('set hidden')
 
     -- Create a link from test25.dir to the current directory.
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       feed_command('!rd /q/s test25.dir')
       feed_command('!mklink /j test25.dir .')
     else
@@ -33,7 +33,7 @@ describe('jump to a tag with hidden set', function()
 
     -- Create tags.text, with the current directory name inserted.
     feed_command('/tags line')
-    feed_command('r !' .. (helpers.iswin() and 'cd' or 'pwd'))
+    feed_command('r !' .. (helpers.is_os('win') and 'cd' or 'pwd'))
     feed('d$/test<cr>')
     feed('hP:.w! tags.test<cr>')
 
@@ -44,7 +44,7 @@ describe('jump to a tag with hidden set', function()
     feed('G<C-]> x:yank a<cr>')
     feed_command("call delete('tags.test')")
     feed_command("call delete('Xxx')")
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       feed_command('!rd /q test25.dir')
     else
       feed_command('!rm -f test25.dir')

--- a/test/functional/legacy/097_glob_path_spec.lua
+++ b/test/functional/legacy/097_glob_path_spec.lua
@@ -10,7 +10,7 @@ describe('glob() and globpath()', function()
   setup(clear)
 
   setup(function()
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       os.execute("md sautest\\autoload")
       os.execute(".>sautest\\autoload\\Test104.vim 2>nul")
       os.execute(".>sautest\\autoload\\footest.vim 2>nul")
@@ -28,7 +28,7 @@ describe('glob() and globpath()', function()
     -- Consistent sorting of file names
     command('set nofileignorecase')
 
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       command([[$put =glob('Xxx{')]])
       command([[$put =glob('Xxx$')]])
 
@@ -72,7 +72,7 @@ describe('glob() and globpath()', function()
   end)
 
   teardown(function()
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       os.execute('del /q/f Xxx{ Xxx$')
       os.execute('rd /q /s sautest')
     else

--- a/test/functional/legacy/delete_spec.lua
+++ b/test/functional/legacy/delete_spec.lua
@@ -48,7 +48,7 @@ describe('Test for delete()', function()
 
   it('symlink directory delete', function()
     command("call mkdir('Xdir1')")
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       command("silent !mklink /j Xlink Xdir1")
     else
       command("silent !ln -s Xdir1 Xlink")

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -7,12 +7,12 @@ local exec_lua = helpers.exec_lua
 local expect_exit = helpers.expect_exit
 local feed = helpers.feed
 local funcs = helpers.funcs
-local iswin = helpers.iswin
 local meths = helpers.meths
 local read_file = helpers.read_file
 local source = helpers.source
 local eq = helpers.eq
 local write_file = helpers.write_file
+local is_os = helpers.is_os
 
 local function sizeoflong()
   if not exec_lua('return pcall(require, "ffi")') then
@@ -376,7 +376,7 @@ describe(':confirm command dialog', function()
       {3:(Y)es, [N]o: }^                                                              |
     ]])
     feed('Y')
-    if iswin() then
+    if is_os('win') then
       screen:expect([[
         foobar                                                                     |
         {0:~                                                                          }|
@@ -416,7 +416,7 @@ describe(':confirm command dialog', function()
       {3:(Y)es, [N]o: }^                                                              |
     ]])
     feed('Y')
-    if iswin() then
+    if is_os('win') then
       screen:expect([[
         foobar                                                                     |
         {1:                                                                           }|
@@ -493,7 +493,7 @@ describe(':confirm command dialog', function()
       {3:(Y)es, [N]o: }^                                                              |
     ]])
     feed('Y')
-    if iswin() then
+    if is_os('win') then
       screen:expect([[
         a                                                                          |
         b                                                                          |

--- a/test/functional/legacy/filechanged_spec.lua
+++ b/test/functional/legacy/filechanged_spec.lua
@@ -1,7 +1,7 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, source = helpers.clear, helpers.source
 local call, eq, meths = helpers.call, helpers.eq, helpers.meths
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 local function expected_empty()
@@ -17,7 +17,7 @@ describe('file changed dialog', function()
   end)
 
   it('works', function()
-    skip(iswin())
+    skip(is_os('win'))
     source([[
       func Test_file_changed_dialog()
         au! FileChangedShell

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -7,10 +7,10 @@ local mkdir_p = helpers.mkdir_p
 local rmdir = helpers.rmdir
 local nvim_dir = helpers.nvim_dir
 local test_build_dir = helpers.test_build_dir
-local iswin = helpers.iswin
 local nvim_prog = helpers.nvim_prog
+local is_os = helpers.is_os
 
-local nvim_prog_basename = iswin() and 'nvim.exe' or 'nvim'
+local nvim_prog_basename = is_os('win') and 'nvim.exe' or 'nvim'
 
 before_each(clear)
 
@@ -102,7 +102,7 @@ describe('vim.fs', function()
       eq('C:/Users/jdoe', exec_lua [[ return vim.fs.normalize('C:\\Users\\jdoe') ]])
     end)
     it('works with ~', function()
-      if iswin() then
+      if is_os('win') then
         pending([[$HOME does not exist on Windows ¯\_(ツ)_/¯]])
       end
       eq(os.getenv('HOME') .. '/src/foo', exec_lua [[ return vim.fs.normalize('~/src/foo') ]])

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -8,12 +8,12 @@ local feed = helpers.feed
 local clear = helpers.clear
 local funcs = helpers.funcs
 local meths = helpers.meths
-local iswin = helpers.iswin
 local command = helpers.command
 local write_file = helpers.write_file
 local exec_capture = helpers.exec_capture
 local exec_lua = helpers.exec_lua
 local pcall_err = helpers.pcall_err
+local is_os = helpers.is_os
 
 local screen
 
@@ -135,7 +135,7 @@ describe('print', function()
         print("very slow")
         vim.api.nvim_command("sleep 1m") -- force deferred event processing
       end
-    ]], (iswin() and "timeout 1") or "sleep 0.1")
+    ]], (is_os('win') and "timeout 1") or "sleep 0.1")
     eq('very slow\nvery fast', exec_capture('lua test()'))
   end)
 end)

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -5,7 +5,7 @@ local eq = helpers.eq
 local clear = helpers.clear
 local command = helpers.command
 local pathsep = helpers.get_pathsep()
-local iswin = helpers.iswin()
+local is_os = helpers.is_os
 local curbufmeths = helpers.curbufmeths
 local exec_lua = helpers.exec_lua
 local feed_command = helpers.feed_command
@@ -18,7 +18,7 @@ describe('vim.secure', function()
     local xstate = 'Xstate'
 
     setup(function()
-      helpers.mkdir_p(xstate .. pathsep .. (iswin and 'nvim-data' or 'nvim'))
+      helpers.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
     end)
 
     teardown(function()

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -2,7 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local eq = helpers.eq
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 local write_file = require('test.helpers').write_file
 
@@ -169,7 +169,7 @@ describe('URI methods', function()
 
   describe('uri from bufnr', function()
     it('Windows paths should not be treated as uris', function()
-      skip(not iswin(), "Not applicable on non-Windows")
+      skip(not is_os('win'), "Not applicable on non-Windows")
 
       local file = helpers.tmpname()
       write_file(file, 'Test content')

--- a/test/functional/options/autochdir_spec.lua
+++ b/test/functional/options/autochdir_spec.lua
@@ -16,7 +16,7 @@ describe("'autochdir'", function()
 
     -- With 'autochdir' on, we should get the directory of tty-test.c.
     clear('--cmd', 'set autochdir', targetdir..'/tty-test.c')
-    eq(helpers.iswin() and expected:gsub('/', '\\') or expected, funcs.getcwd())
+    eq(helpers.is_os('win') and expected:gsub('/', '\\') or expected, funcs.getcwd())
   end)
 
   it('is not overwritten by getwinvar() call #17609',function()

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -12,13 +12,13 @@ local eq = helpers.eq
 local ok = helpers.ok
 local funcs = helpers.funcs
 local insert = helpers.insert
-local iswin = helpers.iswin
 local neq = helpers.neq
 local mkdir = helpers.mkdir
 local rmdir = helpers.rmdir
 local alter_slashes = helpers.alter_slashes
 local tbl_contains = helpers.tbl_contains
 local expect_exit = helpers.expect_exit
+local is_os = helpers.is_os
 
 describe('startup defaults', function()
   describe(':filetype', function()
@@ -240,7 +240,7 @@ describe('startup defaults', function()
 
   describe('$NVIM_LOG_FILE', function()
     local xdgdir = 'Xtest-startup-xdg-logpath'
-    local xdgstatedir = iswin() and xdgdir..'/nvim-data' or xdgdir..'/nvim'
+    local xdgstatedir = is_os('win') and xdgdir..'/nvim-data' or xdgdir..'/nvim'
     after_each(function()
       os.remove('Xtest-logpath')
       rmdir(xdgdir)
@@ -279,7 +279,7 @@ describe('XDG defaults', function()
     clear()
     local rtp = eval('split(&runtimepath, ",")')
     local rv = {}
-    local expected = (iswin()
+    local expected = (is_os('win')
                       and { [[\nvim-data\site]], [[\nvim-data\site\after]], }
                       or { '/nvim/site', '/nvim/site/after', })
 
@@ -327,10 +327,10 @@ describe('XDG defaults', function()
     return vimruntime, libdir
   end
 
-  local env_sep = iswin() and ';' or ':'
-  local data_dir = iswin() and 'nvim-data' or 'nvim'
-  local state_dir = iswin() and 'nvim-data' or 'nvim'
-  local root_path = iswin() and 'C:' or ''
+  local env_sep = is_os('win') and ';' or ':'
+  local data_dir = is_os('win') and 'nvim-data' or 'nvim'
+  local state_dir = is_os('win') and 'nvim-data' or 'nvim'
+  local root_path = is_os('win') and 'C:' or ''
 
   describe('with too long XDG variables', function()
     before_each(function()
@@ -497,7 +497,7 @@ describe('XDG defaults', function()
 
     it('are escaped properly', function()
       local vimruntime, libdir = vimruntime_and_libdir()
-      local path_sep = iswin() and '\\' or '/'
+      local path_sep = is_os('win') and '\\' or '/'
       eq(('\\, \\, \\,' .. path_sep .. 'nvim'
           .. ',\\,-\\,-\\,' .. path_sep .. 'nvim'
           .. ',-\\,-\\,-' .. path_sep .. 'nvim'
@@ -549,9 +549,9 @@ end)
 describe('stdpath()', function()
   -- Windows appends 'nvim-data' instead of just 'nvim' to prevent collisions
   -- due to XDG_CONFIG_HOME, XDG_DATA_HOME and XDG_STATE_HOME being the same.
-  local datadir = iswin() and 'nvim-data' or 'nvim'
-  local statedir = iswin() and 'nvim-data' or 'nvim'
-  local env_sep = iswin() and ';' or ':'
+  local datadir = is_os('win') and 'nvim-data' or 'nvim'
+  local statedir = is_os('win') and 'nvim-data' or 'nvim'
+  local env_sep = is_os('win') and ';' or ':'
 
   it('acceptance', function()
     clear()  -- Do not explicitly set any env vars.
@@ -704,7 +704,7 @@ describe('stdpath()', function()
   context('returns a List', function()
     -- Some OS specific variables the system would have set.
     local function base_env()
-      if iswin() then
+      if is_os('win') then
         return {
           HOME='C:\\Users\\docwhat', -- technically, is not a usual PATH
           HOMEDRIVE='C:',

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -17,9 +17,9 @@ local retry = helpers.retry
 local NIL = helpers.NIL
 local read_file = require('test.helpers').read_file
 local write_file = require('test.helpers').write_file
-local isCI = helpers.isCI
+local is_ci = helpers.is_ci
 local meths = helpers.meths
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 -- Use these to get access to a coroutine so that I can run async tests and use
@@ -27,7 +27,7 @@ local skip = helpers.skip
 local run, stop = helpers.run, helpers.stop
 
 -- TODO(justinmk): hangs on Windows https://github.com/neovim/neovim/pull/11837
-if skip(iswin()) then return end
+if skip(is_os('win')) then return end
 
 -- Fake LSP server.
 local fake_lsp_code = 'test/functional/fixtures/fake-lsp-server.lua'
@@ -318,7 +318,7 @@ describe('LSP', function()
     end)
 
     it('should succeed with manual shutdown', function()
-      if isCI() then
+      if is_ci() then
         pending('hangs the build on CI #14028, re-enable with freeze timeout #14204')
         return
       elseif helpers.skip_fragile(pending) then

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -8,8 +8,8 @@ local nvim_prog = helpers.nvim_prog
 local matches = helpers.matches
 local write_file = helpers.write_file
 local tmpname = helpers.tmpname
-local isCI = helpers.isCI
 local skip = helpers.skip
+local is_ci = helpers.is_ci
 
 clear()
 if funcs.executable('man') == 0 then
@@ -162,7 +162,7 @@ describe(':Man', function()
   end)
 
   it('reports non-existent man pages for absolute paths', function()
-    skip(isCI('cirrus'))
+    skip(is_ci('cirrus'))
     local actual_file = tmpname()
     -- actual_file must be an absolute path to an existent file for us to test against it
     matches('^/.+', actual_file)

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -2140,7 +2140,7 @@ end)
 
 describe('plugin/shada.vim', function()
   local epoch = os.date('%Y-%m-%dT%H:%M:%S', 0)
-  local eol = helpers.iswin() and '\r\n' or '\n'
+  local eol = helpers.is_os('win') and '\r\n' or '\n'
   before_each(function()
     -- Note: reset() is called explicitly in each test.
     os.remove(fname)

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -2,10 +2,10 @@
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
 local helpers = require('test.functional.helpers')(nil)
-local iswin = helpers.iswin
 local busted = require("busted")
+local is_os = helpers.is_os
 
-if iswin() then
+if is_os('win') then
   local ffi = require('ffi')
   ffi.cdef[[
   typedef int errno_t;

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -9,7 +9,7 @@ local curbufmeths = helpers.curbufmeths
 local insert = helpers.insert
 local expect = helpers.expect
 local feed = helpers.feed
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 do
@@ -26,7 +26,7 @@ before_each(function()
 end)
 
 describe('legacy perl provider', function()
-  skip(iswin())
+  skip(is_os('win'))
 
   it('feature test', function()
     eq(1, eval('has("perl")'))
@@ -70,7 +70,7 @@ describe('legacy perl provider', function()
 end)
 
 describe('perl provider', function()
-  skip(iswin())
+  skip(is_os('win'))
   teardown(function ()
     os.remove('Xtest-perl-hello.pl')
     os.remove('Xtest-perl-hello-plugin.pl')

--- a/test/functional/shada/compatibility_spec.lua
+++ b/test/functional/shada/compatibility_spec.lua
@@ -12,7 +12,7 @@ local wshada, sdrcmd, shada_fname = get_shada_rw('Xtest-functional-shada-compati
 
 local mock_file_path = '/a/b/'
 local mock_file_path2 = '/d/e/'
-if helpers.iswin() then
+if helpers.is_os('win') then
   mock_file_path = 'C:/a/'
   mock_file_path2 = 'C:/d/'
 end

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -14,7 +14,7 @@ local wshada, sdrcmd, shada_fname =
   get_shada_rw('Xtest-functional-shada-merging.shada')
 
 local mock_file_path = '/a/b/'
-if helpers.iswin() then
+if helpers.is_os('win') then
   mock_file_path = 'C:/a/'
 end
 

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -5,7 +5,7 @@ local meths, nvim_command, funcs, eq =
 local write_file, spawn, set_session, nvim_prog, exc_exec =
   helpers.write_file, helpers.spawn, helpers.set_session, helpers.nvim_prog,
   helpers.exc_exec
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 local lfs = require('lfs')
@@ -250,7 +250,7 @@ describe('ShaDa support code', function()
   end)
 
   it('does not crash when ShaDa file directory is not writable', function()
-    skip(iswin())
+    skip(is_os('win'))
 
     funcs.mkdir(dirname, '', 0)
     eq(0, funcs.filewritable(dirname))

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -6,7 +6,7 @@ local feed_data = thelpers.feed_data
 local enter_altscreen = thelpers.enter_altscreen
 local exit_altscreen = thelpers.exit_altscreen
 
-if helpers.skip(helpers.iswin()) then return end
+if helpers.skip(helpers.is_os('win')) then return end
 
 describe(':terminal altscreen', function()
   local screen

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -2,7 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local child_session = require('test.functional.terminal.helpers')
 local ok = helpers.ok
 
-if helpers.skip(helpers.iswin()) then return end
+if helpers.skip(helpers.is_os('win')) then return end
 
 describe('api', function()
   local screen

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -15,7 +15,7 @@ local matches = helpers.matches
 local exec_lua = helpers.exec_lua
 local sleep = helpers.sleep
 local funcs = helpers.funcs
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 describe(':terminal buffer', function()
@@ -202,7 +202,7 @@ describe(':terminal buffer', function()
 
     -- Save the buffer number of the terminal for later testing.
     local tbuf = eval('bufnr("%")')
-    local exitcmd = helpers.iswin()
+    local exitcmd = helpers.is_os('win')
       and "['cmd', '/c', 'exit']"
       or "['sh', '-c', 'exit']"
     source([[
@@ -264,7 +264,7 @@ describe(':terminal buffer', function()
   end)
 
   it('it works with set rightleft #11438', function()
-    skip(iswin())
+    skip(is_os('win'))
     local columns = eval('&columns')
     feed(string.rep('a', columns))
     command('set rightleft')

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -9,7 +9,7 @@ local matches = helpers.matches
 local feed_command = helpers.feed_command
 local hide_cursor = thelpers.hide_cursor
 local show_cursor = thelpers.show_cursor
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 describe(':terminal cursor', function()
@@ -90,7 +90,7 @@ describe(':terminal cursor', function()
 
   describe('when invisible', function()
     it('is not highlighted and is detached from screen cursor', function()
-      skip(iswin())
+      skip(is_os('win'))
       hide_cursor()
       screen:expect([[
         tty ready                                         |
@@ -363,7 +363,7 @@ describe('buffer cursor position is correct in terminal without number column', 
   end)
 
   describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
-    if skip(iswin(), "Encoding problem?") then return end
+    if skip(is_os('win'), "Encoding problem?") then return end
 
     before_each(function()
       setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
@@ -446,7 +446,7 @@ describe('buffer cursor position is correct in terminal without number column', 
   end)
 
   describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    skip(iswin(), "Encoding problem?")
+    skip(is_os('win'), "Encoding problem?")
 
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')
@@ -743,7 +743,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
   end)
 
   describe('in a line with single-cell composed multibyte characters and no trailing spaces,', function()
-    if skip(iswin(), "Encoding problem?") then return end
+    if skip(is_os('win'), "Encoding problem?") then return end
 
     before_each(function()
       setup_ex_register('µ̳µ̳µ̳µ̳µ̳µ̳µ̳µ̳')
@@ -826,7 +826,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
   end)
 
   describe('in a line with double-cell multibyte characters and no trailing spaces,', function()
-    skip(iswin(), "Encoding problem?")
+    skip(is_os('win'), "Encoding problem?")
 
     before_each(function()
       setup_ex_register('哦哦哦哦哦哦哦哦')

--- a/test/functional/terminal/edit_spec.lua
+++ b/test/functional/terminal/edit_spec.lua
@@ -36,7 +36,7 @@ describe(':edit term://*', function()
   end)
 
   it("runs TermOpen early enough to set buffer-local 'scrollback'", function()
-    if helpers.skip(helpers.iswin()) then return end
+    if helpers.skip(helpers.is_os('win')) then return end
     local columns, lines = 20, 4
     local scr = get_screen(columns, lines)
     local rep = 97

--- a/test/functional/terminal/ex_terminal_spec.lua
+++ b/test/functional/terminal/ex_terminal_spec.lua
@@ -8,10 +8,10 @@ local feed_command, eval = helpers.feed_command, helpers.eval
 local funcs = helpers.funcs
 local retry = helpers.retry
 local ok = helpers.ok
-local iswin = helpers.iswin
 local command = helpers.command
-local isCI = helpers.isCI
 local skip = helpers.skip
+local is_os = helpers.is_os
+local is_ci = helpers.is_ci
 
 describe(':terminal', function()
   local screen
@@ -47,8 +47,8 @@ describe(':terminal', function()
   end)
 
   it("reads output buffer on terminal reporting #4151", function()
-    skip(isCI('cirrus') or iswin())
-    if iswin() then
+    skip(is_ci('cirrus') or is_os('win'))
+    if is_os('win') then
       feed_command([[terminal powershell -NoProfile -NoLogo -Command Write-Host -NoNewline "\"$([char]27)[6n\""; Start-Sleep -Milliseconds 500 ]])
     else
       feed_command([[terminal printf '\e[6n'; sleep 0.5 ]])
@@ -57,7 +57,7 @@ describe(':terminal', function()
   end)
 
   it("in normal-mode :split does not move cursor", function()
-    if iswin() then
+    if is_os('win') then
       feed_command([[terminal for /L \\%I in (1,0,2) do ( echo foo & ping -w 100 -n 1 127.0.0.1 > nul )]])
     else
       feed_command([[terminal while true; do echo foo; sleep .1; done]])
@@ -144,7 +144,7 @@ describe(':terminal (with fake shell)', function()
   end
 
   it('with no argument, acts like termopen()', function()
-    skip(iswin())
+    skip(is_os('win'))
     terminal_with_fake_shell()
     retry(nil, 4 * screen.timeout, function()
     screen:expect([[
@@ -168,7 +168,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("with no argument, but 'shell' has arguments, acts like termopen()", function()
-    skip(iswin())
+    skip(is_os('win'))
     nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
     terminal_with_fake_shell()
     screen:expect([[
@@ -180,7 +180,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('executes a given command through the shell', function()
-    skip(iswin())
+    skip(is_os('win'))
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell('echo hi')
     screen:expect([[
@@ -192,7 +192,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it("executes a given command through the shell, when 'shell' has arguments", function()
-    skip(iswin())
+    skip(is_os('win'))
     nvim('set_option', 'shell', testprg('shell-test')..' -t jeff')
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell('echo hi')
@@ -205,7 +205,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('allows quotes and slashes', function()
-    skip(iswin())
+    skip(is_os('win'))
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell([[echo 'hello' \ "world"]])
     screen:expect([[
@@ -242,7 +242,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('works with :find', function()
-    skip(iswin())
+    skip(is_os('win'))
     terminal_with_fake_shell()
     screen:expect([[
       ^ready $                                           |
@@ -253,7 +253,7 @@ describe(':terminal (with fake shell)', function()
     eq('term://', string.match(eval('bufname("%")'), "^term://"))
     feed([[<C-\><C-N>]])
     feed_command([[find */shadacat.py]])
-    if iswin() then
+    if is_os('win') then
       eq('scripts\\shadacat.py', eval('bufname("%")'))
     else
       eq('scripts/shadacat.py', eval('bufname("%")'))
@@ -261,7 +261,7 @@ describe(':terminal (with fake shell)', function()
   end)
 
   it('works with gf', function()
-    skip(iswin())
+    skip(is_os('win'))
     command('set shellxquote=')   -- win: avoid extra quotes
     terminal_with_fake_shell([[echo "scripts/shadacat.py"]])
     retry(nil, 4 * screen.timeout, function()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -7,7 +7,7 @@ local nvim_prog_abs = helpers.nvim_prog_abs
 local eq, eval = helpers.eq, helpers.eval
 local funcs = helpers.funcs
 local nvim_set = helpers.nvim_set
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 describe(':terminal highlight', function()
@@ -60,7 +60,7 @@ describe(':terminal highlight', function()
       end)
 
       local function pass_attrs()
-        skip(iswin())
+        skip(is_os('win'))
         screen:expect(sub([[
           tty ready                                         |
           {NUM:text}text{10: }                                         |
@@ -75,7 +75,7 @@ describe(':terminal highlight', function()
       it('will pass the corresponding attributes', pass_attrs)
 
       it('will pass the corresponding attributes on scrollback', function()
-        skip(iswin())
+        skip(is_os('win'))
         pass_attrs()
         local lines = {}
         for i = 1, 8 do
@@ -199,7 +199,7 @@ describe(':terminal highlight forwarding', function()
   end)
 
   it('will handle cterm and rgb attributes', function()
-    skip(iswin())
+    skip(is_os('win'))
     thelpers.set_fg(3)
     thelpers.feed_data('text')
     thelpers.feed_termcode('[38:2:255:128:0m')
@@ -251,7 +251,7 @@ describe(':terminal highlight with custom palette', function()
   end)
 
   it('will use the custom color', function()
-    skip(iswin())
+    skip(is_os('win'))
     thelpers.set_fg(3)
     thelpers.feed_data('text')
     thelpers.clear_attrs()

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -3,7 +3,7 @@ local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, eval = helpers.clear, helpers.eq, helpers.eval
 local feed, nvim, command = helpers.feed, helpers.nvim, helpers.command
 local feed_data = thelpers.feed_data
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 describe(':terminal mouse', function()
@@ -68,7 +68,7 @@ describe(':terminal mouse', function()
     end)
 
     it('does not leave terminal mode on left-release', function()
-      skip(iswin())
+      skip(is_os('win'))
       feed('<LeftRelease>')
       eq('t', eval('mode(1)'))
     end)
@@ -89,7 +89,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse press, drag and release to the program', function()
-        skip(iswin())
+        skip(is_os('win'))
         feed('<LeftMouse><1,2>')
         screen:expect([[
           line27                                            |
@@ -133,7 +133,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse scroll to the program', function()
-        skip(iswin())
+        skip(is_os('win'))
         feed('<ScrollWheelUp><0,0>')
         screen:expect([[
           line27                                            |
@@ -147,7 +147,7 @@ describe(':terminal mouse', function()
       end)
 
       it('dragging and scrolling do not interfere with each other', function()
-        skip(iswin())
+        skip(is_os('win'))
         feed('<LeftMouse><1,2>')
         screen:expect([[
           line27                                            |
@@ -201,7 +201,7 @@ describe(':terminal mouse', function()
       end)
 
       it('will forward mouse clicks to the program with the correct even if set nu', function()
-        skip(iswin())
+        skip(is_os('win'))
         command('set number')
         -- When the display area such as a number is clicked, it returns to the
         -- normal mode.
@@ -232,7 +232,7 @@ describe(':terminal mouse', function()
     end)
 
     describe('with a split window and other buffer', function()
-      skip(iswin())
+      skip(is_os('win'))
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -3,7 +3,6 @@ local helpers = require('test.functional.helpers')(after_each)
 local thelpers = require('test.functional.terminal.helpers')
 local clear, eq, curbuf = helpers.clear, helpers.eq, helpers.curbuf
 local feed, testprg, feed_command = helpers.feed, helpers.testprg, helpers.feed_command
-local iswin = helpers.iswin
 local eval = helpers.eval
 local command = helpers.command
 local matches = helpers.matches
@@ -16,6 +15,7 @@ local pcall_err = helpers.pcall_err
 local exec_lua = helpers.exec_lua
 local assert_alive = helpers.assert_alive
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 describe(':terminal scrollback', function()
   local screen
@@ -140,7 +140,7 @@ describe(':terminal scrollback', function()
 
 
     describe('and height decreased by 1', function()
-      if skip(iswin()) then return end
+      if skip(is_os('win')) then return end
       local function will_hide_top_line()
         feed([[<C-\><C-N>]])
         screen:try_resize(screen._width - 2, screen._height - 1)
@@ -186,7 +186,7 @@ describe(':terminal scrollback', function()
     -- XXX: Can't test this reliably on Windows unless the cursor is _moved_
     --      by the resize. http://docs.libuv.org/en/v1.x/signal.html
     --      See also: https://github.com/rprichard/winpty/issues/110
-    if skip(iswin()) then return end
+    if skip(is_os('win')) then return end
 
     describe('and the height is decreased by 2', function()
       before_each(function()
@@ -265,7 +265,7 @@ describe(':terminal scrollback', function()
       -- XXX: Can't test this reliably on Windows unless the cursor is _moved_
       --      by the resize. http://docs.libuv.org/en/v1.x/signal.html
       --      See also: https://github.com/rprichard/winpty/issues/110
-      if skip(iswin()) then return end
+      if skip(is_os('win')) then return end
       local function pop_then_push()
         screen:try_resize(screen._width, screen._height + 1)
         screen:expect([[
@@ -347,7 +347,7 @@ end)
 
 describe(':terminal prints more lines than the screen height and exits', function()
   it('will push extra lines to scrollback', function()
-    skip(iswin())
+    skip(is_os('win'))
     clear()
     local screen = Screen.new(30, 7)
     screen:attach({rgb=false})
@@ -397,21 +397,21 @@ describe("'scrollback' option", function()
 
   it('set to 0 behaves as 1', function()
     local screen
-    if iswin() then
+    if is_os('win') then
       screen = thelpers.screen_setup(nil, "['cmd.exe']", 30)
     else
       screen = thelpers.screen_setup(nil, "['sh']", 30)
     end
 
     curbufmeths.set_option('scrollback', 0)
-    feed_data(('%s REP 31 line%s'):format(testprg('shell-test'), iswin() and '\r' or '\n'))
+    feed_data(('%s REP 31 line%s'):format(testprg('shell-test'), is_os('win') and '\r' or '\n'))
     screen:expect{any='30: line                      '}
     retry(nil, nil, function() expect_lines(7) end)
   end)
 
   it('deletes lines (only) if necessary', function()
     local screen
-    if iswin() then
+    if is_os('win') then
       command([[let $PROMPT='$$']])
       screen = thelpers.screen_setup(nil, "['cmd.exe']", 30)
     else
@@ -424,7 +424,7 @@ describe("'scrollback' option", function()
     -- Wait for prompt.
     screen:expect{any='%$'}
 
-    feed_data(('%s REP 31 line%s'):format(testprg('shell-test'), iswin() and '\r' or '\n'))
+    feed_data(('%s REP 31 line%s'):format(testprg('shell-test'), is_os('win') and '\r' or '\n'))
     screen:expect{any='30: line                      '}
 
     retry(nil, nil, function() expect_lines(33, 2) end)
@@ -437,8 +437,8 @@ describe("'scrollback' option", function()
     -- 'scrollback' option is synchronized with the internal sb_buffer.
     command('sleep 100m')
 
-    feed_data(('%s REP 41 line%s'):format(testprg('shell-test'), iswin() and '\r' or '\n'))
-    if iswin() then
+    feed_data(('%s REP 41 line%s'):format(testprg('shell-test'), is_os('win') and '\r' or '\n'))
+    if is_os('win') then
       screen:expect{grid=[[
         37: line                      |
         38: line                      |
@@ -462,8 +462,8 @@ describe("'scrollback' option", function()
     expect_lines(58)
 
     -- Verify off-screen state
-    matches((iswin() and '^36: line[ ]*$' or '^35: line[ ]*$'), eval("getline(line('w0') - 1)"))
-    matches((iswin() and '^27: line[ ]*$' or '^26: line[ ]*$'), eval("getline(line('w0') - 10)"))
+    matches((is_os('win') and '^36: line[ ]*$' or '^35: line[ ]*$'), eval("getline(line('w0') - 1)"))
+    matches((is_os('win') and '^27: line[ ]*$' or '^26: line[ ]*$'), eval("getline(line('w0') - 10)"))
   end)
 
   it('deletes extra lines immediately', function()
@@ -607,7 +607,7 @@ describe("pending scrollback line handling", function()
   end)
 
   it("does not crash after nvim_buf_call #14891", function()
-    skip(iswin())
+    skip(is_os('win'))
     exec_lua [[
       local a = vim.api
       local bufnr = a.nvim_create_buf(false, true)

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -3,12 +3,12 @@ local thelpers = require('test.functional.terminal.helpers')
 local feed_data = thelpers.feed_data
 local feed, clear = helpers.feed, helpers.clear
 local poke_eventloop = helpers.poke_eventloop
-local iswin = helpers.iswin
 local command = helpers.command
 local retry = helpers.retry
 local eq = helpers.eq
 local eval = helpers.eval
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 describe(':terminal window', function()
   local screen
@@ -19,7 +19,7 @@ describe(':terminal window', function()
   end)
 
   it('sets topline correctly #8556', function()
-    skip(iswin())
+    skip(is_os('win'))
     -- Test has hardcoded assumptions of dimensions.
     eq(7, eval('&lines'))
     feed_data('\n\n\n')  -- Add blank lines.
@@ -55,7 +55,7 @@ describe(':terminal window', function()
         {3:-- TERMINAL --}                                    |
       ]])
 
-      skip(iswin(), 'win: :terminal resize is unreliable #7007')
+      skip(is_os('win'), 'win: :terminal resize is unreliable #7007')
 
       -- numberwidth=9
       feed([[<C-\><C-N>]])
@@ -171,7 +171,7 @@ describe(':terminal with multigrid', function()
     ]])
 
     screen:try_resize_grid(2, 20, 10)
-    if iswin() then
+    if is_os('win') then
       screen:expect{any="rows: 10, cols: 20"}
     else
       screen:expect([[
@@ -200,7 +200,7 @@ describe(':terminal with multigrid', function()
     end
 
     screen:try_resize_grid(2, 70, 3)
-    if iswin() then
+    if is_os('win') then
       screen:expect{any="rows: 3, cols: 70"}
     else
       screen:expect([[
@@ -222,7 +222,7 @@ describe(':terminal with multigrid', function()
     end
 
     screen:try_resize_grid(2, 0, 0)
-    if iswin() then
+    if is_os('win') then
       screen:expect{any="rows: 6, cols: 50"}
     else
       screen:expect([[

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -8,9 +8,9 @@ local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 local meths = helpers.meths
-local iswin = helpers.iswin
 local sleep = helpers.sleep
 local retry = helpers.retry
+local is_os = helpers.is_os
 
 describe(':terminal', function()
   local screen
@@ -96,7 +96,7 @@ describe(':terminal', function()
     local w1, h1 = screen._width - 3, screen._height - 2
     local w2, h2 = w1 - 6, h1 - 3
 
-    if iswin() then
+    if is_os('win') then
       -- win: SIGWINCH is unreliable, use a weaker test. #7506
       retry(3, 30000, function()
         screen:try_resize(w1, h1)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -5,7 +5,7 @@ local eq = helpers.eq
 local insert = helpers.insert
 local exec_lua = helpers.exec_lua
 local feed = helpers.feed
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 local skip = helpers.skip
 
 before_each(clear)
@@ -684,7 +684,7 @@ int x = INT_MAX;
       end)
 
       it("should not inject bad languages", function()
-        skip(iswin())
+        skip(is_os('win'))
         exec_lua([=[
         vim.treesitter.add_directive("inject-bad!", function(match, _, _, pred, metadata)
           metadata.language = "{"

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -4,10 +4,10 @@ local clear, feed = helpers.clear, helpers.feed
 local source = helpers.source
 local command = helpers.command
 local assert_alive = helpers.assert_alive
-local uname = helpers.uname
 local exec = helpers.exec
 local eval = helpers.eval
 local eq = helpers.eq
+local is_os = helpers.is_os
 
 local function new_screen(opt)
   local screen = Screen.new(25, 5)
@@ -717,7 +717,7 @@ describe('cmdline redraw', function()
   end)
 
   it('with <Cmd>', function()
-    if string.find(uname(), 'bsd') then
+    if is_os('bsd') then
       pending('FIXME #10804')
     end
     command('cmap a <Cmd>call sin(0)<CR>')  -- no-op

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -51,7 +51,7 @@ local function test_embed(ext_linegrid)
   end)
 
   it("doesn't erase output when setting color scheme", function()
-    if 'openbsd' == helpers.uname() then
+    if helpers.is_os('openbsd') then
       pending('FIXME #10804')
     end
     startup('--cmd', 'echoerr "foo"', '--cmd', 'color default', '--cmd', 'echoerr "bar"')

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -4,10 +4,10 @@ local Screen = require('test.functional.ui.screen')
 local clear, insert = helpers.clear, helpers.insert
 local command = helpers.command
 local meths = helpers.meths
-local iswin = helpers.iswin
 local testprg = helpers.testprg
 local thelpers = require('test.functional.terminal.helpers')
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 describe('ext_hlstate detailed highlights', function()
   local screen
@@ -183,7 +183,7 @@ describe('ext_hlstate detailed highlights', function()
   end)
 
   it("work with :terminal", function()
-    skip(iswin())
+    skip(is_os('win'))
 
     screen:set_default_attr_ids({
       [1] = {{}, {{hi_name = "TermCursorNC", ui_name = "TermCursorNC", kind = "ui"}}},
@@ -212,7 +212,7 @@ describe('ext_hlstate detailed highlights', function()
     thelpers.set_bold()
     thelpers.feed_data('z\n')
     -- TODO(bfredl): check if this distinction makes sense
-    if iswin() then
+    if is_os('win') then
       screen:expect([[
         ^tty ready                               |
         x {5:y z}                                   |
@@ -238,7 +238,7 @@ describe('ext_hlstate detailed highlights', function()
 
     thelpers.feed_termcode("[A")
     thelpers.feed_termcode("[2C")
-    if iswin() then
+    if is_os('win') then
       screen:expect([[
         ^tty ready                               |
         x {6:y}{5: z}                                   |

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -9,12 +9,13 @@ local meths = helpers.meths
 local async_meths = helpers.async_meths
 local test_build_dir = helpers.test_build_dir
 local nvim_prog = helpers.nvim_prog
-local iswin = helpers.iswin
 local exec = helpers.exec
 local exc_exec = helpers.exc_exec
 local exec_lua = helpers.exec_lua
 local poke_eventloop = helpers.poke_eventloop
 local assert_alive = helpers.assert_alive
+local is_os = helpers.is_os
+local is_ci = helpers.is_ci
 
 describe('ui/ext_messages', function()
   local screen
@@ -1496,7 +1497,7 @@ describe('ui/msg_puts_printf', function()
     screen = Screen.new(25, 5)
     screen:attach()
 
-    if iswin() then
+    if is_os('win') then
       if os.execute('chcp 932 > NUL 2>&1') ~= 0 then
         pending('missing japanese language features', function() end)
         return
@@ -1507,7 +1508,7 @@ describe('ui/msg_puts_printf', function()
       if (exc_exec('lang ja_JP.UTF-8') ~= 0) then
         pending('Locale ja_JP.UTF-8 not supported', function() end)
         return
-      elseif helpers.isCI() then
+      elseif is_ci() then
         -- Fails non--Windows CI. Message catalog directory issue?
         pending('fails on unix CI', function() end)
         return

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -6,7 +6,6 @@ local mkdir, write_file, rmdir = helpers.mkdir, helpers.write_file, helpers.rmdi
 local eq = helpers.eq
 local feed = helpers.feed
 local feed_command = helpers.feed_command
-local iswin = helpers.iswin
 local clear = helpers.clear
 local command = helpers.command
 local testprg = helpers.testprg
@@ -14,6 +13,7 @@ local nvim_dir = helpers.nvim_dir
 local has_powershell = helpers.has_powershell
 local set_shell_powershell = helpers.set_shell_powershell
 local skip = helpers.skip
+local is_os = helpers.is_os
 
 describe("shell command :!", function()
   local screen
@@ -37,7 +37,7 @@ describe("shell command :!", function()
   end)
 
   it("displays output without LF/EOF. #4646 #4569 #3772", function()
-    skip(iswin())
+    skip(is_os('win'))
     -- NOTE: We use a child nvim (within a :term buffer)
     --       to avoid triggering a UI flush.
     child_session.feed_data(":!printf foo; sleep 200\n")
@@ -53,7 +53,7 @@ describe("shell command :!", function()
   end)
 
   it("throttles shell-command output greater than ~10KB", function()
-    skip('openbsd' == helpers.uname(), 'FIXME #10804')
+    skip(is_os('openbsd'), 'FIXME #10804')
     child_session.feed_data((":!%s REP 30001 foo\n"):format(testprg('shell-test')))
 
     -- If we observe any line starting with a dot, then throttling occurred.
@@ -95,7 +95,7 @@ describe("shell command :!", function()
   end)
 
   it('handles control codes', function()
-    skip(iswin(), 'missing printf')
+    skip(is_os('win'), 'missing printf')
     local screen = Screen.new(50, 4)
     screen:set_default_attr_ids {
       [1] = {bold = true, reverse = true};
@@ -170,10 +170,10 @@ describe("shell command :!", function()
     end)
 
     it("doesn't truncate Last line of shell output #3269", function()
-      command(helpers.iswin()
+      command(is_os('win')
         and [[nnoremap <silent>\l :!dir /b bang_filter_spec<cr>]]
         or  [[nnoremap <silent>\l :!ls bang_filter_spec<cr>]])
-      local result = (helpers.iswin()
+      local result = (is_os('win')
         and [[:!dir /b bang_filter_spec]]
         or  [[:!ls bang_filter_spec    ]])
       feed([[\l]])
@@ -212,7 +212,7 @@ describe("shell command :!", function()
 
     it('handles multibyte sequences split over buffer boundaries', function()
       command('cd '..nvim_dir)
-      local cmd = iswin() and '!shell-test UTF-8  ' or '!./shell-test UTF-8'
+      local cmd = is_os('win') and '!shell-test UTF-8  ' or '!./shell-test UTF-8'
       feed_command(cmd)
       -- Note: only the first example of split composed char works
       screen:expect([[
@@ -262,7 +262,7 @@ describe("shell command :!", function()
                                                      |
         Press ENTER or type command to continue^      |
       ]])
-      if iswin() then
+      if is_os('win') then
         feed_command([[!& 'cmd.exe' /c 'echo $a']])
         screen:expect([[
           :!& 'cmd.exe' /c 'echo $a'                   |

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -5,8 +5,8 @@ local feed, command = helpers.feed, helpers.command
 local insert = helpers.insert
 local eq = helpers.eq
 local eval = helpers.eval
-local iswin = helpers.iswin
 local funcs, meths, exec_lua = helpers.funcs, helpers.meths, helpers.exec_lua
+local is_os = helpers.is_os
 
 describe('screen', function()
   local screen
@@ -128,18 +128,18 @@ local function screen_tests(linegrid)
     end)
 
     it('has correct default title with named file', function()
-      local expected = (iswin() and 'myfile (C:\\mydir) - NVIM' or 'myfile (/mydir) - NVIM')
+      local expected = (is_os('win') and 'myfile (C:\\mydir) - NVIM' or 'myfile (/mydir) - NVIM')
       command('set title')
-      command(iswin() and 'file C:\\mydir\\myfile' or 'file /mydir/myfile')
+      command(is_os('win') and 'file C:\\mydir\\myfile' or 'file /mydir/myfile')
       screen:expect(function()
         eq(expected, screen.title)
       end)
     end)
 
     describe('is not changed by', function()
-      local file1 = iswin() and 'C:\\mydir\\myfile1' or '/mydir/myfile1'
-      local file2 = iswin() and 'C:\\mydir\\myfile2' or '/mydir/myfile2'
-      local expected = (iswin() and 'myfile1 (C:\\mydir) - NVIM' or 'myfile1 (/mydir) - NVIM')
+      local file1 = is_os('win') and 'C:\\mydir\\myfile1' or '/mydir/myfile1'
+      local file2 = is_os('win') and 'C:\\mydir\\myfile2' or '/mydir/myfile2'
+      local expected = (is_os('win') and 'myfile1 (C:\\mydir) - NVIM' or 'myfile1 (/mydir) - NVIM')
       local buf2
 
       before_each(function()

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -5,8 +5,8 @@ local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local feed = helpers.feed
 local insert = helpers.insert
-local uname = helpers.uname
 local command = helpers.command
+local is_os = helpers.is_os
 
 describe("'spell'", function()
   local screen
@@ -27,7 +27,7 @@ describe("'spell'", function()
   end)
 
   it('joins long lines #7937', function()
-    if uname() == 'openbsd' then pending('FIXME #12104', function() end) return end
+    if is_os('openbsd') then pending('FIXME #12104', function() end) return end
     command('set spell')
     insert([[
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -1,13 +1,13 @@
 local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear, feed, command = helpers.clear, helpers.feed, helpers.command
-local iswin = helpers.iswin
 local funcs = helpers.funcs
 local meths = helpers.meths
 local eq = helpers.eq
 local eval = helpers.eval
 local retry = helpers.retry
 local testprg = helpers.testprg
+local is_os = helpers.is_os
 
 describe("'wildmenu'", function()
   local screen
@@ -159,7 +159,7 @@ describe("'wildmenu'", function()
     -- must wait the full timeout. So make it reasonable.
     screen.timeout = 1000
 
-    if not iswin() then
+    if not is_os('win') then
       command('set shell=sh')  -- Need a predictable "$" prompt.
       command('let $PS1 = "$"')
     end
@@ -169,7 +169,7 @@ describe("'wildmenu'", function()
 
     -- Check for a shell prompt to verify that the terminal loaded.
     retry(nil, nil, function()
-      if iswin() then
+      if is_os('win') then
         eq('Microsoft', eval("matchstr(join(getline(1, '$')), 'Microsoft')"))
       else
         eq('$', eval([[matchstr(getline(1), '\$')]]))

--- a/test/functional/vimscript/eval_spec.lua
+++ b/test/functional/vimscript/eval_spec.lua
@@ -71,13 +71,13 @@ describe("backtick expansion", function()
   end)
 
   it("with default 'shell'", function()
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       command(":silent args `dir /b *2`")
     else
       command(":silent args `echo ***2`")
     end
     eq({ "file2", }, eval("argv()"))
-    if helpers.iswin() then
+    if helpers.is_os('win') then
       command(":silent args `dir /s/b *4`")
       eq({ "subdir\\file4", }, eval("map(argv(), 'fnamemodify(v:val, \":.\")')"))
     else

--- a/test/functional/vimscript/executable_spec.lua
+++ b/test/functional/vimscript/executable_spec.lua
@@ -1,15 +1,16 @@
 local helpers = require('test.functional.helpers')(after_each)
-local eq, clear, call, iswin, write_file, command =
-  helpers.eq, helpers.clear, helpers.call, helpers.iswin, helpers.write_file,
+local eq, clear, call, write_file, command =
+  helpers.eq, helpers.clear, helpers.call, helpers.write_file,
   helpers.command
 local exc_exec = helpers.exc_exec
 local eval = helpers.eval
+local is_os = helpers.is_os
 
 describe('executable()', function()
   before_each(clear)
 
   it('returns 1 for commands in $PATH', function()
-    local exe = iswin() and 'ping' or 'ls'
+    local exe = is_os('win') and 'ping' or 'ls'
     eq(1, call('executable', exe))
     command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
     eq(1, call('executable', 'null'))
@@ -17,7 +18,7 @@ describe('executable()', function()
     eq(1, call('executable', 'false'))
   end)
 
-  if iswin() then
+  if is_os('win') then
     it('exepath respects shellslash', function()
       command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
       eq([[test\functional\fixtures\bin\null.CMD]], call('fnamemodify', call('exepath', 'null'), ':.'))
@@ -56,8 +57,8 @@ describe('executable()', function()
     -- Some executable in build/bin/, *not* in $PATH nor CWD.
     local sibling_exe = 'printargs-test'
     -- Windows: siblings are in Nvim's "pseudo-$PATH".
-    local expected = iswin() and 1 or 0
-    if iswin() then
+    local expected = is_os('win') and 1 or 0
+    if is_os('win') then
       eq('arg1=lemon;arg2=sky;arg3=tree;',
          call('system', sibling_exe..' lemon sky tree'))
     end
@@ -69,7 +70,7 @@ describe('executable()', function()
       clear()
       write_file('Xtest_not_executable', 'non-executable file')
       write_file('Xtest_executable', 'executable file (exec-bit set)')
-      if not iswin() then  -- N/A for Windows.
+      if not is_os('win') then  -- N/A for Windows.
         call('system', {'chmod', '-x', 'Xtest_not_executable'})
         call('system', {'chmod', '+x', 'Xtest_executable'})
       end
@@ -90,14 +91,17 @@ describe('executable()', function()
     end)
 
     it('set, qualified as a path', function()
-      local expected = iswin() and 0 or 1
+      local expected = is_os('win') and 0 or 1
       eq(expected, call('executable', './Xtest_executable'))
     end)
   end)
 end)
 
 describe('executable() (Windows)', function()
-  if not iswin() then return end  -- N/A for Unix.
+  if not is_os('win') then
+    pending('N/A for non-windows')
+    return
+  end
 
   local exts = {'bat', 'exe', 'com', 'cmd'}
   setup(function()

--- a/test/functional/vimscript/execute_spec.lua
+++ b/test/functional/vimscript/execute_spec.lua
@@ -8,7 +8,7 @@ local funcs = helpers.funcs
 local Screen = require('test.functional.ui.screen')
 local command = helpers.command
 local feed = helpers.feed
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 
 describe('execute()', function()
   before_each(clear)
@@ -265,7 +265,7 @@ describe('execute()', function()
   -- This deviates from vim behavior, but is consistent
   -- with how nvim currently displays the output.
   it('captures shell-command output', function()
-    local win_lf = iswin() and '\13' or ''
+    local win_lf = is_os('win') and '\13' or ''
     eq('\n:!echo foo\r\n\nfoo'..win_lf..'\n', funcs.execute('!echo foo'))
   end)
 

--- a/test/functional/vimscript/exepath_spec.lua
+++ b/test/functional/vimscript/exepath_spec.lua
@@ -1,19 +1,20 @@
 local helpers = require('test.functional.helpers')(after_each)
-local eq, clear, call, iswin =
-  helpers.eq, helpers.clear, helpers.call, helpers.iswin
+local eq, clear, call =
+  helpers.eq, helpers.clear, helpers.call
 local command = helpers.command
 local exc_exec = helpers.exc_exec
 local matches = helpers.matches
+local is_os = helpers.is_os
 
 describe('exepath()', function()
   before_each(clear)
 
   it('returns 1 for commands in $PATH', function()
-    local exe = iswin() and 'ping' or 'ls'
-    local ext_pat = iswin() and '%.EXE$' or '$'
+    local exe = is_os('win') and 'ping' or 'ls'
+    local ext_pat = is_os('win') and '%.EXE$' or '$'
     matches(exe .. ext_pat, call('exepath', exe))
     command('let $PATH = fnamemodify("./test/functional/fixtures/bin", ":p")')
-    ext_pat = iswin() and '%.CMD$' or '$'
+    ext_pat = is_os('win') and '%.CMD$' or '$'
     matches('null' .. ext_pat, call('exepath', 'null'))
     matches('true' .. ext_pat, call('exepath', 'true'))
     matches('false' .. ext_pat, call('exepath', 'false'))
@@ -30,7 +31,7 @@ describe('exepath()', function()
     end
   end)
 
-  if iswin() then
+  if is_os('win') then
     it('append extension if omitted', function()
       local filename = 'cmd'
       local pathext = '.exe'

--- a/test/functional/vimscript/fnamemodify_spec.lua
+++ b/test/functional/vimscript/fnamemodify_spec.lua
@@ -1,12 +1,12 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local eq = helpers.eq
-local iswin = helpers.iswin
 local fnamemodify = helpers.funcs.fnamemodify
 local getcwd = helpers.funcs.getcwd
 local command = helpers.command
 local write_file = helpers.write_file
 local alter_slashes = helpers.alter_slashes
+local is_os = helpers.is_os
 
 local function eq_slashconvert(expected, got)
   eq(alter_slashes(expected), alter_slashes(got))
@@ -27,7 +27,7 @@ describe('fnamemodify()', function()
     local root = helpers.pathroot()
     eq(root, fnamemodify([[/]], ':p:h'))
     eq(root, fnamemodify([[/]], ':p'))
-    if iswin() then
+    if is_os('win') then
       eq(root, fnamemodify([[\]], ':p:h'))
       eq(root, fnamemodify([[\]], ':p'))
       command('set shellslash')
@@ -114,7 +114,7 @@ describe('fnamemodify()', function()
   it('handles shell escape', function()
     local expected
 
-    if iswin() then
+    if is_os('win') then
       -- we expand with double-quotes on Windows
       expected = [["hello there! quote ' newline]] .. '\n' .. [["]]
     else

--- a/test/functional/vimscript/functions_spec.lua
+++ b/test/functional/vimscript/functions_spec.lua
@@ -9,12 +9,12 @@ local helpers = require('test.functional.helpers')(after_each)
 
 local clear = helpers.clear
 local eval = helpers.eval
-local iswin = helpers.iswin
 local matches = helpers.matches
+local is_os = helpers.is_os
 
 before_each(clear)
 
 it('windowsversion()', function()
   clear()
-  matches(iswin() and '^%d+%.%d+$' or '^$', eval('windowsversion()'))
+  matches(is_os('win') and '^%d+%.%d+$' or '^$', eval('windowsversion()'))
 end)

--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -2,7 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local clear = helpers.clear
 local funcs = helpers.funcs
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 
 describe('has()', function()
   before_each(clear)
@@ -51,7 +51,7 @@ describe('has()', function()
   end)
 
   it('"unnamedplus"', function()
-    if (not iswin()) and funcs.has("clipboard") == 1 then
+    if (not is_os('win')) and funcs.has("clipboard") == 1 then
       eq(1, funcs.has("unnamedplus"))
     else
       eq(0, funcs.has("unnamedplus"))

--- a/test/functional/vimscript/hostname_spec.lua
+++ b/test/functional/vimscript/hostname_spec.lua
@@ -3,7 +3,7 @@ local eq = helpers.eq
 local ok = helpers.ok
 local call = helpers.call
 local clear = helpers.clear
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 
 describe('hostname()', function()
   before_each(clear)
@@ -13,8 +13,8 @@ describe('hostname()', function()
     ok(string.len(actual) > 0)
     if call('executable', 'hostname') == 1 then
       local expected = string.gsub(call('system', 'hostname'), '[\n\r]', '')
-      eq((iswin() and expected:upper() or expected),
-         (iswin() and actual:upper() or actual))
+      eq((is_os('win') and expected:upper() or expected),
+         (is_os('win') and actual:upper() or actual))
     end
   end)
 end)

--- a/test/functional/vimscript/msgpack_functions_spec.lua
+++ b/test/functional/vimscript/msgpack_functions_spec.lua
@@ -5,7 +5,7 @@ local eval, eq = helpers.eval, helpers.eq
 local command = helpers.command
 local nvim = helpers.nvim
 local exc_exec = helpers.exc_exec
-local iswin = helpers.iswin
+local is_os = helpers.is_os
 
 describe('msgpack*() functions', function()
   before_each(clear)
@@ -467,7 +467,7 @@ describe('msgpackparse() function', function()
     eval(cmd)
     eval(cmd)  -- do it again (try to force segfault)
     local api_info = eval(cmd)  -- do it again
-    if iswin() then
+    if is_os('win') then
       helpers.assert_alive()
       pending('msgpackparse() has a bug on windows')
       return

--- a/test/functional/vimscript/server_spec.lua
+++ b/test/functional/vimscript/server_spec.lua
@@ -1,11 +1,11 @@
 local helpers = require('test.functional.helpers')(after_each)
 local eq, neq, eval = helpers.eq, helpers.neq, helpers.eval
 local clear, funcs, meths = helpers.clear, helpers.funcs, helpers.meths
-local iswin = helpers.iswin
 local ok = helpers.ok
 local matches = helpers.matches
 local pcall_err = helpers.pcall_err
 local mkdir = helpers.mkdir
+local is_os = helpers.is_os
 
 local function clear_serverlist()
   for _, server in pairs(funcs.serverlist()) do
@@ -19,7 +19,7 @@ describe('server', function()
     mkdir(dir)
     clear({ env={ XDG_RUNTIME_DIR=dir } })
     matches(dir, funcs.stdpath('run'))
-    if not iswin() then
+    if not is_os('win') then
       matches(dir, funcs.serverstart())
     end
   end)
@@ -65,7 +65,7 @@ describe('server', function()
     eq('', meths.get_vvar('servername'))
 
     -- v:servername and $NVIM take the next available server.
-    local servername = (iswin() and [[\\.\pipe\Xtest-functional-server-pipe]]
+    local servername = (is_os('win') and [[\\.\pipe\Xtest-functional-server-pipe]]
                                 or './Xtest-functional-server-socket')
     funcs.serverstart(servername)
     eq(servername, meths.get_vvar('servername'))
@@ -130,7 +130,7 @@ describe('server', function()
     local n = eval('len(serverlist())')
 
     -- Add some servers.
-    local servs = (iswin()
+    local servs = (is_os('win')
       and { [[\\.\pipe\Xtest-pipe0934]], [[\\.\pipe\Xtest-pipe4324]] }
       or  { [[./Xtest-pipe0934]], [[./Xtest-pipe4324]] })
     for _, s in ipairs(servs) do
@@ -164,7 +164,7 @@ describe('startup --listen', function()
   end)
 
   it('sets v:servername, overrides $NVIM_LISTEN_ADDRESS', function()
-    local addr = (iswin() and [[\\.\pipe\Xtest-listen-pipe]]
+    local addr = (is_os('win') and [[\\.\pipe\Xtest-listen-pipe]]
                           or './Xtest-listen-pipe')
     clear({ env={ NVIM_LISTEN_ADDRESS='./Xtest-env-pipe' },
             args={ '--listen', addr } })

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -9,9 +9,9 @@ local command = helpers.command
 local insert = helpers.insert
 local expect = helpers.expect
 local exc_exec = helpers.exc_exec
-local iswin = helpers.iswin
 local os_kill = helpers.os_kill
 local pcall_err = helpers.pcall_err
+local is_os = helpers.is_os
 
 local Screen = require('test.functional.ui.screen')
 
@@ -85,7 +85,7 @@ describe('system()', function()
     end)
 
     it('does NOT run in shell', function()
-      if iswin() then
+      if is_os('win') then
         eq("%PATH%\n", eval("system(['powershell', '-NoProfile', '-NoLogo', '-ExecutionPolicy', 'RemoteSigned', '-Command', 'Write-Output', '%PATH%'])"))
       else
         eq("* $PATH %PATH%\n", eval("system(['echo', '*', '$PATH', '%PATH%'])"))
@@ -94,7 +94,7 @@ describe('system()', function()
   end)
 
   it('sets v:shell_error', function()
-    if iswin() then
+    if is_os('win') then
       eval([[system("cmd.exe /c exit")]])
       eq(0, eval('v:shell_error'))
       eval([[system("cmd.exe /c exit 1")]])
@@ -123,7 +123,7 @@ describe('system()', function()
       screen:attach()
     end)
 
-    if iswin() then
+    if is_os('win') then
       local function test_more()
         eq('root = true', eval([[get(split(system('"more" ".editorconfig"'), "\n"), 0, '')]]))
       end
@@ -184,7 +184,7 @@ describe('system()', function()
       -- * on Windows, expected to default to Western European enc
       -- * on Linux, expected to default to UTF8
       command([[let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ']])
-      eq(iswin() and '??\n' or 'ああ\n', eval([[system('Write-Output "ああ"')]]))
+      eq(is_os('win') and '??\n' or 'ああ\n', eval([[system('Write-Output "ああ"')]]))
     end)
 
     it('`echo` and waits for its return', function()
@@ -213,7 +213,7 @@ describe('system()', function()
 
       screen:try_resize(72, 14)
       feed(':4verbose echo system("echo hi")<cr>')
-      if iswin() then
+      if is_os('win') then
         screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' '"echo hi"'"]]}
       else
         screen:expect{any=[[Executing command: "'fake_shell' 'cmdflag' 'echo hi'"]]}
@@ -243,7 +243,7 @@ describe('system()', function()
     end)
 
     it('`yes` interrupted with CTRL-C', function()
-      feed(':call system("' .. (iswin()
+      feed(':call system("' .. (is_os('win')
         and 'for /L %I in (1,0,2) do @echo y'
         or  'yes') .. '")<cr>')
       screen:expect([[
@@ -260,7 +260,7 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-]] .. (iswin()
+]] .. (is_os('win')
         and [[
         :call system("for /L %I in (1,0,2) do @echo y")      |]]
         or  [[
@@ -286,7 +286,7 @@ describe('system()', function()
 
     it('`yes` interrupted with mapped CTRL-C', function()
       command('nnoremap <C-C> i')
-      feed(':call system("' .. (iswin()
+      feed(':call system("' .. (is_os('win')
         and 'for /L %I in (1,0,2) do @echo y'
         or  'yes') .. '")<cr>')
       screen:expect([[
@@ -303,7 +303,7 @@ describe('system()', function()
         ~                                                    |
         ~                                                    |
         ~                                                    |
-]] .. (iswin()
+]] .. (is_os('win')
         and [[
         :call system("for /L %I in (1,0,2) do @echo y")      |]]
         or  [[
@@ -330,7 +330,7 @@ describe('system()', function()
 
   describe('passing no input', function()
     it('returns the program output', function()
-      if iswin() then
+      if is_os('win') then
         eq("echoed\n", eval('system("echo echoed")'))
       else
         eq("echoed", eval('system("echo -n echoed")'))
@@ -438,7 +438,7 @@ describe('systemlist()', function()
   before_each(clear)
 
   it('sets v:shell_error', function()
-    if iswin() then
+    if is_os('win') then
       eval([[systemlist("cmd.exe /c exit")]])
       eq(0, eval('v:shell_error'))
       eval([[systemlist("cmd.exe /c exit 1")]])
@@ -617,12 +617,12 @@ describe('systemlist()', function()
       return
     end
     helpers.set_shell_powershell()
-    eq({iswin() and 'あ\r' or 'あ'}, eval([[systemlist('Write-Output あ')]]))
+    eq({is_os('win') and 'あ\r' or 'あ'}, eval([[systemlist('Write-Output あ')]]))
     -- Sanity test w/ default encoding
     -- * on Windows, expected to default to Western European enc
     -- * on Linux, expected to default to UTF8
     command([[let &shellcmdflag = '-NoLogo -NoProfile -ExecutionPolicy RemoteSigned -Command ']])
-    eq({iswin() and '?\r' or 'あ'}, eval([[systemlist('Write-Output あ')]]))
+    eq({is_os('win') and '?\r' or 'あ'}, eval([[systemlist('Write-Output あ')]]))
   end)
 
 end)
@@ -639,7 +639,7 @@ describe('shell :!', function()
       1
       4
       2]])
-    if iswin() then
+    if is_os('win') then
       feed(':4verbose %!sort /R<cr>')
       screen:expect{
         any=[[Executing command: .?& { Get%-Content .* | & sort /R } 2>&1 | Out%-File %-Encoding UTF8 .*; exit $LastExitCode"]]


### PR DESCRIPTION
Extend the capabilities of is_os to detect more platforms such as
freebsd and openbsd. Also remove `iswin()` helper function as it can be
replaced by `is_os("win")`.