### PR TITLE
docs: add missing docs from some Vim patches

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1836,7 +1836,8 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
           cannot take a register.
         • bang: (boolean) Whether command contains a |<bang>| (!) modifier.
         • args: (array) Command arguments.
-        • addr: (string) Value of |:command-addr|. Uses short name.
+        • addr: (string) Value of |:command-addr|. Uses short name or "line"
+          for -addr=lines.
         • nargs: (string) Value of |:command-nargs|.
         • nextcmd: (string) Next command if there are multiple commands
           separated by a |:bar|. Empty if there isn't a next command.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -204,7 +204,6 @@ gR			Enter Virtual Replace mode: Each character you type
 							*v_S*
 {Visual}["x]S		Delete the highlighted lines [into register x] and
 			start insert (for {Visual} see |Visual-mode|).
-
 							*v_R*
 {Visual}["x]R		Currently just like {Visual}["x]S.  In a next version
 			it might work differently.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1311,6 +1311,7 @@ exist, the next-higher scope in the hierarchy applies.
 :cd[!] {path}		Change the current directory to {path}.
 			If {path} is relative, it is searched for in the
 			directories listed in |'cdpath'|.
+			Clear any window-local directory.
 			Does not change the meaning of an already opened file,
 			because its full path name is remembered.  Files from
 			the |arglist| may change though!

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -651,6 +651,10 @@ The special key name "<Plug>" can be used for an internal mapping, which is
 not to be matched with any key sequence.  This is useful in plugins
 |using-<Plug>|.
 
+							*<MouseMove>*
+The special key name "<MouseMove>" can be used to handle mouse movement.  It
+needs to be enabled with 'mousemoveevent'.
+
 							*<Char>* *<Char->*
 To map a character by its decimal, octal or hexadecimal number the <Char>
 construct can be used:
@@ -1439,7 +1443,7 @@ Possible attributes are:
 		    number.
 	-count=N    A count (default N) which is specified either in the line
 		    number position, or as an initial argument (like |:Next|).
-		    Specifying -count (without a default) acts like -count=0
+	-count	    acts like -count=0
 
 Note that -range=N and -count=N are mutually exclusive - only one should be
 specified.
@@ -1450,14 +1454,16 @@ which by default correspond to the current line, last line and the whole
 buffer, relate to arguments, (loaded) buffers, windows or tab pages.
 
 Possible values are (second column is the short name used in listing):
-    -addr=lines		  line	Range of lines (this is the default)
+    -addr=lines		  	Range of lines (this is the default for -range)
     -addr=arguments	  arg	Range for arguments
     -addr=buffers	  buf	Range for buffers (also not loaded buffers)
     -addr=loaded_buffers  load	Range for loaded buffers
     -addr=windows	  win	Range for windows
     -addr=tabs		  tab	Range for tab pages
     -addr=quickfix	  qf	Range for quickfix entries
-    -addr=other		  ?	other kind of range
+    -addr=other		  ?	other kind of range; can use ".", "$" and "%"
+				as with "lines" (this is the default for
+				-count)
 
 
 Incremental preview ~

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -820,7 +820,7 @@ Type					effect ~
 					the clipboard ("* and "+ registers)
     {menu-entry}			what the menu is defined to in
 					Cmdline-mode.
-    <LeftMouse> (*)			next page
+    <LeftMouse>				next page (*)
 
 Any other key causes the meaning of the keys to be displayed.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4123,7 +4123,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	checked for set commands.  If 'modeline' is off or 'modelines' is zero
 	no lines are checked.  See |modeline|.
 
-				*'modifiable'* *'ma'* *'nomodifiable'* *'noma'* *E21*
+				*'modifiable'* *'ma'* *'nomodifiable'* *'noma'*
+				*E21*
 'modifiable' 'ma'	boolean	(default on)
 			local to buffer
 	When off the buffer contents cannot be changed.  The 'fileformat' and

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -800,6 +800,7 @@ Short explanation of each option:		*option-list*
 'mousefocus'	  'mousef'  keyboard focus follows the mouse
 'mousehide'	  'mh'	    hide mouse pointer while typing
 'mousemodel'	  'mousem'  changes meaning of mouse buttons
+'mousemoveevent'  'mousemev'  report mouse moves with <MouseMove>
 'mousescroll'		    amount to scroll by when scrolling with a mouse
 'mouseshape'	  'mouses'  shape of the mouse pointer in different modes
 'mousetime'	  'mouset'  max time between mouse double-click
@@ -901,6 +902,7 @@ Short explanation of each option:		*option-list*
 'tabstop'	  'ts'	    number of spaces that <Tab> in file uses
 'tagbsearch'	  'tbs'     use binary searching in tags files
 'tagcase'	  'tc'      how to handle case when searching in tags files
+'tagfunc'	  'tfu'	    function to get list of tag matches
 'taglength'	  'tl'	    number of significant characters for a tag
 'tagrelative'	  'tr'	    file names in tag file are relative
 'tags'		  'tag'     list of file names used by the tag command

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -624,8 +624,7 @@ If the command is a normal search command (it starts and ends with "/" or
 "?"), some special handling is done:
 - Searching starts on line 1 of the file.
   The direction of the search is forward for "/", backward for "?".
-  Note that 'wrapscan' does not matter, the whole file is always searched.  (Vi
-  does use 'wrapscan', which caused tags sometimes not be found.)
+  Note that 'wrapscan' does not matter, the whole file is always searched.
 - If the search fails, another try is done ignoring case.  If that fails too,
   a search is done for:
 	"^tagname[ \t]*("

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -255,7 +255,8 @@ well stand for "source").
 The windows that were open are restored, with the same position and size as
 before.  Mappings and option values are like before.
    What exactly is restored depends on the 'sessionoptions' option.  The
-default value is "blank,buffers,curdir,folds,help,options,winsize".
+default value is:
+"blank,buffers,curdir,folds,help,options,tabpages,winsize,terminal".
 
 	blank		keep empty windows
 	buffers		all buffers, not only the ones in a window
@@ -263,7 +264,9 @@ default value is "blank,buffers,curdir,folds,help,options,winsize".
 	folds		folds, also manually created ones
 	help		the help window
 	options		all options and mappings
+	tabpages	all tab pages
 	winsize		window sizes
+	terminal	include terminal windows
 
 Change this to your liking.  To also restore the size of the Vim window, for
 example, use: >

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -57,7 +57,7 @@
 ///                         Omitted if command cannot take a register.
 ///         - bang: (boolean) Whether command contains a |<bang>| (!) modifier.
 ///         - args: (array) Command arguments.
-///         - addr: (string) Value of |:command-addr|. Uses short name.
+///         - addr: (string) Value of |:command-addr|. Uses short name or "line" for -addr=lines.
 ///         - nargs: (string) Value of |:command-nargs|.
 ///         - nextcmd: (string) Next command if there are multiple commands separated by a |:bar|.
 ///                             Empty if there isn't a next command.


### PR DESCRIPTION
This is cherry-picked from these Vim patches:

Only applicable change outside vi_diff.txt in patch 8.1.1226:
https://github.com/vim/vim/commit/6c60f47fb9251e686217d51cf81847e14d0dd26d

Most changes outside starting.txt and vi_diff.txt in patch 8.1.1280:
https://github.com/vim/vim/commit/25c9c680ec4dfbb51f4ef21c3460a48d3c67ffc8

Missing docs for 'mousemoveevent':
https://github.com/vim/vim/commit/cbaff5e06ec525d31dc44093125c42029e01d508
