### PR TITLE
ci: automatically draft all conflicting pull requests

### DIFF
--- a/.github/workflows/draft_prs.yml
+++ b/.github/workflows/draft_prs.yml
@@ -1,0 +1,13 @@
+name: Draft conflicting PRs
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: "echo run script"
+


### PR DESCRIPTION
A pull request that is conflicting cannot be ready for review since it
can't be merged. Signaling that a PR is ready for review when it isn't
also makes it more difficult to find the pull requests that are actually
ready for review.
