### PR TITLE
ci: remove needs:response label if author responds

### DIFF
--- a/.github/scripts/unstale.js
+++ b/.github/scripts/unstale.js
@@ -1,0 +1,19 @@
+module.exports = async ({ github, context }) => {
+  const commenter = context.actor;
+  const issue = await github.rest.issues.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+  });
+  const author = issue.data.user.login;
+  const labels = issue.data.labels.map((e) => e.name);
+
+  if (author === commenter && labels.includes("needs:response")) {
+    github.rest.issues.removeLabel({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: context.issue.number,
+      name: "needs:response",
+    });
+  }
+};

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -3,9 +3,11 @@ on:
   schedule:
     - cron: '30 1 * * *' # Run every day at 01:30
   workflow_dispatch:
+  issue_comment:
 
 jobs:
-  stale:
+  close:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -24,3 +26,17 @@ jobs:
           close-pr-message: "This PR has been closed since a request for
             changes has not been answered for 30 days. It can be reopened when
             the requested changes are provided."
+
+  remove-label:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/unstale.js')
+            await script({github, context})


### PR DESCRIPTION
The default behavior of the stale action is to indiscriminately remove
the `needs:response` label for any activity whatsoever, from anyone. The
other option is to turn it off completely, meaning the maintainers needs
to manually remove the label themselves when the author responds for an
issue to not close automatically. Neither of these behaviors are useful
to us.