### PR TITLE
vim-patch:partial:9.0.1196: code is indented more than necessary

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -326,10 +326,12 @@ void tv_list_free_list(list_T *const l)
 void tv_list_free(list_T *const l)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (!tv_in_free_unref_items) {
-    tv_list_free_contents(l);
-    tv_list_free_list(l);
+  if (tv_in_free_unref_items) {
+    return;
   }
+
+  tv_list_free_contents(l);
+  tv_list_free_list(l);
 }
 
 /// Unreference a list

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -403,22 +403,24 @@ int name_to_mod_mask(int c)
 int simplify_key(const int key, int *modifiers)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  if (*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL | MOD_MASK_ALT)) {
-    // TAB is a special case.
-    if (key == TAB && (*modifiers & MOD_MASK_SHIFT)) {
-      *modifiers &= ~MOD_MASK_SHIFT;
-      return K_S_TAB;
-    }
-    const int key0 = KEY2TERMCAP0(key);
-    const int key1 = KEY2TERMCAP1(key);
-    for (int i = 0; modifier_keys_table[i] != NUL; i += MOD_KEYS_ENTRY_SIZE) {
-      if (key0 == modifier_keys_table[i + 3]
-          && key1 == modifier_keys_table[i + 4]
-          && (*modifiers & modifier_keys_table[i])) {
-        *modifiers &= ~modifier_keys_table[i];
-        return TERMCAP2KEY(modifier_keys_table[i + 1],
-                           modifier_keys_table[i + 2]);
-      }
+  if (!(*modifiers & (MOD_MASK_SHIFT | MOD_MASK_CTRL | MOD_MASK_ALT))) {
+    return key;
+  }
+
+  // TAB is a special case.
+  if (key == TAB && (*modifiers & MOD_MASK_SHIFT)) {
+    *modifiers &= ~MOD_MASK_SHIFT;
+    return K_S_TAB;
+  }
+  const int key0 = KEY2TERMCAP0(key);
+  const int key1 = KEY2TERMCAP1(key);
+  for (int i = 0; modifier_keys_table[i] != NUL; i += MOD_KEYS_ENTRY_SIZE) {
+    if (key0 == modifier_keys_table[i + 3]
+        && key1 == modifier_keys_table[i + 4]
+        && (*modifiers & modifier_keys_table[i])) {
+      *modifiers &= ~modifier_keys_table[i];
+      return TERMCAP2KEY(modifier_keys_table[i + 1],
+                         modifier_keys_table[i + 2]);
     }
   }
   return key;

--- a/src/nvim/locale.c
+++ b/src/nvim/locale.c
@@ -317,23 +317,26 @@ static char **find_locales(void)
 static void init_locales(void)
 {
 # ifndef MSWIN
-  if (!did_init_locales) {
-    did_init_locales = true;
-    locales = find_locales();
+  if (did_init_locales) {
+    return;
   }
+
+  did_init_locales = true;
+  locales = find_locales();
 # endif
 }
 
 # if defined(EXITFREE)
 void free_locales(void)
 {
-  int i;
-  if (locales != NULL) {
-    for (i = 0; locales[i] != NULL; i++) {
-      xfree(locales[i]);
-    }
-    XFREE_CLEAR(locales);
+  if (locales == NULL) {
+    return;
   }
+
+  for (int i = 0; locales[i] != NULL; i++) {
+    xfree(locales[i]);
+  }
+  XFREE_CLEAR(locales);
 }
 # endif
 

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -653,29 +653,31 @@ fmark_T *getnextmark(pos_T *startpos, int dir, int begin_line)
 // until the mark is used to avoid a long startup delay.
 static void fname2fnum(xfmark_T *fm)
 {
-  if (fm->fname != NULL) {
-    // First expand "~/" in the file name to the home directory.
-    // Don't expand the whole name, it may contain other '~' chars.
+  if (fm->fname == NULL) {
+    return;
+  }
+
+  // First expand "~/" in the file name to the home directory.
+  // Don't expand the whole name, it may contain other '~' chars.
 #ifdef BACKSLASH_IN_FILENAME
-    if (fm->fname[0] == '~' && (fm->fname[1] == '/' || fm->fname[1] == '\\')) {
+  if (fm->fname[0] == '~' && (fm->fname[1] == '/' || fm->fname[1] == '\\')) {
 #else
-    if (fm->fname[0] == '~' && (fm->fname[1] == '/')) {
+  if (fm->fname[0] == '~' && (fm->fname[1] == '/')) {
 #endif
 
-      expand_env("~/", NameBuff, MAXPATHL);
-      int len = (int)strlen(NameBuff);
-      xstrlcpy(NameBuff + len, fm->fname + 2, (size_t)(MAXPATHL - len));
-    } else {
-      xstrlcpy(NameBuff, fm->fname, MAXPATHL);
-    }
-
-    // Try to shorten the file name.
-    os_dirname(IObuff, IOSIZE);
-    char *p = path_shorten_fname(NameBuff, IObuff);
-
-    // buflist_new() will call fmarks_check_names()
-    (void)buflist_new(NameBuff, p, (linenr_T)1, 0);
+    expand_env("~/", NameBuff, MAXPATHL);
+    int len = (int)strlen(NameBuff);
+    xstrlcpy(NameBuff + len, fm->fname + 2, (size_t)(MAXPATHL - len));
+  } else {
+    xstrlcpy(NameBuff, fm->fname, MAXPATHL);
   }
+
+  // Try to shorten the file name.
+  os_dirname(IObuff, IOSIZE);
+  char *p = path_shorten_fname(NameBuff, IObuff);
+
+  // buflist_new() will call fmarks_check_names()
+  (void)buflist_new(NameBuff, p, (linenr_T)1, 0);
 }
 
 // Check all file marks for a name that matches the file name in buf.

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -880,12 +880,14 @@ static int matchadd_dict_arg(typval_T *tv, const char **conceal_char, win_T **wi
     *conceal_char = tv_get_string(&di->di_tv);
   }
 
-  if ((di = tv_dict_find(tv->vval.v_dict, S_LEN("window"))) != NULL) {
-    *win = find_win_by_nr_or_id(&di->di_tv);
-    if (*win == NULL) {
-      emsg(_(e_invalwindow));
-      return FAIL;
-    }
+  if ((di = tv_dict_find(tv->vval.v_dict, S_LEN("window"))) == NULL) {
+    return OK;
+  }
+
+  *win = find_win_by_nr_or_id(&di->di_tv);
+  if (*win == NULL) {
+    emsg(_(e_invalwindow));
+    return FAIL;
   }
 
   return OK;

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -767,11 +767,13 @@ void mf_set_fnames(memfile_T *mfp, char *fname)
 /// Used before doing a :cd
 void mf_fullname(memfile_T *mfp)
 {
-  if (mfp != NULL && mfp->mf_fname != NULL && mfp->mf_ffname != NULL) {
-    xfree(mfp->mf_fname);
-    mfp->mf_fname = mfp->mf_ffname;
-    mfp->mf_ffname = NULL;
+  if (mfp == NULL || mfp->mf_fname == NULL || mfp->mf_ffname == NULL) {
+    return;
   }
+
+  xfree(mfp->mf_fname);
+  mfp->mf_fname = mfp->mf_ffname;
+  mfp->mf_ffname = NULL;
 }
 
 /// Return true if there are any translations pending for memfile.

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1377,17 +1377,19 @@ char *make_percent_swname(const char *dir, const char *name)
 {
   char *d = NULL;
   char *f = fix_fname(name != NULL ? name : "");
-  if (f != NULL) {
-    char *s = xstrdup(f);
-    for (d = s; *d != NUL; MB_PTR_ADV(d)) {
-      if (vim_ispathsep(*d)) {
-        *d = '%';
-      }
-    }
-    d = concat_fnames(dir, s, true);
-    xfree(s);
-    xfree(f);
+  if (f == NULL) {
+    return NULL;
   }
+
+  char *s = xstrdup(f);
+  for (d = s; *d != NUL; MB_PTR_ADV(d)) {
+    if (vim_ispathsep(*d)) {
+      *d = '%';
+    }
+  }
+  d = concat_fnames(dir, s, true);
+  xfree(s);
+  xfree(f);
   return d;
 }
 

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -1449,9 +1449,11 @@ void show_popupmenu(void)
   }
 
   // Only show a popup when it is defined and has entries
-  if (menu != NULL && menu->children != NULL) {
-    pum_show_popupmenu(menu);
+  if (menu == NULL || menu->children == NULL) {
+    return;
   }
+
+  pum_show_popupmenu(menu);
 }
 
 /// Execute "menu".  Use by ":emenu" and the window toolbar.

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -606,50 +606,59 @@ void validate_virtcol(void)
 void validate_virtcol_win(win_T *wp)
 {
   check_cursor_moved(wp);
-  if (!(wp->w_valid & VALID_VIRTCOL)) {
-    getvvcol(wp, &wp->w_cursor, NULL, &(wp->w_virtcol), NULL);
-    redraw_for_cursorcolumn(wp);
-    wp->w_valid |= VALID_VIRTCOL;
+
+  if (wp->w_valid & VALID_VIRTCOL) {
+    return;
   }
+
+  getvvcol(wp, &wp->w_cursor, NULL, &(wp->w_virtcol), NULL);
+  redraw_for_cursorcolumn(wp);
+  wp->w_valid |= VALID_VIRTCOL;
 }
 
 // Validate curwin->w_cline_height only.
 void validate_cheight(void)
 {
   check_cursor_moved(curwin);
-  if (!(curwin->w_valid & VALID_CHEIGHT)) {
-    curwin->w_cline_height = plines_win_full(curwin, curwin->w_cursor.lnum,
-                                             NULL, &curwin->w_cline_folded,
-                                             true);
-    curwin->w_valid |= VALID_CHEIGHT;
+
+  if (curwin->w_valid & VALID_CHEIGHT) {
+    return;
   }
+
+  curwin->w_cline_height = plines_win_full(curwin, curwin->w_cursor.lnum,
+                                           NULL, &curwin->w_cline_folded,
+                                           true);
+  curwin->w_valid |= VALID_CHEIGHT;
 }
 
 // Validate w_wcol and w_virtcol only.
 void validate_cursor_col(void)
 {
   validate_virtcol();
-  if (!(curwin->w_valid & VALID_WCOL)) {
-    colnr_T col = curwin->w_virtcol;
-    colnr_T off = curwin_col_off();
-    col += off;
-    int width = curwin->w_width_inner - off + curwin_col_off2();
 
-    // long line wrapping, adjust curwin->w_wrow
-    if (curwin->w_p_wrap && col >= (colnr_T)curwin->w_width_inner
-        && width > 0) {
-      // use same formula as what is used in curs_columns()
-      col -= ((col - curwin->w_width_inner) / width + 1) * width;
-    }
-    if (col > (int)curwin->w_leftcol) {
-      col -= curwin->w_leftcol;
-    } else {
-      col = 0;
-    }
-    curwin->w_wcol = col;
-
-    curwin->w_valid |= VALID_WCOL;
+  if (curwin->w_valid & VALID_WCOL) {
+    return;
   }
+
+  colnr_T col = curwin->w_virtcol;
+  colnr_T off = curwin_col_off();
+  col += off;
+  int width = curwin->w_width_inner - off + curwin_col_off2();
+
+  // long line wrapping, adjust curwin->w_wrow
+  if (curwin->w_p_wrap && col >= (colnr_T)curwin->w_width_inner
+      && width > 0) {
+    // use same formula as what is used in curs_columns()
+    col -= ((col - curwin->w_width_inner) / width + 1) * width;
+  }
+  if (col > (int)curwin->w_leftcol) {
+    col -= curwin->w_leftcol;
+  } else {
+    col = 0;
+  }
+  curwin->w_wcol = col;
+
+  curwin->w_valid |= VALID_WCOL;
 }
 
 // Compute offset of a window, occupied by absolute or relative line number,

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -292,34 +292,36 @@ void vim_beep(unsigned val)
 {
   called_vim_beep = true;
 
-  if (emsg_silent == 0 && !in_assert_fails) {
-    if (!((bo_flags & val) || (bo_flags & BO_ALL))) {
-      static int beeps = 0;
-      static uint64_t start_time = 0;
+  if (emsg_silent != 0 || in_assert_fails) {
+    return;
+  }
 
-      // Only beep up to three times per half a second,
-      // otherwise a sequence of beeps would freeze Vim.
-      if (start_time == 0 || os_hrtime() - start_time > 500000000U) {
-        beeps = 0;
-        start_time = os_hrtime();
-      }
-      beeps++;
-      if (beeps <= 3) {
-        if (p_vb) {
-          ui_call_visual_bell();
-        } else {
-          ui_call_bell();
-        }
+  if (!((bo_flags & val) || (bo_flags & BO_ALL))) {
+    static int beeps = 0;
+    static uint64_t start_time = 0;
+
+    // Only beep up to three times per half a second,
+    // otherwise a sequence of beeps would freeze Vim.
+    if (start_time == 0 || os_hrtime() - start_time > 500000000U) {
+      beeps = 0;
+      start_time = os_hrtime();
+    }
+    beeps++;
+    if (beeps <= 3) {
+      if (p_vb) {
+        ui_call_visual_bell();
+      } else {
+        ui_call_bell();
       }
     }
+  }
 
-    // When 'debug' contains "beep" produce a message.  If we are sourcing
-    // a script or executing a function give the user a hint where the beep
-    // comes from.
-    if (vim_strchr(p_debug, 'e') != NULL) {
-      msg_source(HL_ATTR(HLF_W));
-      msg_attr(_("Beep!"), HL_ATTR(HLF_W));
-    }
+  // When 'debug' contains "beep" produce a message.  If we are sourcing
+  // a script or executing a function give the user a hint where the beep
+  // comes from.
+  if (vim_strchr(p_debug, 'e') != NULL) {
+    msg_source(HL_ATTR(HLF_W));
+    msg_attr(_("Beep!"), HL_ATTR(HLF_W));
   }
 }
 


### PR DESCRIPTION
#### vim-patch:partial:9.0.1196: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11813)

https://github.com/vim/vim/commit/e8575988969579f9e1439181ae338b2ff74054a8

Partial port as this depends on some previous eval and 'smoothscroll'
patches.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>