### PR TITLE
vim-patch:9.0.1172: when 'selection' is "exclusive" then "1v" is one char short

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -379,12 +379,19 @@ static bool check_top_offset(void)
   return false;
 }
 
+/// Update w_curswant.
+void update_curswant_force(void)
+{
+  validate_virtcol();
+  curwin->w_curswant = curwin->w_virtcol;
+  curwin->w_set_curswant = false;
+}
+
+/// Update w_curswant if w_set_curswant is set.
 void update_curswant(void)
 {
   if (curwin->w_set_curswant) {
-    validate_virtcol();
-    curwin->w_curswant = curwin->w_virtcol;
-    curwin->w_set_curswant = false;
+    update_curswant_force();
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5011,10 +5011,12 @@ static void nv_visual(cmdarg_T *cap)
       VIsual_mode = resel_VIsual_mode;
       if (VIsual_mode == 'v') {
         if (resel_VIsual_line_count <= 1) {
-          validate_virtcol();
+          update_curswant_force();
           assert(cap->count0 >= INT_MIN && cap->count0 <= INT_MAX);
-          curwin->w_curswant = (curwin->w_virtcol
-                                + resel_VIsual_vcol * (int)cap->count0 - 1);
+          curwin->w_curswant += resel_VIsual_vcol * (int)cap->count0;
+          if (*p_sel != 'e') {
+            curwin->w_curswant--;
+          }
         } else {
           curwin->w_curswant = resel_VIsual_vcol;
         }
@@ -5024,10 +5026,9 @@ static void nv_visual(cmdarg_T *cap)
         curwin->w_curswant = MAXCOL;
         coladvance(MAXCOL);
       } else if (VIsual_mode == Ctrl_V) {
-        validate_virtcol();
+        update_curswant_force();
         assert(cap->count0 >= INT_MIN && cap->count0 <= INT_MAX);
-        curwin->w_curswant = (curwin->w_virtcol
-                              + resel_VIsual_vcol * (int)cap->count0 - 1);
+        curwin->w_curswant += resel_VIsual_vcol * (int)cap->count0 - 1;
         coladvance(curwin->w_curswant);
       } else {
         curwin->w_set_curswant = true;
@@ -5276,9 +5277,7 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
       coladvance((colnr_T)i);
 
       // Make sure we stick in this column.
-      validate_virtcol();
-      curwin->w_curswant = curwin->w_virtcol;
-      curwin->w_set_curswant = false;
+      update_curswant_force();
       if (curwin->w_cursor.col > 0 && curwin->w_p_wrap) {
         // Check for landing on a character that got split at
         // the end of the line.  We do not want to advance to
@@ -5309,9 +5308,7 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
     }
 
     // Make sure we stick in this column.
-    validate_virtcol();
-    curwin->w_curswant = curwin->w_virtcol;
-    curwin->w_set_curswant = false;
+    update_curswant_force();
   }
 }
 

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1338,6 +1338,18 @@ func Test_visual_reselect_with_count()
   call delete('XvisualReselect')
 endfunc
 
+func Test_visual_reselect_exclusive()
+  new
+  call setline(1, ['abcde', 'abcde'])
+  set selection=exclusive
+  normal 1G0viwd
+  normal 2G01vd
+  call assert_equal(['', ''], getline(1, 2))
+
+  set selection&
+  bwipe!
+endfunc
+
 func Test_visual_block_insert_round_off()
   new
   " The number of characters are tuned to fill a 4096 byte allocated block,


### PR DESCRIPTION
#### vim-patch:9.0.1172: when 'selection' is "exclusive" then "1v" is one char short

Problem:    When 'selection' is "exclusive" then "1v" is one char short.
Solution:   Add one character when 'selection' is "exclusive.

https://github.com/vim/vim/commit/79c11e399be3d96ed6d1c7458b1380e878ec717b

Cherry-pick update_curswant_force() refactor from patch 9.0.0482.

Co-authored-by: Bram Moolenaar <Bram@vim.org>