### PR TITLE
vim-patch:9.0.1337: yuck files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1131,6 +1131,7 @@ local extension = {
   yml = 'yaml',
   yaml = 'yaml',
   yang = 'yang',
+  yuck = 'yuck',
   ['z8a'] = 'z8a',
   zig = 'zig',
   zir = 'zir',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -665,6 +665,7 @@ let s:filename_checks = {
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml', '.clangd', '.clang-format', '.clang-tidy'],
     \ 'yang': ['file.yang'],
+    \ 'yuck': ['file.yuck'],
     \ 'z8a': ['file.z8a'],
     \ 'zig': ['file.zig'],
     \ 'zimbu': ['file.zu'],


### PR DESCRIPTION
Problem:    Yuck files are not recognized.
Solution:   Add a filetype pattern for yuck files. (Amaan Qureshi,
            closes vim/vim#12033)

https://github.com/vim/vim/commit/cfce5cf542db20c7beba5b4211c0ae3305a64a43

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
