### PR TITLE
vim-patch:8.2.2336: Vim9: not possible to extend dictionary with different type

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -138,6 +138,9 @@ expandcmd({string} [, {options}])
 				String	expand {string} like with `:edit`
 extend({expr1}, {expr2} [, {expr3}])
 				List/Dict insert items of {expr2} into {expr1}
+extendnew({expr1}, {expr2} [, {expr3}])
+				List/Dict like |extend()| but creates a new
+					List or Dictionary
 feedkeys({string} [, {mode}])	Number	add key sequence to typeahead buffer
 filereadable({file})		Number	|TRUE| if {file} is a readable file
 filewritable({file})		Number	|TRUE| if {file} is a writable file
@@ -2118,6 +2121,14 @@ extend({expr1}, {expr2} [, {expr3}])			*extend()*
 
 		Can also be used as a |method|: >
 			mylist->extend(otherlist)
+
+
+extendnew({expr1}, {expr2} [, {expr3}])			*extendnew()*
+		Like |extend()| but instead of adding items to {expr1} a new
+		List or Dictionary is created and returned.  {expr1} remains
+		unchanged.  Items can still be changed by {expr2}, if you
+		don't want that use |deepcopy()| first.
+
 
 feedkeys({string} [, {mode}])				*feedkeys()*
 		Characters in {string} are queued for processing as if they

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -650,6 +650,7 @@ List manipulation:					*list-functions*
 	insert()		insert an item somewhere in a List
 	add()			append an item to a List
 	extend()		append a List to a List
+	extendnew()		make a new List and append items
 	remove()		remove one or more items from a List
 	copy()			make a shallow copy of a List
 	deepcopy()		make a full copy of a List
@@ -681,6 +682,7 @@ Dictionary manipulation:				*dict-functions*
 	empty()			check if Dictionary is empty
 	remove()		remove an entry from a Dictionary
 	extend()		add entries from one Dictionary to another
+	extendnew()		make a new Dictionary and append items
 	filter()		remove selected entries from a Dictionary
 	map()			change each Dictionary entry
 	keys()			get List of Dictionary keys

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -120,6 +120,7 @@ return {
     expand={args={1, 3}, base=1},
     expandcmd={args={1, 2}, base=1},
     extend={args={2, 3}, base=1},
+    extendnew={args={2, 3}, base=1},
     feedkeys={args={1, 2}, base=1},
     file_readable={args=1, base=1, func='f_filereadable'},  -- obsolete
     filereadable={args=1, base=1, fast=true},

--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -881,6 +881,18 @@ func Test_listdict_extend()
   call assert_equal([1, 5, 7, 1, 5, 7], l)
 endfunc
 
+func Test_listdict_extendnew()
+  " Test extendnew() with lists
+  let l = [1, 2, 3]
+  call assert_equal([1, 2, 3, 4, 5], extendnew(l, [4, 5]))
+  call assert_equal([1, 2, 3], l)
+
+  " Test extend() with dictionaries.
+  let d = {'a': {'b': 'B'}}
+  call assert_equal({'a': {'b': 'B'}, 'c': 'cc'}, extendnew(d, {'c': 'cc'}))
+  call assert_equal({'a': {'b': 'B'}}, d)
+endfunc
+
 func s:check_scope_dict(x, fixed)
   func s:gen_cmd(cmd, x)
     return substitute(a:cmd, '\<x\ze:', a:x, 'g')


### PR DESCRIPTION
#### vim-patch:8.2.2336: Vim9: not possible to extend dictionary with different type

Problem:    Vim9: it is not possible to extend a dictionary with different
            item types.
Solution:   Add extendnew().

https://github.com/vim/vim/commit/b0e6b513648db7035046613431a4aa9d71ef4653

Co-authored-by: Bram Moolenaar <Bram@vim.org>