### PR TITLE
fix(treesitter): really restore syntax

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -88,7 +88,6 @@ function TSHighlighter.new(tree, opts)
     end
   end
 
-  self.orig_syntax = vim.bo[self.bufnr].syntax
   self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
 
   vim.bo[self.bufnr].syntax = ''
@@ -120,8 +119,11 @@ function TSHighlighter:destroy()
   end
 
   if vim.api.nvim_buf_is_loaded(self.bufnr) then
-    vim.bo[self.bufnr].syntax = self.orig_syntax
     vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
+    vim.b[self.bufnr].ts_highlight = nil
+    if vim.g.syntax_on == 1 then
+      a.nvim_exec_autocmds('FileType', { group = 'syntaxset', buffer = self.bufnr })
+    end
   end
 end
 


### PR DESCRIPTION
Two ways to solve this:

1. Re-run the `syntaxset` augroup
2. Set syntax to `vim.bo.filetype`

I've gone with 1.