### PR TITLE
vim-patch:8.2.0711: temp directory might be cleared

### DIFF
--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -46,6 +46,26 @@ check_function_exists(strcasecmp HAVE_STRCASECMP)
 check_function_exists(strncasecmp HAVE_STRNCASECMP)
 check_function_exists(strptime HAVE_STRPTIME)
 
+check_c_source_compiles("
+#include <sys/types.h>
+#include <dirent.h>
+int main(void)
+{
+  DIR *dir = opendir(\"dirname\");
+  dirfd(dir);
+  return 0;
+}
+" HAVE_DIRFD)
+
+check_c_source_compiles("
+#include <sys/file.h>
+int main(void)
+{
+  flock(10, LOCK_SH);
+  return 0;
+}
+" HAVE_FLOCK)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
   check_c_source_compiles("
 #include <termios.h>

--- a/cmake.config/config.h.in
+++ b/cmake.config/config.h.in
@@ -54,6 +54,8 @@
 #  undef HAVE_SYS_UIO_H
 # endif
 #endif
+#cmakedefine HAVE_DIRFD
+#cmakedefine HAVE_FLOCK
 #cmakedefine HAVE_FORKPTY
 
 #ifndef UNIT_TESTING


### PR DESCRIPTION
#### vim-patch:8.2.0711: temp directory might be cleared

Problem:    With a long running Vim the temp directory might be cleared on
            some systems.
Solution:   Lock the temp directory. (closes vim/vim#6044)

https://github.com/vim/vim/commit/b2d0e51366dea6843f991f31a457f5456d162678