### PR TITLE
ci: enable CI_BUILD on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Build nvim
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE='RelWithDebInfo' -DDEPS_PREFIX="$env:DEPS_PREFIX"
+          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE='RelWithDebInfo' -DDEPS_PREFIX="$env:DEPS_PREFIX" -DCI_BUILD=ON
           cmake --build build
 
       - name: Install test deps

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -455,8 +455,11 @@ endforeach()
 
 list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 
-if(NOT MSVC)
-  # xdiff, mpack, lua-cjson: inlined external project, we don't maintain it. #9306
+# xdiff, mpack, lua-cjson: inlined external project, we don't maintain it. #9306
+if(MSVC)
+  set_source_files_properties(
+    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} /wd4090")
+else()
   set_source_files_properties(
     ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion -Wno-strict-prototypes")
 endif()

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2709,7 +2709,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
     if (li_tv->v_type != VAR_LIST || li_tv->vval.v_list == NULL) {
       semsg(_(e_list_item_nr_is_not_list), item);
-      xfree(ptrs);
+      xfree((void *)ptrs);
       return;
     }
 
@@ -2727,23 +2727,23 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         n1 = lili_tv->vval.v_number;
         if (n1 < 0x100) {
           emsg(_(e_only_values_of_0x100_and_higher_supported));
-          xfree(ptrs);
+          xfree((void *)ptrs);
           return;
         }
       } else if (i == 1 && lili_tv->vval.v_number < n1) {
         semsg(_(e_list_item_nr_range_invalid), item);
-        xfree(ptrs);
+        xfree((void *)ptrs);
         return;
       } else if (i == 2 && (lili_tv->vval.v_number < 1 || lili_tv->vval.v_number > 2)) {
         semsg(_(e_list_item_nr_cell_width_invalid), item);
-        xfree(ptrs);
+        xfree((void *)ptrs);
         return;
       }
     }
 
     if (i != 3) {
       semsg(_(e_list_item_nr_does_not_contain_3_numbers), item);
-      xfree(ptrs);
+      xfree((void *)ptrs);
       return;
     }
 
@@ -2762,7 +2762,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     const varnumber_T n1 = TV_LIST_ITEM_TV(lili)->vval.v_number;
     if (item > 0 && n1 <= table[item - 1].last) {
       semsg(_(e_overlapping_ranges_for_nr), (long)n1);
-      xfree(ptrs);
+      xfree((void *)ptrs);
       xfree(table);
       return;
     }
@@ -2773,7 +2773,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     table[item].width = (char)TV_LIST_ITEM_TV(lili)->vval.v_number;
   }
 
-  xfree(ptrs);
+  xfree((void *)ptrs);
 
   cw_interval_T *const cw_table_save = cw_table;
   const size_t cw_table_size_save = cw_table_size;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3006,7 +3006,7 @@ static int do_more_prompt(int typed_char)
 
 #if defined(MSWIN)
 /// Headless (no UI) error message handler.
-static void do_msg(char *str, bool errmsg)
+static void do_msg(const char *str, bool errmsg)
 {
   static bool did_err = false;
   assert(str != NULL);
@@ -3026,13 +3026,13 @@ static void do_msg(char *str, bool errmsg)
   }
 }
 
-void os_errmsg(char *str)
+void os_errmsg(const char *str)
 {
   do_msg(str, true);
 }
 
 /// Headless (no UI) message handler.
-void os_msg(char *str)
+void os_msg(const char *str)
 {
   do_msg(str, false);
 }


### PR DESCRIPTION
This will ensure warnings are treated as errors when using MSVC.

Also fix const correctness warnings. The warnings in mbyte.c are false
positives that triggers this warning on MSVC v19.32 and lower, which our
CI still use. The (void *) casts can be removed once the CI MSVC version
has been upgraded to v19.33 or higher.