### PR TITLE
vim-patch:9.0.1271: using sizeof() and subtract array size is tricky

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1347,7 +1347,7 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
     // Make sure dict is valid
     assert(dict != NULL);
 
-    v = xmalloc(sizeof(dictitem_T) + strlen(varname));
+    v = xmalloc(offsetof(dictitem_T, di_key) + strlen(varname) + 1);
     STRCPY(v->di_key, varname);
     if (hash_add(ht, (char *)v->di_key) == FAIL) {
       xfree(v);

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1092,7 +1092,7 @@ static int ff_check_visited(ff_visited_T **visited_list, char *fname, char *wc_p
   }
 
   // New file/dir.  Add it to the list of visited files/dirs.
-  vp = xmalloc(sizeof(ff_visited_T) + strlen(ff_expand_buffer));
+  vp = xmalloc(offsetof(ff_visited_T, ffv_fname) + strlen(ff_expand_buffer) + 1);
 
   if (!url) {
     vp->file_id_valid = true;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -149,7 +149,7 @@ struct data_block {
 #define DB_INDEX_MASK   (~DB_MARKED)
 
 #define INDEX_SIZE  (sizeof(unsigned))      // size of one db_index entry
-#define HEADER_SIZE (sizeof(DATA_BL) - INDEX_SIZE)  // size of data block header
+#define HEADER_SIZE (offsetof(DATA_BL, db_index))  // size of data block header
 
 enum {
   B0_FNAME_SIZE_ORG = 900,      // what it was in older versions
@@ -2720,7 +2720,8 @@ static bhdr_T *ml_new_ptr(memfile_T *mfp)
   PTR_BL *pp = hp->bh_data;
   pp->pb_id = PTR_ID;
   pp->pb_count = 0;
-  pp->pb_count_max = (uint16_t)((mfp->mf_page_size - sizeof(PTR_BL)) / sizeof(PTR_EN) + 1);
+  pp->pb_count_max
+    = (uint16_t)((mfp->mf_page_size - offsetof(PTR_BL, pb_pointer)) / sizeof(PTR_EN));
 
   return hp;
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2514,7 +2514,7 @@ static void store_sb_text(char **sb_str, char *s, int attr, int *sb_col, int fin
   }
 
   if (s > *sb_str) {
-    mp = xmalloc((sizeof(msgchunk_T) + (size_t)(s - *sb_str)));
+    mp = xmalloc(offsetof(msgchunk_T, sb_text) + (size_t)(s - *sb_str) + 1);
     mp->sb_eol = (char)finish;
     mp->sb_msg_col = *sb_col;
     mp->sb_attr = attr;

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -7511,7 +7511,7 @@ static regprog_T *nfa_regcomp(uint8_t *expr, int re_flags)
   post2nfa(postfix, post_ptr, true);
 
   // allocate the regprog with space for the compiled regexp
-  size_t prog_size = sizeof(nfa_regprog_T) + sizeof(nfa_state_T) * (size_t)(nstate - 1);
+  size_t prog_size = offsetof(nfa_regprog_T, state) + sizeof(nfa_state_T) * (size_t)nstate;
   prog = xmalloc(prog_size);
   state_ptr = prog->state;
   prog->re_in_use = false;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1745,7 +1745,7 @@ void count_common_word(slang_T *lp, char *word, int len, uint8_t count)
   const size_t p_len = strlen(p);
   hashitem_T *hi = hash_lookup(&lp->sl_wordcount, (const char *)p, p_len, hash);
   if (HASHITEM_EMPTY(hi)) {
-    wc = xmalloc(sizeof(wordcount_T) + p_len);
+    wc = xmalloc(offsetof(wordcount_T, wc_word) + p_len + 1);
     memcpy(wc->wc_word, p, p_len + 1);
     wc->wc_count = count;
     hash_add_item(&lp->sl_wordcount, hi, (char *)wc->wc_word, hash);

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3855,7 +3855,7 @@ static void *getroom(spellinfo_T *spin, size_t len, bool align)
 
   if (bl == NULL || (size_t)bl->sb_used + len > SBLOCKSIZE) {
     // Allocate a block of memory. It is not freed until much later.
-    bl = xcalloc(1, (sizeof(sblock_T) + SBLOCKSIZE));
+    bl = xcalloc(1, offsetof(sblock_T, sb_data) + SBLOCKSIZE + 1);
     bl->sb_next = spin->si_blocks;
     spin->si_blocks = bl;
     bl->sb_used = 0;

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -2828,7 +2828,7 @@ static void add_sound_suggest(suginfo_T *su, char *goodword, int score, langp_T 
   hi = hash_lookup(&slang->sl_sounddone, (const char *)goodword, goodword_len,
                    hash);
   if (HASHITEM_EMPTY(hi)) {
-    sft = xmalloc(sizeof(sftword_T) + goodword_len);
+    sft = xmalloc(offsetof(sftword_T, sft_word) + goodword_len + 1);
     sft->sft_score = (int16_t)score;
     memcpy(sft->sft_word, goodword, goodword_len + 1);
     hash_add_item(&slang->sl_sounddone, hi, (char *)sft->sft_word, hash);


### PR DESCRIPTION
#### vim-patch:9.0.1271: using sizeof() and subtract array size is tricky

Problem:    Using sizeof() and subtract array size is tricky.
Solution:   Use offsetof() instead. (closes vim/vim#11926)

https://github.com/vim/vim/commit/1b438a8228a415720efb5ca1c0503f5467292e8e