### PR TITLE
Drop the build in MinGW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@ if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
 
+if(MINGW)
+  message(FATAL_ERROR "Builds on this system are not supported.")
+endif()
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -6,6 +6,10 @@ if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 
+if(CYGWIN OR MSYS)
+  message(FATAL_ERROR ".deps construction is not supported by this system. Install the individual dependent libraries.")
+endif()
+
 # Point CMake at any custom modules we may ship
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" "${PROJECT_SOURCE_DIR}/../cmake")
 


### PR DESCRIPTION
#18122 has not yet been corrected in `MinGW`(`MinGW-W64`). 

We need to change `CMakeList.txt` to use `gcc`(`c:\msys64\ucrt64\bin\gcc.exe`) which uses `UCRT`. This requires the following changes.

- Ensure that the C runtime library that `gcc` links to is `UCRT`, if not, change it so that an error occurs.
- Fix `luarocks` because it fails to detect lua modules(`dll`) under `.deps` due to a problem in `luarocks` (This may have already been fixed in recent `luarocks`). Ref. #18495.
- Perhaps `cmake` embeds manifest only for `MSVC`, so create a custom build rule to embed it using `mt.exe` or similar.

If there are no contributors who can modify the above changes, why not make it unsupported for building with `MinGW`?

I think that the construction of `.deps` in `CYGWIN` and `MSYS` should be an explicit error because it is not supported. Ref. https://github.com/neovim/neovim/issues/14783#issuecomment-860115093