### PR TITLE
fix(lsp): adjust gravity of semantic tokens extmarks

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -408,6 +408,8 @@ function STHighlighter:on_win(topline, botline)
             hl_group = '@' .. token.type,
             end_col = token.end_col,
             priority = vim.highlight.priorities.semantic_tokens,
+            right_gravity = false,
+            end_right_gravity = true,
             strict = false,
           })
 
@@ -417,7 +419,9 @@ function STHighlighter:on_win(topline, botline)
               api.nvim_buf_set_extmark(self.bufnr, state.namespace, token.line, token.start_col, {
                 hl_group = '@' .. modifier,
                 end_col = token.end_col,
-                priority = vim.highlight.priorities.semantic_tokens,
+                priority = vim.highlight.priorities.semantic_tokens + 1,
+                right_gravity = false,
+                end_right_gravity = true,
                 strict = false,
               })
             end


### PR DESCRIPTION
 Fixes #21543

This should provide a better user experience when appending or prepending text to a word that has a semantic token extmark. More often than not, the appended/prepended text to the word will end up becoming part of the token anyway, so just use that extmark as the user types.