### PR TITLE
docs(lua): lua-guide: <Nop> is for rhs of vim.keymap.set(), not lhs

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -406,9 +406,9 @@ mandatory arguments:
   prefix for which the mapping will take effect. The prefixes are the ones
   listed in |:map-modes|, or "!" for |:map!|, or empty string for |:map|.
 • {lhs} is a string with the key sequences that should trigger the mapping.
-  An empty string is equivalent to |<Nop>|, which disables a key.
 • {rhs} is either a string with a Vim command or a Lua function that should
   be executed when the {lhs} is entered.
+  An empty string is equivalent to |<Nop>|, which disables a key.
 
 Examples:
 >lua


### PR DESCRIPTION
`vim.keymap.set('n', 'a', '')` or `vim.keymap.set('n', 'a', '<Nop>')` disables `a` in Normal mode.
Empty string or `<Nop>` is for `{rhs}` argument for vim.keymap.set(), not `{lhs}`.

This mistake was originally from [nanotee/nvim-lua-guide](https://github.com/nanotee/nvim-lua-guide/blob/393ea845b88661a8f54ec251ecca0b06a3c7fc49/README.md#defining-mappings) and here I assume lua-guide.txt in this Neovim repo is considered as the maintained version now.


I feel like maybe we should clean up explanations about `vim.keymap.set()` in lua-guide.txt to favor `:h vim.keymap.set()` (already linked) though. They have overlapping explanations and if we have practically useful examples, probably we should put them in `:h vim.keymap.set()`  for better discoverability. (or reverse link to lua-guide via `See also` but this is too much IMHO)
