### PR TITLE
refactor: convert drawline.c draw states to enum

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -53,6 +53,18 @@
 #define MB_FILLER_CHAR '<'  // character used when a double-width character
                             // doesn't fit.
 
+/// possible draw states in win_line(), drawn in sequence.
+typedef enum {
+  WL_START = 0,  // nothing done yet
+  WL_CMDLINE,    // cmdline window column
+  WL_FOLD,       // 'foldcolumn'
+  WL_SIGN,       // column for signs
+  WL_NR,         // line number
+  WL_BRI,        // 'breakindent'
+  WL_SBR,        // 'showbreak' or 'diff'
+  WL_LINE,       // text in the line
+} LineDrawState;
+
 /// for line_putchar. Contains the state that needs to be remembered from
 /// putting one character to the next.
 typedef struct {
@@ -604,16 +616,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
   int left_curline_col = 0;
   int right_curline_col = 0;
 
-  // draw_state: items that are drawn in sequence:
-#define WL_START        0               // nothing done yet
-#define WL_CMDLINE      (WL_START + 1)    // cmdline window column
-#define WL_FOLD         (WL_CMDLINE + 1)  // 'foldcolumn'
-#define WL_SIGN         (WL_FOLD + 1)     // column for signs
-#define WL_NR           (WL_SIGN + 1)     // line number
-#define WL_BRI          (WL_NR + 1)       // 'breakindent'
-#define WL_SBR          (WL_BRI + 1)      // 'showbreak' or 'diff'
-#define WL_LINE         (WL_SBR + 1)      // text in the line
-  int draw_state = WL_START;            // what to draw next
+  LineDrawState draw_state = WL_START;  // what to draw next
 
   int syntax_flags    = 0;
   int syntax_seqnr    = 0;


### PR DESCRIPTION
Minor refactor from #20621 broken out into separate PR for easier review(didn't get a response [here](https://github.com/neovim/neovim/pull/20621#discussion_r1013982297)). Need this defined at the top of the file for use outside of `win_line()`. Converted from defines to enum according to https://github.com/neovim/neovim/issues/6371.