### PR TITLE
vim-patch:9.0.1362: ml_get error when going to another tab

### DIFF
--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -846,4 +846,19 @@ func Test_lastused_tabpage()
   tabonly!
 endfunc
 
+" this was giving ml_get errors
+func Test_tabpage_last_line()
+  enew
+  call setline(1, repeat(['a'], &lines + 5))
+  $
+  tabnew
+  call setline(1, repeat(['b'], &lines + 20))
+  $
+  tabNext
+  call assert_equal('a', getline('.'))
+
+  bwipe!
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4813,7 +4813,7 @@ static void win_enter_ext(win_T *const wp, const int flags)
 
   // Might need to scroll the old window before switching, e.g., when the
   // cursor was moved.
-  if (*p_spk == 'c') {
+  if (*p_spk == 'c' && !curwin_invalid) {
     update_topline(curwin);
   }
 


### PR DESCRIPTION
#### vim-patch:9.0.1362: ml_get error when going to another tab

Problem:    ml_get error when going to another tab. (Daniel J. Perry)
Solution:   Do not call update_topline() if "curwin" is invalid.

https://github.com/vim/vim/commit/99ad3a8bb95c6f860545a050472b6181e33bac1a

Co-authored-by: Bram Moolenaar <Bram@vim.org>