### PR TITLE
fix(tui): presume that the terminal handles strikethrough as SGR 9

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2035,7 +2035,7 @@ static void augment_terminfo(TUIData *tui, const char *term, long vte_version, l
 
   // terminfo describes strikethrough modes as rmxx/smxx with respect
   // to the ECMA-48 strikeout/crossed-out attributes.
-  tui->unibi_ext.enter_strikethrough_mode = unibi_find_ext_str(ut, "smxx");
+  tui->unibi_ext.enter_strikethrough_mode = (int)unibi_add_ext_str(ut, "smxx", "\x1b[9m");
 
   // Dickey ncurses terminfo does not include the setrgbf and setrgbb
   // capabilities, proposed by Rüdiger Sonderfeld on 2013-10-15.  Adding


### PR DESCRIPTION
While looking into altfont (#21888) I happened to be in this area, when someone on IRC mentioned that strikethrough doesn't actually work. Locally tested it to find, indeed it does not. It would have needed the user to locally modify their terminfo file, in a way that they're very unlikely to do. Instead of that, we can just presume that if the terminal has strikethrough, it's probably SGR 9.

It's fairly safe to do this anyway, because terminals should just be ignoring SGR codes they don't recognise, so either we get strikethrough or we don't, but if we don't nothing bad should happen.