### PR TITLE
perf: memory align structs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ else()
   add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion
     -Wdouble-promotion
-    -Wpadded
+    # -Wpadded
     -Wmissing-noreturn
     -Wmissing-format-attribute
     -Wmissing-prototypes)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ else()
   add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion
     -Wdouble-promotion
+    -Wpadded
     -Wmissing-noreturn
     -Wmissing-format-attribute
     -Wmissing-prototypes)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -159,7 +159,7 @@ list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 if(NOT MSVC)
   # xdiff, mpack, lua-cjson: inlined external project, we don't maintain it. #9306
   set_source_files_properties(
-    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion -Wno-strict-prototypes")
+    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion -Wno-strict-prototypes -Wno-padded")
 endif()
 
 if(NOT "${MIN_LOG_LEVEL}" MATCHES "^$")

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -109,6 +109,7 @@ typedef enum {
 
 struct object {
   ObjectType type;
+  char __pad[4];
   union {
     Boolean boolean;
     Integer integer;

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -63,6 +63,7 @@ static inline bool is_internal_call(const uint64_t channel_id)
 
 typedef struct {
   ErrorType type;
+  char __pad[4];
   char *msg;
 } Error;
 

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -13,23 +13,25 @@
 // not the current buffer.
 typedef struct {
   buf_T *save_curbuf;             ///< saved curbuf
-  bool use_aucmd_win;             ///< using aucmd_win
   handle_T save_curwin_handle;    ///< ID of saved curwin
   handle_T new_curwin_handle;     ///< ID of new curwin
   handle_T save_prevwin_handle;   ///< ID of saved prevwin
   bufref_T new_curbuf;            ///< new curbuf
   char *globaldir;                ///< saved value of globaldir
   bool save_VIsual_active;        ///< saved VIsual_active
+  bool use_aucmd_win;             ///< using aucmd_win
+  char __pad0[6];
 } aco_save_T;
 
 typedef struct AutoCmd_S AutoCmd;
 struct AutoCmd_S {
   AucmdExecutable exec;
+  int64_t id;                           // ID used for uniquely tracking an autocmd.
+  sctx_T script_ctx;                    // script context where it is defined
   bool once;                            // "One shot": removed after execution
   bool nested;                          // If autocommands nest here
   bool last;                            // last command in list
-  int64_t id;                           // ID used for uniquely tracking an autocmd.
-  sctx_T script_ctx;                    // script context where it is defined
+  char __pad;
   char *desc;                           // Description for the autocmd.
   AutoCmd *next;                        // Next AutoCmd in list
 };
@@ -47,6 +49,7 @@ struct AutoPat_S {
   int buflocal_nr;                      // !=0 for buffer-local AutoPat
   char allow_dirs;                      // Pattern may match whole path
   char last;                            // last pattern for apply_autocmds()
+  char __pad[2];
 };
 
 /// Struct used to keep status while executing autocommands for an event.
@@ -54,13 +57,13 @@ typedef struct AutoPatCmd_S AutoPatCmd;
 struct AutoPatCmd_S {
   AutoPat *curpat;          // next AutoPat to examine
   AutoCmd *nextcmd;         // next AutoCmd to execute
-  int group;                // group being used
   char *fname;              // fname to match with
   char *sfname;             // sfname to match with
   char *tail;               // tail of fname
   event_T event;            // current event
   sctx_T script_ctx;        // script context where it is defined
   int arg_bufnr;            // initially equal to <abuf>, set to zero when buf is deleted
+  int group;                // group being used
   Object *data;             // arbitrary data
   AutoPatCmd *next;         // chain of active apc-s for auto-invalidation
 };

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -156,6 +156,7 @@ typedef struct {
 #define w_p_briopt w_onebuf_opt.wo_briopt  // 'breakindentopt'
   int wo_diff;
 #define w_p_diff w_onebuf_opt.wo_diff  // 'diff'
+  char __pad0[4];
   char *wo_fdc;
 #define w_p_fdc w_onebuf_opt.wo_fdc    // 'foldcolumn'
   char *wo_fdc_save;
@@ -194,24 +195,24 @@ typedef struct {
 #define w_p_nu w_onebuf_opt.wo_nu       // 'number'
   int wo_rnu;
 #define w_p_rnu w_onebuf_opt.wo_rnu     // 'relativenumber'
+  long wo_nuw;
+#define w_p_nuw w_onebuf_opt.wo_nuw    // 'numberwidth'
   char *wo_ve;
 #define w_p_ve w_onebuf_opt.wo_ve       // 'virtualedit'
   unsigned wo_ve_flags;
 #define w_ve_flags w_onebuf_opt.wo_ve_flags  // flags for 'virtualedit'
-  long wo_nuw;
-#define w_p_nuw w_onebuf_opt.wo_nuw    // 'numberwidth'
   int wo_wfh;
 #define w_p_wfh w_onebuf_opt.wo_wfh    // 'winfixheight'
   int wo_wfw;
 #define w_p_wfw w_onebuf_opt.wo_wfw    // 'winfixwidth'
-  int wo_pvw;
-#define w_p_pvw w_onebuf_opt.wo_pvw    // 'previewwindow'
   int wo_rl;
 #define w_p_rl w_onebuf_opt.wo_rl      // 'rightleft'
   char *wo_rlc;
 #define w_p_rlc w_onebuf_opt.wo_rlc    // 'rightleftcmd'
   long wo_scr;
 #define w_p_scr w_onebuf_opt.wo_scr     // 'scroll'
+  int wo_pvw;
+#define w_p_pvw w_onebuf_opt.wo_pvw    // 'previewwindow'
   int wo_spell;
 #define w_p_spell w_onebuf_opt.wo_spell  // 'spell'
   int wo_cuc;
@@ -238,6 +239,7 @@ typedef struct {
 #define w_p_wrap w_onebuf_opt.wo_wrap   // 'wrap'
   int wo_wrap_save;             // 'wrap' state saved for diff mode
 #define w_p_wrap_save w_onebuf_opt.wo_wrap_save
+  char __pad3[4];
   char *wo_cocu;                 // 'concealcursor'
 #define w_p_cocu w_onebuf_opt.wo_cocu
   long wo_cole;                         // 'conceallevel'
@@ -417,6 +419,7 @@ typedef struct {
   hashtab_T b_keywtab_ic;               // idem, ignore case
   bool b_syn_error;                     // true when error occurred in HL
   bool b_syn_slow;                      // true when 'redrawtime' reached
+  char __pad0[2];
   int b_syn_ic;                         // ignore case for :syn cmds
   int b_syn_foldlevel;                  // how to compute foldlevel on a line
   int b_syn_spell;                      // SYNSPL_ values
@@ -428,6 +431,7 @@ typedef struct {
                                         // "containedin" argument
   int b_syn_sync_flags;                 // flags about how to sync
   int16_t b_syn_sync_id;                // group to sync on
+  char __pad1[2];
   linenr_T b_syn_sync_minlines;         // minimal sync lines offset
   linenr_T b_syn_sync_maxlines;         // maximal sync lines offset
   linenr_T b_syn_sync_linebreaks;       // offset for multi-line pattern
@@ -453,6 +457,7 @@ typedef struct {
   //                    validity (MAXLNUM means no check needed)
   synstate_T *b_sst_array;
   int b_sst_len;
+  char __pad2[4];
   synstate_T *b_sst_first;
   synstate_T *b_sst_firstfree;
   int b_sst_freecount;
@@ -512,12 +517,12 @@ struct file_buffer {
   handle_T handle;              // unique id for the buffer (buffer number)
 #define b_fnum handle
 
+  int b_nwindows;               // nr of windows open on this buffer
+                                //
   memline_T b_ml;               // associated memline (also contains line count
 
   buf_T *b_next;          // links in list of buffers
   buf_T *b_prev;
-
-  int b_nwindows;               // nr of windows open on this buffer
 
   int b_flags;                  // various BF_ flags
   int b_locked;                 // Buffer is being closed or referenced, don't
@@ -537,13 +542,15 @@ struct file_buffer {
   char *b_fname;           // current file name, points to b_ffname or
                            // b_sfname
 
-  bool file_id_valid;
   FileID file_id;
+  bool file_id_valid;
 
-  int b_changed;                // 'modified': Set to true if something in the
-                                // file has been changed and not written out.
+
   bool b_changed_invalid;       // Set if BufModified autocmd has not been
                                 // triggered since the last time b_changed was
+  char __pad0[2];
+  int b_changed;                // 'modified': Set to true if something in the
+                                // file has been changed and not written out.
                                 // modified.
 
   /// Change-identifier incremented for each change, including undo.
@@ -563,6 +570,7 @@ struct file_buffer {
   // work, remember changes made and update everything at once.
   bool b_mod_set;               // true when there are changes since the last
                                 // time the display was updated
+  char __pad2[2];
   linenr_T b_mod_top;           // topmost lnum that was changed
   linenr_T b_mod_bot;           // lnum below last changed line, AFTER the
                                 // change
@@ -579,6 +587,7 @@ struct file_buffer {
   long b_mtime_read_ns;         // nanoseconds of last read time
   uint64_t b_orig_size;         // size of original file in bytes
   int b_orig_mode;              // mode of original file
+  char __pad3[4];
   time_t b_last_used;           // time when the buffer was last used; used
                                 // for viminfo
 
@@ -588,6 +597,7 @@ struct file_buffer {
   visualinfo_T b_visual;
   int b_visual_mode_eval;            // b_visual.vi_mode for visualmode()
 
+  char __pad4[4];
   fmark_T b_last_cursor;        // cursor position when last unloading this
                                 // buffer
   fmark_T b_last_insert;        // where Insert mode was left
@@ -597,6 +607,7 @@ struct file_buffer {
   fmark_T b_changelist[JUMPLISTSIZE];
   int b_changelistlen;                  // number of active entries
   bool b_new_change;                    // set by u_savecommon()
+  char __pad22[3];
 
   // Character table, only used in charset.c for 'iskeyword'
   // bitset with 4*64=256 bits: 1 bit per character 0-255.
@@ -615,6 +626,9 @@ struct file_buffer {
   pos_T b_op_end;
 
   bool b_marks_read;            // Have we read ShaDa marks yet?
+  bool b_scanned;               // ^N/^P have scanned this buffer
+
+  char __pad12[2];
 
   // The following only used in undo.c.
   u_header_T *b_u_oldhead;     // pointer to oldest header
@@ -623,6 +637,7 @@ struct file_buffer {
   u_header_T *b_u_curhead;     // pointer to current header
   int b_u_numhead;              // current number of headers
   bool b_u_synced;              // entry lists are synced
+  char __pad13[3];
   long b_u_seq_last;            // last used undo sequence number
   long b_u_save_nr_last;        // counter for last file write
   long b_u_seq_cur;             // uh_seq of header below which we are now
@@ -634,7 +649,6 @@ struct file_buffer {
   linenr_T b_u_line_lnum;       // line number of line in u_line
   colnr_T b_u_line_colnr;       // optional column number
 
-  bool b_scanned;               // ^N/^P have scanned this buffer
 
   // flags for use of ":lmap" and IM control
   long b_p_iminsert;            // input mode for insert
@@ -647,14 +661,16 @@ struct file_buffer {
   int16_t b_kmap_state;         // using "lmap" mappings
 #define KEYMAP_INIT    1       // 'keymap' was set, call keymap_init()
 #define KEYMAP_LOADED  2       // 'keymap' mappings have been loaded
+  char __pad15[6];
   garray_T b_kmap_ga;           // the keymap table
 
   // Options local to a buffer.
   // They are here because their value depends on the type of file
   // or contents of the file being edited.
-  bool b_p_initialized;                 // set when options initialized
-
   LastSet b_p_script_ctx[BV_COUNT];     // SCTXs for buffer-local options
+
+  bool b_p_initialized;                 // set when options initialized
+  char __pad16[7];
 
   int b_p_ai;                   ///< 'autoindent'
   int b_p_ai_nopaste;           ///< b_p_ai saved for paste mode
@@ -668,6 +684,7 @@ struct file_buffer {
   int b_has_qf_entry;           ///< quickfix exists for buffer
   int b_p_bl;                   ///< 'buflisted'
   long b_p_channel;             ///< 'channel'
+  char __pad17[4];
   int b_p_cin;                  ///< 'cindent'
   char *b_p_cino;               ///< 'cinoptions'
   char *b_p_cink;               ///< 'cinkeys'
@@ -696,37 +713,37 @@ struct file_buffer {
   char *b_p_ft;                 ///< 'filetype'
   char *b_p_fo;                 ///< 'formatoptions'
   char *b_p_flp;                ///< 'formatlistpat'
-  int b_p_inf;                  ///< 'infercase'
   char *b_p_isk;                ///< 'iskeyword'
   char *b_p_def;                ///< 'define' local value
   char *b_p_inc;                ///< 'include'
   char *b_p_inex;               ///< 'includeexpr'
   uint32_t b_p_inex_flags;      ///< flags for 'includeexpr'
+  int b_p_inf;                  ///< 'infercase'
   char *b_p_inde;               ///< 'indentexpr'
   uint32_t b_p_inde_flags;      ///< flags for 'indentexpr'
+  int b_p_swf;                  ///< 'swapfile'
   char *b_p_indk;               ///< 'indentkeys'
   char *b_p_fp;                 ///< 'formatprg'
   char *b_p_fex;                ///< 'formatexpr'
   uint32_t b_p_fex_flags;       ///< flags for 'formatexpr'
-  char *b_p_kp;                 ///< 'keywordprg'
   int b_p_lisp;                 ///< 'lisp'
+  char *b_p_kp;                 ///< 'keywordprg'
   char *b_p_lop;                ///< 'lispoptions'
   char *b_p_menc;               ///< 'makeencoding'
   char *b_p_mps;                ///< 'matchpairs'
   int b_p_ml;                   ///< 'modeline'
   int b_p_ml_nobin;             ///< b_p_ml saved for binary mode
   int b_p_ma;                   ///< 'modifiable'
-  char *b_p_nf;                 ///< 'nrformats'
   int b_p_pi;                   ///< 'preserveindent'
+  char *b_p_nf;                 ///< 'nrformats'
   char *b_p_qe;                 ///< 'quoteescape'
   int b_p_ro;                   ///< 'readonly'
+  int b_p_si;                   ///< 'smartindent'
   long b_p_sw;                  ///< 'shiftwidth'
   long b_p_scbk;                ///< 'scrollback'
-  int b_p_si;                   ///< 'smartindent'
   long b_p_sts;                 ///< 'softtabstop'
   long b_p_sts_nopaste;         ///< b_p_sts saved for paste mode
   char *b_p_sua;                ///< 'suffixesadd'
-  int b_p_swf;                  ///< 'swapfile'
   long b_p_smc;                 ///< 'synmaxcol'
   char *b_p_syn;                ///< 'syntax'
   long b_p_ts;                  ///< 'tabstop'
@@ -750,15 +767,16 @@ struct file_buffer {
   char *b_p_ep;                 ///< 'equalprg' local value
   char *b_p_path;               ///< 'path' local value
   int b_p_ar;                   ///< 'autoread' local value
+  char __pad30[4];
   char *b_p_tags;               ///< 'tags' local value
   char *b_p_tc;                 ///< 'tagcase' local value
   unsigned b_tc_flags;          ///< flags for 'tagcase'
+  int b_p_udf;                  ///< 'undofile'
   char *b_p_dict;               ///< 'dictionary' local value
   char *b_p_tsr;                ///< 'thesaurus' local value
   char *b_p_tsrfu;              ///< 'thesaurusfunc' local value
   Callback b_tsrfu_cb;          ///< 'thesaurusfunc' callback
   long b_p_ul;                  ///< 'undolevels' local value
-  int b_p_udf;                  ///< 'undofile'
   char *b_p_lw;                 ///< 'lispwords' local value
 
   // end of buffer options
@@ -808,6 +826,7 @@ struct file_buffer {
   int b_start_eof;              // last line had eof (CTRL-Z) when it was read
   int b_start_eol;              // last line had eol when it was read
   int b_start_ffc;              // first char of 'ff' when edit started
+  char __pad_31[4];
   char *b_start_fenc;           // 'fileencoding' when edit started or NULL
   int b_bad_char;               // "++bad=" argument when edit started or 0
   int b_start_bomb;             // 'bomb' when it was read
@@ -831,12 +850,18 @@ struct file_buffer {
   bool b_spell;                 // True for a spell file buffer, most fields
                                 // are not used!  Use the B_SPELL macro to
                                 // access b_spell without #ifdef.
+  // whether an update callback has requested codepoint size of deleted regions.
+  bool update_need_codepoints;
+
+  char __pad5[3];
 
   char *b_prompt_text;          // set by prompt_setprompt()
   Callback b_prompt_callback;   // set by prompt_setcallback()
   Callback b_prompt_interrupt;  // set by prompt_setinterrupt()
   int b_prompt_insert;          // value for restart_edit when entering
                                 // a prompt buffer window.
+
+  int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 
   synblock_T b_s;               // Info related to syntax highlighting.  w_s
                                 // normally points to this, but some windows
@@ -846,6 +871,7 @@ struct file_buffer {
   struct {
     int size;                   // last calculated number of sign columns
     bool valid;                 // calculated sign columns is valid
+    char __pad[3];
     linenr_T sentinel;          // a line number which is holding up the signcolumn
     int max;                    // Maximum value size is valid for.
   } b_signcols;
@@ -853,8 +879,6 @@ struct file_buffer {
   Terminal *terminal;           // Terminal instance associated with the buffer
 
   dict_T *additional_data;      // Additional data from shada file if any.
-
-  int b_mapped_ctrl_c;          // modes where CTRL-C is mapped
 
   MarkTree b_marktree[1];
   Map(uint32_t, uint32_t) b_extmark_ns[1];         // extmark namespaces
@@ -866,9 +890,6 @@ struct file_buffer {
   kvec_t(uint64_t) update_channels;
   // array of lua callbacks for buffer updates.
   kvec_t(BufUpdateCallbacks) update_callbacks;
-
-  // whether an update callback has requested codepoint size of deleted regions.
-  bool update_need_codepoints;
 
   // Measurements of the deleted or replaced region since the last update
   // event. Some consumers of buffer changes need to know the byte size (like
@@ -1073,23 +1094,24 @@ typedef struct {
   Window window;
   lpos_T bufpos;
   int height, width;
+  int zindex;
   double row, col;
   FloatAnchor anchor;
   FloatRelative relative;
   bool external;
   bool focusable;
-  int zindex;
-  WinStyle style;
   bool border;
   bool title;
-  bool shadow;
+  WinStyle style;
   schar_T border_chars[8];
   int border_hl_ids[8];
   int border_attr[8];
   AlignTextPos title_pos;
-  VirtText title_chunks;
   int title_width;
+  VirtText title_chunks;
   bool noautocmd;
+  bool shadow;
+  char __pad[6];
 } FloatConfig;
 
 #define FLOAT_CONFIG_INIT ((FloatConfig){ .height = 0, .width = 0, \
@@ -1116,15 +1138,17 @@ typedef struct {
 struct window_S {
   handle_T handle;                  ///< unique identifier for the window
 
+  char __pad5[4];
+
   buf_T *w_buffer;            ///< buffer we are a window into (used
                               ///< often, keep it the first item!)
 
   synblock_T *w_s;                 ///< for :ownsyntax
 
+  int *w_ns_hl_attr;
   int w_ns_hl;
   int w_ns_hl_winhl;
   int w_ns_hl_active;
-  int *w_ns_hl_attr;
 
   int w_hl_id_normal;               ///< 'winhighlight' normal id
   int w_hl_attr_normal;             ///< 'winhighlight' normal final attrs
@@ -1132,11 +1156,14 @@ struct window_S {
 
   int w_hl_needs_update;            ///< attrs need to be recalculated
 
+  char __pad6[4];
+
   win_T *w_prev;              ///< link to previous window
   win_T *w_next;              ///< link to next window
   bool w_closing;                   ///< window is being closed, don't let
                                     ///  autocommands close it too.
 
+  char __pad7[7];
   frame_T *w_frame;             ///< frame containing this window
 
   pos_T w_cursor;                   ///< cursor position in buffer
@@ -1154,6 +1181,7 @@ struct window_S {
 
   // the next seven are used to update the visual part
   char w_old_visual_mode;           ///< last known VIsual_mode
+  char __pad8[3];
   linenr_T w_old_cursor_lnum;       ///< last known end of visual part
   colnr_T w_old_cursor_fcol;        ///< first column for block visual part
   colnr_T w_old_cursor_lcol;        ///< last column for block visual part
@@ -1162,6 +1190,8 @@ struct window_S {
   colnr_T w_old_curswant;           ///< last known value of Curswant
 
   linenr_T w_last_cursor_lnum_rnu;  ///< cursor lnum when 'rnu' was last redrawn
+                                    ///
+  char __pad14[4];
 
   // 'listchars' characters. Defaults set in set_chars_option().
   struct {
@@ -1178,6 +1208,7 @@ struct window_S {
     int *multispace;
     int *leadmultispace;
     int conceal;
+    char __pad0[4];
   } w_p_lcs_chars;
 
   // 'fillchars' characters. Defaults set in set_chars_option().
@@ -1208,11 +1239,13 @@ struct window_S {
                                     // top of the window
   char w_topline_was_set;           // flag set to true when topline is set,
                                     // e.g. by winrestview()
+  char __pad10[3];
   int w_topfill;                    // number of filler lines above w_topline
   int w_old_topfill;                // w_topfill at last redraw
   bool w_botfill;                   // true when filler lines are actually
                                     // below w_topline (at end of file)
   bool w_old_botfill;               // w_botfill at last redraw
+  char __pad11[2];
   colnr_T w_leftcol;                // window column number of the left most
                                     // character in the window; used when
                                     // 'wrap' is off
@@ -1272,11 +1305,14 @@ struct window_S {
 
   bool w_viewport_invalid;
 
+  char __pad12[3];
+
   // w_cline_height is the number of physical lines taken by the buffer line
   // that the cursor is on.  We use this to avoid extra calls to plines_win().
   int w_cline_height;               // current size of cursor line
   bool w_cline_folded;              // cursor line is folded
 
+  char __pad15[3];
   int w_cline_row;                  // starting row of the cursor line
 
   colnr_T w_virtcol;                // column number of the cursor in the
@@ -1313,6 +1349,7 @@ struct window_S {
                                     // manually
   bool w_foldinvalid;               // when true: folding needs to be
                                     // recomputed
+  char __pad16[2];
   int w_nrwidth;                    // width of 'number' and 'relativenumber'
                                     // column being used
   int w_scwidth;                    // width of 'signcolumn'
@@ -1327,6 +1364,8 @@ struct window_S {
   bool w_redr_status;               // if true statusline/winbar must be redrawn
   bool w_redr_border;               // if true border must be redrawn
 
+  char __pad17[2];
+
   // remember what is shown in the ruler for this window (if 'ruler' set)
   pos_T w_ru_cursor;                // cursor position shown in ruler
   colnr_T w_ru_virtcol;             // virtcol shown in ruler
@@ -1334,16 +1373,19 @@ struct window_S {
   linenr_T w_ru_line_count;         // line count used for ruler
   int w_ru_topfill;                 // topfill shown in ruler
   char w_ru_empty;                  // true if ruler shows 0-1 (empty line)
+  char __pad18[3];
 
-  int w_alt_fnum;                   // alternate file (for # and CTRL-^)
+  char *w_localdir;            // absolute path of local directory or NULL
+  char *w_prevdir;             // previous directory
 
   alist_T *w_alist;             // pointer to arglist for this window
+  int w_alt_fnum;                   // alternate file (for # and CTRL-^)
   int w_arg_idx;                    // current index in argument list (can be
                                     // out of range!)
   int w_arg_idx_invalid;            // editing another file than w_arg_idx
 
-  char *w_localdir;            // absolute path of local directory or NULL
-  char *w_prevdir;             // previous directory
+  char __pad19[4];
+
   // Options local to a window.
   // They are local because they influence the layout of the window or
   // depend on the window layout.
@@ -1359,18 +1401,21 @@ struct window_S {
   uint32_t w_p_fdt_flags;           // flags for 'foldtext'
   int *w_p_cc_cols;                 // array of columns to highlight or NULL
   uint8_t w_p_culopt_flags;         // flags for cursorline highlighting
+  char __pad0[7];
   long w_p_siso;                    // 'sidescrolloff' local value
   long w_p_so;                      // 'scrolloff' local value
 
   int w_briopt_min;                 // minimum width for breakindent
   int w_briopt_shift;               // additional shift for breakindent
   bool w_briopt_sbr;                // sbr in 'briopt'
+  char __pad1[3];
   int w_briopt_list;                // additional indent for lists
   int w_briopt_vcol;                // indent for specific column
 
   // transform a pointer to a "onebuf" option into a "allbuf" option
 #define GLOBAL_WO(p)    ((char *)(p) + sizeof(winopt_T))
 
+  char __pad2[4];
   long w_scbind_pos;
 
   ScopeDictDictItem w_winvar;  ///< Variable for "w:" dictionary.
@@ -1387,10 +1432,10 @@ struct window_S {
   int w_jumplistlen;                    // number of active entries
   int w_jumplistidx;                    // current position
 
-  int w_changelistidx;                  // current position in b_changelist
-
   matchitem_T *w_match_head;            // head of match list
   int w_next_match_id;                  // next match ID
+
+  int w_changelistidx;                  // current position in b_changelist
 
   // the tagstack grows from 0 upwards:
   // entry 0: older
@@ -1402,9 +1447,10 @@ struct window_S {
 
   ScreenGrid w_grid;                    // the grid specific to the window
   ScreenGrid w_grid_alloc;              // the grid specific to the window
+  FloatConfig w_float_config;
   bool w_pos_changed;                   // true if window position changed
   bool w_floating;                       ///< whether the window is floating
-  FloatConfig w_float_config;
+  char __pad4[2];
 
   // w_fraction is the fractional row of the cursor within the window, from
   // 0 at the top row to FRACTION_MULT at the last row.
@@ -1415,6 +1461,8 @@ struct window_S {
 
   linenr_T w_nrwidth_line_count;        // line count when ml_nrwidth_width was computed.
   int w_nrwidth_width;                  // nr of chars to print line count.
+                                        //
+  char __pad50[4];
 
   qf_info_T *w_llist;                 // Location list for this window
   // Location list reference used in the location list window.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -128,6 +128,7 @@ typedef struct buffheader buffheader_T;
 struct buffblock {
   buffblock_T *b_next;  // pointer to next buffblock
   char b_str[1];        // contents (actually longer)
+  char __pad[7];
 };
 
 // header used for the stuff buffer and the redo buffer
@@ -273,11 +274,12 @@ struct wininfo_S {
   wininfo_T *wi_prev;         // previous entry or NULL for first entry
   win_T *wi_win;          // pointer to window that did set wi_mark
   fmark_T wi_mark;                // last cursor mark in the file
-  bool wi_optset;               // true when wi_opt has useful values
   winopt_T wi_opt;              // local window options
+  bool wi_optset;               // true when wi_opt has useful values
   bool wi_fold_manual;          // copy of w_fold_manual
-  garray_T wi_folds;            // clone of w_folds
+  char __pad[2];
   int wi_changelistidx;         // copy of w_changelistidx
+  garray_T wi_folds;            // clone of w_folds
 };
 
 // Argument list: Array of file names.
@@ -320,6 +322,7 @@ typedef struct {
   int tb_silent;                // nr of silently mapped bytes in tb_buf[]
   int tb_no_abbr_cnt;           // nr of bytes without abbrev. in tb_buf[]
   int tb_change_cnt;            // nr of time tb_buf was changed; never zero
+  char __pad[4];
 } typebuf_T;
 
 // Struct to hold the saved typeahead for save_typeahead().
@@ -349,9 +352,10 @@ struct mapblock {
   char m_silent;                // <silent> used, don't echo commands
   char m_nowait;                // <nowait> used
   char m_expr;                  // <expr> used, m_str is an expression
-  sctx_T m_script_ctx;          // SCTX where map was defined
-  char *m_desc;                 // description of mapping
   bool m_replace_keycodes;      // replace keycodes in result of expression
+  sctx_T m_script_ctx;          // SCTX where map was defined
+  char __pad[4];
+  char *m_desc;                 // description of mapping
 };
 
 /// Used for highlighting in the status line.
@@ -485,6 +489,7 @@ typedef struct {
   LuaRef on_reload;
   bool utf_sizes;
   bool preview;
+  char __pad[2];
 } BufUpdateCallbacks;
 #define BUF_UPDATE_CALLBACKS_INIT { LUA_NOREF, LUA_NOREF, LUA_NOREF, \
                                     LUA_NOREF, LUA_NOREF, false, false }
@@ -902,6 +907,7 @@ struct diffblock_S {
   linenr_T df_count[DB_COUNT];          // nr of inserted/changed lines
   bool is_linematched;  // has the linematch algorithm ran on this diff hunk to divide it into
                         // smaller diff hunks?
+  char __pad[7];
 };
 
 #define SNAP_HELP_IDX   0
@@ -915,6 +921,7 @@ struct diffblock_S {
 typedef struct tabpage_S tabpage_T;
 struct tabpage_S {
   handle_T handle;
+  char __pad[4];
   tabpage_T *tp_next;      ///< next tabpage or NULL
   frame_T *tp_topframe;    ///< topframe for the windows
   win_T *tp_curwin;        ///< current window in this Tab page
@@ -957,11 +964,12 @@ typedef struct w_line {
 // Windows are kept in a tree of frames.  Each frame has a column (FR_COL)
 // or row (FR_ROW) layout or is a leaf, which has a window.
 struct frame_S {
-  char fr_layout;               // FR_LEAF, FR_COL or FR_ROW
   int fr_width;
   int fr_newwidth;              // new width used in win_equal_rec()
   int fr_height;
   int fr_newheight;             // new height used in win_equal_rec()
+  char fr_layout;               // FR_LEAF, FR_COL or FR_ROW
+  char __pad0[7];
   frame_T *fr_parent;       // containing frame or NULL
   frame_T *fr_next;         // frame right or below in same parent, NULL
                             // for last
@@ -993,6 +1001,7 @@ typedef struct {
   colnr_T endcol;       // in win_line() points to char where HL ends
   bool is_addpos;       // position specified directly by matchaddpos()
   bool has_cursor;      // true if the cursor is inside the match, used for CurSearch
+  char __pad[6];
   proftime_T tm;        // for a time limit
 } match_T;
 

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -53,6 +53,7 @@ typedef struct {
   garray_T buffer;
   bool eof;
   bool buffered;
+  char __pad[6];
   const char *type;
 } CallbackReader;
 

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -68,7 +68,7 @@ struct Decoration {
 };
 #define DECORATION_INIT { KV_INITIAL_VALUE, KV_INITIAL_VALUE, 0, kVTEndOfLine, \
                           kHlModeUnknown, false, false, false, false, kNone, \
-                          DECOR_PRIORITY_BASE, 0, 0, NULL, 0, 0, 0, 0, 0, false }
+                          DECOR_PRIORITY_BASE, 0, 0, 0, NULL, 0, 0, 0, 0, 0, false, 0 }
 
 typedef struct {
   int start_row;

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -30,7 +30,11 @@ EXTERN const char *const hl_mode_str[] INIT(= { "", "replace", "combine", "blend
 
 #define VIRTTEXT_EMPTY ((VirtText)KV_INITIAL_VALUE)
 
-typedef kvec_t(struct virt_line { VirtText line; bool left_col; }) VirtLines;
+typedef kvec_t(struct virt_line {
+  VirtText line;
+  bool left_col;
+  char __pad[7];
+}) VirtLines;
 
 struct Decoration {
   VirtText virt_text;
@@ -48,6 +52,7 @@ struct Decoration {
   TriState spell;
   // TODO(bfredl): style, etc
   DecorPriority priority;
+  char __pad0[2];
   int col;  // fixed col value, like win_col
   int virt_text_width;  // width of virt_text
   char_u *sign_text;
@@ -59,6 +64,7 @@ struct Decoration {
   // probably want some kind of glyph cache for that..
   int conceal_char;
   bool ui_watched;  // watched for win_extmark
+  char __pad1[3];
 };
 #define DECORATION_INIT { KV_INITIAL_VALUE, KV_INITIAL_VALUE, 0, kVTEndOfLine, \
                           kHlModeUnknown, false, false, false, false, kNone, \

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -299,6 +299,7 @@ struct funccall_S {
   linenr_T breakpoint;  ///< Next line with breakpoint or zero.
   int dbg_tick;  ///< debug_tick when breakpoint was set.
   int level;  ///< Top nesting level of executed function.
+  char __pad[4];
   proftime_T prof_child;  ///< Time spent in a child.
   funccall_T *caller;  ///< Calling function or NULL; or next funccal in
                        ///< list pointed to by previous_funccal.

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -67,6 +67,7 @@ typedef struct {
     LuaRef luaref;
   } data;
   CallbackType type;
+  char __pad[4];
 } Callback;
 
 #define CALLBACK_INIT { .type = kCallbackNone }
@@ -206,6 +207,7 @@ typedef struct {
   struct { \
     typval_T di_tv;  /* Structure that holds scope dictionary itself. */ \
     uint8_t di_flags;  /* Flags. */ \
+    char __pad1[6]; \
     char_u di_key[__VA_ARGS__];  /* Key value. */ \
   }
 
@@ -247,6 +249,7 @@ struct dictvar_S {
   QUEUE watchers;         ///< Dictionary key watchers set by user code.
 
   LuaRef lua_table_ref;
+  char __pad[4];
 };
 
 /// Structure to hold info about a Blob
@@ -314,6 +317,7 @@ struct ufunc {
   int uf_flags;
   int uf_calls;         ///< nr of active calls
   bool uf_cleared;       ///< func_clear() was already called
+  char __pad0[3];
   garray_T uf_args;          ///< arguments
   garray_T uf_def_args;      ///< default argument expressions
   garray_T uf_lines;         ///< function lines
@@ -347,11 +351,12 @@ struct ufunc {
 
 struct partial_S {
   int pt_refcount;    ///< Reference count.
+  int pt_argc;        ///< Number of arguments.
   char *pt_name;      ///< Function name; when NULL use pt_func->name.
   ufunc_T *pt_func;   ///< Function pointer; when NULL lookup function with pt_name.
   bool pt_auto;       ///< When true the partial was created by using dict.member
                       ///< in handle_subscript().
-  int pt_argc;        ///< Number of arguments.
+  char __pad[7];
   typval_T *pt_argv;  ///< Arguments in allocated array.
   dict_T *pt_dict;    ///< Dict for "self".
 };

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -41,6 +41,7 @@ typedef struct loop {
   uv_async_t async;
   uv_mutex_t mutex;
   int recursive;
+  char __pad[4];
 } Loop;
 
 #define CREATE_EVENT(multiqueue, handler, argc, ...) \

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -28,8 +28,6 @@ typedef void (*stream_write_cb)(Stream *stream, void *data, int status);
 typedef void (*stream_close_cb)(Stream *stream, void *data);
 
 struct stream {
-  bool closed;
-  bool did_eof;
   union {
     uv_pipe_t pipe;
     uv_tcp_t tcp;
@@ -42,6 +40,9 @@ struct stream {
   uv_buf_t uvbuf;
   RBuffer *buffer;
   uv_file fd;
+  bool closed;
+  bool did_eof;
+  char __pad1[2];
   stream_read_cb read_cb;
   stream_write_cb write_cb;
   void *cb_data;

--- a/src/nvim/event/time.h
+++ b/src/nvim/event/time.h
@@ -14,6 +14,7 @@ struct time_watcher {
   time_cb cb, close_cb;
   MultiQueue *events;
   bool blockable;
+  char __pad[7];
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -141,6 +141,7 @@ typedef struct cmdname {
 typedef struct eslist_elem eslist_T;
 struct eslist_elem {
   int saved_emsg_silent;  // saved value of "emsg_silent"
+  char __pad[4];
   eslist_T *next;         // next element on the list
 };
 
@@ -153,6 +154,7 @@ enum {
 typedef struct {
   int cs_flags[CSTACK_LEN];         // CSF_ flags
   char cs_pending[CSTACK_LEN];      // CSTP_: what's pending in ":finally"
+  char __pad[6];
   union {
     void *csp_rv[CSTACK_LEN];       // return typeval for pending return
     void *csp_ex[CSTACK_LEN];       // exception for pending throw
@@ -162,8 +164,8 @@ typedef struct {
   int cs_idx;                       // current entry, or -1 if none
   int cs_looplevel;                 // nr of nested ":while"s and ":for"s
   int cs_trylevel;                  // nr of nested ":try"s
-  eslist_T *cs_emsg_silent_list;    // saved values of "emsg_silent"
   int cs_lflags;                    // loop flags: CSL_ flags
+  eslist_T *cs_emsg_silent_list;    // saved values of "emsg_silent"
 } cstack_T;
 #define cs_rettv       cs_pend.csp_rv
 #define cs_exception   cs_pend.csp_ex
@@ -194,8 +196,8 @@ struct exarg {
   linenr_T line2;               ///< the second line number or count
   cmd_addr_T addr_type;         ///< type of the count/range
   int flags;                    ///< extra flags after count: EXFLAG_
-  char *do_ecmd_cmd;            ///< +command arg to be used in edited file
   linenr_T do_ecmd_lnum;        ///< the line number in an edited file
+  char *do_ecmd_cmd;            ///< +command arg to be used in edited file
   int append;                   ///< true with ":w >>file" command
   int usefilter;                ///< true with ":w !command" and ":r!command"
   int amount;                   ///< number of '>' or '<' for shift command
@@ -207,6 +209,7 @@ struct exarg {
   int force_enc;                ///< ++enc= argument (index in cmd[])
   int bad_char;                 ///< BAD_KEEP, BAD_DROP or replacement byte
   int useridx;                  ///< user command index
+  char __pad[4];
   char *errmsg;                 ///< returned error message
   LineGetter getline;           ///< Function used to get the next line
   void *cookie;                 ///< argument for getline()

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -116,6 +116,7 @@ typedef enum {
 typedef struct aucmd_executable_t AucmdExecutable;
 struct aucmd_executable_t {
   AucmdExecutableType type;
+  char __pad[4];
   union {
     char *cmd;
     Callback cb;
@@ -275,17 +276,19 @@ typedef struct {
 
   int cmod_split;  ///< flags for win_split()
   int cmod_tab;  ///< > 0 when ":tab" was used
+  char __pad0[4];
   char *cmod_filter_pat;
   regmatch_T cmod_filter_regmatch;  ///< set by :filter /pat/
   bool cmod_filter_force;  ///< set for :filter!
 
+  char __pad1[3];
   int cmod_verbose;  ///< 0 if not set, > 0 to set 'verbose' to cmod_verbose - 1
 
   // values for undo_cmdmod()
   char *cmod_save_ei;  ///< saved value of 'eventignore'
   int cmod_did_sandbox;  ///< set when "sandbox" was incremented
-  long cmod_verbose_save;  ///< if 'verbose' was set: value of p_verbose plus one
   int cmod_save_msg_silent;  ///< if non-zero: saved value of msg_silent + 1
+  long cmod_verbose_save;  ///< if 'verbose' was set: value of p_verbose plus one
   int cmod_save_msg_scroll;  ///< for restoring msg_scroll
   int cmod_did_esilent;  ///< incremented when emsg_silent is
 } cmdmod_T;

--- a/src/nvim/extmark_defs.h
+++ b/src/nvim/extmark_defs.h
@@ -7,6 +7,7 @@
 typedef struct {
   char *text;
   int hl_id;
+  char __pad[4];
 } VirtTextChunk;
 
 typedef kvec_t(VirtTextChunk) VirtText;

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -45,8 +45,6 @@ enum {
 /// screen width.
 typedef struct ScreenGrid ScreenGrid;
 struct ScreenGrid {
-  handle_T handle;
-
   schar_T *chars;
   sattr_T *attrs;
   size_t *line_offset;
@@ -60,13 +58,6 @@ struct ScreenGrid {
   int rows;
   int cols;
 
-  // The state of the grid is valid. Otherwise it needs to be redrawn.
-  bool valid;
-
-  // only draw internally and don't send updates yet to the compositor or
-  // external UI.
-  bool throttled;
-
   // TODO(bfredl): maybe physical grids and "views" (i e drawing
   // specifications) should be two separate types?
   // offsets for the grid relative to another grid. Used for grids
@@ -74,6 +65,13 @@ struct ScreenGrid {
   int row_offset;
   int col_offset;
   ScreenGrid *target;
+
+  // The state of the grid is valid. Otherwise it needs to be redrawn.
+  bool valid;
+
+  // only draw internally and don't send updates yet to the compositor or
+  // external UI.
+  bool throttled;
 
   // whether the compositor should blend the grid with the background grid
   bool blending;
@@ -104,11 +102,12 @@ struct ScreenGrid {
   // compositor should momentarily ignore the grid. Used internally when
   // moving around grids etc.
   bool comp_disabled;
+
+  char __pad[3];
+  handle_T handle;
 };
 
-#define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, false, \
-                           false, 0, 0, NULL, false, true, 0, \
-                           0, 0, 0, 0, 0,  false }
+#define SCREEN_GRID_INIT { 0 }
 
 typedef struct {
   int args[3];

--- a/src/nvim/hashtab.h
+++ b/src/nvim/hashtab.h
@@ -66,6 +66,7 @@ typedef struct hashtable_S {
   size_t ht_used;               /// number of items used
   size_t ht_filled;             /// number of items used or removed
   int ht_locked;                /// counter for hash_lock()
+  char __pad[4];
   hashitem_T *ht_array;         /// points to the array, allocated when it's
                                 /// not "ht_smallarray"
   hashitem_T ht_smallarray[HT_INIT_SIZE];      /// initial array

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -73,6 +73,7 @@ typedef struct filemark {
   int fnum;             ///< File number.
   Timestamp timestamp;  ///< Time when this mark was last set.
   fmarkv_T view;  ///< View the mark was created on
+  char __pad[4];
   dict_T *additional_data;  ///< Additional data from ShaDa file.
 } fmark_T;
 

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -27,8 +27,8 @@ typedef struct {
 typedef struct {
   mtpos_t pos;
   int lvl;
-  mtnode_t *node;
   int i;
+  mtnode_t *node;
   iterstate_t s[MT_MAX_DEPTH];
 } MarkTreeIter;
 

--- a/src/nvim/memfile_defs.h
+++ b/src/nvim/memfile_defs.h
@@ -91,6 +91,7 @@ typedef struct memfile {
   char *mf_fname;                    /// name of the file
   char_u *mf_ffname;                 /// idem, full path
   int mf_fd;                         /// file descriptor
+  char __pad0[4];
   bhdr_T *mf_free_first;             /// first block header in free list
   bhdr_T *mf_used_first;             /// mru block header in used list
   bhdr_T *mf_used_last;              /// lru block header in used list
@@ -102,6 +103,7 @@ typedef struct memfile {
   blocknr_T mf_infile_count;         /// number of pages in the file
   unsigned mf_page_size;             /// number of bytes in a page
   bool mf_dirty;                     /// true if there are dirty blocks
+  char __pad1[3];
 } memfile_T;
 
 #endif  // NVIM_MEMFILE_DEFS_H

--- a/src/nvim/memline_defs.h
+++ b/src/nvim/memline_defs.h
@@ -13,10 +13,12 @@ typedef struct info_pointer {
   linenr_T ip_low;              // lowest lnum in this block
   linenr_T ip_high;             // highest lnum in this block
   int ip_index;                 // index for block with current lnum
+  char __pad[4];
 } infoptr_T;    // block/index pair
 
 typedef struct ml_chunksize {
   int mlcs_numlines;
+  char __pad[4];
   long mlcs_totalsize;
 } chunksize_T;
 
@@ -41,8 +43,6 @@ typedef struct ml_chunksize {
 ///             moves, where N is the height (typically 1-3).
 ///
 typedef struct memline {
-  linenr_T ml_line_count;       // number of lines in the buffer
-
   memfile_T *ml_mfp;          // pointer to associated memfile
 
   infoptr_T *ml_stack;        // stack of pointer blocks (array of IPTRs)
@@ -60,10 +60,12 @@ typedef struct memline {
   size_t ml_line_offset;        // cached byte offset of ml_line_lnum
   int ml_line_offset_ff;        // fileformat of cached line
 
+  linenr_T ml_line_count;       // number of lines in the buffer
   bhdr_T *ml_locked;       // block used by last ml_get
   linenr_T ml_locked_low;       // first line in ml_locked
   linenr_T ml_locked_high;      // last line in ml_locked
   int ml_locked_lineadd;        // number of lines inserted in ml_locked
+  char __pad[4];
   chunksize_T *ml_chunksize;
   int ml_numchunks;
   int ml_usedchunks;

--- a/src/nvim/normal.h
+++ b/src/nvim/normal.h
@@ -34,21 +34,22 @@ typedef struct oparg_S {
                                 // valid when motion_type is kMTCharWise)
   bool end_adjusted;            // backuped b_op_end one char (only used by
                                 // do_format())
+  bool empty;                   // op_start and op_end the same (only used by
+                                // op_change())
   pos_T start;                  // start of the operator
   pos_T end;                    // end of the operator
   pos_T cursor_start;           // cursor position before motion for "gw"
 
   long line_count;              // number of lines from op_start to op_end
                                 // (inclusive)
-  bool empty;                   // op_start and op_end the same (only used by
-                                // op_change())
-  bool is_VIsual;               // operator on Visual area
   colnr_T start_vcol;           // start col for block mode operator
   colnr_T end_vcol;             // end col for block mode operator
   long prev_opcount;            // ca.opcount saved for K_EVENT
   long prev_count0;             // ca.count0 saved for K_EVENT
   bool excl_tr_ws;              // exclude trailing whitespace for yank of a
                                 // block
+  bool is_VIsual;               // operator on Visual area
+  char __pad[6];
 } oparg_T;
 
 // Arguments for Normal mode commands.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -984,6 +984,7 @@ enum {
 /// Stores an identifier of a script or channel that last set an option.
 typedef struct {
   sctx_T script_ctx;       /// script context where the option was last set
+  char __pad[4];
   uint64_t channel_id;     /// Only used when script_id is SID_API_CLIENT.
 } LastSet;
 

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -64,6 +64,7 @@ struct regprog {
   unsigned re_engine;  ///< Automatic, backtracking or NFA engine.
   unsigned re_flags;   ///< Second argument for vim_regcomp().
   bool re_in_use;      ///< prog is being executed
+  char __pad[3];
 };
 
 // Structure used by the back track matcher.
@@ -136,6 +137,7 @@ typedef struct {
 // from 1 to zero the matches need to be freed.
 struct reg_extmatch {
   int16_t refcnt;
+  char __pad[6];
   char_u *matches[NSUBEXP];
 };
 

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -11,8 +11,9 @@
 // Sign group
 typedef struct signgroup_S {
   uint16_t sg_refcount;   // number of signs in this group
-  int sg_next_sign_id;    // next sign id for this group
   char sg_name[1];        // sign group name
+  char __pad2[1];
+  int sg_next_sign_id;    // next sign id for this group
 } signgroup_T;
 
 // Macros to get the sign group structure from the group name
@@ -26,6 +27,7 @@ struct sign_entry {
   int se_typenr;           // typenr of sign
   int se_priority;         // priority for highlighting
   bool se_has_text_or_icon;  // has text or icon
+  char __pad[7];
   linenr_T se_lnum;             // line number which has this sign
   signgroup_T *se_group;            // sign group
   sign_entry_T *se_next;             // next entry in a list of signs

--- a/src/nvim/syntax_defs.h
+++ b/src/nvim/syntax_defs.h
@@ -47,17 +47,17 @@ typedef struct buf_state {
 struct syn_state {
   synstate_T *sst_next;        // next entry in used or free list
   linenr_T sst_lnum;            // line number for this state
+  int sst_next_flags;           // flags for sst_next_list
   union {
     bufstate_T sst_stack[SST_FIX_STATES];          // short state stack
     garray_T sst_ga;            // growarray for long state stack
   } sst_union;
-  int sst_next_flags;           // flags for sst_next_list
   int sst_stacksize;            // number of states on the stack
+  linenr_T sst_change_lnum;     // when non-zero, change in this line
+                                // may have made the state invalid
   int16_t *sst_next_list;       // "nextgroup" list in this state
                                 // (this is a copy, don't free it!
   disptick_T sst_tick;          // tick when last displayed
-  linenr_T sst_change_lnum;     // when non-zero, change in this line
-                                // may have made the state invalid
 };
 
 #endif  // NVIM_SYNTAX_DEFS_H

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -76,6 +76,7 @@ struct TUIData {
   Loop *loop;
   unibi_var_t params[9];
   char buf[OUTBUF_SIZE];
+  char __pad;
   size_t bufpos;
   char norm[CNORM_COMMAND_MAX_SIZE];
   char invis[CNORM_COMMAND_MAX_SIZE];
@@ -88,18 +89,18 @@ struct TUIData {
     uv_pipe_t pipe;
   } output_handle;
   bool out_isatty;
-  SignalWatcher winch_handle, cont_handle;
   bool cont_received;
-  UGrid grid;
-  kvec_t(Rect) invalid_regions;
-  int row, col;
-  int out_fd;
   bool scroll_region_is_full_screen;
   bool can_change_scroll_region;
   bool can_set_lr_margin;  // smglr
   bool can_set_left_right_margin;
   bool can_scroll;
   bool can_erase_chars;
+  SignalWatcher winch_handle, cont_handle;
+  UGrid grid;
+  kvec_t(Rect) invalid_regions;
+  int row, col;
+  int out_fd;
   bool immediate_wrap_after_last_column;
   bool bce;
   bool mouse_enabled;
@@ -108,13 +109,14 @@ struct TUIData {
   bool cork, overflow;
   bool cursor_color_changed;
   bool is_starting;
+  bool default_attr;
+  bool can_clear_attr;
+  char __pad1[7];
   FILE *screenshot;
   cursorentry_T cursor_shapes[SHAPE_IDX_COUNT];
   HlAttrs clear_attrs;
-  kvec_t(HlAttrs) attrs;
   int print_attr_id;
-  bool default_attr;
-  bool can_clear_attr;
+  kvec_t(HlAttrs) attrs;
   ModeShape showing_mode;
   struct {
     int enable_mouse, disable_mouse;

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -52,10 +52,12 @@ struct ui_t {
   bool override;  ///< Force highest-requested UI capabilities.
   bool composed;
   bool ui_ext[kUIExtCount];  ///< Externalized UI capabilities.
+  char __pad0[3];
   int width;
   int height;
   int pum_nlines;  /// actual nr. lines shown in PUM
   bool pum_pos;  /// UI reports back pum position?
+  char __pad1[3];
   double pum_row;
   double pum_col;
   double pum_height;
@@ -72,6 +74,7 @@ struct ui_t {
 typedef struct ui_event_callback {
   LuaRef cb;
   bool ext_widgets[kUIGlobalCount];
+  char __pad[3];
 } UIEventCallback;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -25,11 +25,10 @@ struct u_entry {
   linenr_T ue_top;              // number of line above undo block
   linenr_T ue_bot;              // number of line below undo block
   linenr_T ue_lcount;           // linecount when u_save called
+  int ue_magic;                 // magic number to check allocation
+                                // Used as padding when U_DEBUG is undefined
   char **ue_array;              // array of lines in undo block
   long ue_size;                 // number of lines in ue_array
-#ifdef U_DEBUG
-  int ue_magic;                 // magic number to check allocation
-#endif
 };
 
 struct u_header {
@@ -52,21 +51,20 @@ struct u_header {
     long seq;
   } uh_alt_prev;
   long uh_seq;                  // sequence number, higher == newer undo
-  int uh_walk;                  // used by undo_time()
   u_entry_T *uh_entry;        // pointer to first entry
   u_entry_T *uh_getbot_entry;   // pointer to where ue_bot must be set
   pos_T uh_cursor;              // cursor position before saving
+  int uh_walk;                  // used by undo_time()
   long uh_cursor_vcol;
   int uh_flags;                 // see below
+  int uh_magic;                 // magic number to check allocation
+                                // Used as padding when U_DEBUG is undefined
   fmark_T uh_namedm[NMARKS];    // marks before undo/after redo
   extmark_undo_vec_t uh_extmark;  // info to move extmarks
   visualinfo_T uh_visual;       // Visual areas before undo/after redo
   time_t uh_time;               // timestamp when the change was made
   long uh_save_nr;              // set when the file was saved after the
                                 // changes in this block
-#ifdef U_DEBUG
-  int uh_magic;                 // magic number to check allocation
-#endif
 };
 
 // values for uh_flags

--- a/src/nvim/usercmd.h
+++ b/src/nvim/usercmd.h
@@ -6,15 +6,15 @@
 typedef struct ucmd {
   char *uc_name;                // The command name
   uint32_t uc_argt;             // The argument type
+  int uc_compl;                 // completion type
   char *uc_rep;                 // The command's replacement string
   long uc_def;                  // The default value for a range/count
-  int uc_compl;                 // completion type
   cmd_addr_T uc_addr_type;      // The command's address type
   sctx_T uc_script_ctx;         // SCTX where the command was defined
-  char *uc_compl_arg;           // completion argument if any
   LuaRef uc_compl_luaref;       // Reference to Lua completion function
   LuaRef uc_preview_luaref;     // Reference to Lua preview function
   LuaRef uc_luaref;             // Reference to Lua function
+  char *uc_compl_arg;           // completion argument if any
 } ucmd_T;
 
 #define UC_BUFFER       1       // -buffer: local to current buffer

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -1573,6 +1573,7 @@ typedef struct {
   size_t orig_len;  ///< Length of orininal string (e.g. 4 for "\x80").
   size_t act_len;  ///< Length of resulting character(s) (e.g. 1 for "\x80").
   bool escape_not_known;  ///< True if escape sequence in original is not known.
+  char __pad[7];
 } StringShift;
 
 /// Parse and highlight single- or double-quoted string

--- a/src/nvim/viml/parser/expressions.h
+++ b/src/nvim/viml/parser/expressions.h
@@ -143,6 +143,7 @@ typedef struct {
     struct {
       ExprVarScope scope;  ///< Scope character or 0 if not present.
       bool autoload;  ///< Has autoload characters.
+      char __pad[3];
     } var;  ///< For kExprLexPlainIdentifier
 
     struct {

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -37,6 +37,7 @@ typedef struct {
   tabpage_T *sw_curtab;
   bool sw_same_win;  ///< VIsual_active was not reset
   bool sw_visual_active;
+  char __pad[6];
 } switchwin_T;
 
 /// Execute a block of code in the context of window `wp` in tabpage `tp`.


### PR DESCRIPTION
- add compiler option `-Wpadded`
- make padding explicit.

Not sure if the trade-off is worth it here, but there are quite a few cases where simply re-ordering some fields does save us memory.