### PR TITLE
docs: fix treesitter parse errors

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -40,15 +40,15 @@ requires a namespace.
 
                                                         *diagnostic-structure*
 A diagnostic is a Lua table with the following keys. Required keys are
-indicated with (*):
+indicated with (+):
 
     bufnr: Buffer number
-    lnum(*): The starting line of the diagnostic
+    lnum(+): The starting line of the diagnostic
     end_lnum: The final line of the diagnostic
-    col(*): The starting column of the diagnostic
+    col(+): The starting column of the diagnostic
     end_col: The final column of the diagnostic
     severity: The severity of the diagnostic |vim.diagnostic.severity|
-    message(*): The diagnostic text
+    message(+): The diagnostic text
     source: The source of the diagnostic
     code: The diagnostic code
     user_data: Arbitrary data plugins or users can add

--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -71,7 +71,7 @@ local keyword are not accessible outside of the command. This won't work:
 <
 You can also use `:lua=`, which is the same as `:lua vim.pretty_print(...)`,
 to conveniently check the value of a variable or a table:
->lua
+>vim
     :lua=package
 <
 To run a Lua script in an external file, you can use the |:source| command

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -528,7 +528,7 @@ get_node_range({node_or_range})              *vim.treesitter.get_node_range()*
     Returns the node's range or an unpacked range table
 
     Parameters: ~
-      • {node_or_range}  (|TSNode||table) Node or table of positions
+      • {node_or_range}  (|TSNode| | table) Node or table of positions
 
     Return: ~
         (integer) start_row
@@ -1017,7 +1017,7 @@ LanguageTree:named_node_for_range({self}, {range}, {opts})
       • {self}
 
     Return: ~
-        |TSNode||nil Found node
+        |TSNode| | nil Found node
 
 LanguageTree:parse({self})                              *LanguageTree:parse()*
     Parses all defined regions using a treesitter parser for the language this

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -505,8 +505,7 @@ get_captures_at_pos({bufnr}, {row}, {col})
       • {col}    (integer) Position column
 
     Return: ~
-        table[] List of captures `{ capture = "capture name", metadata = { ...
-        } }`
+        table[] List of captures `{ capture = "name", metadata = { ... } }`
 
 get_node({opts})                                   *vim.treesitter.get_node()*
     Returns the smallest named node at the given position
@@ -838,7 +837,7 @@ Query:iter_captures({self}, {node}, {source}, {start}, {stop})
        -- typically useful info about the node:
        local type = node:type() -- type of the captured node
        local row1, col1, row2, col2 = node:range() -- range of the capture
-       ... use the info here ...
+       -- ... use the info here ...
      end
 <
 
@@ -871,7 +870,7 @@ Query:iter_matches({self}, {node}, {source}, {start}, {stop})
 
          local node_data = metadata[id] -- Node level metadata
 
-         ... use the info here ...
+         -- ... use the info here ...
        end
      end
 <

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -157,7 +157,7 @@ end
 
 --- Returns the node's range or an unpacked range table
 ---
----@param node_or_range (TSNode|table) Node or table of positions
+---@param node_or_range (TSNode | table) Node or table of positions
 ---
 ---@return integer start_row
 ---@return integer start_col
@@ -339,7 +339,7 @@ end
 ---             - lang string|nil Parser language
 ---             - ignore_injections boolean Ignore injected languages (default true)
 ---
----@return TSNode|nil under the cursor
+---@return TSNode | nil Node at the given position
 ---@deprecated
 function M.get_node_at_pos(bufnr, row, col, opts)
   vim.deprecate('vim.treesitter.get_node_at_pos()', 'vim.treesitter.get_node()', '0.10')

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -218,7 +218,7 @@ end
 ---@param row integer Position row
 ---@param col integer Position column
 ---
----@return table[] List of captures `{ capture = "capture name", metadata = { ... } }`
+---@return table[] List of captures `{ capture = "name", metadata = { ... } }`
 function M.get_captures_at_pos(bufnr, row, col)
   if bufnr == 0 then
     bufnr = a.nvim_get_current_buf()

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -653,7 +653,7 @@ end
 ---@param range Range `{ start_line, start_col, end_line, end_col }`
 ---@param opts table|nil Optional keyword arguments:
 ---             - ignore_injections boolean Ignore injected languages (default true)
----@return TSNode|nil Found node
+---@return TSNode | nil Found node
 function LanguageTree:named_node_for_range(range, opts)
   local tree = self:tree_for_range(range, opts)
   if tree then

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -639,7 +639,7 @@ end
 ---   -- typically useful info about the node:
 ---   local type = node:type() -- type of the captured node
 ---   local row1, col1, row2, col2 = node:range() -- range of the capture
----   ... use the info here ...
+---   -- ... use the info here ...
 --- end
 --- </pre>
 ---
@@ -693,7 +693,7 @@ end
 ---
 ---     local node_data = metadata[id] -- Node level metadata
 ---
----     ... use the info here ...
+---     -- ... use the info here ...
 ---   end
 --- end
 --- </pre>

--- a/test/functional/lua/help_spec.lua
+++ b/test/functional/lua/help_spec.lua
@@ -21,9 +21,8 @@ describe(':help docs', function()
     ok(rv.helpfiles > 100, '>100 :help files', rv.helpfiles)
     eq({}, rv.invalid_links, 'invalid tags in :help docs')
     eq({}, rv.invalid_urls, 'invalid URLs in :help docs')
-    -- Check that parse errors did not increase wildly.
-    -- TODO: Fix all parse errors in :help files.
-    ok(rv.err_count < 250, '<250 parse errors', rv.err_count)
+    -- Check that parse errors did not increase.
+    ok(rv.err_count == 0, 'no parse errors', rv.err_count)
   end)
 
   it('gen_help_html.lua generates HTML', function()


### PR DESCRIPTION
* Work around tree-sitter-vimdoc parsing errors introduced in a recent PR.
* Drop the tolerance of the test to 0 to make sure this doesn't happen again.