### PR TITLE
vim-patch:9.0.{1030,1032}: using freed memory with the cmdline popup menu

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -745,6 +745,11 @@ char *ExpandOne(expand_T *xp, char *str, char *orig, int options, int mode)
     FreeWild(xp->xp_numfiles, xp->xp_files);
     xp->xp_numfiles = -1;
     XFREE_CLEAR(orig_save);
+
+    // The entries from xp_files may be used in the PUM, remove it.
+    if (compl_match_array != NULL) {
+      cmdline_pum_remove();
+    }
   }
   findex = 0;
 

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2281,6 +2281,21 @@ func Test_wildmenu_pum()
   call delete('Xdir', 'rf')
 endfunc
 
+func Test_wildmenu_pum_clear_entries()
+  " This was using freed memory.  Run in a terminal to get the pum to update.
+  let lines =<< trim END
+    set wildoptions=pum
+    set wildchar=<C-E>
+  END
+  call writefile(lines, 'XwildmenuTest', 'D')
+  let buf = RunVimInTerminal('-S XwildmenuTest', #{rows: 10})
+
+  call term_sendkeys(buf, ":\<C-E>\<C-E>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_clear_entries_1', {})
+
+  set wildoptions& wildchar&
+endfunc
+
 " this was going over the end of IObuff
 func Test_report_error_with_composing()
   let caught = 'no'

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2282,6 +2282,8 @@ func Test_wildmenu_pum()
 endfunc
 
 func Test_wildmenu_pum_clear_entries()
+  CheckRunVimInTerminal
+
   " This was using freed memory.  Run in a terminal to get the pum to update.
   let lines =<< trim END
     set wildoptions=pum

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2583,6 +2583,29 @@ describe('builtin popupmenu', function()
     ]]}
   end)
 
+  -- oldtest: Test_wildmenu_pum_clear_entries()
+  it('wildoptions=pum when using Ctrl-E as wildchar vim-patch:9.0.1030', function()
+    screen:try_resize(30, 10)
+    exec([[
+      set wildoptions=pum
+      set wildchar=<C-E>
+    ]])
+    feed(':sign <C-E><C-E>')
+    screen:expect([[
+                                    |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~    }{s: define         }{1:         }|
+      {1:~    }{n: jump           }{1:         }|
+      {1:~    }{n: list           }{1:         }|
+      {1:~    }{n: place          }{1:         }|
+      {1:~    }{n: undefine       }{1:         }|
+      {1:~    }{n: unplace        }{1:         }|
+      :sign define^                  |
+    ]])
+    assert_alive()
+  end)
+
   it("'pumblend' RGB-color", function()
     screen:try_resize(60,14)
     screen:set_default_attr_ids({


### PR DESCRIPTION
#### vim-patch:9.0.1030: using freed memory with the cmdline popup menu

Problem:    Using freed memory with the cmdline popup menu.
Solution:   Clear the popup menu when clearing the matches.

https://github.com/vim/vim/commit/038e6d20e680ce8c850d07f6b035c4e1904c1201

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1032: test fails when terminal feature is missing

Problem:    Test fails when terminal feature is missing.
Solution:   Use CheckRunVimInTerminal.

https://github.com/vim/vim/commit/b9603f6498e5637e111bd1dca0eab88c8dd0f99b

Co-authored-by: Bram Moolenaar <Bram@vim.org>