### PR TITLE
vim-patch:9.0.0527: long sign text may overflow buffer

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -413,13 +413,13 @@ static void get_sign_display_info(bool nrcol, win_T *wp, winlinevars_T *wlv, int
         wlv->c_final = NUL;
 
         if (nrcol) {
-          int n, width = number_width(wp) - 2;
-          for (n = 0; n < width; n++) {
+          int width = number_width(wp) - 2;
+          size_t n;
+          for (n = 0; (int)n < width; n++) {
             wlv->extra[n] = ' ';
           }
           wlv->extra[n] = NUL;
-          STRCAT(wlv->extra, wlv->p_extra);
-          STRCAT(wlv->extra, " ");
+          snprintf(wlv->extra + n, sizeof(wlv->extra) - n, "%s ", wlv->p_extra);
           wlv->p_extra = wlv->extra;
           wlv->n_extra = (int)strlen(wlv->p_extra);
         } else {

--- a/src/nvim/testdir/test_signs.vim
+++ b/src/nvim/testdir/test_signs.vim
@@ -196,6 +196,20 @@ func Test_sign()
 			  \ bufnr('%'), 'E155:')
 endfunc
 
+func Test_sign_many_bytes()
+  new
+  set signcolumn=number
+  set number
+  call setline(1, 'some text')
+  " composing characters can use many bytes, check for overflow
+  sign define manyBytes text=▶᷄᷅᷆◀᷄᷅᷆᷇
+  sign place 17 line=1 name=manyBytes
+  redraw
+
+  bwipe!
+  sign undefine manyBytes
+endfunc
+
 " Undefining placed sign is not recommended.
 " Quoting :help sign
 "


### PR DESCRIPTION
#### vim-patch:9.0.0527: long sign text may overflow buffer

Problem:    Long sign text may overflow buffer.
Solution:   Use a larger buffer.  Prevent for overflow.

https://github.com/vim/vim/commit/2b1ddf19f8f14365d0b998b4ac12ca85c0923475

Don't change the size of extra[] as it's already large enough.

N/A patches for version.c:

vim-patch:9.0.0523: more compiler warnings for arguments in small version

Co-authored-by: Bram Moolenaar <Bram@vim.org>