### PR TITLE
vim-patch:9.0.0958: messages test is flaky

### DIFF
--- a/src/nvim/testdir/test_messages.vim
+++ b/src/nvim/testdir/test_messages.vim
@@ -353,7 +353,7 @@ func Test_echo_verbose_system()
 
   " display a page and go back, results in exactly the same view
   call term_sendkeys(buf, ' ')
-  call TermWait(buf)
+  call TermWait(buf, 50)
   call term_sendkeys(buf, 'b')
   call VerifyScreenDump(buf, 'Test_verbose_system_1', {})
 
@@ -366,7 +366,7 @@ func Test_echo_verbose_system()
   call VerifyScreenDump(buf, 'Test_verbose_system_2', {})
 
   call term_sendkeys(buf, ' ')
-  call TermWait(buf)
+  call TermWait(buf, 50)
   call term_sendkeys(buf, 'b')
   call VerifyScreenDump(buf, 'Test_verbose_system_2', {})
 


### PR DESCRIPTION
#### vim-patch:9.0.0958: messages test is flaky

Problem:    Messages test is flaky.
Solution:   Add a short delay.

https://github.com/vim/vim/commit/19cf525c20f9915ffcddda35c27608528f6af047

Co-authored-by: Bram Moolenaar <Bram@vim.org>