### PR TITLE
feat(editorconfig): allow editorconfig to be toggled dynamically

### DIFF
--- a/runtime/doc/editorconfig.txt
+++ b/runtime/doc/editorconfig.txt
@@ -13,16 +13,18 @@ the opened file are applied.
 
 For more information on EditorConfig, see https://editorconfig.org/.
 
-                                                       *g:editorconfig_enable*
-EditorConfig integration can be disabled by adding >lua
+                                               *g:editorconfig* *b:editorconfig*
+EditorConfig integration can be disabled globally by adding >lua
 
-    vim.g.editorconfig_enable = false
+    vim.g.editorconfig = false
 <
-to the user's |init.lua| file (or the Vimscript equivalent to |init.vim|).
+to the user's |init.lua| file (or the Vimscript equivalent to |init.vim|). It
+can also be disabled per-buffer by setting the |b:editorconfig| buffer-local
+variable to `false`.
 
-                                                              *b:editorconfig*
 When Nvim finds a valid .editorconfig file it will store the applied
-properties in the buffer variable |b:editorconfig|.
+properties in the buffer variable |b:editorconfig| if it was not already set to
+`false` by the user.
 
                                                      *editorconfig-properties*
 The following properties are supported by default:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -53,7 +53,7 @@ The following new APIs or features were added.
 • EditorConfig support is now builtin. This is enabled by default and happens
   automatically. To disable it, users should add >lua
 
-    vim.g.editorconfig_enable = false
+    vim.g.editorconfig = false
 <
   (or the Vimscript equivalent) to their |config| file.
 

--- a/runtime/plugin/editorconfig.lua
+++ b/runtime/plugin/editorconfig.lua
@@ -3,8 +3,7 @@ vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead', 'BufFilePost' }, {
   group = group,
   callback = function(args)
     -- Buffer-local enable has higher priority
-    local enable =
-      vim.F.if_nil(vim.b.editorconfig_enable, vim.F.if_nil(vim.g.editorconfig_enable, true))
+    local enable = vim.F.if_nil(vim.b.editorconfig, vim.F.if_nil(vim.g.editorconfig, true))
     if not enable then
       return
     end

--- a/runtime/plugin/editorconfig.lua
+++ b/runtime/plugin/editorconfig.lua
@@ -1,11 +1,14 @@
-if vim.g.editorconfig_enable == false or vim.g.editorconfig_enable == 0 then
-  return
-end
-
 local group = vim.api.nvim_create_augroup('editorconfig', {})
 vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead', 'BufFilePost' }, {
   group = group,
   callback = function(args)
+    -- Buffer-local enable has higher priority
+    local enable =
+      vim.F.if_nil(vim.b.editorconfig_enable, vim.F.if_nil(vim.g.editorconfig_enable, true))
+    if not enable then
+      return
+    end
+
     require('editorconfig').config(args.buf)
   end,
 })

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -4,6 +4,8 @@ local command = helpers.command
 local eq = helpers.eq
 local pathsep = helpers.get_pathsep()
 local curbufmeths = helpers.curbufmeths
+local funcs = helpers.funcs
+local meths = helpers.meths
 
 local testdir = 'Xtest-editorconfig'
 
@@ -190,5 +192,19 @@ But not this one
 
   it('sets textwidth', function()
     test_case('max_line_length.txt', { textwidth = 42 })
+  end)
+
+  it('can be disabled globally', function()
+    meths.set_var('editorconfig_enable', false)
+    meths.set_option_value('shiftwidth', 42, {})
+    test_case('3_space.txt', { shiftwidth = 42 })
+  end)
+
+  it('can be disabled per-buffer', function()
+    meths.set_option_value('shiftwidth', 42, {})
+    local bufnr = funcs.bufadd(testdir .. pathsep .. '3_space.txt')
+    meths.buf_set_var(bufnr, 'editorconfig_enable', false)
+    test_case('3_space.txt', { shiftwidth = 42 })
+    test_case('4_space.py', { shiftwidth = 4 })
   end)
 end)

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -195,7 +195,7 @@ But not this one
   end)
 
   it('can be disabled globally', function()
-    meths.set_var('editorconfig_enable', false)
+    meths.set_var('editorconfig', false)
     meths.set_option_value('shiftwidth', 42, {})
     test_case('3_space.txt', { shiftwidth = 42 })
   end)
@@ -203,7 +203,7 @@ But not this one
   it('can be disabled per-buffer', function()
     meths.set_option_value('shiftwidth', 42, {})
     local bufnr = funcs.bufadd(testdir .. pathsep .. '3_space.txt')
-    meths.buf_set_var(bufnr, 'editorconfig_enable', false)
+    meths.buf_set_var(bufnr, 'editorconfig', false)
     test_case('3_space.txt', { shiftwidth = 42 })
     test_case('4_space.py', { shiftwidth = 4 })
   end)


### PR DESCRIPTION
Rather than only check `editorconfig_enable` when the plugin is loaded,
check it each time the autocommand fires, so that users may enable or
disable it dynamically.

Also check for a buffer local version of the variable, so that
editorconfig can be enabled or disabled per-buffer.
