### PR TITLE
docs(README): remove CI from Project Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ See [`:help nvim-from-vim`](https://neovim.io/doc/user/nvim.html#nvim-from-vim) 
 Project layout
 --------------
 
-    ├─ ci/              build automation
     ├─ cmake/           CMake utils
     ├─ cmake.config/    CMake defines
     ├─ cmake.deps/      subproject to fetch and build dependencies (optional)


### PR DESCRIPTION
The CI directory has been removed and should be removed from Project Layout.