### PR TITLE
feat(api): add nvim_win_get_foldinfo()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2815,6 +2815,25 @@ nvim_win_get_cursor({window})                          *nvim_win_get_cursor()*
     Return: ~
         (row, col) tuple
 
+nvim_win_get_foldinfo({window}, {lnum})                *nvim_win_get_foldinfo()*
+    Get fold information for {line} in {window}. Useful to build a custom fold
+    column in the |'statuscolumn'|.
+
+    Parameters: ~
+      • {window}  Window handle, or 0 for current window
+      • {line}    Line number to get the fold information for
+
+    Return: ~
+        Dictionary containing fold information for {line}, with these keys:
+        • level: (number) Level of the deepest fold. When zero, the rest of the
+                          keys are invalid.
+        • start: (number) Line number where the deepest fold containing {line}
+                          starts.
+        • lines: (number) When non-zero, this indicates the number of lines
+                          from {line} until the end of a closed fold.
+        • low_level: (number) Lowest fold level that starts at {line}.
+        • max_depth: (number) Maximum fold depth in {window}.
+
 nvim_win_get_height({window})                          *nvim_win_get_height()*
     Gets the window height
 


### PR DESCRIPTION
Problem:    Unable to request the lowest fold level that starts at a
            specific line number, and maximum fold depth in a window.
            (Both of which are useful to build a custom fold column
            through `'statuscolumn'`).
Solution:   Add a `nvim_win_get_foldinfo({window}, {lnum})` API-function
            that returns this, together with other relevant fold
            information for a specific line in a window.