### PR TITLE
vim-patch:8.2.{4155,4412}

### DIFF
--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -188,6 +188,7 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
   if (clock_local_ptr == NULL) {
     xstrlcpy(result, _("(Invalid)"), result_len);
   } else {
+    // xgettext:no-c-format
     strftime(result, result_len, _("%a %b %d %H:%M:%S %Y"), clock_local_ptr);
   }
   xstrlcat(result, "\n", result_len);

--- a/src/nvim/po/cleanup.vim
+++ b/src/nvim/po/cleanup.vim
@@ -22,7 +22,9 @@ silent g/^msgstr"/s//msgstr "/
 silent g/^msgid"/s//msgid "/
 silent g/^msgstr ""\(\n"\)\@!/?^msgid?,.s/^/#\~ /
 
+" clean up empty lines
 silent g/^\n\n\n/.d
+silent! %s/\n\+\%$//
 
 if s:was_diff
   setl diff


### PR DESCRIPTION
#### vim-patch:8.2.4155: translating strftime() argument results in check error

Problem:    Translating strftime() argument results in check error.
Solution:   Add gettext comment.

https://github.com/vim/vim/commit/7e93577a957e4f402bb690c4c8629fd831e24a9d

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4412: translation cleanup script does not remove empty lines at end

Problem:    Translation cleanup script does not remove empty lines at end.
Solution:   Remove empty lines at the end. (Ken Takata, closes vim/vim#9794)

https://github.com/vim/vim/commit/0257599036ceb3658b27a4de07834ca0d2fa418e