### PR TITLE
feat(fs.lua): pass path to vim.fs.find function predicate and lazy evaluate the predicate

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2384,9 +2384,9 @@ find({names}, {opts})                                          *vim.fs.find()*
       • {names}  (string|table|fun(name: string, path: string): boolean) Names
                  of the files and directories to find. Must be base names,
                  paths and globs are not supported when {names} is a string or
-                 a table. If {names} is a function, it will be called for each
-                 file and directory within the traversed directory with the
-                 base name of the file and directory and the path of the
+                 a table. If {names} is a function, it will be called once for
+                 each file or directory within the traversed directory with
+                 the base name of the file and directory and the path of the
                  directory being traversed. The function should return `true`
                  if the given file or directory is considered a match.
       • {opts}   (table) Optional keyword arguments:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2359,26 +2359,33 @@ find({names}, {opts})                                          *vim.fs.find()*
     The search can be narrowed to find only files or only directories by
     specifying {type} to be "file" or "directory", respectively.
 
+    If {names} is a function, it is called for each file and directory within
+    the traversed directory and it would be passed the base name of each file
+    or directory and the path of the directory being traversed. The function
+    should return `true` if the given file or directory is considered a match.
+
     Parameters: ~
       • {names}  (string|table|fun(name: string, path: string): boolean) Names
                  of the files and directories to find. Must be base names,
                  paths and globs are not supported. The function is called per
                  file and directory within the traversed directories to test
                  if they match {names}.
-      • {opts}   (table) Optional keyword arguments:
-                 • path (string): Path to begin searching from. If omitted,
-                   the |current-directory| is used.
-                 • upward (boolean, default false): If true, search upward
-                   through parent directories. Otherwise, search through child
-                   directories (recursively).
-                 • stop (string): Stop searching when this directory is
-                   reached. The directory itself is not searched.
-                 • type (string): Find only files ("file") or directories
-                   ("directory"). If omitted, both files and directories that
-                   match {names} are included.
-                 • limit (number, default 1): Stop the search after finding
-                   this many matches. Use `math.huge` to place no limit on the
-                   number of matches.
+
+    Parameters: ~
+      • {opts}  (table) Optional keyword arguments:
+                • path (string): Path to begin searching from. If omitted, the
+                  |current-directory| is used.
+                • upward (boolean, default false): If true, search upward
+                  through parent directories. Otherwise, search through child
+                  directories (recursively).
+                • stop (string): Stop searching when this directory is
+                  reached. The directory itself is not searched.
+                • type (string): Find only files ("file") or directories
+                  ("directory"). If omitted, both files and directories that
+                  match {names} are included.
+                • limit (number, default 1): Stop the search after finding
+                  this many matches. Use `math.huge` to place no limit on the
+                  number of matches.
 
     Return: ~
         (table) Normalized paths |vim.fs.normalize()| of all matching files or

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2374,7 +2374,7 @@ find({names}, {opts})                                          *vim.fs.find()*
        {limit = math.huge, type = 'directory', path = './runtime/'}
      )
 
-     -- get all the C++ source and header files inside lib/
+     -- get all files ending with .cpp or .hpp inside lib/
      local cpp_hpp = vim.fs.find(function(name, path)
        return name:match('.*%.[ch]pp$') and path:match('[/\\]lib$')
      end, {limit = math.huge, type = 'file'})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2360,11 +2360,11 @@ find({names}, {opts})                                          *vim.fs.find()*
     specifying {type} to be "file" or "directory", respectively.
 
     Parameters: ~
-      • {names}  (string|table|fun(name: string): boolean) Names of the files
-                 and directories to find. Must be base names, paths and globs
-                 are not supported. The function is called per file and
-                 directory within the traversed directories to test if they
-                 match {names}.
+      • {names}  (string|table|fun(name: string, path: string): boolean) Names
+                 of the files and directories to find. Must be base names,
+                 paths and globs are not supported. The function is called per
+                 file and directory within the traversed directories to test
+                 if they match {names}.
       • {opts}   (table) Optional keyword arguments:
                  • path (string): Path to begin searching from. If omitted,
                    the |current-directory| is used.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2384,11 +2384,12 @@ find({names}, {opts})                                          *vim.fs.find()*
       • {names}  (string|table|fun(name: string, path: string): boolean) Names
                  of the files and directories to find. Must be base names,
                  paths and globs are not supported when {names} is a string or
-                 a table. If {names} is a function, it will be called once for
-                 each file or directory within the traversed directory with
-                 the base name of the file and directory and the path of the
-                 directory being traversed. The function should return `true`
-                 if the given file or directory is considered a match.
+                 a table. If {names} is a function, it is called for each
+                 traversed file and directory with args:
+                 • name: base name of the current item
+                 • path: full path of the current item The function should
+                   return `true` if the given file or directory is considered
+                   a match.
       • {opts}   (table) Optional keyword arguments:
                  • path (string): Path to begin searching from. If omitted,
                    the |current-directory| is used.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2359,33 +2359,50 @@ find({names}, {opts})                                          *vim.fs.find()*
     The search can be narrowed to find only files or only directories by
     specifying {type} to be "file" or "directory", respectively.
 
-    If {names} is a function, it is called for each file and directory within
-    the traversed directory and it would be passed the base name of each file
-    or directory and the path of the directory being traversed. The function
-    should return `true` if the given file or directory is considered a match.
+    Examples: >lua
+
+     -- location of Cargo.toml from the current buffer's path
+     local cargo = vim.fs.find('Cargo.toml', {
+       upward = true,
+       stop = vim.loop.os_homedir(),
+       path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
+     })
+
+     -- list all test directories under the runtime directory
+     local test_dirs = vim.fs.find(
+       {'test', 'tst', 'testdir'},
+       {limit = math.huge, type = 'directory', path = './runtime/'}
+     )
+
+     -- get all the C++ source and header files inside lib/
+     local cpp_hpp = vim.fs.find(function(name, path)
+       return name:match('.*%.[ch]pp$') and path:match('[/\\]lib$')
+     end, {limit = math.huge, type = 'file'})
+<
 
     Parameters: ~
       • {names}  (string|table|fun(name: string, path: string): boolean) Names
                  of the files and directories to find. Must be base names,
-                 paths and globs are not supported. The function is called per
-                 file and directory within the traversed directories to test
-                 if they match {names}.
-
-    Parameters: ~
-      • {opts}  (table) Optional keyword arguments:
-                • path (string): Path to begin searching from. If omitted, the
-                  |current-directory| is used.
-                • upward (boolean, default false): If true, search upward
-                  through parent directories. Otherwise, search through child
-                  directories (recursively).
-                • stop (string): Stop searching when this directory is
-                  reached. The directory itself is not searched.
-                • type (string): Find only files ("file") or directories
-                  ("directory"). If omitted, both files and directories that
-                  match {names} are included.
-                • limit (number, default 1): Stop the search after finding
-                  this many matches. Use `math.huge` to place no limit on the
-                  number of matches.
+                 paths and globs are not supported when {names} is a string or
+                 a table. If {names} is a function, it will be called for each
+                 file and directory within the traversed directory with the
+                 base name of the file and directory and the path of the
+                 directory being traversed. The function should return `true`
+                 if the given file or directory is considered a match.
+      • {opts}   (table) Optional keyword arguments:
+                 • path (string): Path to begin searching from. If omitted,
+                   the |current-directory| is used.
+                 • upward (boolean, default false): If true, search upward
+                   through parent directories. Otherwise, search through child
+                   directories (recursively).
+                 • stop (string): Stop searching when this directory is
+                   reached. The directory itself is not searched.
+                 • type (string): Find only files ("file") or directories
+                   ("directory"). If omitted, both files and directories that
+                   match {names} are included.
+                 • limit (number, default 1): Stop the search after finding
+                   this many matches. Use `math.huge` to place no limit on the
+                   number of matches.
 
     Return: ~
         (table) Normalized paths |vim.fs.normalize()| of all matching files or

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -168,9 +168,9 @@ end
 ---@param names (string|table|fun(name: string, path: string): boolean) Names of the files
 ---             and directories to find.
 ---             Must be base names, paths and globs are not supported when {names} is a string or a table.
----             If {names} is a function, it will be called once for each file or directory
----             within the traversed directory with the base name of the
----             file and directory and the path of the directory being traversed.
+---             If {names} is a function, it is called for each traversed file and directory with args:
+---             - name: base name of the current item
+---             - path: full path of the current item
 ---             The function should return `true` if the given file or directory is considered a match.
 ---
 ---@param opts (table) Optional keyword arguments:

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -168,7 +168,7 @@ end
 ---@param names (string|table|fun(name: string, path: string): boolean) Names of the files
 ---             and directories to find.
 ---             Must be base names, paths and globs are not supported when {names} is a string or a table.
----             If {names} is a function, it will be called for each file and directory
+---             If {names} is a function, it will be called once for each file or directory
 ---             within the traversed directory with the base name of the
 ---             file and directory and the path of the directory being traversed.
 ---             The function should return `true` if the given file or directory is considered a match.

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -159,7 +159,7 @@ end
 ---   {limit = math.huge, type = 'directory', path = './runtime/'}
 --- )
 ---
---- -- get all the C++ source and header files inside lib/
+--- -- get all files ending with .cpp or .hpp inside lib/
 --- local cpp_hpp = vim.fs.find(function(name, path)
 ---   return name:match('.*%.[ch]pp$') and path:match('[/\\\\]lib$')
 --- end, {limit = math.huge, type = 'file'})

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -144,7 +144,7 @@ end
 --- The search can be narrowed to find only files or only directories by
 --- specifying {type} to be "file" or "directory", respectively.
 ---
----@param names (string|table|fun(name: string): boolean) Names of the files
+---@param names (string|table|fun(name: string, path: string): boolean) Names of the files
 ---             and directories to find.
 ---             Must be base names, paths and globs are not supported.
 ---             The function is called per file and directory within the
@@ -201,7 +201,7 @@ function M.find(names, opts)
       test = function(p)
         local t = {}
         for name, type in M.dir(p) do
-          if names(name) and (not opts.type or opts.type == type) then
+          if (not opts.type or opts.type == type) and names(name, p) then
             table.insert(t, join_paths(p, name))
           end
         end

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -150,6 +150,11 @@ end
 ---             The function is called per file and directory within the
 ---             traversed directories to test if they match {names}.
 ---
+---             If {names} is a function, it is called for each file and directory within the
+---             traversed directory and it would be passed the base name of each file or directory and
+---             the path of the directory being traversed.
+---             The function should return `true` if the given file or directory is considered a match.
+---
 ---@param opts (table) Optional keyword arguments:
 ---                       - path (string): Path to begin searching from. If
 ---                              omitted, the |current-directory| is used.

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -8,6 +8,7 @@ local mkdir_p = helpers.mkdir_p
 local rmdir = helpers.rmdir
 local nvim_dir = helpers.nvim_dir
 local test_build_dir = helpers.test_build_dir
+local test_source_path = helpers.test_source_path
 local nvim_prog = helpers.nvim_prog
 local is_os = helpers.is_os
 
@@ -252,6 +253,16 @@ describe('vim.fs', function()
         local opts = { path = dir, upward = true, type = 'directory' }
         return vim.fs.find(function(x) return x == 'no-match' end, opts)
       ]], nvim_dir))
+      eq(
+        exec_lua([[
+          local dir = ...
+          return vim.tbl_map(vim.fs.basename, vim.fn.glob(dir..'/contrib/*', false, true))
+        ]], test_source_path),
+        exec_lua([[
+          local dir = ...
+          local opts = { path = dir, limit = math.huge }
+          return vim.tbl_map(vim.fs.basename, vim.fs.find(function(_, d) return d:match('[\\/]contrib$') end, opts))
+        ]], test_source_path))
     end)
   end)
 


### PR DESCRIPTION
Predicates can do more complex filters if they know were the file/directory is located, right now there's no easy way to get files under certain directories (ex: grab all files under `test/`) or exclude the content of certain paths (ex. `build/`, `.git/`)