### PR TITLE
build: enable ccache by default if available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,11 @@ Developer guidelines
   make distclean
   make  # Nvim build system uses ninja automatically, if available.
   ```
+- Install `ccache` for faster rebuilds of Nvim. Nvim will use it automatically
+  if it's found. To disable caching use:
+  ```
+  CCACHE_DISABLE=true make
+  ```
 
 Pull requests (PRs)
 ---------------------

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -688,6 +688,13 @@ set_target_properties(nvim
   EXPORT_COMPILE_COMMANDS ON
   ENABLE_EXPORTS TRUE)
 
+find_program(CCACHE_PRG ccache)
+if(CCACHE_PRG)
+  set_target_properties(nvim
+    PROPERTIES
+    C_COMPILER_LAUNCHER "${CMAKE_COMMAND};-E;env;CCACHE_SLOPPINESS=pch_defines,time_macros;${CCACHE_PRG}")
+endif()
+
 if(${CMAKE_VERSION} VERSION_LESS 3.20)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()


### PR DESCRIPTION
Initial benchmarks show that this gives a nice 50% compile time
reduction for neovim. This shouldn't affect users or CI, but it's a nice
speedup for local development. The C_COMPILER_LAUNCHER target property
is only supported by Makefiles and Ninja generators only, so this won't
give a speedup when using the Xcode and Visual Studio generators even if
ccache is available.