### PR TITLE
fix(lsp): token_edit.data might be null on deletion

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -323,7 +323,9 @@ function STHighlighter:process_response(response, client, version)
     local idx = 1
     for _, token_edit in ipairs(token_edits) do
       vim.list_extend(tokens, old_tokens, idx, token_edit.start)
-      vim.list_extend(tokens, token_edit.data)
+      if token_edit.data then
+        vim.list_extend(tokens, token_edit.data)
+      end
       idx = token_edit.start + token_edit.deleteCount + 1
     end
     vim.list_extend(tokens, old_tokens, idx)

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -1109,7 +1109,36 @@ int main()
             extmark_added = true,
           }
         },
-      }
+      },
+      {
+        it = 'optional token_edit.data on deletion',
+        legend = [[{
+          "tokenTypes": [
+            "comment", "keyword", "operator", "string", "number", "regexp", "type", "class", "interface", "enum", "enumMember", "typeParameter", "function", "method", "property", "variable", "parameter", "module", "intrinsic", "selfParameter", "clsParameter", "magicFunction", "builtinConstant", "parenthesis", "curlybrace", "bracket", "colon", "semicolon", "arrow"
+          ],
+          "tokenModifiers": [
+            "declaration", "static", "abstract", "async", "documentation", "typeHint", "typeHintComment", "readonly", "decorator", "builtin"
+          ]
+        }]],
+        text1 = [[string = "test"]],
+        text2 = [[]],
+        response1 = [[{"data": [0, 0, 6, 15, 1], "resultId": "1"}]],
+        response2 = [[{"edits": [{ "start": 0, "deleteCount": 5 }], "resultId": "2"}]],
+        expected1 = {
+          {
+            line = 0,
+            modifiers = {
+              'declaration',
+            },
+            start_col = 0,
+            end_col = 6,
+            type = 'variable',
+            extmark_added = true,
+          }
+        },
+        expected2 = {
+        },
+      },
     }) do
       it(test.it, function()
         exec_lua(create_server_definition)


### PR DESCRIPTION
While using a private python lsp server, it was giving this error on text deletion:
```
Error executing vim.schedule lua callback: vim/shared.lua:0: src: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'list_extend'
        ...local/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:328: in function 'process_response'
        ...local/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:269: in function 'handler'
        /usr/local/share/nvim/runtime/lua/vim/lsp.lua:1391: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
This happened because `token_edit` was:
```lua
{
  deleteCount = 5,
  start = 5
}
```

Therefore, conditionally extending the list only when `token_edit.data` is not null fixes the issue.
This server is correctly handled by [nvim-semantic-tokens](https://github.com/theHamsta/nvim-semantic-tokens/).