### PR TITLE
perf(completion): use one call to globpath() for .vim and .lua

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1190,34 +1190,28 @@ int ExpandRTDir(char *pat, int flags, int *num_file, char ***file, char *dirname
   garray_T ga;
   ga_init(&ga, (int)sizeof(char *), 10);
 
-  // TODO(bfredl): this is bullshit, exandpath should not reinvent path logic.
+  // TODO(bfredl): this is bullshit, expandpath should not reinvent path logic.
   for (int i = 0; dirnames[i] != NULL; i++) {
-    size_t size = strlen(dirnames[i]) + pat_len + 7;
+    size_t size = strlen(dirnames[i]) + pat_len + 16;
     char *s = xmalloc(size);
-    snprintf(s, size, "%s/%s*.vim", dirnames[i], pat);
-    globpath(p_rtp, s, &ga, 0);
-    snprintf(s, size, "%s/%s*.lua", dirnames[i], pat);
+    snprintf(s, size, "%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);
     globpath(p_rtp, s, &ga, 0);
     xfree(s);
   }
 
   if (flags & DIP_START) {
     for (int i = 0; dirnames[i] != NULL; i++) {
-      size_t size = strlen(dirnames[i]) + pat_len + 22;
+      size_t size = strlen(dirnames[i]) + pat_len + 31;
       char *s = xmalloc(size);
-      snprintf(s, size, "pack/*/start/*/%s/%s*.vim", dirnames[i], pat);  // NOLINT
-      globpath(p_pp, s, &ga, 0);
-      snprintf(s, size, "pack/*/start/*/%s/%s*.lua", dirnames[i], pat);  // NOLINT
+      snprintf(s, size, "pack/*/start/*/%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);  // NOLINT
       globpath(p_pp, s, &ga, 0);
       xfree(s);
     }
 
     for (int i = 0; dirnames[i] != NULL; i++) {
-      size_t size = strlen(dirnames[i]) + pat_len + 22;
+      size_t size = strlen(dirnames[i]) + pat_len + 31;
       char *s = xmalloc(size);
-      snprintf(s, size, "start/*/%s/%s*.vim", dirnames[i], pat);  // NOLINT
-      globpath(p_pp, s, &ga, 0);
-      snprintf(s, size, "start/*/%s/%s*.lua", dirnames[i], pat);  // NOLINT
+      snprintf(s, size, "start/*/%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);  // NOLINT
       globpath(p_pp, s, &ga, 0);
       xfree(s);
     }
@@ -1225,21 +1219,17 @@ int ExpandRTDir(char *pat, int flags, int *num_file, char ***file, char *dirname
 
   if (flags & DIP_OPT) {
     for (int i = 0; dirnames[i] != NULL; i++) {
-      size_t size = strlen(dirnames[i]) + pat_len + 20;
+      size_t size = strlen(dirnames[i]) + pat_len + 29;
       char *s = xmalloc(size);
-      snprintf(s, size, "pack/*/opt/*/%s/%s*.vim", dirnames[i], pat);  // NOLINT
-      globpath(p_pp, s, &ga, 0);
-      snprintf(s, size, "pack/*/opt/*/%s/%s*.lua", dirnames[i], pat);  // NOLINT
+      snprintf(s, size, "pack/*/opt/*/%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);  // NOLINT
       globpath(p_pp, s, &ga, 0);
       xfree(s);
     }
 
     for (int i = 0; dirnames[i] != NULL; i++) {
-      size_t size = strlen(dirnames[i]) + pat_len + 20;
+      size_t size = strlen(dirnames[i]) + pat_len + 29;
       char *s = xmalloc(size);
-      snprintf(s, size, "opt/*/%s/%s*.vim", dirnames[i], pat);  // NOLINT
-      globpath(p_pp, s, &ga, 0);
-      snprintf(s, size, "opt/*/%s/%s*.lua", dirnames[i], pat);  // NOLINT
+      snprintf(s, size, "opt/*/%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);  // NOLINT
       globpath(p_pp, s, &ga, 0);
       xfree(s);
     }


### PR DESCRIPTION
Test using the following test script (timings with ASAN):
```vim
let start = reltime()
for i in range(100)
  call getcompletion('', 'filetype')
endfor
echomsg reltimefloat(reltime(start))
```
Without this PR: 3.251825 seconds
With this PR: 2.747285 seconds
