### PR TITLE
vim-patch:8.2.1707: small inconsitency in highlight test

### DIFF
--- a/src/nvim/testdir/test_highlight.vim
+++ b/src/nvim/testdir/test_highlight.vim
@@ -819,11 +819,11 @@ func Test_highlight_clear_restores_context()
   let patContextDefault = fnamemodify(scriptContextDefault, ':t') .. ' line 1'
   let patContextRelink = fnamemodify(scriptContextRelink, ':t') .. ' line 2'
 
-  exec "source" scriptContextDefault
+  exec 'source ' .. scriptContextDefault
   let hlContextDefault = execute("verbose hi Context")
   call assert_match(patContextDefault, hlContextDefault)
 
-  exec "source" scriptContextRelink
+  exec 'source ' .. scriptContextRelink
   let hlContextRelink = execute("verbose hi Context")
   call assert_match(patContextRelink, hlContextRelink)
 


### PR DESCRIPTION
#### vim-patch:8.2.1707: small inconsitency in highlight test

Problem:    Small inconsitency in highlight test.
Solution:   Use one argument for :execute. (Antony Scriven, vim/vim#6975)

https://github.com/vim/vim/commit/2bbada811625ee53c7bcdf689dbf409e9975ea8f