### PR TITLE
fix(events): skip WinScrolled for newly-created float windows

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5405,6 +5405,18 @@ static int check_window_scroll_resize(int *size_count, win_T **first_scroll_win,
   int tot_skipcol = 0;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    // Skip floating windows that do not have a snapshot (usually becuase they are newly-created),
+    // as unlike split windows, creating floating windows do not cause other windows to resize.
+    if (wp->w_floating && wp->w_last_topline == 0) {
+      wp->w_last_topline = wp->w_topline;
+      wp->w_last_topfill = wp->w_topfill;
+      wp->w_last_leftcol = wp->w_leftcol;
+      wp->w_last_skipcol = wp->w_skipcol;
+      wp->w_last_width = wp->w_width;
+      wp->w_last_height = wp->w_height;
+      continue;
+    }
+
     const bool size_changed = wp->w_last_width != wp->w_width
                               || wp->w_last_height != wp->w_height;
     if (size_changed) {

--- a/test/functional/autocmd/win_scrolled_resized_spec.lua
+++ b/test/functional/autocmd/win_scrolled_resized_spec.lua
@@ -287,6 +287,15 @@ describe('WinScrolled', function()
   it('is triggered by mouse scrolling in unfocused floating window #18222', function()
     local screen = Screen.new(80, 24)
     screen:attach()
+
+    exec([[
+      let g:scrolled = 0
+      autocmd WinScrolled * let g:scrolled += 1
+      autocmd WinScrolled * let g:amatch = expand('<amatch>')
+      autocmd WinScrolled * let g:v_event = deepcopy(v:event)
+    ]])
+    eq(0, eval('g:scrolled'))
+
     local buf = meths.create_buf(true, true)
     meths.buf_set_lines(buf, 0, -1, false, {'a', 'b', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'})
     local win = meths.open_win(buf, false, {
@@ -298,12 +307,7 @@ describe('WinScrolled', function()
       style = 'minimal'
     })
     local winid_str = tostring(win.id)
-    exec([[
-      let g:scrolled = 0
-      autocmd WinScrolled * let g:scrolled += 1
-      autocmd WinScrolled * let g:amatch = expand('<amatch>')
-      autocmd WinScrolled * let g:v_event = deepcopy(v:event)
-    ]])
+    -- WinScrolled should not be triggered when creating a new floating window
     eq(0, eval('g:scrolled'))
 
     meths.input_mouse('wheel', 'down', '', 0, 3, 3)


### PR DESCRIPTION
Fix #21297

Unlike split windows, creating a new floating window does not cause
other windows to resize, so it doesn't make much sense to trigger
WinScrolled or WinResized when creating a new floating window.
