### PR TITLE
vim-patch:9.0.1036: undo misbehaves when writing from an insert mode mapping

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -908,6 +908,12 @@ check_pum:
       }
       pum_want.active = false;
     }
+
+    if (curbuf->b_u_synced) {
+      // The K_EVENT, K_COMMAND, or K_LUA caused undo to be synced.
+      // Need to save the line for undo before inserting the next char.
+      ins_need_undo = true;
+    }
     break;
 
   case K_HOME:        // <Home>

--- a/test/functional/editor/undo_spec.lua
+++ b/test/functional/editor/undo_spec.lua
@@ -9,6 +9,7 @@ local feed = helpers.feed
 local feed_command = helpers.feed_command
 local insert = helpers.insert
 local funcs = helpers.funcs
+local exec = helpers.exec
 
 local function lastmessage()
   local messages = funcs.split(funcs.execute('messages'), '\n')
@@ -66,6 +67,40 @@ describe('u CTRL-R g- g+', function()
   it('can find the previous sequence after undoing to a branch', function()
     undo_and_redo(4, 'u', '<C-r>', '1')
     undo_and_redo(4, 'g-', 'g+', '1')
+  end)
+
+  describe('undo works correctly when writing in Insert mode', function()
+    before_each(function()
+      exec([[
+        edit Xtestfile.txt
+        set undolevels=100 undofile
+        write
+      ]])
+    end)
+
+    after_each(function()
+      command('bwipe!')
+      os.remove('Xtestfile.txt')
+      os.remove('Xtestfile.txt.un~')
+    end)
+
+    -- oldtest: Test_undo_after_write()
+    it('using <Cmd> mapping', function()
+      command('imap . <Cmd>write<CR>')
+      feed('Otest.<CR>boo!!!<Esc>')
+      expect([[
+        test
+        boo!!!
+        ]])
+
+      feed('u')
+      expect([[
+        test
+        ]])
+
+      feed('u')
+      expect('')
+    end)
   end)
 end)
 

--- a/test/functional/editor/undo_spec.lua
+++ b/test/functional/editor/undo_spec.lua
@@ -10,6 +10,7 @@ local feed_command = helpers.feed_command
 local insert = helpers.insert
 local funcs = helpers.funcs
 local exec = helpers.exec
+local exec_lua = helpers.exec_lua
 
 local function lastmessage()
   local messages = funcs.split(funcs.execute('messages'), '\n')
@@ -88,6 +89,45 @@ describe('u CTRL-R g- g+', function()
     it('using <Cmd> mapping', function()
       command('imap . <Cmd>write<CR>')
       feed('Otest.<CR>boo!!!<Esc>')
+      expect([[
+        test
+        boo!!!
+        ]])
+
+      feed('u')
+      expect([[
+        test
+        ]])
+
+      feed('u')
+      expect('')
+    end)
+
+    it('using Lua mapping', function()
+      exec_lua([[
+        vim.api.nvim_set_keymap('i', '.', '', {callback = function()
+          vim.cmd('write')
+        end})
+      ]])
+      feed('Otest.<CR>boo!!!<Esc>')
+      expect([[
+        test
+        boo!!!
+        ]])
+
+      feed('u')
+      expect([[
+        test
+        ]])
+
+      feed('u')
+      expect('')
+    end)
+
+    it('using RPC call', function()
+      feed('Otest')
+      command('write')
+      feed('<CR>boo!!!<Esc>')
       expect([[
         test
         boo!!!


### PR DESCRIPTION
#### vim-patch:9.0.1036: undo misbehaves when writing from an insert mode mapping

Problem:    Undo misbehaves when writing from an insert mode mapping.
Solution:   Sync undo when writing.

https://github.com/vim/vim/commit/3f8f82772313af9f2417b06651f30988b63e1c96

Co-authored-by: Bram Moolenaar <Bram@vim.org>