### PR TITLE
fix(treesitter): maintain cursor position when toggling anonymous nodes

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -506,8 +506,26 @@ function M.inspect_tree(opts)
   a.nvim_buf_set_keymap(b, 'n', 'a', '', {
     desc = 'Toggle anonymous nodes',
     callback = function()
+      local row, col = unpack(a.nvim_win_get_cursor(w))
+      local curnode = pg:get(row)
+      while curnode and not curnode.named do
+        row = row - 1
+        curnode = pg:get(row)
+      end
+
       pg.opts.anon = not pg.opts.anon
       pg:draw(b)
+
+      if not curnode then
+        return
+      end
+
+      local id = curnode.id
+      for i, node in pg:iter() do
+        if node.id == id then
+          a.nvim_win_set_cursor(w, { i, col })
+        end
+      end
     end,
   })
   a.nvim_buf_set_keymap(b, 'n', 'I', '', {

--- a/runtime/lua/vim/treesitter/playground.lua
+++ b/runtime/lua/vim/treesitter/playground.lua
@@ -146,9 +146,9 @@ local decor_ns = api.nvim_create_namespace('ts.playground')
 ---@return string
 local function get_range_str(lnum, col, end_col, end_lnum)
   if lnum == end_lnum then
-    return string.format('[%d:%d-%d]', lnum + 1, col + 1, end_col)
+    return string.format('[%d:%d - %d]', lnum + 1, col + 1, end_col)
   end
-  return string.format('[%d:%d-%d:%d]', lnum + 1, col + 1, end_lnum + 1, end_col)
+  return string.format('[%d:%d - %d:%d]', lnum + 1, col + 1, end_lnum + 1, end_col)
 end
 
 --- Write the contents of this Playground into {bufnr}.
@@ -163,7 +163,8 @@ function TSPlayground:draw(bufnr)
   for _, item in self:iter() do
     local range_str = get_range_str(item.lnum, item.col, item.end_lnum, item.end_col)
     local lang_str = self.opts.lang and string.format(' %s', item.lang) or ''
-    local line = string.rep(' ', item.depth) .. item.text .. '; ' .. range_str .. lang_str
+    local line =
+      string.format('%s%s ; %s%s', string.rep(' ', item.depth), item.text, range_str, lang_str)
 
     if self.opts.lang then
       lang_hl_marks[#lang_hl_marks + 1] = {


### PR DESCRIPTION
When toggling anonymous nodes in the :InspectTree window, keep the
cursor fixed relative to the node within the tree. This prevents the
cursor from jumping.

I also attached a small commit to use `string.format` to generate each line in the window rather than concatenating with `..`, and some minor formatting changes (added spaces around the `-` character in node ranges and added a space before the comment character).

Before:

```
local_declaration: (variable_declaration); [3:1-52:2]
 (assignment_statement); [3:7-52:2]
  (variable_list); [3:7-15:2]
```

After:

```
local_declaration: (variable_declaration) ; [2:1 - 46:1]
 (assignment_statement) ; [2:7 - 46:1]
  (variable_list) ; [2:7 - 12:1]
```