### PR TITLE
vim-patch:9.0.0865: duplicate arguments are not always detected

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -693,8 +693,17 @@ void ex_next(exarg_T *eap)
 void ex_argdedupe(exarg_T *eap FUNC_ATTR_UNUSED)
 {
   for (int i = 0; i < ARGCOUNT; i++) {
+    // Expand each argument to a full path to catch different paths leading
+    // to the same file.
+    char *firstFullname = FullName_save(ARGLIST[i].ae_fname, false);
+
     for (int j = i + 1; j < ARGCOUNT; j++) {
-      if (path_fnamecmp(ARGLIST[i].ae_fname, ARGLIST[j].ae_fname) == 0) {
+      char *secondFullname = FullName_save(ARGLIST[j].ae_fname, false);
+      bool areNamesDuplicate = path_fnamecmp(firstFullname, secondFullname) == 0;
+      xfree(secondFullname);
+
+      if (areNamesDuplicate) {
+        // remove one duplicate argument
         xfree(ARGLIST[j].ae_fname);
         memmove(ARGLIST + j, ARGLIST + j + 1,
                 (size_t)(ARGCOUNT - j - 1) * sizeof(aentry_T));
@@ -709,6 +718,8 @@ void ex_argdedupe(exarg_T *eap FUNC_ATTR_UNUSED)
         j--;
       }
     }
+
+    xfree(firstFullname);
   }
 }
 

--- a/src/nvim/testdir/test_arglist.vim
+++ b/src/nvim/testdir/test_arglist.vim
@@ -418,15 +418,19 @@ func Test_argdedupe()
   call Reset_arglist()
   argdedupe
   call assert_equal([], argv())
+
   args a a a aa b b a b aa
   argdedupe
   call assert_equal(['a', 'aa', 'b'], argv())
+
   args a b c
   argdedupe
   call assert_equal(['a', 'b', 'c'], argv())
+
   args a
   argdedupe
   call assert_equal(['a'], argv())
+
   args a A b B
   argdedupe
   if has('fname_case')
@@ -434,11 +438,17 @@ func Test_argdedupe()
   else
     call assert_equal(['a', 'b'], argv())
   endif
+
   args a b a c a b
   last
   argdedupe
   next
   call assert_equal('c', expand('%:t'))
+
+  args a ./a
+  argdedupe
+  call assert_equal(['a'], argv())
+
   %argd
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.0865: duplicate arguments are not always detected

Problem:    Duplicate arguments are not always detected.
Solution:   Expand to full path before comparing arguments. (Nir Lichtman,
            closes vim/vim#11505)

https://github.com/vim/vim/commit/b3052aa1b555ab5a81b1459a4972290381b0e7e4

Co-authored-by: Nir Lichtman <nir@lichtman.org>