### PR TITLE
fix(tui): make a copy of data->params before unibi_format()

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1635,11 +1635,13 @@ static void unibi_goto(UI *ui, int row, int col)
     } \
     if (str) { \
       unibi_var_t vars[26 + 26]; \
+      unibi_var_t params[9]; \
       size_t orig_pos = data->bufpos; \
       memset(&vars, 0, sizeof(vars)); \
       data->cork = true; \
 retry: \
-      unibi_format(vars, vars + 26, str, data->params, out, ui, pad, ui); \
+      memcpy(params, data->params, sizeof(params)); \
+      unibi_format(vars, vars + 26, str, params, out, ui, pad, ui); \
       if (data->overflow) { \
         data->bufpos = orig_pos; \
         flush_buf(ui); \


### PR DESCRIPTION
Problem:    When unibi_format() modifies params and data->buf overflows,
            unibi_format() is called again, causing the params to be
            modified twice. This can happen for escape sequences that
            use the %i terminfo format specifier (e.g. cursor_address),
            which makes unibi_format() increase the param by 1.
Solution:   Make a copy of data->params before calling unibi_format().
