### PR TITLE
feat(lsp): utility functions for getting and showing tokens

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1340,7 +1340,7 @@ start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     |vim.lsp.buf_attach_client()|. To opt-out of semantic highlighting with a
     server that supports it, you can delete the semanticTokensProvider table
     from the {server_capabilities} of your client in your |LspAttach| callback
-    or your configuration's `on_attach` callback. >lua
+    or your configuration's `on_attach` callback: >lua
 
        client.server_capabilities.semanticTokensProvider = nil
 <

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1332,6 +1332,22 @@ force_refresh({bufnr})               *vim.lsp.semantic_tokens.force_refresh()*
     Parameters: ~
       • {bufnr}  (nil|number) default: current buffer
 
+                                        *vim.lsp.semantic_tokens.get_at_pos()*
+get_at_pos({bufnr}, {row}, {col})
+    Return the semantic token(s) at the given position. If called without
+    argument, returns the token under the cursor.
+
+    Parameters: ~
+      • {bufnr}  (number|nil) Buffer number (0 for current buffer, default)
+      • {row}    (number|nil) Position row (default cursor position)
+      • {col}    (number|nil) Position column (default cursor position)
+
+    Return: ~
+        table[]|nil tokens Table of tokens at position
+
+show_at_cursor()                    *vim.lsp.semantic_tokens.show_at_cursor()*
+    Show the semantic token(s) under the cursor.
+
 start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     Start the semantic token highlighting engine for the given buffer with the
     given client. The client must already be attached to the buffer.

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -409,7 +409,17 @@ function STHighlighter:on_win(topline, botline)
             strict = false,
           })
 
-          --TODO(jdrouhard): do something with the modifiers
+          -- TODO(bfredl) use single extmark when hl_group supports table
+          if #token.modifiers > 0 then
+            for _, modifier in pairs(token.modifiers) do
+              api.nvim_buf_set_extmark(self.bufnr, state.namespace, token.line, token.start_col, {
+                hl_group = '@' .. modifier,
+                end_col = token.end_col,
+                priority = vim.highlight.priorities.semantic_tokens,
+                strict = false,
+              })
+            end
+          end
 
           token.extmark_added = true
         end
@@ -494,7 +504,7 @@ local M = {}
 --- opt-out of semantic highlighting with a server that supports it, you can
 --- delete the semanticTokensProvider table from the {server_capabilities} of
 --- your client in your |LspAttach| callback or your configuration's
---- `on_attach` callback.
+--- `on_attach` callback:
 --- <pre>lua
 ---   client.server_capabilities.semanticTokensProvider = nil
 --- </pre>

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -69,9 +69,12 @@ describe('semantic token highlighting', function()
         [4] = { bold = true, foreground = Screen.colors.SeaGreen };
         [5] = { foreground = tonumber('0x6a0dad') };
         [6] = { foreground = Screen.colors.Blue1 };
+        [7] = { bold = true, foreground = Screen.colors.DarkCyan };
+        [8] = { bold = true, foreground = Screen.colors.SlateBlue };
       }
       command([[ hi link @namespace Type ]])
       command([[ hi link @function Special ]])
+      command([[ hi @declaration gui=bold ]])
 
       exec_lua(create_server_definition)
       exec_lua([[
@@ -107,9 +110,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            int {2:x};                              |
+            int {7:x};                              |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |
@@ -199,9 +202,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            int {2:x};                              |
+            int {7:x};                              |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |
@@ -228,9 +231,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            int {2:x};                              |
+            int {7:x};                              |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |
@@ -251,9 +254,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            int {2:x};                              |
+            int {7:x};                              |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |
@@ -309,9 +312,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            ^int {3:x}();                            |
+            ^int {8:x}();                            |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {3:x} << "\n";             |
         {6:#else}                                   |
@@ -512,9 +515,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            int {2:x};                              |
+            int {7:x};                              |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |
@@ -536,9 +539,9 @@ describe('semantic token highlighting', function()
       screen:expect { grid = [[
         #include <iostream>                     |
                                                 |
-        int {3:main}()                              |
+        int {8:main}()                              |
         {                                       |
-            ^int {2:x}();                            |
+            ^int {7:x}();                            |
         #ifdef {5:__cplusplus}                      |
             {4:std}::{2:cout} << {2:x} << "\n";             |
         {6:#else}                                   |


### PR DESCRIPTION
Added two utility functions:
* `get_at_pos(bufnr, row, col)`: returns a table of tokens (to account for possibly multiple servers); defaults to cursor position if called with empty arguments
* `show_at_cursor()`: prints the styled token type and modifiers (using above function)
This is consistent with similar `vim.treesitter` functions (see https://github.com/neovim/neovim/pull/21374).

(Originally done while adding simple implementation of token modifiers, but that was split off to #21390 so it won't get blocked by the API discussion here.)
