### PR TITLE
fix(ui-ext): log and clear error in ui_comp_event

### DIFF
--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -12,7 +12,7 @@
 #define ARRAY_DICT_INIT KV_INITIAL_VALUE
 #define STRING_INIT { .data = NULL, .size = 0 }
 #define OBJECT_INIT { .type = kObjectTypeNil }
-#define ERROR_INIT { .type = kErrorTypeNone, .msg = NULL }
+#define ERROR_INIT ((Error) { .type = kErrorTypeNone, .msg = NULL })
 #define REMOTE_TYPE(type) typedef handle_T type
 
 #define ERROR_SET(e) ((e)->type != kErrorTypeNone)

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -186,7 +186,7 @@ void unpacker_init(Unpacker *p)
   mpack_parser_init(&p->parser, 0);
   p->parser.data.p = p;
   mpack_tokbuf_init(&p->reader);
-  p->unpack_error = (Error)ERROR_INIT;
+  p->unpack_error = ERROR_INIT;
 
   p->arena = (Arena)ARENA_EMPTY;
 }

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -711,16 +711,17 @@ static void ui_comp_event(UI *ui, char *name, Array args)
   bool handled = false;
 
   map_foreach_value(&ui_event_cbs, event_cb, {
+    err.type = kErrorTypeNone;
+    err.msg = NULL;
     Object res = nlua_call_ref(event_cb->cb, name, args, false, &err);
     if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
       handled = true;
     }
+    if (err.type != kErrorTypeNone) {
+      ELOG("Error while executing ui_comp_event callback: %s", err.msg);
+    }
   })
-  if (err.type != kErrorTypeNone) {
-    ELOG("Error while executing ui_comp_event callback: %s", err.msg);
-  } else {
-    api_clear_error(&err);
-  }
+  api_clear_error(&err);
 
   if (!handled) {
     ui_composed_call_event(name, args);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -716,6 +716,11 @@ static void ui_comp_event(UI *ui, char *name, Array args)
       handled = true;
     }
   })
+  if (err.type != kErrorTypeNone) {
+    ELOG("Error while executing ui_comp_event callback: %s", err.msg);
+  } else {
+    api_clear_error(&err);
+  }
 
   if (!handled) {
     ui_composed_call_event(name, args);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -706,13 +706,11 @@ static void ui_comp_grid_resize(UI *ui, Integer grid, Integer width, Integer hei
 
 static void ui_comp_event(UI *ui, char *name, Array args)
 {
-  Error err = ERROR_INIT;
   UIEventCallback *event_cb;
   bool handled = false;
-
+  Error initerr = ERROR_INIT;
   map_foreach_value(&ui_event_cbs, event_cb, {
-    err.type = kErrorTypeNone;
-    err.msg = NULL;
+    Error err = initerr;
     Object res = nlua_call_ref(event_cb->cb, name, args, false, &err);
     if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
       handled = true;
@@ -720,8 +718,9 @@ static void ui_comp_event(UI *ui, char *name, Array args)
     if (err.type != kErrorTypeNone) {
       ELOG("Error while executing ui_comp_event callback: %s", err.msg);
     }
+    api_clear_error(&err);
   })
-  api_clear_error(&err);
+  api_clear_error(&initerr);
 
   if (!handled) {
     ui_composed_call_event(name, args);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -715,7 +715,7 @@ static void ui_comp_event(UI *ui, char *name, Array args)
     if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
       handled = true;
     }
-    if (err.type != kErrorTypeNone) {
+    if (ERROR_SET(&err)) {
       ELOG("Error while executing ui_comp_event callback: %s", err.msg);
     }
     api_clear_error(&err);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -708,7 +708,7 @@ static void ui_comp_event(UI *ui, char *name, Array args)
 {
   UIEventCallback *event_cb;
   bool handled = false;
-  Error initerr = ERROR_INIT;
+  const Error initerr = ERROR_INIT;
   map_foreach_value(&ui_event_cbs, event_cb, {
     Error err = initerr;
     Object res = nlua_call_ref(event_cb->cb, name, args, false, &err);
@@ -720,7 +720,6 @@ static void ui_comp_event(UI *ui, char *name, Array args)
     }
     api_clear_error(&err);
   })
-  api_clear_error(&initerr);
 
   if (!handled) {
     ui_composed_call_event(name, args);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -708,9 +708,8 @@ static void ui_comp_event(UI *ui, char *name, Array args)
 {
   UIEventCallback *event_cb;
   bool handled = false;
-  const Error initerr = ERROR_INIT;
   map_foreach_value(&ui_event_cbs, event_cb, {
-    Error err = initerr;
+    Error err = ERROR_INIT;
     Object res = nlua_call_ref(event_cb->cb, name, args, false, &err);
     if (res.type == kObjectTypeBoolean && res.data.boolean == true) {
       handled = true;


### PR DESCRIPTION
Fix #20789

Fix for memory leak in ui_comp_event. See [issue 20789 for more context](https://github.com/neovim/neovim/issues/20789).

I've verified that `make unittest` passes. I've had issues prior to this change, on `master`, where `make functionaltest` fails(with a timeout) on `timer_spec.lua`. Unfortunately it's still the case, and I cannot verify that they pass. I'm hoping the CI pipeline will handle the valid testing for me.

Thanks for your time.