### PR TITLE
vim-patch:9.0.1288: FunC files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -423,6 +423,7 @@ local extension = {
   fsh = 'fsh',
   fsi = 'fsharp',
   fsx = 'fsharp',
+  fc = 'func',
   fusion = 'fusion',
   gdb = 'gdb',
   gdmo = 'gdmo',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -211,6 +211,7 @@ let s:filename_checks = {
     \ 'fsh': ['file.fsh'],
     \ 'fsharp': ['file.fs', 'file.fsi', 'file.fsx'],
     \ 'fstab': ['fstab', 'mtab'],
+    \ 'func': ['file.fc'],
     \ 'fusion': ['file.fusion'],
     \ 'fvwm': ['/.fvwm/file', 'any/.fvwm/file'],
     \ 'gdb': ['.gdbinit', 'gdbinit', 'file.gdb', '.config/gdbearlyinit', '.gdbearlyinit'],


### PR DESCRIPTION
Problem:    FunC files are not recognized.
Solution:   Recognize FunC files. (Amaan Qureshi, closes vim/vim#11949)

https://github.com/vim/vim/commit/91deac45392fe93094b9c31403b1ae771dc71938

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
