### PR TITLE
vim-patch:9.0.0858: "!!sort" in a closed fold sorts too many lines

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3224,6 +3224,8 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, int 
   char *cmd = skipwhite(*ptr);
   linenr_T lnum = MAXLNUM;
   do {
+    const int base_char = (uint8_t)(*cmd);
+
     switch (*cmd) {
     case '.':                               // '.' - Cursor position
       cmd++;
@@ -3482,9 +3484,10 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, int 
       } else {
         i = (char_u)(*cmd++);
       }
-      if (!ascii_isdigit(*cmd)) {       // '+' is '+1', but '+0' is not '+1'
+      if (!ascii_isdigit(*cmd)) {       // '+' is '+1'
         n = 1;
       } else {
+        // "number", "+number" or "-number"
         n = getdigits_int32(&cmd, false, MAXLNUM);
         if (n == MAXLNUM) {
           emsg(_(e_line_number_out_of_range));
@@ -3499,10 +3502,16 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, int 
       } else if (addr_type == ADDR_LOADED_BUFFERS || addr_type == ADDR_BUFFERS) {
         lnum = compute_buffer_local_count(addr_type, lnum, (i == '-') ? -1 * n : n);
       } else {
-        // Relative line addressing, need to adjust for folded lines
-        // now, but only do it after the first address.
-        if (addr_type == ADDR_LINES && (i == '-' || i == '+')
-            && address_count >= 2) {
+        // Relative line addressing: need to adjust for closed folds
+        // after the first address.
+        // Subtle difference: "number,+number" and "number,-number"
+        // adjusts to end of closed fold before adding/subtracting,
+        // while "number,.+number" adjusts to end of closed fold after
+        // adding to make "!!" expanded into ".,.+N" work correctly.
+        bool adjust_for_folding = addr_type == ADDR_LINES
+                                  && (i == '-' || i == '+')
+                                  && address_count >= 2;
+        if (adjust_for_folding && (i == '-' || base_char != '.')) {
           (void)hasFolding(lnum, NULL, &lnum);
         }
         if (i == '-') {
@@ -3513,6 +3522,11 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, int 
             goto error;
           }
           lnum += n;
+          // ".+number" rounds up to the end of a closed fold after
+          // adding, so that ":!!sort" sorts one closed fold.
+          if (adjust_for_folding && base_char == '.') {
+            (void)hasFolding(lnum, NULL, &lnum);
+          }
         }
       }
     }

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -986,4 +986,40 @@ func Test_indent_append_blank_small_fold_close()
   bw!
 endfunc
 
+func Test_sort_closed_fold()
+  CheckExecutable sort
+
+  call setline(1, [
+        \ 'Section 1',
+        \ '   how',
+        \ '   now',
+        \ '   brown',
+        \ '   cow',
+        \ 'Section 2',
+        \ '   how',
+        \ '   now',
+        \ '   brown',
+        \ '   cow',
+        \])
+  setlocal foldmethod=indent sw=3
+  normal 2G
+
+  " The "!!" expands to ".,.+3" and must only sort four lines
+  call feedkeys("!!sort\<CR>", 'xt')
+  call assert_equal([
+        \ 'Section 1',
+        \ '   brown',
+        \ '   cow',
+        \ '   how',
+        \ '   now',
+        \ 'Section 2',
+        \ '   how',
+        \ '   now',
+        \ '   brown',
+        \ '   cow',
+        \ ], getline(1, 10))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0858: "!!sort" in a closed fold sorts too many lines

Problem:    "!!sort" in a closed fold sorts too many lines.
Solution:   Round to end of fold after adding the line count.

https://github.com/vim/vim/commit/f00112d558eb9a7d1d5413c096960ddcc52c9f66

N/A patches for version.c:

vim-patch:9.0.0855: comment not located above the code it refers to

Problem:    Comment not located above the code it refers to.
Solution:   Move the comment. (closes vim/vim#11527)

https://github.com/vim/vim/commit/09a93e3e66689c691a00fce25e4ce310d81edaee

vim-patch:9.0.0859: compiler warning for unused variable

Problem:    Compiler warning for unused variable.
Solution:   Add #ifdef.

https://github.com/vim/vim/commit/fd3084b6e298477dec4979515c6b4a8a3c3beeb2

Co-authored-by: Bram Moolenaar <Bram@vim.org>