### PR TITLE
vim-patch:8.2.0961: MS-Windows: no completion for locales

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -689,6 +689,7 @@ static char *find_longest_match(expand_T *xp, int options)
 /// options = WILD_SILENT:           don't print warning messages
 /// options = WILD_ESCAPE:           put backslash before special chars
 /// options = WILD_ICASE:            ignore case for files
+/// options = WILD_ALLLINKS:         keep broken links
 ///
 /// The variables xp->xp_context and xp->xp_backslash must have been set!
 ///

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -879,23 +879,19 @@ func Test_cmdline_complete_languages()
   call feedkeys(":language \<c-a>\<c-b>\"\<cr>", 'tx')
   call assert_match('^"language .*\<collate\>.*\<ctype\>.*\<messages\>.*\<time\>', @:)
 
-  if has('unix')
-    " TODO: these tests don't work on Windows. lang appears to be 'C'
-    " but C does not appear in the completion. Why?
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call feedkeys(":language messages \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call feedkeys(":language ctype \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
+  call feedkeys(":language time \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 
-    call feedkeys(":language collate \<c-a>\<c-b>\"\<cr>", 'tx')
-    call assert_match('^"language .*\<' . lang . '\>', @:)
-  endif
+  call feedkeys(":language collate \<c-a>\<c-b>\"\<cr>", 'tx')
+  call assert_match('^"language .*\<' . lang . '\>', @:)
 endfunc
 
 func Test_cmdline_complete_env_variable()


### PR DESCRIPTION
#### vim-patch:8.2.0961: MS-Windows: no completion for locales

Problem:    MS-Windows: no completion for locales.
Solution:   Use the directories in $VIMRUNTIME/lang to complete locales.
            (Christian Brabandt, closes 36248)

https://github.com/vim/vim/commit/ec68028604b6ee799b2ef5fc861ec5163e82914f

Nvim does not have runtime/lang directory.