### PR TITLE
refactor!: remove has("debug")

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,11 +117,6 @@ endif()
 message(STATUS "CMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}")
 
 set_default_buildtype()
-if(CMAKE_BUILD_TYPE MATCHES Debug)
-  set(DEBUG 1)
-else()
-  set(DEBUG 0)
-endif()
 
 # If not in a git repo (e.g., a tarball) these tokens define the complete
 # version string, else they are combined with the result of `git describe`.

--- a/cmake.config/config.h.in
+++ b/cmake.config/config.h.in
@@ -1,8 +1,6 @@
 #ifndef AUTO_CONFIG_H
 #define AUTO_CONFIG_H
 
-#cmakedefine DEBUG
-
 #cmakedefine SIZEOF_INT @SIZEOF_INT@
 #cmakedefine SIZEOF_INTMAX_T @SIZEOF_INTMAX_T@
 #cmakedefine SIZEOF_INT32_T @SIZEOF_INT32_T@

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -156,13 +156,10 @@ local function check_performance()
     health.report_ok(buildtype)
   else
     health.report_info(buildtype)
-    health.report_warn(
-      'Non-optimized ' .. (has('debug') and '(DEBUG) ' or '') .. 'build. Nvim will be slower.',
-      {
-        'Install a different Nvim package, or rebuild with `CMAKE_BUILD_TYPE=RelWithDebInfo`.',
-        suggest_faq,
-      }
-    )
+    health.report_warn('Non-optimized debug build. Nvim will be slower.', {
+      'Install a different Nvim package, or rebuild with `CMAKE_BUILD_TYPE=RelWithDebInfo`.',
+      suggest_faq,
+    })
   end
 
   -- check for slow shell invocation

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3064,9 +3064,6 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     "conceal",
     "cursorbind",
     "cursorshape",
-#ifdef DEBUG
-    "debug",
-#endif
     "dialog_con",
     "diff",
     "digraphs",


### PR DESCRIPTION
This value can not be relied on as it doesn't work for
multi-configuration generators. I don't think this undocumented option
is used much, if at all, so I think we should remove it.