### PR TITLE
vim-patch:9.0.0259: crash with mouse click when not initialized

### DIFF
--- a/src/nvim/testdir/test_tabline.vim
+++ b/src/nvim/testdir/test_tabline.vim
@@ -147,4 +147,18 @@ func Test_tabline_20_format_items_no_overrun()
   set showtabline& tabline&
 endfunc
 
+func Test_mouse_click_in_tab()
+  " This used to crash because TabPageIdxs[] was not initialized
+  let lines =<< trim END
+      tabnew
+      set mouse=a
+      exe "norm \<LeftMouse>"
+  END
+  call writefile(lines, 'Xclickscript')
+  call RunVim([], [], "-e -s -S Xclickscript -c qa")
+
+  call delete('Xclickscript')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0259: crash with mouse click when not initialized

Problem:    Crash with mouse click when not initialized.
Solution:   Check TabPageIdxs[] is not NULL.

https://github.com/vim/vim/commit/80525751c5ce9ed82c41d83faf9ef38667bf61b1

Co-authored-by: Bram Moolenaar <Bram@vim.org>