### PR TITLE
vim-patch:9.0.1106: not all postfix files are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1532,6 +1532,7 @@ local filename = {
   ['.latexmkrc'] = 'perl',
   ['pf.conf'] = 'pf',
   ['main.cf'] = 'pfmain',
+  ['main.cf.proto'] = 'pfmain',
   pinerc = 'pine',
   ['.pinercex'] = 'pine',
   ['.pinerc'] = 'pine',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -421,7 +421,7 @@ let s:filename_checks = {
     \ 'pdf': ['file.pdf'],
     \ 'perl': ['file.plx', 'file.al', 'file.psgi', 'gitolite.rc', '.gitolite.rc', 'example.gitolite.rc', '.latexmkrc', 'latexmkrc'],
     \ 'pf': ['pf.conf'],
-    \ 'pfmain': ['main.cf'],
+    \ 'pfmain': ['main.cf', 'main.cf.proto'],
     \ 'php': ['file.php', 'file.php9', 'file.phtml', 'file.ctp', 'file.phpt', 'file.theme'],
     \ 'pike': ['file.pike', 'file.pmod'],
     \ 'pilrc': ['file.rcp'],


### PR DESCRIPTION
Problem:    Not all postfix files are recognized.
Solution:   Recognize main.cf.proto files. (closes vim/vim#11732)

https://github.com/vim/vim/commit/09ce0b8e1197c85dacf97e75b9b9ac18e0d192df

Co-authored-by: KodeToad <3880336+KodeToad@users.noreply.github.com>
