### PR TITLE
docs(README): add Kotlin as a language which can use the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Features
 
 - Modern [GUIs](https://github.com/neovim/neovim/wiki/Related-projects#gui)
 - [API access](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
-  from any language including C/C++, C#, Clojure, D, Elixir, Go, Haskell, Java,
+  from any language including C/C++, C#, Clojure, D, Elixir, Go, Haskell, Java/Kotlin,
   JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket, Ruby, Rust
 - Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
 - Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)


### PR DESCRIPTION
[Kotlin](https://kotlinlang.org/) is 100% interoperable with Java (kind of like C/C++). If Java can use the API, Kotlin can use it as well.