### PR TITLE
feat(edit)!: remove old c implementation of hebrew keymap

### DIFF
--- a/runtime/doc/hebrew.txt
+++ b/runtime/doc/hebrew.txt
@@ -30,17 +30,10 @@ Details
    +  'rightleft' ('rl') sets window orientation to right-to-left.  This means
       that the logical text 'ABC' will be displayed as 'CBA', and will start
       drawing at the right edge of the window, not the left edge.
-   +  'hkmap' ('hk') sets keyboard mapping to Hebrew, in insert/replace modes.
-   +  'aleph' ('al'), numeric, holds the decimal code of Aleph, for keyboard
-      mapping.
-   +  'hkmapp' ('hkp') sets keyboard mapping to "phonetic hebrew"
-
-   NOTE: these three ('hkmap', 'hkmapp' and 'aleph') are obsolete.  You should
-	 use ":set keymap=hebrewp" instead.
-
-   +  'delcombine' ('deco'), boolean, if editing UTF-8 encoded Hebrew, allows
-      one to remove the niqud or te`amim by pressing 'x' on a character (with
-      associated niqud).
+   +  'keymap' ('kmp') sets keyboard mapping. use values "hebrew" or "heprewp"
+      (the latter option enables phonetic mapping)
+   +  'delcombine' ('deco'), boolean, allows one to remove the niqud or
+      te`amim by pressing 'x' on a character (with associated niqud).
 
    +  'rightleftcmd' ('rlc') makes the command-prompt for searches show up on
       the right side.  It only takes effect if the window is 'rightleft'.
@@ -62,10 +55,10 @@ Details
 
    +  CTRL-_ in insert/replace modes toggles 'revins' and 'hkmap' as follows:
 
-      When in rightleft window, 'revins' and 'nohkmap' are toggled, since
+      When in rightleft window, 'revins' is toggled, since
       English will likely be inserted in this case.
 
-      When in norightleft window, 'revins' 'hkmap' are toggled, since Hebrew
+      When in norightleft window, 'revins' is toggled, since Hebrew
       will likely be inserted in this case.
 
       CTRL-_ moves the cursor to the end of the typed text.

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -221,11 +221,11 @@ CTRL-Y		Insert the character which is above the cursor.
 		able to copy characters from a long line.
 
 						*i_CTRL-_*
-CTRL-_		Switch between languages, as follows:
-		-  When in a rightleft window, revins and nohkmap are toggled,
+CTRL-_		Switch between insert direction, by toggling 'revins', as follows:
+		-  When in a rightleft window, 'revins' is toggled,
 		   since English will likely be inserted in this case.
-		-  When in a norightleft window, revins and hkmap are toggled,
-		   since Hebrew will likely be inserted in this case.
+		-  When in a norightleft window, 'revins' is toggled,
+		   since a rightleft language will likely be inserted in this case.
 
 		CTRL-_ moves the cursor to the end of the typed text.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -211,6 +211,8 @@ The following deprecated functions or APIs were removed.
   changes need to be contributed there first.)
   See https://github.com/neovim/neovim/pull/20674.
 
+- 'hkmap', 'hkmapp' and 'aleph' options were removed. Use 'keymap' option instead.
+
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -575,16 +575,6 @@ supported use something like this: >
 							*E355*
 A jump table for the options with a short description can be found at |Q_op|.
 
-					*'aleph'* *'al'* *aleph* *Aleph*
-'aleph' 'al'		number	(default 224)
-			global
-	The ASCII code for the first letter of the Hebrew alphabet.  The
-	routine that maps the keyboard in Hebrew mode, both in Insert mode
-	(when hkmap is set) and on the command-line (when hitting CTRL-_)
-	outputs the Hebrew characters in the range [aleph..aleph+26].
-	aleph=128 applies to PC code, and aleph=224 applies to ISO 8859-8.
-	See |rileft.txt|.
-
 			*'allowrevins'* *'ari'* *'noallowrevins'* *'noari'*
 'allowrevins' 'ari'	boolean	(default off)
 			global
@@ -3194,20 +3184,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	is remembered.  This option decides how many entries may be stored in
 	each of these histories (see |cmdline-editing|).
 	The maximum value is 10000.
-
-					 *'hkmap'* *'hk'* *'nohkmap'* *'nohk'*
-'hkmap' 'hk'		boolean (default off)
-			global
-	When on, the keyboard is mapped for the Hebrew character set.
-	Normally you would set 'allowrevins' and use CTRL-_ in insert mode to
-	toggle this option.  See |rileft.txt|.
-
-				 *'hkmapp'* *'hkp'* *'nohkmapp'* *'nohkp'*
-'hkmapp' 'hkp'		boolean (default off)
-			global
-	When on, phonetic keyboard mapping is used.  'hkmap' must also be on.
-	This is useful if you have a non-Hebrew keyboard.
-	See |rileft.txt|.
 
 				 *'hlsearch'* *'hls'* *'nohlsearch'* *'nohls'*
 'hlsearch' 'hls'	boolean	(default on)

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -258,7 +258,7 @@ argument.
 -A		Arabic mode.  Sets the 'arabic' option on.
 
 							*-H*
--H		Hebrew mode.  Sets the 'hkmap' and 'rightleft' options on.
+-H		Hebrew mode.  Sets the 'rightleft' option on and 'keymap' to "hebrew"
 
 							*-V* *verbose*
 -V[N]		Verbose.  Sets the 'verbose' option to [N] (default: 10).

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -594,6 +594,7 @@ Highlight groups:
 <
 
 Options:
+  *'aleph'* *'al'*
   antialias
   *'balloondelay'* *'bdlay'*
   *'ballooneval'* *'beval'* *'noballooneval'* *'nobeval'*
@@ -617,6 +618,9 @@ Options:
   *'guifontset'* *'gfs'* (Use 'guifont' instead.)
   *'guipty'* (Nvim uses pipes and PTYs consistently on all platforms.)
   'highlight' (Names of builtin |highlight-groups| cannot be changed.)
+  *'hkmap'* *'hk'* use `set keymap=hebrew` instead.
+  *'hkmapp'* *'hkp'* use `set keymap=hebrewp` instead.
+
   *'imactivatefunc'* *'imaf'*
   *'imactivatekey'* *'imak'*
   *'imstatusfunc'* *'imsf'*

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -523,10 +523,6 @@ static int insert_execute(VimState *state, int key)
     did_cursorhold = true;
   }
 
-  if (p_hkmap && KeyTyped) {
-    s->c = hkmap(s->c);  // Hebrew mode mapping
-  }
-
   // Special handling of keys while the popup menu is visible or wanted
   // and the cursor is still in the completed word.  Only when there is
   // a match, skip this when no matches were found.
@@ -2140,9 +2136,6 @@ void insertchar(int c, int flags, int second_indent)
                || (virtcol += byte2cells((uint8_t)buf[i - 1])) < (colnr_T)textwidth)
            && !(!no_abbr && !vim_iswordc(c) && vim_iswordc((uint8_t)buf[i - 1]))) {
       c = vgetc();
-      if (p_hkmap && KeyTyped) {
-        c = hkmap(c);                       // Hebrew mode mapping
-      }
       buf[i++] = (char)c;
     }
 
@@ -3212,101 +3205,6 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
   return false;
 }
 
-// Map Hebrew keyboard when in hkmap mode.
-int hkmap(int c)
-  FUNC_ATTR_PURE
-{
-  if (p_hkmapp) {   // phonetic mapping, by Ilya Dogolazky
-    enum {
-      hALEF = 0, BET, GIMEL, DALET, HEI, VAV, ZAIN, HET, TET, IUD,
-      KAFsofit, hKAF, LAMED, MEMsofit, MEM, NUNsofit, NUN, SAMEH, AIN,
-      PEIsofit, PEI, ZADIsofit, ZADI, KOF, RESH, hSHIN, TAV,
-    };
-    static char_u map[26] = {
-      (char_u)hALEF,  // a
-      (char_u)BET,  // b
-      (char_u)hKAF,  // c
-      (char_u)DALET,  // d
-      (char_u) - 1,  // e
-      (char_u)PEIsofit,  // f
-      (char_u)GIMEL,  // g
-      (char_u)HEI,  // h
-      (char_u)IUD,  // i
-      (char_u)HET,  // j
-      (char_u)KOF,  // k
-      (char_u)LAMED,  // l
-      (char_u)MEM,  // m
-      (char_u)NUN,  // n
-      (char_u)SAMEH,  // o
-      (char_u)PEI,  // p
-      (char_u) - 1,  // q
-      (char_u)RESH,  // r
-      (char_u)ZAIN,  // s
-      (char_u)TAV,  // t
-      (char_u)TET,  // u
-      (char_u)VAV,  // v
-      (char_u)hSHIN,  // w
-      (char_u) - 1,  // x
-      (char_u)AIN,  // y
-      (char_u)ZADI,  // z
-    };
-
-    if (c == 'N' || c == 'M' || c == 'P' || c == 'C' || c == 'Z') {
-      return (int)(map[CHAR_ORD(c)] - 1 + p_aleph);
-    } else if (c == 'x') {  // '-1'='sofit'
-      return 'X';
-    } else if (c == 'q') {
-      return '\'';       // {geresh}={'}
-    } else if (c == 246) {
-      return ' ';        // \"o --> ' ' for a german keyboard
-    } else if (c == 228) {
-      return ' ';        // \"a --> ' '      -- / --
-    } else if (c == 252) {
-      return ' ';        // \"u --> ' '      -- / --
-    } else if (c >= 'a' && c <= 'z') {
-      // NOTE: islower() does not do the right thing for us on Linux so we
-      // do this the same was as 5.7 and previous, so it works correctly on
-      // all systems.  Specifically, the e.g. Delete and Arrow keys are
-      // munged and won't work if e.g. searching for Hebrew text.
-      return (int)(map[CHAR_ORD_LOW(c)] + p_aleph);
-    } else {
-      return c;
-    }
-  } else {
-    switch (c) {
-    case '`':
-      return ';';
-    case '/':
-      return '.';
-    case '\'':
-      return ',';
-    case 'q':
-      return '/';
-    case 'w':
-      return '\'';
-
-    // Hebrew letters - set offset from 'a'
-    case ',':
-      c = '{'; break;
-    case '.':
-      c = 'v'; break;
-    case ';':
-      c = 't'; break;
-    default: {
-      static char_u str[] = "zqbcxlsjphmkwonu ydafe rig";
-
-      if (c < 'a' || c > 'z') {
-        return c;
-      }
-      c = str[CHAR_ORD_LOW(c)];
-      break;
-    }
-    }
-
-    return (int)(CHAR_ORD_LOW(c) + p_aleph);
-  }
-}
-
 static void ins_reg(void)
 {
   bool need_redraw = false;
@@ -3581,7 +3479,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
   return true;
 }
 
-// Toggle language: hkmap and revins_on.
+// Toggle language: revins_on.
 // Move to end of reverse inserted text.
 static void ins_ctrl_(void)
 {
@@ -3600,7 +3498,6 @@ static void ins_ctrl_(void)
   } else {
     revins_scol = -1;
   }
-  p_hkmap = curwin->w_p_rl ^ p_ri;        // be consistent!
   showmode();
 }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -189,8 +189,6 @@ static int cedit_key = -1;  ///< key value of 'cedit' option
 static handle_T cmdpreview_bufnr = 0;
 static long cmdpreview_ns = 0;
 
-static int cmd_hkmap = 0;  // Hebrew mapping during command line
-
 static void save_viewstate(win_T *wp, viewstate_T *vs)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -680,11 +678,6 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool clea
     s->break_ctrl_c = true;
   }
 
-  // start without Hebrew mapping for a command line
-  if (s->firstc == ':' || s->firstc == '=' || s->firstc == '>') {
-    cmd_hkmap = 0;
-  }
-
   init_ccline(s->firstc, s->indent);
   ccline.prompt_id = last_prompt_id++;
   ccline.level = cmdline_level;
@@ -1166,9 +1159,6 @@ static int command_line_execute(VimState *state, int key)
 
   if (KeyTyped) {
     s->some_key_typed = true;
-    if (cmd_hkmap) {
-      s->c = hkmap(s->c);
-    }
 
     if (cmdmsg_rl && !KeyStuffed) {
       // Invert horizontal movements and operations.  Only when
@@ -2101,7 +2091,6 @@ static int command_line_handle_key(CommandLineState *s)
     if (!p_ari) {
       break;
     }
-    cmd_hkmap = !cmd_hkmap;
     return command_line_not_changed(s);
 
   default:

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1147,8 +1147,8 @@ static void command_line_scan(mparm_T *parmp)
       case 'h':    // "-h" give help message
         usage();
         os_exit(0);
-      case 'H':    // "-H" start in Hebrew mode: rl + hkmap set.
-        p_hkmap = true;
+      case 'H':    // "-H" start in Hebrew mode: rl + keymap=hebrew set.
+        set_option_value_give_err("keymap", 0L, "hebrew", 0);
         set_option_value_give_err("rl", 1L, NULL, 0);
         break;
       case 'M':    // "-M"  no changes or writing of files

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -769,10 +769,6 @@ static void normal_get_additional_char(NormalState *s)
 
       // adjust chars > 127, except after "tTfFr" commands
       LANGMAP_ADJUST(*cp, !lang);
-      // adjust Hebrew mapped char
-      if (p_hkmap && lang && KeyTyped) {
-        *cp = hkmap(*cp);
-      }
     }
 
     // When the next character is CTRL-\ a following CTRL-N means the

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5026,7 +5026,6 @@ static void paste_option_changed(void)
   static int save_sta = 0;
   static int save_ru = 0;
   static int save_ri = 0;
-  static int save_hkmap = 0;
 
   if (p_paste) {
     // Paste switched from off to on.
@@ -5052,7 +5051,6 @@ static void paste_option_changed(void)
       save_sta = p_sta;
       save_ru = p_ru;
       save_ri = p_ri;
-      save_hkmap = p_hkmap;
       // save global values for local buffer options
       p_ai_nopaste = p_ai;
       p_et_nopaste = p_et;
@@ -5089,7 +5087,6 @@ static void paste_option_changed(void)
     }
     p_ru = 0;                       // no ruler
     p_ri = 0;                       // no reverse insert
-    p_hkmap = 0;                    // no Hebrew keyboard
     // set global values for local buffer options
     p_tw = 0;
     p_wm = 0;
@@ -5129,7 +5126,6 @@ static void paste_option_changed(void)
     }
     p_ru = save_ru;
     p_ri = save_ri;
-    p_hkmap = save_hkmap;
     // set global values for local buffer options
     p_ai = p_ai_nopaste;
     p_et = p_et_nopaste;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -386,7 +386,6 @@ enum {
 
 // The following are actual variables for the options
 
-EXTERN long p_aleph;            // 'aleph'
 EXTERN char *p_ambw;            ///< 'ambiwidth'
 EXTERN int p_acd;               ///< 'autochdir'
 EXTERN int p_ai;                ///< 'autoindent'
@@ -544,8 +543,6 @@ EXTERN int p_hid;               // 'hidden'
 EXTERN char *p_hl;              // 'highlight'
 EXTERN int p_hls;               // 'hlsearch'
 EXTERN long p_hi;               // 'history'
-EXTERN int p_hkmap;             // 'hkmap'
-EXTERN int p_hkmapp;            // 'hkmapp'
 EXTERN int p_arshape;           // 'arabicshape'
 EXTERN int p_icon;              // 'icon'
 EXTERN char *p_iconstring;      // 'iconstring'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -55,8 +55,6 @@ return {
       full_name='aleph', abbreviation='al',
       short_desc=N_("ASCII code of the letter Aleph (Hebrew)"),
       type='number', scope={'global'},
-      redraw={'curswant'},
-      varname='p_aleph',
       defaults={if_true=224}
     },
     {
@@ -1071,16 +1069,16 @@ return {
     },
     {
       full_name='hkmap', abbreviation='hk',
-      short_desc=N_("Hebrew keyboard mapping"),
+      short_desc=N_("No description"),
       type='bool', scope={'global'},
-      varname='p_hkmap',
+      varname='p_force_off',
       defaults={if_true=false}
     },
     {
       full_name='hkmapp', abbreviation='hkp',
-      short_desc=N_("phonetic Hebrew keyboard mapping"),
+      short_desc=N_("No description"),
       type='bool', scope={'global'},
-      varname='p_hkmapp',
+      varname='p_force_off',
       defaults={if_true=false}
     },
     {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -534,9 +534,6 @@ int showmode(void)
         } else if (restart_edit == 'V') {
           msg_puts_attr(_(" (vreplace)"), attr);
         }
-        if (p_hkmap) {
-          msg_puts_attr(_(" Hebrew"), attr);
-        }
         if (State & MODE_LANGMAP) {
           if (curwin->w_p_arab) {
             msg_puts_attr(_(" Arabic"), attr);

--- a/src/nvim/testdir/test_charsearch.vim
+++ b/src/nvim/testdir/test_charsearch.vim
@@ -86,6 +86,7 @@ endfunc
 
 " Test for character search with 'hkmap'
 func Test_charsearch_hkmap()
+  throw "Skipped: Nvim does not support 'hkmap'"
   new
   set hkmap
   call setline(1, "ùðáâ÷ëòéïçìêöî")

--- a/src/nvim/testdir/test_cmdline.vim
+++ b/src/nvim/testdir/test_cmdline.vim
@@ -2111,7 +2111,8 @@ func Test_cmdline_revins()
   call assert_equal("\"abc\<c-_>", @:)
   set allowrevins
   call feedkeys(":\"abc\<c-_>xyz\<c-_>\<CR>", 'xt')
-  call assert_equal('"abcñèæ', @:)
+  " call assert_equal('"abcñèæ', @:)
+  call assert_equal('"abcxyz', @:)
   set allowrevins&
 endfunc
 

--- a/src/nvim/testdir/test_edit.vim
+++ b/src/nvim/testdir/test_edit.vim
@@ -516,7 +516,8 @@ func Test_edit_CTRL_()
   call setline(1, ['abc'])
   call cursor(1, 1)
   call feedkeys("i\<c-_>xyz\<esc>", 'tnix')
-  call assert_equal(["æèñabc"], getline(1, '$'))
+  " call assert_equal(["æèñabc"], getline(1, '$'))
+  call assert_equal(["zyxabc"], getline(1, '$'))
   call assert_true(&revins)
   call setline(1, ['abc'])
   call cursor(1, 1)
@@ -1913,6 +1914,7 @@ endfunc
 
 " Test for 'hkmap' and 'hkmapp'
 func Test_edit_hkmap()
+  throw "Skipped: Nvim does not support 'hkmap'"
   CheckFeature rightleft
   if has('win32') && !has('gui')
     " Test fails on the MS-Windows terminal version

--- a/src/nvim/testdir/test_paste.vim
+++ b/src/nvim/testdir/test_paste.vim
@@ -20,7 +20,8 @@ endfunc
 func Test_paste_opt_restore()
   set autoindent expandtab ruler showmatch
   if has('rightleft')
-    set revins hkmap
+    " set hkmap
+    set revins
   endif
   set smarttab softtabstop=3 textwidth=27 wrapmargin=12
   if has('vartabs')
@@ -33,7 +34,7 @@ func Test_paste_opt_restore()
   call assert_false(&expandtab)
   if has('rightleft')
     call assert_false(&revins)
-    call assert_false(&hkmap)
+    " call assert_false(&hkmap)
   endif
   call assert_false(&ruler)
   call assert_false(&showmatch)
@@ -51,7 +52,7 @@ func Test_paste_opt_restore()
   call assert_true(&expandtab)
   if has('rightleft')
     call assert_true(&revins)
-    call assert_true(&hkmap)
+    " call assert_true(&hkmap)
   endif
   call assert_true(&ruler)
   call assert_true(&showmatch)

--- a/src/nvim/testdir/test_startup.vim
+++ b/src/nvim/testdir/test_startup.vim
@@ -389,7 +389,7 @@ endfunc
 " Test the -A, -F and -H arguments (Arabic, Farsi and Hebrew modes).
 func Test_A_F_H_arg()
   let after =<< trim [CODE]
-    call writefile([&rightleft, &arabic, 0, &hkmap], "Xtestout")
+    call writefile([&rightleft, &arabic, 0, &hkmap, &keymap], "Xtestout")
     qall
   [CODE]
 
@@ -397,17 +397,17 @@ func Test_A_F_H_arg()
   " 'encoding' is not utf-8.
   if has('arabic') && &encoding == 'utf-8' && RunVim([], after, '-e -s -A')
     let lines = readfile('Xtestout')
-    call assert_equal(['1', '1', '0', '0'], lines)
+    call assert_equal(['1', '1', '0', '0', 'arabic'], lines)
   endif
 
   if has('farsi') && RunVim([], after, '-F')
     let lines = readfile('Xtestout')
-    call assert_equal(['1', '0', '1', '0'], lines)
+    call assert_equal(['1', '0', '1', '0', '???'], lines)
   endif
 
   if has('rightleft') && RunVim([], after, '-H')
     let lines = readfile('Xtestout')
-    call assert_equal(['1', '0', '0', '1'], lines)
+    call assert_equal(['1', '0', '0', '0', 'hebrew'], lines)
   endif
 
   call delete('Xtestout')


### PR DESCRIPTION
This feature has long been obsolete. The 'keymap' option can be used to support language keymaps, including hebrew and hebrewp (phonetic mapping). There is no need to keep the old c code with hardcoded keymaps for some languages.