### PR TITLE
fix(search.c): prevent memory corruption

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2643,6 +2643,9 @@ static void cmdline_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, bool sh
     t[1] = ' ';
     len += 2;
   }
+  if (len > strlen(msgbuf)) {
+    len = strlen(msgbuf);
+  }
 
   memmove(msgbuf + strlen(msgbuf) - len, t, len);
   if (dirc == '?' && stat.cur == maxcount + 1) {


### PR DESCRIPTION
Ensure that memmove call will not corrupt msgbuf memory

This way the buffer may contain a trimmed message like `[2/`, but at least the Neovim instance wouldn't crash

Fixes #22064