### PR TITLE
fix(editorconfig): do not highlight unknown properties as errors

### DIFF
--- a/runtime/syntax/editorconfig.vim
+++ b/runtime/syntax/editorconfig.vim
@@ -1,7 +1,7 @@
 runtime! syntax/dosini.vim
 unlet! b:current_syntax
 
-syntax match editorconfigInvalidProperty "^\s*\zs\w\+\ze\s*="
+syntax match editorconfigUnknownProperty "^\s*\zs\w\+\ze\s*="
 syntax keyword editorconfigProperty root
 
 lua<<
@@ -12,7 +12,6 @@ end
 vim.cmd(string.format('syntax keyword editorconfigProperty %s', table.concat(props, ' ')))
 .
 
-hi def link editorconfigInvalidProperty Error
 hi def link editorconfigProperty dosiniLabel
 
 let b:current_syntax = 'editorconfig'


### PR DESCRIPTION
Other plugins may define their own custom properties outside of Neovim's
builtin EditorConfig support. Instead of highlighting these unknown
properties as errors, do not highlight them at all.

This still differentiates between known and unknown properties, which
helps to catch typos or mistakes, but does not use the garish "error"
highlight that signals something is wrong.

See discussion here: https://github.com/neovim/neovim/pull/21633#issuecomment-1373986962
