### PR TITLE
test: re-bundle cat on windows

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -740,6 +740,7 @@ if(WIN32)
   set(EXTERNAL_BLOBS_SCRIPT
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
+      cat.exe
       curl-ca-bundle.crt
       curl.exe
       diff.exe

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -230,6 +230,7 @@ describe('channels', function()
   end)
 
   it('can use buffered output mode', function()
+    skip(funcs.executable('grep') == 0, 'missing "grep" command')
     source([[
       let g:job_opts = {
       \ 'on_stdout': function('OnEvent'),
@@ -262,6 +263,7 @@ describe('channels', function()
   end)
 
   it('can use buffered output mode with no stream callback', function()
+    skip(funcs.executable('grep') == 0, 'missing "grep" command')
     source([[
       function! OnEvent(id, data, event) dict
         call rpcnotify(1, a:event, a:id, a:data, self.stdout)

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -806,7 +806,6 @@ describe('jobs', function()
     end)
 
     it('can be called recursively', function()
-      skip(is_os('win'), "TODO: Need `cat`")
       source([[
       let g:opts = {}
       let g:counter = 0

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -9,7 +9,6 @@ local curbufmeths = helpers.curbufmeths
 local insert = helpers.insert
 local expect = helpers.expect
 local feed = helpers.feed
-local skip = helpers.skip
 
 do
   clear()

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -10,7 +10,6 @@ local insert = helpers.insert
 local expect = helpers.expect
 local feed = helpers.feed
 local skip = helpers.skip
-local funcs = helpers.funcs
 
 do
   clear()
@@ -19,10 +18,6 @@ do
     pending(string.format("Missing perl host, or perl version is too old (%s)", reason), function() end)
     return
   end
-end
-
-if skip(funcs.executable('perl') == 0, 'missing "perl" command') then
-  return
 end
 
 before_each(function()

--- a/test/functional/provider/perl_spec.lua
+++ b/test/functional/provider/perl_spec.lua
@@ -9,8 +9,8 @@ local curbufmeths = helpers.curbufmeths
 local insert = helpers.insert
 local expect = helpers.expect
 local feed = helpers.feed
-local is_os = helpers.is_os
 local skip = helpers.skip
+local funcs = helpers.funcs
 
 do
   clear()
@@ -21,13 +21,15 @@ do
   end
 end
 
+if skip(funcs.executable('perl') == 0, 'missing "perl" command') then
+  return
+end
+
 before_each(function()
   clear()
 end)
 
 describe('legacy perl provider', function()
-  skip(is_os('win'))
-
   it('feature test', function()
     eq(1, eval('has("perl")'))
   end)
@@ -70,7 +72,6 @@ describe('legacy perl provider', function()
 end)
 
 describe('perl provider', function()
-  skip(is_os('win'))
   teardown(function ()
     os.remove('Xtest-perl-hello.pl')
     os.remove('Xtest-perl-hello-plugin.pl')

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -16,6 +16,8 @@ local poke_eventloop = helpers.poke_eventloop
 local assert_alive = helpers.assert_alive
 local is_os = helpers.is_os
 local is_ci = helpers.is_ci
+local funcs = helpers.funcs
+local skip = helpers.skip
 
 describe('ui/ext_messages', function()
   local screen
@@ -1917,6 +1919,7 @@ aliquip ex ea commodo consequat.]])
   end)
 
   it('with :!cmd does not crash on resize', function()
+    skip(funcs.executable('sleep') == 0, 'missing "sleep" command')
     feed(':!sleep 1<cr>')
     screen:expect{grid=[[
                                          |


### PR DESCRIPTION
The builtin cat was removed in 4bc9229ecbec514e9a87cfc4be88ea27a971e9a1
as it is not used during runtime but only for tests. However, it is a
very small and useful utility program that we need for a lot of our
tests, so there's no harm in bundling it, and it helps us avoid
complicating our build system by having two versions of neovim (neovim
for users and neovim for testins).

Also skip tests if "grep" or "sleep" isn't available.