### PR TITLE
refactor(main.c): remove unreachable use_builtin_ui conditions

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1794,7 +1794,7 @@ v:event		Dictionary of event data for the current |autocommand|.  Valid
 			abort		Whether the event triggered during
 					an aborting condition (e.g. |c_Esc| or
 					|c_CTRL-C| for |CmdlineLeave|).
-			chan		|channel-id| or 0 for "internal".
+			chan		|channel-id|
 			cmdlevel	Level of cmdline.
 			cmdtype		Type of cmdline, |cmdline-char|.
 			cwd		Current working directory.

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -383,6 +383,7 @@ int main(int argc, char **argv)
   if (ui_client_channel_id) {
     ui_client_run(remote_ui);  // NORETURN
   }
+  assert(!ui_client_channel_id && !use_builtin_ui);
 
   // Wait for UIs to set up Nvim or show early messages
   // and prompts (--cmd, swapfile dialog, …).
@@ -583,13 +584,13 @@ int main(int argc, char **argv)
   set_vim_var_nr(VV_VIM_DID_ENTER, 1L);
   apply_autocmds(EVENT_VIMENTER, NULL, NULL, false, curbuf);
   TIME_MSG("VimEnter autocommands");
-  if (use_remote_ui || use_builtin_ui) {
-    do_autocmd_uienter(use_remote_ui ? CHAN_STDIO : 0, true);
+  if (use_remote_ui) {
+    do_autocmd_uienter(CHAN_STDIO, true);
     TIME_MSG("UIEnter autocommands");
   }
 
 #ifdef MSWIN
-  if (use_remote_ui || use_builtin_ui) {
+  if (use_remote_ui) {
     os_icon_init();
   }
   os_title_save();

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -208,7 +208,7 @@ static void tinput_wait_enqueue(void **argv)
       input->paste = 2;
     }
     rbuffer_reset(input->key_buffer);
-  } else {  // enqueue input for the main thread or Nvim server
+  } else {  // enqueue input
     RBUFFER_UNTIL_EMPTY(input->key_buffer, buf, len) {
       const String keys = { .data = buf, .size = len };
       MAXSIZE_TEMP_ARRAY(args, 1);


### PR DESCRIPTION
When use_builtin_ui is true, Nvim will exit before line 385 is reached.
