### PR TITLE
docs(lua): adjust some type annotations

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -974,7 +974,7 @@ stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
     Parameters: ~
       • {client_id}  number|table id or |vim.lsp.client| object, or list
                      thereof
-      • {force}      (boolean) (optional) shutdown forcefully
+      • {force}      (boolean|nil) shutdown forcefully
 
 tagfunc({...})                                             *vim.lsp.tagfunc()*
     Provides an interface between the built-in client and 'tagfunc'.
@@ -1174,7 +1174,7 @@ references({context}, {options})                    *vim.lsp.buf.references()*
     window.
 
     Parameters: ~
-      • {context}  (table) Context for the request
+      • {context}  (table|nil) Context for the request
       • {options}  (table|nil) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
@@ -1566,7 +1566,7 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
       • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
-      • {reuse_win}        (boolean) Jump to existing window if buffer is
+      • {reuse_win}        (boolean|nil) Jump to existing window if buffer is
                            already open.
 
     Return: ~
@@ -1657,7 +1657,7 @@ make_position_params({window}, {offset_encoding})
     Parameters: ~
       • {window}           (number|nil) window handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
+      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
 
@@ -1788,7 +1788,7 @@ show_document({location}, {offset_encoding}, {opts})
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
       • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
-      • {opts}             (table) options
+      • {opts}             (table|nil) options
                            • reuse_win (boolean) Jump to existing window if
                              buffer is already open.
                            • focus (boolean) Whether to focus/jump to location

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1678,8 +1678,8 @@ list_slice({list}, {start}, {finish})                       *vim.list_slice()*
 
     Parameters: ~
       • {list}    (list) Table
-      • {start}   (number) Start range of slice
-      • {finish}  (number) End range of slice
+      • {start}   (number|nil) Start range of slice
+      • {finish}  (number|nil) End range of slice
 
     Return: ~
         (list) Copy of table sliced from start to finish (inclusive)

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1805,7 +1805,7 @@ end
 --- already for this client, then force-shutdown is attempted.
 ---
 ---@param client_id number|table id or |vim.lsp.client| object, or list thereof
----@param force boolean (optional) shutdown forcefully
+---@param force boolean|nil shutdown forcefully
 function lsp.stop_client(client_id, force)
   local ids = type(client_id) == 'table' and client_id or { client_id }
   for _, id in ipairs(ids) do

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -383,7 +383,7 @@ end
 
 --- Lists all the references to the symbol under the cursor in the quickfix window.
 ---
----@param context (table) Context for the request
+---@param context (table|nil) Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 ---@param options table|nil additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1077,7 +1077,7 @@ end
 ---
 ---@param location table (`Location`|`LocationLink`)
 ---@param offset_encoding "utf-8" | "utf-16" | "utf-32"
----@param opts table options
+---@param opts table|nil options
 ---        - reuse_win (boolean) Jump to existing window if buffer is already open.
 ---        - focus (boolean) Whether to focus/jump to location if possible. Defaults to true.
 ---@return boolean `true` if succeeded
@@ -1134,7 +1134,7 @@ end
 ---
 ---@param location table (`Location`|`LocationLink`)
 ---@param offset_encoding "utf-8" | "utf-16" | "utf-32"
----@param reuse_win boolean Jump to existing window if buffer is already open.
+---@param reuse_win boolean|nil Jump to existing window if buffer is already open.
 ---@return boolean `true` if the jump succeeded
 function M.jump_to_location(location, offset_encoding, reuse_win)
   if offset_encoding == nil then
@@ -1908,7 +1908,7 @@ end
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
 ---
 ---@param window number|nil: window handle or 0 for current, defaults to current
----@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
+---@param offset_encoding string|nil utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@returns `TextDocumentPositionParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
 function M.make_position_params(window, offset_encoding)

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -516,8 +516,8 @@ end
 ---
 ---@generic T
 ---@param list T[] (list) Table
----@param start number Start range of slice
----@param finish number End range of slice
+---@param start number|nil Start range of slice
+---@param finish number|nil End range of slice
 ---@return T[] (list) Copy of table sliced from start to finish (inclusive)
 function vim.list_slice(list, start, finish)
   local new_list = {}


### PR DESCRIPTION
For example, this pr fixes the following sumneko_lua warnings.

```lua
vim.list_slice({ 1, 2, 3 }, 2) -- This function requires 3 argument(s) but instead it is receiving 2.
vim.lsp.stop_client(vim.lsp.get_active_clients()) -- This function requires 2 argument(s) but instead it is receiving 1.
```

