### PR TITLE
fix(lsp): add workspace.diagnostics.refreshSupport

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -832,6 +832,9 @@ function protocol.make_client_capabilities()
         },
         hierarchicalWorkspaceSymbolSupport = true,
       },
+      diagnostics = {
+        refreshSupport = true,
+      },
       configuration = true,
       workspaceFolders = true,
       applyEdit = true,


### PR DESCRIPTION
some servers will check this field before send `workspace.diagnostic.refresh` request.