### PR TITLE
vim-patch:9.0.1137: some conditions are always false

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1654,7 +1654,7 @@ static void setwinvar(typval_T *argvars, typval_T *rettv, int off)
   const char *varname = tv_get_string_chk(&argvars[off + 1]);
   typval_T *varp = &argvars[off + 2];
 
-  if (win == NULL || varname == NULL || varp == NULL) {
+  if (win == NULL || varname == NULL) {
     return;
   }
 


### PR DESCRIPTION
#### vim-patch:9.0.1137: some conditions are always false

Problem:    Some conditions are always false.
Solution:   Remove the useless conditions. (closes vim/vim#11776)

https://github.com/vim/vim/commit/ea720aea851e645f4c8ec3b20afb27c7ca38184c