### PR TITLE
feat(filetype): add smali for extension detection

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -949,6 +949,7 @@ local extension = {
   ice = 'slice',
   score = 'slrnsc',
   sol = 'solidity',
+  smali = 'smali',
   tpl = 'smarty',
   ihlp = 'smcl',
   smcl = 'smcl',


### PR DESCRIPTION
As per the title, smali is not autodetected by filetypes in nvim. As treesitter recently gained a smali grammar, it would be nice to have auto detection by extension as well. All smali filetypes end in .smali, and to my knowledge no other filetype has this extension.