### PR TITLE
ci: bump api-docs runner to ubuntu-latest

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   regen-api-docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
This was set explicitly to ubuntu.22.04 as ubuntu-latest pointed to
ubuntu.20.04, and we needed 22.04 to have a new enough doxygen version
for this job to work. Now that ubuntu-latest points to 22.04 this
workaround is no longer needed.
