### PR TITLE
vim-patch:9.0.1281: Cadence files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -191,6 +191,7 @@ local extension = {
   qc = 'c',
   cabal = 'cabal',
   capnp = 'capnp',
+  cdc = 'cdc',
   cdl = 'cdl',
   toc = 'cdrtoc',
   cfc = 'cf',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -522,6 +522,7 @@ let s:filename_checks = {
     \ 'sinda': ['file.sin', 'file.s85'],
     \ 'sisu': ['file.sst', 'file.ssm', 'file.ssi', 'file.-sst', 'file._sst', 'file.sst.meta', 'file.-sst.meta', 'file._sst.meta'],
     \ 'skill': ['file.il', 'file.ils', 'file.cdf'],
+    \ 'cdc': ['file.cdc'],
     \ 'slang': ['file.sl'],
     \ 'slice': ['file.ice'],
     \ 'slpconf': ['/etc/slp.conf', 'any/etc/slp.conf'],


### PR DESCRIPTION
Problem:    Cadence files are not recognized.
Solution:   Recognize Cadence files. (Janez Podhostnik, closes vim/vim#11951)

https://github.com/vim/vim/commit/cb626a4692df7154be02b47d6089ec679e95cb44

Co-authored-by: Janez Podhostnik <janez.podhostnik@gmail.com>
