### PR TITLE
vim-patch:8.2.4928: various white space and cosmetic mistakes

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3661,8 +3661,7 @@ static bool ins_start_select(int c)
 static void ins_insert(int replaceState)
 {
   set_vim_var_string(VV_INSERTMODE, ((State & REPLACE_FLAG) ? "i" :
-                                     replaceState == MODE_VREPLACE ? "v" :
-                                     "r"), 1);
+                                     replaceState == MODE_VREPLACE ? "v" : "r"), 1);
   ins_apply_autocmds(EVENT_INSERTCHANGE);
   if (State & REPLACE_FLAG) {
     State = MODE_INSERT | (State & MODE_LANGMAP);

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -140,6 +140,8 @@ void win_findbuf(typval_T *argvars, list_T *list)
 /// Find window specified by "vp" in tabpage "tp".
 ///
 /// @param tp  NULL for current tab page
+/// @return  current window if "vp" is number zero.
+///          NULL if not found.
 win_T *find_win_by_nr(typval_T *vp, tabpage_T *tp)
 {
   int nr = (int)tv_get_number_chk(vp, NULL);

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -29,7 +29,8 @@
 # include "input.c.generated.h"  // IWYU pragma: export
 #endif
 
-/// Ask for a reply from the user, 'y' or 'n'
+/// Ask for a reply from the user, a 'y' or a 'n', with prompt "str" (which
+/// should have been translated already).
 ///
 /// No other characters are accepted, the message is repeated until a valid
 /// reply is entered or <C-c> is hit.

--- a/src/nvim/testdir/test_cursorline.vim
+++ b/src/nvim/testdir/test_cursorline.vim
@@ -319,7 +319,7 @@ func Test_cursorline_cursorbind_horizontal_scroll()
 
   let lines =<< trim END
       call setline(1, 'aa bb cc dd ee ff gg hh ii jj kk ll mm' ..
-      \ ' nn oo pp qq rr ss tt uu vv ww xx yy zz')
+                    \ ' nn oo pp qq rr ss tt uu vv ww xx yy zz')
       set nowrap
       " The following makes the cursor apparent on the screen dump
       set sidescroll=1 cursorcolumn


### PR DESCRIPTION
#### vim-patch:8.2.4928: various white space and cosmetic mistakes

Problem:    Various white space and cosmetic mistakes.
Solution:   Change spaces to tabs, improve comments.

https://github.com/vim/vim/commit/6ed545e79735f23ff8e650bc2f0967e5a0baedc9

Co-authored-by: Bram Moolenaar <Bram@vim.org>