### PR TITLE
vim-patch:8.1.1827: allocating more memory than needed for extended structs

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -252,7 +252,7 @@ static void add_buff(buffheader_T *const buf, const char *const s, ptrdiff_t sle
     } else {
       len = (size_t)slen;
     }
-    buffblock_T *p = xmalloc(sizeof(buffblock_T) + len);
+    buffblock_T *p = xmalloc(offsetof(buffblock_T, b_str) + len + 1);
     buf->bh_space = len - (size_t)slen;
     xstrlcpy(p->b_str, s, (size_t)slen + 1);
 

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -2862,7 +2862,7 @@ static regprog_T *bt_regcomp(uint8_t *expr, int re_flags)
   }
 
   // Allocate space.
-  bt_regprog_T *r = xmalloc(sizeof(bt_regprog_T) + (size_t)regsize);
+  bt_regprog_T *r = xmalloc(offsetof(bt_regprog_T, program) + (size_t)regsize);
   r->re_in_use = false;
 
   // Second pass: emit code.

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -103,7 +103,7 @@ static signgroup_T *sign_group_ref(const char *groupname)
   hi = hash_lookup(&sg_table, (char *)groupname, strlen(groupname), hash);
   if (HASHITEM_EMPTY(hi)) {
     // new group
-    group = xmalloc(sizeof(signgroup_T) + strlen(groupname));
+    group = xmalloc(offsetof(signgroup_T, sg_name) + strlen(groupname) + 1);
 
     STRCPY(group->sg_name, groupname);
     group->sg_refcount = 1;

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -10,9 +10,9 @@
 
 // Sign group
 typedef struct signgroup_S {
-  uint16_t sg_refcount;   // number of signs in this group
-  int sg_next_sign_id;    // next sign id for this group
-  char sg_name[1];        // sign group name
+  int sg_next_sign_id;   ///< next sign id for this group
+  uint16_t sg_refcount;  ///< number of signs in this group
+  char sg_name[1];       ///< sign group name, actually longer
 } signgroup_T;
 
 // Macros to get the sign group structure from the group name

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3736,7 +3736,7 @@ static void add_keyword(char *const name, const int id, const int flags,
                      sizeof(name_folded))
       : name;
 
-  keyentry_T *const kp = xmalloc(sizeof(keyentry_T) + strlen(name_ic));
+  keyentry_T *const kp = xmalloc(offsetof(keyentry_T, keyword) + strlen(name_ic) + 1);
   STRCPY(kp->keyword, name_ic);
   kp->k_syn.id = (int16_t)id;
   kp->k_syn.inc_tag = current_syn_inc_tag;


### PR DESCRIPTION
#### vim-patch:8.1.1827: allocating more memory than needed for extended structs

Problem:    Allocating more memory than needed for extended structs.
Solution:   Use offsetof() instead of sizeof(). (Dominique Pelle,
            closes vim/vim#4786)

https://github.com/vim/vim/commit/47ed553fd5bebfc36eb8aa81686eeaa5a84eccac