### PR TITLE
fix(lsp): use buffer scheme for files not stored on disk

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2032,7 +2032,12 @@ end
 ---@returns `TextDocumentIdentifier`
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier
 function M.make_text_document_params(bufnr)
-  return { uri = vim.uri_from_bufnr(bufnr or 0) }
+  bufnr = bufnr or 0
+  local uri = vim.uri_from_bufnr(bufnr)
+  if not uv.fs_stat(api.nvim_buf_get_name(bufnr)) then
+    uri = uri:gsub('^file://', 'buffer://')
+  end
+  return { uri = uri }
 end
 
 --- Create the workspace params
@@ -2065,7 +2070,7 @@ function M.make_formatting_params(options)
     insertSpaces = vim.bo.expandtab,
   })
   return {
-    textDocument = { uri = vim.uri_from_bufnr(0) },
+    textDocument = M.make_text_document_params(0),
     options = options,
   }
 end

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -272,6 +272,7 @@ function tests.text_document_save_did_open()
     end;
     body = function()
       notify('start')
+      expect_notification('textDocument/didClose')
       expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave')
       notify('shutdown')
@@ -292,6 +293,8 @@ function tests.text_document_sync_save_bool()
     end;
     body = function()
       notify('start')
+      expect_notification('textDocument/didClose')
+      expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave', {textDocument = { uri = "file://" }})
       notify('shutdown')
     end;
@@ -313,6 +316,8 @@ function tests.text_document_sync_save_includeText()
     end;
     body = function()
       notify('start')
+      expect_notification('textDocument/didClose')
+      expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave', {
         textDocument = {
           uri = "file://"
@@ -459,7 +464,7 @@ function tests.basic_check_buffer_open()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
@@ -486,13 +491,13 @@ function tests.basic_check_buffer_open_and_change()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {
@@ -522,13 +527,13 @@ function tests.basic_check_buffer_open_and_change_noeol()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n");
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {
@@ -557,13 +562,13 @@ function tests.basic_check_buffer_open_and_change_multi()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {
@@ -572,7 +577,7 @@ function tests.basic_check_buffer_open_and_change_multi()
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 4;
         };
         contentChanges = {
@@ -602,13 +607,13 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {
@@ -617,7 +622,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 4;
         };
         contentChanges = {
@@ -626,7 +631,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
       })
       expect_notification('textDocument/didClose', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
         };
       })
       expect_notification("finish")
@@ -660,13 +665,13 @@ function tests.basic_check_buffer_open_and_change_incremental()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {
@@ -703,13 +708,13 @@ function tests.basic_check_buffer_open_and_change_incremental_editing()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n");
-          uri = "file://";
+          uri = "buffer://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "file://";
+          uri = "buffer://";
           version = 3;
         };
         contentChanges = {


### PR DESCRIPTION
Sending `didOpen` with a `file` scheme causes problems with some
language servers because they expect the file to exist on disk.

See https://github.com/microsoft/language-server-protocol/pull/1679
