### PR TITLE
vim-patch:9.0.0876: code is indented more than needed

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -108,68 +108,72 @@ static int sort_func_compare(const void *s1, const void *s2)
 }
 
 /// Escape special characters in the cmdline completion matches.
-static void ExpandEscape(expand_T *xp, char *str, int numfiles, char **files, int options)
+static void wildescape(expand_T *xp, const char *str, int numfiles, char **files)
 {
-  int i;
   char *p;
   const int vse_what = xp->xp_context == EXPAND_BUFFERS ? VSE_BUFFER : VSE_NONE;
 
+  if (xp->xp_context == EXPAND_FILES
+      || xp->xp_context == EXPAND_FILES_IN_PATH
+      || xp->xp_context == EXPAND_SHELLCMD
+      || xp->xp_context == EXPAND_BUFFERS
+      || xp->xp_context == EXPAND_DIRECTORIES) {
+    // Insert a backslash into a file name before a space, \, %, #
+    // and wildmatch characters, except '~'.
+    for (int i = 0; i < numfiles; i++) {
+      // for ":set path=" we need to escape spaces twice
+      if (xp->xp_backslash == XP_BS_THREE) {
+        p = vim_strsave_escaped(files[i], " ");
+        xfree(files[i]);
+        files[i] = p;
+#if defined(BACKSLASH_IN_FILENAME)
+        p = vim_strsave_escaped(files[i], " ");
+        xfree(files[i]);
+        files[i] = p;
+#endif
+      }
+#ifdef BACKSLASH_IN_FILENAME
+      p = vim_strsave_fnameescape(files[i], vse_what);
+#else
+      p = vim_strsave_fnameescape(files[i], xp->xp_shell ? VSE_SHELL : vse_what);
+#endif
+      xfree(files[i]);
+      files[i] = p;
+
+      // If 'str' starts with "\~", replace "~" at start of
+      // files[i] with "\~".
+      if (str[0] == '\\' && str[1] == '~' && files[i][0] == '~') {
+        escape_fname(&files[i]);
+      }
+    }
+    xp->xp_backslash = XP_BS_NONE;
+
+    // If the first file starts with a '+' escape it.  Otherwise it
+    // could be seen as "+cmd".
+    if (*files[0] == '+') {
+      escape_fname(&files[0]);
+    }
+  } else if (xp->xp_context == EXPAND_TAGS) {
+    // Insert a backslash before characters in a tag name that
+    // would terminate the ":tag" command.
+    for (int i = 0; i < numfiles; i++) {
+      p = vim_strsave_escaped(files[i], "\\|\"");
+      xfree(files[i]);
+      files[i] = p;
+    }
+  }
+}
+
+/// Escape special characters in the cmdline completion matches.
+static void ExpandEscape(expand_T *xp, char *str, int numfiles, char **files, int options)
+{
   // May change home directory back to "~"
   if (options & WILD_HOME_REPLACE) {
     tilde_replace(str, numfiles, files);
   }
 
   if (options & WILD_ESCAPE) {
-    if (xp->xp_context == EXPAND_FILES
-        || xp->xp_context == EXPAND_FILES_IN_PATH
-        || xp->xp_context == EXPAND_SHELLCMD
-        || xp->xp_context == EXPAND_BUFFERS
-        || xp->xp_context == EXPAND_DIRECTORIES) {
-      // Insert a backslash into a file name before a space, \, %, #
-      // and wildmatch characters, except '~'.
-      for (i = 0; i < numfiles; i++) {
-        // for ":set path=" we need to escape spaces twice
-        if (xp->xp_backslash == XP_BS_THREE) {
-          p = vim_strsave_escaped(files[i], " ");
-          xfree(files[i]);
-          files[i] = p;
-#if defined(BACKSLASH_IN_FILENAME)
-          p = vim_strsave_escaped(files[i], (char_u *)" ");
-          xfree(files[i]);
-          files[i] = p;
-#endif
-        }
-#ifdef BACKSLASH_IN_FILENAME
-        p = vim_strsave_fnameescape((const char *)files[i], vse_what);
-#else
-        p = vim_strsave_fnameescape((const char *)files[i],
-                                    xp->xp_shell ? VSE_SHELL : vse_what);
-#endif
-        xfree(files[i]);
-        files[i] = p;
-
-        // If 'str' starts with "\~", replace "~" at start of
-        // files[i] with "\~".
-        if (str[0] == '\\' && str[1] == '~' && files[i][0] == '~') {
-          escape_fname(&files[i]);
-        }
-      }
-      xp->xp_backslash = XP_BS_NONE;
-
-      // If the first file starts with a '+' escape it.  Otherwise it
-      // could be seen as "+cmd".
-      if (*files[0] == '+') {
-        escape_fname(&files[0]);
-      }
-    } else if (xp->xp_context == EXPAND_TAGS) {
-      // Insert a backslash before characters in a tag name that
-      // would terminate the ":tag" command.
-      for (i = 0; i < numfiles; i++) {
-        p = vim_strsave_escaped(files[i], "\\|\"");
-        xfree(files[i]);
-        files[i] = p;
-      }
-    }
+    wildescape(xp, str, numfiles, files);
   }
 }
 
@@ -2644,30 +2648,31 @@ static void expand_shellcmd_onedir(char *buf, char *s, size_t l, char *pat, char
 
   // Expand matches in one directory of $PATH.
   int ret = expand_wildcards(1, &buf, numMatches, matches, flags);
-  if (ret == OK) {
-    ga_grow(gap, *numMatches);
-    {
-      for (int i = 0; i < *numMatches; i++) {
-        char *name = (*matches)[i];
-
-        if (strlen(name) > l) {
-          // Check if this name was already found.
-          hash_T hash = hash_hash((char_u *)name + l);
-          hashitem_T *hi =
-            hash_lookup(ht, (const char *)(name + l), strlen(name + l), hash);
-          if (HASHITEM_EMPTY(hi)) {
-            // Remove the path that was prepended.
-            STRMOVE(name, name + l);
-            ((char **)gap->ga_data)[gap->ga_len++] = name;
-            hash_add_item(ht, hi, (char_u *)name, hash);
-            name = NULL;
-          }
-        }
-        xfree(name);
-      }
-      xfree(*matches);
-    }
+  if (ret != OK) {
+    return;
   }
+
+  ga_grow(gap, *numMatches);
+
+  for (int i = 0; i < *numMatches; i++) {
+    char *name = (*matches)[i];
+
+    if (strlen(name) > l) {
+      // Check if this name was already found.
+      hash_T hash = hash_hash((char_u *)name + l);
+      hashitem_T *hi =
+        hash_lookup(ht, (const char *)(name + l), strlen(name + l), hash);
+      if (HASHITEM_EMPTY(hi)) {
+        // Remove the path that was prepended.
+        STRMOVE(name, name + l);
+        ((char **)gap->ga_data)[gap->ga_len++] = name;
+        hash_add_item(ht, hi, (char_u *)name, hash);
+        name = NULL;
+      }
+    }
+    xfree(name);
+  }
+  xfree(*matches);
 }
 
 /// Complete a shell command.
@@ -3074,8 +3079,7 @@ static int wildmenu_process_key_filenames(CmdlineInfo *cclp, int key, expand_T *
       j -= utf_head_off(cclp->cmdbuff, cclp->cmdbuff + j);
       if (vim_ispathsep(cclp->cmdbuff[j])
 #ifdef BACKSLASH_IN_FILENAME
-          && vim_strchr((const char_u *)" *?[{`$%#", cclp->cmdbuff[j + 1])
-          == NULL
+          && vim_strchr(" *?[{`$%#", (uint8_t)cclp->cmdbuff[j + 1]) == NULL
 #endif
           ) {
         if (found) {


### PR DESCRIPTION
#### vim-patch:9.0.0876: code is indented more than needed

Problem:    Code is indented more than needed.
Solution:   Split ExpandEscape() in two. (Yegappan Lakshmanan, closes vim/vim#11539)

https://github.com/vim/vim/commit/68353e5270fca45daffee5b5f882853cdfa40f76

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>