### PR TITLE
project: extend "steps to reproduce" instructions in lsp_bug_report

### DIFF
--- a/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
@@ -31,8 +31,38 @@ body:
     attributes:
       label: 'Steps to reproduce using "nvim -u minimal_init.lua"'
       description: |
-        - Create a minimal_init.lua using vim.lsp.start - read `:h lsp-quickstart` and `:h vim.lsp.start` for more information.
-        - _Note_: if the issue is with an autocompletion or other LSP plugin, report to that plugin's issue tracker.
+        - Create a minimal_init.lua using vim.lsp.start:
+
+        ```lua
+        --- CHANGE THESE
+        local pattern = 'the-filetype'
+        local cmd = {'name-of-language-server-executable'}
+        -- Add files/folders here that indicate the root of a project
+        local root_markers = {'.git', '.editorconfig'}
+        -- Change to table with settings if required
+        local settings = vim.empty_dict()
+
+        vim.api.nvim_create_autocmd('FileType', {
+          pattern = pattern,
+          callback = function(args)
+            local match = vim.fs.find(root_markers, { path = args.file, upward = true })[1]
+            local root_dir = match and vim.fn.fnamemodify(match, ':p:h') or vim.NIL
+            vim.lsp.start({
+              name = 'bugged-ls',
+              cmd = cmd,
+              root_dir = root_dir,
+              settings = settings
+            })
+          end
+        })
+        ```
+
+        See `:h lsp-quickstart` and `:h vim.lsp.start` for more information
+
+        - Provide a short code example and describe the folder layout
+        - Describe how to trigger the issue. E.g. using `:lua vim.lsp.buf.*` commands
+
+        _Note_: if the issue is with an autocompletion or other LSP plugin, report to that plugin's issue tracker.
     validations:
       required: true
 


### PR DESCRIPTION
It looks like people struggle to come up with a `minimal.lua` lsp on their own. This adds a short variant that should be mostly copy & paste