### PR TITLE
feat(treesitter)!: consolidate `get_{node,captures}` functions

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -481,16 +481,6 @@ library.
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*
 
-                                     *vim.treesitter.get_captures_at_cursor()*
-get_captures_at_cursor({winnr})
-    Returns a list of highlight capture names under the cursor
-
-    Parameters: ~
-      • {winnr}  (number|nil) Window handle or 0 for current window (default)
-
-    Return: ~
-        string[] List of capture names
-
                                         *vim.treesitter.get_captures_at_pos()*
 get_captures_at_pos({bufnr}, {row}, {col})
     Returns a list of highlight captures at the given position
@@ -601,6 +591,13 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
 
     Return: ~
         (boolean) True if the {node} contains the {range}
+
+                                    *vim.treesitter.show_captures_at_cursor()*
+show_captures_at_cursor({winnr})
+    Shows the list of highlight capture names under the cursor
+
+    Parameters: ~
+      • {winnr}  (number|nil) Window handle or 0 for current window (default)
 
 show_tree({opts})                                 *vim.treesitter.show_tree()*
     Open a window that displays a textual representation of the nodes in the

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -489,39 +489,36 @@ get_captures_at_pos({bufnr}, {row}, {col})
     string as well as a table of metadata (`priority`, `conceal`, ...; empty
     if none are defined).
 
-    Parameters: ~
-      • {bufnr}  (number) Buffer number (0 for current buffer)
-      • {row}    (number) Position row
-      • {col}    (number) Position column
-
-    Return: ~
-        table[] List of captures `{ capture = "capture name", metadata = { ...
-        } }`
-
-get_node_at_cursor({winnr})              *vim.treesitter.get_node_at_cursor()*
-    Returns the smallest named node under the cursor
+    If called without argument, returns the captures at cursor.
 
     Parameters: ~
-      • {winnr}  (number|nil) Window handle or 0 for current window (default)
+      • {bufnr}  (number|nil) Buffer number (0 for current buffer)
+      • {row}    (number) Position row (default cursor position if `bufnr` is
+                 `nil) @param col (number) Position column (default cursor
+                 position if`bufnr`is`nil)
 
     Return: ~
-        (string) Name of node under the cursor
+        table[] matches List of captures `{ capture = "capture name", metadata
+        = { ... } }`
 
                                             *vim.treesitter.get_node_at_pos()*
 get_node_at_pos({bufnr}, {row}, {col}, {opts})
     Returns the smallest named node at the given position
 
+    If called without argument, returns the node at cursor.
+
     Parameters: ~
-      • {bufnr}  (number) Buffer number (0 for current buffer)
-      • {row}    (number) Position row
-      • {col}    (number) Position column
-      • {opts}   (table) Optional keyword arguments:
+      • {bufnr}  (number|nil) Buffer number (0 for current buffer)
+      • {row}    (number) Position row (default cursor position if `bufnr` is
+                 `nil) @param col (number) Position column (default cursor
+                 position if`bufnr`is`nil)
+      • {opts}   (table|nil) Optional keyword arguments:
                  • lang string|nil Parser language
                  • ignore_injections boolean Ignore injected languages
                    (default true)
 
     Return: ~
-        userdata|nil |tsnode| under the cursor
+        userdata|nil _ |tsnode| under the cursor
 
 get_node_range({node_or_range})              *vim.treesitter.get_node_range()*
     Returns the node's range or an unpacked range table

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -493,13 +493,12 @@ get_captures_at_pos({bufnr}, {row}, {col})
 
     Parameters: ~
       • {bufnr}  (number|nil) Buffer number (0 for current buffer)
-      • {row}    (number) Position row (default cursor position if `bufnr` is
-                 `nil) @param col (number) Position column (default cursor
-                 position if`bufnr`is`nil)
+      • {row}    (number|nil) Position row (default cursor position)
+      • {col}    (number|nil) Position column (default cursor position)
 
     Return: ~
-        table[] matches List of captures `{ capture = "capture name", metadata
-        = { ... } }`
+        table[] List of captures `{ capture = "capture name", metadata = { ...
+        } }`
 
                                             *vim.treesitter.get_node_at_pos()*
 get_node_at_pos({bufnr}, {row}, {col}, {opts})
@@ -509,9 +508,8 @@ get_node_at_pos({bufnr}, {row}, {col}, {opts})
 
     Parameters: ~
       • {bufnr}  (number|nil) Buffer number (0 for current buffer)
-      • {row}    (number) Position row (default cursor position if `bufnr` is
-                 `nil) @param col (number) Position column (default cursor
-                 position if`bufnr`is`nil)
+      • {row}    (number|nil) Position row (default cursor position)
+      • {col}    (number|nil) Position column (default cursor position)
       • {opts}   (table|nil) Optional keyword arguments:
                  • lang string|nil Parser language
                  • ignore_injections boolean Ignore injected languages

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -248,25 +248,24 @@ function M.get_captures_at_pos(bufnr, row, col)
   return matches
 end
 
---- Returns a list of highlight capture names under the cursor
+--- Shows the list of highlight capture names under the cursor
 ---
 ---@param winnr (number|nil) Window handle or 0 for current window (default)
----
----@return string[] List of capture names
-function M.get_captures_at_cursor(winnr)
+function M.show_captures_at_cursor(winnr)
   winnr = winnr or 0
   local bufnr = a.nvim_win_get_buf(winnr)
   local cursor = a.nvim_win_get_cursor(winnr)
 
   local data = M.get_captures_at_pos(bufnr, cursor[1] - 1, cursor[2])
 
-  local captures = {}
-
+  local msg = {}
   for _, capture in ipairs(data) do
-    table.insert(captures, capture.capture)
+    local capture_name = '@' .. capture.capture
+    msg[#msg + 1] = { capture_name, capture_name }
+    msg[#msg + 1] = { ' ' }
   end
 
-  return captures
+  a.nvim_echo(msg, false, {})
 end
 
 --- Returns the smallest named node at the given position

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -200,23 +200,24 @@ end
 --- If called without argument, returns the captures at cursor.
 ---
 ---@param bufnr number|nil Buffer number (0 for current buffer)
----@param row number Position row (default cursor position if `bufnr` is `nil)
----@param col number Position column (default cursor position if `bufnr` is `nil)
+---@param row number|nil Position row (default cursor position)
+---@param col number|nil Position column (default cursor position)
 ---
----@return table[] matches List of captures `{ capture = "capture name", metadata = { ... } }`
+---@return table[] List of captures `{ capture = "capture name", metadata = { ... } }`
 function M.get_captures_at_pos(bufnr, row, col)
-  if bufnr == nil then
+  if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
+  end
+
+  local buf_highlighter = M.highlighter.active[bufnr]
+  if not buf_highlighter then
+    return {}
+  end
+
+  if not (row and col) then
     local cursor = a.nvim_win_get_cursor(0)
     row = cursor[1] - 1
     col = cursor[2]
-  elseif bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
-  end
-  local buf_highlighter = M.highlighter.active[bufnr]
-
-  if not buf_highlighter then
-    return {}
   end
 
   local matches = {}
@@ -280,30 +281,30 @@ end
 --- If called without argument, returns the node at cursor.
 ---
 ---@param bufnr number|nil Buffer number (0 for current buffer)
----@param row number Position row (default cursor position if `bufnr` is `nil)
----@param col number Position column (default cursor position if `bufnr` is `nil)
+---@param row number|nil Position row (default cursor position)
+---@param col number|nil Position column (default cursor position)
 ---@param opts table|nil Optional keyword arguments:
 ---             - lang string|nil Parser language
 ---             - ignore_injections boolean Ignore injected languages (default true)
 ---
 ---@return userdata|nil _ |tsnode| under the cursor
 function M.get_node_at_pos(bufnr, row, col, opts)
-  if bufnr == nil then
-    bufnr = a.nvim_get_current_buf()
-    local cursor = a.nvim_win_get_cursor(0)
-    row = cursor[1] - 1
-    col = cursor[2]
-  elseif bufnr == 0 then
+  if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
-  local ts_range = { row, col, row, col }
 
   local root_lang_tree = M.get_parser(bufnr, opts and opts.lang)
   if not root_lang_tree then
     return
   end
 
-  return root_lang_tree:named_node_for_range(ts_range, opts)
+  if not (row and col) then
+    local cursor = a.nvim_win_get_cursor(0)
+    row = cursor[1] - 1
+    col = cursor[2]
+  end
+
+  return root_lang_tree:named_node_for_range({ row, col, row, col }, opts)
 end
 
 --- Starts treesitter highlighting for a buffer


### PR DESCRIPTION
Problem: The `vim.treesitter` API has too many similar functions around returning/showing nodes and captures.

Solution: Consolidate the API by moving functionality into existing functions or better differentiation:
1. allow `get_{node,captures}_at_pos()` to be called with no arguments to return the full(!) node/captures at the cursor
2. add `show_captures_at_cursor()` to print(!) the correctly highlighted captures at the cursor
3. remove `get_{node,captures}_at_cursor()`

As the treesitter API is still marked as experimental and the two removed functions were meant to be used for interactive debugging, do we need to go through a full deprecation cycle here?

@gpanders (who asked about 1.) @justinmk (who likes a tidy API)