### PR TITLE
Allowed for pager functionality with syntax highlighting without loading user-added plugins

### DIFF
--- a/runtime/macros/less.sh
+++ b/runtime/macros/less.sh
@@ -8,9 +8,9 @@ if test -t 1; then
       echo "Missing filename" 1>&2
       exit
     fi
-    nvim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' -
+    nvim -u NORC --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' -
   else
-    nvim --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' "$@"
+    nvim -u NORC --cmd 'let no_plugin_maps = 1' -c 'runtime! macros/less.vim' "$@"
   fi
 else
   # Output is not a terminal, cat arguments or stdin


### PR DESCRIPTION
Some people want want to have nvim as a pager, but don’t want their bar and all their other plugins loaded. This only loads native plugins and has default functionality. I could make another commit with an environment variable to remove this functionality, but I think that most would be in favor of this change.