### PR TITLE
build(deps): bump libvterm to v0.3.1

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -168,8 +168,8 @@ set(UNIBILIUM_SHA256 29815283c654277ef77a3adcc8840db79ddbb20a0f0b0c8f648bd8cd49a
 set(LIBTERMKEY_URL https://www.leonerd.org.uk/code/libtermkey/libtermkey-0.22.tar.gz)
 set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3014600)
 
-set(LIBVTERM_URL https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.tar.gz)
-set(LIBVTERM_SHA256 61eb0d6628c52bdf02900dfd4468aa86a1a7125228bab8a67328981887483358)
+set(LIBVTERM_URL https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.1.tar.gz)
+set(LIBVTERM_SHA256 25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397)
 
 set(LUV_VERSION 1.44.2-1)
 set(LUV_URL https://github.com/luvit/luv/archive/80c8c00baebe3e994d1616d4b54097c2d6e14834.tar.gz)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1298,6 +1298,7 @@ describe('TUI', function()
       [7] = {reverse = true, foreground = Screen.colors.SeaGreen4},
       [8] = {foreground = Screen.colors.SeaGreen4},
       [9] = {bold = true, foreground = Screen.colors.Blue1},
+      [10] = {foreground = Screen.colors.Blue},
     })
 
     feed_data(':hi SpecialKey ctermfg=3 guifg=SeaGreen\n')
@@ -1318,9 +1319,9 @@ describe('TUI', function()
     feed_data(':set termguicolors\n')
     screen:expect([[
       {7:^}{8:G}                                                |
-      {9:~                                                 }|
-      {9:~                                                 }|
-      {9:~                                                 }|
+      {9:~}{10:                                                 }|
+      {9:~}{10:                                                 }|
+      {9:~}{10:                                                 }|
       {3:[No Name] [+]                                     }|
       :set termguicolors                                |
       {4:-- TERMINAL --}                                    |


### PR DESCRIPTION
[821](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/821). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-12-29
Don't bother to emit the unrecognised sequence in DECRQSS response as it provides an echo roundtrip possibility

[820](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/820). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-11-26
erase_internal() should only set fg/bg colour, resetting other attributes (especially RV)

[819](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/819). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-11-09
Added vterm_screen_set_default_colors(), which repaints the cells in the buffer(s)

[818](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/818). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-11-09
Permit either colour argument to be NULL to vterm_state_set_default_colors()

[817](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/817). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-10-01
Delete the mk_wcswidth functions as they're not used; guard the CJK-wide one with an ifdef as by default we don't use it

[816](https://bazaar.launchpad.net/~libvterm/libvterm/trunk/revision/816). By [Paul "LeoNerd" Evans](https://launchpad.net/~leonerd) on 2022-10-01
Make sure to supply empty (void) prototype to functions that take no arguments in bin/vterm-ctrl.c