### PR TITLE
fix: don't disable compositor widgets when a GUI with multigrid attaches

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -204,7 +204,7 @@ void ui_refresh(void)
     width = MIN(ui->width, width);
     height = MIN(ui->height, height);
     for (UIExtension j = 0; (int)j < kUIExtCount; j++) {
-      bool in_compositor = ui->composed && compositor->ui_ext[j];
+      bool in_compositor = (ui->composed || j < kUIGlobalCount) && compositor->ui_ext[j];
       ext_widgets[j] &= (ui->ui_ext[j] || in_compositor || inclusive);
     }
   }


### PR DESCRIPTION
vim.ui_attach doesnt receive cmdline and messages events in a GUI with ext_multigrid

The issue was caused by the lines below.

When a GUI enabled multigrid, it won't attach to the compositor.
https://github.com/neovim/neovim/blob/c404f9b4baf57b946d4dd8d00fce5225e2b5131b/src/nvim/ui.c#L352

Which means that on the line below, the ext will be disabled, since `ui->composed == false`.
https://github.com/neovim/neovim/blob/c404f9b4baf57b946d4dd8d00fce5225e2b5131b/src/nvim/ui.c#L207

This PR fixes it.

Fixes #21068