### PR TITLE
docs(lsp): type annotation for lsp.client

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -564,7 +564,7 @@ buf_notify({bufnr}, {method}, {params})                 *vim.lsp.buf_notify()*
     Send a notification to a server
 
     Parameters: ~
-      • {bufnr}   (number|nil) The number of the buffer
+      • {bufnr}   (integer|nil) The number of the buffer
       • {method}  (string) Name of the request method
       • {params}  (any) Arguments to send to the server
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -154,6 +154,8 @@ local all_buffer_active_clients = {}
 local uninitialized_clients = {}
 
 ---@private
+---@param bufnr? integer
+---@param fn fun(client: lsp.Client, client_id: integer, bufnr: integer)
 local function for_each_buffer_client(bufnr, fn, restrict_client_ids)
   validate({
     fn = { fn, 'f' },
@@ -1216,6 +1218,7 @@ function lsp.start_client(config)
     return
   end
 
+  ---@class lsp.Client
   local client = {
     id = client_id,
     name = name,
@@ -1366,7 +1369,7 @@ function lsp.start_client(config)
   --- checks for capabilities and handler availability.
   ---
   ---@param method string LSP method name.
-  ---@param params table LSP request params.
+  ---@param params table|nil LSP request params.
   ---@param handler lsp-handler|nil Response |lsp-handler| for this method.
   ---@param bufnr integer Buffer handle (0 for current).
   ---@return boolean status, integer|nil request_id {status} is a bool indicating
@@ -2063,7 +2066,7 @@ function lsp.buf_request_sync(bufnr, method, params, timeout_ms)
 end
 
 --- Send a notification to a server
----@param bufnr (number|nil) The number of the buffer
+---@param bufnr (integer|nil) The number of the buffer
 ---@param method (string) Name of the request method
 ---@param params (any) Arguments to send to the server
 ---


### PR DESCRIPTION
* Also fix newly found type mismatch.
* Note that it generates new warnings about using `@private` client methods. A proper fix would be to revamp the lsp client documentation altogether.