### PR TITLE
vim-patch:9.0.0950: the pattern "\_s\zs" matches at EOL

### DIFF
--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1816,7 +1816,7 @@ func Test_search_smartcase_utf8()
 
   set ignorecase& smartcase&
   let &encoding = save_enc
-  close!
+  bwipe!
 endfunc
 
 " Test searching past the end of a file
@@ -1825,7 +1825,29 @@ func Test_search_past_eof()
   call setline(1, ['Line'])
   exe "normal /\\n\\zs\<CR>"
   call assert_equal([1, 4], [line('.'), col('.')])
-  close!
+  bwipe!
+endfunc
+
+" Test setting the start of the match and still finding a next match in the
+" same line.
+func Test_search_set_start_same_line()
+  new
+  set cpo-=c
+
+  call setline(1, ['1', '2', '3 .', '4', '5'])
+  exe "normal /\\_s\\zs\\S\<CR>"
+  call assert_equal([2, 1], [line('.'), col('.')])
+  exe 'normal n'
+  call assert_equal([3, 1], [line('.'), col('.')])
+  exe 'normal n'
+  call assert_equal([3, 3], [line('.'), col('.')])
+  exe 'normal n'
+  call assert_equal([4, 1], [line('.'), col('.')])
+  exe 'normal n'
+  call assert_equal([5, 1], [line('.'), col('.')])
+
+  set cpo+=c
+  bwipe!
 endfunc
 
 " Test for various search offsets


### PR DESCRIPTION
#### vim-patch:9.0.0950: the pattern "\\_s\\zs" matches at EOL

Problem:    The pattern "\\_s\\zs" matches at EOL.
Solution:   Make the pattern "\\_s\\zs" match at the start of the next line.

https://github.com/vim/vim/commit/c96311b5be307f5a1d1b20a0ec930d63964e7335

Co-authored-by: Bram Moolenaar <Bram@vim.org>