### PR TITLE
vim-patch:9.0.1278: go.work.sum files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1433,6 +1433,7 @@ local filename = {
   gnashrc = 'gnash',
   ['.gnuplot'] = 'gnuplot',
   ['go.sum'] = 'gosum',
+  ['go.work.sum'] = 'gosum',
   ['go.work'] = 'gowork',
   ['.gprc'] = 'gp',
   ['/.gnupg/gpg.conf'] = 'gpg',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -235,7 +235,7 @@ let s:filename_checks = {
     \ 'gnuplot': ['file.gpi', '.gnuplot'],
     \ 'go': ['file.go'],
     \ 'gomod': ['go.mod'],
-    \ 'gosum': ['go.sum'],
+    \ 'gosum': ['go.sum', 'go.work.sum'],
     \ 'gowork': ['go.work'],
     \ 'gp': ['file.gp', '.gprc'],
     \ 'gpg': ['/.gnupg/options', '/.gnupg/gpg.conf', '/usr/any/gnupg/options.skel', 'any/.gnupg/gpg.conf', 'any/.gnupg/options', 'any/usr/any/gnupg/options.skel'],


### PR DESCRIPTION
Problem:    go.work.sum files are not recognized.
Solution:   Recognize go.work.sum files as the gosum filetype. (Amaan Qureshi,
            closes vim/vim#11940)

https://github.com/vim/vim/commit/4ad8ae8465e30df38dba31910f130891b16d38a0

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
