### PR TITLE
vim-patch:8.2.5142: startup test fails if there is a status bar

### DIFF
--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -520,7 +520,9 @@ func Test_geometry()
       call writefile([&columns, &lines, getwinposx(), getwinposy(), string(getwinpos())], "Xtest_geometry")
       qall
     [CODE]
-    if RunVim([], after, '-f -g -geometry 31x13+41+43')
+    " Some window managers have a bar at the top that pushes windows down,
+    " need to use at least 130, let's do 150
+    if RunVim([], after, '-f -g -geometry 31x13+41+150')
       let lines = readfile('Xtest_geometry')
       " Depending on the GUI library and the windowing system the final size
       " might be a bit different, allow for some tolerance.  Tuned based on
@@ -528,8 +530,8 @@ func Test_geometry()
       call assert_inrange(31, 35, str2nr(lines[0]))
       call assert_equal('13', lines[1])
       call assert_equal('41', lines[2])
-      call assert_equal('43', lines[3])
-      call assert_equal('[41, 43]', lines[4])
+      call assert_equal('150', lines[3])
+      call assert_equal('[41, 150]', lines[4])
     endif
   endif
 


### PR DESCRIPTION
#### vim-patch:8.2.5142: startup test fails if there is a status bar

Problem:    Startup test fails if there is a status bar at the top of the
            screen. (Ernie Rael)
Solution:   Use a larger vertical offset in the test.

https://github.com/vim/vim/commit/fa04eae5a5b9394079bde2d37ce6f9f8a5567d48

Co-authored-by: Bram Moolenaar <Bram@vim.org>