### PR TITLE
vim-patch:9.0.0862: default value of 'endoffile' is wrong

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2164,7 +2164,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	See 'fileencoding' to control file-content encoding.
 
 			*'endoffile'* *'eof'* *'noendoffile'* *'noeof'*
-'endoffile' 'eof'	boolean	(default on)
+'endoffile' 'eof'	boolean	(default off)
 			local to buffer
 	Indicates that a CTRL-Z character was found at the end of the file
 	when reading it.  Normally only happens when 'fileformat' is "dos".

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -649,7 +649,7 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_eof',
-      defaults={if_true=true}
+      defaults={if_true=false}
     },
     {
       full_name='endofline', abbreviation='eol',

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1264,5 +1264,17 @@ func Test_keywordprg_empty()
   let &keywordprg = k
 endfunc
 
+" check that the very first buffer created does not have 'endoffile' set
+func Test_endoffile_default()
+  let after =<< trim [CODE]
+    call writefile([execute('set eof?')], 'Xtestout')
+    qall!
+  [CODE]
+  if RunVim([], after, '')
+    call assert_equal(["\nnoendoffile"], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0862: default value of 'endoffile' is wrong

Problem:    Default value of 'endoffile' is wrong.
Solution:   The default must be 'noendoffile'.

https://github.com/vim/vim/commit/0aad88f073602849d1623122eb3c323f8e252def

Co-authored-by: Bram Moolenaar <Bram@vim.org>