### PR TITLE
Use valid application id in nvim.appdata.xml

### DIFF
--- a/runtime/nvim.appdata.xml
+++ b/runtime/nvim.appdata.xml
@@ -7,7 +7,7 @@
     https://github.com/flathub/io.neovim.nvim
 -->
 <component type="desktop-application">
-  <id>nvim</id>
+  <id>io.neovim.nvim</id>
   <translation type="gettext">nvim</translation>
   <project_license>Apache-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
@@ -58,5 +58,6 @@
   <url type="translate">https://github.com/neovim/neovim/tree/master/src/nvim/po</url>
   <provides>
     <binary>nvim</binary>
+    <id>nvim</id>
   </provides>
 </component>


### PR DESCRIPTION
According to [AppStream spec](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic), the `<id>` tag should contain a reverse-DNS scheme, consisting of `{tld}.{vendor}.{product}`. Since the flathub requires that, the flatpak build replaces `<id>nvim</id>` with `<id>io.neovim.nvim</id>`. That results in ID mismatch between flatpak version and version from distribution's repositories. Because of that, software stores are displaying two different neovims, instead of one neovim with options to download it either from flatpak or from distribution's repos. We can use the `<provides><id>nvim</id></provides>`, for everyone who was expecting the id to be `nvim`