### PR TITLE
fix(ui): make sure screen is valid after resizing

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -645,6 +645,8 @@ void remote_ui_grid_resize(UI *ui, Integer grid, Integer width, Integer height)
   Array args = data->call_buf;
   if (ui->ui_ext[kUILinegrid]) {
     ADD_C(args, INTEGER_OBJ(grid));
+  } else {
+    data->client_col = -1;  // force cursor update
   }
   ADD_C(args, INTEGER_OBJ(width));
   ADD_C(args, INTEGER_OBJ(height));

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -318,6 +318,10 @@ void screen_resize(int width, int height)
   resizing_autocmd = false;
   redraw_all_later(UPD_CLEAR);
 
+  if (State != MODE_ASKMORE && State != MODE_EXTERNCMD && State != MODE_CONFIRM) {
+    screenclear();
+  }
+
   if (starting != NO_SCREEN) {
     maketitle();
 


### PR DESCRIPTION
Fix #22225

Problem:
When not inside an Ex command, screen_resize() calls update_screen(),
which calls screenclear() and set the screen as valid. However, when
inside an Ex command, redrawing is postponed so update_screen() screen
doesn't do anything, and the screen is still invalid after the resize,
causing ui_comp_raw_line() to be no-op until update_screen() is called
on the main loop.

Solution:
Restore the call to screenclear() inside screen_resize() so that the
screen is invalid after screen_resize(). Since screenclear() changes
redraw type from UPD_CLEAR to UPD_NOT_VALID, it is called at most once
for each resize, so this shouldn't change how much code is run in the
common (not inside an Ex command) case.
