### PR TITLE
feat: implement NVIM_APPNAME

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -55,6 +55,10 @@ NEW FEATURES                                                    *news-features*
 
 The following new APIs or features were added.
 
+• A new environment variable named NVIM_APPNAME enables configuring the
+  directories where Neovim should find its configuration and state files. See
+  `:help $NVIM_APPNAME` .
+
 • |nvim_open_win()| now accepts a relative `mouse` option to open a floating win
   relative to the mouse. Note that the mouse doesn't update frequently without
   setting `vim.o.mousemoveevent = true`

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1385,6 +1385,18 @@ STATE DIRECTORY (DEFAULT) ~
 Note: Throughout the user manual these defaults are used as placeholders, e.g.
 "~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
 
+NVIM_APPNAME					*$NVIM_APPNAME*
+The XDG directories used by Nvim can be further configured by setting the
+`$NVIM_APPNAME` environment variable. This variable controls the directory
+Neovim will look for (and auto-create) in the various XDG parent directories.
+For example, setting `$NVIM_APPNAME` to "neovim" before running Neovim will
+result in Neovim looking for configuration files in `$XDG_CONFIG_HOME/neovim`
+instead of `$XDG_CONFIG_HOME/nvim`.
+
+Note: Similarly to the $XDG environment variables, when
+`$XDG_CONFIG_HOME/nvim` is mentionned, it should be understood as
+`$XDG_CONFIG_HOME/$NVIM_APPNAME`.
+
 LOG FILE					*$NVIM_LOG_FILE* *E5430*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5368,13 +5368,14 @@ void get_xdg_var_list(const XDGVarType xdg, typval_T *rettv)
     return;
   }
   const void *iter = NULL;
+  const char *appname = get_appname();
   do {
     size_t dir_len;
     const char *dir;
     iter = vim_env_iter(ENV_SEPCHAR, dirs, iter, &dir, &dir_len);
     if (dir != NULL && dir_len > 0) {
       char *dir_with_nvim = xmemdupz(dir, dir_len);
-      dir_with_nvim = concat_fnames_realloc(dir_with_nvim, "nvim", true);
+      dir_with_nvim = concat_fnames_realloc(dir_with_nvim, appname, true);
       tv_list_append_string(list, dir_with_nvim, (ssize_t)strlen(dir_with_nvim));
       xfree(dir_with_nvim);
     }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5181,7 +5181,10 @@ static void vim_mktempdir(void)
 
     // "/tmp/" exists, now try to create "/tmp/nvim.<user>/".
     add_pathsep(tmp);
-    xstrlcat(tmp, "nvim.", sizeof(tmp));
+
+    const char *appname = get_appname();
+    xstrlcat(tmp, appname, sizeof(tmp));
+    xstrlcat(tmp, ".", sizeof(tmp));
     xstrlcat(tmp, user, sizeof(tmp));
     (void)os_mkdir(tmp, 0700);  // Always create, to avoid a race.
     bool owned = os_file_owned(tmp);

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -91,13 +91,14 @@ char *server_address_new(const char *name)
 {
   static uint32_t count = 0;
   char fmt[ADDRESS_MAX_SIZE];
+  const char *appname = get_appname();
 #ifdef MSWIN
   int r = snprintf(fmt, sizeof(fmt), "\\\\.\\pipe\\%s.%" PRIu64 ".%" PRIu32,
-                   name ? name : "nvim", os_get_pid(), count++);
+                   name ? name : appname, os_get_pid(), count++);
 #else
   char *dir = stdpaths_get_xdg_var(kXDGRuntimeDir);
   int r = snprintf(fmt, sizeof(fmt), "%s/%s.%" PRIu64 ".%" PRIu32,
-                   dir, name ? name : "nvim", os_get_pid(), count++);
+                   dir, name ? name : appname, os_get_pid(), count++);
   xfree(dir);
 #endif
   if ((size_t)r >= sizeof(fmt)) {


### PR DESCRIPTION
This commit implements the ability to control all of the XDG paths
Neovim should use. This is done by setting an environment variable named
NVIM_APPNAME. For example, setting $NVIM_APPNAME makes Neovim look for
its configuration directory in $XDG_CONFIG_HOME/$NVIM_APPNAME instead of
$XDG_CONFIG_HOME/nvim.

If NVIM_APPNAME is not set or is an empty string, "nvim" will be used as
default.

The usecase for this feature is to enable an easy way to switch from
configuration to configuration. One might argue that the various $XDG
environment variables can already be used for this usecase. However,
setting $XDG environment variables also affects tools spawned by Neovim.
For example, while setting $XDG_CONFIG_HOME will enable Neovim to use a
different configuration directory, it will also prevent Git from finding
its "default" configuration.

Closes https://github.com/neovim/neovim/issues/21691 .
