### PR TITLE
revert: "refactor(treesitter): simplify some range functions"

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -2,7 +2,6 @@ local a = vim.api
 local query = require('vim.treesitter.query')
 local language = require('vim.treesitter.language')
 local LanguageTree = require('vim.treesitter.languagetree')
-local Range = require('vim.treesitter._range')
 
 ---@type table<integer,LanguageTree>
 local parsers = setmetatable({}, { __mode = 'v' })
@@ -191,7 +190,20 @@ end
 ---
 ---@return boolean True if the position is in node range
 function M.is_in_node_range(node, line, col)
-  return M.node_contains(node, { line, col, line, col })
+  local start_line, start_col, end_line, end_col = M.get_node_range(node)
+  if line >= start_line and line <= end_line then
+    if line == start_line and line == end_line then
+      return col >= start_col and col < end_col
+    elseif line == start_line then
+      return col >= start_col
+    elseif line == end_line then
+      return col < end_col
+    else
+      return true
+    end
+  else
+    return false
+  end
 end
 
 --- Determines if a node contains a range
@@ -201,11 +213,11 @@ end
 ---
 ---@return boolean True if the {node} contains the {range}
 function M.node_contains(node, range)
-  vim.validate({
-    node = { node, 'userdata' },
-    range = { range, Range.validate, 'integer list with 4 or 6 elements' },
-  })
-  return Range.contains({ node:range() }, range)
+  local start_row, start_col, end_row, end_col = node:range()
+  local start_fits = start_row < range[1] or (start_row == range[1] and start_col <= range[2])
+  local end_fits = end_row > range[3] or (end_row == range[3] and end_col >= range[4])
+
+  return start_fits and end_fits
 end
 
 --- Returns a list of highlight captures at the given position

--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -54,26 +54,6 @@ M.cmp_pos = {
 setmetatable(M.cmp_pos, { __call = cmp_pos })
 
 ---@private
----Check if a variable is a valid range object
----@param r any
----@return boolean
-function M.validate(r)
-  if type(r) ~= 'table' or #r ~= 6 and #r ~= 4 then
-    return false
-  end
-
-  for _, e in
-    ipairs(r --[[@as any[] ]])
-  do
-    if type(e) ~= 'number' then
-      return false
-    end
-  end
-
-  return true
-end
-
----@private
 ---@param r1 Range4|Range6
 ---@param r2 Range4|Range6
 ---@return boolean


### PR DESCRIPTION
Reverts neovim/neovim#22549 because it breaks backward-compatibility.