### PR TITLE
build: enable cmake workflow presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 6,
   "configurePresets": [
     {
       "name": "base",
@@ -14,9 +14,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },
-      "inherits": [
-        "base"
-      ]
+      "inherits": ["base"]
     },
     {
       "name": "debug",
@@ -25,9 +23,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       },
-      "inherits": [
-        "base"
-      ]
+      "inherits": ["base"]
     },
     {
       "name": "release",
@@ -36,9 +32,7 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       },
-      "inherits": [
-        "base"
-      ]
+      "inherits": ["base"]
     },
     {
       "name": "windows-default",
@@ -54,9 +48,7 @@
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "hostOS": [
-            "Windows"
-          ]
+          "hostOS": ["Windows"]
         }
       },
       "condition": {
@@ -64,9 +56,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "inherits": [
-        "base"
-      ]
+      "inherits": ["base"]
     },
     {
       "name": "iwyu",
@@ -75,9 +65,7 @@
       "cacheVariables": {
         "ENABLE_IWYU": "ON"
       },
-      "inherits": [
-        "base"
-      ]
+      "inherits": ["base"]
     }
   ],
   "buildPresets": [
@@ -105,6 +93,21 @@
     {
       "name": "iwyu",
       "configurePreset": "iwyu"
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "iwyu",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "iwyu"
+        },
+        {
+          "type": "build",
+          "name": "iwyu"
+        }
+      ]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,10 +246,9 @@ You can lint a single file (but this will _not_ exclude legacy errors):
 For managing includes in C files, use [include-what-you-use].
 
 - [Install include-what-you-use][include-what-you-use-install]
-- To see which includes needs fixing just use the cmake preset `iwyu`:
+- To see which includes needs fixing use the cmake preset `iwyu`:
   ```
-  cmake --preset iwyu
-  cmake --build --preset iwyu
+  cmake --workflow --preset iwyu
   ```
 - There's also a make target that automatically fixes the suggestions from
   IWYU:

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,7 @@ lintlua lintsh lintc check-single-includes generated-sources lintcommit lint for
 test: functionaltest unittest
 
 iwyu: build/.ran-cmake
-	cmake --preset iwyu
-	cmake --build --preset iwyu > build/iwyu.log
+	cmake --workflow --fresh --preset iwyu > build/iwyu.log
 	iwyu-fix-includes --only_re="src/nvim" --ignore_re="src/nvim/(auto|map.h|eval/encode.c)" --safe_headers < build/iwyu.log
 	cmake -B build -U ENABLE_IWYU
 


### PR DESCRIPTION
Workflow presets allows combining configure, build, test and packaging
steps and makes it possible to run everything in a single command. So

cmake --preset iwyu
cmake --build --preset iwyu

instead becomes

cmake --workflow --preset iwyu

Workflow presets requires at least cmake version 3.25 to use.
