### PR TITLE
vim-patch:9.0.{1298,1299}: c_CTRL-R_CTRL-R doesn't trigger incsearch

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1598,8 +1598,10 @@ static int command_line_insert_reg(CommandLineState *s)
     }
   }
 
+  bool literally = false;
   if (s->c != ESC) {               // use ESC to cancel inserting register
-    cmdline_paste(s->c, i == Ctrl_R, false);
+    literally = i == Ctrl_R;
+    cmdline_paste(s->c, literally, false);
 
     // When there was a serious error abort getting the
     // command line.
@@ -1624,8 +1626,9 @@ static int command_line_insert_reg(CommandLineState *s)
   ccline.special_char = NUL;
   redrawcmd();
 
-  // The text has been stuffed, the command line didn't change yet.
-  return CMDLINE_NOT_CHANGED;
+  // The text has been stuffed, the command line didn't change yet, but it
+  // will change soon.  The caller must take care of it.
+  return literally ? CMDLINE_NOT_CHANGED : CMDLINE_CHANGED;
 }
 
 /// Handle the Left and Right mouse clicks in the command-line mode.
@@ -1857,12 +1860,13 @@ static int command_line_handle_key(CommandLineState *s)
 
   case Ctrl_R:                        // insert register
     switch (command_line_insert_reg(s)) {
-    case CMDLINE_NOT_CHANGED:
-      return command_line_not_changed(s);
     case GOTO_NORMAL_MODE:
       return 0;  // back to cmd mode
+    case CMDLINE_NOT_CHANGED:
+      s->is_state.incsearch_postponed = true;
+      FALLTHROUGH;
     default:
-      return command_line_changed(s);
+      return command_line_not_changed(s);
     }
 
   case Ctrl_D:

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1626,9 +1626,9 @@ static int command_line_insert_reg(CommandLineState *s)
   ccline.special_char = NUL;
   redrawcmd();
 
-  // The text has been stuffed, the command line didn't change yet, but it
-  // will change soon.  The caller must take care of it.
-  return literally ? CMDLINE_NOT_CHANGED : CMDLINE_CHANGED;
+  // With "literally": the command line has already changed.
+  // Else: the text has been stuffed, but the command line didn't change yet.
+  return literally ? CMDLINE_CHANGED : CMDLINE_NOT_CHANGED;
 }
 
 /// Handle the Left and Right mouse clicks in the command-line mode.
@@ -1862,9 +1862,8 @@ static int command_line_handle_key(CommandLineState *s)
     switch (command_line_insert_reg(s)) {
     case GOTO_NORMAL_MODE:
       return 0;  // back to cmd mode
-    case CMDLINE_NOT_CHANGED:
-      s->is_state.incsearch_postponed = true;
-      FALLTHROUGH;
+    case CMDLINE_CHANGED:
+      return command_line_changed(s);
     default:
       return command_line_not_changed(s);
     }

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -1897,17 +1897,15 @@ func Test_Cmdline()
   call assert_equal(':', g:entered)
   au! CmdlineChanged
 
+  autocmd CmdlineChanged : let g:log += [getcmdline()]
+
   let g:log = []
   cnoremap <F1> <Cmd>call setcmdline('ls')<CR>
-  autocmd CmdlineChanged : let g:log += [getcmdline()]
   call feedkeys(":\<F1>", 'xt')
   call assert_equal(['ls'], g:log)
-  unlet g:log
-  au! CmdlineChanged
   cunmap <F1>
 
   let g:log = []
-  autocmd CmdlineChanged : let g:log += [getcmdline()]
   call feedkeys(":sign \<Tab>\<Tab>\<C-N>\<C-P>\<S-Tab>\<S-Tab>\<Esc>", 'xt')
   call assert_equal([
         \ 's',
@@ -1938,6 +1936,22 @@ func Test_Cmdline()
         \ 'sign unplace',
         \ ], g:log)
   set wildmenu& wildoptions&
+
+  let g:log = []
+  let @r = 'abc'
+  call feedkeys(":0\<C-R>r1\<C-R>\<C-O>r2\<C-R>\<C-R>r3\<Esc>", 'xt')
+  call assert_equal([
+        \ '0',
+        \ '0a',
+        \ '0ab',
+        \ '0abc',
+        \ '0abc1',
+        \ '0abc1abc',
+        \ '0abc1abc2',
+        \ '0abc1abc2abc',
+        \ '0abc1abc2abc3',
+        \ ], g:log)
+
   unlet g:log
   au! CmdlineChanged
 

--- a/src/nvim/testdir/test_hlsearch.vim
+++ b/src/nvim/testdir/test_hlsearch.vim
@@ -1,5 +1,8 @@
 " Test for v:hlsearch
 
+source check.vim
+source screendump.vim
+
 func Test_hlsearch()
   new
   call setline(1, repeat(['aaa'], 10))
@@ -63,3 +66,23 @@ func Test_hlsearch_eol_highlight()
   set nohlsearch
   bwipe!
 endfunc
+
+func Test_hlsearch_Ctrl_R()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      set incsearch hlsearch
+      let @" = "text"
+      put
+  END
+  call writefile(lines, 'XhlsearchCtrlR', 'D')
+  let buf = RunVimInTerminal('-S XhlsearchCtrlR', #{rows: 6, cols: 60})
+
+  call term_sendkeys(buf, "/\<C-R>\<C-R>\"")
+  call VerifyScreenDump(buf, 'Test_hlsearch_ctrlr_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -10,7 +10,6 @@ local testprg = helpers.testprg
 
 describe('search highlighting', function()
   local screen
-  local colors = Screen.colors
 
   before_each(function()
     clear()
@@ -18,9 +17,9 @@ describe('search highlighting', function()
     screen:attach()
     screen:set_default_attr_ids( {
       [1] = {bold=true, foreground=Screen.colors.Blue},
-      [2] = {background = colors.Yellow}, -- Search
+      [2] = {background = Screen.colors.Yellow}, -- Search
       [3] = {reverse = true},
-      [4] = {foreground = colors.Red}, -- Message
+      [4] = {foreground = Screen.colors.Red}, -- Message
       [6] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGrey}, -- Folded
     })
   end)
@@ -498,6 +497,20 @@ describe('search highlighting', function()
       {1:~                   }│{1:~                  }|
       //^                                      |
     ]])
+    feed('<Esc>')
+
+    -- incsearch works after c_CTRL-R_CTRL-R
+    command('let @" = "file"')
+    feed('/<C-R><C-R>"')
+    screen:expect([[
+      the first line      │the first line     |
+      in a little {3:file}    │in a little {2:file}   |
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      /file^                                   |
+    ]])
   end)
 
   it('works with incsearch and offset', function()
@@ -572,12 +585,12 @@ describe('search highlighting', function()
   it('works with matchadd and syntax', function()
     screen:set_default_attr_ids {
       [1] = {bold=true, foreground=Screen.colors.Blue};
-      [2] = {background = colors.Yellow};
+      [2] = {background = Screen.colors.Yellow};
       [3] = {reverse = true};
-      [4] = {foreground = colors.Red};
-      [5] = {bold = true, background = colors.Green};
-      [6] = {italic = true, background = colors.Magenta};
-      [7] = {bold = true, background = colors.Yellow};
+      [4] = {foreground = Screen.colors.Red};
+      [5] = {bold = true, background = Screen.colors.Green};
+      [6] = {italic = true, background = Screen.colors.Magenta};
+      [7] = {bold = true, background = Screen.colors.Yellow};
       [8] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGray};
     }
     feed_command('set hlsearch')


### PR DESCRIPTION
#### vim-patch:9.0.1298: inserting register on the cmdline does not trigger incsearch

Problem:    Inserting a register on the command line does not trigger
            incsearch or update hlsearch.
Solution:   Have cmdline_insert_reg() return CMDLINE_CHANGED when appropriate
            and handle it correctly. (Ken Takata, closes vim/vim#11960)

https://github.com/vim/vim/commit/c4b7dec38292fe1cfad7aa5f244031fc6f7c7a09

Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:9.0.1299: change for triggering incsearch not sufficiently tested

Problem:    Change for triggering incsearch not sufficiently tested.
Solution:   Add a test case.  Simplify the code. (closes vim/vim#11971)

https://github.com/vim/vim/commit/412e0e4ed903682f352d8ea58ded480930cc664f