### PR TITLE
test(termxx_spec): fix TermClose bdelete test flakiness

### DIFF
--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -22,6 +22,8 @@ describe('autocmd TermClose', function()
 
 
   local function test_termclose_delete_own_buf()
+    -- The terminal process needs to keep running so that TermClose isn't triggered immediately.
+    nvim('set_option', 'shell', string.format('"%s" INTERACT', testprg('shell-test')))
     command('autocmd TermClose * bdelete!')
     command('terminal')
     matches('^TermClose Autocommands for "%*": Vim%(bdelete%):E937: Attempt to delete a buffer that is in use: term://',


### PR DESCRIPTION
Problem:
If shell-test finishes before the next RPC call, TermClose has already
been triggered, so the test fails.

Solution:
Add INTERACT argument so that shell-test keeps running.
