### PR TITLE
vim-patch:9.0.1245: code is indented more than necessary

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7823,34 +7823,35 @@ static void f_strftime(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   // MSVC returns NULL for an invalid value of seconds.
   if (curtime_ptr == NULL) {
     rettv->vval.v_string = xstrdup(_("(Invalid)"));
-  } else {
-    vimconv_T conv;
-
-    conv.vc_type = CONV_NONE;
-    char *enc = enc_locale();
-    convert_setup(&conv, p_enc, enc);
-    if (conv.vc_type != CONV_NONE) {
-      p = string_convert(&conv, p, NULL);
-    }
-    char result_buf[256];
-    if (p == NULL || strftime(result_buf, sizeof(result_buf), p, curtime_ptr) == 0) {
-      result_buf[0] = NUL;
-    }
-
-    if (conv.vc_type != CONV_NONE) {
-      xfree(p);
-    }
-    convert_setup(&conv, enc, p_enc);
-    if (conv.vc_type != CONV_NONE) {
-      rettv->vval.v_string = string_convert(&conv, result_buf, NULL);
-    } else {
-      rettv->vval.v_string = xstrdup(result_buf);
-    }
-
-    // Release conversion descriptors.
-    convert_setup(&conv, NULL, NULL);
-    xfree(enc);
+    return;
   }
+
+  vimconv_T conv;
+
+  conv.vc_type = CONV_NONE;
+  char *enc = enc_locale();
+  convert_setup(&conv, p_enc, enc);
+  if (conv.vc_type != CONV_NONE) {
+    p = string_convert(&conv, p, NULL);
+  }
+  char result_buf[256];
+  if (p == NULL || strftime(result_buf, sizeof(result_buf), p, curtime_ptr) == 0) {
+    result_buf[0] = NUL;
+  }
+
+  if (conv.vc_type != CONV_NONE) {
+    xfree(p);
+  }
+  convert_setup(&conv, enc, p_enc);
+  if (conv.vc_type != CONV_NONE) {
+    rettv->vval.v_string = string_convert(&conv, result_buf, NULL);
+  } else {
+    rettv->vval.v_string = xstrdup(result_buf);
+  }
+
+  // Release conversion descriptors.
+  convert_setup(&conv, NULL, NULL);
+  xfree(enc);
 }
 
 /// "strgetchar()" function
@@ -8654,6 +8655,7 @@ static void f_timer_pause(typval_T *argvars, typval_T *unused, EvalFuncData fptr
     emsg(_(e_number_exp));
     return;
   }
+
   int paused = (bool)tv_get_number(&argvars[1]);
   timer_T *timer = find_timer_by_nr(tv_get_number(&argvars[0]));
   if (timer != NULL) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3208,17 +3208,19 @@ static inline void _nothing_conv_dict_end(typval_T *const tv, dict_T **const dic
 /// @param[in,out]  tv  Value to free.
 void tv_clear(typval_T *const tv)
 {
-  if (tv != NULL && tv->v_type != VAR_UNKNOWN) {
-    // WARNING: do not translate the string here, gettext is slow and function
-    // is used *very* often. At the current state encode_vim_to_nothing() does
-    // not error out and does not use the argument anywhere.
-    //
-    // If situation changes and this argument will be used, translate it in the
-    // place where it is used.
-    const int evn_ret = encode_vim_to_nothing(NULL, tv, "tv_clear() argument");
-    (void)evn_ret;
-    assert(evn_ret == OK);
+  if (tv == NULL || tv->v_type == VAR_UNKNOWN) {
+    return;
   }
+
+  // WARNING: do not translate the string here, gettext is slow and function
+  // is used *very* often. At the current state encode_vim_to_nothing() does
+  // not error out and does not use the argument anywhere.
+  //
+  // If situation changes and this argument will be used, translate it in the
+  // place where it is used.
+  const int evn_ret = encode_vim_to_nothing(NULL, tv, "tv_clear() argument");
+  (void)evn_ret;
+  assert(evn_ret == OK);
 }
 
 //{{{3 Free
@@ -3228,35 +3230,37 @@ void tv_clear(typval_T *const tv)
 /// @param  tv  Object to free.
 void tv_free(typval_T *tv)
 {
-  if (tv != NULL) {
-    switch (tv->v_type) {
-    case VAR_PARTIAL:
-      partial_unref(tv->vval.v_partial);
-      break;
-    case VAR_FUNC:
-      func_unref(tv->vval.v_string);
-      FALLTHROUGH;
-    case VAR_STRING:
-      xfree(tv->vval.v_string);
-      break;
-    case VAR_BLOB:
-      tv_blob_unref(tv->vval.v_blob);
-      break;
-    case VAR_LIST:
-      tv_list_unref(tv->vval.v_list);
-      break;
-    case VAR_DICT:
-      tv_dict_unref(tv->vval.v_dict);
-      break;
-    case VAR_BOOL:
-    case VAR_SPECIAL:
-    case VAR_NUMBER:
-    case VAR_FLOAT:
-    case VAR_UNKNOWN:
-      break;
-    }
-    xfree(tv);
+  if (tv == NULL) {
+    return;
   }
+
+  switch (tv->v_type) {
+  case VAR_PARTIAL:
+    partial_unref(tv->vval.v_partial);
+    break;
+  case VAR_FUNC:
+    func_unref(tv->vval.v_string);
+    FALLTHROUGH;
+  case VAR_STRING:
+    xfree(tv->vval.v_string);
+    break;
+  case VAR_BLOB:
+    tv_blob_unref(tv->vval.v_blob);
+    break;
+  case VAR_LIST:
+    tv_list_unref(tv->vval.v_list);
+    break;
+  case VAR_DICT:
+    tv_dict_unref(tv->vval.v_dict);
+    break;
+  case VAR_BOOL:
+  case VAR_SPECIAL:
+  case VAR_NUMBER:
+  case VAR_FLOAT:
+  case VAR_UNKNOWN:
+    break;
+  }
+  xfree(tv);
 }
 
 //{{{3 Copy

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -77,31 +77,32 @@ static void ga_concat_esc(garray_T *gap, const char *p, int clen)
     memmove(buf, p, (size_t)clen);
     buf[clen] = NUL;
     ga_concat(gap, buf);
-  } else {
-    switch (*p) {
-    case BS:
-      ga_concat(gap, "\\b"); break;
-    case ESC:
-      ga_concat(gap, "\\e"); break;
-    case FF:
-      ga_concat(gap, "\\f"); break;
-    case NL:
-      ga_concat(gap, "\\n"); break;
-    case TAB:
-      ga_concat(gap, "\\t"); break;
-    case CAR:
-      ga_concat(gap, "\\r"); break;
-    case '\\':
-      ga_concat(gap, "\\\\"); break;
-    default:
-      if ((uint8_t)(*p) < ' ' || *p == 0x7f) {
-        vim_snprintf(buf, NUMBUFLEN, "\\x%02x", *p);
-        ga_concat(gap, buf);
-      } else {
-        ga_append(gap, (uint8_t)(*p));
-      }
-      break;
+    return;
+  }
+
+  switch (*p) {
+  case BS:
+    ga_concat(gap, "\\b"); break;
+  case ESC:
+    ga_concat(gap, "\\e"); break;
+  case FF:
+    ga_concat(gap, "\\f"); break;
+  case NL:
+    ga_concat(gap, "\\n"); break;
+  case TAB:
+    ga_concat(gap, "\\t"); break;
+  case CAR:
+    ga_concat(gap, "\\r"); break;
+  case '\\':
+    ga_concat(gap, "\\\\"); break;
+  default:
+    if ((uint8_t)(*p) < ' ' || *p == 0x7f) {
+      vim_snprintf(buf, NUMBUFLEN, "\\x%02x", *p);
+      ga_concat(gap, buf);
+    } else {
+      ga_append(gap, (uint8_t)(*p));
     }
+    break;
   }
 }
 

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -736,22 +736,24 @@ void check_auto_format(bool end_insert)
   int c = ' ';
   int cc;
 
-  if (did_add_space) {
-    cc = gchar_cursor();
-    if (!WHITECHAR(cc)) {
-      // Somehow the space was removed already.
+  if (!did_add_space) {
+    return;
+  }
+
+  cc = gchar_cursor();
+  if (!WHITECHAR(cc)) {
+    // Somehow the space was removed already.
+    did_add_space = false;
+  } else {
+    if (!end_insert) {
+      inc_cursor();
+      c = gchar_cursor();
+      dec_cursor();
+    }
+    if (c != NUL) {
+      // The space is no longer at the end of the line, delete it.
+      del_char(false);
       did_add_space = false;
-    } else {
-      if (!end_insert) {
-        inc_cursor();
-        c = gchar_cursor();
-        dec_cursor();
-      }
-      if (c != NUL) {
-        // The space is no longer at the end of the line, delete it.
-        del_char(false);
-        did_add_space = false;
-      }
     }
   }
 }


### PR DESCRIPTION
#### vim-patch:9.0.1245: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11879)

https://github.com/vim/vim/commit/032713f8299abd92fcfb1e490d1ae5c1ecadde41

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>