### PR TITLE
fix(windows): treat powershell as not-Unix-like in Windows

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -302,7 +302,9 @@ static bool is_executable(const char *name, char **abspath)
 static bool is_executable_ext(const char *name, char **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
-  const bool is_unix_shell = strstr((char *)path_tail(p_sh), "sh") != NULL;
+  const bool is_unix_shell = strstr(path_tail(p_sh), "powershell") == NULL
+                             && strstr(path_tail(p_sh), "pwsh") == NULL
+                             && strstr(path_tail(p_sh), "sh") != NULL;
   char *nameext = strrchr(name, '.');
   size_t nameext_len = nameext ? strlen(nameext) : 0;
   xstrlcpy(os_buf, name, sizeof(os_buf));

--- a/src/nvim/testdir/test_shell.vim
+++ b/src/nvim/testdir/test_shell.vim
@@ -22,22 +22,7 @@ func Test_shell_options()
           \ ['tcsh', '-c', '|& tee', '', '>&', '', '']]
   endif
   if has('win32')
-    let shells += [['cmd', '/c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', ''],
-          \ ['cmd.exe', '/c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '('],
-          \ ['powershell.exe', '-Command', '2>&1 | Out-File -Encoding default',
-          \           '', '2>&1 | Out-File -Encoding default', '"&|<>()@^', '"'],
-          \ ['powershell', '-Command', '2>&1 | Out-File -Encoding default', '',
-          \               '2>&1 | Out-File -Encoding default', '"&|<>()@^', '"'],
-          \ ['sh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['ksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['mksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['pdksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['zsh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['zsh-beta.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['bash.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['dash.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
-          \ ['csh.exe', '-c', '>&', '', '>&', '"&|<>()@^', '"'],
-          \ ['tcsh.exe', '-c', '>&', '', '>&', '"&|<>()@^', '"']]
+    let shells += [['cmd', '/s /c', '>%s 2>&1', '', '>%s 2>&1', '', '"']]
   endif
 
   " start a new Vim instance with 'shell' set to each of the supported shells
@@ -148,8 +133,8 @@ func Test_shellslash()
   " The shell and cmdflag, and expected slash in tempname with shellslash set or
   " unset.  The assert checks the file separator before the leafname.
   " ".*\\\\[^\\\\]*$"
-  let shells = [['cmd', '/c', '\\', '/'],
-        \ ['powershell', '-Command', '\\', '/'],
+  let shells = [['cmd', '/c', '/', '/'],
+        \ ['powershell', '-Command', '/', '/'],
         \ ['sh', '-c', '/', '/']]
   for e in shells
     exe 'set shell=' .. e[0] .. ' | set shellcmdflag=' .. e[1]

--- a/src/nvim/testdir/test_shell.vim
+++ b/src/nvim/testdir/test_shell.vim
@@ -1,0 +1,160 @@
+" Test for the shell related options ('shell', 'shellcmdflag', 'shellpipe',
+" 'shellquote', 'shellredir', 'shellxescape', and 'shellxquote')
+
+source check.vim
+source shared.vim
+
+func Test_shell_options()
+  " For each shell, the following options are checked:
+  " 'shellcmdflag', 'shellpipe', 'shellquote', 'shellredir', 'shellxescape',
+  " 'shellxquote'
+  let shells = []
+  if has('unix')
+    let shells += [['sh', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['ksh', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['mksh', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['zsh', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['zsh-beta', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['bash', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['fish', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['ash', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['dash', '-c', '2>&1| tee', '', '>%s 2>&1', '', ''],
+          \ ['csh', '-c', '|& tee', '', '>&', '', ''],
+          \ ['tcsh', '-c', '|& tee', '', '>&', '', '']]
+  endif
+  if has('win32')
+    let shells += [['cmd', '/c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', ''],
+          \ ['cmd.exe', '/c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '('],
+          \ ['powershell.exe', '-c', '>', '', '>', '"&|<>()@^', '"'],
+          \ ['powershell', '-c', '>', '', '>', '"&|<>()@^', '"'],
+          \ ['sh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['ksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['mksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['pdksh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['zsh.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['zsh-beta.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['bash.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['dash.exe', '-c', '>%s 2>&1', '', '>%s 2>&1', '"&|<>()@^', '"'],
+          \ ['csh.exe', '-c', '>&', '', '>&', '"&|<>()@^', '"'],
+          \ ['tcsh.exe', '-c', '>&', '', '>&', '"&|<>()@^', '"']]
+  endif
+
+  let after =<< trim END
+    let l = [&shell, &shellcmdflag, &shellpipe, &shellquote]
+    let l += [&shellredir, &shellxescape, &shellxquote]
+    call writefile([json_encode(l)], 'Xtestout')
+    qall!
+  END
+  for e in shells
+    if RunVim([], after, '--cmd "set shell=' .. e[0] .. '"')
+      call assert_equal(e, json_decode(readfile('Xtestout')[0]))
+    endif
+  endfor
+
+  for e in shells
+    exe 'set shell=' .. e[0]
+    if e[0] =~# '.*csh$' || e[0] =~# '.*csh.exe$'
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' \\!%#'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\\\!\\%\\#'"
+    else
+      let str1 = "'cmd \"arg1\" '\\''arg2'\\'' !%#'"
+      let str2 = "'cmd \"arg1\" '\\''arg2'\\'' \\!\\%\\#'"
+    endif
+    call assert_equal(str1, shellescape("cmd \"arg1\" 'arg2' !%#"), e[0])
+    call assert_equal(str2, shellescape("cmd \"arg1\" 'arg2' !%#", 1), e[0])
+  endfor
+  set shell&
+  call delete('Xtestout')
+endfunc
+
+" Test for the 'shell' option
+func Test_shell()
+  throw 'Skipped: Nvim missing :shell currently'
+  CheckUnix
+  let save_shell = &shell
+  set shell=
+  let caught_e91 = 0
+  try
+    shell
+  catch /E91:/
+    let caught_e91 = 1
+  endtry
+  call assert_equal(1, caught_e91)
+  let &shell = save_shell
+endfunc
+
+" Test for the 'shellquote' option
+func Test_shellquote()
+  CheckUnix
+  set shellquote=#
+  set verbose=20
+  redir => v
+  silent! !echo Hello
+  redir END
+  set verbose&
+  set shellquote&
+  call assert_match(': "#echo Hello#"', v)
+endfunc
+
+func Test_shellescape()
+  let save_shell = &shell
+  set shell=bash
+  call assert_equal("'text'", shellescape('text'))
+  call assert_equal("'te\"xt'", 'te"xt'->shellescape())
+  call assert_equal("'te'\\''xt'", shellescape("te'xt"))
+
+  call assert_equal("'te%xt'", shellescape("te%xt"))
+  call assert_equal("'te\\%xt'", shellescape("te%xt", 1))
+  call assert_equal("'te#xt'", shellescape("te#xt"))
+  call assert_equal("'te\\#xt'", shellescape("te#xt", 1))
+  call assert_equal("'te!xt'", shellescape("te!xt"))
+  call assert_equal("'te\\!xt'", shellescape("te!xt", 1))
+
+  call assert_equal("'te\nxt'", shellescape("te\nxt"))
+  call assert_equal("'te\\\nxt'", shellescape("te\nxt", 1))
+  set shell=tcsh
+  call assert_equal("'te\\!xt'", shellescape("te!xt"))
+  call assert_equal("'te\\\\!xt'", shellescape("te!xt", 1))
+  call assert_equal("'te\\\nxt'", shellescape("te\nxt"))
+  call assert_equal("'te\\\\\nxt'", shellescape("te\nxt", 1))
+
+  let &shell = save_shell
+endfunc
+
+" Test for 'shellxquote'
+func Test_shellxquote()
+  CheckUnix
+
+  let save_shell = &shell
+  let save_sxq = &shellxquote
+  let save_sxe = &shellxescape
+
+  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell')
+  call setfperm('Xtestshell', "r-x------")
+  set shell=./Xtestshell
+
+  set shellxquote=\\"
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c "pwd"]'], readfile('Xlog'))
+
+  set shellxquote=(
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c (pwd)]'], readfile('Xlog'))
+
+  set shellxquote=\\"(
+  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c "(pwd)"]'], readfile('Xlog'))
+
+  set shellxescape=\"&<<()@^
+  set shellxquote=(
+  call feedkeys(":!pwd\"&<<{}@^\<CR>\<CR>", 'xt')
+  call assert_equal(['Cmd: [-c (pwd^"^&^<^<{}^@^^)]'], readfile('Xlog'))
+
+  let &shell = save_shell
+  let &shellxquote = save_sxq
+  let &shellxescape = save_sxe
+  call delete('Xtestshell')
+  call delete('Xlog')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -725,27 +725,6 @@ func Test_read_stdin()
   call delete('Xtestout')
 endfunc
 
-func Test_set_shell()
-  let after =<< trim [CODE]
-    call writefile([&shell], "Xtestout")
-    quit!
-  [CODE]
-
-  if has('win32')
-    let $SHELL = 'C:\with space\cmd.exe'
-    let expected = '"C:\with space\cmd.exe"'
-  else
-    let $SHELL = '/bin/with space/sh'
-    let expected = '"/bin/with space/sh"'
-  endif
-
-  if RunVimPiped([], after, '', '')
-    let lines = readfile('Xtestout')
-    call assert_equal(expected, lines[0])
-  endif
-  call delete('Xtestout')
-endfunc
-
 func Test_progpath()
   " Tests normally run with "./vim" or "../vim", these must have been expanded
   " to a full path.

--- a/src/nvim/testdir/test_system.vim
+++ b/src/nvim/testdir/test_system.vim
@@ -142,40 +142,4 @@ func Test_system_with_shell_quote()
   endtry
 endfunc
 
-" Test for 'shellxquote'
-func Test_Shellxquote()
-  CheckUnix
-
-  let save_shell = &shell
-  let save_sxq = &shellxquote
-  let save_sxe = &shellxescape
-
-  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell')
-  call setfperm('Xtestshell', "r-x------")
-  set shell=./Xtestshell
-
-  set shellxquote=\\"
-  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
-  call assert_equal(['Cmd: [-c "pwd"]'], readfile('Xlog'))
-
-  set shellxquote=(
-  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
-  call assert_equal(['Cmd: [-c (pwd)]'], readfile('Xlog'))
-
-  set shellxquote=\\"(
-  call feedkeys(":!pwd\<CR>\<CR>", 'xt')
-  call assert_equal(['Cmd: [-c "(pwd)"]'], readfile('Xlog'))
-
-  set shellxescape=\"&<<()@^
-  set shellxquote=(
-  call feedkeys(":!pwd\"&<<{}@^\<CR>\<CR>", 'xt')
-  call assert_equal(['Cmd: [-c (pwd^"^&^<^<{}^@^^)]'], readfile('Xlog'))
-
-  let &shell = save_shell
-  let &shellxquote = save_sxq
-  let &shellxescape = save_sxe
-  call delete('Xtestshell')
-  call delete('Xlog')
-endfunc
-
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fixes #21045.

This takes part of vim patch [v8.2.3071](https://github.com/vim/vim/commit/127950241e84c822d3c50f46a00d42a70d2d5cb6) to make `pwsh` and `powershell` return the same `exepath()`s (including extensions) as `cmd.exe`.