### PR TITLE
vim-patch:9.0.1274: FIRRTL files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -385,6 +385,7 @@ local extension = {
   ['m4gl'] = 'fgl',
   ['4gl'] = 'fgl',
   ['4gh'] = 'fgl',
+  fir = 'firrtl',
   fish = 'fish',
   focexec = 'focexec',
   fex = 'focexec',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -199,6 +199,7 @@ let s:filename_checks = {
     \ 'fennel': ['file.fnl'],
     \ 'fetchmail': ['.fetchmailrc'],
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
+    \ 'firrtl': ['file.fir'],
     \ 'fish': ['file.fish'],
     \ 'focexec': ['file.fex', 'file.focexec'],
     \ 'form': ['file.frm'],


### PR DESCRIPTION
Problem:    FIRRTL files are not recognized.
Solution:   Add a pattern for FIRRTL files. (Amaan Qureshi, closes vim/vim#11931)

https://github.com/vim/vim/commit/685bf83b73d0fe6fd36bb2949bebd6aae66a139e

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
