### PR TITLE
feat!(lsp): custom callback for semantic token highlighting

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1361,21 +1361,41 @@ start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     Parameters: ~
       • {bufnr}      (number)
       • {client_id}  (number)
-      • {opts}       (nil|table) Optional keyword arguments
-                     • debounce (number, default: 200): Debounce token
+      • {opts}       (table|nil) Optional keyword arguments:
+                     • debounce (number|nil, default: 200): Debounce token
                        requests to the server by the given number in
                        milliseconds
-                     • hl_cb (function({bufnr}, {ns_id}, {*token})): If given,
-                       this function is called for each token when it needs to
-                       be highlighted. The callback should apply an extmark or
-                       highlight. See |nvim_buf_add_highlight()| and
-                       |nvim_buf_set_extmark()|. {token} is a table with the
-                       following:
+                     • hl_cb (function|nil): If given, this function is called
+                       for each token when it needs to be highlighted. It is
+                       called with the buffer number, namespace id (ns_id),
+                       and a table defining the semantic token to be
+                       highlighted: hl_cb(bufnr, ns_id, token). The callback
+                       should apply an extmark or highlight using the given
+                       namespace. See |nvim_buf_add_highlight()| and
+                       |nvim_buf_set_extmark()|. The {token} parameter is a
+                       table with the following:
                        • line : line number 0-based
                        • start_col : start column 0-based
                        • end_col : end column 0-based
                        • type : token type as string
                        • modifiers : token modifiers as strings
+                     • Example: >lua
+
+                       vim.lsp.semantic_tokens.start(bufnr, client_id, {
+                         hl_cb = function(bufnr, ns_id, token)
+                           local hl_group = '@' .. token.type
+                           if token.type == 'variable' and vim.tbl_contains(token.modifiers, 'declaration') then
+                             hl_group = hl_group .. '.declaration'
+                           end
+                           api.nvim_buf_set_extmark(bufnr, ns_id, token.line, token.start_col, {
+                             hl_group = hl_group,
+                             end_col = token.end_col,
+                             priority = vim.highlight.priorities.semantic_tokens,
+                             strict = false,
+                           })
+                         end
+                       })
+<
 
 stop({bufnr}, {client_id})                    *vim.lsp.semantic_tokens.stop()*
     Stop the semantic token highlighting engine for the given buffer with the

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1354,16 +1354,9 @@ get_at_pos({bufnr}, {row}, {col})
 
 start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     Start the semantic token highlighting engine for the given buffer with the
-    given client. The client must already be attached to the buffer.
-
-    NOTE: This is currently called automatically by
-    |vim.lsp.buf_attach_client()|. To opt-out of semantic highlighting with a
-    server that supports it, you can delete the semanticTokensProvider table
-    from the {server_capabilities} of your client in your |LspAttach| callback
-    or your configuration's `on_attach` callback: >lua
-
-       client.server_capabilities.semanticTokensProvider = nil
-<
+    given client. The client must already be attached to the buffer. This
+    function can be called in your |LspAttach| autocmd or `on_attach`
+    callback.
 
     Parameters: ~
       • {bufnr}      (number)
@@ -1372,15 +1365,22 @@ start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
                      • debounce (number, default: 200): Debounce token
                        requests to the server by the given number in
                        milliseconds
+                     • hl_cb (function({bufnr}, {ns_id}, {*token})): If given,
+                       this function is called for each token when it needs to
+                       be highlighted. The callback should apply an extmark or
+                       highlight. See |nvim_buf_add_highlight()| and
+                       |nvim_buf_set_extmark()|. {token} is a table with the
+                       following:
+                       • line : line number 0-based
+                       • start_col : start column 0-based
+                       • end_col : end column 0-based
+                       • type : token type as string
+                       • modifiers : token modifiers as strings
 
 stop({bufnr}, {client_id})                    *vim.lsp.semantic_tokens.stop()*
     Stop the semantic token highlighting engine for the given buffer with the
-    given client.
-
-    NOTE: This is automatically called by a |LspDetach| autocmd that is set up
-    as part of `start()`, so you should only need this function to manually
-    disengage the semantic token engine without fully detaching the LSP client
-    from the buffer.
+    given client. Automatically called if your LSP client is detached from a
+    buffer where semantic token highlighting is enabled.
 
     Parameters: ~
       • {bufnr}      (number)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -73,10 +73,7 @@ The following new APIs or features were added.
   semantic tokens, syntax groups and extmarks.
 
 • Added support for semantic token highlighting to the LSP client. This
-  functionality is enabled by default when a client that supports this feature
-  is attached to a buffer. Opt-out can be performed by deleting the
-  `semanticTokensProvider` from the LSP client's {server_capabilities} in the
-  `LspAttach` callback.
+  functionality is disabled by default.
 
   See |lsp-semantic_tokens| for more information.
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1535,15 +1535,6 @@ function lsp.start_client(config)
       pcall(config.on_attach, client, bufnr)
     end
 
-    -- schedule the initialization of semantic tokens to give the above
-    -- on_attach and LspAttach callbacks the ability to schedule wrap the
-    -- opt-out (deleting the semanticTokensProvider from capabilities)
-    vim.schedule(function()
-      if vim.tbl_get(client.server_capabilities, 'semanticTokensProvider', 'full') then
-        semantic_tokens.start(bufnr, client.id)
-      end
-    end)
-
     client.attached_buffers[bufnr] = true
   end
 

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -511,18 +511,40 @@ local M = {}
 ---
 ---@param bufnr number
 ---@param client_id number
----@param opts (nil|table) Optional keyword arguments
----  - debounce (number, default: 200): Debounce token requests
----        to the server by the given number in milliseconds
----  - hl_cb (function({bufnr}, {ns_id}, {*token})): If given, this function is called
----        for each token when it needs to be highlighted. The callback should
----        apply an extmark or highlight. See |nvim_buf_add_highlight()| and
----        |nvim_buf_set_extmark()|. {token} is a table with the following:
+---@param opts (table|nil) Optional keyword arguments:
+---  - debounce (number|nil, default: 200):
+---      Debounce token requests to the server by the given number in milliseconds
+---
+---  - hl_cb (function|nil):
+---      If given, this function is called for each token when it needs to be
+---      highlighted. It is called with the buffer number, namespace id (ns_id), and a
+---      table defining the semantic token to be highlighted: hl_cb(bufnr, ns_id, token).
+---      The callback should apply an extmark or highlight using the given namespace.
+---      See |nvim_buf_add_highlight()| and |nvim_buf_set_extmark()|.
+---      The {token} parameter is a table with the following:
 ---           - line : line number 0-based
 ---           - start_col : start column 0-based
 ---           - end_col : end column 0-based
 ---           - type : token type as string
 ---           - modifiers : token modifiers as strings
+---
+---      Example:
+---                 <pre>lua
+---                   vim.lsp.semantic_tokens.start(bufnr, client_id, {
+---                     hl_cb = function(bufnr, ns_id, token)
+---                       local hl_group = '@' .. token.type
+---                       if token.type == 'variable' and vim.tbl_contains(token.modifiers, 'declaration') then
+---                         hl_group = hl_group .. '.declaration'
+---                       end
+---                       api.nvim_buf_set_extmark(bufnr, ns_id, token.line, token.start_col, {
+---                         hl_group = hl_group,
+---                         end_col = token.end_col,
+---                         priority = vim.highlight.priorities.semantic_tokens,
+---                         strict = false,
+---                       })
+---                     end
+---                   })
+---                 </pre>
 function M.start(bufnr, client_id, opts)
   vim.validate({
     bufnr = { bufnr, 'n', false },

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -98,11 +98,12 @@ describe('semantic token highlighting', function()
       ]], legend, response, edit_response)
     end)
 
-    it('buffer is highlighted when attached', function()
+    it('buffer is highlighted when semantic token highlighting is started', function()
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -132,6 +133,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -167,6 +169,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -224,6 +227,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -286,6 +290,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -304,6 +309,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]])
 
       insert(text)
@@ -371,70 +377,6 @@ describe('semantic token highlighting', function()
       ]])
       matches('%[LSP%] No client with id %d', notifications[1][1])
     end)
-
-    it('opt-out: does not activate semantic token highlighting if disabled in client attach',
-      function()
-        exec_lua([[
-          bufnr = vim.api.nvim_get_current_buf()
-          vim.api.nvim_win_set_buf(0, bufnr)
-          client_id = vim.lsp.start({
-            name = 'dummy',
-            cmd = server.cmd,
-            on_attach = vim.schedule_wrap(function(client, bufnr)
-              client.server_capabilities.semanticTokensProvider = nil
-            end),
-          })
-        ]])
-        eq(true, exec_lua("return vim.lsp.buf_is_attached(bufnr, client_id)"))
-
-        insert(text)
-
-        screen:expect { grid = [[
-          #include <iostream>                     |
-                                                  |
-          int main()                              |
-          {                                       |
-              int x;                              |
-          #ifdef __cplusplus                      |
-              std::cout << x << "\n";             |
-          #else                                   |
-              printf("%d\n", x);                  |
-          #endif                                  |
-          }                                       |
-          ^}                                       |
-          {1:~                                       }|
-          {1:~                                       }|
-          {1:~                                       }|
-                                                  |
-        ]] }
-
-        local notifications = exec_lua([[
-          local notifications = {}
-          vim.notify = function(...) table.insert(notifications, 1, {...}) end
-          vim.lsp.semantic_tokens.start(bufnr, client_id)
-          return notifications
-        ]])
-        eq('[LSP] Server does not support semantic tokens', notifications[1][1])
-
-        screen:expect { grid = [[
-          #include <iostream>                     |
-                                                  |
-          int main()                              |
-          {                                       |
-              int x;                              |
-          #ifdef __cplusplus                      |
-              std::cout << x << "\n";             |
-          #else                                   |
-              printf("%d\n", x);                  |
-          #endif                                  |
-          }                                       |
-          ^}                                       |
-          {1:~                                       }|
-          {1:~                                       }|
-          {1:~                                       }|
-                                                  |
-          ]], unchanged = true }
-      end)
 
   it('ignores null responses from the server', function()
       exec_lua([[
@@ -504,6 +446,7 @@ describe('semantic token highlighting', function()
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server2.cmd })
+        vim.lsp.semantic_tokens.start(bufnr, client_id)
       ]], legend, response, edit_response)
 
       insert(text)
@@ -873,6 +816,7 @@ b = "as"]],
           bufnr = vim.api.nvim_get_current_buf()
           vim.api.nvim_win_set_buf(0, bufnr)
           client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+          vim.lsp.semantic_tokens.start(bufnr, client_id)
         ]], test.legend, test.response)
 
         insert(test.text)
@@ -1182,8 +1126,10 @@ int main()
           vim.api.nvim_win_set_buf(0, bufnr)
           client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
 
-          -- speed up vim.api.nvim_buf_set_lines calls by changing debounce to 10 for these tests
           semantic_tokens = vim.lsp.semantic_tokens
+          semantic_tokens.start(bufnr, client_id)
+
+          -- speed up vim.api.nvim_buf_set_lines calls by changing debounce to 10 for these tests
           vim.schedule(function()
             semantic_tokens.stop(bufnr, client_id)
             semantic_tokens.start(bufnr, client_id, { debounce = 10 })


### PR DESCRIPTION
This is simply a draft that adds support for allowing a user to provide a callback to add the actual highlight or extmark if desired. The discussion about allowing more customizability for semantic tokens is discussed in #21576.

I'm absolutely open to suggestions or alternate takes on this. My original proposal in the linked issue was to extend the highlight group infrastructure to allow adding N modifiers to a main highlight group name with a `#` separator, but as discussed, even implementing this may not cover all possible use cases someone could want or come up with. The most flexible solution seemed to be to allow users to receive the semantic tokens in a callback so they can perform their own logic and decide how to add the highlights.

This PR also changes the _default_ for semantic token highlighting to be _not_ enabled. Users won't have to erase the `semanticTokensProvider` from their client capabilities to opt-out any longer, but those people who do still want it will need to add a `start(...)` call to their `LspAttach`/`on_attach()` callbacks to opt-in.

Doing it this way has some advantages:

1. The sky's the limit. Savvy/advanced users can do whatever they wish with the semantic tokens as they are displayed on the screen.
2. We don't lock ourselves into a highlighting API that ends up not being flexible enough for the things people can come up with.
3. It doesn't preclude us from adding something more railroaded/"official" down the line (like the original `#` proposal), as long as we always leave this "escape hatch" in place.
4. It gives those who want the added flexibility something they can work with now, instead of waiting for that more baked-in API.

Disadvantages:
1. There is still no "de-facto" way for colorscheme authors to stylize specific combinations of tokens and modifiers. This can likely be "fixed" or worked around by colorschemes or plugins that provide their own callbacks that add highlights/extmarks with specific combinations in specific ways.
2. Adding a callback for tokens locks us a little since the token format itself must not change without breaking the API.

There are two ways this callback could work. The way I have it in this PR is the most flexible, but an alternative could be that the callback should _return_ a highlight group name (or names in a list, or names and priorities in a list) and the built-in semantic token engine would continue to apply the extmark using either the callback's return value, or what it's doing now if there isn't a callback (the token type prepended with `@` and another extmark per modifier).

As an example, I have this in my `LspAttach` autocmd callback:

```lua
vim.lsp.semantic_tokens.start(bufnr, client.id, {
  hl_cb = function(bufnr, ns, token)
    local hl_group = '@' .. token.type
    if token.type == 'parameter' and
        not vim.tbl_contains(token.modifiers, 'declaration') then
      hl_group = hl_group .. '.reference'
    end
    if token.type == 'variable' and vim.tbl_contains(token.modifiers, 'declaration') then
      hl_group = hl_group .. '.declaration'
    end
    api.nvim_buf_set_extmark(bufnr, ns, token.line, token.start_col, {
      hl_group = hl_group,
      end_col = token.end_col,
      priority = vim.highlight.priorities.semantic_tokens,
      strict = false,
    })
  end
})
```

And I have custom highlights for `@variable.declaration` and `@parameter.reference`.

Pinging @mfussenegger @clason @swarn @rebelot @lewis6991 and @justinmk for input.