### PR TITLE
refactor: remove COMMA

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -320,7 +320,7 @@ EXTERN int garbage_collect_at_exit INIT(= false);
 #define SID_STR         (-10)     // for sourcing a string with no script item
 
 // Script CTX being sourced or was sourced to define the current function.
-EXTERN sctx_T current_sctx INIT(= { 0 COMMA 0 COMMA 0 });
+EXTERN sctx_T current_sctx INIT(= { 0, 0, 0 });
 // ID of the current channel making a client API call
 EXTERN uint64_t current_channel_id INIT(= 0);
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -11,7 +11,6 @@
 #else
 # ifndef INIT
 #  define INIT(...) __VA_ARGS__
-#  define COMMA ,
 # endif
 #endif
 


### PR DESCRIPTION
It is not needed in Nvim. Ref #6068
