### PR TITLE
vim-patch:9.0.1244: cursor displayed in wrong position when leaving Insert mode

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2526,10 +2526,12 @@ static int vgetorpeek(bool advance)
           // move cursor left, if possible
           if (curwin->w_cursor.col != 0) {
             if (curwin->w_wcol > 0) {
-              if (did_ai) {
-                // We are expecting to truncate the trailing
-                // white-space, so find the last non-white
-                // character -- webb
+              // After auto-indenting and no text is following,
+              // we are expecting to truncate the trailing
+              // white-space, so find the last non-white
+              // character -- webb
+              if (did_ai
+                  && *skipwhite(get_cursor_line_ptr() + curwin->w_cursor.col) == NUL) {
                 curwin->w_wcol = 0;
                 ptr = (char_u *)get_cursor_line_ptr();
                 chartabsize_T cts;


### PR DESCRIPTION
#### vim-patch:9.0.1244: cursor displayed in wrong position when leaving Insert mode

Problem:    Cursor briefly displayed in a wrong position when pressing Esc in
            Insert mode after autoindent was used.
Solution:   Do not adjust the cursor position for assumed deleted white space
            if text is following.

https://github.com/vim/vim/commit/0f843ef091eceb470caece1d90fdfe08926fe076

Co-authored-by: Bram Moolenaar <Bram@vim.org>