### PR TITLE
build: set libtermkey project language to C

### DIFF
--- a/cmake.deps/cmake/LibvtermCMakeLists.txt
+++ b/cmake.deps/cmake/LibvtermCMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(libvterm LANGUAGES C)
+project(libvterm C)
 
 include(GNUInstallDirs)
 

--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(tree-sitter LANGUAGES C)
+project(tree-sitter C)
 
 add_library(tree-sitter lib/src/lib.c)
 target_include_directories(tree-sitter

--- a/cmake.deps/cmake/libtermkeyCMakeLists.txt
+++ b/cmake.deps/cmake/libtermkeyCMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(libtermkey)
+project(libtermkey C)
 
 add_definitions(-D _CRT_SECURE_NO_WARNINGS)
 add_definitions(-DHAVE_UNIBILIUM)


### PR DESCRIPTION
This will prevent cmake from failing the build if a C++ compiler isn't
found.
