### PR TITLE
Fixed #21239

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -206,7 +206,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
 /// @param[out] err   Error details, if any
 /// @return 0-indexed (row, col) tuple or empty list () if extmark id was
 /// absent
-ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
+Array nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
                                             Integer id, Dictionary opts,
                                             Error *err)
   FUNC_API_SINCE(7)


### PR DESCRIPTION
Fixed the issue of the incorrect data type of `nvim_buf_get_extmark_by_id` and thus closes the issue #21239. 

The bug with this was the incorrect data type of `ArrayOf(Integers)` which should actually be `Array`

