### PR TITLE
build: enable ccache project-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
+find_program(CCACHE_PRG ccache)
+if(CCACHE_PRG)
+  set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env CCACHE_SLOPPINESS=pch_defines,time_macros ${CCACHE_PRG})
+endif()
+
 # Prefer our bundled versions of dependencies.
 if(DEFINED ENV{DEPS_BUILD_DIR})
   if(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -688,13 +688,6 @@ set_target_properties(nvim
   EXPORT_COMPILE_COMMANDS ON
   ENABLE_EXPORTS TRUE)
 
-find_program(CCACHE_PRG ccache)
-if(CCACHE_PRG)
-  set_target_properties(nvim
-    PROPERTIES
-    C_COMPILER_LAUNCHER "${CMAKE_COMMAND};-E;env;CCACHE_SLOPPINESS=pch_defines,time_macros;${CCACHE_PRG}")
-endif()
-
 if(${CMAKE_VERSION} VERSION_LESS 3.20)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()


### PR DESCRIPTION
Currently, only the nvim target uses ccache but not libnvim or
unittests. It is generally a good idea to operate on targets rather than
globally, but this is an exception as there isn't a target where we
don't want to use ccache on.
