### PR TITLE
build(bump_deps.lua): run command -v in shell

### DIFF
--- a/scripts/bump_deps.lua
+++ b/scripts/bump_deps.lua
@@ -54,7 +54,7 @@ local function run_die(cmd, err_msg)
 end
 
 local function require_executable(cmd)
-  local cmd_path = run_die({ 'command', '-v', cmd }, cmd .. ' not found!')
+  local cmd_path = run_die({ 'sh', '-c', 'command -v ' .. cmd }, cmd .. ' not found!')
   run_die({ 'test', '-x', cmd_path }, cmd .. ' is not executable')
 end
 


### PR DESCRIPTION
When I run `./scripts/bump_deps.lua` I get an error:
```
Vim:E475: Invalid value for argument cmd: 'command' is not executable
```
Running `command -v` in shell fixes this.
