### PR TITLE
vim-patch:9.0.0149: test for fuzzy completion fails sometimes

### DIFF
--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2704,17 +2704,18 @@ endfunc
 " buffer name fuzzy completion
 func Test_fuzzy_completion_bufname()
   set wildoptions&
-  edit SomeFile.txt
+  " Use a long name to reduce the risk of matching a random directory name
+  edit SomeRandomFileWithLetters.txt
   enew
-  call feedkeys(":b SF\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b SF', @:)
-  call feedkeys(":b S*File.txt\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b SomeFile.txt', @:)
+  call feedkeys(":b SRFWL\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b SRFWL', @:)
+  call feedkeys(":b S*FileWithLetters.txt\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b SomeRandomFileWithLetters.txt', @:)
   set wildoptions=fuzzy
-  call feedkeys(":b SF\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b SomeFile.txt', @:)
-  call feedkeys(":b S*File.txt\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b S*File.txt', @:)
+  call feedkeys(":b SRFWL\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b SomeRandomFileWithLetters.txt', @:)
+  call feedkeys(":b S*FileWithLetters.txt\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b S*FileWithLetters.txt', @:)
   %bw!
   set wildoptions&
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.0149: test for fuzzy completion fails sometimes

Problem:    Test for fuzzy completion fails sometimes.
Solution:   Use a more specific file name to minimize the chance of matching a
            random directory name.

https://github.com/vim/vim/commit/5ac4b1a24e3ba52698a0d24b22cdd2e1c7895417

Co-authored-by: Bram Moolenaar <Bram@vim.org>