### PR TITLE
feat(diagnostic): don't open qf or loclist if no diagnostics available

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -478,13 +478,17 @@ local function set_list(loclist, opts)
   -- numbers beyond the end of the buffer
   local diagnostics = get_diagnostics(bufnr, opts, false)
   local items = M.toqflist(diagnostics)
+  if next(items) == nil then
+    vim.notify('No diagnostics available')
+    return
+  end
   if loclist then
     vim.fn.setloclist(winnr, {}, ' ', { title = title, items = items })
   else
     vim.fn.setqflist({}, ' ', { title = title, items = items })
   end
   if open then
-    api.nvim_command(loclist and 'lopen' or 'botright copen')
+    api.nvim_command(loclist and 'lwindow' or 'botright cwindow')
   end
 end
 


### PR DESCRIPTION
Currently in the absence of diagnostics, calling `vim.diagnostic.setqflist/setloclist` will still open `qf/loclist`, so this pr check result size and notify msg if no diagnostics available, finally `return`.