### PR TITLE
feat(terminal): allow piping to jobs

### DIFF
--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -333,7 +333,8 @@ static void close_cb(Stream *stream, void *data)
 Channel *channel_job_start(char **argv, CallbackReader on_stdout, CallbackReader on_stderr,
                            Callback on_exit, bool pty, bool rpc, bool overlapped, bool detach,
                            ChannelStdinMode stdin_mode, const char *cwd, uint16_t pty_width,
-                           uint16_t pty_height, dict_T *env, varnumber_T *status_out)
+                           uint16_t pty_height, dict_T *env, varnumber_T *status_out,
+                           int stdin_descriptor)
 {
   Channel *chan = channel_alloc(kChannelStreamProc);
   chan->on_data = on_stdout;
@@ -370,6 +371,7 @@ Channel *channel_job_start(char **argv, CallbackReader on_stdout, CallbackReader
   proc->cwd = cwd;
   proc->env = env;
   proc->overlapped = overlapped;
+  proc->stdin_fd = stdin_descriptor;
 
   char *cmd = xstrdup(proc->argv[0]);
   bool has_in, has_out, has_err;

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -35,6 +35,9 @@ struct process {
   char **argv;
   dict_T *env;
   Stream in, out, err;
+  int stdin_fd;  // File descriptor that should be used for stdin. -1 if stdin
+                 // should be left as-is. Differs from `in` because `in` is a
+                 // handle to the process's pty.
   /// Exit handler. If set, user must call process_free().
   process_exit_cb cb;
   internal_process_cb internal_exit_cb, internal_close_cb;
@@ -58,6 +61,7 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
     .in = { .closed = false },
     .out = { .closed = false },
     .err = { .closed = false },
+    .stdin_fd = -1,
     .cb = NULL,
     .closed = false,
     .internal_close_cb = NULL,

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2833,8 +2833,8 @@ module.cmds = {
   },
   {
     command='terminal',
-    flags=bit.bor(BANG, FILES, CMDWIN, LOCK_OK),
-    addr_type='ADDR_NONE',
+    flags=bit.bor(BANG, FILES, CMDWIN, LOCK_OK, RANGE),
+    addr_type='ADDR_LINES',
     func='ex_terminal',
   },
   {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7267,12 +7267,30 @@ void set_pressedreturn(bool val)
 static void ex_terminal(exarg_T *eap)
 {
   char ex_cmd[1024];
+  int stdin_descriptor = -1;
+
+  // If we have something to pipe to the terminal
+  if (eap->addr_count > 0) {
+    int fd[2];
+    if (pipe(fd)) {
+      emsg(_(e_extermpipefail));
+      return;
+    }
+    for (linenr_T lnum = eap->line1; lnum <= eap->line2; lnum++) {
+      char* line = ml_get_buf(curbuf, lnum, false);
+      size_t len = strlen(line);
+      write(fd[1], line, len);
+      write(fd[1], "\n", 1);
+    }
+    close(fd[1]);
+    stdin_descriptor = fd[0];
+  }
 
   if (*eap->arg != NUL) {  // Run {cmd} in 'shell'.
     char *name = vim_strsave_escaped(eap->arg, "\"\\");
     snprintf(ex_cmd, sizeof(ex_cmd),
-             ":enew%s | call termopen(\"%s\")",
-             eap->forceit ? "!" : "", name);
+             ":enew%s | call termopen(\"%s\",{'stdin_fd':%i})",
+             eap->forceit ? "!" : "", name, stdin_descriptor);
     xfree(name);
   } else {  // No {cmd}: run the job with tokenized 'shell'.
     if (*p_sh == NUL) {
@@ -7293,8 +7311,8 @@ static void ex_terminal(exarg_T *eap)
     shell_free_argv(argv);
 
     snprintf(ex_cmd, sizeof(ex_cmd),
-             ":enew%s | call termopen([%s])",
-             eap->forceit ? "!" : "", shell_argv + 1);
+             ":enew%s | call termopen([%s],{'stdin_fd':%i})",
+             eap->forceit ? "!" : "", shell_argv + 1, stdin_descriptor);
   }
 
   do_cmdline_cmd(ex_cmd);

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -903,6 +903,7 @@ EXTERN char e_channotpty[] INIT(= N_("E904: channel is not a pty"));
 EXTERN char e_stdiochan2[] INIT(= N_("E905: Couldn't open stdio channel: %s"));
 EXTERN char e_invstream[] INIT(= N_("E906: invalid stream for channel"));
 EXTERN char e_invstreamrpc[] INIT(= N_("E906: invalid stream for rpc channel, use 'rpc'"));
+EXTERN char e_extermpipefail[] INIT(= N_("E907: cannot create pipe for terminal"));
 EXTERN char e_streamkey[] INIT(= N_("E5210: dict key '%s' already set for buffered stream in channel %" PRIu64));
 EXTERN char e_libcall[] INIT(= N_("E364: Library call failed for \"%s()\""));
 EXTERN char e_fsync[] INIT(= N_("E667: Fsync failed: %s"));

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -290,6 +290,10 @@ static void init_child(PtyProcess *ptyproc)
 
   assert(proc->env);
   environ = tv_dict_to_env(proc->env);
+  if (proc->stdin_fd != -1) {
+    dup2(proc->stdin_fd, STDIN_FILENO);
+    close(proc->stdin_fd);
+  }
   execvp(prog, proc->argv);
   ELOG("execvp(%s) failed: %s", prog, strerror(errno));
 

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -54,7 +54,7 @@ uint64_t ui_client_start_server(int argc, char **argv)
   Channel *channel = channel_job_start(args, CALLBACK_READER_INIT,
                                        on_err, CALLBACK_NONE,
                                        false, true, true, false, kChannelStdinPipe,
-                                       NULL, 0, 0, NULL, &exit_status);
+                                       NULL, 0, 0, NULL, &exit_status, -1);
 
   // If stdin is not a pty, it is forwarded to the client.
   // Replace stdin in the TUI process with the tty fd.

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -241,6 +241,15 @@ describe(':terminal buffer', function()
     feed_command('bdelete!')
   end)
 
+  it('can be #piped to', function()
+    feed_command('new')
+    feed_command('norm ihello')
+    feed_command('norm oworld')
+    feed_command('%term cat')
+    sleep(500)
+    screen:expect{any='hello\nworld\n\nProcess exited 0'}
+  end)
+
   describe('handles confirmations', function()
     it('with :confirm', function()
       feed_command('terminal')


### PR DESCRIPTION
This commit enables piping the current buffer's content to a job running
in a terminal with `:%term job`. It does so in a way that makes the old
`:%term sudo tee` trick work again.

Closes https://github.com/neovim/neovim/issues/22157
Closes https://github.com/neovim/neovim/issues/6233
Maybe good enough to close https://github.com/neovim/neovim/issues/12103
Relates to https://github.com/neovim/neovim/issues/5431
