### PR TITLE
vim-patch:9.0.1213: adding a line below the last one does not expand fold

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -418,14 +418,7 @@ void appended_lines(linenr_T lnum, linenr_T count)
 /// Like appended_lines(), but adjust marks first.
 void appended_lines_mark(linenr_T lnum, long count)
 {
-  // Skip mark_adjust when adding a line after the last one, there can't
-  // be marks there. But it's still needed in diff mode.
-  if (lnum + count < curbuf->b_ml.ml_line_count || curwin->w_p_diff) {
-    mark_adjust(lnum + 1, (linenr_T)MAXLNUM, (linenr_T)count, 0L, kExtmarkUndo);
-  } else {
-    extmark_adjust(curbuf, lnum + 1, (linenr_T)MAXLNUM, (linenr_T)count, 0L,
-                   kExtmarkUndo);
-  }
+  mark_adjust(lnum + 1, (linenr_T)MAXLNUM, (linenr_T)count, 0L, kExtmarkUndo);
   changed_lines(lnum + 1, 0, lnum + 1, (linenr_T)count, true);
 }
 
@@ -1694,13 +1687,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
     }
     // Postpone calling changed_lines(), because it would mess up folding
     // with markers.
-    // Skip mark_adjust when adding a line after the last one, there can't
-    // be marks there. But still needed in diff mode.
-    if (curwin->w_cursor.lnum + 1 < curbuf->b_ml.ml_line_count
-        || curwin->w_p_diff) {
-      mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L,
-                  kExtmarkNOOP);
-    }
+    mark_adjust(curwin->w_cursor.lnum + 1, (linenr_T)MAXLNUM, 1L, 0L, kExtmarkNOOP);
     did_append = true;
   } else {
     // In MODE_VREPLACE state we are starting to replace the next line.

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1483,4 +1483,17 @@ func Test_indent_with_L_command()
   bwipe!
 endfunc
 
+" Make sure that when there is a fold at the bottom of the buffer and a newline
+" character is appended to the line, the fold gets expanded (instead of the new
+" line not being part of the fold).
+func Test_expand_fold_at_bottom_of_buffer()
+  new
+  " create a fold on the only line
+  fold
+  execute "normal A\<CR>"
+  call assert_equal([1, 1], range(1, 2)->map('foldlevel(v:val)'))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1213: adding a line below the last one does not expand fold

Problem:    Adding a line below the last one does not expand fold.
Solution:   Do not skip mark_adjust() when adding lines below the last one.
            (Brandon Simmons, closes vim/vim#11832)

https://github.com/vim/vim/commit/da3dd7d857ba4fb4bf408dedd1d9d6a2d5e2ae9f

Co-authored-by: Brandon Simmons <simmsbra@gmail.com>