### PR TITLE
vim-patch:8.2.3564: invalid memory access when scrolling without valid screen

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -158,7 +158,6 @@ void update_topline(win_T *wp)
   if (!default_grid.chars || wp->w_height_inner == 0) {
     wp->w_topline = wp->w_cursor.lnum;
     wp->w_botline = wp->w_topline;
-    wp->w_valid |= VALID_BOTLINE|VALID_BOTLINE_AP;
     wp->w_viewport_invalid = true;
     wp->w_scbind_pos = 1;
     return;

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -323,7 +323,6 @@ func RunVim(before, after, arguments)
 endfunc
 
 func RunVimPiped(before, after, arguments, pipecmd)
-  let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
   let cmd = GetVimCommand()
   let args = ''
   if len(a:before) > 0
@@ -338,7 +337,9 @@ func RunVimPiped(before, after, arguments, pipecmd)
   " Optionally run Vim under valgrind
   " let cmd = 'valgrind --tool=memcheck --leak-check=yes --num-callers=25 --log-file=valgrind ' . cmd
 
-  exe "silent !" . a:pipecmd . cmd . args . ' ' . a:arguments
+  let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
+  " Nvim does not support -Z flag, remove it.
+  exe "silent !" . a:pipecmd . cmd . args . ' ' . substitute(a:arguments, '-Z', '', 'g')
 
   if len(a:before) > 0
     call delete('Xbefore.vim')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -36,14 +36,14 @@ func CountSpaces(type, ...)
   else
     silent exe "normal! `[v`]y"
   endif
-  let g:a=strlen(substitute(@@, '[^ ]', '', 'g'))
+  let g:a = strlen(substitute(@@, '[^ ]', '', 'g'))
   let &selection = sel_save
   let @@ = reg_save
 endfunc
 
 func OpfuncDummy(type, ...)
   " for testing operatorfunc
-  let g:opt=&linebreak
+  let g:opt = &linebreak
 
   if a:0  " Invoked from Visual mode, use gv command.
     silent exe "normal! gvy"
@@ -54,7 +54,7 @@ func OpfuncDummy(type, ...)
   endif
   " Create a new dummy window
   new
-  let g:bufnr=bufnr('%')
+  let g:bufnr = bufnr('%')
 endfunc
 
 func Test_normal00_optrans()
@@ -1284,6 +1284,22 @@ func Test_vert_scroll_cmds()
 
   set foldenable&
   close!
+endfunc
+
+func Test_scroll_in_ex_mode()
+  " This was using invalid memory because w_botline was invalid.
+  let lines =<< trim END
+      diffsplit
+      norm os00(
+      call writefile(['done'], 'Xdone')
+      qa!
+  END
+  call writefile(lines, 'Xscript')
+  call assert_equal(1, RunVim([], [], '--clean -X -Z -e -s -S Xscript'))
+  call assert_equal(['done'], readfile('Xdone'))
+
+  call delete('Xscript')
+  call delete('Xdone')
 endfunc
 
 " Test for the 'sidescroll' option

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -6088,7 +6088,7 @@ func Test_lopen_bwipe_all()
     qall!
   END
   call writefile(lines, 'Xscript')
-  if RunVim([], [], '--clean -n -S Xscript')
+  if RunVim([], [], '-u NONE -n -X -Z -e -m -s -S Xscript')
     call assert_equal(['done'], readfile('Xresult'))
   endif
 


### PR DESCRIPTION
#### vim-patch:8.2.3564: invalid memory access when scrolling without valid screen

Problem:    Invalid memory access when scrolling without a valid screen.
Solution:   Do not set VALID_BOTLINE in w_valid.

https://github.com/vim/vim/commit/777e7c21b7627be80961848ac560cb0a9978ff43

Co-authored-by: Bram Moolenaar <Bram@vim.org>