### PR TITLE
fix(diagnostic): revert notification on missing diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -477,10 +477,6 @@ local function set_list(loclist, opts)
   -- numbers beyond the end of the buffer
   local diagnostics = get_diagnostics(bufnr, opts, false)
   local items = M.toqflist(diagnostics)
-  if next(items) == nil then
-    vim.notify('No diagnostics available')
-    return
-  end
   if loclist then
     vim.fn.setloclist(winnr, {}, ' ', { title = title, items = items })
   else


### PR DESCRIPTION
This reverts a change introduced in
4ace9e7e417fe26c8b73ff1d6042e6e4f3df9ebf.

Closes #21599.
