### PR TITLE
build: don't check environment variable to detect CI

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -1,13 +1,5 @@
 # Set LC_ALL to meet expectations of some locale-sensitive tests.
 set(ENV{LC_ALL} "en_US.UTF-8")
-
-if(POLICY CMP0012)
-  # Avoid policy warning due to CI=true. This is needed even if the main
-  # project has already set this policy as project settings aren't inherited
-  # when using cmake script mode (-P).
-  cmake_policy(SET CMP0012 NEW)
-endif()
-
 set(ENV{VIMRUNTIME} ${WORKING_DIR}/runtime)
 set(ENV{NVIM_RPLUGIN_MANIFEST} ${BUILD_DIR}/Xtest_rplugin_manifest)
 set(ENV{XDG_CONFIG_HOME} ${BUILD_DIR}/Xtest_xdg/config)
@@ -99,7 +91,7 @@ if(NOT res EQUAL 0)
   endif()
 
   # Dump the logfile on CI (if not displayed and moved already).
-  if($ENV{CI})
+  if(CI_BUILD)
     if(EXISTS $ENV{NVIM_LOG_FILE} AND NOT EXISTS $ENV{NVIM_LOG_FILE}.displayed)
       file(READ $ENV{NVIM_LOG_FILE} out)
       message(STATUS "$NVIM_LOG_FILE: $ENV{NVIM_LOG_FILE}\n${out}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ if(BUSTED_PRG)
         -D BUILD_DIR=${CMAKE_BINARY_DIR}
         -D TEST_TYPE=unit
         -D CIRRUS_CI=$ENV{CIRRUS_CI}
+        -D CI_BUILD=${CI_BUILD}
         -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
       DEPENDS ${UNITTEST_PREREQS}
       USES_TERMINAL)
@@ -50,6 +51,7 @@ if(BUSTED_PRG)
       -D DEPS_PREFIX=${DEPS_PREFIX}
       -D TEST_TYPE=functional
       -D CIRRUS_CI=$ENV{CIRRUS_CI}
+      -D CI_BUILD=${CI_BUILD}
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     USES_TERMINAL)
@@ -66,6 +68,7 @@ if(BUSTED_PRG)
       -D BUILD_DIR=${CMAKE_BINARY_DIR}
       -D TEST_TYPE=benchmark
       -D CIRRUS_CI=$ENV{CIRRUS_CI}
+      -D CI_BUILD=${CI_BUILD}
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${BENCHMARK_PREREQS}
     USES_TERMINAL)
@@ -85,6 +88,7 @@ if(BUSTED_LUA_PRG)
       -D BUILD_DIR=${CMAKE_BINARY_DIR}
       -D TEST_TYPE=functional
       -D CIRRUS_CI=$ENV{CIRRUS_CI}
+      -D CI_BUILD=${CI_BUILD}
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     USES_TERMINAL)


### PR DESCRIPTION
Instead use the cmake option, which should act as the definitive source
to determine whether we use CI or not.