### PR TITLE
fix: vim.opt_local:append ignoring global option value

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -526,7 +526,7 @@ local function create_option_accessor(scope)
 
   return setmetatable({}, {
     __index = function(_, k)
-      return make_option(k, a.nvim_get_option_value(k, { scope = scope }))
+      return make_option(k, a.nvim_get_option_value(k, {}))
     end,
 
     __newindex = function(_, k, v)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2187,6 +2187,22 @@ describe('lua stdlib', function()
     end)
   end) -- vim.opt
 
+  describe('opt_local', function()
+    it('should be able to append to an array list type option', function()
+      eq({ "foo,bar,baz,qux" }, exec_lua [[
+        local result = {}
+
+        vim.opt.tags = "foo,bar"
+        vim.opt_local.tags:append("baz")
+        vim.opt_local.tags:append("qux")
+
+        table.insert(result, vim.bo.tags)
+
+        return result
+      ]])
+    end)
+  end)
+
   it('vim.cmd', function()
     exec_lua [[
     vim.cmd "autocmd BufNew * ++once lua BUF = vim.fn.expand('<abuf>')"


### PR DESCRIPTION
Closes #18225