### PR TITLE
fix(tui): set stdin as "blocking" on exit

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -457,6 +457,7 @@ static void tui_terminal_stop(TUIData *tui)
 void tui_stop(TUIData *tui)
 {
   tui_terminal_stop(tui);
+  stream_set_blocking(tui->input.in_fd, true);   // normalize stream (#2598)
   tinput_destroy(&tui->input);
   tui->stopped = true;
   signal_watcher_close(&tui->winch_handle, NULL);


### PR DESCRIPTION
This fixes a regression from #21605 that stdin is no longer set as
"blocking" after Nvim TUI exits, and the problems described in #2598
happen again.

I'm not sure if this should be done in TUI code or common exiting code.
I added this call in tui_stop() as it is also present in tui_suspend().
