### PR TITLE
[Backport release-0.8] fix(decoration): do not reset must_redraw after calling providers

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1002,9 +1002,6 @@ static void draw_sep_connectors_win(win_T *wp)
 /// bot: from bot_start to last row (when scrolled up)
 static void win_update(win_T *wp, DecorProviders *providers)
 {
-  bool called_decor_providers = false;
-win_update_start:
-  ;
   buf_T *buf = wp->w_buffer;
   int type;
   int top_end = 0;              // Below last row of the top area that needs
@@ -1082,13 +1079,6 @@ win_update_start:
 
   DecorProviders line_providers;
   decor_providers_invoke_win(wp, providers, &line_providers, &provider_err);
-  if (must_redraw != 0) {
-    must_redraw = 0;
-    if (!called_decor_providers) {
-      called_decor_providers = true;
-      goto win_update_start;
-    }
-  }
 
   redraw_win_signcol(wp);
 


### PR DESCRIPTION
Resetting must_redraw caused a strange bug #21278.
Remove the goto as well, as it doesn't make much sense after #20665.