### PR TITLE
docs(lua): correct vim.spell.check example

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -733,7 +733,7 @@ vim.spell.check({str})                                     *vim.spell.check()*
         vim.spell.check("the quik brown fox")
         -- =>
         -- {
-        --     {'quik', 'bad', 4}
+        --     {'quik', 'bad', 5}
         -- }
 <
     Parameters: ~


### PR DESCRIPTION
:wave: `:lua =vim.spell.check("the quik brown fox")` => `{ { "quik", "bad", 5 } }`