### PR TITLE
vim-patch:8.1.1313: warnings for using localtime() and ctime()

### DIFF
--- a/src/nvim/hardcopy.c
+++ b/src/nvim/hardcopy.c
@@ -2403,7 +2403,6 @@ bool mch_print_begin(prt_settings_T *psettings)
   struct prt_ps_resource_S res_encoding;
   char buffer[256];
   char *p_encoding;
-  char_u *p;
   struct prt_ps_resource_S res_cidfont;
   struct prt_ps_resource_S res_cmap;
 
@@ -2416,14 +2415,9 @@ bool mch_print_begin(prt_settings_T *psettings)
   prt_dsc_textline("For", buffer);
   prt_dsc_textline("Creator", longVersion);
   // Note: to ensure Clean8bit I don't think we can use LC_TIME
+
   char ctime_buf[100];  // hopefully enough for every language
-  char *p_time = os_ctime(ctime_buf, sizeof(ctime_buf));
-  // Note: os_ctime() adds a \n so we have to remove it :-(
-  p = (char_u *)vim_strchr(p_time, '\n');
-  if (p != NULL) {
-    *p = NUL;
-  }
-  prt_dsc_textline("CreationDate", p_time);
+  prt_dsc_textline("CreationDate", os_ctime(ctime_buf, sizeof(ctime_buf), false));
   prt_dsc_textline("DocumentData", "Clean8Bit");
   prt_dsc_textline("Orientation", "Portrait");
   prt_dsc_text(("Pages"), "atend");

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1462,7 +1462,7 @@ static time_t swapfile_info(char_u *fname)
 #endif
     x = file_info.stat.st_mtim.tv_sec;
     char ctime_buf[100];  // hopefully enough for every language
-    msg_puts(os_ctime_r(&x, ctime_buf, sizeof(ctime_buf)));
+    msg_puts(os_ctime_r(&x, ctime_buf, sizeof(ctime_buf), true));
   }
 
   // print the original file name
@@ -3121,7 +3121,7 @@ static void attention_message(buf_T *buf, char_u *fname)
     msg_puts(_("             dated: "));
     time_t x = file_info.stat.st_mtim.tv_sec;
     char ctime_buf[50];
-    msg_puts(os_ctime_r(&x, ctime_buf, sizeof(ctime_buf)));
+    msg_puts(os_ctime_r(&x, ctime_buf, sizeof(ctime_buf), true));
     if (swap_mtime != 0 && x > swap_mtime) {
       msg_puts(_("      NEWER than swap file!\n"));
     }

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -179,7 +179,8 @@ struct tm *os_localtime(struct tm *result) FUNC_ATTR_NONNULL_ALL
 /// @param result[out] Pointer to a 'char' where the result should be placed
 /// @param result_len length of result buffer
 /// @return human-readable string of current local time
-char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t result_len)
+char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t result_len,
+                 bool add_newline)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
   struct tm clock_local;
@@ -197,7 +198,9 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
       xstrlcpy(result, _("(Invalid)"), result_len - 1);
     }
   }
-  xstrlcat(result, "\n", result_len);
+  if (add_newline) {
+    xstrlcat(result, "\n", result_len);
+  }
   return result;
 }
 
@@ -206,11 +209,11 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
 /// @param result[out] Pointer to a 'char' where the result should be placed
 /// @param result_len length of result buffer
 /// @return human-readable string of current local time
-char *os_ctime(char *result, size_t result_len)
+char *os_ctime(char *result, size_t result_len, bool add_newline)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
   time_t rawtime = time(NULL);
-  return os_ctime_r(&rawtime, result, result_len);
+  return os_ctime_r(&rawtime, result, result_len, add_newline);
 }
 
 /// Portable version of POSIX strptime()


### PR DESCRIPTION
#### vim-patch:8.1.1313: warnings for using localtime() and ctime()

Problem:    Warnings for using localtime() and ctime().
Solution:   Use localtime_r() if available.  Avoid using ctime().

https://github.com/vim/vim/commit/63d2555c9cefbbeeca3ec87fdd5d241e9488f9dd

Co-authored-by: Bram Moolenaar <Bram@vim.org>