### PR TITLE
feat(treesitter)!: remove silent option from language.add()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -686,11 +686,6 @@ add({lang}, {opts})                            *vim.treesitter.language.add()*
                 • path (string|nil) Optional path the parser is located at
                 • symbol_name (string|nil) Internal symbol name for the
                   language to load
-                • silent (boolean|nil) Don't throw an error if language not
-                  found
-
-    Return: ~
-        (boolean) If the specified language is installed
 
 get_lang({filetype})                      *vim.treesitter.language.get_lang()*
     Parameters: ~

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -184,7 +184,7 @@ function LanguageTree:parse()
   local seen_langs = {} ---@type table<string,boolean>
 
   for lang, injection_ranges in pairs(injections_by_lang) do
-    local has_lang = language.add(lang, { silent = true })
+    local has_lang = pcall(language.add, lang)
 
     -- Child language trees should just be ignored if not found, since
     -- they can depend on the text of a node. Intermediate strings

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -20,10 +20,9 @@ describe('treesitter language API', function()
     matches("Failed to load parser for language 'borklang': uv_dlopen: .+",
        pcall_err(exec_lua, "parser = vim.treesitter.add('borklang', { path = 'borkbork.so' })"))
 
-    -- Should not throw an error when silent
-    eq(false, exec_lua("return vim.treesitter.add('borklang', { silent = true })"))
+    eq(false, exec_lua("return pcall(vim.treesitter.add, 'borklang')"))
 
-    eq(false, exec_lua("return vim.treesitter.add('borklang', { path = 'borkbork.so', silent = true })"))
+    eq(false, exec_lua("return pcall(vim.treesitter.add, 'borklang', { path = 'borkbork.so' })"))
 
     eq(".../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.inspect_language('borklang')"))


### PR DESCRIPTION
Simply use `pcall` if you want to silence an error.
