### PR TITLE
fix: set taskbar and window icon in windows

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -589,7 +589,7 @@ int main(int argc, char **argv)
   }
 
 #ifdef MSWIN
-  if (use_builtin_ui) {
+  if (use_remote_ui || use_builtin_ui) {
     os_icon_init();
   }
   os_title_save();


### PR DESCRIPTION
Problem: After TUI refactor commit, code for setting Windows taskbar icon wasn't being executed because of a backdated conditional.

Solution: Update the conditional to take TUI refactor into account.

Ref: https://github.com/neovim/neovim/pull/20634#discussion_r1088993820