### PR TITLE
fix(api): nvim_create_autocmd crash on invalid types inside pattern array

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -940,7 +940,7 @@ static bool get_patterns_from_pattern_or_buf(Array *patterns, Object pattern, Ob
         patlen = aucmd_pattern_length(pat);
       }
     } else if (v->type == kObjectTypeArray) {
-      if (!check_autocmd_string_array(*patterns, "pattern", err)) {
+      if (!check_autocmd_string_array(v->data.array, "pattern", err)) {
         return false;
       }
 

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -613,6 +613,20 @@ describe('autocmd api', function()
         eq(false, success)
         matches("'group' must be a string or an integer", code)
       end)
+
+      it('raises error for invalid pattern array', function()
+        local success, code = unpack(meths.exec_lua([[
+          return {pcall(function()
+            vim.api.nvim_create_autocmd("FileType", {
+              pattern = {{}},
+              command = "echo 'hello'",
+            })
+          end)}
+        ]], {}))
+
+        eq(false, success)
+        matches("All entries in 'pattern' must be strings", code)
+      end)
     end)
 
     describe('patterns', function()


### PR DESCRIPTION
Fix #21755 