### PR TITLE
ci: add individual timeout limits for all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,10 +266,12 @@ jobs:
 
       - if: matrix.flavor != 'tsan' && matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
         name: Unittests
+        timeout-minutes: 5
         run: ./ci/run_tests.sh unittests
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: Functionaltests
+        timeout-minutes: 15
         run: ./ci/run_tests.sh functionaltests
 
       - if: matrix.flavor != 'tsan' && (success() || failure() && steps.abort_job.outputs.status == 'success')
@@ -340,6 +342,7 @@ jobs:
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: Run functionaltests
+        timeout-minutes: 15
         run: cmake --build build --target functionaltest
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'


### PR DESCRIPTION
The CI somtimes freezes on a specific test, wasting 45 minutes for the
entire job. Adding a timeout of 15 minutes to functionaltest and 5
minutes to unittests will mitigate the problem.