### PR TITLE
fix(diff): avoid restoring invalid 'foldcolumn' value

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1502,7 +1502,7 @@ void ex_diffoff(exarg_T *eap)
         free_string_option(wp->w_p_fdm);
         wp->w_p_fdm = xstrdup(*wp->w_p_fdm_save ? wp->w_p_fdm_save : "manual");
         free_string_option(wp->w_p_fdc);
-        wp->w_p_fdc = xstrdup(wp->w_p_fdc_save);
+        wp->w_p_fdc = xstrdup(*wp->w_p_fdc_save ? wp->w_p_fdc_save : "0");
 
         if (wp->w_p_fdl == 0) {
           wp->w_p_fdl = wp->w_p_fdl_save;

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -8,6 +8,8 @@ local insert = helpers.insert
 local write_file = helpers.write_file
 local dedent = helpers.dedent
 local exec = helpers.exec
+local eq = helpers.eq
+local meths = helpers.meths
 
 describe('Diff mode screen', function()
   local fname = 'Xtest-functional-diff-screen-1'
@@ -1489,6 +1491,26 @@ it('Align the filler lines when changing text in diff mode', function()
     {3:[No Name] [+]       }{8:[No Name] [+]       }|
                                             |
   ]]}
+end)
+
+it("diff mode doesn't restore invalid 'foldcolumn' value #21647", function()
+  clear()
+  local screen = Screen.new(60, 6)
+  screen:set_default_attr_ids({
+    [0] = {foreground = Screen.colors.Blue, bold = true};
+  })
+  screen:attach()
+  eq('0', meths.get_option_value('foldcolumn', {}))
+  command('diffsplit | bd')
+  screen:expect([[
+    ^                                                            |
+    {0:~                                                           }|
+    {0:~                                                           }|
+    {0:~                                                           }|
+    {0:~                                                           }|
+                                                                |
+  ]])
+  eq('0', meths.get_option_value('foldcolumn', {}))
 end)
 
 -- oldtest: Test_diff_binary()


### PR DESCRIPTION
Fix #21647

Use "0" for 'foldcolumn' when w_p_fdc_save is empty, like how
"manual" is used for 'foldmethod' when w_p_fdm_save is empty.
