### PR TITLE
fix(lsp): ignore hover and signatureHelp responses on buffer change

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -328,6 +328,10 @@ end
 function M.hover(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method
+  if api.nvim_get_current_buf() ~= ctx.bufnr then
+    -- Ignore result since buffer changed. This happens for slow language servers.
+    return
+  end
   if not (result and result.contents) then
     vim.notify('No information available')
     return
@@ -408,6 +412,10 @@ M['textDocument/implementation'] = location_handler
 function M.signature_help(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method
+  if api.nvim_get_current_buf() ~= ctx.bufnr then
+    -- Ignore result since buffer changed. This happens for slow language servers.
+    return
+  end
   -- When use `autocmd CompleteDone <silent><buffer> lua vim.lsp.buf.signature_help()` to call signatureHelp handler
   -- If the completion item doesn't have signatures It will make noise. Change to use `print` that can use `<silent>` to ignore
   if not (result and result.signatures and result.signatures[1]) then


### PR DESCRIPTION
Language servers can take some time to respond to the `textDocument/hover` and `textDocument/signatureHelp` messages (either because they are slow on large projects, like `tsserver`, or because they are initializing, which takes time). During that time, the user could have already moved to another buffer. The popup was always shown in the current buffer, which could be a different one than the buffer for which the request was sent.

This was particularly annoying when moving to a buffer with a `BufLeave` autocmd, as that autocmd was triggered when the hover popup was shown for the original buffer. This is the case with Telescope (I do `vim.lsp.buf.hover()` on the variable before `tsserver` is initialized, and then quickly open Telescope):


https://user-images.githubusercontent.com/889383/202846983-8b763175-c220-46ed-bfe5-171b018445b4.mp4



Ignoring the response from these 2 messages if they are for a buffer that is not the current one leads to less noise. The popup will only be shown for the buffer for which it was requested. The same Telescope problem reproduction but having this PR checked out:

https://user-images.githubusercontent.com/889383/202846907-4d6f22fd-d64d-4389-a43d-d52aaf08fce2.mp4



A more robust solution could involve cancelling the hover/signatureHelp request if the buffer changes so the language server can free its resources. It could be implemented in the future. I tried refactoring `vim.lsp.buf.hover()` to call `cancel` (the function returned from `client.request`) but it didn't help with the server initialization case.