### PR TITLE
refactor: use uint8_t for blobs and ga_append()

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1648,7 +1648,7 @@ void set_var_lval(lval_T *lp, char *endp, typval_T *rettv, int copy, const bool 
           // the end is an error otherwise.
           if (lp->ll_n1 < gap->ga_len || lp->ll_n1 == gap->ga_len) {
             ga_grow(&lp->ll_blob->bv_ga, 1);
-            tv_blob_set(lp->ll_blob, (int)lp->ll_n1, (char_u)val);
+            tv_blob_set(lp->ll_blob, (int)lp->ll_n1, (uint8_t)val);
             if (lp->ll_n1 == gap->ga_len) {
               gap->ga_len++;
             }
@@ -2660,10 +2660,10 @@ static int eval5(char **arg, typval_T *rettv, int evaluate)
         blob_T *const b = tv_blob_alloc();
 
         for (int i = 0; i < tv_blob_len(b1); i++) {
-          ga_append(&b->bv_ga, (char)tv_blob_get(b1, i));
+          ga_append(&b->bv_ga, tv_blob_get(b1, i));
         }
         for (int i = 0; i < tv_blob_len(b2); i++) {
-          ga_append(&b->bv_ga, (char)tv_blob_get(b2, i));
+          ga_append(&b->bv_ga, tv_blob_get(b2, i));
         }
 
         tv_clear(rettv);
@@ -3688,7 +3688,7 @@ static int get_number_tv(char **arg, typval_T *rettv, bool evaluate, bool want_s
         return FAIL;
       }
       if (blob != NULL) {
-        ga_append(&blob->bv_ga, (char)((hex2nr(*bp) << 4) + hex2nr(*(bp + 1))));
+        ga_append(&blob->bv_ga, (uint8_t)((hex2nr(*bp) << 4) + hex2nr(*(bp + 1))));
       }
       if (bp[2] == '.' && ascii_isxdigit(bp[3])) {
         bp++;
@@ -4881,7 +4881,7 @@ void filter_map(typval_T *argvars, typval_T *rettv, int map)
         }
         if (map) {
           if (tv.vval.v_number != val) {
-            tv_blob_set(b, i, (char_u)tv.vval.v_number);
+            tv_blob_set(b, i, (uint8_t)tv.vval.v_number);
           }
         } else if (rem) {
           char *const p = argvars[0].vval.v_blob->bv_ga.ga_data;

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -309,7 +309,7 @@ int encode_read_from_list(ListReaderState *const state, char *const buf, const s
         if (buf_[i_] == '\'') { \
           ga_append(gap, '\''); \
         } \
-        ga_append(gap, buf_[i_]); \
+        ga_append(gap, (uint8_t)buf_[i_]); \
       } \
       ga_append(gap, '\''); \
     } \

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -51,7 +51,7 @@ int eexe_mod_op(typval_T *const tv1, const typval_T *const tv2, const char *cons
         blob_T *const b1 = tv1->vval.v_blob;
         blob_T *const b2 = tv2->vval.v_blob;
         for (int i = 0; i < tv_blob_len(b2); i++) {
-          ga_append(&b1->bv_ga, (char)tv_blob_get(b2, i));
+          ga_append(&b1->bv_ga, tv_blob_get(b2, i));
         }
       }
       return OK;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -375,7 +375,7 @@ static void f_add(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       const varnumber_T n = tv_get_number_chk(&argvars[1], &error);
 
       if (!error) {
-        ga_append(&b->bv_ga, (char)n);
+        ga_append(&b->bv_ga, (uint8_t)n);
         tv_copy(&argvars[0], rettv);
       }
     }
@@ -3584,9 +3584,9 @@ static void f_insert(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
 
     ga_grow(&b->bv_ga, 1);
-    char_u *const p = (char_u *)b->bv_ga.ga_data;
+    uint8_t *const p = (uint8_t *)b->bv_ga.ga_data;
     memmove(p + before + 1, p + before, (size_t)(len - before));
-    *(p + before) = (char_u)val;
+    *(p + before) = (uint8_t)val;
     b->bv_ga.ga_len++;
 
     tv_copy(&argvars[0], rettv);
@@ -5976,7 +5976,7 @@ static void f_reverse(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     const int len = tv_blob_len(b);
 
     for (int i = 0; i < len / 2; i++) {
-      const char_u tmp = tv_blob_get(b, i);
+      const uint8_t tmp = tv_blob_get(b, i);
       tv_blob_set(b, i, tv_blob_get(b, len - i - 1));
       tv_blob_set(b, len - i - 1, tmp);
     }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2730,7 +2730,7 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
     }
     if (argvars[2].v_type == VAR_UNKNOWN) {
       // Remove one item, return its value.
-      char_u *const p = (char_u *)b->bv_ga.ga_data;
+      uint8_t *const p = (uint8_t *)b->bv_ga.ga_data;
       rettv->vval.v_number = (varnumber_T)(*(p + idx));
       memmove(p + idx, p + idx + 1, (size_t)(len - idx - 1));
       b->bv_ga.ga_len--;
@@ -2752,9 +2752,8 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
       blob->bv_ga.ga_len = (int)(end - idx + 1);
       ga_grow(&blob->bv_ga, (int)(end - idx + 1));
 
-      char_u *const p = (char_u *)b->bv_ga.ga_data;
-      memmove((char_u *)blob->bv_ga.ga_data, p + idx,
-              (size_t)(end - idx + 1));
+      uint8_t *const p = (uint8_t *)b->bv_ga.ga_data;
+      memmove(blob->bv_ga.ga_data, p + idx, (size_t)(end - idx + 1));
       tv_blob_set_ret(rettv, blob);
 
       if (len - end - 1 > 0) {

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -358,7 +358,7 @@ static inline int tv_blob_len(const blob_T *const b)
   return b->bv_ga.ga_len;
 }
 
-static inline char_u tv_blob_get(const blob_T *b, int idx)
+static inline uint8_t tv_blob_get(const blob_T *b, int idx)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the byte at index `idx` in the blob.
@@ -367,12 +367,12 @@ static inline char_u tv_blob_get(const blob_T *b, int idx)
 /// @param[in]  idx  Index in a blob. Must be valid.
 ///
 /// @return Byte value at the given index.
-static inline char_u tv_blob_get(const blob_T *const b, int idx)
+static inline uint8_t tv_blob_get(const blob_T *const b, int idx)
 {
-  return ((char_u *)b->bv_ga.ga_data)[idx];
+  return ((uint8_t *)b->bv_ga.ga_data)[idx];
 }
 
-static inline void tv_blob_set(blob_T *b, int idx, char_u c)
+static inline void tv_blob_set(blob_T *b, int idx, uint8_t c)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Store the byte `c` at index `idx` in the blob.
@@ -380,9 +380,9 @@ static inline void tv_blob_set(blob_T *b, int idx, char_u c)
 /// @param[in]  b  Blob to index. Cannot be NULL.
 /// @param[in]  idx  Index in a blob. Must be valid.
 /// @param[in]  c  Value to store.
-static inline void tv_blob_set(blob_T *const b, int idx, char_u c)
+static inline void tv_blob_set(blob_T *const b, int idx, uint8_t c)
 {
-  ((char_u *)b->bv_ga.ga_data)[idx] = c;
+  ((uint8_t *)b->bv_ga.ga_data)[idx] = c;
 }
 
 /// Initialize VimL object

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -216,7 +216,7 @@ void ga_concat_len(garray_T *const gap, const char *restrict s, const size_t len
 ///
 /// @param gap
 /// @param c
-void ga_append(garray_T *gap, char c)
+void ga_append(garray_T *gap, uint8_t c)
 {
-  GA_APPEND(char, gap, c);
+  GA_APPEND(uint8_t, gap, c);
 }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2993,16 +2993,16 @@ char *getcmdkeycmd(int promptc, void *cookie, int indent, bool do_concat)
       ga_concat(&line_ga, "<SNR>");
     } else {
       if (cmod != 0) {
-        ga_append(&line_ga, (char)K_SPECIAL);
-        ga_append(&line_ga, (char)KS_MODIFIER);
-        ga_append(&line_ga, (char)cmod);
+        ga_append(&line_ga, K_SPECIAL);
+        ga_append(&line_ga, KS_MODIFIER);
+        ga_append(&line_ga, (uint8_t)cmod);
       }
       if (IS_SPECIAL(c1)) {
-        ga_append(&line_ga, (char)K_SPECIAL);
-        ga_append(&line_ga, (char)K_SECOND(c1));
-        ga_append(&line_ga, (char)K_THIRD(c1));
+        ga_append(&line_ga, K_SPECIAL);
+        ga_append(&line_ga, (uint8_t)K_SECOND(c1));
+        ga_append(&line_ga, (uint8_t)K_THIRD(c1));
       } else {
-        ga_append(&line_ga, (char)c1);
+        ga_append(&line_ga, (uint8_t)c1);
       }
     }
 
@@ -3038,7 +3038,7 @@ bool map_execute_lua(void)
     } else if (c1 == '\r' || c1 == '\n') {
       c1 = NUL;  // end the line
     } else {
-      ga_append(&line_ga, (char)c1);
+      ga_append(&line_ga, (uint8_t)c1);
     }
   }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1199,7 +1199,7 @@ static char_u *translate_mapping(char_u *str, int cpo_flags)
     }
 
     if (c) {
-      ga_append(&ga, (char)c);
+      ga_append(&ga, (uint8_t)c);
     }
   }
   ga_append(&ga, NUL);

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -98,7 +98,7 @@ static void ga_concat_esc(garray_T *gap, const char *p, int clen)
         vim_snprintf(buf, NUMBUFLEN, "\\x%02x", *p);
         ga_concat(gap, buf);
       } else {
-        ga_append(gap, *p);
+        ga_append(gap, (uint8_t)(*p));
       }
       break;
     }


### PR DESCRIPTION
A blob is used as a sequence of bytes and usually accessed individually,
not as as a NUL-terminuated string, so uint8_t should be better.

Not sure about ga_append(), but using uint8_t leads to fewer casts.
