### PR TITLE
vim-patch:8.2.{3193,4204,4389},9.0.{1011,1016}: screenpos() fixes

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1023,6 +1023,8 @@ EXTERN char e_highlight_group_name_invalid_char[] INIT(= N_("E5248: Invalid char
 
 EXTERN char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight group name too long"));
 
+EXTERN char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line number: %ld"));
+
 EXTERN char e_undobang_cannot_redo_or_move_branch[]
 INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -996,6 +996,10 @@ void f_screenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     .col    = (colnr_T)tv_get_number(&argvars[2]) - 1,
     .coladd = 0
   };
+  if (pos.lnum > wp->w_buffer->b_ml.ml_line_count) {
+    semsg(_(e_invalid_line_number_nr), pos.lnum);
+    return;
+  }
   int row = 0;
   int scol = 0, ccol = 0, ecol = 0;
   textpos2screenpos(wp, &pos, &row, &scol, &ccol, &ecol, false);

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -926,6 +926,8 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
     linenr_T lnum = pos->lnum;
     is_folded = hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
     row = plines_m_win(wp, wp->w_topline, lnum - 1) + 1;
+    // Add filler lines above this buffer line.
+    row += win_get_fill(wp, lnum);
     visible_row = true;
   } else if (!local || pos->lnum < wp->w_topline) {
     row = 0;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -921,7 +921,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   colnr_T coloff = 0;
   bool visible_row = false;
 
-  if (pos->lnum >= wp->w_topline && pos->lnum < wp->w_botline) {
+  if (pos->lnum >= wp->w_topline && pos->lnum <= wp->w_botline) {
     row = plines_m_win(wp, wp->w_topline, pos->lnum - 1) + 1;
     visible_row = true;
   } else if (pos->lnum < wp->w_topline) {
@@ -955,15 +955,15 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
 
     col -= wp->w_leftcol;
 
-    if (col >= 0 && col < wp->w_width) {
+    if (col >= 0 && col < wp->w_width && row + rowoff <= wp->w_height) {
       coloff = col - scol + (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1;
     } else {
+      // character is left, right or below of the window
       scol = ccol = ecol = 0;
-      // character is left or right of the window
       if (local) {
         coloff = col < 0 ? -1 : wp->w_width_inner + 1;
       } else {
-        row = 0;
+        row = rowoff = 0;
       }
     }
   }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -933,7 +933,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   bool existing_row = (pos->lnum > 0
                        && pos->lnum <= wp->w_buffer->b_ml.ml_line_count);
 
-  if ((local && existing_row) || visible_row) {
+  if ((local || visible_row) && existing_row) {
     colnr_T off;
     colnr_T col;
     int width;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -920,9 +920,12 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   int rowoff = 0;
   colnr_T coloff = 0;
   bool visible_row = false;
+  bool is_folded = false;
 
   if (pos->lnum >= wp->w_topline && pos->lnum <= wp->w_botline) {
-    row = plines_m_win(wp, wp->w_topline, pos->lnum - 1) + 1;
+    linenr_T lnum = pos->lnum;
+    is_folded = hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
+    row = plines_m_win(wp, wp->w_topline, lnum - 1) + 1;
     visible_row = true;
   } else if (!local || pos->lnum < wp->w_topline) {
     row = 0;
@@ -933,7 +936,10 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   bool existing_row = (pos->lnum > 0
                        && pos->lnum <= wp->w_buffer->b_ml.ml_line_count);
 
-  if ((local || visible_row) && existing_row) {
+  if (is_folded) {
+    row += local ? 0 : wp->w_winrow + wp->w_winrow_off;
+    coloff = (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1;
+  } else if ((local || visible_row) && existing_row) {
     colnr_T off;
     colnr_T col;
     int width;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -924,7 +924,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   if (pos->lnum >= wp->w_topline && pos->lnum <= wp->w_botline) {
     row = plines_m_win(wp, wp->w_topline, pos->lnum - 1) + 1;
     visible_row = true;
-  } else if (pos->lnum < wp->w_topline) {
+  } else if (!local || pos->lnum < wp->w_topline) {
     row = 0;
   } else {
     row = wp->w_height_inner;
@@ -957,6 +957,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
 
     if (col >= 0 && col < wp->w_width && row + rowoff <= wp->w_height) {
       coloff = col - scol + (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1;
+      row += local ? 0 : wp->w_winrow + wp->w_winrow_off;
     } else {
       // character is left, right or below of the window
       scol = ccol = ecol = 0;
@@ -967,7 +968,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       }
     }
   }
-  *rowp = (local ? 0 : wp->w_winrow + wp->w_winrow_off) + row + rowoff;
+  *rowp = row + rowoff;
   *scolp = scol + coloff;
   *ccolp = ccol + coloff;
   *ecolp = ecol + coloff;

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -144,6 +144,22 @@ func Test_screenpos_fold()
   bwipe!
 endfunc
 
+func Test_screenpos_diff()
+  CheckFeature diff
+
+  enew!
+  call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+  vnew
+  call setline(1, ['a', 'b', 'c', 'g', 'h', 'i'])
+  windo diffthis
+  wincmd w
+  call assert_equal(#{col: 3, row: 7, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+
+  windo diffoff
+  bwipe!
+  bwipe!
+endfunc
+
 func Test_screenpos_number()
   rightbelow new
   rightbelow 73vsplit

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -1,7 +1,10 @@
 " Tests for cursor() and other functions that get/set the cursor position
 
+source check.vim
+
 func Test_wrong_arguments()
   call assert_fails('call cursor(1. 3)', 'E474:')
+  call assert_fails('call cursor(v:_null_list)', 'E474:')
 endfunc
 
 func Test_move_cursor()
@@ -118,12 +121,27 @@ func Test_screenpos()
   bwipe!
   set display&
 
-  call assert_equal({'col': 1, 'row': 1, 'endcol': 1, 'curscol': 1}, screenpos(win_getid(), 1, 1))
+  call assert_equal(#{col: 1, row: 1, endcol: 1, curscol: 1}, screenpos(win_getid(), 1, 1))
   " nmenu WinBar.TEST :
   setlocal winbar=TEST
-  call assert_equal({'col': 1, 'row': 2, 'endcol': 1, 'curscol': 1}, screenpos(win_getid(), 1, 1))
+  call assert_equal(#{col: 1, row: 2, endcol: 1, curscol: 1}, screenpos(win_getid(), 1, 1))
   " nunmenu WinBar.TEST
   setlocal winbar&
+endfunc
+
+func Test_screenpos_fold()
+  CheckFeature folding
+
+  enew!
+  call setline(1, range(10))
+  3,5fold
+  redraw
+  call assert_equal(2, screenpos(1, 2, 1).row)
+  call assert_equal(#{col: 1, row: 3, endcol: 1, curscol: 1}, screenpos(1, 3, 1))
+  call assert_equal(3, screenpos(1, 4, 1).row)
+  call assert_equal(3, screenpos(1, 5, 1).row)
+  call assert_equal(4, screenpos(1, 6, 1).row)
+  bwipe!
 endfunc
 
 func Test_screenpos_number()

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -109,7 +109,7 @@ func Test_screenpos()
 	\ 'col': wincol + 7,
 	\ 'curscol': wincol + 7,
 	\ 'endcol': wincol + 7}, winid->screenpos(line('$'), 8))
-  call assert_equal({'row': winrow - 1, 'col': 0, 'curscol': 0, 'endcol': 0},
+  call assert_equal({'row': 0, 'col': 0, 'curscol': 0, 'endcol': 0},
         \ winid->screenpos(line('$'), 22))
 
   close

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -155,6 +155,9 @@ func Test_screenpos_number()
   let pos = screenpos(winid, 1, 66)
   call assert_equal(winrow, pos.row)
   call assert_equal(wincol + 66 + 3, pos.col)
+
+  call assert_fails('echo screenpos(0, 2, 1)', 'E966:')
+
   close
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_cursor_func.vim
+++ b/src/nvim/testdir/test_cursor_func.vim
@@ -82,25 +82,41 @@ func Test_screenpos()
   let winid = win_getid()
   let [winrow, wincol] = win_screenpos(winid)
   call assert_equal({'row': winrow,
-    \ 'col': wincol + 0,
-    \ 'curscol': wincol + 7,
-    \ 'endcol': wincol + 7}, winid->screenpos(1, 1))
+	\ 'col': wincol + 0,
+	\ 'curscol': wincol + 7,
+	\ 'endcol': wincol + 7}, winid->screenpos(1, 1))
   call assert_equal({'row': winrow,
-    \ 'col': wincol + 13,
-    \ 'curscol': wincol + 13,
-    \ 'endcol': wincol + 13}, winid->screenpos(1, 7))
+	\ 'col': wincol + 13,
+	\ 'curscol': wincol + 13,
+	\ 'endcol': wincol + 13}, winid->screenpos(1, 7))
   call assert_equal({'row': winrow + 2,
-    \ 'col': wincol + 1,
-    \ 'curscol': wincol + 1,
-    \ 'endcol': wincol + 1}, screenpos(winid, 2, 22))
+	\ 'col': wincol + 1,
+	\ 'curscol': wincol + 1,
+	\ 'endcol': wincol + 1}, screenpos(winid, 2, 22))
   setlocal number
   call assert_equal({'row': winrow + 3,
-    \ 'col': wincol + 9,
-    \ 'curscol': wincol + 9,
-    \ 'endcol': wincol + 9}, screenpos(winid, 2, 22))
+	\ 'col': wincol + 9,
+	\ 'curscol': wincol + 9,
+	\ 'endcol': wincol + 9}, screenpos(winid, 2, 22))
+
+  let wininfo = getwininfo(winid)[0]
+  call setline(3, ['x']->repeat(wininfo.height))
+  call setline(line('$') + 1, 'x'->repeat(wininfo.width * 3))
+  setlocal nonumber display=lastline so=0
+  exe "normal G\<C-Y>\<C-Y>"
+  redraw
+  call assert_equal({'row': winrow + wininfo.height - 1,
+	\ 'col': wincol + 7,
+	\ 'curscol': wincol + 7,
+	\ 'endcol': wincol + 7}, winid->screenpos(line('$'), 8))
+  call assert_equal({'row': winrow - 1, 'col': 0, 'curscol': 0, 'endcol': 0},
+        \ winid->screenpos(line('$'), 22))
+
   close
   call assert_equal({}, screenpos(999, 1, 1))
+
   bwipe!
+  set display&
 
   call assert_equal({'col': 1, 'row': 1, 'endcol': 1, 'curscol': 1}, screenpos(win_getid(), 1, 1))
   " nmenu WinBar.TEST :

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -849,7 +849,7 @@ void win_config_float(win_T *wp, FloatConfig fconfig)
       pos_T pos = { wp->w_float_config.bufpos.lnum + 1,
                     wp->w_float_config.bufpos.col, 0 };
       int trow, tcol, tcolc, tcole;
-      textpos2screenpos(wp, &pos, &trow, &tcol, &tcolc, &tcole, true);
+      textpos2screenpos(parent, &pos, &trow, &tcol, &tcolc, &tcole, true);
       row += trow - 1;
       col += tcol - 1;
     }


### PR DESCRIPTION
Fix #19543

#### vim-patch:8.2.3193: screenpos() is wrong when 'display' is "lastline"

Problem:    screenpos() is wrong when the last line is partially visible and
            'display' is "lastline".
Solution:   Also compute the position for a partially visible line.

https://github.com/vim/vim/commit/189663bdac1156237c49925f77bd197c1bdea12c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4204: screenpos() has non-zero row for invisible text

Problem:    screenpos() has non-zero row for invisible text.
Solution:   Only add the window row when the text is visible.

https://github.com/vim/vim/commit/7924a17791217d50be5a91989a9641bf68e7a735

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4389: screenpos() does not handle a position in a closed fold

Problem:    screenpos() does not handle a position in a closed fold.
Solution:   Check if the position is inside a closed fold.

https://github.com/vim/vim/commit/4556a2e8681c5c98fb4c7ca0a016924a69b4452a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1011: ml_get error when using screenpos()

Problem:    ml_get error when using screenpos().
Solution:   Give an error for the line number.

https://github.com/vim/vim/commit/99d19438cabaf13074229d9a32e3a4af9ce98744

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1016: screenpos() does not count filler lines for diff mode

Problem:    screenpos() does not count filler lines for diff mode.
Solution:   Add filler lines. (closes 11658)

https://github.com/vim/vim/commit/1cb16c3a20a9d17df1a8dc3813ef64dc98e42637

Co-authored-by: Bram Moolenaar <Bram@vim.org>