### PR TITLE
fix(inspect): always resolve full treesitter lang hl groups

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -69,7 +69,7 @@ function vim.inspect_pos(bufnr, row, col, filter)
   -- treesitter
   if filter.treesitter then
     for _, capture in pairs(vim.treesitter.get_captures_at_pos(bufnr, row, col)) do
-      capture.hl_group = '@' .. capture.capture
+      capture.hl_group = '@' .. capture.capture .. '.' .. capture.lang
       table.insert(results.treesitter, resolve_hl(capture))
     end
   end


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/292349/221837636-b709d994-3fa6-4d77-82f3-d151c965ff4a.png)

After:
![image](https://user-images.githubusercontent.com/292349/221837661-5095e5a2-e8c1-4ea7-a463-27dd23156353.png)

