### PR TITLE
ci(windows): set $PSNativeCommandArgumentPassing = 'Legacy'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,8 @@ jobs:
 
       - name: Install test deps
         run: |
+          $PSNativeCommandArgumentPassing = 'Legacy'
+
           & build\bin\nvim.exe "--version"
 
           # Ensure that the "win32" feature is set.


### PR DESCRIPTION
Ref https://github.com/actions/runner-images/issues/6586

Some runners are using new images, while some others are using old
image. This is the only way I can find that makes it work on both.