### PR TITLE
fix(treesitter): escape all '}' in require_language

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -16,7 +16,9 @@ function M.require_language(lang, path, silent, symbol_name)
     return true
   end
   if path == nil then
+    local extra_escape_chars = '}'
     local fname = 'parser/' .. vim.fn.fnameescape(lang) .. '.*'
+    fname = vim.fn.escape(fname, extra_escape_chars)
     local paths = a.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
       if silent then


### PR DESCRIPTION
Fix for #21485.