### PR TITLE
vim-patch:9.0.1182: go checksum files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1425,6 +1425,7 @@ local filename = {
   gnashpluginrc = 'gnash',
   gnashrc = 'gnash',
   ['.gnuplot'] = 'gnuplot',
+  ['go.sum'] = 'gosum',
   ['go.work'] = 'gowork',
   ['.gprc'] = 'gp',
   ['/.gnupg/gpg.conf'] = 'gpg',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -232,6 +232,7 @@ let s:filename_checks = {
     \ 'gnuplot': ['file.gpi', '.gnuplot'],
     \ 'go': ['file.go'],
     \ 'gomod': ['go.mod'],
+    \ 'gosum': ['go.sum'],
     \ 'gowork': ['go.work'],
     \ 'gp': ['file.gp', '.gprc'],
     \ 'gpg': ['/.gnupg/options', '/.gnupg/gpg.conf', '/usr/any/gnupg/options.skel', 'any/.gnupg/gpg.conf', 'any/.gnupg/options', 'any/usr/any/gnupg/options.skel'],


### PR DESCRIPTION
Problem:    go checksum files are not recognized.
Solution:   Add the name of go checksum files. (Amaan Qureshi, closes vim/vim#11803)

https://github.com/vim/vim/commit/043d7b2c84cda275354aa023b5769660ea70a168

Co-authored-by: Amaan Q <amaanq12@gmail.com>
