### PR TITLE
ci(stale): disable remove-stale-when-updated

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,7 @@ jobs:
           days-before-stale: -1
           stale-issue-label: needs:response
           stale-pr-label: needs:response
+          remove-stale-when-updated: false
           close-issue-message: "This issue has been closed since a request for
             information has not been answered for 30 days. It can be reopened
             when the requested information is provided."


### PR DESCRIPTION
The needs:response label should only be added and removed manually, and
the action's behavior of removing the label on any activity (e.g. title
change, removing reviewers) is unwanted.
