### PR TITLE
docs(tutor): fix TODO line demo

### DIFF
--- a/runtime/tutor/tutor.tutor.json
+++ b/runtime/tutor/tutor.tutor.json
@@ -2,8 +2,8 @@
     "expect": {
 	"63": "This is text with **important information**",
 	"64": "This is text with **important information**",
-	"71": "Document '&variable'",
-	"72": "Document '&variable'",
+	"71": "TODO: Document '&variable'",
+	"72": "TODO: Document '&variable'",
 	"78": "# This is a level 1 header",
 	"79": "# This is a level 1 header",
     	"80": "### This is a level 3 header",


### PR DESCRIPTION
Inside the Tutor file (`:Tutor tutor`), in the markdown tutorial section, it says:

<img width="456" alt="image" src="https://user-images.githubusercontent.com/13385000/214106629-9056c00b-2a4e-4bf6-ae83-31aa9c9424ea.png">

Here, it is expected that the user add the word `TODO:` to show how the markdown is rendered, but the tutor is configured to expect the text without the word TODO. This PR fixes this behavior.