### PR TITLE
css for doc website: eliminate horizontal scroll bar and text overflow

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -913,9 +913,12 @@ local function gen_css(fname)
       padding-bottom: 10px;
       /* Tabs are used for alignment in old docs, so we must match Vim's 8-char expectation. */
       tab-size: 8;
-      white-space: pre;
+      white-space: pre-wrap;
       font-size: 16px;
       font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+    }
+    a {
+      word-break: break-all;
     }
     a.help-tag, a.help-tag:focus, a.help-tag:hover {
       color: inherit;


### PR DESCRIPTION
Please see: https://github.com/neovim/neovim.github.io/issues/315
before:
![before](https://user-images.githubusercontent.com/104709852/213185852-6985bbac-4f4b-4c5f-bbf5-3a40b1e938e0.png)
after:
![after](https://user-images.githubusercontent.com/104709852/213185902-a05b6f78-8d8d-4a44-a533-cd8f1e562cb6.png)

