### PR TITLE
fix(tui): do not set ui_client_termname if it is already set

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -310,11 +310,12 @@ static void terminfo_start(UI *ui)
 #endif
 
   // Set up unibilium/terminfo.
-  ui_client_termname = NULL;
   if (term) {
     data->ut = unibi_from_term(term);
     if (data->ut) {
-      ui_client_termname = xstrdup(term);
+      if (!ui_client_termname) {
+        ui_client_termname = xstrdup(term);
+      }
       if (!data->term) {
         data->term = xstrdup(term);
       }

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -34,7 +34,7 @@ EXTERN TriState ui_client_bg_respose INIT(= kNone);
 /// by convention, this uses fd=3 (next free number after stdio)
 EXTERN bool ui_client_forward_stdin INIT(= false);
 
-EXTERN char *ui_client_termname INIT(= "null");
+EXTERN char *ui_client_termname INIT(= NULL);
 
 #define UI_CLIENT_STDIN_FD 3
 #ifdef INCLUDE_GENERATED_DECLARATIONS


### PR DESCRIPTION
Fix #21606

It is fine to initialize ui_client_termname to NULL as it is only used
after tui_start().
