### PR TITLE
fix(diff): adjust extmarks after diffput/diffget

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -31,6 +31,7 @@
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/extmark.h"
 #include "nvim/extmark_defs.h"
 #include "nvim/fileio.h"
 #include "nvim/fold.h"
@@ -3102,6 +3103,9 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
         if (buf_empty && (curbuf->b_ml.ml_line_count == 2)) {
           // Added the first line into an empty buffer, need to
           // delete the dummy empty line.
+          // This has a side effect of incrementing curbuf->deleted_bytes,
+          // which results in inaccurate reporting of the byte count of
+          // previous contents in buffer-update events.
           buf_empty = false;
           ml_delete((linenr_T)2, false);
         }
@@ -3143,6 +3147,7 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
           }
         }
       }
+      extmark_adjust(curbuf, lnum, lnum + count - 1, (long)MAXLNUM, added, kExtmarkUndo);
       changed_lines(lnum, 0, lnum + count, added, true);
 
       if (did_free) {


### PR DESCRIPTION
Problem: on_bytes is not triggered by diffput/diffget if the line count does not change.

## Demonstration of the problem
```
nvim --clean
```
```vim
call setline(1, 'a')
new
call setline(1, 'b')
lua vim.api.nvim_buf_attach(0, false, {on_lines = function(t, _, _, ...) vim.pretty_print(t, ...) end})
lua vim.api.nvim_buf_attach(0, false, {on_bytes = function(t, _, _, ...) vim.pretty_print(t, ...) end})
windo diffthis
wincmd p
diffget
```

### Expected behavior
It should print something like this
(for example, replace `diffget` with `call setline(1, 'a')` in the above script.).
```
"bytes"    0    0    0    0    1    1    0    1    1
"lines"    0    1    1    2
```

### Actual behavior (without this patch, on current master f64098a2df774c79dd454f63ac491570cdcaf2b2)
```
"lines"    0    1    1    3
```

* (critical) `on_byte` is not triggered.
    * Note that this may break treesitter sync-ing.
      Example:
      ```vim
      call setline(1, 'function fun() end')
      new
      call setline(1, 'unction fun() end')
      setf lua
      lua vim.treesitter.start()
      windo diffthis
      wincmd p
      diffget
      ```
      ![image](https://user-images.githubusercontent.com/19489738/221644674-c00dc512-a307-4be7-9873-71d958ae38ea.png)

* (minor) "byte count of previous contents" is 3, instead of 2.


### Behavior with this patch:
```
"bytes"    0    0    0    1    0    3    1    0    2
"lines"    0    1    1    3
```
* `on_byte` is triggered.
    * treesitter sync works as expected.
      ![image](https://user-images.githubusercontent.com/19489738/221644972-7b23c3e3-eb9d-4cb0-ae5d-8a21d116dc33.png)

* "byte count of previous contents" is still 3.
  The patch adds a comment on why this happens.
  I believe this isn't really a critical issue, so I didn't try to fix it.
