### PR TITLE
perf(diagnostic): use api variable and improve validate

### DIFF
--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1776,7 +1776,7 @@ end)
         return lines
       ]])
 
-      eq(".../diagnostic.lua:0: prefix: expected 'string' or 'table' or 'function', got 42",
+      eq(".../diagnostic.lua:0: prefix: expected string|table|function, got number",
         pcall_err(exec_lua, [[ vim.diagnostic.open_float({ prefix = 42 }) ]]))
     end)
 


### PR DESCRIPTION
reduce once hash lookup and the we can simply use a table contains the type instead of use a function in `vim.validate`