### PR TITLE
fix(semantic_tokens.lua): Fix nil tokens/data in semantic_tokens.lua

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -330,7 +330,7 @@ function STHighlighter:process_response(response, client, version)
     end
     vim.list_extend(tokens, old_tokens, idx)
   else
-    tokens = response.data
+    tokens = response.data or {}
   end
 
   -- Update the state with the new results
@@ -378,7 +378,7 @@ function STHighlighter:on_win(topline, botline)
       --
       -- Instead, we have to use normal extmarks that can attach to locations
       -- in the buffer and are persisted between redraws.
-      local highlights = current_result.highlights
+      local highlights = current_result.highlights or {}
       local idx = binary_search(highlights, topline)
 
       for i = idx, #highlights do
@@ -612,7 +612,7 @@ function M.get_at_pos(bufnr, row, col)
 
   local tokens = {}
   for client_id, client in pairs(highlighter.client_state) do
-    local highlights = client.current_result.highlights
+    local highlights = client.current_result.highlights or {}
     if highlights then
       local idx = binary_search(highlights, row)
       for i = idx, #highlights do

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -852,6 +852,20 @@ b = "as"]],
           },
         },
       },
+      {
+        it = 'nil_data',
+        text = [[some text]],
+        response = [[{}]], -- Data is nil
+        legend = [[{
+          "tokenTypes": [
+            "namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator"
+          ],
+          "tokenModifiers": [
+            "declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary"
+          ]
+        }]],
+        expected = {},
+      },
     }) do
       it(test.it, function()
         exec_lua(create_server_definition)


### PR DESCRIPTION
Some (poorly-implemented) LSPs can return an empty JSON object in LSP responses, which could cause tokens to be nil, which would eventually cause an error and a bad UI experience. This fix makes sure that the tokens variable is always set to a non-nil value.