### PR TITLE
docs: fix treesitter parsing errors

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2535,8 +2535,8 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
     Region can be given as (row,col) tuples, or valid extmark ids (whose
     positions define the bounds). 0 and -1 are understood as (0,0) and (-1,-1)
     respectively, thus the following are equivalent: >lua
-      nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
-      nvim_buf_get_extmarks(0, my_ns, [0,0], [-1,-1], {})
+      vim.api.nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
+      vim.api.nvim_buf_get_extmarks(0, my_ns, {0,0}, {-1,-1}, {})
 <
 
     If `end` is less than `start`, traversal works backwards. (Useful with
@@ -3071,8 +3071,8 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                       borders but not horizontal ones. By default,
                       `FloatBorder` highlight is used, which links to
                       `WinSeparator` when not defined. It could also be
-                      specified by character: [ {"+", "MyCorner"}, {"x",
-                      "MyBorder"} ].
+                      specified by character: [ ["+", "MyCorner"], ["x",
+                      "MyBorder"] ].
 
                   • title: Title (optional) in window border, String or list.
                     List is [text, highlight] tuples. if is string the default

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -68,8 +68,8 @@ bufnr([{expr} [, {create}]])	Number	Number of the buffer {expr}
 bufwinid({expr})		Number	|window-ID| of buffer {expr}
 bufwinnr({expr})		Number	window number of buffer {expr}
 byte2line({byte})		Number	line number at byte count {byte}
-byteidx({expr}, {nr})		Number	byte index of {nr}'th char in {expr}
-byteidxcomp({expr}, {nr})	Number	byte index of {nr}'th char in {expr}
+byteidx({expr}, {nr})		Number	byte index of {nr}th char in {expr}
+byteidxcomp({expr}, {nr})	Number	byte index of {nr}th char in {expr}
 call({func}, {arglist} [, {dict}])
 				any	call {func} with arguments {arglist}
 ceil({expr})			Float	round {expr} up
@@ -318,9 +318,9 @@ matchfuzzypos({list}, {str} [, {dict}])
 matchlist({expr}, {pat} [, {start} [, {count}]])
 				List	match and submatches of {pat} in {expr}
 matchstr({expr}, {pat} [, {start} [, {count}]])
-				String	{count}'th match of {pat} in {expr}
+				String	{count}th match of {pat} in {expr}
 matchstrpos({expr}, {pat} [, {start} [, {count}]])
-				List	{count}'th match of {pat} in {expr}
+				List	{count}th match of {pat} in {expr}
 max({expr})			Number	maximum value of items in {expr}
 menu_get({path} [, {modes}])	List	description of |menus| matched by {path}
 menu_info({name} [, {mode}])	Dict	get menu item information
@@ -956,7 +956,7 @@ byte2line({byte})					*byte2line()*
 			GetOffset()->byte2line()
 
 byteidx({expr}, {nr})					*byteidx()*
-		Return byte index of the {nr}'th character in the String
+		Return byte index of the {nr}th character in the String
 		{expr}.  Use zero for the first character, it then returns
 		zero.
 		If there are no multibyte characters the returned value is
@@ -1508,7 +1508,7 @@ debugbreak({pid})					*debugbreak()*
 		Specifically used to interrupt a program being debugged.  It
 		will cause process {pid} to get a SIGTRAP.  Behavior for other
 		processes is undefined. See |terminal-debug|.
-		{Sends a SIGINT to a process {pid} other than MS-Windows}
+		(Sends a SIGINT to a process {pid} other than MS-Windows)
 
 		Returns |TRUE| if successfully interrupted the program.
 		Otherwise returns |FALSE|.
@@ -1597,9 +1597,9 @@ dictwatcheradd({dict}, {pattern}, {callback})		      *dictwatcheradd()*
 			call dictwatcheradd(g:, '*', 'OnDictChanged')
 <
 		For now {pattern} only accepts very simple patterns that can
-		contain a '*' at the end of the string, in which case it will
-		match every key that begins with the substring before the '*'.
-		That means if '*' is not the last character of {pattern}, only
+		contain a "*" at the end of the string, in which case it will
+		match every key that begins with the substring before the "*".
+		That means if "*" is not the last character of {pattern}, only
 		keys that are exactly equal as {pattern} will be matched.
 
 		The {callback} receives three arguments:
@@ -4956,7 +4956,7 @@ match({expr}, {pat} [, {start} [, {count}]])			*match()*
 		If {start} is out of range ({start} > strlen({expr}) for a
 		String or {start} > len({expr}) for a |List|) -1 is returned.
 
-		When {count} is given use the {count}'th match.  When a match
+		When {count} is given use the {count}th match.  When a match
 		is found in a String the search for the next one starts one
 		character further.  Thus this example results in 1: >
 			echo match("testing", "..", 0, 2)
@@ -5186,7 +5186,7 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 		   :let l = readfile("buffer.c")->matchfuzzy("str")
 <		results in a list of lines in "buffer.c" fuzzy matching "str". >
 		   :echo ['one two', 'two one']->matchfuzzy('two one')
-<		results in ['two one', 'one two']. >
+<		results in `['two one', 'one two']` . >
 		   :echo ['one two', 'two one']->matchfuzzy('two one',
 						\ {'matchseq': 1})
 <		results in ['two one'].
@@ -6683,7 +6683,7 @@ searchcount([{options}])					*searchcount()*
 		  pos		|List|		`[lnum, col, off]` value
 						when recomputing the result.
 						this changes "current" result
-						value. see |cursor()|, |getpos()
+						value. see |cursor()|, |getpos()|
 						(default: cursor's position)
 
 		Can also be used as a |method|: >
@@ -8147,7 +8147,7 @@ strwidth({string})					*strwidth()*
 submatch({nr} [, {list}])			*submatch()* *E935*
 		Only for an expression in a |:substitute| command or
 		substitute() function.
-		Returns the {nr}'th submatch of the matched text.  When {nr}
+		Returns the {nr}th submatch of the matched text.  When {nr}
 		is 0 the whole matched text is returned.
 		Note that a NL in the string can stand for a line break of a
 		multi-line match or a NUL character in the text.

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -345,9 +345,9 @@ escaped with a backslash.
 Wildcards in {file} are expanded, but as with file completion, 'wildignore'
 and 'suffixes' apply.  Which wildcards are supported depends on the system.
 These are the common ones:
-	?	matches one character
-	*	matches anything, including nothing
-	**	matches anything, including nothing, recurses into directories
+	`?`	matches one character
+	`*`	matches anything, including nothing
+	`**`	matches anything, including nothing, recurses into directories
 	[abc]	match 'a', 'b' or 'c'
 
 To avoid the special meaning of the wildcards prepend a backslash.  However,
@@ -406,7 +406,7 @@ external command, by putting an equal sign right after the first backtick,
 e.g.: >
 	:e `=tempname()`
 The expression can contain just about anything, thus this can also be used to
-avoid the special meaning of '"', '|', '%' and '#'.  However, 'wildignore'
+avoid the special meaning of '"', "|", '%' and '#'.  However, 'wildignore'
 does apply like to other wildcards.
 
 Environment variables in the expression are expanded when evaluating the
@@ -894,7 +894,7 @@ changed.  This is done for all *.c files.
 Example: >
 	:args *.[ch]
 	:argdo %s/\<my_foo\>/My_Foo/ge | update
-This changes the word "my_foo" to "My_Foo" in all *.c and *.h files.  The "e"
+This changes the word "my_foo" to "My_Foo" in all "*.c" and "*.h" files.  The "e"
 flag is used for the ":substitute" command to avoid an error for files where
 "my_foo" isn't used.  ":update" writes the file only if changes were made.
 
@@ -1276,8 +1276,8 @@ unmodified.
 For MS-Windows you can modify the filters that are used in the browse
 dialog.  By setting the g:browsefilter or b:browsefilter variables, you can
 change the filters globally or locally to the buffer.  The variable is set to
-a string in the format "{filter label}\t{pattern};{pattern}\n" where {filter
-label} is the text that appears in the "Files of Type" comboBox, and {pattern}
+a string in the format "{filter label}\t{pattern};{pattern}\n" where "{filter
+label}" is the text that appears in the "Files of Type" comboBox, and {pattern}
 is the pattern which filters the filenames.  Several patterns can be given,
 separated by ';'.
 
@@ -1576,8 +1576,8 @@ which is slightly different.
 There are three different types of searching:
 
 1) Downward search:					*starstar*
-   Downward search uses the wildcards '*', '**' and possibly others
-   supported by your operating system.  '*' and '**' are handled inside Vim,
+   Downward search uses the wildcards "*", "**" and possibly others
+   supported by your operating system.  "*" and "**" are handled inside Vim,
    so they work on all operating systems.  Note that "**" only acts as a
    special wildcard when it is at the start of a name.
 
@@ -1585,12 +1585,12 @@ There are three different types of searching:
    search pattern this would be ".*".  Note that the "." is not used for file
    searching.
 
-   '**' is more sophisticated:
+   "**" is more sophisticated:
       - It ONLY matches directories.
       - It matches up to 30 directories deep by default, so you can use it to
 	search an entire directory tree
       - The maximum number of levels matched can be given by appending a number
-	to '**'.
+	to "**".
 	Thus '/usr/**2' can match: >
 		/usr
 		/usr/include
@@ -1601,14 +1601,14 @@ There are three different types of searching:
 		....
 <	It does NOT match '/usr/include/g++/std' as this would be three
 	levels.
-	The allowed number range is 0 ('**0' is removed) to 100
+	The allowed number range is 0 ("**0" is removed) to 100
 	If the given number is smaller than 0 it defaults to 30, if it's
 	bigger than 100 then 100 is used.  The system also has a limit on the
 	path length, usually 256 or 1024 bytes.
-      - '**' can only be at the end of the path or be followed by a path
+      - "**" can only be at the end of the path or be followed by a path
 	separator or by a number and a path separator.
 
-   You can combine '*' and '**' in any order: >
+   You can combine "*" and "**" in any order: >
 	/usr/**/sys/*
 	/usr/*tory/sys/**
 	/usr/**2/sys/*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -840,8 +840,8 @@ Example: >
 All expressions within one level are parsed from left to right.
 
 
+------------------------------------------------------------------------------
 expr1							*expr1* *ternary* *E109*
------
 
 expr2 ? expr1 : expr1
 
@@ -867,8 +867,8 @@ You should always put a space before the ':', otherwise it can be mistaken for
 use in a variable such as "a:1".
 
 
+------------------------------------------------------------------------------
 expr2 and expr3						*expr2* *expr3*
----------------
 
 expr3 || expr3 ..	logical OR		*expr-barbar*
 expr4 && expr4 ..	logical AND		*expr-&&*
@@ -906,8 +906,8 @@ This is valid whether "b" has been defined or not.  The second clause will
 only be evaluated if "b" has been defined.
 
 
+------------------------------------------------------------------------------
 expr4							*expr4*
------
 
 expr5 {cmp} expr5
 
@@ -1010,8 +1010,9 @@ can be matched like an ordinary character.  Examples:
 	"foo\nbar" =~ "\\n"	evaluates to 0
 
 
+------------------------------------------------------------------------------
 expr5 and expr6						*expr5* *expr6*
----------------
+
 expr6 + expr6   Number addition, |List| or |Blob| concatenation	*expr-+*
 expr6 - expr6   Number subtraction				*expr--*
 expr6 . expr6   String concatenation				*expr-.*
@@ -1064,8 +1065,9 @@ None of these work for |Funcref|s.
 . and % do not work for Float. *E804*
 
 
+------------------------------------------------------------------------------
 expr7							*expr7*
------
+
 ! expr7			logical NOT		*expr-!*
 - expr7			unary minus		*expr-unary--*
 + expr7			unary plus		*expr-unary-+*
@@ -1082,8 +1084,9 @@ These three can be repeated and mixed.  Examples:
 	--9	    == 9
 
 
+------------------------------------------------------------------------------
 expr8							*expr8*
------
+
 This expression is either |expr9| or a sequence of the alternatives below,
 in any order.  E.g., these are all possible:
 	expr8[expr1].name
@@ -1234,8 +1237,9 @@ When using the lambda form there must be no white space between the } and the
 
 
 							*expr9*
+------------------------------------------------------------------------------
 number
-------
+
 number			number constant			*expr-number*
 
 			*0x* *hex-number* *0o* *octal-number* *binary-number*
@@ -1297,9 +1301,9 @@ function.  Example: >
 <	7.853981633974483e-01
 
 
-
+------------------------------------------------------------------------------
 string					*string* *String* *expr-string* *E114*
-------
+
 "string"		string constant		*expr-quote*
 
 Note that double quotes are used.
@@ -1338,16 +1342,17 @@ encodings.  Use "\u00ff" to store character 255 correctly as UTF-8.
 Note that "\000" and "\x00" force the end of the string.
 
 
+------------------------------------------------------------------------------
 blob-literal				*blob-literal* *E973*
-------------
 
 Hexadecimal starting with 0z or 0Z, with an arbitrary number of bytes.
 The sequence must be an even number of hex characters.  Example: >
 	:let b = 0zFF00ED015DAF
 
 
+------------------------------------------------------------------------------
 literal-string						*literal-string* *E115*
----------------
+
 'string'		string constant			*expr-'*
 
 Note that single quotes are used.
@@ -1361,8 +1366,9 @@ to be doubled.  These two commands are equivalent: >
 	if a =~ '\s*'
 
 
+------------------------------------------------------------------------------
 option						*expr-option* *E112* *E113*
-------
+
 &option			option value, local value if possible
 &g:option		global option value
 &l:option		local option value
@@ -1376,8 +1382,9 @@ and there is no buffer-local or window-local value, the global value is used
 anyway.
 
 
+------------------------------------------------------------------------------
 register						*expr-register* *@r*
---------
+
 @r			contents of register 'r'
 
 The result is the contents of the named register, as a single string.
@@ -1394,8 +1401,9 @@ nesting							*expr-nesting* *E110*
 (expr1)			nested expression
 
 
+------------------------------------------------------------------------------
 environment variable					*expr-env*
---------------------
+
 $VAR			environment variable
 
 The String value of any environment variable.  When it is not defined, the
@@ -1420,20 +1428,23 @@ The first one probably doesn't echo anything, the second echoes the $shell
 variable (if your shell supports it).
 
 
+------------------------------------------------------------------------------
 internal variable					*expr-variable*
------------------
+
 variable		internal variable
 See below |internal-variables|.
 
 
+------------------------------------------------------------------------------
 function call		*expr-function* *E116* *E118* *E119* *E120*
--------------
+
 function(expr1, ...)	function call
 See below |functions|.
 
 
+------------------------------------------------------------------------------
 lambda expression				*expr-lambda* *lambda*
------------------
+
 {args -> expr1}		lambda expression
 
 A lambda expression creates a new unnamed function which returns the result of
@@ -1524,7 +1535,7 @@ specified by what is prepended:
 |tabpage-variable|   t:	  Local to the current tab page.
 |global-variable|    g:	  Global.
 |local-variable|     l:	  Local to a function.
-|script-variable|    s:	  Local to a |:source|'ed Vim script.
+|script-variable|    s:	  Local to a |:source|d Vim script.
 |function-argument|  a:	  Function argument (only inside a function).
 |vim-variable|       v:	  Global, predefined by Vim.
 
@@ -1922,10 +1933,10 @@ v:fname_in	The name of the input file.  Valid while evaluating:
 v:fname_out	The name of the output file.  Only valid while
 		evaluating:
 			option		used for ~
-			'charconvert'	resulting converted file (*)
+			'charconvert'	resulting converted file [1]
 			'diffexpr'	output of diff
 			'patchexpr'	resulting patched file
-		(*) When doing conversion for a write command (e.g., ":w
+		[1] When doing conversion for a write command (e.g., ":w
 		file") it will be equal to v:fname_in.  When doing conversion
 		for a read command (e.g., ":e file") it will be a temporary
 		file and different from v:fname_in.

--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -37,8 +37,9 @@ The SQL ftplugin provides a number of options to assist with file
 navigation.
 
 
+------------------------------------------------------------------------------
 1.1 Matchit					*sql-matchit*
------------
+
 The matchit plugin (https://www.vim.org/scripts/script.php?script_id=39)
 provides many additional features and can be customized for different
 languages.  The matchit plugin is configured by defining a local
@@ -85,8 +86,9 @@ The following keywords are supported: >
     returns
 
 
+------------------------------------------------------------------------------
 1.2 Text Object Motions				*sql-object-motions*
------------------------
+
 Vim has a number of predefined keys for working with text |object-motions|.
 This filetype plugin attempts to translate these keys to maps which make sense
 for the SQL language.
@@ -99,8 +101,9 @@ file): >
     []		    move backwards to the previous 'end'
 
 
+------------------------------------------------------------------------------
 1.3 Predefined Object Motions			*sql-predefined-objects*
------------------------------
+
 Most relational databases support various standard features, tables, indices,
 triggers and stored procedures.  Each vendor also has a variety of proprietary
 objects.  The next set of maps have been created to help move between these
@@ -166,8 +169,9 @@ with comments: >
 
 
 
+------------------------------------------------------------------------------
 1.4 Macros					   *sql-macros*
-----------
+
 Vim's feature to find macro definitions, |'define'|, is supported using this
 regular expression: >
     \c\<\(VARIABLE\|DECLARE\|IN\|OUT\|INOUT\)\>
@@ -230,8 +234,9 @@ The majority of people work with only one vendor's database product, it would
 be nice to specify a default in your |init.vim|.
 
 
+------------------------------------------------------------------------------
 2.1 SQLSetType					*sqlsettype* *SQLSetType*
---------------
+
 For the people that work with many different databases, it is nice to be
 able to flip between the various vendors rules (indent, syntax) on a per
 buffer basis, at any time.  The ftplugin/sql.vim file defines this function: >
@@ -259,8 +264,9 @@ of available Vim script names: >
     :SQL<Tab><space><Tab>
 
 
+------------------------------------------------------------------------------
 2.2 SQLGetType					*sqlgettype* *SQLGetType*
---------------
+
 At anytime you can determine which SQL dialect you are using by calling the
 SQLGetType command.  The ftplugin/sql.vim file defines this function: >
     SQLGetType
@@ -269,8 +275,9 @@ This will echo: >
     Current SQL dialect in use:sqlanywhere
 
 
+------------------------------------------------------------------------------
 2.3 SQL Dialect Default				*sql-type-default*
------------------------
+
 As mentioned earlier, the default syntax rules for Vim is based on Oracle
 (PL/SQL).  You can override this default by placing one of the following in
 your |init.vim|: >
@@ -325,8 +332,9 @@ highlight rules.  The dynamic mode populates the popups with data retrieved
 directly from a database.  This includes, table lists, column lists,
 procedures names and more.
 
+------------------------------------------------------------------------------
 4.1 Static Mode					*sql-completion-static*
----------------
+
 The static popups created contain items defined by the active syntax rules
 while editing a file with a filetype of SQL.  The plugin defines (by default)
 various maps to help the user refine the list of items to be displayed.
@@ -399,8 +407,9 @@ Here are some examples of the entries which are pulled from the syntax files: >
 	 - Integer, Char, Varchar, Date, DateTime, Timestamp, ...
 
 
+------------------------------------------------------------------------------
 4.2 Dynamic Mode				*sql-completion-dynamic*
-----------------
+
 Dynamic mode populates the popups with data directly from a database.  In
 order for the dynamic feature to be enabled you must have the dbext.vim
 plugin installed, (https://vim.sourceforge.net/script.php?script_id=356).
@@ -448,8 +457,8 @@ necessary to clear the plugins cache.  The default map for this is: >
     imap <buffer> <C-C>R <C-\><C-O>:call sqlcomplete#Map('ResetCache')<CR><C-X><C-O>
 
 
+------------------------------------------------------------------------------
 4.3 SQL Tutorial				*sql-completion-tutorial*
-----------------
 
 This tutorial is designed to take you through the common features of the SQL
 completion plugin so that: >
@@ -462,8 +471,8 @@ First, create a new buffer: >
      :e tutorial.sql
 
 
-Static features
----------------
+Static features ~
+
 To take you through the various lists, simply enter insert mode, hit:
     <C-C>s   (show SQL statements)
 At this point, you can page down through the list until you find "select".
@@ -484,8 +493,8 @@ depending on the syntax file you are using.  The SQL Anywhere syntax file
 	DECLARE customer_id <C-C>T <-- Choose a type from the list
 
 
-Dynamic features
-----------------
+Dynamic features ~
+
 To take advantage of the dynamic features you must first install the
 dbext.vim plugin (https://vim.sourceforge.net/script.php?script_id=356).  It
 also comes with a tutorial.  From the SQL completion plugin's perspective,
@@ -597,8 +606,8 @@ Similar to the table list, <C-C>v, will display a list of views in the
 database.
 
 
+------------------------------------------------------------------------------
 4.4 Completion Customization			*sql-completion-customization*
-----------------------------
 
 The SQL completion plugin can be customized through various options set in
 your |init.vim|: >
@@ -657,14 +666,14 @@ your |init.vim|: >
 	  option.
 >
 
+------------------------------------------------------------------------------
 4.5 SQL Maps					*sql-completion-maps*
-------------
 
 The default SQL maps have been described in other sections of this document in
 greater detail.  Here is a list of the maps with a brief description of each.
 
-Static Maps
------------
+Static Maps ~
+
 These are maps which use populate the completion list using Vim's syntax
 highlighting rules. >
     <C-C>a
@@ -680,8 +689,8 @@ highlighting rules. >
     <C-C>s
 <       - Displays all SQL syntax items defined as 'sqlStatement'. >
 
-Dynamic Maps
-------------
+Dynamic Maps ~
+
 These are maps which use populate the completion list using the dbext.vim
 plugin. >
     <C-C>t
@@ -713,8 +722,8 @@ plugin. >
 <	- This maps removes all cached items and forces the SQL completion
 	  to regenerate the list of items.
 
-Customizing Maps
-----------------
+Customizing Maps ~
+
 You can create as many additional key maps as you like.  Generally, the maps
 will be specifying different syntax highlight groups.
 
@@ -733,8 +742,8 @@ chosen since it will work on both Windows and *nix platforms.  On the windows
 platform you can also use <C-Space> or ALT keys.
 
 
+------------------------------------------------------------------------------
 4.6 Using with other filetypes			*sql-completion-filetypes*
-------------------------------
 
 Many times SQL can be used with different filetypes.  For example Perl, Java,
 PHP, Javascript can all interact with a database.  Often you need both the SQL
@@ -746,8 +755,8 @@ This can be enabled easily with the following steps (assuming a Perl file): >
     2.  :set filetype=sql
     3.  :set ft=perl
 
-Step 1
-------
+Step 1 ~
+
 Begins by editing a Perl file.  Vim automatically sets the filetype to
 "perl".  By default, Vim runs the appropriate filetype file
 ftplugin/perl.vim.  If you are using the syntax completion plugin by following
@@ -755,8 +764,8 @@ the directions at |ft-syntax-omni| then the |'omnifunc'| option has been set to
 "syntax#Complete".  Pressing <C-X><C-O> will display the omni popup containing
 the syntax items for Perl.
 
-Step 2
-------
+Step 2 ~
+
 Manually setting the filetype to "sql" will also fire the appropriate filetype
 files ftplugin/sql.vim.  This file will define a number of buffer specific
 maps for SQL completion, see |sql-completion-maps|.  Now these maps have
@@ -767,8 +776,8 @@ begin with <C-C>, the maps will toggle the |'omnifunc'| when in use.  So you
 can use <C-X><C-O> to continue using the completion for Perl (using the syntax
 completion plugin) and <C-C> to use the SQL completion features.
 
-Step 3
-------
+Step 3 ~
+
 Setting the filetype back to Perl sets all the usual "perl" related items back
 as they were.
 

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -44,8 +44,8 @@ Scrollbars						*gui-scrollbars*
 There are vertical scrollbars and a horizontal scrollbar.  You may
 configure which ones appear with the 'guioptions' option.
 
-The interface looks like this (with ":set guioptions=mlrb"):
-
+The interface looks like this (with `:set guioptions=mlrb`):
+>
 		       +------------------------------+ `
 		       | File  Edit		 Help | <- Menu bar (m) `
 		       +-+--------------------------+-+ `
@@ -66,7 +66,7 @@ The interface looks like this (with ":set guioptions=mlrb"):
 		       +-+--------------------------+-+ `
 		       | |< ####		   >| | <- Bottom `
 		       +-+--------------------------+-+    scrollbar (b) `
-
+<
 Any of the scrollbar or menu components may be turned off by not putting the
 appropriate letter in the 'guioptions' string.  The bottom scrollbar is
 only useful when 'nowrap' is set.
@@ -123,7 +123,7 @@ message).  Keep Shift pressed to change to the directory instead.
 If Vim happens to be editing a command line, the names of the dropped files
 and directories will be inserted at the cursor.  This allows you to use these
 names with any Ex command.  Special characters (space, tab, double quote and
-'|'; backslash on non-MS-Windows systems) will be escaped.
+"|"; backslash on non-MS-Windows systems) will be escaped.
 
 ==============================================================================
 Menus							*menus*
@@ -569,14 +569,14 @@ Tooltips & Menu tips
 See section |42.4| in the user manual.
 
 							*:tmenu*
-:tm[enu] {menupath} {rhs}	Define a tip for a menu or tool.  {only in
-				X11 and Win32 GUI}
+:tm[enu] {menupath} {rhs}	Define a tip for a menu or tool.  (only in
+				X11 and Win32 GUI)
 
-:tm[enu] [menupath]		List menu tips. {only in X11 and Win32 GUI}
+:tm[enu] [menupath]		List menu tips. (only in X11 and Win32 GUI)
 
 							*:tunmenu*
 :tu[nmenu] {menupath}		Remove a tip for a menu or tool.
-				{only in X11 and Win32 GUI}
+				(only in X11 and Win32 GUI)
 
 Note: To create menus for terminal mode, use |:tlmenu| instead.
 

--- a/runtime/doc/hebrew.txt
+++ b/runtime/doc/hebrew.txt
@@ -11,8 +11,9 @@ Lottem. <alottem at gmail dot com>  Ron Aaron <ron at ronware dot org> is
 currently helping support these features.
 
 
+------------------------------------------------------------------------------
 Introduction
-------------
+
 Hebrew-specific options are 'hkmap', 'hkmapp' 'keymap'=hebrew and 'aleph'.
 Hebrew-useful options are 'delcombine', 'allowrevins', 'revins', 'rightleft'
 and 'rightleftcmd'.
@@ -22,8 +23,9 @@ from right to left instead of the usual left to right.  This is useful
 primarily when editing Hebrew or other Middle-Eastern languages.
 See |rileft.txt| for further details.
 
+------------------------------------------------------------------------------
 Details
---------------
+
 +  Options:
    +  'rightleft' ('rl') sets window orientation to right-to-left.  This means
       that the logical text 'ABC' will be displayed as 'CBA', and will start
@@ -31,7 +33,7 @@ Details
    +  'hkmap' ('hk') sets keyboard mapping to Hebrew, in insert/replace modes.
    +  'aleph' ('al'), numeric, holds the decimal code of Aleph, for keyboard
       mapping.
-   +  'hkmapp' ('hkp') sets keyboard mapping to 'phonetic hebrew'
+   +  'hkmapp' ('hkp') sets keyboard mapping to "phonetic hebrew"
 
    NOTE: these three ('hkmap', 'hkmapp' and 'aleph') are obsolete.  You should
 	 use ":set keymap=hebrewp" instead.
@@ -51,7 +53,7 @@ Details
       ('deco' does nothing if UTF8 encoding is not active).
 
 +  Vim arguments:
-   +  'vim -H file' starts editing a Hebrew file, i.e. 'rightleft' and 'hkmap'
+   +  `vim -H file` starts editing a Hebrew file, i.e. 'rightleft' and 'hkmap'
       are set.
 
 +  Keyboard:
@@ -116,8 +118,9 @@ when exiting 'revins' via CTRL-_, the cursor moves to the end of the typed
 text (if possible).
 
 
+------------------------------------------------------------------------------
 Pasting when in a rightleft window
-----------------------------------
+
 When cutting text with the mouse and pasting it in a rightleft window
 the text will be reversed, because the characters come from the cut buffer
 from the left to the right, while inserted in the file from the right to
@@ -125,8 +128,9 @@ the left.   In order to avoid it, toggle 'revins' (by typing CTRL-? or CTRL-_)
 before pasting.
 
 
+------------------------------------------------------------------------------
 Hebrew characters and the 'isprint' variable
---------------------------------------------
+
 Sometimes Hebrew character codes are in the non-printable range defined by
 the 'isprint' variable.  For example in the Linux console, the Hebrew font
 encoding starts from 128, while the default 'isprint' variable is @,161-255.

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -342,7 +342,7 @@ should begin with the name of the Vim plugin.  The tag name is usually right
 aligned on a line.
 
 When referring to an existing help tag and to create a hot-link, place the
-name between two bars (|) eg. |help-writing|.
+name between two bars ("|") eg. |help-writing|.
 
 When referring to a Vim command and to create a hot-link, place the
 name between two backticks, eg. inside `:filetype`.  You will see this is

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -35,7 +35,7 @@ The rest of this section describes the 'cindent' option.
 
 Note that 'cindent' indenting does not work for every code scenario.  Vim
 is not a C compiler: it does not recognize all syntax.  One requirement is
-that toplevel functions have a '{' in the first column.  Otherwise they are
+that toplevel functions have a "{" in the first column.  Otherwise they are
 easily confused with declarations.
 
 These five options control C program indenting:
@@ -60,12 +60,12 @@ used instead.  The format of 'cinkeys' and 'indentkeys' is equal.
 The default is "0{,0},0),0],:,0#,!^F,o,O,e" which specifies that indenting
 occurs as follows:
 
-	"0{"	if you type '{' as the first character in a line
-	"0}"	if you type '}' as the first character in a line
-	"0)"	if you type ')' as the first character in a line
-	"0]"	if you type ']' as the first character in a line
-	":"	if you type ':' after a label or case statement
-	"0#"	if you type '#' as the first character in a line
+	"0{"	if you type "{" as the first character in a line
+	"0}"	if you type "}" as the first character in a line
+	"0)"	if you type ")" as the first character in a line
+	"0]"	if you type "]" as the first character in a line
+	":"	if you type ":" after a label or case statement
+	"0#"	if you type "#" as the first character in a line
 	"!^F"	if you type CTRL-F (which is not inserted)
 	"o"	if you type a <CR> anywhere or use the "o" command (not in
 		insert mode!)
@@ -74,21 +74,21 @@ occurs as follows:
 		line
 
 Characters that can precede each key:				*i_CTRL-F*
-!	When a '!' precedes the key, Vim will not insert the key but will
+!	When a "!" precedes the key, Vim will not insert the key but will
 	instead reindent the current line.  This allows you to define a
 	command key for reindenting the current line.  CTRL-F is the default
 	key for this.  Be careful if you define CTRL-I for this because CTRL-I
 	is the ASCII code for <Tab>.
-*	When a '*' precedes the key, Vim will reindent the line before
+*	When a "*" precedes the key, Vim will reindent the line before
 	inserting the key.  If 'cinkeys' contains "*<Return>", Vim reindents
 	the current line before opening a new line.
-0	When a zero precedes the key (but appears after '!' or '*') Vim will
+0	When a zero precedes the key (but appears after "!" or "*") Vim will
 	reindent the line only if the key is the first character you type in
 	the line.  When used before "=" Vim will only reindent the line if
 	there is only white space before the word.
 
-When neither '!' nor '*' precedes the key, Vim reindents the line after you
-type the key.  So ';' sets the indentation of a line which includes the ';'.
+When neither "!" nor "*" precedes the key, Vim reindents the line after you
+type the key.  So ";" sets the indentation of a line which includes the ";".
 
 Special key names:
 <>	Angle brackets mean spelled-out names of keys.  For example: "<Up>",
@@ -154,8 +154,8 @@ The examples below assume a 'shiftwidth' of 4.
 	eN    Add N to the prevailing indent inside a set of braces if the
 	      opening brace at the End of the line (more precise: is not the
 	      first character in a line).  This is useful if you want a
-	      different indent when the '{' is at the start of the line from
-	      when '{' is at the end of the line.  (default 0).
+	      different indent when the "{" is at the start of the line from
+	      when "{" is at the end of the line.  (default 0).
 
 		cino=		    cino=e2		cino=e-2 >
 		  if (cond) {	      if (cond) {	  if (cond) {
@@ -169,8 +169,8 @@ The examples below assume a 'shiftwidth' of 4.
 							*cino-n*
 	nN    Add N to the prevailing indent for a statement after an "if",
 	      "while", etc., if it is NOT inside a set of braces.  This is
-	      useful if you want a different indent when there is no '{'
-	      before the statement from when there is a '{' before it.
+	      useful if you want a different indent when there is no "{"
+	      before the statement from when there is a "{" before it.
 	      (default 0).
 
 		cino=		    cino=n2		cino=n-2 >
@@ -193,7 +193,7 @@ The examples below assume a 'shiftwidth' of 4.
 		      int foo;		    int foo;		  int foo;
 <
 							*cino-{*
-	{N    Place opening braces N characters from the prevailing indent.
+	`{N`    Place opening braces N characters from the prevailing indent.
 	      This applies only for opening braces that are inside other
 	      braces.  (default 0).
 
@@ -203,7 +203,7 @@ The examples below assume a 'shiftwidth' of 4.
 		      foo;		  foo;		      foo;
 <
 							*cino-}*
-	}N    Place closing braces N characters from the matching opening
+	`}N`    Place closing braces N characters from the matching opening
 	      brace.  (default 0).
 
 		cino=		    cino={2,}-0.5s	cino=}2 >
@@ -846,7 +846,7 @@ own 'formatoptions'): >
 
 Else, 't' will be removed from the 'formatoptions' string and "qrowcb" will be
 added, see |fo-table| for more information.
--------------
+
 
 							*PHP_outdentSLComments*
 To add extra indentation to single-line comments: >
@@ -858,7 +858,7 @@ Only single-line comments will be affected such as: >
     # Comment
     // Comment
     /* Comment */
--------------
+<
 
 							*PHP_default_indenting*
 To add extra indentation to every PHP lines with N being the number of
@@ -878,18 +878,17 @@ For example, with N = 1, this will give:
 	$command_hist = TRUE;
     ?>
 (Notice the extra indentation between the PHP container markers and the code)
--------------
 
 							*PHP_outdentphpescape*
 To indent PHP escape tags as the surrounding non-PHP code (only affects the
 PHP escape tags): >
     :let g:PHP_outdentphpescape = 0
--------------
+<
 
 							*PHP_removeCRwhenUnix*
 To automatically remove '\r' characters when the 'fileformat' is set to Unix: >
     :let g:PHP_removeCRwhenUnix = 1
--------------
+<
 
 							*PHP_BracesAtCodeLevel*
 To indent braces at the same level than the code they contain: >
@@ -908,7 +907,6 @@ Instead of: >
 
 NOTE:	Indenting will be a bit slower if this option is used because some
 	optimizations won't be available.
--------------
 
 					*PHP_vintage_case_default_indent*
 To indent 'case:' and 'default:' statements in switch() blocks: >
@@ -918,7 +916,6 @@ In PHP braces are not required inside 'case/default' blocks therefore 'case:'
 and 'default:' are indented at the same level than the 'switch()' to avoid
 meaningless indentation. You can use the above option to return to the
 traditional way.
--------------
 
 							*PHP_noArrowMatching*
 By default the indent script will indent multi-line chained calls by matching
@@ -927,17 +924,16 @@ the position of the '->': >
     $user_name_very_long->name()
                         ->age()
                         ->info();
-
+<
 You can revert to the classic way of indenting by setting this option to 1: >
     :let g:PHP_noArrowMatching = 1
-
+<
 You will obtain the following result: >
 
     $user_name_very_long->name()
         ->age()
         ->info();
-
--------------
+<
 
 					*PHP_IndentFunctionCallParameters*
 Extra indentation levels to add to parameters in multi-line function calls. >
@@ -954,14 +950,13 @@ Function call arguments will indent 1 extra level. For two-space indentation: >
           $and_that
       );
     }
-
--------------
+<
 
 				*PHP_IndentFunctionDeclarationParameters*
 Extra indentation levels to add to arguments in multi-line function
 definitions. >
     let g:PHP_IndentFunctionDeclarationParameters = 1
-
+<
 Function arguments in declarations will indent 1 extra level. For two-space
 indentation: >
 
@@ -974,7 +969,7 @@ indentation: >
         $and_that
       );
     }
-
+<
 
 PYTHON							*ft-python-indent*
 
@@ -1145,7 +1140,6 @@ to the vimrc file, which causes the previous alignment example to change: >
   );
   END ENTITY sync;
 
-----------------------------------------
 
 Alignment of right-hand side assignment "<=" statements are performed by
 default. This causes the following alignment example: >
@@ -1164,7 +1158,6 @@ to the vimrc file, which causes the previous alignment example to change: >
     (sig_b OR sig_c)) OR
     (bus_a(0) AND sig_d);
 
-----------------------------------------
 
 Full-line comments (lines that begin with "--") are indented to be aligned with
 the very previous line's comment, PROVIDED that a whitespace follows after

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -257,8 +257,8 @@ CTRL-]		Trigger abbreviation, without inserting a character.
 
 						*i_<Insert>*
 <Insert>	Toggle between Insert and Replace mode.
------------------------------------------------------------------------
 
+-----------------------------------------------------------------------
 						*i_backspacing*
 The effect of the <BS>, CTRL-W, and CTRL-U depend on the 'backspace' option
 (unless 'revins' is set).  This is a comma-separated list of items:
@@ -378,6 +378,7 @@ CTRL-G u	close undo sequence, start new change	     *i_CTRL-G_u*
 CTRL-G U	don't start a new undo block with the next   *i_CTRL-G_U*
 		left/right cursor movement, if the cursor
 		stays within the same line
+
 -----------------------------------------------------------------------
 
 The CTRL-O command sometimes has a side effect: If the cursor was beyond the
@@ -1450,13 +1451,13 @@ At the moment (beginning of 2006) there are two main browsers - MS Internet
 Explorer and Mozilla Firefox. These two applications are covering over 90% of
 market. Theoretically standards are created by W3C organisation
 (https://www.w3.org/) but they are not always followed/implemented.
-
+>
 		IE	FF	W3C  Omni completion ~
 		+/-	+/-	+    +		     ~
 		+	+	-    +		     ~
 		+	-	-    -		     ~
 		-	+	-    -		     ~
-
+<
 Regardless from state of implementation in browsers but if element is defined
 in standards, completion plugin will place element in suggestion list. When
 both major engines implemented element, even if this is not in standards it

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -520,12 +520,12 @@ CTRL-O in Insert mode you get a beep but you are still in Insert mode, type
 		TO mode						    ~
 		Normal	Visual	Select	Insert	  Replace   Cmd-line  Ex ~
 FROM mode								 ~
-Normal			v V ^V	  *4	 *1	   R gR     : / ? !   Q
-Visual		 *2		  ^G	 c C	    --	      :       --
-Select		 *5	^O ^G		 *6	    --	      --      --
+Normal			v V ^V	  `*4`	 *1	   R gR     : / ? !   Q
+Visual		 `*2`		  ^G	 c C	    --	      :       --
+Select		 `*5`	^O ^G		 `*6`	    --	      --      --
 Insert		 <Esc>	  --	  --		  <Insert>    --      --
 Replace		 <Esc>	  --	  --	<Insert>	      --      --
-Command-line	 *3	  --	  --	 :start	    --		      --
+Command-line	 `*3`	  --	  --	 :start	    --		      --
 Ex		 :vi	  --	  --	 --	    --	      --
 
 -- not possible
@@ -589,26 +589,26 @@ Lines longer than the window width will wrap, unless the 'wrap' option is off
 
 If the window has room after the last line of the buffer, Vim will show '~' in
 the first column of the last lines in the window, like this:
-
+>
 	+-----------------------+
 	|some line		|
 	|last line		|
 	|~			|
 	|~			|
 	+-----------------------+
-
+<
 Thus the '~' lines indicate that the end of the buffer was reached.
 
 If the last line in a window doesn't fit, Vim will indicate this with a '@' in
 the first column of the last lines in the window, like this:
-
+>
 	+-----------------------+
 	|first line		|
 	|second line		|
 	|@			|
 	|@			|
 	+-----------------------+
-
+<
 Thus the '@' lines indicate that there is a line that doesn't fit in the
 window.
 
@@ -616,14 +616,14 @@ When the "lastline" flag is present in the 'display' option, you will not see
 '@' characters at the left side of window.  If the last line doesn't fit
 completely, only the part that fits is shown, and the last three characters of
 the last line are replaced with "@@@", like this:
-
+>
 	+-----------------------+
 	|first line		|
 	|second line		|
 	|a very long line that d|
 	|oesn't fit in the wi@@@|
 	+-----------------------+
-
+<
 If there is a single line that is too long to fit in the window, this is a
 special situation.  Vim will show only part of the line, around where the
 cursor is.  There are no special characters shown, so that you can edit all
@@ -704,9 +704,9 @@ Definitions						*definitions* *jargon*
 
 A screen contains one or more windows, separated by status lines and with the
 command line at the bottom.
-
+>
 	+-------------------------------+
-screen	| window 1	| window 2	|
+ screen	| window 1	| window 2	|
 	|		|		|
 	|		|		|
 	|= status line =|= status line =|
@@ -716,7 +716,7 @@ screen	| window 1	| window 2	|
 	|==== status line ==============|
 	|command line			|
 	+-------------------------------+
-
+<
 The command line is also used for messages.  It scrolls up the screen when
 there is not enough room in the command line.
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1502,8 +1502,7 @@ region({bufnr}, {pos1}, {pos2}, {regtype}, {inclusive})         *vim.region()*
                      end-inclusive
 
     Return: ~
-        table<integer, {}> region lua table of the form {linenr =
-        {startcol,endcol}}
+        (table) region Table of the form `{linenr = {startcol,endcol}}`
 
 schedule_wrap({cb})                                      *vim.schedule_wrap()*
     Defers callback `cb` until the Nvim API is safe to call.
@@ -1711,8 +1710,7 @@ split({s}, {sep}, {kwargs})                                      *vim.split()*
     Parameters: ~
       • {s}       (string) String to split
       • {sep}     (string) Separator or pattern
-      • {kwargs}  ({plain: boolean, trimempty: boolean}|nil) Keyword
-                  arguments:
+      • {kwargs}  (table|nil) Keyword arguments:
                   • plain: (boolean) If `true` use `sep` literally (passed to
                     string.find)
                   • trimempty: (boolean) If `true` remove empty items from the

--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -2626,7 +2626,7 @@ uv.fs_read({fd}, {size} [, {offset} [, {callback}]])              *uv.fs_read()*
                 indicates EOF.
 
                 If `offset` is nil or omitted, it will default to `-1`, which
-                indicates 'use and update the current file offset.'
+                indicates "use and update the current file offset."
 
                 Note: When `offset` is >= 0, the current file offset will not
                 be updated by the read.
@@ -2665,7 +2665,7 @@ uv.fs_write({fd}, {data} [, {offset} [, {callback}]])            *uv.fs_write()*
                 written.
 
                 If `offset` is nil or omitted, it will default to `-1`, which
-                indicates 'use and update the current file offset.'
+                indicates "use and update the current file offset."
 
                 Note: When `offset` is >= 0, the current file offset will not
                 be updated by the write.

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -666,9 +666,9 @@ This is useful to specify a (multibyte) character in a 'keymap' file.
 Upper and lowercase differences are ignored.
 
 							*map-comments*
-It is not possible to put a comment after these commands, because the '"'
+It is not possible to put a comment after these commands, because the `"`
 character is considered to be part of the {lhs} or {rhs}. However, one can
-use |", since this starts a new, empty command with a comment.
+use `|"`, since this starts a new, empty command with a comment.
 
 							*map_bar* *map-bar*
 Since the '|' character is used to separate a map command from the next

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -625,7 +625,7 @@ and what the keymaps are to get those characters:
 
 glyph   encoding	   keymap ~
 Char UTF-8 cp1255  hebrew  hebrewp  name ~
-א    0x5d0  0xe0     t	      a     'alef
+א    0x5d0  0xe0     t	      a     ´alef
 ב    0x5d1  0xe1     c	      b     bet
 ג    0x5d2  0xe2     d	      g     gimel
 ד    0x5d3  0xe3     s	      d     dalet
@@ -706,7 +706,7 @@ Char UTF-8 hebrew name
 
 Combining forms:
 ﬠ    0xfb20  X`   Alternative `ayin
-ﬡ    0xfb21  X'   Alternative 'alef
+ﬡ    0xfb21  X'   Alternative ´alef
 ﬢ    0xfb22  X-d  Alternative dalet
 ﬣ    0xfb23  X-h  Alternative he
 ﬤ    0xfb24  X-k  Alternative kaf

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -312,7 +312,7 @@ g<Down>			[count] display lines downward.  |exclusive| motion.
 `-`  <minus>		[count] lines upward, on the first non-blank
 			character |linewise|.
 
-+		or					*+*
+`+`		or					*+*
 CTRL-M		or					*CTRL-M* *<CR>*
 <CR>			[count] lines downward, on the first non-blank
 			character |linewise|.
@@ -438,9 +438,9 @@ between Vi and Vim.
 }			[count] |paragraph|s forward.  |exclusive| motion.
 
 							*]]*
-]]			[count] |section|s forward or to the next '{' in the
+]]			[count] |section|s forward or to the next "{" in the
 			first column.  When used after an operator, then also
-			stops below a '}' in the first column.  |exclusive|
+			stops below a "}" in the first column.  |exclusive|
 			Note that |exclusive-linewise| often applies.
 
 							*][*
@@ -449,12 +449,12 @@ between Vi and Vim.
 			Note that |exclusive-linewise| often applies.
 
 							*[[*
-[[			[count] |section|s backward or to the previous '{' in
+[[			[count] |section|s backward or to the previous "{" in
 			the first column.  |exclusive|
 			Note that |exclusive-linewise| often applies.
 
 							*[]*
-[]			[count] |section|s backward or to the previous '}' in
+[]			[count] |section|s backward or to the previous "}" in
 			the first column.  |exclusive|
 			Note that |exclusive-linewise| often applies.
 
@@ -1004,8 +1004,8 @@ These commands are not marks themselves, but jump to a mark:
 			Note that ":keepjumps" must be used for every command.
 			When invoking a function the commands in that function
 			can still change the jumplist.  Also, for
-			":keepjumps exe 'command '" the "command" won't keep
-			jumps.  Instead use: ":exe 'keepjumps command'"
+			`:keepjumps exe 'command '` the "command" won't keep
+			jumps.  Instead use: `:exe 'keepjumps command'`
 
 ==============================================================================
 8. Jumps					*jump-motions*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -145,7 +145,7 @@ This sets the 'titlestring' option to "hi" and 'iconstring' to "there": >
 
 Similarly, the double quote character starts a comment.  To include the '"' in
 the option value, use '\"' instead.  This example sets the 'titlestring'
-option to 'hi "there"': >
+option to "hi "there"": >
    :set titlestring=hi\ \"there\"
 
 For Win32 backslashes in file names are mostly not removed.  More precise: For
@@ -1325,7 +1325,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	These names are recognized:
 
 						*clipboard-unnamed*
-	unnamed		When included, Vim will use the clipboard register '*'
+	unnamed		When included, Vim will use the clipboard register "*"
 			for all yank, delete, change and put operations which
 			would normally go to the unnamed register.  When a
 			register is explicitly specified, it will always be
@@ -1336,8 +1336,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*clipboard-unnamedplus*
 	unnamedplus	A variant of the "unnamed" flag which uses the
-			clipboard register '+' (|quoteplus|) instead of
-			register '*' for all yank, delete, change and put
+			clipboard register "+" (|quoteplus|) instead of
+			register "*" for all yank, delete, change and put
 			operations which would normally go to the unnamed
 			register.  When "unnamed" is also included to the
 			option, yank and delete operations (but not put)
@@ -4357,7 +4357,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	w x	updown		up-down sizing arrows
 	w x	leftright	left-right sizing arrows
 	w x	busy		The system's usual busy pointer
-	w x	no		The system's usual 'no input' pointer
+	w x	no		The system's usual "no input" pointer
 	  x	udsizing	indicates up-down resizing
 	  x	lrsizing	indicates left-right resizing
 	  x	crosshair	like a big thin +
@@ -4434,12 +4434,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 		'nonu'          'nu'            'nonu'          'nu'
 		'nornu'         'nornu'         'rnu'           'rnu'
-
+>
 	    |apple          |  1 apple      |  2 apple      |  2 apple
 	    |pear           |  2 pear       |  1 pear       |  1 pear
 	    |nobody         |  3 nobody     |  0 nobody     |3   nobody
 	    |there          |  4 there      |  1 there      |  1 there
-
+<
 						*'numberwidth'* *'nuw'*
 'numberwidth' 'nuw'	number	(default: 4)
 			local to window
@@ -5798,11 +5798,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 	alternative.
 	Normally 'autoindent' should also be on when using 'smartindent'.
 	An indent is automatically inserted:
-	- After a line ending in '{'.
+	- After a line ending in "{".
 	- After a line starting with a keyword from 'cinwords'.
-	- Before a line starting with '}' (only with the "O" command).
+	- Before a line starting with "}" (only with the "O" command).
 	When typing '}' as the first character in a new line, that line is
-	given the same indent as the matching '{'.
+	given the same indent as the matching "{".
 	When typing '#' as the first character in a new line, the indent for
 	that line is removed, the '#' is put in the first column.  The indent
 	is restored for the next line.  If you don't want this, use this
@@ -6085,12 +6085,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	field	    meaning ~
 	-	    Left justify the item.  The default is right justified
 		    when minwid is larger than the length of the item.
-	0	    Leading zeroes in numeric items.  Overridden by '-'.
-	minwid	    Minimum width of the item, padding as set by '-' & '0'.
+	0	    Leading zeroes in numeric items.  Overridden by "-".
+	minwid	    Minimum width of the item, padding as set by "-" & "0".
 		    Value must be 50 or less.
-	maxwid	    Maximum width of the item.  Truncation occurs with a '<'
+	maxwid	    Maximum width of the item.  Truncation occurs with a "<"
 		    on the left for text items.  Numeric items will be
-		    shifted down to maxwid-2 digits followed by '>'number
+		    shifted down to maxwid-2 digits followed by ">"number
 		    where number is the amount of missing digits, much like
 		    an exponential notation.
 	item	    A one letter code as described below.
@@ -6139,22 +6139,22 @@ A jump table for the options with a short description can be found at |Q_op|.
 	S S   'showcmd' content, see 'showcmdloc'.
 	a S   Argument list status as in default title.  ({current} of {max})
 	      Empty if the argument file count is zero or one.
-	{ NF  Evaluate expression between '%{' and '}' and substitute result.
-	      Note that there is no '%' before the closing '}'.  The
-	      expression cannot contain a '}' character, call a function to
+	{ NF  Evaluate expression between "%{" and "}" and substitute result.
+	      Note that there is no "%" before the closing "}".  The
+	      expression cannot contain a "}" character, call a function to
 	      work around that.  See |stl-%{| below.
-	{% -  This is almost same as { except the result of the expression is
+	`{%` -  This is almost same as "{" except the result of the expression is
 	      re-evaluated as a statusline format string.  Thus if the
-	      return value of expr contains % items they will get expanded.
-	      The expression can contain the } character, the end of
-	      expression is denoted by %}.
+	      return value of expr contains "%" items they will get expanded.
+	      The expression can contain the "}" character, the end of
+	      expression is denoted by "%}".
 	      For example: >
 		func! Stl_filename() abort
 		    return "%t"
 		endfunc
 <	        `stl=%{Stl_filename()}`   results in `"%t"`
 	        `stl=%{%Stl_filename()%}` results in `"Name of current file"`
-	%} -  End of `{%` expression
+	%} -  End of "{%" expression
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -2821,12 +2821,12 @@ your browsing preferences.  (see also: |netrw-settings|)
 				function 'netrw_gitignore#Hide() automatically
 				hiding all gitignored files.
 				For more details see |netrw-gitignore|.
+				 default: ""
 
-				Examples:
-				 let g:netrw_list_hide= '.*\.swp$'
-				 let g:netrw_list_hide= netrw_gitignore#Hide() .. '.*\.swp$'
-				default: ""
-
+				Examples: >
+				  let g:netrw_list_hide= '.*\.swp$'
+				  let g:netrw_list_hide= netrw_gitignore#Hide() .. '.*\.swp$'
+<
   *g:netrw_localcopycmd*	="cp"           Linux/Unix/MacOS/Cygwin
 				=expand("$COMSPEC")             Windows
 				Copies marked files (|netrw-mf|) to target
@@ -3268,7 +3268,7 @@ If there are marked files:  (see |netrw-mf|)
     	mr  [query: reply with *.c]
 	R   [query: reply with s/^\(.*\)\.c$/\1.cpp/]
 <
-    This example will mark all *.c files and then rename them to *.cpp
+    This example will mark all "*.c" files and then rename them to "*.cpp"
     files.  Netrw will protect you from overwriting local files without
     confirmation, but not remote ones.
 
@@ -3280,7 +3280,7 @@ If there are marked files:  (see |netrw-mf|)
 	<c-x><c-x> : a pair of contiguous ctrl-x's tells netrw to ignore any
 		     portion of the string preceding the double ctrl-x's.
 <
-    WARNING:~
+    WARNING: ~
 
     Note that moving files is a dangerous operation; copies are safer.  That's
     because a "move" for remote files is actually a copy + delete -- and if
@@ -3776,9 +3776,9 @@ Example: Clear netrw's marked file list via a mapping on gu >
 <
 								*netrw-P22*
 	P22. I get an error message when I try to copy or move a file:      {{{2
-
+>
 		**error** (netrw) tried using g:netrw_localcopycmd<cp>; it doesn't work!
-
+<
 	     What's wrong?
 
 	     Netrw uses several system level commands to do things (see
@@ -4001,9 +4001,9 @@ netrw:
 		Nov 22, 2016	* (glacambre) reported that files containing
 				  spaces weren't being obtained properly via
 				  scp.  Fix: apparently using single quotes
-				  such as with 'file name' wasn't enough; the
+				  such as with "file name" wasn't enough; the
 				  spaces inside the quotes also had to be
-				  escaped (ie. 'file\ name').
+				  escaped (ie. "file\ name").
 				* Also fixed obtain (|netrw-O|) to be able to
 				  obtain files with spaces in their names
 		Dec 20, 2016	* (xc1427) Reported that using "I" (|netrw-I|)

--- a/runtime/doc/pi_spec.txt
+++ b/runtime/doc/pi_spec.txt
@@ -34,8 +34,8 @@ also check if the name, version and release matches.  The plugin is smart
 enough to ask you if it should update the package release, if you have not
 done so.
 
+------------------------------------------------------------------------------
 Setting a map					*spec-setting-a-map*
--------------
 
 As you should know, you can easily set a map to access any Vim command (or
 anything, for that matter).  If you don't like the default map of
@@ -54,8 +54,8 @@ This command will add a map only in the spec file buffers.
 ==============================================================================
 2. Customizing					*spec-customizing*
 
+------------------------------------------------------------------------------
 The format string				*spec_chglog_format*
------------------
 
 You can easily customize how your spec file entry will look like.  To do
 this just set the variable "spec_chglog_format" in your vimrc file like
@@ -72,8 +72,8 @@ address once.
 To discover which format options you can use, take a look at the strftime()
 function man page.
 
+------------------------------------------------------------------------------
 Where to insert new items			*spec_chglog_prepend*
--------------------------
 
 The plugin will usually insert new %changelog entry items (note that it's
 not the entry itself) after the existing ones.  If you set the
@@ -83,8 +83,8 @@ spec_chglog_prepend variable >
 
 it will insert new items before the existing ones.
 
+------------------------------------------------------------------------------
 Inserting release info				*spec_chglog_release_info*
-----------------------
 
 If you want, the plugin may automatically insert release information
 on each changelog entry.  One advantage of turning this feature on is

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1585,8 +1585,9 @@ A call of |:clist| writes them accordingly with their correct filenames:
 
 Unlike the other prefixes that all match against whole lines, %P, %Q and %O
 can be used to match several patterns in the same line.  Thus it is possible
-to parse even nested files like in the following line:
+to parse even nested files like in the following line: >
   {"file1" {"file2" error1} error2 {"file3" error3 {"file4" error4 error5}}}
+<
 The %O then parses over strings that do not contain any push/pop file name
 information.  See |errorformat-LaTeX| for an extended example.
 
@@ -1946,9 +1947,9 @@ by Vim.
 
 The default format for the lines displayed in the quickfix window and location
 list window is:
-
+>
     <filename>|<lnum> col <col>|<text>
-
+<
 The values displayed in each line correspond to the "bufnr", "lnum", "col" and
 "text" fields returned by the |getqflist()| function.
 

--- a/runtime/doc/rileft.txt
+++ b/runtime/doc/rileft.txt
@@ -12,8 +12,9 @@ These functions were originally created by Avner Lottem:
    E-mail: alottem@iil.intel.com
    Phone:  +972-4-8307322
 
+------------------------------------------------------------------------------
 Introduction
-------------
+
 Some languages such as Arabic, Farsi, Hebrew (among others) require the
 ability to display their text from right-to-left.  Files in those languages
 are stored conventionally and the right-to-left requirement is only a
@@ -32,8 +33,9 @@ as this kind of support is out of the scope of a simple addition to an
 existing editor (and it's not sanctioned by Unicode either).
 
 
+------------------------------------------------------------------------------
 Highlights
-----------
+
 o  Editing left-to-right files as in the original Vim, no change.
 
 o  Viewing and editing files in right-to-left windows.  File orientation
@@ -56,11 +58,11 @@ o  Many languages use and require right-to-left support.  These languages
    current supported languages include - |arabic.txt| and |hebrew.txt|.
 
 
+------------------------------------------------------------------------------
 Of Interest...
---------------
 
 o  Invocations
-   -----------
+
    + 'rightleft' ('rl') sets window orientation to right-to-left.
    + 'delcombine' ('deco'), boolean, if editing UTF-8 encoded languages,
      allows one to remove a composing character which gets superimposed
@@ -69,7 +71,7 @@ o  Invocations
      (such as search) to be utilized in right-to-left orientation as well.
 
 o  Typing backwards					*ins-reverse*
-   ----------------
+
    In lieu of using the full-fledged 'rightleft' option, one can opt for
    reverse insertion.  When the 'revins' (reverse insert) option is set,
    inserting happens backwards.  This can be used to type right-to-left
@@ -85,15 +87,16 @@ o  Typing backwards					*ins-reverse*
    in the status line when reverse Insert mode is active.
 
 o  Pasting when in a rightleft window
-   ----------------------------------
+
    When cutting text with the mouse and pasting it in a rightleft window
    the text will be reversed, because the characters come from the cut buffer
    from the left to the right, while inserted in the file from the right to
    the left.   In order to avoid it, toggle 'revins' before pasting.
 
 
+------------------------------------------------------------------------------
 Bugs
-----
+
 o  Does not handle CTRL-A and CTRL-X commands (add and subtract) correctly
    when in rightleft window.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -483,13 +483,13 @@ accordingly, proceeding as follows:
 	However, directories in 'runtimepath' ending in "after" are skipped
 	here and only loaded after packages, see below.
 	Loading plugins won't be done when:
-	- The 'loadplugins' option was reset in a vimrc file.
+	- The |'loadplugins'| option was reset in a vimrc file.
 	- The |--noplugin| command line argument is used.
 	- The |--clean| command line argument is used.
 	- The "-u NONE" command line argument is used |-u|.
-	Note that using "-c 'set noloadplugins'" doesn't work, because the
+	Note that using `-c 'set noloadplugins'` doesn't work, because the
 	commands from the command line have not been executed yet.  You can
-	use "--cmd 'set noloadplugins'" or "--cmd 'set loadplugins'" |--cmd|.
+	use `--cmd 'set noloadplugins'` or `--cmd 'set loadplugins'` |--cmd|.
 
 	Packages are loaded.  These are plugins, as above, but found in the
 	"start" directory of each entry in 'packpath'.  Every plugin directory

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2475,7 +2475,7 @@ from the rest of the name (like 'PkgName::' in '$PkgName::VarName'): >
 (In Vim 6.x it was the other way around: "perl_want_scope_in_variables"
 enabled it.)
 
-If you do not want complex things like '@{${"foo"}}' to be parsed: >
+If you do not want complex things like `@{${"foo"}}` to be parsed: >
 
 	:let perl_no_extended_vars = 1
 
@@ -5042,7 +5042,7 @@ ctermbg={color-nr}				*ctermbg*
 	a number instead of a color name.
 
 	Note that for 16 color ansi style terminals (including xterms), the
-	numbers in the NR-8 column is used.  Here '*' means 'add 8' so that 
+	numbers in the NR-8 column is used.  Here "*" means "add 8" so that 
 	Blue is 12, DarkGray is 8 etc.
 
 	Note that for some color terminals these names may result in the wrong

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -59,9 +59,9 @@ CTRL-]			Jump to the definition of the keyword under the
 CTRL-] is the default telnet escape key.  When you type CTRL-] to jump to a
 tag, you will get the telnet prompt instead.  Most versions of telnet allow
 changing or disabling the default escape key.  See the telnet man page.  You
-can 'telnet -E {Hostname}' to disable the escape character, or 'telnet -e
-{EscapeCharacter} {Hostname}' to specify another escape character.  If
-possible, try to use "ssh" instead of "telnet" to avoid this problem.
+can `telnet -E {Hostname}` to disable the escape character, or
+`telnet -e {EscapeCharacter} {Hostname}` to specify another escape character.
+If possible, try to use "ssh" instead of "telnet" to avoid this problem.
 
 							*tag-priority*
 When there are multiple matches for a tag, this priority is used:
@@ -404,7 +404,7 @@ is added to the command and on the 'autowrite' option:
 
   tag in       file	   autowrite			~
 current file  changed	!   option	  action	~
------------------------------------------------------------------------------
+ ---------------------------------------------------------------------------
     yes		 x	x     x	  goto tag
     no		 no	x     x	  read other file, goto tag
     no		yes    yes    x   abandon current file, read other file, goto
@@ -412,7 +412,7 @@ current file  changed	!   option	  action	~
     no		yes	no    on  write current file, read other file, goto
 				  tag
     no		yes	no   off  fail
------------------------------------------------------------------------------
+ ---------------------------------------------------------------------------
 
 - If the tag is in the current file, the command will always work.
 - If the tag is in another file and the current file was not changed, the
@@ -561,8 +561,8 @@ ctags).
 		with Vi, it ignores the following fields. Example:
 			APP	file	/^static int APP;$/;"	v
 		When {tagaddress} is not a line number or search pattern, then
-		{term} must be |;".  Here the bar ends the command (excluding
-		the bar) and ;" is used to have Vi ignore the rest of the
+		{term} must be `|;"`.  Here the bar ends the command (excluding
+		the bar) and `;"` is used to have Vi ignore the rest of the
 		line.  Example:
 			APP	file.c	call cursor(3, 4)|;"	v
 
@@ -848,9 +848,9 @@ Common arguments for the commands above:
 	a comment (even though syntax highlighting does recognize it).
 	Note: Since a macro definition mostly doesn't look like a comment, the
 	[!] makes no difference for ":dlist", ":dsearch" and ":djump".
-[/]	A pattern can be surrounded by '/'.  Without '/' only whole words are
-	matched, using the pattern "\<pattern\>".  Only after the second '/' a
-	next command can be appended with '|'.  Example: >
+[/]	A pattern can be surrounded by "/".  Without "/" only whole words are
+	matched, using the pattern "\<pattern\>".  Only after the second "/" a
+	next command can be appended with "|".  Example: >
 	:isearch /string/ | echo "the last one"
 <	For a ":djump", ":dsplit", ":dlist" and ":dsearch" command the pattern
 	is used as a literal string, not as a search pattern.

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -297,7 +297,7 @@ be able to give comments to the parts of the mapping. >
 (<> notation |<>|.  Note that this is all typed literally.  ^W is "^" "W", not
 CTRL-W.)
 
-Note that the last comment starts with |", because the ":execute" command
+Note that the last comment starts with `|"`, because the ":execute" command
 doesn't accept a comment directly.
 
 You also need to set 'textwidth' to a non-zero value, e.g., >

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -343,7 +343,6 @@ is used as a method: >
 
 
 ==============================================================================
-
 3. Automatically loading functions ~
 							*autoload-functions*
 When using many or large functions, it's possible to automatically define them

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -33,7 +33,7 @@ On Unix you can type this at any command prompt.  If you are running Microsoft
 Windows, open a Command Prompt and enter the command.  In either case, Vim
 starts editing a file called file.txt.  Because this is a new file, you get a
 blank window. This is what your screen will look like:
-
+>
 	+---------------------------------------+
 	|#					|
 	|~					|
@@ -43,7 +43,7 @@ blank window. This is what your screen will look like:
 	|"file.txt" [New file]			|
 	+---------------------------------------+
 		('#' is the cursor position.)
-
+<
 The tilde (~) lines indicate lines not in the file.  In other words, when Vim
 runs out of file to display, it displays tilde lines.  At the bottom of the
 screen, a message line indicates the file is named file.txt and shows that you
@@ -83,7 +83,7 @@ limerick, this is what you type: >
 After typing "turtle" you press the <Enter> key to start a new line.  Finally
 you press the <Esc> key to stop Insert mode and go back to Normal mode.  You
 now have two lines of text in your Vim window:
-
+>
 	+---------------------------------------+
 	|A very intelligent turtle		|
 	|Found programming Unix a hurdle	|
@@ -91,7 +91,7 @@ now have two lines of text in your Vim window:
 	|~					|
 	|					|
 	+---------------------------------------+
-
+<
 
 WHAT IS THE MODE?
 
@@ -105,7 +105,7 @@ with a colon).  Finish this command by pressing the <Enter> key (all commands
 that start with a colon are finished this way).
    Now, if you type the "i" command Vim will display --INSERT-- at the bottom
 of the window.  This indicates you are in Insert mode.
-
+>
 	+---------------------------------------+
 	|A very intelligent turtle		|
 	|Found programming Unix a hurdle	|
@@ -113,7 +113,7 @@ of the window.  This indicates you are in Insert mode.
 	|~					|
 	|-- INSERT --				|
 	+---------------------------------------+
-
+<
 If you press <Esc> to go back to Normal mode the last line will be made blank.
 
 
@@ -182,7 +182,7 @@ throwback to the old days of the typewriter, when you deleted things by typing
 xxxx over them.)  Move the cursor to the beginning of the first line, for
 example, and type xxxxxxx (seven x's) to delete "A very ".  The result should
 look like this:
-
+>
 	+---------------------------------------+
 	|intelligent turtle			|
 	|Found programming Unix a hurdle	|
@@ -190,14 +190,14 @@ look like this:
 	|~					|
 	|					|
 	+---------------------------------------+
-
+<
 Now you can insert new text, for example by typing: >
 
 	iA young <Esc>
 
 This begins an insert (the i), inserts the words "A young", and then exits
 insert mode (the final <Esc>).	The result:
-
+>
 	+---------------------------------------+
 	|A young intelligent turtle		|
 	|Found programming Unix a hurdle	|
@@ -205,13 +205,13 @@ insert mode (the final <Esc>).	The result:
 	|~					|
 	|					|
 	+---------------------------------------+
-
+<
 
 DELETING A LINE
 
 To delete a whole line use the "dd" command.  The following line will
 then move up to fill the gap:
-
+>
 	+---------------------------------------+
 	|Found programming Unix a hurdle	|
 	|~					|
@@ -219,7 +219,7 @@ then move up to fill the gap:
 	|~					|
 	|					|
 	+---------------------------------------+
-
+<
 
 DELETING A LINE BREAK
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -107,7 +107,7 @@ Display an incomplete command in the lower right corner of the Vim window,
 left of the ruler.  For example, when you type "2f", Vim is waiting for you to
 type the character to find and "2f" is displayed.  When you press "w" next,
 the "2fw" command is executed and the displayed "2f" is removed.
-
+>
 	+-------------------------------------------------+
 	|text in the Vim window				  |
 	|~						  |
@@ -119,7 +119,7 @@ the "2fw" command is executed and the displayed "2f" is removed.
 
 >
 	set incsearch
-
+<
 Display matches for a search pattern while you type.
 
 >

--- a/runtime/doc/usr_08.txt
+++ b/runtime/doc/usr_08.txt
@@ -32,7 +32,7 @@ The easiest way to open a new window is to use the following command: >
 
 This command splits the screen into two windows and leaves the cursor in the
 top one:
-
+>
 	+----------------------------------+
 	|/* file one.c */		   |
 	|~				   |
@@ -43,7 +43,7 @@ top one:
 	|one.c=============================|
 	|				   |
 	+----------------------------------+
-
+<
 What you see here is two windows on the same file.  The line with "====" is
 the status line.  It displays information about the window above it.  (In
 practice the status line will be in reverse video.)
@@ -87,7 +87,7 @@ The following command opens a second window and starts editing the given file:
 	:split two.c
 
 If you were editing one.c, then the result looks like this:
-
+>
 	+----------------------------------+
 	|/* file two.c */		   |
 	|~				   |
@@ -98,7 +98,7 @@ If you were editing one.c, then the result looks like this:
 	|one.c=============================|
 	|				   |
 	+----------------------------------+
-
+<
 To open a window on a new, empty file, use this: >
 
 	:new
@@ -170,7 +170,7 @@ or: >
 	:vsplit two.c
 
 The result looks something like this:
-
+>
 	+--------------------------------------+
 	|/* file two.c */   |/* file one.c */  |
 	|~		    |~		       |
@@ -179,7 +179,7 @@ The result looks something like this:
 	|two.c===============one.c=============|
 	|				       |
 	+--------------------------------------+
-
+<
 Actually, the | lines in the middle will be in reverse video.  This is called
 the vertical separator.  It separates the two windows left and right of it.
 
@@ -218,7 +218,7 @@ cursor keys can also be used, if you like.
 You have split a few windows, but now they are in the wrong place.  Then you
 need a command to move the window somewhere else.  For example, you have three
 windows like this:
-
+>
 	+----------------------------------+
 	|/* file two.c */		   |
 	|~				   |
@@ -233,7 +233,7 @@ windows like this:
 	|one.c=============================|
 	|				   |
 	+----------------------------------+
-
+<
 Clearly the last one should be at the top.  Go to that window (using CTRL-W w)
 and then type this command: >
 
@@ -244,7 +244,7 @@ the very top.  You will notice that K is again used for moving upwards.
    When you have vertical splits, CTRL-W K will move the current window to the
 top and make it occupy the full width of the Vim window.  If this is your
 layout:
-
+>
 	+-------------------------------------------+
 	|/* two.c */  |/* three.c */  |/* one.c */  |
 	|~	      |~	      |~	    |
@@ -255,9 +255,9 @@ layout:
 	|two.c=========three.c=========one.c========|
 	|					    |
 	+-------------------------------------------+
-
+<
 Then using CTRL-W K in the middle window (three.c) will result in:
-
+>
 	+-------------------------------------------+
 	|/* three.c */				    |
 	|~					    |
@@ -268,7 +268,7 @@ Then using CTRL-W K in the middle window (three.c) will result in:
 	|two.c==================one.c===============|
 	|					    |
 	+-------------------------------------------+
-
+<
 The other three similar commands (you can probably guess these now):
 
 	CTRL-W H	move window to the far left
@@ -316,7 +316,7 @@ To make Vim open a window for each file, start it with the "-o" argument: >
 	vim -o one.txt two.txt three.txt
 
 This results in:
-
+>
 	+-------------------------------+
 	|file one.txt			|
 	|~				|
@@ -329,7 +329,7 @@ This results in:
 	|three.txt======================|
 	|				|
 	+-------------------------------+
-
+<
 The "-O" argument is used to get vertically split windows.
    When Vim is already running, the ":all" command opens a window for each
 file in the argument list.  ":vertical all" does it with vertical splits.
@@ -347,7 +347,7 @@ Type this command in a shell to start Nvim in diff mode: >
 
 Vim will start, with two windows side by side.  You will only see the line
 in which you added characters, and a few lines above and below it.
-
+>
 	 VV		      VV
 	+-----------------------------------------+
 	|+ +--123 lines: /* a|+ +--123 lines: /* a|  <- fold
@@ -366,7 +366,7 @@ in which you added characters, and a few lines above and below it.
 	|main.c~==============main.c==============|
 	|					  |
 	+-----------------------------------------+
-
+<
 (This picture doesn't show the highlighting, use "nvim -d" for that.)
 
 The lines that were not modified have been collapsed into one line.  This is
@@ -519,7 +519,7 @@ Assume you are editing "thisfile".  To create a new tab page use this command: >
 
 This will edit the file "thatfile" in a window that occupies the whole Vim
 window.  And you will notice a bar at the top with the two file names:
-
+>
 	+----------------------------------+
 	| thisfile | /thatfile/ __________X|    (thatfile is bold)
 	|/* thatfile */			   |
@@ -530,13 +530,13 @@ window.  And you will notice a bar at the top with the two file names:
 	|~				   |
 	|				   |
 	+----------------------------------+
-
+<
 You now have two tab pages.  The first one has a window for "thisfile" and the
 second one a window for "thatfile".  It's like two pages that are on top of
 each other, with a tab sticking out of each page showing the file name.
 
 Now use the mouse to click on "thisfile" in the top line.  The result is
-
+>
 	+----------------------------------+
 	| /thisfile/ | thatfile __________X|    (thisfile is bold)
 	|/* thisfile */			   |
@@ -547,7 +547,7 @@ Now use the mouse to click on "thisfile" in the top line.  The result is
 	|~				   |
 	|				   |
 	+----------------------------------+
-
+<
 Thus you can switch between tab pages by clicking on the label in the top
 line.  If you don't have a mouse or don't want to use it, you can use the "gt"
 command.  Mnemonic: Goto Tab.
@@ -558,7 +558,7 @@ Now let's create another tab page with the command: >
 
 This makes a new tab page with one window that is editing the same buffer as
 the window we were in:
-
+>
 	+-------------------------------------+
 	| thisfile | /thisfile/ | thatfile __X|   (thisfile is bold)
 	|/* thisfile */			      |
@@ -569,7 +569,7 @@ the window we were in:
 	|~				      |
 	|				      |
 	+-------------------------------------+
-
+<
 You can put ":tab" before any Ex command that opens a window.  The window will
 be opened in a new tab page.  Another example: >
 

--- a/runtime/doc/usr_10.txt
+++ b/runtime/doc/usr_10.txt
@@ -813,10 +813,10 @@ REDRAWING THE SCREEN
 If the external command produced an error message, the display may have been
 messed up.  Vim is very efficient and only redraws those parts of the screen
 that it knows need redrawing.  But it can't know about what another program
-has written.  To tell Vim to redraw the screen: >
-
+has written.  To tell Vim to redraw the screen:
+>
 	CTRL-L
-
+<
 ==============================================================================
 
 Next chapter: |usr_11.txt|  Recovering from a crash

--- a/runtime/doc/usr_20.txt
+++ b/runtime/doc/usr_20.txt
@@ -338,7 +338,7 @@ Open the command line window with this command: >
 
 Vim now opens a (small) window at the bottom.  It contains the command line
 history, and an empty line at the end:
-
+>
 	+-------------------------------------+
 	|other window			      |
 	|~				      |
@@ -353,7 +353,7 @@ history, and an empty line at the end:
 	|command-line=========================|
 	|				      |
 	+-------------------------------------+
-
+<
 You are now in Normal mode.  You can use the "hjkl" keys to move around.  For
 example, move up with "5k" to the ":e config.h.in" line.  Type "$h" to go to
 the "i" of "in" and type "cwout".  Now you have changed the line to:

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -302,7 +302,7 @@ session file as a starting point.
 use, and save this in a session.  Then you can go back to this layout whenever
 you want.
    For example, this is a nice layout to use:
-
+>
 	+----------------------------------------+
 	|		   VIM - main help file  |
 	|					 |
@@ -318,7 +318,7 @@ you want.
 	|~/=========|[No File]===================|
 	|					 |
 	+----------------------------------------+
-
+<
 This has a help window at the top, so that you can read this text.  The narrow
 vertical window on the left contains a file explorer.  This is a Vim plugin
 that lists the contents of a directory.  You can select files to edit there.
@@ -454,7 +454,7 @@ Use this format for the modeline:
 
 The "any-text" indicates that you can put any text before and after the part
 that Vim will use.  This allows making it look like a comment, like what was
-done above with /* and */.
+done above with "/*" and "*/".
    The " vim:" part is what makes Vim recognize this line.  There must be
 white space before "vim", or "vim" must be at the start of the line.  Thus
 using something like "gvim:" will not work.

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -325,16 +325,16 @@ Let's attempt to show this with one line of text.  The cursor is on the "w" of
 currently visible.  The "window"s below the text indicate the text that is
 visible after the command left of it.
 
-			      |<-- current window -->|
+			      `|<-- current window -->|`
 		some long text, part of which is visible in the window ~
-	ze	  |<--	   window     -->|
-	zH	   |<--     window     -->|
-	4zh		  |<--	   window     -->|
-	zh		     |<--     window	 -->|
-	zl		       |<--	window	   -->|
-	4zl			  |<--	   window     -->|
-	zL				|<--	 window     -->|
-	zs			       |<--	window	   -->|
+	ze	  `|<--	   window     -->|`
+	zH	   `|<--     window     -->|`
+	4zh		  `|<--	   window     -->|`
+	zh		     `|<--     window	 -->|`
+	zl		       `|<--	window	   -->|`
+	4zl			  `|<--	   window     -->|`
+	zL				`|<--	 window     -->|`
+	zs			       `|<--	window	   -->|`
 
 
 MOVING WITH WRAP OFF
@@ -350,7 +350,7 @@ scroll:
 	gM		to middle of the text in this line
 	g$		to last visible character in this line
 
-		|<--	  window     -->|
+		`|<--	  window     -->|`
 	some long    text, part of which is visible in one line ~
 		 g0  g^    gm	   gM g$
 
@@ -365,7 +365,7 @@ broken halfway, which makes them hard to read.
 'linebreak' option.  Vim then breaks lines at an appropriate place when
 displaying the line.  The text in the file remains unchanged.
    Without 'linebreak' text might look like this:
-
+>
 	+---------------------------------+
 	|letter generation program for a b|
 	|ank.  They wanted to send out a s|
@@ -373,12 +373,13 @@ displaying the line.  The text in the file remains unchanged.
 	|eir richest 1000 customers.  Unfo|
 	|rtunately for the programmer, he |
 	+---------------------------------+
+<
 After: >
 
 	:set linebreak
 
 it looks like this:
-
+>
 	+---------------------------------+
 	|letter generation program for a  |
 	|bank.  They wanted to send out a |
@@ -386,7 +387,7 @@ it looks like this:
 	|their richest 1000 customers.    |
 	|Unfortunately for the programmer,|
 	+---------------------------------+
-
+<
 Related options:
 'breakat' specifies the characters where a break can be inserted.
 'showbreak' specifies a string to show at the start of broken line.
@@ -425,7 +426,7 @@ That looks complicated.  Let's break it up in pieces:
 			into one line.
 
 Starting with this text, containing eight lines broken at column 30:
-
+>
 	+----------------------------------+
 	|A letter generation program	   |
 	|for a bank.  They wanted to	   |
@@ -436,9 +437,9 @@ Starting with this text, containing eight lines broken at column 30:
 	|customers.  Unfortunately for	   |
 	|the programmer,		   |
 	+----------------------------------+
-
+<
 You end up with two lines:
-
+>
 	+----------------------------------+
 	|A letter generation program for a |
 	|bank.	They wanted to send out a s|
@@ -446,7 +447,7 @@ You end up with two lines:
 	|To their richest 1000 customers.  |
 	|Unfortunately for the programmer, |
 	+----------------------------------+
-
+<
 Note that this doesn't work when the separating line is blank but not empty;
 when it contains spaces and/or tabs.  This command does work with blank lines:
 >

--- a/runtime/doc/usr_29.txt
+++ b/runtime/doc/usr_29.txt
@@ -53,7 +53,7 @@ function.
    The "write_line" function calls "write_char".  You need to figure out what
 it does.  So you position the cursor over the call to "write_char" and press
 CTRL-].  Now you are at the definition of "write_char".
-
+>
 	+-------------------------------------+
 	|void write_block(char **s; int cnt)  |
 	|{				      |
@@ -79,7 +79,7 @@ CTRL-].  Now you are at the definition of "write_char".
 				       |    putchar((int)(unsigned char)c); |
 				       |}				    |
 				       +------------------------------------+
-
+<
 The ":tags" command shows the list of tags that you traversed through:
 
 	:tags
@@ -425,7 +425,7 @@ MOVING IN COMMENTS
 
 To move back to the start of a comment use "[/".  Move forward to the end of a
 comment with "]/".  This only works for /* - */ comments.
-
+>
 	  +->	  +-> /*
 	  |    [/ |    * A comment about      --+
        [/ |	  +--  * wonderful life.	| ]/
@@ -434,7 +434,7 @@ comment with "]/".  This only works for /* - */ comments.
 	  +--	       foo = bar * 3;	      --+
 						| ]/
 		       /* a short comment */  <-+
-
+<
 ==============================================================================
 *29.4*	Finding global identifiers
 
@@ -575,7 +575,7 @@ and jump to the first place where the word under the cursor is used: >
 Hint: Goto Definition.  This command is very useful to find a variable or
 function that was declared locally ("static", in C terms).  Example (cursor on
 "counter"):
-
+>
 	   +->   static int counter = 0;
 	   |
 	   |     int get_counter(void)
@@ -583,7 +583,7 @@ function that was declared locally ("static", in C terms).  Example (cursor on
 	   |	     ++counter;
 	   +--	     return counter;
 		 }
-
+<
 To restrict the search even further, and look only in the current function,
 use this command: >
 
@@ -593,7 +593,7 @@ This will go back to the start of the current function and find the first
 occurrence of the word under the cursor.  Actually, it searches backwards to
 an empty line above a "{" in the first column.  From there it searches forward
 for the identifier.  Example (cursor on "idx"):
-
+>
 		int find_entry(char *name)
 		{
 	   +->	    int idx;
@@ -602,7 +602,7 @@ for the identifier.  Example (cursor on "idx"):
 	   |		if (strcmp(table[idx].name, name) == 0)
 	   +--		    return idx;
 		}
-
+<
 ==============================================================================
 
 Next chapter: |usr_30.txt|  Editing programs

--- a/runtime/doc/usr_30.txt
+++ b/runtime/doc/usr_30.txt
@@ -56,7 +56,7 @@ From this you can see that you have errors in the file "main.c".  When you
 press <Enter>, Vim displays the file "main.c", with the cursor positioned on
 line 6, the first line with an error.  You did not need to specify the file or
 the line number, Vim knew where to go by looking in the error messages.
-
+>
 		+---------------------------------------------------+
 		|int main()					    |
 		|{						    |
@@ -69,7 +69,7 @@ the line number, Vim knew where to go by looking in the error messages.
 		| ~						    |
 		|(3 of 12): too many arguments to function 'do_sub' |
 		+---------------------------------------------------+
-
+<
 The following command goes to where the next error occurs: >
 
 	:cnext

--- a/runtime/doc/usr_32.txt
+++ b/runtime/doc/usr_32.txt
@@ -169,10 +169,10 @@ To travel forward in time again use the |:later| command: >
 The arguments are "s", "m" and "h", just like with |:earlier|.
 
 If you want even more details, or want to manipulate the information, you can
-use the |undotree()| function.  To see what it returns: >
-
+use the |undotree()| function.  To see what it returns:
+>
 	:echo undotree()
-
+<
 ==============================================================================
 
 Next chapter: |usr_40.txt|  Make new commands

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -226,7 +226,7 @@ When using a space inside a mapping, use <Space> (seven characters): >
 This makes the spacebar move a blank-separated word forward.
 
 It is not possible to put a comment directly after a mapping, because the "
-character is considered to be part of the mapping.  You can use |", this
+character is considered to be part of the mapping.  You can use `|"`, this
 starts a new, empty command with a comment.  Example: >
 
 	:map <Space> W|     " Use spacebar to move forward a word
@@ -657,10 +657,10 @@ To ignore all events, use the following command: >
 
 	:set eventignore=all
 
-To set it back to the normal behavior, make 'eventignore' empty: >
-
+To set it back to the normal behavior, make 'eventignore' empty:
+>
 	:set eventignore=
-
+<
 ==============================================================================
 
 Next chapter: |usr_41.txt|  Write a Vim script

--- a/runtime/doc/usr_42.txt
+++ b/runtime/doc/usr_42.txt
@@ -81,7 +81,7 @@ the far right.
    The second number (340) determines the location of the item within the
 pull-down menu.  Lower numbers go on top, higher number on the bottom.  These
 are the priorities in the File menu:
-
+>
 			+-----------------+
 	    10.310	|Open...	  |
 	    10.320	|Split-Open...	  |
@@ -99,7 +99,7 @@ are the priorities in the File menu:
 	    10.610	|Save-Exit	  |
 	    10.620	|Exit		  |
 			+-----------------+
-
+<
 Notice that there is room in between the numbers.  This is where you can
 insert your own items, if you really want to (it's often better to leave the
 standard menus alone and add a new menu for your own items).
@@ -168,11 +168,11 @@ inserts a CTRL-C or CTRL-O for you.  For example, if you use this command:
 
 Then the resulting menu commands will be:
 
-	Normal mode:		*
-	Visual mode:		CTRL-C *
-	Operator-pending mode:	CTRL-C *
-	Insert mode:		CTRL-O *
-	Command-line mode:	CTRL-C *
+	Normal mode:		`*`
+	Visual mode:		CTRL-C `*`
+	Operator-pending mode:	CTRL-C `*`
+	Insert mode:		CTRL-O `*`
+	Command-line mode:	CTRL-C `*`
 
 When in Command-line mode the CTRL-C will abandon the command typed so far.
 In Visual and Operator-pending mode CTRL-C will stop the mode.  The CTRL-O in

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -284,8 +284,8 @@ Opens a vertically split, full-height window on the "tags" file at the far
 left of the Vim window.
 
 
+------------------------------------------------------------------------------
 Closing a window
-----------------
 
 :q[uit]
 :{count}q[uit]						*:count_quit*
@@ -693,8 +693,8 @@ Note: ":next" is an exception, because it must accept a list of file names
 for compatibility with Vi.
 
 
+------------------------------------------------------------------------------
 The argument list and multiple windows
---------------------------------------
 
 The current position in the argument list can be different for each window.
 Remember that when doing ":e file", the position in the argument list stays

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -391,7 +391,7 @@ end
 ---@param pos2 integer[] (line, column) tuple marking end of region
 ---@param regtype string type of selection, see |setreg()|
 ---@param inclusive boolean indicating whether the selection is end-inclusive
----@return table<integer, {}> region lua table of the form {linenr = {startcol,endcol}}
+---@return table region Table of the form `{linenr = {startcol,endcol}}`
 function vim.region(bufnr, pos1, pos2, regtype, inclusive)
   if not vim.api.nvim_buf_is_loaded(bufnr) then
     vim.fn.bufload(bufnr)

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -113,7 +113,7 @@ end
 ---
 ---@param s string String to split
 ---@param sep string Separator or pattern
----@param kwargs ({plain: boolean, trimempty: boolean}|nil) Keyword arguments:
+---@param kwargs (table|nil) Keyword arguments:
 ---       - plain: (boolean) If `true` use `sep` literally (passed to string.find)
 ---       - trimempty: (boolean) If `true` remove empty items from the front
 ---         and back of the list

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -256,8 +256,8 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
 /// positions define the bounds). 0 and -1 are understood as (0,0) and (-1,-1)
 /// respectively, thus the following are equivalent:
 /// <pre>lua
-///   nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
-///   nvim_buf_get_extmarks(0, my_ns, [0,0], [-1,-1], {})
+///   vim.api.nvim_buf_get_extmarks(0, my_ns, 0, -1, {})
+///   vim.api.nvim_buf_get_extmarks(0, my_ns, {0,0}, {-1,-1}, {})
 /// </pre>
 ///
 /// If `end` is less than `start`, traversal works backwards. (Useful

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -141,7 +141,7 @@
 ///     will only make vertical borders but not horizontal ones.
 ///     By default, `FloatBorder` highlight is used, which links to `WinSeparator`
 ///     when not defined.  It could also be specified by character:
-///       [ {"+", "MyCorner"}, {"x", "MyBorder"} ].
+///       [ ["+", "MyCorner"], ["x", "MyBorder"] ].
 ///   - title: Title (optional) in window border, String or list.
 ///     List is [text, highlight] tuples. if is string the default
 ///     highlight group is `FloatTitle`.


### PR DESCRIPTION
As our documentation at https://neovim.io/doc/user/ is generated from our vimdoc help files via treesitter, (some) help files taken from vim/vim that use ambiguous syntax that is not (easily) parseable with https://github.com/neovim/tree-sitter-vimdoc show up as visible errors in the generated HTML.

In a nutshell, the problems are from
* using single quotes for actual quoting (which conflict with option names) -> use double quotes or backticks instead
* using ASCII tables, whose vertical bars conflict with tag names -> put tables into code blocks
* using ASCII underline for h3 headings -> use proper `------` section delimiters.

(I did not fix all parsing errors reported by `vim.treesitter.show_tree()` as that would be too intrusive. Long term it would be nice, though, to have consistent and unambiguous (tree-sitter-parseable) syntax in all help files; we should then document our choices somewhere.)

This is a batch PR fixing the problems so far reported; some of these changes would probably be acceptable upstream, if someone is sufficiently motivated to make a PR.

Closes #21587 (and a metric ton of issues on the https://github.com/neovim/tree-sitter-vimdoc repo)