### PR TITLE
vim-patch:9.0.1329: completion of map includes simplified ones

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1342,7 +1342,7 @@ int ExpandMappings(char *pat, regmatch_T *regmatch, int *numMatches, char ***mat
       mp = maphash[hash];
     }
     for (; mp; mp = mp->m_next) {
-      if (!(mp->m_mode & expand_mapmodes)) {
+      if (mp->m_simplified || !(mp->m_mode & expand_mapmodes)) {
         continue;
       }
 

--- a/src/nvim/testdir/test_mapping.vim
+++ b/src/nvim/testdir/test_mapping.vim
@@ -759,11 +759,12 @@ func Test_mapcomplete()
   call feedkeys(":abbr! \<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal("\"abbr! \x01", @:)
 
-  " Multiple matches for a map
-  nmap ,f /H<CR>
-  omap ,f /H<CR>
+  " When multiple matches have the same {lhs}, it should only appear once.
+  " The simplified form should also not be included.
+  nmap ,<C-F> /H<CR>
+  omap ,<C-F> /H<CR>
   call feedkeys(":map ,\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"map ,f', @:)
+  call assert_equal('"map ,<C-F>', @:)
   mapclear
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.1329: completion of map includes simplified ones

Problem:    Completion of map includes simplified ones.
Solution:   Do not complete simplified mappings. (closes vim/vim#12013)

https://github.com/vim/vim/commit/997b8a015cd39141866e953651d55c705275cbd6