### PR TITLE
vim-patch:9.0.0969: matchparen highlight is not updated when switching buffers

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2021 Apr 08
+" Last Change: 2022 Nov 28
 
 " Exit quickly when:
 " - this plugin was already loaded (or disabled)
@@ -19,8 +19,8 @@ endif
 
 augroup matchparen
   " Replace all matchparen autocommands
-  autocmd! CursorMoved,CursorMovedI,WinEnter,WinScrolled * call s:Highlight_Matching_Pair()
-  autocmd! WinLeave * call s:Remove_Matches()
+  autocmd! CursorMoved,CursorMovedI,WinEnter,BufWinEnter,WinScrolled * call s:Highlight_Matching_Pair()
+  autocmd! WinLeave,BufLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()
   endif

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2334,9 +2334,8 @@ function Test_dirchanged_auto()
 endfunc
 
 " Test TextChangedI and TextChangedP
-" See test/functional/viml/completion_spec.lua'
 func Test_ChangedP()
-  CheckFunction test_override
+  throw 'Skipped: use test/functional/editor/completion_spec.lua'
   new
   call setline(1, ['foo', 'bar', 'foobar'])
   call test_override("char_avail", 1)

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -226,7 +226,6 @@ endfunc
 
 " Test for scrolling that modifies buffer during visual block
 func Test_visual_block_scroll()
-  " See test/functional/legacy/visual_mode_spec.lua
   CheckScreendump
 
   let lines =<< trim END
@@ -237,7 +236,7 @@ func Test_visual_block_scroll()
   END
 
   let filename = 'Xvisualblockmodifiedscroll'
-  call writefile(lines, filename)
+  call writefile(lines, filename, 'D')
 
   let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
   call term_sendkeys(buf, "V\<C-D>\<C-D>")
@@ -245,11 +244,40 @@ func Test_visual_block_scroll()
   call VerifyScreenDump(buf, 'Test_display_visual_block_scroll', {})
 
   call StopVimInTerminal(buf)
-  call delete(filename)
+endfunc
+
+" Test for clearing paren highlight when switching buffers
+func Test_matchparen_clear_highlight()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set hidden
+    call setline(1, ['()'])
+    normal 0
+
+    func OtherBuffer()
+       enew
+       exe "normal iaa\<Esc>0"
+    endfunc
+  END
+  call writefile(lines, 'XMatchparenClear', 'D')
+  let buf = RunVimInTerminal('-S XMatchparenClear', #{rows: 5})
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, ":call OtherBuffer()\<CR>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_display_scroll_at_topline()
-  " See test/functional/legacy/display_spec.lua
   CheckScreendump
 
   let buf = RunVimInTerminal('', #{cols: 20})

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1029,7 +1029,8 @@ describe('completion', function()
     ]])
   end)
 
-  it('TextChangedP autocommand', function()
+  -- oldtest: Test_ChangedP()
+  it('TextChangedI and TextChangedP autocommands', function()
     curbufmeths.set_lines(0, 1, false, { 'foo', 'bar', 'foobar'})
     source([[
       set complete=. completeopt=menuone

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -58,6 +58,51 @@ describe('display', function()
     ]])
   end)
 
+  -- oldtest: Test_matchparen_clear_highlight()
+  it('matchparen highlight is cleared when switching buffer', function()
+    local screen = Screen.new(20, 5)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},
+      [1] = {background = Screen.colors.Cyan},
+    })
+    screen:attach()
+
+    local screen1 = [[
+      {1:^()}                  |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+                          |
+    ]]
+    local screen2 = [[
+      ^aa                  |
+      {0:~                   }|
+      {0:~                   }|
+      {0:~                   }|
+                          |
+    ]]
+
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set hidden
+      call setline(1, ['()'])
+      normal 0
+    ]])
+    screen:expect(screen1)
+
+    exec([[
+      enew
+      exe "normal iaa\<Esc>0"
+    ]])
+    screen:expect(screen2)
+
+    feed('<C-^>')
+    screen:expect(screen1)
+
+    feed('<C-^>')
+    screen:expect(screen2)
+  end)
+
   local function run_test_display_lastline(euro)
     local screen = Screen.new(75, 10)
     screen:set_default_attr_ids({

--- a/test/functional/legacy/source_spec.lua
+++ b/test/functional/legacy/source_spec.lua
@@ -7,6 +7,7 @@ local write_file = helpers.write_file
 before_each(clear)
 
 describe(':source!', function()
+  -- oldtest: Test_nested_script()
   it('gives E22 when scripts nested too deep', function()
     write_file('Xscript.vim', [[
     :source! Xscript.vim

--- a/test/functional/legacy/visual_mode_spec.lua
+++ b/test/functional/legacy/visual_mode_spec.lua
@@ -1,31 +1,28 @@
 local helpers = require('test.functional.helpers')(after_each)
 
 local Screen = require('test.functional.ui.screen')
-local call = helpers.call
 local clear = helpers.clear
 local feed = helpers.feed
-local feed_command = helpers.feed_command
-local funcs = helpers.funcs
-local meths = helpers.meths
-local eq = helpers.eq
 local exec = helpers.exec
 
-describe('visual line mode', function()
-  local screen
+before_each(clear)
 
+describe('visual line mode', function()
+  -- oldtest: Test_visual_block_scroll()
   it('redraws properly after scrolling with matchparen loaded and scrolloff=1', function()
-    clear{args={'-u', 'NORC'}}
-    screen = Screen.new(30, 7)
+    local screen = Screen.new(30, 7)
     screen:attach()
     screen:set_default_attr_ids({
       [1] = {bold = true},
       [2] = {background = Screen.colors.LightGrey},
     })
 
-    eq(1, meths.get_var('loaded_matchparen'))
-    feed_command('set scrolloff=1')
-    funcs.setline(1, {'a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'})
-    call('cursor', 5, 1)
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set scrolloff=1
+      call setline(1, ['a', 'b', 'c', 'd', 'e', '', '{', '}', '{', 'f', 'g', '}'])
+      call cursor(5, 1)
+    ]])
 
     feed('V<c-d><c-d>')
     screen:expect([[
@@ -41,8 +38,8 @@ describe('visual line mode', function()
 end)
 
 describe('visual block mode', function()
+  -- oldtest: Test_visual_block_with_virtualedit()
   it('shows selection correctly with virtualedit=block', function()
-    clear()
     local screen = Screen.new(30, 7)
     screen:set_default_attr_ids({
       [1] = {bold = true},  -- ModeMsg

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -51,6 +51,7 @@ describe("'spell'", function()
 
   end)
 
+  -- oldtest: Test_spell_screendump()
   it('has correct highlight at start of line', function()
     insert([[
     "This is some text without any spell errors.  Everything",


### PR DESCRIPTION
Fix #19985

#### vim-patch:9.0.0969: matchparen highlight is not updated when switching buffers

Problem:    Matchparen highlight is not updated when switching buffers.
Solution:   Listen to the BufLeave and the BufWinEnter autocmd events.

https://github.com/vim/vim/commit/28a896f54d4b2f2b4bef8ef4144dde1673c9d6e7

Co-authored-by: Bram Moolenaar <Bram@vim.org>