### PR TITLE
test: find warnings from latest ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   lint:
     if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       CACHE_UNCRUSTIFY: ${{ github.workspace }}/.cache/uncrustify
@@ -132,15 +132,15 @@ jobs:
         include:
           - flavor: asan
             cc: clang
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             flags: -D CLANG_ASAN_UBSAN=ON
           - flavor: tsan
             cc: clang
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             flags: -D CLANG_TSAN=ON
           - flavor: uchar
             cc: gcc
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             flags: -D UNSIGNED_CHAR=ON
           - cc: clang
             runner: macos-12
@@ -150,7 +150,7 @@ jobs:
             # 2. No treesitter parsers installed.
           - flavor: functionaltest-lua
             cc: gcc
-            runner: ubuntu-22.04
+            runner: ubuntu-latest
             deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON
             flags: -D PREFER_LUA=ON
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
https://github.com/lewis6991/gitsigns.nvim/pull/753 Keeps failing because it uses ubuntu-latest. Try and resolve all these errors.


E.g.:
```
/home/runner/work/gitsigns.nvim/gitsigns.nvim/deps/nvim-nightly/neovim/src/nvim/ex_getln.c:2510:41: error: ‘cmdpreview_win’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 2510 |   if (icm_split && cmdpreview_type == 2 && cmdpreview_win != NULL) {
      |      
```