### PR TITLE
vim-patch:9.0.1051: after a failed CTRL-W ] next command splits window

### DIFF
--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1811,4 +1811,17 @@ function Test_splitkeep_status()
   call VerifyScreenDump(buf, 'Test_splitkeep_status_1', {})
 endfunction
 
+function Test_new_help_window_on_error()
+  help change.txt
+  execute "normal! /CTRL-@\<CR>"
+  silent! execute "normal! \<C-W>]"
+
+  let wincount = winnr('$')
+  help 'mod'
+
+  call assert_equal(wincount, winnr('$'))
+  call assert_equal(expand("<cword>"), "'mod'")
+endfunction
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -494,6 +494,7 @@ newwindow:
     // Execute the command right here, required when
     // "wincmd ]" was used in a function.
     do_nv_ident(Ctrl_RSB, NUL);
+    postponed_split = 0;
     break;
 
   // edit file name under cursor in a new window
@@ -594,6 +595,7 @@ wingotofile:
       // Execute the command right here, required when
       // "wincmd g}" was used in a function.
       do_nv_ident('g', xchar);
+      postponed_split = 0;
       break;
 
     case 'f':                       // CTRL-W gf: "gf" in a new tab page


### PR DESCRIPTION
#### vim-patch:9.0.1051: after a failed CTRL-W ] next command splits window

Problem:    After a failed CTRL-W ] next command splits window.
Solution:   Reset postponed_split. (Rob Pilling, closes vim/vim#11698)

https://github.com/vim/vim/commit/cb94c910706fdd575cc25797d7858e084f1e3524

Co-authored-by: Rob Pilling <robpilling@gmail.com>