### PR TITLE
feat(treesitter): async parsing

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -905,7 +905,7 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
     Return: ~
         (`boolean`) True if the {node} contains the {range}
 
-start({bufnr}, {lang})                                *vim.treesitter.start()*
+start({bufnr}, {lang}, {opts})                        *vim.treesitter.start()*
     Starts treesitter highlighting for a buffer
 
     Can be used in an ftplugin or FileType autocommand.
@@ -928,6 +928,11 @@ start({bufnr}, {lang})                                *vim.treesitter.start()*
                  buffer)
       • {lang}   (`string?`) Language of the parser (default: from buffer
                  filetype)
+      • {opts}   (table|nil) Options:
+                 • max_loop_time (integer|nil): When provided, parsing will
+                   run asynchronously by segmenting the parse over Nvim's
+                   event loop where each segment will run for at most this
+                   value in ms. Defaults to 10ms.
 
 stop({bufnr})                                          *vim.treesitter.stop()*
     Stops treesitter highlighting for a buffer
@@ -1375,7 +1380,7 @@ LanguageTree:named_node_for_range({range}, {opts})
     Return: ~
         (`TSNode?`)
 
-LanguageTree:parse({range})                             *LanguageTree:parse()*
+LanguageTree:parse({range}, {opts})                     *LanguageTree:parse()*
     Recursively parse all regions in the language tree using
     |treesitter-parsers| for the corresponding languages and run injection
     queries on the parsed trees to determine whether child trees should be
@@ -1391,6 +1396,15 @@ LanguageTree:parse({range})                             *LanguageTree:parse()*
                  Can be slow!) Set to `false|nil` to only parse regions with
                  empty ranges (typically only the root tree without
                  injections).
+      • {opts}  (`table?`) Options:
+                • max_loop_time (`integer?`): Maximum time parsing can run on
+                  the event loop per iteration. If parsing reaches or exceeds
+                  this time, parsing is paused and continued in the next loop
+                  iteration. If source is a buffer, parsing is cancelled when
+                  the buffer's changedtick is updated. This causes this
+                  function to be non-blocking and thus will return nil.
+                • callback (`fun(trees: table<integer, TSTree>)`): Called when
+                  parsing completes.
 
     Return: ~
         (`table<integer, TSTree>`)

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -63,8 +63,6 @@ function M._create_parser(bufnr, lang, opts)
     { on_bytes = bytes_cb, on_detach = detach_cb, on_reload = reload_cb, preview = true }
   )
 
-  self:parse()
-
   return self
 end
 
@@ -411,10 +409,16 @@ end
 ---
 ---@param bufnr (integer|nil) Buffer to be highlighted (default: current buffer)
 ---@param lang (string|nil) Language of the parser (default: from buffer filetype)
-function M.start(bufnr, lang)
+---@param opts table|nil Options:
+---                      - max_loop_time (integer|nil): When provided, parsing will run asynchronously
+---                        by segmenting the parse over Nvim's event loop where each segment
+---                        will run for at most this value in ms. Defaults to 10ms.
+function M.start(bufnr, lang, opts)
   bufnr = bufnr or api.nvim_get_current_buf()
   local parser = M.get_parser(bufnr, lang)
-  M.highlighter.new(parser)
+  opts = opts or {}
+  opts.max_loop_time = opts.max_loop_time or 10
+  M.highlighter.new(parser, opts)
 end
 
 --- Stops treesitter highlighting for a buffer

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -369,7 +369,11 @@ static int parser_parse(lua_State *L)
   // Sometimes parsing fails (timeout, or wrong parser ABI)
   // In those case, just return an error.
   if (!new_tree) {
-    return luaL_error(L, "An error occurred when parsing.");
+    if (ts_parser_timeout_micros(p) == 0) {
+      // No timeout set, must of had error
+      return luaL_error(L, "An error occurred when parsing.");
+    }
+    return 0;
   }
 
   // The new tree will be pushed to the stack, without copy, ownership is now to the lua GC.


### PR DESCRIPTION
## Idea

Use `TSParser:set_timeout` to set the maximum time to parse each event-loop iteration. If the timeout is reach, parsing will be deferred and resumed at a later point in the event loop. This should result in less editor blocking and lag, especially during the initial load of a buffer.

- `TSParser:parse()` will come in two variants:

  ```lua
  TSParser:parse(opts) -- synchronous, returns trees and changes directly
  TSParser:parse(opts, callback) -- asynchronous, returns trees and changes as args to the callback
  ```

To enable:
```lua
vim.api.nvim_create_autocmd('FileType', {
  callback = function()
    local lang = vim.treesitter.language.get_lang(vim.bo.filetype)
    if lang and pcall(vim.treesitter.language.add, lang) then
      -- vim.treesitter.start()  -- sync
      vim.treesitter.start(nil, nil, { timeout = 1 }) -- async
    end
  end,
})
```

## Notes

- As the synchronous version of `parse` will still be supported, this'll mean any plugins calling the synchronous version will now block the UI instead of highlighter, so they will all have to adapt to the async version in order to not negate the benefits of this PR.

- How does `'redrawtime'` fit into this? Or does it not?

- How do we handle subsequent calls to `parse` whilst one is in-progress?
   For subsequent calls, don't run the parse again, but save the callback and call it when the currently running parse completes. If a synchronous parse is requested, we cancel the async one in flight.