### PR TITLE
vim-patch:9.0.0733: use of strftime() is not safe

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8445,9 +8445,7 @@ static void f_strftime(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       p = string_convert(&conv, p, NULL);
     }
     char result_buf[256];
-    if (p != NULL) {
-      (void)strftime(result_buf, sizeof(result_buf), p, curtime_ptr);
-    } else {
+    if (p == NULL || strftime(result_buf, sizeof(result_buf), p, curtime_ptr) == 0) {
       result_buf[0] = NUL;
     }
 

--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -2416,7 +2416,7 @@ bool mch_print_begin(prt_settings_T *psettings)
   prt_dsc_textline("For", buffer);
   prt_dsc_textline("Creator", longVersion);
   // Note: to ensure Clean8bit I don't think we can use LC_TIME
-  char ctime_buf[50];
+  char ctime_buf[100];  // hopefully enough for every language
   char *p_time = os_ctime(ctime_buf, sizeof(ctime_buf));
   // Note: os_ctime() adds a \n so we have to remove it :-(
   p = (char_u *)vim_strchr(p_time, '\n');

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1461,7 +1461,7 @@ static time_t swapfile_info(char_u *fname)
     msg_puts(_("             dated: "));
 #endif
     x = file_info.stat.st_mtim.tv_sec;
-    char ctime_buf[50];
+    char ctime_buf[100];  // hopefully enough for every language
     msg_puts(os_ctime_r(&x, ctime_buf, sizeof(ctime_buf)));
   }
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -186,10 +186,16 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
   struct tm *clock_local_ptr = os_localtime_r(clock, &clock_local);
   // MSVC returns NULL for an invalid value of seconds.
   if (clock_local_ptr == NULL) {
-    xstrlcpy(result, _("(Invalid)"), result_len);
+    xstrlcpy(result, _("(Invalid)"), result_len - 1);
   } else {
     // xgettext:no-c-format
-    strftime(result, result_len, _("%a %b %d %H:%M:%S %Y"), clock_local_ptr);
+    if (strftime(result, result_len - 1, _("%a %b %d %H:%M:%S %Y"), clock_local_ptr) == 0) {
+      // Quoting "man strftime":
+      // > If the length of the result string (including the terminating
+      // > null byte) would exceed max bytes, then strftime() returns 0,
+      // > and the contents of the array are undefined.
+      xstrlcpy(result, _("(Invalid)"), result_len - 1);
+    }
   }
   xstrlcat(result, "\n", result_len);
   return result;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2600,12 +2600,16 @@ void undo_fmt_time(char_u *buf, size_t buflen, time_t tt)
   if (time(NULL) - tt >= 100) {
     struct tm curtime;
     os_localtime_r(&tt, &curtime);
+    size_t n;
     if (time(NULL) - tt < (60L * 60L * 12L)) {
       // within 12 hours
-      (void)strftime((char *)buf, buflen, "%H:%M:%S", &curtime);
+      n = strftime((char *)buf, buflen, "%H:%M:%S", &curtime);
     } else {
       // longer ago
-      (void)strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", &curtime);
+      n = strftime((char *)buf, buflen, "%Y/%m/%d %H:%M:%S", &curtime);
+    }
+    if (n == 0) {
+      buf[0] = NUL;
     }
   } else {
     int64_t seconds = time(NULL) - tt;


### PR DESCRIPTION
#### vim-patch:9.0.0733: use of strftime() is not safe

Problem:    Use of strftime() is not safe.
Solution:   Check the return value of strftime().  Use a larger buffer and
            correctly pass the available space. (Dominique Pellé, closes
            vim/vim#11348)

https://github.com/vim/vim/commit/84d14ccdb50dc9f362066a2c83bfaf331314e5ea

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>