### PR TITLE
fix(api): nvim_win_set_cursor redraw cursorcolumn for non-current window

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -118,8 +118,13 @@ void nvim_win_set_cursor(Window window, ArrayOf(Integer, 2) pos, Error *err)
   // Make sure we stick in this column.
   win->w_set_curswant = true;
 
-  // make sure cursor is in visible range even if win != curwin
-  update_topline_win(win);
+  // make sure cursor is in visible range and
+  // cursorcolumn and cursorline are updated even if win != curwin
+  switchwin_T switchwin;
+  switch_win(&switchwin, win, NULL, true);
+  update_topline(curwin);
+  validate_cursor();
+  restore_win(&switchwin, true);
 
   redraw_later(win, UPD_VALID);
   win->w_redr_status = true;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -341,15 +341,6 @@ void update_topline(win_T *wp)
   *so_ptr = save_so;
 }
 
-// Update win->w_topline to move the cursor onto the screen.
-void update_topline_win(win_T *win)
-{
-  switchwin_T switchwin;
-  switch_win(&switchwin, win, NULL, true);
-  update_topline(curwin);
-  restore_win(&switchwin, true);
-}
-
 // Return the scrolljump value to use for the current window.
 // When 'scrolljump' is positive use it as-is.
 // When 'scrolljump' is negative use it as a percentage of the window height.

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -229,6 +229,46 @@ describe('API/win', function()
                                                                     |
       ]])
     end)
+
+    it('updates cursorcolumn in non-current window', function()
+      local screen = Screen.new(60, 8)
+      screen:set_default_attr_ids({
+        [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+        [2] = {background = Screen.colors.Grey90},  -- CursorColumn
+        [3] = {bold = true, reverse = true},  -- StatusLine
+        [4] = {reverse = true},  -- StatusLineNC
+      })
+      screen:attach()
+      command('set cursorcolumn')
+      insert([[
+        aaa
+        bbb
+        ccc
+        ddd]])
+      local oldwin = curwin()
+      command('vsplit')
+      screen:expect([[
+        aa{2:a}                           │aa{2:a}                          |
+        bb{2:b}                           │bb{2:b}                          |
+        cc{2:c}                           │cc{2:c}                          |
+        dd^d                           │ddd                          |
+        {1:~                             }│{1:~                            }|
+        {1:~                             }│{1:~                            }|
+        {3:[No Name] [+]                  }{4:[No Name] [+]                }|
+                                                                    |
+      ]])
+      window('set_cursor', oldwin, {2, 0})
+      screen:expect([[
+        aa{2:a}                           │{2:a}aa                          |
+        bb{2:b}                           │bbb                          |
+        cc{2:c}                           │{2:c}cc                          |
+        dd^d                           │{2:d}dd                          |
+        {1:~                             }│{1:~                            }|
+        {1:~                             }│{1:~                            }|
+        {3:[No Name] [+]                  }{4:[No Name] [+]                }|
+                                                                    |
+      ]])
+    end)
   end)
 
   describe('{get,set}_height', function()


### PR DESCRIPTION
fix #19063
this fixes the cursorcolumn not being redrawn for non-current windows in `nvim_win_set_cursor()`