### PR TITLE
feat(man.lua): reformat manpage when window was resized

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -613,6 +613,11 @@ Variables:
 *g:man_hardwrap*            Hard-wrap to $MANWIDTH or window width if $MANWIDTH is
                           empty. Enabled by default. Set |FALSE| to enable soft
                           wrapping.
+*g:man_redraw_resized*      Redraw manpage if window was resized. Doesn't work
+                            if vim is used as a pager, i.e. rendered manpage is
+                            read from stdin.
+*g:man_redraw_debounce_ms*  Debounce time for |man_redraw_resized| in
+                            milliseconds. By default 1000.
 
 To use Nvim as a manpager: >
      export MANPAGER='nvim +Man!'

--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -32,3 +32,41 @@ vim.api.nvim_create_autocmd('BufReadCmd', {
     require('man').read_page(vim.fn.matchstr(params.match, 'man://\\zs.*'))
   end,
 })
+
+if (vim.g.man_redraw_resized or 1) == 1 then
+  local resize_timer, resized_winids
+
+  local function redraw_manpages()
+    local winid = vim.api.nvim_get_current_win()
+    if
+      resized_winids == nil
+      or vim.b.pager
+      or not vim.api.nvim_win_is_valid(winid)
+      or not vim.tbl_contains(resized_winids, winid)
+    then
+      return
+    end
+    local ref = vim.fn.matchstr(vim.fn.bufname(), 'man://\\zs.*')
+    if ref == '' then
+      return
+    end
+    local winview = vim.fn.winsaveview()
+    pcall(require('man').read_page, ref)
+    vim.fn.winrestview(winview)
+    resize_timer, resized_winids = nil, nil
+  end
+
+  vim.api.nvim_create_autocmd('WinResized', {
+    group = augroup,
+    callback = function()
+      if vim.bo.filetype ~= 'man' then
+        return
+      end
+      if resize_timer ~= nil then
+        resize_timer:stop()
+      end
+      resized_winids = vim.v.event.windows
+      resize_timer = vim.defer_fn(redraw_manpages, vim.g.man_redraw_debounce_ms or 1000)
+    end,
+  })
+end


### PR DESCRIPTION
When windows containing a `ft=man` buffer are resized, the word wrapping / tables / other statically rendered stuff breaks. Though can't find a good solution for manpages opened via `PAGER='nvim +Man!` feature, maybe you have an idea?