### PR TITLE
fix(treesitter): raise ts_match_limit to 256

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1319,7 +1319,7 @@ static int node_rawquery(lua_State *L)
   } else {
     cursor = ts_query_cursor_new();
   }
-  ts_query_cursor_set_match_limit(cursor, 64);
+  ts_query_cursor_set_match_limit(cursor, 256);
   ts_query_cursor_exec(cursor, query, node);
 
   bool captures = lua_toboolean(L, 3);


### PR DESCRIPTION
Problem: Some complex queries may not return all matches.

Solution: Raise `ts_match_limit` from current 64 (twice the original
default) to 256 (which Helix uses, and seems to be enough for the reported
problematic cases).

If this leads performance regressions in other queries, we should add a
generic querying timeout instead of relying on a low value here.

Fixes #22055
