### PR TITLE
fix(diagnostic): clear stale cache on reset

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -922,7 +922,7 @@ M.handlers.signs = {
   end,
   hide = function(namespace, bufnr)
     local ns = M.get_namespace(namespace)
-    if ns.user_data.sign_group then
+    if ns.user_data.sign_group and api.nvim_buf_is_valid(bufnr) then
       vim.fn.sign_unplace(ns.user_data.sign_group, { buffer = bufnr })
     end
   end,
@@ -977,7 +977,9 @@ M.handlers.underline = {
     local ns = M.get_namespace(namespace)
     if ns.user_data.underline_ns then
       diagnostic_cache_extmarks[bufnr][ns.user_data.underline_ns] = {}
-      api.nvim_buf_clear_namespace(bufnr, ns.user_data.underline_ns, 0, -1)
+      if api.nvim_buf_is_valid(bufnr) then
+        api.nvim_buf_clear_namespace(bufnr, ns.user_data.underline_ns, 0, -1)
+      end
     end
   end,
 }
@@ -1040,7 +1042,9 @@ M.handlers.virtual_text = {
     local ns = M.get_namespace(namespace)
     if ns.user_data.virt_text_ns then
       diagnostic_cache_extmarks[bufnr][ns.user_data.virt_text_ns] = {}
-      api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_text_ns, 0, -1)
+      if api.nvim_buf_is_valid(bufnr) then
+        api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_text_ns, 0, -1)
+      end
     end
   end,
 }
@@ -1470,11 +1474,15 @@ function M.reset(namespace, bufnr)
       M.hide(iter_namespace, iter_bufnr)
     end
 
-    api.nvim_exec_autocmds('DiagnosticChanged', {
-      modeline = false,
-      buffer = iter_bufnr,
-      data = { diagnostics = {} },
-    })
+    if api.nvim_buf_is_valid(iter_bufnr) then
+      api.nvim_exec_autocmds('DiagnosticChanged', {
+        modeline = false,
+        buffer = iter_bufnr,
+        data = { diagnostics = {} },
+      })
+    else
+      diagnostic_cache[iter_bufnr] = nil
+    end
   end
 end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -160,6 +160,24 @@ describe('vim.diagnostic', function()
     ]])
   end)
 
+  it('removes diagnostic from stale cache on reset', function()
+    local diagnostics = exec_lua [[
+      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
+        make_error('Diagnostic #1', 1, 1, 1, 1),
+        make_error('Diagnostic #2', 2, 1, 2, 1),
+      })
+      local other_bufnr = vim.fn.bufadd('test | test')
+      vim.cmd('noautocmd bwipeout! ' .. diagnostic_bufnr)
+      return vim.diagnostic.get(diagnostic_bufnr)
+    ]]
+    eq(2, #diagnostics)
+    diagnostics = exec_lua [[
+      vim.diagnostic.reset()
+      return vim.diagnostic.get()
+    ]]
+    eq(0, #diagnostics)
+  end)
+
   it('resolves buffer number 0 to the current buffer', function()
     eq(2, exec_lua [[
       vim.api.nvim_set_current_buf(diagnostic_bufnr)


### PR DESCRIPTION
The BufWipeout autocmd is not 100% reliable and may leave stale entries
in the cache. This is sort of a hack/workaround to ensure
`vim.diagnostic.reset` calls don't fail if there are stale cache entries
but instead clears them

Fixes errors like

    Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/diagnostic.lua:1458: Invalid buffer id: 22
    stack traceback:
            [C]: in function 'nvim_exec_autocmds'
            /usr/share/nvim/runtime/lua/vim/diagnostic.lua:1458: in function 'reset'


---

Happy to get pointed to a better solution. We discussed something like a
`on_delete` hook for `nvim_buf_attach` in chat that's like BufWipeout except
reliable, but maybe this is good enough in the meantime.
