### PR TITLE
feat(option): add new option disable load all built in plugins

### DIFF
--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -591,6 +591,7 @@ EXTERN char *p_lcs;             // 'listchars'
 
 EXTERN int p_lz;                // 'lazyredraw'
 EXTERN int p_lpl;               // 'loadplugins'
+EXTERN int p_lbpl;              // 'loadpbuiltinlugins'
 EXTERN int p_magic;             // 'magic'
 EXTERN char *p_menc;            // 'makeencoding'
 EXTERN char *p_mef;             // 'makeef'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1415,6 +1415,13 @@ return {
       defaults={if_true=true}
     },
     {
+      full_name='loadbuiltinplugins', abbreviation='lbpl',
+      short_desc=N_("load built-in plugin scripts when starting up"),
+      type='bool', scope={'global'},
+      varname='p_lbpl',
+      defaults={if_true=true}
+    },
+    {
       full_name='magic',
       short_desc=N_("special characters in search patterns"),
       type='bool', scope={'global'},

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1130,8 +1130,10 @@ void load_plugins(void)
     }
 
     // don't use source_runtime() yet so we can check for :packloadall below
-    source_in_path(rtp_copy, plugin_pattern_vim, DIP_ALL | DIP_NOAFTER);
-    source_in_path(rtp_copy, plugin_pattern_lua, DIP_ALL | DIP_NOAFTER);
+    if (p_lbpl) {
+      source_in_path(rtp_copy, plugin_pattern_vim, DIP_ALL | DIP_NOAFTER);
+      source_in_path(rtp_copy, plugin_pattern_lua, DIP_ALL | DIP_NOAFTER);
+    }
     TIME_MSG("loading rtp plugins");
 
     // Only source "start" packages if not done already with a :packloadall


### PR DESCRIPTION
 maybe useful for some people who don't use the built in plugins and don't want load the scripts of them.  although can use set the variable like `vim.g.loaded_tarPlugin = 1` to avoid run the this script but it still load this script in startup and if we want disable multiples built-in plugins need write much more variables like that.  maybe we can make it simple just one option like this `vim.opt.loadbuiltinplugins/lbpl = false` ( no test and doc currently because this option name a little long )..any advice ? if we don't need this pr I will  close then.