### PR TITLE
build: remove REQUIRED option from add_glob_target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,6 @@ find_program(UNCRUSTIFY_PRG uncrustify)
 find_program(SHELLCHECK_PRG shellcheck)
 
 add_glob_target(
-  REQUIRED
   TARGET lintlua-luacheck
   COMMAND ${LUACHECK_PRG}
   FLAGS -q

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -4,7 +4,6 @@
 # depends on the value of TOUCH_STRATEGY.
 #
 # Options:
-# REQUIRED            - Abort if COMMAND doesn't exist.
 #
 # Single value arguments:
 # TARGET         - Name of the target
@@ -53,7 +52,7 @@
 #             files.
 function(add_glob_target)
   cmake_parse_arguments(ARG
-    "REQUIRED"
+    ""
     "TARGET;COMMAND;GLOB_PAT;TOUCH_STRATEGY"
     "FLAGS;FILES;GLOB_DIRS;EXCLUDE"
     ${ARGN}
@@ -61,14 +60,8 @@ function(add_glob_target)
 
   if(NOT ARG_COMMAND)
     add_custom_target(${ARG_TARGET})
-    if(ARG_REQUIRED)
-      add_custom_command(TARGET ${ARG_TARGET}
-        COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET}: ${ARG_COMMAND} not found"
-        COMMAND false)
-    else()
-      add_custom_command(TARGET ${ARG_TARGET}
-        COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET} SKIP: ${ARG_COMMAND} not found")
-    endif()
+    add_custom_command(TARGET ${ARG_TARGET}
+      COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET} SKIP: ${ARG_COMMAND} not found")
     return()
   endif()
 


### PR DESCRIPTION
The REQUIRED option doesn't really serve a purpose. We can only
comfortably require linters that we provide ourselves without
potentially blocking contributors, but that means there's no reason to
require it as we already know it's provided by us.
