### PR TITLE
statuscolumn: make %l follow default wrap behavior 

### DIFF
--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -210,6 +210,8 @@ describe('statuscolumn', function()
       {1:10│ }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{0:@@@}|
                                                            |
     ]])
+    command("set stc=%C%s%=%l│\\ ")
+    screen:expect_unchanged()
     command('set signcolumn=auto:2 foldcolumn=auto')
     command('sign define piet1 text=>> texthl=LineNr')
     command('sign define piet2 text=>! texthl=NonText')


### PR DESCRIPTION
This is based on #21747

Omit line numbers on lines that are wrapped or virtual, matching the
behavior prior to `statuscolumn`. This can always be overridden using
`%{}` expressions.