### PR TITLE
ci: add ASAN job with RelWithDebInfo build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,10 +140,10 @@ jobs:
             cc: gcc
             runner: ubuntu-22.04
             flags: -D UNSIGNED_CHAR=ON
-          - flavor: release
+          - flavor: release asan
             cc: gcc
             runner: ubuntu-22.04
-            flags: -D CMAKE_BUILD_TYPE=Release
+            flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CLANG_ASAN_UBSAN=ON
           - cc: clang
             runner: macos-12
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,7 +141,7 @@ jobs:
             runner: ubuntu-22.04
             flags: -D UNSIGNED_CHAR=ON
           - flavor: release asan
-            cc: gcc
+            cc: clang
             runner: ubuntu-22.04
             flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CLANG_ASAN_UBSAN=ON
           - cc: clang


### PR DESCRIPTION
This will help us catch release-only bugs that may not show up on debug
build.
