### PR TITLE
docs(treesitter): change links for `eq?` and `set!` to codeblocks 

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -212,7 +212,7 @@ treesitter queries from Lua.
 TREESITTER QUERY PREDICATES                            *treesitter-predicates*
 
 Predicates are special scheme nodes that are evaluated to conditionally capture
-nodes. For example, the |eq?| predicate can be used as follows: >
+nodes. For example, the `eq?` predicate can be used as follows: >
 
     ((identifier) @foo (#eq? @foo "foo"))
 <
@@ -261,7 +261,7 @@ predicates.
 TREESITTER QUERY DIRECTIVES                            *treesitter-directives*
 
 Treesitter directives store metadata for a node or match and perform side
-effects. For example, the |set!| predicate sets metadata on the match or node: >
+effects. For example, the `set!` directive sets metadata on the match or node: >
 
         ((identifier) @foo (#set! "type" "parameter"))
 <


### PR DESCRIPTION
- Change `|eq?|` to `|treesitter-predicate-eq?|` as `|eq?|` doesn't point to anything
- Change `|set!|` to `|treesitter-directive-set!|` as `|set!|` doesn't point to anything
- Change `predicate` to `directive` when describing `treesitter-directive-set!`