### PR TITLE
vim-patch:9.0.1129: sporadic Test_range() failure

### DIFF
--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1437,6 +1437,19 @@ func Test_inputlist()
   call assert_fails('call inputlist("")', 'E686:')
 endfunc
 
+func Test_range_inputlist()
+  " flush out any garbage left in the buffer
+  while getchar(0)
+  endwhile
+
+  call feedkeys(":let result = inputlist(range(10))\<CR>1\<CR>", 'x')
+  call assert_equal(1, result)
+  call feedkeys(":let result = inputlist(range(3, 10))\<CR>1\<CR>", 'x')
+  call assert_equal(1, result)
+
+  unlet result
+endfunc
+
 func Test_balloon_show()
   CheckFeature balloon_eval
 
@@ -2164,12 +2177,6 @@ func Test_range()
   " index()
   call assert_equal(1, index(range(1, 5), 2))
   call assert_fails("echo index([1, 2], 1, [])", 'E745:')
-
-  " inputlist()
-  call feedkeys(":let result = inputlist(range(10))\<CR>1\<CR>", 'x')
-  call assert_equal(1, result)
-  call feedkeys(":let result = inputlist(range(3, 10))\<CR>1\<CR>", 'x')
-  call assert_equal(1, result)
 
   " insert()
   call assert_equal([42, 1, 2, 3, 4, 5], insert(range(1, 5), 42))


### PR DESCRIPTION
#### vim-patch:9.0.1129: sporadic Test_range() failure

Problem:    Sporadic Test_range() failure.
Solution:   Clear typeahead.  Move to a separate function. (issue vim/vim#22771)

https://github.com/vim/vim/commit/7bdcba08bb5e4c39093cdedee187177d705c7cb9

Co-authored-by: Bram Moolenaar <Bram@vim.org>