### PR TITLE
fix(semantic_tokens.lua): Fix nil tokens in semantic_tokens.lua

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -329,7 +329,7 @@ function STHighlighter:process_response(response, client, version)
       idx = token_edit.start + token_edit.deleteCount + 1
     end
     vim.list_extend(tokens, old_tokens, idx)
-  else
+  elseif response.data then
     tokens = response.data
   end
 


### PR DESCRIPTION
Some (poorly-implemented) LSPs can return an empty JSON object in LSP responses, which could cause tokens to be nil, which would eventually cause an error and a bad UI experience. This fix makes sure that the tokens variable is always set to a non-nil value.