### PR TITLE
fix(api): avoid memory leak with click functions in nvim_eval_statusline()

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1323,7 +1323,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       }
       stl_items[curitem].type = ClickFunc;
       stl_items[curitem].start = out_p;
-      stl_items[curitem].cmd = xmemdupz(t, (size_t)(fmt_p - t));
+      stl_items[curitem].cmd = tabtab ? xmemdupz(t, (size_t)(fmt_p - t)) : NULL;
       stl_items[curitem].minwid = minwid;
       fmt_p++;
       curitem++;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3211,6 +3211,17 @@ describe('API', function()
             'TextWithNoHighlight%#WarningMsg#TextWithWarningHighlight',
             { use_winbar = true, highlights = true }))
       end)
+      it('no memory leak with click functions', function()
+        meths.eval_statusline('%@ClickFunc@StatusLineStringWithClickFunc%T', {})
+        eq({
+            str = 'StatusLineStringWithClickFunc',
+            width = 29
+          },
+          meths.eval_statusline(
+            '%@ClickFunc@StatusLineStringWithClickFunc%T',
+            {})
+          )
+      end)
     end)
   end)
   describe('nvim_parse_cmd', function()


### PR DESCRIPTION
Problem:    Allocated click function memory is lost due to `nvim_eval_statusline()` not passing in a `StlClickRecord`.
Solution:   Do not allocate click function memory if `tabtab == NULL`.

Resolve https://github.com/neovim/neovim/issues/21764, supersede https://github.com/neovim/neovim/pull/21842.