### PR TITLE
docs: dark/light color/accessibilty pass for generated html docs

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -843,8 +843,14 @@ end
 local function gen_css(fname)
   local css = [[
     :root {
-      --code-color: #008B8B;
-      --tag-color: gray;
+      --code-color: #004b4b;
+      --tag-color: #095943;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --code-color: #00c243;
+        --tag-color: #00b7b7;
+      }
     }
     @media (min-width: 40em) {
       .toc {
@@ -861,11 +867,6 @@ local function gen_css(fname)
       .golden-grid {
         /* Disable grid for narrow viewport (mobile phone). */
         display: block;
-      }
-    }
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --code-color: cyan;
       }
     }
     .toc {
@@ -887,7 +888,7 @@ local function gen_css(fname)
     }
     h1, h2, h3, h4, h5 {
       font-family: sans-serif;
-      border-bottom: 1px solid #41464bd6; /*rgba(0, 0, 0, .9);*/
+      border-bottom: 1px solid var(--tag-color); /*rgba(0, 0, 0, .9);*/
     }
     h3, h4, h5 {
       border-bottom-style: dashed;


### PR DESCRIPTION
Color pass and AAA contrast accessibility pass.

![Screenshot 2022-12-08 at 16-29-54 Vim_diff - Neovim docs](https://user-images.githubusercontent.com/15027/206574344-cf1350d1-0b81-457f-93f9-e6d13682a740.png)
![Screenshot 2022-12-08 at 16-46-34 Vim_diff - Neovim docs](https://user-images.githubusercontent.com/15027/206574362-d671b726-dd0f-4da6-a735-efb42857a4d6.png)
