### PR TITLE
vim-patch:partial:dd60c365cd26

### DIFF
--- a/runtime/autoload/python.vim
+++ b/runtime/autoload/python.vim
@@ -22,8 +22,7 @@ let s:maxoff = 50       " maximum number of lines to look backwards for ()
 function s:SearchBracket(fromlnum, flags)
   return searchpairpos('[[({]', '', '[])}]', a:flags,
           \ {-> synstack('.', col('.'))
-          \   ->map({_, id -> id->synIDattr('name')})
-          \   ->match('\%(Comment\|Todo\|String\)$') >= 0},
+          \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\|String\)$'}) >= 0},
           \ [0, a:fromlnum - s:maxoff]->max(), g:python_indent.searchpair_timeout)
 endfunction
 
@@ -157,15 +156,13 @@ function python#GetIndent(lnum, ...)
     " the start of the comment.  synID() is slow, a linear search would take
     " too long on a long line.
     if synstack(plnum, pline_len)
-    \ ->map({_, id -> id->synIDattr('name')})
-    \ ->match('\%(Comment\|Todo\)$') >= 0
+    \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\)$'}) >= 0
       let min = 1
       let max = pline_len
       while min < max
 	let col = (min + max) / 2
         if synstack(plnum, col)
-        \ ->map({_, id -> id->synIDattr('name')})
-        \ ->match('\%(Comment\|Todo\)$') >= 0
+        \ ->indexof({_, id -> synIDattr(id, 'name') =~ '\%(Comment\|Todo\)$'}) >= 0
 	  let max = col
 	else
 	  let min = col + 1

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2126,8 +2126,7 @@ extend({expr1}, {expr2} [, {expr3}])			*extend()*
 extendnew({expr1}, {expr2} [, {expr3}])			*extendnew()*
 		Like |extend()| but instead of adding items to {expr1} a new
 		List or Dictionary is created and returned.  {expr1} remains
-		unchanged.  Items can still be changed by {expr2}, if you
-		don't want that use |deepcopy()| first.
+		unchanged.
 
 
 feedkeys({string} [, {mode}])				*feedkeys()*
@@ -8725,6 +8724,8 @@ timer_start({time}, {callback} [, {options}])
 		{time} is the waiting time in milliseconds. This is the
 		minimum time before invoking the callback.  When the system is
 		busy or Vim is not waiting for input the time will be longer.
+		Zero can be used to execute the callback when Vim is back in
+		the main loop.
 
 		{callback} is the function to call.  It can be the name of a
 		function or a |Funcref|.  It is called with one argument, which

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -276,7 +276,9 @@ gr{char}		Replace the virtual characters under the cursor with
 			{char}.  This replaces in screen space, not file
 			space.  See |gR| and |Virtual-Replace-mode| for more
 			details.  As with |r| a count may be given.
-			{char} can be entered like with |r|.
+			{char} can be entered like with |r|, but characters
+			that have a special meaning in Insert mode, such as
+			most CTRL-keys, cannot be used.
 
 						*digraph-arg*
 The argument for Normal mode commands like |r| and |t| is a single character.
@@ -976,7 +978,7 @@ inside of strings can change!  Also see 'softtabstop' option. >
 <			to display registers '1' and 'a'.  Spaces are allowed
 			in {arg}.
 
-							*:di* *:display*
+							*:di* *:dis* *:display*
 :di[splay] [arg]	Same as :registers.
 
 							*y* *yank*

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1205,12 +1205,14 @@ functions used in one script use the same name as in other scripts.  To avoid
 this, they can be made local to the script.
 
 						*<SID>* *<SNR>* *E81*
-The string "<SID>" can be used in a mapping or menu.
+The string "<SID>" can be used in a mapping or menu.  This is useful if you
+have a script-local function that you want to call from a mapping in the same
+script.
    When executing the map command, Vim will replace "<SID>" with the special
 key code <SNR>, followed by a number that's unique for the script, and an
 underscore.  Example: >
 	:map <SID>Add
-could define a mapping "<SNR>23_Add".
+would define a mapping "<SNR>23_Add".
 
 When defining a function in a script, "s:" can be prepended to the name to
 make it local to the script.  But when a mapping is executed from outside of

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -595,23 +595,23 @@ sign_placelist({list})
 		|sign_place()| function.  The {list} argument specifies the
 		List of signs to place. Each list item is a dict with the
 		following sign attributes:
-		    buffer	buffer name or number. For the accepted
+		    buffer	Buffer name or number. For the accepted
 				values, see |bufname()|.
-		    group	sign group. {group} functions as a namespace
+		    group	Sign group. {group} functions as a namespace
 				for {id}, thus two groups can use the same
 				IDs. If not specified or set to an empty
 				string, then the global group is used.   See
 				|sign-group| for more information.
-		    id		sign identifier. If not specified or zero,
+		    id		Sign identifier. If not specified or zero,
 				then a new unique identifier is allocated.
 				Otherwise the specified number is used. See
 				|sign-identifier| for more information.
-		    lnum	line number in the buffer where the sign is to
+		    lnum	Line number in the buffer where the sign is to
 				be placed. For the accepted values, see
 				|line()|.
-		    name	name of the sign to place. See |sign_define()|
+		    name	Name of the sign to place. See |sign_define()|
 				for more information.
-		    priority	priority of the sign. When multiple signs are
+		    priority	Priority of the sign. When multiple signs are
 				placed on a line, the sign with the highest
 				priority is used. If not specified, the
 				default value of 10 is used. See

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2756,17 +2756,25 @@ For highlighted doctests and code inside: >
 	:let python_no_doctest_highlight = 1
 or >
 	:let python_no_doctest_code_highlight = 1
-(first option implies second one).
+The first option implies the second one.
 
 For highlighted trailing whitespace and mix of spaces and tabs: >
 	:let python_space_error_highlight = 1
 
-If you want all possible Python highlighting (the same as setting the
-preceding last option and unsetting all other ones): >
+If you want all possible Python highlighting: >
 	:let python_highlight_all = 1
+This has the same effect as setting python_space_error_highlight and
+unsetting all the other ones.
 
-Note: Only existence of these options matter, not their value. You can replace
-      1 above with anything.
+If you use Python 2 or straddling code (Python 2 and 3 compatible),
+you can enforce the use of an older syntax file with support for
+Python 2 and up to Python 3.5.  >
+	: let python_use_python2_syntax = 1
+This option will exclude all modern Python 3.6 or higher features.
+
+Note: Only existence of these options matters, not their value.
+      You can replace 1 above with anything.
+
 
 QUAKE						*quake.vim* *ft-quake-syntax*
 
@@ -5179,7 +5187,7 @@ Conceal		Placeholder characters substituted for concealed
 							*hl-CurSearch*
 CurSearch	Used for highlighting a search pattern under the cursor
 		(see 'hlsearch').
-							*hl-Cursor*
+						*hl-Cursor* *hl-lCursor*
 Cursor		Character under the cursor.
 lCursor		Character under the cursor when |language-mapping|
 		is used (see 'guicursor').

--- a/runtime/ftplugin/quarto.vim
+++ b/runtime/ftplugin/quarto.vim
@@ -1,0 +1,1 @@
+runtime ftplugin/rmd.vim

--- a/runtime/ftplugin/r.vim
+++ b/runtime/ftplugin/r.vim
@@ -2,7 +2,7 @@
 " Language: R
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sat Aug 15, 2020  11:37AM
+" Last Change:	Sun Apr 24, 2022  09:14AM
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -22,7 +22,7 @@ setlocal comments=:#',:###,:##,:#
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "R Source Files (*.R)\t*.R\n" .
-        \ "Files that include R (*.Rnw *.Rd *.Rmd *.Rrst)\t*.Rnw;*.Rd;*.Rmd;*.Rrst\n" .
+        \ "Files that include R (*.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
         \ "All Files (*.*)\t*.*\n"
 endif
 

--- a/runtime/ftplugin/rhelp.vim
+++ b/runtime/ftplugin/rhelp.vim
@@ -2,7 +2,7 @@
 " Language: R help file
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sat Aug 15, 2020  12:01PM
+" Last Change:	Sun Apr 24, 2022  09:12AM
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -18,7 +18,7 @@ set cpo&vim
 setlocal iskeyword=@,48-57,_,.
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst\n" .
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
         \ "All Files (*.*)\t*.*\n"
 endif
 

--- a/runtime/ftplugin/rmd.vim
+++ b/runtime/ftplugin/rmd.vim
@@ -2,7 +2,7 @@
 " Language: R Markdown file
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sat Aug 15, 2020  12:03PM
+" Last Change:	Sun Apr 24, 2022  09:12AM
 " Original work by Alex Zvoleff (adjusted from R help for rmd by Michel Kuhlmann)
 
 " Only do this when not yet done for this buffer
@@ -32,12 +32,23 @@ function! FormatRmd()
   return 1
 endfunction
 
-" If you do not want 'comments' dynamically defined, put in your vimrc:
-" let g:rmd_dynamic_comments = 0
+function! SetRmdCommentStr()
+    if (search("^[ \t]*```[ ]*{r", "bncW") > search("^[ \t]*```$", "bncW")) || ((search('^---$', 'Wn') || search('^\.\.\.$', 'Wn')) && search('^---$', 'bnW'))
+        set commentstring=#\ %s
+    else
+        set commentstring=<!--\ %s\ -->
+    endif
+endfunction
+
+" If you do not want both 'comments' and 'commentstring' dynamically defined,
+" put in your vimrc: let g:rmd_dynamic_comments = 0
 if !exists("g:rmd_dynamic_comments") || (exists("g:rmd_dynamic_comments") && g:rmd_dynamic_comments == 1)
   setlocal formatexpr=FormatRmd()
+  augroup RmdCStr
+    autocmd!
+    autocmd CursorMoved <buffer> call SetRmdCommentStr()
+  augroup END
 endif
-
 
 " Enables pandoc if it is installed
 unlet! b:did_ftplugin
@@ -47,7 +58,7 @@ runtime ftplugin/pandoc.vim
 let b:did_ftplugin = 1
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst\n" .
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
         \ "All Files (*.*)\t*.*\n"
 endif
 

--- a/runtime/ftplugin/rnoweb.vim
+++ b/runtime/ftplugin/rnoweb.vim
@@ -2,7 +2,7 @@
 " Language: Rnoweb
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sat Aug 15, 2020  12:02PM
+" Last Change:	Sun Apr 24, 2022  09:13AM
 
 " Only do this when not yet done for this buffer
 if exists("b:did_ftplugin")
@@ -25,8 +25,25 @@ setlocal suffixesadd=.bib,.tex
 setlocal comments=b:%,b:#,b:##,b:###,b:#'
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst\n" .
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
         \ "All Files (*.*)\t*.*\n"
+endif
+
+function! SetRnwCommentStr()
+    if (search("^\s*<<.*>>=", "bncW") > search("^@", "bncW"))
+        set commentstring=#\ %s
+    else
+        set commentstring=%\ %s
+    endif
+endfunction
+
+" If you do not want both 'comments' and 'commentstring' dynamically defined,
+" put in your vimrc: let g:rnw_dynamic_comments = 0
+if !exists("g:rnw_dynamic_comments") || (exists("g:rnw_dynamic_comments") && g:rnw_dynamic_comments == 1)
+  augroup RnwCStr
+    autocmd!
+    autocmd CursorMoved <buffer> call SetRnwCommentStr()
+  augroup END
 endif
 
 if exists('b:undo_ftplugin')

--- a/runtime/ftplugin/rrst.vim
+++ b/runtime/ftplugin/rrst.vim
@@ -2,7 +2,7 @@
 " Language: reStructuredText documentation format with R code
 " Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sat Aug 15, 2020  12:02PM
+" Last Change:	Sun Apr 24, 2022  09:13AM
 " Original work by Alex Zvoleff
 
 " Only do this when not yet done for this buffer
@@ -38,7 +38,7 @@ if !exists("g:rrst_dynamic_comments") || (exists("g:rrst_dynamic_comments") && g
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst\n" .
+  let b:browsefilter = "R Source Files (*.R *.Rnw *.Rd *.Rmd *.Rrst *.qmd)\t*.R;*.Rnw;*.Rd;*.Rmd;*.Rrst;*.qmd\n" .
         \ "All Files (*.*)\t*.*\n"
 endif
 

--- a/runtime/indent/quarto.vim
+++ b/runtime/indent/quarto.vim
@@ -1,0 +1,1 @@
+runtime indent/rmd.vim

--- a/runtime/indent/r.vim
+++ b/runtime/indent/r.vim
@@ -2,7 +2,7 @@
 " Language:	R
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sun Aug 19, 2018  09:13PM
+" Last Change:	Wed Oct 26, 2022  12:04PM
 
 
 " Only load this indent file when no other was loaded.
@@ -13,6 +13,8 @@ let b:did_indent = 1
 
 setlocal indentkeys=0{,0},:,!^F,o,O,e
 setlocal indentexpr=GetRIndent()
+
+let b:undo_indent = "setl inde< indk<"
 
 " Only define the function once.
 if exists("*GetRIndent")
@@ -28,7 +30,7 @@ let g:r_indent_ess_comments   = get(g:, 'r_indent_ess_comments',    0)
 let g:r_indent_comment_column = get(g:, 'r_indent_comment_column', 40)
 let g:r_indent_ess_compatible = get(g:, 'r_indent_ess_compatible',  0)
 let g:r_indent_op_pattern     = get(g:, 'r_indent_op_pattern',
-      \ '\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\)\s*$')
+      \ '\(&\||\|+\|-\|\*\|/\|=\|\~\|%\|->\||>\)\s*$')
 
 function s:RDelete_quotes(line)
   let i = 0
@@ -359,17 +361,19 @@ function GetRIndent()
   let olnum = s:Get_prev_line(lnum)
   let oline = getline(olnum)
   if olnum > 0
-    if line =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
-      if oline =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
+    if substitute(line, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
+      if substitute(oline, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
         return indent(lnum)
       else
         return indent(lnum) + shiftwidth()
       endif
     else
-      if oline =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
+      if substitute(oline, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
         return indent(lnum) - shiftwidth()
       endif
     endif
+  elseif substitute(line, '#.*', '', '') =~ g:r_indent_op_pattern && s:Get_paren_balance(line, "(", ")") == 0
+    return indent(lnum) + shiftwidth()
   endif
 
   let post_fun = 0

--- a/runtime/indent/rhelp.vim
+++ b/runtime/indent/rhelp.vim
@@ -2,7 +2,7 @@
 " Language:	R Documentation (Help), *.Rd
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Tue Apr 07, 2015  04:38PM
+" Last Change:	Feb 25, 2023
 
 
 " Only load this indent file when no other was loaded.
@@ -19,6 +19,8 @@ setlocal nosmartindent
 setlocal nolisp
 setlocal indentkeys=0{,0},:,!^F,o,O,e
 setlocal indentexpr=GetCorrectRHelpIndent()
+
+let b:undo_indent = "setl ai< cin< inde< indk< lisp< si<"
 
 " Only define the functions once.
 if exists("*GetRHelpIndent")

--- a/runtime/indent/rmd.vim
+++ b/runtime/indent/rmd.vim
@@ -2,7 +2,7 @@
 " Language:	Rmd
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Sun Mar 28, 2021  08:05PM
+" Last Change:	Wed Nov 09, 2022  09:44PM
 
 
 " Only load this indent file when no other was loaded.
@@ -15,6 +15,8 @@ let b:did_indent = 1
 
 setlocal indentkeys=0{,0},<:>,!^F,o,O,e
 setlocal indentexpr=GetRmdIndent()
+
+let b:undo_indent = "setl inde< indk<"
 
 if exists("*GetRmdIndent")
   finish
@@ -47,6 +49,8 @@ function s:GetMdIndent()
     return indent(v:lnum - 1) + 2
   elseif pline =~ '^\s*\d\+\.\s\+'
     return indent(v:lnum - 1) + 3
+  elseif pline =~ '^\[\^\S\+\]: '
+    return indent(v:lnum - 1) + shiftwidth()
   endif
   return indent(prevnonblank(v:lnum - 1))
 endfunction

--- a/runtime/indent/rnoweb.vim
+++ b/runtime/indent/rnoweb.vim
@@ -2,7 +2,7 @@
 " Language:	Rnoweb
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Fri Apr 15, 2016  10:58PM
+" Last Change:	Feb 25, 2023
 
 
 " Only load this indent file when no other was loaded.
@@ -28,6 +28,8 @@ let b:did_indent = 1
 
 setlocal indentkeys=0{,0},!^F,o,O,e,},=\bibitem,=\item
 setlocal indentexpr=GetRnowebIndent()
+
+let b:undo_indent = "setl inde< indk<"
 
 if exists("*GetRnowebIndent")
   finish

--- a/runtime/indent/rrst.vim
+++ b/runtime/indent/rrst.vim
@@ -2,7 +2,7 @@
 " Language:	Rrst
 " Author:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Homepage:     https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	Tue Apr 07, 2015  04:38PM
+" Last Change:	Feb 25, 2023
 
 
 " Only load this indent file when no other was loaded.
@@ -15,6 +15,8 @@ let b:did_indent = 1
 
 setlocal indentkeys=0{,0},:,!^F,o,O,e
 setlocal indentexpr=GetRrstIndent()
+
+let b:undo_indent = "setl inde< indk<"
 
 if exists("*GetRrstIndent")
   finish

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -108,8 +108,9 @@ func s:Highlight_Matching_Pair()
     " searchpairpos()'s skip argument.
     " We match "escape" for special items, such as lispEscapeSpecial, and
     " match "symbol" for lispBarSymbol.
-    let s_skip = '!empty(filter(map(synstack(line("."), col(".")), ''synIDattr(v:val, "name")''), ' .
-	\ '''v:val =~? "string\\|character\\|singlequote\\|escape\\|symbol\\|comment"''))'
+    let s_skip = 'synstack(".", col("."))'
+        \ . '->indexof({_, id -> synIDattr(id, "name") =~? '
+        \ . '"string\\|character\\|singlequote\\|escape\\|symbol\\|comment"}) >= 0'
     " If executing the expression determines that the cursor is currently in
     " one of the syntax types, then we want searchpairpos() to find the pair
     " within those syntax types (i.e., not skip).  Otherwise, the cursor is

--- a/runtime/syntax/python2.vim
+++ b/runtime/syntax/python2.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
-" Language:	Python
+" Language:	Python 2
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2023 Feb 26
+" Last Change:	2016 Oct 29
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "
@@ -35,23 +35,15 @@
 "
 "   let python_highlight_all = 1
 "
-" The use of Python 2 compatible syntax highlighting can be enforced.
-" The straddling code (Python 2 and 3 compatible), up to Python 3.5,
-" will be also supported.
-"
-"   let python_use_python2_syntax = 1
-"
-" This option will exclude all modern Python 3.6 or higher features.
-"
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+" NOTE: This file is a copy of the last commit of runtime/syntax/python.vim
+" that still supported Python 2. There is support for Python 3, up to 3.5,
+" and it was kept in the file as is, because it supports the straddling code
+" (Python 2 and 3 compatible) better.
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 " quit when a syntax file was already loaded.
 if exists("b:current_syntax")
-  finish
-endif
-
-" Use of Python 2 and 3.5 or lower requested.
-if exists("python_use_python2_syntax")
-  runtime! syntax/python2.vim
   finish
 endif
 
@@ -85,17 +77,30 @@ endif
 
 " Keep Python keywords in alphabetical order inside groups for easy
 " comparison with the table in the 'Python Language Reference'
-" https://docs.python.org/reference/lexical_analysis.html#keywords.
+" https://docs.python.org/2/reference/lexical_analysis.html#keywords,
+" https://docs.python.org/3/reference/lexical_analysis.html#keywords.
 " Groups are in the order presented in NAMING CONVENTIONS in syntax.txt.
 " Exceptions come last at the end of each group (class and def below).
 "
-" The list can be checked using:
+" Keywords 'with' and 'as' are new in Python 2.6
+" (use 'from __future__ import with_statement' in Python 2.5).
 "
-" python3 -c 'import keyword, pprint; pprint.pprint(keyword.kwlist + keyword.softkwlist, compact=True)'
+" Some compromises had to be made to support both Python 3 and 2.
+" We include Python 3 features, but when a definition is duplicated,
+" the last definition takes precedence.
+"
+" - 'False', 'None', and 'True' are keywords in Python 3 but they are
+"   built-ins in 2 and will be highlighted as built-ins below.
+" - 'exec' is a built-in in Python 3 and will be highlighted as
+"   built-in below.
+" - 'nonlocal' is a keyword in Python 3 and will be highlighted.
+" - 'print' is a built-in in Python 3 and will be highlighted as
+"   built-in below (use 'from __future__ import print_function' in 2)
+" - async and await were added in Python 3.5 and are soft keywords.
 "
 syn keyword pythonStatement	False None True
-syn keyword pythonStatement	as assert break continue del global
-syn keyword pythonStatement	lambda nonlocal pass return with yield
+syn keyword pythonStatement	as assert break continue del exec global
+syn keyword pythonStatement	lambda nonlocal pass print return with yield
 syn keyword pythonStatement	class def nextgroup=pythonFunction skipwhite
 syn keyword pythonConditional	elif else if
 syn keyword pythonRepeat	for while
@@ -104,14 +109,7 @@ syn keyword pythonException	except finally raise try
 syn keyword pythonInclude	from import
 syn keyword pythonAsync		async await
 
-" Soft keywords
-" These keywords do not mean anything unless used in the right context.
-" See https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords
-" for more on this.
-syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
-syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
-
-" Decorators
+" Decorators (new in Python 2.4)
 " A dot must be allowed because of @MyClass.myfunc decorators.
 syn match   pythonDecorator	"@" display contained
 syn match   pythonDecoratorName	"@\s*\h\%(\w\|\.\)*" display contains=pythonDecorator
@@ -146,7 +144,7 @@ syn region  pythonString matchgroup=pythonQuotes
       \ start=+[uU]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
       \ contains=pythonEscape,@Spell
 syn region  pythonString matchgroup=pythonTripleQuotes
-      \ start=+[uU]\=\z('''\|"""\)+ skip=+\\["']+ end="\z1" keepend
+      \ start=+[uU]\=\z('''\|"""\)+ end="\z1" keepend
       \ contains=pythonEscape,pythonSpaceError,pythonDoctest,@Spell
 syn region  pythonRawString matchgroup=pythonQuotes
       \ start=+[uU]\=[rR]\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
@@ -176,7 +174,8 @@ syn match   pythonEscape	"\\$"
 " - 08e0 or 08j are highlighted,
 "
 " and so on, as specified in the 'Python Language Reference'.
-" https://docs.python.org/reference/lexical_analysis.html#numeric-literals
+" https://docs.python.org/2/reference/lexical_analysis.html#numeric-literals
+" https://docs.python.org/3/reference/lexical_analysis.html#numeric-literals
 if !exists("python_no_number_highlight")
   " numbers (including longs and complex)
   syn match   pythonNumber	"\<0[oO]\=\o\+[Ll]\=\>"
@@ -193,37 +192,37 @@ endif
 
 " Group the built-ins in the order in the 'Python Library Reference' for
 " easier comparison.
-" https://docs.python.org/library/constants.html
-" http://docs.python.org/library/functions.html
+" https://docs.python.org/2/library/constants.html
+" https://docs.python.org/3/library/constants.html
+" http://docs.python.org/2/library/functions.html
+" http://docs.python.org/3/library/functions.html
+" http://docs.python.org/2/library/functions.html#non-essential-built-in-functions
+" http://docs.python.org/3/library/functions.html#non-essential-built-in-functions
 " Python built-in functions are in alphabetical order.
-"
-" The list can be checked using:
-"
-" python3 -c 'import builtins, pprint; pprint.pprint(dir(builtins), compact=True)'
-"
-" The constants added by the `site` module are not listed below because they
-" should not be used in programs, only in interactive interpreter.
-" Similarly for some other attributes and functions `__`-enclosed from the
-" output of the above command.
-"
 if !exists("python_no_builtin_highlight")
   " built-in constants
   " 'False', 'True', and 'None' are also reserved words in Python 3
   syn keyword pythonBuiltin	False True None
   syn keyword pythonBuiltin	NotImplemented Ellipsis __debug__
-  " constants added by the `site` module
-  syn keyword pythonBuiltin	quit exit copyright credits license
   " built-in functions
-  syn keyword pythonBuiltin	abs all any ascii bin bool breakpoint bytearray
-  syn keyword pythonBuiltin	bytes callable chr classmethod compile complex
-  syn keyword pythonBuiltin	delattr dict dir divmod enumerate eval exec
-  syn keyword pythonBuiltin	filter float format frozenset getattr globals
-  syn keyword pythonBuiltin	hasattr hash help hex id input int isinstance
+  syn keyword pythonBuiltin	abs all any bin bool bytearray callable chr
+  syn keyword pythonBuiltin	classmethod compile complex delattr dict dir
+  syn keyword pythonBuiltin	divmod enumerate eval filter float format
+  syn keyword pythonBuiltin	frozenset getattr globals hasattr hash
+  syn keyword pythonBuiltin	help hex id input int isinstance
   syn keyword pythonBuiltin	issubclass iter len list locals map max
   syn keyword pythonBuiltin	memoryview min next object oct open ord pow
   syn keyword pythonBuiltin	print property range repr reversed round set
-  syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
-  syn keyword pythonBuiltin	tuple type vars zip __import__
+  syn keyword pythonBuiltin	setattr slice sorted staticmethod str
+  syn keyword pythonBuiltin	sum super tuple type vars zip __import__
+  " Python 2 only
+  syn keyword pythonBuiltin	basestring cmp execfile file
+  syn keyword pythonBuiltin	long raw_input reduce reload unichr
+  syn keyword pythonBuiltin	unicode xrange
+  " Python 3 only
+  syn keyword pythonBuiltin	ascii bytes exec
+  " non-essential built-in functions; Python 2 only
+  syn keyword pythonBuiltin	apply buffer coerce intern
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
 	\ contains=ALLBUT,pythonBuiltin,pythonFunction,pythonAsync
@@ -231,27 +230,28 @@ if !exists("python_no_builtin_highlight")
 endif
 
 " From the 'Python Library Reference' class hierarchy at the bottom.
-" http://docs.python.org/library/exceptions.html
+" http://docs.python.org/2/library/exceptions.html
+" http://docs.python.org/3/library/exceptions.html
 if !exists("python_no_exception_highlight")
   " builtin base exceptions (used mostly as base classes for other exceptions)
   syn keyword pythonExceptions	BaseException Exception
-  syn keyword pythonExceptions	ArithmeticError BufferError LookupError
+  syn keyword pythonExceptions	ArithmeticError BufferError
+  syn keyword pythonExceptions	LookupError
+  " builtin base exceptions removed in Python 3
+  syn keyword pythonExceptions	EnvironmentError StandardError
   " builtin exceptions (actually raised)
-  syn keyword pythonExceptions	AssertionError AttributeError EOFError
-  syn keyword pythonExceptions	FloatingPointError GeneratorExit ImportError
-  syn keyword pythonExceptions	IndentationError IndexError KeyError
-  syn keyword pythonExceptions	KeyboardInterrupt MemoryError
-  syn keyword pythonExceptions	ModuleNotFoundError NameError
-  syn keyword pythonExceptions	NotImplementedError OSError OverflowError
-  syn keyword pythonExceptions	RecursionError ReferenceError RuntimeError
-  syn keyword pythonExceptions	StopAsyncIteration StopIteration SyntaxError
+  syn keyword pythonExceptions	AssertionError AttributeError
+  syn keyword pythonExceptions	EOFError FloatingPointError GeneratorExit
+  syn keyword pythonExceptions	ImportError IndentationError
+  syn keyword pythonExceptions	IndexError KeyError KeyboardInterrupt
+  syn keyword pythonExceptions	MemoryError NameError NotImplementedError
+  syn keyword pythonExceptions	OSError OverflowError ReferenceError
+  syn keyword pythonExceptions	RuntimeError StopIteration SyntaxError
   syn keyword pythonExceptions	SystemError SystemExit TabError TypeError
-  syn keyword pythonExceptions	UnboundLocalError UnicodeDecodeError
-  syn keyword pythonExceptions	UnicodeEncodeError UnicodeError
+  syn keyword pythonExceptions	UnboundLocalError UnicodeError
+  syn keyword pythonExceptions	UnicodeDecodeError UnicodeEncodeError
   syn keyword pythonExceptions	UnicodeTranslateError ValueError
   syn keyword pythonExceptions	ZeroDivisionError
-  " builtin exception aliases for OSError
-  syn keyword pythonExceptions	EnvironmentError IOError WindowsError
   " builtin OS exceptions in Python 3
   syn keyword pythonExceptions	BlockingIOError BrokenPipeError
   syn keyword pythonExceptions	ChildProcessError ConnectionAbortedError
@@ -259,13 +259,18 @@ if !exists("python_no_exception_highlight")
   syn keyword pythonExceptions	ConnectionResetError FileExistsError
   syn keyword pythonExceptions	FileNotFoundError InterruptedError
   syn keyword pythonExceptions	IsADirectoryError NotADirectoryError
-  syn keyword pythonExceptions	PermissionError ProcessLookupError TimeoutError
+  syn keyword pythonExceptions	PermissionError ProcessLookupError
+  syn keyword pythonExceptions	RecursionError StopAsyncIteration
+  syn keyword pythonExceptions	TimeoutError
+  " builtin exceptions deprecated/removed in Python 3
+  syn keyword pythonExceptions	IOError VMSError WindowsError
   " builtin warnings
   syn keyword pythonExceptions	BytesWarning DeprecationWarning FutureWarning
   syn keyword pythonExceptions	ImportWarning PendingDeprecationWarning
-  syn keyword pythonExceptions	ResourceWarning RuntimeWarning
-  syn keyword pythonExceptions	SyntaxWarning UnicodeWarning
+  syn keyword pythonExceptions	RuntimeWarning SyntaxWarning UnicodeWarning
   syn keyword pythonExceptions	UserWarning Warning
+  " builtin warnings in Python 3
+  syn keyword pythonExceptions	ResourceWarning
 endif
 
 if exists("python_space_error_highlight")

--- a/runtime/syntax/quarto.vim
+++ b/runtime/syntax/quarto.vim
@@ -1,0 +1,17 @@
+" Language: Quarto (Markdown with chunks of R, Python and other languages)
+" Provisory Maintainer: Jakson Aquino <jalvesaq@gmail.com>
+" Homepage: https://github.com/jalvesaq/R-Vim-runtime
+" Last Change: Fri Feb 24, 2023  08:26AM
+"
+" The developers of tools for Quarto maintain Vim runtime files in their
+" Github repository and, if required, I will hand over the maintenance of
+" this script for them.
+
+runtime syntax/rmd.vim
+
+syn match quartoShortarg /\S\+/ contained
+syn keyword quartoShortkey var meta env pagebreak video include contained
+syn region quartoShortcode matchgroup=PreProc start='{{< ' end=' >}}' contains=quartoShortkey,quartoShortarg transparent keepend
+
+hi def link quartoShortkey Include
+hi def link quartoShortarg String

--- a/runtime/syntax/r.vim
+++ b/runtime/syntax/r.vim
@@ -5,7 +5,7 @@
 " 		      Tom Payne <tom@tompayne.org>
 " Contributor:        Johannes Ranke <jranke@uni-bremen.de>
 " Homepage:           https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:	      Sun Mar 28, 2021  01:47PM
+" Last Change:	      Thu Nov 17, 2022  10:13PM
 " Filenames:	      *.R *.r *.Rhistory *.Rt
 "
 " NOTE: The highlighting of R functions might be defined in
@@ -65,41 +65,35 @@ if g:r_syntax_hl_roxygen
   " roxygen line containing only a roxygen comment marker, optionally followed
   " by whitespace is called an empty roxygen line.
 
+  syn match rOCommentKey "^\s*#\{1,2}'" contained
+  syn region rOExamples start="^\s*#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
+  
+  " R6 classes may contain roxygen lines independent of roxygen blocks
+  syn region rOR6Class start=/R6Class(/ end=/)/ transparent contains=ALLBUT,rError,rBraceError,rCurlyError fold
+  syn match rOR6Block "#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
+  syn match rOR6Block "^\s*#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
+
   " First we match all roxygen blocks as containing only a title. In case an
   " empty roxygen line ending the title or a tag is found, this will be
   " overridden later by the definitions of rOBlock.
-  syn match rOTitleBlock "\%^\(\s*#\{1,2}' .*\n\)\{1,}" contains=rOCommentKey,rOTitleTag
-  syn match rOTitleBlock "^\s*\n\(\s*#\{1,2}' .*\n\)\{1,}" contains=rOCommentKey,rOTitleTag
+  syn match rOTitleBlock "\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{1,}" contains=rOCommentKey,rOTitleTag
 
   " A title as part of a block is always at the beginning of the block, i.e.
   " either at the start of a file or after a completely empty line.
-  syn match rOTitle "\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
-  syn match rOTitle "^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
+  syn match rOTitle "\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" contained contains=rOCommentKey,rOTitleTag
   syn match rOTitleTag contained "@title"
 
   " When a roxygen block has a title and additional content, the title
   " consists of one or more roxygen lines (as little as possible are matched),
   " followed either by an empty roxygen line
-  syn region rOBlock start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlock start="\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*$" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
 
   " or by a roxygen tag (we match everything starting with @ but not @@ which is used as escape sequence for a literal @).
-  syn region rOBlock start="\%^\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlock start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlock start="\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{-}\s*#\{1,2}' @\(@\)\@!" end="^\s*\(#\{1,2}'\)\@!" contains=rOTitle,rOTag,rOExamples,@Spell keepend fold
 
   " If a block contains an @rdname, @describeIn tag, it may have paragraph breaks, but does not have a title
-  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="\%^\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-  syn region rOBlockNoTitle start="^\s*\n\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
-
-  syn match rOCommentKey "^\s*#\{1,2}'" contained
-  syn region rOExamples start="^\s*#\{1,2}' @examples.*"rs=e+1,hs=e+1 end="^\(#\{1,2}' @.*\)\@=" end="^\(#\{1,2}'\)\@!" contained contains=rOTag fold
-
-  " R6 classes may contain roxygen lines independent of roxygen blocks
-  syn region rOR6Class start=/R6Class(/ end=/)/ transparent contains=ALLBUT,rError,rBraceError,rCurlyError fold
-  syn match rOR6Block "#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
-  syn match rOR6Block "^\s*#\{1,2}'.*" contains=rOTag,rOExamples,@Spell containedin=rOR6Class contained
+  syn region rOBlockNoTitle start="\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @rdname" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
+  syn region rOBlockNoTitle start="\(\%^\|^\s*\n\)\@<=\(\s*#\{1,2}' .*\n\)\{-1,}\s*#\{1,2}'\s*\n\(\s*#\{1,2}'.*\n\)\{-}\s*#\{1,2}' @describeIn" end="^\s*\(#\{1,2}'\)\@!" contains=rOTag,rOExamples,@Spell keepend fold
 
   " rOTag list originally generated from the lists that were available in
   " https://github.com/klutometis/roxygen/R/rd.R and
@@ -245,14 +239,15 @@ syn match rOperator    "&"
 syn match rOperator    '-'
 syn match rOperator    '\*'
 syn match rOperator    '+'
-if &filetype != "rmd" && &filetype != "rrst"
-  syn match rOperator    "[|!<>^~/:]"
-else
+if &filetype == "quarto" || &filetype == "rmd" || &filetype == "rrst"
   syn match rOperator    "[|!<>^~`/:]"
+else
+  syn match rOperator    "[|!<>^~/:]"
 endif
 syn match rOperator    "%\{2}\|%\S\{-}%"
 syn match rOperator '\([!><]\)\@<=='
 syn match rOperator '=='
+syn match rOperator '|>'
 syn match rOpError  '\*\{3}'
 syn match rOpError  '//'
 syn match rOpError  '&&&'
@@ -318,10 +313,13 @@ if &filetype == "rhelp"
 endif
 
 " Type
+syn match rType "\\"
 syn keyword rType array category character complex double function integer list logical matrix numeric vector data.frame
 
 " Name of object with spaces
-if &filetype != "rmd" && &filetype != "rrst"
+if &filetype == "rmd" || &filetype == "rrst" || &filetype == "quarto"
+  syn region rNameWSpace start="`" end="`" contains=rSpaceFun containedin=rmdrChunk
+else
   syn region rNameWSpace start="`" end="`" contains=rSpaceFun
 endif
 

--- a/runtime/syntax/rmd.vim
+++ b/runtime/syntax/rmd.vim
@@ -1,7 +1,7 @@
-" markdown Text with R statements
-" Language: markdown with R code chunks
+" Language: Markdown with chunks of R, Python and other languages
+" Maintainer: Jakson Aquino <jalvesaq@gmail.com>
 " Homepage: https://github.com/jalvesaq/R-Vim-runtime
-" Last Change: Wed Apr 21, 2021  09:55AM
+" Last Change: Fri Feb 24, 2023  08:28AM
 "
 "   For highlighting pandoc extensions to markdown like citations and TeX and
 "   many other advanced features like folding of markdown sections, it is
@@ -13,63 +13,120 @@ if exists("b:current_syntax")
   finish
 endif
 
+let s:cpo_save = &cpo
+set cpo&vim
+
 " Highlight the header of the chunks as R code
 let g:rmd_syn_hl_chunk = get(g:, 'rmd_syn_hl_chunk', 0)
 
 " Pandoc-syntax has more features, but it is slower.
 " https://github.com/vim-pandoc/vim-pandoc-syntax
-let g:pandoc#syntax#codeblocks#embeds#langs = get(g:, 'pandoc#syntax#codeblocks#embeds#langs', ['r'])
+
+" Don't waste time loading syntax that will be discarded:
+let s:save_pandoc_lngs = get(g:, 'pandoc#syntax#codeblocks#embeds#langs', [])
+let g:pandoc#syntax#codeblocks#embeds#langs = []
+
+" Step_1: Source pandoc.vim if it is installed:
 runtime syntax/pandoc.vim
 if exists("b:current_syntax")
-  " Recognize inline R code
-  syn region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@R containedin=pandocLaTeXRegion,yamlFlowString keepend
-  hi def link rmdInlineDelim Delimiter
-
-  " Fix recognition of language chunks (code adapted from pandoc, 2021-03-28)
-  " Knitr requires braces in the block's header
-  for s:lng in g:pandoc#syntax#codeblocks#embeds#langs
-    let s:nm = matchstr(s:lng, '^[^=]*')
-    exe 'syn clear pandocDelimitedCodeBlock_'.s:nm
-    exe 'syn clear pandocDelimitedCodeBlockinBlockQuote_'.s:nm
-    if g:rmd_syn_hl_chunk
-      exe 'syn region rmd'.s:nm.'ChunkDelim matchgroup=rmdCodeDelim start="^\s*```\s*{\s*'.s:nm.'\>" matchgroup=rmdCodeDelim end="}$" keepend containedin=rmd'.s:nm.'Chunk contains=@R'
-      exe 'syn region rmd'.s:nm.'Chunk start="^\s*```\s*{\s*'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=rmd'.s:nm.'ChunkDelim,@'.toupper(s:nm)
-    else
-      exe 'syn region rmd'.s:nm.'Chunk matchgroup=rmdCodeDelim start="^\s*```\s*{\s*'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=@'.toupper(s:nm)
-    endif
-  endfor
-  unlet s:lng
-  unlet s:nm
-  hi def link rmdInlineDelim Delimiter
-  hi def link rmdCodeDelim Delimiter
-  let b:current_syntax = "rmd"
-  finish
-endif
-
-" Configuration if not using pandoc syntax:
-" Add syntax highlighting of YAML header
-let g:rmd_syn_hl_yaml = get(g:, 'rmd_syn_hl_yaml', 1)
-" Add syntax highlighting of citation keys
-let g:rmd_syn_hl_citations = get(g:, 'rmd_syn_hl_citations', 1)
-
-let s:cpo_save = &cpo
-set cpo&vim
-
-" R chunks will not be highlighted by syntax/markdown because their headers
-" follow a non standard pattern: "```{lang" instead of "^```lang".
-" Make a copy of g:markdown_fenced_languages to highlight the chunks later:
-if exists('g:markdown_fenced_languages')
-  if !exists('g:rmd_fenced_languages')
-    let g:rmd_fenced_languages = deepcopy(g:markdown_fenced_languages)
-    let g:markdown_fenced_languages = []
+  if hlexists('pandocDelimitedCodeBlock')
+    syn clear pandocDelimitedCodeBlock
   endif
+
+  if len(s:save_pandoc_lngs) > 0 && !exists('g:rmd_fenced_languages')
+    let g:rmd_fenced_languages = deepcopy(s:save_pandoc_lngs)
+  endif
+
+  " Recognize inline R code
+  syn region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@Rmdr containedin=pandocLaTeXRegion,yamlFlowString keepend
 else
-  let g:rmd_fenced_languages = ['r']
+  " Step_2: Source markdown.vim if pandoc.vim is not installed
+
+  " Configuration if not using pandoc syntax:
+  " Add syntax highlighting of YAML header
+  let g:rmd_syn_hl_yaml = get(g:, 'rmd_syn_hl_yaml', 1)
+  " Add syntax highlighting of citation keys
+  let g:rmd_syn_hl_citations = get(g:, 'rmd_syn_hl_citations', 1)
+
+  " R chunks will not be highlighted by syntax/markdown because their headers
+  " follow a non standard pattern: "```{lang" instead of "^```lang".
+  " Make a copy of g:markdown_fenced_languages to highlight the chunks later:
+  if exists('g:markdown_fenced_languages') && !exists('g:rmd_fenced_languages')
+    let g:rmd_fenced_languages = deepcopy(g:markdown_fenced_languages)
+  endif
+
+  if exists('g:markdown_fenced_languages') && len(g:markdown_fenced_languages) > 0
+    let s:save_mfl = deepcopy(g:markdown_fenced_languages)
+  endif
+  " Don't waste time loading syntax that will be discarded:
+  let g:markdown_fenced_languages = []
+  runtime syntax/markdown.vim
+  if exists('s:save_mfl') > 0
+    let g:markdown_fenced_languages = deepcopy(s:save_mfl)
+    unlet s:save_mfl
+  endif
+  syn region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@Rmdr keepend
+
+  " Step_2a: Add highlighting for both YAML and citations which are pandoc
+  " specific, but also used in Rmd files
+
+  " You don't need this if either your markdown/syntax.vim already highlights
+  " the YAML header or you are writing standard markdown
+  if g:rmd_syn_hl_yaml
+    " Basic highlighting of YAML header
+    syn match rmdYamlFieldTtl /^\s*\zs\w\%(-\|\w\)*\ze:/ contained
+    syn match rmdYamlFieldTtl /^\s*-\s*\zs\w\%(-\|\w\)*\ze:/ contained
+    syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start='"' skip='\\"' end='"' contains=yamlEscape,rmdrInline contained
+    syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start="'" skip="''"  end="'" contains=yamlSingleEscape,rmdrInline contained
+    syn match  yamlEscape contained '\\\%([\\"abefnrtv\^0_ NLP\n]\|x\x\x\|u\x\{4}\|U\x\{8}\)'
+    syn match  yamlSingleEscape contained "''"
+    syn match yamlComment /#.*/ contained
+    " A second colon is a syntax error, unles within a string or following !expr
+    syn match yamlColonError /:\s*[^'^"^!]*:/ contained
+    if &filetype == 'quarto'
+      syn region pandocYAMLHeader matchgroup=rmdYamlBlockDelim start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^---$/ keepend contains=rmdYamlFieldTtl,yamlFlowString,yamlComment,yamlColonError
+    else
+      syn region pandocYAMLHeader matchgroup=rmdYamlBlockDelim start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ keepend contains=rmdYamlFieldTtl,yamlFlowString,yamlComment,yamlColonError
+    endif
+    hi def link rmdYamlBlockDelim Delimiter
+    hi def link rmdYamlFieldTtl Identifier
+    hi def link yamlFlowString String
+    hi def link yamlComment Comment
+    hi def link yamlColonError Error
+  endif
+
+  " You don't need this if either your markdown/syntax.vim already highlights
+  " citations or you are writing standard markdown
+  if g:rmd_syn_hl_citations
+    " From vim-pandoc-syntax
+    " parenthetical citations
+    syn match pandocPCite /\^\@<!\[[^\[\]]\{-}-\{0,1}@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*.\{-}\]/ contains=pandocEmphasis,pandocStrong,pandocLatex,pandocCiteKey,@Spell,pandocAmpersandEscape display
+    " in-text citations with location
+    syn match pandocICite /@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*\s\[.\{-1,}\]/ contains=pandocCiteKey,@Spell display
+    " cite keys
+    syn match pandocCiteKey /\(-\=@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*\)/ containedin=pandocPCite,pandocICite contains=@NoSpell display
+    syn match pandocCiteAnchor /[-@]/ contained containedin=pandocCiteKey display
+    syn match pandocCiteLocator /[\[\]]/ contained containedin=pandocPCite,pandocICite
+    hi def link pandocPCite Operator
+    hi def link pandocICite Operator
+    hi def link pandocCiteKey Label
+    hi def link pandocCiteAnchor Operator
+    hi def link pandocCiteLocator Operator
+  endif
 endif
 
-runtime syntax/markdown.vim
+" Step_3: Highlight code blocks.
+
+syn region rmdCodeBlock matchgroup=rmdCodeDelim start="^\s*```\s*{.*}$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend
+syn region rmdCodeBlock matchgroup=rmdCodeDelim start="^\s*```.+$" matchgroup=rmdCodeDelim end="^```$" keepend
+hi link rmdCodeBlock Special
 
 " Now highlight chunks:
+syn region knitrBodyOptions start='^#| ' end='$' contained  containedin=rComment,pythonComment contains=knitrBodyVar,knitrBodyValue transparent
+syn match knitrBodyValue ': \zs.*\ze$' keepend contained containedin=knitrBodyOptions
+syn match knitrBodyVar '| \zs\S\{-}\ze:' contained containedin=knitrBodyOptions
+
+let g:rmd_fenced_languages = get(g:, 'rmd_fenced_languages', ['r'])
 for s:type in g:rmd_fenced_languages
   if s:type =~ '='
     let s:ft = substitute(s:type, '.*=', '', '')
@@ -81,58 +138,40 @@ for s:type in g:rmd_fenced_languages
   unlet! b:current_syntax
   exe 'syn include @Rmd'.s:nm.' syntax/'.s:ft.'.vim'
   if g:rmd_syn_hl_chunk
-    exe 'syn region rmd'.s:nm.'ChunkDelim matchgroup=rmdCodeDelim start="^\s*```\s*{\s*'.s:nm.'\>" matchgroup=rmdCodeDelim end="}$" keepend containedin=rmd'.s:nm.'Chunk contains=@Rmdr'
-    exe 'syn region rmd'.s:nm.'Chunk start="^\s*```\s*{\s*'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=rmd'.s:nm.'ChunkDelim,@Rmd'.s:nm
+    exe 'syn match knitrChunkDelim /```\s*{\s*'.s:nm.'/ contained containedin=knitrChunkBrace contains=knitrChunkLabel'
+    exe 'syn match knitrChunkLabelDelim /```\s*{\s*'.s:nm.',\=\s*[-[:alnum:]]\{-1,}[,}]/ contained containedin=knitrChunkBrace'
+    syn match knitrChunkDelim /}\s*$/ contained containedin=knitrChunkBrace
+    exe 'syn match knitrChunkBrace /```\s*{\s*'.s:nm.'.*$/ contained containedin=rmd'.s:nm.'Chunk contains=knitrChunkDelim,knitrChunkLabelDelim,@Rmd'.s:nm
+    exe 'syn region rmd'.s:nm.'Chunk start="^\s*```\s*{\s*=\?'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=knitrChunkBrace,@Rmd'.s:nm
+
+    hi link knitrChunkLabel Identifier
+    hi link knitrChunkDelim rmdCodeDelim
+    hi link knitrChunkLabelDelim rmdCodeDelim
   else
-    exe 'syn region rmd'.s:nm.'Chunk matchgroup=rmdCodeDelim start="^\s*```\s*{\s*'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=@Rmd'.s:nm
+    exe 'syn region rmd'.s:nm.'Chunk matchgroup=rmdCodeDelim start="^\s*```\s*{\s*=\?'.s:nm.'\>.*$" matchgroup=rmdCodeDelim end="^\s*```\ze\s*$" keepend contains=@Rmd'.s:nm
   endif
 endfor
 unlet! s:type
 
-" Recognize inline R code
-syn region rmdrInline matchgroup=rmdInlineDelim start="`r "  end="`" contains=@Rmdr keepend
+" Step_4: Highlight code recognized by pandoc but not defined in pandoc.vim yet:
+syn match pandocDivBegin '^:::\+ {.\{-}}' contains=pandocHeaderAttr
+syn match pandocDivEnd '^:::\+$'
 
+hi def link knitrBodyVar PreProc
+hi def link knitrBodyValue Constant
+hi def link knitrBodyOptions rComment
+hi def link pandocDivBegin Delimiter
+hi def link pandocDivEnd Delimiter
 hi def link rmdInlineDelim Delimiter
 hi def link rmdCodeDelim Delimiter
 
-" You don't need this if either your markdown/syntax.vim already highlights
-" the YAML header or you are writing standard markdown
-if g:rmd_syn_hl_yaml
-  " Minimum highlighting of yaml header
-  syn match rmdYamlFieldTtl /^\s*\zs\w*\ze:/ contained
-  syn match rmdYamlFieldTtl /^\s*-\s*\zs\w*\ze:/ contained
-  syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start='"' skip='\\"' end='"' contains=yamlEscape,rmdrInline contained
-  syn region yamlFlowString matchgroup=yamlFlowStringDelimiter start="'" skip="''"  end="'" contains=yamlSingleEscape,rmdrInline contained
-  syn match  yamlEscape contained '\\\%([\\"abefnrtv\^0_ NLP\n]\|x\x\x\|u\x\{4}\|U\x\{8}\)'
-  syn match  yamlSingleEscape contained "''"
-  syn region pandocYAMLHeader matchgroup=rmdYamlBlockDelim start=/\%(\%^\|\_^\s*\n\)\@<=\_^-\{3}\ze\n.\+/ end=/^\([-.]\)\1\{2}$/ keepend contains=rmdYamlFieldTtl,yamlFlowString
-  hi def link rmdYamlBlockDelim Delimiter
-  hi def link rmdYamlFieldTtl Identifier
-  hi def link yamlFlowString String
+if len(s:save_pandoc_lngs)
+  let g:pandoc#syntax#codeblocks#embeds#langs = s:save_pandoc_lngs
 endif
-
-" You don't need this if either your markdown/syntax.vim already highlights
-" citations or you are writing standard markdown
-if g:rmd_syn_hl_citations
-  " From vim-pandoc-syntax
-  " parenthetical citations
-  syn match pandocPCite /\^\@<!\[[^\[\]]\{-}-\{0,1}@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*.\{-}\]/ contains=pandocEmphasis,pandocStrong,pandocLatex,pandocCiteKey,@Spell,pandocAmpersandEscape display
-  " in-text citations with location
-  syn match pandocICite /@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*\s\[.\{-1,}\]/ contains=pandocCiteKey,@Spell display
-  " cite keys
-  syn match pandocCiteKey /\(-\=@[[:alnum:]_][[:alnum:]à-öø-ÿÀ-ÖØ-ß_:.#$%&\-+?<>~\/]*\)/ containedin=pandocPCite,pandocICite contains=@NoSpell display
-  syn match pandocCiteAnchor /[-@]/ contained containedin=pandocCiteKey display
-  syn match pandocCiteLocator /[\[\]]/ contained containedin=pandocPCite,pandocICite
-  hi def link pandocPCite Operator
-  hi def link pandocICite Operator
-  hi def link pandocCiteKey Label
-  hi def link pandocCiteAnchor Operator
-  hi def link pandocCiteLocator Operator
-endif
-
-let b:current_syntax = "rmd"
-
+unlet s:save_pandoc_lngs
 let &cpo = s:cpo_save
 unlet s:cpo_save
+
+let b:current_syntax = "rmd"
 
 " vim: ts=8 sw=2

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -2,8 +2,8 @@
 " Language:		shell (sh) Korn shell (ksh) bash (sh)
 " Maintainer:		Charles E. Campbell <NcampObell@SdrPchip.AorgM-NOSPAM>
 " Previous Maintainer:	Lennart Schultz <Lennart.Schultz@ecmwf.int>
-" Last Change:		Dec 20, 2022
-" Version:		205
+" Last Change:		Feb 11, 2023
+" Version:		207
 " URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
 " This file includes many ideas from Eric Brunet (eric.brunet@ens.fr) and heredoc fixes from Felipe Contreras
@@ -166,7 +166,7 @@ if exists("b:is_kornshell") || exists("b:is_bash")
  syn cluster shLoopoList	add=shForPP
 endif
 syn cluster shPPSLeftList	contains=shAlias,shArithmetic,shCmdParenRegion,shCommandSub,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shEcho,shEscape,shExDoubleQuote,shExpr,shExSingleQuote,shHereDoc,shNumber,shOperator,shOption,shPosnParm,shHereString,shRedir,shSingleQuote,shSpecial,shStatement,shSubSh,shTest,shVariable
-syn cluster shPPSRightList	contains=shComment,shDeref,shDerefSimple,shEscape,shPosnParm
+syn cluster shPPSRightList	contains=shDeref,shDerefSimple,shEscape,shPosnParm
 syn cluster shSubShList	contains=@shCommandSubList,shCommandSubBQ,shCaseEsac,shColon,shCommandSub,shComment,shDo,shEcho,shExpr,shFor,shIf,shHereString,shRedir,shSetList,shSource,shStatement,shVariable,shCtrlSeq,shOperator
 syn cluster shTestList	contains=shArithmetic,shCharClass,shCommandSub,shCommandSubBQ,shCtrlSeq,shDeref,shDerefSimple,shDoubleQuote,shSpecialDQ,shExDoubleQuote,shExpr,shExSingleQuote,shNumber,shOperator,shSingleQuote,shTest,shTestOpr
 syn cluster shNoZSList	contains=shSpecialNoZS
@@ -335,7 +335,7 @@ syn match   shEscape	contained	'\%(^\)\@!\%(\\\\\)*\\.'	nextgroup=shComment
 " systems too, however, so the following syntax will flag $(..) as
 " an Error under /bin/sh.  By consensus of vimdev'ers!
 if exists("b:is_kornshell") || exists("b:is_bash") || exists("b:is_posix")
- syn region shCommandSub matchgroup=shCmdSubRegion start="\$(\ze[^(]\|$"  skip='\\\\\|\\.' end=")"  contains=@shCommandSubList
+ syn region shCommandSub matchgroup=shCmdSubRegion start="\$(\ze[^(]"  skip='\\\\\|\\.' end=")"  contains=@shCommandSubList
  syn region shArithmetic matchgroup=shArithRegion  start="\$((" skip='\\\\\|\\.' end="))" contains=@shArithList
  syn region shArithmetic matchgroup=shArithRegion  start="\$\[" skip='\\\\\|\\.' end="\]" contains=@shArithList
  syn match  shSkipInitWS contained	"^\s\+"
@@ -503,7 +503,6 @@ endif
 " ksh: ${.sh.*} variables: {{{1
 " ========================================
 if exists("b:is_kornshell")
-" syn match  shDerefVar	contained	"[.]*"	nextgroup=@shDerefVarList
  syn match  shDerefVar	contained	"\.\+"	nextgroup=@shDerefVarList
 endif
 
@@ -548,6 +547,7 @@ syn region  shDerefVarArray   contained	matchgroup=shDeref start="\[" end="]"	co
 "        bash : ${parameter,pattern}  Case modification
 "        bash : ${parameter,,pattern} Case modification
 "        bash : ${@:start:qty}        display command line arguments from start to start+qty-1 (inferred)
+"        bash : ${parameter@operator} transforms parameter (operator∈[uULqEPARa])
 syn cluster shDerefPatternList	contains=shDerefPattern,shDerefString
 if !exists("g:sh_no_error")
  syn match shDerefOpError	contained	":[[:punct:]]"
@@ -563,6 +563,7 @@ if exists("b:is_bash") || exists("b:is_kornshell") || exists("b:is_posix")
 endif
 if exists("b:is_bash")
  syn match  shDerefOp	contained	"[,^]\{1,2}"	nextgroup=@shDerefPatternList
+ syn match  shDerefOp	contained	"@[uULQEPAKa]"
 endif
 syn region shDerefString	contained	matchgroup=shDerefDelim start=+\%(\\\)\@<!'+ end=+'+	contains=shStringSpecial
 syn region shDerefString	contained	matchgroup=shDerefDelim start=+\%(\\\)\@<!"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial


### PR DESCRIPTION
Update runtime files

https://github.com/vim/vim/commit/dd60c365cd2630794be84d63c4fe287124a30b97

Co-authored-by: Bram Moolenaar <Bram@vim.org>

Skip: eval.txt, repeat.txt (needs `getscriptinfo()`)
