### PR TITLE
vim-patch:8.2.{4675,4676},9.0.0869: no error for missing expression after :elseif

### DIFF
--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -899,7 +899,13 @@ void ex_else(exarg_T *eap)
 
   if (eap->cmdidx == CMD_elseif) {
     bool error;
-    result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);
+    // When skipping we ignore most errors, but a missing expression is
+    // wrong, perhaps it should have been "else".
+    if (skip && ends_excmd(*eap->arg)) {
+      semsg(_(e_invexpr2), eap->arg);
+    } else {
+      result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);
+    }
 
     // When throwing error exceptions, we want to throw always the first
     // of several errors in a row.  This is what actually happens when

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -901,7 +901,8 @@ void ex_else(exarg_T *eap)
     bool error;
     // When skipping we ignore most errors, but a missing expression is
     // wrong, perhaps it should have been "else".
-    if (skip && ends_excmd(*eap->arg)) {
+    // A double quote here is the start of a string, not a comment.
+    if (skip && *eap->arg != '"' && ends_excmd(*eap->arg)) {
       semsg(_(e_invexpr2), eap->arg);
     } else {
       result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -3024,7 +3024,7 @@ func Test_nested_if_else_errors()
 
   " :elseif without :if
   let code =<< trim END
-    elseif
+    elseif 1
   END
   call writefile(code, 'Xtest')
   call AssertException(['source Xtest'], 'Vim(elseif):E582: :elseif without :if')
@@ -3032,7 +3032,7 @@ func Test_nested_if_else_errors()
   " :elseif without :if
   let code =<< trim END
     while 1
-      elseif
+      elseif 1
     endwhile
   END
   call writefile(code, 'Xtest')
@@ -3042,7 +3042,7 @@ func Test_nested_if_else_errors()
   let code =<< trim END
     try
     finally
-      elseif
+      elseif 1
     endtry
   END
   call writefile(code, 'Xtest')
@@ -3051,7 +3051,7 @@ func Test_nested_if_else_errors()
   " :elseif without :if
   let code =<< trim END
     try
-      elseif
+      elseif 1
     endtry
   END
   call writefile(code, 'Xtest')
@@ -3062,7 +3062,7 @@ func Test_nested_if_else_errors()
     try
       throw "a"
     catch /a/
-      elseif
+      elseif 1
     endtry
   END
   call writefile(code, 'Xtest')

--- a/src/nvim/testdir/test_vimscript.vim
+++ b/src/nvim/testdir/test_vimscript.vim
@@ -193,6 +193,16 @@ func Test_if_while()
     call assert_equal('ab3j3b2c2b1f1h1km', g:Xpath)
 endfunc
 
+" Check double quote after skipped "elseif" does not give error E15
+func Test_skipped_elseif()
+  if "foo" ==? "foo"
+      let result = "first"
+  elseif "foo" ==? "foo"
+      let result = "second"
+  endif
+  call assert_equal('first', result)
+endfunc
+
 "-------------------------------------------------------------------------------
 " Test 4:   :return							    {{{1
 "-------------------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:8.2.4675: no error for missing expression after :elseif

Problem:    No error for missing expression after :elseif. (Ernie Rael)
Solution:   Check for missing expression.

https://github.com/vim/vim/commit/fa010cdfb115fd2f6bae7ea6f6e63be906b5e347

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4676: test fails with different error

Problem:    Test fails with different error.
Solution:   Add argument for :elseif.

https://github.com/vim/vim/commit/292e1b9f681054a1de8fa22315ae6eedd7acb205

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0869: bogus error when string used after :elseif

Problem:    Bogus error when string used after :elseif.
Solution:   Do not consider a double quote the start of a comment.

https://github.com/vim/vim/commit/28c56d501352bd98472d23667bade683877cadcc

Co-authored-by: Bram Moolenaar <Bram@vim.org>