### PR TITLE
fix(diff): fix a crash in diff mode with linematch enabled

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1891,7 +1891,7 @@ static void count_filler_lines_and_topline(int *curlinenum_to, int *linesfiller,
   const diff_T *curdif = thistopdiff;
   int ch_virtual_lines = 0;
   int isfiller = 0;
-  while (virtual_lines_passed) {
+  while (virtual_lines_passed > 0) {
     if (ch_virtual_lines) {
       virtual_lines_passed--;
       ch_virtual_lines--;


### PR DESCRIPTION
@lewis6991 

This is a fix for a segfault that I encountered while in diff mode with linematch enabled. When I had two files open side by side in diff mode and deleted all of the contents of one file, the w_topfill value, which indicates the number of filler lines at the top of the window is set to be a negative number, and it will result in the virtual_lines_passed variable also being negative, and this while loop will run when it shouldn't. While calculating where the cursor and topline should be with linematch enabled, I use this topfill value to put the cursor and top line where it should be in the other windows. I did not expect that topfill number to be set to a negative, and that causes the segfault. So this is a fix for that instance when it is set to a negative number for the top fill.