### PR TITLE
vim-patch:9.0.1026: type of w_last_topfill is wrong

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1191,9 +1191,9 @@ struct window_S {
   colnr_T w_skipcol;                // starting column when a single line
                                     // doesn't fit in the window
 
-  // five fields that are only used when there is a WinScrolled autocommand
+  // six fields that are only used when there is a WinScrolled autocommand
   linenr_T w_last_topline;          ///< last known value for w_topline
-  linenr_T w_last_topfill;          ///< last known value for w_topfill
+  int w_last_topfill;               ///< last known value for w_topfill
   colnr_T w_last_leftcol;           ///< last known value for w_leftcol
   colnr_T w_last_skipcol;           ///< last known value for w_skipcol
   int w_last_width;                 ///< last known value for w_width


### PR DESCRIPTION
#### vim-patch:9.0.1026: type of w_last_topfill is wrong

Problem:    type of w_last_topfill is wrong.
Solution:   Use "int" instead of "linenr_T". (closes vim/vim#11670)

https://github.com/vim/vim/commit/2e613453eeeac3ef3405478c33775dd77d135bc7