### PR TITLE
vim-patch:9.0.0238: Shift-Tab shows matches on cmdline when 'wildmenu' is off

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -869,6 +869,24 @@ func Test_cmdline_complete_user_cmd()
   call feedkeys(":Foo b\\x\<Tab>\<Home>\"\<cr>", 'tx')
   call assert_equal('"Foo b\x', @:)
   delcommand Foo
+
+  redraw
+  call assert_equal('~', Screenline(&lines - 1))
+  command! FooOne :
+  command! FooTwo :
+
+  set nowildmenu
+  call feedkeys(":Foo\<Tab>\<Home>\"\<cr>", 'tx')
+  call assert_equal('"FooOne', @:)
+  call assert_equal('~', Screenline(&lines - 1))
+
+  call feedkeys(":Foo\<S-Tab>\<Home>\"\<cr>", 'tx')
+  call assert_equal('"FooTwo', @:)
+  call assert_equal('~', Screenline(&lines - 1))
+
+  delcommand FooOne
+  delcommand FooTwo
+  set wildmenu&
 endfunc
 
 func Test_complete_user_cmd()


### PR DESCRIPTION
#### vim-patch:9.0.0238: Shift-Tab shows matches on cmdline when 'wildmenu' is off

Problem:    Shift-Tab shows matches on cmdline when 'wildmenu' is off.
Solution:   Only show matches when 'wildmode' contains "list".

https://github.com/vim/vim/commit/300175fd7f874be78826a00f5cb60a7ec2f20655

Code change has already been ported.

Co-authored-by: Bram Moolenaar <Bram@vim.org>