### PR TITLE
feat(docs): better parsing of types of Lua annotations

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -452,7 +452,7 @@ fromqflist({list})                               *vim.diagnostic.fromqflist()*
                 |getloclist()|.
 
     Return: ~
-        Diagnostic [] array of |diagnostic-structure|
+        ( Diagnostic []) array of |diagnostic-structure|
 
 get({bufnr}, {opts})                                    *vim.diagnostic.get()*
     Get current diagnostics.
@@ -467,7 +467,7 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                  • severity: See |diagnostic-severity|.
 
     Return: ~
-        Diagnostic [] table A list of diagnostic items |diagnostic-structure|.
+        ( Diagnostic []) table A list of diagnostic items |diagnostic-structure|.
 
 get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
     Get namespace metadata.
@@ -491,7 +491,7 @@ get_next({opts})                                   *vim.diagnostic.get_next()*
       • {opts}  (table|nil) See |vim.diagnostic.goto_next()|
 
     Return: ~
-        Diagnostic|nil Next diagnostic
+        (Diagnostic|nil) Next diagnostic
 
 get_next_pos({opts})                           *vim.diagnostic.get_next_pos()*
     Return the position of the next diagnostic in the current buffer.
@@ -500,17 +500,17 @@ get_next_pos({opts})                           *vim.diagnostic.get_next_pos()*
       • {opts}  (table|nil) See |vim.diagnostic.goto_next()|
 
     Return: ~
-        table|false Next diagnostic position as a (row, col) tuple or false if
-        no next diagnostic.
+        (table|false) Next diagnostic position as a (row, col) tuple or false
+        if no next diagnostic.
 
 get_prev({opts})                                   *vim.diagnostic.get_prev()*
     Get the previous diagnostic closest to the cursor position.
 
     Parameters: ~
-      • {opts}  nil|table See |vim.diagnostic.goto_next()|
+      • {opts}  (nil|table) See |vim.diagnostic.goto_next()|
 
     Return: ~
-        Diagnostic|nil Previous diagnostic
+        (Diagnostic|nil) Previous diagnostic
 
 get_prev_pos({opts})                           *vim.diagnostic.get_prev_pos()*
     Return the position of the previous diagnostic in the current buffer.
@@ -519,7 +519,7 @@ get_prev_pos({opts})                           *vim.diagnostic.get_prev_pos()*
       • {opts}  (table|nil) See |vim.diagnostic.goto_next()|
 
     Return: ~
-        table|false Previous diagnostic position as a (row, col) tuple or
+        (table|false) Previous diagnostic position as a (row, col) tuple or
         false if there is no prior diagnostic
 
 goto_next({opts})                                 *vim.diagnostic.goto_next()*
@@ -606,7 +606,7 @@ match({str}, {pat}, {groups}, {severity_map}, {defaults})
                         default to 0 and "severity" defaults to ERROR.
 
     Return: ~
-        Diagnostic|nil: |diagnostic-structure| or `nil` if {pat} fails to
+        (Diagnostic|nil) : |diagnostic-structure| or `nil` if {pat} fails to
         match {str}.
 
 open_float({opts}, {...})                        *vim.diagnostic.open_float()*
@@ -663,7 +663,7 @@ open_float({opts}, {...})                        *vim.diagnostic.open_float()*
                   from |vim.diagnostic.config()|.
 
     Return: ~
-        number|nil, number|nil: ({float_bufnr}, {win_id})
+        (number|nil) : ({float_bufnr}, {win_id})
 
 reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
     Remove all diagnostics from the given namespace.
@@ -744,6 +744,6 @@ toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
       • {diagnostics}  (table) List of diagnostics |diagnostic-structure|.
 
     Return: ~
-        table[] of quickfix list items |setqflist-what|
+        (table[]) of quickfix list items |setqflist-what|
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -725,7 +725,7 @@ get_buffers_by_client_id({client_id})
       • {client_id}  (number) client id
 
     Return: ~
-        (list) of buffer ids
+        list of buffer ids
 
 get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
     Gets a client by id, or nil if the id is invalid. The returned client may
@@ -818,7 +818,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
     Parameters: ~
       • {config}  (table) Same configuration as documented in
                   |vim.lsp.start_client()|
-      • {opts}    nil|table Optional keyword arguments:
+      • {opts}    (nil|table) Optional keyword arguments:
                   • reuse_client (fun(client: client, config: table): boolean)
                     Predicate used to decide if a client should be re-used.
                     Used on all running clients. The default implementation
@@ -962,7 +962,7 @@ stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
     for this client, then force-shutdown is attempted.
 
     Parameters: ~
-      • {client_id}  number|table id or |vim.lsp.client| object, or list
+      • {client_id}  (number|table) id or |vim.lsp.client| object, or list
                      thereof
       • {force}      (boolean|nil) shutdown forcefully
 
@@ -1431,8 +1431,8 @@ apply_text_document_edit({text_document_edit}, {index}, {offset_encoding})
     document.
 
     Parameters: ~
-      • {text_document_edit}  (table) a `TextDocumentEdit` object
-      • {index}               (number) Optional index of the edit, if from a
+      • {text_document_edit}  (table) : a `TextDocumentEdit` object
+      • {index}               (number) : Optional index of the edit, if from a
                               list of edits (or nil, if not from a list)
 
     See also: ~
@@ -1483,8 +1483,8 @@ character_offset({buf}, {row}, {col}, {offset_encoding})
 
     Parameters: ~
       • {buf}              (number) buffer number (0 for current)
-      • {row}              0-indexed line
-      • {col}              0-indexed byte offset in line
+      • {row}              (indexed) line
+      • {col}              (indexed) byte offset in line
       • {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of `buf`
 
@@ -1515,14 +1515,14 @@ convert_signature_help_to_markdown_lines({signature_help}, {ft}, {triggers})
     Converts `textDocument/SignatureHelp` response to markdown lines.
 
     Parameters: ~
-      • {signature_help}  Response of `textDocument/SignatureHelp`
-      • {ft}              optional filetype that will be use as the `lang` for
-                          the label markdown code block
-      • {triggers}        optional list of trigger characters from the lsp
+      • {signature_help}  (Response) of `textDocument/SignatureHelp`
+      • {ft}              (optional) filetype that will be use as the `lang`
+                          for the label markdown code block
+      • {triggers}        (optional) list of trigger characters from the lsp
                           server. used to better determine parameter offsets
 
     Return: ~
-        (list) of lines of converted markdown.
+        list of lines of converted markdown.
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
@@ -1544,7 +1544,7 @@ get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
     Returns indentation size.
 
     Parameters: ~
-      • {bufnr}  (number|nil) Buffer handle, defaults to current
+      • {bufnr}  (number|nil) : Buffer handle, defaults to current
 
     Return: ~
         (number) indentation size
@@ -1558,7 +1558,7 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
+      • {offset_encoding}  ("utf-8"|"utf-16"|"utf-32")
       • {reuse_win}        (boolean|nil) Jump to existing window if buffer is
                            already open.
 
@@ -1585,8 +1585,8 @@ lookup_section({settings}, {section})          *vim.lsp.util.lookup_section()*
     Helper function to return nested values in language server settings
 
     Parameters: ~
-      • {settings}  a table of language server settings
-      • {section}   a string indicating the field of the settings table
+      • {settings}  (a) table of language server settings
+      • {section}   (a) string indicating the field of the settings table
 
     Return: ~
         (table or string) The value of settings accessed via section
@@ -1630,13 +1630,13 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
     similar to |vim.lsp.util.make_range_params()|.
 
     Parameters: ~
-      • {start_pos}        number[]|nil {row, col} mark-indexed position.
+      • {start_pos}        (number[]|nil) {row, col} mark-indexed position.
                            Defaults to the start of the last visual selection.
-      • {end_pos}          number[]|nil {row, col} mark-indexed position.
+      • {end_pos}          (number[]|nil) {row, col} mark-indexed position.
                            Defaults to the end of the last visual selection.
       • {bufnr}            (number|nil) buffer handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
+      • {offset_encoding}  ("utf-8"|"utf-16"|"utf-32"|nil) defaults to
                            `offset_encoding` of first client of `bufnr`
 
     Return: ~
@@ -1649,7 +1649,7 @@ make_position_params({window}, {offset_encoding})
     cursor position.
 
     Parameters: ~
-      • {window}           (number|nil) window handle or 0 for current,
+      • {window}           (number|nil) : window handle or 0 for current,
                            defaults to current
       • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of buffer of
@@ -1669,9 +1669,9 @@ make_range_params({window}, {offset_encoding})
     `textDocument/rangeFormatting`.
 
     Parameters: ~
-      • {window}           (number|nil) window handle or 0 for current,
+      • {window}           (number|nil) : window handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
+      • {offset_encoding}  ("utf-8"|"utf-16"|"utf-32"|nil) defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
 
@@ -1684,7 +1684,7 @@ make_text_document_params({bufnr})
     Creates a `TextDocumentIdentifier` object for the current buffer.
 
     Parameters: ~
-      • {bufnr}  (number|nil) Buffer handle, defaults to current
+      • {bufnr}  (number|nil) : Buffer handle, defaults to current
 
     Return: ~
         `TextDocumentIdentifier`
@@ -1739,7 +1739,7 @@ parse_snippet({input})                          *vim.lsp.util.parse_snippet()*
       • {input}  (string) unparsed snippet
 
     Return: ~
-        (string) parsed snippet
+        string parsed snippet
 
 preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
     Previews a location in a floating window
@@ -1750,7 +1750,7 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
       definition)
 
     Parameters: ~
-      • {location}  a single `Location` or `LocationLink`
+      • {location}  (a) single `Location` or `LocationLink`
 
     Return: ~
         (bufnr,winnr) buffer and window number of floating window or nil
@@ -1770,7 +1770,7 @@ set_lines({lines}, {A}, {B}, {new_lines})           *vim.lsp.util.set_lines()*
       • {lines}      (table) Original list of strings
       • {A}          (table) Start position; a 2-tuple of {line, col} numbers
       • {B}          (table) End position; a 2-tuple of {line, col} numbers
-      • {new_lines}  A list of strings to replace the original
+      • {new_lines}  (A) list of strings to replace the original
 
     Return: ~
         (table) The modified {lines} object
@@ -1781,7 +1781,7 @@ show_document({location}, {offset_encoding}, {opts})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
+      • {offset_encoding}  ("utf-8"|"utf-16"|"utf-32")
       • {opts}             (table|nil) options
                            • reuse_win (boolean) Jump to existing window if
                              buffer is already open.
@@ -1805,7 +1805,7 @@ stylize_markdown({bufnr}, {contents}, {opts})
 
     Parameters: ~
       • {contents}  (table) of lines to show in window
-      • {opts}      dictionary with optional fields
+      • {opts}      (dictionary) with optional fields
                     • height of floating window
                     • width of floating window
                     • wrap_at character to wrap at for computing height
@@ -1822,7 +1822,7 @@ symbols_to_items({symbols}, {bufnr})         *vim.lsp.util.symbols_to_items()*
     Converts symbols to quickfix list items.
 
     Parameters: ~
-      • {symbols}  DocumentSymbol[] or SymbolInformation[]
+      • {symbols}  (DocumentSymbol[]) or SymbolInformation[]
 
               *vim.lsp.util.text_document_completion_list_to_complete_items()*
 text_document_completion_list_to_complete_items({result}, {prefix})
@@ -1830,7 +1830,7 @@ text_document_completion_list_to_complete_items({result}, {prefix})
     vim-compatible |complete-items|.
 
     Parameters: ~
-      • {result}  The result of a `textDocument/completion` call, e.g. from
+      • {result}  (The) result of a `textDocument/completion` call, e.g. from
                   |vim.lsp.buf.completion()|, which may be one of
                   `CompletionItem[]`, `CompletionList` or `null`
       • {prefix}  (string) the prefix to filter the completion items
@@ -1930,7 +1930,7 @@ notify({method}, {params})                              *vim.lsp.rpc.notify()*
 
     Parameters: ~
       • {method}  (string) The invoked LSP method
-      • {params}  (table|nil) Parameters for the invoked LSP method
+      • {params}  (table|nil) : Parameters for the invoked LSP method
 
     Return: ~
         (bool) `true` if notification could be sent, `false` if not
@@ -1959,7 +1959,7 @@ rpc_response_error({code}, {message}, {data})
       • {code}     (number) RPC error code defined in
                    `vim.lsp.protocol.ErrorCodes`
       • {message}  (string|nil) arbitrary message to send to server
-      • {data}     any|nil arbitrary data to send to server
+      • {data}     (any|nil) arbitrary data to send to server
 
                                                          *vim.lsp.rpc.start()*
 start({cmd}, {cmd_args}, {dispatchers}, {extra_spawn_params})
@@ -2012,7 +2012,7 @@ compute_diff({___MissingCloseParenHere___})
       • {offset_encoding}  (string) encoding requested by language server
 
     Return: ~
-        (table) TextDocumentContentChangeEvent see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentContentChangeEvent
+        table TextDocumentContentChangeEvent see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentContentChangeEvent
 
 
 ==============================================================================

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1340,7 +1340,7 @@ cmd({command})                                                     *vim.cmd()*
 <
 
     Parameters: ~
-      • {command}  string|table Command(s) to execute. If a string, executes
+      • {command}  (string|table) Command(s) to execute. If a string, executes
                    multiple lines of Vim script at once. In this case, it is
                    an alias to |nvim_exec()|, where `output` is set to false.
                    Thus it works identical to |:source|. If a table, executes
@@ -1373,13 +1373,13 @@ deprecate({name}, {alternative}, {version}, {plugin}, {backtrace})
     Display a deprecation notification to the user.
 
     Parameters: ~
-      • {name}         string Deprecated function.
+      • {name}         (string) Deprecated function.
       • {alternative}  (string|nil) Preferred alternative function.
-      • {version}      string Version in which the deprecated function will be
-                       removed.
-      • {plugin}       string|nil Plugin name that the function will be
+      • {version}      (string) Version in which the deprecated function will
+                       be removed.
+      • {plugin}       (string|nil) Plugin name that the function will be
                        removed from. Defaults to "Nvim".
-      • {backtrace}    boolean|nil Prints backtrace. Defaults to true.
+      • {backtrace}    (boolean|nil) Prints backtrace. Defaults to true.
 
 inspect({object}, {options})                                   *vim.inspect()*
     Gets a human-readable representation of the given object.
@@ -1428,11 +1428,11 @@ on_key({fn}, {ns_id})                                           *vim.on_key()*
         {fn} will receive the keys after mappings have been evaluated
 
     Parameters: ~
-      • {fn}     (function) Callback function. It should take one string
+      • {fn}     (function) : Callback function. It should take one string
                  argument. On each key press, Nvim passes the key char to
                  fn(). |i_CTRL-V| If {fn} is nil, it removes the callback for
                  the associated {ns_id}
-      • {ns_id}  number? Namespace ID. If nil or 0, generates and returns a
+      • {ns_id}  (number?) Namespace ID. If nil or 0, generates and returns a
                  new |nvim_create_namespace()| id.
 
     Return: ~
@@ -1460,16 +1460,16 @@ paste({lines}, {phase})                                          *vim.paste()*
 <
 
     Parameters: ~
-      • {lines}  string[] # |readfile()|-style list of lines to paste.
+      • {lines}  (string[]) # |readfile()|-style list of lines to paste.
                  |channel-lines|
-      • {phase}  paste_phase -1: "non-streaming" paste: the call contains all
+      • {phase}  (pastephase) -1: "non-streaming" paste: the call contains all
                  lines. If paste is "streamed", `phase` indicates the stream state:
                  • 1: starts the paste (exactly once)
                  • 2: continues the paste (zero or more times)
                  • 3: ends the paste (exactly once)
 
     Return: ~
-        (boolean) # false if client should cancel the paste.
+        boolean # false if client should cancel the paste.
 
     See also: ~
         |paste| @alias paste_phase -1 | 1 | 2 | 3
@@ -1481,7 +1481,7 @@ pretty_print({...})                                       *vim.pretty_print()*
 <
 
     Return: ~
-        any # given arguments.
+        (any) # given arguments.
 
     See also: ~
         |vim.inspect()|
@@ -1492,9 +1492,9 @@ region({bufnr}, {pos1}, {pos2}, {regtype}, {inclusive})         *vim.region()*
 
     Parameters: ~
       • {bufnr}      (number) of buffer
-      • {pos1}       integer[] (line, column) tuple marking beginning of
+      • {pos1}       (integer[]) (line, column) tuple marking beginning of
                      region
-      • {pos2}       integer[] (line, column) tuple marking end of region
+      • {pos2}       (integer[]) (line, column) tuple marking end of region
       • {regtype}    (string) type of selection, see |setreg()|
       • {inclusive}  (boolean) indicating whether the selection is
                      end-inclusive
@@ -1526,11 +1526,11 @@ inspect_pos({bufnr}, {row}, {col}, {filter})               *vim.inspect_pos()*
     Can also be pretty-printed with `:Inspect!`.                   *:Inspect!*
 
     Parameters: ~
-      • {bufnr}   (number|nil) defaults to the current buffer
-      • {row}     (number|nil) row to inspect, 0-based. Defaults to the row of
-                  the current cursor
-      • {col}     (number|nil) col to inspect, 0-based. Defaults to the col of
-                  the current cursor
+      • {bufnr}   (number) defaults to the current buffer
+      • {row}     (number) row to inspect, 0-based. Defaults to the row of the
+                  current cursor
+      • {col}     (number) col to inspect, 0-based. Defaults to the col of the
+                  current cursor
       • {filter}  (table|nil) a table with key-value pairs to filter the items
                   • syntax (boolean): include syntax based highlight groups
                     (defaults to true)
@@ -1559,11 +1559,11 @@ show_pos({bufnr}, {row}, {col}, {filter})                     *vim.show_pos()*
     Can also be shown with `:Inspect`.                              *:Inspect*
 
     Parameters: ~
-      • {bufnr}   (number|nil) defaults to the current buffer
-      • {row}     (number|nil) row to inspect, 0-based. Defaults to the row of
-                  the current cursor
-      • {col}     (number|nil) col to inspect, 0-based. Defaults to the col of
-                  the current cursor
+      • {bufnr}   (number) defaults to the current buffer
+      • {row}     (number) row to inspect, 0-based. Defaults to the row of the
+                  current cursor
+      • {col}     (number) col to inspect, 0-based. Defaults to the col of the
+                  current cursor
       • {filter}  (table|nil) see |vim.inspect_pos()|
 
 
@@ -1575,8 +1575,8 @@ deep_equal({a}, {b})                                        *vim.deep_equal()*
     Tables are compared recursively unless they both provide the `eq` metamethod. All other types are compared using the equality `==` operator.
 
     Parameters: ~
-      • {a}  any First value
-      • {b}  any Second value
+      • {a}  (any) First value
+      • {b}  (any) Second value
 
     Return: ~
         (boolean) `true` if values are equals, else `false`
@@ -1589,10 +1589,10 @@ deepcopy({orig})                                              *vim.deepcopy()*
     not copied and will throw an error.
 
     Parameters: ~
-      • {orig}  (table) Table to copy
+      • {orig}  (T) Table to copy
 
     Return: ~
-        (table) Table of copied keys and (nested) values.
+        (T) Table of copied keys and (nested) values.
 
 defaulttable({create})                                    *vim.defaulttable()*
     Creates a table whose members are automatically created when accessed, if
@@ -1649,7 +1649,7 @@ is_callable({f})                                           *vim.is_callable()*
     Returns true if object `f` can be called as a function.
 
     Parameters: ~
-      • {f}  any Any object
+      • {f}  (any) Any object
 
     Return: ~
         (boolean) `true` if `f` is callable, else `false`
@@ -1660,13 +1660,13 @@ list_extend({dst}, {src}, {start}, {finish})               *vim.list_extend()*
     NOTE: This mutates dst!
 
     Parameters: ~
-      • {dst}     (table) List which will be modified and appended to
+      • {dst}     (T) List which will be modified and appended to
       • {src}     (table) List from which values will be inserted
       • {start}   (number|nil) Start index on src. Defaults to 1
       • {finish}  (number|nil) Final index on src. Defaults to `#src`
 
     Return: ~
-        (table) dst
+        (T) dst
 
     See also: ~
         |vim.tbl_extend()|
@@ -1702,7 +1702,7 @@ spairs({t})                                                     *vim.spairs()*
       • {t}  (table) List-like table
 
     Return: ~
-        iterator over sorted keys and their values
+        (iterator) over sorted keys and their values
 
     See also: ~
         Based on https://github.com/premake/premake-core/blob/master/src/base/table.lua
@@ -1728,7 +1728,7 @@ split({s}, {sep}, {kwargs})                                      *vim.split()*
                     front and back of the list
 
     Return: ~
-        string[] List of split components
+        (string[]) List of split components
 
     See also: ~
         |vim.gsplit()|
@@ -1760,7 +1760,7 @@ tbl_contains({t}, {value})                                *vim.tbl_contains()*
 
     Parameters: ~
       • {t}      (table) Table to check
-      • {value}  any Value to compare
+      • {value}  (any) Value to compare
 
     Return: ~
         (boolean) `true` if `t` contains `value`
@@ -1792,7 +1792,7 @@ tbl_deep_extend({behavior}, {...})                     *vim.tbl_deep_extend()*
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
-      • {...}       (table) Two or more map-like tables
+      • {...}       (T) Two or more map-like tables
 
     Return: ~
         (table) Merged table
@@ -1856,7 +1856,7 @@ tbl_get({o}, {...})                                            *vim.tbl_get()*
                index the table
 
     Return: ~
-        any Nested value indexed by key (if it exists), else nil
+        (any) Nested value indexed by key (if it exists), else nil
 
 tbl_isempty({t})                                           *vim.tbl_isempty()*
     Checks if a table is empty.
@@ -2285,10 +2285,10 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
 <
 
     Parameters: ~
-      • {mode}  string|table Same mode short names as |nvim_set_keymap()|. Can
-                also be list of modes to create mapping on multiple modes.
+      • {mode}  (string|table) Same mode short names as |nvim_set_keymap()|.
+                Can also be list of modes to create mapping on multiple modes.
       • {lhs}   (string) Left-hand side |{lhs}| of the mapping.
-      • {rhs}   string|function Right-hand side |{rhs}| of the mapping. Can
+      • {rhs}   (string|function) Right-hand side |{rhs}| of the mapping. Can
                 also be a Lua function.
       • {opts}  (table|nil) A table of |:map-arguments|.
                 • Accepts options accepted by the {opts} parameter in
@@ -2335,7 +2335,7 @@ dir({path}, {opts})                                             *vim.fs.dir()*
                   current directory. Only useful when depth > 1
 
     Return: ~
-        Iterator over files and directories in {path}. Each iteration yields
+        (Iterator) over files and directories in {path}. Each iteration yields
         two values: name and type. Each "name" is the basename of the file or
         directory relative to {path}. Type is one of "file" or "directory".
 
@@ -2458,7 +2458,7 @@ trust({opts})                                             *vim.secure.trust()*
     The trust database is located at |$XDG_STATE_HOME|/nvim/trust.
 
     Parameters: ~
-      • {opts}  (table)
+      • {opts}  (table) :
                 • action (string): "allow" to add a file to the trust database
                   and trust it, "deny" to add a file to the trust database and
                   deny it, "remove" to remove file from the trust database

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -489,7 +489,7 @@ get_captures_at_cursor({winnr})
       • {winnr}  (integer|nil) Window handle or 0 for current window (default)
 
     Return: ~
-        string[] List of capture names
+        (string[]) List of capture names
 
                                         *vim.treesitter.get_captures_at_pos()*
 get_captures_at_pos({bufnr}, {row}, {col})
@@ -505,8 +505,8 @@ get_captures_at_pos({bufnr}, {row}, {col})
       • {col}    (integer) Position column
 
     Return: ~
-        table[] List of captures `{ capture = "capture name", metadata = { ...
-        } }`
+        (table[]) List of captures `{ capture = "capture name", metadata = {
+        ... } }`
 
 get_node_at_cursor({winnr})              *vim.treesitter.get_node_at_cursor()*
     Returns the smallest named node under the cursor
@@ -531,13 +531,13 @@ get_node_at_pos({bufnr}, {row}, {col}, {opts})
                    (default true)
 
     Return: ~
-        |TSNode||nil under the cursor
+        (TSNode|nil) under the cursor
 
 get_node_range({node_or_range})              *vim.treesitter.get_node_range()*
     Returns the node's range or an unpacked range table
 
     Parameters: ~
-      • {node_or_range}  (|TSNode||table) Node or table of positions
+      • {node_or_range}  (TSNode|table) Node or table of positions
 
     Return: ~
         (integer) start_row
@@ -559,7 +559,7 @@ get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
       • {opts}   (table|nil) Options to pass to the created language tree
 
     Return: ~
-        |LanguageTree| object to use for parsing
+        ( LanguageTree ) object to use for parsing
 
                                           *vim.treesitter.get_string_parser()*
 get_string_parser({str}, {lang}, {opts})
@@ -571,14 +571,14 @@ get_string_parser({str}, {lang}, {opts})
       • {opts}  (table|nil) Options to pass to the created language tree
 
     Return: ~
-        |LanguageTree| object to use for parsing
+        ( LanguageTree ) object to use for parsing
 
 is_ancestor({dest}, {source})                   *vim.treesitter.is_ancestor()*
     Determines whether a node is the ancestor of another
 
     Parameters: ~
-      • {dest}    |TSNode| Possible ancestor
-      • {source}  |TSNode| Possible descendant
+      • {dest}    (TSNode) Possible ancestor
+      • {source}  (TSNode) Possible descendant
 
     Return: ~
         (boolean) True if {dest} is an ancestor of {source}
@@ -588,7 +588,7 @@ is_in_node_range({node}, {line}, {col})
     Determines whether (line, col) position is in node range
 
     Parameters: ~
-      • {node}  |TSNode| defining the range
+      • {node}  (TSNode) defining the range
       • {line}  (integer) Line (0-based)
       • {col}   (integer) Column (0-based)
 
@@ -599,7 +599,7 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
     Determines if a node contains a range
 
     Parameters: ~
-      • {node}   |TSNode|
+      • {node}   (TSNode)
       • {range}  (table)
 
     Return: ~
@@ -712,8 +712,8 @@ add_directive({name}, {handler}, {force})
 
     Parameters: ~
       • {name}     (string) Name of the directive, without leading #
-      • {handler}  function(match:table<string,|TSNode|>, pattern:string,
-                   bufnr:number, predicate:string[], metadata:table)
+      • {handler}  (function(match:table<string,TSNode>, pattern:string,
+                   bufnr:number, predicate:string[], metadata:table))
                    • match: see |treesitter-query|
                      • node-level data are accessible via `match[capture_id]`
 
@@ -729,8 +729,8 @@ add_predicate({name}, {handler}, {force})
 
     Parameters: ~
       • {name}     (string) Name of the predicate, without leading #
-      • {handler}  function(match:table<string,|TSNode|>, pattern:string,
-                   bufnr:number, predicate:string[])
+      • {handler}  (function(match:table<string,TSNode>, pattern:string,
+                   bufnr:number, predicate:string[]))
                    • see |vim.treesitter.query.add_directive()| for argument
                      meanings
       • {force}    (boolean)
@@ -740,7 +740,7 @@ get_node_text({node}, {source}, {opts})
     Gets the text corresponding to a given node
 
     Parameters: ~
-      • {node}    |TSNode|
+      • {node}    (TSNode)
       • {source}  (number|string) Buffer or string from which the {node} is
                   extracted
       • {opts}    (table|nil) Optional parameters.
@@ -761,7 +761,7 @@ get_query({lang}, {query_name})             *vim.treesitter.query.get_query()*
       • {query_name}  (string) Name of the query (e.g. "highlights")
 
     Return: ~
-        Query|nil Parsed query
+        (Query|nil) Parsed query
 
                                       *vim.treesitter.query.get_query_files()*
 get_query_files({lang}, {query_name}, {is_included})
@@ -774,20 +774,20 @@ get_query_files({lang}, {query_name}, {is_included})
                        as `nil`
 
     Return: ~
-        string[] query_files List of files to load for given query and
+        (string[]) query_files List of files to load for given query and
         language
 
 list_directives()                     *vim.treesitter.query.list_directives()*
     Lists the currently available directives to use in queries.
 
     Return: ~
-        string[] List of supported directives.
+        (string[]) List of supported directives.
 
 list_predicates()                     *vim.treesitter.query.list_predicates()*
     Lists the currently available predicates to use in queries.
 
     Return: ~
-        string[] List of supported predicates.
+        (string[]) List of supported predicates.
 
 parse_query({lang}, {query})              *vim.treesitter.query.parse_query()*
     Parse {query} as a string. (If the query is in a file, the caller should
@@ -806,7 +806,7 @@ parse_query({lang}, {query})              *vim.treesitter.query.parse_query()*
       • {query}  (string) Query in s-expr syntax
 
     Return: ~
-        Query Parsed query
+        ( Query ) Parsed query
 
                                                        *Query:iter_captures()*
 Query:iter_captures({self}, {node}, {source}, {start}, {stop})
@@ -834,7 +834,7 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-      • {node}    |TSNode| under which the search will occur
+      • {node}    (TSNode) under which the search will occur
       • {source}  (integer|string) Source buffer or string to extract text
                   from
       • {start}   (number) Starting line for the search
@@ -842,7 +842,7 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop})
       • {self}
 
     Return: ~
-        (fun(): integer, TSNode, TSMetadata ): capture id, capture node, metadata
+        (fun(): integer, TSNode, TSMetadata ) : capture id, capture node, metadata
 
                                                         *Query:iter_matches()*
 Query:iter_matches({self}, {node}, {source}, {start}, {stop})
@@ -868,14 +868,14 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
 <
 
     Parameters: ~
-      • {node}    |TSNode| under which the search will occur
+      • {node}    (TSNode) under which the search will occur
       • {source}  (integer|string) Source buffer or string to search
       • {start}   (integer) Starting line for the search
       • {stop}    (integer) Stopping line for the search (end-exclusive)
       • {self}
 
     Return: ~
-        (fun(): integer, table<integer,TSNode>, table): pattern id, match,
+        (fun(): integer, table<integer,TSNode>, table) : pattern id, match,
         metadata
 
                                             *vim.treesitter.query.set_query()*
@@ -898,12 +898,12 @@ new({tree}, {opts})                         *vim.treesitter.highlighter.new()*
     Creates a new highlighter using
 
     Parameters: ~
-      • {tree}  |LanguageTree| parser object to use for highlighting
+      • {tree}  ( LanguageTree ) parser object to use for highlighting
       • {opts}  (table|nil) Configuration of the highlighter:
                 • queries table overwrite queries used by the highlighter
 
     Return: ~
-        TSHighlighter Created highlighter object
+        ( TSHighlighter ) Created highlighter object
 
 TSHighlighter:destroy({self})                        *TSHighlighter:destroy()*
     Removes all internal references to the highlighter
@@ -925,7 +925,7 @@ LanguageTree:contains({self}, {range})               *LanguageTree:contains()*
     Determines whether {range} is contained in the |LanguageTree|.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (Range) `{ start_line, start_col, end_line, end_col }`
       • {self}
 
     Return: ~
@@ -946,7 +946,7 @@ LanguageTree:for_each_child({self}, {fn}, {include_self})
     Invokes the callback for each |LanguageTree| and its children recursively
 
     Parameters: ~
-      • {fn}            fun(tree: LanguageTree, lang: string)
+      • {fn}            (fun(tree: LanguageTree, lang: string))
       • {include_self}  (boolean|nil) Whether to include the invoking tree in
                         the results
       • {self}
@@ -957,7 +957,7 @@ LanguageTree:for_each_tree({self}, {fn})        *LanguageTree:for_each_tree()*
     Note: This includes the invoking tree's child trees as well.
 
     Parameters: ~
-      • {fn}    fun(tree: TSTree, ltree: LanguageTree)
+      • {fn}    (fun(tree: TSTree, ltree: LanguageTree))
       • {self}
 
 LanguageTree:included_regions({self})        *LanguageTree:included_regions()*
@@ -990,25 +990,25 @@ LanguageTree:language_for_range({self}, {range})
     Gets the appropriate language that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (Range) `{ start_line, start_col, end_line, end_col }`
       • {self}
 
     Return: ~
-        |LanguageTree| Managing {range}
+        ( LanguageTree ) Managing {range}
 
                                          *LanguageTree:named_node_for_range()*
 LanguageTree:named_node_for_range({self}, {range}, {opts})
     Gets the smallest named node that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (Range) `{ start_line, start_col, end_line, end_col }`
       • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
       • {self}
 
     Return: ~
-        |TSNode||nil Found node
+        (TSNode|nil) Found node
 
 LanguageTree:parse({self})                              *LanguageTree:parse()*
     Parses all defined regions using a treesitter parser for the language this
@@ -1019,7 +1019,7 @@ LanguageTree:parse({self})                              *LanguageTree:parse()*
       • {self}
 
     Return: ~
-        TSTree[]
+        (TSTree[])
         (table|nil) Change list
 
 LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
@@ -1050,14 +1050,14 @@ LanguageTree:tree_for_range({self}, {range}, {opts})
     Gets the tree that contains {range}.
 
     Parameters: ~
-      • {range}  (table) `{ start_line, start_col, end_line, end_col }`
+      • {range}  (Range) `{ start_line, start_col, end_line, end_col }`
       • {opts}   (table|nil) Optional keyword arguments:
                  • ignore_injections boolean Ignore injected languages
                    (default true)
       • {self}
 
     Return: ~
-        TSTree|nil
+        (TSTree|nil)
 
 LanguageTree:trees({self})                              *LanguageTree:trees()*
     Returns all trees this language tree contains. Does not include child
@@ -1081,6 +1081,6 @@ new({source}, {lang}, {opts})              *vim.treesitter.languagetree.new()*
                     per language.
 
     Return: ~
-        |LanguageTree| parser object
+        ( LanguageTree ) parser object
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:


### PR DESCRIPTION
## Problem

EmmyLua allows fairly complex types. e.g.:

```lua
---@param a MyClass | table<integer,string[]> | fun(a: boolean): string, Myclass Some description
```

However, currently our documentation generator assumes the type is a contiguous string with no whitespace.

## Solution

Implement a EmmyLua type parser for extracting types.

This will also allow us to easier augment the types for better documentation. E.g. `MyUndocumentedClass[] -> table`.

