### PR TITLE
vim-patch:8.2.4917: fuzzy expansion of option names is not right

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2727,7 +2727,7 @@ static int ExpandFromContext(expand_T *xp, char *pat, char ***matches, int *numM
 
   if (xp->xp_context == EXPAND_SETTINGS
       || xp->xp_context == EXPAND_BOOL_SETTINGS) {
-    ret = ExpandSettings(xp, &regmatch, pat, numMatches, matches);
+    ret = ExpandSettings(xp, &regmatch, pat, numMatches, matches, fuzzy);
   } else if (xp->xp_context == EXPAND_MAPPINGS) {
     ret = ExpandMappings(pat, &regmatch, numMatches, matches);
   } else if (xp->xp_context == EXPAND_USER_DEFINED) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4740,7 +4740,7 @@ static bool match_str(char *const str, regmatch_T *const regmatch, char **const 
 }
 
 int ExpandSettings(expand_T *xp, regmatch_T *regmatch, char *fuzzystr, int *numMatches,
-                   char ***matches)
+                   char ***matches, const bool can_fuzzy)
 {
   int num_normal = 0;  // Nr of matching non-term-code settings
   int count = 0;
@@ -4748,7 +4748,7 @@ int ExpandSettings(expand_T *xp, regmatch_T *regmatch, char *fuzzystr, int *numM
   int ic = regmatch->rm_ic;  // remember the ignore-case flag
 
   fuzmatch_str_T *fuzmatch = NULL;
-  const bool fuzzy = cmdline_fuzzy_complete(fuzzystr);
+  const bool fuzzy = can_fuzzy && cmdline_fuzzy_complete(fuzzystr);
 
   // do this loop twice:
   // loop == 0: count the number of matching options

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -1238,6 +1238,30 @@ func Test_opt_cdhome()
   set cdhome&
 endfunc
 
+func Test_set_completion_2()
+  CheckOption termguicolors
+
+  " Test default option completion
+  set wildoptions=
+  call feedkeys(":set termg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set termguicolors', @:)
+
+  call feedkeys(":set notermg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set notermguicolors', @:)
+
+  " Test fuzzy option completion
+  set wildoptions=fuzzy
+  call feedkeys(":set termg\<C-A>\<C-B>\"\<CR>", 'tx')
+  " Nvim doesn't have 'termencoding'
+  " call assert_equal('"set termguicolors termencoding', @:)
+  call assert_equal('"set termguicolors', @:)
+
+  call feedkeys(":set notermg\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set notermguicolors', @:)
+
+  set wildoptions=
+endfunc
+
 func Test_switchbuf_reset()
   set switchbuf=useopen
   sblast


### PR DESCRIPTION
#### vim-patch:8.2.4917: fuzzy expansion of option names is not right

Problem:    Fuzzy expansion of option names is not right.
Solution:   Pass the fuzzy flag down the call chain. (Christian Brabandt,
            closes vim/vim#10380)

https://github.com/vim/vim/commit/cb747899bd99361a299a163f3aa55d5fe7d6f798

Co-authored-by: Christian Brabandt <cb@256bit.org>