### PR TITLE
fix: uv_tty_set_mode failed in Windows

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -359,12 +359,7 @@ static void terminfo_start(TUIData *tui)
     if (ret) {
       ELOG("uv_tty_init failed: %s", uv_strerror(ret));
     }
-#ifdef MSWIN
-    ret = uv_tty_set_mode(&tui->output_handle.tty, UV_TTY_MODE_RAW);
-    if (ret) {
-      ELOG("uv_tty_set_mode failed: %s", uv_strerror(ret));
-    }
-#else
+#ifndef MSWIN
     int retry_count = 10;
     // A signal may cause uv_tty_set_mode() to fail (e.g., SIGCONT). Retry a
     // few times. #12322


### PR DESCRIPTION
Problem:  uv_tty_set_mode on stdout in Windows exits with error.
Cause:    Windows cannot set the properties of the output of a tty.
Solution: Remove call to uv_tty_set_mode.

Ref: #21445
Ref: https://github.com/libuv/libuv/commit/88634c1405097c19582e870d278dd0e29dc55455#r100598822

Fixes #21445