### PR TITLE
build: test multi-config generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
-
 env:
   BIN_DIR: ${{ github.workspace }}/bin
   INSTALL_PREFIX: ${{ github.workspace }}/nvim-install
@@ -116,3 +115,25 @@ jobs:
           cmake -B build -G Ninja
           cmake --build build
 
+  multi-config:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: ./.github/scripts/install_deps.sh
+
+      - name: Build third-party deps
+        run: |
+          cmake -S cmake.deps -B .deps -G "Ninja Multi-Config"
+          cmake --build .deps
+
+      - name: Configure
+        run: cmake -B build -G Ninja -D CMAKE_C_COMPILER=gcc
+
+      - name: Release
+        run: cmake --build build --config Release
+
+      - name: MinSizeRel
+        run: cmake --build build --config MinSizeRel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,10 +140,6 @@ jobs:
             cc: gcc
             runner: ubuntu-22.04
             flags: -D UNSIGNED_CHAR=ON
-          - flavor: release
-            cc: gcc
-            runner: ubuntu-22.04
-            flags: -D CMAKE_BUILD_TYPE=Release
           - cc: clang
             runner: macos-12
 
@@ -210,7 +206,7 @@ jobs:
         id: abort_job
         run: echo "status=${{ job.status }}" >> $GITHUB_OUTPUT
 
-      - if: matrix.flavor != 'tsan' && matrix.flavor != 'release' && matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
+      - if: matrix.flavor != 'tsan' && matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
         name: Unittest
         timeout-minutes: 5
         run: cmake --build build --target unittest


### PR DESCRIPTION
Multi-config generators can be tricky so testing them would be good.
Also test GCC release and MinSizeRel build types as they're prone to
unusual warnings. Remove release testing from test.yml as this is a
sufficient replacement.
