### PR TITLE
build: cmake cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,6 @@ include(Util)
 
 set(TOUCHES_DIR ${PROJECT_BINARY_DIR}/touches)
 
-set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
 find_program(CCACHE_PRG ccache)
 if(CCACHE_PRG)
   set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env CCACHE_SLOPPINESS=pch_defines,time_macros ${CCACHE_PRG})
@@ -72,7 +70,7 @@ endif()
 
 list(INSERT CMAKE_PREFIX_PATH 0 ${DEPS_PREFIX})
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(APPLE)
   # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
   # fall back to local system version. Needs to be done both here and in cmake.deps.
   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
@@ -84,7 +82,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message(STATUS "Using deployment target ${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 
-if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(WIN32 OR APPLE)
   # Ignore case when comparing filenames on Windows and Mac.
   set(CASE_INSENSITIVE_FILENAME TRUE)
   # Enable fixing case-insensitive filenames for Windows and Mac.
@@ -259,7 +257,7 @@ add_glob_target(
   TARGET lintsh
   COMMAND ${SHELLCHECK_PRG}
   FLAGS -x -a
-  GLOB_DIRS scripts ci
+  GLOB_DIRS scripts
   GLOB_PAT *.sh
   EXCLUDE
     scripts/pvscheck.sh

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ ifeq (,$(BUILD_TOOL))
   endif
 endif
 
-
 # Only need to handle Ninja here.  Make will inherit the VERBOSE variable, and the -j, -l, and -n flags.
 ifeq ($(CMAKE_GENERATOR),Ninja)
   ifneq ($(VERBOSE),)

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -118,7 +118,7 @@ endif()
 
 # If the macOS deployment target is not set manually (via $MACOSX_DEPLOYMENT_TARGET),
 # fall back to local system version. Needs to be done here and in top-level CMakeLists.txt.
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(APPLE)
   if(NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     execute_process(COMMAND sw_vers -productVersion
                     OUTPUT_VARIABLE MACOS_VERSION
@@ -156,7 +156,6 @@ set(LIBTERMKEY_SHA256 6945bd3c4aaa83da83d80a045c5563da4edd7d0374c62c0d35aec09eb3
 set(LIBVTERM_URL https://www.leonerd.org.uk/code/libvterm/libvterm-0.3.1.tar.gz)
 set(LIBVTERM_SHA256 25a8ad9c15485368dfd0a8a9dca1aec8fea5c27da3fa74ec518d5d3787f0c397)
 
-set(LUV_VERSION 1.44.2-1)
 set(LUV_URL https://github.com/luvit/luv/archive/e8e7b7e13225348a8806118a3ea9e021383a9536.tar.gz)
 set(LUV_SHA256 531dfbcb6fffe3fdfa806860b39035e54b07ee1ff3bb2af813e175febf7e9ccc)
 

--- a/cmake.deps/cmake/BuildLua.cmake
+++ b/cmake.deps/cmake/BuildLua.cmake
@@ -1,6 +1,6 @@
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(LUA_TARGET linux)
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif(APPLE)
   set(LUA_TARGET macosx)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   set(LUA_TARGET freebsd)

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -38,7 +38,7 @@ function(BuildLuajit)
 endfunction()
 
 check_c_compiler_flag(-fno-stack-check HAS_NO_STACK_CHECK)
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin" AND HAS_NO_STACK_CHECK)
+if(APPLE AND HAS_NO_STACK_CHECK)
   set(NO_STACK_CHECK "CFLAGS+=-fno-stack-check")
 else()
   set(NO_STACK_CHECK "")
@@ -58,7 +58,7 @@ set(BUILDCMD_UNIX ${MAKE_PRG} -j CFLAGS=-fPIC
 
 # Setting MACOSX_DEPLOYMENT_TARGET is mandatory for LuaJIT; use version set by
 # cmake.deps/CMakeLists.txt (either environment variable or current system version).
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(APPLE)
   set(DEPLOYMENT_TARGET "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -30,7 +30,7 @@ if(UNIX)
     list(APPEND LUAROCKS_OPTS
       --with-lua=${DEPS_INSTALL_DIR})
   else()
-    find_package(LuaJit)
+    find_package(Luajit)
     if(LUAJIT_FOUND)
       list(APPEND LUAROCKS_OPTS
         --with-lua-include=${LUAJIT_INCLUDE_DIRS}

--- a/cmake.deps/cmake/BuildLuv.cmake
+++ b/cmake.deps/cmake/BuildLuv.cmake
@@ -14,7 +14,7 @@ if(USE_BUNDLED_LUAJIT)
 elseif(USE_BUNDLED_LUA)
   list(APPEND LUV_CMAKE_ARGS -D WITH_LUA_ENGINE=Lua)
 else()
-  find_package(LuaJit)
+  find_package(Luajit)
   if(LUAJIT_FOUND)
     list(APPEND LUV_CMAKE_ARGS -D WITH_LUA_ENGINE=LuaJit)
   else()
@@ -23,9 +23,7 @@ else()
 endif()
 
 if(USE_BUNDLED_LIBUV)
-  list(APPEND LUV_CMAKE_ARGS
-    -D CMAKE_PREFIX_PATH=${DEPS_INSTALL_DIR}
-    -D LIBUV_LIBRARIES=uv_a)
+  list(APPEND LUV_CMAKE_ARGS -D CMAKE_PREFIX_PATH=${DEPS_INSTALL_DIR})
 endif()
 
 list(APPEND LUV_CMAKE_ARGS

--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -6,3 +6,9 @@ find_library(ICONV_LIBRARY NAMES iconv libiconv)
 find_package_handle_standard_args(Iconv DEFAULT_MSG
   ICONV_INCLUDE_DIR)
 mark_as_advanced(ICONV_INCLUDE_DIR ICONV_LIBRARY)
+
+add_library(iconv INTERFACE)
+target_include_directories(iconv SYSTEM BEFORE INTERFACE ${ICONV_INCLUDE_DIR})
+if(ICONV_LIBRARY)
+  target_link_libraries(iconv INTERFACE ${ICONV_LIBRARY})
+endif()

--- a/cmake/FindLibTermkey.cmake
+++ b/cmake/FindLibTermkey.cmake
@@ -1,5 +1,0 @@
-find_path(LIBTERMKEY_INCLUDE_DIR termkey.h)
-find_library(LIBTERMKEY_LIBRARY NAMES termkey)
-find_package_handle_standard_args(LibTermkey DEFAULT_MSG
-  LIBTERMKEY_LIBRARY LIBTERMKEY_INCLUDE_DIR)
-mark_as_advanced(LIBTERMKEY_INCLUDE_DIR LIBTERMKEY_LIBRARY)

--- a/cmake/FindLibintl.cmake
+++ b/cmake/FindLibintl.cmake
@@ -3,32 +3,32 @@ include(CheckVariableExists)
 
 # Append custom gettext path to CMAKE_PREFIX_PATH
 # if installed via Mac Homebrew
-if (CMAKE_HOST_APPLE)
-    find_program(HOMEBREW_PROG brew)
-    if (EXISTS ${HOMEBREW_PROG})
-        execute_process(COMMAND ${HOMEBREW_PROG} --prefix gettext
+if (APPLE)
+    find_program(HOMEBREW_PRG brew)
+    if (EXISTS ${HOMEBREW_PRG})
+        execute_process(COMMAND ${HOMEBREW_PRG} --prefix gettext
             OUTPUT_STRIP_TRAILING_WHITESPACE
             OUTPUT_VARIABLE HOMEBREW_GETTEXT_PREFIX)
         list(APPEND CMAKE_PREFIX_PATH "${HOMEBREW_GETTEXT_PREFIX}")
     endif()
 endif()
 
-find_path(LibIntl_INCLUDE_DIR
+find_path(LIBINTL_INCLUDE_DIR
     NAMES libintl.h
     PATH_SUFFIXES gettext
 )
 
-find_library(LibIntl_LIBRARY
+find_library(LIBINTL_LIBRARY
     NAMES intl libintl
 )
 
-if (LibIntl_INCLUDE_DIR)
-  list(APPEND CMAKE_REQUIRED_INCLUDES "${LibIntl_INCLUDE_DIR}")
+if (LIBINTL_INCLUDE_DIR)
+  list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBINTL_INCLUDE_DIR}")
 endif()
 # On some systems (linux+glibc) libintl is passively available.
 # So only specify the library if one was found.
-if (LibIntl_LIBRARY)
-  list(APPEND CMAKE_REQUIRED_LIBRARIES "${LibIntl_LIBRARY}")
+if (LIBINTL_LIBRARY)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "${LIBINTL_LIBRARY}")
 endif()
 if (MSVC)
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${ICONV_LIBRARY})
@@ -36,7 +36,7 @@ endif()
 
 # On macOS, if libintl is a static library then we also need
 # to link libiconv and CoreFoundation.
-get_filename_component(LibIntl_EXT "${LibIntl_LIBRARY}" EXT)
+get_filename_component(LibIntl_EXT "${LIBINTL_LIBRARY}" EXT)
 if (APPLE AND (LibIntl_EXT STREQUAL ".a"))
   set(LibIntl_STATIC TRUE)
   find_library(CoreFoundation_FRAMEWORK CoreFoundation)
@@ -59,14 +59,14 @@ endif()
 if (LibIntl_STATIC)
   list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES  "${ICONV_LIBRARY}" "${CoreFoundation_FRAMEWORK}")
 endif()
-if (LibIntl_INCLUDE_DIR)
-  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${LibIntl_INCLUDE_DIR}")
+if (LIBINTL_INCLUDE_DIR)
+  list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${LIBINTL_INCLUDE_DIR}")
 endif()
-if (LibIntl_LIBRARY)
-  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${LibIntl_LIBRARY}")
+if (LIBINTL_LIBRARY)
+  list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${LIBINTL_LIBRARY}")
 endif()
 
-set(REQUIRED_VARIABLES LibIntl_LIBRARY LIBTERMKEY_INCLUDE_DIR)
+set(REQUIRED_VARIABLES LIBINTL_LIBRARY LIBINTL_INCLUDE_DIR)
 if (HAVE_WORKING_LIBINTL)
   # On some systems (linux+glibc) libintl is passively available.
   # If HAVE_WORKING_LIBINTL then we consider the requirement satisfied.
@@ -75,6 +75,6 @@ if (HAVE_WORKING_LIBINTL)
   check_variable_exists(_nl_msg_cat_cntr HAVE_NL_MSG_CAT_CNTR)
 endif()
 
-find_package_handle_standard_args(LibIntl DEFAULT_MSG
+find_package_handle_standard_args(Libintl DEFAULT_MSG
   ${REQUIRED_VARIABLES})
-mark_as_advanced(LIBTERMKEY_INCLUDE_DIR LIBTERMKEY_LIBRARY)
+mark_as_advanced(LIBINTL_LIBRARY LIBINTL_INCLUDE_DIR)

--- a/cmake/FindLibluv.cmake
+++ b/cmake/FindLibluv.cmake
@@ -8,7 +8,7 @@ find_library(LIBLUV_LIBRARY NAMES ${LIBLUV_NAMES})
 set(LIBLUV_LIBRARIES ${LIBLUV_LIBRARY})
 set(LIBLUV_INCLUDE_DIRS ${LIBLUV_INCLUDE_DIR})
 
-find_package_handle_standard_args(LibLUV DEFAULT_MSG
+find_package_handle_standard_args(Libluv DEFAULT_MSG
   LIBLUV_LIBRARY LIBLUV_INCLUDE_DIR)
 
 mark_as_advanced(LIBLUV_INCLUDE_DIR LIBLUV_LIBRARY)

--- a/cmake/FindLibtermkey.cmake
+++ b/cmake/FindLibtermkey.cmake
@@ -1,0 +1,9 @@
+find_path(LIBTERMKEY_INCLUDE_DIR termkey.h)
+find_library(LIBTERMKEY_LIBRARY NAMES termkey)
+find_package_handle_standard_args(Libtermkey DEFAULT_MSG
+  LIBTERMKEY_LIBRARY LIBTERMKEY_INCLUDE_DIR)
+mark_as_advanced(LIBTERMKEY_INCLUDE_DIR LIBTERMKEY_LIBRARY)
+
+add_library(libtermkey INTERFACE)
+target_include_directories(libtermkey SYSTEM BEFORE INTERFACE ${LIBTERMKEY_INCLUDE_DIR})
+target_link_libraries(libtermkey INTERFACE ${LIBTERMKEY_LIBRARY})

--- a/cmake/FindLibuv.cmake
+++ b/cmake/FindLibuv.cmake
@@ -63,7 +63,7 @@ if(Threads_FOUND)
   list(APPEND LIBUV_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
-find_package_handle_standard_args(LibUV DEFAULT_MSG
+find_package_handle_standard_args(Libuv DEFAULT_MSG
                                   LIBUV_LIBRARY LIBUV_INCLUDE_DIR)
 
 mark_as_advanced(LIBUV_INCLUDE_DIR LIBUV_LIBRARY)

--- a/cmake/FindLibvterm.cmake
+++ b/cmake/FindLibvterm.cmake
@@ -11,7 +11,7 @@ if(LIBVTERM_INCLUDE_DIR AND EXISTS "${LIBVTERM_INCLUDE_DIR}/vterm.h")
   set(VTERM_VERSION ${VTERM_VERSION_MAJOR}.${VTERM_VERSION_MINOR})
 endif()
 
-find_package_handle_standard_args(libvterm
+find_package_handle_standard_args(Libvterm
   REQUIRED_VARS LIBVTERM_INCLUDE_DIR LIBVTERM_LIBRARY
   VERSION_VAR VTERM_VERSION)
 

--- a/cmake/FindLuajit.cmake
+++ b/cmake/FindLuajit.cmake
@@ -14,7 +14,7 @@ find_library(LUAJIT_LIBRARY NAMES ${LUAJIT_NAMES})
 set(LUAJIT_LIBRARIES ${LUAJIT_LIBRARY})
 set(LUAJIT_INCLUDE_DIRS ${LUAJIT_INCLUDE_DIR})
 
-find_package_handle_standard_args(LuaJit DEFAULT_MSG
+find_package_handle_standard_args(Luajit DEFAULT_MSG
                                   LUAJIT_LIBRARY LUAJIT_INCLUDE_DIR)
 
 mark_as_advanced(LUAJIT_INCLUDE_DIR LUAJIT_LIBRARY)

--- a/cmake/FindMsgpack.cmake
+++ b/cmake/FindMsgpack.cmake
@@ -22,9 +22,25 @@ find_library(MSGPACK_LIBRARY NAMES ${MSGPACK_NAMES}
 
 mark_as_advanced(MSGPACK_INCLUDE_DIR MSGPACK_LIBRARY)
 
-set(MSGPACK_LIBRARIES ${MSGPACK_LIBRARY})
-set(MSGPACK_INCLUDE_DIRS ${MSGPACK_INCLUDE_DIR})
-
 find_package_handle_standard_args(Msgpack
   REQUIRED_VARS MSGPACK_LIBRARY MSGPACK_INCLUDE_DIR
   VERSION_VAR MSGPACK_VERSION_STRING)
+
+add_library(msgpack INTERFACE)
+target_include_directories(msgpack SYSTEM BEFORE INTERFACE ${MSGPACK_INCLUDE_DIR})
+target_link_libraries(msgpack INTERFACE ${MSGPACK_LIBRARY})
+
+list(APPEND CMAKE_REQUIRED_INCLUDES "${MSGPACK_INCLUDE_DIR}")
+check_c_source_compiles("
+#include <msgpack.h>
+
+int
+main(void)
+{
+  return MSGPACK_OBJECT_FLOAT32;
+}
+" MSGPACK_HAS_FLOAT32)
+list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${MSGPACK_INCLUDE_DIR}")
+if(MSGPACK_HAS_FLOAT32)
+  target_compile_definitions(msgpack INTERFACE NVIM_MSGPACK_HAS_FLOAT32)
+endif()

--- a/cmake/FindTreeSitter.cmake
+++ b/cmake/FindTreeSitter.cmake
@@ -1,5 +1,0 @@
-find_path(TreeSitter_INCLUDE_DIR tree_sitter/api.h)
-find_library(TreeSitter_LIBRARY NAMES tree-sitter)
-find_package_handle_standard_args(TreeSitter DEFAULT_MSG
-  TreeSitter_LIBRARY TreeSitter_INCLUDE_DIR)
-mark_as_advanced(TreeSitter_LIBRARY TreeSitter_INCLUDE_DIR)

--- a/cmake/FindTreesitter.cmake
+++ b/cmake/FindTreesitter.cmake
@@ -1,0 +1,40 @@
+find_path(TREESITTER_INCLUDE_DIR tree_sitter/api.h)
+find_library(TREESITTER_LIBRARY NAMES tree-sitter)
+find_package_handle_standard_args(Treesitter DEFAULT_MSG
+  TREESITTER_LIBRARY TREESITTER_INCLUDE_DIR)
+mark_as_advanced(TREESITTER_LIBRARY TREESITTER_INCLUDE_DIR)
+
+add_library(treesitter INTERFACE)
+target_include_directories(treesitter SYSTEM BEFORE INTERFACE ${TREESITTER_INCLUDE_DIR})
+target_link_libraries(treesitter INTERFACE ${TREESITTER_LIBRARY})
+
+list(APPEND CMAKE_REQUIRED_INCLUDES "${TREESITTER_INCLUDE_DIR}")
+list(APPEND CMAKE_REQUIRED_LIBRARIES "${TREESITTER_LIBRARY}")
+check_c_source_compiles("
+#include <tree_sitter/api.h>
+int
+main(void)
+{
+  TSQueryCursor *cursor = ts_query_cursor_new();
+  ts_query_cursor_set_match_limit(cursor, 32);
+  return 0;
+}
+" TS_HAS_SET_MATCH_LIMIT)
+if(TS_HAS_SET_MATCH_LIMIT)
+  target_compile_definitions(treesitter INTERFACE NVIM_TS_HAS_SET_MATCH_LIMIT)
+endif()
+check_c_source_compiles("
+#include <stdlib.h>
+#include <tree_sitter/api.h>
+int
+main(void)
+{
+  ts_set_allocator(malloc, calloc, realloc, free);
+  return 0;
+}
+" TS_HAS_SET_ALLOCATOR)
+if(TS_HAS_SET_ALLOCATOR)
+  target_compile_definitions(treesitter INTERFACE NVIM_TS_HAS_SET_ALLOCATOR)
+endif()
+list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${TREESITTER_INCLUDE_DIR}")
+list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${TREESITTER_LIBRARY}")

--- a/cmake/FindUnibilium.cmake
+++ b/cmake/FindUnibilium.cmake
@@ -1,7 +1,7 @@
 find_path(UNIBILIUM_INCLUDE_DIR unibilium.h)
 find_library(UNIBILIUM_LIBRARY unibilium)
 
-find_package_handle_standard_args(unibilium
+find_package_handle_standard_args(Unibilium
   REQUIRED_VARS UNIBILIUM_INCLUDE_DIR UNIBILIUM_LIBRARY)
 
 add_library(unibilium INTERFACE)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -1,22 +1,19 @@
 add_library(main_lib INTERFACE)
 add_executable(nvim main.c)
 
-add_library(libuv_lib INTERFACE)
+add_library(libuv INTERFACE)
 find_package(libuv CONFIG)
 if(TARGET libuv::uv_a)
-  target_link_libraries(libuv_lib INTERFACE libuv::uv_a)
+  target_link_libraries(libuv INTERFACE libuv::uv_a)
+  mark_as_advanced(libuv_DIR)
 else()
   # Fall back to find module for older libuv versions that don't provide config file
-  find_package(LibUV 1.28.0 REQUIRED MODULE)
-  target_include_directories(libuv_lib SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIRS})
-  target_link_libraries(libuv_lib INTERFACE ${LIBUV_LIBRARIES})
+  find_package(Libuv 1.28.0 REQUIRED MODULE)
+  target_include_directories(libuv SYSTEM BEFORE INTERFACE ${LIBUV_INCLUDE_DIRS})
+  target_link_libraries(libuv INTERFACE ${LIBUV_LIBRARIES})
 endif()
 
-find_package(Msgpack 1.0.0 REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${MSGPACK_INCLUDE_DIRS})
-target_link_libraries(main_lib INTERFACE ${MSGPACK_LIBRARIES})
-
-find_package(LibLUV 1.43.0 REQUIRED)
+find_package(Libluv 1.43.0 REQUIRED)
 target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBLUV_INCLUDE_DIRS})
 # Use "luv" as imported library, to work around CMake using "-lluv" for
 # "luv.so".  #10407
@@ -24,33 +21,28 @@ add_library(luv UNKNOWN IMPORTED)
 set_target_properties(luv PROPERTIES IMPORTED_LOCATION ${LIBLUV_LIBRARIES})
 target_link_libraries(main_lib INTERFACE luv)
 
-find_package(TreeSitter REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${TreeSitter_INCLUDE_DIR})
-target_link_libraries(main_lib INTERFACE ${TreeSitter_LIBRARY})
-
-find_package(unibilium 2.0 REQUIRED)
-target_link_libraries(main_lib INTERFACE unibilium)
-
-find_package(LibTermkey 0.22 REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBTERMKEY_INCLUDE_DIR})
-target_link_libraries(main_lib INTERFACE ${LIBTERMKEY_LIBRARY})
-
-find_package(libvterm 0.3 REQUIRED)
-target_link_libraries(main_lib INTERFACE libvterm)
-
 find_package(Iconv REQUIRED)
-target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${ICONV_INCLUDE_DIR})
-if(ICONV_LIBRARY)
-  target_link_libraries(main_lib INTERFACE ${ICONV_LIBRARY})
-endif()
+find_package(Libtermkey 0.22 REQUIRED)
+find_package(Libvterm 0.3 REQUIRED)
+find_package(Msgpack 1.0.0 REQUIRED)
+find_package(Treesitter REQUIRED)
+find_package(Unibilium 2.0 REQUIRED)
+
+target_link_libraries(main_lib INTERFACE
+  iconv
+  libtermkey
+  libvterm
+  msgpack
+  treesitter
+  unibilium)
 
 option(ENABLE_LIBINTL "enable libintl" ON)
 if(ENABLE_LIBINTL)
-  # LibIntl (not Intl) selects our FindLibIntl.cmake script. #8464
-  find_package(LibIntl REQUIRED)
-  target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LibIntl_INCLUDE_DIR})
-  if (LibIntl_LIBRARY)
-    target_link_libraries(main_lib INTERFACE ${LibIntl_LIBRARY})
+  # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
+  find_package(Libintl REQUIRED)
+  target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBINTL_INCLUDE_DIR})
+  if (LIBINTL_LIBRARY)
+    target_link_libraries(main_lib INTERFACE ${LIBINTL_LIBRARY})
   endif()
 endif()
 
@@ -61,9 +53,9 @@ if(PREFER_LUA)
   target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUA_INCLUDE_DIR})
   target_link_libraries(main_lib INTERFACE ${LUA_LIBRARIES})
   # Passive (not REQUIRED): if LUAJIT_FOUND is not set, fixtures for unittests is skipped.
-  find_package(LuaJit)
+  find_package(Luajit)
 else()
-  find_package(LuaJit REQUIRED)
+  find_package(Luajit REQUIRED)
   target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LUAJIT_INCLUDE_DIRS})
   target_link_libraries(main_lib INTERFACE ${LUAJIT_LIBRARIES})
 endif()
@@ -191,52 +183,6 @@ if(UNSIGNED_CHAR)
   target_compile_options(main_lib INTERFACE -funsigned-char)
 endif()
 
-list(APPEND CMAKE_REQUIRED_INCLUDES "${MSGPACK_INCLUDE_DIRS}")
-check_c_source_compiles("
-#include <msgpack.h>
-
-int
-main(void)
-{
-  return MSGPACK_OBJECT_FLOAT32;
-}
-" MSGPACK_HAS_FLOAT32)
-list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${MSGPACK_INCLUDE_DIRS}")
-if(MSGPACK_HAS_FLOAT32)
-  target_compile_definitions(main_lib INTERFACE NVIM_MSGPACK_HAS_FLOAT32)
-endif()
-
-list(APPEND CMAKE_REQUIRED_INCLUDES "${TreeSitter_INCLUDE_DIRS}")
-list(APPEND CMAKE_REQUIRED_LIBRARIES "${TreeSitter_LIBRARIES}")
-check_c_source_compiles("
-#include <tree_sitter/api.h>
-int
-main(void)
-{
-  TSQueryCursor *cursor = ts_query_cursor_new();
-  ts_query_cursor_set_match_limit(cursor, 32);
-  return 0;
-}
-" TS_HAS_SET_MATCH_LIMIT)
-if(TS_HAS_SET_MATCH_LIMIT)
-  target_compile_definitions(main_lib INTERFACE NVIM_TS_HAS_SET_MATCH_LIMIT)
-endif()
-check_c_source_compiles("
-#include <stdlib.h>
-#include <tree_sitter/api.h>
-int
-main(void)
-{
-  ts_set_allocator(malloc, calloc, realloc, free);
-  return 0;
-}
-" TS_HAS_SET_ALLOCATOR)
-if(TS_HAS_SET_ALLOCATOR)
-  target_compile_definitions(main_lib INTERFACE NVIM_TS_HAS_SET_ALLOCATOR)
-endif()
-list(REMOVE_ITEM CMAKE_REQUIRED_INCLUDES "${TreeSitter_INCLUDE_DIRS}")
-list(REMOVE_ITEM CMAKE_REQUIRED_LIBRARIES "${TreeSitter_LIBRARIES}")
-
 target_compile_definitions(main_lib INTERFACE INCLUDE_GENERATED_DECLARATIONS)
 
 # Remove --sort-common from linker flags, as this seems to cause bugs (see #2641, #3374).
@@ -260,7 +206,7 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang")
   if(CMAKE_SYSTEM_NAME STREQUAL "SunOS")
     target_link_libraries(nvim PRIVATE -Wl,--no-undefined -lsocket)
-  elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  elseif(NOT APPLE)
     target_link_libraries(nvim PRIVATE -Wl,--no-undefined)
   endif()
 
@@ -287,7 +233,7 @@ if(WIN32)
     # Enable wmain
     target_link_libraries(nvim PRIVATE -municode)
   endif()
-elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+elseif(APPLE)
   target_link_libraries(nvim PRIVATE "-framework CoreServices")
 endif()
 
@@ -437,7 +383,7 @@ else()
 endif()
 
 # Log level (MIN_LOG_LEVEL in log.h)
-if($ENV{CI} MATCHES "true")
+if($ENV{CI})
   set(MIN_LOG_LEVEL 3)
 endif()
 if("${MIN_LOG_LEVEL}" MATCHES "^$")
@@ -466,7 +412,7 @@ get_target_property(prop main_lib INTERFACE_INCLUDE_DIRECTORIES)
 foreach(gen_include ${prop})
   list(APPEND gen_cflags "-I${gen_include}")
 endforeach()
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_OSX_SYSROOT)
+if(APPLE AND CMAKE_OSX_SYSROOT)
   list(APPEND gen_cflags "-isysroot")
   list(APPEND gen_cflags "${CMAKE_OSX_SYSROOT}")
 endif()
@@ -718,7 +664,7 @@ if(${CMAKE_VERSION} VERSION_LESS 3.20)
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
-target_link_libraries(nvim PRIVATE main_lib PUBLIC libuv_lib)
+target_link_libraries(nvim PRIVATE main_lib PUBLIC libuv)
 install_helper(TARGETS nvim)
 if(MSVC)
   install(FILES $<TARGET_PDB_FILE:nvim> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)
@@ -829,12 +775,10 @@ if(WIN32)
   file(WRITE ${PROJECT_BINARY_DIR}/external_blobs.cmake ${EXTERNAL_BLOBS_SCRIPT})
   add_custom_target(external_blobs
     COMMAND ${CMAKE_COMMAND} -P ${PROJECT_BINARY_DIR}/external_blobs.cmake)
-  set_target_properties(external_blobs PROPERTIES FOLDER deps)
   add_dependencies(nvim_runtime_deps external_blobs)
 else()
   add_custom_target(nvim_runtime_deps)  # Stub target to avoid CMP0046.
 endif()
-set_target_properties(nvim_runtime_deps PROPERTIES FOLDER deps)
 
 file(MAKE_DIRECTORY ${BINARY_LIB_DIR})
 
@@ -862,7 +806,7 @@ set_target_properties(
     OUTPUT_NAME ${LIBNVIM_NAME}
 )
 target_compile_definitions(libnvim PRIVATE MAKE_LIB)
-target_link_libraries(libnvim PRIVATE main_lib PUBLIC libuv_lib)
+target_link_libraries(libnvim PRIVATE main_lib PUBLIC libuv)
 
 if(CLANG_ASAN_UBSAN)
   message(STATUS "Enabling Clang address sanitizer and undefined behavior sanitizer for nvim.")

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -95,7 +95,6 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
       COMMENT "Checking ${name}.po"
       VERBATIM
       DEPENDS ${poFile})
-    set_target_properties(check-po-${name} PROPERTIES FOLDER po/check)
   endmacro()
 
   macro(BuildPoIconvGenericWithCharset
@@ -182,9 +181,7 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
 
     BuildMo(${LANGUAGE})
   endforeach()
-  set_target_properties(${UPDATE_PO_TARGETS} PROPERTIES FOLDER po/update)
 
   add_custom_target(translations ALL DEPENDS ${LANGUAGE_MO_FILES})
   add_custom_target(update-po DEPENDS ${UPDATE_PO_TARGETS})
-  set_target_properties(translations update-po PROPERTIES FOLDER po)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,6 @@ if(BUSTED_PRG)
     add_custom_target(unittest
       COMMAND ${CMAKE_COMMAND}
         -D BUSTED_PRG=${BUSTED_PRG}
-        -D LUA_PRG=${LUA_PRG}
         -D NVIM_PRG=$<TARGET_FILE:nvim>
         -D WORKING_DIR=${PROJECT_SOURCE_DIR}
         -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
@@ -30,7 +29,6 @@ if(BUSTED_PRG)
         -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
       DEPENDS ${UNITTEST_PREREQS}
       USES_TERMINAL)
-    set_target_properties(unittest PROPERTIES FOLDER test)
   else()
     message(WARNING "disabling unit tests: no Luajit FFI in ${LUA_PRG}")
   endif()
@@ -42,7 +40,6 @@ if(BUSTED_PRG)
   add_custom_target(functionaltest
     COMMAND ${CMAKE_COMMAND}
       -D BUSTED_PRG=${BUSTED_PRG}
-      -D LUA_PRG=${LUA_PRG}
       -D NVIM_PRG=$<TARGET_FILE:nvim>
       -D WORKING_DIR=${PROJECT_SOURCE_DIR}
       -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
@@ -55,12 +52,10 @@ if(BUSTED_PRG)
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     USES_TERMINAL)
-  set_target_properties(functionaltest PROPERTIES FOLDER test)
 
   add_custom_target(benchmark
     COMMAND ${CMAKE_COMMAND}
       -D BUSTED_PRG=${BUSTED_PRG}
-      -D LUA_PRG=${LUA_PRG}
       -D NVIM_PRG=$<TARGET_FILE:nvim>
       -D WORKING_DIR=${PROJECT_SOURCE_DIR}
       -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
@@ -72,7 +67,6 @@ if(BUSTED_PRG)
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${BENCHMARK_PREREQS}
     USES_TERMINAL)
-  set_target_properties(benchmark PROPERTIES FOLDER test)
 endif()
 
 find_program(BUSTED_LUA_PRG busted-lua)
@@ -80,7 +74,6 @@ if(BUSTED_LUA_PRG)
   add_custom_target(functionaltest-lua
     COMMAND ${CMAKE_COMMAND}
       -D BUSTED_PRG=${BUSTED_LUA_PRG}
-      -D LUA_PRG=${LUA_PRG}
       -D NVIM_PRG=$<TARGET_FILE:nvim>
       -D WORKING_DIR=${PROJECT_SOURCE_DIR}
       -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
@@ -92,5 +85,4 @@ if(BUSTED_LUA_PRG)
       -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
     DEPENDS ${FUNCTIONALTEST_PREREQS}
     USES_TERMINAL)
-    set_target_properties(functionaltest-lua PROPERTIES FOLDER test)
 endif()


### PR DESCRIPTION
- Remove unused code
- Use consistent casing. Variable names such as LibLuV_LIBRARIES is
  needlessly jarring, even if the name might be technically correct.
- Use title casing for packages. find_package(unibilium) requires the
  find_module to be named "Findunibilium.cmake", which makes it harder
  to spot when scanning the files. Instead, use "Unibilium".