### PR TITLE
fix(fs): prevent duplicate slash when find match is in root (#21497)

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -147,6 +147,7 @@ function M.find(names, opts)
     end
   end
 
+  ---@private
   local function join(dir, name)
     if dir:match('/$') then
       return '/' .. name

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -147,6 +147,14 @@ function M.find(names, opts)
     end
   end
 
+  local function join(dir, name)
+    if dir:match('/$') then
+      return '/' .. name
+    else
+      return dir .. '/' .. name
+    end
+  end
+
   if opts.upward then
     local test
 
@@ -155,7 +163,7 @@ function M.find(names, opts)
         local t = {}
         for name, type in M.dir(p) do
           if names(name) and (not opts.type or opts.type == type) then
-            table.insert(t, p .. '/' .. name)
+            table.insert(t, join(p, name))
           end
         end
         return t
@@ -164,7 +172,7 @@ function M.find(names, opts)
       test = function(p)
         local t = {}
         for _, name in ipairs(names) do
-          local f = p .. '/' .. name
+          local f = join(p, name)
           local stat = vim.loop.fs_stat(f)
           if stat and (not opts.type or opts.type == stat.type) then
             t[#t + 1] = f
@@ -201,7 +209,7 @@ function M.find(names, opts)
       end
 
       for other, type_ in M.dir(dir) do
-        local f = dir .. '/' .. other
+        local f = join(dir, other)
         if type(names) == 'function' then
           if names(other) and (not opts.type or opts.type == type_) then
             if add(f) then

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -153,6 +153,10 @@ describe('vim.fs', function()
         local dir, nvim = ...
         return vim.fs.find(nvim, { path = dir, type = 'file' })
       ]], test_build_dir, nvim_prog_basename))
+      eq({'/tmp'}, exec_lua([[
+        local dir = ...
+        return vim.fs.find('tmp', { path = dir, upward = true, type = 'directory' })
+      ]], nvim_dir))
     end)
 
     it('accepts predicate as names', function()


### PR DESCRIPTION
I really don't like the test, and am definitely open to suggestions. However, the bug is around finding a path in the root of the filesystem. I chose `/tmp` as I believe it to be valid and accessible on any OS other than windows. I'm not sure if you have an expectation that tests can pass on windows, or if only the CI environment is necessary.