### PR TITLE
vim-patch:9.0.1223: cannot use setcellwidths() below 0x100

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6951,7 +6951,7 @@ setcellwidths({list})					*setcellwidths()*
 		{low} and {high} can be the same, in which case this refers to
 		one character.  Otherwise it is the range of characters from
 		{low} to {high} (inclusive).		*E1111* *E1114*
-		Only characters with value 0x100 and higher can be used.
+		Only characters with value 0x80 and higher can be used.
 
 		{width} must be either 1 or 2, indicating the character width
 		in screen cells.			*E1112*

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -100,8 +100,8 @@ static char e_list_item_nr_cell_width_invalid[]
   = N_("E1112: List item %d cell width invalid");
 static char e_overlapping_ranges_for_nr[]
   = N_("E1113: Overlapping ranges for 0x%lx");
-static char e_only_values_of_0x100_and_higher_supported[]
-  = N_("E1114: Only values of 0x100 and higher supported");
+static char e_only_values_of_0x80_and_higher_supported[]
+  = N_("E1114: Only values of 0x80 and higher supported");
 
 // To speed up BYTELEN(); keep a lookup table to quickly get the length in
 // bytes of a UTF-8 character from the first byte of a UTF-8 string.  Bytes
@@ -482,12 +482,16 @@ static bool intable(const struct interval *table, size_t n_items, int c)
 ///       gen_unicode_tables.lua, which must be manually invoked as needed.
 int utf_char2cells(int c)
 {
-  if (c >= 0x100) {
+  // Use the value from setcellwidths() at 0x80 and higher, unless the
+  // character is not printable.
+  if (c >= 0x80 && vim_isprintc(c)) {
     int n = cw_value(c);
     if (n != 0) {
       return n;
     }
+  }
 
+  if (c >= 0x100) {
     if (!utf_printable(c)) {
       return 6;                 // unprintable, displays <xxxx>
     }
@@ -2724,8 +2728,8 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       }
       if (i == 0) {
         n1 = lili_tv->vval.v_number;
-        if (n1 < 0x100) {
-          emsg(_(e_only_values_of_0x100_and_higher_supported));
+        if (n1 < 0x80) {
+          emsg(_(e_only_values_of_0x80_and_higher_supported));
           xfree((void *)ptrs);
           return;
         }

--- a/src/nvim/testdir/test_utf8.vim
+++ b/src/nvim/testdir/test_utf8.vim
@@ -167,6 +167,39 @@ func Test_setcellwidths()
   call assert_equal(2, strwidth("\u1339"))
   call assert_equal(1, strwidth("\u133a"))
 
+  for aw in ['single', 'double']
+    exe 'set ambiwidth=' . aw
+    " Handle \u0080 to \u009F as control chars even on MS-Windows.
+    set isprint=@,161-255
+
+    call setcellwidths([])
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u00A1"))
+    call assert_equal((aw == 'single') ? 1 : 2, strwidth("\u2010"))
+
+    call setcellwidths([[0x81, 0x81, 1], [0xA1, 0xA1, 1],
+                      \ [0x2010, 0x2010, 1], [0xFEFF, 0xFEFF, 1]])
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal(1, strwidth("\u00A1"))
+    call assert_equal(1, strwidth("\u2010"))
+
+    call setcellwidths([[0x81, 0x81, 2], [0xA1, 0xA1, 2],
+                      \ [0x2010, 0x2010, 2], [0xFEFF, 0xFEFF, 2]])
+    " Control chars
+    call assert_equal(4, strwidth("\u0081"))
+    call assert_equal(6, strwidth("\uFEFF"))
+    " Ambiguous width chars
+    call assert_equal(2, strwidth("\u00A1"))
+    call assert_equal(2, strwidth("\u2010"))
+  endfor
+  set ambiwidth& isprint&
+
   call setcellwidths([])
 
   call assert_fails('call setcellwidths(1)', 'E714:')


### PR DESCRIPTION
#### vim-patch:9.0.1223: cannot use setcellwidths() below 0x100

Problem:    Cannot use setcellwidths() below 0x100.
Solution:   Also accept characters between 0x80 and 0x100. (Ken Takata,
            closes vim/vim#11834)

https://github.com/vim/vim/commit/7193323b7796c05573f3aa89d422e848feb3a8dc

Co-authored-by: K.Takata <kentkt@csc.jp>