### PR TITLE
fix(ui): fix fragile UI_CALL macro invocation

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -115,10 +115,6 @@ static char uilog_last_event[1024] = { 0 };
 # include "ui_events_call.generated.h"
 #endif
 
-#ifndef EXITFREE
-# undef entered_free_all_mem
-#endif
-
 void ui_init(void)
 {
   default_grid.handle = 1;


### PR DESCRIPTION
fixup #21605 

Depending on the phase of the moon, `UI_CALL` expanding `UI_LOG` expanding the default value of `entered_free_all_mem` might or might not work.

