### PR TITLE
vim-patch:8.2.{4668,4670},9.0.0430: cannot use repeat() with a blob

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -380,7 +380,8 @@ remove({blob}, {idx} [, {end}])	Number/Blob
 					remove bytes {idx}-{end} from {blob}
 remove({dict}, {key})		any	remove entry {key} from {dict}
 rename({from}, {to})		Number	rename (move) file from {from} to {to}
-repeat({expr}, {count})		String	repeat {expr} {count} times
+repeat({expr}, {count})		List/Blob/String
+					repeat {expr} {count} times
 resolve({filename})		String	get filename a shortcut points to
 reverse({list})			List	reverse {list} in-place
 round({expr})			Float	round off {expr}
@@ -6420,8 +6421,8 @@ repeat({expr}, {count})					*repeat()*
 		result.  Example: >
 			:let separator = repeat('-', 80)
 <		When {count} is zero or negative the result is empty.
-		When {expr} is a |List| the result is {expr} concatenated
-		{count} times.  Example: >
+		When {expr} is a |List| or a |Blob| the result is {expr}
+		concatenated {count} times.  Example: >
 			:let longlist = repeat(['a', 'b'], 3)
 <		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1613,7 +1613,7 @@ void set_var_lval(lval_T *lp, char *endp, typval_T *rettv, int copy, const bool 
           lp->ll_n2 = tv_blob_len(lp->ll_blob) - 1;
         }
 
-        if (tv_blob_set_range(lp->ll_blob, lp->ll_n1, lp->ll_n2, rettv) == FAIL) {
+        if (tv_blob_set_range(lp->ll_blob, (int)lp->ll_n1, (int)lp->ll_n2, rettv) == FAIL) {
           return;
         }
       } else {
@@ -4938,6 +4938,8 @@ theend:
   return retval;
 }
 
+/// "function()" function
+/// "funcref()" function
 void common_function(typval_T *argvars, typval_T *rettv, bool is_funcref)
 {
   char *s;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2743,14 +2743,14 @@ int tv_blob_check_range(int bloblen, varnumber_T n1, varnumber_T n2, bool quiet)
 /// Set bytes "n1" to "n2" (inclusive) in "dest" to the value of "src".
 /// Caller must make sure "src" is a blob.
 /// Returns FAIL if the number of bytes does not match.
-int tv_blob_set_range(blob_T *dest, long n1, long n2, typval_T *src)
+int tv_blob_set_range(blob_T *dest, int n1, int n2, typval_T *src)
 {
   if (n2 - n1 + 1 != tv_blob_len(src->vval.v_blob)) {
     emsg(_("E972: Blob value does not have the right number of bytes"));
     return FAIL;
   }
 
-  for (int il = (int)n1, ir = 0; il <= (int)n2; il++) {
+  for (int il = n1, ir = 0; il <= n2; il++) {
     tv_blob_set(dest, il, tv_blob_get(src->vval.v_blob, ir++));
   }
   return OK;

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -715,6 +715,18 @@ func Test_blob2string()
   call assert_equal(v, string(b))
 endfunc
 
+func Test_blob_repeat()
+  call assert_equal(0z, repeat(0z00, 0))
+  call assert_equal(0z00, repeat(0z00, 1))
+  call assert_equal(0z0000, repeat(0z00, 2))
+  call assert_equal(0z00000000, repeat(0z0000, 2))
+
+  call assert_equal(0z, repeat(0z12, 0))
+  call assert_equal(0z, repeat(0z1234, 0))
+  call assert_equal(0z1234, repeat(0z1234, 1))
+  call assert_equal(0z12341234, repeat(0z1234, 2))
+endfunc
+
 " Test for blob allocation failure
 func Test_blob_alloc_failure()
   CheckFunction test_alloc_fail

--- a/src/nvim/testdir/test_blob.vim
+++ b/src/nvim/testdir/test_blob.vim
@@ -1,5 +1,6 @@
 " Tests for the Blob types
 
+source check.vim
 source vim9.vim
 
 func TearDown()
@@ -712,6 +713,46 @@ func Test_blob2string()
   let v ..= '01'
   exe 'let b = ' .. v
   call assert_equal(v, string(b))
+endfunc
+
+" Test for blob allocation failure
+func Test_blob_alloc_failure()
+  CheckFunction test_alloc_fail
+  " blob variable
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let v = 0z10', 'E342:')
+
+  " blob slice
+  let v = 0z1020
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = v[0:0]', 'E342:')
+  call assert_equal(0z1020, x)
+
+  " blob remove()
+  let v = 0z10203040
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = remove(v, 1, 2)', 'E342:')
+  call assert_equal(0, x)
+
+  " list2blob()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let a = list2blob([1, 2, 4])', 'E342:')
+  call assert_equal(0, a)
+
+  " mapnew()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = mapnew(0z1234, {_, v -> 1})', 'E342:')
+  call assert_equal(0, x)
+
+  " copy()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = copy(v)', 'E342:')
+  call assert_equal(0z, x)
+
+  " readblob()
+  call test_alloc_fail(GetAllocId('blob_alloc'), 0, 0)
+  call assert_fails('let x = readblob("test_blob.vim")', 'E342:')
+  call assert_equal(0, x)
 endfunc
 
 " Test for the indexof() function

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -451,4 +451,75 @@ func Test_buffer_maxmem()
   " set maxmem& maxmemtot&
 endfunc
 
+" Test for a allocation failure when adding a new buffer
+func Test_buflist_alloc_failure()
+  CheckFunction test_alloc_fail
+  %bw!
+
+  edit Xfile1
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('edit Xfile2', 'E342:')
+
+  " test for bufadd()
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('call bufadd("Xbuffer")', 'E342:')
+
+  " test for setting the arglist
+  edit Xfile2
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('next Xfile3', 'E342:')
+
+  " test for setting the alternate buffer name when writing a file
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('write Xother', 'E342:')
+  call delete('Xother')
+
+  " test for creating a buffer using bufnr()
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails("call bufnr('Xnewbuf', v:true)", 'E342:')
+
+  " test for renaming buffer using :file
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('file Xnewfile', 'E342:')
+
+  " test for creating a buffer for a popup window
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('call popup_create("mypop", {})', 'E342:')
+
+  if has('terminal')
+    " test for creating a buffer for a terminal window
+    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call assert_fails('call term_start(&shell)', 'E342:')
+    %bw!
+  endif
+
+  " test for loading a new buffer after wiping out all the buffers
+  edit Xfile4
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('%bw!', 'E342:')
+
+  " test for :checktime loading the buffer
+  call writefile(['one'], 'Xfile5')
+  if has('unix')
+    edit Xfile5
+    " sleep for some time to make sure the timestamp is different
+    sleep 200m
+    call writefile(['two'], 'Xfile5')
+    set autoread
+    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call assert_fails('checktime', 'E342:')
+    set autoread&
+    bw!
+  endif
+
+  " test for :vimgrep loading a dummy buffer
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('vimgrep two Xfile5', 'E342:')
+  call delete('Xfile5')
+
+  " test for quickfix command loading a buffer
+  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call assert_fails('cexpr "Xfile6:10:Line10"', 'E342:')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_buffer.vim
+++ b/src/nvim/testdir/test_buffer.vim
@@ -451,51 +451,51 @@ func Test_buffer_maxmem()
   " set maxmem& maxmemtot&
 endfunc
 
-" Test for a allocation failure when adding a new buffer
+" Test for buffer allocation failure
 func Test_buflist_alloc_failure()
   CheckFunction test_alloc_fail
   %bw!
 
   edit Xfile1
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('edit Xfile2', 'E342:')
 
   " test for bufadd()
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('call bufadd("Xbuffer")', 'E342:')
 
   " test for setting the arglist
   edit Xfile2
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('next Xfile3', 'E342:')
 
   " test for setting the alternate buffer name when writing a file
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('write Xother', 'E342:')
   call delete('Xother')
 
   " test for creating a buffer using bufnr()
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails("call bufnr('Xnewbuf', v:true)", 'E342:')
 
   " test for renaming buffer using :file
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('file Xnewfile', 'E342:')
 
   " test for creating a buffer for a popup window
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('call popup_create("mypop", {})', 'E342:')
 
   if has('terminal')
     " test for creating a buffer for a terminal window
-    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
     call assert_fails('call term_start(&shell)', 'E342:')
     %bw!
   endif
 
   " test for loading a new buffer after wiping out all the buffers
   edit Xfile4
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('%bw!', 'E342:')
 
   " test for :checktime loading the buffer
@@ -506,19 +506,19 @@ func Test_buflist_alloc_failure()
     sleep 200m
     call writefile(['two'], 'Xfile5')
     set autoread
-    call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+    call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
     call assert_fails('checktime', 'E342:')
     set autoread&
     bw!
   endif
 
   " test for :vimgrep loading a dummy buffer
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('vimgrep two Xfile5', 'E342:')
   call delete('Xfile5')
 
   " test for quickfix command loading a buffer
-  call test_alloc_fail(GetAllocId('buflistnew_bvars'), 0, 0)
+  call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('cexpr "Xfile6:10:Line10"', 'E342:')
 endfunc
 

--- a/src/nvim/testdir/test_swap.vim
+++ b/src/nvim/testdir/test_swap.vim
@@ -235,7 +235,6 @@ func Test_swap_recover()
     autocmd SwapExists * let v:swapchoice = 'r'
   augroup END
 
-
   call mkdir('Xswap')
   let $Xswap = 'foo'  " Check for issue #4369.
   set dir=Xswap//

--- a/src/nvim/testdir/test_tabpage.vim
+++ b/src/nvim/testdir/test_tabpage.vim
@@ -846,6 +846,30 @@ func Test_lastused_tabpage()
   tabonly!
 endfunc
 
+" Test for tabpage allocation failure
+func Test_tabpage_alloc_failure()
+  CheckFunction test_alloc_fail
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('tabnew', 'E342:')
+
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  edit Xfile1
+  call assert_fails('tabedit Xfile2', 'E342:')
+  call assert_equal(1, winnr('$'))
+  call assert_equal(1, tabpagenr('$'))
+  call assert_equal('Xfile1', @%)
+
+  new
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('wincmd T', 'E342:')
+  bw!
+
+  call test_alloc_fail(GetAllocId('newtabpage_tvars'), 0, 0)
+  call assert_fails('tab split', 'E342:')
+  call assert_equal(2, winnr('$'))
+  call assert_equal(1, tabpagenr('$'))
+endfunc
+
 " this was giving ml_get errors
 func Test_tabpage_last_line()
   enew

--- a/src/nvim/testdir/test_window_cmd.vim
+++ b/src/nvim/testdir/test_window_cmd.vim
@@ -1525,6 +1525,52 @@ func Test_win_move_statusline()
   %bwipe!
 endfunc
 
+" Test for window allocation failure
+func Test_window_alloc_failure()
+  CheckFunction test_alloc_fail
+  %bw!
+
+  " test for creating a new window above current window
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('above new', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  " test for creating a new window below current window
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('below new', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  " test for popup window creation failure
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('call popup_create("Hello", {})', 'E342:')
+  call assert_equal([], popup_list())
+
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('split', 'E342:')
+  call assert_equal(1, winnr('$'))
+
+  edit Xfile1
+  edit Xfile2
+  call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  call assert_fails('sb Xfile1', 'E342:')
+  call assert_equal(1, winnr('$'))
+  call assert_equal('Xfile2', @%)
+  %bw!
+
+  " FIXME: The following test crashes Vim
+  " test for new tabpage creation failure
+  " call test_alloc_fail(GetAllocId('newwin_wvars'), 0, 0)
+  " call assert_fails('tabnew', 'E342:')
+  " call assert_equal(1, tabpagenr('$'))
+  " call assert_equal(1, winnr('$'))
+
+  " This test messes up the internal Vim window/frame information. So the
+  " Test_window_cmd_cmdwin_with_vsp() test fails after running this test.
+  " Open a new tab and close everything else to fix this issue.
+  tabnew
+  tabonly
+endfunc
+
 func Test_win_equal_last_status()
   let save_lines = &lines
   set lines=20


### PR DESCRIPTION
#### vim-patch:8.2.4668: buffer allocation failures insufficiently tested

Problem:    Buffer allocation failures insufficiently tested.
Solution:   Add tests for memory allocation failures. (Yegappan Lakshmanan,
            closes vim/vim#10064)

https://github.com/vim/vim/commit/0dac1ab5791819ee9a496273eea38f69a217ac45

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.4670: memory allocation failures for new tab page not tested

Problem:    Memory allocation failures for new tab page not tested.
Solution:   Add tests with failing memory allocation. (Yegappan Lakshmanan,
            closes vim/vim#10067)

https://github.com/vim/vim/commit/72bb47e38f6805050ed6d969f17591bed71f83d4

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0430: cannot use repeat() with a blob

Problem:    Cannot use repeat() with a blob.
Solution:   Implement blob repeat. (closes vim/vim#11090)

https://github.com/vim/vim/commit/375141e1f80dced9be738568a3418f65813f4a2f

Co-authored-by: Bakudankun <bakudankun@gmail.com>