### PR TITLE
vim-patch:9.0.1236: code in same_leader() can be simplified

### DIFF
--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -530,9 +530,6 @@ static bool same_leader(linenr_T lnum, int leader1_len, char *leader1_flags, int
     return leader2_len == 0;
   }
 
-  char *lnum_line = NULL;
-  int line_len = 0;
-
   // If first leader has 'f' flag, the lines can be joined only if the
   // second line does not have a leader.
   // If first leader has 'e' flag, the lines can never be joined.
@@ -547,10 +544,7 @@ static bool same_leader(linenr_T lnum, int leader1_len, char *leader1_flags, int
         return false;
       }
       if (*p == COM_START) {
-        if (lnum_line == NULL) {
-          lnum_line = ml_get(lnum);
-          line_len = (int)strlen(lnum_line);
-        }
+        int line_len = (int)strlen(ml_get(lnum));
         if (line_len <= leader1_len) {
           return false;
         }


### PR DESCRIPTION
#### vim-patch:9.0.1236: code in same_leader() can be simplified

Problem:    Code in same_leader() can be simplified.
Solution:   Simplify code that is executed only once. (closes vim/vim#11867)

https://github.com/vim/vim/commit/9cbf791995514e72476399fe06e055a707ec0158