### PR TITLE
vim-patch:9.0.1256: NetworkManager connection files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -226,6 +226,7 @@ local extension = {
   hook = function(path, bufnr)
     return M.getlines(bufnr, 1) == '[Trigger]' and 'conf'
   end,
+  nmconnection = 'confini',
   mklx = 'context',
   mkiv = 'context',
   mkii = 'context',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -123,7 +123,7 @@ let s:filename_checks = {
     \ 'conaryrecipe': ['file.recipe'],
     \ 'conf': ['auto.master'],
     \ 'config': ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
-    \ 'confini': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials'],
+    \ 'confini': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],
     \ 'cook': ['file.cook'],
     \ 'cpp': ['file.cxx', 'file.c++', 'file.hh', 'file.hxx', 'file.hpp', 'file.ipp', 'file.moc', 'file.tcc', 'file.inl', 'file.tlh'],


### PR DESCRIPTION
Problem:    NetworkManager connection files are not recognized.
Solution:   Add a pattern for NetworkManager connection files. (closes vim/vim#11893)

https://github.com/vim/vim/commit/04e4f1d98556e67d7337224b67b71c828410ee0f

Co-authored-by: ObserverOfTime <chronobserver@disroot.org>
