### PR TITLE
vim-patch:9.0.{0795,0803,0810}: readblob() offset and size

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6164,7 +6164,12 @@ readblob({fname} [, {offset} [, {size}]])			*readblob()*
 			readblob('file.bin', 0, 100)
 <		If {size} is -1 or omitted, the whole data starting from
 		{offset} will be read.
-		When the file can't be opened an error message is given and
+		This can be also used to read the data from a character device
+		on Unix when {size} is explicitly set.  Only if the device
+		supports seeking {offset} can be used.  Otherwise it should be
+		zero.  E.g. to read 10 bytes from a serial console: >
+			readblob('/dev/ttyS0', 0, 10)
+<		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
 		When trying to read bytes beyond the end of the file the
 		result is an empty blob.

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6171,8 +6171,10 @@ readblob({fname} [, {offset} [, {size}]])			*readblob()*
 			readblob('/dev/ttyS0', 0, 10)
 <		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
-		When trying to read bytes beyond the end of the file the
-		result is an empty blob.
+		When the offset is beyond the end of the file the result is an
+		empty blob.
+		When trying to read more bytes than are available the result
+		is truncated.
 		Also see |readfile()| and |writefile()|.
 
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -359,7 +359,8 @@ pyxeval({expr})			any	evaluate |python_x| expression
 rand([{expr}])			Number	get pseudo-random number
 range({expr} [, {max} [, {stride}]])
 				List	items from {expr} to {max}
-readblob({fname})		Blob	read a |Blob| from {fname}
+readblob({fname} [, {offset} [, {size}]])
+				Blob	read a |Blob| from {fname}
 readdir({dir} [, {expr}])	List	file names in {dir} selected by {expr}
 readfile({fname} [, {type} [, {max}]])
 				List	get list of lines from file {fname}
@@ -6110,6 +6111,25 @@ pyxeval({expr})						*pyxeval()*
 		Can also be used as a |method|: >
 			GetExpr()->pyxeval()
 <
+rand([{expr}])						*rand()*
+		Return a pseudo-random Number generated with an xoshiro128**
+		algorithm using seed {expr}.  The returned number is 32 bits,
+		also on 64 bits systems, for consistency.
+		{expr} can be initialized by |srand()| and will be updated by
+		rand().  If {expr} is omitted, an internal seed value is used
+		and updated.
+		Returns -1 if {expr} is invalid.
+
+		Examples: >
+			:echo rand()
+			:let seed = srand()
+			:echo rand(seed)
+			:echo rand(seed) % 16  " random number 0 - 15
+<
+		Can also be used as a |method|: >
+			seed->rand()
+<
+
 							*E726* *E727*
 range({expr} [, {max} [, {stride}]])				*range()*
 		Returns a |List| with Numbers:
@@ -6132,29 +6152,22 @@ range({expr} [, {max} [, {stride}]])				*range()*
 		Can also be used as a |method|: >
 			GetExpr()->range()
 <
-rand([{expr}])						*rand()*
-		Return a pseudo-random Number generated with an xoshiro128**
-		algorithm using seed {expr}.  The returned number is 32 bits,
-		also on 64 bits systems, for consistency.
-		{expr} can be initialized by |srand()| and will be updated by
-		rand().  If {expr} is omitted, an internal seed value is used
-		and updated.
-		Returns -1 if {expr} is invalid.
 
-		Examples: >
-			:echo rand()
-			:let seed = srand()
-			:echo rand(seed)
-			:echo rand(seed) % 16  " random number 0 - 15
-<
-		Can also be used as a |method|: >
-			seed->rand()
-<
-
-readblob({fname})					*readblob()*
+readblob({fname} [, {offset} [, {size}]])			*readblob()*
 		Read file {fname} in binary mode and return a |Blob|.
+		If {offset} is specified, read the file from the specified
+		offset.  If it is a negative value, it is used as an offset
+		from the end of the file.  E.g., to read the last 12 bytes: >
+			readblob('file.bin', -12)
+<		If {size} is specified, only the specified size will be read.
+		E.g. to read the first 100 bytes of a file: >
+			readblob('file.bin', 0, 100)
+<		If {size} is -1 or omitted, the whole data starting from
+		{offset} will be read.
 		When the file can't be opened an error message is given and
 		the result is an empty |Blob|.
+		When trying to read bytes beyond the end of the file the
+		result is an empty blob.
 		Also see |readfile()| and |writefile()|.
 
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5893,10 +5893,11 @@ int read_blob(FILE *const fd, typval_T *rettv, off_T offset, off_T size_arg)
   }
   // Trying to read bytes that aren't there results in an empty blob, not an
   // error.
-  if (size < 0 || size > (off_T)os_fileinfo_size(&file_info)) {
+  if (size < 0 || (!S_ISCHR(file_info.stat.st_mode)
+                   && size > (off_T)os_fileinfo_size(&file_info))) {
     return OK;
   }
-  if (vim_fseek(fd, offset, whence) != 0) {
+  if (offset != 0 && vim_fseek(fd, offset, whence) != 0) {
     return OK;
   }
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -296,7 +296,7 @@ return {
     perleval={args=1, base=1},
     rand={args={0, 1}, base=1},
     range={args={1, 3}, base=1},
-    readblob={args=1, base=1},
+    readblob={args={1, 3}, base=1},
     readdir={args={1, 2}, base=1},
     readfile={args={1, 3}, base=1},
     reduce={args={2, 3}, base=1},

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -439,9 +439,28 @@ func Test_blob_read_write()
       call writefile(b, 'Xblob')
       VAR br = readfile('Xblob', 'B')
       call assert_equal(b, br)
+      VAR br2 = readblob('Xblob')
+      call assert_equal(b, br2)
+      VAR br3 = readblob('Xblob', 1)
+      call assert_equal(b[1 :], br3)
+      VAR br4 = readblob('Xblob', 1, 2)
+      call assert_equal(b[1 : 2], br4)
+      VAR br5 = readblob('Xblob', -3)
+      call assert_equal(b[-3 :], br5)
+      VAR br6 = readblob('Xblob', -3, 2)
+      call assert_equal(b[-3 : -2], br6)
+
+      VAR br1e = readblob('Xblob', 10000)
+      call assert_equal(0z, br1e)
+      VAR br2e = readblob('Xblob', -10000)
+      call assert_equal(0z, br2e)
+
       call delete('Xblob')
   END
   call CheckLegacyAndVim9Success(lines)
+
+  call assert_fails("call readblob('notexist')", 'E484:')
+  " TODO: How do we test for the E485 error?
 
   " This was crashing when calling readfile() with a directory.
   call assert_fails("call readfile('.', 'B')", 'E17: "." is a directory')

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -459,6 +459,11 @@ func Test_blob_read_write()
   END
   call CheckLegacyAndVim9Success(lines)
 
+  if filereadable('/dev/random')
+    let b = readblob('/dev/random', 0, 10)
+    call assert_equal(10, len(b))
+  endif
+
   call assert_fails("call readblob('notexist')", 'E484:')
   " TODO: How do we test for the E485 error?
 

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -450,10 +450,17 @@ func Test_blob_read_write()
       VAR br6 = readblob('Xblob', -3, 2)
       call assert_equal(b[-3 : -2], br6)
 
+      #" reading past end of file, empty result
       VAR br1e = readblob('Xblob', 10000)
       call assert_equal(0z, br1e)
-      VAR br2e = readblob('Xblob', -10000)
-      call assert_equal(0z, br2e)
+
+      #" reading too much, result is truncated
+      VAR blong = readblob('Xblob', -1000)
+      call assert_equal(b, blong)
+      LET blong = readblob('Xblob', -10, 8)
+      call assert_equal(b, blong)
+      LET blong = readblob('Xblob', 0, 10)
+      call assert_equal(b, blong)
 
       call delete('Xblob')
   END


### PR DESCRIPTION
#### vim-patch:9.0.0795: readblob() always reads the whole file

Problem:    readblob() always reads the whole file.
Solution:   Add arguments to read part of the file. (Ken Takata,
            closes vim/vim#11402)

https://github.com/vim/vim/commit/11df3aeee548b959ccd4b9a4d3c44651eab6b3ce

Remove trailing whitespace in test as done in patch 9.0.1257.
Move the help for rand() before range().

Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:9.0.0803: readblob() cannot read from character device

Problem:    readblob() cannot read from character device.
Solution:   Use S_ISCHR() to not check the size. (Ken Takata, closes vim/vim#11407)

https://github.com/vim/vim/commit/43625762a9751cc6e6e4d8f54fbc8b82d98fb20d

S_ISCHR is always defined in Nvim.

Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:9.0.0810: readblob() returns empty when trying to read too much

Problem:    readblob() returns empty when trying to read too much.
Solution:   Return what is available.

https://github.com/vim/vim/commit/5b2a3d77d320d76f12b1666938a9d58c2a848205

Co-authored-by: Bram Moolenaar <Bram@vim.org>