### PR TITLE
vim-patch:8.2.4959: using NULL regexp program

### DIFF
--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -423,6 +423,12 @@ func Test_buf_pattern_invalid()
   vsplit 00000000000000000000000000
   silent! buf [0--]\&\zs*\zs*e
   bwipe!
+
+  " similar case with different code path
+  split 0
+  edit ÿ
+  silent! buf [0--]\&\zs*\zs*0
+  bwipe!
 endfunc
 
 " Test for the 'maxmem' and 'maxmemtot' options


### PR DESCRIPTION
#### vim-patch:8.2.4959: using NULL regexp program

Problem:    Using NULL regexp program.
Solution:   Check for regexp program becoming NULL in more places.

https://github.com/vim/vim/commit/b62dc5e7825bc195efe3041d5b3a9f1528359e1c

Co-authored-by: Bram Moolenaar <Bram@vim.org>