### PR TITLE
vim-patch:partial:9.0.1237: code is indented more than necessary

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -126,12 +126,14 @@ static char *provider_err = NULL;
 void conceal_check_cursor_line(void)
 {
   bool should_conceal = conceal_cursor_line(curwin);
-  if (curwin->w_p_cole > 0 && (conceal_cursor_used != should_conceal)) {
-    redrawWinline(curwin, curwin->w_cursor.lnum);
-    // Need to recompute cursor column, e.g., when starting Visual mode
-    // without concealing.
-    curs_columns(curwin, true);
+  if (curwin->w_p_cole <= 0 || conceal_cursor_used == should_conceal) {
+    return;
   }
+
+  redrawWinline(curwin, curwin->w_cursor.lnum);
+  // Need to recompute cursor column, e.g., when starting Visual mode
+  // without concealing.
+  curs_columns(curwin, true);
 }
 
 /// Resize default_grid to Rows and Columns.
@@ -837,25 +839,29 @@ static bool vsep_connected(win_T *wp, WindowCorner corner)
 /// Draw the vertical separator right of window "wp"
 static void draw_vsep_win(win_T *wp)
 {
-  if (wp->w_vsep_width) {
-    // draw the vertical separator right of this window
-    int hl;
-    int c = fillchar_vsep(wp, &hl);
-    grid_fill(&default_grid, wp->w_winrow, W_ENDROW(wp),
-              W_ENDCOL(wp), W_ENDCOL(wp) + 1, c, ' ', hl);
+  if (!wp->w_vsep_width) {
+    return;
   }
+
+  // draw the vertical separator right of this window
+  int hl;
+  int c = fillchar_vsep(wp, &hl);
+  grid_fill(&default_grid, wp->w_winrow, W_ENDROW(wp),
+            W_ENDCOL(wp), W_ENDCOL(wp) + 1, c, ' ', hl);
 }
 
 /// Draw the horizontal separator below window "wp"
 static void draw_hsep_win(win_T *wp)
 {
-  if (wp->w_hsep_height) {
-    // draw the horizontal separator below this window
-    int hl;
-    int c = fillchar_hsep(wp, &hl);
-    grid_fill(&default_grid, W_ENDROW(wp), W_ENDROW(wp) + 1,
-              wp->w_wincol, W_ENDCOL(wp), c, c, hl);
+  if (!wp->w_hsep_height) {
+    return;
   }
+
+  // draw the horizontal separator below this window
+  int hl;
+  int c = fillchar_hsep(wp, &hl);
+  grid_fill(&default_grid, W_ENDROW(wp), W_ENDROW(wp) + 1,
+            wp->w_wincol, W_ENDCOL(wp), c, c, hl);
 }
 
 /// Get the separator connector for specified window corner of window "wp"

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -142,16 +142,16 @@ void grid_putchar(ScreenGrid *grid, int c, int row, int col, int attr)
 /// Also return its attribute in *attrp;
 void grid_getbytes(ScreenGrid *grid, int row, int col, char *bytes, int *attrp)
 {
-  size_t off;
-
   grid_adjust(&grid, &row, &col);
 
   // safety check
-  if (grid->chars != NULL && row < grid->rows && col < grid->cols) {
-    off = grid->line_offset[row] + (size_t)col;
-    *attrp = grid->attrs[off];
-    schar_copy(bytes, grid->chars[off]);
+  if (grid->chars == NULL || row >= grid->rows || col >= grid->cols) {
+    return;
   }
+
+  size_t off = grid->line_offset[row] + (size_t)col;
+  *attrp = grid->attrs[off];
+  schar_copy(bytes, grid->chars[off]);
 }
 
 /// put string '*text' on the window grid at position 'row' and 'col', with

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -821,12 +821,14 @@ static void source_all_matches(char *pat)
   int num_files;
   char **files;
 
-  if (gen_expand_wildcards(1, &pat, &num_files, &files, EW_FILE) == OK) {
-    for (int i = 0; i < num_files; i++) {
-      (void)do_source(files[i], false, DOSO_NONE);
-    }
-    FreeWild(num_files, files);
+  if (gen_expand_wildcards(1, &pat, &num_files, &files, EW_FILE) != OK) {
+    return;
   }
+
+  for (int i = 0; i < num_files; i++) {
+    (void)do_source(files[i], false, DOSO_NONE);
+  }
+  FreeWild(num_files, files);
 }
 
 /// Add the package directory to 'runtimepath'

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -295,52 +295,54 @@ bool get_keymap_str(win_T *wp, char *fmt, char *buf, int len)
     return false;
   }
 
-  {
-    buf_T *old_curbuf = curbuf;
-    win_T *old_curwin = curwin;
-    char *s;
+  buf_T *old_curbuf = curbuf;
+  win_T *old_curwin = curwin;
+  char *s;
 
-    curbuf = wp->w_buffer;
-    curwin = wp;
-    STRCPY(buf, "b:keymap_name");       // must be writable
-    emsg_skip++;
-    s = p = eval_to_string(buf, NULL, false);
-    emsg_skip--;
-    curbuf = old_curbuf;
-    curwin = old_curwin;
-    if (p == NULL || *p == NUL) {
-      if (wp->w_buffer->b_kmap_state & KEYMAP_LOADED) {
-        p = wp->w_buffer->b_p_keymap;
-      } else {
-        p = "lang";
-      }
+  curbuf = wp->w_buffer;
+  curwin = wp;
+  STRCPY(buf, "b:keymap_name");       // must be writable
+  emsg_skip++;
+  s = p = eval_to_string(buf, NULL, false);
+  emsg_skip--;
+  curbuf = old_curbuf;
+  curwin = old_curwin;
+  if (p == NULL || *p == NUL) {
+    if (wp->w_buffer->b_kmap_state & KEYMAP_LOADED) {
+      p = wp->w_buffer->b_p_keymap;
+    } else {
+      p = "lang";
     }
-    if (vim_snprintf(buf, (size_t)len, fmt, p) > len - 1) {
-      buf[0] = NUL;
-    }
-    xfree(s);
   }
+  if (vim_snprintf(buf, (size_t)len, fmt, p) > len - 1) {
+    buf[0] = NUL;
+  }
+  xfree(s);
   return buf[0] != NUL;
 }
 
 /// Prepare for 'hlsearch' highlighting.
 void start_search_hl(void)
 {
-  if (p_hls && !no_hlsearch) {
-    end_search_hl();  // just in case it wasn't called before
-    last_pat_prog(&screen_search_hl.rm);
-    // Set the time limit to 'redrawtime'.
-    screen_search_hl.tm = profile_setlimit(p_rdt);
+  if (!p_hls || no_hlsearch) {
+    return;
   }
+
+  end_search_hl();  // just in case it wasn't called before
+  last_pat_prog(&screen_search_hl.rm);
+  // Set the time limit to 'redrawtime'.
+  screen_search_hl.tm = profile_setlimit(p_rdt);
 }
 
 /// Clean up for 'hlsearch' highlighting.
 void end_search_hl(void)
 {
-  if (screen_search_hl.rm.regprog != NULL) {
-    vim_regfree(screen_search_hl.rm.regprog);
-    screen_search_hl.rm.regprog = NULL;
+  if (screen_search_hl.rm.regprog == NULL) {
+    return;
   }
+
+  vim_regfree(screen_search_hl.rm.regprog);
+  screen_search_hl.rm.regprog = NULL;
 }
 
 /// Check if there should be a delay.  Used before clearing or redrawing the
@@ -671,11 +673,13 @@ void clearmode(void)
 static void recording_mode(int attr)
 {
   msg_puts_attr(_("recording"), attr);
-  if (!shortmess(SHM_RECORDING)) {
-    char s[4];
-    snprintf(s, ARRAY_SIZE(s), " @%c", reg_recording);
-    msg_puts_attr(s, attr);
+  if (shortmess(SHM_RECORDING)) {
+    return;
   }
+
+  char s[4];
+  snprintf(s, ARRAY_SIZE(s), " @%c", reg_recording);
+  msg_puts_attr(s, attr);
 }
 
 void get_trans_bufname(buf_T *buf)

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -122,17 +122,17 @@ static signgroup_T *sign_group_ref(const char *groupname)
 /// removed, then remove the group.
 static void sign_group_unref(char *groupname)
 {
-  signgroup_T *group;
-
   hashitem_T *hi = hash_find(&sg_table, groupname);
-  if (!HASHITEM_EMPTY(hi)) {
-    group = HI2SG(hi);
-    group->sg_refcount--;
-    if (group->sg_refcount == 0) {
-      // All the signs in this group are removed
-      hash_remove(&sg_table, hi);
-      xfree(group);
-    }
+  if (HASHITEM_EMPTY(hi)) {
+    return;
+  }
+
+  signgroup_T *group = HI2SG(hi);
+  group->sg_refcount--;
+  if (group->sg_refcount == 0) {
+    // All the signs in this group are removed
+    hash_remove(&sg_table, hi);
+    xfree(group);
   }
 }
 


### PR DESCRIPTION
#### vim-patch:partial:9.0.1237: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11858)

https://github.com/vim/vim/commit/6ec66660476562e643deceb7c325cd0e8c903663

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>