### PR TITLE
fix(remote): don't leak memory on failure to connect to server

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -885,7 +885,7 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
       os_errmsg("Remote ui failed to start: ");
       os_errmsg(connect_error);
       os_errmsg("\n");
-      exit(1);
+      os_exit(1);
     }
 
     ui_client_channel_id = chan;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2410,9 +2410,7 @@ describe("TUI as a client", function()
     clear()
     local screen = thelpers.screen_setup(0,
       string.format([=[["%s", "-u", "NONE", "-i", "NONE", "--server", "127.0.0.1:2436546", "--remote-ui"]]=],
-                    nvim_prog))
-
-    screen:try_resize(60, 7)
+                    nvim_prog), 60)
 
     screen:expect([[
       Remote ui failed to start: {MATCH:.*}|


### PR DESCRIPTION
Also fix the race between output and resize in the test for this.