### PR TITLE
ci: build all build types on each PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,26 +114,3 @@ jobs:
         run: |
           cmake -B build -G Ninja
           cmake --build build
-
-  multi-config:
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        run: ./.github/scripts/install_deps.sh
-
-      - name: Build third-party deps
-        run: |
-          cmake -S cmake.deps -B .deps -G "Ninja Multi-Config"
-          cmake --build .deps
-
-      - name: Configure
-        run: cmake -B build -G "Ninja Multi-Config" -D CMAKE_C_COMPILER=gcc
-
-      - name: Release
-        run: cmake --build build --config Release
-
-      - name: MinSizeRel
-        run: cmake --build build --config MinSizeRel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -294,6 +294,34 @@ jobs:
           echo 'Core dumps found'
           exit 1
 
+  build-types:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: ./.github/scripts/install_deps.sh
+
+      - uses: ./.github/actions/cache
+
+      - name: Build third-party deps
+        run: |
+          cmake -S cmake.deps -B $DEPS_BUILD_DIR -G "Ninja Multi-Config"
+          cmake --build $DEPS_BUILD_DIR
+
+      - name: Configure
+        run: cmake -B build -G "Ninja Multi-Config" -D CMAKE_C_COMPILER=gcc
+
+      - name: Release
+        run: cmake --build build --config Release
+
+      - name: RelWithDebInfo
+        run: cmake --build build --config RelWithDebInfo
+
+      - name: MinSizeRel
+        run: cmake --build build --config MinSizeRel
+
   windows:
     runs-on: windows-2019
     timeout-minutes: 45


### PR DESCRIPTION
Building with Release and RelWithDebInfo build types only on build
system changes is too optimistic, as shown by
https://github.com/neovim/neovim/pull/22436 and
659234c95a23307486a4b7496f3f4391a4bdbe58.
