### PR TITLE
vim-patch:9.0.1376: accessing invalid memory with put in Visual block mode

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3346,7 +3346,7 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
         ptr += yanklen;
 
         // insert block's trailing spaces only if there's text behind
-        if ((j < count - 1 || !shortline) && spaces) {
+        if ((j < count - 1 || !shortline) && spaces > 0) {
           memset(ptr, ' ', (size_t)spaces);
           ptr += spaces;
         } else {
@@ -3684,6 +3684,15 @@ error:
 
   msgmore(nr_lines);
   curwin->w_set_curswant = true;
+
+  // Make sure the cursor is not after the NUL.
+  int len = (int)strlen(get_cursor_line_ptr());
+  if (curwin->w_cursor.col > len) {
+    if (cur_ve_flags == VE_ALL) {
+      curwin->w_cursor.coladd = curwin->w_cursor.col - len;
+    }
+    curwin->w_cursor.col = len;
+  }
 
 end:
   if (cmdmod.cmod_flags & CMOD_LOCKMARKS) {

--- a/src/nvim/testdir/test_put.vim
+++ b/src/nvim/testdir/test_put.vim
@@ -235,5 +235,16 @@ func Test_put_visual_mode()
   set selection&
 endfunc
 
+func Test_put_visual_block_mode()
+  enew
+  exe "norm 0R\<CR>\<C-C>V"
+  sil exe "norm \<C-V>c	\<MiddleDrag>"
+  set ve=all
+  sil norm vz=p
+
+  bwipe!
+  set ve=
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1376: accessing invalid memory with put in Visual block mode

Problem:    Accessing invalid memory with put in Visual block mode.
Solution:   Adjust the cursor column if needed.

https://github.com/vim/vim/commit/1c73b65229c25e3c1fd8824ba958f7cc4d604f9c

Co-authored-by: Bram Moolenaar <Bram@vim.org>