### PR TITLE
fix(options): restore exists() behavior for options

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3674,6 +3674,7 @@ static int eval_index(char **arg, typval_T *rettv, int evaluate, int verbose)
 int get_option_tv(const char **const arg, typval_T *const rettv, const bool evaluate)
   FUNC_ATTR_NONNULL_ARG(1)
 {
+  const bool working = (**arg == '+');  // has("+option")
   int scope;
 
   // Isolate the option name and find its value.
@@ -3718,6 +3719,10 @@ int get_option_tv(const char **const arg, typval_T *const rettv, const bool eval
       rettv->v_type = VAR_STRING;
       rettv->vval.v_string = stringval;
     }
+  } else if (working && (opt_type == gov_hidden_bool
+                         || opt_type == gov_hidden_number
+                         || opt_type == gov_hidden_string)) {
+    ret = FAIL;
   }
 
   *option_end = c;                  // put back for error messages

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1721,14 +1721,9 @@ static void f_exists(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       xfree(exp);
     }
   } else if (*p == '&' || *p == '+') {  // Option.
-    bool working = (*p == '+');  // whether option needs to be working
-    int opt_flags;
-
-    if (find_option_end(&p, &opt_flags) != NULL) {
-      int opt_idx = findoption(p);
-      n = (opt_idx >= 0 && (!working || get_varp_scope(get_option(opt_idx), opt_flags) != NULL));
-    } else {
-      n = false;
+    n = (get_option_tv(&p, NULL, true) == OK);
+    if (*skipwhite(p) != NUL) {
+      n = false;  // Trailing garbage.
     }
   } else if (*p == '*') {  // Internal or user defined function.
     n = function_exists(p + 1, false);

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -6,6 +6,7 @@ local command, exec = helpers.command, helpers.exec
 local eval = helpers.eval
 local feed_command, eq = helpers.feed_command, helpers.eq
 local curbufmeths = helpers.curbufmeths
+local funcs = helpers.funcs
 local meths = helpers.meths
 
 describe('colorscheme compatibility', function()
@@ -13,7 +14,9 @@ describe('colorscheme compatibility', function()
     clear()
   end)
 
-  it('t_Co is set to 256 by default', function()
+  it('&t_Co exists and is set to 256 by default', function()
+    eq(1, funcs.exists('&t_Co'))
+    eq(1, funcs.exists('+t_Co'))
     eq('256', eval('&t_Co'))
   end)
 end)


### PR DESCRIPTION
Fix #21499

Duplicating `get_option_value()` logic for an obscure future refactor isn't really worthwhile, and `findoption()` isn't used anywhere else outside the options code.
