### PR TITLE
vim-patch:9.0.1017: test for srand() fails on MS-Windows

### DIFF
--- a/src/nvim/testdir/test_random.vim
+++ b/src/nvim/testdir/test_random.vim
@@ -12,18 +12,9 @@ func Test_Rand()
   call assert_equal(2658065534, rand(r))
   call assert_equal(3104308804, rand(r))
 
-  " Nvim does not support test_settime
-  " call test_settime(12341234)
   let s = srand()
-  if !has('win32') && filereadable('/dev/urandom')
-    " using /dev/urandom
-    call assert_notequal(s, srand())
-  " else
-  "   " using time()
-  "   call assert_equal(s, srand())
-  "   call test_settime(12341235)
-  "   call assert_notequal(s, srand())
-  endif
+  " using /dev/urandom or used time, result is different each time
+  call assert_notequal(s, srand())
 
   " Nvim does not support test_srand_seed
   " call test_srand_seed(123456789)
@@ -41,8 +32,6 @@ func Test_Rand()
   call assert_fails('echo rand([1, [2], 3, 4])', 'E730:')
   call assert_fails('echo rand([1, 2, [3], 4])', 'E730:')
   call assert_fails('echo rand([1, 2, 3, [4]])', 'E730:')
-
-  " call test_settime(0)
 endfunc
 
 func Test_issue_5587()


### PR DESCRIPTION
#### vim-patch:9.0.1017: test for srand() fails on MS-Windows

Problem:    Test for srand() fails on MS-Windows.
Solution:   Do not expect the same result a second time.

https://github.com/vim/vim/commit/9dacdb1d56ee0f9272f3fc956a12f15f84ffb205

Co-authored-by: Bram Moolenaar <Bram@vim.org>