### PR TITLE
docs: mention getmousepos() for click execute function label

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6168,6 +6168,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	         is a bug that denotes that new mouse button recognition was 
 	         added without modifying code that reacts on mouse clicks on 
 	         this label.
+	      Use |getmousepos()|.winid in the specified function to get the
+	      corresponding window id of the clicked item.
 	< -   Where to truncate line if too long.  Default is at the start.
 	      No width fields allowed.
 	= -   Separation point between alignment sections. Each section will


### PR DESCRIPTION
I saw you added the documentation label to https://github.com/neovim/neovim/issues/18741 @justinmk. Does this resolve that issue?