### PR TITLE
vim-patch:9.0.0530: using freed memory when autocmd changes mark

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -551,6 +551,7 @@ MarkMoveRes mark_move_to(fmark_T *fm, MarkMove flags)
     // Need to change buffer
     fm_copy = *fm;  // Copy, autocommand may change it
     fm = &fm_copy;
+    // Jump to the file with the mark
     res |= switch_to_mark_buf(fm, !(flags & kMarkJumpList));
     // Failed switching buffer
     if (res & kMarkMoveFailed) {
@@ -568,6 +569,7 @@ MarkMoveRes mark_move_to(fmark_T *fm, MarkMove flags)
   // Move the cursor while keeping track of what changed for the caller
   pos_T prev_pos = curwin->w_cursor;
   pos_T pos = fm->mark;
+  // Set lnum again, autocommands my have changed it
   curwin->w_cursor = fm->mark;
   if (flags & kMarkBeginLine) {
     beginline(BL_WHITE | BL_FIX);

--- a/src/nvim/testdir/test_marks.vim
+++ b/src/nvim/testdir/test_marks.vim
@@ -304,4 +304,17 @@ func Test_getmarklist()
   close!
 endfunc
 
+" This was using freed memory
+func Test_jump_mark_autocmd()
+  next 00
+  edit 0
+  sargument
+  au BufEnter 0 all
+  sil norm 
+
+  au! BufEnter
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0530: using freed memory when autocmd changes mark

Problem:    Using freed memory when autocmd changes mark.
Solution:   Copy the mark before editing another buffer.

https://github.com/vim/vim/commit/8ecfa2c56b4992c7f067b92488aa9acea5a454ad

Nvim already copies the mark.

Co-authored-by: Bram Moolenaar <Bram@vim.org>