### PR TITLE
ci: remove unnecessary END_MARKER variable

### DIFF
--- a/ci/common/suite.sh
+++ b/ci/common/suite.sh
@@ -1,8 +1,6 @@
-# Test success marker. If END_MARKER file exists, we know that all tests 
-# finished. If FAIL_SUMMARY_FILE exists we know that some tests failed, this 
-# file will contain information about failed tests. Build is considered 
-# successful if tests ended without any of them failing.
-END_MARKER="$BUILD_DIR/.tests_finished"
+# If FAIL_SUMMARY_FILE exists we know that some tests failed, this file will
+# contain information about failed tests. Build is considered successful if
+# tests ended without any of them failing.
 FAIL_SUMMARY_FILE="$BUILD_DIR/.test_errors"
 
 fail() {
@@ -26,10 +24,6 @@ ended_successfully() {
         rm -f "$FAIL_SUMMARY_FILE"
     fi
 
-    return 1
-  fi
-  if ! test -f "${END_MARKER}" ; then
-    echo 'ended_successfully called before end marker was touched'
     return 1
   fi
   return 0

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -35,8 +35,6 @@ build_nvim() {
   cd "${CI_BUILD_DIR}"
 }
 
-rm -f "$END_MARKER"
-
 # Run all tests (with some caveats) if no input argument is given
 if (($# == 0)); then
   tests=('build_nvim')
@@ -58,7 +56,6 @@ for i in "${tests[@]}"; do
   eval "$i" || fail "$i"
 done
 
-touch "${END_MARKER}"
 ended_successfully
 
 if [[ -s "${GCOV_ERROR_FILE}" ]]; then


### PR DESCRIPTION
The tests end when they end, we don't need to keep track of it.
