### PR TITLE
ci: fix lintc to use external dependencies instead of bundled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup common environment variables
-        run: ./.github/workflows/env.sh lint
+        run: ./.github/workflows/env.sh lintc
 
       - name: Install apt packages
         run: |
@@ -141,14 +141,17 @@ jobs:
             libtree-sitter-dev \
             libunibilium-dev \
             libuv1-dev \
-            libvterm-dev \
             lua-busted \
             lua-filesystem \
             lua-inspect \
             lua-lpeg \
-            lua-luv-dev \
             lua-nvim \
             luajit
+            # libvterm-dev \
+            # lua-luv-dev
+
+            # Remove comments from packages once we start using these external
+            # dependencies. See env.sh for more context.
 
       - uses: ./.github/actions/cache
 
@@ -156,7 +159,7 @@ jobs:
         run: ./ci/before_script.sh
 
       - name: Build nvim
-        run: ./ci/run_tests.sh build_nvim
+        run: make
 
       - if: "!cancelled()"
         name: Determine if run should be aborted

--- a/.github/workflows/env.sh
+++ b/.github/workflows/env.sh
@@ -44,13 +44,15 @@ EOF
 BUILD_UCHAR=1
 EOF
     ;;
-  lint)
+  lintc)
 # Re-enable once system deps are available
 #    BUILD_FLAGS="$BUILD_FLAGS -DLIBLUV_LIBRARY:FILEPATH=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/lua/5.1/luv.so -DLIBLUV_INCLUDE_DIR:PATH=/usr/include/lua5.1"
-    DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED_LUV=ON"
-    cat <<EOF >> "$GITHUB_ENV"
-USE_BUNDLED=OFF
-EOF
+
+    # Ideally all dependencies should external for this job, but some
+    # dependencies don't have the required version available. We use the
+    # bundled versions for these with the hopes of being able to remove them
+    # later on.
+    DEPS_CMAKE_FLAGS="$DEPS_CMAKE_FLAGS -DUSE_BUNDLED=OFF -DUSE_BUNDLED_LUV=ON -DUSE_BUNDLED_LIBVTERM=ON"
     ;;
   functionaltest-lua)
     BUILD_FLAGS="$BUILD_FLAGS -DPREFER_LUA=ON"


### PR DESCRIPTION
Use the bundled libvterm dependency as the external package is outdated,
with the hopes of being able to use the external package once its
version meets our required version.

Co-authored-by: Christian Clason