### PR TITLE
vim-patch:8.2.4483: command completion makes two rounds to collect matches

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2415,31 +2415,34 @@ int ExpandBufnames(char *pat, int *num_file, char ***file, int options)
           }
         }
 
-        if (p != NULL) {
-          if (round == 1) {
+        if (p == NULL) {
+          continue;
+        }
+
+        if (round == 1) {
+          count++;
+          continue;
+        }
+
+        if (options & WILD_HOME_REPLACE) {
+          p = home_replace_save(buf, p);
+        } else {
+          p = xstrdup(p);
+        }
+
+        if (!fuzzy) {
+          if (matches != NULL) {
+            matches[count].buf = buf;
+            matches[count].match = p;
             count++;
           } else {
-            if (options & WILD_HOME_REPLACE) {
-              p = home_replace_save(buf, p);
-            } else {
-              p = xstrdup(p);
-            }
-
-            if (!fuzzy) {
-              if (matches != NULL) {
-                matches[count].buf = buf;
-                matches[count].match = p;
-                count++;
-              } else {
-                (*file)[count++] = p;
-              }
-            } else {
-              fuzmatch[count].idx = count;
-              fuzmatch[count].str = p;
-              fuzmatch[count].score = score;
-              count++;
-            }
+            (*file)[count++] = p;
           }
+        } else {
+          fuzmatch[count].idx = count;
+          fuzmatch[count].str = p;
+          fuzmatch[count].score = score;
+          count++;
         }
       }
       if (count == 0) {         // no match found, break here

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -27,7 +27,8 @@ typedef struct growarray {
 #define GA_APPEND(item_type, gap, item) \
   do { \
     ga_grow(gap, 1); \
-    ((item_type *)(gap)->ga_data)[(gap)->ga_len++] = (item); \
+    ((item_type *)(gap)->ga_data)[(gap)->ga_len] = (item); \
+    (gap)->ga_len++; \
   } while (0)
 
 #define GA_APPEND_VIA_PTR(item_type, gap) \

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2876,6 +2876,24 @@ func Test_fuzzy_completion_userdefined_func()
   set wildoptions&
 endfunc
 
+" <SNR> functions should be sorted to the end
+func Test_fuzzy_completion_userdefined_snr_func()
+  func s:Sendmail()
+  endfunc
+  func SendSomemail()
+  endfunc
+  func S1e2n3dmail()
+  endfunc
+  set wildoptions=fuzzy
+  call feedkeys(":call sendmail\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"call SendSomemail() S1e2n3dmail() '
+        \ .. expand("<SID>") .. 'Sendmail()', @:)
+  set wildoptions&
+  delfunc s:Sendmail
+  delfunc SendSomemail
+  delfunc S1e2n3dmail
+endfunc
+
 " user defined command name completion
 func Test_fuzzy_completion_userdefined_cmd()
   set wildoptions&


### PR DESCRIPTION
#### vim-patch:8.2.4483: command completion makes two rounds to collect matches

Problem:    Command completion makes two rounds to collect matches.
Solution:   Use a growarray to collect matches. (Yegappan Lakshmanan,
            closes vim/vim#9860)

https://github.com/vim/vim/commit/5de4c4372d4366bc85cb66efb3e373439b9471c5

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>