### PR TITLE
build: fix help tags generation when SHELL=fish

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -63,7 +63,7 @@ foreach(DF ${DOCFILES})
 endforeach()
 
 add_custom_command(OUTPUT ${GENERATED_HELP_TAGS}
-  COMMAND ${CMAKE_COMMAND} -E remove doc/*
+  COMMAND ${CMAKE_COMMAND} -E remove_directory doc
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     ${PROJECT_SOURCE_DIR}/runtime/doc doc
   COMMAND "${PROJECT_BINARY_DIR}/bin/nvim"


### PR DESCRIPTION
this is what I got when I tried to run `make functionaltest`. not sure if it is because I am in a nix shell but this patch fixes the issue for me
```console
make[3]: *** No rule to make target 'runtime/doc/tags', needed by 'CMakeFiles/functionaltest'.  Stop.
make[2]: *** [CMakeFiles/Makefile2:752: CMakeFiles/functionaltest.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:759: CMakeFiles/functionaltest.dir/rule] Error 2
make: *** [Makefile:307: functionaltest] Error 2
```

here are the commands I ran 
```bash
nix develop ./contrib
cmakeConfigurePhase
buildPhase
make functionaltest
```

without this patch, I have to run `make runtime` or `make` before `make functionaltest` for the error to not come up