### PR TITLE
refactor(PVS): suppress false positive V547 in drawline.c

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1824,7 +1824,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
           syntax_attr = get_syntax_attr((colnr_T)v - 1,
                                         has_spell ? &can_spell : NULL, false);
 
-          if (did_emsg) {
+          if (did_emsg) {  // -V547
             wp->w_s->b_syn_error = true;
             has_syntax = false;
           } else {


### PR DESCRIPTION
The statement `if (did_emsg)` is never executed as `did_emsg` is set to false right before it. The else is always executed, which simply sets `did_emsg` to its previous value, even though `did_emsg` never changes. Therefore, we can remove the variable `save_did_ems`g, its code, and the `if-else` statement.

Unless I missed something(such as `did_emsg` changing somewhere), this approach seems to be correct.

EDIT: See discussion