### PR TITLE
vim-patch:9.0.1090: FHIR Shorthand files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -419,6 +419,7 @@ local extension = {
   fs = function(path, bufnr)
     return require('vim.filetype.detect').fs(bufnr)
   end,
+  fsh = 'fsh',
   fsi = 'fsharp',
   fsx = 'fsharp',
   fusion = 'fusion',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -204,6 +204,7 @@ let s:filename_checks = {
     \ 'fpcmake': ['file.fpc'],
     \ 'framescript': ['file.fsl'],
     \ 'freebasic': ['file.fb'],
+    \ 'fsh': ['file.fsh'],
     \ 'fsharp': ['file.fs', 'file.fsi', 'file.fsx'],
     \ 'fstab': ['fstab', 'mtab'],
     \ 'fusion': ['file.fusion'],


### PR DESCRIPTION
Problem:    FHIR Shorthand files are not recognized.
Solution:   Add a pattern to detect FSH files. (Matthew Gramigna,
            closes vim/vim#11738)

https://github.com/vim/vim/commit/c9207d5d79310bd4628ce46d8db588fac17878a0

Co-authored-by: mgramigna <mgramigna@mitre.org>
