### PR TITLE
test(fileio_spec): avoid expect_exit() without calling clear()

### DIFF
--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -22,6 +22,7 @@ local tmpname = helpers.tmpname
 local trim = helpers.trim
 local currentdir = helpers.funcs.getcwd
 local assert_alive = helpers.assert_alive
+local check_close = helpers.check_close
 local expect_exit = helpers.expect_exit
 local write_file = helpers.write_file
 local Screen = require('test.functional.ui.screen')
@@ -34,7 +35,7 @@ describe('fileio', function()
   before_each(function()
   end)
   after_each(function()
-    expect_exit(command, ':qall!')
+    check_close()
     os.remove('Xtest_startup_shada')
     os.remove('Xtest_startup_file1')
     os.remove('Xtest_startup_file1~')
@@ -270,7 +271,7 @@ describe('tmpdir', function()
   end)
 
   after_each(function()
-    expect_exit(command, ':qall!')
+    check_close()
     os.remove(testlog)
   end)
 

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -397,9 +397,12 @@ local function remove_args(args, args_rm)
   return new_args
 end
 
-function module.check_close(old_session)
+function module.check_close()
+  if not session then
+    return
+  end
   local start_time = luv.now()
-  old_session:close()
+  session:close()
   luv.update_time()  -- Update cached value of luv.now() (libuv: uv_now()).
   local end_time = luv.now()
   local delta = end_time - start_time
@@ -408,12 +411,13 @@ function module.check_close(old_session)
           "This indicates a likely problem with the test even if it passed!\n")
     io.stdout:flush()
   end
+  session = nil
 end
 
 --- @param io_extra used for stdin_fd, see :help ui-option
 function module.spawn(argv, merge, env, keep, io_extra)
-  if session and not keep then
-    module.check_close(session)
+  if not keep then
+    module.check_close()
   end
 
   local child_stream = ChildProcessStream.spawn(


### PR DESCRIPTION
Since before_each() doesn't call clear() in these tests, after_each()
may call expect_exit() without calling clear() if a test is skipped,
causing frequent test failures on Cirrus CI. Close the session instead.
