### PR TITLE
vim-patch:8.2.1768,0e6adf8a29d5,fa3b72348d88

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -872,28 +872,35 @@ Here is an example that counts the number of spaces with <F4>: >
 	" doubling <F4> works on a line
 	nnoremap <expr> <F4><F4> CountSpaces() .. '_'
 
-	function CountSpaces(type = '') abort
+	function CountSpaces(virtualedit = '', irregular_block = v:false, type = '') abort
 	  if a:type == ''
-	    set opfunc=CountSpaces
+	    let &operatorfunc = function('CountSpaces', [&virtualedit, v:false])
+	    set virtualedit=block
 	    return 'g@'
 	  endif
 
+	  let cb_save = &clipboard
 	  let sel_save = &selection
 	  let reg_save = getreginfo('"')
-	  let cb_save = &clipboard
 	  let visual_marks_save = [getpos("'<"), getpos("'>")]
 
 	  try
-	    set clipboard= selection=inclusive
-	    let commands = #{line: "'[V']y", char: "`[v`]y", block: "`[\<c-v>`]y"}
-	    silent exe 'noautocmd keepjumps normal! ' .. get(commands, a:type, '')
-	    echom count(getreg('"'), ' ')
+	    set clipboard= selection=inclusive virtualedit=
+	    let commands = #{line: "'[V']", char: "`[v`]", block: "`[\<C-V>`]"}->get(a:type, 'v')
+	    if getpos("']")[-1] != 0 || a:irregular_block
+	      let commands ..= 'oO$'
+	      let &operatorfunc = function('CountSpaces', [a:virtualedit, v:true])
+	    endif
+	    let commands ..= 'y'
+	    execute 'silent noautocmd keepjumps normal! ' .. commands
+	    echomsg getreg('"')->count(' ')
 	  finally
 	    call setreg('"', reg_save)
 	    call setpos("'<", visual_marks_save[0])
 	    call setpos("'>", visual_marks_save[1])
 	    let &clipboard = cb_save
 	    let &selection = sel_save
+	    let &virtualedit = a:virtualedit
 	  endtry
 	endfunction
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -872,35 +872,56 @@ Here is an example that counts the number of spaces with <F4>: >
 	" doubling <F4> works on a line
 	nnoremap <expr> <F4><F4> CountSpaces() .. '_'
 
-	function CountSpaces(virtualedit = '', irregular_block = v:false, type = '') abort
+	function CountSpaces(context = {}, type = '') abort
 	  if a:type == ''
-	    let &operatorfunc = function('CountSpaces', [&virtualedit, v:false])
+	    let context = #{
+	      \ dot_command: v:false,
+	      \ extend_block: '',
+	      \ virtualedit: [&l:virtualedit, &g:virtualedit],
+	      \ }
+	    let &operatorfunc = function('CountSpaces', [context])
 	    set virtualedit=block
 	    return 'g@'
 	  endif
 
-	  let cb_save = &clipboard
-	  let sel_save = &selection
-	  let reg_save = getreginfo('"')
-	  let visual_marks_save = [getpos("'<"), getpos("'>")]
+	  let save = #{
+	    \ clipboard: &clipboard,
+	    \ selection: &selection,
+	    \ virtualedit: [&l:virtualedit, &g:virtualedit],
+	    \ register: getreginfo('"'),
+	    \ visual_marks: [getpos("'<"), getpos("'>")],
+	    \ }
 
 	  try
 	    set clipboard= selection=inclusive virtualedit=
-	    let commands = #{line: "'[V']", char: "`[v`]", block: "`[\<C-V>`]"}->get(a:type, 'v')
-	    if getpos("']")[-1] != 0 || a:irregular_block
-	      let commands ..= 'oO$'
-	      let &operatorfunc = function('CountSpaces', [a:virtualedit, v:true])
+	    let commands = #{
+	      \ line: "'[V']",
+	      \ char: "`[v`]",
+	      \ block: "`[\<C-V>`]",
+	      \ }[a:type]
+	    let [_, _, col, off] = getpos("']")
+	    if off != 0
+	      let vcol = getline("'[")->strpart(0, col + off)->strdisplaywidth()
+	      if vcol >= [line("'["), '$']->virtcol() - 1
+	        let a:context.extend_block = '$'
+	      else
+	        let a:context.extend_block = vcol .. '|'
+	      endif
+	    endif
+	    if a:context.extend_block != ''
+	      let commands ..= 'oO' .. a:context.extend_block
 	    endif
 	    let commands ..= 'y'
 	    execute 'silent noautocmd keepjumps normal! ' .. commands
 	    echomsg getreg('"')->count(' ')
 	  finally
-	    call setreg('"', reg_save)
-	    call setpos("'<", visual_marks_save[0])
-	    call setpos("'>", visual_marks_save[1])
-	    let &clipboard = cb_save
-	    let &selection = sel_save
-	    let &virtualedit = a:virtualedit
+	    call setreg('"', save.register)
+	    call setpos("'<", save.visual_marks[0])
+	    call setpos("'>", save.visual_marks[1])
+	    let &clipboard = save.clipboard
+	    let &selection = save.selection
+	    let [&l:virtualedit, &g:virtualedit] = get(a:context.dot_command ? save : a:context, 'virtualedit')
+	    let a:context.dot_command = v:true
 	  endtry
 	endfunction
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -324,7 +324,7 @@ the name, e.g. "<lambda>123".  Examples:
 	set opfunc={a\ ->\ MyOpFunc(a)}
 	" set using a funcref variable
 	let Fn = function('MyTagFunc')
-	let &tagfunc = string(Fn)
+	let &tagfunc = Fn
 	" set using a lambda expression
 	let &tagfunc = {t -> MyTagFunc(t)}
 	" set using a variable with lambda expression

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Mar 29
+" Last Change:	2020 Sep 28
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
 " in all modes and avoid side effects from mappings defined by the user.
@@ -88,6 +88,21 @@ an 9999.70 &Help.O&rphans		:help kcc<CR>
 an 9999.75 &Help.-sep2-			<Nop>
 an 9999.80 &Help.&Version		:version<CR>
 an 9999.90 &Help.&About			:intro<CR>
+
+if exists(':tlmenu')
+  tlnoremenu 9999.10 &Help.&Overview<Tab><F1>		<C-W>:help<CR>
+  tlnoremenu 9999.20 &Help.&User\ Manual		<C-W>:help usr_toc<CR>
+  tlnoremenu 9999.30 &Help.&How-To\ Links		<C-W>:help how-to<CR>
+  tlnoremenu <silent> 9999.40 &Help.&Find\.\.\.		<C-W>:call <SID>Helpfind()<CR>
+  tlnoremenu 9999.45 &Help.-sep1-			<Nop>
+  tlnoremenu 9999.50 &Help.&Credits			<C-W>:help credits<CR>
+  tlnoremenu 9999.60 &Help.Co&pying			<C-W>:help copying<CR>
+  tlnoremenu 9999.70 &Help.&Sponsor/Register		<C-W>:help sponsor<CR>
+  tlnoremenu 9999.70 &Help.O&rphans			<C-W>:help kcc<CR>
+  tlnoremenu 9999.75 &Help.-sep2-			<Nop>
+  tlnoremenu 9999.80 &Help.&Version			<C-W>:version<CR>
+  tlnoremenu 9999.90 &Help.&About			<C-W>:intro<CR>
+endif
 
 fun! s:Helpfind()
   if !exists("g:menutrans_help_dialog")

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -2,7 +2,7 @@
 " You can also use this as a start for your own set of menus.
 "
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Sep 28
+" Last Change:	2021 Dec 22
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
 " in all modes and avoid side effects from mappings defined by the user.
@@ -714,6 +714,11 @@ endfunc
 func s:BMCanAdd(name, num)
   " no directory or unlisted buffer
   if isdirectory(a:name) || !buflisted(a:num)
+    return 0
+  endif
+
+  " no name with control characters
+  if a:name =~ '[\x01-\x1f]'
     return 0
   endif
 


### PR DESCRIPTION
#### vim-patch:8.2.1768: cannot use the help menu from a terminal window

Problem:    Cannot use the help menu from a terminal window.
Solution:   Add ":tlnoremenu" commands. (Yee Cheng Chin, closes vim/vim#7023)

https://github.com/vim/vim/commit/b45cd36bd90f71e4a35b1ef1f75a3bedef6d8bac

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:0e6adf8a29d5

Update runtime files

https://github.com/vim/vim/commit/0e6adf8a29d5c2c96c42cc7157f71bf22c2ad471

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:fa3b72348d88

Update runtime files

https://github.com/vim/vim/commit/fa3b72348d88343390fbe212cfc230fec1602fc2

Co-authored-by: Bram Moolenaar <Bram@vim.org>