### PR TITLE
vim-patch:9.0.0963: function name does not match autocmd event name

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1084,8 +1084,8 @@ static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, 
 
   if (*errmsg == NULL) {
     if (!starting) {
-      trigger_optionsset_string(opt_idx, opt_flags, saved_origval, saved_origval_l,
-                                saved_origval_g, saved_newval);
+      trigger_optionset_string(opt_idx, opt_flags, saved_origval, saved_origval_l,
+                               saved_origval_g, saved_newval);
     }
     if (options[opt_idx].flags & P_UI_OPTION) {
       ui_call_option_set(cstr_as_string(options[opt_idx].fullname),

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -161,8 +161,8 @@ void didset_string_options(void)
 /// "oldval_l"  the old local value (only non-NULL if global and local value are set)
 /// "oldval_g"  the old global value (only non-NULL if global and local value are set)
 /// "newval"    the new value
-void trigger_optionsset_string(int opt_idx, int opt_flags, char *oldval, char *oldval_l,
-                               char *oldval_g, char *newval)
+void trigger_optionset_string(int opt_idx, int opt_flags, char *oldval, char *oldval_l,
+                              char *oldval_g, char *newval)
 {
   // Don't do this recursively.
   if (oldval != NULL
@@ -448,8 +448,8 @@ char *set_string_option(const int opt_idx, const char *const value, const int op
   // call autocommand after handling side effects
   if (errmsg == NULL) {
     if (!starting) {
-      trigger_optionsset_string(opt_idx, opt_flags, saved_oldval, saved_oldval_l, saved_oldval_g,
-                                saved_newval);
+      trigger_optionset_string(opt_idx, opt_flags, saved_oldval, saved_oldval_l, saved_oldval_g,
+                               saved_newval);
     }
     if (opt->flags & P_UI_OPTION) {
       ui_call_option_set(cstr_as_string(opt->fullname),

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3237,7 +3237,7 @@ func Test_cclose_from_copen()
 endfunc
 
 func Test_cclose_in_autocmd()
-  " Problem is only triggered if "starting" is zero, so that the OptionsSet
+  " Problem is only triggered if "starting" is zero, so that the OptionSet
   " event will be triggered.
   " call test_override('starting', 1)
   augroup QF_Test


### PR DESCRIPTION
#### vim-patch:9.0.0963: function name does not match autocmd event name

Problem:    Function name does not match autocmd event name.
Solution:   Rename "optionsset" to "optionset". (closes vim/vim#11630)

https://github.com/vim/vim/commit/269aa2b29ac3e4c0083d929e2477c95e7bd1177a