### PR TITLE
perf(statusline): UI elements are always redrawn on K_EVENT

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1279,13 +1279,14 @@ struct window_S {
   bool w_redr_border;               // if true border must be redrawn
   bool w_redr_statuscol;            // if true 'statuscolumn' must be redrawn
 
-  // remember what is shown in the ruler for this window (if 'ruler' set)
-  pos_T w_ru_cursor;                // cursor position shown in ruler
-  colnr_T w_ru_virtcol;             // virtcol shown in ruler
-  linenr_T w_ru_topline;            // topline shown in ruler
-  linenr_T w_ru_line_count;         // line count used for ruler
-  int w_ru_topfill;                 // topfill shown in ruler
-  char w_ru_empty;                  // true if ruler shows 0-1 (empty line)
+  // remember what is shown in the 'statusline'-format elements
+  pos_T w_stl_cursor;                // cursor position when last redrawn
+  colnr_T w_stl_virtcol;             // virtcol when last redrawn
+  linenr_T w_stl_topline;            // topline when last redrawn
+  linenr_T w_stl_line_count;         // line count when last redrawn
+  int w_stl_topfill;                 // topfill when last redrawn
+  char w_stl_empty;                  // true if elements show 0-1 (empty line)
+  int w_stl_state;                   // State when last redrawn
 
   int w_alt_fnum;                   // alternate file (for # and CTRL-^)
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -907,6 +907,9 @@ theend:
     ui_call_cmdline_hide(ccline.level);
     msg_ext_clear_later();
   }
+  if (!cmd_silent) {
+    status_redraw_all();  // redraw to show mode change
+  }
 
   cmdline_level--;
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -92,6 +92,7 @@
 #include "nvim/spell.h"
 #include "nvim/spellfile.h"
 #include "nvim/spellsuggest.h"
+#include "nvim/statusline.h"
 #include "nvim/strings.h"
 #include "nvim/tag.h"
 #include "nvim/terminal.h"
@@ -2251,8 +2252,13 @@ static char *set_bool_option(const int opt_idx, char *const varp, const int valu
     ui_call_option_set(cstr_as_string(options[opt_idx].fullname),
                        BOOLEAN_OBJ(*varp));
   }
-
-  comp_col();                       // in case 'ruler' or 'showcmd' changed
+  if ((int *)varp == &p_ru || (int *)varp == &p_sc) {
+    // in case 'ruler' or 'showcmd' changed
+    comp_col();
+    if ((int *)varp == &p_ru) {
+      win_redr_ruler(curwin);
+    }
+  }
   if (curwin->w_curswant != MAXCOL
       && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0) {
     curwin->w_set_curswant = true;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -49,6 +49,7 @@
 #include "nvim/spell.h"
 #include "nvim/spellfile.h"
 #include "nvim/spellsuggest.h"
+#include "nvim/statusline.h"
 #include "nvim/strings.h"
 #include "nvim/tag.h"
 #include "nvim/ui.h"
@@ -1220,6 +1221,7 @@ static void did_set_statusline(win_T *win, char **varp, char **gvarp, char **err
   }
   if (varp == &p_ruf && *errmsg == NULL) {
     comp_col();
+    win_redr_ruler(curwin);
   }
   // add / remove window bars for 'winbar'
   if (gvarp == &p_wbr) {

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -611,7 +611,7 @@ int showmode(void)
   // the ruler is after the mode message and must be redrawn
   win_T *last = lastwin_nofloating();
   if (redrawing() && last->w_status_height == 0 && global_stl_height() == 0) {
-    win_redr_ruler(last, true);
+    win_redr_ruler(last);
   }
 
   redraw_cmdline = false;


### PR DESCRIPTION
Problem:    'statusline'-format UI elements are redrawn on each K_EVENT.
Solution:   Only redraw UI elements when something relevant has changed.


Fix https://github.com/neovim/neovim/issues/4847 (untested)
Fix https://github.com/neovim/neovim/issues/14303
Fix https://github.com/neovim/neovim/issues/17937