### PR TITLE
fix: pvs warnings

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -382,7 +382,7 @@ static void parse_border_title(Object title, Object title_pos, FloatConfig *fcon
     return;
   }
 
-  if (title.type == kObjectTypeArray && title.data.array.size == 0) {
+  if (title.data.array.size == 0) {
     api_set_error(err, kErrorTypeValidation, "title cannot be an empty array");
     return;
   }
@@ -391,7 +391,6 @@ static void parse_border_title(Object title, Object title_pos, FloatConfig *fcon
   fconfig->title_chunks = parse_virt_text(title.data.array, err, &fconfig->title_width);
 
   fconfig->title = true;
-  return;
 }
 
 static bool parse_title_pos(Object title_pos, FloatConfig *fconfig, Error *err)

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -862,7 +862,7 @@ void ex_endif(exarg_T *eap)
 /// Handle ":else" and ":elseif".
 void ex_else(exarg_T *eap)
 {
-  int result;
+  bool result = false;
   cstack_T *const cstack = eap->cstack;
 
   bool skip = CHECK_SKIP;

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -1,3 +1,6 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check
+// it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
 #include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -380,6 +380,7 @@ bool unpacker_parse_redraw(Unpacker *p)
   size_t size = p->read_size;
   GridLineEvent *g = p->grid_line_event;
 
+// -V:NEXT_TYPE:501
 #define NEXT_TYPE(tok, typ) \
   result = mpack_rtoken(&data, &size, &tok); \
   if (result == MPACK_EOF) { \

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -974,7 +974,7 @@ int os_file_mkdir(char *fname, int32_t mode)
     *tail = NUL;
     int r;
     char *failed_dir;
-    if ((r = os_mkdir_recurse(fname, mode, &failed_dir) < 0)) {
+    if (((r = os_mkdir_recurse(fname, mode, &failed_dir)) < 0)) {
       semsg(_(e_mkdir), failed_dir, os_strerror(r));
       xfree(failed_dir);
     }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6711,7 +6711,7 @@ static bool mark_quickfix_ctx(qf_info_T *qi, int copyID)
     typval_T *ctx = qi->qf_lists[i].qf_ctx;
     if (ctx != NULL && ctx->v_type != VAR_NUMBER
         && ctx->v_type != VAR_STRING && ctx->v_type != VAR_FLOAT) {
-      abort = abort || set_ref_in_item(ctx, copyID, NULL, NULL);
+      abort = set_ref_in_item(ctx, copyID, NULL, NULL);
     }
 
     Callback *cb = &qi->qf_lists[i].qf_qftf_cb;


### PR DESCRIPTION
- fix(PVS/V009): start file with special comment

- fix(PVS/V501): identical sub-expressions for comparison

- fix(PVS/V560): part of conditional expression is always true/false

- fix(PVS/V593): review expression of type A = B < C

- fix(PVS/V614): potentially uninitialized variable used