### PR TITLE
refactor(spell): use uint8_t for "byts" variables

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -444,7 +444,7 @@ static void find_word(matchinf_T *mip, int mode)
     // Check for word with matching case in keep-case tree.
     ptr = mip->mi_word;
     flen = 9999;                    // no case folding, always enough bytes
-    byts = (uint8_t *)slang->sl_kbyts;
+    byts = slang->sl_kbyts;
     idxs = slang->sl_kidxs;
 
     if (mode == FIND_KEEPCOMPOUND) {
@@ -455,7 +455,7 @@ static void find_word(matchinf_T *mip, int mode)
     // Check for case-folded in case-folded tree.
     ptr = mip->mi_fword;
     flen = mip->mi_fwordlen;        // available case-folded bytes
-    byts = (uint8_t *)slang->sl_fbyts;
+    byts = slang->sl_fbyts;
     idxs = slang->sl_fidxs;
 
     if (mode == FIND_PREFIX) {
@@ -1062,7 +1062,7 @@ static void find_prefix(matchinf_T *mip, int mode)
   int wlen = 0;
   slang_T *slang = mip->mi_lp->lp_slang;
 
-  uint8_t *byts = (uint8_t *)slang->sl_pbyts;
+  uint8_t *byts = slang->sl_pbyts;
   if (byts == NULL) {
     return;                     // array is empty
   }
@@ -3194,7 +3194,7 @@ void spell_dump_compl(char *pat, int ic, Direction *dir, int dumpflags_arg)
   int curi[MAXWLEN];
   char word[MAXWLEN];
   int c;
-  char *byts;
+  uint8_t *byts;
   idx_T *idxs;
   linenr_T lnum = 0;
   int depth;
@@ -3296,7 +3296,7 @@ void spell_dump_compl(char *pat, int ic, Direction *dir, int dumpflags_arg)
           // Do one more byte at this node.
           n = arridx[depth] + curi[depth];
           curi[depth]++;
-          c = (uint8_t)byts[n];
+          c = byts[n];
           if (c == 0 || depth >= MAXWLEN - 1) {
             // End of word or reached maximum length, deal with the
             // word.
@@ -3462,7 +3462,7 @@ static linenr_T dump_prefixes(slang_T *slang, char *word, char *pat, Direction *
     has_word_up = true;
   }
 
-  char *byts = slang->sl_pbyts;
+  uint8_t *byts = slang->sl_pbyts;
   idx_T *idxs = slang->sl_pidxs;
   if (byts != NULL) {           // array not is empty
     // Loop over all prefixes, building them byte-by-byte in prefix[].
@@ -3472,7 +3472,7 @@ static linenr_T dump_prefixes(slang_T *slang, char *word, char *pat, Direction *
     curi[0] = 1;
     while (depth >= 0 && !got_int) {
       int n = arridx[depth];
-      int len = (uint8_t)byts[n];
+      int len = byts[n];
       if (curi[depth] > len) {
         // Done all bytes at this node, go up one level.
         depth--;
@@ -3481,7 +3481,7 @@ static linenr_T dump_prefixes(slang_T *slang, char *word, char *pat, Direction *
         // Do one more byte at this node.
         n += curi[depth];
         curi[depth]++;
-        c = (uint8_t)byts[n];
+        c = byts[n];
         if (c == 0) {
           // End of prefix, find out how many IDs there are.
           int i;

--- a/src/nvim/spell_defs.h
+++ b/src/nvim/spell_defs.h
@@ -119,12 +119,12 @@ struct slang_S {
   char *sl_fname;           // name of .spl file
   bool sl_add;              // true if it's a .add file.
 
-  char *sl_fbyts;           // case-folded word bytes
+  uint8_t *sl_fbyts;        // case-folded word bytes
   long sl_fbyts_len;        // length of sl_fbyts
   idx_T *sl_fidxs;          // case-folded word indexes
-  char *sl_kbyts;           // keep-case word bytes
+  uint8_t *sl_kbyts;        // keep-case word bytes
   idx_T *sl_kidxs;          // keep-case word indexes
-  char *sl_pbyts;           // prefix tree word bytes
+  uint8_t *sl_pbyts;        // prefix tree word bytes
   idx_T *sl_pidxs;          // prefix tree word indexes
 
   char *sl_info;            // infotext string or NULL
@@ -172,7 +172,7 @@ struct slang_S {
 
   // Info from the .sug file.  Loaded on demand.
   time_t sl_sugtime;            // timestamp for .sug file
-  char *sl_sbyts;         // soundfolded word bytes
+  uint8_t *sl_sbyts;      // soundfolded word bytes
   idx_T *sl_sidxs;        // soundfolded word indexes
   buf_T *sl_sugbuf;       // buffer with word number table
   bool sl_sugloaded;            // true when .sug file was loaded or failed to

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -838,9 +838,8 @@ endOK:
 
 // Fill in the wordcount fields for a trie.
 // Returns the total number of words.
-static void tree_count_words(const char *byts_in, idx_T *idxs)
+static void tree_count_words(const uint8_t *byts, idx_T *idxs)
 {
-  const uint8_t *byts= (const uint8_t *)byts_in;
   int depth;
   idx_T arridx[MAXWLEN];
   int curi[MAXWLEN];
@@ -1675,12 +1674,12 @@ static int *mb_str2wide(char *s)
 /// @param prefixcnt  when "prefixtree" is true: prefix count
 ///
 /// @return  zero when OK, SP_ value for an error.
-static int spell_read_tree(FILE *fd, char **bytsp, long *bytsp_len, idx_T **idxsp, bool prefixtree,
-                           int prefixcnt)
+static int spell_read_tree(FILE *fd, uint8_t **bytsp, long *bytsp_len, idx_T **idxsp,
+                           bool prefixtree, int prefixcnt)
   FUNC_ATTR_NONNULL_ARG(1, 2, 4)
 {
   int idx;
-  char *bp;
+  uint8_t *bp;
   idx_T *ip;
 
   // The tree size was computed when writing the file, so that we can
@@ -1729,10 +1728,9 @@ static int spell_read_tree(FILE *fd, char **bytsp, long *bytsp_len, idx_T **idxs
 /// @param startidx  current index in "byts" and "idxs"
 /// @param prefixtree  true for reading PREFIXTREE
 /// @param maxprefcondnr  maximum for <prefcondnr>
-static idx_T read_tree_node(FILE *fd, char *byts_in, idx_T *idxs, int maxidx, idx_T startidx,
+static idx_T read_tree_node(FILE *fd, uint8_t *byts, idx_T *idxs, int maxidx, idx_T startidx,
                             bool prefixtree, int maxprefcondnr)
 {
-  uint8_t *byts = (uint8_t *)byts_in;
   int len;
   int n;
   idx_T idx = startidx;
@@ -1819,8 +1817,7 @@ static idx_T read_tree_node(FILE *fd, char *byts_in, idx_T *idxs, int maxidx, id
         idxs[startidx + i] &= ~SHARED_MASK;
       } else {
         idxs[startidx + i] = idx;
-        idx = read_tree_node(fd, (char *)byts, idxs, maxidx, idx,
-                             prefixtree, maxprefcondnr);
+        idx = read_tree_node(fd, byts, idxs, maxidx, idx, prefixtree, maxprefcondnr);
         if (idx < 0) {
           break;
         }
@@ -4955,7 +4952,7 @@ theend:
 // Build the soundfold trie for language "slang".
 static int sug_filltree(spellinfo_T *spin, slang_T *slang)
 {
-  char_u *byts;
+  uint8_t *byts;
   idx_T *idxs;
   int depth;
   idx_T arridx[MAXWLEN];
@@ -4975,7 +4972,7 @@ static int sug_filltree(spellinfo_T *spin, slang_T *slang)
 
   // Go through the whole case-folded tree, soundfold each word and put it
   // in the trie.
-  byts = (char_u *)slang->sl_fbyts;
+  byts = slang->sl_fbyts;
   idxs = slang->sl_fidxs;
 
   arridx[0] = 0;

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -1181,7 +1181,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
 
   if (soundfold) {
     // Going through the soundfold tree.
-    byts = fbyts = (uint8_t *)slang->sl_sbyts;
+    byts = fbyts = slang->sl_sbyts;
     idxs = fidxs = slang->sl_sidxs;
     pbyts = NULL;
     pidxs = NULL;
@@ -1190,9 +1190,9 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
   } else {
     // When there are postponed prefixes we need to use these first.  At
     // the end of the prefix we continue in the case-fold tree.
-    fbyts = (uint8_t *)slang->sl_fbyts;
+    fbyts = slang->sl_fbyts;
     fidxs = slang->sl_fidxs;
-    pbyts = (uint8_t *)slang->sl_pbyts;
+    pbyts = slang->sl_pbyts;
     pidxs = slang->sl_pidxs;
     if (pbyts != NULL) {
       byts = pbyts;
@@ -2381,7 +2381,7 @@ static void find_keepcap_word(slang_T *slang, char *fword, char *kword)
   int c;
   idx_T lo, hi, m;
   char *p;
-  uint8_t *byts = (uint8_t *)slang->sl_kbyts;      // array with bytes of the words
+  uint8_t *byts = slang->sl_kbyts;      // array with bytes of the words
   idx_T *idxs = slang->sl_kidxs;      // array with indexes
 
   if (byts == NULL) {
@@ -2824,7 +2824,7 @@ static void add_sound_suggest(suginfo_T *su, char *goodword, int score, langp_T 
     // previous wordnr.
     orgnr += bytes2offset(&nrline);
 
-    byts = (uint8_t *)slang->sl_fbyts;
+    byts = slang->sl_fbyts;
     idxs = slang->sl_fidxs;
 
     // Lookup the word "orgnr" one of the two tries.
@@ -2957,7 +2957,7 @@ static int soundfold_find(slang_T *slang, char *word)
   uint8_t *ptr = (uint8_t *)word;
   int wordnr = 0;
 
-  uint8_t *byts = (uint8_t *)slang->sl_sbyts;
+  uint8_t *byts = slang->sl_sbyts;
   idx_T *idxs = slang->sl_sidxs;
 
   for (;;) {


### PR DESCRIPTION
Avoid casting back and forth.
