### PR TITLE
fix(column): no longer reset nrwidth_line_count for 'statuscolumn'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -442,14 +442,12 @@ static void get_statuscol_str(win_T *wp, linenr_T lnum, int row, int startrow, i
   if (wp->w_statuscol_line_count != wp->w_nrwidth_line_count) {
     wp->w_statuscol_line_count = wp->w_nrwidth_line_count;
     set_vim_var_nr(VV_VIRTNUM, 0);
-    build_statuscol_str(wp, wp->w_nrwidth_line_count, 0, stcp->width,
-                        ' ', stcp->text, &stcp->hlrec, stcp);
+    build_statuscol_str(wp, wp->w_nrwidth_line_count, 0, stcp);
     stcp->width += stcp->truncate;
   }
   set_vim_var_nr(VV_VIRTNUM, virtnum);
 
-  int width = build_statuscol_str(wp, lnum, relnum, stcp->width,
-                                  ' ', stcp->text, &stcp->hlrec, stcp);
+  int width = build_statuscol_str(wp, lnum, relnum, stcp);
   // Force a redraw in case of error or when truncated
   if (*wp->w_p_stc == NUL || (stcp->truncate > 0 && wp->w_nrwidth < MAX_NUMBERWIDTH)) {
     if (stcp->truncate) {  // Avoid truncating 'statuscolumn'

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2158,9 +2158,6 @@ static char *set_bool_option(const int opt_idx, char_u *const varp, const int va
     if (curwin->w_p_spell) {
       errmsg = did_set_spelllang(curwin);
     }
-  } else if (((int *)varp == &curwin->w_p_nu || (int *)varp == &curwin->w_p_rnu)
-             && *curwin->w_p_stc != NUL) {  // '(relative)number' + 'statuscolumn'
-    curwin->w_nrwidth_line_count = 0;
   }
 
   if ((int *)varp == &curwin->w_p_arab) {

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -885,11 +885,8 @@ void draw_tabline(void)
 /// Build the 'statuscolumn' string for line "lnum". When "relnum" == -1,
 /// the v:lnum and v:relnum variables don't have to be updated.
 ///
-/// @param hlrec  HL attributes (can be NULL)
-/// @param stcp  Status column attributes (can be NULL)
 /// @return  The width of the built status column string for line "lnum"
-int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int fillchar,
-                        char *buf, stl_hlrec_t **hlrec, statuscol_T *stcp)
+int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, statuscol_T *stcp)
 {
   bool fillclick = relnum >= 0 && lnum == wp->w_topline;
 
@@ -900,8 +897,8 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int
 
   StlClickRecord *clickrec;
   char *stc = xstrdup(wp->w_p_stc);
-  int width = build_stl_str_hl(wp, buf, MAXPATHL, stc, "statuscolumn", OPT_LOCAL, fillchar,
-                               maxwidth, hlrec, fillclick ? &clickrec : NULL, stcp);
+  int width = build_stl_str_hl(wp, stcp->text, MAXPATHL, stc, "statuscolumn", OPT_LOCAL, ' ',
+                               stcp->width, &stcp->hlrec, fillclick ? &clickrec : NULL, stcp);
   xfree(stc);
 
   // Only update click definitions once per window per redraw
@@ -909,7 +906,7 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, int maxwidth, int
     stl_clear_click_defs(wp->w_statuscol_click_defs, wp->w_statuscol_click_defs_size);
     wp->w_statuscol_click_defs = stl_alloc_click_defs(wp->w_statuscol_click_defs, width,
                                                       &wp->w_statuscol_click_defs_size);
-    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, buf, width, false);
+    stl_fill_click_defs(wp->w_statuscol_click_defs, clickrec, stcp->text, width, false);
   }
 
   return width;


### PR DESCRIPTION
**fix(column): no longer reset nrwidth_line_count for 'statuscolumn'**
Problem:    We still explicitly reset `nrwidth_line_count` when changing
            `'number'` or `'relativenumber'` but this is no longer
            needed since the introduction of a `statuscol_line_count`.
Solution:   Remove reset of `nrwidth_line_count`. Resolve
            https://github.com/neovim/neovim/pull/22094#issuecomment-1416168926.

**refactor(column): remove unused build_statuscol_str() arguments**
    Problem:    `build_statuscol_str()` still has arguments that were
                necessary for building a status column string in
                `number_width()`, which was abandoned in #22094.
    Solution:   Remove unused arguments.
