### PR TITLE
vim-patch:9.0.1243: :setglobal cannot use script-local function for "expr" option

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1497,12 +1497,12 @@ static void did_set_vartabstop(buf_T *buf, win_T *win, char **varp, char **errms
   }
 }
 
-static void did_set_optexpr(win_T *win, char **p_opt, char **varp, char **gvarp)
+static void did_set_optexpr(char **varp)
 {
-  char *name = get_scriptlocal_funcname(*p_opt);
+  char *name = get_scriptlocal_funcname(*varp);
   if (name != NULL) {
-    free_string_option(*p_opt);
-    *p_opt = name;
+    free_string_option(*varp);
+    *varp = name;
   }
 }
 
@@ -1808,23 +1808,18 @@ static char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char
     did_set_varsoftabstop(buf, varp, &errmsg);
   } else if (varp == &buf->b_p_vts) {  // 'vartabstop'
     did_set_vartabstop(buf, win, varp, &errmsg);
-  } else if (varp == &p_dex) {  // 'diffexpr'
-    did_set_optexpr(win, &p_dex, varp, gvarp);
-  } else if (varp == &win->w_p_fde) {  // 'foldexpr'
-    did_set_optexpr(win, &win->w_p_fde, varp, gvarp);
-    if (foldmethodIsExpr(win)) {
+  } else if (varp == &p_dex  // 'diffexpr'
+             || gvarp == &win->w_allbuf_opt.wo_fde  // 'foldexpr'
+             || gvarp == &win->w_allbuf_opt.wo_fdt  // 'foldtext'
+             || gvarp == &p_fex  // 'formatexpr'
+             || gvarp == &p_inex  // 'includeexpr'
+             || gvarp == &p_inde  // 'indentexpr'
+             || varp == &p_pex  // 'patchexpr'
+             || varp == &p_ccv) {  // 'charconvert'
+    did_set_optexpr(varp);
+    if (varp == &win->w_p_fde && foldmethodIsExpr(win)) {
       foldUpdateAll(win);
     }
-  } else if (varp == &win->w_p_fdt) {  // 'foldtext'
-    did_set_optexpr(win, &win->w_p_fdt, varp, gvarp);
-  } else if (varp == &p_pex) {  // 'patchexpr'
-    did_set_optexpr(win, &p_pex, varp, gvarp);
-  } else if (gvarp == &p_fex) {  // 'formatexpr'
-    did_set_optexpr(win, &buf->b_p_fex, varp, gvarp);
-  } else if (gvarp == &p_inex) {  // 'includeexpr'
-    did_set_optexpr(win, &buf->b_p_inex, varp, gvarp);
-  } else if (gvarp == &p_inde) {  // 'indentexpr'
-    did_set_optexpr(win, &buf->b_p_inde, varp, gvarp);
   } else if (gvarp == &p_cfu) {  // 'completefunc'
     set_completefunc_option(&errmsg);
   } else if (gvarp == &p_ofu) {  // 'omnifunc'

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -336,8 +336,23 @@ func Test_edit_11_indentexpr()
   endfunc
   set indentexpr=s:NewIndentExpr()
   call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &indentexpr)
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &g:indentexpr)
   set indentexpr=<SID>NewIndentExpr()
   call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &indentexpr)
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &g:indentexpr)
+  setlocal indentexpr=
+  setglobal indentexpr=s:NewIndentExpr()
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &g:indentexpr)
+  call assert_equal('', &indentexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &indentexpr)
+  bw!
+  setglobal indentexpr=<SID>NewIndentExpr()
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &g:indentexpr)
+  call assert_equal('', &indentexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'NewIndentExpr()', &indentexpr)
+  bw!
   set indentexpr&
 
   bw!

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1305,6 +1305,7 @@ func Test_foldexpr_scriptlocal_func()
   set foldmethod=expr foldexpr=s:FoldFunc()
   redraw!
   call assert_equal(expand('<SID>') .. 'FoldFunc()', &foldexpr)
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &g:foldexpr)
   call assert_equal(1, g:FoldLnum)
   set foldmethod& foldexpr=
   bw!
@@ -1314,8 +1315,31 @@ func Test_foldexpr_scriptlocal_func()
   set foldmethod=expr foldexpr=<SID>FoldFunc()
   redraw!
   call assert_equal(expand('<SID>') .. 'FoldFunc()', &foldexpr)
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &g:foldexpr)
   call assert_equal(1, g:FoldLnum)
-  set foldmethod& foldexpr=
+  bw!
+  call setline(1, 'abc')
+  setlocal foldmethod& foldexpr&
+  setglobal foldmethod=expr foldexpr=s:FoldFunc()
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &g:foldexpr)
+  call assert_equal('0', &foldexpr)
+  enew!
+  call setline(1, 'abc')
+  redraw!
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &foldexpr)
+  call assert_equal(1, g:FoldLnum)
+  bw!
+  call setline(1, 'abc')
+  setlocal foldmethod& foldexpr&
+  setglobal foldmethod=expr foldexpr=<SID>FoldFunc()
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &g:foldexpr)
+  call assert_equal('0', &foldexpr)
+  enew!
+  call setline(1, 'abc')
+  redraw!
+  call assert_equal(expand('<SID>') .. 'FoldFunc()', &foldexpr)
+  call assert_equal(1, g:FoldLnum)
+  set foldmethod& foldexpr&
   delfunc s:FoldFunc
   bw!
 endfunc
@@ -1329,23 +1353,51 @@ func Test_foldtext_scriptlocal_func()
   new | only
   call setline(1, range(50))
   let g:FoldTextArgs = []
-  set foldmethod=manual
   set foldtext=s:FoldText()
   norm! 4Gzf4j
   redraw!
   call assert_equal(expand('<SID>') .. 'FoldText()', &foldtext)
+  call assert_equal(expand('<SID>') .. 'FoldText()', &g:foldtext)
   call assert_equal([4, 8], g:FoldTextArgs)
   set foldtext&
   bw!
   new | only
   call setline(1, range(50))
   let g:FoldTextArgs = []
-  set foldmethod=manual
   set foldtext=<SID>FoldText()
   norm! 8Gzf4j
   redraw!
   call assert_equal(expand('<SID>') .. 'FoldText()', &foldtext)
+  call assert_equal(expand('<SID>') .. 'FoldText()', &g:foldtext)
   call assert_equal([8, 12], g:FoldTextArgs)
+  set foldtext&
+  bw!
+  call setline(1, range(50))
+  let g:FoldTextArgs = []
+  setlocal foldtext&
+  setglobal foldtext=s:FoldText()
+  call assert_equal(expand('<SID>') .. 'FoldText()', &g:foldtext)
+  call assert_equal('foldtext()', &foldtext)
+  enew!
+  call setline(1, range(50))
+  norm! 12Gzf4j
+  redraw!
+  call assert_equal(expand('<SID>') .. 'FoldText()', &foldtext)
+  call assert_equal([12, 16], g:FoldTextArgs)
+  set foldtext&
+  bw!
+  call setline(1, range(50))
+  let g:FoldTextArgs = []
+  setlocal foldtext&
+  setglobal foldtext=<SID>FoldText()
+  call assert_equal(expand('<SID>') .. 'FoldText()', &g:foldtext)
+  call assert_equal('foldtext()', &foldtext)
+  enew!
+  call setline(1, range(50))
+  norm! 16Gzf4j
+  redraw!
+  call assert_equal(expand('<SID>') .. 'FoldText()', &foldtext)
+  call assert_equal([16, 20], g:FoldTextArgs)
   set foldtext&
   bw!
   delfunc s:FoldText

--- a/src/nvim/testdir/test_gf.vim
+++ b/src/nvim/testdir/test_gf.vim
@@ -234,6 +234,7 @@ func Test_includeexpr_scriptlocal_func()
   endfunc
   set includeexpr=s:IncludeFunc()
   call assert_equal(expand('<SID>') .. 'IncludeFunc()', &includeexpr)
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &g:includeexpr)
   new | only
   call setline(1, 'TestFile1')
   let g:IncludeFname = ''
@@ -242,11 +243,35 @@ func Test_includeexpr_scriptlocal_func()
   bw!
   set includeexpr=<SID>IncludeFunc()
   call assert_equal(expand('<SID>') .. 'IncludeFunc()', &includeexpr)
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &g:includeexpr)
   new | only
   call setline(1, 'TestFile2')
   let g:IncludeFname = ''
   call assert_fails('normal! gf', 'E447:')
   call assert_equal('TestFile2', g:IncludeFname)
+  bw!
+  setlocal includeexpr=
+  setglobal includeexpr=s:IncludeFunc()
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &g:includeexpr)
+  call assert_equal('', &includeexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &includeexpr)
+  call setline(1, 'TestFile3')
+  let g:IncludeFname = ''
+  call assert_fails('normal! gf', 'E447:')
+  call assert_equal('TestFile3', g:IncludeFname)
+  bw!
+  setlocal includeexpr=
+  setglobal includeexpr=<SID>IncludeFunc()
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &g:includeexpr)
+  call assert_equal('', &includeexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'IncludeFunc()', &includeexpr)
+  call setline(1, 'TestFile4')
+  let g:IncludeFname = ''
+  call assert_fails('normal! gf', 'E447:')
+  call assert_equal('TestFile4', g:IncludeFname)
+  bw!
   set includeexpr&
   delfunc s:IncludeFunc
   bw!

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -262,6 +262,7 @@ func Test_formatexpr_scriptlocal_func()
   endfunc
   set formatexpr=s:Format()
   call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
   new | only
   call setline(1, range(1, 40))
   let g:FormatArgs = []
@@ -270,6 +271,7 @@ func Test_formatexpr_scriptlocal_func()
   bw!
   set formatexpr=<SID>Format()
   call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
   new | only
   call setline(1, range(1, 40))
   let g:FormatArgs = []
@@ -277,6 +279,7 @@ func Test_formatexpr_scriptlocal_func()
   call assert_equal([4, 2], g:FormatArgs)
   bw!
   let &formatexpr = 's:Format()'
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
   new | only
   call setline(1, range(1, 40))
   let g:FormatArgs = []
@@ -284,12 +287,55 @@ func Test_formatexpr_scriptlocal_func()
   call assert_equal([6, 2], g:FormatArgs)
   bw!
   let &formatexpr = '<SID>Format()'
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
   new | only
   call setline(1, range(1, 40))
   let g:FormatArgs = []
   normal! 8GVjgq
   call assert_equal([8, 2], g:FormatArgs)
+  bw!
   setlocal formatexpr=
+  setglobal formatexpr=s:Format()
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
+  call assert_equal('', &formatexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call setline(1, range(1, 40))
+  let g:FormatArgs = []
+  normal! 10GVjgq
+  call assert_equal([10, 2], g:FormatArgs)
+  bw!
+  setglobal formatexpr=<SID>Format()
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
+  call assert_equal('', &formatexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call setline(1, range(1, 40))
+  let g:FormatArgs = []
+  normal! 12GVjgq
+  call assert_equal([12, 2], g:FormatArgs)
+  bw!
+  let &g:formatexpr = 's:Format()'
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
+  call assert_equal('', &formatexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call setline(1, range(1, 40))
+  let g:FormatArgs = []
+  normal! 14GVjgq
+  call assert_equal([14, 2], g:FormatArgs)
+  bw!
+  let &g:formatexpr = '<SID>Format()'
+  call assert_equal(expand('<SID>') .. 'Format()', &g:formatexpr)
+  call assert_equal('', &formatexpr)
+  new
+  call assert_equal(expand('<SID>') .. 'Format()', &formatexpr)
+  call setline(1, range(1, 40))
+  let g:FormatArgs = []
+  normal! 16GVjgq
+  call assert_equal([16, 2], g:FormatArgs)
+  bw!
+  set formatexpr=
   delfunc s:Format
   bw!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1243: :setglobal cannot use script-local function for "expr" option

Problem:    :setglobal cannot use script-local function for "expr" option.
Solution:   Use the pointer to the option value properly. (closes vim/vim#11883)

https://github.com/vim/vim/commit/01d4efe2e87632aa085897d3d64e27585908f977