### PR TITLE
ci: add team reviewers

### DIFF
--- a/.github/scripts/remove-reviewers.js
+++ b/.github/scripts/remove-reviewers.js
@@ -6,11 +6,13 @@ module.exports = async ({github, context}) => {
   });
 
   const reviewers = requestedReviewers.data.users.map(e => e.login)
+  const team_reviewers = requestedReviewers.data.teams.map(e => e.name);
 
   github.rest.pulls.removeRequestedReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.issue.number,
-    reviewers: reviewers
+    reviewers: reviewers,
+    team_reviewers: team_reviewers
   });
 }

--- a/.github/scripts/reviews.js
+++ b/.github/scripts/reviews.js
@@ -7,6 +7,7 @@ module.exports = async ({github, context}) => {
   const labels = pr_data.data.labels.map(e => e.name)
 
   const reviewers = new Set()
+  const team_reviewers = new Array()
   if (labels.includes('api')) {
     reviewers.add("bfredl")
     reviewers.add("muniter")
@@ -18,9 +19,7 @@ module.exports = async ({github, context}) => {
   }
 
   if (labels.includes('ci')) {
-    reviewers.add("dundargoc")
-    reviewers.add("jamessan")
-    reviewers.add("justinmk")
+    team_reviewers.push('ci');
   }
 
   if (labels.includes('column')) {
@@ -58,8 +57,7 @@ module.exports = async ({github, context}) => {
   }
 
   if (labels.includes('lsp')) {
-    reviewers.add("glepnir")
-    reviewers.add("mfussenegger")
+    team_reviewers.push('lsp');
   }
 
   if (labels.includes('project-management')) {
@@ -76,9 +74,7 @@ module.exports = async ({github, context}) => {
   }
 
   if (labels.includes('treesitter')) {
-    reviewers.add("bfredl")
-    reviewers.add("clason")
-    reviewers.add("vigoux")
+    team_reviewers.push('treesitter');
   }
 
   if (labels.includes('typo')) {
@@ -102,6 +98,7 @@ module.exports = async ({github, context}) => {
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.issue.number,
-    reviewers: Array.from(reviewers)
+    reviewers: Array.from(reviewers),
+    team_reviewers: team_reviewers
   });
 }

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -13,6 +13,7 @@ jobs:
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/reviews.js')
             await script({github, context})

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -44,6 +44,7 @@ jobs:
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/reviews.js')
             await script({github, context})

--- a/.github/workflows/remove-reviewers.yml
+++ b/.github/workflows/remove-reviewers.yml
@@ -12,6 +12,7 @@ jobs:
       - name: 'Remove reviewers'
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/remove-reviewers.js')
             await script({github, context})


### PR DESCRIPTION
Using team reviewers when possible reduces the churn on the git history
as we'll be able to add or remove reviewers without needing to change
the workflow files.

This requires using Github fine-grained personal access tokens with Pull
Requests set to "Read and write" and Members to "Read-only".
