### PR TITLE
vim-patch:9.0.0866: no test for what patch 8.2.2207 fixes

### DIFF
--- a/src/nvim/testdir/test_popup.vim
+++ b/src/nvim/testdir/test_popup.vim
@@ -862,7 +862,6 @@ func Test_popup_position()
 endfunc
 
 func Test_popup_command()
-  CheckScreendump
   CheckFeature menu
 
   menu Test.Foo Foo
@@ -870,13 +869,18 @@ func Test_popup_command()
   call assert_fails('popup Test.Foo.X', 'E327:')
   call assert_fails('popup Foo', 'E337:')
   unmenu Test.Foo
+endfunc
+
+func Test_popup_command_dump()
+  CheckFeature menu
+  CheckScreendump
 
   let script =<< trim END
     func StartTimer()
       call timer_start(100, {-> ChangeMenu()})
     endfunc
     func ChangeMenu()
-      nunmenu PopUp.&Paste
+      aunmenu PopUp.&Paste
       nnoremenu 1.40 PopUp.&Paste :echomsg "pasted"<CR>
       echomsg 'changed'
     endfunc

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -3039,17 +3039,8 @@ describe('builtin popupmenu', function()
     eq('bar', meths.get_var('menustr'))
   end)
 
-  -- oldtest: Test_popup_command()
+  -- oldtest: Test_popup_command_dump()
   it(':popup command', function()
-    exec([[
-      menu Test.Foo Foo
-      call assert_fails('popup Test.Foo', 'E336:')
-      call assert_fails('popup Test.Foo.X', 'E327:')
-      call assert_fails('popup Foo', 'E337:')
-      unmenu Test.Foo
-    ]])
-    eq({}, meths.get_vvar('errors'))
-
     exec([[
       func ChangeMenu()
         aunmenu PopUp.&Paste


### PR DESCRIPTION
#### vim-patch:9.0.0866: no test for what patch 8.2.2207 fixes

Problem:    No test for what patch 8.2.2207 fixes.
Solution:   Add a test case. (closes vim/vim#11531)

https://github.com/vim/vim/commit/f7570f2107d91f35dc67dd0e400fc638585b226c