### PR TITLE
ci: don't use asan_symbolize for the ASAN job

### DIFF
--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -30,7 +30,6 @@ case "$FLAVOR" in
     BUILD_FLAGS="$BUILD_FLAGS -DPREFER_LUA=ON"
     cat <<EOF >> "$GITHUB_ENV"
 CLANG_SANITIZER=ASAN_UBSAN
-SYMBOLIZER=asan_symbolize-14
 ASAN_OPTIONS=detect_leaks=1:check_initialization_order=1:log_path=$GITHUB_WORKSPACE/build/log/asan:intercept_tls_get_addr=0
 UBSAN_OPTIONS=print_stacktrace=1 log_path=$GITHUB_WORKSPACE/build/log/ubsan
 EOF


### PR DESCRIPTION
asan_symbolize-14 gives a deprecation as it relies on outdated python
features. We can safely stop using asan_symbolize as it's only needed
for special cases such as cross compilation which we don't have to worry
about.
