### PR TITLE
fix(terminal): handle ED 3 (clear scrollback) properly

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -378,6 +378,7 @@ TERMINAL
 
 • |nvim_open_term()| can be called with a non-empty buffer. The buffer
   contents are piped to the PTY and displayed as terminal output.
+• CSI 3 J (the sequence to clear terminal scrollback) is now supported.
 
 TREESITTER
 
@@ -433,9 +434,8 @@ These existing features changed their behavior.
 • 'scrollback' maximum value increased from 100000 to 1000000
 • |matchfuzzy()| and |matchfuzzypos()| use an improved fuzzy matching algorithm
   (same as fzy).
-- Windows: Paths like "\Windows" and "/Windows" are now considered to be
+• Windows: Paths like "\Windows" and "/Windows" are now considered to be
   absolute paths (to the current drive) and no longer relative.
-
 • When 'shelltemp' is off, shell commands now use `pipe()` and not `socketpair()`
   for input and output. This matters mostly for Linux where some command lines
   using "/dev/stdin" and similiar would break as these special files can be

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -155,9 +155,7 @@ struct terminal {
   size_t sb_current;                // Lines stored in sb_buffer.
   size_t sb_size;                   // Capacity of sb_buffer.
   // "virtual index" that points to the first sb_buffer row that we need to
-  // push to the terminal buffer when refreshing the scrollback. When negative,
-  // it actually points to entries that are no longer in sb_buffer (because the
-  // window height has increased) and must be deleted from the terminal buffer
+  // push to the terminal buffer when refreshing the scrollback.
   int sb_pending;
   size_t sb_deleted;                // Lines deleted from sb_buffer.
   size_t sb_deleted_last;           // Value of sb_deleted on last refresh_scrollback()
@@ -171,6 +169,7 @@ struct terminal {
   // refresh_timer_cb may be called after the buffer was freed, and there's
   // no way to know if the memory was reused.
   handle_T buf_handle;
+  bool in_altscreen;
   // program exited
   bool closed;
   // when true, the terminal's destruction is already enqueued.
@@ -216,6 +215,7 @@ static VTermScreenCallbacks vterm_screen_callbacks = {
   .theme = term_theme,
   .sb_pushline = term_sb_push,  // Called before a line goes offscreen.
   .sb_popline = term_sb_pop,
+  .sb_clear = term_sb_clear,
 };
 
 static VTermSelectionCallbacks vterm_selection_callbacks = {
@@ -1467,6 +1467,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
 
   switch (prop) {
   case VTERM_PROP_ALTSCREEN:
+    term->in_altscreen = val->boolean;
     break;
 
   case VTERM_PROP_CURSORVISIBLE:
@@ -1613,7 +1614,7 @@ static int term_sb_pop(int cols, VTermScreenCell *cells, void *data)
     return 0;
   }
 
-  if (term->sb_pending) {
+  if (term->sb_pending > 0) {
     term->sb_pending--;
   }
 
@@ -1682,6 +1683,26 @@ static int term_selection_set(VTermSelectionMask mask, VTermStringFragment frag,
     char *data = xmemdupz(term->selection.items, kv_size(term->selection));
     multiqueue_put(main_loop.events, term_clipboard_set, (void *)mask, data);
   }
+
+  return 1;
+}
+
+static int term_sb_clear(void *data)
+{
+  Terminal *term = data;
+
+  if (term->in_altscreen || !term->sb_size || !term->sb_current) {
+    return 1;
+  }
+
+  for (size_t i = 0; i < term->sb_current; i++) {
+    xfree(term->sb_buffer[i]);
+  }
+
+  term->sb_deleted += term->sb_current;
+  term->sb_current = 0;
+  term->sb_pending = 0;
+  invalidate_terminal(term, -1, -1);
 
   return 1;
 }
@@ -2366,6 +2387,15 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
   int width, height;
   vterm_get_size(term->vt, &height, &width);
 
+  int max_line_count = (int)term->sb_current - term->sb_pending + height;
+  // Remove extra lines at the top if scrollback lines have been deleted.
+  while (deleted > 0 && buf->b_ml.ml_line_count > max_line_count) {
+    ml_delete_buf(buf, 1, false);
+    deleted_lines_buf(buf, 1, 1);
+    deleted--;
+  }
+  max_line_count += term->sb_pending;
+
   // May still have pending scrollback after increase in terminal height if the
   // scrollback wasn't refreshed in time; append these to the top of the buffer.
   int row_offset = term->sb_pending;
@@ -2381,21 +2411,15 @@ static void refresh_scrollback(Terminal *term, buf_T *buf)
     // This means that either the window height has decreased or the screen
     // became full and libvterm had to push all rows up. Convert the first
     // pending scrollback row into a string and append it just above the visible
-    // section of the buffer
-    if (((int)buf->b_ml.ml_line_count - height) >= (int)term->sb_size) {
-      // scrollback full, delete lines at the top
-      ml_delete_buf(buf, 1, false);
-      deleted_lines_buf(buf, 1, 1);
-    }
+    // section of the buffer.
     fetch_row(term, -term->sb_pending - row_offset, width);
-    int buf_index = (int)buf->b_ml.ml_line_count - height;
+    int buf_index = buf->b_ml.ml_line_count - height;
     ml_append_buf(buf, buf_index, term->textbuf, 0, false);
     appended_lines_buf(buf, buf_index, 1);
     term->sb_pending--;
   }
 
-  // Remove extra lines at the bottom
-  int max_line_count = (int)term->sb_current + height;
+  // Remove extra lines at the bottom.
   while (buf->b_ml.ml_line_count > max_line_count) {
     ml_delete_buf(buf, buf->b_ml.ml_line_count, false);
     deleted_lines_buf(buf, buf->b_ml.ml_line_count, 1);

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -52,12 +52,14 @@ describe(':terminal altscreen', function()
       line3                                             |
                                                         |*3
     ]])
+    -- ED 3 is no-op in altscreen
+    feed_data('\027[3J')
+    screen:expect_unchanged()
   end)
 
-  describe('on exit', function()
-    before_each(exit_altscreen)
-
-    it('restores buffer state', function()
+  describe('restores buffer state', function()
+    local function test_exit_altscreen_restores_buffer_state()
+      exit_altscreen()
       screen:expect([[
         line4                                             |
         line5                                             |
@@ -77,6 +79,20 @@ describe(':terminal altscreen', function()
         line5                                             |
                                                           |
       ]])
+    end
+
+    it('after exit', function()
+      test_exit_altscreen_restores_buffer_state()
+    end)
+
+    it('after ED 2 and ED 3 and exit', function()
+      feed_data('\027[H\027[2J\027[3J')
+      screen:expect([[
+        ^                                                  |
+                                                          |*5
+        {5:-- TERMINAL --}                                    |
+      ]])
+      test_exit_altscreen_restores_buffer_state()
     end)
   end)
 

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -534,8 +534,8 @@ describe(':terminal window', function()
     end)
     command('botright new')
     screen:expect([[
-      rows: 2, cols: 25        │rows: 5, cols: 50       |
-                               │rows: 2, cols: 50       |
+      rows: 2, cols: 25        │rows: 5, cols: 25       |
+                               │rows: 5, cols: 50       |
       {18:foo [-]                   foo [-]                 }|
       ^                                                  |
       {4:~                                                 }|
@@ -545,11 +545,11 @@ describe(':terminal window', function()
     command('quit')
     eq(1, eval('g:fired'))
     screen:expect([[
-      rows: 5, cols: 50        │rows: 5, cols: 25       |
-      rows: 5, cols: 25        │rows: 5, cols: 50       |
-      rows: 2, cols: 25        │rows: 2, cols: 50       |
+      rows: 5, cols: 50        │tty ready               |
       rows: 5, cols: 25        │rows: 5, cols: 25       |
-      ^                         │rows: 5, cols: 40       |
+      rows: 2, cols: 25        │rows: 5, cols: 50       |
+      rows: 5, cols: 25        │rows: 2, cols: 50       |
+      ^                         │rows: 5, cols: 25       |
       {17:foo [-]                   }{18:foo [-]                 }|
                                                         |
     ]])
@@ -558,14 +558,28 @@ describe(':terminal window', function()
     command('set showtabline=0 | tabnew | tabprevious | wincmd > | tabonly')
     eq(2, eval('g:fired'))
     screen:expect([[
-      rows: 5, cols: 25         │rows: 5, cols: 25      |
-      rows: 2, cols: 25         │rows: 5, cols: 50      |
-      rows: 5, cols: 25         │rows: 2, cols: 50      |
-      rows: 5, cols: 26         │rows: 5, cols: 25      |
-      ^                          │rows: 5, cols: 40      |
+      rows: 5, cols: 25         │tty ready              |
+      rows: 2, cols: 25         │rows: 5, cols: 25      |
+      rows: 5, cols: 25         │rows: 5, cols: 50      |
+      rows: 5, cols: 26         │rows: 2, cols: 50      |
+      ^                          │rows: 5, cols: 25      |
       {17:foo [-]                    }{18:foo [-]                }|
                                                         |
     ]])
+    n.expect([[
+      tty ready
+      rows: 5, cols: 25
+      rows: 5, cols: 50
+      rows: 2, cols: 50
+      rows: 5, cols: 25
+      rows: 5, cols: 40
+      rows: 5, cols: 25
+      rows: 5, cols: 50
+      rows: 5, cols: 25
+      rows: 2, cols: 25
+      rows: 5, cols: 25
+      rows: 5, cols: 26
+      ]])
   end)
 
   it('restores window options when switching terminals', function()


### PR DESCRIPTION
Fix #34087

Problem:  Terminal doesn't handle ED 3 (clear scrollback) properly.
Solution: Add vterm callback for sb_clear().

Also fix another problem that scrollback lines may be duplicated when
pushing to scrollback immediately after reducing window height, as can
be seen in the changes to test/functional/terminal/window_spec.lua.
