### PR TITLE
fix(intro): make :help news line easier to translate

### DIFF
--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -5625,9 +5625,6 @@ msgstr "$VIMRUNTIME öntanımlı konumu: \""
 msgid "Nvim is open source and freely distributable"
 msgstr "Nvim açık kaynaklıdır ve özgürce dağıtılabilir"
 
-msgid "https://neovim.io/#chat"
-msgstr "https://neovim.io/#chat"
-
 msgid "type  :help nvim<Enter>       if you are new! "
 msgstr "eğer yeniyseniz         :help nvim<Enter>       "
 

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -5550,9 +5550,6 @@ msgstr " заміна для $VIMRUNTIME: \""
 msgid "Nvim is open source and freely distributable"
 msgstr "Nvim — це відкрита й вільно розповсюджувана програма"
 
-msgid "https://neovim.io/#chat"
-msgstr "https://neovim.io/#chat"
-
 msgid "type  :help nvim<Enter>       if you are new! "
 msgstr ":help nvim<Enter>       якщо ви вперше!       "
 

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -19,7 +19,7 @@ msgstr ""
 "Project-Id-Version: Vim(Simplified Chinese)\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-11-17 08:00+0800\n"
-"PO-Revision-Date: 2022-11-17 22:29+0800\n"
+"PO-Revision-Date: 2023-01-24 13:00+0800\n"
 "Last-Translator: Sizhe Zhao <prc.zhao@outlook.com>\n"
 "Language-Team: Simplified Chinese <i18n-translation@lists.linux.net.cn>\n"
 "Language: zh_CN\n"
@@ -7250,11 +7250,11 @@ msgstr "Nvim 是可自由分发的开放源代码软件"
 
 #: ../version.c:2808
 msgid "type  :help nvim<Enter>       if you are new! "
-msgstr ""
+msgstr "输入  :help nvim<Enter>       了解 Neovim！   "
 
 #: ../version.c:2809
 msgid "type  :checkhealth<Enter>     to optimize Nvim"
-msgstr ""
+msgstr "输入  :checkhealth<Enter>     优化 Neovim     "
 
 #: ../version.c:2810
 msgid "type  :q<Enter>               to exit         "
@@ -7262,11 +7262,12 @@ msgstr "输入  :q<Enter>               退出            "
 
 #: ../version.c:2811
 msgid "type  :help<Enter>            for help        "
-msgstr ""
+msgstr "输入  :help<Enter>            查看帮助        "
 
 #: ../version.c:2813
-msgid "type  :help news<Enter> to see changes in"
-msgstr ""
+#, c-format
+msgid "type  :help news<Enter> to see changes in v%s.%s"
+msgstr "输入  :help news<Enter>       查看 v%s.%s 的变化"
 
 #: ../version.c:2816
 msgid "Help poor children in Uganda!"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -7248,10 +7248,6 @@ msgstr "  $VIMRUNTIME 预设值: \""
 msgid "Nvim is open source and freely distributable"
 msgstr "Nvim 是可自由分发的开放源代码软件"
 
-#: ../version.c:2806
-msgid "https://neovim.io/#chat"
-msgstr ""
-
 #: ../version.c:2808
 msgid "type  :help nvim<Enter>       if you are new! "
 msgstr ""

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -29,6 +29,7 @@
 #include "nvim/highlight_defs.h"
 #include "nvim/lua/executor.h"
 #include "nvim/mbyte.h"
+#include "nvim/memory.h"
 #include "nvim/message.h"
 #include "nvim/option_defs.h"
 #include "nvim/os/os_defs.h"
@@ -2789,6 +2790,8 @@ void intro_message(int colon)
   long blanklines;
   int sponsor;
   char *p;
+  char *mesg;
+  int mesg_size;
   static char *(lines[]) = {
     N_(NVIM_VERSION_LONG),
     "",
@@ -2800,8 +2803,7 @@ void intro_message(int colon)
     N_("type  :q<Enter>               to exit         "),
     N_("type  :help<Enter>            for help        "),
     "",
-    N_("type  :help news<Enter> to see changes in")
-    " v" STR(NVIM_VERSION_MAJOR) "." STR(NVIM_VERSION_MINOR),
+    N_("type  :help news<Enter> to see changes in v%s.%s"),
     "",
     N_("Help poor children in Uganda!"),
     N_("type  :help iccf<Enter>       for information "),
@@ -2834,24 +2836,39 @@ void intro_message(int colon)
     for (i = 0; i < (int)ARRAY_SIZE(lines); i++) {
       p = lines[i];
 
+      if (strstr(p, "news") != NULL) {
+        p = _(p);
+        mesg_size = snprintf(NULL, 0, p,
+                             STR(NVIM_VERSION_MAJOR), STR(NVIM_VERSION_MINOR));
+        assert(mesg_size > 0);
+        mesg = xmallocz((size_t)mesg_size);
+        snprintf(mesg, mesg_size + 1, p,
+                 STR(NVIM_VERSION_MAJOR), STR(NVIM_VERSION_MINOR));
+      }
+
       if (sponsor != 0) {
         if (strstr(p, "children") != NULL) {
-          p = sponsor < 0
+          mesg = sponsor < 0
               ? N_("Sponsor Vim development!")
               : N_("Become a registered Vim user!");
-        } else if (strstr(p, "iccf") != NULL) {
-          p = sponsor < 0
+          p = NULL;
+        }
+        if (strstr(p, "iccf") != NULL) {
+          mesg = sponsor < 0
               ? N_("type  :help sponsor<Enter>    for information ")
               : N_("type  :help register<Enter>   for information ");
-        } else if (strstr(p, "Orphans") != NULL) {
-          p = N_("menu  Help->Sponsor/Register  for information    ");
+          p = NULL;
         }
       }
 
-      if (*p != NUL) {
-        do_intro_line(row, _(p), 0);
+      if (*mesg != NUL) {
+        do_intro_line(row, mesg, 0);
       }
       row++;
+
+      if (p != NULL) {
+        XFREE_CLEAR(mesg);
+      }
     }
   }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2862,7 +2862,11 @@ void intro_message(int colon)
       }
 
       if (mesg == NULL) {
-        mesg = _(p);
+        if (*p != NUL) {
+          mesg = _(p);
+        } else {
+          mesg = "";
+        }
       }
 
       if (*mesg != NUL) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2835,6 +2835,8 @@ void intro_message(int colon)
   if (((row >= 2) && (Columns >= 50)) || colon) {
     for (i = 0; i < (int)ARRAY_SIZE(lines); i++) {
       p = lines[i];
+      mesg = NULL;
+      mesg_size = 0;
 
       if (strstr(p, "news") != NULL) {
         p = _(p);
@@ -2849,16 +2851,18 @@ void intro_message(int colon)
       if (sponsor != 0) {
         if (strstr(p, "children") != NULL) {
           mesg = sponsor < 0
-              ? N_("Sponsor Vim development!")
-              : N_("Become a registered Vim user!");
-          p = NULL;
+              ? _("Sponsor Vim development!")
+              : _("Become a registered Vim user!");
         }
         if (strstr(p, "iccf") != NULL) {
           mesg = sponsor < 0
-              ? N_("type  :help sponsor<Enter>    for information ")
-              : N_("type  :help register<Enter>   for information ");
-          p = NULL;
+              ? _("type  :help sponsor<Enter>    for information ")
+              : _("type  :help register<Enter>   for information ");
         }
+      }
+
+      if (mesg == NULL) {
+        mesg = _(p);
       }
 
       if (*mesg != NUL) {
@@ -2866,7 +2870,7 @@ void intro_message(int colon)
       }
       row++;
 
-      if (p != NULL) {
+      if (mesg_size > 0) {
         XFREE_CLEAR(mesg);
       }
     }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2844,7 +2844,7 @@ void intro_message(int colon)
                              STR(NVIM_VERSION_MAJOR), STR(NVIM_VERSION_MINOR));
         assert(mesg_size > 0);
         mesg = xmallocz((size_t)mesg_size);
-        snprintf(mesg, mesg_size + 1, p,
+        snprintf(mesg, (size_t)mesg_size + 1, p,
                  STR(NVIM_VERSION_MAJOR), STR(NVIM_VERSION_MINOR));
       }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2793,7 +2793,7 @@ void intro_message(int colon)
     N_(NVIM_VERSION_LONG),
     "",
     N_("Nvim is open source and freely distributable"),
-    N_("https://neovim.io/#chat"),
+    "https://neovim.io/#chat",
     "",
     N_("type  :help nvim<Enter>       if you are new! "),
     N_("type  :checkhealth<Enter>     to optimize Nvim"),


### PR DESCRIPTION
This PR introduces two changes:
1. `"https://neovim.io/#chat"` is no longer marked as translatable. ([ref](https://www.gnu.org/software/gettext/manual/html_node/Preparing-Strings.html#No-embedded-URLs))
2. The `:help news<Enter>` line can now be properly translated for `zh_CN.UTF-8`. Previous approach makes it difficult to translate because of the word order.