### PR TITLE
docs: clarify "pipe" mode for sockconnect

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1959,7 +1959,7 @@ exp({expr})						*exp()*
 			Compute()->exp()
 
 expand({string} [, {nosuf} [, {list}]])				*expand()*
-		Expand wildcards and the following special keywords in 
+		Expand wildcards and the following special keywords in
 		{string}.  'wildignorecase' applies.
 
 		If {list} is given and it is |TRUE|, a List will be returned.
@@ -7569,10 +7569,14 @@ sinh({expr})						*sinh()*
 
 sockconnect({mode}, {address} [, {opts}])		 *sockconnect()*
 		Connect a socket to an address. If {mode} is "pipe" then
-		{address} should be the path of a named pipe. If {mode} is
-		"tcp" then {address} should be of the form "host:port" where
-		the host should be an ip adderess or host name, and port the
-		port number.
+		{address} should be the path of a local domain socket (on
+		unix) or named pipe (on Windows). If {mode} is "tcp" then
+		{address} should be of the form "host:port" where the host
+		should be an ip adderess or host name, and port the port
+		number.
+
+		For "pipe" mode, see |luv-pipe-handle|. For "tcp" mode, see
+		|luv-tcp-handle|.
 
 		Returns a |channel| ID. Close the socket with |chanclose()|.
 		Use |chansend()| to send data over a bytes socket, and


### PR DESCRIPTION
Make it more clear that on unix the "pipe" mode of sockconnect uses unix local domain sockets, not named pipes (FIFOs) which are not currently supported.

See discussion in #22080.

Signed-off-by: Thayne McCombs