### PR TITLE
refactor(pty): remove old logic for inheriting termios from host terminal

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -279,15 +279,6 @@ int main(int argc, char **argv)
   // argument list "global_alist".
   command_line_scan(&params);
 
-#ifndef MSWIN
-  int tty_fd = params.input_isatty
-    ? STDIN_FILENO
-    : (params.output_isatty
-       ? STDOUT_FILENO
-       : (params.err_isatty ? STDERR_FILENO : -1));
-  pty_process_save_termios(tty_fd);
-#endif
-
   nlua_init(argv, argc, params.lua_arg0);
   TIME_MSG("init lua interpreter");
 


### PR DESCRIPTION
This logic currently does not a apply to nvim running in TUI, and fully restoring it is going to require some work.

Copying the chat:
> question: is pty_process_save_termios() a feature we actually care about, or can we just rely init_termios() being sensible?
> nvim attempting to mimic a few isolated flags of the host terminal inside :terminal seems weird to me. it is not like :terminal behaves like the host emulator anyway (unless it happens to be an identical version of libvterm)

also:
>  TODO(jkeyes): We could pass NULL to forkpty() instead ...

@justinmk is this TODO still valid? Man pages do not refer to what is actually happening when you pass in NULL (it gets inherited from some other implicit state, I would assume), so `init_termios()` seems like the more robust option.