### PR TITLE
vim-patch:9.0.1361: extendnew() not sufficiently tested

### DIFF
--- a/src/nvim/testdir/test_listdict.vim
+++ b/src/nvim/testdir/test_listdict.vim
@@ -886,11 +886,15 @@ func Test_listdict_extendnew()
   let l = [1, 2, 3]
   call assert_equal([1, 2, 3, 4, 5], extendnew(l, [4, 5]))
   call assert_equal([1, 2, 3], l)
+  lockvar l
+  call assert_equal([1, 2, 3, 4, 5], extendnew(l, [4, 5]))
 
-  " Test extend() with dictionaries.
+  " Test extendnew() with dictionaries.
   let d = {'a': {'b': 'B'}}
   call assert_equal({'a': {'b': 'B'}, 'c': 'cc'}, extendnew(d, {'c': 'cc'}))
   call assert_equal({'a': {'b': 'B'}}, d)
+  lockvar d
+  call assert_equal({'a': {'b': 'B'}, 'c': 'cc'}, extendnew(d, {'c': 'cc'}))
 endfunc
 
 func s:check_scope_dict(x, fixed)


### PR DESCRIPTION
#### vim-patch:9.0.1361: extendnew() not sufficiently tested

Problem:    extendnew() not sufficiently tested.
Solution:   Add a few more test cases for extendnew(). (closes vim/vim#12075)

https://github.com/vim/vim/commit/341f3876b34f47fdb1c82b0ad9bae448be73a220