### PR TITLE
feat(treesitter): add `q` mapping to playground to close playground

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -452,6 +452,12 @@ function M.show_tree(opts)
       pg:draw(b)
     end,
   })
+  a.nvim_buf_set_keymap(b, 'n', 'gq', '', {
+    desc = 'Close the current window',
+    callback = function()
+      a.nvim_win_close(0, false)
+    end,
+  })
 
   local group = a.nvim_create_augroup('treesitter/playground', {})
 


### PR DESCRIPTION
I don't whether this is in scope for the built-in playground, but my muscle memory always wants to use `q` to close the built-in playground, because I'm used to this from other plugins to have this for these small UI helper windows.

Feel free to close if not suited as a default. 