### PR TITLE
ci: remove base branch from cache key

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -3,7 +3,7 @@ description: "This action caches neovim dependencies"
 runs:
   using: "composite"
   steps:
-    - run: echo "CACHE_KEY=${{ github.job }}-${{ github.base_ref }}" >> $GITHUB_ENV
+    - run: echo "CACHE_KEY=${{ github.job }}" >> $GITHUB_ENV
       shell: bash
 
     - if: ${{ matrix }}


### PR DESCRIPTION
Using the base branch as cache means that pull requests won't be able to
use the cache from the master branch, since the master branch cache
doesn't have a base_ref as it's generated from a push. Removing base_ref
makes the cache key from master and PR branch the same, provided the any
build files don't change.
