### PR TITLE
fix(statusline): memory leak in nvim_eval_statusline

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1325,6 +1325,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       stl_items[curitem].type = ClickFunc;
       stl_items[curitem].start = out_p;
       stl_items[curitem].cmd = xmemdupz(t, (size_t)(fmt_p - t));
+      xfree(stl_items[curitem].cmd);
       stl_items[curitem].minwid = minwid;
       fmt_p++;
       curitem++;


### PR DESCRIPTION
closes #21764 

I don't have much experience with neovim's/vim's code, but I believe that this patch is correct(correct me if I'm wrong, I'm trying to learn).

currently fails on tests, put up a temporary commit.