### PR TITLE
vim-patch:9.0.{0910,0914}

### DIFF
--- a/src/nvim/testdir/test_bufline.vim
+++ b/src/nvim/testdir/test_bufline.vim
@@ -98,12 +98,25 @@ func Test_appendbufline()
   new
   let b = bufnr('%')
   hide
+
+  new
+  call setline(1, ['line1', 'line2', 'line3'])
+  normal! 2gggg
+  call assert_equal(2, line("''"))
+
   call assert_equal(0, appendbufline(b, 0, ['foo', 'bar']))
   call assert_equal(['foo'], getbufline(b, 1))
   call assert_equal(['bar'], getbufline(b, 2))
   call assert_equal(['foo', 'bar'], getbufline(b, 1, 2))
+  call assert_equal(0, appendbufline(b, 0, 'baz'))
+  call assert_equal(['baz', 'foo', 'bar'], getbufline(b, 1, 3))
+
+  " appendbufline() in a hidden buffer shouldn't move marks in current window.
+  call assert_equal(2, line("''"))
+  bwipe!
+
   exe "bd!" b
-  call assert_equal([], getbufline(b, 1, 2))
+  call assert_equal([], getbufline(b, 1, 3))
 
   split Xtest
   call setline(1, ['a', 'b', 'c'])
@@ -145,10 +158,21 @@ func Test_deletebufline()
   let b = bufnr('%')
   call setline(1, ['aaa', 'bbb', 'ccc'])
   hide
+
+  new
+  call setline(1, ['line1', 'line2', 'line3'])
+  normal! 2gggg
+  call assert_equal(2, line("''"))
+
   call assert_equal(0, deletebufline(b, 2))
   call assert_equal(['aaa', 'ccc'], getbufline(b, 1, 2))
   call assert_equal(0, deletebufline(b, 2, 8))
   call assert_equal(['aaa'], getbufline(b, 1, 2))
+
+  " deletebufline() in a hidden buffer shouldn't move marks in current window.
+  call assert_equal(2, line("''"))
+  bwipe!
+
   exe "bd!" b
   call assert_equal(1, b->deletebufline(1))
 


### PR DESCRIPTION
#### vim-patch:9.0.0910: setting lines in another buffer may not work well

Problem:    Setting lines in another buffer may not work well.
Solution:   Make sure the buffer being changed has a window. (issue vim/vim#11558)

https://github.com/vim/vim/commit/c934bfa1b765505e5fc491f2ee7cc106894cafc8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0914: deletebufline() may move marks in the wrong window

Problem:    deletebufline() may move marks in the wrong window.
Solution:   Find a window for the buffer being changed. (closes vim/vim#11583)

https://github.com/vim/vim/commit/228e422855d43965f2c3319ff0cdc26ea422c10f

Cherry-pick code change from patch 9.0.0961.

Co-authored-by: Bram Moolenaar <Bram@vim.org>