### PR TITLE
vim-patch:9.0.0883: a silent mapping may cause dots on the command line

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -215,6 +215,9 @@ The search string will not be echoed when using this mapping.  Messages from
 the executed command are still given though.  To shut them up too, add a
 ":silent" in the executed command: >
 	:map <silent> ,h :exe ":silent normal /Header\r"<CR>
+Note that the effect of a command might also be silenced, e.g., when the
+mapping selects another entry for command line completion it won't be
+displayed.
 Prompts will still be given, e.g., for inputdialog().
 Using "<silent>" for an abbreviation is possible, but will cause redrawing of
 the command line to fail.

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -173,7 +173,9 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
     return FAIL;
   }
 
-  if (!(ui_has(kUICmdline) || ui_has(kUIWildmenu))) {
+  // If cmd_silent is set then don't show the dots, because redrawcmd() below
+  // won't remove them.
+  if (!cmd_silent && !(ui_has(kUICmdline) || ui_has(kUIWildmenu))) {
     msg_puts("...");  // show that we are busy
     ui_flush();
   }


### PR DESCRIPTION
#### vim-patch:9.0.0883: a silent mapping may cause dots on the command line

Problem:    A silent mapping may cause dots on the command line.
Solution:   Don't show dots for completion if they are not going to be removed
            again.

https://github.com/vim/vim/commit/698a00f55d60043d51b1c98cbbf3f9fd10badd2f

Co-authored-by: Bram Moolenaar <Bram@vim.org>