### PR TITLE
vim-patch:8.2.{1890,2777}

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2750,6 +2750,23 @@ int tv_blob_set_range(blob_T *dest, long n1, long n2, typval_T *src)
   return OK;
 }
 
+/// Store one byte "byte" in blob "blob" at "idx".
+/// Append one byte if needed.
+void tv_blob_set_append(blob_T *blob, int idx, uint8_t byte)
+{
+  garray_T *gap = &blob->bv_ga;
+
+  // Allow for appending a byte.  Setting a byte beyond
+  // the end is an error otherwise.
+  if (idx <= gap->ga_len) {
+    if (idx == gap->ga_len) {
+      ga_grow(gap, 1);
+      gap->ga_len++;
+    }
+    tv_blob_set(blob, idx, byte);
+  }
+}
+
 /// "remove({blob})" function
 void tv_blob_remove(typval_T *argvars, typval_T *rettv, const char *arg_errmsg)
 {

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -372,7 +372,7 @@ static inline uint8_t tv_blob_get(const blob_T *const b, int idx)
   return ((uint8_t *)b->bv_ga.ga_data)[idx];
 }
 
-static inline void tv_blob_set(blob_T *b, int idx, uint8_t c)
+static inline void tv_blob_set(blob_T *blob, int idx, uint8_t c)
   REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Store the byte `c` at index `idx` in the blob.
@@ -380,9 +380,9 @@ static inline void tv_blob_set(blob_T *b, int idx, uint8_t c)
 /// @param[in]  b  Blob to index. Cannot be NULL.
 /// @param[in]  idx  Index in a blob. Must be valid.
 /// @param[in]  c  Value to store.
-static inline void tv_blob_set(blob_T *const b, int idx, uint8_t c)
+static inline void tv_blob_set(blob_T *const blob, int idx, uint8_t c)
 {
-  ((uint8_t *)b->bv_ga.ga_data)[idx] = c;
+  ((uint8_t *)blob->bv_ga.ga_data)[idx] = c;
 }
 
 /// Initialize VimL object

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -120,86 +120,166 @@ func Test_blob_assign()
 endfunc
 
 func Test_blob_get_range()
+  let lines =<< trim END
+      VAR b = 0z0011223344
+      call assert_equal(0z2233, b[2 : 3])
+      call assert_equal(0z223344, b[2 : -1])
+      call assert_equal(0z00, b[0 : -5])
+      call assert_equal(0z, b[0 : -11])
+      call assert_equal(0z44, b[-1 :])
+      call assert_equal(0z0011223344, b[:])
+      call assert_equal(0z0011223344, b[: -1])
+      call assert_equal(0z, b[5 : 6])
+      call assert_equal(0z0011, b[-10 : 1])
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  " legacy script white space
   let b = 0z0011223344
   call assert_equal(0z2233, b[2:3])
-  call assert_equal(0z223344, b[2:-1])
-  call assert_equal(0z00, b[0:-5])
-  call assert_equal(0z, b[0:-11])
-  call assert_equal(0z44, b[-1:])
-  call assert_equal(0z0011223344, b[:])
-  call assert_equal(0z0011223344, b[:-1])
-  call assert_equal(0z, b[5:6])
-  call assert_equal(0z0011, b[-10:1])
 endfunc
 
 func Test_blob_get()
-  let b = 0z0011223344
-  call assert_equal(0x00, get(b, 0))
-  call assert_equal(0x22, get(b, 2, 999))
-  call assert_equal(0x44, get(b, 4))
-  call assert_equal(0x44, get(b, -1))
-  call assert_equal(-1, get(b, 5))
-  call assert_equal(999, get(b, 5, 999))
-  call assert_equal(-1, get(b, -8))
-  call assert_equal(999, get(b, -8, 999))
-  call assert_equal(10, get(v:_null_blob, 2, 10))
+  let lines =<< trim END
+      VAR b = 0z0011223344
+      call assert_equal(0x00, get(b, 0))
+      call assert_equal(0x22, get(b, 2, 999))
+      call assert_equal(0x44, get(b, 4))
+      call assert_equal(0x44, get(b, -1))
+      call assert_equal(-1, get(b, 5))
+      call assert_equal(999, get(b, 5, 999))
+      call assert_equal(-1, get(b, -8))
+      call assert_equal(999, get(b, -8, 999))
+      call assert_equal(10, get(v:_null_blob, 2, 10))
 
-  call assert_equal(0x00, b[0])
-  call assert_equal(0x22, b[2])
-  call assert_equal(0x44, b[4])
-  call assert_equal(0x44, b[-1])
-  call assert_fails('echo b[5]', 'E979:')
-  call assert_fails('echo b[-8]', 'E979:')
+      call assert_equal(0x00, b[0])
+      call assert_equal(0x22, b[2])
+      call assert_equal(0x44, b[4])
+      call assert_equal(0x44, b[-1])
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+      VAR b = 0z0011223344
+      echo b[5]
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E979:')
+
+  let lines =<< trim END
+      VAR b = 0z0011223344
+      echo b[-8]
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E979:')
 endfunc
 
 func Test_blob_to_string()
-  let b = 0z00112233445566778899aabbccdd
-  call assert_equal('0z00112233.44556677.8899AABB.CCDD', string(b))
-  call assert_equal(b, eval(string(b)))
-  call remove(b, 4, -1)
-  call assert_equal('0z00112233', string(b))
-  call remove(b, 0, 3)
-  call assert_equal('0z', string(b))
+  let lines =<< trim END
+      VAR b = 0z00112233445566778899aabbccdd
+      call assert_equal('0z00112233.44556677.8899AABB.CCDD', string(b))
+      call assert_equal(b, eval(string(b)))
+      call remove(b, 4, -1)
+      call assert_equal('0z00112233', string(b))
+      call remove(b, 0, 3)
+      call assert_equal('0z', string(b))
+      call assert_equal('0z', string(v:_null_blob))
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_blob_compare()
-  let b1 = 0z0011
-  let b2 = 0z1100
-  let b3 = 0z001122
-  call assert_true(b1 == b1)
-  call assert_false(b1 == b2)
-  call assert_false(b1 == b3)
-  call assert_true(b1 != b2)
-  call assert_true(b1 != b3)
-  call assert_true(b1 == 0z0011)
-  call assert_fails('echo b1 == 9', 'E977:')
-  call assert_fails('echo b1 != 9', 'E977:')
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR b3 = 0z001122
+      call assert_true(b1 == b1)
+      call assert_false(b1 == b2)
+      call assert_false(b1 == b3)
+      call assert_true(b1 != b2)
+      call assert_true(b1 != b3)
+      call assert_true(b1 == 0z0011)
 
-  call assert_false(b1 is b2)
-  let b2 = b1
-  call assert_true(b1 == b2)
-  call assert_true(b1 is b2)
-  let b2 = copy(b1)
-  call assert_true(b1 == b2)
-  call assert_false(b1 is b2)
-  let b2 = b1[:]
-  call assert_true(b1 == b2)
-  call assert_false(b1 is b2)
+      call assert_false(b1 is b2)
+      LET b2 = b1
+      call assert_true(b1 == b2)
+      call assert_true(b1 is b2)
+      LET b2 = copy(b1)
+      call assert_true(b1 == b2)
+      call assert_false(b1 is b2)
+      LET b2 = b1[:]
+      call assert_true(b1 == b2)
+      call assert_false(b1 is b2)
+      call assert_true(b1 isnot b2)
+  END
+  call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails('let x = b1 > b2')
-  call assert_fails('let x = b1 < b2')
-  call assert_fails('let x = b1 - b2')
-  call assert_fails('let x = b1 / b2')
-  call assert_fails('let x = b1 * b2')
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      echo b1 == 9
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      echo b1 != 9
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E977:', 'E1072', 'E1072'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR x = b1 > b2
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E978:', 'E1072:', 'E1072:'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR x = b1 < b2
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E978:', 'E1072:', 'E1072:'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR x = b1 - b2
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E974:', 'E1036:', 'E974:'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR x = b1 / b2
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E974:', 'E1036:', 'E974:'])
+
+  let lines =<< trim END
+      VAR b1 = 0z0011
+      VAR b2 = 0z1100
+      VAR x = b1 * b2
+  END
+  call CheckLegacyAndVim9Failure(lines, ['E974:', 'E1036:', 'E974:'])
 endfunc
 
-" test for range assign
-func Test_blob_range_assign()
-  let b = 0z00
-  let b[1] = 0x11
-  let b[2] = 0x22
-  call assert_equal(0z001122, b)
-  call assert_fails('let b[4] = 0x33', 'E979:')
+func Test_blob_index_assign()
+  let lines =<< trim END
+      VAR b = 0z00
+      LET b[1] = 0x11
+      LET b[2] = 0x22
+      call assert_equal(0z001122, b)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+      VAR b = 0z00
+      LET b[2] = 0x33
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E979:')
+
+  let lines =<< trim END
+      VAR b = 0z00
+      LET b[-2] = 0x33
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E979:')
 endfunc
 
 func Test_blob_for_loop()


### PR DESCRIPTION
#### vim-patch:8.2.1890: Vim9: strange error for subtracting from a list

Problem:    Vim9: strange error for subtracting from a list.
Solution:   Check getting a number, not a string.

https://github.com/vim/vim/commit/081db1a66d17e46ac3b03b7514f11a004a35009a

Cherry-pick eval_addblob() and eval_addlist() from patch 8.2.0149.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2777: Vim9: blob operations not tested in all ways

Problem:    Vim9: blob operations not tested in all ways.
Solution:   Run tests with CheckLegacyAndVim9Success().  Make blob assign with
            index work.

https://github.com/vim/vim/commit/51e933261b984db014e858d79387a826d2626fb6

Cherry-pick related changes from patches 8.2.{0633,0634}.

N/A patches for version.c:

vim-patch:8.2.2779: memory access error in remove() for blob

Problem:    Memory access error in remove() for blob.
Solution:   Adjust length for memmove().

https://github.com/vim/vim/commit/f7e92aae1581203306a340b4c0059cc74adea9d6

Co-authored-by: Bram Moolenaar <Bram@vim.org>