### PR TITLE
fix(Windows): restore console title at exit

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -584,6 +584,7 @@ int main(int argc, char **argv)
   if (use_builtin_ui) {
     os_icon_init();
   }
+  os_title_save();
 #endif
 
   // Adjust default register name for "unnamed" in 'clipboard'. Can only be
@@ -775,6 +776,7 @@ void getout(int exitval)
 #ifdef MSWIN
   // Restore Windows console icon before exiting.
   os_icon_set(NULL, NULL);
+  os_title_reset();
 #endif
 
   os_exit(exitval);

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -10,6 +10,7 @@
 # include "os/os_win_console.c.generated.h"
 #endif
 
+static char origTitle[256] = { 0 };
 static HWND hWnd = NULL;
 static HICON hOrigIconSmall = NULL;
 static HICON hOrigIcon = NULL;
@@ -91,4 +92,16 @@ void os_icon_init(void)
       os_icon_set(hVimIcon, hVimIcon);
     }
   }
+}
+
+/// Saves the original Windows console title.
+void os_title_save(void)
+{
+  GetConsoleTitle(origTitle, sizeof(origTitle));
+}
+
+/// Resets the original Windows console title.
+void os_title_reset(void)
+{
+  SetConsoleTitle(origTitle);
 }


### PR DESCRIPTION
Fixes #21404
