### PR TITLE
build: enable unit testing on release builds

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -626,8 +626,8 @@ if(PREFER_LUA)
   message(STATUS "luajit not used, skipping unit tests")
 else()
   glob_wrapper(UNIT_TEST_FIXTURES ${PROJECT_SOURCE_DIR}/test/unit/fixtures/*.c)
-  target_sources(nvim PRIVATE $<$<CONFIG:Debug>:${UNIT_TEST_FIXTURES}>)
-  target_compile_definitions(nvim PRIVATE $<$<CONFIG:Debug>:UNIT_TESTING>)
+  target_sources(nvim PRIVATE ${UNIT_TEST_FIXTURES})
+  target_compile_definitions(nvim PRIVATE UNIT_TESTING)
 endif()
 
 target_sources(main_lib INTERFACE


### PR DESCRIPTION
Unittests not working on release builds can lead to confusing
situations, such as contributors wondering why their tests aren't
working if they forgot they've built with a release build. This only
increased the Release executable size by 8 kB on my personal machine,
which is an acceptable tradeoff.
