### PR TITLE
fix(lsp): assert workspace/applyEdit receives params

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -131,9 +131,10 @@ end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
 M['workspace/applyEdit'] = function(_, workspace_edit, ctx)
-  if not workspace_edit then
-    return
-  end
+  assert(
+    workspace_edit,
+    'workspace/applyEdit must be called with `ApplyWorkspaceEditParams`. Server is violating the specification'
+  )
   -- TODO(ashkan) Do something more with label?
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)


### PR DESCRIPTION
According to the specification `workspace/applyEdit` must be called with
`ApplyWorkspaceEditParams`.

So far the client just returned, which could lead to a misleading error  because `workspace/applyEdit` must respond with a
`ApplyWorkspaceEditResult`.

This adds an assertion to clarify that the server is violating the
specification.

See https://github.com/neovim/neovim/issues/21925
