### PR TITLE
feat(treesitter): allow capture text to be transformed

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -154,6 +154,9 @@ The following new APIs or features were added.
 • Treesitter captures can now be transformed by directives. This will allow
   more complicated dynamic language injections.
 
+• |vim.treesitter.query.get_node_text()| now accepts a `metadata` option for
+  writing custom directives using |vim.treesitter.query.add_directive()|.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -151,6 +151,9 @@ The following new APIs or features were added.
 
 • |:highlight| now supports an additional attribute "altfont".
 
+• Treesitter captures can now be transformed by directives. This will allow
+  more complicated dynamic language injections.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -746,6 +746,9 @@ get_node_text({node}, {source}, {opts})
       • {opts}    (table|nil) Optional parameters.
                   • concat: (boolean) Concatenate result in a string (default
                     true)
+                  • metadata (table) Metadata of a specific capture. This
+                    would be set to `metadata[capture_id]` when using
+                    |vim.treesitter.query.add_directive()|.
 
     Return: ~
         (string[]|string|nil)

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -354,6 +354,14 @@ local function get_range_from_metadata(node, id, metadata)
   return { node:range() }
 end
 
+---@private
+local function get_node_text(node, id, metadata, source)
+  if metadata[id] and metadata[id].text then
+    return metadata[id].text
+  end
+  return query.get_node_text(node, source)
+end
+
 --- Gets language injection points by language.
 ---
 --- This is where most of the injection processing occurs.
@@ -408,7 +416,7 @@ function LanguageTree:_get_injections()
 
         -- Lang should override any other language tag
         if name == 'language' and not lang then
-          lang = query.get_node_text(node, self._source) --[[@as string]]
+          lang = get_node_text(node, id, metadata, self._source) --[[@as string]]
         elseif name == 'combined' then
           combined = true
         elseif name == 'content' and #ranges == 0 then

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -354,14 +354,6 @@ local function get_range_from_metadata(node, id, metadata)
   return { node:range() }
 end
 
----@private
-local function get_node_text(node, id, metadata, source)
-  if metadata[id] and metadata[id].text then
-    return metadata[id].text
-  end
-  return query.get_node_text(node, source)
-end
-
 --- Gets language injection points by language.
 ---
 --- This is where most of the injection processing occurs.
@@ -416,7 +408,7 @@ function LanguageTree:_get_injections()
 
         -- Lang should override any other language tag
         if name == 'language' and not lang then
-          lang = get_node_text(node, id, metadata, self._source) --[[@as string]]
+          lang = query.get_node_text(node, self._source, { metadata = metadata[id] })
         elseif name == 'combined' then
           combined = true
         elseif name == 'content' and #ranges == 0 then

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -452,6 +452,21 @@ local directive_handlers = {
       metadata[capture_id].range = range
     end
   end,
+
+  -- Transform the content of the node
+  -- Example: (#gsub! @_node ".*%.(.*)" "%1")
+  ['gsub!'] = function(match, _, bufnr, pred, metadata)
+    assert(#pred == 4)
+
+    local id = pred[2]
+    local node = match[id]
+    local text = M.get_node_text(node, bufnr, { metadata = metadata[id] }) or ''
+
+    if not metadata[id] then
+      metadata[id] = {}
+    end
+    metadata[id].text = text:gsub(pred[3], pred[4])
+  end,
 }
 
 --- Adds a new predicate to be used in queries

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -445,9 +445,11 @@ local directive_handlers = {
   ['offset!'] = function(match, _, _, pred, metadata)
     ---@cast pred integer[]
     local capture_id = pred[2]
-    local offset_node = match[capture_id]
-    local range = { offset_node:range() }
-    ---@cast range integer[] bug in sumneko
+    if not metadata[capture_id] then
+      metadata[capture_id] = {}
+    end
+
+    local range = metadata[capture_id].range or { match[capture_id]:range() }
     local start_row_offset = pred[3] or 0
     local start_col_offset = pred[4] or 0
     local end_row_offset = pred[5] or 0
@@ -460,9 +462,6 @@ local directive_handlers = {
 
     -- If this produces an invalid range, we just skip it.
     if range[1] < range[3] or (range[1] == range[3] and range[2] <= range[4]) then
-      if not metadata[capture_id] then
-        metadata[capture_id] = {}
-      end
       metadata[capture_id].range = range
     end
   end,

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -277,6 +277,9 @@ end]]
       function fake_node:end_()
         return 3, 0, 23
       end
+      function fake_node:range()
+        return 3, 0, 3, 0
+      end
       return vim.treesitter.get_node_text(fake_node, 0) == nil
     ]])
     eq(true, result)
@@ -295,6 +298,9 @@ end]]
       end
       function fake_node:end_()
         return 1, 0, 7
+      end
+      function fake_node:range()
+        return 1, 0, 1, 0
       end
       return vim.treesitter.get_node_text(fake_node, 0) == ''
     ]])

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -728,7 +728,7 @@ int x = INT_MAX;
         return list
         ]]
 
-        eq({ 'offset!', 'set!' }, res_list)
+        eq({ 'gsub!', 'offset!', 'set!' }, res_list)
       end)
     end)
   end)


### PR DESCRIPTION
closes #19460

this is a continuation of #19460 with support for ranges and some internal changes and bugfixes

### Description of the Original PR:
---

## Goal

Allow language injections of the form:

```bash
#!/bin/bash

echo ' 
local x = function() end
' > file.lua
```

For this we need to transform `file.lua` -> `lua`.

For reference the above injection requires the following bash query:

```lisp
; echo ' ' > file.ext
(redirected_statement
  body: (command
    name: (_)
    argument: (raw_string) @content
  )
  redirect: (file_redirect
    destination: (
      (word) @language
      (#gsub @language ".*%.(.*)" "%1")
    )
  )
)
```