### PR TITLE
vim-patch:9.0.1221: code is indented more than necessary

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1193,18 +1193,20 @@ static void put_reedit_in_typebuf(int silent)
 {
   char_u buf[3];
 
-  if (restart_edit != NUL) {
-    if (restart_edit == 'V') {
-      buf[0] = 'g';
-      buf[1] = 'R';
-      buf[2] = NUL;
-    } else {
-      buf[0] = (char_u)(restart_edit == 'I' ? 'i' : restart_edit);
-      buf[1] = NUL;
-    }
-    if (ins_typebuf((char *)buf, REMAP_NONE, 0, true, silent) == OK) {
-      restart_edit = NUL;
-    }
+  if (restart_edit == NUL) {
+    return;
+  }
+
+  if (restart_edit == 'V') {
+    buf[0] = 'g';
+    buf[1] = 'R';
+    buf[2] = NUL;
+  } else {
+    buf[0] = (char_u)(restart_edit == 'I' ? 'i' : restart_edit);
+    buf[1] = NUL;
+  }
+  if (ins_typebuf((char *)buf, REMAP_NONE, 0, true, silent) == OK) {
+    restart_edit = NUL;
   }
 }
 
@@ -2574,12 +2576,14 @@ void free_register(yankreg_T *reg)
   FUNC_ATTR_NONNULL_ALL
 {
   set_yreg_additional_data(reg, NULL);
-  if (reg->y_array != NULL) {
-    for (size_t i = reg->y_size; i-- > 0;) {  // from y_size - 1 to 0 included
-      xfree(reg->y_array[i]);
-    }
-    XFREE_CLEAR(reg->y_array);
+  if (reg->y_array == NULL) {
+    return;
   }
+
+  for (size_t i = reg->y_size; i-- > 0;) {  // from y_size - 1 to 0 included
+    xfree(reg->y_array[i]);
+  }
+  XFREE_CLEAR(reg->y_array);
 }
 
 /// Yanks the text between "oap->start" and "oap->end" into a yank register.

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -703,17 +703,17 @@ void script_prof_save(proftime_T *tm)
 /// Count time spent in children after invoking another script or function.
 void script_prof_restore(const proftime_T *tm)
 {
-  scriptitem_T *si;
+  if (!SCRIPT_ID_VALID(current_sctx.sc_sid)) {
+    return;
+  }
 
-  if (current_sctx.sc_sid > 0 && current_sctx.sc_sid <= script_items.ga_len) {
-    si = &SCRIPT_ITEM(current_sctx.sc_sid);
-    if (si->sn_prof_on && --si->sn_pr_nest == 0) {
-      si->sn_pr_child = profile_end(si->sn_pr_child);
-      // don't count wait time
-      si->sn_pr_child = profile_sub_wait(*tm, si->sn_pr_child);
-      si->sn_pr_children = profile_add(si->sn_pr_children, si->sn_pr_child);
-      si->sn_prl_children = profile_add(si->sn_prl_children, si->sn_pr_child);
-    }
+  scriptitem_T *si = &SCRIPT_ITEM(current_sctx.sc_sid);
+  if (si->sn_prof_on && --si->sn_pr_nest == 0) {
+    si->sn_pr_child = profile_end(si->sn_pr_child);
+    // don't count wait time
+    si->sn_pr_child = profile_sub_wait(*tm, si->sn_pr_child);
+    si->sn_pr_children = profile_add(si->sn_pr_children, si->sn_pr_child);
+    si->sn_prl_children = profile_add(si->sn_prl_children, si->sn_pr_child);
   }
 }
 
@@ -787,17 +787,17 @@ static void script_dump_profile(FILE *fd)
 /// Dump the profiling info.
 void profile_dump(void)
 {
-  FILE *fd;
+  if (profile_fname == NULL) {
+    return;
+  }
 
-  if (profile_fname != NULL) {
-    fd = os_fopen(profile_fname, "w");
-    if (fd == NULL) {
-      semsg(_(e_notopen), profile_fname);
-    } else {
-      script_dump_profile(fd);
-      func_dump_profile(fd);
-      fclose(fd);
-    }
+  FILE *fd = os_fopen(profile_fname, "w");
+  if (fd == NULL) {
+    semsg(_(e_notopen), profile_fname);
+  } else {
+    script_dump_profile(fd);
+    func_dump_profile(fd);
+    fclose(fd);
   }
 }
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1184,32 +1184,36 @@ static int prog_magic_wrong(void)
 // used (to increase speed).
 static void cleanup_subexpr(void)
 {
-  if (rex.need_clear_subexpr) {
-    if (REG_MULTI) {
-      // Use 0xff to set lnum to -1
-      memset(rex.reg_startpos, 0xff, sizeof(lpos_T) * NSUBEXP);
-      memset(rex.reg_endpos, 0xff, sizeof(lpos_T) * NSUBEXP);
-    } else {
-      memset(rex.reg_startp, 0, sizeof(char *) * NSUBEXP);
-      memset(rex.reg_endp, 0, sizeof(char *) * NSUBEXP);
-    }
-    rex.need_clear_subexpr = false;
+  if (!rex.need_clear_subexpr) {
+    return;
   }
+
+  if (REG_MULTI) {
+    // Use 0xff to set lnum to -1
+    memset(rex.reg_startpos, 0xff, sizeof(lpos_T) * NSUBEXP);
+    memset(rex.reg_endpos, 0xff, sizeof(lpos_T) * NSUBEXP);
+  } else {
+    memset(rex.reg_startp, 0, sizeof(char *) * NSUBEXP);
+    memset(rex.reg_endp, 0, sizeof(char *) * NSUBEXP);
+  }
+  rex.need_clear_subexpr = false;
 }
 
 static void cleanup_zsubexpr(void)
 {
-  if (rex.need_clear_zsubexpr) {
-    if (REG_MULTI) {
-      // Use 0xff to set lnum to -1
-      memset(reg_startzpos, 0xff, sizeof(lpos_T) * NSUBEXP);
-      memset(reg_endzpos, 0xff, sizeof(lpos_T) * NSUBEXP);
-    } else {
-      memset(reg_startzp, 0, sizeof(char *) * NSUBEXP);
-      memset(reg_endzp, 0, sizeof(char *) * NSUBEXP);
-    }
-    rex.need_clear_zsubexpr = false;
+  if (!rex.need_clear_zsubexpr) {
+    return;
   }
+
+  if (REG_MULTI) {
+    // Use 0xff to set lnum to -1
+    memset(reg_startzpos, 0xff, sizeof(lpos_T) * NSUBEXP);
+    memset(reg_endzpos, 0xff, sizeof(lpos_T) * NSUBEXP);
+  } else {
+    memset(reg_startzp, 0, sizeof(char *) * NSUBEXP);
+    memset(reg_endzp, 0, sizeof(char *) * NSUBEXP);
+  }
+  rex.need_clear_zsubexpr = false;
 }
 
 // Advance rex.lnum, rex.line and rex.input to the next line.

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -3468,15 +3468,17 @@ static void save_subexpr(regbehind_T *bp)
   // When "rex.need_clear_subexpr" is set we don't need to save the values, only
   // remember that this flag needs to be set again when restoring.
   bp->save_need_clear_subexpr = rex.need_clear_subexpr;
-  if (!rex.need_clear_subexpr) {
-    for (int i = 0; i < NSUBEXP; i++) {
-      if (REG_MULTI) {
-        bp->save_start[i].se_u.pos = rex.reg_startpos[i];
-        bp->save_end[i].se_u.pos = rex.reg_endpos[i];
-      } else {
-        bp->save_start[i].se_u.ptr = rex.reg_startp[i];
-        bp->save_end[i].se_u.ptr = rex.reg_endp[i];
-      }
+  if (rex.need_clear_subexpr) {
+    return;
+  }
+
+  for (int i = 0; i < NSUBEXP; i++) {
+    if (REG_MULTI) {
+      bp->save_start[i].se_u.pos = rex.reg_startpos[i];
+      bp->save_end[i].se_u.pos = rex.reg_endpos[i];
+    } else {
+      bp->save_start[i].se_u.ptr = rex.reg_startp[i];
+      bp->save_end[i].se_u.ptr = rex.reg_endp[i];
     }
   }
 }
@@ -3487,15 +3489,17 @@ static void restore_subexpr(regbehind_T *bp)
 {
   // Only need to restore saved values when they are not to be cleared.
   rex.need_clear_subexpr = bp->save_need_clear_subexpr;
-  if (!rex.need_clear_subexpr) {
-    for (int i = 0; i < NSUBEXP; i++) {
-      if (REG_MULTI) {
-        rex.reg_startpos[i] = bp->save_start[i].se_u.pos;
-        rex.reg_endpos[i] = bp->save_end[i].se_u.pos;
-      } else {
-        rex.reg_startp[i] = bp->save_start[i].se_u.ptr;
-        rex.reg_endp[i] = bp->save_end[i].se_u.ptr;
-      }
+  if (rex.need_clear_subexpr) {
+    return;
+  }
+
+  for (int i = 0; i < NSUBEXP; i++) {
+    if (REG_MULTI) {
+      rex.reg_startpos[i] = bp->save_start[i].se_u.pos;
+      rex.reg_endpos[i] = bp->save_end[i].se_u.pos;
+    } else {
+      rex.reg_startp[i] = bp->save_start[i].se_u.ptr;
+      rex.reg_endp[i] = bp->save_end[i].se_u.ptr;
     }
   }
 }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -3285,25 +3285,27 @@ static void nfa_postfix_dump(char_u *expr, int retval)
   FILE *f;
 
   f = fopen(NFA_REGEXP_DUMP_LOG, "a");
-  if (f != NULL) {
-    fprintf(f, "\n-------------------------\n");
-    if (retval == FAIL) {
-      fprintf(f, ">>> NFA engine failed... \n");
-    } else if (retval == OK) {
-      fprintf(f, ">>> NFA engine succeeded !\n");
-    }
-    fprintf(f, "Regexp: \"%s\"\nPostfix notation (char): \"", expr);
-    for (p = post_start; *p && p < post_ptr; p++) {
-      nfa_set_code(*p);
-      fprintf(f, "%s, ", code);
-    }
-    fprintf(f, "\"\nPostfix notation (int): ");
-    for (p = post_start; *p && p < post_ptr; p++) {
-      fprintf(f, "%d ", *p);
-    }
-    fprintf(f, "\n\n");
-    fclose(f);
+  if (f == NULL) {
+    return;
   }
+
+  fprintf(f, "\n-------------------------\n");
+  if (retval == FAIL) {
+    fprintf(f, ">>> NFA engine failed... \n");
+  } else if (retval == OK) {
+    fprintf(f, ">>> NFA engine succeeded !\n");
+  }
+  fprintf(f, "Regexp: \"%s\"\nPostfix notation (char): \"", expr);
+  for (p = post_start; *p && p < post_ptr; p++) {
+    nfa_set_code(*p);
+    fprintf(f, "%s, ", code);
+  }
+  fprintf(f, "\"\nPostfix notation (int): ");
+  for (p = post_start; *p && p < post_ptr; p++) {
+    fprintf(f, "%d ", *p);
+  }
+  fprintf(f, "\n\n");
+  fclose(f);
 }
 
 // Print the NFA starting with a root node "state".
@@ -3381,22 +3383,24 @@ static void nfa_dump(nfa_regprog_T *prog)
 {
   FILE *debugf = fopen(NFA_REGEXP_DUMP_LOG, "a");
 
-  if (debugf != NULL) {
-    nfa_print_state(debugf, prog->start);
-
-    if (prog->reganch) {
-      fprintf(debugf, "reganch: %d\n", prog->reganch);
-    }
-    if (prog->regstart != NUL) {
-      fprintf(debugf, "regstart: %c (decimal: %d)\n",
-              prog->regstart, prog->regstart);
-    }
-    if (prog->match_text != NULL) {
-      fprintf(debugf, "match_text: \"%s\"\n", prog->match_text);
-    }
-
-    fclose(debugf);
+  if (debugf == NULL) {
+    return;
   }
+
+  nfa_print_state(debugf, prog->start);
+
+  if (prog->reganch) {
+    fprintf(debugf, "reganch: %d\n", prog->reganch);
+  }
+  if (prog->regstart != NUL) {
+    fprintf(debugf, "regstart: %c (decimal: %d)\n",
+            prog->regstart, prog->regstart);
+  }
+  if (prog->match_text != NULL) {
+    fprintf(debugf, "match_text: \"%s\"\n", prog->match_text);
+  }
+
+  fclose(debugf);
 }
 #endif  // REGEXP_DEBUG
 
@@ -4427,16 +4431,18 @@ static void clear_sub(regsub_T *sub)
 static void copy_sub(regsub_T *to, regsub_T *from)
 {
   to->in_use = from->in_use;
-  if (from->in_use > 0) {
-    // Copy the match start and end positions.
-    if (REG_MULTI) {
-      memmove(&to->list.multi[0], &from->list.multi[0],
-              sizeof(struct multipos) * (size_t)from->in_use);
-      to->orig_start_col = from->orig_start_col;
-    } else {
-      memmove(&to->list.line[0], &from->list.line[0],
-              sizeof(struct linepos) * (size_t)from->in_use);
-    }
+  if (from->in_use <= 0) {
+    return;
+  }
+
+  // Copy the match start and end positions.
+  if (REG_MULTI) {
+    memmove(&to->list.multi[0], &from->list.multi[0],
+            sizeof(struct multipos) * (size_t)from->in_use);
+    to->orig_start_col = from->orig_start_col;
+  } else {
+    memmove(&to->list.line[0], &from->list.line[0],
+            sizeof(struct linepos) * (size_t)from->in_use);
   }
 }
 
@@ -4446,31 +4452,35 @@ static void copy_sub_off(regsub_T *to, regsub_T *from)
   if (to->in_use < from->in_use) {
     to->in_use = from->in_use;
   }
-  if (from->in_use > 1) {
-    // Copy the match start and end positions.
-    if (REG_MULTI) {
-      memmove(&to->list.multi[1], &from->list.multi[1],
-              sizeof(struct multipos) * (size_t)(from->in_use - 1));
-    } else {
-      memmove(&to->list.line[1], &from->list.line[1],
-              sizeof(struct linepos) * (size_t)(from->in_use - 1));
-    }
+  if (from->in_use <= 1) {
+    return;
+  }
+
+  // Copy the match start and end positions.
+  if (REG_MULTI) {
+    memmove(&to->list.multi[1], &from->list.multi[1],
+            sizeof(struct multipos) * (size_t)(from->in_use - 1));
+  } else {
+    memmove(&to->list.line[1], &from->list.line[1],
+            sizeof(struct linepos) * (size_t)(from->in_use - 1));
   }
 }
 
 // Like copy_sub() but only do the end of the main match if \ze is present.
 static void copy_ze_off(regsub_T *to, regsub_T *from)
 {
-  if (rex.nfa_has_zend) {
-    if (REG_MULTI) {
-      if (from->list.multi[0].end_lnum >= 0) {
-        to->list.multi[0].end_lnum = from->list.multi[0].end_lnum;
-        to->list.multi[0].end_col = from->list.multi[0].end_col;
-      }
-    } else {
-      if (from->list.line[0].end != NULL) {
-        to->list.line[0].end = from->list.line[0].end;
-      }
+  if (!rex.nfa_has_zend) {
+    return;
+  }
+
+  if (REG_MULTI) {
+    if (from->list.multi[0].end_lnum >= 0) {
+      to->list.multi[0].end_lnum = from->list.multi[0].end_lnum;
+      to->list.multi[0].end_col = from->list.multi[0].end_col;
+    }
+  } else {
+    if (from->list.line[0].end != NULL) {
+      to->list.line[0].end = from->list.line[0].end;
     }
   }
 }
@@ -7554,11 +7564,13 @@ fail:
 // Free a compiled regexp program, returned by nfa_regcomp().
 static void nfa_regfree(regprog_T *prog)
 {
-  if (prog != NULL) {
-    xfree(((nfa_regprog_T *)prog)->match_text);
-    xfree(((nfa_regprog_T *)prog)->pattern);
-    xfree(prog);
+  if (prog == NULL) {
+    return;
   }
+
+  xfree(((nfa_regprog_T *)prog)->match_text);
+  xfree(((nfa_regprog_T *)prog)->pattern);
+  xfree(prog);
 }
 
 /// Match a regexp against a string.


### PR DESCRIPTION
#### vim-patch:9.0.1221: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11833)

https://github.com/vim/vim/commit/f97a295ccaa9803367f3714cdefce4e2283c771d

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>