### PR TITLE
vim-patch:8.2.{4553,4562}: linear tag search is not optimal

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1609,7 +1609,6 @@ static tags_read_status_T findtags_get_next_line(findtags_state_T *st, tagsearch
 
     // skip empty and blank lines
     do {
-      sinfo_p->curr_offset = vim_ftell(st->fp);
       eof = vim_fgets((char_u *)st->lbuf, st->lbuf_size, st->fp);
     } while (!eof && vim_isblankline(st->lbuf));
 
@@ -2161,7 +2160,7 @@ line_read_in:
       xfree(st->lbuf);
       st->lbuf = xmalloc((size_t)st->lbuf_size);
 
-      if (st->state == TS_STEP_FORWARD) {
+      if (st->state == TS_STEP_FORWARD || st->state == TS_LINEAR) {
         // Seek to the same position to read the same line again
         vim_ignored = vim_fseek(st->fp, search_info.curr_offset, SEEK_SET);
       }

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -264,8 +264,15 @@ func Test_tag_complete_with_overlong_line()
   call writefile(tagslines, 'Xtags')
   set tags=Xtags
 
+  " try with binary search
+  set tagbsearch
   call feedkeys(":tag inbou\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"tag inboundGSV inboundGovernor inboundGovernorCounters', @:)
+  " try with linear search
+  set notagbsearch
+  call feedkeys(":tag inbou\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"tag inboundGSV inboundGovernor inboundGovernorCounters', @:)
+  set tagbsearch&
 
   call delete('Xtags')
   set tags&


### PR DESCRIPTION
#### vim-patch:8.2.4553: linear tag search is a bit slow

Problem:    Linear tag search is a bit slow.
Solution:   Remove a vim_ftell() call. (Yegappan Lakshmanan, closes vim/vim#9937)

https://github.com/vim/vim/commit/8b530b3158cbd3aee2ad9cad8e7b7964faabb51e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.4562: linear tag search is not optimal

Problem:    Linear tag search is not optimal.
Solution:   Improve linear tag search performance. (Yegappan Lakshmanan,
            closes vim/vim#9944)

https://github.com/vim/vim/commit/b29b96806f1472371fb3cc01d48394e00b95cfc8

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>