### PR TITLE
feat(treesitter)!: remove g:ts_highlight_lua

### DIFF
--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,3 +1,0 @@
-if vim.g.ts_highlight_lua then
-  vim.treesitter.start()
-end


### PR DESCRIPTION
This variable was only meant for easy testing during the development
cycle for treesitter highlighting while Lua was the only parser useable
for daily driving. Now that we have a good vimdoc parser, this approach
simply doesn't scale and should be removed sooner rather than later.

Instead of setting this variable, people should add the autocommand
directly to their config:
```lua
vim.api.nvim_create_autocmd('FileType', {
  pattern = 'lua', -- or { 'lua', 'help' }
  callback = function() vim.treesitter.start() end,
})
```
(or put `vim.treesitter.start` in a `ftplugin`).
