### PR TITLE
vim-patch:9.0.1324: "gj" and "gk" do not move correctly over a closed fold

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2479,19 +2479,10 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
           curwin->w_curswant -= width2;
         } else {
           // to previous line
-
-          // Move to the start of a closed fold.  Don't do that when
-          // 'foldopen' contains "all": it will open in a moment.
-          if (!(fdo_flags & FDO_ALL)) {
-            (void)hasFolding(curwin->w_cursor.lnum,
-                             &curwin->w_cursor.lnum, NULL);
-          }
-          if (curwin->w_cursor.lnum == 1) {
+          if (!cursor_up_inner(curwin, 1)) {
             retval = false;
             break;
           }
-          curwin->w_cursor.lnum--;
-
           linelen = linetabsize(get_cursor_line_ptr());
           if (linelen > width1) {
             int w = (((linelen - width1 - 1) / width2) + 1) * width2;
@@ -2511,15 +2502,10 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
           curwin->w_curswant += width2;
         } else {
           // to next line
-
-          // Move to the end of a closed fold.
-          (void)hasFolding(curwin->w_cursor.lnum, NULL,
-                           &curwin->w_cursor.lnum);
-          if (curwin->w_cursor.lnum == curbuf->b_ml.ml_line_count) {
+          if (!cursor_down_inner(curwin, 1)) {
             retval = false;
             break;
           }
-          curwin->w_cursor.lnum++;
           curwin->w_curswant %= width2;
           // Check if the cursor has moved below the number display
           // when width1 < width2 (with cpoptions+=n). Subtract width2

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1548,4 +1548,11 @@ func Test_expand_fold_at_bottom_of_buffer()
   bwipe!
 endfunc
 
+func Test_fold_screenrow_motion()
+  call setline(1, repeat(['aaaa'], 5))
+  1,4fold
+  norm Ggkzo
+  call assert_equal(1, line('.'))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
**vim-patch:9.0.1324: "gj" and "gk" do not move correctly over a closed fold**

Problem:    "gj" and "gk" do not move correctly over a closed fold.
Solution:   Use the same code as used for "j"/"k" to go to the next/previous
            line. (Luuk van Baal, closes vim/vim#12007)

https://github.com/vim/vim/commit/441a7a94482f704b66253b8d08130f27b6b13736

Fix https://github.com/neovim/neovim/issues/15490