### PR TITLE
vim-patch:9.0.1014: zir files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1122,6 +1122,7 @@ local extension = {
   yang = 'yang',
   ['z8a'] = 'z8a',
   zig = 'zig',
+  zir = 'zir',
   zu = 'zimbu',
   zut = 'zimbutempl',
   zsh = 'zsh',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -653,6 +653,7 @@ let s:filename_checks = {
     \ 'zig': ['file.zig'],
     \ 'zimbu': ['file.zu'],
     \ 'zimbutempl': ['file.zut'],
+    \ 'zir': ['file.zir'],
     \ 'zsh': ['.zprofile', '/etc/zprofile', '.zfbfmarks', 'file.zsh', '.zcompdump', '.zlogin', '.zlogout', '.zshenv', '.zshrc', '.zcompdump-file', '.zlog', '.zlog-file', '.zsh', '.zsh-file', 'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file'],
     \
     \ 'help': [$VIMRUNTIME . '/doc/help.txt'],


### PR DESCRIPTION
Problem:    Zir files are not recognized.
Solution:   Add a pattern for Zir files. (closes vim/vim#11664)

https://github.com/vim/vim/commit/25201016d5043954689a4c9f7833935294149404

Co-authored-by: Bram Moolenaar <Bram@vim.org>
