### PR TITLE
vim-patch:9.0.1132: code is indented more than needed

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -631,50 +631,52 @@ void do_argfile(exarg_T *eap, int argn)
     } else {
       emsg(_("E165: Cannot go beyond last file"));
     }
+
+    return;
+  }
+
+  setpcmark();
+
+  // split window or create new tab page first
+  if (*eap->cmd == 's' || cmdmod.cmod_tab != 0) {
+    if (win_split(0, 0) == FAIL) {
+      return;
+    }
+    RESET_BINDING(curwin);
   } else {
-    setpcmark();
-
-    // split window or create new tab page first
-    if (*eap->cmd == 's' || cmdmod.cmod_tab != 0) {
-      if (win_split(0, 0) == FAIL) {
-        return;
-      }
-      RESET_BINDING(curwin);
-    } else {
-      // if 'hidden' set, only check for changed file when re-editing
-      // the same buffer
-      other = true;
-      if (buf_hide(curbuf)) {
-        p = fix_fname(alist_name(&ARGLIST[argn]));
-        other = otherfile(p);
-        xfree(p);
-      }
-      if ((!buf_hide(curbuf) || !other)
-          && check_changed(curbuf, CCGD_AW
-                           | (other ? 0 : CCGD_MULTWIN)
-                           | (eap->forceit ? CCGD_FORCEIT : 0)
-                           | CCGD_EXCMD)) {
-        return;
-      }
+    // if 'hidden' set, only check for changed file when re-editing
+    // the same buffer
+    other = true;
+    if (buf_hide(curbuf)) {
+      p = fix_fname(alist_name(&ARGLIST[argn]));
+      other = otherfile(p);
+      xfree(p);
     }
-
-    curwin->w_arg_idx = argn;
-    if (argn == ARGCOUNT - 1 && curwin->w_alist == &global_alist) {
-      arg_had_last = true;
+    if ((!buf_hide(curbuf) || !other)
+        && check_changed(curbuf, CCGD_AW
+                         | (other ? 0 : CCGD_MULTWIN)
+                         | (eap->forceit ? CCGD_FORCEIT : 0)
+                         | CCGD_EXCMD)) {
+      return;
     }
+  }
 
-    // Edit the file; always use the last known line number.
-    // When it fails (e.g. Abort for already edited file) restore the
-    // argument index.
-    if (do_ecmd(0, alist_name(&ARGLIST[curwin->w_arg_idx]), NULL,
-                eap, ECMD_LAST,
-                (buf_hide(curwin->w_buffer) ? ECMD_HIDE : 0)
-                + (eap->forceit ? ECMD_FORCEIT : 0), curwin) == FAIL) {
-      curwin->w_arg_idx = old_arg_idx;
-    } else if (eap->cmdidx != CMD_argdo) {
-      // like Vi: set the mark where the cursor is in the file.
-      setmark('\'');
-    }
+  curwin->w_arg_idx = argn;
+  if (argn == ARGCOUNT - 1 && curwin->w_alist == &global_alist) {
+    arg_had_last = true;
+  }
+
+  // Edit the file; always use the last known line number.
+  // When it fails (e.g. Abort for already edited file) restore the
+  // argument index.
+  if (do_ecmd(0, alist_name(&ARGLIST[curwin->w_arg_idx]), NULL,
+              eap, ECMD_LAST,
+              (buf_hide(curwin->w_buffer) ? ECMD_HIDE : 0)
+              + (eap->forceit ? ECMD_FORCEIT : 0), curwin) == FAIL) {
+    curwin->w_arg_idx = old_arg_idx;
+  } else if (eap->cmdidx != CMD_argdo) {
+    // like Vi: set the mark where the cursor is in the file.
+    setmark('\'');
   }
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1018,13 +1018,15 @@ void prepare_vimvar(int idx, typval_T *save_tv)
 void restore_vimvar(int idx, typval_T *save_tv)
 {
   vimvars[idx].vv_tv = *save_tv;
-  if (vimvars[idx].vv_type == VAR_UNKNOWN) {
-    hashitem_T *hi = hash_find(&vimvarht, (char *)vimvars[idx].vv_di.di_key);
-    if (HASHITEM_EMPTY(hi)) {
-      internal_error("restore_vimvar()");
-    } else {
-      hash_remove(&vimvarht, hi);
-    }
+  if (vimvars[idx].vv_type != VAR_UNKNOWN) {
+    return;
+  }
+
+  hashitem_T *hi = hash_find(&vimvarht, (char *)vimvars[idx].vv_di.di_key);
+  if (HASHITEM_EMPTY(hi)) {
+    internal_error("restore_vimvar()");
+  } else {
+    hash_remove(&vimvarht, hi);
   }
 }
 
@@ -6685,12 +6687,13 @@ void set_vim_var_dict(const VimVarIndex idx, dict_T *const val)
   tv_clear(&vimvars[idx].vv_di.di_tv);
   vimvars[idx].vv_type = VAR_DICT;
   vimvars[idx].vv_dict = val;
-
-  if (val != NULL) {
-    val->dv_refcount++;
-    // Set readonly
-    tv_dict_set_keys_readonly(val);
+  if (val == NULL) {
+    return;
   }
+
+  val->dv_refcount++;
+  // Set readonly
+  tv_dict_set_keys_readonly(val);
 }
 
 /// Set the v:argv list.

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -486,9 +486,11 @@ void f_win_execute(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   int id = (int)tv_get_number(argvars);
   tabpage_T *tp;
   win_T *wp = win_id2wp_tp(id, &tp);
-  if (wp != NULL && tp != NULL) {
-    WIN_EXECUTE(wp, tp, execute_common(argvars, rettv, 1));
+  if (wp == NULL || tp == NULL) {
+    return;
   }
+
+  WIN_EXECUTE(wp, tp, execute_common(argvars, rettv, 1));
 }
 
 /// "win_findbuf()" function

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5171,11 +5171,13 @@ static void ex_find(exarg_T *eap)
     }
   }
 
-  if (fname != NULL) {
-    eap->arg = fname;
-    do_exedit(eap, NULL);
-    xfree(fname);
+  if (fname == NULL) {
+    return;
   }
+
+  eap->arg = fname;
+  do_exedit(eap, NULL);
+  xfree(fname);
 }
 
 /// ":edit", ":badd", ":balt", ":visual".

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2014,11 +2014,13 @@ void set_file_options(int set_options, exarg_T *eap)
 /// Set forced 'fileencoding'.
 void set_forced_fenc(exarg_T *eap)
 {
-  if (eap->force_enc != 0) {
-    char *fenc = enc_canonize(eap->cmd + eap->force_enc);
-    set_string_option_direct("fenc", -1, fenc, OPT_FREE|OPT_LOCAL, 0);
-    xfree(fenc);
+  if (eap->force_enc == 0) {
+    return;
   }
+
+  char *fenc = enc_canonize(eap->cmd + eap->force_enc);
+  set_string_option_direct("fenc", -1, fenc, OPT_FREE|OPT_LOCAL, 0);
+  xfree(fenc);
 }
 
 /// Find next fileencoding to use from 'fileencodings'.
@@ -5348,35 +5350,40 @@ static void vim_opentempdir(void)
   }
 
   DIR *dp = opendir(vim_tempdir);
-
-  if (dp != NULL) {
-    vim_tempdir_dp = dp;
-    flock(dirfd(vim_tempdir_dp), LOCK_SH);
+  if (dp == NULL) {
+    return;
   }
+
+  vim_tempdir_dp = dp;
+  flock(dirfd(vim_tempdir_dp), LOCK_SH);
 }
 
 /// Close temporary directory - it automatically release file lock.
 static void vim_closetempdir(void)
 {
-  if (vim_tempdir_dp != NULL) {
-    closedir(vim_tempdir_dp);
-    vim_tempdir_dp = NULL;
+  if (vim_tempdir_dp == NULL) {
+    return;
   }
+
+  closedir(vim_tempdir_dp);
+  vim_tempdir_dp = NULL;
 }
 #endif
 
 /// Delete the temp directory and all files it contains.
 void vim_deltempdir(void)
 {
-  if (vim_tempdir != NULL) {
-#if defined(HAVE_FLOCK) && defined(HAVE_DIRFD)
-    vim_closetempdir();
-#endif
-    // remove the trailing path separator
-    path_tail(vim_tempdir)[-1] = NUL;
-    delete_recursive(vim_tempdir);
-    XFREE_CLEAR(vim_tempdir);
+  if (vim_tempdir == NULL) {
+    return;
   }
+
+#if defined(HAVE_FLOCK) && defined(HAVE_DIRFD)
+  vim_closetempdir();
+#endif
+  // remove the trailing path separator
+  path_tail(vim_tempdir)[-1] = NUL;
+  delete_recursive(vim_tempdir);
+  XFREE_CLEAR(vim_tempdir);
 }
 
 /// Gets path to Nvim's own temp dir (ending with slash).
@@ -5401,9 +5408,10 @@ char *vim_gettempdir(void)
 static bool vim_settempdir(char *tempdir)
 {
   char *buf = verbose_try_malloc(MAXPATHL + 2);
-  if (!buf) {
+  if (buf == NULL) {
     return false;
   }
+
   vim_FullName(tempdir, buf, MAXPATHL, false);
   add_pathsep(buf);
   vim_tempdir = xstrdup(buf);


### PR DESCRIPTION
#### vim-patch:9.0.1132: code is indented more than needed

Problem:    Code is indented more than needed.
Solution:   Use an early return to reduce indentation. (Yegappan Lakshmanan,
            closes vim/vim#11769)

https://github.com/vim/vim/commit/dc4daa3a3915fba11ac87d27977240d9a5e0d47d

Omit expand_autoload_callback(): only applies to Vim9 script.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>