### PR TITLE
build: enable MSVC level 3 warnings

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -78,8 +78,7 @@ if(ENABLE_IWYU)
 endif()
 
 if(MSVC)
-  # TODO(dundargoc): bump warning level
-  target_compile_options(main_lib INTERFACE -W2)
+  target_compile_options(main_lib INTERFACE -W3)
 
   # Disable warnings that give too many false positives.
   target_compile_options(main_lib INTERFACE -wd4311 -wd4146)
@@ -406,7 +405,7 @@ list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
 # xdiff, mpack, lua-cjson: inlined external project, we don't maintain it. #9306
 if(MSVC)
   set_source_files_properties(
-    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} /wd4090 /wd4244")
+    ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -wd4090 -wd4244 -wd4267")
 else()
   set_source_files_properties(
     ${EXTERNAL_SOURCES} PROPERTIES COMPILE_FLAGS "${COMPILE_FLAGS} -Wno-conversion -Wno-missing-noreturn -Wno-missing-format-attribute -Wno-double-promotion -Wno-strict-prototypes")

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -512,7 +512,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
     } else if (cmd->count.type != kObjectTypeInteger || cmd->count.data.integer < 0) {
       VALIDATION_ERROR("'count' must be a non-negative Integer");
     }
-    set_cmd_count(&ea, cmd->count.data.integer, true);
+    set_cmd_count(&ea, (linenr_T)cmd->count.data.integer, true);
   }
 
   if (HAS_KEY(cmd->reg)) {
@@ -1005,7 +1005,7 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
                          Error *err)
 {
   uint32_t argt = 0;
-  long def = -1;
+  int64_t def = -1;
   cmd_addr_T addr_type_arg = ADDR_NONE;
   int compl = EXPAND_NOTHING;
   char *compl_arg = NULL;

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -181,7 +181,7 @@ void nvim_set_option_value(String name, Object value, Dict(option) *opts, Error 
 
   switch (value.type) {
   case kObjectTypeInteger:
-    numval = value.data.integer;
+    numval = (long)value.data.integer;
     break;
   case kObjectTypeBoolean:
     numval = value.data.boolean ? 1 : 0;

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -32,12 +32,14 @@
 #include "nvim/msgpack_rpc/server.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/shell.h"
+#include "nvim/path.h"
 #include "nvim/rbuffer.h"
+
 #ifdef MSWIN
+# include "nvim/os/fs.h"
 # include "nvim/os/os_win_console.h"
 # include "nvim/os/pty_conpty_win.h"
 #endif
-#include "nvim/path.h"
 
 static bool did_stdio = false;
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -3409,7 +3409,7 @@ static int parse_diff_ed(char *line, diffhunk_T *hunk)
   linenr_T f1 = getdigits_int32(&p, true, 0);
   if (*p == ',') {
     p++;
-    l1 = getdigits(&p, true, 0);
+    l1 = getdigits_long(&p, true, 0);
   } else {
     l1 = f1;
   }
@@ -3417,10 +3417,10 @@ static int parse_diff_ed(char *line, diffhunk_T *hunk)
     return FAIL;        // invalid diff format
   }
   int difftype = (uint8_t)(*p++);
-  long f2 = getdigits(&p, true, 0);
+  long f2 = getdigits_long(&p, true, 0);
   if (*p == ',') {
     p++;
-    l2 = getdigits(&p, true, 0);
+    l2 = getdigits_long(&p, true, 0);
   } else {
     l2 = f2;
   }
@@ -3458,18 +3458,18 @@ static int parse_diff_unified(char *line, diffhunk_T *hunk)
     long oldcount;
     long newline;
     long newcount;
-    long oldline = getdigits(&p, true, 0);
+    long oldline = getdigits_long(&p, true, 0);
     if (*p == ',') {
       p++;
-      oldcount = getdigits(&p, true, 0);
+      oldcount = getdigits_long(&p, true, 0);
     } else {
       oldcount = 1;
     }
     if (*p++ == ' ' && *p++ == '+') {
-      newline = getdigits(&p, true, 0);
+      newline = getdigits_long(&p, true, 0);
       if (*p == ',') {
         p++;
-        newcount = getdigits(&p, true, 0);
+        newcount = getdigits_long(&p, true, 0);
       } else {
         newcount = 1;
       }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -492,7 +492,7 @@ buf_T *get_buf_arg(typval_T *arg)
 /// "byte2line(byte)" function
 static void f_byte2line(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  long boff = tv_get_number(&argvars[0]) - 1;
+  long boff = (long)tv_get_number(&argvars[0]) - 1;
   if (boff < 0) {
     rettv->vval.v_number = -1;
   } else {
@@ -978,11 +978,11 @@ static void f_count(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       listitem_T *li = tv_list_first(l);
       if (argvars[2].v_type != VAR_UNKNOWN) {
         if (argvars[3].v_type != VAR_UNKNOWN) {
-          long idx = tv_get_number_chk(&argvars[3], &error);
+          int64_t idx = tv_get_number_chk(&argvars[3], &error);
           if (!error) {
             li = tv_list_find(l, (int)idx);
             if (li == NULL) {
-              semsg(_(e_listidx), (int64_t)idx);
+              semsg(_(e_listidx), idx);
             }
           }
         }
@@ -3589,7 +3589,7 @@ static void f_insert(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     semsg(_(e_listblobarg), "insert()");
   } else if (!value_check_lock(tv_list_locked((l = argvars[0].vval.v_list)),
                                N_("insert() argument"), TV_TRANSLATE)) {
-    long before = 0;
+    int64_t before = 0;
     if (argvars[2].v_type != VAR_UNKNOWN) {
       before = tv_get_number_chk(&argvars[2], &error);
     }
@@ -3602,7 +3602,7 @@ static void f_insert(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (before != tv_list_len(l)) {
       item = tv_list_find(l, (int)before);
       if (item == NULL) {
-        semsg(_(e_listidx), (int64_t)before);
+        semsg(_(e_listidx), before);
         l = NULL;
       }
     }
@@ -4371,11 +4371,11 @@ static void find_some_match(typval_T *const argvars, typval_T *const rettv,
                             const SomeMatchType type)
 {
   char *str = NULL;
-  long len = 0;
+  int64_t len = 0;
   char *expr = NULL;
   regmatch_T regmatch;
-  long start = 0;
-  long nth = 1;
+  int64_t start = 0;
+  int64_t nth = 1;
   colnr_T startcol = 0;
   bool match = false;
   list_T *l = NULL;
@@ -5387,7 +5387,7 @@ static void read_file_or_blob(typval_T *argvars, typval_T *rettv, bool always_bl
   char *prev = NULL;               // previously read bytes, if any
   ptrdiff_t prevlen  = 0;               // length of data in prev
   ptrdiff_t prevsize = 0;               // size of prev buffer
-  long maxline  = MAXLNUM;
+  int64_t maxline  = MAXLNUM;
 
   if (argvars[1].v_type != VAR_UNKNOWN) {
     if (strcmp(tv_get_string(&argvars[1]), "b") == 0) {
@@ -6161,8 +6161,8 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 {
   bool save_p_ws = p_ws;
   int retval = 0;               // default: FAIL
-  long lnum_stop = 0;
-  long time_limit = 0;
+  linenr_T lnum_stop = 0;
+  int64_t time_limit = 0;
   int options = SEARCH_KEEP;
   bool use_skip = false;
 
@@ -6184,7 +6184,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 
   // Optional arguments: line number to stop searching, timeout and skip.
   if (argvars[1].v_type != VAR_UNKNOWN && argvars[2].v_type != VAR_UNKNOWN) {
-    lnum_stop = tv_get_number_chk(&argvars[2], NULL);
+    lnum_stop = (linenr_T)tv_get_number_chk(&argvars[2], NULL);
     if (lnum_stop < 0) {
       goto theend;
     }
@@ -6214,7 +6214,7 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
   pos_T pos = save_cursor = curwin->w_cursor;
   pos_T firstpos = { 0 };
   searchit_arg_T sia = {
-    .sa_stop_lnum = (linenr_T)lnum_stop,
+    .sa_stop_lnum = lnum_stop,
     .sa_tm = &tm,
   };
 
@@ -6652,8 +6652,8 @@ static int searchpair_cmn(typval_T *argvars, pos_T *match_pos)
   bool save_p_ws = p_ws;
   int flags = 0;
   int retval = 0;  // default: FAIL
-  long lnum_stop = 0;
-  long time_limit = 0;
+  linenr_T lnum_stop = 0;
+  int64_t time_limit = 0;
 
   // Get the three pattern arguments: start, middle, end. Will result in an
   // error if not a valid argument.
@@ -6695,7 +6695,7 @@ static int searchpair_cmn(typval_T *argvars, pos_T *match_pos)
     skip = &argvars[4];
 
     if (argvars[5].v_type != VAR_UNKNOWN) {
-      lnum_stop = tv_get_number_chk(&argvars[5], NULL);
+      lnum_stop = (linenr_T)tv_get_number_chk(&argvars[5], NULL);
       if (lnum_stop < 0) {
         semsg(_(e_invarg2), tv_get_string(&argvars[5]));
         goto theend;
@@ -6711,7 +6711,7 @@ static int searchpair_cmn(typval_T *argvars, pos_T *match_pos)
   }
 
   retval = (int)do_searchpair(spat, mpat, epat, dir, skip,
-                              flags, match_pos, (linenr_T)lnum_stop, time_limit);
+                              flags, match_pos, lnum_stop, time_limit);
 
 theend:
   p_ws = save_p_ws;
@@ -6758,7 +6758,7 @@ static void f_searchpairpos(typval_T *argvars, typval_T *rettv, EvalFuncData fpt
 /// @returns  0 or -1 for no match,
 long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir,
                    const typval_T *skip, int flags, pos_T *match_pos, linenr_T lnum_stop,
-                   long time_limit)
+                   int64_t time_limit)
   FUNC_ATTR_NONNULL_ARG(1, 2, 3)
 {
   long retval = 0;
@@ -8695,7 +8695,8 @@ static void f_timer_start(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (!callback_from_typval(&callback, &argvars[1])) {
     return;
   }
-  rettv->vval.v_number = (varnumber_T)timer_start(tv_get_number(&argvars[0]), repeat, &callback);
+  rettv->vval.v_number = (varnumber_T)timer_start((const long)tv_get_number(&argvars[0]), repeat,
+                                                  &callback);
 }
 
 /// "timer_stop(timerid)" function

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -905,14 +905,14 @@ void tv_list_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
     return;
   }
 
-  long idx = tv_get_number_chk(&argvars[1], &error);
+  int64_t idx = tv_get_number_chk(&argvars[1], &error);
 
   listitem_T *item;
 
   if (error) {
     // Type error: do nothing, errmsg already given.
   } else if ((item = tv_list_find(l, (int)idx)) == NULL) {
-    semsg(_(e_listidx), (int64_t)idx);
+    semsg(_(e_listidx), idx);
   } else {
     if (argvars[2].v_type == VAR_UNKNOWN) {
       // Remove one item, return its value.
@@ -922,11 +922,11 @@ void tv_list_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
     } else {
       listitem_T *item2;
       // Remove range of items, return list with values.
-      long end = tv_get_number_chk(&argvars[2], &error);
+      int64_t end = tv_get_number_chk(&argvars[2], &error);
       if (error) {
         // Type error: do nothing.
       } else if ((item2 = tv_list_find(l, (int)end)) == NULL) {
-        semsg(_(e_listidx), (int64_t)end);
+        semsg(_(e_listidx), end);
       } else {
         int cnt = 0;
 
@@ -1140,7 +1140,7 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
 {
   ListSortItem *ptrs;
   long len;
-  long i;
+  int i;
 
   // Pointer to current info struct used in compare function. Save and restore
   // the current one for nested calls.
@@ -1184,7 +1184,7 @@ static void do_sort_uniq(typval_T *argvars, typval_T *rettv, bool sort)
       } else {
         bool error = false;
 
-        i = tv_get_number_chk(&argvars[1], &error);
+        i = (int)tv_get_number_chk(&argvars[1], &error);
         if (error) {
           goto theend;  // type error; errmsg already given
         }
@@ -2715,7 +2715,7 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
   }
 
   bool error = false;
-  long idx = tv_get_number_chk(&argvars[1], &error);
+  int64_t idx = tv_get_number_chk(&argvars[1], &error);
 
   if (!error) {
     const int len = tv_blob_len(b);
@@ -2725,7 +2725,7 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
       idx = len + idx;
     }
     if (idx < 0 || idx >= len) {
-      semsg(_(e_blobidx), (int64_t)idx);
+      semsg(_(e_blobidx), idx);
       return;
     }
     if (argvars[2].v_type == VAR_UNKNOWN) {
@@ -2736,7 +2736,7 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
       b->bv_ga.ga_len--;
     } else {
       // Remove range of items, return blob with values.
-      long end = tv_get_number_chk(&argvars[2], &error);
+      int64_t end = tv_get_number_chk(&argvars[2], &error);
       if (error) {
         return;
       }
@@ -2745,7 +2745,7 @@ void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
         end = len + end;
       }
       if (end >= len || idx > end) {
-        semsg(_(e_blobidx), (int64_t)end);
+        semsg(_(e_blobidx), end);
         return;
       }
       blob_T *const blob = tv_blob_alloc();

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -696,7 +696,7 @@ static char *ex_let_one(char *arg, typval_T *const tv, const bool copy, const bo
 
       if (!failed) {
         if (opt_type != gov_string || s != NULL) {
-          char *err = set_option_value(arg, n, s, scope);
+          char *err = set_option_value(arg, (long)n, s, scope);
           arg_end = p;
           if (err != NULL) {
             emsg(_(err));

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -192,9 +192,9 @@ win_T *find_tabwin(typval_T *wvp, typval_T *tvp)
 
   if (wvp->v_type != VAR_UNKNOWN) {
     if (tvp->v_type != VAR_UNKNOWN) {
-      long n = tv_get_number(tvp);
+      int n = (int)tv_get_number(tvp);
       if (n >= 0) {
-        tp = find_tabpage((int)n);
+        tp = find_tabpage(n);
       }
     } else {
       tp = curtab;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2946,7 +2946,7 @@ void ex_z(exarg_T *eap)
       bigness = 2 * curbuf->b_ml.ml_line_count;
     }
 
-    p_window = bigness;
+    p_window = (int)bigness;
     if (*kind == '=') {
       bigness += 2;
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1311,16 +1311,16 @@ static void parse_register(exarg_T *eap)
 }
 
 // Change line1 and line2 of Ex command to use count
-void set_cmd_count(exarg_T *eap, long count, bool validate)
+void set_cmd_count(exarg_T *eap, linenr_T count, bool validate)
 {
   if (eap->addr_type != ADDR_LINES) {  // e.g. :buffer 2, :sleep 3
-    eap->line2 = (linenr_T)count;
+    eap->line2 = count;
     if (eap->addr_count == 0) {
       eap->addr_count = 1;
     }
   } else {
     eap->line1 = eap->line2;
-    eap->line2 += (linenr_T)count - 1;
+    eap->line2 += count - 1;
     eap->addr_count++;
     // Be vi compatible: no error message for out of range.
     if (validate && eap->line2 > curbuf->b_ml.ml_line_count) {
@@ -1338,7 +1338,7 @@ static int parse_count(exarg_T *eap, char **errormsg, bool validate)
   if ((eap->argt & EX_COUNT) && ascii_isdigit(*eap->arg)
       && (!(eap->argt & EX_BUFNAME) || *(p = skipdigits(eap->arg + 1)) == NUL
           || ascii_iswhite(*p))) {
-    long n = getdigits_long(&eap->arg, false, -1);
+    linenr_T n = getdigits_int32(&eap->arg, false, -1);
     eap->arg = skipwhite(eap->arg);
 
     if (eap->args != NULL) {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -583,7 +583,7 @@ void stuffRedoReadbuff(const char *s)
   add_buff(&readbuf2, s, -1L);
 }
 
-void stuffReadbuffLen(const char *s, long len)
+void stuffReadbuffLen(const char *s, ptrdiff_t len)
 {
   add_buff(&readbuf1, s, len);
 }
@@ -635,7 +635,7 @@ void stuffescaped(const char *arg, bool literally)
       arg++;
     }
     if (arg > start) {
-      stuffReadbuffLen(start, (arg - start));
+      stuffReadbuffLen(start, arg - start);
     }
 
     // stuff a single special character

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -78,20 +78,20 @@ static int regex_match_line(lua_State *lstate)
     return luaL_error(lstate, "not enough args");
   }
 
-  long bufnr = luaL_checkinteger(lstate, 2);
+  handle_T bufnr = (handle_T)luaL_checkinteger(lstate, 2);
   linenr_T rownr = (linenr_T)luaL_checkinteger(lstate, 3);
-  long start = 0, end = -1;
+  int start = 0, end = -1;
   if (narg >= 4) {
-    start = luaL_checkinteger(lstate, 4);
+    start = (int)luaL_checkinteger(lstate, 4);
   }
   if (narg >= 5) {
-    end = luaL_checkinteger(lstate, 5);
+    end = (int)luaL_checkinteger(lstate, 5);
     if (end < 0) {
       return luaL_error(lstate, "invalid end");
     }
   }
 
-  buf_T *buf = bufnr ? handle_get_buffer((int)bufnr) : curbuf;
+  buf_T *buf = bufnr ? handle_get_buffer(bufnr) : curbuf;
   if (!buf || buf->b_ml.ml_mfp == NULL) {
     return luaL_error(lstate, "invalid buffer");
   }
@@ -218,7 +218,7 @@ static int nlua_str_utf_start(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 {
   size_t s1_len;
   const char *s1 = luaL_checklstring(lstate, 1, &s1_len);
-  long offset = luaL_checkinteger(lstate, 2);
+  ptrdiff_t offset = luaL_checkinteger(lstate, 2);
   if (offset < 0 || offset > (intptr_t)s1_len) {
     return luaL_error(lstate, "index out of range");
   }
@@ -238,7 +238,7 @@ static int nlua_str_utf_end(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
 {
   size_t s1_len;
   const char *s1 = luaL_checklstring(lstate, 1, &s1_len);
-  long offset = luaL_checkinteger(lstate, 2);
+  ptrdiff_t offset = luaL_checkinteger(lstate, 2);
   if (offset < 0 || offset > (intptr_t)s1_len) {
     return luaL_error(lstate, "index out of range");
   }

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -393,7 +393,7 @@ static int parser_parse(lua_State *L)
   TSTree *new_tree = NULL;
   size_t len;
   const char *str;
-  long bufnr;
+  handle_T bufnr;
   buf_T *buf;
   TSInput input;
 
@@ -406,13 +406,13 @@ static int parser_parse(lua_State *L)
     break;
 
   case LUA_TNUMBER:
-    bufnr = lua_tointeger(L, 3);
-    buf = handle_get_buffer((handle_T)bufnr);
+    bufnr = (handle_T)lua_tointeger(L, 3);
+    buf = handle_get_buffer(bufnr);
 
     if (!buf) {
 #define BUFSIZE 256
       char ebuf[BUFSIZE] = { 0 };
-      vim_snprintf(ebuf, BUFSIZE, "invalid buffer handle: %ld", bufnr);
+      vim_snprintf(ebuf, BUFSIZE, "invalid buffer handle: %d", bufnr);
       return luaL_argerror(L, 3, ebuf);
 #undef BUFSIZE
     }
@@ -898,8 +898,8 @@ static int node_child(lua_State *L)
   if (!node_check(L, 1, &node)) {
     return 0;
   }
-  long num = lua_tointeger(L, 2);
-  TSNode child = ts_node_child(node, (uint32_t)num);
+  uint32_t num = (uint32_t)lua_tointeger(L, 2);
+  TSNode child = ts_node_child(node, num);
 
   push_node(L, child, 1);
   return 1;
@@ -911,8 +911,8 @@ static int node_named_child(lua_State *L)
   if (!node_check(L, 1, &node)) {
     return 0;
   }
-  long num = lua_tointeger(L, 2);
-  TSNode child = ts_node_named_child(node, (uint32_t)num);
+  uint32_t num = (uint32_t)lua_tointeger(L, 2);
+  TSNode child = ts_node_named_child(node, num);
 
   push_node(L, child, 1);
   return 1;

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -257,13 +257,13 @@ static NluaXdiffMode process_xdl_diff_opts(lua_State *lstate, xdemitconf_t *cfg,
       if (check_xdiff_opt(v->type, kObjectTypeInteger, "ctxlen", err)) {
         goto exit_1;
       }
-      cfg->ctxlen = v->data.integer;
+      cfg->ctxlen = (long)v->data.integer;
     } else if (strequal("interhunkctxlen", k.data)) {
       if (check_xdiff_opt(v->type, kObjectTypeInteger, "interhunkctxlen",
                           err)) {
         goto exit_1;
       }
-      cfg->interhunkctxlen = v->data.integer;
+      cfg->interhunkctxlen = (long)v->data.integer;
     } else if (strequal("linematch", k.data)) {
       *linematch = api_object_to_bool(*v, "linematch", false, err);
       if (ERROR_SET(err)) {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -182,6 +182,9 @@ void early_init(mparm_T *paramp)
 #ifdef MSWIN
   OSVERSIONINFO ovi;
   ovi.dwOSVersionInfoSize = sizeof(ovi);
+  // Disable warning about GetVersionExA being deprecated. There doesn't seem to be a conventient
+  // replacement that doesn't add a ton of extra code as of writing this.
+# pragma warning(suppress : 4996)
   GetVersionEx(&ovi);
   snprintf(windowsVersion, sizeof(windowsVersion), "%d.%d",
            (int)ovi.dwMajorVersion, (int)ovi.dwMinorVersion);

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2627,8 +2627,8 @@ char *string_convert_ext(const vimconv_T *const vcp, char *ptr, size_t *lenp, si
 
 /// Table set by setcellwidths().
 typedef struct {
-  long first;
-  long last;
+  int64_t first;
+  int64_t last;
   char width;
 } cw_interval_T;
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -307,7 +307,7 @@ int ml_open(buf_T *buf)
     b0p->b0_uname[B0_UNAME_SIZE - 1] = NUL;
     os_get_hostname((char *)b0p->b0_hname, B0_HNAME_SIZE);
     b0p->b0_hname[B0_HNAME_SIZE - 1] = NUL;
-    long_to_char(os_get_pid(), b0p->b0_pid);
+    long_to_char((long)os_get_pid(), b0p->b0_pid);
   }
 
   // Always sync block number 0 to disk, so we can check the file name in

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4137,7 +4137,7 @@ int do_join(size_t count, int insert_space, int save_undo, int use_formatoptions
     linenr_T lnum = curwin->w_cursor.lnum + t;
     colnr_T mincol = (colnr_T)0;
     linenr_T lnum_amount = -t;
-    long col_amount = (cend - newp - spaces_removed);
+    colnr_T col_amount = (colnr_T)(cend - newp - spaces_removed);
 
     mark_col_adjust(lnum, mincol, lnum_amount, col_amount, spaces_removed);
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -30,7 +30,9 @@
 #include <string.h>
 
 #include "auto/config.h"
+#include "nvim/api/extmark.h"
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/helpers.h"
 #include "nvim/ascii.h"
 #include "nvim/autocmd.h"
 #include "nvim/buffer.h"
@@ -61,6 +63,7 @@
 #include "nvim/keycodes.h"
 #include "nvim/locale.h"
 #include "nvim/log.h"
+#include "nvim/lua/executor.h"
 #include "nvim/macros.h"
 #include "nvim/mapping.h"
 #include "nvim/mbyte.h"
@@ -75,6 +78,8 @@
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
 #include "nvim/optionstr.h"
+#include "nvim/os/input.h"
+#include "nvim/os/lang.h"
 #include "nvim/os/os.h"
 #include "nvim/path.h"
 #include "nvim/popupmenu.h"
@@ -95,14 +100,10 @@
 #include "nvim/undo.h"
 #include "nvim/vim.h"
 #include "nvim/window.h"
-#ifdef MSWIN
-# include "nvim/os/pty_conpty_win.h"
+
+#ifdef BACKSLASH_IN_FILENAME
+# include "nvim/arglist.h"
 #endif
-#include "nvim/api/extmark.h"
-#include "nvim/api/private/helpers.h"
-#include "nvim/lua/executor.h"
-#include "nvim/os/input.h"
-#include "nvim/os/lang.h"
 
 static char e_unknown_option[]
   = N_("E518: Unknown option");

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -34,7 +34,11 @@
 #include "nvim/vim.h"
 
 #ifdef MSWIN
-# include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
+# include "nvim/mbyte.h"
+#endif
+
+#ifdef BACKSLASH_IN_FILENAME
+# include "nvim/fileio.h"
 #endif
 
 #ifdef HAVE__NSGETENVIRON

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -27,6 +27,10 @@
 #include "nvim/rbuffer.h"
 #include "nvim/types.h"
 
+#ifdef MSWIN
+# include "nvim/os/os_win_console.h"
+#endif
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fileio.c.generated.h"
 #endif

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -12,14 +12,20 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <uv.h>
 
 #include "auto/config.h"
+#include "nvim/ascii.h"
 #include "nvim/gettext.h"
 #include "nvim/globals.h"
 #include "nvim/log.h"
 #include "nvim/macros.h"
+#include "nvim/memory.h"
+#include "nvim/message.h"
 #include "nvim/option_defs.h"
 #include "nvim/os/fs_defs.h"
+#include "nvim/os/os.h"
+#include "nvim/path.h"
 #include "nvim/types.h"
 #include "nvim/vim.h"
 
@@ -27,23 +33,16 @@
 # include <sys/uio.h>
 #endif
 
-#include <uv.h>
-
-#include "nvim/ascii.h"
-#include "nvim/memory.h"
-#include "nvim/message.h"
-#include "nvim/os/os.h"
-#include "nvim/path.h"
-
-struct iovec;
-
 #ifdef MSWIN
-# include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
+# include "nvim/mbyte.h"
+# include "nvim/option.h"
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fs.c.generated.h"
 #endif
+
+struct iovec;
 
 #define RUN_UV_FS_FUNC(ret, func, ...) \
   do { \

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1031,7 +1031,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, long count, i
   struct soffset old_off;
   int retval;                   // Return value
   char *p;
-  long c;
+  int64_t c;
   char *dircp;
   char *strcopy = NULL;
   char *ps;

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1,6 +1,5 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
-//
 
 #include <assert.h>
 #include <inttypes.h>
@@ -1390,7 +1389,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
     NumberBase base = kNumBaseDecimal;
     bool itemisflag = false;
     bool fillable = true;
-    long num = -1;
+    int num = -1;
     char *str = NULL;
     switch (opt) {
     case STL_FILEPATH:
@@ -1520,10 +1519,10 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       // Overload %l with v:lnum for 'statuscolumn'
       if (opt_name != NULL && strcmp(opt_name, "statuscolumn") == 0) {
         if (wp->w_p_nu && !get_vim_var_nr(VV_VIRTNUM)) {
-          num = get_vim_var_nr(VV_LNUM);
+          num = (int)get_vim_var_nr(VV_LNUM);
         }
       } else {
-        num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) ? 0L : (long)(wp->w_cursor.lnum);
+        num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) ? 0L : wp->w_cursor.lnum;
       }
       break;
 
@@ -1544,7 +1543,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
                                    ? 0 : (int)wp->w_cursor.col + 1))) {
         break;
       }
-      num = (long)virtcol;
+      num = virtcol;
       break;
     }
 
@@ -1604,8 +1603,8 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       long l = ml_find_line_or_offset(wp->w_buffer, wp->w_cursor.lnum, NULL,
                                       false);
       num = (wp->w_buffer->b_ml.ml_flags & ML_EMPTY) || l < 0 ?
-            0L : l + 1 + ((State & MODE_INSERT) == 0 && empty_line ?
-                          0 : (int)wp->w_cursor.col);
+            0L : (int)l + 1 + ((State & MODE_INSERT) == 0 && empty_line ?
+                               0 : (int)wp->w_cursor.col);
       break;
     }
     case STL_BYTEVAL_X:
@@ -1625,7 +1624,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       // Overload %r with v:relnum for 'statuscolumn'
       if (opt_name != NULL && strcmp(opt_name, "statuscolumn") == 0) {
         if (wp->w_p_rnu && !get_vim_var_nr(VV_VIRTNUM)) {
-          num = get_vim_var_nr(VV_RELNUM);
+          num = (int)get_vim_var_nr(VV_RELNUM);
         }
       } else {
         itemisflag = true;
@@ -1889,7 +1888,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
 
         // { Reduce the number by base^n
         while (num_chars-- > maxwid) {
-          num /= (long)base;
+          num /= (int)base;
         }
         // }
 

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -34,15 +34,17 @@
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
-#include "nvim/ui_client.h"
-#ifdef MSWIN
-# include "nvim/os/os_win_console.h"
-#endif
 #include "nvim/tui/input.h"
 #include "nvim/tui/terminfo.h"
 #include "nvim/tui/tui.h"
 #include "nvim/ugrid.h"
 #include "nvim/ui.h"
+#include "nvim/ui_client.h"
+
+#ifdef MSWIN
+# include "nvim/os/os_win_console.h"
+# include "nvim/os/tty.h"
+#endif
 
 // Space reserved in two output buffers to make the cursor normal or invisible
 // when flushing. No existing terminal will require 32 bytes to do that.

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -22,6 +22,10 @@
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
 
+#ifdef MSWIN
+# include "nvim/os/os_win_console.h"
+#endif
+
 static TUIData *tui = NULL;
 static bool ui_client_is_remote = false;
 
@@ -31,7 +35,6 @@ static bool ui_client_is_remote = false;
 # include "ui_events_client.generated.h"
 #endif
 // uncrustify:on
-//
 
 uint64_t ui_client_start_server(int argc, char **argv)
 {

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -531,15 +531,13 @@ static void uc_list(char *name, size_t name_len)
       if (a & (EX_RANGE | EX_COUNT)) {
         if (a & EX_COUNT) {
           // -count=N
-          snprintf(IObuff + len, IOSIZE, "%" PRId64 "c",
-                   (int64_t)cmd->uc_def);
+          snprintf(IObuff + len, IOSIZE, "%" PRId64 "c", cmd->uc_def);
           len += (int)strlen(IObuff + len);
         } else if (a & EX_DFLALL) {
           IObuff[len++] = '%';
         } else if (cmd->uc_def >= 0) {
           // -range=N
-          snprintf(IObuff + len, IOSIZE, "%" PRId64 "",
-                   (int64_t)cmd->uc_def);
+          snprintf(IObuff + len, IOSIZE, "%" PRId64 "", cmd->uc_def);
           len += (int)strlen(IObuff + len);
         } else {
           IObuff[len++] = '.';
@@ -862,9 +860,9 @@ char *uc_validate_name(char *name)
 /// This function takes ownership of compl_arg, compl_luaref, and luaref.
 ///
 /// @return  OK if the command is created, FAIL otherwise.
-int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, long def, int flags,
-                   int compl, char *compl_arg, LuaRef compl_luaref, LuaRef preview_luaref,
-                   cmd_addr_T addr_type, LuaRef luaref, bool force)
+int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, int64_t def,
+                   int flags, int compl, char *compl_arg, LuaRef compl_luaref,
+                   LuaRef preview_luaref, cmd_addr_T addr_type, LuaRef luaref, bool force)
   FUNC_ATTR_NONNULL_ARG(1, 3)
 {
   ucmd_T *cmd = NULL;
@@ -1540,13 +1538,13 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
   case ct_RANGE:
   case ct_COUNT: {
     char num_buf[20];
-    long num = (type == ct_LINE1) ? eap->line1 :
-               (type == ct_LINE2) ? eap->line2 :
-               (type == ct_RANGE) ? eap->addr_count :
-               (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
+    int64_t num = (type == ct_LINE1) ? eap->line1 :
+                  (type == ct_LINE2) ? eap->line2 :
+                  (type == ct_RANGE) ? eap->addr_count :
+                  (eap->addr_count > 0) ? eap->line2 : cmd->uc_def;
     size_t num_len;
 
-    snprintf(num_buf, sizeof(num_buf), "%" PRId64, (int64_t)num);
+    snprintf(num_buf, sizeof(num_buf), "%" PRId64, num);
     num_len = strlen(num_buf);
     result = num_len;
 
@@ -1783,7 +1781,7 @@ Dictionary commands_array(buf_T *buf)
     Object obj = NIL;
     if (cmd->uc_argt & EX_COUNT) {
       if (cmd->uc_def >= 0) {
-        snprintf(str, sizeof(str), "%" PRId64, (int64_t)cmd->uc_def);
+        snprintf(str, sizeof(str), "%" PRId64, cmd->uc_def);
         obj = STRING_OBJ(cstr_to_string(str));    // -count=N
       } else {
         obj = STRING_OBJ(cstr_to_string("0"));    // -count
@@ -1796,7 +1794,7 @@ Dictionary commands_array(buf_T *buf)
       if (cmd->uc_argt & EX_DFLALL) {
         obj = STRING_OBJ(cstr_to_string("%"));    // -range=%
       } else if (cmd->uc_def >= 0) {
-        snprintf(str, sizeof(str), "%" PRId64, (int64_t)cmd->uc_def);
+        snprintf(str, sizeof(str), "%" PRId64, cmd->uc_def);
         obj = STRING_OBJ(cstr_to_string(str));    // -range=N
       } else {
         obj = STRING_OBJ(cstr_to_string("."));    // -range

--- a/src/nvim/usercmd.h
+++ b/src/nvim/usercmd.h
@@ -12,7 +12,7 @@ typedef struct ucmd {
   char *uc_name;                // The command name
   uint32_t uc_argt;             // The argument type
   char *uc_rep;                 // The command's replacement string
-  long uc_def;                  // The default value for a range/count
+  int64_t uc_def;               // The default value for a range/count
   int uc_compl;                 // completion type
   cmd_addr_T uc_addr_type;      // The command's address type
   sctx_T uc_script_ctx;         // SCTX where the command was defined


### PR DESCRIPTION
MSVC has 4 different warning levels: 1 (severe), 2 (significant), 3
(production quality) and 4 (informational). Enabling level 3 warnings
mostly revealed conversion problems, similar to GCC/clang -Wconversion
flag.