### PR TITLE
vim-patch:9.0.0942: Workflow Description Language files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1071,6 +1071,7 @@ local extension = {
   vue = 'vue',
   wat = 'wast',
   wast = 'wast',
+  wdl = 'wdl',
   wm = 'webmacro',
   wbt = 'winbatch',
   wml = 'wml',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -623,6 +623,7 @@ let s:filename_checks = {
     \ 'vroom': ['file.vroom'],
     \ 'vue': ['file.vue'],
     \ 'wast': ['file.wast', 'file.wat'],
+    \ 'wdl': ['file.wdl'],
     \ 'webmacro': ['file.wm'],
     \ 'wget': ['.wgetrc', 'wgetrc'],
     \ 'wget2': ['.wget2rc', 'wget2rc'],


### PR DESCRIPTION
- docs(news): add diagnostic suffix (#21141)
- vim-patch:partial:b59ae59a5870 (#21170)
- vim-patch:9.0.0942: Workflow Description Language files are not recognized
