### PR TITLE
fix(tabline): avoid memory leak in tabline click definitions

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -733,6 +733,10 @@ void draw_tabline(void)
     return;
   }
 
+  // Clear tab_page_click_defs: Clicking outside of tabs has no effect.
+  assert(tab_page_click_defs_size >= (size_t)Columns);
+  stl_clear_click_defs(tab_page_click_defs, tab_page_click_defs_size);
+
   // Use the 'tabline' option if it's set.
   if (*p_tal != NUL) {
     win_redr_custom(NULL, false, false);

--- a/test/functional/ui/tabline_spec.lua
+++ b/test/functional/ui/tabline_spec.lua
@@ -119,4 +119,10 @@ describe("tabline", function()
       [2] = {bold = true, foreground = Screen.colors.Blue};
     }}
   end)
+
+  it('click definitions do not leak memory #21765', function()
+    command('set tabline=%@MyClickFunc@MyClickText%T')
+    command('set showtabline=2')
+    command('redrawtabline')
+  end)
 end)


### PR DESCRIPTION
Problem:    Memory is leaked in tabline click definitions since https://github.com/neovim/neovim/pull/21008.
Solution:   Add back a call to `stl_clear_click_defs()` that was lost in the refactor PR.

Resolve https://github.com/neovim/neovim/issues/21765.