### PR TITLE
fix: Add missing void as function argument

### DIFF
--- a/src/cjson/fpconv.c
+++ b/src/cjson/fpconv.c
@@ -202,7 +202,7 @@ int fpconv_g_fmt(char *str, double num, int precision)
     return len;
 }
 
-void fpconv_init()
+void fpconv_init(void)
 {
     fpconv_update_locale();
 }


### PR DESCRIPTION
```
src/cjson/fpconv.c:205:6: error: old-style function definition [-Werror=old-style-definition]
  205 | void fpconv_init()
      |      ^~~~~~~~~~~
```

See also https://fedoraproject.org/wiki/Changes/PortingToModernC