### PR TITLE
vim-patch:9.0.{1078,1079}

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -378,7 +378,7 @@ int get_indent_lnum(linenr_T lnum)
 int get_indent_buf(buf_T *buf, linenr_T lnum)
 {
   return get_indent_str_vtab(ml_get_buf(buf, lnum, false),
-                             curbuf->b_p_ts,
+                             buf->b_p_ts,
                              buf->b_p_vts_array,
                              false);
 }

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -157,6 +157,27 @@ func Test_indent_fold_max()
   bw!
 endfunc
 
+func Test_indent_fold_tabstop()
+  call setline(1, ['0', '    1', '    1', "\t2", "\t2"])
+  setlocal shiftwidth=4
+  setlocal foldcolumn=1
+  setlocal foldlevel=2
+  setlocal foldmethod=indent
+  redraw
+  call assert_equal('2        2', ScreenLines(5, 10)[0])
+  vsplit
+  windo diffthis
+  botright new
+  " This 'tabstop' value should not be used for folding in other buffers.
+  setlocal tabstop=4
+  diffoff!
+  redraw
+  call assert_equal('2        2', ScreenLines(5, 10)[0])
+
+  bwipe!
+  bwipe!
+endfunc
+
 func Test_manual_fold_with_filter()
   CheckExecutable cat
   for type in ['manual', 'marker']

--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -323,6 +323,11 @@ func Test_CmdErrors()
   call assert_fails('com DoCmd :', 'E174:')
   comclear
   call assert_fails('delcom DoCmd', 'E184:')
+
+  " These used to leak memory
+  call assert_fails('com! -complete=custom,CustomComplete _ :', 'E182:')
+  call assert_fails('com! -complete=custom,CustomComplete docmd :', 'E183:')
+  call assert_fails('com! -complete=custom,CustomComplete -xxx DoCmd :', 'E181:')
 endfunc
 
 func CustomComplete(A, L, P)

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -943,7 +943,7 @@ void ex_command(exarg_T *eap)
     end = skiptowhite(p);
     if (uc_scan_attr(p, (size_t)(end - p), &argt, &def, &flags, &compl, (char_u **)&compl_arg,
                      &addr_type_arg) == FAIL) {
-      return;
+      goto theend;
     }
     p = skipwhite(end);
   }
@@ -953,7 +953,7 @@ void ex_command(exarg_T *eap)
   end = uc_validate_name(name);
   if (!end) {
     emsg(_("E182: Invalid command name"));
-    return;
+    goto theend;
   }
   name_len = (size_t)(end - name);
 
@@ -971,7 +971,12 @@ void ex_command(exarg_T *eap)
   } else {
     uc_add_command(name, name_len, p, argt, def, flags, compl, compl_arg, LUA_NOREF, LUA_NOREF,
                    addr_type_arg, LUA_NOREF, eap->forceit);
+
+    return;  // success
   }
+
+theend:
+  xfree(compl_arg);
 }
 
 /// ":comclear"


### PR DESCRIPTION
Fix #21470

#### vim-patch:9.0.1078: with the +vartabs feature indent folding may use wrong 'ts'

Problem:    With the +vartabs feature indent folding may use wrong 'tabstop'.
Solution:   Use the "buf" argument instead of "curbuf".

https://github.com/vim/vim/commit/07146ad1d33ba0d36b324873e5c461931e6b025e


#### vim-patch:9.0.1079: leaking memory when defining a user command fails

Problem:    Leaking memory when defining a user command fails.
Solution:   Free "compl_arg" when needed. (closes vim/vim#11726)

https://github.com/vim/vim/commit/33e543038b84af7557ab9ecff500fc4ab98dd2a3