### PR TITLE
fix(lsp): ignore null responses for semanticTokens request

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -304,6 +304,11 @@ function STHighlighter:process_response(response, client, version)
   -- reset active request
   state.active_request = {}
 
+  -- skip nil responses
+  if response == nil then
+    return
+  end
+
   -- if we have a response to a delta request, update the state of our tokens
   -- appropriately. if it's a full response, just use that
   local tokens

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -35,10 +35,8 @@ M.create_server_definition = [[
         })
         local handler = handlers[method]
         if handler then
-          local response, err = handler(method, params, callback)
-          if response then
-            callback(err, response)
-          end
+          local response, err = handler(method, params)
+          callback(err, response)
         elseif method == 'initialize' then
           callback(nil, {
             capabilities = opts.capabilities or {}

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -35,7 +35,7 @@ M.create_server_definition = [[
         })
         local handler = handlers[method]
         if handler then
-          local response, err = handler(method, params)
+          local response, err = handler(method, params, callback)
           if response then
             callback(err, response)
           end

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -415,6 +415,75 @@ describe('semantic token highlighting', function()
           ]], unchanged = true }
       end)
 
+  it('ignores null responses from the server', function()
+      exec_lua([[
+        local legend, response, edit_response = ...
+        server2 = _create_server({
+          capabilities = {
+            semanticTokensProvider = {
+              full = { delta = false },
+            },
+          },
+          handlers = {
+            ['textDocument/semanticTokens/full'] = function(_, _, callback)
+              callback(nil, nil)
+            end,
+            ['textDocument/semanticTokens/full/delta'] = function(_, _, callback)
+              callback(nil, nil)
+            end,
+          }
+        })
+        bufnr = vim.api.nvim_get_current_buf()
+        vim.api.nvim_win_set_buf(0, bufnr)
+        client_id = vim.lsp.start({ name = 'dummy', cmd = server2.cmd })
+      ]])
+      eq(true, exec_lua("return vim.lsp.buf_is_attached(bufnr, client_id)"))
+
+      insert(text)
+
+      screen:expect { grid = [[
+        #include <iostream>                     |
+                                                |
+        int main()                              |
+        {                                       |
+            int x;                              |
+        #ifdef __cplusplus                      |
+            std::cout << x << "\n";             |
+        #else                                   |
+            printf("%d\n", x);                  |
+        #endif                                  |
+        }                                       |
+        ^}                                       |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]] }
+
+      exec_lua([[
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
+      ]])
+
+      screen:expect { grid = [[
+        #include <iostream>                     |
+                                                |
+        int main()                              |
+        {                                       |
+            int x;                              |
+        #ifdef __cplusplus                      |
+            std::cout << x << "\n";             |
+        #else                                   |
+            printf("%d\n", x);                  |
+        #endif                                  |
+        }                                       |
+        ^}                                       |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+        ]], unchanged = true }
+    end)
+
     it('does not send delta requests if not supported by server', function()
       exec_lua([[
         local legend, response, edit_response = ...

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -425,11 +425,11 @@ describe('semantic token highlighting', function()
             },
           },
           handlers = {
-            ['textDocument/semanticTokens/full'] = function(_, _, callback)
-              callback(nil, nil)
+            ['textDocument/semanticTokens/full'] = function()
+              return nil
             end,
-            ['textDocument/semanticTokens/full/delta'] = function(_, _, callback)
-              callback(nil, nil)
+            ['textDocument/semanticTokens/full/delta'] = function()
+              return nil
             end,
           }
         })


### PR DESCRIPTION
The spec indicates that the response may be `null`, but it doesn't really say what a `null` response means. Since neovim raises an error if the response is `null`, I figured that ignoring it would be the safest bet.