### PR TITLE
vim-patch:9.0.0089: fuzzy argument completion doesn't work for shell commands

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1416,8 +1416,10 @@ static const char *set_cmd_index(const char *cmd, exarg_T *eap, expand_T *xp, in
     eap->cmdidx = excmd_get_cmdidx(cmd, len);
 
     // User defined commands support alphanumeric characters.
-    // Also when doing fuzzy expansion, support alphanumeric characters.
-    if ((cmd[0] >= 'A' && cmd[0] <= 'Z') || (fuzzy && *p != NUL)) {
+    // Also when doing fuzzy expansion for non-shell commands, support
+    // alphanumeric characters.
+    if ((cmd[0] >= 'A' && cmd[0] <= 'Z')
+        || (fuzzy && eap->cmdidx != CMD_bang && *p != NUL)) {
       while (ASCII_ISALNUM(*p) || *p == '*') {  // Allow * wild card
         p++;
       }

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -3253,6 +3253,16 @@ func Test_cmdline_complete_substitute_short()
   endfor
 endfunc
 
+" Test for :! shell command argument completion
+func Test_cmdline_complete_bang_cmd_argument()
+  set wildoptions=fuzzy
+  call feedkeys(":!vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"!vim test_cmdline.vim', @:)
+  set wildoptions&
+  call feedkeys(":!vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"!vim test_cmdline.vim', @:)
+endfunc
+
 func Check_completion()
   call assert_equal('let a', getcmdline())
   call assert_equal(6, getcmdpos())


### PR DESCRIPTION
#### vim-patch:9.0.0089: fuzzy argument completion doesn't work for shell commands

Problem:    Fuzzy argument completion doesn't work for shell commands.
Solution:   Check for cmdidx not being CMD_bang. (Yegappan Lakshmanan,
            closes vim/vim#10769)

https://github.com/vim/vim/commit/7db3a8e3298bf7c7c3f74cc9c1add04f29e78d2d

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>