### PR TITLE
fix(lsp): workspace removed just need a empty table

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -487,7 +487,7 @@ function M.add_workspace_folder(workspace_folder)
   end
   local params = util.make_workspace_params(
     { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } },
-    { {} }
+    {}
   )
   for _, client in pairs(vim.lsp.get_active_clients({ bufnr = 0 })) do
     local found = false


### PR DESCRIPTION
`removed` should be a empty table. not `{{}}` .

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWorkspaceFolders