### PR TITLE
docs(lua): utilize luaref instead of www.lua.org

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -132,8 +132,7 @@ back to Lua's default search mechanism. The first script found is run and
 
 The return value is cached after the first call to `require()` for each module,
 with subsequent calls returning the cached value without searching for, or
-executing any script. For further details on `require()`, see the Lua
-documentation at https://www.lua.org/manual/5.1/manual.html#pdf-require.
+executing any script. For further details on `require()`, see |luaref-require()|.
 
 For example, if 'runtimepath' is `foo,bar` and |package.cpath| was
 `./?.so;./?.dll` at startup, `require('mod')` searches these paths in order
@@ -1641,6 +1640,7 @@ gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
 
     See also: ~
         |vim.split()|
+        |luaref-patterns|
         https://www.lua.org/pil/20.2.html
         http://lua-users.org/wiki/StringLibraryTutorial
 
@@ -1913,6 +1913,7 @@ trim({s})                                                         *vim.trim()*
         (string) String with whitespace removed from its beginning and end
 
     See also: ~
+        |luaref-patterns|
         https://www.lua.org/pil/20.2.html
 
 validate({opt})                                               *vim.validate()*

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -60,6 +60,7 @@ end)()
 --- Splits a string at each instance of a separator.
 ---
 ---@see |vim.split()|
+---@see |luaref-patterns|
 ---@see https://www.lua.org/pil/20.2.html
 ---@see http://lua-users.org/wiki/StringLibraryTutorial
 ---
@@ -529,6 +530,7 @@ end
 
 --- Trim whitespace (Lua pattern "%s") from both sides of a string.
 ---
+---@see |luaref-patterns|
 ---@see https://www.lua.org/pil/20.2.html
 ---@param s string String to trim
 ---@return string String with whitespace removed from its beginning and end


### PR DESCRIPTION
I was reading `:h lua-require` and in the end it says `see the Lua documentation at https://www.lua.org/manual/5.1/manual.html#pdf-require.` for the Lua 5.1 official reference.
I believe it's more handy to link to `:h luaref-require`, which has the same content and browsable inside Neovim even while offline.

For consistency, I searched for `www.lua.org/manual` in the code base and this was the only place we (accidentally?) link to `www.lua.org/manual`.

Also, I searched `www.lua.org` in the codebase and put `luaref-patterns` when I think applicable along with existing link to lua guides


