### PR TITLE
vim-patch:9.0.1025: WinScrolled is not triggered when filler lines change

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -631,9 +631,9 @@ The information provided by |WinScrolled| is a dictionary for each window that
 has changes, using the window ID as the key, and a total count of the changes
 with the key "all".  Example value for |v:event|:
 	{
-	   all: {width: 0, height: 2, leftcol: 0, topline: 1, skipcol: 0},
-	   1003: {width: 0, height: -1, leftcol: 0, topline: 0, skipcol: 0},
-	   1006: {width: 0, height: 1, leftcol: 0, topline: 1, skipcol: 0},
+	   all: {width: 0, height: 2, leftcol: 0, skipcol: 0, topline: 1, topfill: 0},
+	   1003: {width: 0, height: -1, leftcol: 0, skipcol: 0, topline: 0, topfill: 0},
+	   1006: {width: 0, height: 1, leftcol: 0, skipcol: 0, topline: 1, topfill: 0},
 	}
 
 Note that the "all" entry has the absolute values of the individual windows

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1193,6 +1193,7 @@ struct window_S {
 
   // five fields that are only used when there is a WinScrolled autocommand
   linenr_T w_last_topline;          ///< last known value for w_topline
+  linenr_T w_last_topfill;          ///< last known value for w_topfill
   colnr_T w_last_leftcol;           ///< last known value for w_leftcol
   colnr_T w_last_skipcol;           ///< last known value for w_skipcol
   int w_last_width;                 ///< last known value for w_width

--- a/test/functional/autocmd/win_scrolled_resized_spec.lua
+++ b/test/functional/autocmd/win_scrolled_resized_spec.lua
@@ -70,15 +70,15 @@ describe('WinScrolled', function()
     feed('<C-E>')
     eq(1, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('<C-Y>')
     eq(2, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 0, topline = -1, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = -1, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
   end)
 
@@ -93,15 +93,15 @@ describe('WinScrolled', function()
     feed('zl')
     eq(1, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('zh')
     eq(2, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = -1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = -1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
   end)
 
@@ -115,29 +115,29 @@ describe('WinScrolled', function()
     feed('zl')
     eq(1, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('zl')
     eq(2, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('h')
     eq(3, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = -1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = -1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('zh')
     eq(4, eval('g:scrolled'))
     eq({
-      all = {leftcol = 1, topline = 0, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = -1, topline = 0, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = -1, topline = 0, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
   end)
 
@@ -152,15 +152,15 @@ describe('WinScrolled', function()
     feed('gj')
     eq(1, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 0, width = 0, height = 0, skipcol = width},
-      ['1000'] = {leftcol = 0, topline = 0, width = 0, height = 0, skipcol = width},
+      all = {leftcol = 0, topline = 0, topfill = 0, width = 0, height = 0, skipcol = width},
+      ['1000'] = {leftcol = 0, topline = 0, topfill = 0, width = 0, height = 0, skipcol = width},
     }, eval('g:v_event'))
 
     feed('0')
     eq(2, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 0, width = 0, height = 0, skipcol = width},
-      ['1000'] = {leftcol = 0, topline = 0, width = 0, height = 0, skipcol = -width},
+      all = {leftcol = 0, topline = 0, topfill = 0, width = 0, height = 0, skipcol = width},
+      ['1000'] = {leftcol = 0, topline = 0, topfill = 0, width = 0, height = 0, skipcol = -width},
     }, eval('g:v_event'))
 
     feed('$')
@@ -181,15 +181,15 @@ describe('WinScrolled', function()
     feed('i<C-X><C-E><Esc>')
     eq(1, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('i<C-X><C-Y><Esc>')
     eq(2, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 0, topline = -1, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = -1, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     feed('L')
@@ -198,8 +198,8 @@ describe('WinScrolled', function()
     feed('A<CR><Esc>')
     eq(3, eval('g:scrolled'))
     eq({
-      all = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
-      ['1000'] = {leftcol = 0, topline = 1, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
   end)
 end)
@@ -244,6 +244,46 @@ describe('WinScrolled', function()
     assert_alive()
   end)
 
+  -- oldtest: Test_WinScrolled_diff()
+  it('is triggered for both windows when scrolling in diff mode', function()
+    exec([[
+      set diffopt+=foldcolumn:0
+      call setline(1, ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])
+      vnew
+      call setline(1, ['d', 'e', 'f', 'g', 'h', 'i'])
+      windo diffthis
+      au WinScrolled * let g:v_event = deepcopy(v:event)
+    ]])
+
+    feed('<C-E>')
+    eq({
+      all = {leftcol = 0, topline = 1, topfill = 1, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1001'] = {leftcol = 0, topline = 0, topfill = -1, width = 0, height = 0, skipcol = 0},
+    }, eval('g:v_event'))
+
+    feed('2<C-E>')
+    eq({
+      all = {leftcol = 0, topline = 2, topfill = 2, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 2, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1001'] = {leftcol = 0, topline = 0, topfill = -2, width = 0, height = 0, skipcol = 0},
+    }, eval('g:v_event'))
+
+    feed('<C-E>')
+    eq({
+      all = {leftcol = 0, topline = 2, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1001'] = {leftcol = 0, topline = 1, topfill = 0, width = 0, height = 0, skipcol = 0},
+    }, eval('g:v_event'))
+
+    feed('2<C-Y>')
+    eq({
+      all = {leftcol = 0, topline = 3, topfill = 1, width = 0, height = 0, skipcol = 0},
+      ['1000'] = {leftcol = 0, topline = -2, topfill = 0, width = 0, height = 0, skipcol = 0},
+      ['1001'] = {leftcol = 0, topline = -1, topfill = 1, width = 0, height = 0, skipcol = 0},
+    }, eval('g:v_event'))
+  end)
+
   it('is triggered by mouse scrolling in unfocused floating window #18222', function()
     local screen = Screen.new(80, 24)
     screen:attach()
@@ -270,16 +310,16 @@ describe('WinScrolled', function()
     eq(1, eval('g:scrolled'))
     eq(winid_str, eval('g:amatch'))
     eq({
-      all = {leftcol = 0, topline = 3, width = 0, height = 0, skipcol = 0},
-      [winid_str] = {leftcol = 0, topline = 3, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 3, topfill = 0, width = 0, height = 0, skipcol = 0},
+      [winid_str] = {leftcol = 0, topline = 3, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
 
     meths.input_mouse('wheel', 'up', '', 0, 3, 3)
     eq(2, eval('g:scrolled'))
     eq(tostring(win.id), eval('g:amatch'))
     eq({
-      all = {leftcol = 0, topline = 3, width = 0, height = 0, skipcol = 0},
-      [winid_str] = {leftcol = 0, topline = -3, width = 0, height = 0, skipcol = 0},
+      all = {leftcol = 0, topline = 3, topfill = 0, width = 0, height = 0, skipcol = 0},
+      [winid_str] = {leftcol = 0, topline = -3, topfill = 0, width = 0, height = 0, skipcol = 0},
     }, eval('g:v_event'))
   end)
 end)


### PR DESCRIPTION
#### vim-patch:9.0.1025: WinScrolled is not triggered when filler lines change

Problem:    WinScrolled is not triggered when filler lines change.
Solution:   Add "topfill" to the values that WinScrolled triggers on.
            (closes vim/vim#11668)

https://github.com/vim/vim/commit/3fc84dc2c7efecd7c14ce341cd777475058936fd

Cherry-pick StopVimInTerminal() from patch 9.0.1010.