### PR TITLE
refactor(option.c): break up `do_set()`

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1410,9 +1410,6 @@ int do_set(char *arg, int opt_flags)
         int value_checked = false;
         if (flags & P_BOOL) {                       // boolean
           do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, &errmsg);
-          if (errmsg != NULL) {
-            goto skip;
-          }
         } else {  // Numeric or string.
           if (vim_strchr("=:&<", (uint8_t)nextchar) == NULL
               || prefix != 1) {
@@ -1423,19 +1420,17 @@ int do_set(char *arg, int opt_flags)
           if (flags & P_NUM) {  // numeric
             do_set_num(opt_idx, opt_flags, &arg, nextchar, op, varp, errbuf, sizeof(errbuf),
                        &errmsg);
-            if (errmsg != NULL) {
-              goto skip;
-            }
           } else if (opt_idx >= 0) {  // String.
             do_set_string(opt_idx, opt_flags, &arg, nextchar, op, flags, varp, errbuf,
                           sizeof(errbuf), &value_checked, &errmsg);
-            if (errmsg != NULL) {
-              goto skip;
-            }
           } else {
             // key code option(FIXME(tarruda): Show a warning or something
             // similar)
           }
+        }
+
+        if (errmsg != NULL) {
+          goto skip;
         }
 
         if (opt_idx >= 0) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -831,10 +831,9 @@ static void do_set_num(int opt_idx, int opt_flags, char **argp, int nextchar, co
 }
 
 /// Part of do_set() for string options.
-/// @return  FAIL on failure, do not process further options.
-static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, set_op_T op_arg,
-                         uint32_t flags, char *varp_arg, char *errbuf, size_t errbuflen,
-                         int *value_checked, char **errmsg)
+static void do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, set_op_T op_arg,
+                          uint32_t flags, char *varp_arg, char *errbuf, size_t errbuflen,
+                          int *value_checked, char **errmsg)
 {
   char *arg = *argp;
   set_op_T op = op_arg;
@@ -1163,7 +1162,6 @@ static int do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, 
   xfree(saved_newval);
 
   *argp = arg;
-  return *errmsg == NULL ? OK : FAIL;
 }
 
 /// Parse 'arg' for option settings.
@@ -1429,13 +1427,10 @@ int do_set(char *arg, int opt_flags)
               goto skip;
             }
           } else if (opt_idx >= 0) {  // String.
-            if (do_set_string(opt_idx, opt_flags, &arg, nextchar,
-                              op, flags, varp, errbuf, sizeof(errbuf),
-                              &value_checked, &errmsg) == FAIL) {
-              if (errmsg != NULL) {
-                goto skip;
-              }
-              break;
+            do_set_string(opt_idx, opt_flags, &arg, nextchar, op, flags, varp, errbuf,
+                          sizeof(errbuf), &value_checked, &errmsg);
+            if (errmsg != NULL) {
+              goto skip;
             }
           } else {
             // key code option(FIXME(tarruda): Show a warning or something

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -817,6 +817,78 @@ static void do_set_num(int opt_idx, int opt_flags, char **argp, int nextchar, co
                            errbuf, errbuflen, opt_flags);
 }
 
+// Handle some special cases with string option values
+static void munge_string_opt_val(char **varp, char **oldval, char **const origval,
+                                 char_u **const origval_l, char_u **const origval_g,
+                                 char **const argp, char *const whichwrap, size_t whichwraplen,
+                                 char **const save_argp)
+{
+  // Set 'keywordprg' to ":help" if an empty
+  // value was passed to :set by the user.
+  if (varp == &p_kp && (**argp == NUL || **argp == ' ')) {
+    *save_argp = *argp;
+    *argp = ":help";
+  } else if (varp == &p_bs && ascii_isdigit(**(char_u **)varp)) {
+    // Convert 'backspace' number to string, for
+    // adding, prepending and removing string.
+    const int i = getdigits_int(varp, true, 0);
+    switch (i) {
+    case 0:
+      *varp = empty_option;
+      break;
+    case 1:
+      *varp = xstrdup("indent,eol");
+      break;
+    case 2:
+      *varp = xstrdup("indent,eol,start");
+      break;
+    case 3:
+      *varp = xstrdup("indent,eol,nostop");
+      break;
+    }
+    xfree(*oldval);
+    if (*origval == *oldval) {
+      *origval = *varp;
+    }
+    if (*origval_l == (char_u *)(*oldval)) {
+      *origval_l = *(char_u **)varp;
+    }
+    if (*origval_g == (char_u *)(*oldval)) {
+      *origval_g = *(char_u **)varp;
+    }
+    *oldval = *varp;
+  } else if (varp == &p_ww && ascii_isdigit(**argp)) {
+    // Convert 'whichwrap' number to string, for backwards compatibility
+    // with Vim 3.0.
+    *whichwrap = NUL;
+    int i = getdigits_int(argp, true, 0);
+    if (i & 1) {
+      xstrlcat(whichwrap, "b,", whichwraplen);
+    }
+    if (i & 2) {
+      xstrlcat(whichwrap, "s,", whichwraplen);
+    }
+    if (i & 4) {
+      xstrlcat(whichwrap, "h,l,", whichwraplen);
+    }
+    if (i & 8) {
+      xstrlcat(whichwrap, "<,>,", whichwraplen);
+    }
+    if (i & 16) {
+      xstrlcat(whichwrap, "[,],", whichwraplen);
+    }
+    if (*whichwrap != NUL) {  // remove trailing ,
+      whichwrap[strlen(whichwrap) - 1] = NUL;
+    }
+    *save_argp = *argp;
+    *argp = whichwrap;
+  } else if (**argp == '>' && (varp == &p_dir || varp == &p_bdir)) {
+    // Remove '>' before 'dir' and 'bdir', for backwards compatibility with
+    // version 3.0
+    (*argp)++;
+  }
+}
+
 /// Part of do_set() for string options.
 static void do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar, set_op_T op_arg,
                           uint32_t flags, char *varp_arg, char *errbuf, size_t errbuflen,
@@ -884,70 +956,8 @@ static void do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar,
   } else {
     arg++;  // jump to after the '=' or ':'
 
-    // Set 'keywordprg' to ":help" if an empty
-    // value was passed to :set by the user.
-    if (varp == (char *)&p_kp && (*arg == NUL || *arg == ' ')) {
-      save_arg = arg;
-      arg = ":help";
-    } else if (varp == (char *)&p_bs && ascii_isdigit(**(char_u **)varp)) {
-      // Convert 'backspace' number to string, for
-      // adding, prepending and removing string.
-      int i = getdigits_int((char **)varp, true, 0);
-      switch (i) {
-      case 0:
-        *(char **)varp = empty_option;
-        break;
-      case 1:
-        *(char_u **)varp = (char_u *)xstrdup("indent,eol");
-        break;
-      case 2:
-        *(char_u **)varp = (char_u *)xstrdup("indent,eol,start");
-        break;
-      case 3:
-        *(char_u **)varp = (char_u *)xstrdup("indent,eol,nostop");
-        break;
-      }
-      xfree(oldval);
-      if (origval == oldval) {
-        origval = *(char **)varp;
-      }
-      if (origval_l == (char_u *)oldval) {
-        origval_l = *(char_u **)varp;
-      }
-      if (origval_g == (char_u *)oldval) {
-        origval_g = *(char_u **)varp;
-      }
-      oldval = *(char **)varp;
-    } else if (varp == (char *)&p_ww && ascii_isdigit(*arg)) {
-      // Convert 'whichwrap' number to string, for backwards compatibility
-      // with Vim 3.0.
-      *whichwrap = NUL;
-      int i = getdigits_int(&arg, true, 0);
-      if (i & 1) {
-        xstrlcat(whichwrap, "b,", sizeof(whichwrap));
-      }
-      if (i & 2) {
-        xstrlcat(whichwrap, "s,", sizeof(whichwrap));
-      }
-      if (i & 4) {
-        xstrlcat(whichwrap, "h,l,", sizeof(whichwrap));
-      }
-      if (i & 8) {
-        xstrlcat(whichwrap, "<,>,", sizeof(whichwrap));
-      }
-      if (i & 16) {
-        xstrlcat(whichwrap, "[,],", sizeof(whichwrap));
-      }
-      if (*whichwrap != NUL) {  // remove trailing ,
-        whichwrap[strlen(whichwrap) - 1] = NUL;
-      }
-      save_arg = arg;
-      arg = whichwrap;
-    } else if (*arg == '>' && (varp == (char *)&p_dir || varp == (char *)&p_bdir)) {
-      // Remove '>' before 'dir' and 'bdir', for backwards compatibility with
-      // version 3.0
-      arg++;
-    }
+    munge_string_opt_val((char **)varp, &oldval, &origval, &origval_l, &origval_g, &arg,
+                         whichwrap, sizeof(whichwrap), &save_arg);
 
     // Copy the new string into allocated memory.
     // Can't use set_string_option_direct(), because we need to remove the

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1164,6 +1164,21 @@ static void do_set_string(int opt_idx, int opt_flags, char **argp, int nextchar,
   *argp = arg;
 }
 
+static set_op_T get_op(const char *arg)
+{
+  set_op_T op = OP_NONE;
+  if (*arg != NUL && *(arg + 1) == '=') {
+    if (*arg == '+') {
+      op = OP_ADDING;          // "+="
+    } else if (*arg == '^') {
+      op = OP_PREPENDING;      // "^="
+    } else if (*arg == '-') {
+      op = OP_REMOVING;        // "-="
+    }
+  }
+  return op;
+}
+
 static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errbuf,
                           size_t errbuflen, char **errmsg)
 {
@@ -1229,19 +1244,11 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     len++;
   }
 
-  set_op_T op = OP_NONE;
-  if (arg[len] != NUL && arg[len + 1] == '=') {
-    if (arg[len] == '+') {
-      op = OP_ADDING;                       // "+="
-      len++;
-    } else if (arg[len] == '^') {
-      op = OP_PREPENDING;                   // "^="
-      len++;
-    } else if (arg[len] == '-') {
-      op = OP_REMOVING;                     // "-="
-      len++;
-    }
+  set_op_T op = get_op(arg + len);
+  if (op != OP_NONE) {
+    len++;
   }
+
   uint8_t nextchar = (uint8_t)arg[len];  // next non-white char after option name
 
   if (opt_idx == -1 && key == 0) {          // found a mismatch: skip

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1418,8 +1418,6 @@ int do_set(char *arg, int opt_flags)
   }
 
   while (*arg != NUL) {         // loop to process all options
-    char *startarg = arg;             // remember for error message
-
     if (strncmp(arg, "all", 3) == 0 && !ASCII_ISALPHA(arg[3])
         && !(opt_flags & OPT_MODELINE)) {
       // ":set all"  show all options.
@@ -1438,6 +1436,7 @@ int do_set(char *arg, int opt_flags)
         did_show = true;
       }
     } else {
+      char *startarg = arg;             // remember for error message
       char *errmsg = NULL;
       char errbuf[80];
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1412,7 +1412,7 @@ int do_set(char *arg, int opt_flags)
   bool did_show = false;             // already showed one value
 
   if (*arg == NUL) {
-    showoptions(0, opt_flags);
+    showoptions(false, opt_flags);
     did_show = true;
     goto theend;
   }
@@ -1432,7 +1432,7 @@ int do_set(char *arg, int opt_flags)
         ui_refresh_options();
         redraw_all_later(UPD_CLEAR);
       } else {
-        showoptions(1, opt_flags);
+        showoptions(true, opt_flags);
         did_show = true;
       }
     } else {
@@ -3124,11 +3124,11 @@ static int find_key_option(const char *arg, bool has_lt)
   return find_key_option_len(arg, strlen(arg), has_lt);
 }
 
-/// if 'all' == 0: show changed options
-/// if 'all' == 1: show all normal options
+/// if 'all' == false: show changed options
+/// if 'all' == true: show all normal options
 ///
 /// @param opt_flags  OPT_LOCAL and/or OPT_GLOBAL
-static void showoptions(int all, int opt_flags)
+static void showoptions(bool all, int opt_flags)
 {
 #define INC 20
 #define GAP 3

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1242,7 +1242,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
       len++;
     }
   }
-  char_u nextchar = (uint8_t)arg[len];  // next non-white char after option name
+  uint8_t nextchar = (uint8_t)arg[len];  // next non-white char after option name
 
   if (opt_idx == -1 && key == 0) {          // found a mismatch: skip
     *errmsg = e_unknown_option;
@@ -1256,7 +1256,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     if (options[opt_idx].var == NULL) {         // hidden option: skip
       // Only give an error message when requesting the value of
       // a hidden option, ignore setting it.
-      if (vim_strchr("=:!&<", (uint8_t)nextchar) == NULL
+      if (vim_strchr("=:!&<", nextchar) == NULL
           && (!(options[opt_idx].flags & P_BOOL)
               || nextchar == '?')) {
         *errmsg = e_unsupportedoption;
@@ -1310,7 +1310,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     return;
   }
 
-  if (vim_strchr("?=:!&<", (uint8_t)nextchar) != NULL) {
+  if (vim_strchr("?=:!&<", nextchar) != NULL) {
     *argp += len;
     if (nextchar == '&' && (*argp)[1] == 'v' && (*argp)[2] == 'i') {
       if ((*argp)[3] == 'm') {  // "opt&vim": set to Vim default
@@ -1319,7 +1319,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
         *argp += 2;
       }
     }
-    if (vim_strchr("?!&<", (uint8_t)nextchar) != NULL
+    if (vim_strchr("?!&<", nextchar) != NULL
         && (*argp)[1] != NUL && !ascii_iswhite((*argp)[1])) {
       *errmsg = e_trailing;
       return;
@@ -1332,7 +1332,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
   //
   if (nextchar == '?'
       || (prefix == 1
-          && vim_strchr("=:&<", (uint8_t)nextchar) == NULL
+          && vim_strchr("=:&<", nextchar) == NULL
           && !(flags & P_BOOL))) {
     // print value
     if (*did_show) {
@@ -1365,8 +1365,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     if (flags & P_BOOL) {                       // boolean
       do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, errmsg);
     } else {  // Numeric or string.
-      if (vim_strchr("=:&<", (uint8_t)nextchar) == NULL
-          || prefix != 1) {
+      if (vim_strchr("=:&<", nextchar) == NULL || prefix != 1) {
         *errmsg = e_invarg;
         return;
       }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1444,11 +1444,7 @@ int do_set(char *arg, int opt_flags)
         // - skip blanks
         // - skip one "=val" argument (for hidden options ":set gfn =xx")
         for (int i = 0; i < 2; i++) {
-          while (*arg != NUL && !ascii_iswhite(*arg)) {
-            if (*arg++ == '\\' && *arg != NUL) {
-              arg++;
-            }
-          }
+          arg = skiptowhite_esc(arg);
           arg = skipwhite(arg);
           if (*arg != '=') {
             break;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1420,7 +1420,6 @@ int do_set(char *arg, int opt_flags)
   char errbuf[80];
 
   while (*arg != NUL) {         // loop to process all options
-    char *errmsg = NULL;
     char *startarg = arg;             // remember for error message
 
     if (strncmp(arg, "all", 3) == 0 && !ASCII_ISALPHA(arg[3])
@@ -1441,6 +1440,7 @@ int do_set(char *arg, int opt_flags)
         did_show = true;
       }
     } else {
+      char *errmsg = NULL;
       do_set_option(opt_flags, &arg, &did_show, errbuf, sizeof(errbuf), &errmsg);
 
       // Advance to next argument.
@@ -1458,26 +1458,26 @@ int do_set(char *arg, int opt_flags)
           break;
         }
       }
-    }
 
-    if (errmsg != NULL) {
-      xstrlcpy(IObuff, _(errmsg), IOSIZE);
-      int i = (int)strlen(IObuff) + 2;
-      if (i + (arg - startarg) < IOSIZE) {
-        // append the argument with the error
-        STRCAT(IObuff, ": ");
-        assert(arg >= startarg);
-        memmove(IObuff + i, startarg, (size_t)(arg - startarg));
-        IObuff[i + (arg - startarg)] = NUL;
+      if (errmsg != NULL) {
+        xstrlcpy(IObuff, _(errmsg), IOSIZE);
+        int i = (int)strlen(IObuff) + 2;
+        if (i + (arg - startarg) < IOSIZE) {
+          // append the argument with the error
+          STRCAT(IObuff, ": ");
+          assert(arg >= startarg);
+          memmove(IObuff + i, startarg, (size_t)(arg - startarg));
+          IObuff[i + (arg - startarg)] = NUL;
+        }
+        // make sure all characters are printable
+        trans_characters(IObuff, IOSIZE);
+
+        no_wait_return++;         // wait_return() done later
+        emsg(IObuff);             // show error highlighted
+        no_wait_return--;
+
+        return FAIL;
       }
-      // make sure all characters are printable
-      trans_characters(IObuff, IOSIZE);
-
-      no_wait_return++;         // wait_return() done later
-      emsg(IObuff);             // show error highlighted
-      no_wait_return--;
-
-      return FAIL;
     }
 
     arg = skipwhite(arg);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1248,8 +1248,15 @@ static int parse_option_name(char *arg, int *keyp, int *lenp, int *opt_idxp)
   return OK;
 }
 
-static int validate_opt_idx(win_T *win, int opt_idx, int opt_flags, uint32_t flags, char **errmsg)
+static int validate_opt_idx(win_T *win, int opt_idx, int opt_flags, uint32_t flags, int prefix,
+                            char **errmsg)
 {
+  // Only bools can have a prefix of 'inv' or 'no'
+  if (!(flags & P_BOOL) && prefix != 1) {
+    *errmsg = e_invarg;
+    return FAIL;
+  }
+
   // Skip all options that are not window-local (used when showing
   // an already loaded buffer in a window).
   if ((opt_flags & OPT_WINONLY)
@@ -1351,7 +1358,7 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     flags = P_STRING;
   }
 
-  if (validate_opt_idx(curwin, opt_idx, opt_flags, flags, errmsg) == FAIL) {
+  if (validate_opt_idx(curwin, opt_idx, opt_flags, flags, prefix, errmsg) == FAIL) {
     return;
   }
 
@@ -1408,24 +1415,22 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     return;
   }
 
-  int value_checked = false;
-  if (flags & P_BOOL) {                       // boolean
-    do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, errmsg);
-  } else {  // Numeric or string.
-    if (vim_strchr("=:&<", nextchar) == NULL || prefix != 1) {
-      *errmsg = e_invarg;
-      return;
-    }
+  if (!(flags & P_BOOL) && vim_strchr("=:&<", nextchar) == NULL) {
+    *errmsg = e_invarg;
+    return;
+  }
 
-    if (flags & P_NUM) {  // numeric
-      do_set_num(opt_idx, opt_flags, argp, nextchar, op, varp, errbuf, errbuflen, errmsg);
-    } else if (opt_idx >= 0) {  // String.
-      do_set_string(opt_idx, opt_flags, argp, nextchar, op, flags, varp, errbuf,
-                    errbuflen, &value_checked, errmsg);
-    } else {
-      // key code option(FIXME(tarruda): Show a warning or something
-      // similar)
-    }
+  int value_checked = false;
+  if (flags & P_BOOL) {        // boolean
+    do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, errmsg);
+  } else if (flags & P_NUM) {  // numeric
+    do_set_num(opt_idx, opt_flags, argp, nextchar, op, varp, errbuf, errbuflen, errmsg);
+  } else if (opt_idx >= 0) {   // string.
+    do_set_string(opt_idx, opt_flags, argp, nextchar, op, flags, varp, errbuf,
+                  errbuflen, &value_checked, errmsg);
+  } else {
+    // key code option(FIXME(tarruda): Show a warning or something
+    // similar)
   }
 
   if (*errmsg != NULL) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1417,8 +1417,6 @@ int do_set(char *arg, int opt_flags)
     goto theend;
   }
 
-  char errbuf[80];
-
   while (*arg != NUL) {         // loop to process all options
     char *startarg = arg;             // remember for error message
 
@@ -1441,6 +1439,8 @@ int do_set(char *arg, int opt_flags)
       }
     } else {
       char *errmsg = NULL;
+      char errbuf[80];
+
       do_set_option(opt_flags, &arg, &did_show, errbuf, sizeof(errbuf), &errmsg);
 
       // Advance to next argument.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1405,34 +1405,35 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
     if (nextchar != '?' && nextchar != NUL && !ascii_iswhite(afterchar)) {
       *errmsg = e_trailing;
     }
-  } else {
-    int value_checked = false;
-    if (flags & P_BOOL) {                       // boolean
-      do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, errmsg);
-    } else {  // Numeric or string.
-      if (vim_strchr("=:&<", nextchar) == NULL || prefix != 1) {
-        *errmsg = e_invarg;
-        return;
-      }
+    return;
+  }
 
-      if (flags & P_NUM) {  // numeric
-        do_set_num(opt_idx, opt_flags, argp, nextchar, op, varp, errbuf, errbuflen, errmsg);
-      } else if (opt_idx >= 0) {  // String.
-        do_set_string(opt_idx, opt_flags, argp, nextchar, op, flags, varp, errbuf,
-                      errbuflen, &value_checked, errmsg);
-      } else {
-        // key code option(FIXME(tarruda): Show a warning or something
-        // similar)
-      }
-    }
-
-    if (*errmsg != NULL) {
+  int value_checked = false;
+  if (flags & P_BOOL) {                       // boolean
+    do_set_bool(opt_idx, opt_flags, prefix, nextchar, afterchar, varp, errmsg);
+  } else {  // Numeric or string.
+    if (vim_strchr("=:&<", nextchar) == NULL || prefix != 1) {
+      *errmsg = e_invarg;
       return;
     }
 
-    if (opt_idx >= 0) {
-      did_set_option(opt_idx, opt_flags, op == OP_NONE, value_checked);
+    if (flags & P_NUM) {  // numeric
+      do_set_num(opt_idx, opt_flags, argp, nextchar, op, varp, errbuf, errbuflen, errmsg);
+    } else if (opt_idx >= 0) {  // String.
+      do_set_string(opt_idx, opt_flags, argp, nextchar, op, flags, varp, errbuf,
+                    errbuflen, &value_checked, errmsg);
+    } else {
+      // key code option(FIXME(tarruda): Show a warning or something
+      // similar)
     }
+  }
+
+  if (*errmsg != NULL) {
+    return;
+  }
+
+  if (opt_idx >= 0) {
+    did_set_option(opt_idx, opt_flags, op == OP_NONE, value_checked);
   }
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1179,18 +1179,24 @@ static set_op_T get_op(const char *arg)
   return op;
 }
 
+static int get_option_prefix(char **argp)
+{
+  if (strncmp(*argp, "no", 2) == 0) {
+    *argp += 2;
+    return 0;
+  } else if (strncmp(*argp, "inv", 3) == 0) {
+    *argp += 3;
+    return 2;
+  }
+
+  return 1;
+}
+
 static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errbuf,
                           size_t errbuflen, char **errmsg)
 {
-  int prefix = 1;  // 1: nothing, 0: "no", 2: "inv" in front of name
-
-  if (strncmp(*argp, "no", 2) == 0) {
-    prefix = 0;
-    *argp += 2;
-  } else if (strncmp(*argp, "inv", 3) == 0) {
-    prefix = 2;
-    *argp += 3;
-  }
+  // 1: nothing, 0: "no", 2: "inv" in front of name
+  int prefix = get_option_prefix(argp);
 
   char *arg = *argp;
 
@@ -1221,11 +1227,11 @@ static void do_set_option(int opt_flags, char **argp, bool *did_show, char *errb
       key = find_key_option(arg + 1, true);
     }
   } else {
-    len = 0;
     // The two characters after "t_" may not be alphanumeric.
     if (arg[0] == 't' && arg[1] == '_' && arg[2] && arg[3]) {
       len = 4;
     } else {
+      len = 0;
       while (ASCII_ISALNUM(arg[len]) || arg[len] == '_') {
         len++;
       }


### PR DESCRIPTION
## Problem
`do_set()` is too large with lots of `goto` statements.

## Solution
Break it up into smaller functions and remove `goto` statements.

---

New function hierarchy:
- `do_set()`
   - `do_set_option()`
      - [parse option name]
      - [validate]
      - `do_set_option_value()`
         - `do_set_bool()`
         - `do_set_num()`
         - `do_set_string()`
