### PR TITLE
vim-patch:8.2.1748: closing split window in other tab may cause a crash

### DIFF
--- a/src/nvim/testdir/test_winbuf_close.vim
+++ b/src/nvim/testdir/test_winbuf_close.vim
@@ -192,7 +192,23 @@ func Test_tabwin_close()
   call win_execute(l:wid, 'close')
   " Should not crash.
   call assert_true(v:true)
-  %bwipe!
+
+  " This tests closing a window in another tab, while leaving the tab open
+  " i.e. two windows in another tab.
+  tabedit
+  let w:this_win = 42
+  new
+  let othertab_wid = win_getid()
+  tabprevious
+  call win_execute(othertab_wid, 'q')
+  " drawing the tabline helps check that the other tab's windows and buffers
+  " are still valid
+  redrawtabline
+  " but to be certain, ensure we can focus the other tab too
+  tabnext
+  call assert_equal(42, w:this_win)
+
+  bwipe!
 endfunc
 
 " Test when closing a split window (above/below) restores space to the window

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3058,6 +3058,7 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
 static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp)
 {
   win_T *wp;
+  tabpage_T *win_tp = tp == NULL ? curtab : tp;
 
   if (!win->w_floating) {
     // Remove the window and its frame from the tree of frames.
@@ -3082,10 +3083,10 @@ static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp)
   }
   win_free(win, tp);
 
-  // When deleting the current window of another tab page select a new
-  // current window.
-  if (tp != NULL && win == tp->tp_curwin) {
-    tp->tp_curwin = wp;
+  // When deleting the current window in the tab, select a new current
+  // window.
+  if (win == win_tp->tp_curwin) {
+    win_tp->tp_curwin = wp;
   }
 
   return wp;

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -490,6 +490,8 @@ describe('API/win', function()
 
     it('closing current (float) window of another tabpage #15313', function()
       command('tabedit')
+      command('botright split')
+      local prevwin = curwin().id
       eq(2, eval('tabpagenr()'))
       local win = meths.open_win(0, true, {
         relative='editor', row=10, col=10, width=50, height=10
@@ -499,7 +501,7 @@ describe('API/win', function()
       eq(1, eval('tabpagenr()'))
       meths.win_close(win, false)
 
-      eq(1001, meths.tabpage_get_win(tab).id)
+      eq(prevwin, meths.tabpage_get_win(tab).id)
       assert_alive()
     end)
   end)


### PR DESCRIPTION
#### vim-patch:8.2.1748: closing split window in other tab may cause a crash

Problem:    Closing split window in other tab may cause a crash.
Solution:   Set tp_curwin properly. (Rob Pilling, closes vim/vim#7018)

https://github.com/vim/vim/commit/f3c51bbff1256a52bdd9ede7887f40062be2628c

Co-authored-by: Bram Moolenaar <Bram@vim.org>