### PR TITLE
vim-patch:9.0.0358: 'breakindent' does not indent non-lists

### DIFF
--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -852,7 +852,7 @@ int get_breakindent_win(win_T *wp, char *line)
           if (wp->w_briopt_list > 0) {
             prev_list += wp->w_briopt_list;
           } else {
-            prev_list = (int)(*regmatch.endp - *regmatch.startp);
+            prev_indent = (int)(*regmatch.endp - *regmatch.startp);
           }
         }
         vim_regfree(regmatch.regprog);
@@ -871,12 +871,8 @@ int get_breakindent_win(win_T *wp, char *line)
   bri += win_col_off2(wp);
 
   // add additional indent for numbered lists
-  if (wp->w_briopt_list != 0) {
-    if (wp->w_briopt_list > 0) {
-      bri += prev_list;
-    } else {
-      bri = prev_list;
-    }
+  if (wp->w_briopt_list > 0) {
+    bri += prev_list;
   }
 
   // indent minus the length of the showbreak string

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -856,7 +856,7 @@ func Test_breakindent20_list()
 
   " check formatlistpat indent with different list level
   " showbreak and sbr
-  setl briopt=min:5,sbr,list:-1,shift:2
+  setl briopt=min:5,sbr,list:-1
   setl showbreak=>
   redraw!
   let expect = [
@@ -869,6 +869,44 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 6, 20)
   call s:compare_lines(expect, lines)
+
+  " check formatlistpat indent with different list level
+  " showbreak sbr and shift
+  setl briopt=min:5,sbr,list:-1,shift:2
+  setl showbreak=>
+  redraw!
+  let expect = [
+	\ "* Congress shall    ",
+	\ ">   make no law     ",
+	\ "*** Congress shall  ",
+	\ ">     make no law   ",
+	\ "**** Congress shall ",
+	\ ">      make no law  ",
+	\ ]
+  let lines = s:screen_lines2(1, 6, 20)
+  call s:compare_lines(expect, lines)
+
+  " check breakindent works if breakindentopt=list:-1
+  " for a non list content
+  %delete _
+  call setline(1, ['  Congress shall make no law',
+        \ '    Congress shall make no law',
+        \ '     Congress shall make no law'])
+  norm! 1gg
+  setl briopt=min:5,list:-1
+  setl showbreak=
+  redraw!
+  let expect = [
+	\ "  Congress shall    ",
+	\ "  make no law       ",
+	\ "    Congress shall  ",
+	\ "    make no law     ",
+	\ "     Congress shall ",
+	\ "     make no law    ",
+	\ ]
+  let lines = s:screen_lines2(1, 6, 20)
+  call s:compare_lines(expect, lines)
+
   call s:close_windows('set breakindent& briopt& linebreak& list& listchars& showbreak&')
 endfunc
 


### PR DESCRIPTION
Fix #21907

#### vim-patch:9.0.0358: 'breakindent' does not indent non-lists

Problem:    'breakindent' does not indent non-lists with
            "breakindentopt=list:-1".
Solution:   Adjust indent computation. (Maxim Kim, closes vim/vim#11038)

https://github.com/vim/vim/commit/119167265ebc7eced210a7f8ed2f4b90378f98f1

Co-authored-by: Maxim Kim <habamax@gmail.com>