### PR TITLE
vim-patch:9.0.1189: invalid memory access with folding and using "L"

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3645,7 +3645,9 @@ static void nv_scroll(cmdarg_T *cap)
              && curwin->w_cursor.lnum > curwin->w_topline; n--) {
           (void)hasFolding(curwin->w_cursor.lnum,
                            &curwin->w_cursor.lnum, NULL);
-          curwin->w_cursor.lnum--;
+          if (curwin->w_cursor.lnum > curwin->w_topline) {
+            curwin->w_cursor.lnum--;
+          }
         }
       } else {
         curwin->w_cursor.lnum -= (linenr_T)cap->count1 - 1;

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1475,4 +1475,12 @@ func Test_sort_closed_fold()
   bwipe!
 endfunc
 
+func Test_indent_with_L_command()
+  " The "L" command moved the cursor to line zero, causing the text saved for
+  " undo to use line number -1, which caused trouble for undo later.
+  new
+  sil! norm 8RV{zf8=Lu
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1189: invalid memory access with folding and using "L"

Problem:    Invalid memory access with folding and using "L".
Solution:   Prevent the cursor from moving to line zero.

https://github.com/vim/vim/commit/232bdaaca98c34a99ffadf27bf6ee08be6cc8f6a

Co-authored-by: Bram Moolenaar <Bram@vim.org>