### PR TITLE
fix(lsp): only fire LspDetach for attached buffers

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1138,7 +1138,7 @@ function lsp.start_client(config)
     for bufnr, client_ids in pairs(all_buffer_active_clients) do
       if client_ids[client_id] then
         vim.schedule(function()
-          if client.attached_buffers[bufnr] then
+          if client and client.attached_buffers[bufnr] then
             nvim_exec_autocmds('LspDetach', {
               buffer = bufnr,
               modeline = false,


### PR DESCRIPTION
If the LSP server fails to start then the client never initializes and
thus never calls its on_attach function and an LspAttach event is
never fired. However, the on_exit function still fires a LspDetach
event, so user autocommands that attempt to "clean up" in LspDetach may
run into problems if they assume that the buffer was already attached.

The solution is to only fire an LspDetach event if the buffer was
already attached in the first place.
