### PR TITLE
vim-patch:8.2.{2466,2886},9.0.0936

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5245,7 +5245,7 @@ static void max_min(const typval_T *const tv, typval_T *const rettv, const bool 
     TV_LIST_ITER_CONST(tv->vval.v_list, li, {
       const varnumber_T i = tv_get_number_chk(TV_LIST_ITEM_TV(li), &error);
       if (error) {
-        return;
+        return;  // type error; errmsg already given
       }
       if (domax ? i > n : i < n) {
         n = i;
@@ -5258,7 +5258,7 @@ static void max_min(const typval_T *const tv, typval_T *const rettv, const bool 
     TV_DICT_ITER(tv->vval.v_dict, di, {
       const varnumber_T i = tv_get_number_chk(&di->di_tv, &error);
       if (error) {
-        return;
+        return;  // type error; errmsg already given
       }
       if (domax ? i > n : i < n) {
         n = i;
@@ -5268,6 +5268,7 @@ static void max_min(const typval_T *const tv, typval_T *const rettv, const bool 
     semsg(_(e_listdictarg), domax ? "max()" : "min()");
     return;
   }
+
   rettv->vval.v_number = n;
 }
 

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -92,10 +92,11 @@ func Test_getreg_empty_list()
   let y = x
   call add(x, 'foo')
   call assert_equal(['foo'], y)
+  call assert_fails('call getreg([])', 'E730:')
 endfunc
 
 func Test_loop_over_null_list()
-  let null_list = submatch(1, 1)
+  let null_list = v:_null_list
   for i in null_list
     call assert_report('should not get here')
   endfor

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -110,6 +110,10 @@ func Test_max()
 
   call assert_fails('call max(1)', 'E712:')
   " call assert_fails('call max(v:none)', 'E712:')
+
+  " check we only get one error
+  call assert_fails('call max([#{}, [1]])', ['E728:', 'E728:'])
+  call assert_fails('call max(#{a: {}, b: [1]})', ['E728:', 'E728:'])
 endfunc
 
 func Test_min()
@@ -123,6 +127,10 @@ func Test_min()
 
   call assert_fails('call min(1)', 'E712:')
   " call assert_fails('call min(v:none)', 'E712:')
+
+  " check we only get one error
+  call assert_fails('call min([[1], #{}])', ['E745:', 'E745:'])
+  call assert_fails('call min(#{a: [1], b: #{}})', ['E745:', 'E745:'])
 endfunc
 
 func Test_strwidth()

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -127,6 +127,7 @@ func Test_min()
 
   call assert_fails('call min(1)', 'E712:')
   " call assert_fails('call min(v:none)', 'E712:')
+  call assert_fails('call min([1, {}])', 'E728:')
 
   " check we only get one error
   call assert_fails('call min([[1], #{}])', ['E745:', 'E745:'])
@@ -591,6 +592,7 @@ func Test_tr()
   call assert_fails("let s=tr('abcd', 'abcd', 'def')", 'E475:')
   call assert_equal('hEllO', tr('hello', 'eo', 'EO'))
   call assert_equal('hello', tr('hello', 'xy', 'ab'))
+  call assert_fails('call tr("abc", "123", "₁₂")', 'E475:')
   set encoding=utf8
 endfunc
 

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -516,6 +516,11 @@ func Test_list_locked_var_unlet()
       call assert_equal(expected[depth][u][1], ps)
     endfor
   endfor
+  " Deleting a list range should fail if the range is locked
+  let l = [1, 2, 3, 4]
+  lockvar l[1:2]
+  call assert_fails('unlet l[1:2]', 'E741:')
+  unlet l
 endfunc
 
 " Locked variables and :unlet or list / dict functions

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -299,6 +299,7 @@ endfunc
 
 func Test_set_register()
   call assert_fails("call setreg('#', 200)", 'E86:')
+  " call assert_fails("call setreg('a', test_unknown())", 'E908:')
 
   edit Xfile_alt_1
   let b1 = bufnr('')
@@ -489,6 +490,14 @@ func Test_get_reginfo()
 
   let info = getreginfo('"')
   call assert_equal('z', info.points_to)
+
+  let @a="a1b2"
+  nnoremap <F2> <Cmd>let g:RegInfo = getreginfo()<CR>
+  exe "normal \"a\<F2>"
+  call assert_equal({'regcontents': ['a1b2'], 'isunnamed': v:false,
+        \ 'regtype': 'v'}, g:RegInfo)
+  nunmap <F2>
+  unlet g:RegInfo
 
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_registers.vim
+++ b/src/nvim/testdir/test_registers.vim
@@ -499,6 +499,13 @@ func Test_get_reginfo()
   nunmap <F2>
   unlet g:RegInfo
 
+  " The type of "isunnamed" was VAR_SPECIAL but should be VAR_BOOL.  Can only
+  " be noticed when using json_encod().
+  call setreg('a', 'foo')
+  let reginfo = getreginfo('a')
+  let expected = #{regcontents: ['foo'], isunnamed: v:false, regtype: 'v'}
+  call assert_equal(json_encode(expected), json_encode(reginfo))
+
   bwipe!
 endfunc
 

--- a/src/nvim/testdir/test_user_func.vim
+++ b/src/nvim/testdir/test_user_func.vim
@@ -163,6 +163,16 @@ func Test_default_arg()
 	\ .. "1    return deepcopy(a:)\n"
 	\ .. "   endfunction",
 	\ execute('func Args2'))
+
+  " Error in default argument expression
+  let l =<< trim END
+    func F1(x = y)
+      return a:x * 2
+    endfunc
+    echo F1()
+  END
+  let @a = l->join("\n")
+  call assert_fails("exe @a", 'E121:')
 endfunc
 
 func s:addFoo(lead)


### PR DESCRIPTION
#### vim-patch:8.2.2466: max() and min() can give many error messages

Problem:    Max() and min() can give many error messages.
Solution:   Bail out at the first error. (closes vim/vim#7778)

https://github.com/vim/vim/commit/ab65fc77c5389f7d3f788bbdc3d931561feab131

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2886: various pieces of code not covered by tests

Problem:    Various pieces of code not covered by tests.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#8255)

https://github.com/vim/vim/commit/34fcb697240c1bc9e69417ed75db3b1a83479724

Nvim does not have test_unknown().

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0936: wrong type for "isunnamed" returned by getreginfo()

Problem:    Wrong type for "isunnamed" returned by getreginfo().
Solution:   Use VAR_BOOL instead of VAR_SPECIAL.

https://github.com/vim/vim/commit/82946e1439d31e86dfeb6166415c73e70475cce2

Co-authored-by: Bram Moolenaar <Bram@vim.org>