### PR TITLE
feat(treesitter): playground improvements

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -411,6 +411,7 @@ function M.show_tree(opts)
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'
+  vim.bo[b].filetype = 'query'
 
   local title = opts.title
   if not title then
@@ -424,9 +425,6 @@ function M.show_tree(opts)
   a.nvim_buf_set_name(b, title)
 
   pg:draw(b)
-
-  vim.fn.matchadd('Comment', '\\[[0-9:-]\\+\\]')
-  vim.fn.matchadd('String', '".*"')
 
   a.nvim_buf_clear_namespace(buf, pg.ns, 0, -1)
   a.nvim_buf_set_keymap(b, 'n', '<CR>', '', {
@@ -467,6 +465,15 @@ function M.show_tree(opts)
         end_col = math.max(0, pos.end_col),
         hl_group = 'Visual',
       })
+
+      local topline, botline = vim.fn.line('w0', win), vim.fn.line('w$', win)
+
+      -- Move the cursor if highlighted range is completely out of view
+      if pos.lnum < topline and pos.end_lnum < topline then
+        a.nvim_win_set_cursor(win, { pos.end_lnum + 1, 0 })
+      elseif pos.lnum > botline and pos.end_lnum > botline then
+        a.nvim_win_set_cursor(win, { pos.lnum + 1, 0 })
+      end
     end,
   })
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -96,11 +96,13 @@ function M.get_parser(bufnr, lang, opts)
   if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
-  if lang == nil then
-    lang = a.nvim_buf_get_option(bufnr, 'filetype')
-  end
 
-  if parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
+  if parsers[bufnr] == nil then
+    lang = lang or a.nvim_buf_get_option(bufnr, 'filetype')
+    parsers[bufnr] = M._create_parser(bufnr, lang, opts)
+  elseif lang and parsers[bufnr]:lang() ~= lang then
+    -- Only try to create a new parser if lang is provided
+    -- and it doesn't match the stored parser
     parsers[bufnr] = M._create_parser(bufnr, lang, opts)
   end
 

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -82,7 +82,7 @@ describe('treesitter language API', function()
     command("set filetype=borklang")
     -- Should throw an error when filetype changes to borklang
     eq(".../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
-       pcall_err(exec_lua, "new_parser = vim.treesitter.get_parser(0)"))
+       pcall_err(exec_lua, "new_parser = vim.treesitter.get_parser(0, 'borklang')"))
   end)
 
   it('retrieve the tree given a range', function ()


### PR DESCRIPTION
- Render node ranges as virtual text
- Set `filettype=query`. The virtual text is to avoid parsing errors.
- Make sure highlighted text is always in view.
