### PR TITLE
ci(oldtest): make a copy of scripts of ci/common in testdir

### DIFF
--- a/src/nvim/testdir/runnvim.sh
+++ b/src/nvim/testdir/runnvim.sh
@@ -22,13 +22,12 @@ main() {(
     i=$(( i+1 ))
   done
 
-  export CI_DIR="$root/ci"
   BUILD_DIR="$(dirname "$nvim_prg")/.."
   export BUILD_DIR
   export FAILED=0
 
-  . "$CI_DIR/common/suite.sh"
-  . "$CI_DIR/common/test.sh"
+  . $(dirname $0)/suite.sh
+  . $(dirname $0)/test.sh
 
   # Redirect XDG_CONFIG_HOME so users local config doesn't interfere
   export XDG_CONFIG_HOME="$root"

--- a/src/nvim/testdir/suite.sh
+++ b/src/nvim/testdir/suite.sh
@@ -1,0 +1,36 @@
+# Test success marker. If END_MARKER file exists, we know that all tests
+# finished. If FAIL_SUMMARY_FILE exists we know that some tests failed, this
+# file will contain information about failed tests. Build is considered
+# successful if tests ended without any of them failing.
+END_MARKER="$BUILD_DIR/.tests_finished"
+FAIL_SUMMARY_FILE="$BUILD_DIR/.test_errors"
+
+fail() {
+  local test_name="$1"
+  local message="$2"
+
+  : "${message:=Test $test_name failed}"
+
+  local full_msg="$test_name :: $message"
+  echo "${full_msg}" >> "${FAIL_SUMMARY_FILE}"
+  echo "Failed: $full_msg"
+  export FAILED=1
+}
+
+ended_successfully() {
+  if test -f "${FAIL_SUMMARY_FILE}" ; then
+    echo 'Test failed, complete summary:'
+    cat "${FAIL_SUMMARY_FILE}"
+
+    if [[ "$GITHUB_ACTIONS" == "true" ]]; then
+        rm -f "$FAIL_SUMMARY_FILE"
+    fi
+
+    return 1
+  fi
+  if ! test -f "${END_MARKER}" ; then
+    echo 'ended_successfully called before end marker was touched'
+    return 1
+  fi
+  return 0
+}

--- a/src/nvim/testdir/test.sh
+++ b/src/nvim/testdir/test.sh
@@ -1,0 +1,82 @@
+. $(dirname $0)/suite.sh
+
+print_core() {
+  local app="$1"
+  local core="$2"
+  if test "$app" = quiet ; then
+    echo "Found core $core"
+    return 0
+  fi
+  echo "======= Core file $core ======="
+  if test "${CI_OS_NAME}" = osx ; then
+    lldb -Q -o "bt all" -f "${app}" -c "${core}"
+  else
+    gdb -n -batch -ex 'thread apply all bt full' "${app}" -c "${core}"
+  fi
+}
+
+check_core_dumps() {
+  local del=
+  if test "$1" = "--delete" ; then
+    del=1
+    shift
+  fi
+  local app="${1:-${BUILD_DIR}/bin/nvim}"
+  local cores
+  if test "${CI_OS_NAME}" = osx ; then
+    cores="$(find /cores/ -type f -print)"
+    local _sudo='sudo'
+  else
+    cores="$(find ./ -type f \( -name 'core.*' -o -name core -o -name nvim.core \) -print)"
+    local _sudo=
+  fi
+
+  if test -z "${cores}" ; then
+    return
+  fi
+  local core
+  for core in $cores; do
+    if test "$del" = "1" ; then
+      print_core "$app" "$core" >&2
+      "$_sudo" rm "$core"
+    else
+      print_core "$app" "$core"
+    fi
+  done
+  if test "$app" != quiet ; then
+    fail 'cores' 'Core dumps found'
+  fi
+}
+
+check_logs() {
+  # Iterate through each log to remove an useless warning.
+  # shellcheck disable=SC2044
+  for log in $(find "${1}" -type f -name "${2}"); do
+    sed -i "${log}" \
+      -e '/Warning: noted but unhandled ioctl/d' \
+      -e '/could cause spurious value errors to appear/d' \
+      -e '/See README_MISSING_SYSCALL_OR_IOCTL for guidance/d'
+  done
+
+  # Now do it again, but only consider files with size > 0.
+  local err=""
+  # shellcheck disable=SC2044
+  for log in $(find "${1}" -type f -name "${2}" -size +0); do
+    cat "${log}"
+    err=1
+    rm "${log}"
+  done
+  if test -n "${err}" ; then
+    fail 'logs' 'Runtime errors detected.'
+  fi
+}
+
+valgrind_check() {
+  check_logs "${1}" "valgrind-*"
+}
+
+check_sanitizer() {
+  if test -n "${CLANG_SANITIZER}"; then
+    check_logs "${1}" "*san.*" | cat
+  fi
+}


### PR DESCRIPTION
Having separate copies makes it easier to not accidentally break
something when modifying the scripts.
