### PR TITLE
vim-patch:8.2.3259 when 'indentexpr' causes an error did_throw may hang

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -17,6 +17,7 @@
 #include "nvim/edit.h"
 #include "nvim/eval.h"
 #include "nvim/eval/typval_defs.h"
+#include "nvim/ex_docmd.h"
 #include "nvim/extmark.h"
 #include "nvim/gettext.h"
 #include "nvim/globals.h"
@@ -1152,6 +1153,12 @@ int get_expr_indent(void)
   curwin->w_set_curswant = save_set_curswant;
   check_cursor();
   State = save_State;
+
+  // Reset did_throw, unless 'debug' has "throw" and inside a try/catch.
+  if (did_throw && (vim_strchr(p_debug, 't') == NULL || trylevel == 0)) {
+    handle_did_throw();
+    did_throw = false;
+  }
 
   // If there is an error, just keep the current indent.
   if (indent < 0) {


### PR DESCRIPTION
#### vim-patch:8.2.3259: when 'indentexpr' causes an error did_throw may hang

Problem:    When 'indentexpr' causes an error the did_throw flag may remain
            set.
Solution:   Reset did_throw and show the error.

https://github.com/vim/vim/commit/620c959c6c00e469c4d3b1ab2e08e4767ee142a4

Co-authored-by: Bram Moolenaar <Bram@vim.org>