### PR TITLE
vim-patch:8.2.{3698,3940,4062}: match highlight continues in linebreak

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1844,9 +1844,10 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
               n_extra = 0;
             }
           }
-          if (on_last_col) {
+          if (on_last_col && c != TAB) {
             // Do not continue search/match highlighting over the
-            // line break.
+            // line break, but for TABs the highlighting should
+            // include the complete width of the character
             search_attr = 0;
           }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -618,6 +618,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
 
   LineDrawState draw_state = WL_START;  // what to draw next
 
+  int match_conc      = 0;              ///< cchar for match functions
+  bool on_last_col    = false;
   int syntax_flags    = 0;
   int syntax_seqnr    = 0;
   int prev_syntax_id  = 0;
@@ -627,7 +629,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
                                         ///< force wrapping
   int vcol_off        = 0;              ///< offset for concealed characters
   int did_wcol        = false;
-  int match_conc      = 0;              ///< cchar for match functions
   int old_boguscols = 0;
 #define VCOL_HLC (vcol - vcol_off)
 #define FIX_FOR_BOGUSCOLS \
@@ -1429,8 +1430,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
         // When another match, have to check for start again.
         v = (ptr - line);
         search_attr = update_search_hl(wp, lnum, (colnr_T)v, &line, &screen_search_hl,
-                                       &has_match_conc,
-                                       &match_conc, lcs_eol_one, &search_attr_from_match);
+                                       &has_match_conc, &match_conc, lcs_eol_one,
+                                       &on_last_col, &search_attr_from_match);
         ptr = line + v;  // "line" may have been changed
 
         // Do not allow a conceal over EOL otherwise EOL will be missed
@@ -1842,6 +1843,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             if (n_extra < 0) {
               n_extra = 0;
             }
+          }
+          if (on_last_col) {
+            // Do not continue search/match highlighting over the
+            // line break.
+            search_attr = 0;
           }
 
           if (c == TAB && n_extra + col > grid->cols) {

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -425,7 +425,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
   const int called_emsg_before = called_emsg;
 
   // for :{range}s/pat only highlight inside the range
-  if (lnum < search_first_line || lnum > search_last_line) {
+  if ((lnum < search_first_line || lnum > search_last_line) && cur == NULL) {
     shl->lnum = 0;
     return;
   }

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -677,9 +677,11 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char_u **l
 /// After end, check for start/end of next match.
 /// When another match, have to check for start again.
 /// Watch out for matching an empty string!
+/// "on_last_col" is set to true with non-zero search_attr and the next column
+/// is endcol.
 /// Return the updated search_attr.
 int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char_u **line, match_T *search_hl,
-                     int *has_match_conc, int *match_conc, int lcs_eol_one,
+                     int *has_match_conc, int *match_conc, int lcs_eol_one, bool *on_last_col,
                      bool *search_attr_from_match)
 {
   matchitem_T *cur = wp->w_match_head;  // points to the match list
@@ -792,6 +794,7 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char_u **line, match
     }
     if (shl->attr_cur != 0) {
       search_attr = shl->attr_cur;
+      *on_last_col = col + 1 >= shl->endcol;
       *search_attr_from_match = shl != search_hl;
     }
     if (shl != search_hl && cur != NULL) {

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -421,4 +421,22 @@ func Test_matchdelete_redraw()
   bw!
 endfunc
 
+func Test_match_tab_with_linebreak()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set linebreak
+    call setline(1, "\tix")
+    call matchadd('ErrorMsg', '\t')
+  END
+  call writefile(lines, 'XscriptMatchTabLinebreak')
+  let buf = RunVimInTerminal('-S XscriptMatchTabLinebreak', #{rows: 10})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_match_tab_linebreak', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XscriptMatchTabLinebreak')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -380,6 +380,27 @@ func Test_match_in_linebreak()
   call delete('XscriptMatchLinebreak')
 endfunc
 
+func Test_match_with_incsearch()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set incsearch
+    call setline(1, range(20))
+    call matchaddpos('ErrorMsg', [3])
+  END
+  call writefile(lines, 'XmatchWithIncsearch')
+  let buf = RunVimInTerminal('-S XmatchWithIncsearch', #{rows: 6})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_match_with_incsearch_1', {})
+
+  call term_sendkeys(buf, ":s/0")
+  call VerifyScreenDump(buf, 'Test_match_with_incsearch_2', {})
+
+  call term_sendkeys(buf, "\<CR>")
+  call StopVimInTerminal(buf)
+  call delete('XmatchWithIncsearch')
+endfunc
+
 " Test for deleting matches outside of the screen redraw top/bottom lines
 " This should cause a redraw of those lines.
 func Test_matchdelete_redraw()

--- a/src/nvim/testdir/test_match.vim
+++ b/src/nvim/testdir/test_match.vim
@@ -363,4 +363,41 @@ func Test_matchadd_other_window()
   call delete('XscriptMatchCommon')
 endfunc
 
+func Test_match_in_linebreak()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set breakindent linebreak breakat+=]
+    call printf('%s]%s', repeat('x', 50), repeat('x', 70))->setline(1)
+    call matchaddpos('ErrorMsg', [[1, 51]])
+  END
+  call writefile(lines, 'XscriptMatchLinebreak')
+  let buf = RunVimInTerminal('-S XscriptMatchLinebreak', #{rows: 10})
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_match_linebreak', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XscriptMatchLinebreak')
+endfunc
+
+" Test for deleting matches outside of the screen redraw top/bottom lines
+" This should cause a redraw of those lines.
+func Test_matchdelete_redraw()
+  new
+  call setline(1, range(1, 500))
+  call cursor(250, 1)
+  let m1 = matchaddpos('Search', [[250]])
+  let m2 = matchaddpos('Search', [[10], [450]])
+  redraw!
+  let m3 = matchaddpos('Search', [[240], [260]])
+  call matchdelete(m2)
+  let m = getmatches()
+  call assert_equal(2, len(m))
+  call assert_equal([250], m[0].pos1)
+  redraw!
+  call matchdelete(m1)
+  call assert_equal(1, len(getmatches()))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/match_spec.lua
+++ b/test/functional/legacy/match_spec.lua
@@ -36,3 +36,32 @@ describe('matchaddpos()', function()
     ]])
   end)
 end)
+
+describe('match highlighting', function()
+  -- oldtest: Test_match_in_linebreak()
+  it('does not continue in linebreak vim-patch:8.2.3698', function()
+    local screen = Screen.new(75, 10)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+    })
+    screen:attach()
+    exec([=[
+      set breakindent linebreak breakat+=]
+      call printf('%s]%s', repeat('x', 50), repeat('x', 70))->setline(1)
+      call matchaddpos('ErrorMsg', [[1, 51]])
+    ]=])
+    screen:expect([[
+      ^xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx{1:]}                        |
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx     |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+  end)
+end)

--- a/test/functional/legacy/match_spec.lua
+++ b/test/functional/legacy/match_spec.lua
@@ -97,4 +97,30 @@ describe('match highlighting', function()
       :s/0^                                                                       |
     ]])
   end)
+
+  it('on a Tab vim-patch:8.2.4062', function()
+    local screen = Screen.new(75, 10)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+    })
+    screen:attach()
+    exec([[
+      set linebreak
+      call setline(1, "\tix")
+      call matchadd('ErrorMsg', '\t')
+    ]])
+    screen:expect([[
+      {1:       ^ }ix                                                                 |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+  end)
 end)

--- a/test/functional/legacy/match_spec.lua
+++ b/test/functional/legacy/match_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local exec = helpers.exec
+local feed = helpers.feed
 
 before_each(clear)
 
@@ -62,6 +63,38 @@ describe('match highlighting', function()
       {0:~                                                                          }|
       {0:~                                                                          }|
                                                                                  |
+    ]])
+  end)
+
+  it('is shown with incsearch vim-patch:8.2.3940', function()
+    local screen = Screen.new(75, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Yellow},  -- Search
+      [2] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+    })
+    screen:attach()
+    exec([[
+      set incsearch
+      call setline(1, range(20))
+      call matchaddpos('ErrorMsg', [3])
+    ]])
+    screen:expect([[
+      ^0                                                                          |
+      1                                                                          |
+      {2:2}                                                                          |
+      3                                                                          |
+      4                                                                          |
+                                                                                 |
+    ]])
+    feed(':s/0')
+    screen:expect([[
+      {1:0}                                                                          |
+      1                                                                          |
+      {2:2}                                                                          |
+      3                                                                          |
+      4                                                                          |
+      :s/0^                                                                       |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.3698: match highlighting continues over breakindent

Problem:    Match highlighting continues over breakindent.
Solution:   Stop before the end column.

https://github.com/vim/vim/commit/0c359af5c0fd106d3f57cc0bb7cef1c89b5e1e10

Cherry-pick Test_matchdelete_redraw() from patch 8.2.1077.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3940: match highlight disappears when doing incsearch for ":s/pat"

Problem:    Match highlight disappears when doing incsearch for ":s/pat".
Solution:   Only use line limit for incsearch highlighting.

https://github.com/vim/vim/commit/94fb8274ca8c93a10102d41c8bcc848f75cb7334

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4062: match highlighting of tab too short

Problem:    Match highlighting of tab too short.
Solution:   Do not stop match highlighting if on a Tab. (Christian Brabandt,
            closes vim/vim#9507)

https://github.com/vim/vim/commit/0bbca540f7377889e2154aa5731f6eeffcb5c0cc

Co-authored-by: Bram Moolenaar <Bram@vim.org>