### PR TITLE
vim-patch:partial:d13166e788fc

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2698,6 +2698,8 @@ text...
 			Unlock the internal variable {name}.  Does the
 			opposite of |:lockvar|.
 
+			No error is given if {name} does not exist.
+
 :if {expr1}			*:if* *:end* *:endif* *:en* *E171* *E579* *E580*
 :en[dif]		Execute the commands until the next matching `:else`
 			or `:endif` if {expr1} evaluates to non-zero.

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -355,6 +355,20 @@ TermdebugStopPost		After debugging has ended, gdb-related windows
 				the state before the debugging was restored.
 
 
+Customizing ~
+				*termdebug-customizing* *g:termdebug_config*
+In the past several global variables were used for configuration.  These are
+deprecated and using the g:termdebug_config dictionary is preferred.  When
+g:termdebug_config exists the other global variables will NOT be used.
+The recommended way is to start with an empty dictionary: >
+	let g:termdebug_config = {}
+
+Then you can add entries to the dictionary as mentioned below.  The
+deprecated global variable names are mentioned for completeness.  If you are
+switching over to using g:termdebug_config you can find the old variable name
+and take over the value, then delete the deprecated variable.
+
+
 Prompt mode ~
 						*termdebug-prompt*
 When on MS-Windows, gdb will run in a buffer with 'buftype' set to "prompt".
@@ -368,13 +382,13 @@ This works slightly differently:
 						*termdebug_use_prompt*
 Prompt mode can be used with: >
 	let g:termdebug_config['use_prompt'] = 1
-Or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebug_use_prompt = 1
 <
 						*termdebug_map_K*
 The K key is normally mapped to :Evaluate. If you do not want this use: >
 	let g:termdebug_config['map_K'] = 0
-Or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebug_map_K = 0
 <
 						*termdebug_disasm_window*
@@ -382,7 +396,7 @@ If you want the Asm window shown by default, set the flag to 1.
 the "disasm_window_height" entry can be used to set the window height: >
 	let g:termdebug_config['disasm_window'] = 1
 	let g:termdebug_config['disasm_window_height'] = 15
-or, if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebug_disasm_window = 15
 Any value greater than 1 will set the Asm window height to that value.
 
@@ -400,25 +414,18 @@ interrupt the running program.  But after using the MI command
 communication channel.
 
 
-Customizing ~
-				*termdebug-customizing* *g:termdebug_config*
-In the past several global variables were used for configuration.  These are
-deprecated, using the g:termdebug_config dictionary is preferred.  When
-g:termdebug_config exists the other global variables will not be used.
-
-
 GDB command ~
 							*g:termdebugger*
 To change the name of the gdb command, set "debugger" entry in
 g:termdebug_config or the "g:termdebugger" variable before invoking
 `:Termdebug`: >
 	let g:termdebug_config['command'] = "mygdb"
-Or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebugger = "mygdb"
 
 If the command needs an argument use a List: >
 	let g:termdebug_config['command'] = ['rr', 'replay', '--']
-Or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebugger = ['rr', 'replay', '--']
 
 To not use neovim floating windows for previewing variable evaluation, set the
@@ -451,7 +458,7 @@ Then your gdb is too old.
 
 
 Colors ~
-						*hl-debugPC* *hl-debugBreakpoint*
+					*hl-debugPC* *hl-debugBreakpoint*
 The color of the signs can be adjusted with these highlight groups:
 - debugPC		the current position
 - debugBreakpoint	a breakpoint
@@ -467,7 +474,6 @@ When 'background' is "dark":
 
 Shortcuts ~
 							*termdebug_shortcuts*
-
 You can define your own shortcuts (mappings) to control gdb, that can work in
 any window, using the TermDebugSendCommand() function.  Example: >
 	map ,w :call TermDebugSendCommand('where')<CR>
@@ -476,7 +482,6 @@ The argument is the gdb command.
 
 Popup menu ~
 							*termdebug_popup*
-
 By default the Termdebug plugin sets 'mousemodel' to "popup_setpos" and adds
 these entries to the popup menu:
 	Set breakpoint		`:Break`
@@ -484,17 +489,16 @@ these entries to the popup menu:
 	Evaluate		`:Evaluate`
 If you don't want this then disable it with: >
 	let g:termdebug_config['popup'] = 0
-or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebug_popup = 0
 
 
 Vim window width ~
 							*termdebug_wide*
-
 To change the width of the Vim window when debugging starts and use a vertical
 split: >
 	let g:termdebug_config['wide'] = 163
-Or if there is no g:termdebug_config: >
+If there is no g:termdebug_config you can use: >
 	let g:termdebug_wide = 163
 
 This will set 'columns' to 163 when `:Termdebug` is used.  The value is

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1854,6 +1854,16 @@ following two lines to the syntax coloring file for that language
 Now you just need to make sure that you add all regions that contain
 the preprocessor language to the cluster htmlPreproc.
 
+							*html-folding*
+The HTML syntax file provides syntax |folding| (see |:syn-fold|) between start
+and end tags.  This can be turned on by >
+
+	:let g:html_syntax_folding = 1
+	:set foldmethod=syntax
+
+Note: Syntax folding might slow down syntax highlighting significantly,
+especially for large files.
+
 
 HTML/OS (by Aestiva)				*htmlos.vim* *ft-htmlos-syntax*
 

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Max Ischenko <mfi@ukr.net>
 " Contributor:		Dorai Sitaram <ds26@gte.com>
 "			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
-" Last Change:		2022 Oct 15
+" Last Change:		2022 Nov 16
 
 if exists("b:did_ftplugin")
   finish
@@ -21,7 +21,7 @@ setlocal formatoptions-=t formatoptions+=croql
 let &l:define = '\<function\|\<local\%(\s\+function\)\='
 
 " TODO: handle init.lua
-setlocal includeexpr=substitute(v:fname,'\\.','/','g')
+setlocal includeexpr=substitute(v:fname,'\.','/','g')
 setlocal suffixesadd=.lua
 
 let b:undo_ftplugin = "setlocal cms< com< def< fo< inex< sua<"

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -2,7 +2,7 @@
 "
 " Author: Bram Moolenaar
 " Copyright: Vim license applies, see ":help license"
-" Last Change: 2022 Jun 24
+" Last Change: 2022 Nov 10
 "
 " WORK IN PROGRESS - The basics works stable, more to come
 " Note: In general you need at least GDB 7.12 because this provides the
@@ -154,10 +154,16 @@ func s:StartDebug_internal(dict)
 
   let s:save_columns = 0
   let s:allleft = 0
-  if exists('g:termdebug_wide')
-    if &columns < g:termdebug_wide
+  let wide = 0
+  if exists('g:termdebug_config')
+    let wide = get(g:termdebug_config, 'wide', 0)
+  elseif exists('g:termdebug_wide')
+    let wide = g:termdebug_wide
+  endif
+  if wide > 0
+    if &columns < wide
       let s:save_columns = &columns
-      let &columns = g:termdebug_wide
+      let &columns = wide
       " If we make the Vim window wider, use the whole left half for the debug
       " windows.
       let s:allleft = 1
@@ -168,7 +174,12 @@ func s:StartDebug_internal(dict)
   endif
 
   " Override using a terminal window by setting g:termdebug_use_prompt to 1.
-  let use_prompt = exists('g:termdebug_use_prompt') && g:termdebug_use_prompt
+  let use_prompt = 0
+  if exists('g:termdebug_config')
+    let use_prompt = get(g:termdebug_config, 'use_prompt', 0)
+  elseif exists('g:termdebug_use_prompt')
+    let use_prompt = g:termdebug_use_prompt
+  endif
   if !has('win32') && !use_prompt
     let s:way = 'terminal'
    else
@@ -903,7 +914,14 @@ func s:InstallCommands()
   endif
 
   if has('menu') && &mouse != ''
-    call s:InstallWinbar()
+    " install the window toolbar by default, can be disabled in the config
+    let winbar = 1
+    if exists('g:termdebug_config')
+      let winbar = get(g:termdebug_config, 'winbar', 1)
+    endif
+    if winbar
+      call s:InstallWinbar()
+    endif
 
     let popup = 1
     if exists('g:termdebug_config')

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	Bram Moolenaar (Bram@vim.org)
-" Last Change:	2022 Nov 09
+" Last Change:	2022 Nov 13
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
@@ -11,7 +11,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_]*?\=\ze\(\s\+\*\|$\)"
+syn match helpHeadline		"^[A-Z.][-A-Z0-9 .,()_']*?\=\ze\(\s\+\*\|$\)"
 syn match helpSectionDelim	"^===.*===$"
 syn match helpSectionDelim	"^---.*--$"
 if has("conceal")

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainers: Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 "			Claudio Fleiner <claudio@fleiner.com>
-" Last Change:		2022 Jul 20
+" Last Change:		2022 Nov 18
 
 " Please check :help html.vim for some comments and a description of the options
 
@@ -270,6 +270,16 @@ if main_syntax == "html"
   syn sync match htmlHighlight groupthere javaScript "<script"
   syn sync match htmlHighlightSkip "^.*['\"].*$"
   syn sync minlines=10
+endif
+
+" Folding
+" Originally by Ingo Karkat and Marcus Zanona
+if get(g:, "html_syntax_folding", 0)
+  syn region htmlFold start="<\z(\<\%(area\|base\|br\|col\|command\|embed\|hr\|img\|input\|keygen\|link\|meta\|param\|source\|track\|wbr\>\)\@![a-z-]\+\>\)\%(\_s*\_[^/]\?>\|\_s\_[^>]*\_[^>/]>\)" end="</\z1\_s*>" fold transparent keepend extend containedin=htmlHead,htmlH\d
+  " fold comments (the real ones and the old Netscape ones)
+  if exists("html_wrong_comments")
+    syn region htmlComment start=+<!--+ end=+--\s*>\%(\n\s*<!--\)\@!+ contains=@Spell fold
+  endif
 endif
 
 " The default highlighting.

--- a/runtime/syntax/nsis.vim
+++ b/runtime/syntax/nsis.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Ken Takata
 " URL:			https://github.com/k-takata/vim-nsis
 " Previous Maintainer:	Alex Jakushev <Alex.Jakushev@kemek.lt>
-" Last Change:		2020-10-18
+" Last Change:		2022-11-05
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -394,9 +394,13 @@ syn keyword nsisInstruction	contained CreateShortcut nextgroup=nsisCreateShortcu
 syn region nsisCreateShortcutOpt contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisCreateShortcutKwd
 syn match nsisCreateShortcutKwd	 contained "/NoWorkingDir\>"
 
+syn keyword nsisInstruction	contained GetWinVer nextgroup=nsisGetWinVerOpt skipwhite
+syn region nsisGetWinVerOpt	contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisGetWinVerKwd
+syn keyword nsisGetWinVerKwd	contained Major Minor Build ServicePack
+
 syn keyword nsisInstruction	contained GetDLLVersion GetDLLVersionLocal nextgroup=nsisGetDLLVersionOpt skipwhite
-syn region nsisGetDLLVersionOpt contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisGetDLLVersionKwd
-syn match nsisGetDLLVersionKwd	 contained "/ProductVersion\>"
+syn region nsisGetDLLVersionOpt	contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisGetDLLVersionKwd
+syn match nsisGetDLLVersionKwd	contained "/ProductVersion\>"
 
 syn keyword nsisInstruction	contained GetFullPathName nextgroup=nsisGetFullPathNameOpt skipwhite
 syn region nsisGetFullPathNameOpt contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisGetFullPathNameKwd
@@ -562,10 +566,19 @@ syn match nsisSystem		contained "!execute\>"
 syn match nsisSystem		contained "!makensis\>"
 syn match nsisSystem		contained "!packhdr\>"
 syn match nsisSystem		contained "!finalize\>"
+syn match nsisSystem		contained "!uninstfinalize\>"
 syn match nsisSystem		contained "!system\>"
 syn match nsisSystem		contained "!tempfile\>"
-syn match nsisSystem		contained "!getdllversion\>"
-syn match nsisSystem		contained "!gettlbversion\>"
+
+" Add 'P' to avoid conflicts with nsisGetDLLVersionOpt. ('P' for preprocessor.)
+syn match nsisSystem		contained "!getdllversion\>" nextgroup=nsisPGetdllversionOpt skipwhite
+syn region nsisPGetdllversionOpt contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisPGetdllversionKwd
+syn match nsisPGetdllversionKwd	contained "/\%(noerrors\|packed\|productversion\)\>"
+
+syn match nsisSystem		contained "!gettlbversion\>" nextgroup=nsisPGettlbversionOpt skipwhite
+syn region nsisPGettlbversionOpt contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisPGettlbversionKwd
+syn match nsisPGettlbversionKwd	contained "/\%(noerrors\|packed\)\>"
+
 syn match nsisSystem		contained "!warning\>"
 
 syn match nsisSystem		contained "!pragma\>" nextgroup=nsisPragmaOpt skipwhite
@@ -581,7 +594,10 @@ syn match nsisDefine		contained "!define\>" nextgroup=nsisDefineOpt skipwhite
 syn region nsisDefineOpt	contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisDefineKwd
 syn match nsisDefineKwd		contained "/\%(ifndef\|redef\|date\|utcdate\|file\|intfmt\|math\)\>"
 
-syn match nsisDefine		contained "!undef\>"
+syn match nsisDefine		contained "!undef\>" nextgroup=nsisUndefineOpt skipwhite
+syn region nsisUndefineOpt	contained start="" end="$" transparent keepend contains=@nsisAnyOpt,nsisUndefineKwd
+syn match nsisUndefineKwd	contained "/noerrors\>"
+
 syn match nsisPreCondit		contained "!ifdef\>"
 syn match nsisPreCondit		contained "!ifndef\>"
 
@@ -659,6 +675,7 @@ hi def link nsisWriteRegMultiStrKwd	Constant
 hi def link nsisSetRegViewKwd		Constant
 hi def link nsisCopyFilesKwd		Constant
 hi def link nsisCreateShortcutKwd	Constant
+hi def link nsisGetWinVerKwd		Constant
 hi def link nsisGetDLLVersionKwd	Constant
 hi def link nsisGetFullPathNameKwd	Constant
 hi def link nsisFileAttrib		Constant
@@ -696,9 +713,12 @@ hi def link nsisIncludeKwd		Constant
 hi def link nsisAddplugindirKwd		Constant
 hi def link nsisAppendfileKwd		Constant
 hi def link nsisDelfileKwd		Constant
+hi def link nsisPGetdllversionKwd	Constant
+hi def link nsisPGettlbversionKwd	Constant
 hi def link nsisPragmaKwd		Constant
 hi def link nsisVerboseKwd		Constant
 hi def link nsisDefineKwd		Constant
+hi def link nsisUndefineKwd		Constant
 hi def link nsisIfKwd			Constant
 hi def link nsisSearchparseKwd		Constant
 hi def link nsisSearchreplaceKwd	Constant

--- a/runtime/syntax/ptcap.vim
+++ b/runtime/syntax/ptcap.vim
@@ -53,7 +53,7 @@ syn match ptcapNumberError  "#0x\x*[^[:xdigit:]:\\]"lc=1 contained
 " The `=' operator assigns a string to the preceding flag
 syn match ptcapOperator	    "[@#=]" contained
 
-" Some terminal capabilites have special names like `#5' and `@1', and we
+" Some terminal capabilities have special names like `#5' and `@1', and we
 " need special rules to match these properly
 syn match ptcapSpecialCap   "\W[#@]\d" contains=ptcapDelimiter contained
 

--- a/runtime/syntax/sshconfig.vim
+++ b/runtime/syntax/sshconfig.vim
@@ -6,7 +6,7 @@
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Contributor:  Dean, Adam Kenneth <adam.ken.dean@hpe.com>
-" Last Change:	2022 Nov 09
+" Last Change:	2022 Nov 10
 "		Added RemoteCommand from pull request #4809
 "		Included additional keywords from Martin.
 "		Included PR #5753
@@ -171,6 +171,7 @@ syn keyword sshconfigKeyword EnableSSHKeysign
 syn keyword sshconfigKeyword EscapeChar
 syn keyword sshconfigKeyword ExitOnForwardFailure
 syn keyword sshconfigKeyword FingerprintHash
+syn keyword sshconfigKeyword ForkAfterAuthentication
 syn keyword sshconfigKeyword ForwardAgent
 syn keyword sshconfigKeyword ForwardX11
 syn keyword sshconfigKeyword ForwardX11Timeout
@@ -221,13 +222,16 @@ syn keyword sshconfigKeyword RekeyLimit
 syn keyword sshconfigKeyword RemoteCommand
 syn keyword sshconfigKeyword RemoteForward
 syn keyword sshconfigKeyword RequestTTY
+syn keyword sshconfigKeyword RequiredRSASize
 syn keyword sshconfigKeyword RevokedHostKeys
 syn keyword sshconfigKeyword SecurityKeyProvider
 syn keyword sshconfigKeyword SendEnv
 syn keyword sshconfigKeyword ServerAliveCountMax
 syn keyword sshconfigKeyword ServerAliveInterval
+syn keyword sshconfigKeyword SessionType
 syn keyword sshconfigKeyword SmartcardDevice
 syn keyword sshconfigKeyword SetEnv
+syn keyword sshconfigKeyword StdinNull
 syn keyword sshconfigKeyword StreamLocalBindMask
 syn keyword sshconfigKeyword StreamLocalBindUnlink
 syn keyword sshconfigKeyword StrictHostKeyChecking

--- a/runtime/syntax/sshdconfig.vim
+++ b/runtime/syntax/sshdconfig.vim
@@ -7,7 +7,7 @@
 " Contributor:  Leonard Ehrenfried <leonard.ehrenfried@web.de>	
 " Contributor:  Karsten Hopp <karsten@redhat.com>
 " Originally:	2009-07-09
-" Last Change:	2022 Nov 09
+" Last Change:	2022 Nov 10
 " SSH Version:	8.5p1
 "
 
@@ -221,6 +221,7 @@ syn keyword sshdconfigKeyword Match
 syn keyword sshdconfigKeyword MaxAuthTries
 syn keyword sshdconfigKeyword MaxSessions
 syn keyword sshdconfigKeyword MaxStartups
+syn keyword sshdconfigKeyword ModuliFile
 syn keyword sshdconfigKeyword PasswordAuthentication
 syn keyword sshdconfigKeyword PerSourceMaxStartups
 syn keyword sshdconfigKeyword PerSourceNetBlockSize
@@ -244,6 +245,7 @@ syn keyword sshdconfigKeyword PubkeyAuthentication
 syn keyword sshdconfigKeyword PubkeyAuthOptions
 syn keyword sshdconfigKeyword RSAAuthentication
 syn keyword sshdconfigKeyword RekeyLimit
+syn keyword sshdconfigKeyword RequiredRSASize
 syn keyword sshdconfigKeyword RevokedKeys
 syn keyword sshdconfigKeyword RDomain
 syn keyword sshdconfigKeyword RhostsRSAAuthentication


### PR DESCRIPTION
Update runtime files

https://github.com/vim/vim/commit/d13166e788fcaef59ec65c20b46ca4be16625669

- Skip E1309-1311 (not ported).
- Skip `:echowindow` changes (not ported).
- Skip termdebug winbar doc changes (not fully ported).
- Port missing `g:termdebug_config.{wide,use_prompt}` changes from v8.2.5010.

Co-authored-by: Bram Moolenaar <Bram@vim.org>