### PR TITLE
vim-patch:8.2.{4163,4168}

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1760,7 +1760,8 @@ char_u *trans_function_name(char **pp, bool skip, int flags, funcdict_T *fdp, pa
   // Note that TFN_ flags use the same values as GLV_ flags.
   end = (char_u *)get_lval((char *)start, NULL, &lv, false, skip, flags | GLV_READ_ONLY,
                            lead > 2 ? 0 : FNE_CHECK_START);
-  if (end == start) {
+  if (end == start
+      || (end != NULL && end[-1] == AUTOLOAD_CHAR && *end == '(')) {
     if (!skip) {
       emsg(_("E129: Function name required"));
     }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1760,8 +1760,7 @@ char_u *trans_function_name(char **pp, bool skip, int flags, funcdict_T *fdp, pa
   // Note that TFN_ flags use the same values as GLV_ flags.
   end = (char_u *)get_lval((char *)start, NULL, &lv, false, skip, flags | GLV_READ_ONLY,
                            lead > 2 ? 0 : FNE_CHECK_START);
-  if (end == start
-      || (end != NULL && end[-1] == AUTOLOAD_CHAR && *end == '(')) {
+  if (end == start) {
     if (!skip) {
       emsg(_("E129: Function name required"));
     }

--- a/src/nvim/testdir/sautest/autoload/foo.vim
+++ b/src/nvim/testdir/sautest/autoload/foo.vim
@@ -9,3 +9,7 @@ endfunc
 func foo#addFoo(head)
   return a:head .. 'foo'
 endfunc
+
+func foo#()
+  return 'empty'
+endfunc

--- a/src/nvim/testdir/test_autoload.vim
+++ b/src/nvim/testdir/test_autoload.vim
@@ -10,6 +10,9 @@ func Test_autoload_dict_func()
   call assert_equal(1, g:called_foo_bar_echo)
 
   eval 'bar'->g:foo#addFoo()->assert_equal('barfoo')
+
+  " empty name works in legacy script
+  call assert_equal('empty', foo#())
 endfunc
 
 func Test_source_autoload()
@@ -17,3 +20,6 @@ func Test_source_autoload()
   source sautest/autoload/sourced.vim
   call assert_equal(1, g:loaded_sourced_vim)
 endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.4163: no error for omitting function name after autoload prefix

Problem:    No error for omitting function name after autoload prefix.
Solution:   Check for missing function name. (issue vim/vim#9577)

https://github.com/vim/vim/commit/2017d6f3b1d523204e5471e941cfa687b4da0058

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4168: disallowing empty function name breaks existing plugins

Problem:    Disallowing empty function name breaks existing plugins.
Solution:   Allow empty function name in legacy script.

https://github.com/vim/vim/commit/e6a4200ff47708febcd7cb2b8c3dd3801a975d43

Co-authored-by: Bram Moolenaar <Bram@vim.org>