### PR TITLE
fix(build): fix invalid use of EXITFREE

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -71,7 +71,7 @@ static const char *uilog_last_event = NULL;
 
 static void ui_log(const char *funname)
 {
-# ifndef EXITFREE
+# ifdef EXITFREE
   if (entered_free_all_mem) {
     return;  // do nothing, we cannot log now
   }


### PR DESCRIPTION
fixup 6942528 refactor(ui): ui_log() can now just be a function #22408 

curious that CI didn't catch this. too big a combinatorial explosion of build time flags I suppose (working on it: #22415 )