### PR TITLE
vim-patch:9.0.1360: Cue files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -276,6 +276,7 @@ local extension = {
   feature = 'cucumber',
   cuh = 'cuda',
   cu = 'cuda',
+  cue = 'cue',
   pld = 'cupl',
   si = 'cuplsim',
   cyn = 'cynpp',

--- a/src/nvim/testdir/test_filetype.vim
+++ b/src/nvim/testdir/test_filetype.vim
@@ -140,6 +140,7 @@ let s:filename_checks = {
     \ 'csv': ['file.csv'],
     \ 'cucumber': ['file.feature'],
     \ 'cuda': ['file.cu', 'file.cuh'],
+    \ 'cue': ['file.cue'],
     \ 'cupl': ['file.pld'],
     \ 'cuplsim': ['file.si'],
     \ 'cvs': ['cvs123'],


### PR DESCRIPTION
Problem:    Cue files are not recognized.
Solution:   Add patterns for Cue files. (Amaan Qureshi, closes vim/vim#12067)

https://github.com/vim/vim/commit/80c5b2c0f78b24e52c73bb162dda3ad85acd7e82