### PR TITLE
docs: fix "the the" typos in docs and comments

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1859,8 +1859,8 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 					|CompleteChanged|.
 			scrollbar 	Is |v:true| if popup menu have scrollbar, or
 					|v:false| if not.
-			changed_window 	Is |v:true| if the the event fired
-					while changing window (or tab) on |DirChanged|.
+			changed_window 	Is |v:true| if the event fired while
+					changing window (or tab) on |DirChanged|.
 			status		Job status or exit code, -1 means "unknown". |TermClose|
 
 					*v:exception* *exception-variable*

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -382,7 +382,7 @@ Note:
 - If numlock is on the |TUI| receives plain ASCII values, so mapping <k0>,
   <k1>, ..., <k9> and <kPoint> will not work.
 - Nvim supports mapping multibyte chars with modifiers such as `<M-ä>`. Which
-  combinations actually work depends on the the UI or host terminal.
+  combinations actually work depends on the UI or host terminal.
 - When a key is pressed using a meta or alt modifier and no mapping exists for
   that keypress, Nvim may behave as though <Esc> was pressed before the key.
 - It is possible to notate combined modifiers (e.g. <C-A-T> for CTRL-ALT-T),

--- a/runtime/pack/dist/opt/vimball/autoload/vimball.vim
+++ b/runtime/pack/dist/opt/vimball/autoload/vimball.vim
@@ -189,7 +189,7 @@ endfun
 
 " ---------------------------------------------------------------------
 " vimball#Vimball: extract and distribute contents from a vimball {{{2
-"                  (invoked the the UseVimball command embedded in 
+"                  (invoked the UseVimball command embedded in
 "                  vimballs' prologue)
 fun! vimball#Vimball(really,...)
 "  call Dfunc("vimball#Vimball(really=".a:really.") a:0=".a:0)

--- a/runtime/syntax/php.vim
+++ b/runtime/syntax/php.vim
@@ -68,8 +68,8 @@
 " Known Bugs:
 "  - setting  php_parent_error_close  on  and  php_parent_error_open  off
 "    has these two leaks:
-"     i) A closing ) or ] inside a string match to the last open ( or [
-"        before the string, when the the closing ) or ] is on the same line
+"     i) A closing ) or ] inside a string matches to the last open ( or [
+"        before the string, when the closing ) or ] is on the same line
 "        where the string started. In this case a following ) or ] after
 "        the string would be highlighted as an error, what is incorrect.
 "    ii) Same problem if you are setting php_folding = 2 with a closing

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2797,7 +2797,7 @@ static char_u *replace_stack = NULL;
 static ssize_t replace_stack_nr = 0;           // next entry in replace stack
 static ssize_t replace_stack_len = 0;          // max. number of entries
 
-/// Push character that is replaced onto the the replace stack.
+/// Push character that is replaced onto the replace stack.
 ///
 /// replace_offset is normally 0, in which case replace_push will add a new
 /// character at the end of the stack.  If replace_offset is not 0, that many


### PR DESCRIPTION
I found the first `the the` typo in the `intro.txt` help document and then looked to see where else the same error might be.

If you want separate commits for non-docs or if this commit is too insubstantial, let me know.