### PR TITLE
fix(statuscolumn): always fill click defs array

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -894,13 +894,10 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int
                                fillchar, maxwidth, hlrec, &clickrec, stcp);
   xfree(stc);
 
-  // Allocate and fill click def array if width has changed
-  if (wp->w_status_click_defs_size != (size_t)width) {
-    stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
-    wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, width,
-                                                      &wp->w_statuscol_click_defs_size);
-    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, width, false);
-  }
+  stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
+  wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, width,
+                                                    &wp->w_statuscol_click_defs_size);
+  stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, width, false);
 
   return width;
 }

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -5,6 +5,7 @@ local command = helpers.command
 local eq = helpers.eq
 local eval = helpers.eval
 local exec_lua = helpers.exec_lua
+local feed = helpers.feed
 local meths = helpers.meths
 local pcall_err = helpers.pcall_err
 
@@ -413,6 +414,19 @@ describe('statuscolumn', function()
     eq('', eval("g:testvar"))
   end)
 
+  it('click labels do not leak memory', function()
+    command([[
+      set laststatus=2
+      setlocal statuscolumn=%0@MyClickFunc@abcd%T
+      4vsplit
+      setlocal statusline=abcd
+      redrawstatus
+      setlocal statusline=
+      only
+      redraw
+    ]])
+  end)
+
   it('works with foldcolumn', function()
     -- Fits maximum multibyte foldcolumn #21759
     command([[set stc=%C%=%l\  fdc=9 fillchars=foldsep:𒀀]])
@@ -425,7 +439,7 @@ describe('statuscolumn', function()
       vim.api.nvim_buf_set_extmark(0, ns, 7, 0, {
         virt_lines_leftcol = true, virt_lines = {{{"virt", ""}}} })
     ]])
-    helpers.feed('lh')  -- force update wcol/row
+    feed('lh')  -- force update wcol/row
     screen:expect([[
                 4 aaaaa                                    |
                 5 aaaaa                                    |


### PR DESCRIPTION
Click definitions are always filled for tabline, statusline and winbar,
so they should also be always filled for statuscolumn, otherwise it will
leak memory.


Note: this doesn't actually change the existing code much, because of a
typo in the existing code.