### PR TITLE
fix(fs): prevent duplicate path separator (#21497)

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -74,7 +74,11 @@ end
 
 ---@private
 local function join_paths(...)
-  return table.concat({ ... }, '/')
+  local path_elements = vim.tbl_map(function(element)
+    return element:gsub('/$', '')
+  end, { ... })
+
+  return table.concat(path_elements, '/')
 end
 
 --- Return an iterator over the files and directories located in {path}

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -230,6 +230,10 @@ describe('vim.fs', function()
         local dir, nvim = ...
         return vim.fs.find(nvim, { path = dir, type = 'file' })
       ]], test_build_dir, nvim_prog_basename))
+      eq({test_build_dir}, exec_lua([[
+        local dir, name = ...
+        return vim.fs.find(name, { path = dir .. '/', upward = true, type = 'directory' })
+      ]], nvim_dir))
     end)
 
     it('accepts predicate as names', function()


### PR DESCRIPTION
As this would also happen when a user passes in a `dir` parameter ending in a slash, this should resolve both that and the issue with root dirs.