### PR TITLE
refactor: move init_default_autocmds to lua

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -894,6 +894,26 @@ function vim._init_default_mappings()
   ]])
 end
 
+function vim._init_default_autocmds()
+  local nvim_terminal_augroup = vim.api.nvim_create_augroup('nvim_terminal', {})
+  vim.api.nvim_create_autocmd({ 'bufreadcmd' }, {
+    pattern = 'term://*',
+    group = nvim_terminal_augroup,
+    nested = true,
+    command = "if !exists('b:term_title')|call termopen(matchstr(expand(\"<amatch>\"), '\\c\\mterm://\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), {'cwd': expand(get(matchlist(expand(\"<amatch>\"), '\\c\\mterm://\\(.\\{-}\\)//'), 1, ''))})",
+  })
+  vim.api.nvim_create_autocmd({ 'cmdwinenter' }, {
+    pattern = '[:>]',
+    group = vim.api.nvim_create_augroup('nvim_cmdwin', {}),
+    command = 'syntax sync minlines=1 maxlines=1',
+  })
+end
+
+function vim._init_defaults()
+  vim._init_default_mappings()
+  vim._init_default_autocmds()
+end
+
 require('vim._meta')
 
 return vim

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -175,11 +175,13 @@ typedef struct {
 #define WITH_SCRIPT_CONTEXT(channel_id, code) \
   do { \
     const sctx_T save_current_sctx = current_sctx; \
+    const uint64_t save_channel_id = current_channel_id; \
     current_sctx.sc_sid = \
       (channel_id) == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT; \
     current_sctx.sc_lnum = 0; \
     current_channel_id = channel_id; \
     code; \
+    current_channel_id = save_channel_id; \
     current_sctx = save_current_sctx; \
   } while (0);
 

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -2759,32 +2759,3 @@ void do_autocmd_focusgained(bool gained)
 
   recursive = false;
 }
-
-static void define_autocmd(event_T event, char *pat, char *group, bool once, bool nested, char *cmd)
-{
-  AucmdExecutable exec = AUCMD_EXECUTABLE_INIT;
-  exec.type = CALLABLE_EX;
-  exec.callable.cmd = cmd;  // autocmd_register() makes a copy
-  int group_id = augroup_add(group);
-  autocmd_register(0, event, pat, (int)strlen(pat), group_id, once, nested, NULL, exec);
-}
-
-/// initialization of default autocmds
-void init_default_autocmds(void)
-{
-  // open terminals when opening files that start with term://
-#define PROTO "term://"
-  define_autocmd(EVENT_BUFREADCMD, PROTO "*", "nvim_terminal", false, true,
-                 "if !exists('b:term_title')|call termopen("
-                 // Capture the command string
-                 "matchstr(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\%(.\\{-}//\\%(\\d\\+:\\)\\?\\)\\?\\zs.*'), "
-                 // capture the working directory
-                 "{'cwd': expand(get(matchlist(expand(\"<amatch>\"), "
-                 "'\\c\\m" PROTO "\\(.\\{-}\\)//'), 1, ''))})"
-                 "|endif");
-#undef PROTO
-  // limit syntax synchronization in the command window
-  define_autocmd(EVENT_CMDWINENTER, "[:>]", "nvim_cmdwin", false, false,
-                 "syntax sync minlines=1 maxlines=1");
-}

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -404,19 +404,16 @@ int main(int argc, char **argv)
 
   open_script_files(&params);
 
-  // Default mappings (incl. menus)
+  // Default mappings (incl. menus) & autocommands
   Error err = ERROR_INIT;
-  Object o = NLUA_EXEC_STATIC("return vim._init_default_mappings()",
+  Object o = NLUA_EXEC_STATIC("return vim._init_defaults()",
                               (Array)ARRAY_DICT_INIT, &err);
   assert(!ERROR_SET(&err));
   api_clear_error(&err);
   assert(o.type == kObjectTypeNil);
   api_free_object(o);
 
-  TIME_MSG("init default mappings");
-
-  init_default_autocmds();
-  TIME_MSG("init default autocommands");
+  TIME_MSG("init default mappings & autocommands");
 
   bool vimrc_none = strequal(params.use_vimrc, "NONE");
 

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -209,7 +209,7 @@ describe('autocmd api', function()
 
       local aus = meths.get_autocmds({ event = 'User', pattern = 'Test' })
       local first = aus[1]
-      eq(first.id, 1)
+      eq(true, first.id > 0)
 
       meths.set_var("some_condition", true)
       meths.exec_autocmds("User", {pattern = "Test"})


### PR DESCRIPTION
The original motivation for this change came from developping
https://github.com/neovim/neovim/pull/22159, which will require adding
more autocommand creation to Neovim's startup sequence.
