### PR TITLE
vim-patch:8.2.{3829,3838}: cannot use script-local function for setting *func options

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5157,10 +5157,6 @@ int option_set_callback_func(char *optval, Callback *optcb)
     return OK;
   }
 
-  if (strncmp(optval, "s:", 2) == 0 && !SCRIPT_ID_VALID(current_sctx.sc_sid)) {
-    return FAIL;
-  }
-
   typval_T *tv;
   if (*optval == '{'
       || (strncmp(optval, "function(", 9) == 0)
@@ -5174,7 +5170,26 @@ int option_set_callback_func(char *optval, Callback *optcb)
     // treat everything else as a function name string
     tv = xcalloc(1, sizeof(*tv));
     tv->v_type = VAR_STRING;
-    tv->vval.v_string = xstrdup(optval);
+
+    // Function name starting with "s:" are supported only in a vimscript
+    // context.
+    if (strncmp(optval, "s:", 2) == 0) {
+      char sid_buf[25];
+
+      if (!SCRIPT_ID_VALID(current_sctx.sc_sid)) {
+        emsg(_(e_usingsid));
+        return FAIL;
+      }
+      // Expand s: prefix into <SNR>nr_<name>
+      snprintf(sid_buf, sizeof(sid_buf), "<SNR>%" PRId64 "_",
+               (int64_t)current_sctx.sc_sid);
+      char *funcname = xmalloc(strlen(sid_buf) + strlen(optval + 2) + 1);
+      STRCPY(funcname, sid_buf);
+      STRCAT(funcname, optval + 2);
+      tv->vval.v_string = funcname;
+    } else {
+      tv->vval.v_string = xstrdup(optval);
+    }
   }
 
   Callback cb;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5157,6 +5157,10 @@ int option_set_callback_func(char *optval, Callback *optcb)
     return OK;
   }
 
+  if (strncmp(optval, "s:", 2) == 0 && !SCRIPT_ID_VALID(current_sctx.sc_sid)) {
+    return FAIL;
+  }
+
   typval_T *tv;
   if (*optval == '{'
       || (strncmp(optval, "function(", 9) == 0)

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -79,6 +79,7 @@ typedef struct scriptitem_S {
 /// Growarray to store info about already sourced scripts.
 extern garray_T script_items;
 #define SCRIPT_ITEM(id) (((scriptitem_T *)script_items.ga_data)[(id) - 1])
+#define SCRIPT_ID_VALID(id) ((id) > 0 && (id) <= script_items.ga_len)
 
 typedef void (*DoInRuntimepathCB)(char *, void *);
 

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -591,6 +591,21 @@ func Test_opfunc_callback()
   END
   call CheckTransLegacySuccess(lines)
 
+  " Test for using a script-local function name
+  func s:OpFunc3(type)
+    let g:OpFunc3Args = [a:type]
+  endfunc
+  set opfunc=s:OpFunc3
+  let g:OpFunc3Args = []
+  normal! g@l
+  call assert_equal(['char'], g:OpFunc3Args)
+
+  let &opfunc = 's:OpFunc3'
+  let g:OpFunc3Args = []
+  normal! g@l
+  call assert_equal(['char'], g:OpFunc3Args)
+  delfunc s:OpFunc3
+
   " Using Vim9 lambda expression in legacy context should fail
   " set opfunc=(a)\ =>\ OpFunc1(24,\ a)
   let g:OpFunc1Args = []
@@ -614,14 +629,32 @@ func Test_opfunc_callback()
   let lines =<< trim END
     vim9script
 
-    # Test for using a def function with opfunc
     def g:Vim9opFunc(val: number, type: string): void
       g:OpFunc1Args = [val, type]
     enddef
+
+    # Test for using a def function with opfunc
     set opfunc=function('g:Vim9opFunc',\ [60])
     g:OpFunc1Args = []
     normal! g@l
     assert_equal([60, 'char'], g:OpFunc1Args)
+
+    # Test for using a global function name
+    &opfunc = g:OpFunc2
+    g:OpFunc2Args = []
+    normal! g@l
+    assert_equal(['char'], g:OpFunc2Args)
+    bw!
+
+    # Test for using a script-local function name
+    def s:LocalOpFunc(type: string): void
+      g:LocalOpFuncArgs = [type]
+    enddef
+    &opfunc = s:LocalOpFunc
+    g:LocalOpFuncArgs = []
+    normal! g@l
+    assert_equal(['char'], g:LocalOpFuncArgs)
+    bw!
   END
   " call CheckScriptSuccess(lines)
 

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -5789,6 +5789,23 @@ func Test_qftextfunc_callback()
   END
   call CheckLegacyAndVim9Success(lines)
 
+  " Test for using a script-local function name
+  func s:TqfFunc2(info)
+    let g:TqfFunc2Args = [a:info.start_idx, a:info.end_idx]
+    return ''
+  endfunc
+  let g:TqfFunc2Args = []
+  set quickfixtextfunc=s:TqfFunc2
+  cexpr "F10:10:10:L10"
+  cclose
+  call assert_equal([1, 1], g:TqfFunc2Args)
+
+  let &quickfixtextfunc = 's:TqfFunc2'
+  cexpr "F11:11:11:L11"
+  cclose
+  call assert_equal([1, 1], g:TqfFunc2Args)
+  delfunc s:TqfFunc2
+
   " set 'quickfixtextfunc' to a partial with dict. This used to cause a crash.
   func SetQftfFunc()
     let params = {'qftf': function('g:DictQftfFunc')}

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -267,38 +267,62 @@ func Test_tagfunc_callback()
   END
   call CheckLegacyAndVim9Success(lines)
 
+  " Test for using a script-local function name
+  func s:TagFunc3(pat, flags, info)
+    let g:TagFunc3Args = [a:pat, a:flags, a:info]
+    return v:null
+  endfunc
+  set tagfunc=s:TagFunc3
+  new
+  let g:TagFunc3Args = []
+  call assert_fails('tag a21', 'E433:')
+  call assert_equal(['a21', '', {}], g:TagFunc3Args)
+  bw!
+  let &tagfunc = 's:TagFunc3'
+  new
+  let g:TagFunc3Args = []
+  call assert_fails('tag a22', 'E433:')
+  call assert_equal(['a22', '', {}], g:TagFunc3Args)
+  bw!
+  delfunc s:TagFunc3
+
+  " invalid return value
   let &tagfunc = "{a -> 'abc'}"
   call assert_fails("echo taglist('a')", "E987:")
 
   " Using Vim9 lambda expression in legacy context should fail
   " set tagfunc=(a,\ b,\ c)\ =>\ g:TagFunc1(21,\ a,\ b,\ c)
-  new | only
+  new
   let g:TagFunc1Args = []
   " call assert_fails("tag a17", "E117:")
   call assert_equal([], g:TagFunc1Args)
+  bw!
 
   " Test for using a script local function
   set tagfunc=<SID>ScriptLocalTagFunc
-  new | only
+  new
   let g:ScriptLocalFuncArgs = []
   call assert_fails('tag a15', 'E433:')
   call assert_equal(['a15', '', {}], g:ScriptLocalFuncArgs)
+  bw!
 
   " Test for using a script local funcref variable
   let Fn = function("s:ScriptLocalTagFunc")
   let &tagfunc= Fn
-  new | only
+  new
   let g:ScriptLocalFuncArgs = []
   call assert_fails('tag a16', 'E433:')
   call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
+  bw!
 
   " Test for using a string(script local funcref variable)
   let Fn = function("s:ScriptLocalTagFunc")
   let &tagfunc= string(Fn)
-  new | only
+  new
   let g:ScriptLocalFuncArgs = []
   call assert_fails('tag a16', 'E433:')
   call assert_equal(['a16', '', {}], g:ScriptLocalFuncArgs)
+  bw!
 
   " set 'tagfunc' to a partial with dict. This used to cause a crash.
   func SetTagFunc()
@@ -324,16 +348,37 @@ func Test_tagfunc_callback()
   let lines =<< trim END
     vim9script
 
-    # Test for using function()
-    def Vim9tagFunc(val: number, pat: string, flags: string, info: dict<any>): any
-      g:Vim9tagFuncArgs = [val, pat, flags, info]
+    def Vim9tagFunc(callnr: number, pat: string, flags: string, info: dict<any>): any
+      g:Vim9tagFuncArgs = [callnr, pat, flags, info]
       return null
     enddef
+
+    # Test for using a def function with completefunc
     set tagfunc=function('Vim9tagFunc',\ [60])
-    new | only
+    new
     g:Vim9tagFuncArgs = []
     assert_fails('tag a10', 'E433:')
     assert_equal([60, 'a10', '', {}], g:Vim9tagFuncArgs)
+
+    # Test for using a global function name
+    &tagfunc = g:TagFunc2
+    new
+    g:TagFunc2Args = []
+    assert_fails('tag a11', 'E433:')
+    assert_equal(['a11', '', {}], g:TagFunc2Args)
+    bw!
+
+    # Test for using a script-local function name
+    def s:LocalTagFunc(pat: string, flags: string, info: dict<any> ): any
+      g:LocalTagFuncArgs = [pat, flags, info]
+      return null
+    enddef
+    &tagfunc = s:LocalTagFunc
+    new
+    g:LocalTagFuncArgs = []
+    assert_fails('tag a12', 'E433:')
+    assert_equal(['a12', '', {}], g:LocalTagFuncArgs)
+    bw!
   END
   " call CheckScriptSuccess(lines)
 

--- a/src/nvim/testdir/test_tagfunc.vim
+++ b/src/nvim/testdir/test_tagfunc.vim
@@ -1,6 +1,8 @@
 " Test 'tagfunc'
 
 source vim9.vim
+source check.vim
+source screendump.vim
 
 func TagFunc(pat, flag, info)
   let g:tagfunc_args = [a:pat, a:flag, a:info]


### PR DESCRIPTION
#### vim-patch:8.2.3829: no error when setting a func option to script-local function

Problem:    No error when setting a func option to a script-local function.
Solution:   Give an error if the name starts with "s:".

https://github.com/vim/vim/commit/94c785d235dccacf6cdf38c5903115b61ca8a981

Omit test: reverted in patch 8.2.3838.
Cherry-pick SCRIPT_ID_VALID from patch 8.2.1539.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3838: cannot use script-local function for setting *func options

Problem:    Cannot use script-local function for setting *func options.
Solution:   Use the script context. (Yegappan Lakshmanan, closes vim/vim#9362)

https://github.com/vim/vim/commit/db1a410b610b2c1941311acc57dcc4afec20720e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>