### PR TITLE
ci(windows): treat compiler warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@
 
 # Version should match the tested CMAKE_URL in .github/workflows/ci.yml.
 cmake_minimum_required(VERSION 3.10)
+
+# Can be removed once minimum version is at least 3.15
+if(POLICY CMP0092)
+  cmake_policy(SET CMP0092 NEW)
+endif()
+
 project(nvim C)
 
 if(POLICY CMP0075)
@@ -270,7 +276,7 @@ int main(void)
 option(ENABLE_COMPILER_SUGGESTIONS "Enable -Wsuggest compiler warnings" OFF)
 if(MSVC)
   # XXX: /W4 gives too many warnings. #3241
-  add_compile_options(/W3)
+  add_compile_options(-W1 -wd4311)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-DMSWIN)
 else()
@@ -364,10 +370,14 @@ option(CI_BUILD "CI, extra flags will be set" OFF)
 
 if(CI_BUILD)
   message(STATUS "CI build enabled")
-  add_compile_options(-Werror)
-  if(DEFINED ENV{BUILD_UCHAR})
-    # Get some test coverage for unsigned char
-    add_compile_options(-funsigned-char)
+  if(MSVC)
+    add_compile_options(-WX)
+  else()
+    add_compile_options(-Werror)
+    if(DEFINED ENV{BUILD_UCHAR})
+      # Get some test coverage for unsigned char
+      add_compile_options(-funsigned-char)
+    endif()
   endif()
 endif()
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1512,7 +1512,7 @@ static char *find_pipe(const char *cmd)
 
   for (const char *p = cmd; *p != NUL; p++) {
     if (!inquote && *p == '|') {
-      return p;
+      return (char *)p;
     }
     if (*p == '"') {
       inquote = !inquote;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1639,6 +1639,7 @@ int execute_cmd(exarg_T *eap, CmdParseInfo *cmdinfo, bool preview)
   char *errormsg = NULL;
   int retv = 0;
 
+#undef ERROR
 #define ERROR(msg) \
   do { \
     errormsg = msg; \

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -585,7 +585,7 @@ static bool nlua_init_packages(lua_State *lstate)
   lua_getglobal(lstate, "require");
   lua_pushstring(lstate, "vim._init_packages");
   if (nlua_pcall(lstate, 1, 0)) {
-    mch_errmsg(lua_tostring(lstate, -1));
+    mch_errmsg((char *)lua_tostring(lstate, -1));
     mch_errmsg("\n");
     return false;
   }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1273,7 +1273,7 @@ scripterror:
             vim_snprintf((char *)IObuff, IOSIZE,
                          _("Attempt to open script file again: \"%s %s\"\n"),
                          argv[-1], argv[0]);
-            mch_errmsg((const char *)IObuff);
+            mch_errmsg(IObuff);
             os_exit(2);
           }
           int error;
@@ -1292,7 +1292,7 @@ scripterror:
             vim_snprintf((char *)IObuff, IOSIZE,
                          _("Cannot open for reading: \"%s\": %s\n"),
                          argv[0], os_strerror(error));
-            mch_errmsg((const char *)IObuff);
+            mch_errmsg(IObuff);
             os_exit(2);
           }
           save_typebuf();
@@ -2055,7 +2055,7 @@ static void mainerr(const char *errstr, const char *str)
   mch_errmsg(_(errstr));
   if (str != NULL) {
     mch_errmsg(": \"");
-    mch_errmsg(str);
+    mch_errmsg((char *)str);
     mch_errmsg("\"");
   }
   mch_errmsg(_("\nMore info with \""));

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -67,7 +67,7 @@ conpty_t *os_conpty_init(char **in_name, char **out_name, uint16_t width, uint16
                      | PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE;
 
   sa.nLength = sizeof(sa);
-  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-in-%d-%d",
+  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-in-%lld-%d",
            os_get_pid(), count);
   *in_name = xstrdup(buf);
   if ((in_read = CreateNamedPipeA(*in_name,
@@ -81,7 +81,7 @@ conpty_t *os_conpty_init(char **in_name, char **out_name, uint16_t width, uint16
     emsg = "create input pipe failed";
     goto failed;
   }
-  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-out-%d-%d",
+  snprintf(buf, sizeof(buf), "\\\\.\\pipe\\nvim-term-out-%lld-%d",
            os_get_pid(), count);
   *out_name = xstrdup(buf);
   if ((out_write = CreateNamedPipeA(*out_name,

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1867,7 +1867,7 @@ char *fix_fname(const char *fname)
   fname = xstrdup(fname);
 
 # ifdef USE_FNAME_CASE
-  path_fix_case(fname);  // set correct case for file name
+  path_fix_case((char *)fname);  // set correct case for file name
 # endif
 
   return (char *)fname;


### PR DESCRIPTION
Reduce the warning level from 3 to 1 and fix all warnings.