### PR TITLE
Fix LSP issue template error

### DIFF
--- a/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
@@ -46,7 +46,7 @@ body:
           pattern = pattern,
           callback = function(args)
             local match = vim.fs.find(root_markers, { path = args.file, upward = true })[1]
-            local root_dir = match and vim.fn.fnamemodify(match, ':p:h') or vim.NIL
+            local root_dir = match and vim.fn.fnamemodify(match, ':p:h') or nil
             vim.lsp.start({
               name = 'bugged-ls',
               cmd = cmd,


### PR DESCRIPTION
LSP issue template uses `vim.NIL` which causes error on both neovim v0.8.3 and nightly (v0.9.0 631775c05)

![Screenshot from 2023-02-16 14-58-31](https://user-images.githubusercontent.com/12980409/219403017-6fc4b981-1f08-4190-b93a-d8318bce47fa.png)

`repro.lua` using `vim.NIL` that causes the error. Changing it to `nil` doesn't cause the error.
```lua
--- CHANGE THESE
local pattern = "python"
local cmd = { "pyright-langserver", "--stdio" }
-- Add files/folders here that indicate the root of a project
local root_markers = { ".git", ".editorconfig" }
-- Change to table with settings if required
local settings = vim.empty_dict()

vim.api.nvim_create_autocmd("FileType", {
	pattern = pattern,
	callback = function(args)
		local match = vim.fs.find(root_markers, { path = args.file, upward = true })[1]
		local root_dir = match and vim.fn.fnamemodify(match, ":p:h") or vim.NIL
		vim.lsp.start({
			name = "pyright",
			cmd = cmd,
			root_dir = root_dir,
			settings = settings,
		})
	end,
})

local config = {
	-- virtual_text = true,
	virtual_text = { spacing = 3, prefix = "" },
	signs = {
		active = signs, -- show signs
	},
	update_in_insert = true,
	underline = true,
	severity_sort = true,
	float = {
		focusable = true,
		style = "minimal",
		border = "rounded",
		source = "always",
		header = "",
		prefix = "",
	},
}

vim.diagnostic.config(config)
```