### PR TITLE
vim-patch:9.0.1015: without /dev/urandom srand() seed is too predictable

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5145,10 +5145,11 @@ static void init_srand(uint32_t *const x)
     }
   }
   if (dev_urandom_state != OK) {
-    // Reading /dev/urandom doesn't work, fall back to time().
+    // Reading /dev/urandom doesn't work, fall back to os_hrtime() XOR with process ID
 #endif
   // uncrustify:off
-    *x = (uint32_t)time(NULL);
+    *x = (uint32_t)os_hrtime();
+    *x ^= (uint32_t)os_get_pid();
 #ifndef MSWIN
   }
 #endif

--- a/src/nvim/testdir/test_random.vim
+++ b/src/nvim/testdir/test_random.vim
@@ -1,5 +1,8 @@
 " Tests for srand() and rand()
 
+source check.vim
+source shared.vim
+
 func Test_Rand()
   let r = srand(123456789)
   call assert_equal([1573771921, 319883699, 2742014374, 1324369493], r)
@@ -46,6 +49,22 @@ func Test_issue_5587()
   call rand()
   call garbagecollect()
   call rand()
+endfunc
+
+func Test_srand()
+  CheckNotGui
+
+  let cmd = GetVimCommand() .. ' -V -es -c "echo rand()" -c qa!'
+  let bad = 0
+  for _ in range(10)
+    echo cmd
+    let result1 = system(cmd)
+    let result2 = system(cmd)
+    if result1 ==# result2
+      let bad += 1
+    endif
+  endfor
+  call assert_inrange(0, 4, bad)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1015: without /dev/urandom srand() seed is too predictable

Problem:    Without /dev/urandom srand() seed is too predictable.
Solution:   Use micro seconds and XOR with process ID. (Yasuhiro Matsumoto,
            closes vim/vim#11656)

https://github.com/vim/vim/commit/f0a9c004825ab686270ee57260652cce25e61049

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>