### PR TITLE
vim-patch:8.2.0188: Check commands don't work well with Vim9 script

### DIFF
--- a/src/nvim/testdir/check.vim
+++ b/src/nvim/testdir/check.vim
@@ -1,6 +1,8 @@
 source shared.vim
 source term_util.vim
 
+command -nargs=1 MissingFeature throw 'Skipped: ' .. <args> .. ' feature missing'
+
 " Command to check for the presence of a feature.
 command -nargs=1 CheckFeature call CheckFeature(<f-args>)
 func CheckFeature(name)
@@ -8,7 +10,7 @@ func CheckFeature(name)
   "   throw 'Checking for non-existent feature ' .. a:name
   " endif
   if !has(a:name)
-    throw 'Skipped: ' .. a:name .. ' feature missing'
+    MissingFeature a:name
   endif
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.0188: Check commands don't work well with Vim9 script

Problem:    Check commands don't work well with Vim9 script.
Solution:   Improve constant expression handling.

https://github.com/vim/vim/commit/7f829cab356d63b8e59559285593777a66bcc02b

Co-authored-by: Bram Moolenaar <Bram@vim.org>