### PR TITLE
fix(mouse): statusline click registered as statuscolumn

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1110,7 +1110,7 @@ retnomove:
     ? wp->w_winbar_height != 0
     : false;
 
-  on_statuscol = (grid == (col < win_col_off(wp)))
+  on_statuscol = !on_status_line && !on_winbar && col < win_col_off(wp)
     ? *wp->w_p_stc != NUL
     : false;
 

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -366,5 +366,13 @@ describe('statuscolumn', function()
     eq('0 3 r 7', eval("g:testvar"))
     meths.input_mouse('right', 'press', '', 0, 3, 0)
     eq('0 4 r 7', eval("g:testvar"))
+    command('set laststatus=2 winbar=%f')
+    command('let g:testvar=""')
+    -- Check that winbar click doesn't register as statuscolumn click
+    meths.input_mouse('right', 'press', '', 0, 0, 0)
+    eq('', eval("g:testvar"))
+    -- Check that statusline click doesn't register as statuscolumn click
+    meths.input_mouse('right', 'press', '', 0, 12, 0)
+    eq('', eval("g:testvar"))
   end)
 end)


### PR DESCRIPTION
Problem:  Status line click is registered as status status column click. Solution: Check that mouse is not on the status line.

Resolve https://github.com/luukvbaal/statuscol.nvim/issues/4.