### PR TITLE
vim-patch:9.0.{partial:0913,0915}: only change in current window triggers the WinScrolled event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1096,22 +1096,35 @@ WinNew				When a new window was created.  Not done for
 
 							*WinScrolled*
 WinScrolled			After scrolling the content of a window or
-				resizing a window.
-				The pattern is matched against the
-				|window-ID|.  Both <amatch> and <afile> are
-				set to the |window-ID|.
-				Non-recursive (the event cannot trigger
-				itself).  However, if the command causes the
-				window to scroll or change size another
+				resizing a window in the current tab page.
+
+				When more than one window scrolled or resized
+				only one WinScrolled event is triggered.  You
+				can use the `winlayout()` and `getwininfo()`
+				functions to see what changed.
+
+				The pattern is matched against the |window-ID|
+				of the first window that scrolled or resized.
+				Both <amatch> and <afile> are set to the
+				|window-ID|.
+
+				Only starts triggering after startup finished
+				and the first screen redraw was done.
+
+				Non-recursive: the event will not trigger
+				while executing commands for the WinScrolled
+				event.  However, if the command causes a
+				window to scroll or change size, then another
 				WinScrolled event will be triggered later.
+
 				Does not trigger when the command is added,
 				only after the first scroll or resize.
 
 ==============================================================================
 6. Patterns					*autocmd-pattern* *{aupat}*
 
-The {aupat} argument of `:autocmd` can be a comma-separated list.  This works
-as if the command was given with each pattern separately.  Thus this command: >
+The {aupat} argument of `:autocmd` can be a comma-separated list.  This works as
+if the command was given with each pattern separately.  Thus this command: >
 	:autocmd BufRead *.txt,*.info set et
 Is equivalent to: >
 	:autocmd BufRead *.txt set et

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1142,13 +1142,17 @@ int autocmd_register(int64_t id, event_T event, char *pat, int patlen, int group
     }
 
     // Initialize the fields checked by the WinScrolled trigger to
-    // stop it from firing right after the first autocmd is defined.
+    // prevent it from firing right after the first autocmd is
+    // defined.
     if (event == EVENT_WINSCROLLED && !has_event(EVENT_WINSCROLLED)) {
-      curwin->w_last_topline = curwin->w_topline;
-      curwin->w_last_leftcol = curwin->w_leftcol;
-      curwin->w_last_skipcol = curwin->w_skipcol;
-      curwin->w_last_width = curwin->w_width;
-      curwin->w_last_height = curwin->w_height;
+      tabpage_T *save_curtab = curtab;
+      FOR_ALL_TABS(tp) {
+        unuse_tabpage(curtab);
+        use_tabpage(tp);
+        snapshot_windows_scroll_size();
+      }
+      unuse_tabpage(curtab);
+      use_tabpage(save_curtab);
     }
 
     ap->cmds = NULL;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1397,6 +1397,9 @@ static int normal_check(VimState *state)
       fclose(time_fd);
       time_fd = NULL;
     }
+    // After the first screen update may start triggering WinScrolled
+    // autocmd events.  Store all the scroll positions and sizes now.
+    may_make_initial_scroll_size_snapshot();
   }
 
   // May perform garbage collection when waiting for a character, but

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -428,6 +428,32 @@ func Test_WinScrolled_once_only()
   call StopVimInTerminal(buf)
 endfunc
 
+" Check that WinScrolled is not triggered immediately when defined and there
+" are split windows.
+func Test_WinScrolled_not_when_defined()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, ['aaa', 'bbb'])
+      echo 'nothing happened'
+      func ShowTriggered(id)
+        echo 'triggered'
+      endfunc
+  END
+  call writefile(lines, 'Xtest_winscrolled_not', 'D')
+  let buf = RunVimInTerminal('-S Xtest_winscrolled_not', #{rows: 10, cols: 60, statusoff: 2})
+  call term_sendkeys(buf, ":split\<CR>")
+  call TermWait(buf)
+  " use a timer to show the message after redrawing
+  call term_sendkeys(buf, ":au WinScrolled * call timer_start(100, 'ShowTriggered')\<CR>")
+  call VerifyScreenDump(buf, 'Test_winscrolled_not_when_defined_1', {})
+
+  call term_sendkeys(buf, "\<C-E>")
+  call VerifyScreenDump(buf, 'Test_winscrolled_not_when_defined_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_WinScrolled_long_wrapped()
   CheckRunVimInTerminal
 

--- a/test/functional/autocmd/winscrolled_spec.lua
+++ b/test/functional/autocmd/winscrolled_spec.lua
@@ -1,8 +1,10 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 
 local clear = helpers.clear
 local eq = helpers.eq
 local eval = helpers.eval
+local exec = helpers.exec
 local command = helpers.command
 local feed = helpers.feed
 local meths = helpers.meths
@@ -89,11 +91,42 @@ describe('WinScrolled', function()
   end)
 end)
 
-it('closing window in WinScrolled does not cause use-after-free #13265', function()
-  local lines = {'aaa', 'bbb'}
-  meths.buf_set_lines(0, 0, -1, true, lines)
-  command('vsplit')
-  command('autocmd WinScrolled * close')
-  feed('<C-E>')
-  assert_alive()
+describe('WinScrolled', function()
+  -- oldtest: Test_WinScrolled_mouse()
+  it('is triggered by mouse scrolling in another window', function()
+    local screen = Screen.new(75, 10)
+    screen:attach()
+    exec([[
+      set nowrap scrolloff=0
+      set mouse=a
+      call setline(1, ['foo']->repeat(32))
+      split
+      let g:scrolled = 0
+      au WinScrolled * let g:scrolled += 1
+    ]])
+
+    -- With the upper split focused, send a scroll-down event to the unfocused one.
+    meths.input_mouse('wheel', 'down', '', 0, 6, 0)
+    eq(1, eval('g:scrolled'))
+
+    -- Again, but this time while we're in insert mode.
+    feed('i')
+    meths.input_mouse('wheel', 'down', '', 0, 6, 0)
+    feed('<Esc>')
+    eq(2, eval('g:scrolled'))
+  end)
+
+  -- oldtest: Test_WinScrolled_close_curwin()
+  it('closing window does not cause use-after-free #13265', function()
+    exec([[
+      set nowrap scrolloff=0
+      call setline(1, ['aaa', 'bbb'])
+      vsplit
+      au WinScrolled * close
+    ]])
+
+    -- This was using freed memory
+    feed('<C-E>')
+    assert_alive()
+  end)
 end)

--- a/test/functional/autocmd/winscrolled_spec.lua
+++ b/test/functional/autocmd/winscrolled_spec.lua
@@ -130,4 +130,33 @@ describe('WinScrolled', function()
     feed('<C-E>')
     assert_alive()
   end)
+
+  it('is triggered by mouse scrolling in unfocused floating window #18222', function()
+    local screen = Screen.new(80, 24)
+    screen:attach()
+    local buf = meths.create_buf(true, true)
+    meths.buf_set_lines(buf, 0, -1, false, {'a', 'b', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'})
+    local win = meths.open_win(buf, false, {
+      height = 5,
+      width = 10,
+      col = 0,
+      row = 1,
+      relative = 'editor',
+      style = 'minimal'
+    })
+    exec([[
+      let g:scrolled = 0
+      autocmd WinScrolled * let g:scrolled += 1
+      autocmd WinScrolled * let g:amatch = expand('<amatch>')
+    ]])
+    eq(0, eval('g:scrolled'))
+
+    meths.input_mouse('wheel', 'down', '', 0, 3, 3)
+    eq(1, eval('g:scrolled'))
+    eq(tostring(win.id), eval('g:amatch'))
+
+    meths.input_mouse('wheel', 'down', '', 0, 3, 3)
+    eq(2, eval('g:scrolled'))
+    eq(tostring(win.id), eval('g:amatch'))
+  end)
 end)

--- a/test/functional/autocmd/winscrolled_spec.lua
+++ b/test/functional/autocmd/winscrolled_spec.lua
@@ -104,6 +104,7 @@ describe('WinScrolled', function()
       let g:scrolled = 0
       au WinScrolled * let g:scrolled += 1
     ]])
+    eq(0, eval('g:scrolled'))
 
     -- With the upper split focused, send a scroll-down event to the unfocused one.
     meths.input_mouse('wheel', 'down', '', 0, 6, 0)


### PR DESCRIPTION
Fix #18222

#### vim-patch:partial:9.0.0913: only change in current window triggers the WinScrolled event

Problem:    Only a change in the current window triggers the WinScrolled
            event.
Solution:   Trigger WinScrolled if any window scrolled or changed size.
            (issue vim/vim#11576)

https://github.com/vim/vim/commit/0a60f79fd0c328b47b36279a95282e9f8d9e7512

Skip locking of window layout and E1312.
Copy the latest version of all WinScrolled tests from Vim.
Note: patch 9.0.0915 is needed for the Lua tests to pass.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0915: WinScrolled may trigger immediately when defined

Problem:    WinScrolled may trigger immediately when defined.
Solution:   Initialize the fields in all windows.

https://github.com/vim/vim/commit/29967732761d1ffb5592db5f5aa7036f5b52abf1

Co-authored-by: Bram Moolenaar <Bram@vim.org>