### PR TITLE
vim-patch:9.0.1230: Apache Thrift files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1022,6 +1022,7 @@ local extension = {
   texinfo = 'texinfo',
   text = 'text',
   tfvars = 'terraform-vars',
+  thrift = 'thrift',
   tla = 'tla',
   tli = 'tli',
   toml = 'toml',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -581,6 +581,7 @@ let s:filename_checks = {
     \ 'texmf': ['texmf.cnf'],
     \ 'text': ['file.text', 'file.txt', 'README', 'LICENSE', 'COPYING', 'AUTHORS', '/usr/share/doc/bash-completion/AUTHORS', '/etc/apt/apt.conf.d/README', '/etc/Muttrc.d/README'],
     \ 'tf': ['file.tf', '.tfrc', 'tfrc'],
+    \ 'thrift': ['file.thrift'],
     \ 'tidy': ['.tidyrc', 'tidyrc', 'tidy.conf'],
     \ 'tilde': ['file.t.html'],
     \ 'tla': ['file.tla'],


### PR DESCRIPTION
Problem:   Apache thrift files are not recognized.
Solution:   Add a pattern for thrift files. (Amaan Qureshi, closes https://github.com/vim/vim/pull/11859)