### PR TITLE
feat(shada): shada should not store nobuflisted buffers

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -3630,12 +3630,8 @@ static inline size_t shada_init_jumps(PossiblyFreedShadaEntry *jumps,
              curwin->w_jumplistlen);
       continue;
     }
-    const buf_T *const buf = (fm.fmark.fnum == 0
-                              ? NULL
-                              : buflist_findnr(fm.fmark.fnum));
-    if (buf != NULL
-        ? set_has(ptr_t, removable_bufs, (ptr_t)buf)
-        : fm.fmark.fnum != 0) {
+    const buf_T *const buf = (fm.fmark.fnum == 0 ? NULL : buflist_findnr(fm.fmark.fnum));
+    if (buf != NULL ? ignore_buf(buf, removable_bufs) : fm.fmark.fnum != 0) {
       continue;
     }
     const char *const fname =

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -213,6 +213,20 @@ describe('ShaDa support code', function()
     eq({}, find_file(fname))
   end)
 
+  it("does not store 'nobuflisted' buffer", function()
+    nvim_command('set shellslash')
+    local fname = fn.getcwd() .. '/file'
+    api.nvim_set_var('__fname', fname)
+    nvim_command('edit `=__fname`')
+    api.nvim_set_option_value('buflisted', false, {})
+    nvim_command('wshada! ' .. shada_fname)
+    eq({}, find_file(fname))
+    -- Set 'buflisted', then check again.
+    api.nvim_set_option_value('buflisted', true, {})
+    nvim_command('wshada! ' .. shada_fname)
+    eq({ [7] = 1, [8] = 1, [10] = 1 }, find_file(fname))
+  end)
+
   it('is able to set &shada after &viminfo', function()
     api.nvim_set_option_value('viminfo', "'10", {})
     eq("'10", api.nvim_get_option_value('viminfo', {}))


### PR DESCRIPTION
Problem:  Shada jumplist entries still include entries from e.g. 'nobuflisted' buffers.
Solution: Check `ignore_buf()` before adding jumplist entries, followup to b98eefd8.

Fix #18433