### PR TITLE
vim-patch:9.0.1351: Dhall files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -295,6 +295,7 @@ local extension = {
   desc = 'desc',
   directory = 'desktop',
   desktop = 'desktop',
+  dhall = 'dhall',
   diff = 'diff',
   rej = 'diff',
   Dockerfile = 'dockerfile',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -156,6 +156,7 @@ let s:filename_checks = {
     \ 'denyhosts': ['denyhosts.conf'],
     \ 'desc': ['file.desc'],
     \ 'desktop': ['file.desktop', '.directory', 'file.directory'],
+    \ 'dhall': ['file.dhall'],
     \ 'dictconf': ['dict.conf', '.dictrc'],
     \ 'dictdconf': ['dictd.conf', 'dictdfile.conf', 'dictd-file.conf'],
     \ 'diff': ['file.diff', 'file.rej'],


### PR DESCRIPTION
Problem:    Dhall files are not recognized.
Solution:   Add patterns for Dhall files. (Amaan Qureshi, closes vim/vim#12052)

https://github.com/vim/vim/commit/def5521752abefe12db8cc3111a3b205ad1ac929

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
