### PR TITLE
Fix statusline memory leaks with click labels

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -231,8 +231,12 @@ void stl_fill_click_defs(StlClickDefinition *click_defs, StlClickRecord *click_r
   };
   for (int i = 0; click_recs[i].start != NULL; i++) {
     len += vim_strnsize(buf, (int)(click_recs[i].start - buf));
-    while (col < len) {
-      click_defs[col++] = cur_click_def;
+    if (col < len) {
+      while (col < len) {
+        click_defs[col++] = cur_click_def;
+      }
+    } else {
+      xfree(cur_click_def.func);
     }
     buf = (char *)click_recs[i].start;
     cur_click_def = click_recs[i].def;
@@ -242,8 +246,12 @@ void stl_fill_click_defs(StlClickDefinition *click_defs, StlClickRecord *click_r
       cur_click_def.type = kStlClickDisabled;
     }
   }
-  while (col < width) {
-    click_defs[col++] = cur_click_def;
+  if (col < width) {
+    while (col < width) {
+      click_defs[col++] = cur_click_def;
+    }
+  } else {
+    xfree(cur_click_def.func);
   }
 }
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1987,6 +1987,11 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       // the truncation point
       for (int i = 0; i < itemcnt; i++) {
         if (stl_items[i].start > trunc_p) {
+          for (int j = i; j < itemcnt; j++) {
+            if (stl_items[j].type == ClickFunc) {
+              XFREE_CLEAR(stl_items[j].cmd);
+            }
+          }
           itemcnt = i;
           break;
         }

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -164,6 +164,16 @@ describe('statusline clicks', function()
     meths.input_mouse('right', 'press', '', 0, 6, 5)
     eq('0 1 r', eval("g:testvar"))
   end)
+
+  it('no memory leak with zero-width click labels', function()
+    command([[
+      let &stl = '%@Test@%T%@MyClickFunc@%=%T%@Test@'
+    ]])
+    meths.input_mouse('left', 'press', '', 0, 6, 0)
+    eq('0 1 l', eval("g:testvar"))
+    meths.input_mouse('right', 'press', '', 0, 6, 39)
+    eq('0 1 r', eval("g:testvar"))
+  end)
 end)
 
 describe('global statusline', function()

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -174,6 +174,14 @@ describe('statusline clicks', function()
     meths.input_mouse('right', 'press', '', 0, 6, 39)
     eq('0 1 r', eval("g:testvar"))
   end)
+
+  it('no memory leak with truncated click labels', function()
+    command([[
+      let &stl = '%@MyClickFunc@foo%X' .. repeat('a', 40) .. '%<t%@Test@bar%X%@Test@baz'
+    ]])
+    meths.input_mouse('left', 'press', '', 0, 6, 2)
+    eq('0 1 l', eval("g:testvar"))
+  end)
 end)
 
 describe('global statusline', function()


### PR DESCRIPTION
A zero-width click label isn't assigned to any click definition, so its
function name should be freed when filling click definitions.
