### PR TITLE
ci: add GCC Release testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
             cc: gcc
             runner: ubuntu-22.04
             flags: -D UNSIGNED_CHAR=ON
+          - flavor: release
+            cc: gcc
+            runner: ubuntu-22.04
+            flags: -D CMAKE_BUILD_TYPE=Release
           - cc: clang
             runner: macos-12
 
@@ -262,7 +266,7 @@ jobs:
         id: abort_job
         run: echo "status=${{ job.status }}" >> $GITHUB_OUTPUT
 
-      - if: matrix.flavor != 'tsan' && matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
+      - if: matrix.flavor != 'tsan' && matrix.flavor != 'release' && matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
         name: Unittest
         timeout-minutes: 5
         run: cmake --build build --target unittest

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -92,6 +92,13 @@ else()
     -Wmissing-noreturn
     -Wmissing-format-attribute
     -Wmissing-prototypes)
+
+  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(main_lib INTERFACE
+      $<$<CONFIG:Release>:-Wno-unused-result>
+      $<$<CONFIG:RelWithDebInfo>:-Wno-unused-result>
+      $<$<CONFIG:MinSizeRel>:-Wno-unused-result>)
+  endif()
 endif()
 
 # On FreeBSD 64 math.h uses unguarded C11 extension, which taints clang

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1135,7 +1135,7 @@ void marktree_check(MarkTree *b)
 
   mtpos_t dummy;
   bool last_right = false;
-  size_t nkeys = check_node(b, b->root, &dummy, &last_right);
+  size_t nkeys = marktree_check_node(b, b->root, &dummy, &last_right);
   assert(b->n_keys == nkeys);
   assert(b->n_keys == map_size(b->id2node));
 #else
@@ -1145,7 +1145,7 @@ void marktree_check(MarkTree *b)
 }
 
 #ifndef NDEBUG
-static size_t check_node(MarkTree *b, mtnode_t *x, mtpos_t *last, bool *last_right)
+size_t marktree_check_node(MarkTree *b, mtnode_t *x, mtpos_t *last, bool *last_right)
 {
   assert(x->n <= 2 * T - 1);
   // TODO(bfredl): too strict if checking "in repair" post-delete tree.
@@ -1154,7 +1154,7 @@ static size_t check_node(MarkTree *b, mtnode_t *x, mtpos_t *last, bool *last_rig
 
   for (int i = 0; i < x->n; i++) {
     if (x->level) {
-      n_keys += check_node(b, x->ptr[i], last, last_right);
+      n_keys += marktree_check_node(b, x->ptr[i], last, last_right);
     } else {
       *last = (mtpos_t) { 0, 0 };
     }
@@ -1171,7 +1171,7 @@ static size_t check_node(MarkTree *b, mtnode_t *x, mtpos_t *last, bool *last_rig
   }
 
   if (x->level) {
-    n_keys += check_node(b, x->ptr[x->n], last, last_right);
+    n_keys += marktree_check_node(b, x->ptr[x->n], last, last_right);
     unrelative(x->key[x->n - 1].pos, last);
 
     for (int i = 0; i < x->n + 1; i++) {


### PR DESCRIPTION
We currently have no release testing, so it's good to check for any
unwanted behavior on release builds as well. Prefer GCC over clang, as
GCC release builds seem to create more warnings on release compared to
debug.
