### PR TITLE
refactor: use flexible array in buffblock_T

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -108,12 +108,15 @@ typedef struct buffheader buffheader_T;
 // structure used to store one block of the stuff/redo/recording buffers
 struct buffblock {
   buffblock_T *b_next;  // pointer to next buffblock
-  char b_str[1];        // contents (actually longer)
+  char b_str[];         // contents
 };
 
 // header used for the stuff buffer and the redo buffer
 struct buffheader {
-  buffblock_T bh_first;  // first (dummy) block of list
+  struct {
+    buffblock_T *b_next;
+    char b_str[1];
+  } bh_first;            // first (dummy) block of list
   buffblock_T *bh_curr;  // buffblock for appending
   size_t bh_index;          // index for reading
   size_t bh_space;          // space in bh_curr for appending

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -230,7 +230,7 @@ static void add_buff(buffheader_T *const buf, const char *const s, ptrdiff_t sle
 
   if (buf->bh_first.b_next == NULL) {  // first add to list
     buf->bh_space = 0;
-    buf->bh_curr = &(buf->bh_first);
+    buf->bh_curr = (buffblock_T *)&(buf->bh_first);
   } else if (buf->bh_curr == NULL) {  // buffer has already been read
     iemsg(_("E222: Add to read buffer"));
     return;
@@ -361,11 +361,11 @@ static int read_readbuf(buffheader_T *buf, int advance)
 static void start_stuff(void)
 {
   if (readbuf1.bh_first.b_next != NULL) {
-    readbuf1.bh_curr = &(readbuf1.bh_first);
+    readbuf1.bh_curr = (buffblock_T *)&(readbuf1.bh_first);
     readbuf1.bh_space = 0;
   }
   if (readbuf2.bh_first.b_next != NULL) {
-    readbuf2.bh_curr = &(readbuf2.bh_first);
+    readbuf2.bh_curr = (buffblock_T *)&(readbuf2.bh_first);
     readbuf2.bh_space = 0;
   }
 }


### PR DESCRIPTION
~~buffheader unnecessarily also contained b_str from the buffblock_T struct. inline b_next in buffheader.~~

~~this change is needed for the #22072 refactor, as you couldn't use a flexible array for b_str in buffblock, because it's nested in other structs.~~