### PR TITLE
build(nix): update nixpkgs

### DIFF
--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662019588,
-        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
+        "lastModified": 1669052418,
+        "narHash": "sha256-M1I4BKXBQm2gey1tScemEh5TpHHE3gKptL7BpWUvL8s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
+        "rev": "20fc948445a6c22d4e8d5178e9a6bc6e1f5417c8",
         "type": "github"
       },
       "original": {

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -9,15 +9,6 @@
   outputs = { self, nixpkgs, flake-utils }:
     {
       overlay = final: prev: rec {
-        neovim-unwrapped = prev.neovim-unwrapped.override ({
-          libvterm-neovim = final.libvterm-neovim.overrideAttrs (old: {
-            version = "0.3";
-            src = builtins.fetchTarball {
-              url = "https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz";
-              sha256 = "0zg6sn5brwrnqaab883pdj0l2swk5askbbwbdam0zq55ikbrzgar";
-            };
-          });
-        });
 
         neovim = final.neovim-unwrapped.overrideAttrs (oa: {
           version = "master";

--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -10,7 +10,7 @@
     {
       overlay = final: prev: rec {
         neovim-unwrapped = prev.neovim-unwrapped.override ({
-          libvterm-neovim = prev.libvterm-neovim.overrideAttrs (old: {
+          libvterm-neovim = final.libvterm-neovim.overrideAttrs (old: {
             version = "0.3";
             src = builtins.fetchTarball {
               url = "https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz";


### PR DESCRIPTION
I have issues with the libvterm-neovim override in contrib/flake.nix:

I'm using the following overlay on libvterm-neovim to fix an issue arising on x86_64-linux to aarch64-linux cross-compilation:
```libvterm-neovim.nix
final: prev: {
  libvterm-neovim = prev.libvterm-neovim.overrideAttrs (_: {
    # fix breakage during cross-compilation by always setting LIBTOOL, not just for
    # darwin
    makeFlags = [ "PREFIX=$(out)" "LIBTOOL=${final.libtool}/bin/libtool" ];
  });
}
```
However, by overriding `neovim-unwrapped` with `prev.libvterm-neovim` instead of `final.libvterm-neovim`, it has no effect.
This commit fixes that.

It's working locally for me for native and cross-compiled builds now.

Aside: I'm not sure this overlay here is necessary; it refers to the same version as in `nixos-unstable` currently — updating  flake.lock (`nix flake update`) would get you there. It can have other side-effects of course, but I'm overriding this flake's input to https://github.com/NixOS/nixpkgs/commit/52b2ac8ae18bbad4374ff0dd5aeee0fdf1aea739 right now and neovim builds fine with this.
