### PR TITLE
fix(rpc): don't parse msgpack if buflen is 0

### DIFF
--- a/src/mpack/mpack_core.c
+++ b/src/mpack/mpack_core.c
@@ -173,6 +173,9 @@ MPACK_API int mpack_write(mpack_tokbuf_t *tokbuf, char **buf, size_t *buflen,
 
 int mpack_rtoken(const char **buf, size_t *buflen, mpack_token_t *tok)
 {
+  if (*buflen == 0) {
+    return MPACK_EOF;
+  }
   unsigned char t = ADVANCE(buf, buflen);
   if (t < 0x80) {
     /* positive fixint */


### PR DESCRIPTION
This prevents `buflen` from becoming a very large number when it is 0
when calling mpack_rtoken().
