### PR TITLE
vim-patch:8.1.1226: {not in Vi} remarks get in the way of useful help text

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4123,7 +4123,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	checked for set commands.  If 'modeline' is off or 'modelines' is zero
 	no lines are checked.  See |modeline|.
 
-				*'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
+				*'modifiable'* *'ma'* *'nomodifiable'* *'noma'*
+				*E21*
 'modifiable' 'ma'	boolean	(default on)
 			local to buffer
 	When off the buffer contents cannot be changed.  The 'fileformat' and


### PR DESCRIPTION
#### vim-patch:8.1.1226: {not in Vi} remarks get in the way of useful help text

Problem:    {not in Vi} remarks get in the way of useful help text.
Solution:   Make a list of all Vi options, instead of mentioning what Vi does
            not have.  Update the help text for options.

https://github.com/vim/vim/commit/6c60f47fb9251e686217d51cf81847e14d0dd26d

Co-authored-by: Bram Moolenaar <Bram@vim.org>