### PR TITLE
fix(rpc): ignore redraw events when exiting

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -247,7 +247,8 @@ static void parse_msgpack(Channel *channel)
   Unpacker *p = channel->rpc.unpacker;
   while (unpacker_advance(p)) {
     if (p->type == kMessageTypeRedrawEvent) {
-      if (ui_client_channel_id) {
+      // When exiting, ui_client_stop() has already been called, so don't handle UI events.
+      if (ui_client_channel_id && !exiting) {
         if (p->grid_line_event) {
           ui_client_event_raw_line(p->grid_line_event);
         } else if (p->ui_handler.fn != NULL && p->result.type == kObjectTypeArray) {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2407,6 +2407,11 @@ describe("TUI as a client", function()
       {3:-- TERMINAL --}                                    |
     ]]}
 
+    -- No heap-use-after-free when receiving UI events after deadly signal #22184
+    server:request('nvim_input', ('a'):rep(1000))
+    exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
+    screen:expect({any = '%[Process exited 1%]'})
+
     client_super:close()
     server:close()
   end)


### PR DESCRIPTION
When a TUI client has already stopped, handling UI events will cause a
heap-use-after-free, so ignore them.
