### PR TITLE
feat(lsp): add triggerKind option for vim.lsp.buf.code_action

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1022,6 +1022,8 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                      • only (table|nil): List of LSP `CodeActionKind`s used to
                        filter the code actions. Most language servers support
                        values like `refactor` or `quickfix`.
+                     • triggerKind (number|nil): The reason why code actions
+                       were requested.
 
                    • filter: (function|nil) Predicate taking an `CodeAction`
                      and returning a boolean.
@@ -1036,6 +1038,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
+        vim.lsp.protocol.constants.CodeActionTriggerKind
 
 completion({context})                               *vim.lsp.buf.completion()*
     Retrieves the completion items at the current cursor position. Can only be

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -733,6 +733,7 @@ end
 ---               List of LSP `CodeActionKind`s used to filter the code actions.
 ---               Most language servers support values like `refactor`
 ---               or `quickfix`.
+---        - triggerKind (number|nil): The reason why code actions were requested.
 ---  - filter: (function|nil)
 ---           Predicate taking an `CodeAction` and returning a boolean.
 ---  - apply: (boolean|nil)
@@ -746,6 +747,7 @@ end
 ---           using mark-like indexing. See |api-indexing|
 ---
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
+---@see vim.lsp.protocol.constants.CodeActionTriggerKind
 function M.code_action(options)
   validate({ options = { options, 't', true } })
   options = options or {}
@@ -755,6 +757,9 @@ function M.code_action(options)
     options = { options = options }
   end
   local context = options.context or {}
+  if not context.triggerKind then
+    context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
+  end
   if not context.diagnostics then
     local bufnr = api.nvim_get_current_buf()
     context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -304,6 +304,17 @@ local constants = {
     -- Base kind for an organize imports source action
     SourceOrganizeImports = 'source.organizeImports',
   },
+  -- The reason why code actions were requested.
+  ---@enum lsp.CodeActionTriggerKind
+  CodeActionTriggerKind = {
+    -- Code actions were explicitly requested by the user or by an extension.
+    Invoked = 1,
+    -- Code actions were requested automatically.
+    --
+    -- This typically happens when current selection in a file changes, but can
+    -- also be triggered when file content changes.
+    Automatic = 2,
+  },
 }
 
 for k, v in pairs(constants) do


### PR DESCRIPTION
Lsp spec  3.17 add `triggerKind` option for code action request.
`Tsserver` use this option to make refactors more discoverable.

##spec
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionTriggerKind
##Tsserver mr
microsoft/TypeScript#38378

I set the default value as 'Invoked'. I am not sure it is a right thing.