### PR TITLE
vim-patch:9.0.1277: cursor may move with autocmd in Visual mode

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1535,6 +1535,7 @@ win_found:
     globaldir = aco->globaldir;
 
     // the buffer contents may have changed
+    VIsual_active = aco->save_VIsual_active;
     check_cursor();
     if (curwin->w_topline > curbuf->b_ml.ml_line_count) {
       curwin->w_topline = curbuf->b_ml.ml_line_count;
@@ -1563,14 +1564,16 @@ win_found:
       curwin = save_curwin;
       curbuf = curwin->w_buffer;
       prevwin = win_find_by_handle(aco->save_prevwin_handle);
+
       // In case the autocommand moves the cursor to a position that does not
       // exist in curbuf
+      VIsual_active = aco->save_VIsual_active;
       check_cursor();
     }
   }
 
-  check_cursor();  // just in case lines got deleted
   VIsual_active = aco->save_VIsual_active;
+  check_cursor();  // just in case lines got deleted
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
   }

--- a/src/nvim/testdir/test_functions.vim
+++ b/src/nvim/testdir/test_functions.vim
@@ -1511,7 +1511,7 @@ endfunc
 
 func Test_setbufvar_options()
   " This tests that aucmd_prepbuf() and aucmd_restbuf() properly restore the
-  " window layout.
+  " window layout and cursor position.
   call assert_equal(1, winnr('$'))
   split dummy_preview
   resize 2
@@ -1525,11 +1525,20 @@ func Test_setbufvar_options()
   execute 'belowright vertical split #' . dummy_buf
   call assert_equal(wh, winheight(0))
   let dum1_id = win_getid()
+  call setline(1, 'foo')
+  normal! V$
+  call assert_equal(4, col('.'))
+  call setbufvar('dummy_preview', '&buftype', 'nofile')
+  call assert_equal(4, col('.'))
 
   wincmd h
   let wh = winheight(0)
+  call setline(1, 'foo')
+  normal! V$
+  call assert_equal(4, col('.'))
   let dummy_buf = bufnr('dummy_buf2', v:true)
   eval 'nofile'->setbufvar(dummy_buf, '&buftype')
+  call assert_equal(4, col('.'))
   execute 'belowright vertical split #' . dummy_buf
   call assert_equal(wh, winheight(0))
 


### PR DESCRIPTION
Fix #22107

#### vim-patch:9.0.1277: cursor may move with autocmd in Visual mode

Problem:    Cursor may move with autocmd in Visual mode.
Solution:   Restore "VIsual_active" before calling check_cursor().
            (closes vim/vim#11939)

https://github.com/vim/vim/commit/49f0524fb575bb1cf4881e472afab7d37c579440