### PR TITLE
build!: make libintl a required dependency

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -45,7 +45,7 @@ The following changes may require adaptations in user config or plugins.
     - `printheader`
     - `printmbcharset`
 
-• libiconv is now a required build dependency.
+• libiconv and intl are now required build dependencies.
 
 • Unsaved changes are now preserved rather than discarded when |channel-stdio|
   is closed.

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -32,14 +32,11 @@ target_link_libraries(main_lib INTERFACE
   treesitter
   unibilium)
 
-option(ENABLE_LIBINTL "enable libintl" ON)
-if(ENABLE_LIBINTL)
-  # Libintl (not Intl) selects our FindLibintl.cmake script. #8464
-  find_package(Libintl REQUIRED)
-  target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBINTL_INCLUDE_DIR})
-  if (LIBINTL_LIBRARY)
-    target_link_libraries(main_lib INTERFACE ${LIBINTL_LIBRARY})
-  endif()
+# Libintl (not Intl) selects our FindLibintl.cmake script. #8464
+find_package(Libintl REQUIRED)
+target_include_directories(main_lib SYSTEM BEFORE INTERFACE ${LIBINTL_INCLUDE_DIR})
+if (LIBINTL_LIBRARY)
+  target_link_libraries(main_lib INTERFACE ${LIBINTL_LIBRARY})
 endif()
 
 # The unit test lib requires LuaJIT; it will be skipped if LuaJIT is missing.


### PR DESCRIPTION
Libintl being an optional dependency is not by design, but a workaround
as it didn't use work on all platforms. That should be fixed by now.