### PR TITLE
feat(diagnostic): improve default highlight of suffix in floats

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1376,7 +1376,12 @@ function M.open_float(opts, ...)
   end
 
   local suffix_opt = if_nil(opts.suffix, function(diagnostic)
-    return diagnostic.code and string.format(' [%s]', diagnostic.code) or ''
+    if diagnostic.code then
+      local hlgroup = floating_highlight_map[diagnostic.severity]
+      return string.format(' [%s]', diagnostic.code), hlgroup
+    else
+      return ''
+    end
   end)
 
   local suffix, suffix_hl_group


### PR DESCRIPTION
This changes the highlighting of the default suffix in floating window diagnostics to match the diagnostic message.

Before:
![Screen Shot 2022-11-21 at 11 30 23 PM](https://user-images.githubusercontent.com/54521218/203252087-867d9600-53be-4002-8bfe-7f13b48293df.png)

After:
![Screen Shot 2022-11-21 at 11 18 46 PM](https://user-images.githubusercontent.com/54521218/203250810-5b2e5924-a783-4070-8499-cc0e550785d3.png)

I think this is probably what most users want, and in case they do, implementing this would take the user a bit of work to map a diagnostic severity to the correct highlight group.

The only concern (and the reason I didn't initially implement this) is that the error code blends in with the diagnostic message, but I don't think this would be problematic.

cc @gpanders 