### PR TITLE
docs: slightly change docs on convert_input_to_markdown_lines

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1508,8 +1508,8 @@ convert_input_to_markdown_lines({input}, {contents})
 
     Parameters: ~
       • {input}     (`MarkedString` | `MarkedString[]` | `MarkupContent`)
-      • {contents}  (table, optional, default `{}`) List of strings to extend
-                    with converted lines
+      • {contents}  (table|nil) List of strings to extend with converted
+                    lines. Defaults to {}.
 
     Return: ~
         {contents}, extended with lines of converted markdown.

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -856,7 +856,7 @@ end
 --- `textDocument/signatureHelp`, and potentially others.
 ---
 ---@param input (`MarkedString` | `MarkedString[]` | `MarkupContent`)
----@param contents (table, optional, default `{}`) List of strings to extend with converted lines
+---@param contents (table|nil) List of strings to extend with converted lines. Defaults to {}.
 ---@returns {contents}, extended with lines of converted markdown.
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
 function M.convert_input_to_markdown_lines(input, contents)


### PR DESCRIPTION
This small changes just ensures that if you're using `convert_input_to_markdown_lines`
without `contents` you don't get a warning (when using something like neodev) that
there is an expected second param, since it can be nil.
