### PR TITLE
vim-patch:9.0.{0965,0966,0967}: using one window for executing autocommands is insufficient

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -633,6 +633,11 @@ void do_augroup(char *arg, int del_group)
   }
 }
 
+void autocmd_init(void)
+{
+  CLEAR_FIELD(aucmd_win);
+}
+
 #if defined(EXITFREE)
 void free_all_autocmds(void)
 {
@@ -659,8 +664,26 @@ void free_all_autocmds(void)
     api_free_string(name);
   })
   map_destroy(int, String)(&map_augroup_id_to_name);
+
+  for (int i = 0; i < AUCMD_WIN_COUNT; ++i) {
+    if (aucmd_win[i].auc_win_used) {
+      aucmd_win[i].auc_win_used = false;
+      win_remove(aucmd_win[i].auc_win, NULL);
+    }
+  }
 }
 #endif
+
+/// Return true if "win" is an active entry in aucmd_win[].
+bool is_aucmd_win(win_T *win)
+{
+  for (int i = 0; i < AUCMD_WIN_COUNT; i++) {
+    if (aucmd_win[i].auc_win_used && aucmd_win[i].auc_win == win) {
+      return true;
+    }
+  }
+  return false;
+}
 
 // Return the event number for event name "start".
 // Return NUM_EVENTS if the event name was not found.
@@ -1310,6 +1333,13 @@ void ex_doautoall(exarg_T *eap)
 
     // Find a window for this buffer and save some values.
     aucmd_prepbuf(&aco, buf);
+    if (curbuf != buf) {
+      // Failed to find a window for this buffer.  Better not execute
+      // autocommands then.
+      retval = FAIL;
+      break;
+    }
+
     set_bufref(&bufref, buf);
 
     // execute the autocommands for this buffer
@@ -1319,7 +1349,7 @@ void ex_doautoall(exarg_T *eap)
       // Execute the modeline settings, but don't set window-local
       // options if we are using the current window for another
       // buffer.
-      do_modelines(curwin == aucmd_win ? OPT_NOWIN : 0);
+      do_modelines(is_aucmd_win(curwin) ? OPT_NOWIN : 0);
     }
 
     // restore the current window
@@ -1358,8 +1388,9 @@ bool check_nomodeline(char **argp)
 
 /// Prepare for executing autocommands for (hidden) buffer `buf`.
 /// If the current buffer is not in any visible window, put it in a temporary
-/// floating window `aucmd_win`.
+/// floating window using an entry in `aucmd_win[]`.
 /// Set `curbuf` and `curwin` to match `buf`.
+/// When this fails `curbuf` is not equal `buf`.
 ///
 /// @param aco  structure to save values in
 /// @param buf  new curbuf
@@ -1381,15 +1412,26 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     }
   }
 
-  // Allocate the `aucmd_win` dummy floating window.
-  if (win == NULL && aucmd_win == NULL) {
-    win_alloc_aucmd_win();
-    need_append = false;
-  }
-  if (win == NULL && aucmd_win_used) {
-    // Strange recursive autocommand, fall back to using the current
-    // window.  Expect a few side effects...
-    win = curwin;
+  // Allocate a window when needed.
+  win_T *auc_win = NULL;
+  int auc_idx = AUCMD_WIN_COUNT;
+  if (win == NULL) {
+    for (auc_idx = 0; auc_idx < AUCMD_WIN_COUNT; auc_idx++) {
+      if (!aucmd_win[auc_idx].auc_win_used) {
+        win_alloc_aucmd_win(auc_idx);
+        auc_win = aucmd_win[auc_idx].auc_win;
+        aucmd_win[auc_idx].auc_win_used = true;
+        need_append = false;
+        break;
+      }
+    }
+
+    // If this fails (using all AUCMD_WIN_COUNT entries)
+    // then we can't reliably execute the autocmd,
+    // return with "curbuf" unequal "buf".
+    if (auc_win == NULL) {
+      return;
+    }
   }
 
   aco->save_curwin_handle = curwin->handle;
@@ -1399,42 +1441,41 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
     // There is a window for "buf" in the current tab page, make it the
     // curwin.  This is preferred, it has the least side effects (esp. if
     // "buf" is curbuf).
-    aco->use_aucmd_win = false;
+    aco->use_aucmd_win_idx = -1;
     curwin = win;
   } else {
-    // There is no window for "buf", use "aucmd_win".  To minimize the side
+    // There is no window for "buf", use "auc_win".  To minimize the side
     // effects, insert it in the current tab page.
     // Anything related to a window (e.g., setting folds) may have
     // unexpected results.
-    aco->use_aucmd_win = true;
-    aucmd_win_used = true;
-    aucmd_win->w_buffer = buf;
-    aucmd_win->w_s = &buf->b_s;
+    aco->use_aucmd_win_idx = auc_idx;
+    auc_win->w_buffer = buf;
+    auc_win->w_s = &buf->b_s;
     buf->b_nwindows++;
-    win_init_empty(aucmd_win);  // set cursor and topline to safe values
+    win_init_empty(auc_win);  // set cursor and topline to safe values
 
     // Make sure w_localdir and globaldir are NULL to avoid a chdir() in
     // win_enter_ext().
-    XFREE_CLEAR(aucmd_win->w_localdir);
+    XFREE_CLEAR(auc_win->w_localdir);
     aco->globaldir = globaldir;
     globaldir = NULL;
 
     block_autocmds();  // We don't want BufEnter/WinEnter autocommands.
     if (need_append) {
-      win_append(lastwin, aucmd_win);
-      pmap_put(handle_T)(&window_handles, aucmd_win->handle, aucmd_win);
-      win_config_float(aucmd_win, aucmd_win->w_float_config);
+      win_append(lastwin, auc_win);
+      pmap_put(handle_T)(&window_handles, auc_win->handle, auc_win);
+      win_config_float(auc_win, auc_win->w_float_config);
     }
     // Prevent chdir() call in win_enter_ext(), through do_autochdir()
     int save_acd = p_acd;
     p_acd = false;
     // no redrawing and don't set the window title
     RedrawingDisabled++;
-    win_enter(aucmd_win, false);
+    win_enter(auc_win, false);
     RedrawingDisabled--;
     p_acd = save_acd;
     unblock_autocmds();
-    curwin = aucmd_win;
+    curwin = auc_win;
   }
   curbuf = buf;
   aco->new_curwin_handle = curwin->handle;
@@ -1451,18 +1492,20 @@ void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
 /// @param aco  structure holding saved values
 void aucmd_restbuf(aco_save_T *aco)
 {
-  if (aco->use_aucmd_win) {
+  if (aco->use_aucmd_win_idx >= 0) {
+    win_T *awp = aucmd_win[aco->use_aucmd_win_idx].auc_win;
+
     curbuf->b_nwindows--;
-    // Find "aucmd_win", it can't be closed, but it may be in another tab page.
+    // Find "awp", it can't be closed, but it may be in another tab page.
     // Do not trigger autocommands here.
     block_autocmds();
-    if (curwin != aucmd_win) {
+    if (curwin != awp) {
       FOR_ALL_TAB_WINDOWS(tp, wp) {
-        if (wp == aucmd_win) {
+        if (wp == awp) {
           if (tp != curtab) {
             goto_tabpage_tp(tp, true, true);
           }
-          win_goto(aucmd_win);
+          win_goto(awp);
           goto win_found;
         }
       }
@@ -1477,7 +1520,7 @@ win_found:
       grid_free(&curwin->w_grid_alloc);
     }
 
-    aucmd_win_used = false;
+    aucmd_win[aco->use_aucmd_win_idx].auc_win_used = false;
 
     if (!valid_tabpage_win(curtab)) {
       // no valid window in current tabpage
@@ -1498,8 +1541,8 @@ win_found:
     entering_window(curwin);
 
     prevwin = win_find_by_handle(aco->save_prevwin_handle);
-    vars_clear(&aucmd_win->w_vars->dv_hashtab);         // free all w: variables
-    hash_init(&aucmd_win->w_vars->dv_hashtab);          // re-use the hashtab
+    vars_clear(&awp->w_vars->dv_hashtab);         // free all w: variables
+    hash_init(&awp->w_vars->dv_hashtab);          // re-use the hashtab
 
     xfree(globaldir);
     globaldir = aco->globaldir;

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -25,7 +25,7 @@ struct AutoPat_S;
 // not the current buffer.
 typedef struct {
   buf_T *save_curbuf;             ///< saved curbuf
-  bool use_aucmd_win;             ///< using aucmd_win
+  int use_aucmd_win_idx;          ///< index in aucmd_win[] if >= 0
   handle_T save_curwin_handle;    ///< ID of saved curwin
   handle_T new_curwin_handle;     ///< ID of new curwin
   handle_T save_prevwin_handle;   ///< ID of saved prevwin

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -175,6 +175,19 @@ static int read_buffer(int read_stdin, exarg_T *eap, int flags)
   return retval;
 }
 
+/// Ensure buffer "buf" is loaded.  Does not trigger the swap-exists action.
+void buffer_ensure_loaded(buf_T *buf)
+{
+  if (buf->b_ml.ml_mfp == NULL) {
+    aco_save_T aco;
+
+    aucmd_prepbuf(&aco, buf);
+    swap_exists_action = SEA_NONE;
+    open_buffer(false, NULL, 0);
+    aucmd_restbuf(&aco);
+  }
+}
+
 /// Open current buffer, that is: open the memfile and read the file into
 /// memory.
 ///

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -181,10 +181,13 @@ void buffer_ensure_loaded(buf_T *buf)
   if (buf->b_ml.ml_mfp == NULL) {
     aco_save_T aco;
 
+    // Make sure the buffer is in a window.  If not then skip it.
     aucmd_prepbuf(&aco, buf);
-    swap_exists_action = SEA_NONE;
-    open_buffer(false, NULL, 0);
-    aucmd_restbuf(&aco);
+    if (curbuf == buf) {
+      swap_exists_action = SEA_NONE;
+      open_buffer(false, NULL, 0);
+      aucmd_restbuf(&aco);
+    }
   }
 }
 
@@ -365,18 +368,21 @@ int open_buffer(int read_stdin, exarg_T *eap, int flags_arg)
   if (bufref_valid(&old_curbuf) && old_curbuf.br_buf->b_ml.ml_mfp != NULL) {
     aco_save_T aco;
 
-    // Go to the buffer that was opened.
+    // Go to the buffer that was opened, make sure it is in a window.
+    // If not then skip it.
     aucmd_prepbuf(&aco, old_curbuf.br_buf);
-    do_modelines(0);
-    curbuf->b_flags &= ~(BF_CHECK_RO | BF_NEVERLOADED);
+    if (curbuf == old_curbuf.br_buf) {
+      do_modelines(0);
+      curbuf->b_flags &= ~(BF_CHECK_RO | BF_NEVERLOADED);
 
-    if ((flags & READ_NOWINENTER) == 0) {
-      apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
-                            &retval);
+      if ((flags & READ_NOWINENTER) == 0) {
+        apply_autocmds_retval(EVENT_BUFWINENTER, NULL, NULL, false, curbuf,
+                              &retval);
+      }
+
+      // restore curwin/curbuf and a few other things
+      aucmd_restbuf(&aco);
     }
-
-    // restore curwin/curbuf and a few other things
-    aucmd_restbuf(&aco);
   }
 
   return retval;
@@ -1329,7 +1335,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     // Repeat this so long as we end up in a window with this buffer.
     while (buf == curbuf
            && !(curwin->w_closing || curwin->w_buffer->b_locked > 0)
-           && (lastwin == aucmd_win || !last_window(curwin))) {
+           && (is_aucmd_win(lastwin) || !last_window(curwin))) {
       if (win_close(curwin, false, false) == FAIL) {
         break;
       }
@@ -4168,9 +4174,14 @@ bool buf_contents_changed(buf_T *buf)
   exarg_T ea;
   prep_exarg(&ea, buf);
 
-  // set curwin/curbuf to buf and save a few things
+  // Set curwin/curbuf to buf and save a few things.
   aco_save_T aco;
   aucmd_prepbuf(&aco, newbuf);
+  if (curbuf != newbuf) {
+    // Failed to find a window for "newbuf".
+    wipe_buffer(newbuf, false);
+    return true;
+  }
 
   if (ml_open(curbuf) == OK
       && readfile(buf->b_ffname, buf->b_fname,

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2943,8 +2943,13 @@ void ex_diffgetput(exarg_T *eap)
     // Need to make the other buffer the current buffer to be able to make
     // changes in it.
 
-    // set curwin/curbuf to buf and save a few things
+    // Set curwin/curbuf to buf and save a few things.
     aucmd_prepbuf(&aco, curtab->tp_diffbuf[idx_other]);
+    if (curbuf != curtab->tp_diffbuf[idx_other]) {
+      // Could not find a window for this buffer, the rest is likely to
+      // fail.
+      goto theend;
+    }
   }
 
   const int idx_from = eap->cmdidx == CMD_diffget ? idx_other : idx_cur;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4174,8 +4174,9 @@ bool garbage_collect(bool testing)
       ABORTING(set_ref_in_fmark)(wp->w_jumplist[i].fmark, copyID);
     }
   }
+  // window-local variables in autocmd windows
   for (int i = 0; i < AUCMD_WIN_COUNT; i++) {
-    if (aucmd_win[i].auc_win_used) {
+    if (aucmd_win[i].auc_win != NULL) {
       ABORTING(set_ref_in_item)(&aucmd_win[i].auc_win->w_winvar.di_tv, copyID, NULL, NULL);
     }
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4174,8 +4174,10 @@ bool garbage_collect(bool testing)
       ABORTING(set_ref_in_fmark)(wp->w_jumplist[i].fmark, copyID);
     }
   }
-  if (aucmd_win != NULL) {
-    ABORTING(set_ref_in_item)(&aucmd_win->w_winvar.di_tv, copyID, NULL, NULL);
+  for (int i = 0; i < AUCMD_WIN_COUNT; i++) {
+    if (aucmd_win[i].auc_win_used) {
+      ABORTING(set_ref_in_item)(&aucmd_win[i].auc_win->w_winvar.di_tv, copyID, NULL, NULL);
+    }
   }
 
   // registers (ShaDa additional data)

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -86,6 +86,8 @@ static void find_win_for_curbuf(void)
 ///
 /// Information is saved in "cob" and MUST be restored by calling
 /// change_other_buffer_restore().
+///
+/// If this fails then "curbuf" will not be equal to "buf".
 static void change_other_buffer_prepare(cob_T *cob, buf_T *buf)
 {
   CLEAR_POINTER(cob);
@@ -103,7 +105,9 @@ static void change_other_buffer_prepare(cob_T *cob, buf_T *buf)
     // curwin->w_buffer differ from "curbuf", use the autocmd window.
     curbuf = curwin->w_buffer;
     aucmd_prepbuf(&cob->cob_aco, buf);
-    cob->cob_using_aco = true;
+    if (curbuf == buf) {
+      cob->cob_using_aco = true;
+    }
   }
 }
 

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -302,13 +302,8 @@ void f_bufload(typval_T *argvars, typval_T *unused, EvalFuncData fptr)
 {
   buf_T *buf = get_buf_arg(&argvars[0]);
 
-  if (buf != NULL && buf->b_ml.ml_mfp == NULL) {
-    aco_save_T aco;
-
-    aucmd_prepbuf(&aco, buf);
-    swap_exists_action = SEA_NONE;
-    open_buffer(false, NULL, 0);
-    aucmd_restbuf(&aco);
+  if (buf != NULL) {
+    buffer_ensure_loaded(buf);
   }
 }
 

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1800,13 +1800,15 @@ void f_setbufvar(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (*varname == '&') {
       aco_save_T aco;
 
-      // set curbuf to be our buf, temporarily
+      // Set curbuf to be our buf, temporarily.
       aucmd_prepbuf(&aco, buf);
+      if (curbuf == buf) {
+        // Only when it worked to set "curbuf".
+        set_option_from_tv(varname + 1, varp);
 
-      set_option_from_tv(varname + 1, varp);
-
-      // reset notion of buffer
-      aucmd_restbuf(&aco);
+        // reset notion of buffer
+        aucmd_restbuf(&aco);
+      }
     } else {
       const size_t varname_len = strlen(varname);
       char *const bufvarname = xmalloc(varname_len + 3);

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -590,7 +590,7 @@ static void win_move_into_split(win_T *wp, win_T *targetwin, int size, int flags
   int height = wp->w_height;
   win_T *oldwin = curwin;
 
-  if (wp == targetwin || wp == aucmd_win) {
+  if (wp == targetwin || is_aucmd_win(wp)) {
     return;
   }
 
@@ -674,7 +674,7 @@ void f_win_gettype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       return;
     }
   }
-  if (wp == aucmd_win) {
+  if (is_aucmd_win(wp)) {
     rettv->vval.v_string = xstrdup("autocmd");
   } else if (wp->w_p_pvw) {
     rettv->vval.v_string = xstrdup("preview");

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -683,8 +683,10 @@ void ex_listdo(exarg_T *eap)
                          curbuf);
         } else {
           aucmd_prepbuf(&aco, buf);
-          apply_autocmds(EVENT_SYNTAX, buf->b_p_syn, buf->b_fname, true, buf);
-          aucmd_restbuf(&aco);
+          if (curbuf == buf) {
+            apply_autocmds(EVENT_SYNTAX, buf->b_p_syn, buf->b_fname, true, buf);
+            aucmd_restbuf(&aco);
+          }
         }
 
         // start over, in case autocommands messed things up.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4621,7 +4621,7 @@ static void ex_pclose(exarg_T *eap)
 void ex_win_close(int forceit, win_T *win, tabpage_T *tp)
 {
   // Never close the autocommand window.
-  if (win == aucmd_win) {
+  if (is_aucmd_win(win)) {
     emsg(_(e_autocmd_close));
     return;
   }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2310,6 +2310,12 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
 
     // Set curwin/curbuf to buf and save a few things.
     aucmd_prepbuf(&aco, buf);
+    if (curbuf != buf) {
+      // Could not find a window for "buf".  Doing more might cause
+      // problems, better bail out.
+      return FAIL;
+    }
+
     set_bufref(&bufref, buf);
 
     if (append) {
@@ -3612,24 +3618,26 @@ nofail:
 
     // Apply POST autocommands.
     // Careful: The autocommands may call buf_write() recursively!
+    // Only do this when a window was found for "buf".
     aucmd_prepbuf(&aco, buf);
+    if (curbuf == buf) {
+      if (append) {
+        apply_autocmds_exarg(EVENT_FILEAPPENDPOST, fname, fname,
+                             false, curbuf, eap);
+      } else if (filtering) {
+        apply_autocmds_exarg(EVENT_FILTERWRITEPOST, NULL, fname,
+                             false, curbuf, eap);
+      } else if (reset_changed && whole) {
+        apply_autocmds_exarg(EVENT_BUFWRITEPOST, fname, fname,
+                             false, curbuf, eap);
+      } else {
+        apply_autocmds_exarg(EVENT_FILEWRITEPOST, fname, fname,
+                             false, curbuf, eap);
+      }
 
-    if (append) {
-      apply_autocmds_exarg(EVENT_FILEAPPENDPOST, fname, fname,
-                           false, curbuf, eap);
-    } else if (filtering) {
-      apply_autocmds_exarg(EVENT_FILTERWRITEPOST, NULL, fname,
-                           false, curbuf, eap);
-    } else if (reset_changed && whole) {
-      apply_autocmds_exarg(EVENT_BUFWRITEPOST, fname, fname,
-                           false, curbuf, eap);
-    } else {
-      apply_autocmds_exarg(EVENT_FILEWRITEPOST, fname, fname,
-                           false, curbuf, eap);
+      // restore curwin/curbuf and a few other things
+      aucmd_restbuf(&aco);
     }
-
-    // restore curwin/curbuf and a few other things
-    aucmd_restbuf(&aco);
 
     if (aborting()) {       // autocmds may abort script processing
       retval = false;
@@ -5003,8 +5011,13 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
   aco_save_T aco;
   int flags = READ_NEW;
 
-  // set curwin/curbuf for "buf" and save some things
+  // Set curwin/curbuf for "buf" and save some things.
   aucmd_prepbuf(&aco, buf);
+  if (curbuf != buf) {
+    // Failed to find a window for "buf", it is dangerous to continue,
+    // better bail out.
+    return;
+  }
 
   // Unless reload_options is set, we only want to read the text from the
   // file, not reset the syntax highlighting, clear marks, diff status, etc.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -422,8 +422,18 @@ EXTERN win_T *prevwin INIT(= NULL);  // previous window
 
 EXTERN win_T *curwin;        // currently active window
 
-EXTERN win_T *aucmd_win;     // window used in aucmd_prepbuf()
-EXTERN int aucmd_win_used INIT(= false);  // aucmd_win is being used
+/// When executing autocommands for a buffer that is not in any window, a
+/// special window is created to handle the side effects.  When autocommands
+/// nest we may need more than one.  Allow for up to five, if more are needed
+/// something crazy is happening.
+enum { AUCMD_WIN_COUNT = 5, };
+
+typedef struct {
+  win_T *auc_win;    ///< window used in aucmd_prepbuf()
+  int auc_win_used;  ///< this auc_win is being used
+} aucmdwin_T;
+
+EXTERN aucmdwin_T aucmd_win[AUCMD_WIN_COUNT];
 
 // The window layout is kept in a tree of frames.  topframe points to the top
 // of the tree.

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -429,8 +429,9 @@ EXTERN win_T *curwin;        // currently active window
 enum { AUCMD_WIN_COUNT = 5, };
 
 typedef struct {
-  win_T *auc_win;    ///< window used in aucmd_prepbuf()
-  int auc_win_used;  ///< this auc_win is being used
+  win_T *auc_win;     ///< Window used in aucmd_prepbuf().  When not NULL the
+                      ///< window has been allocated.
+  bool auc_win_used;  ///< This auc_win is being used.
 } aucmdwin_T;
 
 EXTERN aucmdwin_T aucmd_win[AUCMD_WIN_COUNT];

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -251,6 +251,8 @@ int main(int argc, char **argv)
   // `argc` and `argv` are also copied, so that they can be changed.
   init_params(&params, argc, argv);
 
+  autocmd_init();
+
   // Since os_open is called during the init_startuptime, we need to call
   // fs_init before it.
   fs_init();

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3902,21 +3902,27 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
 
     aco_save_T aco;
 
+    bool do_fill = true;
     if (old_last == NULL) {
       // set curwin/curbuf to buf and save a few things
       aucmd_prepbuf(&aco, buf);
+      if (curbuf != buf) {
+        do_fill = false;  // failed to find a window for "buf"
+      }
     }
 
-    qf_update_win_titlevar(qi);
+    if (do_fill) {
+      qf_update_win_titlevar(qi);
 
-    qf_fill_buffer(qf_get_curlist(qi), buf, old_last, qf_winid);
-    buf_inc_changedtick(buf);
+      qf_fill_buffer(qf_get_curlist(qi), buf, old_last, qf_winid);
+      buf_inc_changedtick(buf);
 
-    if (old_last == NULL) {
-      (void)qf_win_pos_update(qi, 0);
+      if (old_last == NULL) {
+        (void)qf_win_pos_update(qi, 0);
 
-      // restore curwin/curbuf and a few other things
-      aucmd_restbuf(&aco);
+        // restore curwin/curbuf and a few other things
+        aucmd_restbuf(&aco);
+      }
     }
 
     // Only redraw when added lines are visible.  This avoids flickering when
@@ -5463,9 +5469,11 @@ static int vgr_process_files(win_T *wp, qf_info_T *qi, vgr_args_T *cmd_args, boo
           // options!
           aco_save_T aco;
           aucmd_prepbuf(&aco, buf);
-          apply_autocmds(EVENT_FILETYPE, buf->b_p_ft, buf->b_fname, true, buf);
-          do_modelines(OPT_NOWIN);
-          aucmd_restbuf(&aco);
+          if (curbuf == buf) {
+            apply_autocmds(EVENT_FILETYPE, buf->b_p_ft, buf->b_fname, true, buf);
+            do_modelines(OPT_NOWIN);
+            aucmd_restbuf(&aco);
+          }
         }
       }
     }
@@ -5623,41 +5631,43 @@ static buf_T *load_dummy_buffer(char *fname, char *dirname_start, char *resultin
     // set curwin/curbuf to buf and save a few things
     aco_save_T aco;
     aucmd_prepbuf(&aco, newbuf);
+    if (curbuf == newbuf) {
+      // Need to set the filename for autocommands.
+      (void)setfname(curbuf, fname, NULL, false);
 
-    // Need to set the filename for autocommands.
-    (void)setfname(curbuf, fname, NULL, false);
+      // Create swap file now to avoid the ATTENTION message.
+      check_need_swap(true);
 
-    // Create swap file now to avoid the ATTENTION message.
-    check_need_swap(true);
+      // Remove the "dummy" flag, otherwise autocommands may not
+      // work.
+      curbuf->b_flags &= ~BF_DUMMY;
 
-    // Remove the "dummy" flag, otherwise autocommands may not
-    // work.
-    curbuf->b_flags &= ~BF_DUMMY;
-
-    bufref_T newbuf_to_wipe;
-    newbuf_to_wipe.br_buf = NULL;
-    int readfile_result = readfile(fname, NULL, (linenr_T)0, (linenr_T)0,
-                                   (linenr_T)MAXLNUM, NULL,
-                                   READ_NEW | READ_DUMMY, false);
-    newbuf->b_locked--;
-    if (readfile_result == OK
-        && !got_int
-        && !(curbuf->b_flags & BF_NEW)) {
-      failed = false;
-      if (curbuf != newbuf) {
-        // Bloody autocommands changed the buffer!  Can happen when
-        // using netrw and editing a remote file.  Use the current
-        // buffer instead, delete the dummy one after restoring the
-        // window stuff.
-        set_bufref(&newbuf_to_wipe, newbuf);
-        newbuf = curbuf;
+      bufref_T newbuf_to_wipe;
+      newbuf_to_wipe.br_buf = NULL;
+      int readfile_result = readfile(fname, NULL, (linenr_T)0, (linenr_T)0,
+                                     (linenr_T)MAXLNUM, NULL,
+                                     READ_NEW | READ_DUMMY, false);
+      newbuf->b_locked--;
+      if (readfile_result == OK
+          && !got_int
+          && !(curbuf->b_flags & BF_NEW)) {
+        failed = false;
+        if (curbuf != newbuf) {
+          // Bloody autocommands changed the buffer!  Can happen when
+          // using netrw and editing a remote file.  Use the current
+          // buffer instead, delete the dummy one after restoring the
+          // window stuff.
+          set_bufref(&newbuf_to_wipe, newbuf);
+          newbuf = curbuf;
+        }
       }
-    }
 
-    // Restore curwin/curbuf and a few other things.
-    aucmd_restbuf(&aco);
-    if (newbuf_to_wipe.br_buf != NULL && bufref_valid(&newbuf_to_wipe)) {
-      wipe_buffer(newbuf_to_wipe.br_buf, false);
+      // Restore curwin/curbuf and a few other things.
+      aucmd_restbuf(&aco);
+
+      if (newbuf_to_wipe.br_buf != NULL && bufref_valid(&newbuf_to_wipe)) {
+        wipe_buffer(newbuf_to_wipe.br_buf, false);
+      }
     }
 
     // Add back the "dummy" flag, otherwise buflist_findname_file_id()

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -387,7 +387,7 @@ void terminal_check_size(Terminal *term)
   // Check if there is a window that displays the terminal and find the maximum width and height.
   // Skip the autocommand window which isn't actually displayed.
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (wp == aucmd_win) {
+    if (is_aucmd_win(wp)) {
       continue;
     }
     if (wp->w_buffer && wp->w_buffer->terminal == term) {

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -3483,4 +3483,27 @@ func Test_autocmd_split_dummy()
   call delete('Xerr')
 endfunc
 
+" This was crashing because there was only one window to execute autocommands
+" in.
+func Test_autocmd_nested_setbufvar()
+  CheckFeature python3
+
+  set hidden
+  edit Xaaa
+  edit Xbbb
+  call setline(1, 'bar')
+  enew
+  au BufWriteCmd Xbbb ++nested call setbufvar('Xaaa', '&ft', 'foo') | bw! Xaaa
+  au FileType foo call py3eval('vim.current.buffer.options["cindent"]')
+  wall
+
+  au! BufWriteCmd
+  au! FileType foo
+  set nohidden
+  call delete('Xaaa')
+  call delete('Xbbb')
+  %bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3092,18 +3092,18 @@ void win_free_all(void)
     win_remove(lastwin, NULL);
     int dummy;
     (void)win_free_mem(wp, &dummy, NULL);
-    for (int i = 0; i < AUCMD_WIN_COUNT; ++i) {
+    for (int i = 0; i < AUCMD_WIN_COUNT; i++) {
       if (aucmd_win[i].auc_win == wp) {
-        aucmd_win[i].auc_win_used = false;
+        aucmd_win[i].auc_win = NULL;
       }
     }
   }
 
-  for (int i = 0; i < AUCMD_WIN_COUNT; ++i) {
-    if (aucmd_win[i].auc_win_used) {
+  for (int i = 0; i < AUCMD_WIN_COUNT; i++) {
+    if (aucmd_win[i].auc_win != NULL) {
       int dummy;
       (void)win_free_mem(aucmd_win[i].auc_win, &dummy, NULL);
-      aucmd_win[i].auc_win_used = false;
+      aucmd_win[i].auc_win = NULL;
     }
   }
 


### PR DESCRIPTION
Fix #20197

#### vim-patch:9.0.0965: using one window for executing autocommands is insufficient

Problem:    Using one window for executing autocommands is insufficient.
Solution:   Use up to five windows for executing autocommands.

https://github.com/vim/vim/commit/e76062c078debed0df818f70e4db14ad7a7cb53a

N/A patches for version.c:

vim-patch:9.0.0966: some compilers don't allow a declaration after a label

Problem:    Some compilers don't allow a declaration after a label.
Solution:   Move the declaration to the start of the block. (John Marriott)

https://github.com/vim/vim/commit/f86490ed4fdab213a28f667abd055c023a73d645

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0967: leaking memory from autocmd windows

Problem:    Leaking memory from autocmd windows.
Solution:   Free window when auc_win is not NULL.

https://github.com/vim/vim/commit/84497cd06f06516f6ce727ea00c47792ce16dc70

Co-authored-by: Bram Moolenaar <Bram@vim.org>