### PR TITLE
feat: added `vim.treesitter.highlighter.highlight_region`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -984,6 +984,12 @@ LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
                   the tree.
       • {self}
 
+                                        *LanguageTree:set_custom_injections()*
+LanguageTree:set_custom_injections({self}, {injections})
+    Parameters: ~
+      • {injections}  table<string, table> table of lang to list of regions
+      • {self}
+
 LanguageTree:source({self})                            *LanguageTree:source()*
     Returns the source content of the language tree (bufnr or string).
 


### PR DESCRIPTION
I added a new method to highlight a region in a buffer with a certain language.

You can test it with the code below. It will highlight the code in the `src` string with lua syntax.

```lua
local src = [[
-- test
function foo()
  return true
end
function foo()
  return true
end
]]

local parser = vim.treesitter.get_parser(0, "lua")
parser:set_custom_injections({ lua = { { { 1, 0, 8, 3 } } } })
parser:invalidate(true)
parser:parse()
]]

local ns = vim.api.nvim_create_namespace("foo")
vim.treesitter.highlighter.highlight_region(0, ns, { 1, 0, 8, 3 }, "lua")
```

My main use-case is to be able to strip the start end end of markdown code blocks, but still be able to correctly highlight them.

### Applications:
- folke/noice.nvim/issues/158
- [nvim-treesitter/nvim-treesitter-context/0dd5eae6dbf226107da2c2041ffbb695d9e267c1/lua/treesitter-context.lua#L540-L602](https://github.com/nvim-treesitter/nvim-treesitter-context/blob/0dd5eae6dbf226107da2c2041ffbb695d9e267c1/lua/treesitter-context.lua#L540-L602)