### PR TITLE
vim-patch:9.0.1233: search() loops forever if "skip" is TRUE for all matches

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6239,7 +6239,9 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
       // didn't find it or no skip argument
       break;
     }
-    firstpos = pos;
+    if (firstpos.lnum == 0) {
+      firstpos = pos;
+    }
 
     // If the skip expression matches, ignore this match.
     {

--- a/src/nvim/testdir/test_search.vim
+++ b/src/nvim/testdir/test_search.vim
@@ -1377,6 +1377,22 @@ func Test_subst_word_under_cursor()
   set noincsearch
 endfunc
 
+func Test_search_skip_all_matches()
+  enew
+  call setline(1, ['no match here',
+        \ 'match this line',
+        \ 'nope',
+        \ 'match in this line',
+        \ 'last line',
+        \ ])
+  call cursor(1, 1)
+  let lnum = search('this', '', 0, 0, 'getline(".") =~ "this line"')
+  " Only check that no match is found.  Previously it searched forever.
+  call assert_equal(0, lnum)
+
+  bwipe!
+endfunc
+
 func Test_search_undefined_behaviour()
   CheckFeature terminal
 


### PR DESCRIPTION
#### vim-patch:9.0.1233: search() loops forever if "skip" is TRUE for all matches

Problem:    search() loops forever if "skip" is TRUE for all matches.
Solution:   Keep the position of the first match.

https://github.com/vim/vim/commit/3d79f0a4309995956bd8889940cca22f7a15881d

Co-authored-by: Bram Moolenaar <Bram@vim.org>