### PR TITLE
vim-patch:8.2.{2945,2952,2960,2973,2981,3080,3103,3440,3498},9.0.0895: recover tests

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -131,7 +131,8 @@ struct data_block {
   unsigned db_free;             // free space available
   unsigned db_txt_start;        // byte where text starts
   unsigned db_txt_end;          // byte just after data block
-  linenr_T db_line_count;       // number of lines in this block
+  // linenr_T db_line_count;
+  long db_line_count;           // number of lines in this block
   unsigned db_index[1];         // index for start of line (actually bigger)
                                 // followed by empty space up to db_txt_start
                                 // followed by the text in the lines until

--- a/src/nvim/testdir/test_diffmode.vim
+++ b/src/nvim/testdir/test_diffmode.vim
@@ -243,6 +243,36 @@ func Test_diffput_two()
   bwipe! b
 endfunc
 
+" Test for :diffget/:diffput with a range that is inside a diff chunk
+func Test_diffget_diffput_range()
+  call setline(1, range(1, 10))
+  new
+  call setline(1, range(11, 20))
+  windo diffthis
+  3,5diffget
+  call assert_equal(['13', '14', '15'], getline(3, 5))
+  call setline(1, range(1, 10))
+  4,8diffput
+  wincmd p
+  call assert_equal(['13', '4', '5', '6', '7', '8', '19'], getline(3, 9))
+  %bw!
+endfunc
+
+" Test for :diffget/:diffput with an empty buffer and a non-empty buffer
+func Test_diffget_diffput_empty_buffer()
+  %d _
+  new
+  call setline(1, 'one')
+  windo diffthis
+  diffget
+  call assert_equal(['one'], getline(1, '$'))
+  %d _
+  diffput
+  wincmd p
+  call assert_equal([''], getline(1, '$'))
+  %bw!
+endfunc
+
 " :diffput and :diffget completes names of buffers which
 " are in diff mode and which are different then current buffer.
 " No completion when the current window is not in diff mode.
@@ -645,7 +675,11 @@ func Test_diffexpr()
   call assert_equal(normattr, screenattr(1, 1))
   call assert_equal(normattr, screenattr(2, 1))
   call assert_notequal(normattr, screenattr(3, 1))
+  diffoff!
 
+  " Try using an non-existing function for 'diffexpr'.
+  set diffexpr=NewDiffFunc()
+  call assert_fails('windo diffthis', ['E117:', 'E97:'])
   diffoff!
   %bwipe!
   set diffexpr& diffopt&
@@ -1316,6 +1350,89 @@ func Test_diff_filler_cursorcolumn()
   call delete('Xtest_diff_cuc')
 endfunc
 
+" Test for adding/removing lines inside diff chunks, between diff chunks
+" and before diff chunks
+func Test_diff_modify_chunks()
+  enew!
+  let w2_id = win_getid()
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  new
+  let w1_id = win_getid()
+  call setline(1, ['a', '2', '3', 'd', 'e', 'f', '7', '8', 'i'])
+  windo diffthis
+
+  " remove a line between two diff chunks and create a new diff chunk
+  call win_gotoid(w2_id)
+  5d
+  call win_gotoid(w1_id)
+  call diff_hlID(5, 1)->synIDattr('name')->assert_equal('DiffAdd')
+
+  " add a line between two diff chunks
+  call win_gotoid(w2_id)
+  normal! 4Goe
+  call win_gotoid(w1_id)
+  call diff_hlID(4, 1)->synIDattr('name')->assert_equal('')
+  call diff_hlID(5, 1)->synIDattr('name')->assert_equal('')
+
+  " remove all the lines in a diff chunk.
+  call win_gotoid(w2_id)
+  7,8d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', 'DiffText', 'DiffText', '', '', '', 'DiffAdd',
+        \ 'DiffAdd', ''], hl)
+
+  " remove lines from one diff chunk to just before the next diff chunk
+  call win_gotoid(w2_id)
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  2,6d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', 'DiffText', 'DiffText', 'DiffAdd', 'DiffAdd',
+        \ 'DiffAdd', 'DiffAdd', 'DiffAdd', ''], hl)
+
+  " remove lines just before the top of a diff chunk
+  call win_gotoid(w2_id)
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  5,6d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', 'DiffText', 'DiffText', '', 'DiffText', 'DiffText',
+        \ 'DiffAdd', 'DiffAdd', ''], hl)
+
+  " remove line after the end of a diff chunk
+  call win_gotoid(w2_id)
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  4d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', 'DiffText', 'DiffText', 'DiffAdd', '', '', 'DiffText',
+        \ 'DiffText', ''], hl)
+
+  " remove lines starting from the end of one diff chunk and ending inside
+  " another diff chunk
+  call win_gotoid(w2_id)
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  4,7d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', 'DiffText', 'DiffText', 'DiffText', 'DiffAdd',
+        \ 'DiffAdd', 'DiffAdd', 'DiffAdd', ''], hl)
+
+  " removing the only remaining diff chunk should make the files equal
+  call win_gotoid(w2_id)
+  call setline(1, ['a', '2', '3', 'x', 'd', 'e', 'f', 'x', '7', '8', 'i'])
+  8d
+  let hl = range(1, 10)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', '', '', 'DiffAdd', '', '', '', '', '', ''], hl)
+  call win_gotoid(w2_id)
+  4d
+  call win_gotoid(w1_id)
+  let hl = range(1, 9)->map({_, lnum -> diff_hlID(lnum, 1)->synIDattr('name')})
+  call assert_equal(['', '', '', '', '', '', '', '', ''], hl)
+
+  %bw!
+endfunc
 
 func Test_diff_binary()
   CheckScreendump

--- a/src/nvim/testdir/test_excmd.vim
+++ b/src/nvim/testdir/test_excmd.vim
@@ -78,6 +78,14 @@ func Test_file_cmd()
   call assert_fails('3file', 'E474:')
   call assert_fails('0,0file', 'E474:')
   call assert_fails('0file abc', 'E474:')
+  if !has('win32')
+    " Change the name of the buffer to the same name
+    new Xfile1
+    file Xfile1
+    call assert_equal('Xfile1', @%)
+    call assert_equal('Xfile1', @#)
+    bw!
+  endif
 endfunc
 
 " Test for the :drop command

--- a/src/nvim/testdir/test_prompt_buffer.vim
+++ b/src/nvim/testdir/test_prompt_buffer.vim
@@ -180,6 +180,8 @@ func Test_prompt_buffer_edit()
   call assert_beeps('normal! S')
   call assert_beeps("normal! \<C-A>")
   call assert_beeps("normal! \<C-X>")
+  call assert_beeps("normal! dp")
+  call assert_beeps("normal! do")
   " pressing CTRL-W in the prompt buffer should trigger the window commands
   call assert_equal(1, winnr())
   exe "normal A\<C-W>\<C-W>"

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -213,9 +213,11 @@ func Test_recover_corrupted_swap_file()
   " Not all fields are written in a system-independent manner.  Detect whether
   " the test is running on a little or big-endian system, so the correct
   " corruption values can be set.
-  let little_endian = b[1008:1011] == 0z33323130
-  " The swap file header fields can be either 32-bit or 64-bit.
-  let system_64bit = b[1012:1015] == 0z00000000
+  " The B0_MAGIC_LONG field may be 32-bit or 64-bit, depending on the system,
+  " even though the value stored is only 32-bits.  Therefore, need to check
+  " both the high and low 32-bits to compute these values.
+  let little_endian = (b[1008:1011] == 0z33323130) || (b[1012:1015] == 0z33323130)
+  let system_64bit = little_endian ? (b[1012:1015] == 0z00000000) : (b[1008:1011] == 0z00000000)
 
   " clear the B0_MAGIC_LONG field
   if system_64bit

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -126,7 +126,6 @@ func Test_nocatch_process_still_running()
   call test_override("uptime", 0)
   sleep 1
 
-  call rename('Xswap', swname)
   call feedkeys('e', 'tL')
   redir => editOutput
   edit Xswaptest
@@ -332,6 +331,7 @@ endfunc
 
 " Test for :recover using an encrypted swap file
 func Test_recover_encrypted_swap_file()
+  CheckFeature cryptv
   CheckUnix
 
   " Recover an encrypted file from the swap file without the original file

--- a/src/nvim/testdir/test_recover.vim
+++ b/src/nvim/testdir/test_recover.vim
@@ -175,6 +175,12 @@ func Test_recover_empty_swap_file()
   call assert_match('Unable to read block 0 from .Xfile1.swp', msg)
   call assert_equal('Xfile1', @%)
   bw!
+
+  " make sure there are no old swap files laying around
+  for f in glob('.sw?', 0, 1)
+    call delete(f)
+  endfor
+
   " :recover from an empty buffer
   call assert_fails('recover', 'E305:')
   call delete('.Xfile1.swp')

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -504,18 +504,18 @@ endfunc
 " Test for renaming a buffer when the swap file is deleted out-of-band
 func Test_missing_swap_file()
   CheckUnix
-  new Xfile1
+  new Xfile2
   call delete(swapname(''))
-  call assert_fails('file Xfile2', 'E301:')
-  call assert_equal('Xfile2', bufname())
-  call assert_true(bufexists('Xfile1'))
+  call assert_fails('file Xfile3', 'E301:')
+  call assert_equal('Xfile3', bufname())
   call assert_true(bufexists('Xfile2'))
+  call assert_true(bufexists('Xfile3'))
   %bw!
 endfunc
 
 " Test for :preserve command
 func Test_preserve()
-  new Xfile1
+  new Xfile4
   setlocal noswapfile
   call assert_fails('preserve', 'E313:')
   bw!
@@ -523,8 +523,8 @@ endfunc
 
 " Test for the v:swapchoice variable
 func Test_swapchoice()
-  call writefile(['aaa', 'bbb'], 'Xfile1')
-  edit Xfile1
+  call writefile(['aaa', 'bbb'], 'Xfile5')
+  edit Xfile5
   preserve
   let swapfname = swapname('')
   let b = readblob(swapfname)
@@ -538,7 +538,7 @@ func Test_swapchoice()
     autocmd!
     autocmd SwapExists * let v:swapchoice = 'o'
   augroup END
-  edit Xfile1
+  edit Xfile5
   call assert_true(&readonly)
   call assert_equal(['aaa', 'bbb'], getline(1, '$'))
   %bw!
@@ -550,11 +550,11 @@ func Test_swapchoice()
     autocmd SwapExists * let v:swapchoice = 'a'
   augroup END
   try
-    edit Xfile1
+    edit Xfile5
   catch /^Vim:Interrupt$/
   endtry
   call assert_equal('', @%)
-  call assert_true(bufexists('Xfile1'))
+  call assert_true(bufexists('Xfile5'))
   %bw!
   call assert_true(filereadable(swapfname))
 
@@ -563,12 +563,12 @@ func Test_swapchoice()
     autocmd!
     autocmd SwapExists * let v:swapchoice = 'd'
   augroup END
-  edit Xfile1
-  call assert_equal('Xfile1', @%)
+  edit Xfile5
+  call assert_equal('Xfile5', @%)
   %bw!
   call assert_false(filereadable(swapfname))
 
-  call delete('Xfile1')
+  call delete('Xfile5')
   call delete(swapfname)
   augroup test_swapchoice
     autocmd!

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -505,7 +505,7 @@ endfunc
 func Test_missing_swap_file()
   CheckUnix
   new Xfile1
-  call delete('.Xfile1.swp')
+  call delete(swapname(''))
   call assert_fails('file Xfile2', 'E301:')
   call assert_equal('Xfile2', bufname())
   call assert_true(bufexists('Xfile1'))


### PR DESCRIPTION
#### vim-patch:8.2.2945: some buffer related code is not tested

Problem:    Some buffer related code is not tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8320)

https://github.com/vim/vim/commit/59b262362f26b3aaea1eeb0078adc33eed59863e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.2952: recover test fails on big endian systems

Problem:    Recover test fails on big endian systems.
Solution:   Disable the failing test on big endian systems. (Yegappan
            Lakshmanan, closes vim/vim#8335)

https://github.com/vim/vim/commit/99285550a9957e2c8669f183557944c6513c4875

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.2960: swap file recovery not sufficiently tested

Problem:    Swap file recovery not sufficiently tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8339)

https://github.com/vim/vim/commit/8cf02e5cf8fb14a5009f12e7af0a47617a0ce88d

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.2973: fix for recovery and diff mode not tested

Problem:    Fix for recovery and diff mode not tested.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8352)

https://github.com/vim/vim/commit/3044324e8dccd470bd854cf7d9457232cc9c220e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.2981: recovery test is not run on big-endian systems

Problem:    Recovery test is not run on big-endian systems.
Solution:   Make it work on big-endian systems. (James McCoy, closes vim/vim#8368)

https://github.com/vim/vim/commit/6654ca702ca64c99965efcad3243ea5f95473252

Co-authored-by: James McCoy <jamessan@jamessan.com>


#### vim-patch:8.2.3080: recover test fails on 32bit systems

Problem:    Recover test fails on 32bit systems. (Ondřej Súkup)
Solution:   Detect 32/64 bit systems. (Yegappan Lakshmanan, closes vim/vim#8485)

https://github.com/vim/vim/commit/576cb75ceb38ed077938d4a1c1265095050f6105

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.3103: swap test may fail on some systems

Problem:    Swap test may fail on some systems when jobs take longer to exit.
Solution:   Use different file names.

https://github.com/vim/vim/commit/f33cae605064c8bdb908a8069d936f752572cd76

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3440: recover test fails if there is an old swap file

Problem:    Recover test fails if there is an old swap file.
Solution:   Delete old swap files.

https://github.com/vim/vim/commit/f2a8bafa4b815e5b4e50a25c2b3a8a24fbe8aa11

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3498: recover test may fail on some systems

Problem:    Recover test may fail on some systems.
Solution:   Adjust the little endian and 64 bit detection. (James McCoy,
            closes vim/vim#8941)

https://github.com/vim/vim/commit/37f341d7236ff8a1e886bbb0f0ba0700ad589373

Co-authored-by: James McCoy <jamessan@jamessan.com>


#### vim-patch:9.0.0895: file renamed twice in test, missing feature check

Problem:    File renamed twice in test; missing feature check.
Solution:   Remove a rename() call.  Add check for cryptv feature.
            (closes vim/vim#11564)

https://github.com/vim/vim/commit/780154bf7a07813e474105837c2b5998009d9c71