### PR TITLE
vim-patch:8.2.2328: some test files may not be deleted

### DIFF
--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -89,6 +89,7 @@ func Test_client_server()
   call writefile(['one', 'two'], 'Xclientfile')
   call system(cmd)
   call WaitForAssert({-> assert_equal('two', remote_expr(name, "getline(2)", "", 2))})
+  call delete('Xclientfile')
 
   " Expression evaluated locally.
   if v:servername == ''


### PR DESCRIPTION
#### vim-patch:8.2.2328: some test files may not be deleted

Problem:    Some test files may not be deleted.
Solution:   Add a delete() call, correct name. (Dominique Pellé, closes vim/vim#7654)

https://github.com/vim/vim/commit/48e11c10548782f573411b6302f77adb69c40401