### PR TITLE
build: delete pthreads import

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -62,12 +62,6 @@ else()
   target_link_libraries(main_lib INTERFACE ${LUAJIT_LIBRARIES})
 endif()
 
-# Determine platform's threading library. Set CMAKE_THREAD_PREFER_PTHREAD
-# explicitly to indicate a strong preference for pthread.
-set(CMAKE_THREAD_PREFER_PTHREAD ON)
-find_package(Threads REQUIRED)
-target_link_libraries(main_lib INTERFACE ${CMAKE_THREAD_LIBS_INIT})
-
 option(ENABLE_IWYU "Run include-what-you-use with the compiler." OFF)
 if(ENABLE_IWYU)
   find_program(IWYU_PRG NAMES include-what-you-use iwyu)


### PR DESCRIPTION
We shouldn't need this as all threading should already be handled by
libuv. Furthermore, it wasn't even used correctly as
CMAKE_THREAD_PREFER_PTHREAD has been removed from cmake a long time ago.