### PR TITLE
build: fix USE_EXISTING_SRC_DIR option

### DIFF
--- a/cmake.deps/cmake/BuildTreesitterParsers.cmake
+++ b/cmake.deps/cmake/BuildTreesitterParsers.cmake
@@ -1,5 +1,11 @@
-function(BuildTSParser LANG TS_URL TS_SHA256 TS_CMAKE_FILE)
-  set(NAME treesitter-${LANG})
+function(BuildTSParser)
+  cmake_parse_arguments(TS
+    ""
+    "LANG;URL;SHA256;CMAKE_FILE"
+    ""
+    ${ARGN})
+
+  set(NAME treesitter-${TS_LANG})
   ExternalProject_Add(${NAME}
     URL ${TS_URL}
     URL_HASH SHA256=${TS_SHA256}
@@ -9,12 +15,36 @@ function(BuildTSParser LANG TS_URL TS_SHA256 TS_CMAKE_FILE)
       ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${TS_CMAKE_FILE}
       ${DEPS_BUILD_DIR}/src/${NAME}/CMakeLists.txt
     CMAKE_ARGS ${DEPS_CMAKE_ARGS}
-      -D PARSERLANG=${LANG}
+      -D PARSERLANG=${TS_LANG}
     CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS})
 endfunction()
 
-BuildTSParser(c ${TREESITTER_C_URL} ${TREESITTER_C_SHA256} TreesitterParserCMakeLists.txt)
-BuildTSParser(lua ${TREESITTER_LUA_URL} ${TREESITTER_LUA_SHA256} TreesitterParserCMakeLists.txt)
-BuildTSParser(vim ${TREESITTER_VIM_URL} ${TREESITTER_VIM_SHA256} TreesitterParserCMakeLists.txt)
-BuildTSParser(help ${TREESITTER_HELP_URL} ${TREESITTER_HELP_SHA256} TreesitterParserCMakeLists.txt)
-BuildTSParser(query ${TREESITTER_QUERY_URL} ${TREESITTER_QUERY_SHA256} TreesitterParserCMakeLists.txt)
+BuildTSParser(
+  LANG c
+  URL ${TREESITTER_C_URL}
+  SHA256 ${TREESITTER_C_SHA256}
+  CMAKE_FILE TreesitterParserCMakeLists.txt)
+
+BuildTSParser(
+  LANG lua
+  URL ${TREESITTER_LUA_URL}
+  SHA256 ${TREESITTER_LUA_SHA256}
+  CMAKE_FILE TreesitterParserCMakeLists.txt)
+
+BuildTSParser(
+  LANG vim
+  URL ${TREESITTER_VIM_URL}
+  SHA256 ${TREESITTER_VIM_SHA256}
+  CMAKE_FILE TreesitterParserCMakeLists.txt)
+
+BuildTSParser(
+  LANG help
+  URL ${TREESITTER_HELP_URL}
+  SHA256 ${TREESITTER_HELP_SHA256}
+  CMAKE_FILE TreesitterParserCMakeLists.txt)
+
+BuildTSParser(
+  LANG query
+  URL ${TREESITTER_QUERY_URL}
+  SHA256 ${TREESITTER_QUERY_SHA256}
+  CMAKE_FILE TreesitterParserCMakeLists.txt)


### PR DESCRIPTION
Since 0007aa50bd3d54259bb4ae717c114f5524ec59fa the build unsets all URL
variable immediately when USE_EXISTING_SRC_DIR is TRUE, which is
correct. However, this causes the function BuildTSParser to break down
as cmake functions aren't traditionally equipped to deal with empty
variables. Using cmake_parse_arguments fixes this issue.
