### PR TITLE
docs: clarify line about converse of lua-heredoc

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -199,8 +199,8 @@ this allows you to pass multiple commands to a single call of |vim.cmd()|:
       highlight link Warning Error
     ]])
 <
-This is the converse of |lua-heredoc| and allows you to include Lua code in
-your `init.vim`.
+This is the converse of |lua-heredoc| and allows you to include Vimscript code in
+your `init.lua`.
 
 If you want to build your Vim command programmatically, the following form can
 be useful (all these are equivalent to the corresponding line above):


### PR DESCRIPTION
Clarify lua-guide.txt. The `vim.cmd([[syntax]])` allows Vimscript code in init.lua rather than Lua code in init.vim.