### PR TITLE
[Backport release-0.8] fix(treesitter): properly restore 'syntax'

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -326,12 +326,8 @@ end
 ---@param lang (string|nil) Language of the parser (default: buffer filetype)
 function M.start(bufnr, lang)
   bufnr = bufnr or a.nvim_get_current_buf()
-
   local parser = M.get_parser(bufnr, lang)
-
   M.highlighter.new(parser)
-
-  vim.b[bufnr].ts_highlight = true
 end
 
 --- Stops treesitter highlighting for a buffer
@@ -343,8 +339,6 @@ function M.stop(bufnr)
   if M.highlighter.active[bufnr] then
     M.highlighter.active[bufnr]:destroy()
   end
-
-  vim.bo[bufnr].syntax = 'on'
 end
 
 return M

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -88,7 +88,9 @@ function TSHighlighter.new(tree, opts)
     end
   end
 
+  self.orig_syntax = vim.bo[self.bufnr].syntax
   vim.bo[self.bufnr].syntax = ''
+  vim.b[self.bufnr].ts_highlight = true
 
   TSHighlighter.active[self.bufnr] = self
 
@@ -114,6 +116,8 @@ function TSHighlighter:destroy()
   if TSHighlighter.active[self.bufnr] then
     TSHighlighter.active[self.bufnr] = nil
   end
+
+  vim.bo[self.bufnr].syntax = self.orig_syntax
 end
 
 ---@private

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -135,6 +135,15 @@ void buf_updates_unregister(buf_T *buf, uint64_t channelid)
   }
 }
 
+void buf_free_callbacks(buf_T *buf)
+{
+  kv_destroy(buf->update_channels);
+  for (size_t i = 0; i < kv_size(buf->update_callbacks); i++) {
+    buffer_update_callbacks_free(kv_A(buf->update_callbacks, i));
+  }
+  kv_destroy(buf->update_callbacks);
+}
+
 void buf_updates_unload(buf_T *buf, bool can_reload)
 {
   size_t size = kv_size(buf->update_channels);

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -11,6 +11,7 @@
 
 #include "nvim/api/extmark.h"
 #include "nvim/arglist.h"
+#include "nvim/buffer_updates.h"
 #include "nvim/context.h"
 #include "nvim/decoration_provider.h"
 #include "nvim/eval.h"
@@ -814,6 +815,11 @@ void free_all_mem(void)
     bufref_T bufref;
     set_bufref(&bufref, buf);
     nextbuf = buf->b_next;
+
+    // Since options (in addition to other stuff) have been freed above we need to ensure no
+    // callbacks are called, so free them before closing the buffer.
+    buf_free_callbacks(buf);
+
     close_buffer(NULL, buf, DOBUF_WIPE, false, false);
     // Didn't work, try next one.
     buf = bufref_valid(&bufref) ? nextbuf : firstbuf;


### PR DESCRIPTION
Backport of #21358
