### PR TITLE
test: fix failing tui_spec.lua tests

### DIFF
--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -4,18 +4,15 @@
 local helpers = require('test.functional.helpers')(nil)
 local Screen = require('test.functional.ui.screen')
 local testprg = helpers.testprg
+local exec_lua = helpers.exec_lua
 local feed_command, nvim = helpers.feed_command, helpers.nvim
 
 local function feed_data(data)
-  -- A string containing NUL bytes is not converted to a Blob when
-  -- calling nvim_set_var() API, so convert it using Lua instead.
-  nvim('exec_lua', 'vim.g.term_data = ...', {data})
-  nvim('command', 'call jobsend(b:terminal_job_id, term_data)')
+  exec_lua('vim.api.nvim_chan_send(vim.b.terminal_job_id, ...)', data)
 end
 
 local function feed_termcode(data)
-  -- feed with the job API
-  nvim('command', 'call jobsend(b:terminal_job_id, "\\x1b'..data..'")')
+  feed_data('\x1b' .. data)
 end
 -- some helpers for controlling the terminal. the codes were taken from
 -- infocmp xterm-256color which is less what libvterm understands

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -8,6 +8,9 @@ local exec_lua = helpers.exec_lua
 local feed_command, nvim = helpers.feed_command, helpers.nvim
 
 local function feed_data(data)
+  if type(data) == 'table' then
+      data = table.concat(data, '\n')
+  end
   exec_lua('vim.api.nvim_chan_send(vim.b.terminal_job_id, ...)', data)
 end
 

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -12,7 +12,7 @@ local function feed_data(data)
 end
 
 local function feed_termcode(data)
-  feed_data('\x1b' .. data)
+  feed_data('\027' .. data)
 end
 
 local function make_lua_executor(session)

--- a/test/functional/terminal/helpers.lua
+++ b/test/functional/terminal/helpers.lua
@@ -14,6 +14,18 @@ end
 local function feed_termcode(data)
   feed_data('\x1b' .. data)
 end
+
+local function make_lua_executor(session)
+  return function(code, ...)
+    local status, rv = session:request('nvim_exec_lua', code, {...})
+    if not status then
+      session:stop()
+      error(rv[2])
+    end
+    return rv
+  end
+end
+
 -- some helpers for controlling the terminal. the codes were taken from
 -- infocmp xterm-256color which is less what libvterm understands
 -- civis/cnorm
@@ -106,6 +118,7 @@ end
 return {
   feed_data = feed_data,
   feed_termcode = feed_termcode,
+  make_lua_executor = make_lua_executor,
   hide_cursor = hide_cursor,
   show_cursor = show_cursor,
   enter_altscreen = enter_altscreen,

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -28,6 +28,7 @@ if helpers.skip(helpers.iswin()) then return end
 describe('TUI', function()
   local screen
   local child_session
+  local child_exec_lua
 
   before_each(function()
     clear()
@@ -45,6 +46,7 @@ describe('TUI', function()
       {3:-- TERMINAL --}                                    |
     ]])
     child_session = helpers.connect(child_server)
+    child_exec_lua = thelpers.make_lua_executor(child_session)
   end)
 
   -- Wait for mode in the child Nvim (avoid "typeahead race" #10826).
@@ -823,8 +825,8 @@ describe('TUI', function()
         pending("tty-test complains about not owning the terminal -- actions/runner#241")
         return
     end
-    feed_data(':set statusline=^^^^^^^\n')
-    feed_data(':terminal '..testprg('tty-test')..'\n')
+    child_exec_lua('vim.o.statusline="^^^^^^^"')
+    child_exec_lua('vim.cmd.terminal(...)', testprg('tty-test'))
     feed_data('i')
     screen:expect{grid=[[
       tty ready                                         |
@@ -1340,12 +1342,9 @@ describe('TUI', function()
       [5] = {{foreground = tonumber('0xff8000')}, {}},
     })
 
-    feed_data(':set statusline=^^^^^^^\n')
-    feed_data(':set termguicolors\n')
-    feed_data(':terminal '..testprg('tty-test')..'\n')
-    -- Depending on platform the above might or might not fit in the cmdline
-    -- so clear it for consistent behavior.
-    feed_data(':\027')
+    child_exec_lua('vim.o.statusline="^^^^^^^"')
+    child_exec_lua('vim.o.termguicolors=true')
+    child_exec_lua('vim.cmd.terminal(...)', testprg('tty-test'))
     screen:expect{grid=[[
       {1:t}ty ready                                         |
                                                         |


### PR DESCRIPTION
When running locally, `testprg('tty-test')` is too long and causes unexpected test failures.
