### PR TITLE
vim-patch:9.0.1315: escaping for completion of map command not properly tested

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1194,7 +1194,7 @@ static char *translate_mapping(char_u *str, int cpo_flags)
     }
 
     if (c == ' ' || c == '\t' || c == Ctrl_J || c == Ctrl_V
-        || (c == '\\' && !cpo_bslash)) {
+        || c == '<' || (c == '\\' && !cpo_bslash)) {
       ga_append(&ga, cpo_bslash ? Ctrl_V : '\\');
     }
 

--- a/src/nvim/testdir/test_autocmd.vim
+++ b/src/nvim/testdir/test_autocmd.vim
@@ -2720,7 +2720,7 @@ func Test_autocmd_bufreadpre()
   close
   close
   call delete('XAutocmdBufReadPre.txt')
-  " set cpo-=g
+  set cpo-=g
 endfunc
 
 " FileChangedShell tested in test_filechanged.vim

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -330,17 +330,21 @@ func Test_map_completion()
   call assert_equal('"map <Left>', getreg(':'))
   call feedkeys(":map <A-Left>\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal("\"map <A-Left>\<Tab>", getreg(':'))
+  call feedkeys(":map <M-Left>\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal("\"map <M-Left>x", getreg(':'))
   unmap ,f
   unmap ,g
   unmap <Left>
   unmap <A-Left>x
 
-  set cpo-=< cpo-=B cpo-=k
+  set cpo-=< cpo-=k
   map <Left> left
   call feedkeys(":map <L\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"map <Left>', getreg(':'))
   call feedkeys(":map <M\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal("\"map <M\<Tab>", getreg(':'))
+  call feedkeys(":map \<C-V>\<C-V><M\<Tab>\<Home>\"\<CR>", 'xt')
+  call assert_equal("\"map \<C-V><Middle>x", getreg(':'))
   unmap <Left>
 
   " set cpo+=<

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -340,7 +340,7 @@ func Test_map_completion()
   call feedkeys(":map <L\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"map <Left>', getreg(':'))
   call feedkeys(":map <M\<Tab>\<Home>\"\<CR>", 'xt')
-  " call assert_equal("\"map <M\<Tab>", getreg(':'))
+  call assert_equal("\"map <M\<Tab>", getreg(':'))
   unmap <Left>
 
   " set cpo+=<
@@ -369,7 +369,7 @@ func Test_map_completion()
   call feedkeys(":map <L\<Tab>\<Home>\"\<CR>", 'xt')
   call assert_equal('"map <Left>', getreg(':'))
   unmap <Left>
-  " set cpo-=k
+  set cpo-=k
 
   call assert_fails('call feedkeys(":map \\\\%(\<Tab>\<Home>\"\<CR>", "xt")', 'E53:')
 

--- a/src/nvim/testdir/test_cpoptions.vim
+++ b/src/nvim/testdir/test_cpoptions.vim
@@ -68,15 +68,20 @@ endfunc
 func Test_cpo_B()
   let save_cpo = &cpo
   new
+  imap <buffer> x<Bslash>k Test
   set cpo-=B
   iabbr <buffer> abc ab\<BS>d
   exe "normal iabc "
   call assert_equal('ab<BS>d ', getline(1))
+  call feedkeys(":imap <buffer> x\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"imap <buffer> x\\k', @:)
   %d
   set cpo+=B
   iabbr <buffer> abc ab\<BS>d
   exe "normal iabc "
   call assert_equal('abd ', getline(1))
+  call feedkeys(":imap <buffer> x\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"imap <buffer> x\k', @:)
   close!
   let &cpo = save_cpo
 endfunc
@@ -195,7 +200,8 @@ func Test_cpo_f()
   set cpo+=f
   read test_cpoptions.vim
   call assert_equal('test_cpoptions.vim', @%)
-  close!
+
+  bwipe!
   let &cpo = save_cpo
 endfunc
 
@@ -428,7 +434,7 @@ func Test_cpo_O()
   let &cpo = save_cpo
 endfunc
 
-" Test for the 'p' flag in 'cpo' is in the test_lispwords.vim file.
+" Test for the 'p' flag in 'cpo' is in the test_lispindent.vim file.
 
 " Test for the 'P' flag in 'cpo' (appending to a file sets the current file
 " name)
@@ -444,7 +450,8 @@ func Test_cpo_P()
   set cpo+=P
   write >> XfileCpoP
   call assert_equal('XfileCpoP', @%)
-  close!
+
+  bwipe!
   call delete('XfileCpoP')
   let &cpo = save_cpo
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1315: escaping for completion of map command not properly tested

Problem:    Escaping for completion of map command not properly tested.
Solution:   Add a few test cases. (closes vim/vim#12009)

https://github.com/vim/vim/commit/c3a26c6bff666a368b0a22d35d2e00aa62770f8c