### PR TITLE
vim-patch:9.0.0969: matchparen highlight is not updated when switching buffers

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2021 Apr 08
+" Last Change: 2022 Nov 28
 
 " Exit quickly when:
 " - this plugin was already loaded (or disabled)
@@ -19,8 +19,8 @@ endif
 
 augroup matchparen
   " Replace all matchparen autocommands
-  autocmd! CursorMoved,CursorMovedI,WinEnter,WinScrolled * call s:Highlight_Matching_Pair()
-  autocmd! WinLeave * call s:Remove_Matches()
+  autocmd! CursorMoved,CursorMovedI,WinEnter,BufWinEnter,WinScrolled * call s:Highlight_Matching_Pair()
+  autocmd! WinLeave,BufLeave * call s:Remove_Matches()
   if exists('##TextChanged')
     autocmd! TextChanged,TextChangedI * call s:Highlight_Matching_Pair()
   endif

--- a/src/nvim/testdir/test_display.vim
+++ b/src/nvim/testdir/test_display.vim
@@ -248,6 +248,37 @@ func Test_visual_block_scroll()
   call delete(filename)
 endfunc
 
+" Test for clearing paren highlight when switching buffers
+func Test_matchparen_clear_highlight()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set hidden
+    call setline(1, ['()'])
+    normal 0
+
+    func OtherBuffer()
+       enew
+       exe "normal iaa\<Esc>0"
+    endfunc
+  END
+  call writefile(lines, 'XMatchparenClear', 'D')
+  let buf = RunVimInTerminal('-S XMatchparenClear', #{rows: 5})
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, ":call OtherBuffer()\<CR>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_1', {})
+
+  call term_sendkeys(buf, "\<C-^>:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_matchparen_clear_highlight_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_display_scroll_at_topline()
   " See test/functional/legacy/display_spec.lua
   CheckScreendump


### PR DESCRIPTION

Problem:    Matchparen highlight is not updated when switching buffers.
Solution:   Listen to the BufLeave and the BufWinEnter autocmd events.

https://github.com/vim/vim/commit/28a896f54d4b2f2b4bef8ef4144dde1673c9d6e7

Co-authored-by: Bram Moolenaar <Bram@vim.org>