### PR TITLE
vim-patch:9.0.1246: code is indented more than necessary

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -760,13 +760,12 @@ static void funccal_unref(funccall_T *fc, ufunc_T *fp, bool force)
 static bool func_remove(ufunc_T *fp)
 {
   hashitem_T *hi = hash_find(&func_hashtab, (char *)UF2HIKEY(fp));
-
-  if (!HASHITEM_EMPTY(hi)) {
-    hash_remove(&func_hashtab, hi);
-    return true;
+  if (HASHITEM_EMPTY(hi)) {
+    return false;
   }
 
-  return false;
+  hash_remove(&func_hashtab, hi);
+  return true;
 }
 
 static void func_clear_items(ufunc_T *fp)

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2985,10 +2985,12 @@ void u_saveline(linenr_T lnum)
 /// (this is used externally for crossing a line while in insert mode)
 void u_clearline(void)
 {
-  if (curbuf->b_u_line_ptr != NULL) {
-    XFREE_CLEAR(curbuf->b_u_line_ptr);
-    curbuf->b_u_line_lnum = 0;
+  if (curbuf->b_u_line_ptr == NULL) {
+    return;
   }
+
+  XFREE_CLEAR(curbuf->b_u_line_ptr);
+  curbuf->b_u_line_lnum = 0;
 }
 
 /// Implementation of the "U" command.


### PR DESCRIPTION
#### vim-patch:9.0.1246: code is indented more than necessary

Problem:    Code is indented more than necessary.
Solution:   Use an early return where it makes sense. (Yegappan Lakshmanan,
            closes vim/vim#11887)

https://github.com/vim/vim/commit/142ed77898facf8f423fee2717efee1749c55f9a

Omit function_using_block_scopes(): only affects Vim9 script.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>