### PR TITLE
fix(lsp): partially revert semantic token gravity change from #21574

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -408,7 +408,6 @@ function STHighlighter:on_win(topline, botline)
             hl_group = '@' .. token.type,
             end_col = token.end_col,
             priority = vim.highlight.priorities.semantic_tokens,
-            right_gravity = false,
             end_right_gravity = true,
             strict = false,
           })
@@ -420,7 +419,6 @@ function STHighlighter:on_win(topline, botline)
                 hl_group = '@' .. modifier,
                 end_col = token.end_col,
                 priority = vim.highlight.priorities.semantic_tokens + 1,
-                right_gravity = false,
                 end_right_gravity = true,
                 strict = false,
               })


### PR DESCRIPTION
This partially reverts #21574. Turns out that setting `right_gravity` to false makes the experience worse when commenting/uncommenting lines when the first character of a line is a semantic token.

```lua
local M = {
  func = function() end,
}
```

comment/uncomment the `func` line and you'll briefly see the whole thing with the highlighting of `@function`. The fix is to just not extend extmarks to the left when changing the contents of the line at the extmark's `start_col` (it should just do the default, which is to move the extmark to the right).

@mfussenegger 