### PR TITLE
fix(lsp): correctly render <pre>{lang} code blocks and separator defaults to false

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1261,7 +1261,7 @@ function M.stylize_markdown(bufnr, contents, opts)
   -- when ft is nil, we get the ft from the regex match
   local matchers = {
     block = { nil, '```+([a-zA-Z0-9_]*)', '```+' },
-    pre = { '', '<pre>', '</pre>' },
+    pre = { nil, '<pre>([a-z0-9]*)', '</pre>' },
     code = { '', '<code>', '</code>' },
     text = { 'text', '<text>', '</text>' },
   }
@@ -1286,8 +1286,6 @@ function M.stylize_markdown(bufnr, contents, opts)
   -- Clean up
   contents = M._trim(contents, opts)
 
-  -- Insert blank line separator after code block?
-  local add_sep = opts.separator == nil and true or opts.separator
   local stripped = {}
   local highlights = {}
   -- keep track of lnums that contain markdown
@@ -1315,7 +1313,7 @@ function M.stylize_markdown(bufnr, contents, opts)
           finish = #stripped,
         })
         -- add a separator, but not on the last line
-        if add_sep and i < #contents then
+        if opts.separator and i < #contents then
           table.insert(stripped, '---')
           markdown_lines[#stripped] = true
         end


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/21154 added support for vimdoc code blocks and a new syntax for `<pre>{lang}` code blocks.

This PR adds support for the last kind to stylized markdown.

It will be rendered as other markdown code-blocks. I didn't make any styling changes.

## Before
![image](https://user-images.githubusercontent.com/292349/205436611-7d9ea5d3-ff8a-4ee8-a070-5b3a10cb399b.png)

## After
![image](https://user-images.githubusercontent.com/292349/205438157-b3da4d37-695b-4d52-80f7-ee9e4eeb71ff.png)

## And with Noice (couldn't help myself ;) )
![image](https://user-images.githubusercontent.com/292349/205436622-e880fd40-8105-438d-a8ea-7d7c01d5db11.png)


