### PR TITLE
vim-patch:8.2.{2757,2765,2767}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1498,21 +1498,14 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
       tv_clear(&var1);
 
       const int bloblen = tv_blob_len(lp->ll_tv->vval.v_blob);
-      if (lp->ll_n1 < 0 || lp->ll_n1 > bloblen
-          || (lp->ll_range && lp->ll_n1 == bloblen)) {
-        if (!quiet) {
-          semsg(_(e_blobidx), (int64_t)lp->ll_n1);
-        }
+      if (tv_blob_check_index(bloblen, lp->ll_n1, lp->ll_range, quiet) == FAIL) {
         tv_clear(&var2);
         return NULL;
       }
       if (lp->ll_range && !lp->ll_empty2) {
         lp->ll_n2 = (long)tv_get_number(&var2);
         tv_clear(&var2);
-        if (lp->ll_n2 < 0 || lp->ll_n2 >= bloblen || lp->ll_n2 < lp->ll_n1) {
-          if (!quiet) {
-            semsg(_(e_blobidx), (int64_t)lp->ll_n2);
-          }
+        if (tv_blob_check_range(bloblen, lp->ll_n1, lp->ll_n2, quiet) == FAIL) {
           return NULL;
         }
       }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1498,7 +1498,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
       tv_clear(&var1);
 
       const int bloblen = tv_blob_len(lp->ll_tv->vval.v_blob);
-      if (tv_blob_check_index(bloblen, lp->ll_n1, lp->ll_range, quiet) == FAIL) {
+      if (tv_blob_check_index(bloblen, lp->ll_n1, quiet) == FAIL) {
         tv_clear(&var2);
         return NULL;
       }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1620,16 +1620,8 @@ void set_var_lval(lval_T *lp, char *endp, typval_T *rettv, int copy, const bool 
           lp->ll_n2 = tv_blob_len(lp->ll_blob) - 1;
         }
 
-        if (lp->ll_n2 - lp->ll_n1 + 1 != tv_blob_len(rettv->vval.v_blob)) {
-          emsg(_("E972: Blob value does not have the right number of bytes"));
+        if (tv_blob_set_range(lp->ll_blob, lp->ll_n1, lp->ll_n2, rettv) == FAIL) {
           return;
-        }
-        if (lp->ll_empty2) {
-          lp->ll_n2 = tv_blob_len(lp->ll_blob);
-        }
-
-        for (int il = (int)lp->ll_n1, ir = 0; il <= (int)lp->ll_n2; il++) {
-          tv_blob_set(lp->ll_blob, il, tv_blob_get(rettv->vval.v_blob, ir++));
         }
       } else {
         bool error = false;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2710,6 +2710,30 @@ bool tv_blob_equal(const blob_T *const b1, const blob_T *const b2)
   return true;
 }
 
+/// Check if "n1" is a valid index for a blob with length "bloblen".
+int tv_blob_check_index(int bloblen, varnumber_T n1, int is_range, bool quiet)
+{
+  if (n1 < 0 || n1 > bloblen) {
+    if (!quiet) {
+      semsg(_(e_blobidx), n1);
+    }
+    return FAIL;
+  }
+  return OK;
+}
+
+/// Check if "n1"-"n2" is a valid range for a blob with length "bloblen".
+int tv_blob_check_range(int bloblen, varnumber_T n1, varnumber_T n2, bool quiet)
+{
+  if (n2 < 0 || n2 >= bloblen || n2 < n1) {
+    if (!quiet) {
+      semsg(_(e_blobidx), n2);
+    }
+    return FAIL;
+  }
+  return OK;
+}
+
 /// Set bytes "n1" to "n2" (inclusive) in "dest" to the value of "src".
 /// Caller must make sure "src" is a blob.
 /// Returns FAIL if the number of bytes does not match.

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2710,6 +2710,22 @@ bool tv_blob_equal(const blob_T *const b1, const blob_T *const b2)
   return true;
 }
 
+/// Set bytes "n1" to "n2" (inclusive) in "dest" to the value of "src".
+/// Caller must make sure "src" is a blob.
+/// Returns FAIL if the number of bytes does not match.
+int tv_blob_set_range(blob_T *dest, long n1, long n2, typval_T *src)
+{
+  if (n2 - n1 + 1 != tv_blob_len(src->vval.v_blob)) {
+    emsg(_("E972: Blob value does not have the right number of bytes"));
+    return FAIL;
+  }
+
+  for (int il = (int)n1, ir = 0; il <= (int)n2; il++) {
+    tv_blob_set(dest, il, tv_blob_get(src->vval.v_blob, ir++));
+  }
+  return OK;
+}
+
 /// "remove({blob})" function
 void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
 {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2711,7 +2711,7 @@ bool tv_blob_equal(const blob_T *const b1, const blob_T *const b2)
 }
 
 /// Check if "n1" is a valid index for a blob with length "bloblen".
-int tv_blob_check_index(int bloblen, varnumber_T n1, int is_range, bool quiet)
+int tv_blob_check_index(int bloblen, varnumber_T n1, bool quiet)
 {
   if (n1 < 0 || n1 > bloblen) {
     if (!quiet) {

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -76,16 +76,47 @@ func Test_blob_assign()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  " TODO: move to above once it works
-  let b = 0zDEADBEEF
-  call assert_fails('let b[2 : 3] = 0z112233', 'E972:')
-  call assert_fails('let b[2 : 3] = 0z11', 'E972:')
-  call assert_fails('let b[3 : 2] = 0z', 'E979:')
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b[2 : 3] = 0z112233
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E972:')
 
-  call assert_fails('let b ..= 0z33', 'E734:')
-  call assert_fails('let b ..= "xx"', 'E734:')
-  call assert_fails('let b += "xx"', 'E734:')
-  call assert_fails('let b[1 : 1] ..= 0z55', 'E734:')
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b[2 : 3] = 0z11
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E972:')
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b[3 : 2] = 0z
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E979:')
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b ..= 0z33
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E734:', 'E1019:', 'E734:'])
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b ..= "xx"
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E734:', 'E1019:', 'E734:'])
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b += "xx"
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E734:', 'E1012:', 'E734:'])
+
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      LET b[1 : 1] ..= 0z55
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E734:', 'E1183:', 'E734:'])
 endfunc
 
 func Test_blob_get_range()

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -1,5 +1,7 @@
 " Tests for the Blob types
 
+source vim9.vim
+
 func TearDown()
   " Run garbage collection after every test
   call test_garbagecollect_now()
@@ -9,73 +11,81 @@ endfunc
 
 " Blob creation from constant
 func Test_blob_create()
-  let b = 0zDEADBEEF
-  call assert_equal(v:t_blob, type(b))
-  call assert_equal(4, len(b))
-  call assert_equal(0xDE, b[0])
-  call assert_equal(0xAD, b[1])
-  call assert_equal(0xBE, b[2])
-  call assert_equal(0xEF, b[3])
-  call assert_fails('let x = b[4]')
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      call assert_equal(v:t_blob, type(b))
+      call assert_equal(4, len(b))
+      call assert_equal(0xDE, b[0])
+      call assert_equal(0xAD, b[1])
+      call assert_equal(0xBE, b[2])
+      call assert_equal(0xEF, b[3])
+      call assert_fails('VAR x = b[4]')
 
-  call assert_equal(0xDE, get(b, 0))
-  call assert_equal(0xEF, get(b, 3))
+      call assert_equal(0xDE, get(b, 0))
+      call assert_equal(0xEF, get(b, 3))
 
-  call assert_fails('let b = 0z1', 'E973:')
-  call assert_fails('let b = 0z1x', 'E973:')
-  call assert_fails('let b = 0z12345', 'E973:')
+      call assert_fails('VAR b = 0z1', 'E973:')
+      call assert_fails('VAR b = 0z1x', 'E973:')
+      call assert_fails('VAR b = 0z12345', 'E973:')
 
-  call assert_equal(0z, v:_null_blob)
+      call assert_equal(0z, v:_null_blob)
 
-  let b = 0z001122.33445566.778899.aabbcc.dd
-  call assert_equal(0z00112233445566778899aabbccdd, b)
-  call assert_fails('let b = 0z1.1')
-  call assert_fails('let b = 0z.')
-  call assert_fails('let b = 0z001122.')
-  call assert_fails('call get("", 1)', 'E896:')
-  call assert_equal(0, len(v:_null_blob))
+      LET b = 0z001122.33445566.778899.aabbcc.dd
+      call assert_equal(0z00112233445566778899aabbccdd, b)
+      call assert_fails('VAR b = 0z1.1')
+      call assert_fails('VAR b = 0z.')
+      call assert_fails('VAR b = 0z001122.')
+      call assert_fails('call get("", 1)', 'E896:')
+      call assert_equal(0, len(v:_null_blob))
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " assignment to a blob
 func Test_blob_assign()
+  let lines =<< trim END
+      VAR b = 0zDEADBEEF
+      VAR b2 = b[1 : 2]
+      call assert_equal(0zADBE, b2)
+
+      VAR bcopy = b[:]
+      call assert_equal(b, bcopy)
+      call assert_false(b is bcopy)
+
+      LET b = 0zDEADBEEF
+      LET b2 = b
+      call assert_true(b is b2)
+      LET b[:] = 0z11223344
+      call assert_equal(0z11223344, b)
+      call assert_equal(0z11223344, b2)
+      call assert_true(b is b2)
+
+      LET b = 0zDEADBEEF
+      LET b[3 :] = 0z66
+      call assert_equal(0zDEADBE66, b)
+      LET b[: 1] = 0z8899
+      call assert_equal(0z8899BE66, b)
+
+      LET b = 0zDEADBEEF
+      LET b += 0z99
+      call assert_equal(0zDEADBEEF99, b)
+
+      VAR l = [0z12]
+      VAR m = deepcopy(l)
+      LET m[0] = 0z34	#" E742 or E741 should not occur.
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  " TODO: move to above once it works
   let b = 0zDEADBEEF
-  let b2 = b[1:2]
-  call assert_equal(0zADBE, b2)
+  call assert_fails('let b[2 : 3] = 0z112233', 'E972:')
+  call assert_fails('let b[2 : 3] = 0z11', 'E972:')
+  call assert_fails('let b[3 : 2] = 0z', 'E979:')
 
-  let bcopy = b[:]
-  call assert_equal(b, bcopy)
-  call assert_false(b is bcopy)
-
-  let b = 0zDEADBEEF
-  let b2 = b
-  call assert_true(b is b2)
-  let b[:] = 0z11223344
-  call assert_equal(0z11223344, b)
-  call assert_equal(0z11223344, b2)
-  call assert_true(b is b2)
-
-  let b = 0zDEADBEEF
-  let b[3:] = 0z66
-  call assert_equal(0zDEADBE66, b)
-  let b[:1] = 0z8899
-  call assert_equal(0z8899BE66, b)
-
-  call assert_fails('let b[2:3] = 0z112233', 'E972:')
-  call assert_fails('let b[2:3] = 0z11', 'E972:')
-  call assert_fails('let b[3:2] = 0z', 'E979:')
-
-  let b = 0zDEADBEEF
-  let b += 0z99
-  call assert_equal(0zDEADBEEF99, b)
-
-  call assert_fails('let b .= 0z33', 'E734:')
-  call assert_fails('let b .= "xx"', 'E734:')
+  call assert_fails('let b ..= 0z33', 'E734:')
+  call assert_fails('let b ..= "xx"', 'E734:')
   call assert_fails('let b += "xx"', 'E734:')
-  call assert_fails('let b[1:1] .= 0z55', 'E734:')
-
-  let l = [0z12]
-  let m = deepcopy(l)
-  let m[0] = 0z34	" E742 or E741 should not occur.
+  call assert_fails('let b[1 : 1] ..= 0z55', 'E734:')
 endfunc
 
 func Test_blob_get_range()

--- a/src/nvim/testdir/vim9.vim
+++ b/src/nvim/testdir/vim9.vim
@@ -98,9 +98,9 @@ endfunc
 " Use ' #"' for a comment
 func CheckLegacyAndVim9Failure(lines, error)
   if type(a:error) == type('string')
-    let legacyError = error
+    let legacyError = a:error
   else
-    let legacyError = error[0]
+    let legacyError = a:error[0]
   endif
 
   let legacylines = a:lines->deepcopy()->map({_, v ->


### PR DESCRIPTION
#### vim-patch:8.2.2757: Vim9: blob tests for legacy and Vim9 script are separate

Problem:    Vim9: blob tests for legacy and Vim9 script are separate.
Solution:   Add CheckLegacyAndVim9Success().  Make blob index assign work.

https://github.com/vim/vim/commit/68452177ca4cda4a9d5f93892e437447cf9404c8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2765: Vim9: not all blob operations work

Problem:    Vim9: not all blob operations work.
Solution:   Run more tests also with Vim9 script and :def functions.  Fix what
            doesn't work.

https://github.com/vim/vim/commit/0e3ff1919603ee4c4a347fdf761dbdbdeb068015

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2767: compiler warning for unused argument

Problem:    Compiler warning for unused argument.
Solution:   Remove the argument.

https://github.com/vim/vim/commit/bd6406f15db210b78fa24dece3bd021a7ac085dc

Co-authored-by: Bram Moolenaar <Bram@vim.org>