### PR TITLE
vim-patch:8.2.0148

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1167,7 +1167,7 @@ static char *translate_mapping(char_u *str, int cpo_flags)
   garray_T ga;
   ga_init(&ga, 1, 40);
 
-  bool cpo_bslash = !(cpo_flags&FLAG_CPO_BSLASH);
+  bool cpo_bslash = cpo_flags & FLAG_CPO_BSLASH;
 
   for (; *str; str++) {
     int c = *str;

--- a/src/nvim/testdir/setup.vim
+++ b/src/nvim/testdir/setup.vim
@@ -26,9 +26,11 @@ if exists('s:did_load')
   set viewoptions&
   set viewoptions+=options
   set switchbuf=
-  " Make "Q" switch to Ex mode.
-  " This does not work for all tests.
-  nnoremap Q gQ
+  if g:testname !~ 'test_mapping.vim$'
+    " Make "Q" switch to Ex mode.
+    " This does not work for all tests.
+    nnoremap Q gQ
+  endif
 endif
 
 " Common preparations for running tests.

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -217,33 +217,33 @@ endfunc
 
 " Test for the 'g' flag in 'cpo' (jump to line 1 when re-editing a file)
 func Test_cpo_g()
-  throw 'Skipped: Nvim does not support cpoptions flag "g"'
   let save_cpo = &cpo
   new test_cpoptions.vim
   set cpo-=g
   normal 20G
   edit
   call assert_equal(20, line('.'))
-  set cpo+=g
-  edit
-  call assert_equal(1, line('.'))
+  " Nvim: no "g" flag in 'cpoptions'.
+  " set cpo+=g
+  " edit
+  " call assert_equal(1, line('.'))
   close!
   let &cpo = save_cpo
 endfunc
 
 " Test for inserting text in a line with only spaces ('H' flag in 'cpoptions')
 func Test_cpo_H()
-  throw 'Skipped: Nvim does not support cpoptions flag "H"'
   let save_cpo = &cpo
   new
   set cpo-=H
   call setline(1, '    ')
   normal! Ia
   call assert_equal('    a', getline(1))
-  set cpo+=H
-  call setline(1, '    ')
-  normal! Ia
-  call assert_equal('   a ', getline(1))
+  " Nvim: no "H" flag in 'cpoptions'.
+  " set cpo+=H
+  " call setline(1, '    ')
+  " normal! Ia
+  " call assert_equal('   a ', getline(1))
   close!
   let &cpo = save_cpo
 endfunc
@@ -560,15 +560,15 @@ endfunc
 " Test for the 'w' flag in 'cpo' ('cw' on a blank character changes only one
 " character)
 func Test_cpo_w()
-  throw 'Skipped: Nvim does not support cpoptions flag "w"'
   let save_cpo = &cpo
   new
-  set cpo+=w
-  call setline(1, 'here      are   some words')
-  norm! 1gg0elcwZZZ
-  call assert_equal('hereZZZ     are   some words', getline('.'))
-  norm! 1gg2elcWYYY
-  call assert_equal('hereZZZ     areYYY  some words', getline('.'))
+  " Nvim: no "w" flag in 'cpoptions'.
+  " set cpo+=w
+  " call setline(1, 'here      are   some words')
+  " norm! 1gg0elcwZZZ
+  " call assert_equal('hereZZZ     are   some words', getline('.'))
+  " norm! 1gg2elcWYYY
+  " call assert_equal('hereZZZ     areYYY  some words', getline('.'))
   set cpo-=w
   call setline(1, 'here      are   some words')
   norm! 1gg0elcwZZZ
@@ -745,16 +745,16 @@ endfunc
 
 " Test for the '*' flag in 'cpo' (':*' is same as ':@')
 func Test_cpo_star()
-  throw 'Skipped: Nvim does not support cpoptions flag "*"'
   let save_cpo = &cpo
   let x = 0
   new
   set cpo-=*
   let @a = 'let x += 1'
   call assert_fails('*a', 'E20:')
-  set cpo+=*
-  *a
-  call assert_equal(1, x)
+  " Nvim: no "*" flag in 'cpoptions'.
+  " set cpo+=*
+  " *a
+  " call assert_equal(1, x)
   close!
   let &cpo = save_cpo
 endfunc
@@ -815,7 +815,6 @@ endfunc
 
 " Test for the '#' flag in 'cpo' (count before 'D', 'o' and 'O' operators)
 func Test_cpo_hash()
-  throw 'Skipped: Nvim does not support cpoptions flag "#"'
   let save_cpo = &cpo
   new
   set cpo-=#
@@ -827,14 +826,15 @@ func Test_cpo_hash()
   normal gg2Otwo
   call assert_equal(['two', 'two', 'three', 'four', 'four'], getline(1, '$'))
   %d
-  set cpo+=#
-  call setline(1, ['one', 'two', 'three'])
-  normal gg2D
-  call assert_equal(['', 'two', 'three'], getline(1, '$'))
-  normal gg2oone
-  call assert_equal(['', 'one', 'two', 'three'], getline(1, '$'))
-  normal gg2Ozero
-  call assert_equal(['zero', '', 'one', 'two', 'three'], getline(1, '$'))
+  " Nvim: no "#" flag in 'cpoptions'.
+  " set cpo+=#
+  " call setline(1, ['one', 'two', 'three'])
+  " normal gg2D
+  " call assert_equal(['', 'two', 'three'], getline(1, '$'))
+  " normal gg2oone
+  " call assert_equal(['', 'one', 'two', 'three'], getline(1, '$'))
+  " normal gg2Ozero
+  " call assert_equal(['zero', '', 'one', 'two', 'three'], getline(1, '$'))
   close!
   let &cpo = save_cpo
 endfunc
@@ -858,16 +858,16 @@ endfunc
 
 " Test for the '\' flag in 'cpo' (backslash in a [] range in a search pattern)
 func Test_cpo_backslash()
-  throw 'Skipped: Nvim does not support cpoptions flag "\"'
   let save_cpo = &cpo
   new
   call setline(1, ['', " \\-string"])
   set cpo-=\
   exe 'normal gg/[ \-]' .. "\<CR>n"
   call assert_equal(3, col('.'))
-  set cpo+=\
-  exe 'normal gg/[ \-]' .. "\<CR>n"
-  call assert_equal(2, col('.'))
+  " Nvim: no "\" flag in 'cpoptions'.
+  " set cpo+=\
+  " exe 'normal gg/[ \-]' .. "\<CR>n"
+  " call assert_equal(2, col('.'))
   close!
   let &cpo = save_cpo
 endfunc
@@ -877,7 +877,6 @@ endfunc
 " Test for the '{' flag in 'cpo' (the "{" and "}" commands stop at a {
 " character at the start of a line)
 func Test_cpo_brace()
-  throw 'Skipped: Nvim does not support cpoptions flag "{"'
   let save_cpo = &cpo
   new
   call setline(1, ['', '{', '    int i;', '}', ''])
@@ -886,11 +885,12 @@ func Test_cpo_brace()
   call assert_equal(5, line('.'))
   normal G{
   call assert_equal(1, line('.'))
-  set cpo+={
-  normal gg}
-  call assert_equal(2, line('.'))
-  normal G{
-  call assert_equal(2, line('.'))
+  " Nvim: no "{" flag in 'cpoptions'.
+  " set cpo+={
+  " normal gg}
+  " call assert_equal(2, line('.'))
+  " normal G{
+  " call assert_equal(2, line('.'))
   close!
   let &cpo = save_cpo
 endfunc

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -934,6 +934,39 @@ func Test_abbr_remove()
   call assert_equal({}, maparg('foo', 'i', 1, 1))
 endfunc
 
+" Trigger an abbreviation using a special key
+func Test_abbr_trigger_special()
+  new
+  iabbr teh the
+  call feedkeys("iteh\<F2>\<Esc>", 'xt')
+  call assert_equal('the<F2>', getline(1))
+  iunab teh
+  close!
+endfunc
+
+" Test for '<' in 'cpoptions'
+func Test_map_cpo_special_keycode()
+  set cpo-=<
+  imap x<Bslash>k Test
+  let d = maparg('x<Bslash>k', 'i', 0, 1)
+  call assert_equal(['x\k', 'Test', 'i'], [d.lhs, d.rhs, d.mode])
+  call feedkeys(":imap x\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"imap x\k', @:)
+  iunmap x<Bslash>k
+  " Nvim: no "<" flag in 'cpoptions'.
+  " set cpo+=<
+  " imap x<Bslash>k Test
+  " let d = maparg('x<Bslash>k', 'i', 0, 1)
+  " call assert_equal(['x<Bslash>k', 'Test', 'i'], [d.lhs, d.rhs, d.mode])
+  " call feedkeys(":imap x\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"imap x<Bslash>k', @:)
+  " iunmap x<Bslash>k
+  set cpo-=<
+  " Modifying 'cpo' above adds some default mappings, remove them
+  mapclear
+  mapclear!
+endfunc
+
 func Test_map_cmdkey_redo()
   func SelectDash()
     call search('^---\n\zs', 'bcW')

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2254,61 +2254,63 @@ func Test_normal29_brace()
   " set cpo+={
   " 1
   " norm! 0d2}
-  " let expected =<< trim [DATA]
-  "   {
-  "   This is no paragraph
-  "   unless the '{' is set
-  "   in 'cpoptions'
-  "   }
-  "   .IP
-  "   The nroff macros IP separates a paragraph
-  "   That means, it must be a '.'
-  "   followed by IP
-  "   .LPIt does not matter, if afterwards some
-  "   more characters follow.
-  "   .SHAlso section boundaries from the nroff
-  "   macros terminate a paragraph. That means
-  "   a character like this:
-  "   .NH
-  "   End of text here
-  "
-  " [DATA]
+
+  let expected =<< trim [DATA]
+    {
+    This is no paragraph
+    unless the '{' is set
+    in 'cpoptions'
+    }
+    .IP
+    The nroff macros IP separates a paragraph
+    That means, it must be a '.'
+    followed by IP
+    .LPIt does not matter, if afterwards some
+    more characters follow.
+    .SHAlso section boundaries from the nroff
+    macros terminate a paragraph. That means
+    a character like this:
+    .NH
+    End of text here
+
+  [DATA]
   " call assert_equal(expected, getline(1, '$'))
-  "
+
   " $
   " norm! d}
-  " let expected =<< trim [DATA]
-  "   {
-  "   This is no paragraph
-  "   unless the '{' is set
-  "   in 'cpoptions'
-  "   }
-  "   .IP
-  "   The nroff macros IP separates a paragraph
-  "   That means, it must be a '.'
-  "   followed by IP
-  "   .LPIt does not matter, if afterwards some
-  "   more characters follow.
-  "   .SHAlso section boundaries from the nroff
-  "   macros terminate a paragraph. That means
-  "   a character like this:
-  "   .NH
-  "   End of text here
-  "
-  " [DATA]
+
+  let expected =<< trim [DATA]
+    {
+    This is no paragraph
+    unless the '{' is set
+    in 'cpoptions'
+    }
+    .IP
+    The nroff macros IP separates a paragraph
+    That means, it must be a '.'
+    followed by IP
+    .LPIt does not matter, if afterwards some
+    more characters follow.
+    .SHAlso section boundaries from the nroff
+    macros terminate a paragraph. That means
+    a character like this:
+    .NH
+    End of text here
+
+  [DATA]
   " call assert_equal(expected, getline(1, '$'))
-  "
+
   " norm! gg}
   " norm! d5}
-  "
-  " let expected =<< trim [DATA]
-  "   {
-  "   This is no paragraph
-  "   unless the '{' is set
-  "   in 'cpoptions'
-  "   }
 
-  " [DATA]
+  let expected =<< trim [DATA]
+    {
+    This is no paragraph
+    unless the '{' is set
+    in 'cpoptions'
+    }
+
+  [DATA]
   " call assert_equal(expected, getline(1, '$'))
 
   " Jumping to a fold should open the fold

--- a/src/nvim/testdir/test_substitute.vim
+++ b/src/nvim/testdir/test_substitute.vim
@@ -296,15 +296,15 @@ endfunc
 
 " Test for *:s%* on :substitute.
 func Test_sub_cmd_6()
-  throw 'Skipped: Nvim does not support cpoptions flag "/"'
   set magic&
-  set cpo+=/
+  " Nvim: no "/" flag in 'cpoptions'.
+  " set cpo+=/
 
   " List entry format: [input, cmd, output]
   let tests = [ ['A', 's/A/a/', ['a']],
 	      \ ['B', 's/B/%/', ['a']],
 	      \ ]
-  call Run_SubCmd_Tests(tests)
+  " call Run_SubCmd_Tests(tests)
 
   set cpo-=/
   let tests = [ ['C', 's/C/c/', ['c']],
@@ -585,10 +585,11 @@ endfunc
 
 func Test_sub_replace_6()
   set magic&
+  " Nvim: no "/" flag in 'cpoptions'.
   " set cpo+=/
   call assert_equal('a', substitute('A', 'A', 'a', ''))
   call assert_equal('%', substitute('B', 'B', '%', ''))
-  " set cpo-=/
+  set cpo-=/
   call assert_equal('c', substitute('C', 'C', 'c', ''))
   call assert_equal('%', substitute('D', 'D', '%', ''))
 endfunc
@@ -853,13 +854,13 @@ func Test_sub_with_no_last_pat()
     call assert_equal([], readfile('Xresult'))
   endif
 
-  " Nvim does not support cpoptions flag "/"'
-  " let lines =<< trim [SCRIPT]
-  "   set cpo+=/
-  "   call assert_fails('s/abc/%/', 'E33:')
-  "   call writefile(v:errors, 'Xresult')
-  "   qall!
-  " [SCRIPT]
+  let lines =<< trim [SCRIPT]
+    set cpo+=/
+    call assert_fails('s/abc/%/', 'E33:')
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  " Nvim: no "/" flag in 'cpoptions'.
   " call writefile(lines, 'Xscript')
   " if RunVim([], [], '--clean -S Xscript')
   "   call assert_equal([], readfile('Xresult'))


### PR DESCRIPTION
#### vim-patch:8.2.0148: mapping related function in wrong source file

Problem:    Mapping related function in wrong source file.
Solution:   Move the function.  Add a few more test cases. (Yegappan
            Lakshmanan, closes vim/vim#5528)

https://github.com/vim/vim/commit/7f51bbe0d19f1f0cb0321326f45a17b4f5155f89

Co-authored-by: Bram Moolenaar <Bram@vim.org>