### PR TITLE
vim-patch:9.0.{1354,1356}: "gr CTRL-G" stays in virtual replace mode

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3444,6 +3444,10 @@ static void ins_ctrl_g(void)
     dont_sync_undo = kNone;
     break;
 
+  case ESC:
+    // Esc after CTRL-G cancels it.
+    break;
+
   // Unknown CTRL-G command, reserved for future expansion.
   default:
     vim_beep(BO_CTRLG);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4720,6 +4720,11 @@ static void nv_vreplace(cmdarg_T *cap)
     if (cap->extra_char == Ctrl_V) {          // get another character
       cap->extra_char = get_literal(false);
     }
+    if (cap->extra_char < ' ') {
+      // Prefix a control character with CTRL-V to avoid it being used as
+      // a command.
+      stuffcharReadbuff(Ctrl_V);
+    }
     stuffcharReadbuff(cap->extra_char);
     stuffcharReadbuff(ESC);
     if (virtual_active()) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4710,7 +4710,7 @@ static void nv_vreplace(cmdarg_T *cap)
     return;
   }
 
-  if (checkclearopq(cap->oap)) {
+  if (checkclearopq(cap->oap) || cap->extra_char == ESC) {
     return;
   }
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -580,6 +580,7 @@ func Test_edit_CTRL_G()
   call assert_equal([0, 3, 7, 0], getpos('.'))
   call feedkeys("i\<c-g>j\<esc>", 'tnix')
   call assert_equal([0, 3, 6, 0], getpos('.'))
+  call assert_nobeep("normal! i\<c-g>\<esc>")
   bw!
 endfunc
 
@@ -2076,20 +2077,6 @@ func Test_edit_CTRL_hat()
   call assert_equal(2, &iminsert)
   call feedkeys("i\<C-^>", 'xt')
   call assert_equal(0, &iminsert)
-
-  bwipe!
-endfunc
-
-" Test "gr" followed by an Insert mode command does get out of Insert mode.
-func Test_edit_gr_special()
-  enew
-  call setline(1, ['abcdef', 'xxxxxx'])
-  exe "normal! gr\<C-O>lx"
-  call assert_equal("\<C-O>def", getline(1))
-
-  call setline(1, 'abcdef')
-  exe "normal! 0gr\<C-G>lx"
-  call assert_equal("\<C-G>def", getline(1))
 
   bwipe!
 endfunc

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -2080,6 +2080,20 @@ func Test_edit_CTRL_hat()
   bwipe!
 endfunc
 
+" Test "gr" followed by an Insert mode command does get out of Insert mode.
+func Test_edit_gr_special()
+  enew
+  call setline(1, ['abcdef', 'xxxxxx'])
+  exe "normal! gr\<C-O>lx"
+  call assert_equal("\<C-O>def", getline(1))
+
+  call setline(1, 'abcdef')
+  exe "normal! 0gr\<C-G>lx"
+  call assert_equal("\<C-G>def", getline(1))
+
+  bwipe!
+endfunc
+
 " Weird long file name was going over the end of NameBuff
 func Test_edit_overlong_file_name()
   CheckUnix

--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -3283,9 +3283,9 @@ func Test_delete_until_paragraph()
 endfunc
 
 " Test for the gr (virtual replace) command
-" Test for the bug fixed by 7.4.387
 func Test_gr_command()
   enew!
+  " Test for the bug fixed by 7.4.387
   let save_cpo = &cpo
   call append(0, ['First line', 'Second line', 'Third line'])
   exe "normal i\<C-G>u"
@@ -3298,10 +3298,12 @@ func Test_gr_command()
   normal 4gro
   call assert_equal('ooooecond line', getline(2))
   let &cpo = save_cpo
+
   normal! ggvegrx
   call assert_equal('xxxxx line', getline(1))
   exe "normal! gggr\<C-V>122"
   call assert_equal('zxxxx line', getline(1))
+
   set virtualedit=all
   normal! 15|grl
   call assert_equal('zxxxx line    l', getline(1))
@@ -3309,8 +3311,25 @@ func Test_gr_command()
   set nomodifiable
   call assert_fails('normal! grx', 'E21:')
   call assert_fails('normal! gRx', 'E21:')
+  call assert_nobeep("normal! gr\<Esc>")
   set modifiable&
-  enew!
+
+  call assert_nobeep("normal! gr\<Esc>")
+  call assert_beeps("normal! cgr\<Esc>")
+
+  call assert_equal('zxxxx line    l', getline(1))
+  exe "normal! 2|gr\<C-V>\<Esc>"
+  call assert_equal("z\<Esc>xx line    l", getline(1))
+
+  call setline(1, 'abcdef')
+  exe "normal! 0gr\<C-O>lx"
+  call assert_equal("\<C-O>def", getline(1))
+
+  call setline(1, 'abcdef')
+  exe "normal! 0gr\<C-G>lx"
+  call assert_equal("\<C-G>def", getline(1))
+
+  bwipe!
 endfunc
 
 func Test_nv_hat_count()


### PR DESCRIPTION
#### vim-patch:9.0.1354: "gr CTRL-G" stays in virtual replace mode

Problem:    "gr CTRL-G" stays in virtual replace mode. (Pierre Ganty)
Solution:   Prepend CTRL-V before control characters.

https://github.com/vim/vim/commit/d6a4ea3aa0d3f4a886ea900e94bf4e8ca8ae8d63

Cherry-pick Test_edit_gr_special() from patch 9.0.1347.

Co-authored-by: Bram Moolenaar <Bram@vim.org>

#### vim-patch:9.0.1356: cannot cancel "gr" with Esc

Problem:    Cannot cancel "gr" with Esc.
Solution:   Make "gr\<Esc>" do nothing. (closes vim/vim#12064)

https://github.com/vim/vim/commit/4f026ea9f1ad9db262f0dba522768c84e5ae37b4

N/A patches for version.c:

vim-patch:9.0.1347: "gr CTRL-O" stays in Insert mode

Problem:    "gr CTRL-O" stays in Insert mode. (Pierre Ganty)
Solution:   Do not set restart_edit when "cmdchar" is 'v'.

https://github.com/vim/vim/commit/2824d1ee325ea61855c26f77e7a4e095b9606720

vim-patch:9.0.1349: "gr" with a count fails

Problem:    "gr" with a count fails.
Solution:   Break out of the loop only after using the count.

https://github.com/vim/vim/commit/3ddb1182b7b8d376e59b444f6b3e213f0dcd3417