### PR TITLE
fix(filetype): make vim.filetype.match() work with contents only

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2449,6 +2449,7 @@ local function match_pattern(name, path, tail, pat)
       return false
     end
   end
+
   -- If the pattern contains a / match against the full path, otherwise just the tail
   local fullpat = '^' .. pat .. '$'
   local matches
@@ -2526,64 +2527,64 @@ function M.match(args)
     name = api.nvim_buf_get_name(bufnr)
   end
 
-  if name then
-    name = normalize_path(name)
-  end
-
   local ft, on_detect
 
-  -- First check for the simple case where the full path exists as a key
-  local path = vim.fn.fnamemodify(name, ':p')
-  ft, on_detect = dispatch(filename[path], path, bufnr)
-  if ft then
-    return ft, on_detect
-  end
+  if name then
+    name = normalize_path(name)
 
-  -- Next check against just the file name
-  local tail = vim.fn.fnamemodify(name, ':t')
-  ft, on_detect = dispatch(filename[tail], path, bufnr)
-  if ft then
-    return ft, on_detect
-  end
-
-  -- Next, check the file path against available patterns with non-negative priority
-  local j = 1
-  for i, v in ipairs(pattern_sorted) do
-    local k = next(v)
-    local opts = v[k][2]
-    if opts.priority < 0 then
-      j = i
-      break
+    -- First check for the simple case where the full path exists as a key
+    local path = vim.fn.fnamemodify(name, ':p')
+    ft, on_detect = dispatch(filename[path], path, bufnr)
+    if ft then
+      return ft, on_detect
     end
 
-    local filetype = v[k][1]
-    local matches = match_pattern(name, path, tail, k)
-    if matches then
-      ft, on_detect = dispatch(filetype, path, bufnr, matches)
-      if ft then
-        return ft, on_detect
+    -- Next check against just the file name
+    local tail = vim.fn.fnamemodify(name, ':t')
+    ft, on_detect = dispatch(filename[tail], path, bufnr)
+    if ft then
+      return ft, on_detect
+    end
+
+    -- Next, check the file path against available patterns with non-negative priority
+    local j = 1
+    for i, v in ipairs(pattern_sorted) do
+      local k = next(v)
+      local opts = v[k][2]
+      if opts.priority < 0 then
+        j = i
+        break
+      end
+
+      local filetype = v[k][1]
+      local matches = match_pattern(name, path, tail, k)
+      if matches then
+        ft, on_detect = dispatch(filetype, path, bufnr, matches)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
-  end
 
-  -- Next, check file extension
-  local ext = vim.fn.fnamemodify(name, ':e')
-  ft, on_detect = dispatch(extension[ext], path, bufnr)
-  if ft then
-    return ft, on_detect
-  end
+    -- Next, check file extension
+    local ext = vim.fn.fnamemodify(name, ':e')
+    ft, on_detect = dispatch(extension[ext], path, bufnr)
+    if ft then
+      return ft, on_detect
+    end
 
-  -- Next, check patterns with negative priority
-  for i = j, #pattern_sorted do
-    local v = pattern_sorted[i]
-    local k = next(v)
+    -- Next, check patterns with negative priority
+    for i = j, #pattern_sorted do
+      local v = pattern_sorted[i]
+      local k = next(v)
 
-    local filetype = v[k][1]
-    local matches = match_pattern(name, path, tail, k)
-    if matches then
-      ft, on_detect = dispatch(filetype, path, bufnr, matches)
-      if ft then
-        return ft, on_detect
+      local filetype = v[k][1]
+      local matches = match_pattern(name, path, tail, k)
+      if matches then
+        ft, on_detect = dispatch(filetype, path, bufnr, matches)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
   end

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -94,6 +94,14 @@ describe('vim.filetype', function()
       return vim.filetype.match({ buf = 0 })
     ]])
   end)
+
+  it('works with contents #22180', function()
+    eq('sh', exec_lua [[
+      -- Needs to be set so detect#sh doesn't fail
+      vim.g.ft_ignore_pat = "\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$"
+      return vim.filetype.match({ contents = { '#!/usr/bin/env bash' } })
+    ]])
+  end)
 end)
 
 describe('filetype.lua', function()


### PR DESCRIPTION
Fixes #22180.