### PR TITLE
vim-patch:9.0.1386: options test fails with some window width

### DIFF
--- a/src/nvim/testdir/test_normal.vim
+++ b/src/nvim/testdir/test_normal.vim
@@ -2540,8 +2540,11 @@ func Test_normal33_g_cmd2()
   norm! g'a
   call assert_equal('>', a[-1:])
   call assert_equal(1, line('.'))
+  let v:errmsg = ''
   call assert_nobeep("normal! g`\<Esc>")
+  call assert_equal('', v:errmsg)
   call assert_nobeep("normal! g'\<Esc>")
+  call assert_equal('', v:errmsg)
 
   " Test for g; and g,
   norm! g;

--- a/src/nvim/testdir/test_options.vim
+++ b/src/nvim/testdir/test_options.vim
@@ -890,8 +890,9 @@ func Test_debug_option()
   exe "normal \<C-c>"
   call assert_equal('Beep!', Screenline(&lines))
   call assert_equal('line    4:', Screenline(&lines - 1))
-  " only match the final colon in the line that shows the source
-  call assert_match(':$', Screenline(&lines - 2))
+  " also check a line above, with a certain window width the colon is there
+  call assert_match('Test_debug_option:$',
+        \ Screenline(&lines - 3) .. Screenline(&lines - 2))
   set debug&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.1386: options test fails with some window width

Problem:    Options test fails with some window width.
Solution:   Adjust what text the test checks with. (closes vim/vim#12111)

https://github.com/vim/vim/commit/30585e03a7ce6cf985f93ca30275bf4dae0d87cc