### PR TITLE
vim-patch:8.2.3889,9.0.{0805,0990}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5510,6 +5510,7 @@ void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv, bool retlist
   }
 }
 
+/// Get a callback from "arg".  It can be a Funcref or a function name.
 bool callback_from_typval(Callback *const callback, typval_T *const arg)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
@@ -5531,16 +5532,14 @@ bool callback_from_typval(Callback *const callback, typval_T *const arg)
       callback->type = kCallbackNone;
       callback->data.funcref = NULL;
     } else {
+      callback->data.funcref = NULL;
       if (arg->v_type == VAR_STRING) {
-        char *newname = get_scriptlocal_funcname(arg->vval.v_string);
-        if (newname != NULL) {
-          xfree(arg->vval.v_string);
-          name = arg->vval.v_string = newname;
-        }
+        callback->data.funcref = get_scriptlocal_funcname(name);
       }
-
-      func_ref((char_u *)name);
-      callback->data.funcref = xstrdup(name);
+      if (callback->data.funcref == NULL) {
+        callback->data.funcref = xstrdup(name);
+      }
+      func_ref((char_u *)callback->data.funcref);
       callback->type = kCallbackFuncref;
     }
   } else if (nlua_is_table_from_lua(arg)) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5170,26 +5170,7 @@ int option_set_callback_func(char *optval, Callback *optcb)
     // treat everything else as a function name string
     tv = xcalloc(1, sizeof(*tv));
     tv->v_type = VAR_STRING;
-
-    // Function name starting with "s:" are supported only in a vimscript
-    // context.
-    if (strncmp(optval, "s:", 2) == 0) {
-      char sid_buf[25];
-
-      if (!SCRIPT_ID_VALID(current_sctx.sc_sid)) {
-        emsg(_(e_usingsid));
-        return FAIL;
-      }
-      // Expand s: prefix into <SNR>nr_<name>
-      snprintf(sid_buf, sizeof(sid_buf), "<SNR>%" PRId64 "_",
-               (int64_t)current_sctx.sc_sid);
-      char *funcname = xmalloc(strlen(sid_buf) + strlen(optval + 2) + 1);
-      STRCPY(funcname, sid_buf);
-      STRCAT(funcname, optval + 2);
-      tv->vval.v_string = funcname;
-    } else {
-      tv->vval.v_string = xstrdup(optval);
-    }
+    tv->vval.v_string = xstrdup(optval);
   }
 
   Callback cb;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3900,6 +3900,9 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
       qf_winid = (int)win->handle;
     }
 
+    // autocommands may cause trouble
+    incr_quickfix_busy();
+
     aco_save_T aco;
 
     if (old_last == NULL) {
@@ -3924,6 +3927,9 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
     if ((win = qf_find_win(qi)) != NULL && old_line_count < win->w_botline) {
       redraw_buf_later(buf, UPD_NOT_VALID);
     }
+
+    // always called after incr_quickfix_busy()
+    decr_quickfix_busy();
   }
 }
 

--- a/src/nvim/testdir/test_expr.vim
+++ b/src/nvim/testdir/test_expr.vim
@@ -525,6 +525,21 @@ func Test_funcref()
   call assert_fails('echo function("min") =~ function("min")', 'E694:')
 endfunc
 
+" Test for calling function() and funcref() outside of a Vim script context.
+func Test_function_outside_script()
+  let cleanup =<< trim END
+    call writefile([execute('messages')], 'Xtest.out')
+    qall
+  END
+  call writefile(cleanup, 'Xverify.vim')
+  call RunVim([], [], "-c \"echo function('s:abc')\" -S Xverify.vim")
+  call assert_match('E81: Using <SID> not in a', readfile('Xtest.out')[0])
+  call RunVim([], [], "-c \"echo funcref('s:abc')\" -S Xverify.vim")
+  call assert_match('E81: Using <SID> not in a', readfile('Xtest.out')[0])
+  call delete('Xtest.out')
+  call delete('Xverify.vim')
+endfunc
+
 func Test_setmatches()
   hi def link 1 Comment
   hi def link 2 PreProc

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -658,6 +658,18 @@ func Test_opfunc_callback()
   END
   " call CheckScriptSuccess(lines)
 
+  " setting 'opfunc' to a script local function outside of a script context
+  " should fail
+  let cleanup =<< trim END
+    call writefile([execute('messages')], 'Xtest.out')
+    qall
+  END
+  call writefile(cleanup, 'Xverify.vim')
+  call RunVim([], [], "-c \"set opfunc=s:abc\" -S Xverify.vim")
+  call assert_match('E81: Using <SID> not in a', readfile('Xtest.out')[0])
+  call delete('Xtest.out')
+  call delete('Xverify.vim')
+
   " cleanup
   set opfunc&
   delfunc OpFunc1

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -3298,6 +3298,21 @@ func Test_resize_from_copen()
   endtry
 endfunc
 
+func Test_filetype_autocmd()
+  " this changes the location list while it is in use to fill a buffer
+  lexpr ''
+  lopen
+  augroup FT_loclist
+    au FileType * call setloclist(0, [], 'f')
+  augroup END
+  silent! lolder
+  lexpr ''
+
+  augroup FT_loclist
+    au! FileType
+  augroup END
+endfunc
+
 func Test_vimgrep_with_textlock()
   new
 
@@ -6164,5 +6179,6 @@ func Test_loclist_replace_autocmd()
   %bw!
   call setloclist(0, [], 'f')
 endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -6180,5 +6180,17 @@ func Test_loclist_replace_autocmd()
   call setloclist(0, [], 'f')
 endfunc
 
+func s:QfTf(_)
+endfunc
+
+func Test_setqflist_cb_arg()
+  " This was changing the callback name in the dictionary.
+  let d = #{quickfixtextfunc: 's:QfTf'}
+  call setqflist([], 'a', d)
+  call assert_equal('s:QfTf', d.quickfixtextfunc)
+
+  call setqflist([], 'f')
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3889: duplicate code for translating script-local function name

Problem:    Duplicate code for translating script-local function name.
Solution:   Move the code to get_scriptlocal_funcname(). (Yegappan Lakshmanan,
            closes vim/vim#9393)

https://github.com/vim/vim/commit/e7f4abd38b6e05100c699900c8f87281e363beb2

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0805: filetype autocmd may cause freed memory access

Problem:    Filetype autocmd may cause freed memory access.
Solution:   Set the quickfix-busy flag while filling the buffer.

https://github.com/vim/vim/commit/d0fab10ed2a86698937e3c3fed2f10bd9bb5e731

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0990: callback name argument is changed by setqflist()

Problem:    Callback name argument is changed by setqflist().
Solution:   Use the expanded function name for the callback, do not store it
            in the argument.

https://github.com/vim/vim/commit/c96b7f5d2af241c5eb1589e9da3dc09e45355e65

Co-authored-by: Bram Moolenaar <Bram@vim.org>