### PR TITLE
vim-patch:8.2.{1195,1197,2240,3108,3109,3495,3499,3526,5145}

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -123,6 +123,14 @@ func CheckCanRunGui()
   endif
 endfunc
 
+" Command to Check for an environment variable
+command -nargs=1 CheckEnv call CheckEnv(<f-args>)
+func CheckEnv(name)
+  if empty('$' .. a:name)
+    throw 'Skipped: Environment variable ' .. a:name .. ' is not set'
+  endif
+endfunc
+
 " Command to check that we are using the GUI
 command CheckGui call CheckGui()
 func CheckGui()

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -171,6 +171,14 @@ func CheckNotAsan()
   endif
 endfunc
 
+" Command to check for X11 based GUI
+command CheckX11BasedGui call CheckX11BasedGui()
+func CheckX11BasedGui()
+  if !g:x11_based_gui
+    throw 'Skipped: requires X11 based GUI'
+  endif
+endfunc
+
 " Command to check for satisfying any of the conditions.
 " e.g. CheckAnyOf Feature:bsd Feature:sun Linux
 command -nargs=+ CheckAnyOf call CheckAnyOf(<f-args>)

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -126,7 +126,7 @@ endfunc
 " Command to Check for an environment variable
 command -nargs=1 CheckEnv call CheckEnv(<f-args>)
 func CheckEnv(name)
-  if empty('$' .. a:name)
+  if empty(eval('$' .. a:name))
     throw 'Skipped: Environment variable ' .. a:name .. ' is not set'
   endif
 endfunc

--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -171,6 +171,14 @@ func CheckNotAsan()
   endif
 endfunc
 
+" Command to check for not running under valgrind
+command CheckNotValgrind call CheckNotValgrind()
+func CheckNotValgrind()
+  if RunningWithValgrind()
+    throw 'Skipped: does not work well with valgrind'
+  endif
+endfunc
+
 " Command to check for X11 based GUI
 command CheckX11BasedGui call CheckX11BasedGui()
 func CheckX11BasedGui()

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -285,6 +285,12 @@ func GetVimCommand(...)
   return cmd
 endfunc
 
+" Return one when it looks like the tests are run with valgrind, which means
+" that everything is much slower.
+func RunningWithValgrind()
+  return GetVimCommand() =~ '\<valgrind\>'
+endfunc
+
 " Get the command to run Vim, with --clean instead of "-u NONE".
 func GetVimCommandClean()
   let cmd = GetVimCommand()

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -13,9 +13,7 @@ source shared.vim
 
 func Check_X11_Connection()
   if has('x11')
-    if empty($DISPLAY)
-      throw 'Skipped: $DISPLAY is not set'
-    endif
+    CheckEnv DISPLAY
     try
       call remote_send('xxx', '')
     catch

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -142,19 +142,19 @@ func Test_client_server()
 
     " Edit multiple files using --remote
     call system(cmd .. ' --remote Xfile1 Xfile2 Xfile3')
-    call assert_equal("Xfile1\nXfile2\nXfile3\n", remote_expr(name, 'argv()'))
+    call assert_match(".*Xfile1\n.*Xfile2\n.*Xfile3\n", remote_expr(name, 'argv()'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit files in separate tab pages
     call system(cmd .. ' --remote-tab Xfile1 Xfile2 Xfile3')
     call WaitForAssert({-> assert_equal('3', remote_expr(name, 'tabpagenr("$")'))})
-    call assert_equal('Xfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
+    call assert_match('.*\<Xfile2', remote_expr(name, 'bufname(tabpagebuflist(2)[0])'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit a file using --remote-wait
     eval name->remote_send(":source $VIMRUNTIME/plugin/rrhelper.vim\<CR>")
     call system(cmd .. ' --remote-wait +enew Xfile1')
-    call assert_equal("Xfile1", remote_expr(name, 'bufname("#")'))
+    call assert_match('.*\<Xfile1', remote_expr(name, 'bufname("#")'))
     eval name->remote_send(":%bw!\<CR>")
 
     " Edit files using --remote-tab-wait

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -184,8 +184,10 @@ func Test_client_server()
 
   call assert_fails('call remote_startserver([])', 'E730:')
   call assert_fails("let x = remote_peek([])", 'E730:')
-  call assert_fails("let x = remote_read('vim10')", ['E573:.*vim10'])
-  call assert_fails("call server2client('abc', 'xyz')", ['E573:.*abc'])
+  call assert_fails("let x = remote_read('vim10')",
+        \ [has('unix') ? 'E573:.*vim10' : 'E277:.*vim10'])
+  call assert_fails("call server2client('abc', 'xyz')",
+        \ [has('unix') ? 'E573:.*abc' : 'E258:.*abc'])
 endfunc
 
 " Uncomment this line to get a debugging log

--- a/src/nvim/testdir/test_clientserver.vim
+++ b/src/nvim/testdir/test_clientserver.vim
@@ -185,9 +185,9 @@ func Test_client_server()
   call assert_fails('call remote_startserver([])', 'E730:')
   call assert_fails("let x = remote_peek([])", 'E730:')
   call assert_fails("let x = remote_read('vim10')",
-        \ [has('unix') ? 'E573:.*vim10' : 'E277:.*vim10'])
+        \ has('unix') ? ['E573:.*vim10'] : 'E277:')
   call assert_fails("call server2client('abc', 'xyz')",
-        \ [has('unix') ? 'E573:.*abc' : 'E258:.*abc'])
+        \ has('unix') ? ['E573:.*abc'] : 'E258:')
 endfunc
 
 " Uncomment this line to get a debugging log

--- a/src/nvim/testdir/test_exit.vim
+++ b/src/nvim/testdir/test_exit.vim
@@ -117,6 +117,7 @@ func Test_exit_error_reading_input()
   CheckNotMSWindows
   " The early exit causes memory not to be freed somehow
   CheckNotAsan
+  CheckNotValgrind
 
   call writefile([":au VimLeave * call writefile(['l = ' .. v:exiting], 'Xtestout')", ":tabnew", "q:"], 'Xscript', 'b')
 

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -525,11 +525,11 @@ func Test_geometry()
       " Depending on the GUI library and the windowing system the final size
       " might be a bit different, allow for some tolerance.  Tuned based on
       " actual failures.
-      call assert_inrange(31, 35, lines[0])
-      call assert_equal(13, lines[1])
-      call assert_equal(41, lines[2])
-      call assert_equal(43, lines[3])
-      call assert_equal([41, 43], lines[4])
+      call assert_inrange(31, 35, str2nr(lines[0]))
+      call assert_equal('13', lines[1])
+      call assert_equal('41', lines[2])
+      call assert_equal('43', lines[3])
+      call assert_equal('[41, 43]', lines[4])
     endif
   endif
 

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -522,7 +522,14 @@ func Test_geometry()
     [CODE]
     if RunVim([], after, '-f -g -geometry 31x13+41+43')
       let lines = readfile('Xtest_geometry')
-      call assert_equal(['31', '13', '41', '43', '[41, 43]'], lines)
+      " Depending on the GUI library and the windowing system the final size
+      " might be a bit different, allow for some tolerance.  Tuned based on
+      " actual failures.
+      call assert_inrange(31, 35, lines[0])
+      call assert_equal(13, lines[1])
+      call assert_equal(41, lines[2])
+      call assert_equal(43, lines[3])
+      call assert_equal([41, 43], lines[4])
     endif
   endif
 


### PR DESCRIPTION
#### vim-patch:8.2.1195: clientserver test fails on MS-Windows

Problem:    Clientserver test fails on MS-Windows.
Solution:   Expect a different error message.

https://github.com/vim/vim/commit/4d57ba02029071e5947a54766e9f5d42e3bb3008

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1197: clientserver test still fails on MS-Windows

Problem:    Clientserver test still fails on MS-Windows.
Solution:   Expect a different error message.

https://github.com/vim/vim/commit/c212dd0a346d57f62013094ea6861eb28e33023c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2240: clientserver test fails if full path is used

Problem:    Clientserver test fails if full path is used.
Solution:   Ignore the path preceding the file name.

https://github.com/vim/vim/commit/41a834d1e3dbf9c8759737bcd6524159a9b93d2a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3108: test for remote_foreground() fails

Problem:    Test for remote_foreground() fails. (Elimar Riesebieter)
Solution:   Check that $DISPLAY is set. (Christian Brabandt)

https://github.com/vim/vim/commit/d6fa7bd5b900dd363d3a824e0ebe3619a1634df6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3109: check for $DISPLAY never fails

Problem:    Check for $DISPLAY never fails.
Solution:   Use eval().

https://github.com/vim/vim/commit/f6d877975ba93fc9b4bee2c5d2aff88dbf9bea59

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3495: GUI geometry startup test fails on some systems

Problem:    GUI geometry startup test fails on some systems. (Drew Vogel)
Solution:   Add tolerance to the size check.

https://github.com/vim/vim/commit/b376aa2da4211fee7eaf16450bb8b37674e45bb0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3499: GUI geometry startup test fails

Problem:    GUI geometry startup test fails.
Solution:   Check string values instead of numbers

https://github.com/vim/vim/commit/3d031a0ae791f901c0c2dedd5d8b9de137c23acc

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3526: tests have clumsy check for X11 based GUI

Problem:    Tests have clumsy check for X11 based GUI.
Solution:   Add CheckX11BasedGui.

https://github.com/vim/vim/commit/40bd5a15405206b130d487af0ca61b5d9b5859f8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.5145: exit test causes spurious valgrind reports

Problem:    Exit test causes spurious valgrind reports.
Solution:   Skip test.  Add CheckNotValgrind.

https://github.com/vim/vim/commit/cf801d4b95180ddaee1bf633ef482232625dd80b

Cherry-pick RunningWithValgrind() from patch 8.2.5136.

Co-authored-by: Bram Moolenaar <Bram@vim.org>