### PR TITLE
docs: Add lua example of autocmds for incsearch

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3400,12 +3400,25 @@ A jump table for the options with a short description can be found at |Q_op|.
 	typing a search command. See also: 'hlsearch'.
 	If you don't want to turn 'hlsearch' on, but want to highlight all
 	matches while searching, you can turn on and off 'hlsearch' with
-	autocmd.  Example: >
+	autocmd.  Example vimscript: >
 		augroup vimrc-incsearch-highlight
 		  autocmd!
 		  autocmd CmdlineEnter /,\? :set hlsearch
 		  autocmd CmdlineLeave /,\? :set nohlsearch
 		augroup END
+<
+        Example lua: >
+                vim.api.nvim_create_augroup('NeovimrcIncSearchHighlight', { clear = true })
+                vim.api.nvim_create_autocmd({ 'CmdlineEnter' }, {
+                  group = NeovimrcIncSearchHighlight,
+                  pattern = '/,\\?',
+                  command = 'set hlsearch',
+                })
+                vim.api.nvim_create_autocmd({ 'CmdlineLeave' }, {
+                  group = NeovimrcIncSearchHighlight,
+                  pattern = '/,\\?',
+                  command = 'set nohlsearch',
+                })
 <
 	CTRL-L can be used to add one character from after the current match
 	to the command line.  If 'ignorecase' and 'smartcase' are set and the


### PR DESCRIPTION
While migrating my init.vim to init.lua I noticed the 'incsearch' documentation has a vimscript example that shows how to enable hlsearch only while searching via a pair of autocmds in an augroup. I thought it would be useful if there was also a lua example.

I am not a lua expert by any means, but after searching public GitHub repositories I found a few examples like the one in this MR. I tried it in my own config and it seems to work well.