### PR TITLE
vim-patch:8.2.1634: loop to handle keys for the command line is too long

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -1100,6 +1100,15 @@ func Test_cmdline_complete_various()
   " completion after a range followed by a pipe (|) character
   call feedkeys(":1,10 | chist\t\<C-B>\"\<CR>", 'xt')
   call assert_equal('"1,10 | chistory', @:)
+
+  " use <Esc> as the 'wildchar' for completion
+  set wildchar=<Esc>
+  call feedkeys(":g/a\\xb/clearj\<Esc>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"g/a\xb/clearjumps', @:)
+  " pressing <esc> twice should cancel the command
+  call feedkeys(":chist\<Esc>\<Esc>", 'xt')
+  call assert_equal('"g/a\xb/clearjumps', @:)
+  set wildchar&
 endfunc
 
 func Test_cmdline_write_alternatefile()


### PR DESCRIPTION
#### vim-patch:8.2.1634: loop to handle keys for the command line is too long

Problem:    Loop to handle keys for the command line is too long.
Solution:   Move a few more parts to separate functions. (Yegappan Lakshmanan,
            closes vim/vim#6895)

https://github.com/vim/vim/commit/9c929713b7588f2e44a1533809d2ba0bbd2631be