### PR TITLE
vim-patch:9.0.1307: setting 'formatoptions' with :let doesn't check for errors

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3084,6 +3084,8 @@ char *set_option_value(const char *const name, const long number, const char *co
                        const int opt_flags)
   FUNC_ATTR_NONNULL_ARG(1)
 {
+  static char errbuf[80];
+
   if (is_tty_option(name)) {
     return NULL;  // Fail silently; many old vimrcs set t_xx options.
   }
@@ -3106,7 +3108,7 @@ char *set_option_value(const char *const name, const long number, const char *co
     if (s == NULL || opt_flags & OPT_CLEAR) {
       s = "";
     }
-    return set_string_option(opt_idx, s, opt_flags);
+    return set_string_option(opt_idx, s, opt_flags, errbuf, sizeof(errbuf));
   }
 
   char_u *varp = (char_u *)get_varp_scope(&(options[opt_idx]), opt_flags);
@@ -3144,7 +3146,7 @@ char *set_option_value(const char *const name, const long number, const char *co
     }
   }
   if (flags & P_NUM) {
-    return set_num_option(opt_idx, varp, numval, NULL, 0, opt_flags);
+    return set_num_option(opt_idx, varp, numval, errbuf, sizeof(errbuf), opt_flags);
   }
   return set_bool_option(opt_idx, (char *)varp, (int)numval, opt_flags);
 }

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -410,7 +410,8 @@ void set_string_option_direct_in_win(win_T *wp, const char *name, int opt_idx, c
 ///                        #OPT_GLOBAL.
 ///
 /// @return NULL on success, an untranslated error message on error.
-char *set_string_option(const int opt_idx, const char *const value, const int opt_flags)
+char *set_string_option(const int opt_idx, const char *const value, const int opt_flags,
+                        char *const errbuf, const size_t errbuflen)
   FUNC_ATTR_NONNULL_ARG(2) FUNC_ATTR_WARN_UNUSED_RESULT
 {
   vimoption_T *opt = get_option(opt_idx);
@@ -442,7 +443,7 @@ char *set_string_option(const int opt_idx, const char *const value, const int op
 
   int value_checked = false;
   char *const errmsg = did_set_string_option(opt_idx, varp, oldval,
-                                             NULL, 0,
+                                             errbuf, errbuflen,
                                              opt_flags, &value_checked);
   if (errmsg == NULL) {
     did_set_option(opt_idx, opt_flags, true, value_checked);


### PR DESCRIPTION
#### vim-patch:9.0.1307: setting 'formatoptions' with :let doesn't check for errors

Problem:    Setting 'formatoptions' with :let doesn't check for errors.
Solution:   Pass "errbuf" to set_string_option(). (Yegappan Lakshmanan,
            closes vim/vim#11974)

https://github.com/vim/vim/commit/32ff96ef018eb1a5bea0953648b4892a6ee71658

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>