### PR TITLE
fix: remove "Compiled by:" from :version/--version

### DIFF
--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -166,25 +166,6 @@ file(GENERATE
   OUTPUT "${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef-$<CONFIG>.h"
   INPUT "${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef.h.gen")
 
-find_program(WHOAMI_PRG whoami)
-find_program(HOSTNAME_PRG hostname)
-mark_as_advanced(HOSTNAME_PRG WHOAMI_PRG)
-
-if (DEFINED ENV{USERNAME})
-  set(USERNAME $ENV{USERNAME})
-elseif (NOT DEFINED USERNAME AND EXISTS ${WHOAMI_PRG})
-  execute_process(COMMAND ${WHOAMI_PRG}
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE USERNAME)
-endif()
-if (DEFINED ENV{HOSTNAME})
-  set(HOSTNAME $ENV{HOSTNAME})
-elseif (NOT DEFINED HOSTNAME AND EXISTS ${HOSTNAME_PRG})
-  execute_process(COMMAND ${HOSTNAME_PRG}
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE HOSTNAME)
-endif()
-
 configure_file (
   "${PROJECT_SOURCE_DIR}/cmake.config/pathdef.c.in"
   "${PROJECT_BINARY_DIR}/cmake.config/auto/pathdef.c"

--- a/cmake.config/pathdef.c.in
+++ b/cmake.config/pathdef.c.in
@@ -4,5 +4,3 @@
 char *default_vim_dir = "${CMAKE_INSTALL_FULL_DATAROOTDIR}/nvim";
 char *default_vimruntime_dir = "";
 char *default_lib_dir = "${CMAKE_INSTALL_FULL_LIBDIR}/nvim";
-char *compiled_user = "${USERNAME}";
-char *compiled_sys = "${HOSTNAME}";

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -806,8 +806,6 @@ enum {
 extern char *default_vim_dir;
 extern char *default_vimruntime_dir;
 extern char *default_lib_dir;
-extern char *compiled_user;
-extern char *compiled_sys;
 #endif
 
 // When a window has a local directory, the absolute path of the global

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2699,23 +2699,6 @@ void list_version(void)
   msg(version_cflags);
 #endif
 
-#ifdef HAVE_PATHDEF
-
-  if ((*compiled_user != NUL) || (*compiled_sys != NUL)) {
-    msg_puts(_("\nCompiled "));
-
-    if (*compiled_user != NUL) {
-      msg_puts(_("by "));
-      msg_puts((const char *)compiled_user);
-    }
-
-    if (*compiled_sys != NUL) {
-      msg_puts("@");
-      msg_puts((const char *)compiled_sys);
-    }
-  }
-#endif  // ifdef HAVE_PATHDEF
-
   version_msg("\n\n");
 
 #ifdef SYS_VIMRC_FILE


### PR DESCRIPTION
The :version output is already crowded as is, the last thing we need is
extraneous messages about who compiled it.