### PR TITLE
ci: create CI job to check if news needs to be updated

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -1,0 +1,31 @@
+name: "news.txt check"
+on:
+  pull_request:
+    branches:
+    - 'master'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ github.event.pull_request.commits }}
+      - name: news.txt needs to be updated
+        run: |
+          for commit in $(git rev-list HEAD); do
+            message=$(git log -n1 --pretty=format:%s $commit)
+            type="$(echo "$message" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')"
+            breaking="$(echo "$message" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')"
+            if [[ "$type" == "feat" ]] || [[ "$breaking" == "breaking-change" ]]; then
+              git diff HEAD~$((${{ github.event.pull_request.commits }}-1)) --name-only | grep runtime/doc/news.txt ||
+              {
+                echo "
+                  Pull request includes a new feature or a breaking change, but
+                  news.txt hasn't been updated yet. news.txt is our primary way of
+                  communicating changes to users so it's important to keep it up to
+                  date."
+                  exit 1
+               }
+            fi
+          done


### PR DESCRIPTION
If any commit message in the PR is either of type "feat" or is a
breaking change, then there's a high probability that news.txt should be
updated. Give an error if news.txt hasn't been updated in that case.

This workflow cannot 100% correctly determine if news.txt should be
updated even if the commit messages were exactly correct. The entries in
news.txt is determined by changes between releases, while the commit
messages are based on the master branch. While it is an approximation,
it is still a useful enough one that it's still valuable to have this
job as a reminder even if it gives an error if it shouldn't. In these
cases it is perfectly fine to ignore the failure for this job.