### PR TITLE
treesitter: Clip injected ranges to the parent LanguageTree's ranges

### DIFF
--- a/runtime/lua/vim/treesitter/_clipping.lua
+++ b/runtime/lua/vim/treesitter/_clipping.lua
@@ -1,0 +1,236 @@
+-- If you are given a range like { 0, 0, 0, 4 }, you can pass this around to any
+-- child LanguageTrees easily. But if you have used a region like the one
+-- marked with xs below...
+--
+-- /// xxxxxxxx
+-- /// xxxx
+-- /// xxxxxxxxxxx
+--
+-- ... then when your child LanguageTree returns its injection query matches,
+-- if those matches are multi-line matches (like a fenced code block in markdown),
+-- then they will clobber the starts of lines. You'll get a region like so:
+--
+-- /// xxxxxxxx
+-- xxxxxxxx
+-- xxxxxxxxxxxxxxx
+--
+-- And hence any 3rd-level child parsers of that one will be working in a range
+-- with some extra comment marks or whatever it is in the middle of it.
+--
+-- So we have to be careful to split up any ranges when passing them to a child
+-- LanguageTree. This file implements that.
+
+---@alias Range6 number[]
+
+local M = {}
+
+-- http://lua-users.org/wiki/BinarySearch
+-- Avoid heap allocs for performance
+local default_fcompval = function(value)
+  return value
+end
+local fcompf = function(a, b)
+  return a < b
+end
+local fcompr = function(a, b)
+  return a > b
+end
+
+--- Finds values in a _sorted_ list using binary search.
+--- If present, returns the range of indices that are == to `value`
+--- If absent, returns the insertion point (duplicated), which may go off the end (#t + 1)
+---@return integer range start
+---@return integer range end
+---@return boolean true if value was present
+function M.binsearch(t, value, fcompval, reversed, start_point, end_point)
+  -- Initialise functions
+  fcompval = fcompval or default_fcompval
+  local fcomp = reversed and fcompr or fcompf
+  --  Initialise numbers
+  local iStart, iEnd, iMid = 1, #t, 0
+  if start_point ~= nil then
+    iStart = start_point
+  end
+  if end_point ~= nil then
+    iEnd = math.min(iEnd, end_point)
+  end
+  local iState = 0
+  -- Binary Search
+  while iStart <= iEnd do
+    -- calculate middle
+    iMid = math.floor((iStart + iEnd) / 2)
+    -- get compare value
+    local value2 = fcompval(t[iMid])
+    -- get all values that match
+    if value == value2 then
+      local tfound, num = { iMid, iMid }, iMid - 1
+      while num > 0 and value == fcompval(t[num]) do
+        tfound[1], num = num, num - 1
+      end
+      num = iMid + 1
+      while num <= #t and value == fcompval(t[num]) do
+        tfound[2], num = num, num + 1
+      end
+      local from, to = unpack(tfound)
+      return from, to, true
+      -- keep searching
+    elseif fcomp(value, value2) then
+      iEnd = iMid - 1
+      iState = 0
+    else
+      iStart = iMid + 1
+      iState = 1
+    end
+  end
+  -- modified to return the right place for such a value to be inserted, with 'false'
+  -- indicating it wasn't in there already
+  return iMid + iState, iMid + iState, false
+end
+
+---@param range Range6
+---@return integer
+---@return integer
+local function range_bytes(range)
+  return range[3], range[6]
+end
+
+---@param dst Range6
+---@param src Range6
+local function copy_start(dst, src)
+  dst[1] = src[1]
+  dst[2] = src[2]
+  dst[3] = src[3]
+end
+
+---@param dst Range6
+---@param src Range6
+local function copy_end(dst, src)
+  dst[4] = src[4]
+  dst[5] = src[5]
+  dst[6] = src[6]
+end
+
+---@return number
+local function range_start(range)
+  return range[3]
+end
+
+---@return number
+local function range_end(range)
+  return range[6]
+end
+
+---@return boolean
+local function range_empty_invalid(range)
+  return range[3] >= range[6]
+end
+
+---@param needle Range6
+---@param haystack Range6[]
+---@return Range6[]
+function M.find_overlaps(needle, haystack)
+  -- assume region sorted
+  local from, to = range_bytes(needle)
+  local istart, _, _ = M.binsearch(haystack, from, range_end)
+  local _, iend, exists = M.binsearch(haystack, to, range_start, false, istart)
+  if not exists then
+    iend = iend - 1
+  end
+  local slice = {}
+  for i = istart, iend do
+    table.insert(slice, haystack[i])
+  end
+  return slice
+end
+
+-- This is the idea:
+-- parent: xxxxxx    xxxx  xxxxx
+-- child:    ----------------
+-- result:   oooo    iiii  oo
+
+-- We assume the overlaps are sorted.
+function M.clip_range_with_overlaps(child, overlapping)
+  local child_from, child_to = range_bytes(child)
+  local results = {}
+
+  if #overlapping == 0 then
+    return results
+  end
+
+  -- step 1, clone the ranges, and coalesce sequences of adjacent ranges
+  -- cloning them avoids messing up the parent range. We don't have to
+  -- coalesce, but we may as well.
+  -- (coalescing = avoid splitting { 0, 4 } against {{0, 2}, {2, 4})
+  local last_r = { unpack(overlapping[1]) }
+  local coalesced = {}
+  if #overlapping > 1 then
+    for i = 2, #overlapping do
+      local r = overlapping[i]
+      if range_end(last_r) == range_start(r) then
+        -- expand the previous range
+        copy_end(last_r, r)
+      else
+        table.insert(coalesced, last_r)
+        last_r = { unpack(r) }
+      end
+    end
+  end
+  table.insert(coalesced, last_r)
+
+  -- step 2, take the overlaps, and remove any bits that arent inside
+  -- the child range
+  for _, parent in ipairs(coalesced) do
+    if range_empty_invalid(parent) then
+      goto continue
+    end
+
+    -- parent: xxxxxx    xxxxxxxx
+    -- child:    ------    ----
+    -- result:   oooo      oooo
+    if range_start(parent) < child_from then
+      copy_start(parent, child)
+    end
+
+    -- parent:   xxxxxx  xxxxxxxx
+    -- child:  ------      ----
+    -- result:   oooo      oooo
+    if range_end(parent) > child_to then
+      copy_end(parent, child)
+    end
+
+    if range_empty_invalid(parent) then
+      goto continue
+    end
+
+    -- if not modified by previous rules, then it's just wholly contained
+    -- parent:   xxxxxx
+    -- child:  -----------
+    -- result:   iiiiii
+    table.insert(results, parent)
+    ::continue::
+  end
+
+  return results
+end
+
+---@param child_region Range6[]
+---@param parent_region Range6[]
+function M.clip_region(child_region, parent_region)
+  if child_region == nil then
+    return {}
+  end
+  if not parent_region or #parent_region == 0 then
+    return child_region
+  end
+  local clipped_region = {}
+  for _, child_range in ipairs(child_region) do
+    local overlapping = M.find_overlaps(child_range, parent_region)
+    local clipped = M.clip_range_with_overlaps(child_range, overlapping)
+    for _, subrange in ipairs(clipped) do
+      table.insert(clipped_region, subrange)
+    end
+  end
+  return clipped_region
+end
+
+return M

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -641,7 +641,7 @@ end
 ---@return userdata|nil Found |tsnode|
 function LanguageTree:named_node_for_range(range, opts)
   local tree = self:tree_for_range(range, opts)
-  return tree:root():named_descendant_for_range(unpack(range))
+  return tree and tree:root():named_descendant_for_range(unpack(range)) or nil
 end
 
 --- Gets the appropriate language that contains {range}.

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -11,35 +11,36 @@ local ok = helpers.ok
 local assert_alive = helpers.assert_alive
 
 describe('API: highlight',function()
-  local expected_rgb = {
-    background = Screen.colors.Yellow,
-    foreground = Screen.colors.Red,
-    special = Screen.colors.Blue,
-    bold = true,
-  }
-  local expected_cterm = {
-    background = 10,
-    underline = true,
-  }
-  local expected_rgb2 = {
-    background = Screen.colors.Yellow,
-    foreground = Screen.colors.Red,
-    special = Screen.colors.Blue,
-    bold = true,
-    italic = true,
-    reverse = true,
-    underline = true,
-    undercurl = true,
-    underdouble = true,
-    underdotted = true,
-    underdashed = true,
-    strikethrough = true,
-    nocombine = true,
-  }
+  local expected_rgb, expected_cterm, expected_rgb2
 
   before_each(function()
     clear()
     command("hi NewHighlight cterm=underline ctermbg=green guifg=red guibg=yellow guisp=blue gui=bold")
+    expected_rgb = {
+      background = Screen.colors.Yellow,
+      foreground = Screen.colors.Red,
+      special = Screen.colors.Blue,
+      bold = true,
+    }
+    expected_cterm = {
+      background = 10,
+      underline = true,
+    }
+    expected_rgb2 = {
+      background = Screen.colors.Yellow,
+      foreground = Screen.colors.Red,
+      special = Screen.colors.Blue,
+      bold = true,
+      italic = true,
+      reverse = true,
+      underline = true,
+      undercurl = true,
+      underdouble = true,
+      underdotted = true,
+      underdashed = true,
+      strikethrough = true,
+      nocombine = true,
+    }
   end)
 
   it("nvim_get_hl_by_id", function()

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -383,7 +383,7 @@ describe('treesitter highlighting', function()
         table.insert(nodes, node)
       end
 
-      parser:set_included_regions({nodes})
+      parser:set_included_regions({{nodes}})
 
       local hl = vim.treesitter.highlighter.new(parser, {queries = {c = "(identifier) @type"}})
     ]]

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -480,7 +480,7 @@ end]]
     -- As stated here, this only includes the function (thus the whole buffer, without the last line)
     local res2 = exec_lua [[
     local root = parser:parse()[1]:root()
-    parser:set_included_regions({{root:child(0)}})
+    parser:set_included_regions({{{root:child(0)}}})
     parser:invalidate()
     return { parser:parse()[1]:root():range() }
     ]]
@@ -500,7 +500,7 @@ end]]
     eq(range, { { 0, 0, 18, 1 } })
 
     local range_tbl = exec_lua [[
-      parser:set_included_regions { { { 0, 0, 17, 1 } } }
+      parser:set_included_regions { { { {0, 0, 17, 1} } } }
       parser:parse()
       return parser:included_regions()
     ]]
@@ -519,7 +519,7 @@ end]]
       table.insert(nodes, node)
     end
 
-    parser:set_included_regions({nodes})
+    parser:set_included_regions({{nodes}})
 
     local root = parser:parse()[1]:root()
 
@@ -786,10 +786,10 @@ int x = INT_MAX;
       local injections = [[ (preproc_arg) @c ]]
       local child_regions = exec_lua([[
       parser = vim.treesitter.get_parser(0, "c", { injections = { c = ... }})
-      parser:set_included_regions({
+      parser:set_included_regions({{
          -- chop off the leading >s
          { {0, 2, 1, 0 }, {1, 2, 2, 0 } }
-      })
+      }})
       parser:parse()
       return parser:children().c:included_regions()
       ]], injections)
@@ -850,7 +850,7 @@ int x = INT_MAX;
       local injections = [[ (preproc_arg) @c ]]
       local child_regions = exec_lua([[
       parser = vim.treesitter.get_parser(0, "c", { injections = { c = ... }})
-      parser:set_included_regions({
+      parser:set_included_regions({{
          -- chop off the leading comment marks
          { {0, 3, 1, 0 }, {1, 3, 2, 0 } },
          -- a second region to obliterate the mask if we do it wrong.
@@ -859,7 +859,7 @@ int x = INT_MAX;
          -- cause the creation of two separate child trees as the second
          -- region contains a define of its own
          { {0, 0, 4, 0} },
-      })
+      }})
       parser:parse()
       return parser:children().c:included_regions()
       ]], injections)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -571,6 +571,28 @@ end]]
     eq({ {0, 10, 0, 13} }, ret)
   end)
 
+  it("gets injection byte offsets for string parsers", function()
+    local txt = [[
+    #define MACRO int c = 5; \
+                  float f = 9.0;
+    ]]
+
+    local ret = exec_lua([[
+    local str = ...
+    local parser = vim.treesitter.get_string_parser(str, "c", {
+      injections = {
+        c = "(preproc_def (preproc_arg) @c) (preproc_function_def value: (preproc_arg) @c)"
+      }
+    })
+    parser:parse();
+    local regions = parser:children().c:included_regions()
+    return regions]], txt)
+
+    eq({
+      { { 0, 17, 17, 1, 32, 63 } }
+    }, ret)
+  end)
+
   it("should use node range when omitted", function()
     local txt = [[
       int foo = 42;

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -135,6 +135,8 @@ local function filter_complex_blocks(body)
   for line in body:gmatch("[^\r\n]+") do
     if not (string.find(line, "(^)", 1, true) ~= nil
             or string.find(line, "_ISwupper", 1, true)
+            or string.find(line, "__uint128_t")
+            or string.find(line, "__darwin_arm_neon") -- one uses __uint128_t, this catches the transitive uses
             or string.find(line, "_Float")
             or string.find(line, "msgpack_zone_push_finalizer")
             or string.find(line, "msgpack_unpacker_reserve_buffer")


### PR DESCRIPTION
Fixes #21309, fixes #18176

> The idea is to take the injected `@rust` range `{ 3, 4, 5, 0 }` and 'clip' or 'hole punch' the bit that isn't allowed, which splits it into two ranges `{3, 4, 4, 0}`, `{4, 4, 5, 0}`.

This is the solution in a nutshell:

1. ~~Write a centred interval tree in Lua based on the [Wikipedia outline](https://en.wikipedia.org/wiki/Interval_tree).~~ Instead, write a binary search for ranges in a region that overlap with a given range. Regions are sorted.
2. Make it work with the 6-length { start_row, start_col, start_byte, end_row, end_col, end_byte } range format.
3. A function to take any injection range, and intersect it with a list of ranges that overlap with it, producing a list of clipped ranges.
4.  Then, add an argument to `LanguageTree:set_included_regions` to supply the _parent_ LanguageTree's `_regions`.
5. In `set_included_regions` we
    * ~~Flatten the parent's regions into one long region~~ match the child region with the parent region
    * ~~Use that region to construct a new interval tree~~
    * For each of the child's new regions, for each range in it, clip the range against the parent ~~interval tree~~ region.

An interval tree or similar structure seems necessary here because when the injection query matches are returned from tree-sitter, they have lost the information about which of the included region(s) they cover. I think you could potentially add something to the TS C API to get information about this (i.e. access to indexes of overlapping regions that TS could store with nodes as it parses) to avoid having to reconstruct the information out of band at a cost. That being said, this seems to work pretty well and does not seem to be a big slowdown. A file with 5000 Rust doc comments is equally (dreadfully) slow with or without this PR.