### PR TITLE
vim-patch:9.0.1348: Un-grammar files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1056,6 +1056,7 @@ local extension = {
   uc = 'uc',
   uit = 'uil',
   uil = 'uil',
+  ungram = 'ungrammar',
   sba = 'vb',
   vb = 'vb',
   dsm = 'vb',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -609,6 +609,7 @@ let s:filename_checks = {
     \ 'typescript': ['file.mts', 'file.cts'],
     \ 'typescript.glimmer': ['file.gts'],
     \ 'typescriptreact': ['file.tsx'],
+    \ 'ungrammar': ['file.ungram'],
     \ 'uc': ['file.uc'],
     \ 'udevconf': ['/etc/udev/udev.conf', 'any/etc/udev/udev.conf'],
     \ 'udevperm': ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],


### PR DESCRIPTION
Problem:    Un-grammar files are not recognized.
Solution:   Add patterns for Un-grammar files. (Amaan Qureshi, closes vim/vim#12034)

https://github.com/vim/vim/commit/44e08c1cf83f5a50f8b21613551304a6651c1161

Co-authored-by: Amaan Qureshi [amaanq12@gmail.com](mailto:amaanq12@gmail.com)