### PR TITLE
vim-patch:8.2.4038: various code not used when features are disabled

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1075,11 +1075,11 @@ int get_spellword(list_T *const list, const char **ret_word)
   return (int)tv_list_find_nr(list, -1, NULL);
 }
 
-// Call some vim script function and return the result in "*rettv".
-// Uses argv[0] to argv[argc-1] for the function arguments. argv[argc]
-// should have type VAR_UNKNOWN.
-//
-// @return  OK or FAIL.
+/// Call some Vim script function and return the result in "*rettv".
+/// Uses argv[0] to argv[argc - 1] for the function arguments. argv[argc]
+/// should have type VAR_UNKNOWN.
+///
+/// @return  OK or FAIL.
 int call_vim_function(const char *func, int argc, typval_T *argv, typval_T *rettv)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -1113,7 +1113,9 @@ fail:
   return ret;
 }
 
-/// Call Vim script function and return the result as a string
+/// Call Vim script function and return the result as a string.
+/// Uses "argv[0]" to "argv[argc - 1]" for the function arguments. "argv[argc]"
+/// should have type VAR_UNKNOWN.
 ///
 /// @param[in]  func  Function name.
 /// @param[in]  argc  Number of arguments.
@@ -1136,7 +1138,8 @@ char *call_func_retstr(const char *const func, int argc, typval_T *argv)
   return retval;
 }
 
-/// Call Vim script function and return the result as a List
+/// Call Vim script function and return the result as a List.
+/// Uses "argv" and "argc" as call_func_retstr().
 ///
 /// @param[in]  func  Function name.
 /// @param[in]  argc  Number of arguments.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -596,8 +596,6 @@ EXTERN char *p_menc;            // 'makeencoding'
 EXTERN char *p_mef;             // 'makeef'
 EXTERN char_u *p_mp;            // 'makeprg'
 EXTERN char *p_mps;             ///< 'matchpairs'
-EXTERN char_u *p_cc;            // 'colorcolumn'
-EXTERN int p_cc_cols[256];      // array for 'colorcolumn' columns
 EXTERN long p_mat;              // 'matchtime'
 EXTERN long p_mco;              // 'maxcombine'
 EXTERN long p_mfd;              // 'maxfuncdepth'


### PR DESCRIPTION
#### vim-patch:8.2.4038: various code not used when features are disabled

Problem:    Various code not used when features are disabled.
Solution:   Add #ifdefs. (Dominique Pellé, closes vim/vim#9491)

https://github.com/vim/vim/commit/748b308eebe8d8860888eb27da08333f175d547d

N/A patches for version.c:

vim-patch:8.2.2186: Vim9: error when using 'opfunc'

Problem:    Vim9: error when using 'opfunc'.
Solution:   Do not expect a return value from 'opfunc'.

https://github.com/vim/vim/commit/5b3d1bb0f5180266c4de4d815b3ea856a2fb3519