### PR TITLE
ci(lintcommit): turn off debug tracing

### DIFF
--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -20,4 +20,4 @@ jobs:
         with:
           neovim: true
       - run: wget https://raw.githubusercontent.com/neovim/neovim/master/scripts/lintcommit.lua
-      - run: nvim --clean -es +"cd pr_nvim" +"lua dofile('../lintcommit.lua').main({trace=true})"
+      - run: nvim --clean -es +"cd pr_nvim" +"lua dofile('../lintcommit.lua').main({trace=false})"


### PR DESCRIPTION
The default output is too verbose and messy for someone not already
familiar with lintcommit, which defeats it purpose.