### PR TITLE
build: add git sha to version when built with nix flake

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -10,9 +10,12 @@
     {
       overlay = final: prev: {
 
-        neovim = final.neovim-unwrapped.overrideAttrs (oa: {
-          version = "master";
+        neovim = final.neovim-unwrapped.overrideAttrs (oa: rec {
+          version = self.shortRev or "dirty";
           src = ../.;
+          preConfigure = ''
+            sed -i cmake.config/versiondef.h.in -e 's/@NVIM_VERSION_PRERELEASE@/-dev-${version}/'
+          '';
         });
 
         # a development binary to help debug issues


### PR DESCRIPTION
Right now if you run neovim nightly with nix it's hard to tell exactly what commit you're running since it doesn't make it into the version string like it does if you build manually without nix:

```
> nix run "github:neovim/neovim?dir=contrib" -- --version
NVIM v0.9.0-dev
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by _nixbld1
```

With this patch, the git sha can show up in the same way:

```
> nix run ./contrib/ -- --version
NVIM v0.9.0-dev-cafe2dd
Build type: Release
LuaJIT 2.1.0-beta3
Compiled by _nixbld1
```

Thanks to @gravndal for pointing me on the right track

closes #21093 