### PR TITLE
fix(tests): initialize Screen.colors in API highlight tests

### DIFF
--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -11,6 +11,9 @@ local ok = helpers.ok
 local assert_alive = helpers.assert_alive
 
 describe('API: highlight',function()
+  clear()
+  Screen.new() -- initialize Screen.colors
+
   local expected_rgb = {
     background = Screen.colors.Yellow,
     foreground = Screen.colors.Red,


### PR DESCRIPTION
Since #21204, running any subset of functional tests that does not invoke `require('test.functional.ui.screen').new()` fails with the following error:
```
-------- Global test environment setup.
-------- Running tests from test/functional/api/highlight_spec.lua
nan ms test/functional/api/highlight_spec.lua:15: attempt to index field 'colors' (a nil value)

stack traceback:
        test/functional/api/highlight_spec.lua:15: in function <test/functional/api/highlight_spec.lua:13>
```
For example, `make functionaltest TEST_FILE=test/functional/api/highlight_spec.lua`

This change adds a call to `Screen.new()` to ensure `Screen.colors` is set before indexing into it.

cc: @bfredl 