### PR TITLE
feat(quickfix): add user_data field to quickfix items

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7210,6 +7210,7 @@ setqflist({list} [, {action} [, {what}]])		*setqflist()*
 		    text	description of the error
 		    type	single-character error type, 'E', 'W', etc.
 		    valid	recognized error message
+		    user_data	custom user data associated with this item.
 
 		The "col", "vcol", "nr", "type" and "text" entries are
 		optional.  Either "lnum" or "pattern" entry can be used to

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1580,6 +1580,9 @@ locations_to_items({locations}, {offset_encoding})
     The result can be passed to the {list} argument of |setqflist()| or
     |setloclist()|.
 
+    The user_data field of each quickfix item is set to the original LSP
+    `Location` or `LocationLink` item.
+
     Parameters: ~
       • {locations}        (table) list of `Location`s or `LocationLink`s
       • {offset_encoding}  (string) offset_encoding for locations

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -108,6 +108,12 @@ The following new APIs or features were added.
   instance in the background and display its UI on demand, which previously
   only was possible usiing a external UI implementation.
 
+• Add a `user_data` field to quickfix items for arbitrary user-defined data
+  associated which each item.
+  For example, |vim.lsp.util.locations_to_items()| now uses it to store the
+  original LSP `Location` or `LocationLink` item.
+
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1728,6 +1728,9 @@ end)
 --- The result can be passed to the {list} argument of |setqflist()| or
 --- |setloclist()|.
 ---
+--- The user_data field of each quickfix item is set to the original
+--- LSP `Location` or `LocationLink` item.
+---
 ---@param locations table list of `Location`s or `LocationLink`s
 ---@param offset_encoding string offset_encoding for locations utf-8|utf-16|utf-32
 ---@returns (table) list of items

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2040,7 +2040,7 @@ dictitem_T *tv_dict_find(const dict_T *const d, const char *const key, const ptr
 /// @param[in]  key  Dictionary key.
 /// @param[in]  rettv  Return value.
 /// @return OK in case of success or FAIL if nothing was found.
-int tv_dict_get_tv(dict_T *d, const char *const key, typval_T *rettv)
+int tv_dict_get_tv(const dict_T *const d, const char *const key, typval_T *rettv)
 {
   dictitem_T *const di = tv_dict_find(d, key, -1);
   if (di == NULL) {


### PR DESCRIPTION
I recently added an extension to clangd that extends the `Location` object with info about the reference's "container" (e.g. enclosing function or class). 

See https://github.com/clangd/clangd/issues/177 and https://github.com/llvm/clangd-www/pull/77 for details.

With this change, it becomes possible to add this info to the displayed text in the quickfix list.

If I haven't missed anything, this should not break any existing API or behavior.