### PR TITLE
fix(tui): set cursor color parameter as string when required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,6 +512,7 @@ if(FEAT_TUI)
   int
   main(void)
   {
+    unibi_str_from_var(unibi_var_from_str(\"\"));
     return unibi_num_from_var(unibi_var_from_num(0));
   }
   " UNIBI_HAS_VAR_FROM)


### PR DESCRIPTION
See #20628. Terminals supporting cursor color changing usually set the "user-defined" `Cs` terminfo capability. Most terminals expect the parameter to the capability to be a string (in hex format like `#0099ff` or like `rgb:00/99/ff`), others may expect a number.

Neovim currently can't handle string parameters, causing terminals to receive a bogus command.

Unfortunately, as the `Cs` capability is "user-defined", there's no strict format. The parameter it takes isn't really standardized. It seems most terminals in use follow xterm; iTerm appears to be an exception.

This PR makes using the `Cs` capability more reliable by following terminfo and sending the color in hex format, at the cost of using unibilium string vars. Alternatively, https://github.com/neovim/neovim/commit/34d41baf8a8e4ab8c006b7f29a8106e60e311aa2 could be reverted and the specific format required by terminals to be hardcoded, instead of reading from terminfo.

Fixes #20628, #19607.