### PR TITLE
fix(tui): avoid stack-use-after-scope with cursor color

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1109,8 +1109,8 @@ void tui_set_mode(TUIData *tui, ModeShape mode)
       // Hopefully the user's default cursor color is inverse.
       unibi_out_ext(tui, tui->unibi_ext.reset_cursor_color);
     } else {
+      char hexbuf[8];
       if (tui->set_cursor_color_as_str) {
-        char hexbuf[8];
         snprintf(hexbuf, 7 + 1, "#%06x", aep.rgb_bg_color);
         UNIBI_SET_STR_VAR(tui->params[0], hexbuf);
       } else {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1512,6 +1512,42 @@ describe('TUI', function()
     exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     screen:expect({any = '%[Process exited 1%]'})
   end)
+
+  it('no stack-use-after-scope with cursor color #22432', function()
+    screen:set_option('rgb', true)
+    command('set termguicolors')
+    child_session:request('nvim_exec', [[
+      set tgc
+      hi Cursor guifg=Red guibg=Green
+      set guicursor=n:block-Cursor/lCursor
+    ]], false)
+    screen:set_default_attr_ids({
+      [1] = {reverse = true},
+      [2] = {bold = true, foreground = Screen.colors.Blue},
+      [3] = {foreground = Screen.colors.Blue},
+      [4] = {reverse = true, bold = true},
+      [5] = {bold = true},
+    })
+    screen:expect([[
+      {1: }                                                 |
+      {2:~}{3:                                                 }|
+      {2:~}{3:                                                 }|
+      {2:~}{3:                                                 }|
+      {4:[No Name]                                         }|
+                                                        |
+      {5:-- TERMINAL --}                                    |
+    ]])
+    feed('i')
+    screen:expect([[
+      {1: }                                                 |
+      {2:~}{3:                                                 }|
+      {2:~}{3:                                                 }|
+      {2:~}{3:                                                 }|
+      {4:[No Name]                                         }|
+      {5:-- INSERT --}                                      |
+      {5:-- TERMINAL --}                                    |
+    ]])
+  end)
 end)
 
 describe('TUI', function()


### PR DESCRIPTION
Fix #22432
