### PR TITLE
fix: add manifest file to correctly determine Windows version

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -95,6 +95,8 @@ if(MSVC)
   # Disable warnings that give too many false positives.
   target_compile_options(main_lib INTERFACE -wd4311 -wd4146)
   target_compile_definitions(main_lib INTERFACE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
+
+  target_sources(main_lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/os/nvim.manifest)
 else()
   target_compile_options(main_lib INTERFACE -Wall -Wextra -pedantic -Wno-unused-parameter
     -Wstrict-prototypes -std=gnu99 -Wshadow -Wconversion

--- a/src/nvim/os/nvim.manifest
+++ b/src/nvim/os/nvim.manifest
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <assemblyIdentity
+    processorArchitecture="*"
+    version="0.9.0.0"
+    type="win32"
+    name="Neovim"
+  />
+  <description>Neovim</description>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
In Windows 8.1 and later, GetVersionEx does not automatically give the
correct information if a manifest file doesn't explicitly mention we
support that version. This will enable further detection for Windows 8.1
and Windows 10/11 when using windowsversion(), with an easy way to add
future versions. A list of all operating system versions can be found
here:
https://learn.microsoft.com/en-us/windows/win32/sysinfo/operating-system-version