### PR TITLE
fix(test): unset XDG_CONFIG_HOME when running oldtest

### DIFF
--- a/src/nvim/testdir/runnvim.sh
+++ b/src/nvim/testdir/runnvim.sh
@@ -30,6 +30,9 @@ main() {(
   . "$CI_DIR/common/suite.sh"
   . "$CI_DIR/common/test.sh"
 
+  # Redirect XDG_CONFIG_HOME so users local config doesn't interfere
+  export XDG_CONFIG_HOME="$root"
+
   export VIMRUNTIME="$root/runtime"
   if ! "$nvim_prg" \
     -u NONE -i NONE \

--- a/src/nvim/testdir/test_taglist.vim
+++ b/src/nvim/testdir/test_taglist.vim
@@ -105,8 +105,8 @@ func Test_tagfiles()
   help
   let tf = tagfiles()
   " Nvim: expectation(s) based on tags in build dir (added to &rtp).
-  "       Filter out the (non-existing) '../../../runtime/doc/tags'.
-  call filter(tf, 'filereadable(v:val)')
+  "       Filter out the '../../../runtime/doc/tags'.
+  call filter(tf, 'v:val != "../../../runtime/doc/tags"')
   call assert_equal(1, len(tf))
   call assert_equal(fnamemodify(expand('$BUILD_DIR/runtime/doc/tags'), ':p:gs?\\?/?'),
 	\           fnamemodify(tf[0], ':p:gs?\\?/?'))


### PR DESCRIPTION
Oldtests that invoke nvim with `exe 'silent !nvim ...'` hang for me. Unsetting `XDG_CONFIG_HOME` stops them hanging.

This probably isn't the best solution so any other suggestions are welcome.