### PR TITLE
vim-patch:partial:9.0.1166: code is indented more than necessary

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2676,19 +2676,20 @@ static int arg_augroup_get(char **argp)
 {
   char *p;
   char *arg = *argp;
-  int group = AUGROUP_ALL;
 
   for (p = arg; *p && !ascii_iswhite(*p) && *p != '|'; p++) {}
-  if (p > arg) {
-    char *group_name = xstrnsave(arg, (size_t)(p - arg));
-    group = augroup_find(group_name);
-    if (group == AUGROUP_ERROR) {
-      group = AUGROUP_ALL;  // no match, use all groups
-    } else {
-      *argp = skipwhite(p);  // match, skip over group name
-    }
-    xfree(group_name);
+  if (p <= arg) {
+    return AUGROUP_ALL;
   }
+
+  char *group_name = xstrnsave(arg, (size_t)(p - arg));
+  int group = augroup_find(group_name);
+  if (group == AUGROUP_ERROR) {
+    group = AUGROUP_ALL;  // no match, use all groups
+  } else {
+    *argp = skipwhite(p);  // match, skip over group name
+  }
+  xfree(group_name);
   return group;
 }
 

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1585,21 +1585,24 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, cons
   case CMD_dsplit:
     // Skip count.
     arg = (const char *)skipwhite(skipdigits(arg));
-    if (*arg == '/') {  // Match regexp, not just whole words.
-      for (++arg; *arg && *arg != '/'; arg++) {
-        if (*arg == '\\' && arg[1] != NUL) {
-          arg++;
-        }
-      }
-      if (*arg) {
-        arg = (const char *)skipwhite(arg + 1);
+    if (*arg != '/') {
+      return NULL;
+    }
 
-        // Check for trailing illegal characters.
-        if (*arg == NUL || strchr("|\"\n", *arg) == NULL) {
-          xp->xp_context = EXPAND_NOTHING;
-        } else {
-          return arg;
-        }
+    // Match regexp, not just whole words.
+    for (++arg; *arg && *arg != '/'; arg++) {
+      if (*arg == '\\' && arg[1] != NUL) {
+        arg++;
+      }
+    }
+    if (*arg) {
+      arg = (const char *)skipwhite(arg + 1);
+
+      // Check for trailing illegal characters.
+      if (*arg == NUL || strchr("|\"\n", *arg) == NULL) {
+        xp->xp_context = EXPAND_NOTHING;
+      } else {
+        return arg;
       }
     }
     break;

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -317,13 +317,15 @@ static int get_maxbacktrace_level(char *sname)
 {
   int maxbacktrace = 0;
 
-  if (sname != NULL) {
-    char *p = sname;
-    char *q;
-    while ((q = strstr(p, "..")) != NULL) {
-      p = q + 2;
-      maxbacktrace++;
-    }
+  if (sname == NULL) {
+    return 0;
+  }
+
+  char *p = sname;
+  char *q;
+  while ((q = strstr(p, "..")) != NULL) {
+    p = q + 2;
+    maxbacktrace++;
   }
   return maxbacktrace;
 }
@@ -458,20 +460,21 @@ void dbg_check_breakpoint(exarg_T *eap)
 /// @return true when the debug mode is entered this time.
 bool dbg_check_skipped(exarg_T *eap)
 {
-  if (debug_skipped) {
-    // Save the value of got_int and reset it.  We don't want a previous
-    // interruption cause flushing the input buffer.
-    int prev_got_int = got_int;
-    got_int = false;
-    debug_breakpoint_name = debug_skipped_name;
-    // eap->skip is true
-    eap->skip = false;
-    dbg_check_breakpoint(eap);
-    eap->skip = true;
-    got_int |= prev_got_int;
-    return true;
+  if (!debug_skipped) {
+    return false;
   }
-  return false;
+
+  // Save the value of got_int and reset it.  We don't want a previous
+  // interruption cause flushing the input buffer.
+  int prev_got_int = got_int;
+  got_int = false;
+  debug_breakpoint_name = debug_skipped_name;
+  // eap->skip is true
+  eap->skip = false;
+  dbg_check_breakpoint(eap);
+  eap->skip = true;
+  got_int |= prev_got_int;
+  return true;
 }
 
 static garray_T dbg_breakp = { 0, 0, sizeof(struct debuggy), 4, NULL };

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1528,30 +1528,31 @@ int get_digraph(bool cmdline)
   no_mapping--;
   allow_keys--;
 
-  if (c != ESC) {
+  if (c == ESC) {  // ESC cancels CTRL-K
+    return NUL;
+  }
+
+  if (IS_SPECIAL(c)) {
+    // insert special key code
+    return c;
+  }
+
+  if (cmdline) {
+    if ((char2cells(c) == 1) && c < 128 && (cmdline_star == 0)) {
+      putcmdline((char)c, true);
+    }
+  } else {
+    add_to_showcmd(c);
+  }
+  no_mapping++;
+  allow_keys++;
+  int cc = plain_vgetc();
+  no_mapping--;
+  allow_keys--;
+
+  if (cc != ESC) {
     // ESC cancels CTRL-K
-    if (IS_SPECIAL(c)) {
-      // insert special key code
-      return c;
-    }
-
-    if (cmdline) {
-      if ((char2cells(c) == 1) && c < 128 && (cmdline_star == 0)) {
-        putcmdline((char)c, true);
-      }
-    } else {
-      add_to_showcmd(c);
-    }
-    no_mapping++;
-    allow_keys++;
-    int cc = plain_vgetc();
-    no_mapping--;
-    allow_keys--;
-
-    if (cc != ESC) {
-      // ESC cancels CTRL-K
-      return digraph_get(c, cc, true);
-    }
+    return digraph_get(c, cc, true);
   }
   return NUL;
 }

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -46,31 +46,33 @@ static int win_getid(typval_T *argvars)
   }
   int winnr = (int)tv_get_number(&argvars[0]);
   win_T *wp;
-  if (winnr > 0) {
-    if (argvars[1].v_type == VAR_UNKNOWN) {
-      wp = firstwin;
-    } else {
-      tabpage_T *tp = NULL;
-      int tabnr = (int)tv_get_number(&argvars[1]);
-      FOR_ALL_TABS(tp2) {
-        if (--tabnr == 0) {
-          tp = tp2;
-          break;
-        }
-      }
-      if (tp == NULL) {
-        return -1;
-      }
-      if (tp == curtab) {
-        wp = firstwin;
-      } else {
-        wp = tp->tp_firstwin;
+  if (winnr <= 0) {
+    return 0;
+  }
+
+  if (argvars[1].v_type == VAR_UNKNOWN) {
+    wp = firstwin;
+  } else {
+    tabpage_T *tp = NULL;
+    int tabnr = (int)tv_get_number(&argvars[1]);
+    FOR_ALL_TABS(tp2) {
+      if (--tabnr == 0) {
+        tp = tp2;
+        break;
       }
     }
-    for (; wp != NULL; wp = wp->w_next) {
-      if (--winnr == 0) {
-        return wp->handle;
-      }
+    if (tp == NULL) {
+      return -1;
+    }
+    if (tp == curtab) {
+      wp = firstwin;
+    } else {
+      wp = tp->tp_firstwin;
+    }
+  }
+  for (; wp != NULL; wp = wp->w_next) {
+    if (--winnr == 0) {
+      return wp->handle;
     }
   }
   return 0;
@@ -288,16 +290,18 @@ static int get_winnr(tabpage_T *tp, typval_T *argvar)
     }
   }
 
-  if (nr > 0) {
-    for (win_T *wp = (tp == curtab) ? firstwin : tp->tp_firstwin;
-         wp != twin; wp = wp->w_next) {
-      if (wp == NULL) {
-        // didn't find it in this tabpage
-        nr = 0;
-        break;
-      }
-      nr++;
+  if (nr <= 0) {
+    return 0;
+  }
+
+  for (win_T *wp = (tp == curtab) ? firstwin : tp->tp_firstwin;
+       wp != twin; wp = wp->w_next) {
+    if (wp == NULL) {
+      // didn't find it in this tabpage
+      nr = 0;
+      break;
     }
+    nr++;
   }
   return nr;
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4510,32 +4510,30 @@ void free_old_sub(void)
 /// @return           true when it was created.
 bool prepare_tagpreview(bool undo_sync)
 {
+  if (curwin->w_p_pvw) {
+    return false;
+  }
+
   // If there is already a preview window open, use that one.
-  if (!curwin->w_p_pvw) {
-    bool found_win = false;
-    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-      if (wp->w_p_pvw) {
-        win_enter(wp, undo_sync);
-        found_win = true;
-        break;
-      }
-    }
-    if (!found_win) {
-      // There is no preview window open yet.  Create one.
-      if (win_split(g_do_tagpreview > 0 ? g_do_tagpreview : 0, 0)
-          == FAIL) {
-        return false;
-      }
-      curwin->w_p_pvw = true;
-      curwin->w_p_wfh = true;
-      RESET_BINDING(curwin);                // don't take over 'scrollbind' and 'cursorbind'
-      curwin->w_p_diff = false;             // no 'diff'
-      set_string_option_direct("fdc", -1,     // no 'foldcolumn'
-                               "0", OPT_FREE, SID_NONE);
-      return true;
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_p_pvw) {
+      win_enter(wp, undo_sync);
+      return false;
     }
   }
-  return false;
+
+  // There is no preview window open yet.  Create one.
+  if (win_split(g_do_tagpreview > 0 ? g_do_tagpreview : 0, 0)
+      == FAIL) {
+    return false;
+  }
+  curwin->w_p_pvw = true;
+  curwin->w_p_wfh = true;
+  RESET_BINDING(curwin);                // don't take over 'scrollbind' and 'cursorbind'
+  curwin->w_p_diff = false;             // no 'diff'
+  set_string_option_direct("fdc", -1,     // no 'foldcolumn'
+                           "0", OPT_FREE, SID_NONE);
+  return true;
 }
 
 /// Shows the effects of the :substitute command being typed ('inccommand').

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4083,12 +4083,14 @@ static char *get_cmdline_completion(void)
   }
   CmdlineInfo *p = get_ccline_ptr();
 
-  if (p != NULL && p->xpc != NULL) {
-    set_expand_context(p->xpc);
-    char *cmd_compl = get_user_cmd_complete(p->xpc, p->xpc->xp_context);
-    if (cmd_compl != NULL) {
-      return xstrdup(cmd_compl);
-    }
+  if (p == NULL || p->xpc == NULL) {
+    return NULL;
+  }
+
+  set_expand_context(p->xpc);
+  char *cmd_compl = get_user_cmd_complete(p->xpc, p->xpc->xp_context);
+  if (cmd_compl != NULL) {
+    return xstrdup(cmd_compl);
   }
 
   return NULL;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -481,7 +481,7 @@ void foldCheckClose(void)
     return;
   }
 
-  // can only be "all" right now
+  // 'foldclose' can only be "all" right now
   checkupdate(curwin);
   if (checkCloseRec(&curwin->w_folds, curwin->w_cursor.lnum,
                     (int)curwin->w_p_fdl)) {

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -356,6 +356,7 @@ bool cin_islabel(void)  // XXX
   if (cin_isscopedecl((char_u *)s)) {
     return false;
   }
+
   if (!cin_islabel_skip(&s)) {
     return false;
   }


### PR DESCRIPTION
#### vim-patch:partial:9.0.1166: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11792)

https://github.com/vim/vim/commit/1cfb14aa972ccf3235ac67f07b7db1175b7c5384

Partial port as some highlight.c changes depend on previous patches.
Cherry-pick fname_match() change from patch 8.2.4959.
Omit internal_func_check_arg_types(): only used for Vim9 script.

N/A patches for version.c:

vim-patch:9.0.1167: EditorConfig files do not have their own filetype

Problem:    EditorConfig files do not have their own filetype.
Solution:   Add the "editorconfig" filetype. (Gregory Anders, closes vim/vim#11779)

https://github.com/vim/vim/commit/d41262ed06564cef98a3800e2928e6e0db91abbf

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>