### PR TITLE
ci: print DLL copy messages only in CI environment

### DIFF
--- a/cmake/WindowsDllCopy.cmake
+++ b/cmake/WindowsDllCopy.cmake
@@ -23,8 +23,9 @@ foreach(DLL_NAME ${DLLS})
     message(FATAL_ERROR "Unable to find dependency ${DLL_NAME}")
   endif()
 
-  message("Copying ${DLL_NAME} to ${DST}")
+  if($ENV{CI} MATCHES "true")
+    message("Copying ${DLL_NAME} to ${DST}")
+  endif()
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${DLL_PATH} ${DST})
   unset(DLL_PATH CACHE)
 endforeach()
-


### PR DESCRIPTION
In Windows, library DLL's are copied in the building process, and a message for each copy is printed.  This is useful to have in the log of CI, but annoying to see when you're building and rebuilding nvim constantly.

This PR enables the said messages only in CI environment, disabling it otherwise.