### PR TITLE
fix: use correct number for INT_MAX

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -886,7 +886,7 @@ int ins_typebuf(char *str, int noremap, int offset, bool nottyped, bool silent)
     // often.
     int newoff = MAXMAPLEN + 4;
     int extra = addlen + newoff + 4 * (MAXMAPLEN + 4);
-    if (typebuf.tb_len > 2147483674 - extra) {
+    if (typebuf.tb_len > INT_MAX - extra) {
       // string is getting too long for 32 bit int
       emsg(_(e_toocompl));          // also calls flush_buffers
       setcursor();


### PR DESCRIPTION
Actually use INT_MAX rather than a number to prevent these types of
situations to begin with.
