### PR TITLE
fix(api): convert title_pos string in nvim_win_get_config

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -299,7 +299,15 @@ Dictionary nvim_win_get_config(Window window, Error *err)
           ADD(titles, ARRAY_OBJ(tuple));
         }
         PUT(rv, "title", ARRAY_OBJ(titles));
-        PUT(rv, "title_pos", INTEGER_OBJ(config->title_pos));
+        char *title_pos;
+        if (config->title_pos == 0) {
+          title_pos = "left";
+        } else if (config->title_pos == 1){
+          title_pos = "center";
+        }else {
+          title_pos = "right";
+        }
+        PUT(rv, "title_pos", CSTR_TO_OBJ(title_pos));
       }
     }
   }

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -302,9 +302,9 @@ Dictionary nvim_win_get_config(Window window, Error *err)
         char *title_pos;
         if (config->title_pos == 0) {
           title_pos = "left";
-        } else if (config->title_pos == 1){
+        } else if (config->title_pos == 1) {
           title_pos = "center";
-        }else {
+        } else {
           title_pos = "right";
         }
         PUT(rv, "title_pos", CSTR_TO_OBJ(title_pos));

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -300,9 +300,9 @@ Dictionary nvim_win_get_config(Window window, Error *err)
         }
         PUT(rv, "title", ARRAY_OBJ(titles));
         char *title_pos;
-        if (config->title_pos == 0) {
+        if (config->title_pos == kAlignLeft) {
           title_pos = "left";
-        } else if (config->title_pos == 1) {
+        } else if (config->title_pos == kAlignCenter) {
           title_pos = "center";
         } else {
           title_pos = "right";

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1739,6 +1739,28 @@ describe('float window', function()
          }))
     end)
 
+    it('validate title_pos in nvim_win_get_config', function()
+      local title_pos = exec_lua([[
+        local bufnr = vim.api.nvim_create_buf(false, false)
+        local opts = {
+          relative = 'editor',
+          col = 2,
+          row = 5,
+          height = 2,
+          width = 9,
+          border = 'double',
+          title = 'Test',
+          title_pos = 'center'
+        }
+
+        local win_id = vim.api.nvim_open_win(bufnr, true, opts)
+        return vim.api.nvim_win_get_config(win_id).title_pos
+      ]])
+
+      eq('center', title_pos)
+    end)
+
+
     it('border with title', function()
       local buf = meths.create_buf(false, false)
       meths.buf_set_lines(buf, 0, -1, true, {' halloj! ',


### PR DESCRIPTION
use `left center right` instead of `0,1,2` in `nvim_win_get_config`.

Fix #21695 