### PR TITLE
vim-patch:partial:938ae280c79b

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -380,6 +380,7 @@ CmdlineChanged			After a change was made to the text inside
 CmdlineEnter			After entering the command-line (including
 				non-interactive use of ":" in a mapping: use
 				|<Cmd>| instead to avoid this).
+				The pattern is matched against |cmdline-char|.
 				<afile> expands to the |cmdline-char|.
 				Sets these |v:event| keys:
 				    cmdlevel

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -225,7 +225,7 @@ gettabwinvar({tabnr}, {winnr}, {name} [, {def}])
 gettagstack([{nr}])		Dict	get the tag stack of window {nr}
 gettext({text})			String	lookup translation of {text}
 getwininfo([{winid}])		List	list of info about each window
-getwinpos([{timeout}])		List	X and Y coord in pixels of the Vim window
+getwinpos([{timeout}])		List	X and Y coord in pixels of Vim window
 getwinposx()			Number	X coord in pixels of Vim window
 getwinposy()			Number	Y coord in pixels of Vim window
 getwinvar({nr}, {varname} [, {def}])
@@ -326,7 +326,7 @@ max({expr})			Number	maximum value of items in {expr}
 menu_get({path} [, {modes}])	List	description of |menus| matched by {path}
 menu_info({name} [, {mode}])	Dict	get menu item information
 min({expr})			Number	minimum value of items in {expr}
-mkdir({name} [, {path} [, {prot}]])
+mkdir({name} [, {flags} [, {prot}]])
 				Number	create directory {name}
 mode([expr])			String	current editing mode
 msgpackdump({list} [, {type}])	List/Blob  dump objects to msgpack
@@ -5432,11 +5432,14 @@ min({expr})	Return the minimum value of all items in {expr}. Example:  >
 			mylist->min()
 
 <							*mkdir()* *E739*
-mkdir({name} [, {path} [, {prot}]])
+mkdir({name} [, {flags} [, {prot}]])
 		Create directory {name}.
 
-		If {path} is "p" then intermediate directories are created as
-		necessary.  Otherwise it must be "".
+		When {flags} is present it must be a string.  An empty string
+		has no effect.
+
+		If {flags} is "p" then intermediate directories are created as
+		necessary.
 
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
@@ -5449,7 +5452,7 @@ mkdir({name} [, {path} [, {prot}]])
 
 <		This function is not available in the |sandbox|.
 
-		If you try to create an existing directory with {path} set to
+		If you try to create an existing directory with {flags} set to
 		"p" mkdir() will silently exit.
 
 		The function result is a Number, which is TRUE if the call was
@@ -6957,7 +6960,7 @@ setcellwidths({list})					*setcellwidths()*
 		{width} must be either 1 or 2, indicating the character width
 		in screen cells.			*E1112*
 		An error is given if the argument is invalid, also when a
-		range overlaps with another. 		*E1113*
+		range overlaps with another.		*E1113*
 
 		If the new value causes 'fillchars' or 'listchars' to become
 		invalid it is rejected and an error is given.

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -584,6 +584,7 @@ followed by another Vim command:
     :registers
     :read !
     :sign
+    :tabdo
     :terminal
     :vglobal
     :windo

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1445,7 +1445,7 @@ See below |functions|.
 ------------------------------------------------------------------------------
 lambda expression				*expr-lambda* *lambda*
 
-{args -> expr1}		lambda expression
+{args -> expr1}		lambda expression			*E451*
 
 A lambda expression creates a new unnamed function which returns the result of
 evaluating |expr1|.  Lambda expressions differ from |user-function|s in

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -634,7 +634,10 @@ MARKDOWN                                                *ft-markdown-plugin*
 
 To enable folding use this: >
 	let g:markdown_folding = 1
-<
+
+'expandtab' will be set by default.  If you do not want that use this: >
+	let g:markdown_recommended_style = 0
+
 
 PDF							*ft-pdf-plugin*
 

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -629,7 +629,7 @@ You can test if Python is available with: >vim
 	if has('pythonx')
 	  echo 'there is Python'
 	endif
-  	if has('python3')
+	if has('python3')
 	  echo 'there is Python 3.x'
 	endif
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -220,7 +220,7 @@ tag		char	      note action in Normal mode	~
 |CTRL-\_CTRL-N|	CTRL-\ CTRL-N	   go to Normal mode (no-op)
 |CTRL-\_CTRL-G|	CTRL-\ CTRL-G	   go to Normal mode (no-op)
 		CTRL-\ a - z	   reserved for extensions
-		CTRL-\ others      not used
+		CTRL-\ others	   not used
 |CTRL-]|	CTRL-]		   :ta to ident under cursor
 |CTRL-^|	CTRL-^		   edit Nth alternate file (equivalent to
 				   ":e #N")
@@ -233,7 +233,7 @@ tag		char	      note action in Normal mode	~
 				2  filter Nmove text through the {filter}
 				   command
 |!!|		!!{filter}	2  filter N lines through the {filter} command
-|quote|		"{register}  	   use {register} for next delete, yank or put
+|quote|		"{register}	   use {register} for next delete, yank or put
 				   ({.%#:} only work with put)
 |#|		#		1  search backward for the Nth occurrence of
 				   the ident under the cursor

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1101,8 +1101,8 @@ cursor column will be replaced with the matches.  If the returned value is
 larger than the cursor column, the cursor column is used.
 
 Negative return values:
-   -2 	To cancel silently and stay in completion mode.
-   -3 	To cancel silently and leave completion mode.
+   -2	To cancel silently and stay in completion mode.
+   -3	To cancel silently and leave completion mode.
    Another negative value: completion starts at the cursor column
 
 On the second invocation the arguments are:
@@ -1154,7 +1154,7 @@ items:
 			item with the same word is already present.
 	empty		when non-zero this match will be added even when it is
 			an empty string
-	user_data 	custom data which is associated with the item and
+	user_data	custom data which is associated with the item and
 			available in |v:completed_item|; it can be any type;
 			defaults to an empty string
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -764,7 +764,7 @@ option).  After that it assumes that the 'q' is to be interpreted as such.  If
 you type slowly, or your system is slow, reset the 'timeout' option.  Then you
 might want to set the 'ttimeout' option.
 
-			      				*map-precedence*
+							*map-precedence*
 Buffer-local mappings (defined using |:map-<buffer>|) take precedence over
 global mappings.  When a buffer-local mapping is the same as a global mapping,
 Vim will use the buffer-local mapping.  In addition, Vim will use a complete
@@ -838,6 +838,11 @@ in the original Vi, you would get back the text before the first undo).
 
 1.10 MAPPING ALT-KEYS					*:map-alt-keys*
 
+For a readable mapping command the <A-k> form can be used.  Note that <A-k>
+and <A-K> are different, the latter will use an upper case letter.  Actually,
+<A-K> and <A-S-K> are the same.  Instead of "A" you can use "M".  If you have
+an actual Meta modifier key, please see |:map-meta-keys|.
+
 In the GUI Nvim handles the |ALT| key itself, thus mapping keys with ALT
 should always work.  But in a terminal Nvim gets a sequence of bytes and has
 to figure out whether ALT was pressed.  Terminals may use ESC to indicate that
@@ -847,7 +852,21 @@ milliseconds, the ESC is interpreted as:
 otherwise it is interpreted as two key presses:
         <ESC> {key}
 
-1.11 MAPPING AN OPERATOR				*:map-operator*
+1.11 MAPPING META-KEYS					*:map-meta-keys*
+
+Mapping keys with the Meta modifier works very similar to using the Alt key.
+What key on your keyboard produces the Meta modifier depends on your keyboard
+and configuration.
+
+Note that mapping <M-a> actually is for using the Alt key.  That can be
+confusing!  It cannot be changed, it would not be backwards compatible.
+
+For the Meta modifier the "T" character is used.  For example, to map Meta-b
+in Insert mode: >
+	:imap <T-b> terrible
+
+
+1.12 MAPPING AN OPERATOR				*:map-operator*
 
 An operator is used before a {motion} command.  To define your own operator
 you must create a mapping that first sets the 'operatorfunc' option and then
@@ -984,7 +1003,7 @@ non-id	  The "non-id" type ends in a non-keyword character, the other
 Examples of strings that cannot be abbreviations: "a.b", "#def", "a b", "_$r"
 
 An abbreviation is only recognized when you type a non-keyword character.
-This can also be the <Esc> that ends insert mode or the <CR> that ends a
+This can also be the <Esc> that ends Insert mode or the <CR> that ends a
 command.  The non-keyword character which ends the abbreviation is inserted
 after the expanded abbreviation.  An exception to this is the character <C-]>,
 which is used to expand an abbreviation without inserting any extra
@@ -1484,7 +1503,7 @@ which by default correspond to the current line, last line and the whole
 buffer, relate to arguments, (loaded) buffers, windows or tab pages.
 
 Possible values are (second column is the short name used in listing):
-    -addr=lines		  	Range of lines (this is the default for -range)
+    -addr=lines			Range of lines (this is the default for -range)
     -addr=arguments	  arg	Range for arguments
     -addr=buffers	  buf	Range for buffers (also not loaded buffers)
     -addr=loaded_buffers  load	Range for loaded buffers

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1186,7 +1186,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			case mapping, the current locale is not effective.
 			This probably only matters for Turkish.
 
-						*'cdhome'* *'cdh'*
+				*'cdhome'* *'cdh'* *'nocdhome'* *'nocdh'*
 'cdhome' 'cdh'		boolean	(default: off)
 			global
 	When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
@@ -4291,7 +4291,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	The 'mousemodel' option is set by the |:behave| command.
 
-						*'mousemoveevent'* *'mousemev'*
+	      *'mousemoveevent'* *'mousemev'* *'nomousemoveevent'* *'nomousemev'*
 'mousemoveevent' 'mousemev'  boolean	(default off)
 			global
 	When on, mouse move events are delivered to the input queue and are
@@ -5550,7 +5550,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  A	don't give the "ATTENTION" message when an existing	*shm-A*
 		swap file is found
 	  I	don't give the intro message when starting Vim,		*shm-I*
-	  	see |:intro|
+		see |:intro|
 	  c	don't give |ins-completion-menu| messages; for		*shm-c*
 		example, "-- XXX completion (YYY)", "match 1 of 2", "The only
 		match", "Pattern not found", "Back at original", etc.
@@ -5559,8 +5559,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  q	use "recording" instead of "recording @a"		*shm-q*
 	  F	don't give the file info when editing a file, like	*shm-F*
 		`:silent` was used for the command
-	  S     do not show search count message when searching, e.g.	*shm-S*
-	        "[1/5]"
+	  S	do not show search count message when searching, e.g.	*shm-S*
+		"[1/5]"
 
 	This gives you the opportunity to avoid that a change between buffers
 	requires you to hit <Enter>, but still gives as useful a message as
@@ -5709,7 +5709,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 'signcolumn' 'scl'	string	(default "auto")
 			local to window
 	When and how to draw the signcolumn. Valid values are:
-	   "auto"   	only when there is a sign to display
+	   "auto"	only when there is a sign to display
 	   "auto:[1-9]" resize to accommodate multiple signs up to the
 	                given number (maximum 9), e.g. "auto:4"
 	   "auto:[1-8]-[2-9]"
@@ -5718,8 +5718,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			at least the given minimum (maximum 8) fixed
 			space. The minimum number should always be less
 			than the maximum number, e.g. "auto:2-5"
-	   "no"	    	never
-	   "yes"    	always
+	   "no"		never
+	   "yes"	always
 	   "yes:[1-9]"  always, with fixed space for signs up to the given
 	                number (maximum 9), e.g. "yes:3"
 	   "number"	display signs in the 'number' column. If the number

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -97,6 +97,8 @@ g#			Like "#", but don't put "\<" and "\>" around the word.
 							*gd*
 gd			Goto local Declaration.  When the cursor is on a local
 			variable, this command will jump to its declaration.
+			This was made to work for C code, in other languages
+			it may not work well.
 			First Vim searches for the start of the current
 			function, just like "[[".  If it is not found the
 			search stops in line 1.  If it is found, Vim goes back
@@ -1129,21 +1131,21 @@ x	A single character, with no special meaning, matches itself
 	  are supported:
 		  Name	      Func	Contents ~
 *[:alnum:]*	  [:alnum:]   isalnum	ASCII letters and digits
-*[:alpha:]*	  [:alpha:]   isalpha  	ASCII letters
-*[:blank:]*	  [:blank:]     	space and tab
-*[:cntrl:]*	  [:cntrl:]   iscntrl 	ASCII control characters
-*[:digit:]*	  [:digit:]     	decimal digits '0' to '9'
+*[:alpha:]*	  [:alpha:]   isalpha	ASCII letters
+*[:blank:]*	  [:blank:]		space and tab
+*[:cntrl:]*	  [:cntrl:]   iscntrl	ASCII control characters
+*[:digit:]*	  [:digit:]		decimal digits '0' to '9'
 *[:graph:]*	  [:graph:]   isgraph	ASCII printable characters excluding
 					space
 *[:lower:]*	  [:lower:]   (1)	lowercase letters (all letters when
 					'ignorecase' is used)
-*[:print:]*	  [:print:]   (2) 	printable characters including space
+*[:print:]*	  [:print:]   (2)	printable characters including space
 *[:punct:]*	  [:punct:]   ispunct	ASCII punctuation characters
-*[:space:]*	  [:space:]     	whitespace characters: space, tab, CR,
+*[:space:]*	  [:space:]		whitespace characters: space, tab, CR,
 					NL, vertical tab, form feed
 *[:upper:]*	  [:upper:]   (3)	uppercase letters (all letters when
 					'ignorecase' is used)
-*[:xdigit:]*	  [:xdigit:]    	hexadecimal digits: 0-9, a-f, A-F
+*[:xdigit:]*	  [:xdigit:]		hexadecimal digits: 0-9, a-f, A-F
 *[:return:]*	  [:return:]		the <CR> character
 *[:tab:]*	  [:tab:]		the <Tab> character
 *[:escape:]*	  [:escape:]		the <Esc> character

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1085,8 +1085,8 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	 <c-tab> Shrink/expand a netrw/explore window                |netrw-c-tab|
 	   -	Makes Netrw go up one directory                      |netrw--|
 	   a	Cycles between normal display,                       |netrw-a|
-	    	hiding (suppress display of files matching g:netrw_list_hide)
-	    	and showing (display only files which match g:netrw_list_hide)
+		hiding (suppress display of files matching g:netrw_list_hide)
+		and showing (display only files which match g:netrw_list_hide)
 	   cd	Make browsing directory the current directory        |netrw-cd|
 	   C	Setting the editing window                           |netrw-C|
 	   d	Make a directory                                     |netrw-d|
@@ -1118,7 +1118,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   mX	Apply arbitrary shell command to marked files en bloc|netrw-mX|
 	   mz	Compress/decompress marked files                     |netrw-mz|
 	   o	Enter the file/directory under the cursor in a new   |netrw-o|
-	    	browser window.  A horizontal split is used.
+		browser window.  A horizontal split is used.
 	   O	Obtain a file specified by cursor                    |netrw-O|
 	   p	Preview the file                                     |netrw-p|
 	   P	Browse in the previously used window                 |netrw-P|
@@ -1134,7 +1134,7 @@ QUICK REFERENCE: MAPS				*netrw-browse-maps* {{{2
 	   u	Change to recently-visited directory                 |netrw-u|
 	   U	Change to subsequently-visited directory             |netrw-U|
 	   v	Enter the file/directory under the cursor in a new   |netrw-v|
-	    	browser window.  A vertical split is used.
+		browser window.  A vertical split is used.
 	   x	View file with an associated program                 |netrw-x|
 	   X	Execute filename under cursor via |system()|           |netrw-X|
 
@@ -2271,7 +2271,7 @@ Example:
 	...
 
 
-MARKED FILES, ARBITRARY SHELL COMMAND, EN BLOC 			*netrw-mX* {{{2
+MARKED FILES, ARBITRARY SHELL COMMAND, EN BLOC			*netrw-mX* {{{2
 	    (See |netrw-mf| and |netrw-mr| for how to mark files)
 		      (uses the global marked-file list)
 
@@ -2611,7 +2611,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				Used to change access permission for a file.
 
   *g:netrw_clipboard*		=1
-  				By default, netrw will attempt to insure that
+				By default, netrw will attempt to insure that
 				the clipboard's values will remain unchanged.
 				However, some users report that they have
 				speed problems with this; consequently, this
@@ -2759,7 +2759,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				escaped before applying glob()
 
   *g:netrw_gx*			="<cfile>"
- 				This option controls how gx (|netrw-gx|) picks
+				This option controls how gx (|netrw-gx|) picks
 				up the text under the cursor.  See |expand()|
 				for possibilities.
 
@@ -2824,11 +2824,11 @@ your browsing preferences.  (see also: |netrw-settings|)
 				directory (|netrw-mt|, |netrw-mc|)
 
   *g:netrw_localcopycmdopt*	=''             Linux/Unix/MacOS/Cygwin
-  				=' \c copy'                     Windows
+				=' \c copy'                     Windows
 				Options for the |g:netrw_localcopycmd|
 
   *g:netrw_localcopydircmd*	="cp"           Linux/Unix/MacOS/Cygwin
- 				=expand("$COMSPEC")             Windows
+				=expand("$COMSPEC")             Windows
 				Copies directories to target directory.
 				(|netrw-mc|, |netrw-mt|)
 
@@ -2854,7 +2854,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				Options for |g:netrw_localmovecmd|
 
   *g:netrw_localrmdir*		="rmdir"        Linux/Unix/MacOS/Cygwin
- 				=expand("$COMSPEC")             Windows
+				=expand("$COMSPEC")             Windows
 				Remove directory command (rmdir)
 				This variable is only used if your vim is
 				earlier than 7.4 or if your vim doesn't
@@ -2890,10 +2890,10 @@ your browsing preferences.  (see also: |netrw-settings|)
 				(see |'ballooneval'|)
 
  *g:netrw_sizestyle*		not defined: actual bytes (default)
- 				="b" : actual bytes       (default)
- 				="h" : human-readable (ex. 5k, 4m, 3g)
+				="b" : actual bytes       (default)
+				="h" : human-readable (ex. 5k, 4m, 3g)
 				       uses 1000 base
- 				="H" : human-readable (ex. 5K, 4M, 3G)
+				="H" : human-readable (ex. 5K, 4M, 3G)
 				       uses 1024 base
 				The long listing (|netrw-i|) and query-file
 				maps (|netrw-qf|) will display file size
@@ -2941,7 +2941,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				 default: "NETRWSERVER"
 
   *g:netrw_sort_by*		sort by "name", "time", "size", or
-  				"exten".
+				"exten".
 				 default: "name"
 
   *g:netrw_sort_direction*	sorting direction: "normal" or "reverse"
@@ -2998,7 +2998,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 					.vim/after/syntax/netrw.vim.
 <				 The netrwGray highlighting is set up by
 				netrw when >
-	       				* netrwGray has not been previously
+					* netrwGray has not been previously
 					  defined
 					* the gui is running
 <				 As an example, I myself use a dark-background
@@ -3256,7 +3256,7 @@ If there are marked files:  (see |netrw-mf|)
     name, applying that substitute, and renaming each file to the result.
     As an example : >
 
-    	mr  [query: reply with *.c]
+	mr  [query: reply with *.c]
 	R   [query: reply with s/^\(.*\)\.c$/\1.cpp/]
 <
     This example will mark all "*.c" files and then rename them to "*.cpp"
@@ -3265,7 +3265,7 @@ If there are marked files:  (see |netrw-mf|)
 
     The ctrl-X character has special meaning for renaming files: >
 
-    	<c-x>      : a single ctrl-x tells netrw to ignore the portion of the response
+	<c-x>      : a single ctrl-x tells netrw to ignore the portion of the response
 	             lying between the last '/' and the ctrl-x.
 
 	<c-x><c-x> : a pair of contiguous ctrl-x's tells netrw to ignore any
@@ -3833,7 +3833,7 @@ netrw:
 	  Decho.vim is provided as a "vimball".  You
 	  should edit the Decho.vba.gz file and source it in: >
 
-	  	vim Decho.vba.gz
+		vim Decho.vba.gz
 		:so %
 		:q
 <
@@ -3875,7 +3875,7 @@ netrw:
 	   To save the file: under linux, the output will be in a separate
 	   remote server window; in it, just save the file with >
 
-	   	:w! DBG
+		:w! DBG
 
 <	   Under a vim that doesn't support clientserver, your debugging
 	   output will appear in another tab: >

--- a/runtime/doc/remote.txt
+++ b/runtime/doc/remote.txt
@@ -46,7 +46,7 @@ The following command line arguments are available:
 				new tabpage.
 								*--remote-send*
    --remote-send {keys}		Send {keys} to server and exit.  The {keys}
-   				are not mapped.  Special key names are
+				are not mapped.  Special key names are
 				recognized, e.g., "<CR>" results in a CR
 				character.
 								*--remote-expr*

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -214,7 +214,7 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			When [where] is omitted only 'runtimepath' is used.
 			Other values:
 				START	search only under "start" in 'packpath'
-				OPT 	search only under "opt" in 'packpath'
+				OPT	search only under "opt" in 'packpath'
 				PACK	search under "start" and "opt" in
 					'packpath'
 				ALL	first use 'runtimepath', then search
@@ -641,15 +641,15 @@ up-to-date easily, but it requires a program like "git" to be available.
 You can do both, github can automatically create an archive for a release.
 
 Your directory layout would be like this:
-   start/foobar/plugin/foo.vim    	" always loaded, defines commands
-   start/foobar/plugin/bar.vim    	" always loaded, defines commands
-   start/foobar/autoload/foo.vim  	" loaded when foo command used
-   start/foobar/doc/foo.txt       	" help for foo.vim
-   start/foobar/doc/tags          	" help tags
-   opt/fooextra/plugin/extra.vim  	" optional plugin, defines commands
-   opt/fooextra/autoload/extra.vim  	" loaded when extra command used
-   opt/fooextra/doc/extra.txt  	        " help for extra.vim
-   opt/fooextra/doc/tags  	        " help tags
+   start/foobar/plugin/foo.vim		" always loaded, defines commands
+   start/foobar/plugin/bar.vim		" always loaded, defines commands
+   start/foobar/autoload/foo.vim	" loaded when foo command used
+   start/foobar/doc/foo.txt		" help for foo.vim
+   start/foobar/doc/tags		" help tags
+   opt/fooextra/plugin/extra.vim	" optional plugin, defines commands
+   opt/fooextra/autoload/extra.vim	" loaded when extra command used
+   opt/fooextra/doc/extra.txt		" help for extra.vim
+   opt/fooextra/doc/tags		" help tags
 
 This allows for the user to do: >
 	mkdir ~/.local/share/nvim/site/pack

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -610,7 +610,7 @@ sign_placelist({list})
 				be placed. For the accepted values, see
 				|line()|.
 		    name	name of the sign to place. See |sign_define()|
-		    		for more information.
+				for more information.
 		    priority	priority of the sign. When multiple signs are
 				placed on a line, the sign with the highest
 				priority is used. If not specified, the

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1271,18 +1271,32 @@ When not set 4 is used.
 
 DOSBATCH				*dosbatch.vim* *ft-dosbatch-syntax*
 
-There is one option with highlighting DOS batch files.	This covers new
-extensions to the Command Interpreter introduced with Windows 2000 and
-is controlled by the variable dosbatch_cmdextversion.  For Windows NT
-this should have the value 1, and for Windows 2000 it should be 2.
+Select the set of Windows Command interpreter extensions that should be
+supported with the variable dosbatch_cmdextversion.  For versions of Windows
+NT (before Windows 2000) this should have the value of 1.  For Windows 2000
+and later it should be 2.
 Select the version you want with the following line: >
 
    :let dosbatch_cmdextversion = 1
 
 If this variable is not defined it defaults to a value of 2 to support
-Windows 2000.
+Windows 2000 and later.
 
-A second option covers whether *.btm files should be detected as type
+The original MS-DOS supports an idiom of using a double colon (::) as an
+alternative way to enter a comment line.  This idiom can be used with the
+current Windows Command Interpreter, but it can lead to problems when used
+inside ( ... ) command blocks.  You can find a discussion about this on
+Stack Overflow -
+
+https://stackoverflow.com/questions/12407800/which-comment-style-should-i-use-in-batch-files
+
+To allow the use of the :: idiom for comments in the Windows Command
+Interpreter or working with MS-DOS bat files, set the
+dosbatch_colons_comment variable to anything: >
+
+   :let dosbatch_colons_comment = 1
+
+There is an option that covers whether *.btm files should be detected as type
 "dosbatch" (MS-DOS batch files) or type "btm" (4DOS batch files).  The latter
 is used by default.  You may select the former with the following line: >
 
@@ -3784,7 +3798,7 @@ SYNTAX ISKEYWORD SETTING				*:syn-iskeyword*
 
 	clear:		Syntax specific iskeyword setting is disabled and the
 			buffer-local 'iskeyword' setting is used.
-	{option}       	Set the syntax 'iskeyword' option to a new value.
+	{option}	Set the syntax 'iskeyword' option to a new value.
 
 	Example: >
   :syntax iskeyword @,48-57,192-255,$,_

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -246,7 +246,7 @@ Credit Card:	You can use PayPal to send money with a Credit card.  This is
 		    Bram@iccf-holland.org
 
 Others:		Transfer to this account if possible:
-		    ING bank: 	IBAN: NL95 INGB 0004 5487 74
+		    ING bank:	IBAN: NL95 INGB 0004 5487 74
 				Swift code: INGBNL2A
 		    under the name "stichting ICCF Holland", Amersfoort
 		Checks are not accepted.

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -234,9 +234,10 @@ Example: >
   call Something('key', 20)	"key: 20"
 
 The argument default expressions are evaluated at the time of the function
-call, not definition.  Thus it is possible to use an expression which is
-invalid the moment the function is defined.  The expressions are also only
-evaluated when arguments are not specified during a call.
+call, not when the function is defined.  Thus it is possible to use an
+expression which is invalid the moment the function is defined.  The
+expressions are also only evaluated when arguments are not specified during a
+call.
 
 								*E989*
 Optional arguments with default expressions must occur after any mandatory

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -495,7 +495,7 @@ You can use the error ID at the start to find help about it: >
 	:help E37
 
 
-Summary: 					*help-summary*  >
+Summary:					*help-summary*  >
 
 1) Use Ctrl-D after typing a topic and let Vim show all available topics.
    Or press Tab to complete: >

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -273,7 +273,7 @@ an archive or as a repository.  For an archive you can follow these steps:
 	   package.
 	2. unpack the archive in that directory.  This assumes the top
 	   directory in the archive is "start": >
-	   	cd ~/.local/share/nvim/site/pack/fancy
+		cd ~/.local/share/nvim/site/pack/fancy
 		unzip /tmp/fancy.zip
 <	   If the archive layout is different make sure that you end up with a
 	   path like this:

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -77,25 +77,25 @@ browser.  This is what you get: >
     9. Directory Browsing	 netrw-browse   netrw-dir   netrw-list   netrw-help
 
     MAPS								 netrw-maps
-     	 <F1>.............Help.......................................|netrw-help|
-     	 <cr>.............Browsing...................................|netrw-cr|
-     	 <del>............Deleting Files or Directories..............|netrw-delete|
-     	 -................Going Up...................................|netrw--|
-     	 a................Hiding Files or Directories................|netrw-a|
-     	 mb...............Bookmarking a Directory....................|netrw-mb|
-     	 gb...............Changing to a Bookmarked Directory.........|netrw-gb|
-     	 cd...............Make Browsing Directory The Current Dir....|netrw-c|
-     	 d................Make A New Directory.......................|netrw-d|
-     	 D................Deleting Files or Directories..............|netrw-D|
-     	 <c-h>............Edit File/Directory Hiding List............|netrw-ctrl-h|
-     	 i................Change Listing Style.......................|netrw-i|
-     	 <c-l>............Refreshing the Listing.....................|netrw-ctrl-l|
-     	 o................Browsing with a Horizontal Split...........|netrw-o|
-     	 p................Use Preview Window.........................|netrw-p|
-     	 P................Edit in Previous Window....................|netrw-p|
-     	 q................Listing Bookmarks and History..............|netrw-qb|
-     	 r................Reversing Sorting Order....................|netrw-r|
-<    	(etc)
+	 <F1>.............Help.......................................|netrw-help|
+	 <cr>.............Browsing...................................|netrw-cr|
+	 <del>............Deleting Files or Directories..............|netrw-delete|
+	 -................Going Up...................................|netrw--|
+	 a................Hiding Files or Directories................|netrw-a|
+	 mb...............Bookmarking a Directory....................|netrw-mb|
+	 gb...............Changing to a Bookmarked Directory.........|netrw-gb|
+	 cd...............Make Browsing Directory The Current Dir....|netrw-c|
+	 d................Make A New Directory.......................|netrw-d|
+	 D................Deleting Files or Directories..............|netrw-D|
+	 <c-h>............Edit File/Directory Hiding List............|netrw-ctrl-h|
+	 i................Change Listing Style.......................|netrw-i|
+	 <c-l>............Refreshing the Listing.....................|netrw-ctrl-l|
+	 o................Browsing with a Horizontal Split...........|netrw-o|
+	 p................Use Preview Window.........................|netrw-p|
+	 P................Edit in Previous Window....................|netrw-p|
+	 q................Listing Bookmarks and History..............|netrw-qb|
+	 r................Reversing Sorting Order....................|netrw-r|
+<	(etc)
 
 The <F1> key thus brings you to a netrw directory browsing contents help page.
 It's a regular help page; use the usual |CTRL-]| to jump to tagged help items
@@ -106,7 +106,7 @@ To select files for display and editing: (with the cursor is atop a filename)
 	<enter>		Open the file in the current window.	   |netrw-cr|
 	o		Horizontally split window and display file |netrw-o|
 	v		Vertically split window and display file   |netrw-v|
-	p		Use the |preview-window| 		   |netrw-p|
+	p		Use the |preview-window|		   |netrw-p|
 	P		Edit in the previous window		   |netrw-P|
 	t		Open file in a new tab			   |netrw-t|
 

--- a/runtime/ftplugin/dosbatch.vim
+++ b/runtime/ftplugin/dosbatch.vim
@@ -1,7 +1,10 @@
 " Vim filetype plugin file
-" Language:    MS-DOS .bat files
-" Maintainer:  Mike Williams <mrw@eandem.co.uk>
-" Last Change: 7th May 2020
+" Language:    MS-DOS/Windows .bat files
+" Maintainer:  Mike Williams <mrmrdubya@gmail.com>
+" Last Change: 12th February 2023
+"
+" Options Flags:
+" dosbatch_colons_comment       - any value to treat :: as comment line
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -15,8 +18,13 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 " BAT comment formatting
-setlocal comments=b:rem,b:@rem,b:REM,b:@REM,:::
-setlocal commentstring=::\ %s
+setlocal comments=b:rem,b:@rem,b:REM,b:@REM
+if exists("dosbatch_colons_comment")
+  setlocal comments+=:::
+  setlocal commentstring=::\ %s
+else
+  setlocal commentstring=REM\ %s
+endif
 setlocal formatoptions-=t formatoptions+=rol
 
 " Lookup DOS keywords using Windows command help.

--- a/runtime/ftplugin/fish.vim
+++ b/runtime/ftplugin/fish.vim
@@ -1,0 +1,15 @@
+" Vim filetype plugin file
+" Language:     fish
+" Maintainer:   Nicholas Boyle (github.com/nickeb96)
+" Repository:   https://github.com/nickeb96/fish.vim
+" Last Change:  February 1, 2023
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+setlocal iskeyword=@,48-57,_,192-255,-,.
+setlocal comments=:#
+setlocal commentstring=#%s
+setlocal formatoptions+=crjq

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Vim
 " Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Nov 27
+" Last Change:	2023 Feb 07
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -98,18 +98,23 @@ if exists("loaded_matchit")
   "   func name
   " require a parenthesis following, then there can be an "endfunc".
   let b:match_words =
-	\ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' .
-	\ '\<\(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\(w\%[hile]\|fo\%[r]\)\>,' .
-	\ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' .
-	\ '{:},' .
-	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' .
-	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,'
+	\ '\<\%(fu\%[nction]\|def\)!\=\s\+\S\+\s*(:\%(\%(^\||\)\s*\)\@<=\<retu\%[rn]\>:\%(\%(^\||\)\s*\)\@<=\<\%(endf\%[unction]\|enddef\)\>,' ..
+	\ '\<\%(wh\%[ile]\|for\)\>:\%(\%(^\||\)\s*\)\@<=\<brea\%[k]\>:\%(\%(^\||\)\s*\)\@<=\<con\%[tinue]\>:\%(\%(^\||\)\s*\)\@<=\<end\%(w\%[hile]\|fo\%[r]\)\>,' ..
+	\ '\<if\>:\%(\%(^\||\)\s*\)\@<=\<el\%[seif]\>:\%(\%(^\||\)\s*\)\@<=\<en\%[dif]\>,' ..
+	\ '{:},' ..
+	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
+	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
+	\ '\<class\>:\<endclass\>,' ..
+	\ '\<inte\%[rface]\>:\<endinterface\>,' ..
+	\ '\<enu\%[m]\>:\<endenum\>,'
+
   " Ignore syntax region commands and settings, any 'en*' would clobber
   " if-endif.
   " - set spl=de,en
   " - au! FileType javascript syntax region foldBraces start=/{/ end=/}/ …
-  let b:match_skip = 'synIDattr(synID(line("."),col("."),1),"name")
-        \ =~? "comment\\|string\\|vimLetHereDoc\\|vimSynReg\\|vimSet"'
+  " Also ignore here-doc and dictionary keys (vimVar).
+  let b:match_skip = 'synIDattr(synID(line("."), col("."), 1), "name")
+	\ =~? "comment\\|string\\|vimSynReg\\|vimSet\\|vimLetHereDoc\\|vimVar"'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/indent/fish.vim
+++ b/runtime/indent/fish.vim
@@ -1,0 +1,82 @@
+" Vim indent file
+" Language:     fish
+" Maintainer:   Nicholas Boyle (github.com/nickeb96)
+" Repository:   https://github.com/nickeb96/fish.vim
+" Last Change:  February 4, 2023
+
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=GetFishIndent(v:lnum)
+setlocal indentkeys+==end,=else,=case
+
+function s:PrevCmdStart(linenum)
+    let l:linenum = a:linenum
+    " look for the first line that isn't a line continuation
+    while l:linenum > 1 && getline(l:linenum - 1) =~# '\\$'
+        let l:linenum = l:linenum - 1
+    endwhile
+    return l:linenum
+endfunction
+
+function GetFishIndent(lnum)
+    let l:shiftwidth = shiftwidth()
+
+    let l:prevlnum = prevnonblank(a:lnum - 1)
+    if l:prevlnum ==# 0
+        return 0
+    endif
+
+    " if the previous line ended with a line continuation
+    if getline(a:lnum - 1) =~# '\\$'
+        if a:lnum ==# 0 || getline(a:lnum - 2) !~# '\\$'
+            " this is the first line continuation in a chain, so indent it
+            return indent(a:lnum - 1) + l:shiftwidth
+        else
+            " use the same indentation as the previous continued line
+            return indent(a:lnum - 1)
+        endif
+    endif
+
+    let l:prevlnum = s:PrevCmdStart(l:prevlnum)
+
+    let l:prevline = getline(l:prevlnum)
+    if l:prevline =~# '^\s*\(begin\|if\|else\|while\|for\|function\|case\|switch\)\>'
+        let l:indent = l:shiftwidth
+    else
+        let l:indent = 0
+    endif
+
+    let l:line = getline(a:lnum)
+    if l:line =~# '^\s*end\>'
+        " find end's matching start
+        let l:depth = 1
+        let l:currentlnum = a:lnum
+        while l:depth > 0 && l:currentlnum > 0
+            let l:currentlnum = s:PrevCmdStart(prevnonblank(l:currentlnum - 1))
+            let l:currentline = getline(l:currentlnum)
+            if l:currentline =~# '^\s*end\>'
+                let l:depth = l:depth + 1
+            elseif l:currentline =~# '^\s*\(begin\|if\|while\|for\|function\|switch\)\>'
+                let l:depth = l:depth - 1
+            endif
+        endwhile
+        if l:currentline =~# '^\s*switch\>'
+            return indent(l:currentlnum)
+        else
+            return indent(l:prevlnum) + l:indent - l:shiftwidth
+        endif
+    elseif l:line =~# '^\s*else\>'
+        return indent(l:prevlnum) + l:indent - l:shiftwidth
+    elseif l:line =~# '^\s*case\>'
+        if getline(l:prevlnum) =~# '^\s*switch\>'
+            return indent(l:prevlnum) + l:indent
+        else
+            return indent(l:prevlnum) + l:indent - l:shiftwidth
+        endif
+    else
+        return indent(l:prevlnum) + l:indent
+    endif
+endfunction

--- a/runtime/syntax/debsources.vim
+++ b/runtime/syntax/debsources.vim
@@ -2,7 +2,7 @@
 " Language:     Debian sources.list
 " Maintainer:   Debian Vim Maintainers
 " Former Maintainer: Matthijs Mohlmann <matthijs@cacholong.nl>
-" Last Change: 2023 Jan 16
+" Last Change: 2023 Feb 06
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debsources.vim
 
 " Standard syntax initialization
@@ -14,7 +14,9 @@ endif
 syn case match
 
 " A bunch of useful keywords
-syn match debsourcesKeyword        /\(deb-src\|deb\|main\|contrib\|non-free\|non-free-firmware\|restricted\|universe\|multiverse\)/
+syn match debsourcesType               /\(deb-src\|deb\)/
+syn match debsourcesFreeComponent      /\(main\|universe\)/
+syn match debsourcesNonFreeComponent   /\(contrib\|non-free-firmware\|non-free\|restricted\|multiverse\)/
 
 " Match comments
 syn match debsourcesComment        /#.*/  contains=@Spell
@@ -48,7 +50,9 @@ exe 'syn match debsourcesUnsupportedDistrKeyword +\([[:alnum:]_./]*\)\<\('. join
 
 " Associate our matches and regions with pretty colours
 hi def link debsourcesLine                    Error
-hi def link debsourcesKeyword                 Statement
+hi def link debsourcesType                    Statement
+hi def link debsourcesFreeComponent           Statement
+hi def link debsourcesNonFreeComponent        Statement
 hi def link debsourcesDistrKeyword            Type
 hi def link debsourcesUnsupportedDistrKeyword WarningMsg
 hi def link debsourcesComment                 Comment

--- a/runtime/syntax/dosbatch.vim
+++ b/runtime/syntax/dosbatch.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
-" Language:	MS-DOS batch file (with NT command extensions)
-" Maintainer:	Mike Williams <mrw@eandem.co.uk>
+" Language:	MS-DOS/Windows batch file (with NT command extensions)
+" Maintainer:	Mike Williams <mrmrdubya@gmail.com>
 " Filenames:    *.bat
-" Last Change:	6th September 2009
-" Web Page:     http://www.eandem.co.uk/mrw/vim
+" Last Change:	12th February 2023
 "
 " Options Flags:
 " dosbatch_cmdextversion	- 1 = Windows NT, 2 = Windows 2000 [default]
+" dosbatch_colons_comment       - any value to treat :: as comment line
 "
 
 " quit when a syntax file was already loaded
@@ -92,7 +92,11 @@ syn match dosbatchComment	"^rem\($\|\s.*$\)"lc=3 contains=dosbatchTodo,dosbatchS
 syn match dosbatchComment	"^@rem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
 syn match dosbatchComment	"\srem\($\|\s.*$\)"lc=4 contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
 syn match dosbatchComment	"\s@rem\($\|\s.*$\)"lc=5 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
-syn match dosbatchComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+if exists("dosbatch_colons_comment")
+  syn match dosbatchComment	"\s*:\s*:.*$" contains=dosbatchTodo,dosbatchSpecialChar,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
+else
+  syn match dosbatchError       "\s*:\s*:.*$"
+endif
 
 " Comments in ()'s - still to handle spaces before rem
 syn match dosbatchComment	"(rem\([^)]\|\^\@<=)\)*"lc=4 contains=dosbatchTodo,@dosbatchNumber,dosbatchVariable,dosbatchArgument,@Spell
@@ -110,34 +114,35 @@ syn keyword dosbatchImplicit    vol xcopy
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
-hi def link dosbatchTodo		Todo
+hi def link dosbatchTodo	Todo
+hi def link dosbatchError	Error
 
 hi def link dosbatchStatement	Statement
 hi def link dosbatchCommands	dosbatchStatement
-hi def link dosbatchLabel		Label
+hi def link dosbatchLabel	Label
 hi def link dosbatchConditional	Conditional
-hi def link dosbatchRepeat		Repeat
+hi def link dosbatchRepeat	Repeat
 
-hi def link dosbatchOperator       Operator
-hi def link dosbatchEchoOperator   dosbatchOperator
-hi def link dosbatchIfOperator     dosbatchOperator
+hi def link dosbatchOperator	Operator
+hi def link dosbatchEchoOperator dosbatchOperator
+hi def link dosbatchIfOperator	dosbatchOperator
 
 hi def link dosbatchArgument	Identifier
-hi def link dosbatchIdentifier     Identifier
+hi def link dosbatchIdentifier	Identifier
 hi def link dosbatchVariable	dosbatchIdentifier
 
 hi def link dosbatchSpecialChar	SpecialChar
-hi def link dosbatchString		String
-hi def link dosbatchNumber		Number
+hi def link dosbatchString	String
+hi def link dosbatchNumber	Number
 hi def link dosbatchInteger	dosbatchNumber
 hi def link dosbatchHex		dosbatchNumber
-hi def link dosbatchBinary		dosbatchNumber
-hi def link dosbatchOctal		dosbatchNumber
+hi def link dosbatchBinary	dosbatchNumber
+hi def link dosbatchOctal	dosbatchNumber
 
 hi def link dosbatchComment	Comment
 hi def link dosbatchImplicit	Function
 
-hi def link dosbatchSwitch		Special
+hi def link dosbatchSwitch	Special
 
 hi def link dosbatchCmd		PreProc
 

--- a/runtime/syntax/fish.vim
+++ b/runtime/syntax/fish.vim
@@ -1,0 +1,225 @@
+" Vim syntax file
+" Language:     fish
+" Maintainer:   Nicholas Boyle (github.com/nickeb96)
+" Repository:   https://github.com/nickeb96/fish.vim
+" Last Change:  February 1, 2023
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+
+" Statements
+syn cluster fishStatement contains=fishKeywordAndOr,fishNot,fishSelectStatement,fishKeyword,fishKeywordIf,fishCommand,fishVariable
+
+syn keyword fishKeywordAndOr and or nextgroup=fishNot,fishSelectStatement,fishKeyword,fishKeywordIf,fishCommand
+hi def link fishKeywordAndOr fishOperator
+
+syn keyword fishNot not skipwhite nextgroup=fishSelectStatement,fishKeyword,fishKeywordIf,fishCommand
+syn match   fishNot /!/ skipwhite nextgroup=fishSelectStatement,fishKeyword,fishKeywordIf,fishCommand
+hi def link fishNot fishOperator
+
+syn keyword fishSelectStatement command builtin skipwhite nextgroup=fishKeyword,fishKeywordIf,fishCommand,fishOption
+hi def link fishSelectStatement fishKeyword
+
+syn keyword fishKeyword end skipwhite nextgroup=@fishTerminator
+
+syn keyword fishKeywordIf if skipwhite nextgroup=@fishStatement
+syn keyword fishKeyword else skipwhite nextgroup=fishKeywordIf,fishSemicolon
+hi def link fishKeywordIf fishKeyword
+
+syn keyword fishKeyword switch skipwhite nextgroup=@fishArgument
+syn keyword fishKeyword case skipwhite nextgroup=@fishArgument
+
+syn keyword fishKeyword while skipwhite nextgroup=@fishStatement
+
+syn keyword fishKeyword for skipwhite nextgroup=fishForVariable
+syn match   fishForVariable /[[:alnum:]_]\+/ contained skipwhite nextgroup=fishKeywordIn
+syn keyword fishKeywordIn in contained skipwhite nextgroup=@fishArgument
+hi def link fishForVariable fishParameter
+hi def link fishKeywordIn fishKeyword
+
+syn keyword fishKeyword _ abbr argparse begin bg bind block break breakpoint cd commandline
+    \ complete continue count disown echo emit eval exec exit false fg function functions
+    \ history jobs math printf pwd random read realpath return set set_color source status
+    \ string test time true type ulimit wait
+    \ skipwhite nextgroup=@fishNext
+syn match   fishKeyword /\<contains\>/ skipwhite nextgroup=@fishNext
+
+syn match   fishCommand /[[:alnum:]_\/[][[:alnum:]+._-]*/ skipwhite nextgroup=@fishNext
+
+
+" Internally Nested Arguments
+
+syn cluster fishSubscriptArgs contains=fishInnerVariable,fishIndexNum,fishIndexRange,fishInnerCommandSub
+
+syn match   fishInnerVariable /\$\+[[:alnum:]_]\+/ contained
+syn match   fishInnerVariable /\$\+[[:alnum:]_]\+\[/me=e-1,he=e-1 contained nextgroup=fishInnerSubscript
+hi def link fishInnerVariable fishVariable
+
+syn region  fishInnerSubscript matchgroup=fishVariable start=/\[/ end=/]/ contained
+    \ keepend contains=@fishSubscriptArgs
+hi def link fishInnerSubscript fishSubscript
+
+syn match   fishIndexNum /[+-]?[[:digit:]]\+/ contained
+hi def link fishIndexNum fishParameter
+
+syn match   fishIndexRange /\.\./ contained
+hi def link fishIndexRange fishParameter
+
+syn region  fishInnerCommandSub matchgroup=fishOperator start=/(/ start=/\$(/ end=/)/ contained
+    \ contains=@fishStatement
+hi def link fishInnerCommandSub fishCommandSub
+
+syn region  fishQuotedCommandSub matchgroup=fishOperator start=/\$(/ end=/)/ contained
+    \ contains=@fishStatement
+hi def link fishQuotedCommandSub fishCommandSub
+
+syn match   fishBraceExpansionComma /,/ contained
+hi def link fishBraceExpansionComma fishOperator
+
+syn match   fishBracedParameter '[[:alnum:]\u5b\u5d@:=+.%/!_-]\+' contained contains=fishInnerPathGlob
+hi def link fishBracedParameter fishParameter
+
+syn region  fishBracedQuote start=/'/ skip=/\\'/ end=/'/ contained
+    \ contains=fishEscapedEscape,fishEscapedSQuote
+syn region  fishBracedQuote start=/"/ skip=/\\"/ end=/"/ contained
+    \ contains=fishEscapedEscape,fishEscapedDQuote,fishEscapedDollar,fishInnerVariable,fishInnerCommandSub
+hi def link fishBracedQuote fishQuote
+
+
+" Arguments
+
+syn cluster fishArgument contains=fishParameter,fishOption,fishVariable,fishPathGlob,fishBraceExpansion,fishQuote,fishCharacter,fishCommandSub,fishRedirection,fishSelfPid
+
+syn match   fishParameter '[[:alnum:]\u5b\u5d@:=+.,%/!_-]\+' contained skipwhite nextgroup=@fishNext
+
+syn match   fishOption /-[[:alnum:]=_-]*/ contained skipwhite nextgroup=@fishNext
+
+syn match   fishPathGlob /\(\~\|*\|?\)/ contained skipwhite nextgroup=@fishNext
+
+syn region  fishBraceExpansion matchgroup=fishOperator start=/{/ end=/}/ contained
+    \ contains=fishBraceExpansionComma,fishInnerVariable,fishInnerCommandSub,fishBracedParameter,fishBracedQuote
+    \ skipwhite nextgroup=@fishNext
+
+syn match   fishVariable /\$\+[[:alnum:]_]\+/ skipwhite nextgroup=@fishNext
+syn match   fishVariable /\$\+[[:alnum:]_]\+\[/me=e-1,he=e-1 nextgroup=fishSubscript
+
+syn region  fishSubscript matchgroup=fishVariable start=/\[/ end=/]/ contained
+    \ keepend contains=@fishSubscriptArgs
+    \ skipwhite nextgroup=@fishNext
+
+syn region  fishCommandSub matchgroup=fishOperator start=/(/ start=/\$(/ end=/)/ contained
+    \ contains=@fishStatement
+    \ skipwhite nextgroup=@fishNext
+
+syn region  fishQuote start=/'/ skip=/\\'/ end=/'/ contained
+    \ contains=fishEscapedEscape,fishEscapedSQuote
+    \ skipwhite nextgroup=@fishNext
+syn region  fishQuote start=/"/ skip=/\\"/ end=/"/ contained
+    \ contains=fishEscapedEscape,fishEscapedDQuote,fishEscapedDollar,fishInnerVariable,fishQuotedCommandSub
+    \ skipwhite nextgroup=@fishNext
+
+syn match   fishEscapedEscape /\\\\/ contained
+syn match   fishEscapedSQuote /\\'/ contained
+syn match   fishEscapedDQuote /\\"/ contained
+syn match   fishEscapedDollar /\\\$/ contained
+hi def link fishEscapedEscape fishCharacter
+hi def link fishEscapedSQuote fishCharacter
+hi def link fishEscapedDQuote fishCharacter
+hi def link fishEscapedDollar fishCharacter
+
+syn match   fishCharacter /\\[0-7]\{1,3}/                          contained skipwhite nextgroup=@fishNext
+syn match   fishCharacter /\\u[0-9a-fA-F]\{4}/                     contained skipwhite nextgroup=@fishNext
+syn match   fishCharacter /\\U[0-9a-fA-F]\{8}/                     contained skipwhite nextgroup=@fishNext
+syn match   fishCharacter /\\x[0-7][0-9a-fA-F]\|\\x[0-9a-fA-F]/    contained skipwhite nextgroup=@fishNext
+syn match   fishCharacter /\\X[0-9a-fA-F]\{1,2}/                   contained skipwhite nextgroup=@fishNext
+syn match   fishCharacter /\\[abcefnrtv[\](){}<>\\*?~%#$|&;'" ]/   contained skipwhite nextgroup=@fishNext
+
+syn match   fishRedirection /</ contained skipwhite nextgroup=fishRedirectionTarget
+syn match   fishRedirection /[0-9&]\?>[>?]\?/ contained skipwhite nextgroup=fishRedirectionTarget
+syn match   fishRedirection /[0-9&]\?>&[0-9-]/ contained skipwhite nextgroup=@fishNext
+
+syn match   fishRedirectionTarget /[[:alnum:]$~*?{,}"'\/._-]\+/ contained contains=fishInnerVariable skipwhite nextgroup=@fishNext
+hi def link fishRedirectionTarget fishRedirection
+
+syn match fishSelfPid /%self\>/ contained nextgroup=@fishNext
+hi def link fishSelfPid fishOperator
+
+
+" Terminators
+
+syn cluster fishTerminator contains=fishPipe,fishBackgroundJob,fishSemicolon,fishSymbolicAndOr
+
+syn match   fishPipe /\(1>\|2>\|&\)\?|/ contained skipwhite nextgroup=@fishStatement
+hi def link fishPipe fishEnd
+
+syn match   fishBackgroundJob /&$/ contained skipwhite nextgroup=@fishStatement
+syn match   fishBackgroundJob /&[^<>&|]/me=s+1,he=s+1 contained skipwhite nextgroup=@fishStatement
+hi def link fishBackgroundJob fishEnd
+
+syn match   fishSemicolon /;/ skipwhite nextgroup=@fishStatement
+hi def link fishSemicolon fishEnd
+
+syn match   fishSymbolicAndOr /\(&&\|||\)/ contained skipwhite skipempty nextgroup=@fishStatement
+hi def link fishSymbolicAndOr fishOperator
+
+
+" Other
+
+syn cluster fishNext contains=fishEscapedNl,@fishArgument,@fishTerminator
+
+syn match   fishEscapedNl /\\$/ skipnl skipwhite contained nextgroup=@fishNext
+
+syn match   fishComment /#.*/ contains=fishTodo,@Spell
+
+syn keyword fishTodo TODO contained
+
+
+
+syn sync minlines=200
+syn sync maxlines=300
+
+
+" Intermediate highlight groups matching $fish_color_* variables
+
+hi def link fishCommand                 fish_color_command
+hi def link fishComment                 fish_color_comment
+hi def link fishEnd                     fish_color_end
+hi def link fishCharacter               fish_color_escape
+hi def link fishKeyword                 fish_color_keyword
+hi def link fishEscapedNl               fish_color_normal
+hi def link fishOperator                fish_color_operator
+hi def link fishVariable                fish_color_operator
+hi def link fishInnerVariable           fish_color_operator
+hi def link fishPathGlob                fish_color_operator
+hi def link fishOption                  fish_color_option
+hi def link fishParameter               fish_color_param
+hi def link fishQuote                   fish_color_quote
+hi def link fishRedirection             fish_color_redirection
+
+
+" Default highlight groups 
+
+hi def link fish_color_param        Normal
+hi def link fish_color_normal       Normal
+hi def link fish_color_option       Normal
+hi def link fish_color_command      Function
+hi def link fish_color_keyword      Keyword
+hi def link fish_color_end          Delimiter
+hi def link fish_color_operator     Operator
+hi def link fish_color_redirection  Type
+hi def link fish_color_quote        String
+hi def link fish_color_escape       Character
+hi def link fish_color_comment      Comment
+
+hi def link fishTodo                Todo
+
+
+let b:current_syntax = 'fish'
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/syntax/fstab.vim
+++ b/runtime/syntax/fstab.vim
@@ -2,8 +2,8 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/syntax/fstab.vim
-" Last Change: 2022 Dec 11
-" Version: 1.6.2
+" Last Change: 2023 Feb 19
+" Version: 1.6.3
 "
 " Credits:
 "   David Necas (Yeti) <yeti@physics.muni.cz>
@@ -389,7 +389,7 @@ syn match fsFreqPassNumber /\d\+\s\+[012]\s*/ contained
 syn match fsDevice /^\s*\zs.\{-1,}\s/me=e-1 nextgroup=fsMountPoint contains=@fsDeviceCluster,@fsGeneralCluster
 syn match fsMountPoint /\s\+.\{-}\s/me=e-1 nextgroup=fsType contains=@fsMountPointCluster,@fsGeneralCluster contained
 syn match fsType /\s\+.\{-}\s/me=e-1 nextgroup=fsOptions contains=@fsTypeCluster,@fsGeneralCluster contained
-syn match fsOptions /\s\+.\{-}\s/me=e-1 nextgroup=fsFreqPass contains=@fsOptionsCluster,@fsGeneralCluster contained
+syn match fsOptions /\s\+.\{-}\%(\s\|$\)/ nextgroup=fsFreqPass contains=@fsOptionsCluster,@fsGeneralCluster contained
 syn match fsFreqPass /\s\+.\{-}$/ contains=@fsFreqPassCluster,@fsGeneralCluster contained
 
 " Whole line comments
@@ -491,4 +491,4 @@ let b:current_syntax = "fstab"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: ts=8 ft=vim
+" vim: ts=8 noet ft=vim

--- a/runtime/syntax/go.vim
+++ b/runtime/syntax/go.vim
@@ -5,7 +5,7 @@
 " go.vim: Vim syntax file for Go.
 " Language:             Go
 " Maintainer:           Billie Cleek <bhcleek@gmail.com>
-" Latest Revision:      2022-11-17
+" Latest Revision:      2023-02-19
 " License:              BSD-style. See LICENSE file in source repository.
 " Repository:           https://github.com/fatih/vim-go
 
@@ -136,8 +136,11 @@ syn keyword     goBoolean                  true false
 syn keyword     goPredefinedIdentifiers    nil iota
 
 hi def link     goBuiltins                 Identifier
+hi def link     goPredefinedIdentifiers    Constant
+" Boolean links to Constant by default by vim: goBoolean and goPredefinedIdentifiers
+" will be highlighted the same, but having the separate groups allows users to
+" have separate highlighting for them if they desire.
 hi def link     goBoolean                  Boolean
-hi def link     goPredefinedIdentifiers    goBoolean
 
 " Comments; their contents
 syn keyword     goTodo              contained TODO FIXME XXX BUG

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainers: Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 "			Claudio Fleiner <claudio@fleiner.com>
-" Last Change:		2022 Nov 18
+" Last Change:		2023 Feb 20
 
 " Please check :help html.vim for some comments and a description of the options
 
@@ -221,7 +221,7 @@ if main_syntax != 'java' || exists("java_javascript")
   " JAVA SCRIPT
   syn include @htmlJavaScript syntax/javascript.vim
   unlet b:current_syntax
-  syn region  javaScript start=+<script\_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlJavaScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
+  syn region  javaScript start=+<script\>\_[^>]*>+ keepend end=+</script\_[^>]*>+me=s-1 contains=@htmlJavaScript,htmlCssStyleComment,htmlScriptTag,@htmlPreproc
   syn region  htmlScriptTag	contained start=+<script+ end=+>+ fold contains=htmlTagN,htmlString,htmlArg,htmlValue,htmlTagError,htmlEvent
   hi def link htmlScriptTag htmlTag
 

--- a/runtime/syntax/poefilter.vim
+++ b/runtime/syntax/poefilter.vim
@@ -2,7 +2,7 @@
 " Language:	PoE item filter
 " Maintainer:	ObserverOfTime <chronobserver@disroot.org>
 " Filenames:	*.filter
-" Last Change:	2022 Oct 07
+" Last Change:	2023 Feb 10
 
 if exists('b:current_syntax')
     finish
@@ -17,7 +17,7 @@ syn match poefilterCommentTag /\[[0-9A-Z\[\]]\+\]/ contained
 syn match poefilterComment /#.*$/ contains=poefilterTodo,poefilterCommentTag,@Spell
 
 " Blocks
-syn keyword poefilterBlock Show Hide
+syn keyword poefilterBlock Show Hide Minimal
 
 " Conditions
 syn keyword poefilterCondition


### PR DESCRIPTION
#### vim-patch:partial:938ae280c79b

Update runtime files.

https://github.com/vim/vim/commit/938ae280c79b8cdb0fca60336ec4c090ecd8bb5a

Partially skip autocmd.txt: needs patch 8.2.5011.
Partially skip builtin.txt: needs patch 9.0.0411.
Partially skip eval.txt: needs patch 8.2.3783.
Cherry-pick :map-meta-keys from patch 9.0.1276.

Co-authored-by: Bram Moolenaar <Bram@vim.org>