### PR TITLE
ci: simplify how environment variables are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
     paths-ignore:
       - 'contrib/**'
 
-# Cancel any in-progress CI runs for a PR if it is updated
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 env:
+  CI_BUILD_DIR: ${{ github.workspace }}
   UNCRUSTIFY_VERSION: uncrustify-0.75.0
   # TEST_FILE: test/functional/core/startup_spec.lua
   # TEST_FILTER: foo
@@ -59,9 +59,9 @@ jobs:
         run: |
           source_dir=uncrustify
           build_dir=uncrustify/build
-          cmake -S $source_dir -B $build_dir -G Ninja -DCMAKE_BUILD_TYPE=Release
+          cmake -S $source_dir -B $build_dir -G Ninja -D CMAKE_BUILD_TYPE=Release
           cmake --build $build_dir
-          mkdir -p $HOME/.cache
+          mkdir -p $CACHE_DIR
           cp $build_dir/uncrustify ${{ env.CACHE_UNCRUSTIFY }}
 
       - uses: ./.github/actions/cache
@@ -302,12 +302,12 @@ jobs:
 
       - name: Build deps
         run: |
-          cmake -S cmake.deps -B $env:DEPS_BUILD_DIR -G Ninja -DCMAKE_BUILD_TYPE='RelWithDebInfo'
+          cmake -S cmake.deps -B $env:DEPS_BUILD_DIR -G Ninja -D CMAKE_BUILD_TYPE='RelWithDebInfo'
           cmake --build $env:DEPS_BUILD_DIR
 
       - name: Build nvim
         run: |
-          cmake -B build -G Ninja -DCMAKE_BUILD_TYPE='RelWithDebInfo' -DDEPS_PREFIX="$env:DEPS_PREFIX" -DCI_BUILD=ON
+          cmake -B build -G Ninja -D CMAKE_BUILD_TYPE='RelWithDebInfo' -D DEPS_PREFIX="$env:DEPS_PREFIX" -D CI_BUILD=ON
           cmake --build build
 
       - name: Install test deps

--- a/ci/before_cache.sh
+++ b/ci/before_cache.sh
@@ -7,10 +7,7 @@ CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source-path=SCRIPTDIR
 source "${CI_DIR}/common/suite.sh"
 
-mkdir -p "${HOME}/.cache"
-
-echo "before_cache.sh: cache size"
-du -chd 1 "${HOME}/.cache" | sort -rh | head -20
+mkdir -p "$CACHE_DIR"
 
 # Update the third-party dependency cache only if the build was successful.
 if ended_successfully && [ -d "${DEPS_BUILD_DIR}" ]; then

--- a/ci/before_script.sh
+++ b/ci/before_script.sh
@@ -10,7 +10,7 @@ if [[ -n "${GCOV}" ]] && [[ ! $(type -P "${GCOV}") ]]; then
 fi
 
 if test "${FUNCTIONALTEST}" = "functionaltest-lua" ; then
-  DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} -DUSE_BUNDLED_LUA=ON"
+  DEPS_CMAKE_FLAGS="${DEPS_CMAKE_FLAGS} -D USE_BUNDLED_LUA=ON"
 fi
 
 mkdir -p "${DEPS_BUILD_DIR}"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -8,7 +8,7 @@ echo "Install neovim module for Python."
 CC=cc python3 -m pip -q install --user --upgrade pynvim
 
 echo "Install neovim RubyGem."
-gem install --no-document --bindir "$HOME/.local/bin" --user-install --pre neovim
+gem install --no-document --bindir "$BIN_DIR" --user-install --pre neovim
 
 echo "Install neovim npm package"
 npm install -g neovim

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -13,7 +13,7 @@ build_nvim() {
   check_core_dumps --delete quiet
 
   if test -n "${CLANG_SANITIZER}" ; then
-    CMAKE_FLAGS="${CMAKE_FLAGS} -DCLANG_${CLANG_SANITIZER}=ON"
+    CMAKE_FLAGS="${CMAKE_FLAGS} -D CLANG_${CLANG_SANITIZER}=ON"
   fi
 
   mkdir -p "${BUILD_DIR}"

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -166,11 +166,12 @@ if(CI_BUILD)
     target_compile_options(main_lib INTERFACE -WX)
   else()
     target_compile_options(main_lib INTERFACE -Werror)
-    if(DEFINED ENV{BUILD_UCHAR})
-      # Get some test coverage for unsigned char
-      target_compile_options(main_lib INTERFACE -funsigned-char)
-    endif()
   endif()
+endif()
+
+option(UNSIGNED_CHAR "Set char to be unsigned" OFF)
+if(UNSIGNED_CHAR)
+  target_compile_options(main_lib INTERFACE -funsigned-char)
 endif()
 
 list(APPEND CMAKE_REQUIRED_INCLUDES "${MSGPACK_INCLUDE_DIRS}")


### PR DESCRIPTION
Having a clear separation between when we manipulate variables and when
we export them to GITHUB_ENV makes it less error-prone.