### PR TITLE
test: unskip working Windows tests

### DIFF
--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -88,7 +88,6 @@ describe('jobs', function()
   end)
 
   it('append environment with pty #env', function()
-    skip(is_os('win'))
     nvim('command', "let $VAR = 'abc'")
     nvim('command', "let $TOTO = 'goodbye world'")
     nvim('command', "let g:job_opts.pty = v:true")
@@ -806,7 +805,6 @@ describe('jobs', function()
     end)
 
     it('can be called recursively', function()
-      skip(is_os('win'), "TODO: Need `cat`")
       source([[
       let g:opts = {}
       let g:counter = 0

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -68,7 +68,6 @@ describe(':terminal mouse', function()
     end)
 
     it('does not leave terminal mode on left-release', function()
-      skip(is_os('win'))
       feed('<LeftRelease>')
       eq('t', eval('mode(1)'))
     end)
@@ -232,7 +231,6 @@ describe(':terminal mouse', function()
     end)
 
     describe('with a split window and other buffer', function()
-      skip(is_os('win'))
       before_each(function()
         feed('<c-\\><c-n>:vsp<cr>')
         screen:expect([[

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -140,7 +140,6 @@ describe(':terminal scrollback', function()
 
 
     describe('and height decreased by 1', function()
-      if skip(is_os('win')) then return end
       local function will_hide_top_line()
         feed([[<C-\><C-N>]])
         screen:try_resize(screen._width - 2, screen._height - 1)
@@ -347,7 +346,6 @@ end)
 
 describe(':terminal prints more lines than the screen height and exits', function()
   it('will push extra lines to scrollback', function()
-    skip(is_os('win'))
     clear()
     local screen = Screen.new(30, 7)
     screen:attach({rgb=false})

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -7,7 +7,6 @@ local exec_lua = helpers.exec_lua
 local pcall_err = helpers.pcall_err
 local feed = helpers.feed
 local is_os = helpers.is_os
-local skip = helpers.skip
 
 before_each(clear)
 
@@ -741,7 +740,6 @@ int x = INT_MAX;
       end)
 
       it("should not inject bad languages", function()
-        skip(is_os('win'))
         exec_lua([=[
         vim.treesitter.add_directive("inject-bad!", function(match, _, _, pred, metadata)
           metadata.language = "{"


### PR DESCRIPTION
Some tests that were previously not working have started to work again
for unspecified reasons, so let's enable them.