### PR TITLE
vim-patch:8.2.4318: various comment and indent mistakes, returning wrong zero

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2572,7 +2572,7 @@ static int eval4(char **arg, typval_T *rettv, int evaluate)
 }
 
 /// Handle fourth level expression:
-///      +       number addition
+///      +       number addition, concatenation of list or blob
 ///      -       number subtraction
 ///      .       string concatenation
 ///      ..      string concatenation

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1000,7 +1000,7 @@ void ui_ext_win_viewport(win_T *wp)
   }
 }
 
-/// If "split_disallowed" is set given an error and return FAIL.
+/// If "split_disallowed" is set give an error and return FAIL.
 /// Otherwise return OK.
 static int check_split_disallowed(void)
 {


### PR DESCRIPTION
#### vim-patch:8.2.4318: various comment and indent mistakes, returning wrong zero

Problem:    Various comment and indent mistakes, returning wrong zero.
Solution:   Fix the mistakes.  Return NULL instead of FAIL.

https://github.com/vim/vim/commit/54969f4ef5825205ecde09ea80f4087fc3b68e5d

N/A patches for version.c:

vim-patch:8.2.3781: the option window script is outdated

Problem:    The option window script is outdated.
Solution:   Add several changes.

https://github.com/vim/vim/commit/a416861c643b03fe5dec9f3bf8c1c9e054b5a9c7

Co-authored-by: Bram Moolenaar <Bram@vim.org>