### PR TITLE
vim-patch:9.0.1191: some Bazel files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1321,6 +1321,7 @@ local filename = {
   ['GNUmakefile.am'] = 'automake',
   ['named.root'] = 'bindzone',
   WORKSPACE = 'bzl',
+  ['WORKSPACE.bzlmod'] = 'bzl',
   BUILD = 'bzl',
   ['cabal.project'] = 'cabalproject',
   ['cabal.config'] = 'cabalconfig',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -91,7 +91,7 @@ let s:filename_checks = {
     \ 'blueprint': ['file.blp'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
-    \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE'],
+    \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
     \ 'bzr': ['bzr_log.any', 'bzr_log.file'],
     \ 'c': ['enlightenment/file.cfg', 'file.qc', 'file.c', 'some-enlightenment/file.cfg'],
     \ 'cabal': ['file.cabal'],


### PR DESCRIPTION
Problem:    Some Bazel files are not recognized.
Solution:   Add an extra Bazel pattern. (Keith Smily, closes vim/vim#11807)

https://github.com/vim/vim/commit/3213952966896ffb1d8fa186bcf8c43359fca0f0

Co-authored-by: Keith Smiley <keithbsmiley@gmail.com>
