### PR TITLE
vim-patch:9.0.1297: wrong value for $LC_CTYPE makes the environ test fail

### DIFF
--- a/src/nvim/testdir/test_environ.vim
+++ b/src/nvim/testdir/test_environ.vim
@@ -73,7 +73,7 @@ func Test_mac_locale()
   " If $LANG is not set then the system locale will be used.
   " Run Vim after unsetting all the locale environmental vars, and capture the
   " output of :lang.
-  let lang_results = system("unset LANG; unset LC_MESSAGES; " ..
+  let lang_results = system("unset LANG; unset LC_MESSAGES; unset LC_CTYPE; " ..
             \ shellescape(v:progpath) ..
             \ " --clean -esX -c 'redir @a' -c 'lang' -c 'put a' -c 'print' -c 'qa!' ")
 


### PR DESCRIPTION
#### vim-patch:9.0.1297: wrong value for $LC_CTYPE makes the environ test fail

Problem:    Wrong value for $LC_CTYPE makes the environ test fail.
Solution:   Unset $LC_CTYPE when running tests. (closes vim/vim#11963)

https://github.com/vim/vim/commit/962d91643520ec3748fcf5af3263d89ccfcdda92

Co-authored-by: WuerfelDev <dev@wuerfeldev.de>