### PR TITLE
test(tui_spec): avoid race between nvim_paste and nvim_input

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1076,8 +1076,7 @@ describe('TUI', function()
     wait_for_mode('i')
     -- "bracketed paste"
     feed_data('\027[200~'..expected..'\027[201~')
-    -- FIXME: Data race between the two feeds
-    if is_os('freebsd') then screen:sleep(1) end
+    expect_child_buf_lines({expected})
     feed_data(' end')
     expected = expected..' end'
     screen:expect([[


### PR DESCRIPTION
Now that the TUI calls nvim_paste and nvim_input through RPC, the data
race is much more likely, as nvim_paste is deferred while nvim_input is
not. Add an expect_child_buf_lines() call to avoid the race.
