### PR TITLE
docs: lua fs module documentation clarifications

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2274,23 +2274,34 @@ dirname({file})                                             *vim.fs.dirname()*
 find({names}, {opts})                                          *vim.fs.find()*
     Find files or directories in the given path.
 
-    Finds any files or directories given in {names} starting from {path}. If
+    Finds any files or directories given in {names} starting from {path} (if given). If
     {upward} is "true" then the search traverses upward through parent
     directories; otherwise, the search traverses downward. Note that downward
     searches are recursive and may search through many directories! If {stop}
-    is non-nil, then the search stops when the directory given in {stop} is
-    reached. The search terminates when {limit} (default 1) matches are found.
-    The search can be narrowed to find only files or or only directories by
-    specifying {type} to be "file" or "directory", respectively.
+    is given, then the search stops when the directory given in {stop} is
+    reached. The search terminates when {limit} (1 if omitted) matches are found.
+    The search can be narrowed to find only files or only directories by
+    specifying {type} to be either 'file' or 'directory', respectively.
+    
+     Examples: >
+       lua = vim.fs.find('aFileOrDirectoryNextToNeovim')
+       => 'C:/Users/jdoe/aFileOrDirectoryNextToNeovim'
+       lua = vim.fs.find('allFilesOrDirectoriesAboveNeovim', {upward = true, limit = math.huge})
+       => '/home/jdoe/allFilesOrDirectoriesAboveNeovim'
+       => '/home/allFilesOrDirectoriesAboveNeovim'
+       lua = vim.fs.find('aFileInHomeDirectory', {path = '/home'})
+       => '/home/jdoe/archive/aFileInHomeDirectory'
+<
 
     Parameters: ~
-      • {names}  (string|table|fun(name: string): boolean) Names of the files
+      • {names}  (string or table/array or fun(name: string): boolean) Names of the files
                  and directories to find. Must be base names, paths and globs
-                 are not supported. If a function it is called per file and
-                 dir within the traversed directories to test if they match.
-      • {opts}   (table) Optional keyword arguments:
+                 are not supported. The function is called per file and
+                 directory within the traversed directories to test if they match with {names}.
+		 
+      • {opts}   (table/array) Optional keyword arguments:
                  • path (string): Path to begin searching from. If omitted,
-                   the current working directory is used.
+                   the current working directory ("nvim" executable) is used.
                  • upward (boolean, default false): If true, search upward
                    through parent directories. Otherwise, search through child
                    directories (recursively).
@@ -2298,29 +2309,27 @@ find({names}, {opts})                                          *vim.fs.find()*
                    reached. The directory itself is not searched.
                  • type (string): Find only files ("file") or directories
                    ("directory"). If omitted, both files and directories that
-                   match {name} are included.
-                 • limit (number, default 1): Stop the search after finding
-                   this many matches. Use `math.huge` to place no limit on the
+                   match {names} are included.
+                 • limit (number, 1 if omitted): Stop the search after finding
+                   {limit} match(es). Use `math.huge` to place no limit on the
                    number of matches.
-
+    
     Return: ~
-        (table) The paths of all matching files or directories
+        (table) The normalized (see below) paths of all matching files or directories in {names}
+	
 
 normalize({path})                                         *vim.fs.normalize()*
-    Normalize a path to a standard format. A tilde (~) character at the
+    Normalize a path to standard format. A tilde (~) character at the
     beginning of the path is expanded to the user's home directory and any
-    backslash (\) characters are converted to forward slashes (/). Environment
+    backslash (\ or \\) characters are converted to forward slashes (/). Environment
     variables are also expanded.
 
-    Example: >
-
-     vim.fs.normalize('C:\Users\jdoe')
+    Examples: >
+     lua = vim.fs.normalize('C:\Users\\jdoe')
      => 'C:/Users/jdoe'
-
-     vim.fs.normalize('~/src/neovim')
-     => '/home/jdoe/src/neovim'
-
-     vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
+     lua = vim.fs.normalize('~/src/neovim')
+     => '/path/to/src/neovim'
+     lua = vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
      => '/Users/jdoe/.config/nvim/init.vim'
 <
 
@@ -2329,7 +2338,8 @@ normalize({path})                                         *vim.fs.normalize()*
 
     Return: ~
         (string) Normalized path
-
+	
+	
 parents({start})                                            *vim.fs.parents()*
     Iterate over all the parents of the given file or directory.
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2271,6 +2271,7 @@ dirname({file})                                             *vim.fs.dirname()*
     Return: ~
         (string) Parent directory of {file}
 
+
 find({names}, {opts})                                          *vim.fs.find()*
     Find files or directories in the given path.
 
@@ -2284,16 +2285,20 @@ find({names}, {opts})                                          *vim.fs.find()*
     specifying {type} to be either 'file' or 'directory', respectively.
     
      Examples: >
+     
        lua = vim.fs.find('aFileOrDirectoryNextToNeovim')
        => 'C:/Users/jdoe/aFileOrDirectoryNextToNeovim'
+       
        lua = vim.fs.find('allFilesOrDirectoriesAboveNeovim', {upward = true, limit = math.huge})
        => '/home/jdoe/allFilesOrDirectoriesAboveNeovim'
        => '/home/allFilesOrDirectoriesAboveNeovim'
+       
        lua = vim.fs.find('aFileInHomeDirectory', {path = '/home'})
        => '/home/jdoe/archive/aFileInHomeDirectory'
 <
 
     Parameters: ~
+    
       • {names}  (string or table/array or fun(name: string): boolean) Names of the files
                  and directories to find. Must be base names, paths and globs
                  are not supported. The function is called per file and
@@ -2315,7 +2320,7 @@ find({names}, {opts})                                          *vim.fs.find()*
                    number of matches.
     
     Return: ~
-        (table) The normalized (see below) paths of all matching files or directories in {names}
+        (table) The normalized paths (see below) of all matching files or directories in {names}
 	
 
 normalize({path})                                         *vim.fs.normalize()*
@@ -2325,10 +2330,13 @@ normalize({path})                                         *vim.fs.normalize()*
     variables are also expanded.
 
     Examples: >
+    
      lua = vim.fs.normalize('C:\Users\\jdoe')
      => 'C:/Users/jdoe'
+     
      lua = vim.fs.normalize('~/src/neovim')
      => '/path/to/src/neovim'
+     
      lua = vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
      => '/Users/jdoe/.config/nvim/init.vim'
 <

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -81,9 +81,11 @@ end
      Examples: >
        lua = vim.fs.find('aFileOrDirectoryNextToNeovim')
        => 'C:/Users/jdoe/aFileOrDirectoryNextToNeovim'
+
        lua = vim.fs.find('allFilesOrDirectoriesAboveNeovim', {upward = true, limit = math.huge})
        => '/home/jdoe/allFilesOrDirectoriesAboveNeovim'
        => '/home/allFilesOrDirectoriesAboveNeovim'
+
        lua = vim.fs.find('aFileInHomeDirectory', {path = '/home'})
        => '/home/jdoe/archive/aFileInHomeDirectory'
 <

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -222,25 +222,32 @@ function M.find(names, opts)
   return matches
 end
 
---- Normalize a path to a standard format. A tilde (~) character at the
---- beginning of the path is expanded to the user's home directory and any
---- backslash (\ or \\) characters are converted to forward slashes (/). Environment
---- variables are also expanded.
----
---- Example:
---- <pre>
---- lua = vim.fs.normalize('C:\Users\\jdoe')
---- => 'C:/Users/jdoe'
----
---- lua = vim.fs.normalize('~/src/neovim')
---- => '/home/jdoe/src/neovim'
----
---- lua = vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
---- => '/Users/jdoe/.config/nvim/init.vim'
---- </pre>
----
----@param path (string) Path to normalize
----@return (string) Normalized path
+
+--[[
+
+    Normalize a path to standard format. A tilde (~) character at the
+    beginning of the path is expanded to the user's home directory and any
+    backslash (\ or \\) characters are converted to forward slashes (/). Environment
+    variables are also expanded.
+
+    Examples:
+
+      lua = vim.fs.normalize('C:\Users\\jdoe')
+      => 'C:/Users/jdoe'
+
+      lua = vim.fs.normalize('~/src/neovim')
+      => '/home/jdoe/src/neovim'
+
+      lua = vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
+      => '/Users/jdoe/.config/nvim/init.vim'
+
+
+    @param path (string) Path to normalize
+
+    @return (string) Normalized path
+
+--]]
+
 function M.normalize(path)
   vim.validate({ path = { path, 's' } })
   return (path:gsub('^~/', vim.env.HOME .. '/'):gsub('%$([%w_]+)', vim.env):gsub('\\', '/'))

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -65,39 +65,55 @@ function M.dir(path)
     vim.loop.fs_scandir(M.normalize(path))
 end
 
---- Find files or directories in the given path.
----
---- Finds any files or directories given in {names} starting from {path}. If
---- {upward} is "true" then the search traverses upward through parent
---- directories; otherwise, the search traverses downward. Note that downward
---- searches are recursive and may search through many directories! If {stop}
---- is non-nil, then the search stops when the directory given in {stop} is
---- reached. The search terminates when {limit} (default 1) matches are found.
---- The search can be narrowed to find only files or or only directories by
---- specifying {type} to be "file" or "directory", respectively.
----
----@param names (string|table|fun(name: string): boolean) Names of the files
----             and directories to find.
----             Must be base names, paths and globs are not supported.
----             If a function it is called per file and dir within the
----             traversed directories to test if they match.
----@param opts (table) Optional keyword arguments:
----                       - path (string): Path to begin searching from. If
----                              omitted, the current working directory is used.
----                       - upward (boolean, default false): If true, search
----                                upward through parent directories. Otherwise,
----                                search through child directories
----                                (recursively).
----                       - stop (string): Stop searching when this directory is
----                              reached. The directory itself is not searched.
----                       - type (string): Find only files ("file") or
----                              directories ("directory"). If omitted, both
----                              files and directories that match {name} are
----                              included.
----                       - limit (number, default 1): Stop the search after
----                               finding this many matches. Use `math.huge` to
----                               place no limit on the number of matches.
----@return (table) The paths of all matching files or directories
+--[[
+
+    Find files or directories in the given path.
+
+    Finds any files or directories given in {names} starting from {path} (if given). If
+    {upward} is "true" then the search traverses upward through parent
+    directories; otherwise, the search traverses downward. Note that downward
+    searches are recursive and may search through many directories! If {stop}
+    is given, then the search stops when the directory given in {stop} is
+    reached. The search terminates when {limit} (1 if omitted) matches are found.
+    The search can be narrowed to find only files or only directories by
+    specifying {type} to be either 'file' or 'directory', respectively.
+    
+     Examples: >
+       lua = vim.fs.find('aFileOrDirectoryNextToNeovim')
+       => 'C:/Users/jdoe/aFileOrDirectoryNextToNeovim'
+       lua = vim.fs.find('allFilesOrDirectoriesAboveNeovim', {upward = true, limit = math.huge})
+       => '/home/jdoe/allFilesOrDirectoriesAboveNeovim'
+       => '/home/allFilesOrDirectoriesAboveNeovim'
+       lua = vim.fs.find('aFileInHomeDirectory', {path = '/home'})
+       => '/home/jdoe/archive/aFileInHomeDirectory'
+<
+
+
+      • @param names  (string or table/array or fun(name: string): boolean) Names of the files
+                 and directories to find. Must be base names, paths and globs
+                 are not supported. The function is called per file and
+                 directory within the traversed directories to test if they match with {names}.
+		 
+      • @param opts  (table/array) Optional keyword arguments:
+                 • path (string): Path to begin searching from. If omitted,
+                   the current working directory ("nvim" executable) is used.
+                 • upward (boolean, default false): If true, search upward
+                   through parent directories. Otherwise, search through child
+                   directories (recursively).
+                 • stop (string): Stop searching when this directory is
+                   reached. The directory itself is not searched.
+                 • type (string): Find only files ("file") or directories
+                   ("directory"). If omitted, both files and directories that
+                   match {names} are included.
+                 • limit (number, 1 if omitted): Stop the search after finding
+                   {limit} match(es). Use `math.huge` to place no limit on the
+                   number of matches.
+
+    
+        @return (table) The normalized (see below) paths of all matching files or directories in {names}
+
+--]]
+
 function M.find(names, opts)
   opts = opts or {}
   vim.validate({
@@ -208,18 +224,18 @@ end
 
 --- Normalize a path to a standard format. A tilde (~) character at the
 --- beginning of the path is expanded to the user's home directory and any
---- backslash (\\) characters are converted to forward slashes (/). Environment
+--- backslash (\ or \\) characters are converted to forward slashes (/). Environment
 --- variables are also expanded.
 ---
 --- Example:
 --- <pre>
---- vim.fs.normalize('C:\\Users\\jdoe')
+--- lua = vim.fs.normalize('C:\Users\\jdoe')
 --- => 'C:/Users/jdoe'
 ---
---- vim.fs.normalize('~/src/neovim')
+--- lua = vim.fs.normalize('~/src/neovim')
 --- => '/home/jdoe/src/neovim'
 ---
---- vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
+--- lua = vim.fs.normalize('$XDG_CONFIG_HOME/nvim/init.vim')
 --- => '/Users/jdoe/.config/nvim/init.vim'
 --- </pre>
 ---


### PR DESCRIPTION
Added examples for the `vim.fs.find()` function, as well as clarifications for both the `vim.fs.find()` and the `vim.fs.normalize()` functions.

I prefixed `lua =` to all example commands since the commands simply do not work without this prefix. For example, (I use MacOS with the latest Neovim build from source):

    Input: 

![Screen Shot 2022-11-19 at 9 38 56 PM](https://user-images.githubusercontent.com/97570339/202887432-fa605273-64b3-4547-a8c3-d35abc9abb47.png)


    Output:
![Screen Shot 2022-11-19 at 9 39 19 PM](https://user-images.githubusercontent.com/97570339/202887450-8ad1ca10-f3f6-405e-9095-ba90b2e4d87d.png)


With `lua =` prefixed:

    Input:

![Screen Shot 2022-11-19 at 9 42 14 PM](https://user-images.githubusercontent.com/97570339/202887489-9aea0c1c-ae33-4e37-bd14-52b6733e929a.png)

Output:

![Screen Shot 2022-11-19 at 9 42 29 PM](https://user-images.githubusercontent.com/97570339/202887510-d0a5667a-6ff3-46cd-b424-81dcf81a9fc5.png)

