### PR TITLE
refactor/options

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3474,7 +3474,7 @@ static void ins_ctrl_hat(void)
       State |= MODE_LANGMAP;
     }
   }
-  set_iminsert_global();
+  set_iminsert_global(curbuf);
   showmode();
   // Show/unshow value of 'keymap' in status lines.
   status_redraw_curbuf();

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1557,9 +1557,9 @@ static void command_line_toggle_langmap(CommandLineState *s)
 
   if (s->b_im_ptr != NULL) {
     if (s->b_im_ptr == &curbuf->b_p_iminsert) {
-      set_iminsert_global();
+      set_iminsert_global(curbuf);
     } else {
-      set_imsearch_global();
+      set_imsearch_global(curbuf);
     }
   }
   ui_cursor_shape();                // may show different cursor shape

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2258,14 +2258,14 @@ static void copy_global_to_buflocal_cb(Callback *globcb, Callback *bufcb)
 /// Invoked when the 'completefunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-int set_completefunc_option(void)
+void set_completefunc_option(char **errmsg)
 {
-  int retval = option_set_callback_func(curbuf->b_p_cfu, &cfu_cb);
-  if (retval == OK) {
-    set_buflocal_cfu_callback(curbuf);
+  if (option_set_callback_func(curbuf->b_p_cfu, &cfu_cb) == FAIL) {
+    *errmsg = e_invarg;
+    return;
   }
 
-  return retval;
+  set_buflocal_cfu_callback(curbuf);
 }
 
 /// Copy the global 'completefunc' callback function to the buffer-local
@@ -2279,14 +2279,13 @@ void set_buflocal_cfu_callback(buf_T *buf)
 /// Invoked when the 'omnifunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-int set_omnifunc_option(void)
+void set_omnifunc_option(buf_T *buf, char **errmsg)
 {
-  int retval = option_set_callback_func(curbuf->b_p_ofu, &ofu_cb);
-  if (retval == OK) {
-    set_buflocal_ofu_callback(curbuf);
+  if (option_set_callback_func(buf->b_p_ofu, &ofu_cb) == FAIL) {
+    *errmsg = e_invarg;
+    return;
   }
-
-  return retval;
+  set_buflocal_ofu_callback(buf);
 }
 
 /// Copy the global 'omnifunc' callback function to the buffer-local 'omnifunc'
@@ -2300,7 +2299,7 @@ void set_buflocal_ofu_callback(buf_T *buf)
 /// Invoked when the 'thesaurusfunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-int set_thesaurusfunc_option(void)
+void set_thesaurusfunc_option(char **errmsg)
 {
   int retval;
 
@@ -2312,7 +2311,9 @@ int set_thesaurusfunc_option(void)
     retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
   }
 
-  return retval;
+  if (retval == FAIL) {
+    *errmsg = e_invarg;
+  }
 }
 
 /// Mark the global 'completefunc' 'omnifunc' and 'thesaurusfunc' callbacks with

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5626,10 +5626,11 @@ static void op_colon(oparg_T *oap)
 static Callback opfunc_cb;
 
 /// Process the 'operatorfunc' option value.
-/// @return  OK or FAIL
-int set_operatorfunc_option(void)
+void set_operatorfunc_option(char **errmsg)
 {
-  return option_set_callback_func(p_opfunc, &opfunc_cb);
+  if (option_set_callback_func(p_opfunc, &opfunc_cb) == FAIL) {
+    *errmsg = e_invarg;
+  }
 }
 
 #if defined(EXITFREE)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2582,7 +2582,7 @@ static char *set_num_option(int opt_idx, char_u *varp, long value, char *errbuf,
 }
 
 /// Called after an option changed: check if something needs to be redrawn.
-void check_redraw(uint32_t flags)
+void check_redraw_for(buf_T *buf, win_T *win, uint32_t flags)
 {
   // Careful: P_RALL is a combination of other P_ flags
   bool all = (flags & P_RALL) == P_RALL;
@@ -2596,17 +2596,22 @@ void check_redraw(uint32_t flags)
   }
 
   if ((flags & P_RBUF) || (flags & P_RWIN) || all) {
-    changed_window_setting();
+    changed_window_setting_win(win);
   }
   if (flags & P_RBUF) {
-    redraw_curbuf_later(UPD_NOT_VALID);
+    redraw_buf_later(buf, UPD_NOT_VALID);
   }
   if (flags & P_RWINONLY) {
-    redraw_later(curwin, UPD_NOT_VALID);
+    redraw_later(win, UPD_NOT_VALID);
   }
   if (all) {
     redraw_all_later(UPD_NOT_VALID);
   }
+}
+
+void check_redraw(uint32_t flags)
+{
+  check_redraw_for(curbuf, curwin, flags);
 }
 
 /// Find index for named option

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2992,58 +2992,62 @@ char *set_option_value(const char *const name, const long number, const char *co
   int opt_idx = findoption(name);
   if (opt_idx < 0) {
     semsg(_("E355: Unknown option: %s"), name);
-  } else {
-    uint32_t flags = options[opt_idx].flags;
-    // Disallow changing some options in the sandbox
-    if (sandbox > 0 && (flags & P_SECURE)) {
-      emsg(_(e_sandbox));
-      return NULL;
-    }
-    if (flags & P_STRING) {
-      const char *s = string;
-      if (s == NULL || opt_flags & OPT_CLEAR) {
-        s = "";
-      }
-      return set_string_option(opt_idx, s, opt_flags);
-    }
+    return NULL;
+  }
 
-    char_u *varp = (char_u *)get_varp_scope(&(options[opt_idx]), opt_flags);
-    if (varp != NULL) {       // hidden option is not changed
-      if (number == 0 && string != NULL) {
-        int idx;
+  uint32_t flags = options[opt_idx].flags;
+  // Disallow changing some options in the sandbox
+  if (sandbox > 0 && (flags & P_SECURE)) {
+    emsg(_(e_sandbox));
+    return NULL;
+  }
 
-        // Either we are given a string or we are setting option
-        // to zero.
-        for (idx = 0; string[idx] == '0'; idx++) {}
-        if (string[idx] != NUL || idx == 0) {
-          // There's another character after zeros or the string
-          // is empty.  In both cases, we are trying to set a
-          // num option using a string.
-          semsg(_("E521: Number required: &%s = '%s'"),
-                name, string);
-          return NULL;  // do nothing as we hit an error
-        }
-      }
-      long numval = number;
-      if (opt_flags & OPT_CLEAR) {
-        if ((int *)varp == &curbuf->b_p_ar) {
-          numval = -1;
-        } else if ((long *)varp == &curbuf->b_p_ul) {
-          numval = NO_LOCAL_UNDOLEVEL;
-        } else if ((long *)varp == &curwin->w_p_so || (long *)varp == &curwin->w_p_siso) {
-          numval = -1;
-        } else {
-          char *s = NULL;
-          (void)get_option_value(name, &numval, &s, NULL, OPT_GLOBAL);
-        }
-      }
-      if (flags & P_NUM) {
-        return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
-      }
-      return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
+  if (flags & P_STRING) {
+    const char *s = string;
+    if (s == NULL || opt_flags & OPT_CLEAR) {
+      s = "";
+    }
+    return set_string_option(opt_idx, s, opt_flags);
+  }
+
+  char_u *varp = (char_u *)get_varp_scope(&(options[opt_idx]), opt_flags);
+  if (varp == NULL) {
+    // hidden option is not changed
+    return NULL;
+  }
+
+  if (number == 0 && string != NULL) {
+    int idx;
+
+    // Either we are given a string or we are setting option
+    // to zero.
+    for (idx = 0; string[idx] == '0'; idx++) {}
+    if (string[idx] != NUL || idx == 0) {
+      // There's another character after zeros or the string
+      // is empty.  In both cases, we are trying to set a
+      // num option using a string.
+      semsg(_("E521: Number required: &%s = '%s'"),
+            name, string);
+      return NULL;  // do nothing as we hit an error
     }
   }
-  return NULL;
+  long numval = number;
+  if (opt_flags & OPT_CLEAR) {
+    if ((int *)varp == &curbuf->b_p_ar) {
+      numval = -1;
+    } else if ((long *)varp == &curbuf->b_p_ul) {
+      numval = NO_LOCAL_UNDOLEVEL;
+    } else if ((long *)varp == &curwin->w_p_so || (long *)varp == &curwin->w_p_siso) {
+      numval = -1;
+    } else {
+      char *s = NULL;
+      (void)get_option_value(name, &numval, &s, NULL, OPT_GLOBAL);
+    }
+  }
+  if (flags & P_NUM) {
+    return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
+  }
+  return set_bool_option(opt_idx, varp, (int)numval, opt_flags);
 }
 
 /// Call set_option_value() and when an error is returned report it.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4508,15 +4508,15 @@ void reset_modifiable(void)
 }
 
 /// Set the global value for 'iminsert' to the local value.
-void set_iminsert_global(void)
+void set_iminsert_global(buf_T *buf)
 {
-  p_iminsert = curbuf->b_p_iminsert;
+  p_iminsert = buf->b_p_iminsert;
 }
 
 /// Set the global value for 'imsearch' to the local value.
-void set_imsearch_global(void)
+void set_imsearch_global(buf_T *buf)
 {
-  p_imsearch = curbuf->b_p_imsearch;
+  p_imsearch = buf->b_p_imsearch;
 }
 
 static int expand_option_idx = -1;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3628,83 +3628,87 @@ void unset_global_local_option(char *name, void *from)
   }
 }
 
-/// Get pointer to option variable, depending on local or global scope.
-///
-/// @param scope  can be OPT_LOCAL, OPT_GLOBAL or a combination.
-char *get_varp_scope(vimoption_T *p, int scope)
+char *get_varp_scope_from(vimoption_T *p, int scope, buf_T *buf, win_T *win)
 {
   if ((scope & OPT_GLOBAL) && p->indir != PV_NONE) {
     if (p->var == VAR_WIN) {
-      return GLOBAL_WO(get_varp(p));
+      return GLOBAL_WO(get_varp_from(p, buf, win));
     }
     return (char *)p->var;
   }
   if ((scope & OPT_LOCAL) && ((int)p->indir & PV_BOTH)) {
     switch ((int)p->indir) {
     case PV_FP:
-      return (char *)&(curbuf->b_p_fp);
+      return (char *)&(buf->b_p_fp);
     case PV_EFM:
-      return (char *)&(curbuf->b_p_efm);
+      return (char *)&(buf->b_p_efm);
     case PV_GP:
-      return (char *)&(curbuf->b_p_gp);
+      return (char *)&(buf->b_p_gp);
     case PV_MP:
-      return (char *)&(curbuf->b_p_mp);
+      return (char *)&(buf->b_p_mp);
     case PV_EP:
-      return (char *)&(curbuf->b_p_ep);
+      return (char *)&(buf->b_p_ep);
     case PV_KP:
-      return (char *)&(curbuf->b_p_kp);
+      return (char *)&(buf->b_p_kp);
     case PV_PATH:
-      return (char *)&(curbuf->b_p_path);
+      return (char *)&(buf->b_p_path);
     case PV_AR:
-      return (char *)&(curbuf->b_p_ar);
+      return (char *)&(buf->b_p_ar);
     case PV_TAGS:
-      return (char *)&(curbuf->b_p_tags);
+      return (char *)&(buf->b_p_tags);
     case PV_TC:
-      return (char *)&(curbuf->b_p_tc);
+      return (char *)&(buf->b_p_tc);
     case PV_SISO:
-      return (char *)&(curwin->w_p_siso);
+      return (char *)&(win->w_p_siso);
     case PV_SO:
-      return (char *)&(curwin->w_p_so);
+      return (char *)&(win->w_p_so);
     case PV_DEF:
-      return (char *)&(curbuf->b_p_def);
+      return (char *)&(buf->b_p_def);
     case PV_INC:
-      return (char *)&(curbuf->b_p_inc);
+      return (char *)&(buf->b_p_inc);
     case PV_DICT:
-      return (char *)&(curbuf->b_p_dict);
+      return (char *)&(buf->b_p_dict);
     case PV_TSR:
-      return (char *)&(curbuf->b_p_tsr);
+      return (char *)&(buf->b_p_tsr);
     case PV_TSRFU:
-      return (char *)&(curbuf->b_p_tsrfu);
+      return (char *)&(buf->b_p_tsrfu);
     case PV_TFU:
-      return (char *)&(curbuf->b_p_tfu);
+      return (char *)&(buf->b_p_tfu);
     case PV_SBR:
-      return (char *)&(curwin->w_p_sbr);
+      return (char *)&(win->w_p_sbr);
     case PV_STL:
-      return (char *)&(curwin->w_p_stl);
+      return (char *)&(win->w_p_stl);
     case PV_WBR:
-      return (char *)&(curwin->w_p_wbr);
+      return (char *)&(win->w_p_wbr);
     case PV_UL:
-      return (char *)&(curbuf->b_p_ul);
+      return (char *)&(buf->b_p_ul);
     case PV_LW:
-      return (char *)&(curbuf->b_p_lw);
+      return (char *)&(buf->b_p_lw);
     case PV_BKC:
-      return (char *)&(curbuf->b_p_bkc);
+      return (char *)&(buf->b_p_bkc);
     case PV_MENC:
-      return (char *)&(curbuf->b_p_menc);
+      return (char *)&(buf->b_p_menc);
     case PV_FCS:
-      return (char *)&(curwin->w_p_fcs);
+      return (char *)&(win->w_p_fcs);
     case PV_LCS:
-      return (char *)&(curwin->w_p_lcs);
+      return (char *)&(win->w_p_lcs);
     case PV_VE:
-      return (char *)&(curwin->w_p_ve);
+      return (char *)&(win->w_p_ve);
     }
     return NULL;     // "cannot happen"
   }
-  return (char *)get_varp(p);
+  return (char *)get_varp_from(p, buf, win);
 }
 
-/// Get pointer to option variable.
-static char_u *get_varp(vimoption_T *p)
+/// Get pointer to option variable, depending on local or global scope.
+///
+/// @param scope  can be OPT_LOCAL, OPT_GLOBAL or a combination.
+char *get_varp_scope(vimoption_T *p, int scope)
+{
+  return get_varp_scope_from(p, scope, curbuf, curwin);
+}
+
+static char_u *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
 {
   // hidden option, always return NULL
   if (p->var == NULL) {
@@ -3717,305 +3721,311 @@ static char_u *get_varp(vimoption_T *p)
 
   // global option with local value: use local value if it's been set
   case PV_EP:
-    return *curbuf->b_p_ep != NUL
-           ? (char_u *)&curbuf->b_p_ep : p->var;
+    return *buf->b_p_ep != NUL
+           ? (char_u *)&buf->b_p_ep : p->var;
   case PV_KP:
-    return *curbuf->b_p_kp != NUL
-           ? (char_u *)&curbuf->b_p_kp : p->var;
+    return *buf->b_p_kp != NUL
+           ? (char_u *)&buf->b_p_kp : p->var;
   case PV_PATH:
-    return *curbuf->b_p_path != NUL
-           ? (char_u *)&(curbuf->b_p_path) : p->var;
+    return *buf->b_p_path != NUL
+           ? (char_u *)&(buf->b_p_path) : p->var;
   case PV_AR:
-    return curbuf->b_p_ar >= 0
-           ? (char_u *)&(curbuf->b_p_ar) : p->var;
+    return buf->b_p_ar >= 0
+           ? (char_u *)&(buf->b_p_ar) : p->var;
   case PV_TAGS:
-    return *curbuf->b_p_tags != NUL
-           ? (char_u *)&(curbuf->b_p_tags) : p->var;
+    return *buf->b_p_tags != NUL
+           ? (char_u *)&(buf->b_p_tags) : p->var;
   case PV_TC:
-    return *curbuf->b_p_tc != NUL
-           ? (char_u *)&(curbuf->b_p_tc) : p->var;
+    return *buf->b_p_tc != NUL
+           ? (char_u *)&(buf->b_p_tc) : p->var;
   case PV_SISO:
-    return curwin->w_p_siso >= 0
-           ? (char_u *)&(curwin->w_p_siso) : p->var;
+    return win->w_p_siso >= 0
+           ? (char_u *)&(win->w_p_siso) : p->var;
   case PV_SO:
-    return curwin->w_p_so >= 0
-           ? (char_u *)&(curwin->w_p_so) : p->var;
+    return win->w_p_so >= 0
+           ? (char_u *)&(win->w_p_so) : p->var;
   case PV_BKC:
-    return *curbuf->b_p_bkc != NUL
-           ? (char_u *)&(curbuf->b_p_bkc) : p->var;
+    return *buf->b_p_bkc != NUL
+           ? (char_u *)&(buf->b_p_bkc) : p->var;
   case PV_DEF:
-    return *curbuf->b_p_def != NUL
-           ? (char_u *)&(curbuf->b_p_def) : p->var;
+    return *buf->b_p_def != NUL
+           ? (char_u *)&(buf->b_p_def) : p->var;
   case PV_INC:
-    return *curbuf->b_p_inc != NUL
-           ? (char_u *)&(curbuf->b_p_inc) : p->var;
+    return *buf->b_p_inc != NUL
+           ? (char_u *)&(buf->b_p_inc) : p->var;
   case PV_DICT:
-    return *curbuf->b_p_dict != NUL
-           ? (char_u *)&(curbuf->b_p_dict) : p->var;
+    return *buf->b_p_dict != NUL
+           ? (char_u *)&(buf->b_p_dict) : p->var;
   case PV_TSR:
-    return *curbuf->b_p_tsr != NUL
-           ? (char_u *)&(curbuf->b_p_tsr) : p->var;
+    return *buf->b_p_tsr != NUL
+           ? (char_u *)&(buf->b_p_tsr) : p->var;
   case PV_TSRFU:
-    return *curbuf->b_p_tsrfu != NUL
-           ? (char_u *)&(curbuf->b_p_tsrfu) : p->var;
+    return *buf->b_p_tsrfu != NUL
+           ? (char_u *)&(buf->b_p_tsrfu) : p->var;
   case PV_FP:
-    return *curbuf->b_p_fp != NUL
-           ? (char_u *)&(curbuf->b_p_fp) : p->var;
+    return *buf->b_p_fp != NUL
+           ? (char_u *)&(buf->b_p_fp) : p->var;
   case PV_EFM:
-    return *curbuf->b_p_efm != NUL
-           ? (char_u *)&(curbuf->b_p_efm) : p->var;
+    return *buf->b_p_efm != NUL
+           ? (char_u *)&(buf->b_p_efm) : p->var;
   case PV_GP:
-    return *curbuf->b_p_gp != NUL
-           ? (char_u *)&(curbuf->b_p_gp) : p->var;
+    return *buf->b_p_gp != NUL
+           ? (char_u *)&(buf->b_p_gp) : p->var;
   case PV_MP:
-    return *curbuf->b_p_mp != NUL
-           ? (char_u *)&(curbuf->b_p_mp) : p->var;
+    return *buf->b_p_mp != NUL
+           ? (char_u *)&(buf->b_p_mp) : p->var;
   case PV_SBR:
-    return *curwin->w_p_sbr != NUL
-           ? (char_u *)&(curwin->w_p_sbr) : p->var;
+    return *win->w_p_sbr != NUL
+           ? (char_u *)&(win->w_p_sbr) : p->var;
   case PV_STL:
-    return *curwin->w_p_stl != NUL
-           ? (char_u *)&(curwin->w_p_stl) : p->var;
+    return *win->w_p_stl != NUL
+           ? (char_u *)&(win->w_p_stl) : p->var;
   case PV_WBR:
-    return *curwin->w_p_wbr != NUL
-           ? (char_u *)&(curwin->w_p_wbr) : p->var;
+    return *win->w_p_wbr != NUL
+           ? (char_u *)&(win->w_p_wbr) : p->var;
   case PV_UL:
-    return curbuf->b_p_ul != NO_LOCAL_UNDOLEVEL
-           ? (char_u *)&(curbuf->b_p_ul) : p->var;
+    return buf->b_p_ul != NO_LOCAL_UNDOLEVEL
+           ? (char_u *)&(buf->b_p_ul) : p->var;
   case PV_LW:
-    return *curbuf->b_p_lw != NUL
-           ? (char_u *)&(curbuf->b_p_lw) : p->var;
+    return *buf->b_p_lw != NUL
+           ? (char_u *)&(buf->b_p_lw) : p->var;
   case PV_MENC:
-    return *curbuf->b_p_menc != NUL
-           ? (char_u *)&(curbuf->b_p_menc) : p->var;
+    return *buf->b_p_menc != NUL
+           ? (char_u *)&(buf->b_p_menc) : p->var;
   case PV_FCS:
-    return *curwin->w_p_fcs != NUL
-           ? (char_u *)&(curwin->w_p_fcs) : p->var;
+    return *win->w_p_fcs != NUL
+           ? (char_u *)&(win->w_p_fcs) : p->var;
   case PV_LCS:
-    return *curwin->w_p_lcs != NUL
-           ? (char_u *)&(curwin->w_p_lcs) : p->var;
+    return *win->w_p_lcs != NUL
+           ? (char_u *)&(win->w_p_lcs) : p->var;
   case PV_VE:
-    return *curwin->w_p_ve != NUL
-           ? (char_u *)&curwin->w_p_ve : p->var;
+    return *win->w_p_ve != NUL
+           ? (char_u *)&win->w_p_ve : p->var;
 
   case PV_ARAB:
-    return (char_u *)&(curwin->w_p_arab);
+    return (char_u *)&(win->w_p_arab);
   case PV_LIST:
-    return (char_u *)&(curwin->w_p_list);
+    return (char_u *)&(win->w_p_list);
   case PV_SPELL:
-    return (char_u *)&(curwin->w_p_spell);
+    return (char_u *)&(win->w_p_spell);
   case PV_CUC:
-    return (char_u *)&(curwin->w_p_cuc);
+    return (char_u *)&(win->w_p_cuc);
   case PV_CUL:
-    return (char_u *)&(curwin->w_p_cul);
+    return (char_u *)&(win->w_p_cul);
   case PV_CULOPT:
-    return (char_u *)&(curwin->w_p_culopt);
+    return (char_u *)&(win->w_p_culopt);
   case PV_CC:
-    return (char_u *)&(curwin->w_p_cc);
+    return (char_u *)&(win->w_p_cc);
   case PV_DIFF:
-    return (char_u *)&(curwin->w_p_diff);
+    return (char_u *)&(win->w_p_diff);
   case PV_FDC:
-    return (char_u *)&(curwin->w_p_fdc);
+    return (char_u *)&(win->w_p_fdc);
   case PV_FEN:
-    return (char_u *)&(curwin->w_p_fen);
+    return (char_u *)&(win->w_p_fen);
   case PV_FDI:
-    return (char_u *)&(curwin->w_p_fdi);
+    return (char_u *)&(win->w_p_fdi);
   case PV_FDL:
-    return (char_u *)&(curwin->w_p_fdl);
+    return (char_u *)&(win->w_p_fdl);
   case PV_FDM:
-    return (char_u *)&(curwin->w_p_fdm);
+    return (char_u *)&(win->w_p_fdm);
   case PV_FML:
-    return (char_u *)&(curwin->w_p_fml);
+    return (char_u *)&(win->w_p_fml);
   case PV_FDN:
-    return (char_u *)&(curwin->w_p_fdn);
+    return (char_u *)&(win->w_p_fdn);
   case PV_FDE:
-    return (char_u *)&(curwin->w_p_fde);
+    return (char_u *)&(win->w_p_fde);
   case PV_FDT:
-    return (char_u *)&(curwin->w_p_fdt);
+    return (char_u *)&(win->w_p_fdt);
   case PV_FMR:
-    return (char_u *)&(curwin->w_p_fmr);
+    return (char_u *)&(win->w_p_fmr);
   case PV_NU:
-    return (char_u *)&(curwin->w_p_nu);
+    return (char_u *)&(win->w_p_nu);
   case PV_RNU:
-    return (char_u *)&(curwin->w_p_rnu);
+    return (char_u *)&(win->w_p_rnu);
   case PV_NUW:
-    return (char_u *)&(curwin->w_p_nuw);
+    return (char_u *)&(win->w_p_nuw);
   case PV_WFH:
-    return (char_u *)&(curwin->w_p_wfh);
+    return (char_u *)&(win->w_p_wfh);
   case PV_WFW:
-    return (char_u *)&(curwin->w_p_wfw);
+    return (char_u *)&(win->w_p_wfw);
   case PV_PVW:
-    return (char_u *)&(curwin->w_p_pvw);
+    return (char_u *)&(win->w_p_pvw);
   case PV_RL:
-    return (char_u *)&(curwin->w_p_rl);
+    return (char_u *)&(win->w_p_rl);
   case PV_RLC:
-    return (char_u *)&(curwin->w_p_rlc);
+    return (char_u *)&(win->w_p_rlc);
   case PV_SCROLL:
-    return (char_u *)&(curwin->w_p_scr);
+    return (char_u *)&(win->w_p_scr);
   case PV_WRAP:
-    return (char_u *)&(curwin->w_p_wrap);
+    return (char_u *)&(win->w_p_wrap);
   case PV_LBR:
-    return (char_u *)&(curwin->w_p_lbr);
+    return (char_u *)&(win->w_p_lbr);
   case PV_BRI:
-    return (char_u *)&(curwin->w_p_bri);
+    return (char_u *)&(win->w_p_bri);
   case PV_BRIOPT:
-    return (char_u *)&(curwin->w_p_briopt);
+    return (char_u *)&(win->w_p_briopt);
   case PV_SCBIND:
-    return (char_u *)&(curwin->w_p_scb);
+    return (char_u *)&(win->w_p_scb);
   case PV_CRBIND:
-    return (char_u *)&(curwin->w_p_crb);
+    return (char_u *)&(win->w_p_crb);
   case PV_COCU:
-    return (char_u *)&(curwin->w_p_cocu);
+    return (char_u *)&(win->w_p_cocu);
   case PV_COLE:
-    return (char_u *)&(curwin->w_p_cole);
+    return (char_u *)&(win->w_p_cole);
 
   case PV_AI:
-    return (char_u *)&(curbuf->b_p_ai);
+    return (char_u *)&(buf->b_p_ai);
   case PV_BIN:
-    return (char_u *)&(curbuf->b_p_bin);
+    return (char_u *)&(buf->b_p_bin);
   case PV_BOMB:
-    return (char_u *)&(curbuf->b_p_bomb);
+    return (char_u *)&(buf->b_p_bomb);
   case PV_BH:
-    return (char_u *)&(curbuf->b_p_bh);
+    return (char_u *)&(buf->b_p_bh);
   case PV_BT:
-    return (char_u *)&(curbuf->b_p_bt);
+    return (char_u *)&(buf->b_p_bt);
   case PV_BL:
-    return (char_u *)&(curbuf->b_p_bl);
+    return (char_u *)&(buf->b_p_bl);
   case PV_CHANNEL:
-    return (char_u *)&(curbuf->b_p_channel);
+    return (char_u *)&(buf->b_p_channel);
   case PV_CI:
-    return (char_u *)&(curbuf->b_p_ci);
+    return (char_u *)&(buf->b_p_ci);
   case PV_CIN:
-    return (char_u *)&(curbuf->b_p_cin);
+    return (char_u *)&(buf->b_p_cin);
   case PV_CINK:
-    return (char_u *)&(curbuf->b_p_cink);
+    return (char_u *)&(buf->b_p_cink);
   case PV_CINO:
-    return (char_u *)&(curbuf->b_p_cino);
+    return (char_u *)&(buf->b_p_cino);
   case PV_CINSD:
-    return (char_u *)&(curbuf->b_p_cinsd);
+    return (char_u *)&(buf->b_p_cinsd);
   case PV_CINW:
-    return (char_u *)&(curbuf->b_p_cinw);
+    return (char_u *)&(buf->b_p_cinw);
   case PV_COM:
-    return (char_u *)&(curbuf->b_p_com);
+    return (char_u *)&(buf->b_p_com);
   case PV_CMS:
-    return (char_u *)&(curbuf->b_p_cms);
+    return (char_u *)&(buf->b_p_cms);
   case PV_CPT:
-    return (char_u *)&(curbuf->b_p_cpt);
+    return (char_u *)&(buf->b_p_cpt);
 #ifdef BACKSLASH_IN_FILENAME
   case PV_CSL:
-    return (char_u *)&(curbuf->b_p_csl);
+    return (char_u *)&(buf->b_p_csl);
 #endif
   case PV_CFU:
-    return (char_u *)&(curbuf->b_p_cfu);
+    return (char_u *)&(buf->b_p_cfu);
   case PV_OFU:
-    return (char_u *)&(curbuf->b_p_ofu);
+    return (char_u *)&(buf->b_p_ofu);
   case PV_EOF:
-    return (char_u *)&(curbuf->b_p_eof);
+    return (char_u *)&(buf->b_p_eof);
   case PV_EOL:
-    return (char_u *)&(curbuf->b_p_eol);
+    return (char_u *)&(buf->b_p_eol);
   case PV_FIXEOL:
-    return (char_u *)&(curbuf->b_p_fixeol);
+    return (char_u *)&(buf->b_p_fixeol);
   case PV_ET:
-    return (char_u *)&(curbuf->b_p_et);
+    return (char_u *)&(buf->b_p_et);
   case PV_FENC:
-    return (char_u *)&(curbuf->b_p_fenc);
+    return (char_u *)&(buf->b_p_fenc);
   case PV_FF:
-    return (char_u *)&(curbuf->b_p_ff);
+    return (char_u *)&(buf->b_p_ff);
   case PV_FT:
-    return (char_u *)&(curbuf->b_p_ft);
+    return (char_u *)&(buf->b_p_ft);
   case PV_FO:
-    return (char_u *)&(curbuf->b_p_fo);
+    return (char_u *)&(buf->b_p_fo);
   case PV_FLP:
-    return (char_u *)&(curbuf->b_p_flp);
+    return (char_u *)&(buf->b_p_flp);
   case PV_IMI:
-    return (char_u *)&(curbuf->b_p_iminsert);
+    return (char_u *)&(buf->b_p_iminsert);
   case PV_IMS:
-    return (char_u *)&(curbuf->b_p_imsearch);
+    return (char_u *)&(buf->b_p_imsearch);
   case PV_INF:
-    return (char_u *)&(curbuf->b_p_inf);
+    return (char_u *)&(buf->b_p_inf);
   case PV_ISK:
-    return (char_u *)&(curbuf->b_p_isk);
+    return (char_u *)&(buf->b_p_isk);
   case PV_INEX:
-    return (char_u *)&(curbuf->b_p_inex);
+    return (char_u *)&(buf->b_p_inex);
   case PV_INDE:
-    return (char_u *)&(curbuf->b_p_inde);
+    return (char_u *)&(buf->b_p_inde);
   case PV_INDK:
-    return (char_u *)&(curbuf->b_p_indk);
+    return (char_u *)&(buf->b_p_indk);
   case PV_FEX:
-    return (char_u *)&(curbuf->b_p_fex);
+    return (char_u *)&(buf->b_p_fex);
   case PV_LISP:
-    return (char_u *)&(curbuf->b_p_lisp);
+    return (char_u *)&(buf->b_p_lisp);
   case PV_LOP:
-    return (char_u *)&(curbuf->b_p_lop);
+    return (char_u *)&(buf->b_p_lop);
   case PV_ML:
-    return (char_u *)&(curbuf->b_p_ml);
+    return (char_u *)&(buf->b_p_ml);
   case PV_MPS:
-    return (char_u *)&(curbuf->b_p_mps);
+    return (char_u *)&(buf->b_p_mps);
   case PV_MA:
-    return (char_u *)&(curbuf->b_p_ma);
+    return (char_u *)&(buf->b_p_ma);
   case PV_MOD:
-    return (char_u *)&(curbuf->b_changed);
+    return (char_u *)&(buf->b_changed);
   case PV_NF:
-    return (char_u *)&(curbuf->b_p_nf);
+    return (char_u *)&(buf->b_p_nf);
   case PV_PI:
-    return (char_u *)&(curbuf->b_p_pi);
+    return (char_u *)&(buf->b_p_pi);
   case PV_QE:
-    return (char_u *)&(curbuf->b_p_qe);
+    return (char_u *)&(buf->b_p_qe);
   case PV_RO:
-    return (char_u *)&(curbuf->b_p_ro);
+    return (char_u *)&(buf->b_p_ro);
   case PV_SCBK:
-    return (char_u *)&(curbuf->b_p_scbk);
+    return (char_u *)&(buf->b_p_scbk);
   case PV_SI:
-    return (char_u *)&(curbuf->b_p_si);
+    return (char_u *)&(buf->b_p_si);
   case PV_STS:
-    return (char_u *)&(curbuf->b_p_sts);
+    return (char_u *)&(buf->b_p_sts);
   case PV_SUA:
-    return (char_u *)&(curbuf->b_p_sua);
+    return (char_u *)&(buf->b_p_sua);
   case PV_SWF:
-    return (char_u *)&(curbuf->b_p_swf);
+    return (char_u *)&(buf->b_p_swf);
   case PV_SMC:
-    return (char_u *)&(curbuf->b_p_smc);
+    return (char_u *)&(buf->b_p_smc);
   case PV_SYN:
-    return (char_u *)&(curbuf->b_p_syn);
+    return (char_u *)&(buf->b_p_syn);
   case PV_SPC:
-    return (char_u *)&(curwin->w_s->b_p_spc);
+    return (char_u *)&(win->w_s->b_p_spc);
   case PV_SPF:
-    return (char_u *)&(curwin->w_s->b_p_spf);
+    return (char_u *)&(win->w_s->b_p_spf);
   case PV_SPL:
-    return (char_u *)&(curwin->w_s->b_p_spl);
+    return (char_u *)&(win->w_s->b_p_spl);
   case PV_SPO:
-    return (char_u *)&(curwin->w_s->b_p_spo);
+    return (char_u *)&(win->w_s->b_p_spo);
   case PV_SW:
-    return (char_u *)&(curbuf->b_p_sw);
+    return (char_u *)&(buf->b_p_sw);
   case PV_TFU:
-    return (char_u *)&(curbuf->b_p_tfu);
+    return (char_u *)&(buf->b_p_tfu);
   case PV_TS:
-    return (char_u *)&(curbuf->b_p_ts);
+    return (char_u *)&(buf->b_p_ts);
   case PV_TW:
-    return (char_u *)&(curbuf->b_p_tw);
+    return (char_u *)&(buf->b_p_tw);
   case PV_UDF:
-    return (char_u *)&(curbuf->b_p_udf);
+    return (char_u *)&(buf->b_p_udf);
   case PV_WM:
-    return (char_u *)&(curbuf->b_p_wm);
+    return (char_u *)&(buf->b_p_wm);
   case PV_VSTS:
-    return (char_u *)&(curbuf->b_p_vsts);
+    return (char_u *)&(buf->b_p_vsts);
   case PV_VTS:
-    return (char_u *)&(curbuf->b_p_vts);
+    return (char_u *)&(buf->b_p_vts);
   case PV_KMAP:
-    return (char_u *)&(curbuf->b_p_keymap);
+    return (char_u *)&(buf->b_p_keymap);
   case PV_SCL:
-    return (char_u *)&(curwin->w_p_scl);
+    return (char_u *)&(win->w_p_scl);
   case PV_WINHL:
-    return (char_u *)&(curwin->w_p_winhl);
+    return (char_u *)&(win->w_p_winhl);
   case PV_WINBL:
-    return (char_u *)&(curwin->w_p_winbl);
+    return (char_u *)&(win->w_p_winbl);
   case PV_STC:
-    return (char_u *)&(curwin->w_p_stc);
+    return (char_u *)&(win->w_p_stc);
   default:
     iemsg(_("E356: get_varp ERROR"));
   }
   // always return a valid pointer to avoid a crash!
-  return (char_u *)&(curbuf->b_p_wm);
+  return (char_u *)&(buf->b_p_wm);
+}
+
+/// Get pointer to option variable.
+static inline char_u *get_varp(vimoption_T *p)
+{
+  return get_varp_from(p, curbuf, curwin);
 }
 
 /// Get the value of 'equalprg', either the buffer-local one or the global one.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -768,6 +768,20 @@ static void did_set_background(char **errmsg)
   }
 }
 
+static void did_set_wildmode(char **errmsg)
+{
+  if (check_opt_wim() == FAIL) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_wildoptions(char **errmsg)
+{
+  if (opt_strings_flags(p_wop, p_wop_values, &wop_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 // 'encoding', 'fileencoding' and 'makeencoding'
 static void did_set_encoding(buf_T *buf, char **varp, char **gvarp, int opt_flags, char **errmsg)
 {
@@ -1449,13 +1463,9 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_bg) {  // 'background'
     did_set_background(&errmsg);
   } else if (varp == &p_wim) {  // 'wildmode'
-    if (check_opt_wim() == FAIL) {
-      errmsg = e_invarg;
-    }
+    did_set_wildmode(&errmsg);
   } else if (varp == &p_wop) {  // 'wildoptions'
-    if (opt_strings_flags(p_wop, p_wop_values, &wop_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_wildoptions(&errmsg);
   } else if (varp == &p_wak) {  // 'winaltkeys'
     if (*p_wak == NUL
         || check_opt_strings(p_wak, p_wak_values, false) != OK) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -829,6 +829,30 @@ static void did_set_fileformat(buf_T *buf, char **varp, const char *oldval, int 
   }
 }
 
+static void did_set_matchpairs(char **varp, char **errmsg)
+{
+  for (char *p = *varp; *p != NUL; p++) {
+    int x2 = -1;
+    int x3 = -1;
+
+    p += utfc_ptr2len(p);
+    if (*p != NUL) {
+      x2 = (unsigned char)(*p++);
+    }
+    if (*p != NUL) {
+      x3 = utf_ptr2char(p);
+      p += utfc_ptr2len(p);
+    }
+    if (x2 != ':' || x3 == -1 || (*p != NUL && *p != ',')) {
+      *errmsg = e_invarg;
+      break;
+    }
+    if (*p == NUL) {
+      break;
+    }
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -969,26 +993,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (gvarp == &p_mps) {  // 'matchpairs'
-    for (char *p = *varp; *p != NUL; p++) {
-      int x2 = -1;
-      int x3 = -1;
-
-      p += utfc_ptr2len(p);
-      if (*p != NUL) {
-        x2 = (unsigned char)(*p++);
-      }
-      if (*p != NUL) {
-        x3 = utf_ptr2char(p);
-        p += utfc_ptr2len(p);
-      }
-      if (x2 != ':' || x3 == -1 || (*p != NUL && *p != ',')) {
-        errmsg = e_invarg;
-        break;
-      }
-      if (*p == NUL) {
-        break;
-      }
-    }
+    did_set_matchpairs(varp, &errmsg);
   } else if (gvarp == &p_com) {  // 'comments'
     for (char *s = *varp; *s;) {
       while (*s && *s != ':') {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1728,29 +1728,17 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
              || varp == &p_pex) {  // '*expr' options
     did_set_optexpr(curbuf, curwin, varp, gvarp);
   } else if (gvarp == &p_cfu) {  // 'completefunc'
-    if (set_completefunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    set_completefunc_option(&errmsg);
   } else if (gvarp == &p_ofu) {  // 'omnifunc'
-    if (set_omnifunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    set_omnifunc_option(curbuf, &errmsg);
   } else if (gvarp == &p_tsrfu) {  // 'thesaurusfunc'
-    if (set_thesaurusfunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    set_thesaurusfunc_option(&errmsg);
   } else if (varp == &p_opfunc) {  // 'operatorfunc'
-    if (set_operatorfunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    set_operatorfunc_option(&errmsg);
   } else if (varp == &p_qftf) {  // 'quickfixtextfunc'
-    if (qf_process_qftf_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    qf_process_qftf_option(&errmsg);
   } else if (gvarp == &p_tfu) {  // 'tagfunc'
-    if (set_tagfunc_option() == FAIL) {
-      errmsg = e_invarg;
-    }
+    set_tagfunc_option(&errmsg);
   } else {
     did_set_option_listflags(curbuf, curwin, varp, errbuf, errbuflen, &errmsg);
   }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -966,6 +966,20 @@ static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, ch
   }
 }
 
+static void did_set_titleiconstring(char **varp)
+{
+  // 'titlestring' and 'iconstring'
+  int flagval = (varp == &p_titlestring) ? STL_IN_TITLE : STL_IN_ICON;
+
+  // NULL => statusline syntax
+  if (vim_strchr(*varp, '%') && check_stl_option(*varp) == NULL) {
+    stl_syntax |= flagval;
+  } else {
+    stl_syntax &= ~flagval;
+  }
+  did_set_title();
+}
+
 static void did_set_buftype(buf_T *buf, win_T *win, char **errmsg)
 {
   // When 'buftype' is set, check for valid value.
@@ -1446,15 +1460,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     fill_breakat_flags();
   } else if (varp == &p_titlestring || varp == &p_iconstring) {
     // 'titlestring' and 'iconstring'
-    int flagval = (varp == &p_titlestring) ? STL_IN_TITLE : STL_IN_ICON;
-
-    // NULL => statusline syntax
-    if (vim_strchr(*varp, '%') && check_stl_option(*varp) == NULL) {
-      stl_syntax |= flagval;
-    } else {
-      stl_syntax &= ~flagval;
-    }
-    did_set_title();
+    did_set_titleiconstring(varp);
   } else if (varp == &p_sel) {  // 'selection'
     if (*p_sel == NUL
         || check_opt_strings(p_sel, p_sel_values, false) != OK) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1520,6 +1520,20 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **
   }
 }
 
+static void did_set_lispoptions(char **varp, char **errmsg)
+{
+  if (**varp != NUL && strcmp(*varp, "expr:0") != 0 && strcmp(*varp, "expr:1") != 0) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_inccommand(char **errmsg)
+{
+  if (check_opt_strings(p_icm, p_icm_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_filetype_or_syntax(char **varp, char *oldval, int *value_checked,
                                        bool *value_changed, char **errmsg)
 {
@@ -1533,6 +1547,20 @@ static void did_set_filetype_or_syntax(char **varp, char *oldval, int *value_che
   // Since we check the value, there is no need to set P_INSECURE,
   // even when the value comes from a modeline.
   *value_checked = true;
+}
+
+static void did_set_winhl(win_T *win, char **errmsg)
+{
+  if (!parse_winhl_opt(win)) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_termpastefilter(char **errmsg)
+{
+  if (opt_strings_flags(p_tpf, p_tpf_values, &tpf_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
 }
 
 static void did_set_optexpr(buf_T *buf, win_T *win, char **varp, char **gvarp)
@@ -1885,23 +1913,15 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     // TODO(vim): recognize errors
     parse_cino(curbuf);
   } else if (gvarp == &p_lop) {  // 'lispoptions'
-    if (**varp != NUL && strcmp(*varp, "expr:0") != 0 && strcmp(*varp, "expr:1") != 0) {
-      errmsg = e_invarg;
-    }
+    did_set_lispoptions(varp, &errmsg);
   } else if (varp == &p_icm) {  // 'inccommand'
-    if (check_opt_strings(p_icm, p_icm_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_inccommand(&errmsg);
   } else if (gvarp == &p_ft || gvarp == &p_syn) {
     did_set_filetype_or_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
   } else if (varp == &curwin->w_p_winhl) {
-    if (!parse_winhl_opt(curwin)) {
-      errmsg = e_invarg;
-    }
+    did_set_winhl(curwin, &errmsg);
   } else if (varp == &p_tpf) {
-    if (opt_strings_flags(p_tpf, p_tpf_values, &tpf_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_termpastefilter(&errmsg);
   } else if (varp == &(curbuf->b_p_vsts)) {  // 'varsofttabstop'
     char *cp;
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -819,6 +819,13 @@ static void did_set_wildoptions(char **errmsg)
   }
 }
 
+static void did_set_eventignore(char **errmsg)
+{
+  if (check_ei() == FAIL) {
+    *errmsg = e_invarg;
+  }
+}
+
 // 'encoding', 'fileencoding' and 'makeencoding'
 static void did_set_encoding(buf_T *buf, char **varp, char **gvarp, int opt_flags, char **errmsg)
 {
@@ -1497,9 +1504,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (varp == &p_ei) {  // 'eventignore'
-    if (check_ei() == FAIL) {
-      errmsg = e_invarg;
-    }
+    did_set_eventignore(&errmsg);
   } else if (varp == &p_enc || gvarp == &p_fenc || gvarp == &p_menc) {
     // 'encoding', 'fileencoding' and 'makeencoding'
     did_set_encoding(curbuf, varp, gvarp, opt_flags, &errmsg);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1078,6 +1078,22 @@ static void did_set_signcolumn(win_T *win, char **varp, const char *oldval, char
   }
 }
 
+static void did_set_pastetoggle(void)
+{
+  // 'pastetoggle': translate key codes like in a mapping
+  if (*p_pt) {
+    char *p = NULL;
+    (void)replace_termcodes(p_pt,
+                            strlen(p_pt),
+                            &p, REPTERM_FROM_PART | REPTERM_DO_LT, NULL,
+                            CPO_TO_CPO_FLAGS);
+    if (p != NULL) {
+      free_string_option(p_pt);
+      p_pt = p;
+    }
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -1371,19 +1387,8 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     if (**varp == NUL || check_opt_strings(*varp, p_fdc_values, false) != OK) {
       errmsg = e_invarg;
     }
-  } else if (varp == &p_pt) {
-    // 'pastetoggle': translate key codes like in a mapping
-    if (*p_pt) {
-      char *p = NULL;
-      (void)replace_termcodes(p_pt,
-                              strlen(p_pt),
-                              &p, REPTERM_FROM_PART | REPTERM_DO_LT, NULL,
-                              CPO_TO_CPO_FLAGS);
-      if (p != NULL) {
-        free_string_option(p_pt);
-        p_pt = p;
-      }
-    }
+  } else if (varp == &p_pt) {  // 'pastetoggle'
+    did_set_pastetoggle();
   } else if (varp == &p_bs) {  // 'backspace'
     if (ascii_isdigit(*p_bs)) {
       if (*p_bs > '3' || p_bs[1] != NUL) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1849,6 +1849,12 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_option_listflag(varp, COCU_ALL, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_mouse) {  // 'mouse'
     did_set_option_listflag(varp, MOUSE_ALL, errbuf, errbuflen, &errmsg);
+  } else if (gvarp == &p_flp) {
+    if (win->w_briopt_list) {
+      // Changing Formatlistpattern when briopt includes the list setting:
+      // redraw
+      redraw_all_later(UPD_NOT_VALID);
+    }
   }
 
   // If error detected, restore the previous value.
@@ -1894,12 +1900,6 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
 
   if (varp == &p_mouse) {
     setmouse();  // in case 'mouse' changed
-  }
-
-  // Changing Formatlistpattern when briopt includes the list setting:
-  // redraw
-  if ((varp == &p_flp || varp == &(buf->b_p_flp)) && win->w_briopt_list) {
-    redraw_all_later(UPD_NOT_VALID);
   }
 
   if (win->w_curswant != MAXCOL

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1467,6 +1467,34 @@ static void did_set_foldmarker(win_T *win, char **varp, char **errmsg)
   }
 }
 
+static void did_set_commentstring(char **varp, char **errmsg)
+{
+  if (**varp != NUL && strstr(*varp, "%s") == NULL) {
+    *errmsg = N_("E537: 'commentstring' must be empty or contain %s");
+  }
+}
+
+static void did_set_foldopen(char **errmsg)
+{
+  if (opt_strings_flags(p_fdo, p_fdo_values, &fdo_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_foldclose(char **errmsg)
+{
+  if (check_opt_strings(p_fcl, p_fcl_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_foldignore(win_T *win)
+{
+  if (foldmethodIsIndent(win)) {
+    foldUpdateAll(win);
+  }
+}
+
 static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **errmsg)
 {
   char *ve = p_ve;
@@ -1844,21 +1872,13 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &curwin->w_allbuf_opt.wo_fmr) {  // 'foldmarker'
     did_set_foldmarker(curwin, varp, &errmsg);
   } else if (gvarp == &p_cms) {  // 'commentstring'
-    if (**varp != NUL && strstr(*varp, "%s") == NULL) {
-      errmsg = N_("E537: 'commentstring' must be empty or contain %s");
-    }
+    did_set_commentstring(varp, &errmsg);
   } else if (varp == &p_fdo) {  // 'foldopen'
-    if (opt_strings_flags(p_fdo, p_fdo_values, &fdo_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_foldopen(&errmsg);
   } else if (varp == &p_fcl) {  // 'foldclose'
-    if (check_opt_strings(p_fcl, p_fcl_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_foldclose(&errmsg);
   } else if (gvarp == &curwin->w_allbuf_opt.wo_fdi) {  // 'foldignore'
-    if (foldmethodIsIndent(curwin)) {
-      foldUpdateAll(curwin);
-    }
+    did_set_foldignore(curwin);
   } else if (gvarp == &p_ve) {  // 'virtualedit'
     did_set_virtualedit(curwin, opt_flags, oldval, &errmsg);
   } else if (gvarp == &p_cino) {  // 'cinoptions'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -819,6 +819,13 @@ static void did_set_wildoptions(char **errmsg)
   }
 }
 
+static void did_set_winaltkeys(char **errmsg)
+{
+  if (*p_wak == NUL || check_opt_strings(p_wak, p_wak_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_eventignore(char **errmsg)
 {
   if (check_ei() == FAIL) {
@@ -1499,10 +1506,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_wop) {  // 'wildoptions'
     did_set_wildoptions(&errmsg);
   } else if (varp == &p_wak) {  // 'winaltkeys'
-    if (*p_wak == NUL
-        || check_opt_strings(p_wak, p_wak_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_winaltkeys(&errmsg);
   } else if (varp == &p_ei) {  // 'eventignore'
     did_set_eventignore(&errmsg);
   } else if (varp == &p_enc || gvarp == &p_fenc || gvarp == &p_menc) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -966,6 +966,16 @@ static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, ch
   }
 }
 
+static void did_set_showbreak(char **varp, char **errmsg)
+{
+  for (char *s = *varp; *s;) {
+    if (ptr2cells(s) != 1) {
+      *errmsg = e_showbreak_contains_unprintable_or_wide_character;
+    }
+    MB_PTR_ADV(s);
+  }
+}
+
 static void did_set_titleiconstring(char **varp)
 {
   // 'titlestring' and 'iconstring'
@@ -1446,12 +1456,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_shada) {  // 'shada'
     did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen, &errmsg);
   } else if (gvarp == &p_sbr) {  // 'showbreak'
-    for (char *s = *varp; *s;) {
-      if (ptr2cells(s) != 1) {
-        errmsg = e_showbreak_contains_unprintable_or_wide_character;
-      }
-      MB_PTR_ADV(s);
-    }
+    did_set_showbreak(varp, &errmsg);
   } else if (varp == &p_guicursor) {  // 'guicursor'
     errmsg = parse_shape_opt(SHAPE_CURSOR);
   } else if (varp == &p_langmap) {  // 'langmap'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -725,6 +725,18 @@ static void did_set_nrformats(char **varp, char **errmsg)
   }
 }
 
+static void did_set_sessionoptions(char *oldval, char **errmsg)
+{
+  if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+  if ((ssop_flags & SSOP_CURDIR) && (ssop_flags & SSOP_SESDIR)) {
+    // Don't allow both "sesdir" and "curdir".
+    (void)opt_strings_flags(oldval, p_ssop_values, &ssop_flags, true);
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_background(char **errmsg)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
@@ -1410,14 +1422,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_nf) {  // 'nrformats'
     did_set_nrformats(varp, &errmsg);
   } else if (varp == &p_ssop) {  // 'sessionoptions'
-    if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
-    if ((ssop_flags & SSOP_CURDIR) && (ssop_flags & SSOP_SESDIR)) {
-      // Don't allow both "sesdir" and "curdir".
-      (void)opt_strings_flags(oldval, p_ssop_values, &ssop_flags, true);
-      errmsg = e_invarg;
-    }
+    did_set_sessionoptions(oldval, &errmsg);
   } else if (varp == &p_vop) {  // 'viewoptions'
     if (opt_strings_flags(p_vop, p_ssop_values, &vop_flags, true) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1094,6 +1094,28 @@ static void did_set_pastetoggle(void)
   }
 }
 
+static void did_set_tagcase(buf_T *buf, int opt_flags, char **errmsg)
+{
+  unsigned int *flags;
+  char *p;
+
+  if (opt_flags & OPT_LOCAL) {
+    p = buf->b_p_tc;
+    flags = &buf->b_tc_flags;
+  } else {
+    p = p_tc;
+    flags = &tc_flags;
+  }
+
+  if ((opt_flags & OPT_LOCAL) && *p == NUL) {
+    // make the local value empty: use the global value
+    *flags = 0;
+  } else if (*p == NUL
+             || opt_strings_flags(p, p_tc_values, flags, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -1402,24 +1424,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (gvarp == &p_tc) {  // 'tagcase'
-    unsigned int *flags;
-    char *p;
-
-    if (opt_flags & OPT_LOCAL) {
-      p = curbuf->b_p_tc;
-      flags = &curbuf->b_tc_flags;
-    } else {
-      p = p_tc;
-      flags = &tc_flags;
-    }
-
-    if ((opt_flags & OPT_LOCAL) && *p == NUL) {
-      // make the local value empty: use the global value
-      *flags = 0;
-    } else if (*p == NUL
-               || opt_strings_flags(p, p_tc_values, flags, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_tagcase(curbuf, opt_flags, &errmsg);
   } else if (varp == &p_cmp) {  // 'casemap'
     if (opt_strings_flags(p_cmp, p_cmp_values, &cmp_flags, true) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1165,8 +1165,8 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **
   }
 }
 
-static void did_set_syntax(char **varp, char *oldval, int *value_checked, bool *value_changed,
-                           char **errmsg)
+static void did_set_filetype_or_syntax(char **varp, char *oldval, int *value_checked,
+                                       bool *value_changed, char **errmsg)
 {
   if (!valid_filetype(*varp)) {
     *errmsg = e_invarg;
@@ -1664,18 +1664,8 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     if (check_opt_strings(p_icm, p_icm_values, false) != OK) {
       errmsg = e_invarg;
     }
-  } else if (gvarp == &p_ft) {
-    if (!valid_filetype(*varp)) {
-      errmsg = e_invarg;
-    } else {
-      value_changed = strcmp(oldval, *varp) != 0;
-
-      // Since we check the value, there is no need to set P_INSECURE,
-      // even when the value comes from a modeline.
-      *value_checked = true;
-    }
-  } else if (gvarp == &p_syn) {
-    did_set_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
+  } else if (gvarp == &p_ft || gvarp == &p_syn) {
+    did_set_filetype_or_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
   } else if (varp == &curwin->w_p_winhl) {
     if (!parse_winhl_opt(curwin)) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -698,6 +698,13 @@ static void did_set_helpfile(void)
   }
 }
 
+static void did_set_cursorlineopt(win_T *win, char **varp, char **errmsg)
+{
+  if (**varp == NUL || fill_culopt_flags(*varp, win) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_helplang(char **errmsg)
 {
   // Check for "", "ab", "ab,cd", etc.
@@ -1457,9 +1464,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     runtime_search_path_invalidate();
   } else if (varp == &curwin->w_p_culopt
              || gvarp == &curwin->w_allbuf_opt.wo_culopt) {  // 'cursorlineopt'
-    if (**varp == NUL || fill_culopt_flags(*varp, curwin) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_cursorlineopt(curwin, varp, &errmsg);
   } else if (varp == &curwin->w_p_cc) {  // 'colorcolumn'
     errmsg = check_colorcolumn(curwin);
   } else if (varp == &p_hlg) {  // 'helplang'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1141,6 +1141,42 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **
   }
 }
 
+static void did_set_optexpr(buf_T *buf, win_T *win, char **varp, char **gvarp)
+{
+  char **p_opt = NULL;
+
+  // If the option value starts with <SID> or s:, then replace that with
+  // the script identifier.
+
+  if (varp == &p_dex) {  // 'diffexpr'
+    p_opt = &p_dex;
+  } else if (varp == &win->w_p_fde) {  // 'foldexpr'
+    p_opt = &win->w_p_fde;
+  } else if (varp == &win->w_p_fdt) {  // 'foldtext'
+    p_opt = &win->w_p_fdt;
+  } else if (varp == &p_pex) {  // 'patchexpr'
+    p_opt = &p_pex;
+  } else if (gvarp == &p_fex) {  // 'formatexpr'
+    p_opt = &buf->b_p_fex;
+  } else if (gvarp == &p_inex) {  // 'includeexpr'
+    p_opt = &buf->b_p_inex;
+  } else if (gvarp == &p_inde) {  // 'indentexpr'
+    p_opt = &buf->b_p_inde;
+  }
+
+  if (p_opt != NULL) {
+    char *name = get_scriptlocal_funcname(*p_opt);
+    if (name != NULL) {
+      free_string_option(*p_opt);
+      *p_opt = name;
+    }
+  }
+
+  if (varp == &win->w_p_fde && foldmethodIsExpr(win)) {
+    foldUpdateAll(win);
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -1594,44 +1630,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
              || gvarp == &p_inex
              || gvarp == &p_inde
              || varp == &p_pex) {  // '*expr' options
-    char **p_opt = NULL;
-
-    // If the option value starts with <SID> or s:, then replace that with
-    // the script identifier.
-
-    if (varp == &p_dex) {  // 'diffexpr'
-      p_opt = &p_dex;
-    }
-    if (varp == &curwin->w_p_fde) {  // 'foldexpr'
-      p_opt = &curwin->w_p_fde;
-    }
-    if (varp == &curwin->w_p_fdt) {  // 'foldtext'
-      p_opt = &curwin->w_p_fdt;
-    }
-    if (gvarp == &p_fex) {  // 'formatexpr'
-      p_opt = &curbuf->b_p_fex;
-    }
-    if (gvarp == &p_inex) {  // 'includeexpr'
-      p_opt = &curbuf->b_p_inex;
-    }
-    if (gvarp == &p_inde) {  // 'indentexpr'
-      p_opt = &curbuf->b_p_inde;
-    }
-    if (varp == &p_pex) {  // 'patchexpr'
-      p_opt = &p_pex;
-    }
-
-    if (p_opt != NULL) {
-      char *name = get_scriptlocal_funcname(*p_opt);
-      if (name != NULL) {
-        free_string_option(*p_opt);
-        *p_opt = name;
-      }
-    }
-
-    if (varp == &curwin->w_p_fde && foldmethodIsExpr(curwin)) {
-      foldUpdateAll(curwin);
-    }
+    did_set_optexpr(curbuf, curwin, varp, gvarp);
   } else if (gvarp == &p_cfu) {  // 'completefunc'
     if (set_completefunc_option() == FAIL) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -745,6 +745,15 @@ static void did_set_sessionoptions(char *oldval, char **errmsg)
   }
 }
 
+static void did_set_ambiwidth(char **errmsg)
+{
+  if (check_opt_strings(p_ambw, p_ambw_values, false) != OK) {
+    *errmsg = e_invarg;
+  } else {
+    *errmsg = check_chars_options();
+  }
+}
+
 static void did_set_background(char **errmsg)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
@@ -1455,11 +1464,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (varp == &p_ambw || (int *)varp == &p_emoji) {  // 'ambiwidth'
-    if (check_opt_strings(p_ambw, p_ambw_values, false) != OK) {
-      errmsg = e_invarg;
-    } else {
-      errmsg = check_chars_options();
-    }
+    did_set_ambiwidth(&errmsg);
   } else if (varp == &p_bg) {  // 'background'
     did_set_background(&errmsg);
   } else if (varp == &p_wim) {  // 'wildmode'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -718,6 +718,13 @@ static void did_set_jumpoptions(char **errmsg)
   }
 }
 
+static void did_set_nrformats(char **varp, char **errmsg)
+{
+  if (check_opt_strings(*varp, p_nf_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_background(char **errmsg)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
@@ -1401,9 +1408,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_jop) {  // 'jumpoptions'
     did_set_jumpoptions(&errmsg);
   } else if (gvarp == &p_nf) {  // 'nrformats'
-    if (check_opt_strings(*varp, p_nf_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_nrformats(varp, &errmsg);
   } else if (varp == &p_ssop) {  // 'sessionoptions'
     if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -690,6 +690,20 @@ static void did_set_helpfile(void)
   }
 }
 
+static void did_set_helplang(char **errmsg)
+{
+  // Check for "", "ab", "ab,cd", etc.
+  for (char *s = p_hlg; *s != NUL; s += 3) {
+    if (s[1] == NUL || ((s[2] != ',' || s[3] == NUL) && s[2] != NUL)) {
+      *errmsg = e_invarg;
+      break;
+    }
+    if (s[2] == NUL) {
+      break;
+    }
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -759,16 +773,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &curwin->w_p_cc) {  // 'colorcolumn'
     errmsg = check_colorcolumn(curwin);
   } else if (varp == &p_hlg) {  // 'helplang'
-    // Check for "", "ab", "ab,cd", etc.
-    for (char *s = p_hlg; *s != NUL; s += 3) {
-      if (s[1] == NUL || ((s[2] != ',' || s[3] == NUL) && s[2] != NUL)) {
-        errmsg = e_invarg;
-        break;
-      }
-      if (s[2] == NUL) {
-        break;
-      }
-    }
+    did_set_helplang(&errmsg);
   } else if (varp == &p_hl) {  // 'highlight'
     if (strcmp(*varp, HIGHLIGHT_INIT) != 0) {
       errmsg = e_unsupportedoption;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1064,6 +1064,20 @@ static void did_set_completeopt(char **errmsg)
   }
 }
 
+static void did_set_signcolumn(win_T *win, char **varp, const char *oldval, char **errmsg)
+{
+  if (check_signcolumn(*varp) != OK) {
+    *errmsg = e_invarg;
+  }
+  // When changing the 'signcolumn' to or from 'number', recompute the
+  // width of the number column if 'number' or 'relativenumber' is set.
+  if (((*oldval == 'n' && *(oldval + 1) == 'u')
+       || (*win->w_p_scl == 'n' && *(win->w_p_scl + 1) == 'u'))
+      && (win->w_p_nu || win->w_p_rnu)) {
+    win->w_nrwidth_line_count = 0;
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -1346,16 +1360,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
 #endif
   } else if (varp == &curwin->w_p_scl) {  // 'signcolumn'
-    if (check_signcolumn(*varp) != OK) {
-      errmsg = e_invarg;
-    }
-    // When changing the 'signcolumn' to or from 'number', recompute the
-    // width of the number column if 'number' or 'relativenumber' is set.
-    if (((*oldval == 'n' && *(oldval + 1) == 'u')
-         || (*curwin->w_p_scl == 'n' && *(curwin->w_p_scl + 1) == 'u'))
-        && (curwin->w_p_nu || curwin->w_p_rnu)) {
-      curwin->w_nrwidth_line_count = 0;
-    }
+    did_set_signcolumn(curwin, varp, oldval, &errmsg);
   } else if (varp == &p_sloc) {  // 'showcmdloc'
     if (check_opt_strings(p_sloc, p_sloc_values, false) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -745,6 +745,13 @@ static void did_set_sessionoptions(char *oldval, char **errmsg)
   }
 }
 
+static void did_set_scrollopt(char **errmsg)
+{
+  if (check_opt_strings(p_sbo, p_scbopt_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_ambiwidth(char **errmsg)
 {
   if (check_opt_strings(p_ambw, p_ambw_values, false) != OK) {
@@ -1460,9 +1467,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (varp == &p_sbo) {  // 'scrollopt'
-    if (check_opt_strings(p_sbo, p_scbopt_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_scrollopt(&errmsg);
   } else if (varp == &p_ambw || (int *)varp == &p_emoji) {  // 'ambiwidth'
     did_set_ambiwidth(&errmsg);
   } else if (varp == &p_bg) {  // 'background'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1111,6 +1111,96 @@ static void did_set_titleiconstring(char **varp)
   did_set_title();
 }
 
+static void did_set_selection(char **errmsg)
+{
+  if (*p_sel == NUL || check_opt_strings(p_sel, p_sel_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_selectmode(char **errmsg)
+{
+  if (check_opt_strings(p_slm, p_slm_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_keymodel(char **errmsg)
+{
+  if (check_opt_strings(p_km, p_km_values, true) != OK) {
+    *errmsg = e_invarg;
+    return;
+  }
+  km_stopsel = (vim_strchr(p_km, 'o') != NULL);
+  km_startsel = (vim_strchr(p_km, 'a') != NULL);
+}
+
+static void did_set_mousemodel(char **errmsg)
+{
+  if (check_opt_strings(p_mousem, p_mousem_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_switchbuf(char **errmsg)
+{
+  if (opt_strings_flags(p_swb, p_swb_values, &swb_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_splitkeep(char **errmsg)
+{
+  if (check_opt_strings(p_spk, p_spk_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_debug(char **errmsg)
+{
+  if (check_opt_strings(p_debug, p_debug_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_display(char **errmsg)
+{
+  if (opt_strings_flags(p_dy, p_dy_values, &dy_flags, true) != OK) {
+    *errmsg = e_invarg;
+    return;
+  }
+  (void)init_chartab();
+  msg_grid_validate();
+}
+
+static void did_set_eoddirection(char **errmsg)
+{
+  if (check_opt_strings(p_ead, p_ead_values, false) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_clipboard(char **errmsg)
+{
+  if (opt_strings_flags(p_cb, p_cb_values, &cb_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_spellsuggest(char **errmsg)
+{
+  if (spell_check_sps() != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
+static void did_set_mkspellmem(char **errmsg)
+{
+  if (spell_check_msm() != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_buftype(buf_T *buf, win_T *win, char **errmsg)
 {
   // When 'buftype' is set, check for valid value.
@@ -1561,54 +1651,27 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     // 'titlestring' and 'iconstring'
     did_set_titleiconstring(varp);
   } else if (varp == &p_sel) {  // 'selection'
-    if (*p_sel == NUL
-        || check_opt_strings(p_sel, p_sel_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_selection(&errmsg);
   } else if (varp == &p_slm) {  // 'selectmode'
-    if (check_opt_strings(p_slm, p_slm_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_selectmode(&errmsg);
   } else if (varp == &p_km) {  // 'keymodel'
-    if (check_opt_strings(p_km, p_km_values, true) != OK) {
-      errmsg = e_invarg;
-    } else {
-      km_stopsel = (vim_strchr(p_km, 'o') != NULL);
-      km_startsel = (vim_strchr(p_km, 'a') != NULL);
-    }
+    did_set_keymodel(&errmsg);
   } else if (varp == &p_mousem) {  // 'mousemodel'
-    if (check_opt_strings(p_mousem, p_mousem_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_mousemodel(&errmsg);
   } else if (varp == &p_mousescroll) {  // 'mousescroll'
     errmsg = check_mousescroll(p_mousescroll);
   } else if (varp == &p_swb) {  // 'switchbuf'
-    if (opt_strings_flags(p_swb, p_swb_values, &swb_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_switchbuf(&errmsg);
   } else if (varp == &p_spk) {  // 'splitkeep'
-    if (check_opt_strings(p_spk, p_spk_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_splitkeep(&errmsg);
   } else if (varp == &p_debug) {  // 'debug'
-    if (check_opt_strings(p_debug, p_debug_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_debug(&errmsg);
   } else if (varp == &p_dy) {  // 'display'
-    if (opt_strings_flags(p_dy, p_dy_values, &dy_flags, true) != OK) {
-      errmsg = e_invarg;
-    } else {
-      (void)init_chartab();
-      msg_grid_validate();
-    }
+    did_set_display(&errmsg);
   } else if (varp == &p_ead) {  // 'eadirection'
-    if (check_opt_strings(p_ead, p_ead_values, false) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_eoddirection(&errmsg);
   } else if (varp == &p_cb) {  // 'clipboard'
-    if (opt_strings_flags(p_cb, p_cb_values, &cb_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_clipboard(&errmsg);
   } else if (varp == &(curwin->w_s->b_p_spl)  // 'spell'
              || varp == &(curwin->w_s->b_p_spf)) {
     // When 'spelllang' or 'spellfile' is set and there is a window for this
@@ -1630,13 +1693,9 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (varp == &p_sps) {  // 'spellsuggest'
-    if (spell_check_sps() != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_spellsuggest(&errmsg);
   } else if (varp == &p_msm) {  // 'mkspellmem'
-    if (spell_check_msm() != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_mkspellmem(&errmsg);
   } else if (gvarp == &p_bh) {
     // When 'bufhidden' is set, check for valid value.
     if (check_opt_strings(curbuf->b_p_bh, p_bufhidden_values, false) != OK) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1020,6 +1020,14 @@ static void did_set_global_listfillchars(win_T *win, char **varp, int opt_flags,
   }
 }
 
+static void did_set_verbosefile(char **errmsg)
+{
+  verbose_stop();
+  if (*p_vfile != NUL && verbose_open() == FAIL) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, char *errbuf,
                           size_t errbuflen, char **errmsg)
 {
@@ -1538,10 +1546,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_cedit) {  // 'cedit'
     errmsg = check_cedit();
   } else if (varp == &p_vfile) {  // 'verbosefile'
-    verbose_stop();
-    if (*p_vfile != NUL && verbose_open() == FAIL) {
-      errmsg = e_invarg;
-    }
+    did_set_verbosefile(&errmsg);
   } else if (varp == &p_shada) {  // 'shada'
     did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen, &errmsg);
   } else if (gvarp == &p_sbr) {  // 'showbreak'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1497,39 +1497,12 @@ static void did_set_vartabstop(buf_T *buf, win_T *win, char **varp, char **errms
   }
 }
 
-static void did_set_optexpr(buf_T *buf, win_T *win, char **varp, char **gvarp)
+static void did_set_optexpr(win_T *win, char **p_opt, char **varp, char **gvarp)
 {
-  char **p_opt = NULL;
-
-  // If the option value starts with <SID> or s:, then replace that with
-  // the script identifier.
-
-  if (varp == &p_dex) {  // 'diffexpr'
-    p_opt = &p_dex;
-  } else if (varp == &win->w_p_fde) {  // 'foldexpr'
-    p_opt = &win->w_p_fde;
-  } else if (varp == &win->w_p_fdt) {  // 'foldtext'
-    p_opt = &win->w_p_fdt;
-  } else if (varp == &p_pex) {  // 'patchexpr'
-    p_opt = &p_pex;
-  } else if (gvarp == &p_fex) {  // 'formatexpr'
-    p_opt = &buf->b_p_fex;
-  } else if (gvarp == &p_inex) {  // 'includeexpr'
-    p_opt = &buf->b_p_inex;
-  } else if (gvarp == &p_inde) {  // 'indentexpr'
-    p_opt = &buf->b_p_inde;
-  }
-
-  if (p_opt != NULL) {
-    char *name = get_scriptlocal_funcname(*p_opt);
-    if (name != NULL) {
-      free_string_option(*p_opt);
-      *p_opt = name;
-    }
-  }
-
-  if (varp == &win->w_p_fde && foldmethodIsExpr(win)) {
-    foldUpdateAll(win);
+  char *name = get_scriptlocal_funcname(*p_opt);
+  if (name != NULL) {
+    free_string_option(*p_opt);
+    *p_opt = name;
   }
 }
 
@@ -1835,14 +1808,23 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_varsoftabstop(buf, varp, &errmsg);
   } else if (varp == &buf->b_p_vts) {  // 'vartabstop'
     did_set_vartabstop(buf, win, varp, &errmsg);
-  } else if (varp == &p_dex
-             || varp == &win->w_p_fde
-             || varp == &win->w_p_fdt
-             || gvarp == &p_fex
-             || gvarp == &p_inex
-             || gvarp == &p_inde
-             || varp == &p_pex) {  // '*expr' options
-    did_set_optexpr(buf, win, varp, gvarp);
+  } else if (varp == &p_dex) {  // 'diffexpr'
+    did_set_optexpr(win, &p_dex, varp, gvarp);
+  } else if (varp == &win->w_p_fde) {  // 'foldexpr'
+    did_set_optexpr(win, &win->w_p_fde, varp, gvarp);
+    if (foldmethodIsExpr(win)) {
+      foldUpdateAll(win);
+    }
+  } else if (varp == &win->w_p_fdt) {  // 'foldtext'
+    did_set_optexpr(win, &win->w_p_fdt, varp, gvarp);
+  } else if (varp == &p_pex) {  // 'patchexpr'
+    did_set_optexpr(win, &p_pex, varp, gvarp);
+  } else if (gvarp == &p_fex) {  // 'formatexpr'
+    did_set_optexpr(win, &buf->b_p_fex, varp, gvarp);
+  } else if (gvarp == &p_inex) {  // 'includeexpr'
+    did_set_optexpr(win, &buf->b_p_inex, varp, gvarp);
+  } else if (gvarp == &p_inde) {  // 'indentexpr'
+    did_set_optexpr(win, &buf->b_p_inde, varp, gvarp);
   } else if (gvarp == &p_cfu) {  // 'completefunc'
     set_completefunc_option(&errmsg);
   } else if (gvarp == &p_ofu) {  // 'omnifunc'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -679,6 +679,17 @@ static void did_set_breakindentopt(win_T *win, char **errmsg)
   }
 }
 
+static void did_set_helpfile(void)
+{
+  // May compute new values for $VIM and $VIMRUNTIME
+  if (didset_vim) {
+    vim_unsetenv_ext("VIM");
+  }
+  if (didset_vimruntime) {
+    vim_unsetenv_ext("VIMRUNTIME");
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -737,13 +748,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;            // error in value
     }
   } else if (varp == &p_hf) {  // 'helpfile'
-    // May compute new values for $VIM and $VIMRUNTIME
-    if (didset_vim) {
-      vim_unsetenv_ext("VIM");
-    }
-    if (didset_vimruntime) {
-      vim_unsetenv_ext("VIMRUNTIME");
-    }
+    did_set_helpfile();
   } else if (varp == &p_rtp || varp == &p_pp) {  // 'runtimepath' 'packpath'
     runtime_search_path_invalidate();
   } else if (varp == &curwin->w_p_culopt

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -733,9 +733,9 @@ static void did_set_jumpoptions(char **errmsg)
   }
 }
 
-static void did_set_nrformats(char **varp, char **errmsg)
+static void did_set_opt_strings(char *val, char **values, bool list, char **errmsg)
 {
-  if (check_opt_strings(*varp, p_nf_values, true) != OK) {
+  if (check_opt_strings(val, values, list) != OK) {
     *errmsg = e_invarg;
   }
 }
@@ -762,13 +762,6 @@ static void did_set_viewoptions(char **errmsg)
 static void did_set_redrawdebug(char **errmsg)
 {
   if (opt_strings_flags(p_rdb, p_rdb_values, &rdb_flags, true) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
-static void did_set_scrollopt(char **errmsg)
-{
-  if (check_opt_strings(p_sbo, p_scbopt_values, true) != OK) {
     *errmsg = e_invarg;
   }
 }
@@ -932,13 +925,6 @@ static void did_set_fileformat(buf_T *buf, char **varp, const char *oldval, int 
     if (get_fileformat(buf) == EOL_MAC || *oldval == 'm') {
       redraw_buf_later(buf, UPD_NOT_VALID);
     }
-  }
-}
-
-static void did_set_fileformats(char **errmsg)
-{
-  if (check_opt_strings(p_ffs, p_ff_values, true) != OK) {
-    *errmsg = e_invarg;
   }
 }
 
@@ -1118,13 +1104,6 @@ static void did_set_selection(char **errmsg)
   }
 }
 
-static void did_set_selectmode(char **errmsg)
-{
-  if (check_opt_strings(p_slm, p_slm_values, true) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
 static void did_set_keymodel(char **errmsg)
 {
   if (check_opt_strings(p_km, p_km_values, true) != OK) {
@@ -1135,30 +1114,9 @@ static void did_set_keymodel(char **errmsg)
   km_startsel = (vim_strchr(p_km, 'a') != NULL);
 }
 
-static void did_set_mousemodel(char **errmsg)
-{
-  if (check_opt_strings(p_mousem, p_mousem_values, false) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
 static void did_set_switchbuf(char **errmsg)
 {
   if (opt_strings_flags(p_swb, p_swb_values, &swb_flags, true) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
-static void did_set_splitkeep(char **errmsg)
-{
-  if (check_opt_strings(p_spk, p_spk_values, false) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
-static void did_set_debug(char **errmsg)
-{
-  if (check_opt_strings(p_debug, p_debug_values, true) != OK) {
     *errmsg = e_invarg;
   }
 }
@@ -1171,13 +1129,6 @@ static void did_set_display(char **errmsg)
   }
   (void)init_chartab();
   msg_grid_validate();
-}
-
-static void did_set_eoddirection(char **errmsg)
-{
-  if (check_opt_strings(p_ead, p_ead_values, false) != OK) {
-    *errmsg = e_invarg;
-  }
 }
 
 static void did_set_clipboard(char **errmsg)
@@ -1234,14 +1185,6 @@ static void did_set_spellsuggest(char **errmsg)
 static void did_set_mkspellmem(char **errmsg)
 {
   if (spell_check_msm() != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
-static void did_set_bufhidden(buf_T *buf, char **errmsg)
-{
-  // When 'bufhidden' is set, check for valid value.
-  if (check_opt_strings(buf->b_p_bh, p_bufhidden_values, false) != OK) {
     *errmsg = e_invarg;
   }
 }
@@ -1355,13 +1298,6 @@ static void did_set_signcolumn(win_T *win, char **varp, const char *oldval, char
        || (*win->w_p_scl == 'n' && *(win->w_p_scl + 1) == 'u'))
       && (win->w_p_nu || win->w_p_rnu)) {
     win->w_nrwidth_line_count = 0;
-  }
-}
-
-static void did_set_showcmdloc(char **errmsg)
-{
-  if (check_opt_strings(p_sloc, p_sloc_values, false) != OK) {
-    *errmsg = e_invarg;
   }
 }
 
@@ -1481,13 +1417,6 @@ static void did_set_foldopen(char **errmsg)
   }
 }
 
-static void did_set_foldclose(char **errmsg)
-{
-  if (check_opt_strings(p_fcl, p_fcl_values, true) != OK) {
-    *errmsg = e_invarg;
-  }
-}
-
 static void did_set_foldignore(win_T *win)
 {
   if (foldmethodIsIndent(win)) {
@@ -1523,13 +1452,6 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **
 static void did_set_lispoptions(char **varp, char **errmsg)
 {
   if (**varp != NUL && strcmp(*varp, "expr:0") != 0 && strcmp(*varp, "expr:1") != 0) {
-    *errmsg = e_invarg;
-  }
-}
-
-static void did_set_inccommand(char **errmsg)
-{
-  if (check_opt_strings(p_icm, p_icm_values, false) != OK) {
     *errmsg = e_invarg;
   }
 }
@@ -1765,7 +1687,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_jop) {  // 'jumpoptions'
     did_set_jumpoptions(&errmsg);
   } else if (gvarp == &p_nf) {  // 'nrformats'
-    did_set_nrformats(varp, &errmsg);
+    did_set_opt_strings(*varp, p_nf_values, true, &errmsg);
   } else if (varp == &p_ssop) {  // 'sessionoptions'
     did_set_sessionoptions(oldval, &errmsg);
   } else if (varp == &p_vop) {  // 'viewoptions'
@@ -1773,7 +1695,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_rdb) {  // 'redrawdebug'
     did_set_redrawdebug(&errmsg);
   } else if (varp == &p_sbo) {  // 'scrollopt'
-    did_set_scrollopt(&errmsg);
+    did_set_opt_strings(p_sbo, p_scbopt_values, true, &errmsg);
   } else if (varp == &p_ambw || (int *)varp == &p_emoji) {  // 'ambiwidth'
     did_set_ambiwidth(&errmsg);
   } else if (varp == &p_bg) {  // 'background'
@@ -1794,7 +1716,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_ff) {  // 'fileformat'
     did_set_fileformat(curbuf, varp, oldval, opt_flags, &errmsg);
   } else if (varp == &p_ffs) {  // 'fileformats'
-    did_set_fileformats(&errmsg);
+    did_set_opt_strings(p_ffs, p_ff_values, true, &errmsg);
   } else if (gvarp == &p_mps) {  // 'matchpairs'
     did_set_matchpairs(varp, &errmsg);
   } else if (gvarp == &p_com) {  // 'comments'
@@ -1825,23 +1747,23 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_sel) {  // 'selection'
     did_set_selection(&errmsg);
   } else if (varp == &p_slm) {  // 'selectmode'
-    did_set_selectmode(&errmsg);
+    did_set_opt_strings(p_slm, p_slm_values, true, &errmsg);
   } else if (varp == &p_km) {  // 'keymodel'
     did_set_keymodel(&errmsg);
   } else if (varp == &p_mousem) {  // 'mousemodel'
-    did_set_mousemodel(&errmsg);
+    did_set_opt_strings(p_mousem, p_mousem_values, false, &errmsg);
   } else if (varp == &p_mousescroll) {  // 'mousescroll'
     errmsg = check_mousescroll(p_mousescroll);
   } else if (varp == &p_swb) {  // 'switchbuf'
     did_set_switchbuf(&errmsg);
   } else if (varp == &p_spk) {  // 'splitkeep'
-    did_set_splitkeep(&errmsg);
+    did_set_opt_strings(p_spk, p_spk_values, false, &errmsg);
   } else if (varp == &p_debug) {  // 'debug'
-    did_set_debug(&errmsg);
+    did_set_opt_strings(p_debug, p_debug_values, true, &errmsg);
   } else if (varp == &p_dy) {  // 'display'
     did_set_display(&errmsg);
   } else if (varp == &p_ead) {  // 'eadirection'
-    did_set_eoddirection(&errmsg);
+    did_set_opt_strings(p_ead, p_ead_values, false, &errmsg);
   } else if (varp == &p_cb) {  // 'clipboard'
     did_set_clipboard(&errmsg);
   } else if (varp == &(curwin->w_s->b_p_spf)) {
@@ -1857,7 +1779,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_msm) {  // 'mkspellmem'
     did_set_mkspellmem(&errmsg);
   } else if (gvarp == &p_bh) {
-    did_set_bufhidden(curbuf, &errmsg);
+    did_set_opt_strings(curbuf->b_p_bh, p_bufhidden_values, false, &errmsg);
   } else if (gvarp == &p_bt) {  // 'buftype'
     did_set_buftype(curbuf, curwin, &errmsg);
   } else if (gvarp == &p_stl || gvarp == &p_wbr || varp == &p_tal
@@ -1878,7 +1800,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &curwin->w_p_scl) {  // 'signcolumn'
     did_set_signcolumn(curwin, varp, oldval, &errmsg);
   } else if (varp == &p_sloc) {  // 'showcmdloc'
-    did_set_showcmdloc(&errmsg);
+    did_set_opt_strings(*varp, p_sloc_values, false, &errmsg);
   } else if (varp == &curwin->w_p_fdc
              || varp == &curwin->w_allbuf_opt.wo_fdc) {
     // 'foldcolumn'
@@ -1904,7 +1826,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_fdo) {  // 'foldopen'
     did_set_foldopen(&errmsg);
   } else if (varp == &p_fcl) {  // 'foldclose'
-    did_set_foldclose(&errmsg);
+    did_set_opt_strings(*varp, p_fcl_values, true, &errmsg);
   } else if (gvarp == &curwin->w_allbuf_opt.wo_fdi) {  // 'foldignore'
     did_set_foldignore(curwin);
   } else if (gvarp == &p_ve) {  // 'virtualedit'
@@ -1915,7 +1837,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_lop) {  // 'lispoptions'
     did_set_lispoptions(varp, &errmsg);
   } else if (varp == &p_icm) {  // 'inccommand'
-    did_set_inccommand(&errmsg);
+    did_set_opt_strings(*varp, p_icm_values, false, &errmsg);
   } else if (gvarp == &p_ft || gvarp == &p_syn) {
     did_set_filetype_or_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
   } else if (varp == &curwin->w_p_winhl) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -656,7 +656,6 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
                             int opt_flags, int *value_checked)
 {
   char *errmsg = NULL;
-  char *s, *p;
   int did_chartab = false;
   vimoption_T *opt = get_option(opt_idx);
   bool free_oldval = (opt->flags & P_ALLOCED);
@@ -746,7 +745,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     errmsg = check_colorcolumn(curwin);
   } else if (varp == &p_hlg) {  // 'helplang'
     // Check for "", "ab", "ab,cd", etc.
-    for (s = p_hlg; *s != NUL; s += 3) {
+    for (char *s = p_hlg; *s != NUL; s += 3) {
       if (s[1] == NUL || ((s[2] != ',' || s[3] == NUL) && s[2] != NUL)) {
         errmsg = e_invarg;
         break;
@@ -849,7 +848,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
 
     if (errmsg == NULL) {
       // canonize the value, so that strcmp() can be used on it
-      p = enc_canonize(*varp);
+      char *p = enc_canonize(*varp);
       xfree(*varp);
       *varp = p;
       if (varp == &p_enc) {
@@ -923,7 +922,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (gvarp == &p_mps) {  // 'matchpairs'
-    for (p = *varp; *p != NUL; p++) {
+    for (char *p = *varp; *p != NUL; p++) {
       int x2 = -1;
       int x3 = -1;
 
@@ -944,7 +943,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       }
     }
   } else if (gvarp == &p_com) {  // 'comments'
-    for (s = *varp; *s;) {
+    for (char *s = *varp; *s;) {
       while (*s && *s != ':') {
         if (vim_strchr(COM_ALL, (uint8_t)(*s)) == NULL
             && !ascii_isdigit(*s) && *s != '-') {
@@ -1014,7 +1013,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     // there would be a disconnect between the check for P_ALLOCED at the start
     // of the function and the set of P_ALLOCED at the end of the function.
     free_oldval = (opt->flags & P_ALLOCED);
-    for (s = p_shada; *s;) {
+    for (char *s = p_shada; *s;) {
       // Check it's a valid character
       if (vim_strchr("!\"%'/:<@cfhnrs", (uint8_t)(*s)) == NULL) {
         errmsg = illegal_char(errbuf, errbuflen, *s);
@@ -1059,7 +1058,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = N_("E528: Must specify a ' value");
     }
   } else if (gvarp == &p_sbr) {  // 'showbreak'
-    for (s = *varp; *s;) {
+    for (char *s = *varp; *s;) {
       if (ptr2cells(s) != 1) {
         errmsg = e_showbreak_contains_unprintable_or_wide_character;
       }
@@ -1188,7 +1187,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     } else if (varp == &curwin->w_p_stc) {
       curwin->w_nrwidth_line_count = 0;
     }
-    s = *varp;
+    char *s = *varp;
     if (varp == &p_ruf && *s == '%') {
       // set ru_wid if 'ruf' starts with "%99("
       if (*++s == '-') {        // ignore a '-'
@@ -1214,7 +1213,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
   } else if (gvarp == &p_cpt) {
     // check if it is a valid value for 'complete' -- Acevedo
-    for (s = *varp; *s;) {
+    for (char *s = *varp; *s;) {
       while (*s == ',' || *s == ' ') {
         s++;
       }
@@ -1284,7 +1283,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_pt) {
     // 'pastetoggle': translate key codes like in a mapping
     if (*p_pt) {
-      p = NULL;
+      char *p = NULL;
       (void)replace_termcodes(p_pt,
                               strlen(p_pt),
                               &p, REPTERM_FROM_PART | REPTERM_DO_LT, NULL,
@@ -1308,6 +1307,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
   } else if (gvarp == &p_tc) {  // 'tagcase'
     unsigned int *flags;
+    char *p;
 
     if (opt_flags & OPT_LOCAL) {
       p = curbuf->b_p_tc;
@@ -1343,7 +1343,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       }
     }
   } else if (gvarp == &curwin->w_allbuf_opt.wo_fmr) {  // 'foldmarker'
-    p = vim_strchr(*varp, ',');
+    char *p = vim_strchr(*varp, ',');
     if (p == NULL) {
       errmsg = N_("E536: comma required");
     } else if (p == *varp || p[1] == NUL) {
@@ -1552,7 +1552,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
     }
   } else {
     // Options that are a list of flags.
-    p = NULL;
+    char *p = NULL;
     if (varp == &p_ww) {  // 'whichwrap'
       p = WW_ALL;
     }
@@ -1568,7 +1568,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       p = MOUSE_ALL;
     }
     if (p != NULL) {
-      for (s = *varp; *s; s++) {
+      for (char *s = *varp; *s; s++) {
         if (vim_strchr(p, (uint8_t)(*s)) == NULL) {
           errmsg = illegal_char(errbuf, errbuflen, *s);
           break;
@@ -1600,7 +1600,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
         && (opt->indir & PV_BOTH)) {
       // global option with local value set to use global value; free
       // the local value and make it empty
-      p = get_varp_scope(opt, OPT_LOCAL);
+      char *p = get_varp_scope(opt, OPT_LOCAL);
       free_string_option(*(char **)p);
       *(char **)p = empty_option;
     } else if (!(opt_flags & OPT_LOCAL) && opt_flags != OPT_GLOBAL) {
@@ -1659,6 +1659,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       // They could set 'spellcapcheck' depending on the language.
       // Use the first name in 'spelllang' up to '_region' or
       // '.encoding'.
+      char *p;
       for (p = q; *p != NUL; p++) {
         if (!ASCII_ISALNUM(*p) && *p != '-') {
           break;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1653,7 +1653,7 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
   } else if (varp == &win->w_p_briopt) {  // 'breakindentopt'
     did_set_breakindentopt(win, &errmsg);
   } else if (varp == &p_isi
-             || varp == &(buf->b_p_isk)
+             || varp == &buf->b_p_isk
              || varp == &p_isp
              || varp == &p_isf) {
     // 'isident', 'iskeyword', 'isprint or 'isfname' option
@@ -1753,13 +1753,13 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_opt_strings(p_ead, p_ead_values, false, &errmsg);
   } else if (varp == &p_cb) {  // 'clipboard'
     did_set_opt_flags(p_cb, p_cb_values, &cb_flags, true, &errmsg);
-  } else if (varp == &(win->w_s->b_p_spf)) {
+  } else if (varp == &win->w_s->b_p_spf) {
     did_set_spellfile(varp, &errmsg);
-  } else if (varp == &(win->w_s->b_p_spl)) {  // 'spell'
+  } else if (varp == &win->w_s->b_p_spl) {  // 'spell'
     did_set_spell(varp, &errmsg);
-  } else if (varp == &(win->w_s->b_p_spc)) {
+  } else if (varp == &win->w_s->b_p_spc) {
     did_set_spellcapcheck(win, &errmsg);
-  } else if (varp == &(win->w_s->b_p_spo)) {  // 'spelloptions'
+  } else if (varp == &win->w_s->b_p_spo) {  // 'spelloptions'
     did_set_spelloptions(win, &errmsg);
   } else if (varp == &p_sps) {  // 'spellsuggest'
     did_set_spellsuggest(&errmsg);
@@ -1831,9 +1831,9 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_winhl(win, &errmsg);
   } else if (varp == &p_tpf) {
     did_set_opt_flags(p_tpf, p_tpf_values, &tpf_flags, true, &errmsg);
-  } else if (varp == &(buf->b_p_vsts)) {  // 'varsofttabstop'
+  } else if (varp == &buf->b_p_vsts) {  // 'varsofttabstop'
     did_set_varsoftabstop(buf, varp, &errmsg);
-  } else if (varp == &(buf->b_p_vts)) {  // 'vartabstop'
+  } else if (varp == &buf->b_p_vts) {  // 'vartabstop'
     did_set_vartabstop(buf, win, varp, &errmsg);
   } else if (varp == &p_dex
              || varp == &win->w_p_fde
@@ -1859,9 +1859,9 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_option_listflag(varp, WW_ALL, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_shm) {  // 'shortmess'
     did_set_option_listflag(varp, SHM_ALL, errbuf, errbuflen, &errmsg);
-  } else if (varp == &(p_cpo)) {  // 'cpoptions'
+  } else if (varp == &p_cpo) {  // 'cpoptions'
     did_set_option_listflag(varp, CPO_VI, errbuf, errbuflen, &errmsg);
-  } else if (varp == &(buf->b_p_fo)) {  // 'formatoptions'
+  } else if (varp == &buf->b_p_fo) {  // 'formatoptions'
     did_set_option_listflag(varp, FO_ALL, errbuf, errbuflen, &errmsg);
   } else if (varp == &win->w_p_cocu) {  // 'concealcursor'
     did_set_option_listflag(varp, COCU_ALL, errbuf, errbuflen, &errmsg);
@@ -1901,11 +1901,11 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     }
 
     // Trigger the autocommand only after setting the flags.
-    if (varp == &(buf->b_p_syn)) {
+    if (varp == &buf->b_p_syn) {
       do_syntax_autocmd(buf, value_changed);
-    } else if (varp == &(buf->b_p_ft)) {
+    } else if (varp == &buf->b_p_ft) {
       do_filetype_autocmd(buf, varp, opt_flags, value_changed);
-    } else if (varp == &(win->w_s->b_p_spl)) {
+    } else if (varp == &win->w_s->b_p_spl) {
       did_set_spelllang_source(win);
     }
   }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -745,6 +745,13 @@ static void did_set_sessionoptions(char *oldval, char **errmsg)
   }
 }
 
+static void did_set_redrawdebug(char **errmsg)
+{
+  if (opt_strings_flags(p_rdb, p_rdb_values, &rdb_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_scrollopt(char **errmsg)
 {
   if (check_opt_strings(p_sbo, p_scbopt_values, true) != OK) {
@@ -1463,9 +1470,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_invarg;
     }
   } else if (varp == &p_rdb) {  // 'redrawdebug'
-    if (opt_strings_flags(p_rdb, p_rdb_values, &rdb_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_redrawdebug(&errmsg);
   } else if (varp == &p_sbo) {  // 'scrollopt'
     did_set_scrollopt(&errmsg);
   } else if (varp == &p_ambw || (int *)varp == &p_emoji) {  // 'ambiwidth'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -668,6 +668,14 @@ static void did_set_backupcopy(buf_T *buf, char *oldval, int opt_flags, char **e
   }
 }
 
+static void did_set_backupext_or_patchmode(char **errmsg)
+{
+  if (strcmp(*p_bex == '.' ? p_bex + 1 : p_bex,
+             *p_pm == '.' ? p_pm + 1 : p_pm) == 0) {
+    *errmsg = e_backupext_and_patchmode_are_equal;
+  }
+}
+
 static void did_set_breakindentopt(win_T *win, char **errmsg)
 {
   if (briopt_check(win) == FAIL) {
@@ -1385,10 +1393,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_bkc) {  // 'backupcopy'
     did_set_backupcopy(curbuf, oldval, opt_flags, &errmsg);
   } else if (varp == &p_bex || varp == &p_pm) {  // 'backupext' and 'patchmode'
-    if (strcmp(*p_bex == '.' ? p_bex + 1 : p_bex,
-               *p_pm == '.' ? p_pm + 1 : p_pm) == 0) {
-      errmsg = e_backupext_and_patchmode_are_equal;
-    }
+    did_set_backupext_or_patchmode(&errmsg);
   } else if (varp == &curwin->w_p_briopt) {  // 'breakindentopt'
     did_set_breakindentopt(curwin, &errmsg);
   } else if (varp == &p_isi

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -711,6 +711,13 @@ static void did_set_highlight(char **varp, char **errmsg)
   }
 }
 
+static void did_set_jumpoptions(char **errmsg)
+{
+  if (opt_strings_flags(p_jop, p_jop_values, &jop_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_background(char **errmsg)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
@@ -1392,9 +1399,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_hl) {  // 'highlight'
     did_set_highlight(varp, &errmsg);
   } else if (varp == &p_jop) {  // 'jumpoptions'
-    if (opt_strings_flags(p_jop, p_jop_values, &jop_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_jumpoptions(&errmsg);
   } else if (gvarp == &p_nf) {  // 'nrformats'
     if (check_opt_strings(*varp, p_nf_values, true) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -745,6 +745,13 @@ static void did_set_sessionoptions(char *oldval, char **errmsg)
   }
 }
 
+static void did_set_viewoptions(char **errmsg)
+{
+  if (opt_strings_flags(p_vop, p_ssop_values, &vop_flags, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_redrawdebug(char **errmsg)
 {
   if (opt_strings_flags(p_rdb, p_rdb_values, &rdb_flags, true) != OK) {
@@ -1466,9 +1473,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_ssop) {  // 'sessionoptions'
     did_set_sessionoptions(oldval, &errmsg);
   } else if (varp == &p_vop) {  // 'viewoptions'
-    if (opt_strings_flags(p_vop, p_ssop_values, &vop_flags, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_viewoptions(&errmsg);
   } else if (varp == &p_rdb) {  // 'redrawdebug'
     did_set_redrawdebug(&errmsg);
   } else if (varp == &p_sbo) {  // 'scrollopt'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -935,6 +935,13 @@ static void did_set_fileformat(buf_T *buf, char **varp, const char *oldval, int 
   }
 }
 
+static void did_set_fileformats(char **errmsg)
+{
+  if (check_opt_strings(p_ffs, p_ff_values, true) != OK) {
+    *errmsg = e_invarg;
+  }
+}
+
 static void did_set_matchpairs(char **varp, char **errmsg)
 {
   for (char *p = *varp; *p != NUL; p++) {
@@ -1517,9 +1524,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_ff) {  // 'fileformat'
     did_set_fileformat(curbuf, varp, oldval, opt_flags, &errmsg);
   } else if (varp == &p_ffs) {  // 'fileformats'
-    if (check_opt_strings(p_ffs, p_ff_values, true) != OK) {
-      errmsg = e_invarg;
-    }
+    did_set_fileformats(&errmsg);
   } else if (gvarp == &p_mps) {  // 'matchpairs'
     did_set_matchpairs(varp, &errmsg);
   } else if (gvarp == &p_com) {  // 'comments'

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1055,6 +1055,15 @@ static void did_set_complete(char **varp, char *errbuf, size_t errbuflen, char *
   }
 }
 
+static void did_set_completeopt(char **errmsg)
+{
+  if (check_opt_strings(p_cot, p_cot_values, true) != OK) {
+    *errmsg = e_invarg;
+  } else {
+    completeopt_was_set();
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -1328,11 +1337,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (gvarp == &p_cpt) {  // 'complete'
     did_set_complete(varp, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_cot) {  // 'completeopt'
-    if (check_opt_strings(p_cot, p_cot_values, true) != OK) {
-      errmsg = e_invarg;
-    } else {
-      completeopt_was_set();
-    }
+    did_set_completeopt(&errmsg);
 #ifdef BACKSLASH_IN_FILENAME
   } else if (gvarp == &p_csl) {  // 'completeslash'
     if (check_opt_strings(p_csl, p_csl_values, false) != OK

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -704,6 +704,13 @@ static void did_set_helplang(char **errmsg)
   }
 }
 
+static void did_set_highlight(char **varp, char **errmsg)
+{
+  if (strcmp(*varp, HIGHLIGHT_INIT) != 0) {
+    *errmsg = e_unsupportedoption;
+  }
+}
+
 static void did_set_background(char **errmsg)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
@@ -1383,9 +1390,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
   } else if (varp == &p_hlg) {  // 'helplang'
     did_set_helplang(&errmsg);
   } else if (varp == &p_hl) {  // 'highlight'
-    if (strcmp(*varp, HIGHLIGHT_INIT) != 0) {
-      errmsg = e_unsupportedoption;
-    }
+    did_set_highlight(varp, &errmsg);
   } else if (varp == &p_jop) {  // 'jumpoptions'
     if (opt_strings_flags(p_jop, p_jop_values, &jop_flags, true) != OK) {
       errmsg = e_invarg;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -668,6 +668,17 @@ static void did_set_backupcopy(buf_T *buf, char *oldval, int opt_flags, char **e
   }
 }
 
+static void did_set_breakindentopt(win_T *win, char **errmsg)
+{
+  if (briopt_check(win) == FAIL) {
+    *errmsg = e_invarg;
+  }
+  // list setting requires a redraw
+  if (win == curwin && win->w_briopt_list) {
+    redraw_all_later(UPD_NOT_VALID);
+  }
+}
+
 /// Handle string options that need some action to perform when changed.
 /// The new value must be allocated.
 ///
@@ -713,13 +724,7 @@ char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf
       errmsg = e_backupext_and_patchmode_are_equal;
     }
   } else if (varp == &curwin->w_p_briopt) {  // 'breakindentopt'
-    if (briopt_check(curwin) == FAIL) {
-      errmsg = e_invarg;
-    }
-    // list setting requires a redraw
-    if (curwin->w_briopt_list) {
-      redraw_all_later(UPD_NOT_VALID);
-    }
+    did_set_breakindentopt(curwin, &errmsg);
   } else if (varp == &p_isi
              || varp == &(curbuf->b_p_isk)
              || varp == &p_isp

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1533,30 +1533,14 @@ static void did_set_optexpr(buf_T *buf, win_T *win, char **varp, char **gvarp)
   }
 }
 
-// handle options that are a list of flags.
-static void did_set_option_listflags(buf_T *buf, win_T *win, char **varp, char *errbuf,
-                                     size_t errbuflen, char **errmsg)
+// handle option that is a list of flags.
+static void did_set_option_listflag(char **varp, char *flags, char *errbuf, size_t errbuflen,
+                                    char **errmsg)
 {
-  char *p = NULL;
-  if (varp == &p_ww) {  // 'whichwrap'
-    p = WW_ALL;
-  } else if (varp == &p_shm) {  // 'shortmess'
-    p = SHM_ALL;
-  } else if (varp == &(p_cpo)) {  // 'cpoptions'
-    p = CPO_VI;
-  } else if (varp == &(buf->b_p_fo)) {  // 'formatoptions'
-    p = FO_ALL;
-  } else if (varp == &win->w_p_cocu) {  // 'concealcursor'
-    p = COCU_ALL;
-  } else if (varp == &p_mouse) {  // 'mouse'
-    p = MOUSE_ALL;
-  }
-  if (p != NULL) {
-    for (char *s = *varp; *s; s++) {
-      if (vim_strchr(p, (uint8_t)(*s)) == NULL) {
-        *errmsg = illegal_char(errbuf, errbuflen, *s);
-        break;
-      }
+  for (char *s = *varp; *s; s++) {
+    if (vim_strchr(flags, *s) == NULL) {
+      *errmsg = illegal_char(errbuf, errbuflen, *s);
+      break;
     }
   }
 }
@@ -1871,8 +1855,18 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     qf_process_qftf_option(&errmsg);
   } else if (gvarp == &p_tfu) {  // 'tagfunc'
     set_tagfunc_option(&errmsg);
-  } else {
-    did_set_option_listflags(buf, win, varp, errbuf, errbuflen, &errmsg);
+  } else if (varp == &p_ww) {  // 'whichwrap'
+    did_set_option_listflag(varp, WW_ALL, errbuf, errbuflen, &errmsg);
+  } else if (varp == &p_shm) {  // 'shortmess'
+    did_set_option_listflag(varp, SHM_ALL, errbuf, errbuflen, &errmsg);
+  } else if (varp == &(p_cpo)) {  // 'cpoptions'
+    did_set_option_listflag(varp, CPO_VI, errbuf, errbuflen, &errmsg);
+  } else if (varp == &(buf->b_p_fo)) {  // 'formatoptions'
+    did_set_option_listflag(varp, FO_ALL, errbuf, errbuflen, &errmsg);
+  } else if (varp == &win->w_p_cocu) {  // 'concealcursor'
+    did_set_option_listflag(varp, COCU_ALL, errbuf, errbuflen, &errmsg);
+  } else if (varp == &p_mouse) {  // 'mouse'
+    did_set_option_listflag(varp, MOUSE_ALL, errbuf, errbuflen, &errmsg);
   }
 
   // If error detected, restore the previous value.

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3854,10 +3854,11 @@ static buf_T *qf_find_buf(qf_info_T *qi)
 }
 
 /// Process the 'quickfixtextfunc' option value.
-/// @return  OK or FAIL
-int qf_process_qftf_option(void)
+void qf_process_qftf_option(char **errmsg)
 {
-  return option_set_callback_func(p_qftf, &qftf_cb);
+  if (option_set_callback_func(p_qftf, &qftf_cb) == FAIL) {
+    *errmsg = e_invarg;
+  }
 }
 
 /// Update the w:quickfix_title variable in the quickfix/location list window in

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -210,22 +210,20 @@ static Callback tfu_cb;         // 'tagfunc' callback function
 /// Reads the 'tagfunc' option value and convert that to a callback value.
 /// Invoked when the 'tagfunc' option is set. The option value can be a name of
 /// a function (string), or function(<name>) or funcref(<name>) or a lambda.
-int set_tagfunc_option(void)
+void set_tagfunc_option(char **errmsg)
 {
   callback_free(&tfu_cb);
   callback_free(&curbuf->b_tfu_cb);
 
   if (*curbuf->b_p_tfu == NUL) {
-    return OK;
+    return;
   }
 
   if (option_set_callback_func(curbuf->b_p_tfu, &tfu_cb) == FAIL) {
-    return FAIL;
+    *errmsg = e_invarg;
   }
 
   callback_copy(&curbuf->b_tfu_cb, &tfu_cb);
-
-  return OK;
 }
 
 #if defined(EXITFREE)


### PR DESCRIPTION
## Problems

- Scope of local variables in options code is too large.
- `did_set_string_option()` is too large (>1000LOC).
- Setting options for a particular window or buffer requires a changing context (assigning `curwin`/`curbuf`).

## Solutions

- Reduce the scope of local variables.
- Break up `did_set_string_option` so it doesn't contain specific logic about each individual option (1038 LOC -> 310 LOC).
- Begin work on making functions not depend on `curbuf` or `curwin` and pass window or buffer handles explicitly.

