### PR TITLE
ci: remove former dependencies that are no longer needed

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ freebsd_task:
   timeout_in: 30m
   install_script:
     - pkg update -f
-    - pkg install -y cmake gmake ninja libtool automake pkgconf unzip wget gettext python libffi git
+    - pkg install -y cmake gmake ninja pkgconf unzip wget gettext python libffi git
   build_deps_script:
     - gmake deps
   build_script:

--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -3,8 +3,8 @@
 os=$(uname -s)
 if [[ $os == Linux ]]; then
   sudo apt-get update
-  sudo apt-get install -y autoconf automake build-essential cmake curl gettext libtool-bin locales-all ninja-build pkg-config unzip "$@"
+  sudo apt-get install -y build-essential cmake curl gettext locales-all ninja-build pkg-config unzip "$@"
 elif [[ $os == Darwin ]]; then
   brew update --quiet
-  brew install automake ninja "$@"
+  brew install ninja "$@"
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y autoconf automake build-essential cmake gettext libtool-bin locales ninja-build pkg-config unzip
+        run: ./.github/scripts/install_deps.sh
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
@@ -74,7 +72,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y autoconf automake build-essential cmake gettext libtool-bin locales ninja-build pkg-config unzip
+          apt-get install -y build-essential cmake gettext locales ninja-build pkg-config unzip
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: CC=gcc-10 make appimage-latest
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
@@ -93,10 +91,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install brew packages
-        run: |
-          brew update --quiet
-          brew install automake ninja
+      - name: Install dependencies
+        run: ./.github/scripts/install_deps.sh
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
       - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')

--- a/.github/workflows/universal_macos.yml
+++ b/.github/workflows/universal_macos.yml
@@ -24,9 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: |
-          brew update --quiet
-          brew install automake ninja
+        run: ./.github/scripts/install_deps.sh
 
       - run: printf 'NVIM_BUILD_TYPE=Release\n' >> $GITHUB_ENV
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -72,10 +72,6 @@ parts:
             sed -i 's|^Icon=.*|Icon=${SNAP}/usr/share/icons/hicolor/128x128/apps/nvim.png|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/nvim.desktop
         build-packages:
             - ninja-build
-            - libtool
-            - libtool-bin
-            - autoconf
-            - automake
             - cmake
             - gawk
             - g++


### PR DESCRIPTION
libtool, autoconf, automake and perl are no longer dependencies of
neovim and doesn't need to be installed in CI anymore. The dependencies
and the commit that removed them as dependencies are the following:

libtool: b05100a9eaad5980ea7652137bc4a1c2d15d752f
perl: 20a932cb72cf077d54e3498ef93341ffe3d4cdbb
autoconf+automake: e23c5fda0a3fe385af615372c474d4dad3b74464