### PR TITLE
vim-patch:9.0.0032: in the quickfix window 'cursorline' overrules QuickFixLine

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -472,7 +472,7 @@ static void apply_cursorline_highlight(win_T *wp, linenr_T lnum, int *line_attr,
         && qf_current_entry(wp) == lnum) {
       *line_attr = hl_combine_attr(*cul_attr, *line_attr);
     } else {
-      *line_attr = *cul_attr;
+      *line_attr = hl_combine_attr(*line_attr, *cul_attr);
     }
   }
 }

--- a/src/nvim/testdir/test_quickfix.vim
+++ b/src/nvim/testdir/test_quickfix.vim
@@ -2959,8 +2959,15 @@ func Test_cwindow_highlight()
   call writefile(lines, 'XtestCwindow')
   let buf = RunVimInTerminal('-S XtestCwindow', #{rows: 12})
   call VerifyScreenDump(buf, 'Test_quickfix_cwindow_1', {})
+
   call term_sendkeys(buf, ":cnext\<CR>")
   call VerifyScreenDump(buf, 'Test_quickfix_cwindow_2', {})
+
+  call term_sendkeys(buf, "\<C-W>j:set cursorline\<CR>")
+  call VerifyScreenDump(buf, 'Test_quickfix_cwindow_3', {})
+
+  call term_sendkeys(buf, "j")
+  call VerifyScreenDump(buf, 'Test_quickfix_cwindow_4', {})
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:    In the quickfix window 'cursorline' overrules QuickFixLine
            highlighting.
Solution:   Combine the attributes.  Add a test. (closes vim/vim#10654)

https://github.com/vim/vim/commit/7fe956d17650b231f173868531bc7466010687f0

Co-authored-by: Bram Moolenaar <Bram@vim.org>
