### PR TITLE
refactor(lsp): implement codelens as decoration provider

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1401,7 +1401,7 @@ function lsp.start_client(config)
         client_id = client_id,
         bufnr = bufnr,
         params = params,
-        version = version
+        version = version,
       }
       handler(err, result, context)
     end, function(request_id)

--- a/runtime/lua/vim/lsp/types.lua
+++ b/runtime/lua/vim/lsp/types.lua
@@ -18,3 +18,21 @@
 ---@class lsp.FileEvent
 ---@field uri string
 ---@field type lsp.FileChangeType
+
+---@class lsp.Position
+---@field line number
+---@field character number
+
+---@class lsp.Range
+---@field start lsp.Position
+---@field end lsp.Position
+
+---@class lsp.Command
+---@field title string
+---@field command string
+---@field arguments any|nil
+
+---@class lsp.CodeLens
+---@field range lsp.Range
+---@field command lsp.Command|nil
+---@field data any|nil

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2109,6 +2109,7 @@ end
 
 M._get_line_byte_from_position = get_line_byte_from_position
 
+---@type table<integer, integer> bufnr -> version
 M.buf_versions = {}
 
 return M

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3080,7 +3080,7 @@ describe('LSP', function()
         name = "prepare_rename_placeholder",
         expected_handlers = {
           {NIL, {}, {method="shutdown", client_id=1}};
-          {NIL, NIL, {method="textDocument/rename", client_id=1, bufnr=1}};
+          {NIL, NIL, {method="textDocument/rename", client_id=1, bufnr=1, version = 3}};
           {NIL, {}, {method="start", client_id=1}};
         },
         expected_text = "placeholder", -- see fake lsp response
@@ -3090,7 +3090,7 @@ describe('LSP', function()
         name = "prepare_rename_range",
         expected_handlers = {
           {NIL, {}, {method="shutdown", client_id=1}};
-          {NIL, NIL, {method="textDocument/rename", client_id=1, bufnr=1}};
+          {NIL, NIL, {method="textDocument/rename", client_id=1, bufnr=1, version = 3}};
           {NIL, {}, {method="start", client_id=1}};
         },
         expected_text = "line", -- see test case and fake lsp response


### PR DESCRIPTION
This makes `codelens.display` a no-op and instead uses a decoration
provider to set the extmarks.

`codelens.save` now also resolves unresolved code-lens but will keep the
old lens & swap them out after they're resolved to avoid flickering.

Alternative to https://github.com/neovim/neovim/pull/19707

## TODO

- [ ] Update docs
- [ ] Update tests
- [ ] Maybe tune internal cache structure
- [ ] Maybe re-add debounce/throttle


Could also consider adding something like a `vim.throttle`:

```lua
local function throttle(fn, opts)
  opts = opts or {}
  local timer = nil
  local changedtick
  if opts.buf then
    changedtick = vim.b[opts.buf].changedtick
  end
  return function(...)
    if timer then
      timer:stop()
      timer:close()
      timer = nil
    end
    if changedtick then
      if vim.b[opts.buf].changedtick == changedtick then
        return
      end
      changedtick = vim.b[opts.buf].changedtick
    end
    local args = {...}
    timer = vim.loop.new_timer()
    local f = function()
      return fn(unpack(args))
    end
    timer:start(opts.debounce_ms or 500, 0, vim.schedule_wrap(f))
  end
end
```


And delegate throttling to users if they want to have it - given that they also need to setup a autocmd to trigger refresh.
