### PR TITLE
vim-patch:9.0.1282: Ron files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -870,6 +870,7 @@ local extension = {
   Snw = 'rnoweb',
   robot = 'robot',
   resource = 'robot',
+  ron = 'ron',
   rsc = 'routeros',
   x = 'rpcgen',
   rpl = 'rpl',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -489,6 +489,7 @@ let s:filename_checks = {
     \ 'rnoweb': ['file.rnw', 'file.snw'],
     \ 'robot': ['file.robot', 'file.resource'],
     \ 'robots': ['robots.txt'],
+    \ 'ron' : ['file.ron'],
     \ 'routeros': ['file.rsc'],
     \ 'rpcgen': ['file.x'],
     \ 'rpl': ['file.rpl'],


### PR DESCRIPTION
Problem:    Ron files are not recognized.
Solution:   Recognize Ron files. (Amaan Qureshi, closes https://github.com/vim/vim/pull/11948)