### PR TITLE
LSP: new option 'center' when opening location

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1068,6 +1068,8 @@ definition({options})                               *vim.lsp.buf.definition()*
                      already open.
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
+                   • center: (boolean|nil) Whether to center the screen
+                     vertically on the location. Defaults to false.
 
 document_highlight()                        *vim.lsp.buf.document_highlight()*
     Send request to the server to resolve document highlights for the current
@@ -1556,7 +1558,7 @@ get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
         'shiftwidth'
 
                                              *vim.lsp.util.jump_to_location()*
-jump_to_location({location}, {offset_encoding}, {reuse_win})
+jump_to_location({location}, {offset_encoding}, {reuse_win}, {center})
     Jumps to a location.
 
     Parameters: ~
@@ -1564,6 +1566,8 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
       • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
       • {reuse_win}        (boolean|nil) Jump to existing window if buffer is
                            already open.
+      • {center}           (boolean|nil) Whether to center the screen
+                           vertically on the location. Defaults to false.
 
     Return: ~
         (boolean) `true` if the jump succeeded
@@ -1790,6 +1794,8 @@ show_document({location}, {offset_encoding}, {opts})
                              buffer is already open.
                            • focus (boolean) Whether to focus/jump to location
                              if possible. Defaults to true.
+                           • center (boolean) Whether to center the screen
+                             vertically on the location. Defaults to false.
 
     Return: ~
         (boolean) `true` if succeeded

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -171,6 +171,9 @@ The following new APIs or features were added.
 
 • |vim.treesitter.foldexpr()| can be used for 'foldexpr' to use treesitter for folding.
 
+• |vim.lsp.buf.definition()| can now take a new boolean option "center" to
+  center the display after opening the definition.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -71,6 +71,8 @@ end
 ---@param options table|nil additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
+---     - center: (boolean|nil) Whether to center the screen
+---               vertically on the location. Defaults to false.
 function M.definition(options)
   local params = util.make_position_params()
   request_with_options('textDocument/definition', params, options)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -380,14 +380,14 @@ local function location_handler(_, result, ctx, config)
       config.on_list({ title = title, items = items })
     else
       if #result == 1 then
-        util.jump_to_location(result[1], client.offset_encoding, config.reuse_win)
+        util.jump_to_location(result[1], client.offset_encoding, config.reuse_win, config.center)
         return
       end
       vim.fn.setqflist({}, ' ', { title = title, items = items })
       api.nvim_command('botright copen')
     end
   else
-    util.jump_to_location(result, client.offset_encoding, config.reuse_win)
+    util.jump_to_location(result, client.offset_encoding, config.reuse_win, config.center)
   end
 end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1086,6 +1086,7 @@ end
 ---@param opts table|nil options
 ---        - reuse_win (boolean) Jump to existing window if buffer is already open.
 ---        - focus (boolean) Whether to focus/jump to location if possible. Defaults to true.
+---        - center (boolean) Whether to center the screen vertically on the location. Defaults to false.
 ---@return boolean `true` if succeeded
 function M.show_document(location, offset_encoding, opts)
   -- location may be Location or LocationLink
@@ -1130,6 +1131,9 @@ function M.show_document(location, offset_encoding, opts)
     api.nvim_win_call(win, function()
       -- Open folds under the cursor
       vim.cmd('normal! zv')
+      if opts.center then
+        vim.cmd('normal! zz')
+      end
     end)
   end
 
@@ -1141,8 +1145,9 @@ end
 ---@param location table (`Location`|`LocationLink`)
 ---@param offset_encoding "utf-8" | "utf-16" | "utf-32"
 ---@param reuse_win boolean|nil Jump to existing window if buffer is already open.
+---@param center boolean|nil Whether to center the screen vertically on the location. Defaults to false.
 ---@return boolean `true` if the jump succeeded
-function M.jump_to_location(location, offset_encoding, reuse_win)
+function M.jump_to_location(location, offset_encoding, reuse_win, center)
   if offset_encoding == nil then
     vim.notify_once(
       'jump_to_location must be called with valid offset encoding',
@@ -1150,7 +1155,11 @@ function M.jump_to_location(location, offset_encoding, reuse_win)
     )
   end
 
-  return M.show_document(location, offset_encoding, { reuse_win = reuse_win, focus = true })
+  return M.show_document(
+    location,
+    offset_encoding,
+    { reuse_win = reuse_win, center = center, focus = true }
+  )
 end
 
 --- Previews a location in a floating window


### PR DESCRIPTION
Example of use:
lua vim.lsp.buf.definition({center=true})

This works for me, but I don't understand the full context, this change may have unexpected (for me) effects.