### PR TITLE
fix(tests): use -l mode for lsp tests

### DIFF
--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -927,10 +927,13 @@ function tests.basic_formatting()
   }
 end
 
--- Tests will be indexed by TEST_NAME
+-- Tests will be indexed by test_name
+local test_name = arg[1]
+local timeout = arg[2]
+assert(type(test_name) == 'string', 'test_name must be specified as first arg.')
 
 local kill_timer = vim.loop.new_timer()
-kill_timer:start(_G.TIMEOUT or 1e3, 0, function()
+kill_timer:start(timeout or 1e3, 0, function()
   kill_timer:stop()
   kill_timer:close()
   log('ERROR', 'LSP', 'TIMEOUT')
@@ -938,14 +941,11 @@ kill_timer:start(_G.TIMEOUT or 1e3, 0, function()
   os.exit(100)
 end)
 
-local test_name = _G.TEST_NAME -- lualint workaround
-assert(type(test_name) == 'string', 'TEST_NAME must be specified.')
 local status, err = pcall(assert(tests[test_name], "Test not found"))
 kill_timer:stop()
 kill_timer:close()
 if not status then
   log('ERROR', 'LSP', tostring(err))
   io.stderr:write(err)
-  os.exit(101)
+  vim.cmd [[101cquit]]
 end
-os.exit(0)

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -80,17 +80,14 @@ M.fake_lsp_logfile = 'Xtest-fake-lsp.log'
 local function fake_lsp_server_setup(test_name, timeout_ms, options, settings)
   exec_lua([=[
     lsp = require('vim.lsp')
-    local test_name, fixture_filename, logfile, timeout, options, settings = ...
+    local test_name, fake_lsp_code, fake_lsp_logfile, timeout, options, settings = ...
     TEST_RPC_CLIENT_ID = lsp.start_client {
       cmd_env = {
-        NVIM_LOG_FILE = logfile;
+        NVIM_LOG_FILE = fake_lsp_logfile;
         NVIM_LUA_NOTRACK = "1";
       };
       cmd = {
-        vim.v.progpath, '-Es', '-u', 'NONE', '--headless',
-        "-c", string.format("lua TEST_NAME = %q", test_name),
-        "-c", string.format("lua TIMEOUT = %d", timeout),
-        "-c", "luafile "..fixture_filename,
+        vim.v.progpath, '-l', fake_lsp_code, test_name, tostring(timeout),
       };
       handlers = setmetatable({}, {
         __index = function(t, method)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -46,16 +46,14 @@ describe('LSP', function()
     local test_name = "basic_init"
     exec_lua([=[
       lsp = require('vim.lsp')
-      local test_name, fixture_filename, logfile = ...
+      local test_name, fake_lsp_code, fake_lsp_logfile = ...
       function test__start_client()
         return lsp.start_client {
           cmd_env = {
-            NVIM_LOG_FILE = logfile;
+            NVIM_LOG_FILE = fake_lsp_logfile;
           };
           cmd = {
-            vim.v.progpath, '-Es', '-u', 'NONE', '--headless',
-            "-c", string.format("lua TEST_NAME = %q", test_name),
-            "-c", "luafile "..fixture_filename;
+            vim.v.progpath, '-l', fake_lsp_code, test_name;
           };
           workspace_folders = {{
               uri = 'file://' .. vim.loop.cwd(),


### PR DESCRIPTION
This fixes "fake server" from leaking memory, which makes ASAN very upset, except on current ASAN CI for some reason.