### PR TITLE
docs: fix extmark api example

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2545,7 +2545,7 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
       -- Create new extmark at line 1, column 1.
       local m1  = a.nvim_buf_set_extmark(0, ns, 0, 0, {})
       -- Create new extmark at line 3, column 1.
-      local m2  = a.nvim_buf_set_extmark(0, ns, 0, 2, {})
+      local m2  = a.nvim_buf_set_extmark(0, ns, 2, 0, {})
       -- Get extmarks only from line 3.
       local ms  = a.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
       -- Get all marks in this buffer + namespace.

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -271,7 +271,7 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
 ///   -- Create new extmark at line 1, column 1.
 ///   local m1  = a.nvim_buf_set_extmark(0, ns, 0, 0, {})
 ///   -- Create new extmark at line 3, column 1.
-///   local m2  = a.nvim_buf_set_extmark(0, ns, 0, 2, {})
+///   local m2  = a.nvim_buf_set_extmark(0, ns, 2, 0, {})
 ///   -- Get extmarks only from line 3.
 ///   local ms  = a.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
 ///   -- Get all marks in this buffer + namespace.


### PR DESCRIPTION
I think there's a small typo in the extmark api docs for `nvim_buf_get_extmarks`, the line and col numbers don't match.

Here's the examples:

before:

it prints:
```
{}
```

after:

it prints:
```
{ { 6, 2, 0 } }
```