### PR TITLE
docs: update buf_notify and rpc.notify params docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -566,7 +566,7 @@ buf_notify({bufnr}, {method}, {params})                 *vim.lsp.buf_notify()*
     Parameters: ~
       • {bufnr}   (number|nil) The number of the buffer
       • {method}  (string) Name of the request method
-      • {params}  (string) Arguments to send to the server
+      • {params}  (any) Arguments to send to the server
 
     Return: ~
         true if any client returns true; false otherwise

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2048,7 +2048,7 @@ end
 --- Send a notification to a server
 ---@param bufnr (number|nil) The number of the buffer
 ---@param method (string) Name of the request method
----@param params (string) Arguments to send to the server
+---@param params (any) Arguments to send to the server
 ---
 ---@returns true if any client returns true; false otherwise
 function lsp.buf_notify(bufnr, method, params)

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -293,7 +293,7 @@ end
 ---@private
 --- Sends a notification to the LSP server.
 ---@param method (string) The invoked LSP method
----@param params (table|nil): Parameters for the invoked LSP method
+---@param params (any): Parameters for the invoked LSP method
 ---@returns (bool) `true` if notification could be sent, `false` if not
 function Client:notify(method, params)
   return self:encode_and_send({


### PR DESCRIPTION
Small, but I was getting warnings about my usage of
`vim.lsp.buf_notify(bufnr, method, {example = example})` since the docs
say that `params` must be a string, however this can really be anything
when it's passed to `rpc.notify` since we just end up calling
`vim.json.encode(payload)` on it. This fixes the docs in those two
places and regenerates them.
