### PR TITLE
feat(diagnostic): add `suffix` option to `open_float()`

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -618,6 +618,9 @@ open_float({opts}, {...})                        *vim.diagnostic.open_float()*
                   {prefix} is a string, it is prepended to each diagnostic in
                   the window with no highlight. Overrides the setting from
                   |vim.diagnostic.config()|.
+                • suffix: Same as {prefix}, but appends the text to the
+                  diagnostic instead of prepending it. Overrides the setting
+                  from |vim.diagnostic.config()|.
 
     Return: ~
         tuple ({float_bufnr}, {win_id})

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -16,7 +16,7 @@ describe('vim.diagnostic', function()
     exec_lua [[
       require('vim.diagnostic')
 
-      function make_diagnostic(msg, x1, y1, x2, y2, severity, source)
+      function make_diagnostic(msg, x1, y1, x2, y2, severity, source, code)
         return {
           lnum = x1,
           col = y1,
@@ -25,23 +25,24 @@ describe('vim.diagnostic', function()
           message = msg,
           severity = severity,
           source = source,
+          code = code,
         }
       end
 
-      function make_error(msg, x1, y1, x2, y2, source)
-        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.ERROR, source)
+      function make_error(msg, x1, y1, x2, y2, source, code)
+        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.ERROR, source, code)
       end
 
-      function make_warning(msg, x1, y1, x2, y2, source)
-        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.WARN, source)
+      function make_warning(msg, x1, y1, x2, y2, source, code)
+        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.WARN, source, code)
       end
 
-      function make_info(msg, x1, y1, x2, y2, source)
-        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.INFO, source)
+      function make_info(msg, x1, y1, x2, y2, source, code)
+        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.INFO, source, code)
       end
 
-      function make_hint(msg, x1, y1, x2, y2, source)
-        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.HINT, source)
+      function make_hint(msg, x1, y1, x2, y2, source, code)
+        return make_diagnostic(msg, x1, y1, x2, y2, vim.diagnostic.severity.HINT, source, code)
       end
 
       function count_diagnostics(bufnr, severity, namespace)
@@ -1778,6 +1779,51 @@ end)
 
       eq(".../diagnostic.lua:0: prefix: expected string|table|function, got number",
         pcall_err(exec_lua, [[ vim.diagnostic.open_float({ prefix = 42 }) ]]))
+    end)
+
+    it('can add a suffix to diagnostics', function()
+      -- Default is to render the diagnostic error code
+      eq({'1. Syntax error [code-x]', '2. Some warning [code-y]'}, exec_lua [[
+        local diagnostics = {
+          make_error("Syntax error", 0, 1, 0, 3, nil, "code-x"),
+          make_warning("Some warning", 1, 1, 1, 3, nil, "code-y"),
+        }
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer"})
+        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+
+      eq({'1. Syntax error', '2. Some warning'}, exec_lua [[
+        local diagnostics = {
+          make_error("Syntax error", 0, 1, 0, 3, nil, "code-x"),
+          make_warning("Some warning", 1, 1, 1, 3, nil, "code-y"),
+        }
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer", suffix = ""})
+        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+
+      -- Suffix is rendered on the last line of a multiline diagnostic
+      eq({'1. Syntax error', '   More context [code-x]'}, exec_lua [[
+        local diagnostics = {
+          make_error("Syntax error\nMore context", 0, 1, 0, 3, nil, "code-x"),
+        }
+        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer"})
+        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+        vim.api.nvim_win_close(winnr, true)
+        return lines
+      ]])
+
+      eq(".../diagnostic.lua:0: suffix: expected string|table|function, got number",
+        pcall_err(exec_lua, [[ vim.diagnostic.open_float({ suffix = 42 }) ]]))
     end)
 
     it('works with the old signature', function()


### PR DESCRIPTION
Closes #18687

This introduces a `suffix` option to `vim.diagnostic.open_float()` (and consequently `vim.diagnostic.config()`) that appends some text to each diagnostic in the float.

It accepts the same types as `prefix`. For multiline diagnostics, the suffix is only appended to the last line. By default, the suffix will render the diagnostic error code, if any.

Highlighting:
Multiline diagnostic without prefix:
![Screen Shot 2022-11-19 at 10 04 55 PM](https://user-images.githubusercontent.com/54521218/202888426-0a06e4d9-2c58-479e-89d7-30eabff0a43e.png)
Multiline diagnostic with prefix:
![Screen Shot 2022-11-19 at 10 21 51 PM](https://user-images.githubusercontent.com/54521218/202888869-88621869-690c-41dc-86cb-8a59afbf604c.png)

(The highlighting behavior is consistent with how it is prior to this change)

cc @gpanders 
