### PR TITLE
feat(diagnostic): add `suffix` option to `virt_text` config

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -365,6 +365,11 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                          the beginning of the virtual text.
                        • prefix: (string) Prepend diagnostic message with
                          prefix.
+                       • suffix: (string or function) Append diagnostic
+                         message with suffix. If a function, it must have the
+                         signature (diagnostic) -> string, where {diagnostic}
+                         is of type |diagnostic-structure|. This can be used
+                         to render an LSP diagnostic error code.
                        • format: (function) A function that takes a diagnostic
                          as input and returns a string. The return value is
                          the text used to display the diagnostic. Example: >

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -613,6 +613,10 @@ end
 ---                       * spacing: (number) Amount of empty spaces inserted at the beginning
 ---                                  of the virtual text.
 ---                       * prefix: (string) Prepend diagnostic message with prefix.
+---                       * suffix: (string or function) Append diagnostic message with suffix.
+---                                 If a function, it must have the signature (diagnostic) ->
+---                                 string, where {diagnostic} is of type |diagnostic-structure|.
+---                                 This can be used to render an LSP diagnostic error code.
 ---                       * format: (function) A function that takes a diagnostic as input and
 ---                                 returns a string. The return value is the text used to display
 ---                                 the diagnostic. Example:
@@ -1039,6 +1043,7 @@ function M._get_virt_text_chunks(line_diags, opts)
 
   opts = opts or {}
   local prefix = opts.prefix or '■'
+  local suffix = opts.suffix or ''
   local spacing = opts.spacing or 4
 
   -- Create a little more space between virtual text and contents
@@ -1052,8 +1057,11 @@ function M._get_virt_text_chunks(line_diags, opts)
   -- TODO(tjdevries): Allow different servers to be shown first somehow?
   -- TODO(tjdevries): Display server name associated with these?
   if last.message then
+    if type(suffix) == 'function' then
+      suffix = suffix(last) or ''
+    end
     table.insert(virt_texts, {
-      string.format('%s %s', prefix, last.message:gsub('\r', ''):gsub('\n', '  ')),
+      string.format('%s %s%s', prefix, last.message:gsub('\r', ''):gsub('\n', '  '), suffix),
       virtual_text_highlight_map[last.severity],
     })
 


### PR DESCRIPTION
Follow-up to https://github.com/neovim/neovim/pull/21130

This introduces a `suffix` option to the `virt_text` config in `vim.diagnostic.config()`. The suffix can either be a string which is appended to the diagnostic message or a function returning such. The function receives a `diagnostic` argument, which is the diagnostic table of the last diagnostic (the one whose message is rendered as virt text).

We could also pass in `i` and `total` to the function, like we do for the `suffix` in `vim.diagnostic.open_float()`. This would enable configuring a suffix like " [3/3]" for a line with 3 diagnostics. I'm not sure how useful that is, though.

Also unlike the `suffix` in `vim.diagnostic.open_float()`, we don't support customizing the highlight. I'm not sure how useful this would be.

Example configuration:
```lua
local function suffix(diagnostic)
  return diagnostic.code and (" [%s]"):format(diagnostic.code) or "" 
end
vim.diagnostic.config({virtual_text = {suffix = suffix}})
```

Screenshot:
![Screen Shot 2022-11-20 at 12 12 56 PM](https://user-images.githubusercontent.com/54521218/202923930-dd57b1f8-bee2-4509-88f5-06bd15809c58.png)

cc @gpanders 
