### PR TITLE
fix(ui): command line issues with 'cmdheight' set to zero

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3841,7 +3841,7 @@ void compute_cmdrow(void)
     cmdline_row = wp->w_winrow + wp->w_height
                   + wp->w_hsep_height + wp->w_status_height + global_stl_height();
   }
-  if (cmdline_row == Rows) {
+  if (cmdline_row == Rows && p_ch > 0) {
     cmdline_row--;
   }
   lines_left = cmdline_row;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2280,6 +2280,8 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
     int minval = 0;
     if (value < minval) {
       errmsg = e_positive;
+    } else {
+      p_ch_was_zero = value == 0;
     }
   } else if (pp == &p_tm) {
     if (value < 0) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -235,7 +235,7 @@ void ui_refresh(void)
   }
 
   if (ext_widgets[kUIMessages]) {
-    p_ch = 0;
+    set_option_value("cmdheight", 0L, NULL, 0);
     command_height();
   }
   ui_mode_info_set();

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5758,8 +5758,8 @@ static void frame_setheight(frame_T *curfrp, int height)
     if (height > ROWS_AVAIL) {
       // If height is greater than the available space, try to create space for
       // the frame by reducing 'cmdheight' if possible, while making sure
-      // `cmdheight` doesn't go below 1.
-      height = (int)MIN((p_ch > 0 ? ROWS_AVAIL + (p_ch - 1) : ROWS_AVAIL), height);
+      // `cmdheight` doesn't go below 1 if it wasn't set to 0 explicitly.
+      height = (int)MIN(ROWS_AVAIL + p_ch - !p_ch_was_zero, height);
     }
     if (height > 0) {
       frame_new_height(curfrp, height, false, false);
@@ -6090,8 +6090,6 @@ void win_setminwidth(void)
 /// Status line of dragwin is dragged "offset" lines down (negative is up).
 void win_drag_status_line(win_T *dragwin, int offset)
 {
-  static bool p_ch_was_zero = false;
-
   // If the user explicitly set 'cmdheight' to zero, then allow for dragging
   // the status line making it zero again.
   if (p_ch == 0) {

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -35,6 +35,8 @@
 #define MIN_COLUMNS     12      // minimal columns for screen
 #define MIN_LINES       2       // minimal lines for screen
 
+// Set to true if 'cmdheight' was explicitly set to 0.
+EXTERN bool p_ch_was_zero INIT(= false);
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "window.h.generated.h"
 #endif

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1364,4 +1364,40 @@ describe('cmdheight=0', function()
     ]])
     assert_alive()
   end)
+
+  it('can only be resized to 0 if set explicitly', function()
+    command('set laststatus=2')
+    command('resize +1')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {2:[No Name]                }|
+                               |
+    ]])
+    command('set cmdheight=0')
+    command('resize -1')
+    command('resize +1')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {2:[No Name]                }|
+    ]])
+  end)
+
+  it("clears cmdline area when resized with external messages", function()
+    clear()
+    screen = new_screen({rgb=true, ext_messages=true})
+    command('set laststatus=2 cmdheight=0')
+    command('resize -1')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {3:[No Name]                }|
+                               |
+    ]])
+  end)
 end)


### PR DESCRIPTION
**fix(ui): allow resize commands to set 'cmdheight' to 0**

Resolve https://github.com/neovim/neovim/issues/21558

**fix: issues with command line if ui elements are externalized**

Resolve https://github.com/neovim/neovim/issues/20888 and handle side effects for setting `'cmdheight'` to zero.