### PR TITLE
fix(options): fix local 'sidescrolloff' doesn't work for mouse

### DIFF
--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -456,12 +456,13 @@ bool leftcol_changed(void)
 
   // If the cursor is right or left of the screen, move it to last or first
   // character.
-  if (curwin->w_virtcol > (colnr_T)(lastcol - p_siso)) {
+  long siso = get_sidescrolloff_value(curwin);
+  if (curwin->w_virtcol > (colnr_T)(lastcol - siso)) {
     retval = true;
-    coladvance((colnr_T)(lastcol - p_siso));
-  } else if (curwin->w_virtcol < curwin->w_leftcol + p_siso) {
+    coladvance((colnr_T)(lastcol - siso));
+  } else if (curwin->w_virtcol < curwin->w_leftcol + siso) {
     retval = true;
-    coladvance((colnr_T)(curwin->w_leftcol + p_siso));
+    coladvance((colnr_T)(curwin->w_leftcol + siso));
   }
 
   // If the start of the character under the cursor is not on the screen,

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2768,7 +2768,7 @@ static void nv_zet(cmdarg_T *cap)
   long old_fdl = curwin->w_p_fdl;
   int old_fen = curwin->w_p_fen;
 
-  int l_p_siso = (int)get_sidescrolloff_value(curwin);
+  int siso = (int)get_sidescrolloff_value(curwin);
 
   if (ascii_isdigit(nchar) && !nv_z_get_count(cap, &nchar)) {
     return;
@@ -2898,8 +2898,8 @@ static void nv_zet(cmdarg_T *cap)
       } else {
         getvcol(curwin, &curwin->w_cursor, &col, NULL, NULL);
       }
-      if (col > l_p_siso) {
-        col -= l_p_siso;
+      if (col > siso) {
+        col -= siso;
       } else {
         col = 0;
       }
@@ -2919,10 +2919,10 @@ static void nv_zet(cmdarg_T *cap)
         getvcol(curwin, &curwin->w_cursor, NULL, NULL, &col);
       }
       n = curwin->w_width_inner - curwin_col_off();
-      if (col + l_p_siso < n) {
+      if (col + siso < n) {
         col = 0;
       } else {
-        col = col + l_p_siso - n + 1;
+        col = col + siso - n + 1;
       }
       if (curwin->w_leftcol != col) {
         curwin->w_leftcol = col;

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -968,6 +968,49 @@ describe('ui/mouse/input', function()
     ]])
   end)
 
+  it("'sidescrolloff' applies to horizontal scrolling", function()
+    command('set nowrap')
+    command('set sidescrolloff=4')
+
+    feed("I <esc>020ib<esc>0")
+    screen:expect([[
+      testing                  |
+      mouse                    |
+      ^bbbbbbbbbbbbbbbbbbbb supp|
+      {0:~                        }|
+                               |
+    ]])
+
+    meths.input_mouse('wheel', 'right', '', 0, 0, 27)
+    screen:expect([[
+      g                        |
+                               |
+      bbbb^bbbbbbbbbb support an|
+      {0:~                        }|
+                               |
+    ]])
+
+    -- window-local 'sidescrolloff' should override global value. #21162
+    command('setlocal sidescrolloff=2')
+    feed('0')
+    screen:expect([[
+      testing                  |
+      mouse                    |
+      ^bbbbbbbbbbbbbbbbbbbb supp|
+      {0:~                        }|
+                               |
+    ]])
+
+    meths.input_mouse('wheel', 'right', '', 0, 0, 27)
+    screen:expect([[
+      g                        |
+                               |
+      bb^bbbbbbbbbbbb support an|
+      {0:~                        }|
+                               |
+    ]])
+  end)
+
   describe('on concealed text', function()
     -- Helpful for reading the test expectations:
     -- :match Error /\^/


### PR DESCRIPTION
Missing part of Vim patch 8.1.0864.