### PR TITLE
feat(ui): restore has('gui_running')

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3868,6 +3868,7 @@ has({feature})	Returns 1 if {feature} is supported, 0 otherwise.  The
 			clipboard	|clipboard| provider is available.
 			fname_case	Case in file names matters (for Darwin and MS-Windows
 					this is not present).
+                        gui_running	Nvim has a GUI.
 			iconv		Can use |iconv()| for conversion.
 			linux		Linux system.
 			mac		MacOS system.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -179,6 +179,8 @@ The following new APIs or features were added.
 
   Additionally |TSNode:range()| now takes an optional {include_bytes} argument.
 
+• |nvim_list_uis()| reports all |ui-option| fields.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -181,6 +181,9 @@ The following new APIs or features were added.
 
 • |nvim_list_uis()| reports all |ui-option| fields.
 
+• Vim's `has('gui_running')` is now supported as a way for plugins to check if
+  a GUI (not the |TUI|) is attached to Nvim. |has()|
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -53,9 +53,8 @@ with these (optional) keys:
 - `term_name`		Sets the name of the terminal 'term'.
 - `term_colors`		Sets the number of supported colors 't_Co'.
 - `term_background`	Sets the default value of 'background'.
-- `stdin_fd`		Read buffer from `fd` as if it was a stdin pipe.
-			This option can only used by |--embed| ui on startup.
-			See |ui-startup-stdin|.
+- `stdin_fd`		Read buffer 1 from this fd as if it were stdin |--|.
+			Only from |--embed| UI on startup. |ui-startup-stdin|
 - `stdin_tty`		Tells if `stdin` is a `tty` or not.
 - `stdout_tty`		Tells if `stdout` is a `tty` or not.
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -113,6 +113,10 @@ void remote_ui_disconnect(uint64_t channel_id)
   kv_destroy(data->call_buf);
   pmap_del(uint64_t)(&connected_uis, channel_id);
   ui_detach_impl(ui, channel_id);
+
+  // Destroy `ui`.
+  XFREE_CLEAR(ui->term_name);
+  XFREE_CLEAR(ui->term_background);
   xfree(ui);
 }
 
@@ -163,15 +167,9 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height, Dictiona
   UI *ui = xcalloc(1, sizeof(UI));
   ui->width = (int)width;
   ui->height = (int)height;
-  ui->pum_nlines = 0;
-  ui->pum_pos = false;
-  ui->pum_width = 0.0;
-  ui->pum_height = 0.0;
   ui->pum_row = -1.0;
   ui->pum_col = -1.0;
   ui->rgb = true;
-  ui->override = false;
-
   CLEAR_FIELD(ui->ui_ext);
 
   for (size_t i = 0; i < options.size; i++) {
@@ -320,6 +318,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
       return;
     });
     set_tty_option("term", string_to_cstr(value.data.string));
+    ui->term_name = string_to_cstr(value.data.string);
     return;
   }
 
@@ -328,6 +327,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
       return;
     });
     t_colors = (int)value.data.integer;
+    ui->term_colors = (int)value.data.integer;
     return;
   }
 
@@ -336,6 +336,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
       return;
     });
     set_tty_background(value.data.string.data);
+    ui->term_background = string_to_cstr(value.data.string);
     return;
   }
 
@@ -351,6 +352,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
     });
 
     stdin_fd = (int)value.data.integer;
+    ui->stdin_fd = (int)value.data.integer;
     return;
   }
 
@@ -359,6 +361,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
       return;
     });
     stdin_isatty = value.data.boolean;
+    ui->stdin_tty = value.data.boolean;
     return;
   }
 
@@ -367,6 +370,7 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
       return;
     });
     stdout_isatty = value.data.boolean;
+    ui->stdout_tty = value.data.boolean;
     return;
   }
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -352,7 +352,6 @@ static void ui_set_option(UI *ui, bool init, String name, Object value, Error *e
     });
 
     stdin_fd = (int)value.data.integer;
-    ui->stdin_fd = (int)value.data.integer;
     return;
   }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3228,7 +3228,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   if (!n) {
-    if (STRNICMP(name, "patch", 5) == 0) {
+    if (STRNICMP(name, "gui_running", 11) == 0) {
+      n = ui_gui_attached();
+    } else if (STRNICMP(name, "patch", 5) == 0) {
       if (name[5] == '-'
           && strlen(name) >= 11
           && ascii_isdigit(name[6])

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -598,6 +598,15 @@ Array ui_array(void)
     PUT(info, "height", INTEGER_OBJ(ui->height));
     PUT(info, "rgb", BOOLEAN_OBJ(ui->rgb));
     PUT(info, "override", BOOLEAN_OBJ(ui->override));
+
+    // TUI fields.
+    PUT(info, "term_name", STRING_OBJ(cstr_to_string(ui->term_name)));
+    PUT(info, "term_background", STRING_OBJ(cstr_to_string(ui->term_background)));
+    PUT(info, "term_colors", INTEGER_OBJ(ui->term_colors));
+    PUT(info, "stdin_fd", INTEGER_OBJ(ui->stdin_fd));
+    PUT(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
+    PUT(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));
+
     for (UIExtension j = 0; j < kUIExtCount; j++) {
       if (ui_ext_names[j][0] != '_' || ui->ui_ext[j]) {
         PUT(info, ui_ext_names[j], BOOLEAN_OBJ(ui->ui_ext[j]));

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -134,6 +134,7 @@ void ui_free_all_mem(void)
 }
 #endif
 
+/// Returns true if any `rgb=true` UI is attached.
 bool ui_rgb_attached(void)
 {
   if (!headless_mode && p_tgc) {
@@ -141,6 +142,18 @@ bool ui_rgb_attached(void)
   }
   for (size_t i = 0; i < ui_count; i++) {
     if (uis[i]->rgb) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Returns true if a GUI is attached.
+bool ui_gui_attached(void)
+{
+  for (size_t i = 0; i < ui_count; i++) {
+    bool tui = uis[i]->stdin_tty || uis[i]->stdout_tty;
+    if (!tui) {
       return true;
     }
   }
@@ -599,11 +612,10 @@ Array ui_array(void)
     PUT(info, "rgb", BOOLEAN_OBJ(ui->rgb));
     PUT(info, "override", BOOLEAN_OBJ(ui->override));
 
-    // TUI fields.
+    // TUI fields. (`stdin_fd` is intentionally omitted.)
     PUT(info, "term_name", STRING_OBJ(cstr_to_string(ui->term_name)));
     PUT(info, "term_background", STRING_OBJ(cstr_to_string(ui->term_background)));
     PUT(info, "term_colors", INTEGER_OBJ(ui->term_colors));
-    PUT(info, "stdin_fd", INTEGER_OBJ(ui->stdin_fd));
     PUT(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
     PUT(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));
 

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -103,6 +103,14 @@ struct ui_t {
   double pum_height;
   double pum_width;
 
+  // TUI fields.
+  char *term_name;
+  char *term_background;
+  int term_colors;
+  int stdin_fd;
+  bool stdin_tty;
+  bool stdout_tty;
+
   // TODO(bfredl): integrate into struct!
   UIData data[1];
 };

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -107,7 +107,6 @@ struct ui_t {
   char *term_name;
   char *term_background;
   int term_colors;
-  int stdin_fd;
   bool stdin_tty;
   bool stdout_tty;
 

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -1,6 +1,8 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
+/// Nvim's own UI client, which attaches to a child or remote Nvim server.
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2549,20 +2549,26 @@ describe('API', function()
         {
           chan = 1,
           ext_cmdline = false,
+          ext_hlstate = false,
+          ext_linegrid = screen._options.ext_linegrid or false,
+          ext_messages = false,
+          ext_multigrid = false,
           ext_popupmenu = false,
           ext_tabline = false,
-          ext_wildmenu = false,
-          ext_linegrid = screen._options.ext_linegrid or false,
-          ext_multigrid = false,
-          ext_hlstate = false,
           ext_termcolors = false,
-          ext_messages = false,
+          ext_wildmenu = false,
           height = 4,
-          rgb = true,
           override = true,
+          rgb = true,
+          stdin_tty = false,
+          stdout_tty = false,
+          term_background = '',
+          term_colors = 0,
+          term_name = '',
           width = 20,
         }
       }
+
       eq(expected, nvim("list_uis"))
 
       screen:detach()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1398,17 +1398,32 @@ describe('TUI', function()
     ]]}
   end)
 
-  it('is included in nvim_list_uis()', function()
-    feed_data(':echo map(nvim_list_uis(), {k,v -> sort(items(filter(v, {k,v -> k[:3] !=# "ext_" })))})\r')
-    screen:expect([=[
-                                                        |
-      {4:~                                                 }|
-      {5:                                                  }|
-      [[['chan', 1], ['height', 6], ['override', v:false|
-      ], ['rgb', v:false], ['width', 50]]]              |
-      {10:Press ENTER or type command to continue}{1: }          |
-      {3:-- TERMINAL --}                                    |
-    ]=])
+  it('in nvim_list_uis()', function()
+    local expected = {
+      {
+         chan = 1,
+         ext_cmdline = false,
+         ext_hlstate = false,
+         ext_linegrid = true,
+         ext_messages = false,
+         ext_multigrid = false,
+         ext_popupmenu = false,
+         ext_tabline = false,
+         ext_termcolors = true,
+         ext_wildmenu = false,
+         height = 6,
+         override = false,
+         rgb = false,
+         stdin_tty = true,
+         stdout_tty = true,
+         term_background = '',
+         term_colors = 256,
+         term_name = 'xterm-256color',  -- $TERM in :terminal.
+         width = 50
+       },
+    }
+    local _, rv = child_session:request('nvim_list_uis')
+    eq(expected, rv)
   end)
 
   it('allows grid to assume wider ambiguous-width characters than host terminal #19686', function()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1399,6 +1399,8 @@ describe('TUI', function()
   end)
 
   it('in nvim_list_uis()', function()
+    -- $TERM in :terminal.
+    local exp_term = is_os('bsd') and 'builtin_xterm' or 'xterm-256color'
     local expected = {
       {
          chan = 1,
@@ -1418,7 +1420,7 @@ describe('TUI', function()
          stdout_tty = true,
          term_background = '',
          term_colors = 256,
-         term_name = 'xterm-256color',  -- $TERM in :terminal.
+         term_name = exp_term,
          width = 50
        },
     }

--- a/test/functional/vimscript/has_spec.lua
+++ b/test/functional/vimscript/has_spec.lua
@@ -1,8 +1,11 @@
 local helpers = require('test.functional.helpers')(after_each)
-local eq = helpers.eq
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
+local connect = helpers.connect
+local eq = helpers.eq
 local funcs = helpers.funcs
 local is_os = helpers.is_os
+local nvim_prog = helpers.nvim_prog
 
 describe('has()', function()
   before_each(clear)
@@ -69,8 +72,22 @@ describe('has()', function()
     end
   end)
 
+  it('"gui_running"', function()
+    eq(0, funcs.has('gui_running'))
+    local tui = Screen.new(50,15)
+    local gui_session = connect(funcs.serverstart())
+    local gui = Screen.new(50,15)
+    eq(0, funcs.has('gui_running'))
+    tui:attach({ext_linegrid=true, rgb=true, stdin_tty=true, stdout_tty=true})
+    gui:attach({ext_multigrid=true, rgb=true}, gui_session)
+    eq(1, funcs.has('gui_running'))
+    tui:detach()
+    eq(1, funcs.has('gui_running'))
+    gui:detach()
+    eq(0, funcs.has('gui_running'))
+  end)
+
   it('does not change v:shell_error', function()
-    local nvim_prog = helpers.nvim_prog
     funcs.system({nvim_prog, '-es', '+73cquit'})
     funcs.has('python3') -- use a call whose implementation shells out
     eq(73, funcs.eval('v:shell_error'))

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -312,7 +312,7 @@ function module.is_os(s)
     or s == 'bsd') then
     error('unknown platform: '..tostring(s))
   end
-  return ((s == 'win' and module.sysname():find('windows'))
+  return not not ((s == 'win' and module.sysname():find('windows'))
     or (s == 'mac' and module.sysname() == 'darwin')
     or (s == 'freebsd' and module.sysname() == 'freebsd')
     or (s == 'openbsd' and module.sysname() == 'openbsd')


### PR DESCRIPTION
In the past this was rejected because there is not a single GUI. But in practice, `has('gui_running')` is also used as a way to detect "is the TUI (not) running?" 

re https://github.com/vimpostor/vim-tpipeline/commit/95a6ccbe9f33bc42dd4cee45731d8bc3fbcd92d1

todo

- > Another solution could be to have the TUI set its name, so that plugins could check nvim_get_chan_info(1).client.name



bsd CI:

```
test/functional/terminal/tui_spec.lua:1427: Expected objects to be the same.
Passed in:
   ...
   *[term_name] = 'builtin_xterm'
```