### PR TITLE
fix(lsp): check if the buffer is a directory before w! it

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -760,7 +760,9 @@ function M.rename(old_fname, new_fname, opts)
 
   -- The there may be pending changes in the buffer
   if vim.fn.isdirectory(old_fname) == 0 then
-    api.nvim_buf_call(oldbuf, function() vim.cmd('w!') end)
+    api.nvim_buf_call(oldbuf, function()
+      vim.cmd('w!')
+    end)
   end
 
   local ok, err = os.rename(old_fname, new_fname)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -759,9 +759,9 @@ function M.rename(old_fname, new_fname, opts)
   vim.fn.bufload(oldbuf)
 
   -- The there may be pending changes in the buffer
-  api.nvim_buf_call(oldbuf, function()
-    vim.cmd('w!')
-  end)
+  if vim.fn.isdirectory(old_fname) == 0 then
+    api.nvim_buf_call(oldbuf, function() vim.cmd('w!') end)
+  end
 
   local ok, err = os.rename(old_fname, new_fname)
   assert(ok, err)


### PR DESCRIPTION
When a LSP client tries to rename a directory, the error «_Vim(write):E502: "path/to/directory" is a directory_»  occurs, so the check is required.

Also closes https://github.com/neovim/neovim/issues/22147