### PR TITLE
feat(exrc): support .nvim.lua

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -98,6 +98,7 @@ CHANGED FEATURES                                                 *news-changes*
 
 The following changes to existing APIs or features add new behavior.
 
+• 'exrc' now supports `.nvim.lua` file.
 • 'exrc' is no longer marked deprecated.
 
 ==============================================================================

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2267,7 +2267,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'exrc'* *'ex'* *'noexrc'* *'noex'*
 'exrc' 'ex'		boolean (default off)
 			global
-	Enables the reading of .nvimrc and .exrc files in the current
+	Enables the reading of .nvim.lua, .nvimrc, and .exrc files in the current
 	directory.
 
 	The file is only sourced if the user indicates the file is trusted. If

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -698,7 +698,7 @@ Short explanation of each option:		*option-list*
 'errorformat'	  'efm'     description of the lines in the error file
 'eventignore'	  'ei'	    autocommand events that are ignored
 'expandtab'	  'et'	    use spaces when <Tab> is inserted
-'exrc'		  'ex'	    read .nvimrc and .exrc in the current directory
+'exrc'		  'ex'	    read init files in the current directory
 'fileencoding'	  'fenc'    file encoding for multibyte text
 'fileencodings'   'fencs'   automatically detected character encodings
 'fileformat'	  'ff'	    file format used for file I/O

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -453,10 +453,11 @@ accordingly, proceeding as follows:
 	set or when using $VIMINIT.
 
      c. If the 'exrc' option is on (which is NOT the default), the current
-	directory is searched for two files.  The first that exists is used,
-	the others are ignored.
-	-  The file ".nvimrc"
-	-  The file ".exrc"
+	directory is searched for the following files, in order of precedence:
+	- ".nvim.lua"
+	- ".nvimrc"
+	- ".exrc"
+	The first that exists is used, the others are ignored.
 
 8. Enable filetype detection.
 	This does the same as the command: >

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -434,8 +434,8 @@ Options:
   'jumpoptions' "view" tries to restore the |mark-view| when moving through
   the |jumplist|, |changelist|, |alternate-file| or using |mark-motions|.
   'shortmess' the "F" flag does not affect output from autocommands
-  'exrc' searches for ".nvimrc" or ".exrc" files. The user is prompted whether
-  to trust the file.
+  'exrc' searches for ".nvim.lua", ".nvimrc", or ".exrc" files. The user is
+  prompted whether to trust the file.
 
 Shell:
   Shell output (|:!|, |:make|, …) is always routed through the UI, so it

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -75,6 +75,10 @@
 # define VIMRC_FILE     ".nvimrc"
 #endif
 
+#ifndef VIMRC_LUA_FILE
+# define VIMRC_LUA_FILE ".nvim.lua"
+#endif
+
 EXTERN struct nvim_stats_s {
   int64_t fsync;
   int64_t redraw;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1987,6 +1987,29 @@ static bool do_user_initialization(void)
   return do_exrc;
 }
 
+// Read initialization commands from ".nvimrc" or ".exrc" in current
+// directory.  This is only done if the 'exrc' option is set.
+// Only do this if VIMRC_FILE is not the same as vimrc file sourced in
+// do_user_initialization.
+static void do_exrc_initialization(void)
+{
+  char *str;
+
+  if (os_path_exists(VIMRC_FILE)) {
+    str = nlua_read_secure(VIMRC_FILE);
+    if (str != NULL) {
+      do_source_str(str, VIMRC_FILE);
+      xfree(str);
+    }
+  } else if (os_path_exists(EXRC_FILE)) {
+    str = nlua_read_secure(EXRC_FILE);
+    if (str != NULL) {
+      do_source_str(str, EXRC_FILE);
+      xfree(str);
+    }
+  }
+}
+
 /// Source startup scripts
 static void source_startup_scripts(const mparm_T *const parmp)
   FUNC_ATTR_NONNULL_ALL
@@ -2005,21 +2028,7 @@ static void source_startup_scripts(const mparm_T *const parmp)
     do_system_initialization();
 
     if (do_user_initialization()) {
-      // Read initialization commands from ".nvimrc" or ".exrc" in current
-      // directory.  This is only done if the 'exrc' option is set.
-      // Only do this if VIMRC_FILE is not the same as vimrc file sourced in
-      // do_user_initialization.
-      char *str = nlua_read_secure(VIMRC_FILE);
-      if (str != NULL) {
-        do_source_str(str, VIMRC_FILE);
-        xfree(str);
-      } else {
-        str = nlua_read_secure(EXRC_FILE);
-        if (str != NULL) {
-          do_source_str(str, EXRC_FILE);
-          xfree(str);
-        }
-      }
+      do_exrc_initialization();
     }
   }
   TIME_MSG("sourcing vimrc file(s)");


### PR DESCRIPTION
- Use the first exrc file found and ignore the rest (as mentioned in `runtime/doc/starting.txt`). This behavior was changed in https://github.com/neovim/neovim/pull/20956 (if the first found file is not trusted, it would try the next one).
- Support `.nvim.lua`