### PR TITLE
vim-patch:9.0.1101: unused global variable

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1039,9 +1039,6 @@ EXTERN char bot_top_msg[] INIT(= N_("search hit BOTTOM, continuing at TOP"));
 
 EXTERN char line_msg[] INIT(= N_(" line "));
 
-// For undo we need to know the lowest time possible.
-EXTERN time_t starttime;
-
 EXTERN FILE *time_fd INIT(= NULL);  // where to write startup timing
 
 // Some compilers warn for not using a return value, but in some situations we

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1406,8 +1406,6 @@ static void init_startuptime(mparm_T *paramp)
       break;
     }
   }
-
-  starttime = time(NULL);
 }
 
 static void check_and_set_isatty(mparm_T *paramp)


### PR DESCRIPTION
#### vim-patch:9.0.1101: unused global variable

Problem:    Unused global variable.
Solution:   Remove the variable. (closes vim/vim#11752)

https://github.com/vim/vim/commit/b536540ab3c13db629432c411e92c05c4a3808ba

Co-authored-by: Bram Moolenaar <Bram@vim.org>