### PR TITLE
vim-patch:8.2.{1208,1209,1210}: using ht_used when looping through a hashtab is less reliable

### DIFF
--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -223,6 +223,7 @@ int hash_add(hashtab_T *ht, char *key)
 void hash_add_item(hashtab_T *ht, hashitem_T *hi, char_u *key, hash_T hash)
 {
   ht->ht_used++;
+  ht->ht_changed++;
   if (hi->hi_key == NULL) {
     ht->ht_filled++;
   }
@@ -242,6 +243,7 @@ void hash_add_item(hashtab_T *ht, hashitem_T *hi, char_u *key, hash_T hash)
 void hash_remove(hashtab_T *ht, hashitem_T *hi)
 {
   ht->ht_used--;
+  ht->ht_changed++;
   hi->hi_key = HI_KEY_REMOVED;
   hash_may_resize(ht, 0);
 }
@@ -384,6 +386,7 @@ static void hash_may_resize(hashtab_T *ht, size_t minitems)
   ht->ht_array = newarray;
   ht->ht_mask = newmask;
   ht->ht_filled = ht->ht_used;
+  ht->ht_changed++;
 }
 
 #define HASH_CYCLE_BODY(hash, p) \

--- a/src/nvim/hashtab.h
+++ b/src/nvim/hashtab.h
@@ -61,14 +61,15 @@ typedef struct hashitem_S {
 ///
 /// The hashtable grows to accommodate more entries when needed.
 typedef struct hashtable_S {
-  hash_T ht_mask;               /// mask used for hash value
-                                /// (nr of items in array is "ht_mask" + 1)
-  size_t ht_used;               /// number of items used
-  size_t ht_filled;             /// number of items used or removed
-  int ht_locked;                /// counter for hash_lock()
-  hashitem_T *ht_array;         /// points to the array, allocated when it's
-                                /// not "ht_smallarray"
-  hashitem_T ht_smallarray[HT_INIT_SIZE];      /// initial array
+  hash_T ht_mask;               ///< mask used for hash value
+                                ///< (nr of items in array is "ht_mask" + 1)
+  size_t ht_used;               ///< number of items used
+  size_t ht_filled;             ///< number of items used or removed
+  int ht_changed;               ///< incremented when adding or removing an item
+  int ht_locked;                ///< counter for hash_lock()
+  hashitem_T *ht_array;         ///< points to the array, allocated when it's
+                                ///< not "ht_smallarray"
+  hashitem_T ht_smallarray[HT_INIT_SIZE];      ///< initial array
 } hashtab_T;
 
 /// Iterate over a hashtab


### PR DESCRIPTION
#### vim-patch:8.2.1210: using ht_used when looping through a hashtab is less reliable

Problem:    Using ht_used when looping through a hashtab is less reliable.
Solution:   Use ht_changed in a few more places.

https://github.com/vim/vim/commit/1f22cc5cdb2da867d6bbf54dd371f279c38a2f56

Co-authored-by: Bram Moolenaar <Bram@vim.org>