### PR TITLE
fix(treesitter): validate language name

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -684,6 +684,7 @@ require_language({lang}, {path}, {silent}, {symbol_name})
 
     Parameters: ~
       • {lang}         (string) Language the parser should parse
+                       (alphanumerical and `_` only)
       • {path}         (string|nil) Optional path the parser is located at
       • {silent}       (boolean|nil) Don't throw an error if language not
                        found

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -6,7 +6,7 @@ local M = {}
 ---
 --- Parsers are searched in the `parser` runtime directory, or the provided {path}
 ---
----@param lang string Language the parser should parse
+---@param lang string Language the parser should parse (alphanumerical and `_` only)
 ---@param path (string|nil) Optional path the parser is located at
 ---@param silent (boolean|nil) Don't throw an error if language not found
 ---@param symbol_name (string|nil) Internal symbol name for the language to load
@@ -16,13 +16,19 @@ function M.require_language(lang, path, silent, symbol_name)
     return true
   end
   if path == nil then
-    local fname = 'parser/' .. vim.fn.fnameescape(lang) .. '.*'
+    if not (lang and lang:match('[%w_]+') == lang) then
+      if silent then
+        return false
+      end
+      error("'" .. lang .. "' is not a valid language name")
+    end
+
+    local fname = 'parser/' .. lang .. '.*'
     local paths = a.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
       if silent then
         return false
       end
-
       error("no parser for '" .. lang .. "' language, see :help treesitter-parsers")
     end
     path = paths[1]

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -31,6 +31,11 @@ describe('treesitter language API', function()
        pcall_err(exec_lua, 'vim.treesitter.require_language("c", nil, false, "borklang")'))
   end)
 
+  it('shows error for invalid language name', function()
+    eq(".../language.lua:0: '/foo/' is not a valid language name",
+      pcall_err(exec_lua, 'vim.treesitter.require_language("/foo/", nil, false)'))
+  end)
+
   it('inspects language', function()
     local keys, fields, symbols = unpack(exec_lua([[
       local lang = vim.treesitter.inspect_language('c')


### PR DESCRIPTION
## Problem

Some injections (like markdown) allow specifying arbitrary language names for code blocks, which may lead to errors when looking for a corresponding parser with the same name in runtimepath.


## Solution

Validate that the language name only contains alphanumeric characters and `_` (e.g., for `c_sharp`) and error otherwise.

### Alternative approach

`lang:gsub('%W','')`, but that would also strip `_`, which is used for a number of language names in nvim-treesitter.

Closes #21485
Supersedes #21943

@bfredl @stsewd 