### PR TITLE
ci: show all logs at the end of a run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,9 +209,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup common environment variables
-        run: |
-          ./.github/workflows/env.sh ${{ matrix.flavor }}
-          mkdir -p "${LOG_DIR}"
+        run: ./.github/workflows/env.sh ${{ matrix.flavor }}
+
+      - name: Create log dir
+        run: mkdir -p "${LOG_DIR}"
 
       - name: Install apt packages
         if: matrix.os == 'linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup common environment variables
-        run: ./.github/workflows/env.sh ${{ matrix.flavor }}
+        run: |
+          ./.github/workflows/env.sh ${{ matrix.flavor }}
+          mkdir -p "${LOG_DIR}"
 
       - name: Install apt packages
         if: matrix.os == 'linux'
@@ -242,9 +244,6 @@ jobs:
           cmake -B build -G Ninja ${CMAKE_FLAGS}
           cmake --build build
 
-      - name: Prepare sanitizer
-        run: ./ci/run_tests.sh prepare_sanitizer
-
       - if: "!cancelled()"
         name: Determine if run should be aborted
         id: abort_job
@@ -271,6 +270,10 @@ jobs:
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: Installtests
         run: ./ci/run_tests.sh installtests
+
+      - if: success() || failure() && steps.abort_job.outputs.status == 'success'
+        name: Show logs
+        run: cat $(find "$LOG_DIR" -type f)
 
   old_cmake:
     name: Test oldest supported cmake

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -19,10 +19,8 @@ check_core_dumps() {
   local cores
   if test "${CI_OS_NAME}" = osx; then
     cores="$(find /cores/ -type f -print)"
-    local _sudo='sudo'
   else
     cores="$(find ./ -type f \( -name 'core.*' -o -name core -o -name nvim.core \) -print)"
-    local _sudo=
   fi
 
   if test -z "${cores}"; then
@@ -36,40 +34,6 @@ check_core_dumps() {
   exit 1
 }
 
-check_logs() {
-  # Iterate through each log to remove an useless warning.
-  # shellcheck disable=SC2044
-  for log in $(find "${1}" -type f -name "${2}"); do
-    sed -i "${log}" \
-      -e '/Warning: noted but unhandled ioctl/d' \
-      -e '/could cause spurious value errors to appear/d' \
-      -e '/See README_MISSING_SYSCALL_OR_IOCTL for guidance/d'
-  done
-
-  # Now do it again, but only consider files with size > 0.
-  local err=""
-  # shellcheck disable=SC2044
-  for log in $(find "${1}" -type f -name "${2}" -size +0); do
-    cat "${log}"
-    err=1
-    rm "${log}"
-  done
-  if test -n "${err}"; then
-    echo 'Runtime errors detected.'
-    exit 1
-  fi
-}
-
-valgrind_check() {
-  check_logs "${1}" "valgrind-*"
-}
-
-check_sanitizer() {
-  if test -n "${CLANG_SANITIZER}"; then
-    check_logs "${1}" "*san.*" | cat
-  fi
-}
-
 unittests() {(
   ulimit -c unlimited || true
   ninja -C "${BUILD_DIR}" unittest || exit
@@ -79,8 +43,6 @@ unittests() {(
 functionaltests() {(
   ulimit -c unlimited || true
   ninja -C "${BUILD_DIR}" "${FUNCTIONALTEST}" || exit
-  check_sanitizer "${LOG_DIR}"
-  valgrind_check "${LOG_DIR}"
   check_core_dumps
 )}
 
@@ -90,8 +52,6 @@ oldtests() {(
     reset
     exit 1
   fi
-  check_sanitizer "${LOG_DIR}"
-  valgrind_check "${LOG_DIR}"
   check_core_dumps
 )}
 
@@ -143,17 +103,5 @@ installtests() {(
     exit 1
   fi
 )}
-
-prepare_sanitizer() {
-  # Invoke nvim to trigger *San early.
-  if ! ("${BUILD_DIR}"/bin/nvim --version && "${BUILD_DIR}"/bin/nvim -u NONE -e -cq | cat -vet); then
-    check_sanitizer "${LOG_DIR}"
-    exit 1
-  fi
-  check_sanitizer "${LOG_DIR}"
-}
-
-rm -rf "${LOG_DIR}"
-mkdir -p "${LOG_DIR}"
 
 eval "$*" || exit


### PR DESCRIPTION
The current CI won't show the logs on error due to early exit. This will
at least show the logs, although for all tests at once.
