### PR TITLE
feat(api): allow empty Lua table for dict sub-items

### DIFF
--- a/src/nvim/api/private/validate.h
+++ b/src/nvim/api/private/validate.h
@@ -38,8 +38,31 @@
 
 #define VALIDATE_T(name, expected_t, actual_t, code) \
   do { \
+    STATIC_ASSERT(expected_t != kObjectTypeDictionary, "use VALIDATE_T_DICT"); \
     if (expected_t != actual_t) { \
       api_err_exp(err, name, api_typename(expected_t), api_typename(actual_t)); \
+      code; \
+    } \
+  } while (0)
+
+/// Checks that `obj_` has type `expected_t`.
+#define VALIDATE_T2(obj_, expected_t, code) \
+  do { \
+    STATIC_ASSERT(expected_t != kObjectTypeDictionary, "use VALIDATE_T_DICT"); \
+    if ((obj_).type != expected_t) { \
+      api_err_exp(err, STR(obj_), api_typename(expected_t), api_typename((obj_).type)); \
+      code; \
+    } \
+  } while (0)
+
+/// Checks that `obj_` has Dict type. Also allows empty Array in a Lua context.
+#define VALIDATE_T_DICT(name, obj_, code) \
+  do { \
+    if ((obj_).type != kObjectTypeDictionary \
+        && !(channel_id == LUA_INTERNAL_CALL \
+             && (obj_).type == kObjectTypeArray \
+             && (obj_).data.array.size == 0)) { \
+      api_err_exp(err, name, api_typename(kObjectTypeDictionary), api_typename((obj_).type)); \
       code; \
     } \
   } while (0)

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -1025,7 +1025,7 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     // TODO(clason): handle via gen_api_dispatch
     cterm_mask_provided = true;
   } else if (HAS_KEY(dict->cterm)) {
-    VALIDATE_T("cterm", kObjectTypeDictionary, dict->cterm.type, {
+    VALIDATE_EXP(false, "cterm", "Dict", api_typename(dict->cterm.type), {
       return hlattrs;
     });
   }

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -24,7 +24,7 @@ describe('nvim_get_commands', function()
     eq({}, meths.get_commands({builtin=false}))
   end)
 
-  it('validates input', function()
+  it('validation', function()
     eq('builtin=true not implemented', pcall_err(meths.get_commands,
       {builtin=true}))
     eq("Invalid key: 'foo'", pcall_err(meths.get_commands,


### PR DESCRIPTION
Problem:
The Lua-API bridge allows Dict params to be empty Lua (list) tables at the function-signature level. But not for _nested_ Dicts, because they are not modeled:
https://github.com/neovim/neovim/blob/fae754073289566051433fae74ec65783f9e7a6a/src/nvim/api/keysets.lua#L184
Some API functions like `nvim_cmd` check for `kObjectTypeDictionary` and
don't handle the case of empty Lua tables (treated as "Array").

Solution:
Introduce `VALIDATE_T_DICT` and use it in places where `kObjectTypeDictionary` was being checked directly.


fixes #21005