### PR TITLE
vim-patch:9.0.1273: "1v" may select block with wrong size

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5072,9 +5072,13 @@ static void nv_visual(cmdarg_T *cap)
         curwin->w_curswant = MAXCOL;
         coladvance(MAXCOL);
       } else if (VIsual_mode == Ctrl_V) {
+        // Update curswant on the original line, that is where "col" is valid.
+        linenr_T lnum = curwin->w_cursor.lnum;
+        curwin->w_cursor.lnum = VIsual.lnum;
         update_curswant_force();
         assert(cap->count0 >= INT_MIN && cap->count0 <= INT_MAX);
         curwin->w_curswant += resel_VIsual_vcol * (int)cap->count0 - 1;
+        curwin->w_cursor.lnum = lnum;
         coladvance(curwin->w_curswant);
       } else {
         curwin->w_set_curswant = true;

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1319,6 +1319,17 @@ func Test_visual_block_with_substitute()
 endfunc
 
 func Test_visual_reselect_with_count()
+  enew
+  call setline(1, ['aaaaaa', '✗ bbbb', '✗ bbbb'])
+  exe "normal! 2Gw\<C-V>jed"
+  exe "normal! gg0lP"
+  call assert_equal(['abbbbaaaaa', '✗bbbb ', '✗ '], getline(1, '$'))
+
+  exe "normal! 1vr."
+  call assert_equal(['a....aaaaa', '✗.... ', '✗ '], getline(1, '$'))
+
+  bwipe!
+
   " this was causing an illegal memory access
   let lines =<< trim END
 


### PR DESCRIPTION
#### vim-patch:9.0.1273: "1v" may select block with wrong size

Problem:    "1v" may select block with wrong size. (Evgeni Chasnovski)
Solution:   Compute "curswant" in the right line.

https://github.com/vim/vim/commit/8f531662e28c37560bf5ac20a059bf00d01ee5a4

Co-authored-by: Bram Moolenaar <Bram@vim.org>