### PR TITLE
build(treesitter): remove TS_HAS_SET_MATCH_LIMIT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,19 +441,6 @@ include_directories(SYSTEM ${TreeSitter_INCLUDE_DIRS})
 
 list(APPEND CMAKE_REQUIRED_INCLUDES "${TreeSitter_INCLUDE_DIRS}")
 list(APPEND CMAKE_REQUIRED_LIBRARIES "${TreeSitter_LIBRARIES}")
-check_c_source_compiles("
-#include <stdlib.h>
-#include <tree_sitter/api.h>
-int
-main(void)
-{
-  ts_set_allocator(malloc, calloc, realloc, free);
-  return 0;
-}
-" TS_HAS_SET_ALLOCATOR)
-if(TS_HAS_SET_ALLOCATOR)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNVIM_TS_HAS_SET_ALLOCATOR")
-endif()
 
 # The unit test lib requires LuaJIT; it will be skipped if LuaJIT is missing.
 option(PREFER_LUA "Prefer Lua over LuaJIT in the nvim executable." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,19 +442,6 @@ include_directories(SYSTEM ${TreeSitter_INCLUDE_DIRS})
 list(APPEND CMAKE_REQUIRED_INCLUDES "${TreeSitter_INCLUDE_DIRS}")
 list(APPEND CMAKE_REQUIRED_LIBRARIES "${TreeSitter_LIBRARIES}")
 check_c_source_compiles("
-#include <tree_sitter/api.h>
-int
-main(void)
-{
-  TSQueryCursor *cursor = ts_query_cursor_new();
-  ts_query_cursor_set_match_limit(cursor, 32);
-  return 0;
-}
-" TS_HAS_SET_MATCH_LIMIT)
-if(TS_HAS_SET_MATCH_LIMIT)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DNVIM_TS_HAS_SET_MATCH_LIMIT")
-endif()
-check_c_source_compiles("
 #include <stdlib.h>
 #include <tree_sitter/api.h>
 int

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1213,11 +1213,7 @@ static int node_rawquery(lua_State *L)
   } else {
     cursor = ts_query_cursor_new();
   }
-  // TODO(clason): API introduced after tree-sitter release 0.19.5
-  // remove guard when minimum ts version is bumped to 0.19.6+
-#ifdef NVIM_TS_HAS_SET_MATCH_LIMIT
   ts_query_cursor_set_match_limit(cursor, 64);
-#endif
   ts_query_cursor_exec(cursor, query, node);
 
   bool captures = lua_toboolean(L, 3);

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -145,9 +145,7 @@ void tslua_init(lua_State *L)
   build_meta(L, TS_META_QUERYCURSOR, querycursor_meta);
   build_meta(L, TS_META_TREECURSOR, treecursor_meta);
 
-#ifdef NVIM_TS_HAS_SET_ALLOCATOR
   ts_set_allocator(xmalloc, xcalloc, xrealloc, xfree);
-#endif
 }
 
 int tslua_has_language(lua_State *L)


### PR DESCRIPTION
Can tree-sitter 0.19.6+ can be required now?

Following what @clason commands me to do while reading the source code 

Same for allocator?