### PR TITLE
build(nix): remove incompatible reproducible patch

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -13,6 +13,14 @@
         neovim = final.neovim-unwrapped.overrideAttrs (oa: rec {
           version = self.shortRev or "dirty";
           src = ../.;
+          # Remove the reproducible patch that was introduced in NixOS/nixpkgs#208103 and doesn't apply against master
+          patches = builtins.filter (p:
+            let
+              patch = if builtins.typeOf p == "set"
+                      then baseNameOf p.name
+                      else baseNameOf p;
+            in
+            patch != "neovim-build-make-generated-source-files-reproducible.patch") oa.patches;
           preConfigure = ''
             sed -i cmake.config/versiondef.h.in -e 's/@NVIM_VERSION_PRERELEASE@/-dev-${version}/'
           '';


### PR DESCRIPTION
NixOS/nixpkgs#208103 introduced a patch that aims to make builds reproducible. This patch applies cleanly against 0.8.2, but doesn't apply against master.

Since the neovim flake uses the "upstream" nixpkgs neovim package, this patch is also pulled in when trying to build the nightly version.

This PR simply removes the reproducible patch from the list of patches that is applied, thereby allowing the master branch to be built once again.

/cc @raboof