### PR TITLE
fix 0.8.3 spelloptions regression

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -88,6 +88,8 @@ function TSHighlighter.new(tree, opts)
     end
   end
 
+  self.orig_spelloptions = vim.bo[self.bufnr].spelloptions
+
   vim.bo[self.bufnr].syntax = ''
   vim.b[self.bufnr].ts_highlight = true
 


### PR DESCRIPTION
I realized that 0.8.3 (as opposed to 0.8.x releases so far) would sometimes clobber my spelloptions settings.

It seems to me that a backport of a master fix wasn't completely done, resulting in the issue. This commit restores the missing line.

see 0887ad1cbb050d2bc6169ad46aa07cf42c90493f for the original commit on master, and 80bbba94d669e3fdda2edddf1c37acda1cfed968 for the backport on the branch, which forgot to backup the original setting value.