### PR TITLE
vim-patch:9.0.1089: unnecessary assignment

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -281,7 +281,6 @@ int ml_open(buf_T *buf)
   buf->b_ml.ml_mfp = mfp;
   buf->b_ml.ml_flags = ML_EMPTY;
   buf->b_ml.ml_line_count = 1;
-  curwin->w_nrwidth_line_count = 0;
 
   // fill block0 struct and write page 0
   hp = mf_new(mfp, false, 1);


### PR DESCRIPTION
**vim-patch:9.0.1089: unnecessary assignment**

Problem:    unnecessary assignment
Solution:   Remove the assignment. (Luuk van Baal, closes vim/vim#11736)

https://github.com/vim/vim/commit/c53e7904b9ac559c7ad6e3acb136027d10aed54e