### PR TITLE
refactor(tui): use nvim_echo() for verbose terminfo

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -717,7 +717,7 @@ nvim_del_var({name})                                          *nvim_del_var()*
     Parameters: ~
       • {name}  Variable name
 
-nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
+nvim_echo({chunks}, {history}, {*opts})                          *nvim_echo()*
     Echo a message.
 
     Parameters: ~
@@ -725,7 +725,11 @@ nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
                    chunk with specified highlight. `hl_group` element can be
                    omitted for no highlight.
       • {history}  if true, add to |message-history|.
-      • {opts}     Optional parameters. Reserved for future use.
+      • {opts}     Optional parameters.
+                   • verbose: Message was printed as a result of 'verbose'
+                     option if Nvim was invoked with -V3log_file, the message
+                     will be redirected to the log_file and surpressed from
+                     direct output.
 
 nvim_err_write({str})                                       *nvim_err_write()*
     Writes a message to the Vim error buffer. Does not append "\n", the

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -219,5 +219,8 @@ return {
   cmd_opts = {
     "output";
   };
+  echo_opts = {
+    "verbose";
+  };
 }
 

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -418,6 +418,22 @@ char *transstr(const char *const s, bool untab)
   return buf;
 }
 
+size_t kv_transstr(StringBuilder *str, const char *const s, bool untab)
+  FUNC_ATTR_NONNULL_ARG(1)
+{
+  if (!s) {
+    return 0;
+  }
+
+  // Compute the length of the result, taking account of unprintable
+  // multi-byte characters.
+  const size_t len = transstr_len(s, untab);
+  kv_ensure_space(*str, len + 1);
+  transstr_buf(s, str->items + str->size, len + 1, untab);
+  str->size += len;  // do not include NUL byte
+  return len;
+}
+
 /// Convert the string "str[orglen]" to do ignore-case comparing.
 /// Use the current locale.
 ///

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -7,6 +7,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/option_defs.h"
 #include "nvim/pos.h"
+#include "nvim/strings.h"
 #include "nvim/types.h"
 
 /// Return the folded-case equivalent of the given character

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2690,7 +2690,7 @@ return {
       full_name='verbose', abbreviation='vbs',
       short_desc=N_("give informative messages"),
       type='number', scope={'global'},
-      varname='p_verbose',
+      varname='p_verbose', redraw={'ui_option'},
       defaults={if_true=0}
     },
     {

--- a/src/nvim/tui/terminfo.h
+++ b/src/nvim/tui/terminfo.h
@@ -3,6 +3,8 @@
 
 #include <unibilium.h>
 
+#include "nvim/api/private/defs.h"
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "tui/terminfo.h.generated.h"
 #endif

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -24,6 +24,7 @@ describe('UI receives option updates', function()
       termguicolors=false,
       ttimeout=true,
       ttimeoutlen=50,
+      verbose=0,
       ext_cmdline=false,
       ext_popupmenu=false,
       ext_tabline=false,


### PR DESCRIPTION
This is needed for #18375 for the obvious reasons. note: verbose_terminfo_event is only temporarily needed until the full TUI process refactor is merged.