### PR TITLE
ci(tsan): run functionaltests instead of oldtests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,11 +261,11 @@ jobs:
         name: Unittests
         run: ./ci/run_tests.sh unittests
 
-      - if: matrix.flavor != 'tsan' && (success() || failure() && steps.abort_job.outputs.status == 'success')
+      - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: Functionaltests
         run: ./ci/run_tests.sh functionaltests
 
-      - if: success() || failure() && steps.abort_job.outputs.status == 'success'
+      - if: matrix.flavor != 'tsan' && (success() || failure() && steps.abort_job.outputs.status == 'success')
         name: Oldtests
         run: ./ci/run_tests.sh oldtests
 

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -17,16 +17,15 @@ rm -f "$END_MARKER"
 if (($# == 0)); then
   tests=('build_nvim')
 
+  # Additional threads aren't created in the unit/old tests
   if test "$CLANG_SANITIZER" != "TSAN"; then
-    # Additional threads are only created when the builtin UI starts, which
-    # doesn't happen in the unit/functional tests
     if test "${FUNCTIONALTEST}" != "functionaltest-lua"; then
       tests+=('unittests')
     fi
-    tests+=('functionaltests')
+    tests+=('oldtests')
   fi
 
-  tests+=('oldtests' 'install_nvim')
+  tests+=('functionaltests' 'install_nvim')
 else
   tests=("$@")
 fi


### PR DESCRIPTION
With TUI as an external process oldtests no longer involve threads, so
TSAN isn't useful. Meanwhile functionaltests may involve threads.
