### PR TITLE
vim-patch:8.2.1260: there is no good test for CursorHold

### DIFF
--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -4,6 +4,7 @@ source shared.vim
 source check.vim
 source term_util.vim
 source screendump.vim
+source load.vim
 
 func s:cleanup_buffers() abort
   for bnr in range(1, bufnr('$'))
@@ -20,8 +21,36 @@ func Test_vim_did_enter()
   " becomes one.
 endfunc
 
+" Test for the CursorHold autocmd
+func Test_CursorHold_autocmd()
+  CheckRunVimInTerminal
+  call writefile(['one', 'two', 'three'], 'Xfile')
+  let before =<< trim END
+    set updatetime=10
+    au CursorHold * call writefile([line('.')], 'Xoutput', 'a')
+  END
+  call writefile(before, 'Xinit')
+  let buf = RunVimInTerminal('-S Xinit Xfile', {})
+  call term_wait(buf)
+  call term_sendkeys(buf, "gg")
+  call term_wait(buf)
+  sleep 50m
+  call term_sendkeys(buf, "j")
+  call term_wait(buf)
+  sleep 50m
+  call term_sendkeys(buf, "j")
+  call term_wait(buf)
+  sleep 50m
+  call StopVimInTerminal(buf)
+
+  call assert_equal(['1', '2', '3'], readfile('Xoutput')[-3:-1])
+
+  call delete('Xinit')
+  call delete('Xoutput')
+  call delete('Xfile')
+endfunc
+
 if has('timers')
-  source load.vim
 
   func ExitInsertMode(id)
     call feedkeys("\<Esc>")

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -67,15 +67,6 @@ func Test_bunload_with_offset()
   call assert_fails('1,4bunload', 'E16:')
   call assert_fails(',100bunload', 'E16:')
 
-  " Use a try-catch for this test. When assert_fails() is used for this
-  " test, the command fails with E515: instead of E90:
-  let caught_E90 = 0
-  try
-    $bunload
-  catch /E90:/
-    let caught_E90 = 1
-  endtry
-  call assert_equal(1, caught_E90)
   call assert_fails('$bunload', 'E90:')
 endfunc
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -3001,24 +3001,6 @@ func Test_normal47_visual_buf_wipe()
   set nomodified
 endfunc
 
-func Test_normal47_autocmd()
-  " disabled, does not seem to be possible currently
-  throw "Skipped: not possible to test cursorhold autocmd while waiting for input in normal_cmd"
-  new
-  call append(0, repeat('-',20))
-  au CursorHold * call feedkeys('2l', '')
-  1
-  set updatetime=20
-  " should delete 12 chars (d12l)
-  call feedkeys('d1', '!')
-  call assert_equal('--------', getline(1))
-
-  " clean up
-  au! CursorHold
-  set updatetime=4000
-  bw!
-endfunc
-
 func Test_normal48_wincmd()
   new
   exe "norm! \<c-w>c"


### PR DESCRIPTION
#### vim-patch:8.2.1260: there is no good test for CursorHold

Problem:    There is no good test for CursorHold.
Solution:   Add a test.  Remove duplicated test. (Yegappan Lakshmanan,
            closes vim/vim#6503

https://github.com/vim/vim/commit/7591116acffc45b5880c49244646651badac1629