### PR TITLE
fix(tui): detach/attach on suspend/resume

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1344,6 +1344,7 @@ static void show_verbose_terminfo(TUIData *tui)
 static void suspend_event(void **argv)
 {
   TUIData *tui = argv[0];
+  ui_client_detach();
   bool enable_mouse = tui->mouse_enabled;
   tui_terminal_stop(tui);
   stream_set_blocking(tui->input.in_fd, true);   // normalize stream (#2598)
@@ -1356,6 +1357,7 @@ static void suspend_event(void **argv)
     tui_mouse_on(tui);
   }
   stream_set_blocking(tui->input.in_fd, false);  // libuv expects this
+  ui_client_attach(tui->width, tui->height, tui->term);
 }
 #endif
 


### PR DESCRIPTION
Problem:
When a TUI client is suspended it still receives UI events from the
server, and has to process these accumulated events when it is resumed.
With mulitple TUI clients this is a bigger problem, considering the
following steps:
1. A TUI client is attached.
2. CTRL-Z is pressed and the first client is suspended.
3. Another TUI client is attached.
4. CTRL-Z is pressed and a "suspend" event is sent to both clients. The
   second client is suspended, while the first client isn't able to
   process the event because it has already been suspended.
5. The first client is resumed. It processes the accumulated "suspend"
   event and suspends immediately.

Solution:
Make a TUI client detach on suspend and re-attach on resume.
