### PR TITLE
build: remove old workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,16 +414,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
   add_definitions(-D_GNU_SOURCE)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT PREFER_LUA AND LUAJIT_VERSION LESS "2.1.0-beta3")
-  # Required for luajit < 2.1.0-beta3.
-  set(CMAKE_EXE_LINKER_FLAGS
-    "${CMAKE_EXE_LINKER_FLAGS} -pagezero_size 10000 -image_base 100000000")
-  set(CMAKE_SHARED_LINKER_FLAGS
-    "${CMAKE_SHARED_LINKER_FLAGS} -image_base 100000000")
-  set(CMAKE_MODULE_LINKER_FLAGS
-    "${CMAKE_MODULE_LINKER_FLAGS} -image_base 100000000")
-endif()
-
 include_directories("${PROJECT_BINARY_DIR}/cmake.config")
 include_directories("${PROJECT_SOURCE_DIR}/src")
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -624,21 +624,11 @@ endif()
 
 if(CLANG_ASAN_UBSAN)
   message(STATUS "Enabling Clang address sanitizer and undefined behavior sanitizer for nvim.")
-  check_c_compiler_flag(-fno-sanitize-recover=all SANITIZE_RECOVER_ALL)
-  if(SANITIZE_RECOVER_ALL)
-    if(CI_BUILD)
-      # Try to recover from all sanitize issues so we get reports about all failures
-      set(SANITIZE_RECOVER -fsanitize-recover=all)     # Clang 3.6+
-    else()
-      set(SANITIZE_RECOVER -fno-sanitize-recover=all)  # Clang 3.6+
-    endif()
+  if(CI_BUILD)
+    # Try to recover from all sanitize issues so we get reports about all failures
+    set(SANITIZE_RECOVER -fsanitize-recover=all)
   else()
-    if(CI_BUILD)
-      # Try to recover from all sanitize issues so we get reports about all failures
-      set(SANITIZE_RECOVER -fsanitize-recover)         # Clang 3.5-
-    else()
-      set(SANITIZE_RECOVER -fno-sanitize-recover)      # Clang 3.5-
-    endif()
+    set(SANITIZE_RECOVER -fno-sanitize-recover=all)
   endif()
   set_property(TARGET nvim APPEND PROPERTY COMPILE_OPTIONS ${SANITIZE_RECOVER} -fno-omit-frame-pointer -fno-optimize-sibling-calls -fsanitize=address -fsanitize=undefined -fsanitize-blacklist=${PROJECT_SOURCE_DIR}/src/.asan-blacklist)
   set_property(TARGET nvim APPEND_STRING PROPERTY LINK_FLAGS "-fsanitize=address -fsanitize=undefined ")


### PR DESCRIPTION
- build: remove workaround for old luajit versions

Luajit version 2.1.0-beta3 was released 2017, there's no reason to use
such an old version on macOS. Also, the version check doesn't work
anymore as LUAJIT_VERSION seems to not be defined anywhere.

- build: remove workaround for ancient clang versions

We don't need to support this as it's only required when using
AddressSanitizer, meaning it only affects developers.