### PR TITLE
Support `altfont` as a term rendering attribute

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8328,6 +8328,7 @@ synIDattr({synID}, {what} [, {mode}])			*synIDattr()*
 		"underdotted"	"1" if dotted underlined
 		"underdashed"	"1" if dashed underlined
 		"strikethrough"	"1" if struckthrough
+		"altfont"	"1" if alternative font
 		"nocombine"	"1" if nocombine
 
 		Returns an empty string on error.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -149,6 +149,8 @@ The following new APIs or features were added.
   deterministic, and a `LUA_GEN_PRG` build parameter has been introduced to
   allow for a workaround for some remaining reproducibility problems.
 
+• |:highlight| now supports an additional attribute "altfont".
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4958,7 +4958,8 @@ the same syntax file on all UIs.
 					*bold* *underline* *undercurl*
 					*underdouble* *underdotted*
 					*underdashed* *inverse* *italic*
-					*standout* *nocombine* *strikethrough*
+					*standout* *strikethrough* *altfont*
+					*nocombine*
 cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 	attr-list is a comma-separated list (without spaces) of the
 	following items (in any order):
@@ -4973,6 +4974,7 @@ cterm={attr-list}			*attr-list* *highlight-cterm* *E418*
 		inverse		same as reverse
 		italic
 		standout
+		altfont
 		nocombine	override attributes instead of combining them
 		NONE		no attributes used (used to reset it)
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -324,6 +324,7 @@ numerical highlight ids to the actual attributes.
 	`underdouble`:		double underlined text. The lines have `special` color.
 	`underdotted`:		underdotted text. The dots have `special` color.
 	`underdashed`:		underdashed text. The dashes have `special` color.
+	`altfont`:		alternative font.
 	`blend`:		Blend level (0-100). Could be used by UIs to
 				support blending floating windows to the
 				background or to signal a transparent cursor.

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -114,6 +114,7 @@ return {
     "underdashed";
     "italic";
     "reverse";
+    "altfont";
     "nocombine";
     "default";
     "cterm";
@@ -140,6 +141,7 @@ return {
     "underdashed";
     "italic";
     "reverse";
+    "altfont";
     "nocombine";
   }};
   -- Autocmds

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -867,6 +867,10 @@ void hlattrs2dict(Dictionary *dict, HlAttrs ae, bool use_rgb)
     PUT_C(hl, "strikethrough", BOOLEAN_OBJ(true));
   }
 
+  if (mask & HL_ALTFONT) {
+    PUT_C(hl, "altfont", BOOLEAN_OBJ(true));
+  }
+
   if (mask & HL_NOCOMBINE) {
     PUT_C(hl, "nocombine", BOOLEAN_OBJ(true));
   }
@@ -932,6 +936,7 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
   CHECK_FLAG(dict, mask, underdashed, , HL_UNDERDASHED);
   CHECK_FLAG(dict, mask, standout, , HL_STANDOUT);
   CHECK_FLAG(dict, mask, strikethrough, , HL_STRIKETHROUGH);
+  CHECK_FLAG(dict, mask, altfont, , HL_ALTFONT);
   if (use_rgb) {
     CHECK_FLAG(dict, mask, fg_indexed, , HL_FG_INDEXED);
     CHECK_FLAG(dict, mask, bg_indexed, , HL_BG_INDEXED);
@@ -1014,6 +1019,7 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     CHECK_FLAG(cterm, cterm_mask, undercurl, , HL_UNDERCURL);
     CHECK_FLAG(cterm, cterm_mask, standout, , HL_STANDOUT);
     CHECK_FLAG(cterm, cterm_mask, strikethrough, , HL_STRIKETHROUGH);
+    CHECK_FLAG(cterm, cterm_mask, altfont, , HL_ALTFONT);
     CHECK_FLAG(cterm, cterm_mask, nocombine, , HL_NOCOMBINE);
   } else if (dict->cterm.type == kObjectTypeArray && dict->cterm.data.array.size == 0) {
     // empty list from Lua API should clear all cterm attributes

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -649,7 +649,7 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     cattrs = battrs;
     cattrs.rgb_fg_color = rgb_blend(ratio, battrs.rgb_fg_color,
                                     fattrs.rgb_bg_color);
-    if (cattrs.rgb_ae_attr & (HL_ANY_UNDERLINE)) {
+    if (cattrs.rgb_ae_attr & (HL_UNDERLINE_MASK)) {
       cattrs.rgb_sp_color = rgb_blend(ratio, battrs.rgb_sp_color,
                                       fattrs.rgb_bg_color);
     } else {
@@ -667,7 +667,7 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
     }
     cattrs.rgb_fg_color = rgb_blend(ratio/2, battrs.rgb_fg_color,
                                     fattrs.rgb_fg_color);
-    if (cattrs.rgb_ae_attr & (HL_ANY_UNDERLINE)) {
+    if (cattrs.rgb_ae_attr & (HL_UNDERLINE_MASK)) {
       cattrs.rgb_sp_color = rgb_blend(ratio/2, battrs.rgb_bg_color,
                                       fattrs.rgb_sp_color);
     } else {
@@ -825,40 +825,42 @@ void hlattrs2dict(Dictionary *dict, HlAttrs ae, bool use_rgb)
   Dictionary hl = *dict;
   int mask  = use_rgb ? ae.rgb_ae_attr : ae.cterm_ae_attr;
 
+  if (mask & HL_INVERSE) {
+    PUT_C(hl, "reverse", BOOLEAN_OBJ(true));
+  }
+
   if (mask & HL_BOLD) {
     PUT_C(hl, "bold", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_STANDOUT) {
-    PUT_C(hl, "standout", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_UNDERLINE) {
-    PUT_C(hl, "underline", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_UNDERCURL) {
-    PUT_C(hl, "undercurl", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_UNDERDOUBLE) {
-    PUT_C(hl, "underdouble", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_UNDERDOTTED) {
-    PUT_C(hl, "underdotted", BOOLEAN_OBJ(true));
-  }
-
-  if (mask & HL_UNDERDASHED) {
-    PUT_C(hl, "underdashed", BOOLEAN_OBJ(true));
   }
 
   if (mask & HL_ITALIC) {
     PUT_C(hl, "italic", BOOLEAN_OBJ(true));
   }
 
-  if (mask & HL_INVERSE) {
-    PUT_C(hl, "reverse", BOOLEAN_OBJ(true));
+  switch (mask & HL_UNDERLINE_MASK) {
+  case HL_UNDERLINE:
+    PUT_C(hl, "underline", BOOLEAN_OBJ(true));
+    break;
+
+  case HL_UNDERDOUBLE:
+    PUT_C(hl, "underdouble", BOOLEAN_OBJ(true));
+    break;
+
+  case HL_UNDERCURL:
+    PUT_C(hl, "undercurl", BOOLEAN_OBJ(true));
+    break;
+
+  case HL_UNDERDOTTED:
+    PUT_C(hl, "underdotted", BOOLEAN_OBJ(true));
+    break;
+
+  case HL_UNDERDASHED:
+    PUT_C(hl, "underdashed", BOOLEAN_OBJ(true));
+    break;
+  }
+
+  if (mask & HL_STANDOUT) {
+    PUT_C(hl, "standout", BOOLEAN_OBJ(true));
   }
 
   if (mask & HL_STRIKETHROUGH) {
@@ -920,15 +922,15 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     m = m | flag; \
   }
 
+  CHECK_FLAG(dict, mask, reverse, , HL_INVERSE);
   CHECK_FLAG(dict, mask, bold, , HL_BOLD);
-  CHECK_FLAG(dict, mask, standout, , HL_STANDOUT);
+  CHECK_FLAG(dict, mask, italic, , HL_ITALIC);
   CHECK_FLAG(dict, mask, underline, , HL_UNDERLINE);
-  CHECK_FLAG(dict, mask, undercurl, , HL_UNDERCURL);
   CHECK_FLAG(dict, mask, underdouble, , HL_UNDERDOUBLE);
+  CHECK_FLAG(dict, mask, undercurl, , HL_UNDERCURL);
   CHECK_FLAG(dict, mask, underdotted, , HL_UNDERDOTTED);
   CHECK_FLAG(dict, mask, underdashed, , HL_UNDERDASHED);
-  CHECK_FLAG(dict, mask, italic, , HL_ITALIC);
-  CHECK_FLAG(dict, mask, reverse, , HL_INVERSE);
+  CHECK_FLAG(dict, mask, standout, , HL_STANDOUT);
   CHECK_FLAG(dict, mask, strikethrough, , HL_STRIKETHROUGH);
   if (use_rgb) {
     CHECK_FLAG(dict, mask, fg_indexed, , HL_FG_INDEXED);
@@ -1005,12 +1007,12 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     }
 
     cterm_mask_provided = true;
+    CHECK_FLAG(cterm, cterm_mask, reverse, , HL_INVERSE);
     CHECK_FLAG(cterm, cterm_mask, bold, , HL_BOLD);
-    CHECK_FLAG(cterm, cterm_mask, standout, , HL_STANDOUT);
+    CHECK_FLAG(cterm, cterm_mask, italic, , HL_ITALIC);
     CHECK_FLAG(cterm, cterm_mask, underline, , HL_UNDERLINE);
     CHECK_FLAG(cterm, cterm_mask, undercurl, , HL_UNDERCURL);
-    CHECK_FLAG(cterm, cterm_mask, italic, , HL_ITALIC);
-    CHECK_FLAG(cterm, cterm_mask, reverse, , HL_INVERSE);
+    CHECK_FLAG(cterm, cterm_mask, standout, , HL_STANDOUT);
     CHECK_FLAG(cterm, cterm_mask, strikethrough, , HL_STRIKETHROUGH);
     CHECK_FLAG(cterm, cterm_mask, nocombine, , HL_NOCOMBINE);
   } else if (dict->cterm.type == kObjectTypeArray && dict->cterm.data.array.size == 0) {

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -22,10 +22,11 @@ typedef enum {
   HL_UNDERCURL       = 0x18,
   HL_UNDERDOTTED     = 0x20,
   HL_UNDERDASHED     = 0x28,
-                       // 0x30 and 0x38 spare for underline styles
+  // 0x30 and 0x38 spare for underline styles
   HL_STANDOUT      = 0x0040,
   HL_STRIKETHROUGH = 0x0080,
-  // 0x0100-0x0200 spare
+  HL_ALTFONT       = 0x0100,
+  // 0x0200 spare
   HL_NOCOMBINE     = 0x0400,
   HL_BG_INDEXED    = 0x0800,
   HL_FG_INDEXED    = 0x1000,

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -15,19 +15,22 @@ typedef enum {
   HL_INVERSE         = 0x01,
   HL_BOLD            = 0x02,
   HL_ITALIC          = 0x04,
+  // The next three bits are all underline styles
+  HL_UNDERLINE_MASK  = 0x38,
   HL_UNDERLINE       = 0x08,
-  HL_UNDERCURL       = 0x10,
-  HL_UNDERDOUBLE     = 0x20,
-  HL_UNDERDOTTED     = 0x40,
-  HL_UNDERDASHED     = 0x80,
-  HL_STANDOUT      = 0x0100,
-  HL_NOCOMBINE     = 0x0200,
-  HL_STRIKETHROUGH = 0x0400,
+  HL_UNDERDOUBLE     = 0x10,
+  HL_UNDERCURL       = 0x18,
+  HL_UNDERDOTTED     = 0x20,
+  HL_UNDERDASHED     = 0x28,
+                       // 0x30 and 0x38 spare for underline styles
+  HL_STANDOUT      = 0x0040,
+  HL_STRIKETHROUGH = 0x0080,
+  // 0x0100-0x0200 spare
+  HL_NOCOMBINE     = 0x0400,
   HL_BG_INDEXED    = 0x0800,
   HL_FG_INDEXED    = 0x1000,
   HL_DEFAULT       = 0x2000,
   HL_GLOBAL        = 0x4000,
-  HL_ANY_UNDERLINE = HL_UNDERLINE | HL_UNDERDOUBLE | HL_UNDERCURL | HL_UNDERDOTTED | HL_UNDERDASHED,
 } HlAttrFlags;
 
 /// Stores a complete highlighting entry, including colors and attributes

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -67,11 +67,13 @@ Map(cstr_t, int) highlight_unames = MAP_INIT;
 static char *(hl_name_table[]) =
 { "bold", "standout", "underline",
   "undercurl", "underdouble", "underdotted", "underdashed",
-  "italic", "reverse", "inverse", "strikethrough", "nocombine", "NONE" };
+  "italic", "reverse", "inverse", "strikethrough", "altfont",
+  "nocombine", "NONE" };
 static int hl_attr_table[] =
 { HL_BOLD, HL_STANDOUT, HL_UNDERLINE,
   HL_UNDERCURL, HL_UNDERDOUBLE, HL_UNDERDOTTED, HL_UNDERDASHED,
-  HL_ITALIC, HL_INVERSE, HL_INVERSE, HL_STRIKETHROUGH, HL_NOCOMBINE, 0 };
+  HL_ITALIC, HL_INVERSE, HL_INVERSE, HL_STRIKETHROUGH, HL_ALTFONT,
+  HL_NOCOMBINE, 0 };
 
 /// Structure that stores information about a highlight group.
 /// The ID of a highlight group is also called group ID.  It is the index in
@@ -1595,7 +1597,12 @@ const char *highlight_has_attr(const int id, const int flag, const int modec)
     attr = hl_table[id - 1].sg_cterm;
   }
 
-  return (attr & flag) ? "1" : NULL;
+  if (flag & HL_UNDERLINE_MASK) {
+    int ul = attr & HL_UNDERLINE_MASK;
+    return ul == flag ? "1" : NULL;
+  } else {
+    return (attr & flag) ? "1" : NULL;
+  }
 }
 
 /// Return color name of the given highlight group

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -137,6 +137,7 @@ struct TUIData {
     int enable_bracketed_paste, disable_bracketed_paste;
     int enable_lr_margin, disable_lr_margin;
     int enter_strikethrough_mode;
+    int enter_altfont_mode;
     int set_rgb_foreground, set_rgb_background;
     int set_cursor_color;
     int reset_cursor_color;
@@ -251,6 +252,7 @@ static void terminfo_start(TUIData *tui)
   tui->unibi_ext.enable_bracketed_paste = -1;
   tui->unibi_ext.disable_bracketed_paste = -1;
   tui->unibi_ext.enter_strikethrough_mode = -1;
+  tui->unibi_ext.enter_altfont_mode = -1;
   tui->unibi_ext.enable_lr_margin = -1;
   tui->unibi_ext.disable_lr_margin = -1;
   tui->unibi_ext.enable_focus_reporting = -1;
@@ -531,6 +533,7 @@ static void update_attrs(TUIData *tui, int attr_id)
   bool reverse = attr & HL_INVERSE;
   bool standout = attr & HL_STANDOUT;
   bool strikethrough = attr & HL_STRIKETHROUGH;
+  bool altfont = attr & HL_ALTFONT;
 
   bool underline;
   bool undercurl;
@@ -589,6 +592,9 @@ static void update_attrs(TUIData *tui, int attr_id)
   }
   if (italic) {
     unibi_out(tui, unibi_enter_italics_mode);
+  }
+  if (altfont && tui->unibi_ext.enter_altfont_mode != -1) {
+    unibi_out_ext(tui, tui->unibi_ext.enter_altfont_mode);
   }
   if (strikethrough && tui->unibi_ext.enter_strikethrough_mode != -1) {
     unibi_out_ext(tui, tui->unibi_ext.enter_strikethrough_mode);
@@ -2037,6 +2043,11 @@ static void augment_terminfo(TUIData *tui, const char *term, long vte_version, l
   // terminfo describes strikethrough modes as rmxx/smxx with respect
   // to the ECMA-48 strikeout/crossed-out attributes.
   tui->unibi_ext.enter_strikethrough_mode = unibi_find_ext_str(ut, "smxx");
+
+  // It should be pretty safe to always enable this, as terminals will ignore
+  // unrecognised SGR numbers.
+  tui->unibi_ext.enter_altfont_mode = (int)unibi_add_ext_str(ut, "ext.enter_altfont_mode",
+                                                             "\x1b[11m");
 
   // Dickey ncurses terminfo does not include the setrgbf and setrgbb
   // capabilities, proposed by Rüdiger Sonderfeld on 2013-10-15.  Adding

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -511,7 +511,7 @@ static bool attrs_differ(TUIData *tui, int id1, int id2, bool rgb)
     return a1.cterm_fg_color != a2.cterm_fg_color
            || a1.cterm_bg_color != a2.cterm_bg_color
            || a1.cterm_ae_attr != a2.cterm_ae_attr
-           || (a1.cterm_ae_attr & HL_ANY_UNDERLINE
+           || (a1.cterm_ae_attr & HL_UNDERLINE_MASK
                && a1.rgb_sp_color != a2.rgb_sp_color);
   }
 }
@@ -538,13 +538,14 @@ static void update_attrs(TUIData *tui, int attr_id)
   bool underdotted;
   bool underdashed;
   if (tui->unibi_ext.set_underline_style != -1) {
-    underline = attr & HL_UNDERLINE;
-    undercurl = attr & HL_UNDERCURL;
-    underdouble = attr & HL_UNDERDOUBLE;
-    underdashed = attr & HL_UNDERDASHED;
-    underdotted = attr & HL_UNDERDOTTED;
+    int ul = attr & HL_UNDERLINE_MASK;
+    underline = ul == HL_UNDERLINE;
+    undercurl = ul == HL_UNDERCURL;
+    underdouble = ul == HL_UNDERDOUBLE;
+    underdashed = ul == HL_UNDERDASHED;
+    underdotted = ul == HL_UNDERDOTTED;
   } else {
-    underline = attr & HL_ANY_UNDERLINE;
+    underline = attr & HL_UNDERLINE_MASK;
     undercurl = false;
     underdouble = false;
     underdotted = false;

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -33,6 +33,7 @@ describe('API: highlight',function()
     reverse = true,
     underline = true,
     strikethrough = true,
+    altfont = true,
     nocombine = true,
   }
   local expected_undercurl = {
@@ -61,7 +62,7 @@ describe('API: highlight',function()
     eq('Invalid highlight id: 30000', string.match(emsg, 'Invalid.*'))
 
     -- Test all highlight properties.
-    command('hi NewHighlight gui=underline,bold,italic,reverse,strikethrough,nocombine')
+    command('hi NewHighlight gui=underline,bold,italic,reverse,strikethrough,altfont,nocombine')
     eq(expected_rgb2, nvim("get_hl_by_id", hl_id, true))
 
     -- Test undercurl
@@ -215,10 +216,12 @@ describe("API: set highlight", function()
     reverse = true,
     underline = true,
     strikethrough = true,
+    altfont = true,
     cterm = {
       italic = true,
       reverse = true,
       strikethrough = true,
+      altfont = true,
       nocombine = true,
     }
   }
@@ -230,6 +233,7 @@ describe("API: set highlight", function()
     reverse = true,
     underline = true,
     strikethrough = true,
+    altfont = true,
   }
   local highlight3_result_cterm = {
     background = highlight_color.ctermbg,
@@ -237,6 +241,7 @@ describe("API: set highlight", function()
     italic = true,
     reverse = true,
     strikethrough = true,
+    altfont = true,
     nocombine = true,
   }
 
@@ -292,7 +297,7 @@ describe("API: set highlight", function()
       exec_capture('highlight Test_hl'))
 
     meths.set_hl(0, 'Test_hl2', highlight3_config)
-    eq('Test_hl2       xxx cterm=italic,reverse,strikethrough,nocombine ctermfg=8 ctermbg=15 gui=bold,underline,italic,reverse,strikethrough guifg=#ff0000 guibg=#0032aa',
+    eq('Test_hl2       xxx cterm=italic,reverse,strikethrough,altfont,nocombine ctermfg=8 ctermbg=15 gui=bold,underline,italic,reverse,strikethrough,altfont guifg=#ff0000 guibg=#0032aa',
       exec_capture('highlight Test_hl2'))
 
     -- Colors are stored with the name they are defined, but

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -32,12 +32,14 @@ describe('API: highlight',function()
     italic = true,
     reverse = true,
     underline = true,
-    undercurl = true,
-    underdouble = true,
-    underdotted = true,
-    underdashed = true,
     strikethrough = true,
     nocombine = true,
+  }
+  local expected_undercurl = {
+    background = Screen.colors.Yellow,
+    foreground = Screen.colors.Red,
+    special = Screen.colors.Blue,
+    undercurl = true,
   }
 
   before_each(function()
@@ -59,8 +61,12 @@ describe('API: highlight',function()
     eq('Invalid highlight id: 30000', string.match(emsg, 'Invalid.*'))
 
     -- Test all highlight properties.
-    command('hi NewHighlight gui=underline,bold,undercurl,underdouble,underdotted,underdashed,italic,reverse,strikethrough,nocombine')
+    command('hi NewHighlight gui=underline,bold,italic,reverse,strikethrough,nocombine')
     eq(expected_rgb2, nvim("get_hl_by_id", hl_id, true))
+
+    -- Test undercurl
+    command('hi NewHighlight gui=undercurl')
+    eq(expected_undercurl, nvim("get_hl_by_id", hl_id, true))
 
     -- Test nil argument.
     err, emsg = pcall(meths.get_hl_by_id, { nil }, false)
@@ -207,16 +213,11 @@ describe("API: set highlight", function()
     bold = true,
     italic = true,
     reverse = true,
-    undercurl = true,
     underline = true,
-    underdashed = true,
-    underdotted = true,
-    underdouble = true,
     strikethrough = true,
     cterm = {
       italic = true,
       reverse = true,
-      undercurl = true,
       strikethrough = true,
       nocombine = true,
     }
@@ -227,11 +228,7 @@ describe("API: set highlight", function()
     bold = true,
     italic = true,
     reverse = true,
-    undercurl = true,
     underline = true,
-    underdashed = true,
-    underdotted = true,
-    underdouble = true,
     strikethrough = true,
   }
   local highlight3_result_cterm = {
@@ -239,7 +236,6 @@ describe("API: set highlight", function()
     foreground = highlight_color.ctermfg,
     italic = true,
     reverse = true,
-    undercurl = true,
     strikethrough = true,
     nocombine = true,
   }
@@ -296,7 +292,7 @@ describe("API: set highlight", function()
       exec_capture('highlight Test_hl'))
 
     meths.set_hl(0, 'Test_hl2', highlight3_config)
-    eq('Test_hl2       xxx cterm=undercurl,italic,reverse,strikethrough,nocombine ctermfg=8 ctermbg=15 gui=bold,underline,undercurl,underdouble,underdotted,underdashed,italic,reverse,strikethrough guifg=#ff0000 guibg=#0032aa',
+    eq('Test_hl2       xxx cterm=italic,reverse,strikethrough,nocombine ctermfg=8 ctermbg=15 gui=bold,underline,italic,reverse,strikethrough guifg=#ff0000 guibg=#0032aa',
       exec_capture('highlight Test_hl2'))
 
     -- Colors are stored with the name they are defined, but


### PR DESCRIPTION
Adds support for `hi Foo cterm=altfont`

Renders altfont in `tui.c` by using `SGR 11`, select first alternative font.

Still TODO:
 - [ ] Talk to terminfo library maintainer (Thomas Dickey) about allocating an official mode name for it
 - [ ] Talk to unibilium (@mauke) about supporting it
 - [x] Write docs
 - [ ] Tests?
 - [ ] Extract altfont knowledge from `:terminal` so it highlights correctly though that too