### PR TITLE
test(lsp): add a screen:expect() between insert() and feed_command()

### DIFF
--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -307,6 +307,24 @@ describe('semantic token highlighting', function()
       ]])
 
       insert(text)
+      screen:expect { grid = [[
+        #include <iostream>                     |
+                                                |
+        int {8:main}()                              |
+        {                                       |
+            int {7:x};                              |
+        #ifdef {5:__cplusplus}                      |
+            {4:std}::{2:cout} << {2:x} << "\n";             |
+        {6:#else}                                   |
+        {6:    printf("%d\n", x);}                  |
+        {6:#endif}                                  |
+        }                                       |
+        ^}                                       |
+        {1:~                                       }|
+        {1:~                                       }|
+        {1:~                                       }|
+                                                |
+      ]] }
       feed_command('%s/int x/int x()/')
       feed_command('noh')
       screen:expect { grid = [[


### PR DESCRIPTION
The insert() and feed_command() type a lot of text, with only one
screen:expect() call after the feed_command() it may time out.
