### PR TITLE
vim-patch:9.0.1212: cannot read back what setcellwidths() has done

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -173,6 +173,7 @@ getbufline({buf}, {lnum} [, {end}])
 getbufoneline({buf}, {lnum})	String	line {lnum} of buffer {buf}
 getbufvar({buf}, {varname} [, {def}])
 				any	variable {varname} in buffer {buf}
+getcellwidths()			List	get character cell width overrides
 getchangelist([{buf}])		List	list of change list items
 getchar([expr])			Number or String
 					get one character from the user
@@ -2745,6 +2746,13 @@ getbufvar({buf}, {varname} [, {def}])				*getbufvar()*
 <		Can also be used as a |method|: >
 			GetBufnr()->getbufvar(varname)
 <
+getcellwidths()						*getcellwidths()*
+		Returns a |List| of cell widths of character ranges overridden
+		by |setcellwidths()|.  The format is equal to the argument of
+		|setcellwidths()|.  If no character ranges have their cell
+		widths overridden, an empty List is returned.
+
+
 getchangelist([{buf}])					*getchangelist()*
 		Returns the |changelist| for the buffer {buf}. For the use
 		of {buf}, see |bufname()| above. If buffer {buf} doesn't

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -624,6 +624,7 @@ String manipulation:					*string-functions*
 	strwidth()		size of string when displayed
 	strdisplaywidth()	size of string when displayed, deals with tabs
 	setcellwidths()		set character cell width overrides
+	getcellwidths()		get character cell width overrides
 	substitute()		substitute a pattern match with a string
 	submatch()		get a specific match in ":s" and substitute()
 	strpart()		get part of a string using byte index

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -148,6 +148,7 @@ return {
     getbufline={args={2, 3}, base=1},
     getbufoneline={args=2, base=1},
     getbufvar={args={2, 3}, base=1},
+    getcellwidths={},
     getchangelist={args={0, 1}, base=1},
     getchar={args={0, 1}},
     getcharmod={},

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2795,6 +2795,21 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   redraw_all_later(UPD_NOT_VALID);
 }
 
+/// "getcellwidths()" function
+void f_getcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  tv_list_alloc_ret(rettv, (ptrdiff_t)cw_table_size);
+
+  for (size_t i = 0; i < cw_table_size; i++) {
+    list_T *entry = tv_list_alloc(3);
+    tv_list_append_number(entry, (varnumber_T)cw_table[i].first);
+    tv_list_append_number(entry, (varnumber_T)cw_table[i].last);
+    tv_list_append_number(entry, (varnumber_T)cw_table[i].width);
+
+    tv_list_append_list(rettv->vval.v_list, entry);
+  }
+}
+
 void f_charclass(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   if (tv_check_for_string_arg(argvars, 0) == FAIL

--- a/src/nvim/testdir/test_utf8.vim
+++ b/src/nvim/testdir/test_utf8.vim
@@ -199,6 +199,26 @@ func Test_setcellwidths()
   call setcellwidths([])
 endfunc
 
+func Test_getcellwidths()
+  call setcellwidths([])
+  call assert_equal([], getcellwidths())
+
+  let widthlist = [
+        \ [0x1330, 0x1330, 2],
+        \ [9999, 10000, 1],
+        \ [0x1337, 0x1339, 2],
+        \]
+  let widthlistsorted = [
+        \ [0x1330, 0x1330, 2],
+        \ [0x1337, 0x1339, 2],
+        \ [9999, 10000, 1],
+        \]
+  call setcellwidths(widthlist)
+  call assert_equal(widthlistsorted, getcellwidths())
+
+  call setcellwidths([])
+endfunc
+
 func Test_setcellwidths_dump()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
#### vim-patch:9.0.1212: cannot read back what setcellwidths() has done

Problem:    Cannot read back what setcellwidths() has done.
Solution:   Add getcellwidths(). (Kota Kato, closes vim/vim#11837)

https://github.com/vim/vim/commit/66bb9ae70f7371456ed76518076d2a344f8ab417

Co-authored-by: Kota Kato <github@kat0h.com>