### PR TITLE
vim-patch:9.0.1378: illegal memory access when using virtual editing

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2684,8 +2684,10 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
           getvcol(curwin, &oap->start, &cs, NULL, &ce);
           if (ce != cs && oap->start.coladd > 0) {
             // Part of a tab selected -- but don't double-count it.
-            bd.startspaces = (ce - cs + 1)
-                             - oap->start.coladd;
+            bd.startspaces = (ce - cs + 1) - oap->start.coladd;
+            if (bd.startspaces < 0) {
+              bd.startspaces = 0;
+            }
             startcol++;
           }
         }

--- a/src/nvim/testdir/test_virtualedit.vim
+++ b/src/nvim/testdir/test_virtualedit.vim
@@ -88,6 +88,16 @@ func Test_edit_change()
   set virtualedit=
 endfunc
 
+func Test_edit_special_char()
+  new
+  se ve=all
+  norm a0
+  sil! exe "norm o00000\<Nul>k<a0s"
+
+  bwipe!
+  set virtualedit=
+endfunc
+
 " Tests for pasting at the beginning, end and middle of a tab character
 " in virtual edit mode.
 func Test_paste_in_tab()


### PR DESCRIPTION
#### vim-patch:9.0.1378: illegal memory access when using virtual editing

Problem:    Illegal memory access when using virtual editing.
Solution:   Make sure "startspaces" is not negative.

https://github.com/vim/vim/commit/c99cbf8f289bdda5d4a77d7ec415850a520330ba

Co-authored-by: Bram Moolenaar <Bram@vim.org>