### PR TITLE
vim-patch:8.2.{0450,0469}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -90,6 +90,7 @@
 #define DICT_MAXNEST 100        // maximum nesting of lists and dicts
 
 static char *e_missbrac = N_("E111: Missing ']'");
+static char *e_list_end = N_("E697: Missing end of List ']': %s");
 static char *e_dictrange = N_("E719: Cannot use [:] with a Dictionary");
 static char *e_nowhitespace
   = N_("E274: No white space allowed before parenthesis");
@@ -4035,7 +4036,7 @@ static int get_list_tv(char **arg, typval_T *rettv, int evaluate)
   }
 
   if (**arg != ']') {
-    semsg(_("E697: Missing end of List ']': %s"), *arg);
+    semsg(_(e_list_end), *arg);
 failret:
     if (evaluate) {
       tv_list_free(l);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -297,6 +297,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, bool evaluate)
   e = (char_u *)(*arg);
   *arg = skipwhite(*arg);
   if (**arg != '}') {
+    semsg(_("E451: Expected }: %s"), *arg);
     goto errret;
   }
   (*arg)++;

--- a/src/nvim/testdir/test_lambda.vim
+++ b/src/nvim/testdir/test_lambda.vim
@@ -62,7 +62,7 @@ endfunc
 function Test_lambda_fails()
   call assert_equal(3, {a, b -> a + b}(1, 2))
   call assert_fails('echo {a, a -> a + a}(1, 2)', 'E853:')
-  call assert_fails('echo {a, b -> a + b)}(1, 2)', 'E15:')
+  call assert_fails('echo {a, b -> a + b)}(1, 2)', 'E451:')
   echo assert_fails('echo 10->{a -> a + 2}', 'E107:')
 endfunc
 

--- a/src/nvim/testdir/test_method.vim
+++ b/src/nvim/testdir/test_method.vim
@@ -153,6 +153,22 @@ endfunc
 
 func Test_method_not_supported()
   call assert_fails('eval 123->changenr()', 'E276:')
+  call assert_fails('echo "abc"->invalidfunc()', 'E117:')
+  " Test for too many or too few arguments to a method
+  call assert_fails('let n="abc"->len(2)', 'E118:')
+  call assert_fails('let n=10->setwinvar()', 'E119:')
 endfunc
 
-" vim: shiftwidth=2 sts=2 expandtab
+" Test for passing optional arguments to methods
+func Test_method_args()
+  let v:errors = []
+  let n = 10->assert_inrange(1, 5, "Test_assert_inrange")
+  if v:errors[0] !~ 'Test_assert_inrange'
+    call assert_report(v:errors[0])
+  else
+    " Test passed
+    let v:errors = []
+  endif
+endfunc
+
+" vim: ts=8 sw=2 sts=2 expandtab tw=80 fdm=marker


### PR DESCRIPTION
#### vim-patch:8.2.0450: not enough testing for restricted mode and function calls

Problem:    Not enough testing for restricted mode and function calls.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5847)

https://github.com/vim/vim/commit/7d941ee032c02a4b682201881eb5c1f1958f17ee


#### vim-patch:8.2.0469: Vim9: no error for missing ] after list

Problem:    Vim9: no error for missing ] after list.
Solution:   Add error message. Add more tests.

https://github.com/vim/vim/commit/ee619e5bc0992e818f2d9540b093b769b9c27651

Co-authored-by: Bram Moolenaar <Bram@vim.org>