### PR TITLE
vim-patch:9.0.1385: g'Esc is considered an error

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -963,7 +963,8 @@ normal_end:
   may_trigger_modechanged();
   // Redraw the cursor with another shape, if we were in Operator-pending
   // mode or did a replace command.
-  if (s->c || s->ca.cmdchar == 'r') {
+  if (s->c || s->ca.cmdchar == 'r'
+      || (s->ca.cmdchar == 'g' && s->ca.nchar == 'r')) {
     ui_cursor_shape();                  // may show different cursor shape
   }
 
@@ -1162,7 +1163,7 @@ static int normal_execute(VimState *state, int key)
 
   State = MODE_NORMAL;
 
-  if (s->ca.nchar == ESC) {
+  if (s->ca.nchar == ESC || s->ca.extra_char == ESC) {
     clearop(&s->oa);
     s->command_finished = true;
     goto finish;
@@ -4706,7 +4707,7 @@ static void nv_vreplace(cmdarg_T *cap)
     return;
   }
 
-  if (checkclearopq(cap->oap) || cap->extra_char == ESC) {
+  if (checkclearopq(cap->oap)) {
     return;
   }
 

--- a/test/functional/ui/mode_spec.lua
+++ b/test/functional/ui/mode_spec.lua
@@ -44,7 +44,10 @@ describe('ui mode_change event', function()
       {0:~                        }|
                                |
     ]], mode="normal"}
+  end)
 
+  -- oldtest: Test_mouse_shape_after_failed_change()
+  it('is restored to Normal mode after failed "c"', function()
     screen:try_resize(50, 4)
     command('set nomodifiable')
 
@@ -62,6 +65,25 @@ describe('ui mode_change event', function()
       {0:~                                                 }|
       {0:~                                                 }|
       {4:E21: Cannot make changes, 'modifiable' is off}     |
+    ]], mode="normal"}
+  end)
+
+  -- oldtest: Test_mouse_shape_after_cancelling_gr()
+  it('is restored to Normal mode after cancelling "gr"', function()
+    feed('gr')
+    screen:expect{grid=[[
+      ^                         |
+      {0:~                        }|
+      {0:~                        }|
+                               |
+    ]], mode="replace"}
+
+    feed('<Esc>')
+    screen:expect{grid=[[
+      ^                         |
+      {0:~                        }|
+      {0:~                        }|
+                               |
     ]], mode="normal"}
   end)
 


### PR DESCRIPTION
#### vim-patch:9.0.1385: g'Esc is considered an error

Problem:    g'Esc is considered an error.
Solution:   Make g'Esc silently abandon the command. (closes vim/vim#12110)

https://github.com/vim/vim/commit/f86dea8119f3141e3d2c680219036d1511101f9b