### PR TITLE
Update nginx plugin

### DIFF
--- a/runtime/ftplugin/nginx.vim
+++ b/runtime/ftplugin/nginx.vim
@@ -3,4 +3,8 @@
 " Maintainer: Chris Aumann <me@chr4.org>
 " Last Change: Apr 15, 2017
 
+setlocal comments=:#
 setlocal commentstring=#\ %s
+setlocal formatoptions+=croql formatoptions-=t
+
+let b:undo_ftplugin = "setl fo< cms< com<"

--- a/runtime/syntax/nginx.vim
+++ b/runtime/syntax/nginx.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: nginx.conf
 " Maintainer: Chris Aumann <me@chr4.org>
-" Last Change: Apr 15, 2017
+" Last Change: Jan 25, 2023
 
 if exists("b:current_syntax")
   finish
@@ -84,6 +84,8 @@ syn keyword ngxListenOptions default_server contained
 syn keyword ngxListenOptions ssl            contained
 syn keyword ngxListenOptions http2          contained
 syn keyword ngxListenOptions spdy           contained
+syn keyword ngxListenOptions http3          contained
+syn keyword ngxListenOptions quic           contained
 syn keyword ngxListenOptions proxy_protocol contained
 syn keyword ngxListenOptions setfib         contained
 syn keyword ngxListenOptions fastopen       contained
@@ -265,8 +267,16 @@ syn keyword ngxDirective http2_max_concurrent_streams
 syn keyword ngxDirective http2_max_field_size
 syn keyword ngxDirective http2_max_header_size
 syn keyword ngxDirective http2_max_requests
+syn keyword ngxDirective http2_push
+syn keyword ngxDirective http2_push_preload
 syn keyword ngxDirective http2_recv_buffer_size
 syn keyword ngxDirective http2_recv_timeout
+syn keyword ngxDirective http3_hq
+syn keyword ngxDirective http3_max_concurrent_pushes
+syn keyword ngxDirective http3_max_concurrent_streams
+syn keyword ngxDirective http3_push
+syn keyword ngxDirective http3_push_preload
+syn keyword ngxDirective http3_stream_buffer_size
 syn keyword ngxDirective if_modified_since
 syn keyword ngxDirective ignore_invalid_headers
 syn keyword ngxDirective image_filter
@@ -444,6 +454,10 @@ syn keyword ngxDirective proxy_temp_path
 syn keyword ngxDirective proxy_timeout
 syn keyword ngxDirective proxy_upload_rate
 syn keyword ngxDirective queue
+syn keyword ngxDirective quic_gso
+syn keyword ngxDirective quic_host_key
+syn keyword ngxDirective quic_mtu
+syn keyword ngxDirective quic_retry
 syn keyword ngxDirective random_index
 syn keyword ngxDirective read_ahead
 syn keyword ngxDirective real_ip_header
@@ -545,8 +559,10 @@ syn keyword ngxDirective ssl_certificate
 syn keyword ngxDirective ssl_certificate_key
 syn keyword ngxDirective ssl_ciphers
 syn keyword ngxDirective ssl_client_certificate
+syn keyword ngxDirective ssl_conf_command
 syn keyword ngxDirective ssl_crl
 syn keyword ngxDirective ssl_dhparam
+syn keyword ngxDirective ssl_early_data
 syn keyword ngxDirective ssl_ecdh_curve
 syn keyword ngxDirective ssl_engine
 syn keyword ngxDirective ssl_handshake_timeout
@@ -556,6 +572,7 @@ syn keyword ngxSSLPreferServerCiphersOn on contained
 syn keyword ngxSSLPreferServerCiphersOff off contained
 syn keyword ngxDirective ssl_preread
 syn keyword ngxDirective ssl_protocols nextgroup=ngxSSLProtocol,ngxSSLProtocolDeprecated skipwhite
+syn keyword ngxDirective ssl_reject_handshake
 syn match ngxSSLProtocol 'TLSv1' contained nextgroup=ngxSSLProtocol,ngxSSLProtocolDeprecated skipwhite
 syn match ngxSSLProtocol 'TLSv1\.1' contained nextgroup=ngxSSLProtocol,ngxSSLProtocolDeprecated skipwhite
 syn match ngxSSLProtocol 'TLSv1\.2' contained nextgroup=ngxSSLProtocol,ngxSSLProtocolDeprecated skipwhite
@@ -622,6 +639,7 @@ syn keyword ngxDirective uwsgi_buffering
 syn keyword ngxDirective uwsgi_buffers
 syn keyword ngxDirective uwsgi_busy_buffers_size
 syn keyword ngxDirective uwsgi_cache
+syn keyword ngxDirective uwsgi_cache_background_update
 syn keyword ngxDirective uwsgi_cache_bypass
 syn keyword ngxDirective uwsgi_cache_key
 syn keyword ngxDirective uwsgi_cache_lock
@@ -2224,6 +2242,19 @@ syn keyword ngxDirectiveThirdParty xss_callback_arg
 syn keyword ngxDirectiveThirdParty xss_override_status
 syn keyword ngxDirectiveThirdParty xss_check_status
 syn keyword ngxDirectiveThirdParty xss_input_types
+
+" CT Module <https://github.com/grahamedgecombe/nginx-ct>
+" Certificate Transparency module for nginx
+syn keyword ngxDirectiveThirdParty ssl_ct
+syn keyword ngxDirectiveThirdParty ssl_ct_static_scts
+
+" Dynamic TLS records patch <https://github.com/cloudflare/sslconfig/blob/master/patches/nginx__dynamic_tls_records.patch>
+" TLS Dynamic Record Resizing
+syn keyword ngxDirectiveThirdParty ssl_dyn_rec_enable
+syn keyword ngxDirectiveThirdParty ssl_dyn_rec_size_hi
+syn keyword ngxDirectiveThirdParty ssl_dyn_rec_size_lo
+syn keyword ngxDirectiveThirdParty ssl_dyn_rec_threshold
+syn keyword ngxDirectiveThirdParty ssl_dyn_rec_timeout
 
 " ZIP Module <https://www.nginx.com/resources/wiki/modules/zip/>
 " ZIP archiver for nginx


### PR DESCRIPTION
This updates the nginx plugin with [upstream](https://github.com/chr4/nginx.vim).

All changes are already integrated or about to be integrated in upstream vim, see:

- https://github.com/vim/vim/pull/11880
- https://github.com/vim/vim/pull/11919
- https://github.com/vim/vim/pull/9003
- https://github.com/vim/vim/pull/11645

I'm not sure about the workflow to get those integrated in neovim, please advise if something is missing. 