### PR TITLE
fix(lsp): do not force use of default handler in codelens.refresh

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -277,7 +277,7 @@ function M.refresh()
     return
   end
   active_refreshes[bufnr] = true
-  vim.lsp.buf_request(0, 'textDocument/codeLens', params, M.on_codelens)
+  vim.lsp.buf_request(0, 'textDocument/codeLens', params)
 end
 
 return M


### PR DESCRIPTION
When passing `handlers['textDocument/codeLens'] = ...` to `vim.lsp.start`, it was not used by `vim.lsp.codelens.refresh()`.

@mfussenegger I'm not sure if this is the intended behaviour, so please close this if it is.