### PR TITLE
refactor(ui): remove some superfluous redraw and ui_flush() calls 

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2740,14 +2740,12 @@ void do_autocmd_focusgained(bool gained)
 {
   static bool recursive = false;
   static Timestamp last_time = (time_t)0;
-  bool need_redraw = false;
 
   if (recursive) {
     return;  // disallow recursion
   }
   recursive = true;
-  need_redraw |= apply_autocmds((gained ? EVENT_FOCUSGAINED : EVENT_FOCUSLOST),
-                                NULL, NULL, false, curbuf);
+  apply_autocmds((gained ? EVENT_FOCUSGAINED : EVENT_FOCUSLOST), NULL, NULL, false, curbuf);
 
   // When activated: Check if any file was modified outside of Vim.
   // Only do this when not done within the last two seconds as:
@@ -2755,30 +2753,8 @@ void do_autocmd_focusgained(bool gained)
   //    has a granularity of 2 seconds.
   // 2. We could get multiple notifications in a row.
   if (gained && last_time + (Timestamp)2000 < os_now()) {
-    need_redraw = check_timestamps(true);
+    check_timestamps(true);
     last_time = os_now();
-  }
-
-  if (need_redraw) {
-    // Something was executed, make sure the cursor is put back where it
-    // belongs.
-    need_wait_return = false;
-
-    if (State & MODE_CMDLINE) {
-      redrawcmdline();
-    } else if ((State & MODE_NORMAL) || (State & MODE_INSERT)) {
-      if (must_redraw != 0) {
-        update_screen();
-      }
-
-      setcursor();
-    }
-
-    ui_flush();
-  }
-
-  if (need_maketitle) {
-    maketitle();
   }
 
   recursive = false;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7469,7 +7469,6 @@ void ex_execute(exarg_T *eap)
     if (eap->cmdidx == CMD_echomsg) {
       msg_ext_set_kind("echomsg");
       msg_attr(ga.ga_data, echo_attr);
-      ui_flush();
     } else if (eap->cmdidx == CMD_echoerr) {
       // We don't want to abort following commands, restore did_emsg.
       int save_did_emsg = did_emsg;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2150,8 +2150,7 @@ void ex_function(exarg_T *eap)
             }
           }
           msg_prt_line(FUNCLINE(fp, j), false);
-          ui_flush();                  // show a line at a time
-          os_breakcheck();
+          line_breakcheck();  // show multiple lines at a time!
         }
         if (!got_int) {
           msg_putchar('\n');

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1507,7 +1507,6 @@ void print_line(linenr_T lnum, int use_number, int list)
   print_line_no_prefix(lnum, use_number, list);
   if (save_silent) {
     msg_putchar('\n');
-    ui_flush();
     silent_mode = save_silent;
   }
   info_message = false;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4838,13 +4838,9 @@ static void ex_stop(exarg_T *eap)
   }
   apply_autocmds(EVENT_VIMSUSPEND, NULL, NULL, false, NULL);
 
-  // TODO(bfredl): the TUI should do this on suspend
-  ui_cursor_goto(Rows - 1, 0);
-  ui_call_grid_scroll(1, 0, Rows, 0, Columns, 1, 0);
+  ui_call_suspend();
   ui_flush();
-  ui_call_suspend();  // call machine specific function
 
-  ui_flush();
   maketitle();
   resettitle();  // force updating the title
   ui_refresh();  // may have resized window

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1549,7 +1549,6 @@ int do_set(char *arg, int opt_flags)
     silent_mode = false;
     info_message = true;        // use os_msg(), not os_errmsg()
     msg_putchar('\n');
-    ui_flush();
     silent_mode = true;
     info_message = false;       // use os_msg(), not os_errmsg()
   }

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1092,7 +1092,6 @@ void pum_show_popupmenu(vimmenu_T *menu)
     pum_is_drawn = true;
     pum_redraw();
     setcursor_mayforce(true);
-    ui_flush();
 
     int c = vgetc();
 

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -472,11 +472,6 @@ int ui_current_col(void)
   return cursor_col;
 }
 
-handle_T ui_cursor_grid(void)
-{
-  return cursor_grid_handle;
-}
-
 void ui_flush(void)
 {
   assert(!ui_client_channel_id);


### PR DESCRIPTION
- Do not reimplement redrawing in focus gained handling. These are just ordinary boring events now. Modes already redraw events themselves.
- `<expr>` mapping has no business "saving" and restoring the low-level UI cursor. 
  The cursor will be put in a reasonable position after input is processed, chill out.
- TUI handles output needed for suspend
- `vgetc()` family of function does flushing