### PR TITLE
fix(column): issues with 'statuscolumn' width

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2176,6 +2176,10 @@ static char *set_bool_option(const int opt_idx, char *const varp, const int valu
     if (curwin->w_p_spell) {
       errmsg = did_set_spelllang(curwin);
     }
+  } else if ((int *)varp == &curwin->w_p_nu && *curwin->w_p_stc != NUL) {
+    // When 'statuscolumn' is set and 'number' is changed:
+    curwin->w_nrwidth_line_count = 0;    // make sure width is reset
+    curwin->w_statuscol_line_count = 0;  // make sure width is re-estimated
   }
 
   if ((int *)varp == &curwin->w_p_arab) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1199,6 +1199,7 @@ static void did_set_statusline(win_T *win, char **varp, char **gvarp, char **err
     ru_wid = 0;
   } else if (varp == &win->w_p_stc) {
     win->w_nrwidth_line_count = 0;
+    win->w_statuscol_line_count = 0;
   }
   char *s = *varp;
   if (varp == &p_ruf && *s == '%') {

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -520,4 +520,42 @@ describe('statuscolumn', function()
       :                                                    |
     ]])
   end)
+
+  it("has correct width when toggling '(relative)number'", function()
+    screen:try_resize(screen._width, 6)
+    command('call setline(1, repeat(["aaaaa"], 100))')
+    command('set relativenumber')
+    command([[set stc=%{!&nu&&!&rnu?'':&rnu?v:relnum?v:relnum:&nu?v:lnum:'0':v:lnum}]])
+    screen:expect([[
+      1  aaaaa                                             |
+      8  ^aaaaa                                             |
+      1  aaaaa                                             |
+      2  aaaaa                                             |
+      3  aaaaa                                             |
+                                                           |
+    ]])
+    -- width correctly estimated with "w_nrwidth_line_count" when setting 'stc'
+    command([[set stc=%{!&nu&&!&rnu?'':&rnu?v:relnum?v:relnum:&nu?v:lnum:'0':v:lnum}]])
+    screen:expect_unchanged()
+    -- zero width when disabling 'number'
+    command('set norelativenumber nonumber')
+    screen:expect([[
+      aaaaa                                                |
+      ^aaaaa                                                |
+      aaaaa                                                |
+      aaaaa                                                |
+      aaaaa                                                |
+                                                           |
+    ]])
+    -- width correctly estimated with "w_nrwidth_line_count" when setting 'nu'
+    command('set number')
+    screen:expect([[
+      7  aaaaa                                             |
+      8  ^aaaaa                                             |
+      9  aaaaa                                             |
+      10 aaaaa                                             |
+      11 aaaaa                                             |
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:    'statuscolumn' width can be incorrect when toggling 'number' or
            setting 'statuscolumn'.
Solution:   Make sure the width is reset and re-estimated when
            'statuscolumn' and 'number' are set. (When 'relativenumber'
            is set this already happens because it always changes
            "nrwidth_line_count".)