### PR TITLE
vim-patch:9.0.1158: code is indented more than necessary

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1150,10 +1150,12 @@ static void ff_push(ff_search_ctx_T *search_ctx, ff_stack_T *stack_ptr)
 {
   // check for NULL pointer, not to return an error to the user, but
   // to prevent a crash
-  if (stack_ptr != NULL) {
-    stack_ptr->ffs_prev = search_ctx->ffsc_stack_ptr;
-    search_ctx->ffsc_stack_ptr = stack_ptr;
+  if (stack_ptr == NULL) {
+    return;
   }
+
+  stack_ptr->ffs_prev = search_ctx->ffsc_stack_ptr;
+  search_ctx->ffsc_stack_ptr = stack_ptr;
 }
 
 /// Pop a dir from the directory stack.


### PR DESCRIPTION
#### vim-patch:9.0.1158: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11787)

https://github.com/vim/vim/commit/7f8b2559a30e2e2a443c35b28e94c6b45ba7ae04

Omit reset_last_used_map(): only used in Vim9 script.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>