### PR TITLE
vim-patch:8.2.{4366,4376}: cmdline completion tests

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -103,6 +103,7 @@ static int sort_func_compare(const void *s1, const void *s2)
   return strcmp(p1, p2);
 }
 
+/// Escape special characters in the cmdline completion matches.
 static void ExpandEscape(expand_T *xp, char_u *str, int numfiles, char **files, int options)
 {
   int i;

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -400,6 +400,17 @@ func Test_CmdCompletion()
   com! -nargs=? -complete=custom,min DoCmd
   call assert_fails("call feedkeys(':DoCmd \t', 'tx')", 'E118:')
 
+  " custom completion for a pattern with a backslash
+  let g:ArgLead = ''
+  func! CustCompl(A, L, P)
+    let g:ArgLead = a:A
+    return ['one', 'two', 'three']
+  endfunc
+  com! -nargs=? -complete=customlist,CustCompl DoCmd
+  call feedkeys(":DoCmd a\\\t", 'xt')
+  call assert_equal('a\', g:ArgLead)
+  delfunc CustCompl
+
   delcom DoCmd
 endfunc
 

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -330,7 +330,7 @@ func CustomComplete(A, L, P)
 endfunc
 
 func CustomCompleteList(A, L, P)
-  return [ "Monday", "Tuesday", "Wednesday", {}]
+  return [ "Monday", "Tuesday", "Wednesday", {}, v:_null_string]
 endfunc
 
 func Test_CmdCompletion()


### PR DESCRIPTION
#### vim-patch:8.2.4366: not enough tests for command line completion

Problem:    Not enough tests for command line completion.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#9760)

https://github.com/vim/vim/commit/4d03d870007c593bce2cfa8d0a6597ca3a20fa35

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.4376: not enough tests for command line completion

Problem:    Not enough tests for command line completion.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#9771)

https://github.com/vim/vim/commit/9773db6f9bce7a6f063e23179976d7825ace4d72

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>