### PR TITLE
vim-patch:8.2.3737: test fails without the 'autochdir' option

### DIFF
--- a/src/nvim/testdir/test_cd.vim
+++ b/src/nvim/testdir/test_cd.vim
@@ -233,6 +233,8 @@ endfunc
 
 func Test_getcwd_actual_dir()
   CheckFunction test_autochdir
+  CheckOption autochdir
+
   let startdir = getcwd()
   call mkdir('Xactual')
   call test_autochdir()


### PR DESCRIPTION
#### vim-patch:8.2.3737: test fails without the 'autochdir' option

Problem:    Test fails without the 'autochdir' option.
Solution:   Check that the option is available. (Dominique Pellé, closes vim/vim#9272)

https://github.com/vim/vim/commit/8dea145e39a2569153cb63487d3403a46a882189

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>