### PR TITLE
Fix typo: '[' instead of '{' for list

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3062,18 +3062,18 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                       any divisor of eight. The array will specifify the eight
                       chars building up the border in a clockwise fashion
                       starting with the top-left corner. As an example, the
-                      double box style could be specified as [ "╔", "═" ,"╗",
-                      "║", "╝", "═", "╚", "║" ]. If the number of chars are
+                      double box style could be specified as { "╔", "═" ,"╗",
+                      "║", "╝", "═", "╚", "║" }. If the number of chars are
                       less than eight, they will be repeated. Thus an ASCII
-                      border could be specified as [ "/", "-", "\\", "|" ], or
-                      all chars the same as [ "x" ]. An empty string can be
-                      used to turn off a specific border, for instance, [ "",
-                      "", "", ">", "", "", "", "<" ] will only make vertical
+                      border could be specified as { "/", "-", "\\", "|" }, or
+                      all chars the same as { "x" }. An empty string can be
+                      used to turn off a specific border, for instance, { "",
+                      "", "", ">", "", "", "", "<" } will only make vertical
                       borders but not horizontal ones. By default,
                       `FloatBorder` highlight is used, which links to
                       `WinSeparator` when not defined. It could also be
-                      specified by character: [ ["+", "MyCorner"], ["x",
-                      "MyBorder"] ].
+                      specified by character: { {"+", "MyCorner"}, {"x",
+                      "MyBorder"} }.
 
                   • title: Title (optional) in window border, String or list.
                     List is [text, highlight] tuples. if is string the default


### PR DESCRIPTION
Hi Team,

it looks like in various parts of the documentation square brackets are used instead of curly brackets. am I missing anything?