### PR TITLE
vim-patch:9.0.1279: display shows lines scrolled down erroneously

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -296,7 +296,9 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
       for (int i = 0; i < wp->w_lines_valid; i++) {
         if (wp->w_lines[i].wl_valid) {
           if (wp->w_lines[i].wl_lnum >= lnum) {
-            if (wp->w_lines[i].wl_lnum < lnume) {
+            // Do not change wl_lnum at index zero, it is used to
+            // compare with w_topline.  Invalidate it instead.
+            if (wp->w_lines[i].wl_lnum < lnume || i == 0) {
               // line included in change
               wp->w_lines[i].wl_valid = false;
             } else if (xtra != 0) {

--- a/src/nvim/testdir/test_move.vim
+++ b/src/nvim/testdir/test_move.vim
@@ -1,5 +1,8 @@
 " Test the ":move" command.
 
+source check.vim
+source screendump.vim
+
 func Test_move()
   enew!
   call append(0, ['line 1', 'line 2', 'line 3'])
@@ -42,5 +45,26 @@ func Test_move()
 
   %bwipeout!
 endfunc
+
+func Test_move_undo()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      call setline(1, ['First', 'Second', 'Third', 'Fourth'])
+  END
+  call writefile(lines, 'Xtest_move_undo.vim', 'D')
+  let buf = RunVimInTerminal('-S Xtest_move_undo.vim', #{rows: 10, cols: 60, statusoff: 2})
+
+  call term_sendkeys(buf, "gg:move +1\<CR>")
+  call VerifyScreenDump(buf, 'Test_move_undo_1', {})
+
+  " here the display would show the last few lines scrolled down
+  call term_sendkeys(buf, "u")
+  call term_sendkeys(buf, ":\<Esc>")
+  call VerifyScreenDump(buf, 'Test_move_undo_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/legacy/move_spec.lua
+++ b/test/functional/legacy/move_spec.lua
@@ -1,0 +1,49 @@
+local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
+local clear = helpers.clear
+local feed = helpers.feed
+local funcs = helpers.funcs
+
+before_each(clear)
+
+describe(':move', function()
+  -- oldtest: Test_move_undo()
+  it('redraws correctly when undone', function()
+    local screen = Screen.new(60, 10)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+
+    funcs.setline(1, {'First', 'Second', 'Third', 'Fourth'})
+    feed('gg:move +1<CR>')
+    screen:expect([[
+      Second                                                      |
+      ^First                                                       |
+      Third                                                       |
+      Fourth                                                      |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      :move +1                                                    |
+    ]])
+
+    -- here the display would show the last few lines scrolled down
+    feed('u')
+    feed(':<Esc>')
+    screen:expect([[
+      ^First                                                       |
+      Second                                                      |
+      Third                                                       |
+      Fourth                                                      |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+                                                                  |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:9.0.1279: display shows lines scrolled down erroneously

Problem:    Display shows lines scrolled down erroneously. (Yishai Lerner)
Solution:   Do not change "wl_lnum" at index zero.

https://github.com/vim/vim/commit/61fdbfa1e3c842252b701aec12f45839ca41ece5

Co-authored-by: Bram Moolenaar <Bram@vim.org>