### PR TITLE
refactor(window): remove aucmd_win check from one_window()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2527,24 +2527,23 @@ void close_windows(buf_T *buf, bool keep_curwin)
   RedrawingDisabled--;
 }
 
-/// Check that the specified window is the last one.
-/// @param win  counted even if floating
-///
-/// @return  true if the specified window is the only window that exists,
-///          false if there is another, possibly in another tab page.
+/// Check if "win" is the last non-floating window that exists.
 bool last_window(win_T *win) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return one_window(win) && first_tabpage->tp_next == NULL;
 }
 
-/// Check if current tab page contains no more than one window other than `aucmd_win[]`.
-/// @param counted_float  counted even if floating, but not if it is `aucmd_win[]`
-bool one_window(win_T *counted_float) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+/// Check if "win" is the only non-floating window in the current tabpage.
+bool one_window(win_T *win) FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  if (win->w_floating) {
+    return false;
+  }
+
   bool seen_one = false;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (!is_aucmd_win(wp) && (!wp->w_floating || wp == counted_float)) {
+    if (!wp->w_floating) {
       if (seen_one) {
         return false;
       }


### PR DESCRIPTION
In most places where `one_window()` or `last_window()` is called, `aucmd_win` has already been checked, so there is no need to check for it again.

The only place where this isn't checked is when using `:wincmd T`. Before this PR using `:wincmd T` in an `aucmd_win` will give a warning when there is only one non-floating window, but E813 error if there are multiple. Now it consistently gives E813 error.
