### PR TITLE
test: use luv.os_uname for fast platform detection

### DIFF
--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -269,7 +269,7 @@ function module.check_logs()
     table.concat(runtime_errors, ', ')))
 end
 
--- Gets (lowercase) OS name from CMake, uname, or manually check if on Windows
+-- Gets (lowercase) OS name from CMAKE_HOST_SYSTEM_NAME or luv.os_uname
 do
   local platform = nil
   function module.uname()
@@ -277,21 +277,11 @@ do
       return platform
     end
 
-    if os.getenv("SYSTEM_NAME") then  -- From CMAKE_HOST_SYSTEM_NAME.
-      platform = string.lower(os.getenv("SYSTEM_NAME"))
-      return platform
+    platform = os.getenv('SYSTEM_NAME') -- From CMAKE_HOST_SYSTEM_NAME
+    if not platform or platform == '' then
+      platform = luv.os_uname().sysname
     end
-
-    local status, f = pcall(module.popen_r, 'uname', '-s')
-    if status then
-      platform = string.lower(f:read("*l"))
-      f:close()
-    elseif package.config:sub(1,1) == '\\' then
-      platform = 'windows'
-    else
-      error('unknown platform')
-    end
-    return platform
+    return platform:lower()
   end
 end
 

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -269,19 +269,10 @@ function module.check_logs()
     table.concat(runtime_errors, ', ')))
 end
 
--- Gets (lowercase) OS name from CMAKE_HOST_SYSTEM_NAME or luv.os_uname
-do
-  local platform = nil
-  function module.uname()
-    if platform then
-      return platform
-    end
-
-    platform = os.getenv('SYSTEM_NAME') -- From CMAKE_HOST_SYSTEM_NAME
-    if not platform or platform == '' then
-      platform = luv.os_uname().sysname
-    end
-    return platform:lower()
+function module.uname()
+  local platform = luv.os_uname()
+  if platform and platform.sysname then
+    return platform.sysname:lower()
   end
 end
 

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -284,7 +284,7 @@ function module.is_os(s)
     or s == 'bsd') then
     error('unknown platform: '..tostring(s))
   end
-  return ((s == 'win' and module.sysname():match('windows'))
+  return ((s == 'win' and module.sysname():find('windows'))
     or (s == 'mac' and module.sysname() == 'darwin')
     or (s == 'freebsd' and module.sysname() == 'freebsd')
     or (s == 'openbsd' and module.sysname() == 'openbsd')

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -269,7 +269,7 @@ function module.check_logs()
     table.concat(runtime_errors, ', ')))
 end
 
-function module.uname()
+function module.sysname()
   local platform = luv.os_uname()
   if platform and platform.sysname then
     return platform.sysname:lower()
@@ -284,11 +284,11 @@ function module.is_os(s)
     or s == 'bsd') then
     error('unknown platform: '..tostring(s))
   end
-  return ((s == 'win' and module.uname() == 'windows')
-    or (s == 'mac' and module.uname() == 'darwin')
-    or (s == 'freebsd' and module.uname() == 'freebsd')
-    or (s == 'openbsd' and module.uname() == 'openbsd')
-    or (s == 'bsd' and string.find(module.uname(), 'bsd')))
+  return ((s == 'win' and module.sysname():match('windows'))
+    or (s == 'mac' and module.sysname() == 'darwin')
+    or (s == 'freebsd' and module.sysname() == 'freebsd')
+    or (s == 'openbsd' and module.sysname() == 'openbsd')
+    or (s == 'bsd' and module.sysname():find('bsd')))
 end
 
 local function tmpdir_get()


### PR DESCRIPTION
use `luv.os_uname` for faster detection of underlying platform

```console
Benchmark Group: 'unames' -----------------------
Benchmark #1: 'luv'
  Time(mean ± σ):    127.0 ns ± 153.0 ns
  Range(min … max):   60.0 ns … 550.0 ns  10 runs
Benchmark #2: 'popen'
  Time(mean ± σ):    300.0 ns ± 268.0 ns
  Range(min … max):  150.0 ns …   1.0 μs  10 runs
Summary
  'luv' ran
  2.4 ± 3.5 times faster than 'popen'
```
