### PR TITLE
fix(lsp): revert semantic token gravity change from #21574

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -408,7 +408,6 @@ function STHighlighter:on_win(topline, botline)
             hl_group = '@' .. token.type,
             end_col = token.end_col,
             priority = vim.highlight.priorities.semantic_tokens,
-            end_right_gravity = true,
             strict = false,
           })
 
@@ -419,7 +418,6 @@ function STHighlighter:on_win(topline, botline)
                 hl_group = '@' .. modifier,
                 end_col = token.end_col,
                 priority = vim.highlight.priorities.semantic_tokens + 1,
-                end_right_gravity = true,
                 strict = false,
               })
             end


### PR DESCRIPTION
This fully reverts https://github.com/neovim/neovim/pull/21574. I partially reverted that original fix in #21680 but left `end_right_gravity` alone. The experience is simply not as good when a highlight is automatically extended to characters beyond what was originally received from the LSP.

```cpp
if (expression // <- type ") {" when cursor is just after the "n"
    printf("sad panda\n");
}
```

If you are typing and pause long enough for the token to register, then want to finish typing the full expression, anything you type before the tokens are synchronized will continue to have the same highlighting as whatever your cursor was on when you paused. It's jarring, but initially this seemed better when I first put up #21574. Instead, I'm seeing weirdly highlighted characters as I type when I'd rather see "normal text" (or treesitter-highlighted) text that is synchronized with the syntax.

@mfussenegger - I promise this is the last gravity change for these tokens. Just took a bit of trial and error to really see the pros and cons of changing the properties.