### PR TITLE
fix(column): estimate 'statuscolumn' width appropriately

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1392,6 +1392,7 @@ struct window_S {
   int w_prev_fraction_row;
 
   linenr_T w_nrwidth_line_count;        // line count when ml_nrwidth_width was computed.
+  linenr_T w_statuscol_line_count;      // line count when 'statuscolumn' width was computed.
   int w_nrwidth_width;                  // nr of chars to print line count.
 
   qf_info_T *w_llist;                 // Location list for this window

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -768,7 +768,6 @@ void comp_col(void)
 /// Otherwise it depends on 'numberwidth' and the line count.
 int number_width(win_T *wp)
 {
-  int n;
   linenr_T lnum;
 
   if (wp->w_p_rnu && !wp->w_p_nu) {
@@ -784,17 +783,13 @@ int number_width(win_T *wp)
   }
   wp->w_nrwidth_line_count = lnum;
 
-  // make best estimate for 'statuscolumn'
+  // reset for 'statuscolumn'
   if (*wp->w_p_stc != NUL) {
-    char buf[MAXPATHL];
-    wp->w_nrwidth_width = 0;
-    n = build_statuscol_str(wp, lnum, 0, 0, NUL, buf, NULL, NULL);
-    n = MAX(n, (wp->w_p_nu || wp->w_p_rnu) * (int)wp->w_p_nuw);
-    wp->w_nrwidth_width = MIN(n, MAX_NUMBERWIDTH);
+    wp->w_nrwidth_width = (wp->w_p_nu || wp->w_p_rnu) * (int)wp->w_p_nuw;
     return wp->w_nrwidth_width;
   }
 
-  n = 0;
+  int n = 0;
   do {
     lnum /= 10;
     n++;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -439,7 +439,7 @@ describe('statuscolumn', function()
       vim.api.nvim_buf_set_extmark(0, ns, 7, 0, {
         virt_lines_leftcol = true, virt_lines = {{{"virt", ""}}} })
     ]])
-    feed('lh')  -- force update wcol/row
+    feed('lh')  -- force update cursor row
     screen:expect([[
                 4 aaaaa                                    |
                 5 aaaaa                                    |
@@ -458,5 +458,24 @@ describe('statuscolumn', function()
     ]])
     command('set stc=')  -- also for the default sign column
     screen:expect_unchanged()
+    -- 'statuscolumn' is not too wide with custom (bogus) fold column
+    command([[set stc=%{foldlevel(v:lnum)>0?repeat('-',foldlevel(v:lnum)):''}%=%l\ ]])
+    feed('Gd10Ggg<C-l>')
+    screen:expect([[
+               1 ^aaaaa                                     |
+               2 aaaaa                                     |
+               3 aaaaa                                     |
+               4 aaaaa                                     |
+               5 aaaaa                                     |
+               6 aaaaa                                     |
+               7 aaaaa                                     |
+      virt                                                 |
+      ---------8 aaaaa                                     |
+      virt                                                 |
+      ---------9 aaaaa                                     |
+      ~                                                    |
+      ~                                                    |
+                                                           |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:    The 'statuscolumn' width is being estimated without the proper context. In particular, this resulted in the fact that a custom fold column could be included in the estimated `number_width()`, and doubly added when actually drawing the status column due to `win_col_off()` also adding the `'foldcolumn'` width. Resulting in a status column that is `'foldcolumn'` cells wider than necessary.
Solution:   Estimate the `'statuscolumn'` width in `get_statuscol_str()` when a buffer's line count has changed.