### PR TITLE
refactor(ui): statusbar invalidation to win_set_inner_size()

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1793,4 +1793,22 @@ function Test_splitkeep_fold()
   call VerifyScreenDump(buf, 'Test_splitkeep_fold_4', {})
 endfunction
 
+function Test_splitkeep_status()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['a', 'b', 'c'])
+    set nomodified
+    set splitkeep=screen
+    let win = winnr()
+    wincmd s
+    wincmd j
+  END
+  call writefile(lines, 'XTestSplitkeepStatus', 'D')
+  let buf = RunVimInTerminal('-S XTestSplitkeepStatus', #{rows: 10})
+
+  call term_sendkeys(buf, ":call win_move_statusline(win, 1)\<CR>")
+  call VerifyScreenDump(buf, 'Test_splitkeep_status_1', {})
+endfunction
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6389,9 +6389,6 @@ void win_new_height(win_T *wp, int height)
   wp->w_height = height;
   wp->w_pos_changed = true;
   win_set_inner_size(wp, true);
-  if (wp->w_status_height) {
-    wp->w_redr_status = true;
-  }
 }
 
 void scroll_to_fraction(win_T *wp, int prev_height)
@@ -6487,7 +6484,6 @@ void scroll_to_fraction(win_T *wp, int prev_height)
   }
 
   redraw_later(wp, UPD_SOME_VALID);
-  wp->w_redr_status = true;
   invalidate_botline_win(wp);
 }
 
@@ -6554,6 +6550,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
   wp->w_width_outer = (wp->w_width_inner + win_border_width(wp));
   wp->w_winrow_off = wp->w_border_adj[0] + wp->w_winbar_height;
   wp->w_wincol_off = wp->w_border_adj[3];
+  wp->w_redr_status = true;
 }
 
 static int win_border_height(win_T *wp)
@@ -6570,10 +6567,8 @@ static int win_border_width(win_T *wp)
 void win_new_width(win_T *wp, int width)
 {
   wp->w_width = width;
-  win_set_inner_size(wp, true);
-
-  wp->w_redr_status = true;
   wp->w_pos_changed = true;
+  win_set_inner_size(wp, true);
 }
 
 void win_comp_scroll(win_T *wp)
@@ -6974,7 +6969,6 @@ int set_winbar_win(win_T *wp, bool make_room, bool valid_cursor)
     }
     wp->w_winbar_height = winbar_height;
     win_set_inner_size(wp, valid_cursor);
-    wp->w_redr_status = wp->w_redr_status || winbar_height;
 
     if (winbar_height == 0) {
       // When removing winbar, deallocate the w_winbar_click_defs array

--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -6,9 +6,11 @@ local exec_lua = helpers.exec_lua
 local feed = helpers.feed
 
 describe('splitkeep', function()
-  local screen = Screen.new()
+  local screen
+
   before_each(function()
     clear('--cmd', 'set splitkeep=screen')
+    screen = Screen.new()
     screen:attach()
   end)
 
@@ -191,6 +193,35 @@ describe('splitkeep', function()
        48 after fold                                       |
        49 +--  7 lines: int FuncName() {···················|
       :quit                                                |
+    ]])
+  end)
+
+  -- oldtest: Test_splitkeep_status()
+  it('does not scroll when split in callback', function()
+    exec([[
+      call setline(1, ['a', 'b', 'c'])
+      set nomodified
+      set splitkeep=screen
+      let win = winnr()
+      wincmd s
+      wincmd j
+    ]])
+    feed(':call win_move_statusline(win, 1)<CR>')
+    screen:expect([[
+      a                                                    |
+      b                                                    |
+      c                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      [No Name]                                            |
+      ^a                                                    |
+      b                                                    |
+      c                                                    |
+      ~                                                    |
+      [No Name]                                            |
+                                                           |
     ]])
   end)
 end)


### PR DESCRIPTION
**vim-patch:9.0.0964: status line not redrawn when 'splitkeep' is "screen"**

Problem:    Status line of other window not redrawn when dragging it when
            'splitkeep' is set to "screen".
Solution:   Set w_redr_status earlier. (Luuk van Baal, closes https://github.com/vim/vim/pull/11635,
            closes https://github.com/vim/vim/issues/11632)

https://github.com/vim/vim/commit/74a694dbe20bb7dea4e06f474cf62e20f9c92f1d

The actual problem fixed by the vim patch was not present in neovim so the first commit only ports the test. Second commit is a minor refactor(not applicable to vim/vim) that could be reviewed independently:

Problem: w_redr_status invalidation is duplicated in multiple functions that all call win_set_inner_size().
Solution: Move to win_set_inner_size.