### PR TITLE
feat(lsp): show active clients in :checkhealth vim.lsp

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -2,8 +2,8 @@ local M = {}
 
 --- Performs a healthcheck for LSP
 function M.check()
-  local report_info = vim.fn['health#report_info']
-  local report_warn = vim.fn['health#report_warn']
+  local report_info = vim.health.report_info
+  local report_warn = vim.health.report_warn
 
   local log = require('vim.lsp.log')
   local current_log_level = log.get_level()
@@ -27,6 +27,18 @@ function M.check()
 
   local report_fn = (log_size / 1000000 > 100 and report_warn or report_info)
   report_fn(string.format('Log size: %d KB', log_size / 1000))
+
+  local clients = vim.lsp.get_active_clients()
+  vim.health.report_start('vim.lsp: Active Clients')
+  if next(clients) then
+    for _, client in pairs(clients) do
+      report_info(
+        string.format('%s (id=%s, root_dir=%s)', client.name, client.id, client.config.root_dir)
+      )
+    end
+  else
+    report_info('No active clients')
+  end
 end
 
 return M


### PR DESCRIPTION
For users using vim.lsp.start it can be useful to get an
overview of active client that is less verbose than a full `:lua
=vim.lsp.get_active_clients()`
