### PR TITLE
vim-patch:9.0.{1214,1215}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2852,7 +2852,7 @@ bool checkforcmd(char **pp, const char *cmd, int len)
       break;
     }
   }
-  if (i >= len && !isalpha((uint8_t)(*pp)[i])) {
+  if (i >= len && !ASCII_ISALPHA((*pp)[i])) {
     *pp = skipwhite(*pp + i);
     return true;
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1106,7 +1106,7 @@ int do_set(char *arg, int opt_flags)
     char *errmsg = NULL;
     char *startarg = arg;             // remember for error message
 
-    if (strncmp(arg, "all", 3) == 0 && !isalpha((uint8_t)arg[3])
+    if (strncmp(arg, "all", 3) == 0 && !ASCII_ISALPHA(arg[3])
         && !(opt_flags & OPT_MODELINE)) {
       // ":set all"  show all options.
       // ":set all&" set all options to their default value.

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1768,7 +1768,7 @@ int path_with_url(const char *fname)
   // non-URL text.
 
   // first character must be alpha
-  if (!isalpha((uint8_t)(*fname))) {
+  if (!ASCII_ISALPHA(*fname)) {
     return 0;
   }
 
@@ -1777,7 +1777,7 @@ int path_with_url(const char *fname)
   }
 
   // check body: alpha or dash
-  for (p = fname + 1; (isalpha((uint8_t)(*p)) || (*p == '-')); p++) {}
+  for (p = fname + 1; (ASCII_ISALPHA(*p) || (*p == '-')); p++) {}
 
   // check last char is not a dash
   if (p[-1] == '-') {

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -629,6 +629,7 @@ func Test_WinScrolled_diff()
         \ }, event)
 
   call StopVimInTerminal(buf)
+  call delete('XscrollEvent')
 endfunc
 
 func Test_WinClosed()


### PR DESCRIPTION
#### vim-patch:9.0.1214: file left behind after running tests

Problem:    File left behind after running tests.
Solution:   Delete the file. (Dominique Pellé, closes vim/vim#11839)

https://github.com/vim/vim/commit/541c87c808df91b55e51fedc4987152a3edfe80d

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>


#### vim-patch:9.0.1215: using isalpha() adds dependency on current locale

Problem:    Using isalpha() adds dependency on current locale.
Solution:   Do not use isalpha() for recognizing a URL or the end of an Ex
            command. (closes vim/vim#11835)

https://github.com/vim/vim/commit/0ef9a5c09482649cf0cc6768ed6fc640b4ed2a0a