### PR TITLE
test(statuscolumn): add more tests for wrapped lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -406,7 +406,7 @@ static void get_statuscol_str(win_T *wp, linenr_T lnum, int row, int startrow, i
                               int cul_attr, int sign_num_attr, SignTextAttrs *sattrs,
                               foldinfo_T foldinfo, char_u *extra, statuscol_T *stcp)
 {
-  long relnum;
+  long relnum = 0;
   bool wrapped = row != startrow + filler_lines;
   bool use_cul = use_cursor_line_sign(wp, lnum);
 

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -240,6 +240,59 @@ describe('statuscolumn', function()
       {2: }{1:  │     }aaaaaa                                      |
                                                            |
     ]])
+    -- v:lnum is the same value on wrapped lines
+    command("set stc=%C%=%{v:lnum}│%s\\ ")
+    screen:expect([[
+      {2: }{1: 4│>>   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 4│     }aaaaaa                                      |
+      {2: }{1: 5│}{0:>!}{1:   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 5│     }aaaaaa                                      |
+      {2: }{1: 6│>>}{0:>!}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 6│     }aaaaaa                                      |
+      {2: }{1: 7│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 7│     }aaaaaa                                      |
+      {2:+}{1: 8│     }{3:^+--  1 line: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {2: }{1: 9│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 9│     }aaaaaa                                      |
+      {2: }{1:10│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:10│     }aaaaaa                                      |
+                                                           |
+    ]])
+    -- v:relnum is the same value on wrapped lines
+    command("set stc=%C%=\\ %{v:relnum}│%s\\ ")
+    screen:expect([[
+      {2: }{1: 4│>>   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 4│     }aaaaaa                                      |
+      {2: }{1: 3│}{0:>!}{1:   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 3│     }aaaaaa                                      |
+      {2: }{1: 2│>>}{0:>!}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 2│     }aaaaaa                                      |
+      {2: }{1: 1│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 1│     }aaaaaa                                      |
+      {2:+}{1: 0│     }{3:^+--  1 line: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {2: }{1: 1│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 1│     }aaaaaa                                      |
+      {2: }{1: 2│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1: 2│     }aaaaaa                                      |
+                                                           |
+    ]])
+    command("set stc=%C%=\\ %{v:wrap?'':v:relnum}│%s\\ ")
+    screen:expect([[
+      {2: }{1: 4│>>   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+      {2: }{1: 3│}{0:>!}{1:   }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+      {2: }{1: 2│>>}{0:>!}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+      {2: }{1: 1│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+      {2:+}{1: 0│     }{3:^+--  1 line: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {2: }{1: 1│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+      {2: }{1: 2│     }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {2: }{1:  │     }aaaaaa                                      |
+                                                           |
+    ]])
   end)
 
   it('works with \'statuscolumn\' clicks', function()


### PR DESCRIPTION
Also initialize a "relnum" variable to suppress a Coverity warning.
The uninitialized value wasn't actually used by build_statuscol_str().
