### PR TITLE
fix(MSVC): set the active code page to utf-8

### DIFF
--- a/src/nvim/os/nvim.manifest
+++ b/src/nvim/os/nvim.manifest
@@ -17,4 +17,9 @@
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
     </application>
   </compatibility>
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+      <activeCodePage>UTF-8</activeCodePage>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </assembly>


### PR DESCRIPTION
Neovim expects character encoding to be UTF-8, and deviation from this
causes bugs such as lua files not being recognized for non-ascii paths.
This changes the behavior of fopen, which defaults to using the
currently active codepage.

Closes: https://github.com/neovim/neovim/issues/18122