### PR TITLE
vim-patch:8.2.{4346,4382,4391},9.0.1195

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -268,6 +268,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   StlClickRecord *tabtab;
   win_T *ewp;
   int p_crb_save;
+  bool save_KeyTyped = KeyTyped;
   bool is_stl_global = global_stl_height() > 0;
 
   ScreenGrid *grid = &default_grid;
@@ -422,6 +423,9 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
 
 theend:
   entered = false;
+
+  // A user function may reset KeyTyped, restore it.
+  KeyTyped = save_KeyTyped;
 }
 
 void win_redr_winbar(win_T *wp)
@@ -639,7 +643,6 @@ int fillchar_status(int *attr, win_T *wp)
 void redraw_custom_statusline(win_T *wp)
 {
   static bool entered = false;
-  bool saved_KeyTyped = KeyTyped;
 
   // When called recursively return.  This can happen when the statusline
   // contains an expression that triggers a redraw.
@@ -650,9 +653,6 @@ void redraw_custom_statusline(win_T *wp)
 
   win_redr_custom(wp, false, false);
   entered = false;
-
-  // A user function may reset KeyTyped, restore it.
-  KeyTyped = saved_KeyTyped;
 }
 
 static void ui_ext_tabline_update(void)

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -268,7 +268,6 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   StlClickRecord *tabtab;
   win_T *ewp;
   int p_crb_save;
-  bool save_KeyTyped = KeyTyped;
   bool is_stl_global = global_stl_height() > 0;
 
   ScreenGrid *grid = &default_grid;
@@ -423,9 +422,6 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
 
 theend:
   entered = false;
-
-  // A user function may reset KeyTyped, restore it.
-  KeyTyped = save_KeyTyped;
 }
 
 void win_redr_winbar(win_T *wp)
@@ -948,6 +944,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
   char *usefmt = fmt;
   const int save_must_redraw = must_redraw;
   const int save_redr_type = curwin->w_redr_type;
+  const bool save_KeyTyped = KeyTyped;
   // TODO(Bram): find out why using called_emsg_before makes tests fail, does it
   // matter?
   // const int called_emsg_before = called_emsg;
@@ -2152,6 +2149,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
   if (opt_name && did_emsg > did_emsg_before) {
     set_string_option_direct(opt_name, -1, "", OPT_FREE | opt_scope, SID_ERROR);
   }
+
+  // A user function may reset KeyTyped, restore it.
+  KeyTyped = save_KeyTyped;
 
   return width;
 }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -639,6 +639,7 @@ int fillchar_status(int *attr, win_T *wp)
 void redraw_custom_statusline(win_T *wp)
 {
   static bool entered = false;
+  bool saved_KeyTyped = KeyTyped;
 
   // When called recursively return.  This can happen when the statusline
   // contains an expression that triggers a redraw.
@@ -649,6 +650,9 @@ void redraw_custom_statusline(win_T *wp)
 
   win_redr_custom(wp, false, false);
   entered = false;
+
+  // A user function may reset KeyTyped, restore it.
+  KeyTyped = saved_KeyTyped;
 }
 
 static void ui_ext_tabline_update(void)

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2304,6 +2304,14 @@ func Test_wildmenu_pum()
       return repeat(['aaaa'], 120)
     endfunc
     command -nargs=* -complete=customlist,CmdCompl Tcmd
+
+    func MyStatusLine() abort
+      return 'status'
+    endfunc
+    func SetupStatusline()
+      set statusline=%!MyStatusLine()
+      set laststatus=2
+    endfunc
   [CODE]
   call writefile(commands, 'Xtest')
 
@@ -2487,6 +2495,13 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, ":ls\<CR>")
   call term_sendkeys(buf, ":com\<Tab> ")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_38', {})
+  call term_sendkeys(buf, "\<C-U>\<CR>")
+
+  " Esc still works to abort the command when 'statusline' is set
+  call term_sendkeys(buf, ":call SetupStatusline()\<CR>")
+  call term_sendkeys(buf, ":si\<Tab>")
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_39', {})
 
   call term_sendkeys(buf, "\<C-U>\<CR>")
   call StopVimInTerminal(buf)

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2312,6 +2312,15 @@ func Test_wildmenu_pum()
       set statusline=%!MyStatusLine()
       set laststatus=2
     endfunc
+
+    func MyTabLine()
+      return 'my tab line'
+    endfunc
+    func SetupTabline()
+      set statusline=
+      set tabline=%!MyTabLine()
+      set showtabline=2
+    endfunc
   [CODE]
   call writefile(commands, 'Xtest')
 
@@ -2502,6 +2511,12 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, ":si\<Tab>")
   call term_sendkeys(buf, "\<Esc>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_39', {})
+
+  " Esc still works to abort the command when 'tabline' is set
+  call term_sendkeys(buf, ":call SetupTabline()\<CR>")
+  call term_sendkeys(buf, ":si\<Tab>")
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_40', {})
 
   call term_sendkeys(buf, "\<C-U>\<CR>")
   call StopVimInTerminal(buf)

--- a/src/nvim/testdir/test_statusline.vim
+++ b/src/nvim/testdir/test_statusline.vim
@@ -569,22 +569,41 @@ func Test_statusline_showcmd()
   CheckScreendump
 
   let lines =<< trim END
+    func MyStatusLine()
+      return '%S'
+    endfunc
+
     set laststatus=2
-    set statusline=%S
+    set statusline=%!MyStatusLine()
     set showcmdloc=statusline
     call setline(1, ['a', 'b', 'c'])
+    set foldopen+=jump
+    1,2fold
+    3
   END
   call writefile(lines, 'XTest_statusline', 'D')
 
   let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 6})
-  call feedkeys("\<C-V>Gl", "xt")
+
+  call term_sendkeys(buf, "g")
   call VerifyScreenDump(buf, 'Test_statusline_showcmd_1', {})
 
-  call feedkeys("\<Esc>1234", "xt")
+  " typing "gg" should open the fold
+  call term_sendkeys(buf, "g")
   call VerifyScreenDump(buf, 'Test_statusline_showcmd_2', {})
 
-  call feedkeys("\<Esc>:set statusline=\<CR>:\<CR>1234", "xt")
+  call term_sendkeys(buf, "\<C-V>Gl")
   call VerifyScreenDump(buf, 'Test_statusline_showcmd_3', {})
+
+  call term_sendkeys(buf, "\<Esc>1234")
+  call VerifyScreenDump(buf, 'Test_statusline_showcmd_4', {})
+
+  call term_sendkeys(buf, "\<Esc>:set statusline=\<CR>")
+  call term_sendkeys(buf, ":\<CR>")
+  call term_sendkeys(buf, "1234")
+  call VerifyScreenDump(buf, 'Test_statusline_showcmd_5', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_tabline.vim
+++ b/src/nvim/testdir/test_tabline.vim
@@ -167,19 +167,41 @@ func Test_tabline_showcmd()
   CheckScreendump
 
   let lines =<< trim END
+    func MyTabLine()
+      return '%S'
+    endfunc
+
     set showtabline=2
+    set tabline=%!MyTabLine()
     set showcmdloc=tabline
     call setline(1, ['a', 'b', 'c'])
+    set foldopen+=jump
+    1,2fold
+    3
   END
   call writefile(lines, 'XTest_tabline', 'D')
 
   let buf = RunVimInTerminal('-S XTest_tabline', {'rows': 6})
 
-  call feedkeys("\<C-V>Gl", "xt")
+  call term_sendkeys(buf, "g")
   call VerifyScreenDump(buf, 'Test_tabline_showcmd_1', {})
 
-  call feedkeys("\<Esc>1234", "xt")
+  " typing "gg" should open the fold
+  call term_sendkeys(buf, "g")
   call VerifyScreenDump(buf, 'Test_tabline_showcmd_2', {})
+
+  call term_sendkeys(buf, "\<C-V>Gl")
+  call VerifyScreenDump(buf, 'Test_tabline_showcmd_3', {})
+
+  call term_sendkeys(buf, "\<Esc>1234")
+  call VerifyScreenDump(buf, 'Test_tabline_showcmd_4', {})
+
+  call term_sendkeys(buf, "\<Esc>:set tabline=\<CR>")
+  call term_sendkeys(buf, ":\<CR>")
+  call term_sendkeys(buf, "1234")
+  call VerifyScreenDump(buf, 'Test_tabline_showcmd_5', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1761,6 +1761,8 @@ function Test_splitkeep_callback()
 
   call term_sendkeys(buf, ":quit\<CR>Gt")
   call VerifyScreenDump(buf, 'Test_splitkeep_callback_4', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 function Test_splitkeep_fold()
@@ -1791,6 +1793,8 @@ function Test_splitkeep_fold()
 
   call term_sendkeys(buf, ":wincmd k\<CR>:quit\<CR>")
   call VerifyScreenDump(buf, 'Test_splitkeep_fold_4', {})
+
+  call StopVimInTerminal(buf)
 endfunction
 
 function Test_splitkeep_status()
@@ -1809,6 +1813,8 @@ function Test_splitkeep_status()
 
   call term_sendkeys(buf, ":call win_move_statusline(win, 1)\<CR>")
   call VerifyScreenDump(buf, 'Test_splitkeep_status_1', {})
+
+  call StopVimInTerminal(buf)
 endfunction
 
 function Test_new_help_window_on_error()

--- a/test/functional/legacy/statusline_spec.lua
+++ b/test/functional/legacy/statusline_spec.lua
@@ -76,14 +76,46 @@ describe('statusline', function()
       [1] = {background = Screen.colors.LightGrey},  -- Visual
       [2] = {bold = true},  -- MoreMsg
       [3] = {bold = true, reverse = true},  -- StatusLine
+      [5] = {background = Screen.colors.LightGrey, foreground = Screen.colors.DarkBlue},  -- Folded
     })
     exec([[
+      func MyStatusLine()
+        return '%S'
+      endfunc
+
       set showcmd
       set laststatus=2
       set statusline=%S
       set showcmdloc=statusline
       call setline(1, ['a', 'b', 'c'])
+      set foldopen+=jump
+      1,2fold
+      3
     ]])
+
+    feed('g')
+    screen:expect([[
+      {5:+--  2 lines: a···································}|
+      ^c                                                 |
+      {0:~                                                 }|
+      {0:~                                                 }|
+      {0:~                                                 }|
+      {3:g                                                 }|
+                                                        |
+    ]])
+
+    -- typing "gg" should open the fold
+    feed('g')
+    screen:expect([[
+      ^a                                                 |
+      b                                                 |
+      c                                                 |
+      {0:~                                                 }|
+      {0:~                                                 }|
+      {3:                                                  }|
+                                                        |
+    ]])
+
     feed('<C-V>Gl')
     screen:expect([[
       {1:a}                                                 |
@@ -94,6 +126,7 @@ describe('statusline', function()
       {3:3x2                                               }|
       {2:-- VISUAL BLOCK --}                                |
     ]])
+
     feed('<Esc>1234')
     screen:expect([[
       a                                                 |
@@ -104,7 +137,10 @@ describe('statusline', function()
       {3:1234                                              }|
                                                         |
     ]])
-    feed('<Esc>:set statusline=<CR>:<CR>1234')
+
+    feed('<Esc>:set statusline=<CR>')
+    feed(':<CR>')
+    feed('1234')
     screen:expect([[
       a                                                 |
       b                                                 |

--- a/test/functional/legacy/tabline_spec.lua
+++ b/test/functional/legacy/tabline_spec.lua
@@ -22,16 +22,49 @@ describe('tabline', function()
       [2] = {bold = true},  -- MoreMsg, TabLineSel
       [3] = {reverse = true},  -- TabLineFill
       [4] = {background = Screen.colors.LightGrey, underline = true},  -- TabLine
+      [5] = {background = Screen.colors.LightGrey, foreground = Screen.colors.DarkBlue},  -- Folded
     })
     exec([[
+      func MyTabLine()
+        return '%S'
+      endfunc
+
       set showcmd
       set showtabline=2
+      set tabline=%!MyTabLine()
       set showcmdloc=tabline
       call setline(1, ['a', 'b', 'c'])
+      set foldopen+=jump
+      1,2fold
+      3
     ]])
+
+    feed('g')
+    screen:expect([[
+      {3:g                                                 }|
+      {5:+--  2 lines: a···································}|
+      ^c                                                 |
+      {0:~                                                 }|
+      {0:~                                                 }|
+      {0:~                                                 }|
+                                                        |
+    ]])
+
+    -- typing "gg" should open the fold
+    feed('g')
+    screen:expect([[
+      {3:                                                  }|
+      ^a                                                 |
+      b                                                 |
+      c                                                 |
+      {0:~                                                 }|
+      {0:~                                                 }|
+                                                        |
+    ]])
+
     feed('<C-V>Gl')
     screen:expect([[
-      {2: + [No Name] }{3:                           }{4:3x2}{3:       }|
+      {3:3x2                                               }|
       {1:a}                                                 |
       {1:b}                                                 |
       {1:c}^                                                 |
@@ -39,7 +72,21 @@ describe('tabline', function()
       {0:~                                                 }|
       {2:-- VISUAL BLOCK --}                                |
     ]])
+
     feed('<Esc>1234')
+    screen:expect([[
+      {3:1234                                              }|
+      a                                                 |
+      b                                                 |
+      ^c                                                 |
+      {0:~                                                 }|
+      {0:~                                                 }|
+                                                        |
+    ]])
+
+    feed('<Esc>:set tabline=<CR>')
+    feed(':<CR>')
+    feed('1234')
     screen:expect([[
       {2: + [No Name] }{3:                           }{4:1234}{3:      }|
       a                                                 |
@@ -47,7 +94,7 @@ describe('tabline', function()
       ^c                                                 |
       {0:~                                                 }|
       {0:~                                                 }|
-                                                        |
+      :                                                 |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:8.2.4346: a custom statusline may cause Esc to work like Enter

Problem:    A custom statusline may cause Esc to work like Enter on the
            command line when the popup menu is displayed.
Solution:   Save and restore KeyTyped.

https://github.com/vim/vim/commit/481acb11413a436653e235d2098990b2ad47d195

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4382: a custom 'tabline' may cause Esc to work like Enter

Problem:    A custom 'tabline' may cause Esc to work like Enter on the
            command line when the popup menu is displayed.
Solution:   Save and restore KeyTyped.

https://github.com/vim/vim/commit/e4835bf34001471a102528659af009bc46361141

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4391: command line executed when typing Esc in the GUI

Problem:    Command line executed when typing Esc in the GUI.
Solution:   Move saving/restoring KeyTyped to build_stl_str_hl().

https://github.com/vim/vim/commit/0e1f36fc59b589e4755fd9102013971f45222084

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1195: restoring KeyTyped when building statusline not tested

Problem:    Restoring KeyTyped when building statusline not tested.
Solution:   Add a test.  Clean up and fix other tests. (closes vim/vim#11815)

https://github.com/vim/vim/commit/378e6c03f98efc88e8c2675e05a548f9bb7889a1