### PR TITLE
vim-patch:9.0.1255: changing 'virtualedit' does not have immediate effect

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1404,10 +1404,11 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, char **
   } else {
     if (opt_strings_flags(ve, p_ve_values, flags, true) != OK) {
       *errmsg = e_invarg;
-    } else if (strcmp(p_ve, oldval) != 0) {
+    } else if (strcmp(ve, oldval) != 0) {
       // Recompute cursor position in case the new 've' setting
       // changes something.
       validate_virtcol_win(win);
+      // XXX: this only works when win == curwin
       coladvance(win->w_virtcol);
     }
   }

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -537,6 +537,19 @@ func Test_global_local_virtualedit()
   set virtualedit&
 endfunc
 
+func Test_virtualedit_setlocal()
+  enew
+  setglobal virtualedit=all
+  setlocal virtualedit=all
+  normal! l
+  redraw
+  setlocal virtualedit=none
+  call assert_equal(1, wincol())
+
+  setlocal virtualedit&
+  set virtualedit&
+endfunc
+
 func Test_virtualedit_mouse()
   let save_mouse = &mouse
   set mouse=a


### PR DESCRIPTION
#### vim-patch:9.0.1255: changing 'virtualedit' does not have immediate effect

Problem:    Changing 'virtualedit' does not have immediate effect.
Solution:   Correct how is checked for a changed value.

https://github.com/vim/vim/commit/8fe5b9c8c1223861cec0484ccc031858ae08d107

Co-authored-by: Bram Moolenaar <Bram@vim.org>