### PR TITLE
vim-patch:8.2.4341: command line not redrawn when finishing popup menu

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2481,6 +2481,13 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, ":sign \<Tab>\<C-A>\<S-Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_37', {})
 
+  " After removing the pum the command line is redrawn
+  call term_sendkeys(buf, ":edit foo\<CR>")
+  call term_sendkeys(buf, ":edit bar\<CR>")
+  call term_sendkeys(buf, ":ls\<CR>")
+  call term_sendkeys(buf, ":com\<Tab> ")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_38', {})
+
   call term_sendkeys(buf, "\<C-U>\<CR>")
   call StopVimInTerminal(buf)
   call delete('Xtest')

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2486,7 +2486,7 @@ describe('builtin popupmenu', function()
     ]])
   end)
 
-  it('wildoptions=pum with scrolled messages ', function()
+  it('wildoptions=pum with scrolled messages', function()
     screen:try_resize(40,10)
     command('set wildmenu')
     command('set wildoptions=pum')


### PR DESCRIPTION
#### vim-patch:8.2.4341: command line not redrawn when finishing popup menu

Problem:    Command line not redrawn when finishing popup menu and the screen
            has scrolled up.
Solution:   Redraw the command line after updating the screen.

https://github.com/vim/vim/commit/414acd342f4a66d930da34d419929985b48bd301

Code change is N/A as Nvim doesn't call update_screen() here.

Co-authored-by: Bram Moolenaar <Bram@vim.org>