### PR TITLE
fix(title): ignore setting title for floating windows

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3271,6 +3271,10 @@ void maketitle(void)
   int mustset;
   char buf[IOSIZE];
 
+  if (curwin->w_floating) {
+    return;
+  }
+
   if (!redrawing()) {
     // Postpone updating the title when 'lazyredraw' is set.
     need_maketitle = true;


### PR DESCRIPTION
Don't set the terminal title for floating windows.

Fixes: https://github.com/neovim/neovim/issues/19380
Related: https://github.com/neovim/neovim/issues/19380
Related: https://github.com/folke/noice.nvim/issues/197