### PR TITLE
refactor(api): consistent VALIDATE messages

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -108,19 +108,19 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
     break;
   case kObjectTypeString:
     group = augroup_find(opts->group.data.string.data);
-    VALIDATE_S((group >= 0), "group", "", {
+    VALIDATE_S((group >= 0), "group", opts->group.data.string.data, {
       goto cleanup;
     });
     break;
   case kObjectTypeInteger:
     group = (int)opts->group.data.integer;
     char *name = augroup_name(group);
-    VALIDATE_S(augroup_exists(name), "group", "", {
+    VALIDATE_INT(augroup_exists(name), "group", opts->group.data.integer, {
       goto cleanup;
     });
     break;
   default:
-    VALIDATE_S(false, "group (must be string or integer)", "", {
+    VALIDATE_EXP(false, "group", "String or Integer", api_typename(opts->group.type), {
       goto cleanup;
     });
   }
@@ -142,7 +142,7 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
         event_set[event_nr] = true;
       })
     } else {
-      VALIDATE_S(false, "event (must be String or Array)", "", {
+      VALIDATE_EXP(false, "event", "String or Array", NULL, {
         goto cleanup;
       });
     }
@@ -160,11 +160,10 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
       pattern_filters[pattern_filter_count] = v.data.string.data;
       pattern_filter_count += 1;
     } else if (v.type == kObjectTypeArray) {
-      if (v.data.array.size > AUCMD_MAX_PATTERNS) {
-        api_set_error(err, kErrorTypeValidation, "Too many patterns (maximum of %d)",
-                      AUCMD_MAX_PATTERNS);
+      VALIDATE((v.data.array.size > AUCMD_MAX_PATTERNS),
+               "Too many patterns (maximum of %d)", AUCMD_MAX_PATTERNS, {
         goto cleanup;
-      }
+      });
 
       FOREACH_ITEM(v.data.array, item, {
         VALIDATE_T("pattern", kObjectTypeString, item.type, {

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -160,7 +160,7 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
       pattern_filters[pattern_filter_count] = v.data.string.data;
       pattern_filter_count += 1;
     } else if (v.type == kObjectTypeArray) {
-      VALIDATE((v.data.array.size > AUCMD_MAX_PATTERNS),
+      VALIDATE((v.data.array.size <= AUCMD_MAX_PATTERNS),
                "Too many patterns (maximum of %d)", AUCMD_MAX_PATTERNS, {
         goto cleanup;
       });

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -207,7 +207,7 @@ Boolean nvim_buf_attach(uint64_t channel_id, Buffer buffer, Boolean send_buffer,
       }
     }
 
-    VALIDATE_S(key_used, "key", k.data, {
+    VALIDATE_S(key_used, "'opts' key", k.data, {
       goto error;
     });
   }
@@ -1074,7 +1074,7 @@ void nvim_buf_delete(Buffer buffer, Dictionary opts, Error *err)
     } else if (strequal("unload", k.data)) {
       unload = api_object_to_bool(v, "unload", false, err);
     } else {
-      VALIDATE_S(false, "key", k.data, {
+      VALIDATE_S(false, "'opts' key", k.data, {
         return;
       });
     }

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1017,7 +1017,7 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
   VALIDATE_S(uc_validate_name(name.data), "command name", name.data, {
     goto err;
   });
-  VALIDATE_S(!mb_islower(name.data[0]), "command name (must begin with an uppercase letter)",
+  VALIDATE_S(!mb_islower(name.data[0]), "command name (must start with uppercase)",
              name.data, {
     goto err;
   });
@@ -1163,7 +1163,7 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
       goto err;
     });
   } else if (HAS_KEY(opts->complete)) {
-    VALIDATE(false, "%s", "Invalid complete: expected Function or String", {
+    VALIDATE_EXP(false, "complete", "Function or String", NULL, {
       goto err;
     });
   }
@@ -1190,7 +1190,7 @@ void create_user_command(String name, Object command, Dict(user_command) *opts, 
     rep = command.data.string.data;
     break;
   default:
-    VALIDATE(false, "%s", "Invalid command: expected Function or String", {
+    VALIDATE_EXP(false, "command", "Function or String", NULL, {
       goto err;
     });
   }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -238,7 +238,7 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
         });
       }
     } else {
-      VALIDATE_S(false, "key", k.data, {
+      VALIDATE_S(false, "'opts' key", k.data, {
         return rv;
       });
     }
@@ -329,7 +329,7 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
         });
       }
     } else {
-      VALIDATE_S(false, "key", k.data, {
+      VALIDATE_S(false, "'opts' key", k.data, {
         return rv;
       });
     }

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -508,12 +508,13 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
   });
 
   uint32_t id = 0;
-  if (opts->id.type == kObjectTypeInteger && opts->id.data.integer > 0) {
-    id = (uint32_t)opts->id.data.integer;
-  } else if (HAS_KEY(opts->id)) {
-    VALIDATE_S(false, "id (must be positive integer)", "", {
+  if (HAS_KEY(opts->id)) {
+    VALIDATE_EXP((opts->id.type == kObjectTypeInteger && opts->id.data.integer > 0),
+                 "id", "positive Integer", NULL, {
       goto error;
     });
+
+    id = (uint32_t)opts->id.data.integer;
   }
 
   int line2 = -1;
@@ -1088,10 +1089,10 @@ static bool extmark_get_index_from_obj(buf_T *buf, Integer ns_id, Object obj, in
     // Check if it is a position
   } else if (obj.type == kObjectTypeArray) {
     Array pos = obj.data.array;
-    VALIDATE((pos.size == 2
-              && pos.items[0].type == kObjectTypeInteger
-              && pos.items[1].type == kObjectTypeInteger),
-             "%s", "Invalid position: expected 2 Integer items", {
+    VALIDATE_EXP((pos.size == 2
+                  && pos.items[0].type == kObjectTypeInteger
+                  && pos.items[1].type == kObjectTypeInteger),
+                 "mark position", "2 Integer items", NULL, {
       return false;
     });
 
@@ -1101,7 +1102,7 @@ static bool extmark_get_index_from_obj(buf_T *buf, Integer ns_id, Object obj, in
     *col = (colnr_T)(pos_col >= 0 ? pos_col : MAXCOL);
     return true;
   } else {
-    VALIDATE(false, "%s", "Invalid position: expected mark id Integer or 2-item Array", {
+    VALIDATE_EXP(false, "mark position", "mark id Integer or 2-item Array", NULL, {
       return false;
     });
   }

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -36,7 +36,7 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
     } else if (!strcmp(opts->scope.data.string.data, "global")) {
       *scope = OPT_GLOBAL;
     } else {
-      VALIDATE(false, "%s", "Invalid scope: expected 'local' or 'global'", {
+      VALIDATE_EXP(false, "scope", "'local' or 'global'", NULL, {
         return FAIL;
       });
     }
@@ -197,7 +197,7 @@ void nvim_set_option_value(String name, Object value, Dict(option) *opts, Error 
     scope |= OPT_CLEAR;
     break;
   default:
-    VALIDATE_EXP(false, "option type", "Integer, Boolean, or String", api_typename(value.type), {
+    VALIDATE_EXP(false, name.data, "Integer/Boolean/String", api_typename(value.type), {
       return;
     });
   }

--- a/src/nvim/api/private/validate.c
+++ b/src/nvim/api/private/validate.c
@@ -9,6 +9,68 @@
 # include "api/private/validate.c.generated.h"
 #endif
 
+/// Creates "Invalid …" message and sets it on `err`.
+void api_err_invalid(Error *err, const char *name, const char *val_s, int64_t val_n, bool quote_val)
+{
+  ErrorType errtype = kErrorTypeValidation;
+  // Treat `name` without whitespace as a parameter (surround in quotes).
+  // Treat `name` with whitespace as a description (no quotes).
+  char *has_space = strchr(name, ' ');
+
+  // No value.
+  if (val_s && val_s[0] == '\0') {
+    if (has_space) {
+      api_set_error(err, errtype, "Invalid %s", name);
+    } else {
+      api_set_error(err, errtype, "Invalid '%s'", name);
+    }
+    return;
+  }
+
+  // Number value.
+  if (val_s == NULL) {
+    if (has_space) {
+      api_set_error(err, errtype, "Invalid %s: %" PRId64, name, val_n);
+    } else {
+      api_set_error(err, errtype, "Invalid '%s': %" PRId64, name, val_n);
+    }
+    return;
+  }
+
+  // String value.
+  if (has_space) {
+    api_set_error(err, errtype, "Invalid %s: '%s'", name, val_s);
+  } else if (quote_val) {
+    api_set_error(err, errtype, "Invalid '%s': '%s'", name, val_s);
+  } else {
+    api_set_error(err, errtype, "Invalid '%s': %s", name, val_s);
+  }
+}
+
+/// Creates "Invalid …: expected …" message and sets it on `err`.
+void api_err_exp(Error *err, const char *name, const char *expected, const char *actual)
+{
+  ErrorType errtype = kErrorTypeValidation;
+  // Treat `name` without whitespace as a parameter (surround in quotes).
+  // Treat `name` with whitespace as a description (no quotes).
+  char *has_space = strchr(name, ' ');
+
+  if (!actual) {
+    if (has_space) {
+      api_set_error(err, errtype, "Invalid %s: expected %s", name, expected);
+    } else {
+      api_set_error(err, errtype, "Invalid '%s': expected %s", name, expected);
+    }
+    return;
+  }
+
+  if (has_space) {
+    api_set_error(err, errtype, "Invalid %s: expected %s, got %s", name, expected, actual);
+  } else {
+    api_set_error(err, errtype, "Invalid '%s': expected %s, got %s", name, expected, actual);
+  }
+}
+
 bool check_string_array(Array arr, char *name, bool disallow_nl, Error *err)
 {
   snprintf(IObuff, sizeof(IObuff), "'%s' item", name);

--- a/src/nvim/api/private/validate.c
+++ b/src/nvim/api/private/validate.c
@@ -19,31 +19,22 @@ void api_err_invalid(Error *err, const char *name, const char *val_s, int64_t va
 
   // No value.
   if (val_s && val_s[0] == '\0') {
-    if (has_space) {
-      api_set_error(err, errtype, "Invalid %s", name);
-    } else {
-      api_set_error(err, errtype, "Invalid '%s'", name);
-    }
+    api_set_error(err, errtype, has_space ? "Invalid %s" : "Invalid '%s'", name);
     return;
   }
 
   // Number value.
   if (val_s == NULL) {
-    if (has_space) {
-      api_set_error(err, errtype, "Invalid %s: %" PRId64, name, val_n);
-    } else {
-      api_set_error(err, errtype, "Invalid '%s': %" PRId64, name, val_n);
-    }
+    api_set_error(err, errtype, has_space ? "Invalid %s: %" PRId64 : "Invalid '%s': %" PRId64,
+                  name, val_n);
     return;
   }
 
   // String value.
   if (has_space) {
-    api_set_error(err, errtype, "Invalid %s: '%s'", name, val_s);
-  } else if (quote_val) {
-    api_set_error(err, errtype, "Invalid '%s': '%s'", name, val_s);
+    api_set_error(err, errtype, quote_val ? "Invalid %s: '%s'" : "Invalid %s: %s", name, val_s);
   } else {
-    api_set_error(err, errtype, "Invalid '%s': %s", name, val_s);
+    api_set_error(err, errtype, quote_val ? "Invalid '%s': '%s'" : "Invalid '%s': %s", name, val_s);
   }
 }
 
@@ -56,19 +47,15 @@ void api_err_exp(Error *err, const char *name, const char *expected, const char 
   char *has_space = strchr(name, ' ');
 
   if (!actual) {
-    if (has_space) {
-      api_set_error(err, errtype, "Invalid %s: expected %s", name, expected);
-    } else {
-      api_set_error(err, errtype, "Invalid '%s': expected %s", name, expected);
-    }
+    api_set_error(err, errtype,
+                  has_space ? "Invalid %s: expected %s" : "Invalid '%s': expected %s",
+                  name, expected);
     return;
   }
 
-  if (has_space) {
-    api_set_error(err, errtype, "Invalid %s: expected %s, got %s", name, expected, actual);
-  } else {
-    api_set_error(err, errtype, "Invalid '%s': expected %s, got %s", name, expected, actual);
-  }
+  api_set_error(err, errtype,
+                has_space ? "Invalid %s: expected %s, got %s" : "Invalid '%s': expected %s, got %s",
+                name, expected, actual);
 }
 
 bool check_string_array(Array arr, char *name, bool disallow_nl, Error *err)

--- a/src/nvim/api/private/validate.h
+++ b/src/nvim/api/private/validate.h
@@ -4,44 +4,6 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 
-#define VALIDATE_INT(cond, name, val_, code) \
-  do { \
-    if (!(cond)) { \
-      api_set_error(err, kErrorTypeValidation, "Invalid " name ": %" PRId64, val_); \
-      code; \
-    } \
-  } while (0)
-
-#define VALIDATE_S(cond, name, val_, code) \
-  do { \
-    if (!(cond)) { \
-      if (strequal(val_, "")) { \
-        api_set_error(err, kErrorTypeValidation, "Invalid " name); \
-      } else { \
-        api_set_error(err, kErrorTypeValidation, "Invalid " name ": '%s'", val_); \
-      } \
-      code; \
-    } \
-  } while (0)
-
-#define VALIDATE_EXP(cond, name, expected, actual, code) \
-  do { \
-    if (!(cond)) { \
-      api_set_error(err, kErrorTypeValidation, "Invalid %s: expected %s, got %s", \
-                    name, expected, actual); \
-      code; \
-    } \
-  } while (0)
-
-#define VALIDATE_T(name, expected_t, actual_t, code) \
-  do { \
-    if (expected_t != actual_t) { \
-      api_set_error(err, kErrorTypeValidation, "Invalid %s: expected %s, got %s", \
-                    name, api_typename(expected_t), api_typename(actual_t)); \
-      code; \
-    } \
-  } while (0)
-
 #define VALIDATE(cond, fmt_, fmt_arg1, code) \
   do { \
     if (!(cond)) { \
@@ -50,10 +12,42 @@
     } \
   } while (0)
 
+#define VALIDATE_INT(cond, name, val_, code) \
+  do { \
+    if (!(cond)) { \
+      api_err_invalid(err, name, NULL, val_, false); \
+      code; \
+    } \
+  } while (0)
+
+#define VALIDATE_S(cond, name, val_, code) \
+  do { \
+    if (!(cond)) { \
+      api_err_invalid(err, name, val_, 0, true); \
+      code; \
+    } \
+  } while (0)
+
+#define VALIDATE_EXP(cond, name, expected, actual, code) \
+  do { \
+    if (!(cond)) { \
+      api_err_exp(err, name, expected, actual); \
+      code; \
+    } \
+  } while (0)
+
+#define VALIDATE_T(name, expected_t, actual_t, code) \
+  do { \
+    if (expected_t != actual_t) { \
+      api_err_exp(err, name, api_typename(expected_t), api_typename(actual_t)); \
+      code; \
+    } \
+  } while (0)
+
 #define VALIDATE_RANGE(cond, name, code) \
   do { \
     if (!(cond)) { \
-      api_set_error(err, kErrorTypeValidation, "Invalid '%s': out of range", name); \
+      api_err_invalid(err, name, "out of range", 0, false); \
       code; \
     } \
   } while (0)

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -655,12 +655,12 @@ Object nvim_get_var(String name, Error *err)
   dictitem_T *di = tv_dict_find(&globvardict, name.data, (ptrdiff_t)name.size);
   if (di == NULL) {  // try to autoload script
     bool found = script_autoload(name.data, name.size, false) && !aborting();
-    VALIDATE_S(found, "global var", name.data, {
+    VALIDATE(found, "Key not found: %s", name.data, {
       return (Object)OBJECT_INIT;
     });
     di = tv_dict_find(&globvardict, name.data, (ptrdiff_t)name.size);
   }
-  VALIDATE_S((di != NULL), "global var (not found)", name.data, {
+  VALIDATE((di != NULL), "Key not found: %s", name.data, {
     return (Object)OBJECT_INIT;
   });
   return vim_to_object(&di->di_tv);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1632,18 +1632,18 @@ Array nvim_call_atomic(uint64_t channel_id, Array calls, Arena *arena, Error *er
 
   size_t i;  // also used for freeing the variables
   for (i = 0; i < calls.size; i++) {
-    VALIDATE_T("calls item", kObjectTypeArray, calls.items[i].type, {
+    VALIDATE_T("'calls' item", kObjectTypeArray, calls.items[i].type, {
       goto theend;
     });
     Array call = calls.items[i].data.array;
-    VALIDATE((call.size == 2), "%s", "calls item must be a 2-item Array", {
+    VALIDATE_EXP((call.size == 2), "'calls' item", "2-item Array", NULL, {
       goto theend;
     });
     VALIDATE_T("name", kObjectTypeString, call.items[0].type, {
       goto theend;
     });
     String name = call.items[0].data.string;
-    VALIDATE_T("args", kObjectTypeArray, call.items[1].type, {
+    VALIDATE_T("call args", kObjectTypeArray, call.items[1].type, {
       goto theend;
     });
     Array args = call.items[1].data.array;
@@ -2108,10 +2108,10 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
     VALIDATE_T("fillchar", kObjectTypeString, opts->fillchar.type, {
       return result;
     });
-    VALIDATE((opts->fillchar.data.string.size != 0
-              && ((size_t)utf_ptr2len(opts->fillchar.data.string.data)
-                  == opts->fillchar.data.string.size)),
-             "%s", "Invalid fillchar: expected single character", {
+    VALIDATE_EXP((opts->fillchar.data.string.size != 0
+                  && ((size_t)utf_ptr2len(opts->fillchar.data.string.data)
+                      == opts->fillchar.data.string.size)),
+                 "fillchar", "single character", NULL, {
       return result;
     });
     fillchar = utf_ptr2char(opts->fillchar.data.string.data);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -654,12 +654,13 @@ Object nvim_get_var(String name, Error *err)
 {
   dictitem_T *di = tv_dict_find(&globvardict, name.data, (ptrdiff_t)name.size);
   if (di == NULL) {  // try to autoload script
-    VALIDATE_S((script_autoload(name.data, name.size, false) && !aborting()), "key", name.data, {
+    bool found = script_autoload(name.data, name.size, false) && !aborting();
+    VALIDATE_S(found, "global var", name.data, {
       return (Object)OBJECT_INIT;
     });
     di = tv_dict_find(&globvardict, name.data, (ptrdiff_t)name.size);
   }
-  VALIDATE_S((di != NULL), "key (not found)", name.data, {
+  VALIDATE_S((di != NULL), "global var (not found)", name.data, {
     return (Object)OBJECT_INIT;
   });
   return vim_to_object(&di->di_tv);
@@ -986,7 +987,7 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
       v->data.luaref = LUA_NOREF;
       break;
     } else {
-      VALIDATE_S(false, "key", k.data, {});
+      VALIDATE_S(false, "'opts' key", k.data, {});
     }
   }
 

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -1089,7 +1089,7 @@ int object_to_color(Object val, char *key, bool rgb, Error *err)
     });
     return color;
   } else {
-    VALIDATE(false, "Invalid %s: expected String or Integer", key, {
+    VALIDATE_EXP(false, key, "String or Integer", NULL, {
       return 0;
     });
   }

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -30,11 +30,11 @@ describe('autocmd api', function()
       }))
       eq("Required: 'command' or 'callback'", pcall_err(meths.create_autocmd, 'FileType', {
       }))
-      eq('Invalid desc: expected String, got Integer', pcall_err(meths.create_autocmd, 'FileType', {
+      eq("Invalid 'desc': expected String, got Integer", pcall_err(meths.create_autocmd, 'FileType', {
         command = 'ls',
         desc = 42,
       }))
-      eq('Invalid callback: expected Lua function or Vim function name, got Integer', pcall_err(meths.create_autocmd, 'FileType', {
+      eq("Invalid 'callback': expected Lua function or Vim function name, got Integer", pcall_err(meths.create_autocmd, 'FileType', {
         callback = 0,
       }))
       eq("Invalid 'event' item: expected String, got Array", pcall_err(meths.create_autocmd,
@@ -301,6 +301,27 @@ describe('autocmd api', function()
   end)
 
   describe('nvim_get_autocmds', function()
+    it('validation', function()
+      eq("Invalid 'group': 9997999", pcall_err(meths.get_autocmds, {
+        group = 9997999,
+      }))
+      eq("Invalid 'group': 'bogus'", pcall_err(meths.get_autocmds, {
+        group = 'bogus',
+      }))
+      eq("Invalid 'group': expected String or Integer, got Array", pcall_err(meths.get_autocmds, {
+        group = {},
+      }))
+      eq("Invalid 'buffer': expected Integer or Array, got Boolean", pcall_err(meths.get_autocmds, {
+        buffer = true,
+      }))
+      eq("Invalid 'event': expected String or Array", pcall_err(meths.get_autocmds, {
+        event = true,
+      }))
+      eq("Invalid 'pattern': expected String or Array, got Boolean", pcall_err(meths.get_autocmds, {
+        pattern = true,
+      }))
+    end)
+
     describe('events', function()
       it('returns one autocmd when there is only one for an event', function()
         command [[au! InsertEnter]]
@@ -414,8 +435,8 @@ describe('autocmd api', function()
           pattern = "<buffer=2>",
         }}, aus)
 
-        eq("Invalid buffer: expected Integer or Array, got String", pcall_err(meths.get_autocmds, { event = "InsertEnter", buffer = "foo" }))
-        eq("Invalid buffer: expected Integer, got String", pcall_err(meths.get_autocmds, { event = "InsertEnter", buffer = { "foo", 42 } }))
+        eq("Invalid 'buffer': expected Integer or Array, got String", pcall_err(meths.get_autocmds, { event = "InsertEnter", buffer = "foo" }))
+        eq("Invalid 'buffer': expected Integer, got String", pcall_err(meths.get_autocmds, { event = "InsertEnter", buffer = { "foo", 42 } }))
         eq("Invalid buffer id: 42", pcall_err(meths.get_autocmds, { event = "InsertEnter", buffer = { 42 } }))
 
         local bufs = {}
@@ -585,7 +606,7 @@ describe('autocmd api', function()
         ]], {}))
 
         eq(false, success)
-        matches("Invalid group: 'NotDefined'", code)
+        matches("Invalid 'group': 'NotDefined'", code)
       end)
 
       it('raises error for undefined augroup id', function()
@@ -603,7 +624,7 @@ describe('autocmd api', function()
         ]], {}))
 
         eq(false, success)
-        matches('Invalid group: 1', code)
+        matches("Invalid 'group': 1", code)
       end)
 
       it('raises error for invalid group type', function()
@@ -618,7 +639,7 @@ describe('autocmd api', function()
         ]], {}))
 
         eq(false, success)
-        matches("Invalid group: expected String or Integer, got Boolean", code)
+        matches("Invalid 'group': expected String or Integer, got Boolean", code)
       end)
 
       it('raises error for invalid pattern array', function()
@@ -695,16 +716,16 @@ describe('autocmd api', function()
 
   describe('nvim_exec_autocmds', function()
     it('validation', function()
-      eq('Invalid group: 9997999', pcall_err(meths.exec_autocmds, 'FileType', {
+      eq("Invalid 'group': 9997999", pcall_err(meths.exec_autocmds, 'FileType', {
         group = 9997999,
       }))
-      eq("Invalid group: 'bogus'", pcall_err(meths.exec_autocmds, 'FileType', {
+      eq("Invalid 'group': 'bogus'", pcall_err(meths.exec_autocmds, 'FileType', {
         group = 'bogus',
       }))
-      eq('Invalid group: expected String or Integer, got Array', pcall_err(meths.exec_autocmds, 'FileType', {
+      eq("Invalid 'group': expected String or Integer, got Array", pcall_err(meths.exec_autocmds, 'FileType', {
         group = {},
       }))
-      eq('Invalid buffer: expected Integer, got Array', pcall_err(meths.exec_autocmds, 'FileType', {
+      eq("Invalid 'buffer': expected Integer, got Array", pcall_err(meths.exec_autocmds, 'FileType', {
         buffer = {},
       }))
       eq("Invalid 'event' item: expected String, got Array", pcall_err(meths.exec_autocmds,

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -762,7 +762,7 @@ describe('API: buffer events:', function()
   it('returns a proper error on nonempty options dict', function()
     clear()
     local b = editoriginal(false)
-    eq("Invalid key: 'builtin'", pcall_err(buffer, 'attach', b, false, {builtin="asfd"}))
+    eq("Invalid 'opts' key: 'builtin'", pcall_err(buffer, 'attach', b, false, {builtin="asfd"}))
   end)
 
   it('nvim_buf_attach returns response after delay #8634', function()

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -543,23 +543,19 @@ describe('nvim_create_user_command', function()
   end)
 
   it('does not allow invalid command names', function()
-    matches("Invalid command name %(must begin with an uppercase letter%): 'test'", pcall_err(exec_lua, [[
+    eq("Invalid command name (must start with uppercase): 'test'", pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('test', 'echo "hi"', {})
     ]]))
-
-    matches('Invalid command name', pcall_err(exec_lua, [[
+    eq("Invalid command name: 't@'", pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('t@', 'echo "hi"', {})
     ]]))
-
-    matches('Invalid command name', pcall_err(exec_lua, [[
+    eq("Invalid command name: 'T@st'", pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('T@st', 'echo "hi"', {})
     ]]))
-
-    matches('Invalid command name', pcall_err(exec_lua, [[
+    eq("Invalid command name: 'Test!'", pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('Test!', 'echo "hi"', {})
     ]]))
-
-    matches('Invalid command name', pcall_err(exec_lua, [[
+    eq("Invalid command name: '💩'", pcall_err(exec_lua, [[
       vim.api.nvim_create_user_command('💩', 'echo "hi"', {})
     ]]))
   end)

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -102,7 +102,6 @@ describe('API/extmarks', function()
   end)
 
   it('validation', function()
-    local ns_invalid = ns2 + 1
     eq("Invalid 'end_col': expected Integer, got Array", pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = {}, end_row = 1 }))
     eq("Invalid 'end_row': expected Integer, got Array", pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_row = {} }))
     eq("Invalid 'id': expected positive Integer", pcall_err(set_extmark, ns, {}, 0, 0, { end_col = 1, end_row = 1 }))

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -101,6 +101,15 @@ describe('API/extmarks', function()
     ns2 = request('nvim_create_namespace', "my-fancy-plugin2")
   end)
 
+  it('validation', function()
+    local ns_invalid = ns2 + 1
+    eq("Invalid 'end_col': expected Integer, got Array", pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = {}, end_row = 1 }))
+    eq("Invalid 'end_row': expected Integer, got Array", pcall_err(set_extmark, ns, marks[2], 0, 0, { end_col = 1, end_row = {} }))
+    eq("Invalid 'id': expected positive Integer", pcall_err(set_extmark, ns, {}, 0, 0, { end_col = 1, end_row = 1 }))
+    eq("Invalid mark position: expected 2 Integer items", pcall_err(get_extmarks, ns, {}, {-1, -1}))
+    eq("Invalid mark position: expected mark id Integer or 2-item Array", pcall_err(get_extmarks, ns, true, {-1, -1}))
+  end)
+
   it("can end extranges past final newline using end_col = 0", function()
     set_extmark(ns, marks[1], 0, 0, {
       end_col = 0,
@@ -1344,10 +1353,10 @@ describe('API/extmarks', function()
 
   it('throws consistent error codes', function()
     local ns_invalid = ns2 + 1
-    eq("Invalid ns_id: 3", pcall_err(set_extmark, ns_invalid, marks[1], positions[1][1], positions[1][2]))
-    eq("Invalid ns_id: 3", pcall_err(curbufmeths.del_extmark, ns_invalid, marks[1]))
-    eq("Invalid ns_id: 3", pcall_err(get_extmarks, ns_invalid, positions[1], positions[2]))
-    eq("Invalid ns_id: 3", pcall_err(get_extmark_by_id, ns_invalid, marks[1]))
+    eq("Invalid 'ns_id': 3", pcall_err(set_extmark, ns_invalid, marks[1], positions[1][1], positions[1][2]))
+    eq("Invalid 'ns_id': 3", pcall_err(curbufmeths.del_extmark, ns_invalid, marks[1]))
+    eq("Invalid 'ns_id': 3", pcall_err(get_extmarks, ns_invalid, positions[1], positions[2]))
+    eq("Invalid 'ns_id': 3", pcall_err(get_extmark_by_id, ns_invalid, marks[1]))
   end)
 
   it('when col = line-length, set the mark on eol', function()

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -240,7 +240,7 @@ describe("API: set highlight", function()
   it('validation', function()
     eq("Invalid 'blend': out of range",
       pcall_err(meths.set_hl, 0, 'Test_hl3', {fg='#FF00FF', blend=999}))
-    eq("Invalid blend: expected Integer, got Array",
+    eq("Invalid 'blend': expected Integer, got Array",
       pcall_err(meths.set_hl, 0, 'Test_hl3', {fg='#FF00FF', blend={}}))
   end)
 

--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -45,11 +45,11 @@ describe('API', function()
     it('validation', function()
       local status, rv = pcall(request, "nvim_get_proc_children", -1)
       eq(false, status)
-      eq("Invalid pid: -1", string.match(rv, "Invalid.*"))
+      eq("Invalid 'pid': -1", string.match(rv, "Invalid.*"))
 
       status, rv = pcall(request, "nvim_get_proc_children", 0)
       eq(false, status)
-      eq("Invalid pid: 0", string.match(rv, "Invalid.*"))
+      eq("Invalid 'pid': 0", string.match(rv, "Invalid.*"))
 
       -- Assume PID 99999 does not exist.
       status, rv = pcall(request, "nvim_get_proc_children", 99999)
@@ -71,11 +71,11 @@ describe('API', function()
     it('validation', function()
       local status, rv = pcall(request, "nvim_get_proc", -1)
       eq(false, status)
-      eq("Invalid pid: -1", string.match(rv, "Invalid.*"))
+      eq("Invalid 'pid': -1", string.match(rv, "Invalid.*"))
 
       status, rv = pcall(request, "nvim_get_proc", 0)
       eq(false, status)
-      eq("Invalid pid: 0", string.match(rv, "Invalid.*"))
+      eq("Invalid 'pid': 0", string.match(rv, "Invalid.*"))
 
       -- Assume PID 99999 does not exist.
       status, rv = pcall(request, "nvim_get_proc", 99999)

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -23,23 +23,23 @@ describe('nvim_ui_attach()', function()
     eq('No such UI option: foo',
       pcall_err(meths.ui_attach, 80, 24, { foo={'foo'} }))
 
-    eq('Invalid ext_linegrid: expected Boolean, got Array',
+    eq("Invalid 'ext_linegrid': expected Boolean, got Array",
       pcall_err(meths.ui_attach, 80, 24, { ext_linegrid={} }))
-    eq('Invalid override: expected Boolean, got Array',
+    eq("Invalid 'override': expected Boolean, got Array",
       pcall_err(meths.ui_attach, 80, 24, { override={} }))
-    eq('Invalid rgb: expected Boolean, got Array',
+    eq("Invalid 'rgb': expected Boolean, got Array",
       pcall_err(meths.ui_attach, 80, 24, { rgb={} }))
-    eq('Invalid term_name: expected String, got Boolean',
+    eq("Invalid 'term_name': expected String, got Boolean",
       pcall_err(meths.ui_attach, 80, 24, { term_name=true }))
-    eq('Invalid term_colors: expected Integer, got Boolean',
+    eq("Invalid 'term_colors': expected Integer, got Boolean",
       pcall_err(meths.ui_attach, 80, 24, { term_colors=true }))
-    eq('Invalid term_background: expected String, got Boolean',
+    eq("Invalid 'term_background': expected String, got Boolean",
       pcall_err(meths.ui_attach, 80, 24, { term_background=true }))
-    eq('Invalid stdin_fd: expected Integer, got String',
+    eq("Invalid 'stdin_fd': expected Integer, got String",
       pcall_err(meths.ui_attach, 80, 24, { stdin_fd='foo' }))
-    eq('Invalid stdin_tty: expected Boolean, got String',
+    eq("Invalid 'stdin_tty': expected Boolean, got String",
       pcall_err(meths.ui_attach, 80, 24, { stdin_tty='foo' }))
-    eq('Invalid stdout_tty: expected Boolean, got String',
+    eq("Invalid 'stdout_tty': expected Boolean, got String",
       pcall_err(meths.ui_attach, 80, 24, { stdout_tty='foo' }))
 
     eq('UI not attached to channel: 1',

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1288,6 +1288,11 @@ describe('API', function()
   end)
 
   describe('set/get/del variables', function()
+    it('validation', function()
+      eq('Key not found: bogus', pcall_err(meths.get_var, 'bogus'))
+      eq('Key not found: bogus', pcall_err(meths.del_var, 'bogus'))
+    end)
+
     it('nvim_get_var, nvim_set_var, nvim_del_var', function()
       nvim('set_var', 'lua', {1, 2, {['3'] = 1}})
       eq({1, 2, {['3'] = 1}}, nvim('get_var', 'lua'))

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -490,7 +490,7 @@ describe('API', function()
       eq('', eval('v:errmsg'))  -- v:errmsg was not updated.
     end)
 
-    it('validates args', function()
+    it('validation', function()
       local too_many_args = { 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x' }
       source([[
         function! Foo(...) abort
@@ -532,7 +532,7 @@ describe('API', function()
       eq('@it works@', nvim('call_dict_function', { result = 'it works', G = 'G'}, 'G', {}))
     end)
 
-    it('validates args', function()
+    it('validation', function()
       command('let g:d={"baz":"zub","meep":[]}')
       eq('Not found: bogus',
         pcall_err(request, 'nvim_call_dict_function', 'g:d', 'bogus', {1,2}))
@@ -648,10 +648,10 @@ describe('API', function()
   end)
 
   describe('nvim_paste', function()
-    it('validates args', function()
-      eq('Invalid phase: -2',
+    it('validation', function()
+      eq("Invalid 'phase': -2",
         pcall_err(request, 'nvim_paste', 'foo', true, -2))
-      eq('Invalid phase: 4',
+      eq("Invalid 'phase': 4",
         pcall_err(request, 'nvim_paste', 'foo', true, 4))
     end)
     local function run_streamed_paste_tests()
@@ -1154,10 +1154,10 @@ describe('API', function()
   end)
 
   describe('nvim_put', function()
-    it('validates args', function()
-      eq("Invalid line: expected String, got Integer",
+    it('validation', function()
+      eq("Invalid 'line': expected String, got Integer",
         pcall_err(request, 'nvim_put', {42}, 'l', false, false))
-      eq("Invalid type: 'x'",
+      eq("Invalid 'type': 'x'",
         pcall_err(request, 'nvim_put', {'foo'}, 'x', false, false))
     end)
     it("fails if 'nomodifiable'", function()
@@ -1259,9 +1259,9 @@ describe('API', function()
         yyybc line 2
         line 3
         ]])
-      eq("Invalid type: 'bx'",
+      eq("Invalid 'type': 'bx'",
          pcall_err(meths.put, {'xxx', 'yyy'}, 'bx', false, true))
-      eq("Invalid type: 'b3x'",
+      eq("Invalid 'type': 'b3x'",
          pcall_err(meths.put, {'xxx', 'yyy'}, 'b3x', false, true))
     end)
   end)
@@ -1411,12 +1411,14 @@ describe('API', function()
     end)
 
     it('validation', function()
-      eq("Invalid scope: expected 'local' or 'global'",
+      eq("Invalid 'scope': expected 'local' or 'global'",
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 'bogus'}))
-      eq("Invalid scope: expected 'local' or 'global'",
+      eq("Invalid 'scope': expected 'local' or 'global'",
         pcall_err(nvim, 'set_option_value', 'scrolloff', 1, {scope = 'bogus'}))
-      eq("Invalid scope: expected String, got Integer",
+      eq("Invalid 'scope': expected String, got Integer",
         pcall_err(nvim, 'get_option_value', 'scrolloff', {scope = 42}))
+      eq("Invalid 'scrolloff': expected Integer/Boolean/String, got Array",
+        pcall_err(nvim, 'set_option_value', 'scrolloff', {}, {}))
     end)
 
     it('can get local values when global value is set', function()
@@ -1786,12 +1788,12 @@ describe('API', function()
   end)
 
   describe('nvim_get_context', function()
-    it('validates args', function()
+    it('validation', function()
       eq("Invalid key: 'blah'",
         pcall_err(nvim, 'get_context', {blah={}}))
-      eq("Invalid types: expected Array, got Integer",
+      eq("Invalid 'types': expected Array, got Integer",
         pcall_err(nvim, 'get_context', {types=42}))
-      eq("Invalid type: 'zub'",
+      eq("Invalid 'type': 'zub'",
         pcall_err(nvim, 'get_context', {types={'jumps', 'zub', 'zam',}}))
     end)
     it('returns map of current editor state', function()
@@ -2238,7 +2240,7 @@ describe('API', function()
         {'nvim_set_var'},
         {'nvim_set_var', {'avar', 2}},
       }
-      eq('calls item must be a 2-item Array',
+      eq("Invalid 'calls' item: expected 2-item Array",
          pcall_err(meths.call_atomic, req))
       -- call before was done, but not after
       eq(1, meths.get_var('avar'))
@@ -2247,7 +2249,7 @@ describe('API', function()
         { 'nvim_set_var', { 'bvar', { 2, 3 } } },
         12,
       }
-      eq("Invalid calls item: expected Array, got Integer",
+      eq("Invalid 'calls' item: expected Array, got Integer",
          pcall_err(meths.call_atomic, req))
       eq({2,3}, meths.get_var('bvar'))
 
@@ -2255,7 +2257,7 @@ describe('API', function()
         {'nvim_set_current_line', 'little line'},
         {'nvim_set_var', {'avar', 3}},
       }
-      eq("Invalid args: expected Array, got String",
+      eq("Invalid call args: expected Array, got String",
          pcall_err(meths.call_atomic, req))
       -- call before was done, but not after
       eq(1, meths.get_var('avar'))
@@ -3119,15 +3121,15 @@ describe('API', function()
          meths.eval_statusline('a%=b', { fillchar = '\031', maxwidth = 5 }))
     end)
     it('rejects multiple-character fillchar', function()
-      eq('Invalid fillchar: expected single character',
+      eq("Invalid 'fillchar': expected single character",
          pcall_err(meths.eval_statusline, '', { fillchar = 'aa' }))
     end)
     it('rejects empty string fillchar', function()
-      eq('Invalid fillchar: expected single character',
+      eq("Invalid 'fillchar': expected single character",
          pcall_err(meths.eval_statusline, '', { fillchar = '' }))
     end)
     it('rejects non-string fillchar', function()
-      eq("Invalid fillchar: expected String, got Integer",
+      eq("Invalid 'fillchar': expected String, got Integer",
          pcall_err(meths.eval_statusline, '', { fillchar = 1 }))
     end)
     it('rejects invalid string', function()

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -751,8 +751,8 @@ describe('Buffer highlighting', function()
 
     it('validates contents', function()
       -- this used to leak memory
-      eq('Invalid chunk: expected Array, got String', pcall_err(set_virtual_text, id1, 0, {"texty"}, {}))
-      eq('Invalid chunk: expected Array, got String', pcall_err(set_virtual_text, id1, 0, {{"very"}, "texty"}, {}))
+      eq("Invalid 'chunk': expected Array, got String", pcall_err(set_virtual_text, id1, 0, {"texty"}, {}))
+      eq("Invalid 'chunk': expected Array, got String", pcall_err(set_virtual_text, id1, 0, {{"very"}, "texty"}, {}))
     end)
 
     it('can be retrieved', function()


### PR DESCRIPTION
Problem:

Validation messages are not consistently formatted.
- Parameter names sometimes are NOT quoted.
- Descriptive names (non-parameters) sometimes ARE quoted.

Solution:

Always quote the `name` value passed to a VALIDATE macro _unless_ the value has whitespace.