### PR TITLE
vim-patch:9.0.0715: wrong argument for append() gives two error messages

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -813,6 +813,8 @@ func Test_append()
 
   " Using $ instead of '$' must give an error
   call assert_fails("call append($, 'foobar')", 'E116:')
+
+  call assert_fails("call append({}, '')", ['E728:', 'E728:'])
 endfunc
 
 " Test for setline()


### PR DESCRIPTION
#### vim-patch:9.0.0715: wrong argument for append() gives two error messages

Problem:    Wrong argument for append() gives two error messages.
Solution:   When getting an error for a number argument don't try using it as
            a string.

https://github.com/vim/vim/commit/801cd35e7e3b21e519e12a1610ee1d721e40893e

Co-authored-by: Bram Moolenaar <Bram@vim.org>