### PR TITLE
vim-patch:9.0.1332: crash when using buffer-local user command in cmdline window

### DIFF
--- a/src/nvim/testdir/test_usercommands.vim
+++ b/src/nvim/testdir/test_usercommands.vim
@@ -736,6 +736,15 @@ func Test_buflocal_ambiguous_usercmd()
   bw!
 endfunc
 
+" Test for using buffer-local user command from cmdwin.
+func Test_buflocal_usercmd_cmdwin()
+  new
+  command -buffer TestCmd edit Test
+  " This used to crash Vim
+  call assert_fails("norm q::TestCmd\<CR>", 'E11:')
+  bw!
+endfunc
+
 " Test for using a multibyte character in a user command
 func Test_multibyte_in_usercmd()
   command SubJapanesePeriodToDot exe "%s/\u3002/./g"

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1625,7 +1625,7 @@ int do_ucmd(exarg_T *eap, bool preview)
   if (eap->cmdidx == CMD_USER) {
     cmd = USER_CMD(eap->useridx);
   } else {
-    cmd = USER_CMD_GA(&curbuf->b_ucmds, eap->useridx);
+    cmd = USER_CMD_GA(&prevwin_curwin()->w_buffer->b_ucmds, eap->useridx);
   }
 
   if (preview) {


### PR DESCRIPTION
Fix #22339

#### vim-patch:9.0.1332: crash when using buffer-local user command in cmdline window

Problem:    Crash when using buffer-local user command in cmdline window.
            (Karl Yngve Lervåg)
Solution:   Use the right buffer to find the user command. (closes vim/vim#12030)

https://github.com/vim/vim/commit/b444ee761a2956a996a75d923281c51fa1a759f3