### PR TITLE
feat(term): enable reflow by default

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -16,8 +16,8 @@ UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b953665559679748
 LIBTERMKEY_URL https://github.com/neovim/deps/raw/aa004f1b2b6470a92363cba8e1cc1874141dacc4/opt/libtermkey-0.22.tar.gz
 LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600
 
-LIBVTERM_URL https://github.com/neovim/deps/raw/aa004f1b2b6470a92363cba8e1cc1874141dacc4/opt/libvterm-0.3.1.tar.gz
-LIBVTERM_SHA256 25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397
+LIBVTERM_URL https://github.com/neovim/deps/raw/6c0a5213d062f2210fd5fecb9524ac27ca018ef4/opt/libvterm-0.3.2.tar.gz
+LIBVTERM_SHA256 91eb5088069f4e6edab69e14c4212f6da0192e65695956dc048016a0dab8bcf6
 
 LUV_URL https://github.com/luvit/luv/archive/c1497c0ffd3e1400a137ac99a614159a685f716b.tar.gz
 LUV_SHA256 fc8c8c777454b78e09c06bd177860da9b79804affc967b015ecccb75b3af6893

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -58,6 +58,10 @@ The following new APIs or features were added.
 
 • Added inline virtual text support to |nvim_buf_set_extmark()|.
 
+• The terminal buffer now supports reflow (wrapped lines adapt when the buffer
+  is resized horizontally). Note: Lines that are not visible and kept in
+  |'scrollback'| are not reflown.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4913,6 +4913,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Minimum is 1, maximum is 100000.
 	Only in |terminal| buffers.
 
+	Note: Lines that are not visible and kept in scrollback are not
+	reflown when the terminal buffer is resized horizontally.
+
 			*'scrollbind'* *'scb'* *'noscrollbind'* *'noscb'*
 'scrollbind' 'scb'	boolean  (default off)
 			local to window

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -220,6 +220,7 @@ Terminal *terminal_open(buf_T *buf, TerminalOptions opts)
   // Set up screen
   rv->vts = vterm_obtain_screen(rv->vt);
   vterm_screen_enable_altscreen(rv->vts, true);
+  vterm_screen_enable_reflow(rv->vts, true);
   // delete empty lines at the end of the buffer
   vterm_screen_set_callbacks(rv->vts, &vterm_screen_callbacks, rv);
   vterm_screen_set_damage_merge(rv->vts, VTERM_DAMAGE_SCROLL);

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -64,7 +64,7 @@ describe(':terminal window', function()
         {7:       1 }tty ready                                |
         {7:       2 }rows: 6, cols: 48                        |
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
-        {7:       4 }WXYZrows: 6, cols: 41                    |
+        {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
         {7:       5 }{1: }                                        |
         {7:       6 }                                         |
         {3:-- TERMINAL --}                                    |
@@ -74,7 +74,7 @@ describe(':terminal window', function()
         {7:       1 }tty ready                                |
         {7:       2 }rows: 6, cols: 48                        |
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
-        {7:       4 }WXYZrows: 6, cols: 41                    |
+        {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
         {7:       5 } abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN|
         {7:       6 }OPQRSTUVWXYZ{1: }                            |
         {3:-- TERMINAL --}                                    |


### PR DESCRIPTION
libvterm v0.3 supports reflow of terminal buffer when Nvim is resized
Since v0.3 is now a required dependency, enable it by default to find
(and fix) possible issues.

Note: Neovim's scrollback buffer does not support reflow (yet), so lines
vanishing into the buffer due to a too small window will be restored
without reflow.
