### PR TITLE
vim-patch:9.0.1319: PRQL files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -810,6 +810,7 @@ local extension = {
   pdb = 'prolog',
   pml = 'promela',
   proto = 'proto',
+  prql = 'prql',
   ['psd1'] = 'ps1',
   ['psm1'] = 'ps1',
   ['ps1'] = 'ps1',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -550,6 +550,7 @@ let s:filename_checks = {
     \ 'spyce': ['file.spy', 'file.spi'],
     \ 'sql': ['file.tyb', 'file.typ', 'file.tyc', 'file.pkb', 'file.pks'],
     \ 'sqlj': ['file.sqlj'],
+    \ 'prql': ['file.prql'],
     \ 'sqr': ['file.sqr', 'file.sqi'],
     \ 'squid': ['squid.conf'],
     \ 'squirrel': ['file.nut'],


### PR DESCRIPTION
Problem:    PRQL files are not recognized.
Solution:   Add a filetype pattern for PRQL files. (Matthias Queitsch,
            closes vim/vim#12018)

https://github.com/vim/vim/commit/9de960ace0f017fcfeaf64a2f6492f0f88b11fdb

Co-authored-by: Matthias Queitsch <matthias.queitsch@mailbox.org>
