### PR TITLE
ci: add universal macos job

### DIFF
--- a/.github/scripts/build_universal_macos.sh
+++ b/.github/scripts/build_universal_macos.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+echo "Provision universal libintl"
+GETTEXT_PREFIX="$(brew --prefix gettext)"
+printf 'GETTEXT_PREFIX=%s\n' "$GETTEXT_PREFIX" >> $GITHUB_ENV
+bottle_tag="arm64_big_sur"
+brew fetch --bottle-tag="$bottle_tag" gettext
+cd "$(mktemp -d)"
+tar xf "$(brew --cache)"/**/*gettext*${bottle_tag}*.tar.gz
+lipo gettext/*/lib/libintl.a "${GETTEXT_PREFIX}/lib/libintl.a" -create -output libintl.a
+mv -f libintl.a /usr/local/lib/
+
+echo "Ensure static linkage to libintl"
+# We're about to mangle `gettext`, so let's remove any potentially broken
+# installs (e.g. curl, git) as those could interfere with our build.
+brew uninstall $(brew uses --installed --recursive gettext)
+brew unlink gettext
+ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/bin"/* /usr/local/bin/
+ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/include"/* /usr/local/include/
+rm -f "$GETTEXT_PREFIX"
+
+echo "Build release"
+cd "$GITHUB_WORKSPACE"
+MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
+export MACOSX_DEPLOYMENT_TARGET
+cmake -S cmake.deps -B .deps -G Ninja -D CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} -D CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -D CMAKE_OSX_ARCHITECTURES=arm64\;x86_64
+cmake --build .deps
+cmake -B build -G Ninja -D CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} -D CMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -D CMAKE_OSX_ARCHITECTURES=arm64\;x86_64
+cmake --build build
+cmake --install build --prefix build/release/nvim-macos
+cd build
+# Make sure we build everything for M1 as well
+for macho in bin/* lib/nvim/parser/*.so; do
+  lipo -info "$macho" | grep -q arm64 || exit 1
+done
+cpack -C "$NVIM_BUILD_TYPE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,40 +101,8 @@ jobs:
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
         run: printf 'NVIM_BUILD_TYPE=RelWithDebInfo\n' >> $GITHUB_ENV
-      - name: Provision universal `libintl`
-        run: |
-          GETTEXT_PREFIX="$(brew --prefix gettext)"
-          printf 'GETTEXT_PREFIX=%s\n' "$GETTEXT_PREFIX" >> $GITHUB_ENV
-          bottle_tag="arm64_big_sur"
-          brew fetch --bottle-tag="$bottle_tag" gettext
-          cd "$(mktemp -d)"
-          tar xf "$(brew --cache)"/**/*gettext*${bottle_tag}*.tar.gz
-          lipo gettext/*/lib/libintl.a "${GETTEXT_PREFIX}/lib/libintl.a" -create -output libintl.a
-          mv -f libintl.a /usr/local/lib/
-      - name: Ensure static linkage to `libintl`
-        run: |
-          # We're about to mangle `gettext`, so let's remove any potentially broken
-          # installs (e.g. curl, git) as those could interfere with our build.
-          brew uninstall $(brew uses --installed --recursive gettext)
-          brew unlink gettext
-          ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/bin"/* /usr/local/bin/
-          ln -sf "$(brew --prefix)/opt/$(readlink "${GETTEXT_PREFIX}")/include"/* /usr/local/include/
-          rm -f "$GETTEXT_PREFIX"
-      - name: Build release
-        run: |
-          export MACOSX_DEPLOYMENT_TARGET="$(sw_vers -productVersion | cut -f1 -d.)"
-          OSX_FLAGS="-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} -DCMAKE_OSX_ARCHITECTURES=arm64\;x86_64"
-          make CMAKE_BUILD_TYPE=${NVIM_BUILD_TYPE} \
-               CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX:PATH= $OSX_FLAGS" \
-               DEPS_CMAKE_FLAGS="$OSX_FLAGS"
-          make DESTDIR="$GITHUB_WORKSPACE/build/release/nvim-macos" install
-          cd "$GITHUB_WORKSPACE/build/"
-          # Make sure we build everything for M1 as well
-          for macho in bin/* lib/nvim/parser/*.so
-          do
-          lipo -info "$macho" | grep -q arm64 || exit 1
-          done
-          cpack -C "$NVIM_BUILD_TYPE"
+      - name: Build universal binary
+        run: ./.github/scripts/build_universal_macos.sh
       - uses: actions/upload-artifact@v3
         with:
           name: nvim-macos

--- a/.github/workflows/universal_macos.yml
+++ b/.github/workflows/universal_macos.yml
@@ -1,0 +1,34 @@
+name: macos-universal
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
+    paths:
+      - '**.cmake'
+      - '**/CMakeLists.txt'
+      - '**/CMakePresets.json'
+      - 'cmake.*/**'
+      - '.github/scripts/build_universal_macos.sh'
+      - '.github/workflow/universal_macos.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos-universal:
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          brew update --quiet
+          brew install automake ninja
+
+      - run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
+
+      - name: Build universal binary
+        run: ./.github/scripts/build_universal_macos.sh


### PR DESCRIPTION
The universal macos release is particularly sensitive to build system
changes. Adding a job that builds a universal binary whenever a cmake
file is changed will help prevent future release breaks.