### PR TITLE
vim-patch:8.2.5148: invalid memory access when using expression on command line

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1613,6 +1613,8 @@ static int command_line_handle_key(CommandLineState *s)
     return 0;                         // back to cmd mode
 
   case Ctrl_R: {                      // insert register
+    const int save_new_cmdpos = new_cmdpos;
+
     putcmdline('"', true);
     no_mapping++;
     allow_keys++;
@@ -1627,8 +1629,6 @@ static int command_line_handle_key(CommandLineState *s)
     no_mapping--;
     allow_keys--;
     // Insert the result of an expression.
-    // Need to save the current command line, to be able to enter
-    // a new one...
     new_cmdpos = -1;
     if (s->c == '=') {
       if (ccline.cmdfirstc == '='   // can't do this recursively
@@ -1660,8 +1660,12 @@ static int command_line_handle_key(CommandLineState *s)
         }
       }
     }
+    new_cmdpos = save_new_cmdpos;
+
+    // remove the double quote
     ccline.special_char = NUL;
     redrawcmd();
+
     return command_line_changed(s);
   }
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1850,6 +1850,11 @@ func Test_cmdline_expr()
   call assert_equal("\"e \<C-\>\<C-Y>", @:)
 endfunc
 
+" This was making the insert position negative
+func Test_cmdline_expr_register()
+  exe "sil! norm! ?\<C-\>e0\<C-R>0\<Esc>?\<C-\>e0\<CR>"
+endfunc
+
 " Test for 'imcmdline' and 'imsearch'
 " This test doesn't actually test the input method functionality.
 func Test_cmdline_inputmethod()


### PR DESCRIPTION
#### vim-patch:8.2.5148: invalid memory access when using expression on command line

Problem:    Invalid memory access when using an expression on the command line.
Solution:   Make sure the position does not go negative.

https://github.com/vim/vim/commit/6046aded8da002b08d380db29de2ba0268b6616e

N/A patches for version.c:

vim-patch:8.2.5149: cannot build without the +eval feature

Problem:    Cannot build without the +eval feature. (Tony Mechelynck)
Solution:   Add #ifdefs.

https://github.com/vim/vim/commit/6689df024bce4309ec5884e445738fe07ee4ffcc

Co-authored-by: Bram Moolenaar <Bram@vim.org>