### PR TITLE
vim-patch:9.0.1270: crash when using search stat in narrow screen

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2644,7 +2644,12 @@ static void cmdline_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, bool sh
     len += 2;
   }
 
-  memmove(msgbuf + strlen(msgbuf) - len, t, len);
+  size_t msgbuf_len = strlen(msgbuf);
+  if (len > msgbuf_len) {
+    len = msgbuf_len;
+  }
+  memmove(msgbuf + msgbuf_len - len, t, len);
+
   if (dirc == '?' && stat.cur == maxcount + 1) {
     stat.cur = -1;
   }

--- a/src/nvim/testdir/test_search_stat.vim
+++ b/src/nvim/testdir/test_search_stat.vim
@@ -270,6 +270,29 @@ func Test_searchcount_fails()
   call assert_fails('echo searchcount({"pos" : [1, 2, []]})', 'E745:')
 endfunc
 
+func Test_search_stat_narrow_screen()
+  " This used to crash Vim
+  let save_columns = &columns
+  try
+    let after =<< trim [CODE]
+      set laststatus=2
+      set columns=16
+      set shortmess-=S showcmd
+      call setline(1, 'abc')
+      call feedkeys("/abc\<CR>:quit!\<CR>")
+      autocmd VimLeavePre * call writefile(["done"], "Xdone")
+    [CODE]
+
+    if !RunVim([], after, '--clean')
+      return
+    endif
+    call assert_equal("done", readfile("Xdone")[0])
+    call delete('Xdone')
+  finally
+    let &columns = save_columns
+  endtry
+endfunc
+
 func Test_searchcount_in_statusline()
   CheckScreendump
 


### PR DESCRIPTION
Close #22064
Close #22065

#### vim-patch:9.0.1270: crash when using search stat in narrow screen

Problem:    Crash when using search stat in narrow screen.
Solution:   Check length of message. (closes vim/vim#11921)

https://github.com/vim/vim/commit/a7d36b732070944aab614944075ec0b409311482