### PR TITLE
perf(statuscolumn): only fill click defs array once per redraw

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6027,6 +6027,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 		      when drawing the actual buffer line, and positive when
 		      drawing the wrapped part of a buffer line.
 
+	NOTE: The %@ click execute function item is supported as well but the
+	specified function will be the same for each row in the same column.
+	It cannot be switched out through a dynamic 'statuscolumn' format, the
+	handler should be written with this in mind.
+
 	Examples: >vim
 		" Relative number with bar separator and click handlers:
 		:set statuscolumn=%@SignCb@%s%=%T%@NumCb@%r│%T

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -874,8 +874,8 @@ void draw_tabline(void)
   redraw_tabline = false;
 }
 
-/// Build the 'statuscolumn' string for line "lnum".  If "setnum" is true,
-/// update the "lnum" and "relnum" vim-variables for a new line.
+/// Build the 'statuscolumn' string for line "lnum". When "relnum" == -1,
+/// the v:lnum and v:relnum variables don't have to be updated.
 ///
 /// @param hlrec  HL attributes (can be NULL)
 /// @param stcp  Status column attributes (can be NULL)
@@ -883,6 +883,8 @@ void draw_tabline(void)
 int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int fillchar,
                         char *buf, stl_hlrec_t **hlrec, statuscol_T *stcp)
 {
+  bool fillclick = relnum >= 0 && lnum == wp->w_topline;
+
   if (relnum >= 0) {
     set_vim_var_nr(VV_LNUM, lnum);
     set_vim_var_nr(VV_RELNUM, relnum);
@@ -890,14 +892,17 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int
 
   StlClickRecord *clickrec;
   char *stc = xstrdup(wp->w_p_stc);
-  int width = build_stl_str_hl(wp, buf, MAXPATHL, stc, "statuscolumn", OPT_LOCAL,
-                               fillchar, maxwidth, hlrec, &clickrec, stcp);
+  int width = build_stl_str_hl(wp, buf, MAXPATHL, stc, "statuscolumn", OPT_LOCAL, fillchar,
+                               maxwidth, hlrec, fillclick ? &clickrec : NULL, stcp);
   xfree(stc);
 
-  stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
-  wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, width,
-                                                    &wp->w_statuscol_click_defs_size);
-  stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, width, false);
+  // Only update click definitions once per window per redraw
+  if (fillclick) {
+    stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
+    wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, width,
+                                                      &wp->w_statuscol_click_defs_size);
+    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, width, false);
+  }
 
   return width;
 }

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -61,7 +61,7 @@ describe('statuscolumn', function()
     ]])
   end)
 
-  it("works with 'statuscolumn'", function()
+  it("works with 'number' and 'relativenumber'", function()
     command([[set stc=%{&nu?v:lnum:''}%=%{&rnu?'\ '.v:relnum:''}│]])
     screen:expect([[
       4 │aaaaa                                             |


### PR DESCRIPTION
Problem:    'statuscolumn' click definitions are cleared, evaluated, allocated and filled each redraw for every row in a window. This despite the fact that we only store a single click definition array for the entire column as opposed to one for each row.
Solution:   Only fill the 'statuscolumn' click definition array once per window per redraw.

Resolve https://github.com/neovim/neovim/issues/21767.