### PR TITLE
vim-patch:9.0.1057: conflict between supercollider and scala filetype detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1097,11 +1097,10 @@ function M.sc(bufnr)
   for _, line in ipairs(getlines(bufnr, 1, 25)) do
     if
       findany(line, {
-        '[A-Za-z0-9]*%s:%s[A-Za-z0-9]',
         'var%s<',
         'classvar%s<',
         '%^this.*',
-        '|%w*|',
+        '|%w+|',
         '%+%s%w*%s{',
         '%*ar%s',
       })

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -1555,13 +1555,6 @@ endfunc
 func Test_sc_file()
   filetype on
 
-  " SC file methods are defined 'Class : Method'
-  call writefile(['SCNvimDocRenderer : SCDocHTMLRenderer {'], 'srcfile.sc')
-  split srcfile.sc
-  call assert_equal('supercollider', &filetype)
-  bwipe!
-  call delete('srcfile.sc')
-
   " SC classes are defined with '+ Class {}'
   call writefile(['+ SCNvim {', '*methodArgs {|method|'], 'srcfile.sc')
   split srcfile.sc


### PR DESCRIPTION
Problem:    Conflict between supercollider and scala filetype detection.
Solution:   Do not check for "Class : Method", it can appear in both
            filetypes. (Chris Kipp, closes vim/vim#11699)

https://github.com/vim/vim/commit/70ef3f546b6ef83e463e91b7e388d9c68ad58894

Co-authored-by: Chris Kipp <ckipp@pm.me>
