### PR TITLE
test(old): change $TMPDIR from Xtest-tmpdir to X-test-tmpdir

### DIFF
--- a/src/nvim/testdir/Makefile
+++ b/src/nvim/testdir/Makefile
@@ -11,7 +11,7 @@ ROOT := ../../..
 
 export SHELL := sh
 export NVIM_PRG := $(NVIM_PRG)
-export TMPDIR := $(abspath Xtest-tmpdir)
+export TMPDIR := $(abspath X-test-tmpdir)
 
 ifeq ($(OS),Windows_NT)
   FIXFF = fixff

--- a/src/nvim/testdir/shared.vim
+++ b/src/nvim/testdir/shared.vim
@@ -9,7 +9,7 @@ source view_util.vim
 
 " {Nvim}
 " Filepath captured from output may be truncated, like this:
-"   /home/va...estdir/Xtest-tmpdir/nvimxbXN4i/10
+"   /home/va...estdir/X-test-tmpdir/nvimxbXN4i/10
 " Get last 2 segments, then combine with $TMPDIR.
 func! Fix_truncated_tmpfile(fname)
   " sanity check

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -7,7 +7,7 @@ source shared.vim
 
 func Test_complete_tab()
   call writefile(['testfile'], 'Xtestfile')
-  call feedkeys(":e Xtestf\t\r", "tx")
+  call feedkeys(":e Xtest\t\r", "tx")
   call assert_equal('testfile', getline(1))
 
   " Pressing <Tab> after '%' completes the current file, also on MS-Windows


### PR DESCRIPTION
I've noticed a patch 8.2.4376 that uses more Xtest directories.
Change $TMPDIR to X-test-tmpdir to avoid more future divergence.
