### PR TITLE
feat(lsp): support set title in lsp relate floatwindow

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1327,14 +1327,14 @@ Lua module: vim.lsp.handlers                                    *lsp-handlers*
 hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
     |lsp-handler| for the method "textDocument/hover" >
 
-         vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
-           vim.lsp.handlers.hover, {
-             -- Use a sharp border with `FloatBorder` highlights
-             border = "single", */
-    // zz:"--      -- add the title in hover float window"
-    /**      title = "hover"
-           }
-         )
+     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
+       vim.lsp.handlers.hover, {
+         -- Use a sharp border with `FloatBorder` highlights
+         border = "single",
+         -- add the title in hover float window
+         title = "hover"
+       }
+     )
 <
 
     Parameters: ~

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1327,12 +1327,14 @@ Lua module: vim.lsp.handlers                                    *lsp-handlers*
 hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
     |lsp-handler| for the method "textDocument/hover" >
 
-     vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
-       vim.lsp.handlers.hover, {
-         -- Use a sharp border with `FloatBorder` highlights
-         border = "single"
-       }
-     )
+         vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
+           vim.lsp.handlers.hover, {
+             -- Use a sharp border with `FloatBorder` highlights
+             border = "single", */
+    // zz:"--      -- add the title in hover float window"
+    /**      title = "hover"
+           }
+         )
 <
 
     Parameters: ~

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -301,7 +301,9 @@ end
 --- vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
 ---   vim.lsp.handlers.hover, {
 ---     -- Use a sharp border with `FloatBorder` highlights
----     border = "single"
+---     border = "single",
+--      -- add the title in hover float window
+---     title = "hover"
 ---   }
 --- )
 --- </pre>

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -302,7 +302,7 @@ end
 ---   vim.lsp.handlers.hover, {
 ---     -- Use a sharp border with `FloatBorder` highlights
 ---     border = "single",
---      -- add the title in hover float window
+---     -- add the title in hover float window
 ---     title = "hover"
 ---   }
 --- )

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1050,6 +1050,13 @@ function M.make_floating_popup_options(width, height, opts)
     col = 1
   end
 
+  local title = (opts.border and opts.title) and opts.title or nil
+  local title_pos
+
+  if title then
+    title_pos = opts.title_pos and opts.title_pos or 'center'
+  end
+
   return {
     anchor = anchor,
     col = col + (opts.offset_x or 0),
@@ -1061,6 +1068,8 @@ function M.make_floating_popup_options(width, height, opts)
     width = width,
     border = opts.border or default_border,
     zindex = opts.zindex or 50,
+    title = title,
+    title_pos = title_pos,
   }
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1054,7 +1054,7 @@ function M.make_floating_popup_options(width, height, opts)
   local title_pos
 
   if title then
-    title_pos = opts.title_pos and opts.title_pos or 'center'
+    title_pos = opts.title_pos or 'center'
   end
 
   return {


### PR DESCRIPTION
support set title in lsprelate float window like hover, diagnostic. etc

```lua
vim.diagnostic.config({
  float = {
    scope = 'cursor',
    border = 'double',
    title = 'Diagnostic:',
    title_pos = 'right',
  }
})

vim.lsp.handlers["textDocument/hover"] = vim.lsp.with(
  vim.lsp.handlers.hover, {
  border = 'double',
  title = 'hover',}
)
```
