### PR TITLE
refactor(params): open -s and -w script files after parsing commands

### DIFF
--- a/src/nvim/main.h
+++ b/src/nvim/main.h
@@ -42,6 +42,9 @@ typedef struct {
   char *listen_addr;                    // --listen {address}
   int remote;                           // --remote-[subcmd] {file1} {file2}
   char *server_addr;                    // --server {address}
+  char *scriptin;                       // -s {filename}
+  char *scriptout;                      // -w/-W {filename}
+  bool scriptout_append;                // append (-w) instead of overwrite (-W)
 } mparm_T;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS


### PR DESCRIPTION
This will be needed for #18375 as only the server should open the scriptfile, and redirected stdin fd will need to be used.

Also executing actions in the middle of `command_line_scan()` is cringe.