### PR TITLE
vim-patch:8.2.{2586,2587,2589}: process id may be invalid

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -90,6 +90,14 @@ func CheckUnix()
   endif
 endfunc
 
+" Command to check for running on Linux
+command CheckLinux call CheckLinux()
+func CheckLinux()
+  if !has('linux')
+    throw 'Skipped: only works on Linux'
+  endif
+endfunc
+
 " Command to check that making screendumps is supported.
 " Caller must source screendump.vim
 command CheckScreendump call CheckScreendump()

--- a/src/nvim/testdir/runtest.vim
+++ b/src/nvim/testdir/runtest.vim
@@ -174,7 +174,12 @@ func RunTheTest(test)
   if a:test =~ 'Test_nocatch_'
     " Function handles errors itself.  This avoids skipping commands after the
     " error.
+    let g:skipped_reason = ''
     exe 'call ' . a:test
+    if g:skipped_reason != ''
+      call add(s:messages, '    Skipped')
+      call add(s:skipped, 'SKIPPED ' . a:test . ': ' . g:skipped_reason)
+    endif
   else
     try
       let s:test = a:test

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -1,5 +1,7 @@
 " Test :recover
 
+source check.vim
+
 func Test_recover_root_dir()
   " This used to access invalid memory.
   split Xtest
@@ -23,6 +25,21 @@ func Test_recover_root_dir()
   set dir&
 endfunc
 
+" Make a copy of the current swap file to "Xswap".
+" Return the name of the swap file.
+func CopySwapfile()
+  preserve
+  " get the name of the swap file
+  let swname = split(execute("swapname"))[0]
+  let swname = substitute(swname, '[[:blank:][:cntrl:]]*\(.\{-}\)[[:blank:][:cntrl:]]*$', '\1', '')
+  " make a copy of the swap file in Xswap
+  set binary
+  exe 'sp ' . swname
+  w! Xswap
+  set nobinary
+  return swname
+endfunc
+
 " Inserts 10000 lines with text to fill the swap file with two levels of pointer
 " blocks.  Then recovers from the swap file and checks all text is restored.
 "
@@ -40,15 +57,9 @@ func Test_swap_file()
     let i += 1
   endwhile
   $delete
-  preserve
-  " get the name of the swap file
-  let swname = split(execute("swapname"))[0]
-  let swname = substitute(swname, '[[:blank:][:cntrl:]]*\(.\{-}\)[[:blank:][:cntrl:]]*$', '\1', '')
-  " make a copy of the swap file in Xswap
-  set binary
-  exe 'sp ' . swname
-  w! Xswap
-  set nobinary
+
+  let swname = CopySwapfile()
+
   new
   only!
   bwipe! Xtest
@@ -69,3 +80,53 @@ func Test_swap_file()
   set undolevels&
   enew! | only
 endfunc
+
+func Test_nocatch_process_still_running()
+  " assume Unix means sysinfo.uptime can be used
+  CheckUnix
+  CheckNotGui
+
+  " don't intercept existing swap file here
+  au! SwapExists
+
+  " Edit a file and grab its swapfile.
+  edit Xswaptest
+  call setline(1, ['a', 'b', 'c'])
+  let swname = CopySwapfile()
+
+  " Forget we edited this file
+  new
+  only!
+  bwipe! Xswaptest
+
+  call rename('Xswap', swname)
+  call feedkeys('e', 'tL')
+  redir => editOutput
+  edit Xswaptest
+  redir END
+  call assert_match('E325: ATTENTION', editOutput)
+  call assert_match('file name: .*Xswaptest', editOutput)
+  call assert_match('process ID: \d* (STILL RUNNING)', editOutput)
+
+  " Forget we edited this file
+  new
+  only!
+  bwipe! Xswaptest
+
+  " pretend we rebooted
+  call test_override("uptime", 0)
+  sleep 1
+
+  call rename('Xswap', swname)
+  call feedkeys('e', 'tL')
+  redir => editOutput
+  edit Xswaptest
+  redir END
+  call assert_match('E325: ATTENTION', editOutput)
+  call assert_notmatch('(STILL RUNNING)', editOutput)
+
+  call test_override("ALL", 0)
+  call delete(swname)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -82,8 +82,9 @@ func Test_swap_file()
 endfunc
 
 func Test_nocatch_process_still_running()
-  " assume Unix means sysinfo.uptime can be used
-  CheckUnix
+  " sysinfo.uptime probably only works on Linux
+  CheckLinux
+  " the GUI dialog can't be handled
   CheckNotGui
 
   " don't intercept existing swap file here

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -82,10 +82,18 @@ func Test_swap_file()
 endfunc
 
 func Test_nocatch_process_still_running()
+  let g:skipped_reason = 'test_override() is N/A'
+  return
   " sysinfo.uptime probably only works on Linux
-  CheckLinux
+  if !has('linux')
+    let g:skipped_reason = 'only works on Linux'
+    return
+  endif
   " the GUI dialog can't be handled
-  CheckNotGui
+  if has('gui_running')
+    let g:skipped_reason = 'only works in the terminal'
+    return
+  endif
 
   " don't intercept existing swap file here
   au! SwapExists


### PR DESCRIPTION
#### vim-patch:8.2.2586: process id may be invalid

Problem:    Process id may be invalid.
Solution:   Use sysinfo.uptime to check for recent reboot. (suggested by Hugo
            van der Sanden)

https://github.com/vim/vim/commit/f52f0606ed9ea19bcfc3a8343af9958f2d99eaf7

test_override() is N/A.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2587: recover test fails on FreeBSD

Problem:    Recover test fails on FreeBSD.
Solution:   Check for Linux.

https://github.com/vim/vim/commit/6635ae1437e6e343c0514524a8dfb19d9525b908

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2589: recover test hangs in the GUI

Problem:    Recover test hangs in the GUI.
Solution:   Add g:skipped_reason to skip a _nocatch_ test.

https://github.com/vim/vim/commit/776b954622b45125dfdcb4a61243ca90956b0825

Now always skip the test as test_override() is N/A.

Co-authored-by: Bram Moolenaar <Bram@vim.org>