### PR TITLE
vim-patch:9.0.{0690,0691,0991,1373}: listchars fixes

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1691,11 +1691,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
     } else if (foldinfo.fi_lines > 0) {
       // skip writing the buffer line itself
       c = NUL;
-      XFREE_CLEAR(p_extra_free);
     } else {
       int c0;
-
-      XFREE_CLEAR(p_extra_free);
 
       // Get a character from the line itself.
       c0 = c = (uint8_t)(*ptr);
@@ -2170,7 +2167,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             c = (n_extra == 0 && wp->w_p_lcs_chars.tab3)
                  ? wp->w_p_lcs_chars.tab3
                  : wp->w_p_lcs_chars.tab1;
-            if (wp->w_p_lbr && p_extra != NULL) {
+            if (wp->w_p_lbr && p_extra != NULL && *p_extra != NUL) {
               c_extra = NUL;  // using p_extra from above
             } else {
               c_extra = wp->w_p_lcs_chars.tab2;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2106,9 +2106,10 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             // If n_extra > 0, it gives the number of chars
             // to use for a tab, else we need to calculate the width
             // for a tab.
-            int len = (tab_len * utf_char2len(wp->w_p_lcs_chars.tab2));
+            int tab2_len = utf_char2len(wp->w_p_lcs_chars.tab2);
+            int len = tab_len * tab2_len;
             if (wp->w_p_lcs_chars.tab3) {
-              len += utf_char2len(wp->w_p_lcs_chars.tab3);
+              len += utf_char2len(wp->w_p_lcs_chars.tab3) - tab2_len;
             }
             if (n_extra > 0) {
               len += n_extra - tab_len;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2103,43 +2103,45 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
               tab_len += n_extra - tab_len;
             }
 
-            // If n_extra > 0, it gives the number of chars
-            // to use for a tab, else we need to calculate the width
-            // for a tab.
-            int tab2_len = utf_char2len(wp->w_p_lcs_chars.tab2);
-            int len = tab_len * tab2_len;
-            if (wp->w_p_lcs_chars.tab3) {
-              len += utf_char2len(wp->w_p_lcs_chars.tab3) - tab2_len;
-            }
-            if (n_extra > 0) {
-              len += n_extra - tab_len;
-            }
-            c = wp->w_p_lcs_chars.tab1;
-            p = xmalloc((size_t)len + 1);
-            memset(p, ' ', (size_t)len);
-            p[len] = NUL;
-            xfree(p_extra_free);
-            p_extra_free = p;
-            for (int i = 0; i < tab_len; i++) {
-              if (*p == NUL) {
-                tab_len = i;
-                break;
+            if (tab_len > 0) {
+              // If n_extra > 0, it gives the number of chars
+              // to use for a tab, else we need to calculate the
+              // width for a tab.
+              int tab2_len = utf_char2len(wp->w_p_lcs_chars.tab2);
+              int len = tab_len * tab2_len;
+              if (wp->w_p_lcs_chars.tab3) {
+                len += utf_char2len(wp->w_p_lcs_chars.tab3) - tab2_len;
               }
-              int lcs = wp->w_p_lcs_chars.tab2;
-
-              // if tab3 is given, use it for the last char
-              if (wp->w_p_lcs_chars.tab3 && i == tab_len - 1) {
-                lcs = wp->w_p_lcs_chars.tab3;
+              if (n_extra > 0) {
+                len += n_extra - tab_len;
               }
-              p += utf_char2bytes(lcs, p);
-              n_extra += utf_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
-            }
-            p_extra = p_extra_free;
+              c = wp->w_p_lcs_chars.tab1;
+              p = xmalloc((size_t)len + 1);
+              memset(p, ' ', (size_t)len);
+              p[len] = NUL;
+              xfree(p_extra_free);
+              p_extra_free = p;
+              for (int i = 0; i < tab_len; i++) {
+                if (*p == NUL) {
+                  tab_len = i;
+                  break;
+                }
+                int lcs = wp->w_p_lcs_chars.tab2;
 
-            // n_extra will be increased by FIX_FOX_BOGUSCOLS
-            // macro below, so need to adjust for that here
-            if (vcol_off > 0) {
-              n_extra -= vcol_off;
+                // if tab3 is given, use it for the last char
+                if (wp->w_p_lcs_chars.tab3 && i == tab_len - 1) {
+                  lcs = wp->w_p_lcs_chars.tab3;
+                }
+                p += utf_char2bytes(lcs, p);
+                n_extra += utf_char2len(lcs) - (saved_nextra > 0 ? 1 : 0);
+              }
+              p_extra = p_extra_free;
+
+              // n_extra will be increased by FIX_FOX_BOGUSCOLS
+              // macro below, so need to adjust for that here
+              if (vcol_off > 0) {
+                n_extra -= vcol_off;
+              }
             }
           }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2170,7 +2170,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
             c = (n_extra == 0 && wp->w_p_lcs_chars.tab3)
                  ? wp->w_p_lcs_chars.tab3
                  : wp->w_p_lcs_chars.tab1;
-            if (wp->w_p_lbr) {
+            if (wp->w_p_lbr && p_extra != NULL) {
               c_extra = NUL;  // using p_extra from above
             } else {
               c_extra = wp->w_p_lcs_chars.tab2;

--- a/src/nvim/testdir/test_breakindent.vim
+++ b/src/nvim/testdir/test_breakindent.vim
@@ -1075,4 +1075,22 @@ func Test_breakindent_column()
   bwipeout!
 endfunc
 
+func Test_linebreak_list()
+  " This was setting wlv.c_extra to NUL while wlv.p_extra is NULL
+  filetype plugin on
+  syntax enable
+  edit! $VIMRUNTIME/doc/index.txt
+  /v_P
+
+  setlocal list
+  setlocal listchars=tab:>-
+  setlocal linebreak
+  setlocal nowrap
+  setlocal filetype=help
+  redraw!
+
+  bwipe!
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/src/nvim/testdir/test_listlbr.vim
+++ b/src/nvim/testdir/test_listlbr.vim
@@ -73,6 +73,30 @@ func Test_linebreak_with_nolist()
   call s:close_windows()
 endfunc
 
+func Test_linebreak_with_list_and_number()
+  call s:test_windows('setl list listchars+=tab:>-')
+  call setline(1, ["abcdefg\thijklmnopqrstu", "v"])
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect_nonumber = [
+\ "abcdefg>------------",
+\ "hijklmnopqrstu$     ",
+\ "v$                  ",
+\ "~                   ",
+\ ]
+  call s:compare_lines(expect_nonumber, lines)
+
+  setl number
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect_number = [
+\ "  1 abcdefg>--------",
+\ "    hijklmnopqrstu$ ",
+\ "  2 v$              ",
+\ "~                   ",
+\ ]
+  call s:compare_lines(expect_number, lines)
+  call s:close_windows()
+endfunc
+
 func Test_should_break()
   call s:test_windows('setl sbr=+ nolist')
   call setline(1, "1\t" . repeat('a', winwidth(0)-2))


### PR DESCRIPTION
#### vim-patch:9.0.0690: buffer size for expanding tab not correctly computed

Problem:    Buffer size for expanding tab not correctly computed.
Solution:   Correctly use size of end character.

https://github.com/vim/vim/commit/a0789478f6ebbb823670b7e14ce13ea3fd3b0217

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0691: lalloc(0) error in listchars test

Problem:    lalloc(0) error in listchars test.
Solution:   Skip generating text for tab if tab_len is zero.

https://github.com/vim/vim/commit/2b7b4f7670f607704307f7715ce56752757c22e3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0991: crash when reading help index with various options set

Problem:    Crash when reading help index with various options set. (Marius
            Gedminas)
Solution:   Do not set wlv.c_extra to NUL when wlv.p_extra is NULL.

https://github.com/vim/vim/commit/c67c89c7589253215d57bad588edcf83a9403560

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1373: wrong text displayed when using both 'linebreak' and 'list'

Problem:    Wrong text displayed when using both 'linebreak' and 'list'.
Solution:   Only set "c_extra" to NUL when "p_extra" is not empty. (Hirohito
            Higashi, closes vim/vim#12065)

https://github.com/vim/vim/commit/194555c001f2b8576483ef34511450b6e9b5e3fd

Cherry-pick a change from patch 9.0.0153.

Co-authored-by: h-east <h.east.727@gmail.com>