### PR TITLE
test(ui): handle the success-failure-success situation

### DIFF
--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -553,10 +553,12 @@ function Screen:_wait(check, flags)
 
     if not err then
       success_seen = true
+      failure_after_success = false
       if did_minimal_timeout then
         self._session:stop()
       end
     elseif success_seen and #args > 0 then
+      success_seen = false
       failure_after_success = true
       -- print(inspect(args))
     end


### PR DESCRIPTION
Problem:
UI tests don't handle the success-failure-success situation well:
1. If minimal timeout is reached between the failure and the second
   success, the session is stopped without waiting for the second
   success, causing the test to fail.
2. If minimal timeout is reached after the second success, the test does
   pass, but there is a warning even though the final state is same as
   the expected state.

Solution:
1. Do not stop waiting if a failure has been seen after a success.
2. Do not show a warning if a success is seen again after a failure.

Fix #22155.
