### PR TITLE
refactor: change char_u to uint8_t or char in sha256.c/undo.c

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5972,18 +5972,18 @@ static void ex_undo(exarg_T *eap)
 
 static void ex_wundo(exarg_T *eap)
 {
-  char hash[UNDO_HASH_SIZE];
+  uint8_t hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(curbuf, (char_u *)hash);
-  u_write_undo(eap->arg, eap->forceit, curbuf, (char_u *)hash);
+  u_compute_hash(curbuf, hash);
+  u_write_undo(eap->arg, eap->forceit, curbuf, hash);
 }
 
 static void ex_rundo(exarg_T *eap)
 {
-  char hash[UNDO_HASH_SIZE];
+  uint8_t hash[UNDO_HASH_SIZE];
 
-  u_compute_hash(curbuf, (char_u *)hash);
-  u_read_undo(eap->arg, (char_u *)hash, NULL);
+  u_compute_hash(curbuf, hash);
+  u_read_undo(eap->arg, hash, NULL);
 }
 
 /// ":redo".

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1554,7 +1554,7 @@ rewind_retry:
               break;
             }
             if (read_undo_file) {
-              sha256_update(&sha_ctx, (char_u *)line_start, (size_t)len);
+              sha256_update(&sha_ctx, (uint8_t *)line_start, (size_t)len);
             }
             lnum++;
             if (--read_count == 0) {
@@ -1610,7 +1610,7 @@ rewind_retry:
               break;
             }
             if (read_undo_file) {
-              sha256_update(&sha_ctx, (char_u *)line_start, (size_t)len);
+              sha256_update(&sha_ctx, (uint8_t *)line_start, (size_t)len);
             }
             lnum++;
             if (--read_count == 0) {
@@ -1667,7 +1667,7 @@ failed:
       error = true;
     } else {
       if (read_undo_file) {
-        sha256_update(&sha_ctx, (char_u *)line_start, (size_t)len);
+        sha256_update(&sha_ctx, (uint8_t *)line_start, (size_t)len);
       }
       read_no_eol_lnum = ++lnum;
     }
@@ -3196,7 +3196,7 @@ restore_backup:
       // Keep it fast!
       ptr = ml_get_buf(buf, lnum, false) - 1;
       if (write_undo_file) {
-        sha256_update(&sha_ctx, (char_u *)ptr + 1, (uint32_t)(strlen(ptr + 1) + 1));
+        sha256_update(&sha_ctx, (uint8_t *)ptr + 1, (uint32_t)(strlen(ptr + 1) + 1));
       }
       while ((c = *++ptr) != NUL) {
         if (c == NL) {
@@ -3605,10 +3605,10 @@ nofail:
   // When writing the whole file and 'undofile' is set, also write the undo
   // file.
   if (retval == OK && write_undo_file) {
-    char hash[UNDO_HASH_SIZE];
+    uint8_t hash[UNDO_HASH_SIZE];
 
-    sha256_finish(&sha_ctx, (char_u *)hash);
-    u_write_undo(NULL, false, buf, (char_u *)hash);
+    sha256_finish(&sha_ctx, hash);
+    u_write_undo(NULL, false, buf, hash);
   }
 
   if (!should_abort(retval)) {

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -32,10 +32,10 @@
 }
 
 #define PUT_UINT32(n, b, i) { \
-  (b)[(i)] = (char_u)((n) >> 24); \
-  (b)[(i) + 1] = (char_u)((n) >> 16); \
-  (b)[(i) + 2] = (char_u)((n) >>  8); \
-  (b)[(i) + 3] = (char_u)((n)); \
+  (b)[(i)] = (uint8_t)((n) >> 24); \
+  (b)[(i) + 1] = (uint8_t)((n) >> 16); \
+  (b)[(i) + 2] = (uint8_t)((n) >>  8); \
+  (b)[(i) + 3] = (uint8_t)((n)); \
 }
 
 void sha256_start(context_sha256_T *ctx)
@@ -53,7 +53,7 @@ void sha256_start(context_sha256_T *ctx)
   ctx->state[7] = 0x5BE0CD19;
 }
 
-static void sha256_process(context_sha256_T *ctx, const char_u data[SHA256_BUFFER_SIZE])
+static void sha256_process(context_sha256_T *ctx, const uint8_t data[SHA256_BUFFER_SIZE])
 {
   uint32_t temp1, temp2, W[SHA256_BUFFER_SIZE];
   uint32_t A, B, C, D, E, F, G, H;
@@ -180,7 +180,7 @@ static void sha256_process(context_sha256_T *ctx, const char_u data[SHA256_BUFFE
   ctx->state[7] += H;
 }
 
-void sha256_update(context_sha256_T *ctx, const char_u *input, size_t length)
+void sha256_update(context_sha256_T *ctx, const uint8_t *input, size_t length)
 {
   if (length == 0) {
     return;
@@ -198,7 +198,7 @@ void sha256_update(context_sha256_T *ctx, const char_u *input, size_t length)
   size_t fill = SHA256_BUFFER_SIZE - left;
 
   if (left && (length >= fill)) {
-    memcpy((void *)(ctx->buffer + left), (void *)input, fill);
+    memcpy(ctx->buffer + left, input, fill);
     sha256_process(ctx, ctx->buffer);
     length -= fill;
     input  += fill;
@@ -212,22 +212,22 @@ void sha256_update(context_sha256_T *ctx, const char_u *input, size_t length)
   }
 
   if (length) {
-    memcpy((void *)(ctx->buffer + left), (void *)input, length);
+    memcpy(ctx->buffer + left, input, length);
   }
 }
 
-static char_u sha256_padding[SHA256_BUFFER_SIZE] = {
+static uint8_t sha256_padding[SHA256_BUFFER_SIZE] = {
   0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-void sha256_finish(context_sha256_T *ctx, char_u digest[SHA256_SUM_SIZE])
+void sha256_finish(context_sha256_T *ctx, uint8_t digest[SHA256_SUM_SIZE])
 {
   uint32_t last, padn;
   uint32_t high, low;
-  char_u msglen[8];
+  uint8_t msglen[8];
 
   high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);
   low  = (ctx->total[0] <<  3);
@@ -265,7 +265,7 @@ void sha256_finish(context_sha256_T *ctx, char_u digest[SHA256_SUM_SIZE])
 const char *sha256_bytes(const uint8_t *restrict buf,  size_t buf_len, const uint8_t *restrict salt,
                          size_t salt_len)
 {
-  char_u sha256sum[SHA256_SUM_SIZE];
+  uint8_t sha256sum[SHA256_SUM_SIZE];
   static char hexit[SHA256_BUFFER_SIZE + 1];  // buf size + NULL
   context_sha256_T ctx;
 
@@ -309,8 +309,8 @@ bool sha256_self_test(void)
 {
   char output[SHA256_BUFFER_SIZE + 1];  // buf size + NULL
   context_sha256_T ctx;
-  char_u buf[1000];
-  char_u sha256sum[SHA256_SUM_SIZE];
+  uint8_t buf[1000];
+  uint8_t sha256sum[SHA256_SUM_SIZE];
   const char *hexit;
 
   static bool sha256_self_tested = false;

--- a/src/nvim/sha256.h
+++ b/src/nvim/sha256.h
@@ -12,7 +12,7 @@
 typedef struct {
   uint32_t total[2];
   uint32_t state[8];
-  char_u buffer[SHA256_BUFFER_SIZE];
+  uint8_t buffer[SHA256_BUFFER_SIZE];
 } context_sha256_T;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS


### PR DESCRIPTION
Use uint8_t for bytes in hashes as it doesn't make sense for them to be signed.