### PR TITLE
vim-patch:8.2.5167: get(Fn, 'name') on funcref returns special byte code

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2528,13 +2528,17 @@ static void f_get(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       const char *const what = tv_get_string(&argvars[1]);
 
       if (strcmp(what, "func") == 0 || strcmp(what, "name") == 0) {
+        const char *name = (const char *)partial_name(pt);
         rettv->v_type = (*what == 'f' ? VAR_FUNC : VAR_STRING);
-        const char *const n = (const char *)partial_name(pt);
-        assert(n != NULL);
-        rettv->vval.v_string = xstrdup(n);
+        assert(name != NULL);
         if (rettv->v_type == VAR_FUNC) {
-          func_ref((char_u *)rettv->vval.v_string);
+          func_ref((char_u *)name);
         }
+        if (*what == 'n' && pt->pt_name == NULL && pt->pt_func != NULL) {
+          // use <SNR> instead of the byte code
+          name = (const char *)printable_func_name(pt->pt_func);
+        }
+        rettv->vval.v_string = xstrdup(name);
       } else if (strcmp(what, "dict") == 0) {
         what_is_dict = true;
         if (pt->pt_dict != NULL) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1652,6 +1652,11 @@ theend:
   return ret;
 }
 
+char_u *printable_func_name(ufunc_T *fp)
+{
+  return fp->uf_name_exp != NULL ? fp->uf_name_exp : fp->uf_name;
+}
+
 /// List the head of the function: "name(arg1, arg2)".
 ///
 /// @param[in]  fp      Function pointer.

--- a/src/nvim/testdir/test_getvar.vim
+++ b/src/nvim/testdir/test_getvar.vim
@@ -133,11 +133,20 @@ func Test_get_lambda()
   call assert_equal([], get(l:L, 'args'))
 endfunc
 
+func s:FooBar()
+endfunc
+
 " get({func}, {what} [, {default}])
 func Test_get_func()
   let l:F = function('tr')
   call assert_equal('tr', get(l:F, 'name'))
   call assert_equal(l:F, get(l:F, 'func'))
+
+  let Fb_func = function('s:FooBar')
+  call assert_match('<SNR>\d\+_FooBar', get(Fb_func, 'name'))
+  let Fb_ref = funcref('s:FooBar')
+  call assert_match('<SNR>\d\+_FooBar', get(Fb_ref, 'name'))
+
   call assert_equal({'func has': 'no dict'}, get(l:F, 'dict', {'func has': 'no dict'}))
   call assert_equal(0, get(l:F, 'dict'))
   call assert_equal([], get(l:F, 'args'))


### PR DESCRIPTION
#### vim-patch:8.2.5167: get(Fn, 'name') on funcref returns special byte code

Problem:    get(Fn, 'name') on funcref returns special byte code.
Solution:   Use the printable name.

https://github.com/vim/vim/commit/1ae8c262df7083dfb4b41485508951c50eccc84c

Cherry-pick printable_func_name() from patch 8.2.0149.

Co-authored-by: Bram Moolenaar <Bram@vim.org>