### PR TITLE
vim-patch:9.0.1176: smithy files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -327,11 +327,7 @@ local extension = {
   end,
   eex = 'eelixir',
   leex = 'eelixir',
-  am = function(path, bufnr)
-    if not path:lower():find('makefile%.am$') then
-      return 'elf'
-    end
-  end,
+  am = 'elf',
   exs = 'elixir',
   elm = 'elm',
   elv = 'elvish',
@@ -956,6 +952,7 @@ local extension = {
   hlp = 'smcl',
   smith = 'smith',
   smt = 'smith',
+  smithy = 'smithy',
   sml = 'sml',
   spt = 'snobol4',
   sno = 'snobol4',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -529,6 +529,7 @@ let s:filename_checks = {
     \ 'smarty': ['file.tpl'],
     \ 'smcl': ['file.hlp', 'file.ihlp', 'file.smcl'],
     \ 'smith': ['file.smt', 'file.smith'],
+    \ 'smithy': ['file.smithy'],
     \ 'sml': ['file.sml'],
     \ 'snobol4': ['file.sno', 'file.spt'],
     \ 'solidity': ['file.sol'],


### PR DESCRIPTION
Problem:    smithy files are not recognized.
Solution:   Add a pattern for Smithy files. (Chris Kipp, closes vim/vim#11804)

https://github.com/vim/vim/commit/f68cddabffcbc5b8fbfe9003182cb4b55ff8d72c

Co-authored-by: Chris Kipp <ckipp@pm.me>

Includes sneak changes to `makefile`/`elf` detection to just rely on ordering, but I'm not sure I prefer that to the explicit logic. (Tests still pass.)