### PR TITLE
vim-patch:9.0.0882: using freed memory after SpellFileMissing autocmd uses bwipe

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -110,6 +110,7 @@
 #include "nvim/types.h"           // for char_u
 #include "nvim/undo.h"            // for u_save_cursor
 #include "nvim/vim.h"             // for curwin, strlen, STRLCPY, STRNCMP
+#include "nvim/window.h"          // for win_valid_any_tab
 
 // Result values.  Lower number is accepted over higher one.
 enum {
@@ -1965,8 +1966,8 @@ char *did_set_spelllang(win_T *wp)
       } else {
         spell_load_lang((char_u *)lang);
         // SpellFileMissing autocommands may do anything, including
-        // destroying the buffer we are using...
-        if (!bufref_valid(&bufref)) {
+        // destroying the buffer we are using or closing the window.
+        if (!bufref_valid(&bufref) || !win_valid_any_tab(wp)) {
           ret_msg = N_("E797: SpellFileMissing autocommand deleted buffer");
           goto theend;
         }

--- a/src/nvim/testdir/test_spell.vim
+++ b/src/nvim/testdir/test_spell.vim
@@ -159,6 +159,19 @@ func Test_spell_file_missing()
   %bwipe!
 endfunc
 
+func Test_spell_file_missing_bwipe()
+  " this was using a window that was wiped out in a SpellFileMissing autocmd
+  set spelllang=xy
+  au SpellFileMissing * n0
+  set spell
+  au SpellFileMissing * bw
+  snext somefile
+
+  au! SpellFileMissing
+  bwipe!
+  set nospell spelllang=en
+endfunc
+
 func Test_spelldump()
   " In case the spell file is not found avoid getting the download dialog, we
   " would get stuck at the prompt.


### PR DESCRIPTION
#### vim-patch:9.0.0882: using freed memory after SpellFileMissing autocmd uses bwipe

Problem:    Using freed memory after SpellFileMissing autocmd uses bwipe.
Solution:   Bail out if the window no longer exists.

https://github.com/vim/vim/commit/c3d27ada14acd02db357f2d16347acc22cb17e93

Co-authored-by: Bram Moolenaar <Bram@vim.org>