### PR TITLE
vim-patch:8.2.{2684,2713}: fold tests

### DIFF
--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -142,6 +142,21 @@ func Test_indent_fold2()
     bw!
 endfunc
 
+" Test for fold indent with indents greater than 'foldnestmax'
+func Test_indent_fold_max()
+  new
+  setlocal foldmethod=indent
+  setlocal shiftwidth=2
+  " 'foldnestmax' default value is 20
+  call setline(1, "\t\t\t\t\t\ta")
+  call assert_equal(20, foldlevel(1))
+  setlocal foldnestmax=10
+  call assert_equal(10, foldlevel(1))
+  setlocal foldnestmax=-1
+  call assert_equal(0, foldlevel(1))
+  bw!
+endfunc
+
 func Test_manual_fold_with_filter()
   CheckExecutable cat
   for type in ['manual', 'marker']
@@ -465,27 +480,6 @@ func Test_move_folds_around_indent()
   bw!
 endfunc
 
-" test for patch 7.3.637
-" Cannot catch the error caused by a foldopen when there is no fold.
-func Test_foldopen_exception()
-  enew!
-  let a = 'No error caught'
-  try
-    foldopen
-  catch
-    let a = matchstr(v:exception,'^[^ ]*')
-  endtry
-  call assert_equal('Vim(foldopen):E490:', a)
-
-  let a = 'No error caught'
-  try
-    foobar
-  catch
-    let a = matchstr(v:exception,'^[^ ]*')
-  endtry
-  call assert_match('E492:', a)
-endfunc
-
 func Test_folddoopen_folddoclosed()
   new
   call setline(1, range(1, 9))
@@ -539,11 +533,24 @@ func Test_fold_error()
   bw!
 endfunc
 
+func Test_foldtext_recursive()
+  new
+  call setline(1, ['{{{', 'some text', '}}}'])
+  setlocal foldenable foldmethod=marker foldtext=foldtextresult(v\:foldstart)
+  " This was crashing because of endless recursion.
+  2foldclose
+  redraw
+  call assert_equal(1, foldlevel(2))
+  call assert_equal(1, foldclosed(2))
+  call assert_equal(3, foldclosedend(2))
+  bwipe!
+endfunc
+
 " Various fold related tests
 
 " Basic test if a fold can be created, opened, moving to the end and closed
 func Test_fold_manual()
-  enew!
+  new
   set fdm=manual
 
   let content = ['1 aa', '2 bb', '3 cc']
@@ -559,12 +566,12 @@ func Test_fold_manual()
   call assert_equal('1 aa', getline(foldclosed('.')))
 
   set fdm&
-  enew!
+  bw!
 endfunc
 
 " test folding with markers.
 func Test_fold_marker()
-  enew!
+  new
   set fdm=marker fdl=1 fdc=3
 
   let content = ['4 dd {{{', '5 ee {{{ }}}', '6 ff }}}']
@@ -578,13 +585,22 @@ func Test_fold_marker()
   normal kYpj
   call assert_equal(0, foldlevel('.'))
 
+  " Use only closing fold marker (without and with a count)
+  set fdl&
+  %d _
+  call setline(1, ['one }}}', 'two'])
+  call assert_equal([0, 0], [foldlevel(1), foldlevel(2)])
+  %d _
+  call setline(1, ['one }}}4', 'two'])
+  call assert_equal([4, 3], [foldlevel(1), foldlevel(2)])
+
   set fdm& fdl& fdc&
-  enew!
+  bw!
 endfunc
 
 " test create fold markers with C filetype
 func Test_fold_create_marker_in_C()
-  enew!
+  bw!
   set fdm=marker fdl=9
   set filetype=c
 
@@ -609,12 +625,12 @@ func Test_fold_create_marker_in_C()
   endfor
 
   set fdm& fdl&
-  enew!
+  bw!
 endfunc
 
 " test folding with indent
 func Test_fold_indent()
-  enew!
+  new
   set fdm=indent sw=2
 
   let content = ['1 aa', '2 bb', '3 cc']
@@ -626,16 +642,14 @@ func Test_fold_indent()
   call assert_equal(1, foldlevel('.'))
 
   set fdm& sw&
-  enew!
+  bw!
 endfunc
 
 " test syntax folding
 func Test_fold_syntax()
-  if !has('syntax')
-    return
-  endif
+  CheckFeature syntax
 
-  enew!
+  new
   set fdm=syntax fdl=0
 
   syn region Hup start="dd" end="ii" fold contains=Fd1,Fd2,Fd3
@@ -659,7 +673,7 @@ func Test_fold_syntax()
   syn clear Fd1 Fd2 Fd3 Hup
 
   set fdm& fdl&
-  enew!
+  bw!
 endfunc
 
 func Flvl()
@@ -678,7 +692,7 @@ endfun
 
 " test expression folding
 func Test_fold_expr()
-  enew!
+  new
   set fdm=expr fde=Flvl()
 
   let content = ['1 aa',
@@ -706,14 +720,14 @@ func Test_fold_expr()
   call assert_equal(0, foldlevel('.'))
 
   set fdm& fde&
-  enew!
+  bw!
 endfunc
 
 " Bug with fdm=indent and moving folds
 " Moving a fold a few times, messes up the folds below the moved fold.
 " Fixed by 7.4.700
 func Test_fold_move()
-  enew!
+  new
   set fdm=indent sw=2 fdl=0
 
   let content = ['', '', 'Line1', '  Line2', '  Line3',
@@ -733,24 +747,33 @@ func Test_fold_move()
   call assert_equal('+--  2 lines: Line8', 10->foldtextresult())
 
   set fdm& sw& fdl&
-  enew!
+  bw!
 endfunc
 
-func Test_foldtext_recursive()
+" test for patch 7.3.637
+" Cannot catch the error caused by a foldopen when there is no fold.
+func Test_foldopen_exception()
   new
-  call setline(1, ['{{{', 'some text', '}}}'])
-  setlocal foldenable foldmethod=marker foldtext=foldtextresult(v\:foldstart)
-  " This was crashing because of endless recursion.
-  2foldclose
-  redraw
-  call assert_equal(1, foldlevel(2))
-  call assert_equal(1, foldclosed(2))
-  call assert_equal(3, foldclosedend(2))
-  bwipe!
+  let a = 'No error caught'
+  try
+    foldopen
+  catch
+    let a = matchstr(v:exception,'^[^ ]*')
+  endtry
+  call assert_equal('Vim(foldopen):E490:', a)
+
+  let a = 'No error caught'
+  try
+    foobar
+  catch
+    let a = matchstr(v:exception,'^[^ ]*')
+  endtry
+  call assert_match('E492:', a)
+  bw!
 endfunc
 
 func Test_fold_last_line_with_pagedown()
-  enew!
+  new
   set fdm=manual
 
   let expect = '+-- 11 lines: 9---'
@@ -770,7 +793,7 @@ func Test_fold_last_line_with_pagedown()
   call assert_equal(expect, ScreenLines(1, len(expect))[0])
 
   set fdm&
-  enew!
+  bw!
 endfunc
 
 func Test_folds_with_rnu()
@@ -861,6 +884,31 @@ func Test_fold_delete_first_line()
   set foldmethod&
 endfunc
 
+" Test for errors in 'foldexpr'
+func Test_fold_expr_error()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  " In a window with no folds, foldlevel() should return 0
+  call assert_equal(0, foldlevel(1))
+
+  " Return a list from the expression
+  set foldexpr=[]
+  set foldmethod=expr
+  for i in range(3)
+    call assert_equal(0, foldlevel(i))
+  endfor
+
+  " expression error
+  set foldexpr=[{]
+  set foldmethod=expr
+  for i in range(3)
+    call assert_equal(0, foldlevel(i))
+  endfor
+
+  set foldmethod& foldexpr&
+  close!
+endfunc
+
 func Test_undo_fold_deletion()
   new
   set fdm=marker
@@ -944,6 +992,165 @@ func Test_fold_relative_move()
   call assert_equal(2, winline())
 
   set fdm& sw& wrap& tw&
+  bw!
+endfunc
+
+" Test for calling foldlevel() from a fold expression
+let g:FoldLevels = []
+func FoldExpr1(lnum)
+  let f = [a:lnum]
+  for i in range(1, line('$'))
+    call add(f, foldlevel(i))
+  endfor
+  call add(g:FoldLevels, f)
+  return getline(a:lnum)[0] == "\t"
+endfunc
+
+func Test_foldexpr_foldlevel()
+  new
+  call setline(1, ['one', "\ttwo", "\tthree"])
+  setlocal foldmethod=expr
+  setlocal foldexpr=FoldExpr1(v:lnum)
+  setlocal foldenable
+  setlocal foldcolumn=3
+  redraw!
+  call assert_equal([[1, -1, -1, -1], [2, -1, -1, -1], [3, 0, 1, -1]],
+        \ g:FoldLevels)
+  set foldmethod& foldexpr& foldenable& foldcolumn&
+  bw!
+endfunc
+
+" Test for returning different values from a fold expression
+func FoldExpr2(lnum)
+  if a:lnum == 1 || a:lnum == 4
+    return -2
+  elseif a:lnum == 2
+    return 'a1'
+  elseif a:lnum == 3
+    return 's4'
+  endif
+  return '='
+endfunc
+
+func Test_foldexpr_2()
+  new
+  call setline(1, ['one', 'two', 'three', 'four'])
+  setlocal foldexpr=FoldExpr2(v:lnum)
+  setlocal foldmethod=expr
+  call assert_equal([0, 1, 1, 0], [foldlevel(1), foldlevel(2), foldlevel(3),
+        \ foldlevel(4)])
+  bw!
+endfunc
+
+" Test for the 'foldclose' option
+func Test_foldclose_opt()
+  CheckScreendump
+
+  let lines =<< trim END
+    set foldmethod=manual foldclose=all foldopen=all
+    call setline(1, ['one', 'two', 'three', 'four'])
+    2,3fold
+    func XsaveFoldLevels()
+      redraw!
+      call writefile([json_encode([foldclosed(1), foldclosed(2), foldclosed(3),
+        \ foldclosed(4)])], 'Xoutput', 'a')
+    endfunc
+  END
+  call writefile(lines, 'Xscript')
+  let rows = 10
+  let buf = RunVimInTerminal('-S Xscript', {'rows': rows})
+  call term_wait(buf)
+  call term_sendkeys(buf, ":set noruler\n")
+  call term_wait(buf)
+  call term_sendkeys(buf, ":call XsaveFoldLevels()\n")
+  call term_sendkeys(buf, "2G")
+  call WaitForAssert({-> assert_equal('two', term_getline(buf, 2))})
+  call term_sendkeys(buf, ":call XsaveFoldLevels()\n")
+  call term_sendkeys(buf, "4G")
+  call WaitForAssert({-> assert_equal('four', term_getline(buf, 3))})
+  call term_sendkeys(buf, ":call XsaveFoldLevels()\n")
+  call term_sendkeys(buf, "3G")
+  call WaitForAssert({-> assert_equal('three', term_getline(buf, 3))})
+  call term_sendkeys(buf, ":call XsaveFoldLevels()\n")
+  call term_sendkeys(buf, "1G")
+  call WaitForAssert({-> assert_equal('four', term_getline(buf, 3))})
+  call term_sendkeys(buf, ":call XsaveFoldLevels()\n")
+
+  " clean up
+  call StopVimInTerminal(buf)
+
+  call assert_equal(['[-1,2,2,-1]', '[-1,-1,-1,-1]', '[-1,2,2,-1]',
+        \ '[-1,-1,-1,-1]', '[-1,2,2,-1]'], readfile('Xoutput'))
+  call delete('Xscript')
+  call delete('Xoutput')
+endfunc
+
+" Test for foldtextresult()
+func Test_foldtextresult()
+  new
+  call assert_equal('', foldtextresult(-1))
+  call assert_equal('', foldtextresult(0))
+  call assert_equal('', foldtextresult(1))
+  call setline(1, ['one', 'two', 'three', 'four'])
+  2,3fold
+  call assert_equal('', foldtextresult(1))
+  call assert_equal('+--  2 lines: two', foldtextresult(2))
+  setlocal foldtext=
+  call assert_equal('+--  2 lines folded ', foldtextresult(2))
+
+  " Fold text for a C comment fold
+  %d _
+  setlocal foldtext&
+  call setline(1, ['', '/*', ' * Comment', ' */', ''])
+  2,4fold
+  call assert_equal('+--  3 lines: Comment', foldtextresult(2))
+
+  bw!
+endfunc
+
+" Test for merging two recursive folds when an intermediate line with no fold
+" is removed
+func Test_fold_merge_recrusive()
+  new
+  call setline(1, ['  one', '    two', 'xxxx', '    three',
+        \ '      four', "\tfive"])
+  setlocal foldmethod=indent shiftwidth=2
+  3d_
+  %foldclose
+  call assert_equal([1, 5], [foldclosed(5), foldclosedend(1)])
+  bw!
+endfunc
+
+" Test for moving a line which is the start of a fold from a recursive fold to
+" outside. The fold length should reduce.
+func Test_fold_move_foldlevel()
+  new
+  call setline(1, ['a{{{', 'b{{{', 'c{{{', 'd}}}', 'e}}}', 'f}}}', 'g'])
+  setlocal foldmethod=marker
+  normal zR
+  call assert_equal([3, 2, 1], [foldlevel(4), foldlevel(5), foldlevel(6)])
+  3move 7
+  call assert_equal([2, 1, 0], [foldlevel(3), foldlevel(4), foldlevel(5)])
+  call assert_equal(1, foldlevel(7))
+
+  " Move a line from outside a fold to inside the fold.
+  %d _
+  call setline(1, ['a', 'b{{{', 'c}}}'])
+  normal zR
+  1move 2
+  call assert_equal([1, 1, 1], [foldlevel(1), foldlevel(2), foldlevel(3)])
+
+  " Move the start of one fold to inside another fold
+  %d _
+  call setline(1, ['a', 'b{{{', 'c}}}', 'd{{{', 'e}}}'])
+  normal zR
+  call assert_equal([0, 1, 1, 1, 1], [foldlevel(1), foldlevel(2),
+        \ foldlevel(3), foldlevel(4), foldlevel(5)])
+  1,2move 4
+  call assert_equal([0, 1, 1, 2, 2], [foldlevel(1), foldlevel(2),
+        \ foldlevel(3), foldlevel(4), foldlevel(5)])
+
+  bw!
 endfunc
 
 " Make sure a fold containing a nested fold is split correctly when using

--- a/src/nvim/testdir/test_mksession.vim
+++ b/src/nvim/testdir/test_mksession.vim
@@ -990,6 +990,38 @@ func Test_altfile()
   call assert_equal('Xtwoalt', bufname('#'))
   only
   bwipe!
+  call delete('Xtest_altfile')
+endfunc
+
+" Test for creating views with manual folds
+func Test_mkview_manual_fold()
+  call writefile(range(1,10), 'Xfile')
+  new Xfile
+  " create recursive folds
+  5,6fold
+  4,7fold
+  mkview Xview
+  normal zE
+  source Xview
+  call assert_equal([-1, 4, 4, 4, 4, -1], [foldclosed(3), foldclosed(4),
+        \ foldclosed(5), foldclosed(6), foldclosed(7), foldclosed(8)])
+  " open one level of fold
+  4foldopen
+  mkview! Xview
+  normal zE
+  source Xview
+  call assert_equal([-1, -1, 5, 5, -1, -1], [foldclosed(3), foldclosed(4),
+        \ foldclosed(5), foldclosed(6), foldclosed(7), foldclosed(8)])
+  " open all the folds
+  %foldopen!
+  mkview! Xview
+  normal zE
+  source Xview
+  call assert_equal([-1, -1, -1, -1, -1, -1], [foldclosed(3), foldclosed(4),
+        \ foldclosed(5), foldclosed(6), foldclosed(7), foldclosed(8)])
+  call delete('Xfile')
+  call delete('Xview')
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_source.vim
+++ b/src/nvim/testdir/test_source.vim
@@ -1,5 +1,8 @@
 " Tests for the :source command.
 
+source check.vim
+source view_util.vim
+
 func Test_source_autocmd()
   call writefile([
 	\ 'let did_source = 1',
@@ -91,6 +94,20 @@ func Test_source_error()
   call assert_fails('scriptencoding utf-8', 'E167:')
   call assert_fails('finish', 'E168:')
   " call assert_fails('scriptversion 2', 'E984:')
+endfunc
+
+" Test for sourcing a script recursively
+func Test_nested_script()
+  CheckRunVimInTerminal
+  call writefile([':source! Xscript.vim', ''], 'Xscript.vim')
+  let buf = RunVimInTerminal('', {'rows': 6})
+  call term_wait(buf)
+  call term_sendkeys(buf, ":set noruler\n")
+  call term_sendkeys(buf, ":source! Xscript.vim\n")
+  call term_wait(buf)
+  call WaitForAssert({-> assert_match('E22: Scripts nested too deep\s*', term_getline(buf, 6))})
+  call delete('Xscript.vim')
+  call StopVimInTerminal(buf)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/fold_spec.lua
+++ b/test/functional/legacy/fold_spec.lua
@@ -309,5 +309,27 @@ describe('folding', function()
       {1:~                                            }|
                                                    |
     ]])
+    feed('2G')
+    screen:expect([[
+      one                                          |
+      ^two                                          |
+      three                                        |
+      four                                         |
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+                                                   |
+    ]])
+    feed('k')
+    screen:expect([[
+      ^one                                          |
+      {2:+--  2 lines: two····························}|
+      four                                         |
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+      {1:~                                            }|
+                                                   |
+    ]])
   end)
 end)

--- a/test/functional/legacy/source_spec.lua
+++ b/test/functional/legacy/source_spec.lua
@@ -1,0 +1,31 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local feed = helpers.feed
+local write_file = helpers.write_file
+
+before_each(clear)
+
+describe(':source!', function()
+  it('gives E22 when scripts nested too deep', function()
+    write_file('Xscript.vim', [[
+    :source! Xscript.vim
+    ]])
+    local screen = Screen.new(75, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+    })
+    screen:attach()
+    feed(':source! Xscript.vim\n')
+    screen:expect([[
+      ^                                                                           |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+      {1:E22: Scripts nested too deep}                                               |
+    ]])
+    os.remove('Xscript.vim')
+  end)
+end)

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -7,7 +7,7 @@ local insert = helpers.insert
 local expect = helpers.expect
 local funcs = helpers.funcs
 local meths = helpers.meths
-local source = helpers.source
+local exec = helpers.exec
 local assert_alive = helpers.assert_alive
 
 
@@ -195,50 +195,6 @@ describe("folded lines", function()
         {7:  }                                           |
         {1:~                                            }|
                                                      |
-        ]])
-      end
-    end)
-
-    it("highlighting with relative line numbers", function()
-      command("set relativenumber cursorline cursorlineopt=number foldmethod=marker")
-      feed_command("set foldcolumn=2")
-      funcs.setline(1, '{{{1')
-      funcs.setline(2, 'line 1')
-      funcs.setline(3, '{{{1')
-      funcs.setline(4, 'line 2')
-      feed("j")
-      if multigrid then
-        screen:expect([[
-        ## grid 1
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [2:---------------------------------------------]|
-          [3:---------------------------------------------]|
-        ## grid 2
-          {7:+ }{8:  1 }{5:+--  2 lines: ·························}|
-          {7:+ }{9:  0 }{5:^+--  2 lines: ·························}|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-        ## grid 3
-          :set foldcolumn=2                            |
-        ]])
-      else
-        screen:expect([[
-          {7:+ }{8:  1 }{5:+--  2 lines: ·························}|
-          {7:+ }{9:  0 }{5:^+--  2 lines: ·························}|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-          {1:~                                            }|
-          :set foldcolumn=2                            |
         ]])
       end
     end)
@@ -1714,7 +1670,7 @@ describe("folded lines", function()
     end)
 
     it('does not crash when foldtext is longer than columns #12988', function()
-      source([[
+      exec([[
         function! MyFoldText() abort
           return repeat('-', &columns + 100)
         endfunction
@@ -1761,7 +1717,7 @@ describe("folded lines", function()
 
     it('work correctly with :move #18668', function()
       screen:try_resize(45, 12)
-      source([[
+      exec([[
         set foldmethod=expr foldexpr=indent(v:lnum)
         let content = ['', '', 'Line1', '  Line2', '  Line3',
               \ 'Line4', '  Line5', '  Line6',


### PR DESCRIPTION
#### vim-patch:8.2.2684: not enough folding code is tested

Problem:    Not enough folding code is tested.
Solution:   Add more test cases. (Yegappan Lakshmanan, closes vim/vim#8046)

https://github.com/vim/vim/commit/5c504f680e63120fea36becfabb8d939d4449e34

Reorder test_fold.vim to match upstream.
Cherry-pick Test_fold_expr_error() from patch 8.2.0633.
Cherry-pick syntax feature check from patch 8.2.1432.
Cherry-pick a delete() call from patch 8.2.2112.


#### vim-patch:8.2.2713: folding code not sufficiently tested

Problem:    Folding code not sufficiently tested.
Solution:   Add a few more test cases. (Yegappan Lakshmanan, closes vim/vim#8064)

https://github.com/vim/vim/commit/68ffe8cade5e0c52680c00cb9f3f87104fbe653a