### PR TITLE
fix(rbuffer): handle edge case where write_ptr has wrapped around too early

### DIFF
--- a/src/nvim/rbuffer.c
+++ b/src/nvim/rbuffer.c
@@ -165,7 +165,8 @@ void rbuffer_consumed_compact(RBuffer *buf, size_t count)
   assert(buf->read_ptr <= buf->write_ptr);
   rbuffer_consumed(buf, count);
   if (buf->read_ptr > buf->start_ptr) {
-    assert((size_t)(buf->read_ptr - buf->write_ptr) == buf->size);
+    assert((size_t)(buf->write_ptr - buf->read_ptr) == buf->size
+           || buf->write_ptr == buf->start_ptr);
     memmove(buf->start_ptr, buf->read_ptr, buf->size);
     buf->read_ptr = buf->start_ptr;
     buf->write_ptr = buf->read_ptr + buf->size;


### PR DESCRIPTION
when using the rbuffer as a linear buffer, exactly filling the buffer will case write_ptr to wrap around too early. For now detect this special case.

Of course, the rbuffer should refactored to a proper ring buffer where `write_pos >= read_pos` always and there is no special case for full buffers. This will be a follow up change.