### PR TITLE
vim-patch:9.0.1331: illegal memory access when using :ball in Visual mode

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3600,6 +3600,10 @@ void ex_buffer_all(exarg_T *eap)
     all = true;
   }
 
+  // Stop Visual mode, the cursor and "VIsual" may very well be invalid after
+  // switching to another buffer.
+  reset_VIsual_and_resel();
+
   setpcmark();
 
   // Close superfluous windows (two windows for the same buffer).

--- a/src/nvim/testdir/test_visual.vim
+++ b/src/nvim/testdir/test_visual.vim
@@ -1536,4 +1536,25 @@ func Test_switch_buffer_ends_visual_mode()
   exe 'bwipe!' buf2
 endfunc
 
+" Check fix for the heap-based buffer overflow bug found in the function
+" utfc_ptr2len and reported at
+" https://huntr.dev/bounties/ae933869-a1ec-402a-bbea-d51764c6618e
+func Test_heap_buffer_overflow()
+  enew
+  set updatecount=0
+
+  norm R0
+  split other
+  norm R000
+  exe "norm \<C-V>l"
+  ball
+  call assert_equal(getpos("."), getpos("v"))
+  call assert_equal('n', mode())
+  norm zW
+
+  %bwipe!
+  set updatecount&
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1331: illegal memory access when using :ball in Visual mode

Problem:    Illegal memory access when using :ball in Visual mode.
Solution:   Stop Visual mode when using :ball. (Pavel Mayorov, closes vim/vim#11923)

https://github.com/vim/vim/commit/e1121b139480f53d1b06f84f3e4574048108fa0b

Co-authored-by: Pavel Mayorov <pmayorov@cloudlinux.com>