### PR TITLE
refactor(sleep): simplify rube goldberg implementation of :sleep

### DIFF
--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -43,7 +43,7 @@ void loop_init(Loop *loop, void *data)
 /// @param once  true: process at most one `Loop.uv` event.
 ///              false: process until `ms` timeout (only has effect if `ms` > 0).
 /// @return  true if `ms` > 0 and was reached
-bool loop_uv_run(Loop *loop, int ms, bool once)
+bool loop_uv_run(Loop *loop, int64_t ms, bool once)
 {
   if (loop->recursive++) {
     abort();  // Should not re-enter uv_run
@@ -82,7 +82,7 @@ bool loop_uv_run(Loop *loop, int ms, bool once)
 ///            > 0: timeout after `ms`.
 ///            < 0: wait forever.
 /// @return  true if `ms` > 0 and was reached
-bool loop_poll_events(Loop *loop, int ms)
+bool loop_poll_events(Loop *loop, int64_t ms)
 {
   bool timeout_expired = loop_uv_run(loop, ms, true);
   multiqueue_process_events(loop->fast_events);

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -58,7 +58,7 @@ typedef struct loop {
 // Poll for events until a condition or timeout
 #define LOOP_PROCESS_EVENTS_UNTIL(loop, multiqueue, timeout, condition) \
   do { \
-    int remaining = timeout; \
+    int64_t remaining = timeout; \
     uint64_t before = (remaining > 0) ? os_hrtime() : 0; \
     while (!(condition)) { \
       LOOP_PROCESS_EVENTS(loop, multiqueue, remaining); \
@@ -66,7 +66,7 @@ typedef struct loop {
         break; \
       } else if (remaining > 0) { \
         uint64_t now = os_hrtime(); \
-        remaining -= (int)((now - before) / 1000000); \
+        remaining -= (int64_t)((now - before) / 1000000); \
         before = now; \
         if (remaining <= 0) { \
           break; \

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5658,15 +5658,11 @@ static void ex_sleep(exarg_T *eap)
   do_sleep(len);
 }
 
-/// Sleep for "msec" milliseconds, but keep checking for a CTRL-C every second.
+/// Sleep for "msec" milliseconds, but return early on CTRL-C.
 void do_sleep(long msec)
 {
   ui_flush();  // flush before waiting
-  for (long left = msec; !got_int && left > 0; left -= 1000L) {
-    int next = left > 1000L ? 1000 : (int)left;
-    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, (int)next, got_int);
-    os_breakcheck();
-  }
+  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, msec, got_int);
 
   // If CTRL-C was typed to interrupt the sleep, drop the CTRL-C from the
   // input buffer, otherwise a following call to input() fails.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1747,7 +1747,7 @@ static void pad(void *ctx, size_t delay, int scale FUNC_ATTR_UNUSED, int force)
   }
 
   flush_buf(ui);
-  loop_uv_run(data->loop, (int)(delay / 10), false);
+  loop_uv_run(data->loop, (int64_t)(delay / 10), false);
 }
 
 static void unibi_set_if_empty(unibi_term *ut, enum unibi_string str, const char *val)


### PR DESCRIPTION
As neovim does have event handling, we are checking for CTRL-C all the time, not once per second.

Also, `do_sleep()` reimplements the same loop as `LOOP_PROCESS_EVENTS_UNTIL` already contains internally. Fix the latter to use the right integer type, so we do not need the extra indirection.