### PR TITLE
vim-patch:8.2.4655: cmdline completion popup menu positioned wrong

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -218,11 +218,16 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       // pum above "pum_win_row"
       pum_above = true;
 
-      // Leave two lines of context if possible
-      if (curwin->w_wrow - curwin->w_cline_row >= 2) {
-        context_lines = 2;
+      if (State == MODE_CMDLINE) {
+        // for cmdline pum, no need for context lines
+        context_lines = 0;
       } else {
-        context_lines = curwin->w_wrow - curwin->w_cline_row;
+        // Leave two lines of context if possible
+        if (curwin->w_wrow - curwin->w_cline_row >= 2) {
+          context_lines = 2;
+        } else {
+          context_lines = curwin->w_wrow - curwin->w_cline_row;
+        }
       }
 
       if (pum_win_row >= size + context_lines) {
@@ -241,13 +246,17 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       // pum below "pum_win_row"
       pum_above = false;
 
-      // Leave two lines of context if possible
-      validate_cheight();
-      if (curwin->w_cline_row + curwin->w_cline_height - curwin->w_wrow >= 3) {
-        context_lines = 3;
+      if (State == MODE_CMDLINE) {
+        // for cmdline pum, no need for context lines
+        context_lines = 0;
       } else {
-        context_lines = curwin->w_cline_row
-                        + curwin->w_cline_height - curwin->w_wrow;
+        // Leave two lines of context if possible
+        validate_cheight();
+        if (curwin->w_cline_row + curwin->w_cline_height - curwin->w_wrow >= 3) {
+          context_lines = 3;
+        } else {
+          context_lines = curwin->w_cline_row + curwin->w_cline_height - curwin->w_wrow;
+        }
       }
 
       pum_row = pum_win_row + context_lines;

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2610,6 +2610,30 @@ func Test_wildmenumode_with_pum()
   cunmap <F2>
 endfunc
 
+" Test for opening the cmdline completion popup menu from the terminal window.
+" The popup menu should be positioned correctly over the status line of the
+" bottom-most window.
+func Test_wildmenu_pum_from_terminal()
+  CheckRunVimInTerminal
+  let python = PythonProg()
+  call CheckPython(python)
+
+  %bw!
+  let cmds = ['set wildmenu wildoptions=pum']
+  let pcmd = python .. ' -c "import sys; sys.stdout.write(sys.stdin.read())"'
+  call add(cmds, "call term_start('" .. pcmd .. "')")
+  call writefile(cmds, 'Xtest')
+  let buf = RunVimInTerminal('-S Xtest', #{rows: 10})
+  call term_sendkeys(buf, "\r\r\r")
+  call term_wait(buf)
+  call term_sendkeys(buf, "\<C-W>:sign \<Tab>")
+  call term_wait(buf)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_term_01', {})
+  call term_wait(buf)
+  call StopVimInTerminal(buf)
+  call delete('Xtest')
+endfunc
+
 func Test_wildmenu_pum_clear_entries()
   CheckRunVimInTerminal
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2781,6 +2781,26 @@ describe('builtin popupmenu', function()
     ]]}
   end)
 
+  it('wildoptions=pum with a wrapped line in buffer vim-patch:8.2.4655', function()
+    screen:try_resize(32, 10)
+    meths.buf_set_lines(0, 0, -1, true, { ('a'):rep(100) })
+    command('set wildoptions+=pum')
+    feed('$')
+    feed(':sign <Tab>')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaa {s: define         }           |
+      {1:~    }{n: jump           }{1:           }|
+      {1:~    }{n: list           }{1:           }|
+      {1:~    }{n: place          }{1:           }|
+      {1:~    }{n: undefine       }{1:           }|
+      {1:~    }{n: unplace        }{1:           }|
+      :sign define^                    |
+    ]])
+  end)
+
   -- oldtest: Test_wildmenu_pum_clear_entries()
   it('wildoptions=pum when using Ctrl-E as wildchar vim-patch:9.0.1030', function()
     screen:try_resize(30, 10)


### PR DESCRIPTION
#### vim-patch:8.2.4655: cmdline completion popup menu positioned wrong

Problem:    Command line completion popup menu positioned wrong when using a
            terminal window.
Solution:   Position the popup menu differently when editing the command line.
            (Yegappan Lakshmanan, closes vim/vim#10050)

https://github.com/vim/vim/commit/1104a6d0c2004d39e9b6cb8f804d12b628a69869

The test in the patch looks a bit hard to understand.
Add a Lua test that is more straightforward.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>