### PR TITLE
vim-patch:9.0.1291: Move language files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -692,6 +692,7 @@ local extension = {
   isc = 'monk',
   moo = 'moo',
   moon = 'moonscript',
+  move = 'move',
   mp = 'mp',
   mpiv = function(path, bufnr)
     return 'mp', function(b)

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -381,6 +381,7 @@ let s:filename_checks = {
     \ 'monk': ['file.isc', 'file.monk', 'file.ssc', 'file.tsc'],
     \ 'moo': ['file.moo'],
     \ 'moonscript': ['file.moon'],
+    \ 'move': ['file.move'],
     \ 'mp': ['file.mp', 'file.mpxl', 'file.mpiv', 'file.mpvi'],
     \ 'mplayerconf': ['mplayer.conf', '/.mplayer/config', 'any/.mplayer/config'],
     \ 'mrxvtrc': ['mrxvtrc', '.mrxvtrc'],


### PR DESCRIPTION
Problem:    Move language files are not recognized.
Solution:   Recognize Move language files. (Amaan Qureshi, closes vim/vim#11947)

https://github.com/vim/vim/commit/6642982beaf4f1f5164f0315a1b3e3c275156089

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
