### PR TITLE
vim-patch:9.0.1263: KDL files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -569,6 +569,7 @@ local extension = {
   libsonnet = 'jsonnet',
   jsp = 'jsp',
   jl = 'julia',
+  kdl = 'kdl',
   kv = 'kivy',
   kix = 'kix',
   kts = 'kotlin',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -302,6 +302,7 @@ let s:filename_checks = {
     \ 'jsp': ['file.jsp'],
     \ 'julia': ['file.jl'],
     \ 'kconfig': ['Kconfig', 'Kconfig.debug', 'Kconfig.file'],
+    \ 'kdl': ['file.kdl'],
     \ 'kivy': ['file.kv'],
     \ 'kix': ['file.kix'],
     \ 'kotlin': ['file.kt', 'file.ktm', 'file.kts'],


### PR DESCRIPTION
Problem:    KDL files are not recognized.
Solution:   Add a pattern for KDL files. (Amaan Qureshi, closes vim/vim#11898)

https://github.com/vim/vim/commit/907349a74331fc1bc48cf43c1e7d54cb9e0e4fc9

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
