### PR TITLE
feat(fs): add `opts` argument to `vim.fs.dir()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2245,13 +2245,18 @@ basename({file})                                           *vim.fs.basename()*
     Return: ~
         (string) Basename of {file}
 
-dir({path})                                                     *vim.fs.dir()*
+dir({path}, {opts})                                             *vim.fs.dir()*
     Return an iterator over the files and directories located in {path}
 
     Parameters: ~
       • {path}  (string) An absolute or relative path to the directory to
                 iterate over. The path is first normalized
                 |vim.fs.normalize()|.
+      • {opts}  table|nil Optional keyword arguments:
+                • depth: integer|nil How deep the traverse (default 1)
+                • skip: (fun(dir_name: string): boolean)|nil Predicate to
+                  control traversal. Return false to stop searching the
+                  current directory. Only useful when depth > 1
 
     Return: ~
         Iterator over files and directories in {path}. Each iteration yields

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -73,6 +73,9 @@ The following new APIs or features were added.
   Similarly, the `virtual_text` configuration in |vim.diagnostic.config()| now
   has a `suffix` option which does nothing by default.
 
+• |vim.fs.dir()| now has a `opts` argument with a depth field to allow
+  recursively searching a directory tree.
+
 • |vim.secure.read()| reads a file and prompts the user if it should be
   trusted and, if so, returns the file's contents.
 


### PR DESCRIPTION
## Problem

`glob()` is slow.

## Solution

Add `opts` with a `depth` field to `vim.fs.dir()` as a performant and more versatile replacement for `glob()`.

For example:
```lua
    for _, kind in ipairs({ '*.vim', '*.lua' }) do
      for _, file in ipairs(vim.fn.glob('my_plugin/after/plugin/**/'..kind, false, true) do
        vim.cmd.source(file)
      end
    end
```
  can now be written as:
```lua
    for path, path_type in vim.fs.dir('my_plugin/after/plugin', {depth = 10}) do
      local ext = path:sub(-4)
      if path_type == "file" and (ext == ".lua" or ext == ".vim") then
        vim.cmd.source(file)
      end
    end
```

And is faster by about a factor of 3.

Inspired from: https://github.com/wbthomason/packer.nvim/pull/1158

Credit to @folke for sharing his `walk()` implementation.

## TODO:
* [x] add tests
