### PR TITLE
ci(news): checkout to HEAD commit instead of merge commit

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: news.txt needs to be updated
         run: |
           for commit in $(git rev-list HEAD~${{ github.event.pull_request.commits }}..HEAD); do


### PR DESCRIPTION
The default merge branch is unreliable when trying to determine number
of commits in a PR. Using the HEAD branch of the PR removes this
ambiguity.