### PR TITLE
vim-patch:9.0.{0196,partial:0202,0204}: indexof()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4087,7 +4087,7 @@ indent({lnum})	The result is a Number, which is indent of line {lnum} in the
 
 index({object}, {expr} [, {start} [, {ic}]])			*index()*
 		Find {expr} in {object} and return its index.  See
-		|filterof()| for using a lambda to select the item.
+		|indexof()| for using a lambda to select the item.
 
 		If {object} is a |List| return the lowest index where the item
 		has a value equal to {expr}.  There is no automatic
@@ -4113,15 +4113,17 @@ index({object}, {expr} [, {start} [, {ic}]])			*index()*
 <		Can also be used as a |method|: >
 			GetObject()->index(what)
 
-indexof({object}, {expr} [, {opt}])			*indexof()*
-		{object} must be a |List| or a |Blob|.
+indexof({object}, {expr} [, {opts}])			*indexof()*
+		Returns the index of an item in {object} where {expr} is
+		v:true.  {object} must be a |List| or a |Blob|.
+
 		If {object} is a |List|, evaluate {expr} for each item in the
-		List until the expression returns v:true and return the index
-		of this item.
+		List until the expression is v:true and return the index of
+		this item.
 
 		If {object} is a |Blob| evaluate {expr} for each byte in the
-		Blob until the expression returns v:true and return the index
-		of this byte.
+		Blob until the expression is v:true and return the index of
+		this byte.
 
 		{expr} must be a |string| or |Funcref|.
 
@@ -4137,16 +4139,17 @@ indexof({object}, {expr} [, {opt}])			*indexof()*
 		The function must return |TRUE| if the item is found and the
 		search should stop.
 
-		The optional argument {opt} is a Dict and supports the
+		The optional argument {opts} is a Dict and supports the
 		following items:
-		    start	start evaluating {expr} at the item with index
-				{start} (may be negative for an item relative
-				to the end).
+		    startidx	start evaluating {expr} at the item with this
+				index; may be negative for an item relative to
+				the end
 		Returns -1 when {expr} evaluates to v:false for all the items.
 		Example: >
-			:let l = [#{n: 10}, #{n: 20}, #{n: 30]]
-			:let idx = indexof(l, "v:val.n == 20")
-			:let idx = indexof(l, {i, v -> v.n == 30})
+			:let l = [#{n: 10}, #{n: 20}, #{n: 30}]
+			:echo indexof(l, "v:val.n == 20")
+			:echo indexof(l, {i, v -> v.n == 30})
+			:echo indexof(l, "v:val.n == 20", #{startidx: 1})
 
 <		Can also be used as a |method|: >
 			mylist->indexof(expr)

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -255,6 +255,8 @@ iconv({expr}, {from}, {to})	String	convert encoding of {expr}
 indent({lnum})			Number	indent of line {lnum}
 index({object}, {expr} [, {start} [, {ic}]])
 				Number	index in {object} where {expr} appears
+indexof({object}, {expr} [, {opts}]])
+				Number	index in {object} where {expr} is true
 input({prompt} [, {text} [, {completion}]])
 				String	get input from the user
 inputlist({textlist})		Number	let the user pick from a choice list
@@ -4084,19 +4086,25 @@ indent({lnum})	The result is a Number, which is indent of line {lnum} in the
 			GetLnum()->indent()
 
 index({object}, {expr} [, {start} [, {ic}]])			*index()*
+		Find {expr} in {object} and return its index.  See
+		|filterof()| for using a lambda to select the item.
+
 		If {object} is a |List| return the lowest index where the item
 		has a value equal to {expr}.  There is no automatic
 		conversion, so the String "4" is different from the Number 4.
 		And the Number 4 is different from the Float 4.0.  The value
-		of 'ignorecase' is not used here, case always matters.
+		of 'ignorecase' is not used here, case matters as indicated by
+		the {ic} argument.
 
 		If {object} is a |Blob| return the lowest index where the byte
 		value is equal to {expr}.
 
 		If {start} is given then start looking at the item with index
 		{start} (may be negative for an item relative to the end).
+
 		When {ic} is given and it is |TRUE|, ignore case.  Otherwise
 		case must match.
+
 		-1 is returned when {expr} is not found in {object}.
 		Example: >
 			:let idx = index(words, "the")
@@ -4104,6 +4112,44 @@ index({object}, {expr} [, {start} [, {ic}]])			*index()*
 
 <		Can also be used as a |method|: >
 			GetObject()->index(what)
+
+indexof({object}, {expr} [, {opt}])			*indexof()*
+		{object} must be a |List| or a |Blob|.
+		If {object} is a |List|, evaluate {expr} for each item in the
+		List until the expression returns v:true and return the index
+		of this item.
+
+		If {object} is a |Blob| evaluate {expr} for each byte in the
+		Blob until the expression returns v:true and return the index
+		of this byte.
+
+		{expr} must be a |string| or |Funcref|.
+
+		If {expr} is a |string|: If {object} is a |List|, inside
+		{expr} |v:key| has the index of the current List item and
+		|v:val| has the value of the item.  If {object} is a |Blob|,
+		inside {expr} |v:key| has the index of the current byte and
+		|v:val| has the byte value.
+
+		If {expr} is a |Funcref| it must take two arguments:
+			1. the key or the index of the current item.
+			2. the value of the current item.
+		The function must return |TRUE| if the item is found and the
+		search should stop.
+
+		The optional argument {opt} is a Dict and supports the
+		following items:
+		    start	start evaluating {expr} at the item with index
+				{start} (may be negative for an item relative
+				to the end).
+		Returns -1 when {expr} evaluates to v:false for all the items.
+		Example: >
+			:let l = [#{n: 10}, #{n: 20}, #{n: 30]]
+			:let idx = indexof(l, "v:val.n == 20")
+			:let idx = indexof(l, {i, v -> v.n == 30})
+
+<		Can also be used as a |method|: >
+			mylist->indexof(expr)
 
 input({prompt} [, {text} [, {completion}]])		*input()*
 input({opts})

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -657,14 +657,16 @@ List manipulation:					*list-functions*
 	map()			change each List item
 	reduce()		reduce a List to a value
 	sort()			sort a List
-	reverse()		reverse the order of a List
+	reverse()		reverse the order of a List or Blob
 	uniq()			remove copies of repeated adjacent items
 	split()			split a String into a List
 	join()			join List items into a String
 	range()			return a List with a sequence of numbers
 	string()		String representation of a List
 	call()			call a function with List as arguments
-	index()			index of a value in a List
+	index()			index of a value in a List or Blob
+	indexof()		index in a List or Blob where an expression
+				evaluates to true
 	max()			maximum value in a List
 	min()			minimum value in a List
 	count()			count number of times a value appears in a List

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -213,6 +213,7 @@ return {
     iconv={args=3, base=1, fast=true},
     indent={args=1, base=1},
     index={args={2, 4}, base=1},
+    indexof={args={2, 3}, base=1},
     input={args={1, 3}, base=1},
     inputdialog={args={1, 3}, base=1},
     inputlist={args=1, base=1},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3509,6 +3509,71 @@ static varnumber_T indexof_eval_expr(typval_T *expr)
   return error ? false : found;
 }
 
+/// Evaluate "expr" for each byte in the Blob "b" starting with the byte at
+/// "startidx" and return the index of the byte where "expr" is TRUE.  Returns
+/// -1 if "expr" doesn't evaluate to TRUE for any of the bytes.
+static varnumber_T indexof_blob(blob_T *b, varnumber_T startidx, typval_T *expr)
+{
+  if (b == NULL) {
+    return -1;
+  }
+
+  if (startidx < 0) {
+    // negative index: index from the last byte
+    startidx = tv_blob_len(b) + startidx;
+    if (startidx < 0) {
+      startidx = 0;
+    }
+  }
+
+  for (varnumber_T idx = startidx; idx < tv_blob_len(b); idx++) {
+    set_vim_var_nr(VV_KEY, idx);
+    set_vim_var_nr(VV_VAL, tv_blob_get(b, (int)idx));
+
+    if (indexof_eval_expr(expr)) {
+      return idx;
+    }
+  }
+
+  return -1;
+}
+
+/// Evaluate "expr" for each item in the List "l" starting with the item at
+/// "startidx" and return the index of the item where "expr" is TRUE.  Returns
+/// -1 if "expr" doesn't evaluate to TRUE for any of the items.
+static varnumber_T indexof_list(list_T *l, varnumber_T startidx, typval_T *expr)
+{
+  if (l == NULL) {
+    return -1;
+  }
+
+  listitem_T *item;
+  varnumber_T idx = 0;
+  if (startidx == 0) {
+    item = tv_list_first(l);
+  } else {
+    // Start at specified item.
+    idx = tv_list_uidx(l, (int)startidx);
+    if (idx == -1) {
+      item = NULL;
+    } else {
+      item = tv_list_find(l, (int)idx);
+      assert(item != NULL);
+    }
+  }
+
+  for (; item != NULL; item = TV_LIST_ITEM_NEXT(l, item), idx++) {
+    set_vim_var_nr(VV_KEY, idx);
+    tv_copy(TV_LIST_ITEM_TV(item), get_vim_var_tv(VV_VAL));
+
+    if (indexof_eval_expr(expr)) {
+      return idx;
+    }
+  }
+
+  return -1;
+}
+
 /// "indexof()" function
 static void f_indexof(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
@@ -3526,7 +3591,6 @@ static void f_indexof(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   varnumber_T startidx = 0;
-  varnumber_T idx = 0;
   if (argvars[2].v_type == VAR_DICT) {
     startidx = tv_dict_get_number_def(argvars[2].vval.v_dict, "startidx", 0);
   }
@@ -3542,56 +3606,11 @@ static void f_indexof(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   did_emsg = false;
 
   if (argvars[0].v_type == VAR_BLOB) {
-    blob_T *const b = argvars[0].vval.v_blob;
-    if (b == NULL) {
-      goto theend;
-    }
-    if (startidx < 0) {
-      startidx = tv_blob_len(b) + startidx;
-      if (startidx < 0) {
-        startidx = 0;
-      }
-    }
-
-    for (idx = startidx; idx < tv_blob_len(b); idx++) {
-      set_vim_var_nr(VV_KEY, idx);
-      set_vim_var_nr(VV_VAL, tv_blob_get(b, (int)idx));
-
-      if (indexof_eval_expr(&argvars[1])) {
-        rettv->vval.v_number = idx;
-        break;
-      }
-    }
+    rettv->vval.v_number = indexof_blob(argvars[0].vval.v_blob, startidx, &argvars[1]);
   } else {
-    list_T *const l = argvars[0].vval.v_list;
-    if (l == NULL) {
-      goto theend;
-    }
-
-    listitem_T *item;
-    if (startidx == 0) {
-      item = tv_list_first(l);
-    } else {
-      // Start at specified item.  Use the cached index that list_find()
-      // sets, so that a negative number also works.
-      item = tv_list_find(l, (int)startidx);
-      if (item != NULL) {
-        idx = l->lv_idx;
-      }
-    }
-
-    for (; item != NULL; item = TV_LIST_ITEM_NEXT(l, item), idx++) {
-      set_vim_var_nr(VV_KEY, idx);
-      tv_copy(TV_LIST_ITEM_TV(item), get_vim_var_tv(VV_VAL));
-
-      if (indexof_eval_expr(&argvars[1])) {
-        rettv->vval.v_number = idx;
-        break;
-      }
-    }
+    rettv->vval.v_number = indexof_list(argvars[0].vval.v_list, startidx, &argvars[1]);
   }
 
-theend:
   restore_vimvar(VV_KEY, &save_key);
   restore_vimvar(VV_VAL, &save_val);
   did_emsg |= save_did_emsg;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3505,6 +3505,7 @@ static varnumber_T indexof_eval_expr(typval_T *expr)
 
   bool error = false;
   varnumber_T found = tv_get_bool_chk(&newtv, &error);
+  tv_clear(&newtv);
 
   return error ? false : found;
 }
@@ -3566,7 +3567,10 @@ static varnumber_T indexof_list(list_T *l, varnumber_T startidx, typval_T *expr)
     set_vim_var_nr(VV_KEY, idx);
     tv_copy(TV_LIST_ITEM_TV(item), get_vim_var_tv(VV_VAL));
 
-    if (indexof_eval_expr(expr)) {
+    bool found = indexof_eval_expr(expr);
+    tv_clear(get_vim_var_tv(VV_VAL));
+
+    if (found) {
       return idx;
     }
   }

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -44,10 +44,16 @@ static char e_string_required_for_argument_nr[]
   = N_("E1174: String required for argument %d");
 static char e_non_empty_string_required_for_argument_nr[]
   = N_("E1175: Non-empty string required for argument %d");
+static char e_dict_required_for_argument_nr[]
+  = N_("E1206: Dictionary required for argument %d");
 static char e_number_required_for_argument_nr[]
   = N_("E1210: Number required for argument %d");
 static char e_string_or_list_required_for_argument_nr[]
   = N_("E1222: String or List required for argument %d");
+static char e_list_or_blob_required_for_argument_nr[]
+  = N_("E1226: List or Blob required for argument %d");
+static char e_string_or_function_required_for_argument_nr[]
+  = N_("E1256: String or function required for argument %d");
 
 bool tv_in_free_unref_items = false;
 
@@ -3905,12 +3911,56 @@ int tv_check_for_opt_number_arg(const typval_T *const args, const int idx)
           || tv_check_for_number_arg(args, idx) != FAIL) ? OK : FAIL;
 }
 
+/// Give an error and return FAIL unless "args[idx]" is a dict.
+int tv_check_for_dict_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  if (args[idx].v_type != VAR_DICT) {
+    semsg(_(e_dict_required_for_argument_nr), idx + 1);
+    return FAIL;
+  }
+  return OK;
+}
+
+/// Check for an optional dict argument at "idx"
+int tv_check_for_opt_dict_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  return (args[idx].v_type == VAR_UNKNOWN
+          || tv_check_for_dict_arg(args, idx) != FAIL) ? OK : FAIL;
+}
+
 /// Give an error and return FAIL unless "args[idx]" is a string or a list.
 int tv_check_for_string_or_list_arg(const typval_T *const args, const int idx)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
   if (args[idx].v_type != VAR_STRING && args[idx].v_type != VAR_LIST) {
     semsg(_(e_string_or_list_required_for_argument_nr), idx + 1);
+    return FAIL;
+  }
+  return OK;
+}
+
+/// Give an error and return FAIL unless "args[idx]" is a string
+/// or a function reference.
+int tv_check_for_string_or_func_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  if (args[idx].v_type != VAR_PARTIAL
+      && args[idx].v_type != VAR_FUNC
+      && args[idx].v_type != VAR_STRING) {
+    semsg(_(e_string_or_function_required_for_argument_nr), idx + 1);
+    return FAIL;
+  }
+  return OK;
+}
+
+/// Give an error and return FAIL unless "args[idx]" is a list or a blob.
+int tv_check_for_list_or_blob_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  if (args[idx].v_type != VAR_LIST && args[idx].v_type != VAR_BLOB) {
+    semsg(_(e_list_or_blob_required_for_argument_nr), idx + 1);
     return FAIL;
   }
   return OK;

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -364,4 +364,31 @@ func Test_blob2string()
   call assert_equal(v, string(b))
 endfunc
 
+" Test for the indexof() function
+func Test_indexof()
+  let b = 0zdeadbeef
+  call assert_equal(0, indexof(b, {i, v -> v == 0xde}))
+  call assert_equal(3, indexof(b, {i, v -> v == 0xef}))
+  call assert_equal(-1, indexof(b, {i, v -> v == 0x1}))
+  call assert_equal(1, indexof(b, "v:val == 0xad"))
+  call assert_equal(-1, indexof(b, "v:val == 0xff"))
+
+  call assert_equal(-1, indexof(0z, "v:val == 0x0"))
+  call assert_equal(-1, indexof(v:_null_blob, "v:val == 0xde"))
+  call assert_equal(-1, indexof(b, v:_null_string))
+  " Nvim doesn't have null functions
+  " call assert_equal(-1, indexof(b, test_null_function())) 
+
+  let b = 0z01020102
+  call assert_equal(1, indexof(b, "v:val == 0x02", #{startidx: 0}))
+  call assert_equal(2, indexof(b, "v:val == 0x01", #{startidx: -2}))
+  call assert_equal(-1, indexof(b, "v:val == 0x01", #{startidx: 5}))
+  call assert_equal(0, indexof(b, "v:val == 0x01", #{startidx: -5}))
+  call assert_equal(0, indexof(b, "v:val == 0x01", v:_null_dict))
+
+  " failure cases
+  call assert_fails('let i = indexof(b, "val == 0xde")', 'E121:')
+  call assert_fails('let i = indexof(b, {})', 'E1256:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -372,6 +372,7 @@ func Test_indexof()
   call assert_equal(-1, indexof(b, {i, v -> v == 0x1}))
   call assert_equal(1, indexof(b, "v:val == 0xad"))
   call assert_equal(-1, indexof(b, "v:val == 0xff"))
+  call assert_equal(-1, indexof(b, {_, v -> "v == 0xad"}))
 
   call assert_equal(-1, indexof(0z, "v:val == 0x0"))
   call assert_equal(-1, indexof(v:_null_blob, "v:val == 0xde"))

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -1067,4 +1067,50 @@ func Test_null_dict()
   call assert_equal({}, {})
 endfunc
 
+" Test for the indexof() function
+func Test_indexof()
+  let l = [#{color: 'red'}, #{color: 'blue'}, #{color: 'green'}]
+  call assert_equal(0, indexof(l, {i, v -> v.color == 'red'}))
+  call assert_equal(2, indexof(l, {i, v -> v.color == 'green'}))
+  call assert_equal(-1, indexof(l, {i, v -> v.color == 'grey'}))
+  call assert_equal(1, indexof(l, "v:val.color == 'blue'"))
+  call assert_equal(-1, indexof(l, "v:val.color == 'cyan'"))
+
+  let l = [#{n: 10}, #{n: 10}, #{n: 20}]
+  call assert_equal(0, indexof(l, "v:val.n == 10", #{startidx: 0}))
+  call assert_equal(1, indexof(l, "v:val.n == 10", #{startidx: -2}))
+  call assert_equal(-1, indexof(l, "v:val.n == 10", #{startidx: 4}))
+  call assert_equal(-1, indexof(l, "v:val.n == 10", #{startidx: -4}))
+  call assert_equal(0, indexof(l, "v:val.n == 10", v:_null_dict))
+
+  call assert_equal(-1, indexof([], {i, v -> v == 'a'}))
+  call assert_equal(-1, indexof(v:_null_list, {i, v -> v == 'a'}))
+  call assert_equal(-1, indexof(l, v:_null_string))
+  " Nvim doesn't have null functions
+  " call assert_equal(-1, indexof(l, test_null_function()))
+
+  " failure cases
+  call assert_fails('let i = indexof(l, "v:val == ''cyan''")', 'E735:')
+  call assert_fails('let i = indexof(l, "color == ''cyan''")', 'E121:')
+  call assert_fails('let i = indexof(l, {})', 'E1256:')
+  call assert_fails('let i = indexof({}, "v:val == 2")', 'E1226:')
+  call assert_fails('let i = indexof([], "v:val == 2", [])', 'E1206:')
+
+  func TestIdx(k, v)
+    return a:v.n == 20
+  endfunc
+  call assert_equal(2, indexof(l, function("TestIdx")))
+  delfunc TestIdx
+  func TestIdx(k, v)
+    return {}
+  endfunc
+  call assert_fails('let i = indexof(l, function("TestIdx"))', 'E728:')
+  delfunc TestIdx
+  func TestIdx(k, v)
+    throw "IdxError"
+  endfunc
+  call assert_fails('let i = indexof(l, function("TestIdx"))', 'E605:')
+  delfunc TestIdx
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -1083,7 +1083,13 @@ func Test_indexof()
   call assert_equal(-1, indexof(l, "v:val.n == 10", #{startidx: -4}))
   call assert_equal(0, indexof(l, "v:val.n == 10", v:_null_dict))
 
+  let s = ["a", "b", "c"]
+  call assert_equal(2, indexof(s, {_, v -> v == 'c'}))
+  call assert_equal(-1, indexof(s, {_, v -> v == 'd'}))
+  call assert_equal(-1, indexof(s, {_, v -> "v == 'd'"}))
+
   call assert_equal(-1, indexof([], {i, v -> v == 'a'}))
+  call assert_equal(-1, indexof([1, 2, 3], {_, v -> "v == 2"}))
   call assert_equal(-1, indexof(v:_null_list, {i, v -> v == 'a'}))
   call assert_equal(-1, indexof(l, v:_null_string))
   " Nvim doesn't have null functions


### PR DESCRIPTION
#### vim-patch:9.0.0196: finding value in list may require a for loop

Problem:    Finding value in list may require a for loop.
Solution:   Add indexof(). (Yegappan Lakshmanan, closes vim/vim#10903)

https://github.com/vim/vim/commit/b218655d5a485f5b193fb18d7240837d42b89812

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:partial:9.0.0202: code and help for indexof() is not ideal

Problem:    Code and help for indexof() is not ideal.
Solution:   Refactor the code, improve the help. (Yegappan Lakshmanan,
            closes vim/vim#10908)

https://github.com/vim/vim/commit/3fbf6cd355de2212e9227f57d545592aae3f688f

Skip CHECK_LIST_MATERIALIZE and set_vim_var_type().
Use tv_list_uidx() instead of lv_idx.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0204: indexof() may leak memory

Problem:    indexof() may leak memory.
Solution:   Free allocated values. (Yegappan Lakshmanan, closes vim/vim#10916)

https://github.com/vim/vim/commit/63acae13f57c5ad4c8ec3146d0c458550b9e984e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>