### PR TITLE
vim-patch:9.0.{0925,0926,0927}

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2471,11 +2471,13 @@ void tv_dict_extend(dict_T *const d1, dict_T *const d2, const char *const action
     }
     if (di1 == NULL) {
       if (*action == 'm') {
-        // cheap way to move a dict item from "d2" to "d1"
+        // Cheap way to move a dict item from "d2" to "d1".
+        // If dict_add() fails then "d2" won't be empty.
         dictitem_T *const new_di = di2;
-        tv_dict_add(d1, new_di);
-        hash_remove(&d2->dv_hashtab, hi2);
-        tv_dict_watcher_notify(d1, (const char *)new_di->di_key, &new_di->di_tv, NULL);
+        if (tv_dict_add(d1, new_di) == OK) {
+          hash_remove(&d2->dv_hashtab, hi2);
+          tv_dict_watcher_notify(d1, (const char *)new_di->di_key, &new_di->di_tv, NULL);
+        }
       } else {
         dictitem_T *const new_di = tv_dict_item_copy(di2);
         if (tv_dict_add(d1, new_di) == FAIL) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5390,6 +5390,7 @@ static int check_window_scroll_resize(int *size_count, win_T **first_scroll_win,
         // tv_list_set_item(winlist, listidx++, &tv);
         tv_list_append_owned_tv(winlist, tv);
       } else if (size_count != NULL) {
+        assert(first_size_win != NULL && first_scroll_win != NULL);
         (*size_count)++;
         if (*first_size_win == NULL) {
           *first_size_win = wp;


### PR DESCRIPTION
#### vim-patch:9.0.0925: two conditions are always false

Problem:    Two conditions are always false.
Solution:   Remove the conditions.  Update return value types to make clear
            what could be returned. (closes vim/vim#11593)

https://github.com/vim/vim/commit/df3c0eb41e1f48596c85af88b42fed22e3cca328


#### vim-patch:9.0.0926: Coverity warns for not using return value of dict_add()

Problem:    Coverity warns for not using return value of dict_add().
Solution:   When dict_add() fails then don't call hash_remove().

https://github.com/vim/vim/commit/bc222152d8dea252aa5f1fa24b5536ed269feb92

N/A patches for version.c:

vim-patch:9.0.0927: Coverity warns for using a NULL pointer

Problem:    Coverity warns for using a NULL pointer.
Solution:   Check for memory allocaion failure.

https://github.com/vim/vim/commit/96cbbe29debba25d7eec8d01955c5ac01f5c420d

Co-authored-by: Bram Moolenaar <Bram@vim.org>