### PR TITLE
feat(lsp)!: semantic token modifiers, LspTokenUpdate

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -482,6 +482,71 @@ LspSignatureActiveParameter
     Used to highlight the active parameter in the signature help. See
     |vim.lsp.handlers.signature_help()|.
 
+------------------------------------------------------------------------------
+LSP SEMANTIC HIGHLIGHTS                               *lsp-semantic-highlight*
+
+When available, the LSP client highlights code using |lsp-semantic_tokens|,
+which are another way that LSP servers can provide information about source
+code.  Note that this is in addition to treesitter syntax highlighting;
+semantic highlighting does not replace syntax highlighting.
+
+The server will typically provide one token per identifier in the source code.
+The token will have a `type` such as "function" or "variable", and 0 or more
+`modifier`s such as "readonly" or "deprecated." The standard types and
+modifiers are described here:
+https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens
+LSP servers may also use off-spec types and modifiers.
+
+The LSP client adds one or more highlights for each token. The highlight
+groups are derived from the token's type and modifiers:
+  • `@lsp.type.<type>.<ft>` for the type
+  • `@lsp.mod.<mod>.<ft>` for each modifier
+  • `@lsp.typemod.<type>.<mod>.<ft>` for each modifier
+Use |:Inspect| to view the higlights for a specific token. Use |:hi| or
+|nvim_set_hl()| to change the appearance of semantic highlights: >vim
+
+    hi @lsp.type.function guifg=Yellow        " function names are yellow
+    hi @lsp.type.variable.lua guifg=Green     " variables in lua are green
+    hi @lsp.mod.deprecated gui=strikethrough  " deprecated is crossed out
+    hi @lsp.typemod.function.async guifg=Blue " async functions are blue
+<
+The value |vim.highlight.priorities|`.semantic_tokens` is the priority of the
+`@lsp.type.*` highlights. The `@lsp.mod.*` and `@lsp.typemod.*` highlights
+have priorities one and two higher, respectively.
+
+You can disable semantic highlights by clearing the highlight groups: >lua
+
+    -- Hide semantic highlights for functions
+    vim.api.nvim_set_hl(0, '@lsp.type.function', {})
+
+    -- Hide all semantic highlights
+    for _, group in ipairs(vim.fn.getcompletion("@lsp", "highlight")) do
+      vim.api.nvim_set_hl(0, group, {})
+    end
+<
+You probably want these inside a |ColorScheme| autocommand.
+
+Use |LspTokenUpdate| and |vim.lsp.semantic_tokens.highlight_token()| for more
+complex highlighting.
+
+The following groups are linked by default to standard |group-name|s:
+>
+    @lsp.type.class         Structure
+    @lsp.type.decorator     Function
+    @lsp.type.enum          Structure
+    @lsp.type.enumMember    Constant
+    @lsp.type.function      Function
+    @lsp.type.interface     Structure
+    @lsp.type.macro         Macro
+    @lsp.type.method        Function
+    @lsp.type.namespace     Structure
+    @lsp.type.parameter     Identifier
+    @lsp.type.property      Identifier
+    @lsp.type.struct        Structure
+    @lsp.type.type          Type
+    @lsp.type.typeParameter TypeDef
+    @lsp.type.variable      Identifier
+<
 ==============================================================================
 EVENTS                                                            *lsp-events*
 
@@ -516,6 +581,29 @@ callback in the "data" table. Example: >lua
       end,
     })
 <
+
+LspTokenUpdate                                                *LspTokenUpdate*
+
+When a visible semantic token is sent or updated by the LSP server, or when an
+existing token becomes visible for the first time. The |autocmd-pattern| is
+the name of the buffer. When used from Lua, the token and client ID are passed
+to the callback in the "data" table. The token fields are documented in
+|vim.lsp.semantic_tokens.get_at_pos()|. Example: >lua
+
+    vim.api.nvim_create_autocmd('LspTokenUpdate', {
+      callback = function(args)
+        local token = args.data.token
+        if token.type == 'variable' and not token.modifiers.readonly then
+          vim.lsp.semantic_tokens.highlight_token(
+            token, args.buf, args.data.client_id, 'MyMutableVariableHighlight'
+          )
+        end
+      end,
+    })
+<
+Note: doing anything other than calling
+|vim.lsp.semantic_tokens.highlight_token()| is considered experimental.
+
 Also the following |User| |autocommand|s are provided:
 
 LspProgressUpdate                                          *LspProgressUpdate*
@@ -1332,7 +1420,8 @@ force_refresh({bufnr})               *vim.lsp.semantic_tokens.force_refresh()*
     highlighting (|vim.lsp.semantic_tokens.start()| has been called for it)
 
     Parameters: ~
-      • {bufnr}  (nil|number) default: current buffer
+      • {bufnr}  (number|nil) filter by buffer. All buffers if nil, current
+                 buffer if 0
 
                                         *vim.lsp.semantic_tokens.get_at_pos()*
 get_at_pos({bufnr}, {row}, {col})
@@ -1345,7 +1434,34 @@ get_at_pos({bufnr}, {row}, {col})
       • {col}    (number|nil) Position column (default cursor position)
 
     Return: ~
-        (table|nil) List of tokens at position
+        (table|nil) List of tokens at position. Each token has the following
+        fields:
+        • line (number) line number, 0-based
+        • start_col (number) start column, 0-based
+        • end_col (number) end column, 0-based
+        • type (string) token type as string, e.g. "variable"
+        • modifiers (table) token modifiers as a set. E.g., { static = true,
+          readonly = true }
+
+                                   *vim.lsp.semantic_tokens.highlight_token()*
+highlight_token({token}, {bufnr}, {client_id}, {hl_group}, {opts})
+    Highlight a semantic token.
+
+    Apply an extmark with a given highlight group for a semantic token. The
+    mark will be deleted by the semantic token engine when appropriate; for
+    example, when the LSP sends updated tokens. This function is intended for
+    use inside |LspTokenUpdate| callbacks.
+
+    Parameters: ~
+      • {token}      (table) a semantic token, found as `args.data.token` in
+                     |LspTokenUpdate|.
+      • {bufnr}      (number) the buffer to highlight
+      • {client_id}  (number) The ID of the |vim.lsp.client|
+      • {hl_group}   (string) Highlight group name
+      • {opts}       (table|nil) Optional parameters.
+                     • priority: (number|nil) Priority for the applied
+                       extmark. Defaults to
+                       `vim.highlight.priorities.semantic_tokens + 3`
 
 start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     Start the semantic token highlighting engine for the given buffer with the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -87,7 +87,7 @@ The following new APIs or features were added.
   `semanticTokensProvider` from the LSP client's {server_capabilities} in the
   `LspAttach` callback.
 
-  See |lsp-semantic_tokens| for more information.
+  See |lsp-semantic-highlight| for more information.
 
 • |vim.treesitter.show_tree()| opens a split window showing a text
   representation of the nodes in a language tree for the current buffer.

--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -2,7 +2,7 @@
 ---@field syntax boolean include syntax based highlight groups (defaults to true)
 ---@field treesitter boolean include treesitter based highlight groups (defaults to true)
 ---@field extmarks boolean|"all" include extmarks. When `all`, then extmarks without a `hl_group` will also be included (defaults to true)
----@field semantic_tokens boolean include semantic tokens (defaults to true)
+---@field semantic_tokens boolean include semantic token highlights (defaults to true)
 local defaults = {
   syntax = true,
   treesitter = true,
@@ -81,47 +81,54 @@ function vim.inspect_pos(bufnr, row, col, filter)
     end
   end
 
-  -- semantic tokens
-  if filter.semantic_tokens then
-    for _, token in ipairs(vim.lsp.semantic_tokens.get_at_pos(bufnr, row, col) or {}) do
-      token.hl_groups = {
-        type = resolve_hl({ hl_group = '@' .. token.type }),
-        modifiers = vim.tbl_map(function(modifier)
-          return resolve_hl({ hl_group = '@' .. modifier })
-        end, token.modifiers or {}),
-      }
-      table.insert(results.semantic_tokens, token)
-    end
+  --- Convert an extmark tuple into a map-like table
+  --- @private
+  local function to_map(extmark)
+    extmark = {
+      id = extmark[1],
+      row = extmark[2],
+      col = extmark[3],
+      opts = resolve_hl(extmark[4]),
+    }
+    extmark.end_row = extmark.opts.end_row or extmark.row -- inclusive
+    extmark.end_col = extmark.opts.end_col or (extmark.col + 1) -- exclusive
+    return extmark
   end
 
-  -- extmarks
-  if filter.extmarks then
-    for ns, nsid in pairs(vim.api.nvim_get_namespaces()) do
-      if ns:find('vim_lsp_semantic_tokens') ~= 1 then
-        local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, nsid, 0, -1, { details = true })
-        for _, extmark in ipairs(extmarks) do
-          extmark = {
-            ns_id = nsid,
-            ns = ns,
-            id = extmark[1],
-            row = extmark[2],
-            col = extmark[3],
-            opts = resolve_hl(extmark[4]),
-          }
-          local end_row = extmark.opts.end_row or extmark.row -- inclusive
-          local end_col = extmark.opts.end_col or (extmark.col + 1) -- exclusive
-          if
-            (filter.extmarks == 'all' or extmark.opts.hl_group) -- filter hl_group
-            and (row >= extmark.row and row <= end_row) -- within the rows of the extmark
-            and (row > extmark.row or col >= extmark.col) -- either not the first row, or in range of the col
-            and (row < end_row or col < end_col) -- either not in the last row or in range of the col
-          then
-            table.insert(results.extmarks, extmark)
-          end
-        end
-      end
-    end
+  --- Check if an extmark overlaps this position
+  --- @private
+  local function is_here(extmark)
+    return (row >= extmark.row and row <= extmark.end_row) -- within the rows of the extmark
+      and (row > extmark.row or col >= extmark.col) -- either not the first row, or in range of the col
+      and (row < extmark.end_row or col < extmark.end_col) -- either not in the last row or in range of the col
   end
+
+  -- all extmarks at this position
+  local extmarks = {}
+  for ns, nsid in pairs(vim.api.nvim_get_namespaces()) do
+    local ns_marks = vim.api.nvim_buf_get_extmarks(bufnr, nsid, 0, -1, { details = true })
+    ns_marks = vim.tbl_map(to_map, ns_marks)
+    ns_marks = vim.tbl_filter(is_here, ns_marks)
+    for _, mark in ipairs(ns_marks) do
+      mark.ns_id = nsid
+      mark.ns = ns
+    end
+    vim.list_extend(extmarks, ns_marks)
+  end
+
+  if filter.semantic_tokens then
+    results.semantic_tokens = vim.tbl_filter(function(extmark)
+      return extmark.ns:find('vim_lsp_semantic_tokens') == 1
+    end, extmarks)
+  end
+
+  if filter.extmarks then
+    results.extmarks = vim.tbl_filter(function(extmark)
+      return extmark.ns:find('vim_lsp_semantic_tokens') ~= 1
+        and (filter.extmarks == 'all' or extmark.opts.hl_group)
+    end, extmarks)
+  end
+
   return results
 end
 
@@ -174,16 +181,17 @@ function vim.show_pos(bufnr, row, col, filter)
     nl()
   end
 
+  -- semantic tokens
   if #items.semantic_tokens > 0 then
     append('Semantic Tokens', 'Title')
     nl()
-    for _, token in ipairs(items.semantic_tokens) do
-      local client = vim.lsp.get_client_by_id(token.client_id)
-      client = client and (' (' .. client.name .. ')') or ''
-      item(token.hl_groups.type, 'type' .. client)
-      for _, modifier in ipairs(token.hl_groups.modifiers) do
-        item(modifier, 'modifier' .. client)
-      end
+    local sorted_marks = vim.fn.sort(items.semantic_tokens, function(left, right)
+      local left_first = left.opts.priority < right.opts.priority
+        or left.opts.priority == right.opts.priority and left.opts.hl_group < right.opts.hl_group
+      return left_first and -1 or 1
+    end)
+    for _, extmark in ipairs(sorted_marks) do
+      item(extmark.opts, 'priority: ' .. extmark.opts.priority)
     end
     nl()
   end
@@ -197,6 +205,7 @@ function vim.show_pos(bufnr, row, col, filter)
     end
     nl()
   end
+
   -- extmarks
   if #items.extmarks > 0 then
     append('Extmarks', 'Title')

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -72,6 +72,7 @@ return {
     'InsertLeavePre',         -- just before leaving Insert mode
     'LspAttach',              -- after an LSP client attaches to a buffer
     'LspDetach',              -- after an LSP client detaches from a buffer
+    'LspTokenUpdate',         -- after a visible LSP token is updated
     'MenuPopup',              -- just before popup menu is displayed
     'ModeChanged',            -- after changing the mode
     'OptionSet',              -- after setting any option
@@ -151,6 +152,7 @@ return {
     DiagnosticChanged=true,
     LspAttach=true,
     LspDetach=true,
+    LspTokenUpdate=true,
     RecordingEnter=true,
     RecordingLeave=true,
     Signal=true,

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -270,16 +270,22 @@ static const char *highlight_init_both[] = {
   "default link @tag Tag",
 
   // LSP semantic tokens
-  "default link @class Structure",
-  "default link @struct Structure",
-  "default link @enum Type",
-  "default link @enumMember Constant",
-  "default link @event Identifier",
-  "default link @interface Identifier",
-  "default link @modifier Identifier",
-  "default link @regexp SpecialChar",
-  "default link @typeParameter Type",
-  "default link @decorator Identifier",
+  "default link @lsp.type.class Structure",
+  "default link @lsp.type.decorator Function",
+  "default link @lsp.type.enum Structure",
+  "default link @lsp.type.enumMember Constant",
+  "default link @lsp.type.function Function",
+  "default link @lsp.type.interface Structure",
+  "default link @lsp.type.macro Macro",
+  "default link @lsp.type.method Function",
+  "default link @lsp.type.namespace Structure",
+  "default link @lsp.type.parameter Identifier",
+  "default link @lsp.type.property Identifier",
+  "default link @lsp.type.struct Structure",
+  "default link @lsp.type.type Type",
+  "default link @lsp.type.typeParameter TypeDef",
+  "default link @lsp.type.variable Identifier",
+
   NULL
 };
 


### PR DESCRIPTION
This is another take on how semantic token highlighting could work in neovim, cf #21576 and #21804. This PR has evolved quite a bit, and is no longer "rule-based."


### Summary

- The default highlighting for semantic tokens adds a number of extmarks for each token, which cover most basic uses and can be higlighted by colorschemes.
- There is a new `LspTokenUpdate` autocommand event that allows more complex token highlighting.


### Default Highlighting

For a token with `n` modifiers, `2n + 1` extmarks are applied:

- `@lsp.type.<type>.<ft>` for the type of the token, priority 125 (`vim.highlight.priorities.semantic_tokens`)
- `@lsp.mod.<modifier>.<ft>` for each modifier of the token, priority 126
- `@lsp.both.<type>.<modifier>.<ft>` for each modifier of the token, priority 127

For example, for the C++ code:
``` cpp
int function(int const p) { return p; }
//            with the cursor here ^
```
The `:Inspect` command shows:
![inspect](https://user-images.githubusercontent.com/926528/221382733-5d5c13e8-8b5b-4393-8144-ff5850a7d18e.png)


#### Default highlight links

<details> <summary>expand</summary>

The following captures are linked by default to standard highlight groups:

| Token Type Highlight      | Linked Group |
| --------------------      | ------------ |
| `@lsp.type.class`         | `Structure` |
| `@lsp.type.decorator`     | `Function` |
| `@lsp.type.enum`          | `Structure` |
| `@lsp.type.enumMember`    | `Constant` |
| `@lsp.type.function`      | `Function` |
| `@lsp.type.interface`     | `Structure` |
| `@lsp.type.macro`         | `Macro` |
| `@lsp.type.method`        | `Function` |
| `@lsp.type.namespace`     | `Structure` |
| `@lsp.type.parameter`     | `Identifier` |
| `@lsp.type.property`      | `Identifier` |
| `@lsp.type.struct`        | `Structure` |
| `@lsp.type.type`          | `Type` |
| `@lsp.type.typeParameter` | `TypeDef` |
| `@lsp.type.variable`      | `Identifier` |

The following semantic types are purposefully not linked:

| Token Type Highlight | Note |
| -------------------- |:---- |
| `@lsp.type`          | Don't add highlights for off-spec token types |
| `@lsp.type.comment`  | This overrides `@text.todo` and other useful marks inside comments |
| `@lsp.type.regexp`   | Let treesitter handle literals |
| `@lsp.type.keyword`  | " |
| `@lsp.type.string`   | " |
| `@lsp.type.number`   | " |
| `@lsp.type.operator` | " |
| `@lsp.type.event`    | Unclear to what this should link |
| `@lsp.type.modifier` | " |

</details>


#### Examples: using default highlighting

<details><summary>expand</summary>

You can disable specific semantic highlights by clearing a highlight group (you probably want this code in a `colorscheme` autocommand):
``` lua
vim.api.nvim_set_hl(0, '@lsp.type.function', {})
```

You can disable _all_ semantic highlights. Note that while this means that no visible highlight are being applied, but the tokens are still there and are still available with `vim.lsp.semantic_tokens.get_at_pos()` and visible with `:Inspect`:
``` lua
for _, group in ipairs(vim.fn.getcompletion("@lsp", "highlight")) do
  vim.api.nvim_set_hl(0, group, {})
end
```

The default links only use `:h highlight-default` groups. If you have a newer colorscheme with treesitter support, you can use the following to link to default treesitter groups, which potentially have more specific highlighting:
``` lua
local links = {
  ['@lsp.type.namespace'] = '@namespace',
  ['@lsp.type.type'] = '@type',
  ['@lsp.type.class'] = '@type',
  ['@lsp.type.enum'] = '@type',
  ['@lsp.type.interface'] = '@type',
  ['@lsp.type.struct'] = '@structure',
  ['@lsp.type.typeParameter'] = 'TypeDef',
  ['@lsp.type.parameter'] = '@parameter',
  ['@lsp.type.variable'] = '@variable',
  ['@lsp.type.property'] = '@property',
  ['@lsp.type.enumMember'] = '@constant',
  ['@lsp.type.function'] = '@function',
  ['@lsp.type.method'] = '@method',
  ['@lsp.type.macro'] = '@macro',
  ['@lsp.type.decorator'] = '@function',
}
for newgroup, oldgroup in pairs(links) do
  vim.api.nvim_set_hl(0, newgroup, { link = oldgroup, default = true })
end
```
Note that some semantic token types have no treesitter equivalent, and there are both server-specific token types and server-specific token modifiers.

You can specialize by filetype. Make C++ functions red:
``` lua
vim.api.nvim_set_hl(0, '@lsp.type.function.cpp', { fg = 'red' })
```

You can highlight all tokens with a given modifier by defining highlight group names:
``` lua
vim.api.nvim_set_hl(0, '@lsp.mod.mutable.rust', { italic = true })
vim.api.nvim_set_hl(0, '@lsp.mod.readOnly', { fg = 'green' })
```

The default `lsp.mod.*` extmarks all have the same priority. If you add modifier highlights that all compose, or highlight modifiers that are mutually exclusive, then everything will work.
``` lua
-- Deprecated default library functions will be both italic and strikethrough.
vim.api.nvim_set_hl(0, '@lsp.mod.defaultLibrary', { italic = true })
vim.api.nvim_set_hl(0, '@lsp.mod.deprecated',     { strikethrough = true })

-- Tokens can only have one scope in cpp, so there's no conflict here.
vim.api.nvim_set_hl(0, '@lsp.mod.fileScope.cpp',  { fg = 'red' })
vim.api.nvim_set_hl(0, '@lsp.mod.globalScope.cpp',{ fg = 'blue' })
```

The default `lsp.both.*` extmarks have higher priority, allowing for specialization:
``` lua
-- Make declarations (class, function, etc...) bold.
vim.api.nvim_set_hl(0, '@lsp.mod.declaration', { bold = true })

-- But not variable declarations.
vim.api.nvim_set_hl(0, '@lsp.both.variable.declaration', { link = '@lsp.type.variable' })
```

</details>


### `LspTokenUpdate` autocommand

The highlight-based customizations described above are straightforward, but limited. If a user wants arbitrary matching logic, they can use the `LspTokenUpdate` event to define callbacks that apply highlights to tokens. The event fires once per updated visible token. The `vim.lsp.semantic_tokens.highlight_token` function is provided to simplify creating a correct extmark for the token.

<details><summary>expand</summary>

#### Examples using `LspTokenUpdate`

Here is an example highlighting mutable global variables:
``` lua
local st = vim.lsp.semantic_tokens
vim.api.nvim_create_autocmd("LspTokenUpdate", {
  callback = function(args)
    local token = args.data.token
    if
      token.type == "variable"
      and token.modifiers.globalScope
      and not token.modifiers.readonly
    then
      st.highlight_token(token, args.buf, args.data.client_id, "MyMutableGlobalHL")
    end
  end,
})

vim.api.nvim_set_hl(0, 'MyMutableGlobalHL', { fg = 'red' })
```

Here's an example that highlights variable names written in ALL_CAPS that _aren't_ constant:
``` lua
local st = vim.lsp.semantic_tokens
vim.api.nvim_create_autocmd("LspTokenUpdate", {
  callback = function(args)
    local token = args.data.token
    if token.type ~= "variable" or token.modifiers.readonly then return end

    local text = vim.api.nvim_buf_get_text(
      args.bufnr, token.line, token.start_col, token.line, token.end_col, {})[1]
    if text ~= string.upper(text) then return end

    st.highlight_token(token, args.buf, args.data.client_id, "Error")
  end,
})
```

</details>
