### PR TITLE
fix(exit): skip unnecessary steps in TUI preserve_exit()

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -811,6 +811,11 @@ void preserve_exit(void)
   really_exiting = true;
   // Ignore SIGHUP while we are already exiting. #9274
   signal_reject_deadly();
+
+  if (ui_client_channel_id) {
+    os_exit(1);
+  }
+
   os_errmsg(IObuff);
   os_errmsg("\n");
   ui_flush();

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -458,6 +458,9 @@ static void tui_terminal_stop(TUIData *tui)
 
 void tui_stop(TUIData *tui)
 {
+  if (tui->stopped) {
+    return;
+  }
   tui_terminal_stop(tui);
   stream_set_blocking(tui->input.in_fd, true);   // normalize stream (#2598)
   tinput_destroy(&tui->input);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -14,6 +14,7 @@ local clear = helpers.clear
 local command = helpers.command
 local dedent = helpers.dedent
 local exec = helpers.exec
+local exec_lua = helpers.exec_lua
 local testprg = helpers.testprg
 local retry = helpers.retry
 local nvim_prog = helpers.nvim_prog
@@ -1505,6 +1506,11 @@ describe('TUI', function()
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
     ]]}
+  end)
+
+  it('no assert failure on deadly signal #21896', function()
+    exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
+    screen:expect({any = '%[Process exited 1%]'})
   end)
 end)
 


### PR DESCRIPTION
Fix #21896

This prevents the TUI from doing unexpected things when receiving a
deadly signal or running out of memory.
