### PR TITLE
fix(tests): only get the color map once, even for multiple test files

### DIFF
--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -2,6 +2,7 @@
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
 local helpers = require('test.functional.helpers')(nil)
+local screen = require('test.functional.ui.screen')
 local busted = require("busted")
 local is_os = helpers.is_os
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -25,36 +25,6 @@ describe('float window', function()
     clear()
     command('hi VertSplit gui=reverse')
   end)
-  local attrs = {
-    [0] = {bold=true, foreground=Screen.colors.Blue},
-    [1] = {background = Screen.colors.LightMagenta},
-    [2] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
-    [3] = {bold = true},
-    [4] = {bold = true, reverse = true},
-    [5] = {reverse = true},
-    [6] = {background = Screen.colors.LightMagenta, bold = true, reverse = true},
-    [7] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-    [8] = {bold = true, foreground = Screen.colors.SeaGreen4},
-    [9] = {background = Screen.colors.LightGrey, underline = true},
-    [10] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta},
-    [11] = {bold = true, foreground = Screen.colors.Magenta},
-    [12] = {background = Screen.colors.Red, bold = true, foreground = Screen.colors.Blue1},
-    [13] = {background = Screen.colors.WebGray},
-    [14] = {foreground = Screen.colors.Brown},
-    [15] = {background = Screen.colors.Grey20},
-    [16] = {background = Screen.colors.Grey20, bold = true, foreground = Screen.colors.Blue1},
-    [17] = {background = Screen.colors.Yellow},
-    [18] = {foreground = Screen.colors.Brown, background = Screen.colors.Grey20},
-    [19] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
-    [20] = {bold = true, foreground = Screen.colors.Brown},
-    [21] = {background = Screen.colors.Gray90},
-    [22] = {background = Screen.colors.LightRed},
-    [23] = {foreground = Screen.colors.Black, background = Screen.colors.White};
-    [24] = {foreground = Screen.colors.Black, background = Screen.colors.Grey80};
-    [25] = {blend = 100, background = Screen.colors.Gray0};
-    [26] = {blend = 80, background = Screen.colors.Gray0};
-    [27] = {background = Screen.colors.LightGray};
-  }
 
   it('behavior', function()
     -- Create three windows and test that ":wincmd <direction>" changes to the
@@ -724,10 +694,40 @@ describe('float window', function()
   end)
 
   local function with_ext_multigrid(multigrid)
-    local screen
+    local screen, attrs
     before_each(function()
       screen = Screen.new(40,7)
       screen:attach {ext_multigrid=multigrid}
+      attrs = {
+        [0] = {bold=true, foreground=Screen.colors.Blue},
+        [1] = {background = Screen.colors.LightMagenta},
+        [2] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
+        [3] = {bold = true},
+        [4] = {bold = true, reverse = true},
+        [5] = {reverse = true},
+        [6] = {background = Screen.colors.LightMagenta, bold = true, reverse = true},
+        [7] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
+        [8] = {bold = true, foreground = Screen.colors.SeaGreen4},
+        [9] = {background = Screen.colors.LightGrey, underline = true},
+        [10] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta},
+        [11] = {bold = true, foreground = Screen.colors.Magenta},
+        [12] = {background = Screen.colors.Red, bold = true, foreground = Screen.colors.Blue1},
+        [13] = {background = Screen.colors.WebGray},
+        [14] = {foreground = Screen.colors.Brown},
+        [15] = {background = Screen.colors.Grey20},
+        [16] = {background = Screen.colors.Grey20, bold = true, foreground = Screen.colors.Blue1},
+        [17] = {background = Screen.colors.Yellow},
+        [18] = {foreground = Screen.colors.Brown, background = Screen.colors.Grey20},
+        [19] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
+        [20] = {bold = true, foreground = Screen.colors.Brown},
+        [21] = {background = Screen.colors.Gray90},
+        [22] = {background = Screen.colors.LightRed},
+        [23] = {foreground = Screen.colors.Black, background = Screen.colors.White};
+        [24] = {foreground = Screen.colors.Black, background = Screen.colors.Grey80};
+        [25] = {blend = 100, background = Screen.colors.Gray0};
+        [26] = {blend = 80, background = Screen.colors.Gray0};
+        [27] = {background = Screen.colors.LightGray};
+      }
       screen:set_default_attr_ids(attrs)
     end)
 

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1403,7 +1403,7 @@ describe('ColorColumn highlight', function()
   before_each(function()
     clear()
     screen = Screen.new(40, 15)
-    Screen:set_default_attr_ids({
+    screen:set_default_attr_ids({
       [1] = {background = Screen.colors.LightRed},  -- ColorColumn
       [2] = {background = Screen.colors.Grey90},  -- CursorLine
       [3] = {foreground = Screen.colors.Brown},  -- LineNr

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -101,13 +101,10 @@ end
 
 local default_screen_timeout = default_timeout_factor * 3500
 
-do
-  local spawn, nvim_prog = helpers.spawn, helpers.nvim_prog
-  local session = spawn({nvim_prog, '-u', 'NONE', '-i', 'NONE', '-N', '--embed'})
+function Screen._init_colors(session)
   local status, rv = session:request('nvim_get_color_map')
   if not status then
-    print('failed to get color map')
-    os.exit(1)
+    error('failed to get color map')
   end
   local colors = rv
   local colornames = {}
@@ -116,12 +113,15 @@ do
     -- this is just a helper to get any canonical name of a color
     colornames[rgb] = name
   end
-  session:close()
   Screen.colors = colors
   Screen.colornames = colornames
 end
 
 function Screen.new(width, height)
+  if not Screen.colors then
+    Screen._init_colors(get_session())
+  end
+
   if not width then
     width = 53
   end


### PR DESCRIPTION
Problem: `test/functional/ui/screen.lua` would be reloaded for each `*_spec.lua` file, which causes an extra nvim session to be started to get the color map each time.

solution: Mark `screen.lua` as a preloaded file, but defer the loading of the color map to the first time `Screen` object is initialised.