### PR TITLE
feat(lsp): add function to clear codelens

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1278,6 +1278,13 @@ on_publish_diagnostics({_}, {result}, {ctx}, {config})
 ==============================================================================
 Lua module: vim.lsp.codelens                                    *lsp-codelens*
 
+clear({client_id}, {bufnr})                         *vim.lsp.codelens.clear()*
+    Clear the lenses
+
+    Parameters: ~
+      • {client_id}  (number|nil) filter by client_id. All clients if nil
+      • {bufnr}      (number|nil) filter by buffer. All buffers if nil
+
 display({lenses}, {bufnr}, {client_id})           *vim.lsp.codelens.display()*
     Display the lenses using virtual text
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -39,6 +39,8 @@ NEW FEATURES                                                    *news-features*
 
 The following new APIs or features were added.
 
+• Added a |vim.lsp.codelens.clear()| function to clear codelenses.
+
 • |vim.inspect_pos()|, |vim.show_pos()| and |:Inspect| allow a user to get or show items
   at a given buffer postion. Currently this includes treesitter captures,
   semantic tokens, syntax groups and extmarks.

--- a/test/functional/plugin/lsp/codelens_spec.lua
+++ b/test/functional/plugin/lsp/codelens_spec.lua
@@ -58,6 +58,41 @@ describe('vim.lsp.codelens', function()
     ]], bufnr)
 
     eq({[1] = {'Lens1', 'LspCodeLens'}}, virtual_text_chunks)
+  end)
 
+  it('can clear all lens', function()
+    local fake_uri = "file:///fake/uri"
+    local bufnr = exec_lua([[
+      fake_uri = ...
+      local bufnr = vim.uri_to_bufnr(fake_uri)
+      local lines = {'So', 'many', 'lines'}
+      vim.fn.bufload(bufnr)
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+      return bufnr
+    ]], fake_uri)
+
+    exec_lua([[
+      local bufnr = ...
+      local lenses = {
+        {
+          range = {
+            start = { line = 0, character = 0, },
+            ['end'] = { line = 0, character = 0 }
+          },
+          command = { title = 'Lens1', command = 'Dummy' }
+        },
+      }
+      vim.lsp.codelens.on_codelens(nil, lenses, {method='textDocument/codeLens', client_id=1, bufnr=bufnr})
+    ]], bufnr)
+
+    local stored_lenses = exec_lua('return vim.lsp.codelens.get(...)', bufnr)
+    eq(1, #stored_lenses)
+
+    exec_lua([[
+      vim.lsp.codelens.clear()
+    ]])
+
+    stored_lenses = exec_lua('return vim.lsp.codelens.get(...)', bufnr)
+    eq(0, #stored_lenses)
   end)
 end)


### PR DESCRIPTION
Currently once you retrieve the lenses you're pretty much stuck with
them as saving new lenses is additive.

Adding a dedicated method to reset lenses allows users to toggle lenses
on/off which can be useful for language servers where they are noisy or
expensive and you only want to see them temporary.


---

~I used `reset` to mirror `vim.diagnostic.reset`, but in the api module there's usually `clear` used for the same purpose. I am not sure which one is preferred?~ Going with `clear`. It has more uses.
