### PR TITLE
build: unset variables ending with "URL" if USE_EXISTING_SRC_DIR is ON

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -196,6 +196,15 @@ set(TREESITTER_QUERY_SHA256 2f2c79a59e3ff550aef849925e589d69b8a146b3af935504366c
 set(TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/c51896d32dcc11a38e41f36e3deb1a6a9c4f4b14.tar.gz)
 set(TREESITTER_SHA256 243e07541a9dd71681984b65bffed2d4a259bef0a4ad28cff55cc1c6878b8d18)
 
+if(USE_EXISTING_SRC_DIR)
+  get_cmake_property(VARS VARIABLES)
+  foreach (VAR ${VARS})
+    if(VAR MATCHES "^.*URL$")
+      unset(${VAR})
+    endif()
+  endforeach()
+endif()
+
 if(USE_BUNDLED_UNIBILIUM)
   include(BuildUnibilium)
 endif()

--- a/cmake.deps/cmake/BuildGettext.cmake
+++ b/cmake.deps/cmake/BuildGettext.cmake
@@ -1,7 +1,4 @@
 if(MSVC)
-  if(USE_EXISTING_SRC_DIR)
-    unset(GETTEXT_URL)
-  endif()
   ExternalProject_Add(gettext
     URL ${GETTEXT_URL}
     URL_HASH SHA256=${GETTEXT_SHA256}

--- a/cmake.deps/cmake/BuildLibiconv.cmake
+++ b/cmake.deps/cmake/BuildLibiconv.cmake
@@ -1,7 +1,4 @@
 if(MSVC)
-  if(USE_EXISTING_SRC_DIR)
-    unset(LIBICONV_URL)
-  endif()
   ExternalProject_Add(libiconv
     URL ${LIBICONV_URL}
     URL_HASH SHA256=${LIBICONV_SHA256}

--- a/cmake.deps/cmake/BuildLibtermkey.cmake
+++ b/cmake.deps/cmake/BuildLibtermkey.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(LIBTERMKEY_URL)
-endif()
 ExternalProject_Add(libtermkey
   URL ${LIBTERMKEY_URL}
   URL_HASH SHA256=${LIBTERMKEY_SHA256}

--- a/cmake.deps/cmake/BuildLibuv.cmake
+++ b/cmake.deps/cmake/BuildLibuv.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(LIBUV_URL)
-endif()
 ExternalProject_Add(libuv
   URL ${LIBUV_URL}
   URL_HASH SHA256=${LIBUV_SHA256}

--- a/cmake.deps/cmake/BuildLibvterm.cmake
+++ b/cmake.deps/cmake/BuildLibvterm.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(LIBVTERM_URL)
-endif()
 ExternalProject_Add(libvterm
   URL ${LIBVTERM_URL}
   URL_HASH SHA256=${LIBVTERM_SHA256}

--- a/cmake.deps/cmake/BuildLua.cmake
+++ b/cmake.deps/cmake/BuildLua.cmake
@@ -42,9 +42,6 @@ set(LUA_INSTALL_TOP_ARG "INSTALL_TOP=${DEPS_INSTALL_DIR}")
 
 message(STATUS "Lua target is ${LUA_TARGET}")
 
-if(USE_EXISTING_SRC_DIR)
-  unset(LUA_URL)
-endif()
 ExternalProject_Add(lua
   URL ${LUA_URL}
   URL_HASH SHA256=${LUA_SHA256}

--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -15,9 +15,6 @@ function(BuildLuajit)
     set(_luajit_TARGET "luajit")
   endif()
 
-  if(USE_EXISTING_SRC_DIR)
-    unset(LUAJIT_URL)
-  endif()
   ExternalProject_Add(${_luajit_TARGET}
     URL ${LUAJIT_URL}
     URL_HASH SHA256=${LUAJIT_SHA256}

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -81,9 +81,6 @@ else()
   message(FATAL_ERROR "Trying to build luarocks in an unsupported system ${CMAKE_SYSTEM_NAME}/${CMAKE_C_COMPILER_ID}")
 endif()
 
-if(USE_EXISTING_SRC_DIR)
-  unset(LUAROCKS_URL)
-endif()
 ExternalProject_Add(luarocks
   URL ${LUAROCKS_URL}
   URL_HASH SHA256=${LUAROCKS_SHA256}

--- a/cmake.deps/cmake/BuildLuv.cmake
+++ b/cmake.deps/cmake/BuildLuv.cmake
@@ -33,9 +33,6 @@ if(CMAKE_GENERATOR MATCHES "Unix Makefiles" AND
     list(APPEND LUV_CMAKE_ARGS -D CMAKE_MAKE_PROGRAM=gmake)
 endif()
 
-if(USE_EXISTING_SRC_DIR)
-  unset(LUA_COMPAT53_URL)
-endif()
 ExternalProject_Add(lua-compat-5.3
   URL ${LUA_COMPAT53_URL}
   URL_HASH SHA256=${LUA_COMPAT53_SHA256}
@@ -45,9 +42,6 @@ ExternalProject_Add(lua-compat-5.3
   BUILD_COMMAND ""
   INSTALL_COMMAND "")
 
-if(USE_EXISTING_SRC_DIR)
-  unset(LUV_URL)
-endif()
 ExternalProject_Add(luv-static
   DEPENDS lua-compat-5.3
   URL ${LUV_URL}

--- a/cmake.deps/cmake/BuildMsgpack.cmake
+++ b/cmake.deps/cmake/BuildMsgpack.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(MSGPACK_URL)
-endif()
 ExternalProject_Add(msgpack
   URL ${MSGPACK_URL}
   URL_HASH SHA256=${MSGPACK_SHA256}

--- a/cmake.deps/cmake/BuildTreesitter.cmake
+++ b/cmake.deps/cmake/BuildTreesitter.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(TREESITTER_URL)
-endif()
 ExternalProject_Add(tree-sitter
   URL ${TREESITTER_URL}
   URL_HASH SHA256=${TREESITTER_SHA256}

--- a/cmake.deps/cmake/BuildTreesitterParsers.cmake
+++ b/cmake.deps/cmake/BuildTreesitterParsers.cmake
@@ -1,8 +1,5 @@
 function(BuildTSParser LANG TS_URL TS_SHA256 TS_CMAKE_FILE)
   set(NAME treesitter-${LANG})
-  if(USE_EXISTING_SRC_DIR)
-    unset(TS_URL)
-  endif()
   ExternalProject_Add(${NAME}
     URL ${TS_URL}
     URL_HASH SHA256=${TS_SHA256}

--- a/cmake.deps/cmake/BuildUnibilium.cmake
+++ b/cmake.deps/cmake/BuildUnibilium.cmake
@@ -1,6 +1,3 @@
-if(USE_EXISTING_SRC_DIR)
-  unset(UNIBILIUM_URL)
-endif()
 ExternalProject_Add(unibilium
   URL ${UNIBILIUM_URL}
   URL_HASH SHA256=${UNIBILIUM_SHA256}

--- a/cmake.deps/cmake/GetBinaryDeps.cmake
+++ b/cmake.deps/cmake/GetBinaryDeps.cmake
@@ -22,9 +22,6 @@ function(GetBinaryDep)
     message(FATAL_ERROR "${URL_VARNAME} and ${HASH_VARNAME} must be set")
   endif()
 
-  if(USE_EXISTING_SRC_DIR)
-    unset(URL)
-  endif()
   ExternalProject_Add(${_gettool_TARGET}
     URL ${URL}
     URL_HASH SHA256=${HASH}


### PR DESCRIPTION
This will reduce required boilerplate, but more importantly it will
automatically unset variables ending on URL. This will help people
needing to avoid to unset the URL variable each time a new dependency is
added.

It is possible that this may remove a non-download variable ending on
"URL" in the future, however, the risk of this is likely much lower than
the risk of someone forgetting to unset the variable.
