### PR TITLE
fix(column): cmdwin cursor is offset with 'statuscolumn'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1199,7 +1199,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
     statuscol.draw = true;
     statuscol.sattrs = sattrs;
     statuscol.foldinfo = foldinfo;
-    statuscol.width = win_col_off(wp);
+    statuscol.width = win_col_off(wp) - (cmdwin_type != 0 && wp == curwin);
     statuscol.use_cul = use_cursor_line_sign(wp, lnum);
     statuscol.sign_cul_attr = statuscol.use_cul ? sign_cul_attr : 0;
     statuscol.num_attr = sign_num_attr ? sign_num_attr

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -478,4 +478,24 @@ describe('statuscolumn', function()
                                                            |
     ]])
   end)
+
+  it('works with cmdwin', function()
+    feed(':set stc=%l<CR>q:k$')
+    screen:expect([[
+      7 aaaaa                                              |
+      8 aaaaa                                              |
+      9 aaaaa                                              |
+      10aaaaa                                              |
+      [No Name] [+]                                        |
+      :1set stc=%^l                                         |
+      :2                                                   |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      ~                                                    |
+      [Command Line]                                       |
+      :                                                    |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem description: https://github.com/luukvbaal/statuscol.nvim/issues/24