### PR TITLE
feat(spell): also source `spell/LANG.lua` when setting `spelllang`

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -440,9 +440,9 @@ find these functions useful:
 SETTING 'spellcapcheck' AUTOMATICALLY			*set-spc-auto*
 
 After the 'spelllang' option has been set successfully, Vim will source the
-files "spell/LANG.vim" in 'runtimepath'.  "LANG" is the value of 'spelllang'
-up to the first comma, dot or underscore.  This can be used to set options
-specifically for the language, especially 'spellcapcheck'.
+files "spell/LANG.vim" and "spell/LANG.lua" in 'runtimepath'.  "LANG" is the
+value of 'spelllang' up to the first comma, dot or underscore.  This can be
+used to set options specifically for the language, especially 'spellcapcheck'.
 
 The distribution includes a few of these files.  Use this command to see what
 they do: >

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1581,7 +1581,7 @@ static void do_spelllang_source(win_T *win)
     q += 4;
   }
 
-  // Source the spell/LANG.vim in 'runtimepath'.
+  // Source the spell/LANG.{vim,lua} in 'runtimepath'.
   // They could set 'spellcapcheck' depending on the language.
   // Use the first name in 'spelllang' up to '_region' or
   // '.encoding'.
@@ -1592,7 +1592,7 @@ static void do_spelllang_source(win_T *win)
     }
   }
   if (p > q) {
-    vim_snprintf(fname, sizeof(fname), "spell/%.*s.vim", (int)(p - q), q);
+    vim_snprintf(fname, sizeof(fname), "spell/%.*s.\\(vim\\|lua\\)", (int)(p - q), q);
     source_runtime(fname, DIP_ALL);
   }
 }


### PR DESCRIPTION
Problem: only Vimscript files are sourced when setting spelling language
Solution: also source Lua files after sourcing Vimscript files

Closes #22110
