### PR TITLE
vim-patch:9.0.1115: code is indented more than needed

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4743,45 +4743,46 @@ void ex_oldfiles(exarg_T *eap)
 
   if (l == NULL) {
     msg(_("No old files"));
-  } else {
-    msg_start();
-    msg_scroll = true;
-    TV_LIST_ITER(l, li, {
-      if (got_int) {
-        break;
-      }
-      nr++;
-      const char *fname = tv_get_string(TV_LIST_ITEM_TV(li));
-      if (!message_filtered((char *)fname)) {
-        msg_outnum(nr);
-        msg_puts(": ");
-        msg_outtrans((char *)tv_get_string(TV_LIST_ITEM_TV(li)));
-        msg_clr_eos();
-        msg_putchar('\n');
-        os_breakcheck();
-      }
-    });
+    return;
+  }
 
-    // Assume "got_int" was set to truncate the listing.
-    got_int = false;
+  msg_start();
+  msg_scroll = true;
+  TV_LIST_ITER(l, li, {
+    if (got_int) {
+      break;
+    }
+    nr++;
+    const char *fname = tv_get_string(TV_LIST_ITEM_TV(li));
+    if (!message_filtered((char *)fname)) {
+      msg_outnum(nr);
+      msg_puts(": ");
+      msg_outtrans((char *)tv_get_string(TV_LIST_ITEM_TV(li)));
+      msg_clr_eos();
+      msg_putchar('\n');
+      os_breakcheck();
+    }
+  });
 
-    // File selection prompt on ":browse oldfiles"
-    if (cmdmod.cmod_flags & CMOD_BROWSE) {
-      quit_more = false;
-      nr = prompt_for_number(false);
-      msg_starthere();
-      if (nr > 0 && nr <= tv_list_len(l)) {
-        const char *const p = tv_list_find_str(l, (int)nr - 1);
-        if (p == NULL) {
-          return;
-        }
-        char *const s = expand_env_save((char *)p);
-        eap->arg = s;
-        eap->cmdidx = CMD_edit;
-        cmdmod.cmod_flags &= ~CMOD_BROWSE;
-        do_exedit(eap, NULL);
-        xfree(s);
+  // Assume "got_int" was set to truncate the listing.
+  got_int = false;
+
+  // File selection prompt on ":browse oldfiles"
+  if (cmdmod.cmod_flags & CMOD_BROWSE) {
+    quit_more = false;
+    nr = prompt_for_number(false);
+    msg_starthere();
+    if (nr > 0 && nr <= tv_list_len(l)) {
+      const char *const p = tv_list_find_str(l, (int)nr - 1);
+      if (p == NULL) {
+        return;
       }
+      char *const s = expand_env_save((char *)p);
+      eap->arg = s;
+      eap->cmdidx = CMD_edit;
+      cmdmod.cmod_flags &= ~CMOD_BROWSE;
+      do_exedit(eap, NULL);
+      xfree(s);
     }
   }
 }

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -705,54 +705,56 @@ void ex_compiler(exarg_T *eap)
     // List all compiler scripts.
     do_cmdline_cmd("echo globpath(&rtp, 'compiler/*.vim')");  // NOLINT
     do_cmdline_cmd("echo globpath(&rtp, 'compiler/*.lua')");  // NOLINT
+    return;
+  }
+
+  size_t bufsize = strlen(eap->arg) + 14;
+  buf = xmalloc(bufsize);
+
+  if (eap->forceit) {
+    // ":compiler! {name}" sets global options
+    do_cmdline_cmd("command -nargs=* CompilerSet set <args>");
   } else {
-    size_t bufsize = strlen(eap->arg) + 14;
-    buf = xmalloc(bufsize);
-    if (eap->forceit) {
-      // ":compiler! {name}" sets global options
-      do_cmdline_cmd("command -nargs=* CompilerSet set <args>");
-    } else {
-      // ":compiler! {name}" sets local options.
-      // To remain backwards compatible "current_compiler" is always
-      // used.  A user's compiler plugin may set it, the distributed
-      // plugin will then skip the settings.  Afterwards set
-      // "b:current_compiler" and restore "current_compiler".
-      // Explicitly prepend "g:" to make it work in a function.
-      old_cur_comp = (char *)get_var_value("g:current_compiler");
-      if (old_cur_comp != NULL) {
-        old_cur_comp = xstrdup(old_cur_comp);
-      }
-      do_cmdline_cmd("command -nargs=* -keepscript CompilerSet setlocal <args>");
+    // ":compiler! {name}" sets local options.
+    // To remain backwards compatible "current_compiler" is always
+    // used.  A user's compiler plugin may set it, the distributed
+    // plugin will then skip the settings.  Afterwards set
+    // "b:current_compiler" and restore "current_compiler".
+    // Explicitly prepend "g:" to make it work in a function.
+    old_cur_comp = (char *)get_var_value("g:current_compiler");
+    if (old_cur_comp != NULL) {
+      old_cur_comp = xstrdup(old_cur_comp);
     }
-    do_unlet(S_LEN("g:current_compiler"), true);
-    do_unlet(S_LEN("b:current_compiler"), true);
+    do_cmdline_cmd("command -nargs=* -keepscript CompilerSet setlocal <args>");
+  }
+  do_unlet(S_LEN("g:current_compiler"), true);
+  do_unlet(S_LEN("b:current_compiler"), true);
 
-    snprintf(buf, bufsize, "compiler/%s.vim", eap->arg);
+  snprintf(buf, bufsize, "compiler/%s.vim", eap->arg);
+  if (source_runtime(buf, DIP_ALL) == FAIL) {
+    // Try lua compiler
+    snprintf(buf, bufsize, "compiler/%s.lua", eap->arg);
     if (source_runtime(buf, DIP_ALL) == FAIL) {
-      // Try lua compiler
-      snprintf(buf, bufsize, "compiler/%s.lua", eap->arg);
-      if (source_runtime(buf, DIP_ALL) == FAIL) {
-        semsg(_("E666: compiler not supported: %s"), eap->arg);
-      }
+      semsg(_("E666: compiler not supported: %s"), eap->arg);
     }
-    xfree(buf);
+  }
+  xfree(buf);
 
-    do_cmdline_cmd(":delcommand CompilerSet");
+  do_cmdline_cmd(":delcommand CompilerSet");
 
-    // Set "b:current_compiler" from "current_compiler".
-    p = (char *)get_var_value("g:current_compiler");
-    if (p != NULL) {
-      set_internal_string_var("b:current_compiler", p);
-    }
+  // Set "b:current_compiler" from "current_compiler".
+  p = (char *)get_var_value("g:current_compiler");
+  if (p != NULL) {
+    set_internal_string_var("b:current_compiler", p);
+  }
 
-    // Restore "current_compiler" for ":compiler {name}".
-    if (!eap->forceit) {
-      if (old_cur_comp != NULL) {
-        set_internal_string_var("g:current_compiler", old_cur_comp);
-        xfree(old_cur_comp);
-      } else {
-        do_unlet(S_LEN("g:current_compiler"), true);
-      }
+  // Restore "current_compiler" for ":compiler {name}".
+  if (!eap->forceit) {
+    if (old_cur_comp != NULL) {
+      set_internal_string_var("g:current_compiler", old_cur_comp);
+      xfree(old_cur_comp);
+    } else {
+      do_unlet(S_LEN("g:current_compiler"), true);
     }
   }
 }
@@ -847,45 +849,46 @@ void ex_drop(exarg_T *eap)
     // edited in a window yet.  It's like ":tab all" but without closing
     // windows or tabs.
     ex_all(eap);
-  } else {
-    // ":drop file ...": Edit the first argument.  Jump to an existing
-    // window if possible, edit in current window if the current buffer
-    // can be abandoned, otherwise open a new window.
-    buf = buflist_findnr(ARGLIST[0].ae_fnum);
-
-    FOR_ALL_TAB_WINDOWS(tp, wp) {
-      if (wp->w_buffer == buf) {
-        goto_tabpage_win(tp, wp);
-        curwin->w_arg_idx = 0;
-        if (!bufIsChanged(curbuf)) {
-          const int save_ar = curbuf->b_p_ar;
-
-          // reload the file if it is newer
-          curbuf->b_p_ar = 1;
-          buf_check_timestamp(curbuf);
-          curbuf->b_p_ar = save_ar;
-        }
-        return;
-      }
-    }
-
-    // Check whether the current buffer is changed. If so, we will need
-    // to split the current window or data could be lost.
-    // Skip the check if the 'hidden' option is set, as in this case the
-    // buffer won't be lost.
-    if (!buf_hide(curbuf)) {
-      emsg_off++;
-      split = check_changed(curbuf, CCGD_AW | CCGD_EXCMD);
-      emsg_off--;
-    }
-
-    // Fake a ":sfirst" or ":first" command edit the first argument.
-    if (split) {
-      eap->cmdidx = CMD_sfirst;
-      eap->cmd[0] = 's';
-    } else {
-      eap->cmdidx = CMD_first;
-    }
-    ex_rewind(eap);
+    return;
   }
+
+  // ":drop file ...": Edit the first argument.  Jump to an existing
+  // window if possible, edit in current window if the current buffer
+  // can be abandoned, otherwise open a new window.
+  buf = buflist_findnr(ARGLIST[0].ae_fnum);
+
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    if (wp->w_buffer == buf) {
+      goto_tabpage_win(tp, wp);
+      curwin->w_arg_idx = 0;
+      if (!bufIsChanged(curbuf)) {
+        const int save_ar = curbuf->b_p_ar;
+
+        // reload the file if it is newer
+        curbuf->b_p_ar = 1;
+        buf_check_timestamp(curbuf);
+        curbuf->b_p_ar = save_ar;
+      }
+      return;
+    }
+  }
+
+  // Check whether the current buffer is changed. If so, we will need
+  // to split the current window or data could be lost.
+  // Skip the check if the 'hidden' option is set, as in this case the
+  // buffer won't be lost.
+  if (!buf_hide(curbuf)) {
+    emsg_off++;
+    split = check_changed(curbuf, CCGD_AW | CCGD_EXCMD);
+    emsg_off--;
+  }
+
+  // Fake a ":sfirst" or ":first" command edit the first argument.
+  if (split) {
+    eap->cmdidx = CMD_sfirst;
+    eap->cmd[0] = 's';
+  } else {
+    eap->cmdidx = CMD_first;
+  }
+  ex_rewind(eap);
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4663,23 +4663,29 @@ static void ex_tabclose(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     cmdwin_result = K_IGNORE;
-  } else if (first_tabpage->tp_next == NULL) {
+    return;
+  }
+
+  if (first_tabpage->tp_next == NULL) {
     emsg(_("E784: Cannot close last tab page"));
-  } else {
-    int tab_number = get_tabpage_arg(eap);
-    if (eap->errmsg == NULL) {
-      tabpage_T *tp = find_tabpage(tab_number);
-      if (tp == NULL) {
-        beep_flush();
-        return;
-      }
-      if (tp != curtab) {
-        tabpage_close_other(tp, eap->forceit);
-        return;
-      } else if (!text_locked() && !curbuf_locked()) {
-        tabpage_close(eap->forceit);
-      }
-    }
+    return;
+  }
+
+  int tab_number = get_tabpage_arg(eap);
+  if (eap->errmsg != NULL) {
+    return;
+  }
+
+  tabpage_T *tp = find_tabpage(tab_number);
+  if (tp == NULL) {
+    beep_flush();
+    return;
+  }
+  if (tp != curtab) {
+    tabpage_close_other(tp, eap->forceit);
+    return;
+  } else if (!text_locked() && !curbuf_locked()) {
+    tabpage_close(eap->forceit);
   }
 }
 
@@ -4688,31 +4694,37 @@ static void ex_tabonly(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     cmdwin_result = K_IGNORE;
-  } else if (first_tabpage->tp_next == NULL) {
+    return;
+  }
+
+  if (first_tabpage->tp_next == NULL) {
     msg(_("Already only one tab page"));
-  } else {
-    int tab_number = get_tabpage_arg(eap);
-    if (eap->errmsg == NULL) {
-      goto_tabpage(tab_number);
-      // Repeat this up to a 1000 times, because autocommands may
-      // mess up the lists.
-      for (int done = 0; done < 1000; done++) {
-        FOR_ALL_TABS(tp) {
-          if (tp->tp_topframe != topframe) {
-            tabpage_close_other(tp, eap->forceit);
-            // if we failed to close it quit
-            if (valid_tabpage(tp)) {
-              done = 1000;
-            }
-            // start over, "tp" is now invalid
-            break;
-          }
+    return;
+  }
+
+  int tab_number = get_tabpage_arg(eap);
+  if (eap->errmsg != NULL) {
+    return;
+  }
+
+  goto_tabpage(tab_number);
+  // Repeat this up to a 1000 times, because autocommands may
+  // mess up the lists.
+  for (int done = 0; done < 1000; done++) {
+    FOR_ALL_TABS(tp) {
+      if (tp->tp_topframe != topframe) {
+        tabpage_close_other(tp, eap->forceit);
+        // if we failed to close it quit
+        if (valid_tabpage(tp)) {
+          done = 1000;
         }
-        assert(first_tabpage);
-        if (first_tabpage->tp_next == NULL) {
-          break;
-        }
+        // start over, "tp" is now invalid
+        break;
       }
+    }
+    assert(first_tabpage);
+    if (first_tabpage->tp_next == NULL) {
+      break;
     }
   }
 }
@@ -4782,25 +4794,27 @@ static void ex_only(exarg_T *eap)
 static void ex_hide(exarg_T *eap)
 {
   // ":hide" or ":hide | cmd": hide current window
-  if (!eap->skip) {
-    if (eap->addr_count == 0) {
-      win_close(curwin, false, eap->forceit);  // don't free buffer
-    } else {
-      int winnr = 0;
-      win_T *win = NULL;
+  if (eap->skip) {
+    return;
+  }
 
-      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-        winnr++;
-        if (winnr == eap->line2) {
-          win = wp;
-          break;
-        }
+  if (eap->addr_count == 0) {
+    win_close(curwin, false, eap->forceit);  // don't free buffer
+  } else {
+    int winnr = 0;
+    win_T *win = NULL;
+
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      winnr++;
+      if (winnr == eap->line2) {
+        win = wp;
+        break;
       }
-      if (win == NULL) {
-        win = lastwin;
-      }
-      win_close(win, false, eap->forceit);
     }
+    if (win == NULL) {
+      win = lastwin;
+    }
+    win_close(win, false, eap->forceit);
   }
 }
 
@@ -5384,50 +5398,51 @@ static void ex_read(exarg_T *eap)
 
   if (eap->usefilter) {  // :r!cmd
     do_bang(1, eap, false, false, true);
-  } else {
-    if (u_save(eap->line2, (linenr_T)(eap->line2 + 1)) == FAIL) {
+    return;
+  }
+
+  if (u_save(eap->line2, (linenr_T)(eap->line2 + 1)) == FAIL) {
+    return;
+  }
+
+  int i;
+  if (*eap->arg == NUL) {
+    if (check_fname() == FAIL) {       // check for no file name
       return;
     }
-    int i;
-
-    if (*eap->arg == NUL) {
-      if (check_fname() == FAIL) {       // check for no file name
-        return;
-      }
-      i = readfile(curbuf->b_ffname, curbuf->b_fname,
-                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
-    } else {
-      if (vim_strchr(p_cpo, CPO_ALTREAD) != NULL) {
-        (void)setaltfname(eap->arg, eap->arg, (linenr_T)1);
-      }
-      i = readfile(eap->arg, NULL,
-                   eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
+    i = readfile(curbuf->b_ffname, curbuf->b_fname,
+                 eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
+  } else {
+    if (vim_strchr(p_cpo, CPO_ALTREAD) != NULL) {
+      (void)setaltfname(eap->arg, eap->arg, (linenr_T)1);
     }
-    if (i != OK) {
-      if (!aborting()) {
-        semsg(_(e_notopen), eap->arg);
-      }
-    } else {
-      if (empty && exmode_active) {
-        // Delete the empty line that remains.  Historically ex does
-        // this but vi doesn't.
-        linenr_T lnum;
-        if (eap->line2 == 0) {
-          lnum = curbuf->b_ml.ml_line_count;
-        } else {
-          lnum = 1;
-        }
-        if (*ml_get(lnum) == NUL && u_savedel(lnum, 1L) == OK) {
-          ml_delete(lnum, false);
-          if (curwin->w_cursor.lnum > 1
-              && curwin->w_cursor.lnum >= lnum) {
-            curwin->w_cursor.lnum--;
-          }
-          deleted_lines_mark(lnum, 1L);
-        }
-      }
-      redraw_curbuf_later(UPD_VALID);
+    i = readfile(eap->arg, NULL,
+                 eap->line2, (linenr_T)0, (linenr_T)MAXLNUM, eap, 0, false);
+  }
+  if (i != OK) {
+    if (!aborting()) {
+      semsg(_(e_notopen), eap->arg);
     }
+  } else {
+    if (empty && exmode_active) {
+      // Delete the empty line that remains.  Historically ex does
+      // this but vi doesn't.
+      linenr_T lnum;
+      if (eap->line2 == 0) {
+        lnum = curbuf->b_ml.ml_line_count;
+      } else {
+        lnum = 1;
+      }
+      if (*ml_get(lnum) == NUL && u_savedel(lnum, 1L) == OK) {
+        ml_delete(lnum, false);
+        if (curwin->w_cursor.lnum > 1
+            && curwin->w_cursor.lnum >= lnum) {
+          curwin->w_cursor.lnum--;
+        }
+        deleted_lines_mark(lnum, 1L);
+      }
+    }
+    redraw_curbuf_later(UPD_VALID);
   }
 }
 
@@ -5584,6 +5599,7 @@ void ex_cd(exarg_T *eap)
     return;
   }
 #endif
+
   CdScope scope = kCdScopeGlobal;
   switch (eap->cmdidx) {
   case CMD_tcd:
@@ -5879,20 +5895,21 @@ static void ex_at(exarg_T *eap)
   // Put the register in the typeahead buffer with the "silent" flag.
   if (do_execreg(c, true, vim_strchr(p_cpo, CPO_EXECBUF) != NULL, true) == FAIL) {
     beep_flush();
-  } else {
-    bool save_efr = exec_from_reg;
-
-    exec_from_reg = true;
-
-    // Execute from the typeahead buffer.
-    // Continue until the stuff buffer is empty and all added characters
-    // have been consumed.
-    while (!stuff_empty() || typebuf.tb_len > prev_len) {
-      (void)do_cmdline(NULL, getexline, NULL, DOCMD_NOWAIT|DOCMD_VERBOSE);
-    }
-
-    exec_from_reg = save_efr;
+    return;
   }
+
+  const bool save_efr = exec_from_reg;
+
+  exec_from_reg = true;
+
+  // Execute from the typeahead buffer.
+  // Continue until the stuff buffer is empty and all added characters
+  // have been consumed.
+  while (!stuff_empty() || typebuf.tb_len > prev_len) {
+    (void)do_cmdline(NULL, getexline, NULL, DOCMD_NOWAIT|DOCMD_VERBOSE);
+  }
+
+  exec_from_reg = save_efr;
 }
 
 /// ":!".
@@ -6222,17 +6239,21 @@ static void ex_mark(exarg_T *eap)
 {
   if (*eap->arg == NUL) {               // No argument?
     emsg(_(e_argreq));
-  } else if (eap->arg[1] != NUL) {         // more than one character?
-    semsg(_(e_trailing_arg), eap->arg);
-  } else {
-    pos_T pos = curwin->w_cursor;             // save curwin->w_cursor
-    curwin->w_cursor.lnum = eap->line2;
-    beginline(BL_WHITE | BL_FIX);
-    if (setmark(*eap->arg) == FAIL) {   // set mark
-      emsg(_("E191: Argument must be a letter or forward/backward quote"));
-    }
-    curwin->w_cursor = pos;             // restore curwin->w_cursor
+    return;
   }
+
+  if (eap->arg[1] != NUL) {         // more than one character?
+    semsg(_(e_trailing_arg), eap->arg);
+    return;
+  }
+
+  pos_T pos = curwin->w_cursor;             // save curwin->w_cursor
+  curwin->w_cursor.lnum = eap->line2;
+  beginline(BL_WHITE | BL_FIX);
+  if (setmark(*eap->arg) == FAIL) {   // set mark
+    emsg(_("E191: Argument must be a letter or forward/backward quote"));
+  }
+  curwin->w_cursor = pos;             // restore curwin->w_cursor
 }
 
 /// Update w_topline, w_leftcol and the cursor position.
@@ -7146,17 +7167,18 @@ void filetype_maybe_enable(void)
 /// ":setfiletype [FALLBACK] {name}"
 static void ex_setfiletype(exarg_T *eap)
 {
-  if (!did_filetype) {
-    char *arg = eap->arg;
+  if (did_filetype) {
+    return;
+  }
 
-    if (strncmp(arg, "FALLBACK ", 9) == 0) {
-      arg += 9;
-    }
+  char *arg = eap->arg;
+  if (strncmp(arg, "FALLBACK ", 9) == 0) {
+    arg += 9;
+  }
 
-    set_option_value_give_err("filetype", 0L, arg, OPT_LOCAL);
-    if (arg != eap->arg) {
-      did_filetype = false;
-    }
+  set_option_value_give_err("filetype", 0L, arg, OPT_LOCAL);
+  if (arg != eap->arg) {
+    did_filetype = false;
   }
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -575,32 +575,34 @@ static int may_add_char_to_search(int firstc, int *c, incsearch_state_T *s)
 
 static void finish_incsearch_highlighting(int gotesc, incsearch_state_T *s, bool call_update_screen)
 {
-  if (s->did_incsearch) {
-    s->did_incsearch = false;
-    if (gotesc) {
+  if (!s->did_incsearch) {
+    return;
+  }
+
+  s->did_incsearch = false;
+  if (gotesc) {
+    curwin->w_cursor = s->save_cursor;
+  } else {
+    if (!equalpos(s->save_cursor, s->search_start)) {
+      // put the '" mark at the original position
       curwin->w_cursor = s->save_cursor;
-    } else {
-      if (!equalpos(s->save_cursor, s->search_start)) {
-        // put the '" mark at the original position
-        curwin->w_cursor = s->save_cursor;
-        setpcmark();
-      }
-      curwin->w_cursor = s->search_start;  // -V519
+      setpcmark();
     }
-    restore_viewstate(curwin, &s->old_viewstate);
-    highlight_match = false;
+    curwin->w_cursor = s->search_start;  // -V519
+  }
+  restore_viewstate(curwin, &s->old_viewstate);
+  highlight_match = false;
 
-    // by default search all lines
-    search_first_line = 0;
-    search_last_line = MAXLNUM;
+  // by default search all lines
+  search_first_line = 0;
+  search_last_line = MAXLNUM;
 
-    magic_overruled = s->magic_overruled_save;
+  magic_overruled = s->magic_overruled_save;
 
-    validate_cursor();          // needed for TAB
-    redraw_all_later(UPD_SOME_VALID);
-    if (call_update_screen) {
-      update_screen();
-    }
+  validate_cursor();          // needed for TAB
+  redraw_all_later(UPD_SOME_VALID);
+  if (call_update_screen) {
+    update_screen();
   }
 }
 


### PR DESCRIPTION
#### vim-patch:9.0.1115: code is indented more than needed

Problem:    Code is indented more than needed.
Solution:   Use an early return to reduce indenting. (Yegappan Lakshmanan,
            closes vim/vim#11758)

https://github.com/vim/vim/commit/ed0c1d5d4b30d03b26ff08841f6da2ddf44025a7

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>