### PR TITLE
fix(lua): always return nil values in vim.tbl_get when no results

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -395,15 +395,14 @@ end
 function vim.tbl_get(o, ...)
   local keys = { ... }
   if #keys == 0 then
-    return
+    return nil
   end
   for i, k in ipairs(keys) do
-    if type(o[k]) ~= 'table' and next(keys, i) then
-      return nil
-    end
     o = o[k]
     if o == nil then
-      return
+      return nil
+    elseif type(o) ~= 'table' and next(keys, i) then
+      return nil
     end
   end
   return o

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -512,6 +512,8 @@ describe('lua stdlib', function()
     eq(NIL, exec_lua("return vim.tbl_get({ unindexable = function () end }, 'unindexable', 'missing_key')"))
     eq(NIL, exec_lua("return vim.tbl_get({}, 'missing_key')"))
     eq(NIL, exec_lua("return vim.tbl_get({})"))
+    eq(1, exec_lua("return select('#', vim.tbl_get({}))"))
+    eq(1, exec_lua("return select('#', vim.tbl_get({ nested = {} }, 'nested', 'missing_key'))"))
   end)
 
   it('vim.tbl_extend', function()


### PR DESCRIPTION
While `return` and `return nil` are for most intents and purposes
identical, there are situations where they're not. For example,
calculating the amount of values via the `select()` function will yield
varying results:

```lua
local function nothing() return     end
local function null()    return nil end

select('#', nothing()) -- 0
select('#', null())    -- 1
```

`vim.tbl_get` currently returns both nil and no results, which makes it
unreliable to use in certain situations without manually accounting for
these discrepancies.
