### PR TITLE
docs(maintain): add note on updating `luvref.txt`

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -69,6 +69,7 @@ Some can be auto-bumped by `scripts/bump_deps.lua`.
 * [LuaJIT](https://github.com/LuaJIT/LuaJIT)
 * [Lua](https://www.lua.org/download.html)
 * [Luv](https://github.com/luvit/luv)
+    * When bumping, also sync [our bundled documentation](https://github.com/neovim/neovim/blob/master/runtime/doc/luvref.txt) with [the upstream documentation](https://github.com/luvit/luv/blob/master/docs.md).
 * [gettext](https://ftp.gnu.org/pub/gnu/gettext/)
 * [libiconv](https://ftp.gnu.org/pub/gnu/libiconv)
 * [libtermkey](https://github.com/neovim/libtermkey)

--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -3888,11 +3888,11 @@ uv.metrics_idle_time()                                  *uv.metrics_idle_time()*
 ==============================================================================
 CREDITS                                                            *luv-credits*
 
-This document is a reformatted version of the LUV documentation, based on
-commit c51e705 (5 May 2022) of the luv repository
-https://github.com/luvit/luv/commit/c51e7052ec4f0a25058f70c1b4ee99dd36180e59.
+This document is a reformatted version of the LUV documentation, up-to-date
+with commit e8e7b7e (3 Feb 2023) of the luv repository
+https://github.com/luvit/luv/commit/e8e7b7e13225348a8806118a3ea9e021383a9536.
 
-Included from https://github.com/nanotee/luv-vimdocs with kind permission.
+Based on https://github.com/nanotee/luv-vimdocs with kind permission.
 
 
 vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Reminder to self that when we bump luv, we should (manually) update our bundled documentation from upstream. (Easiest way is to check the commit log for https://github.com/luvit/luv/blob/master/docs.md and port each commit by hand.)