### PR TITLE
ci: skip ruby provider tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,9 +338,6 @@ jobs:
           # Sanity check
           python -c "import pynvim; print(str(pynvim))"
 
-          gem.cmd install --pre neovim
-          Get-Command -CommandType Application neovim-ruby-host.bat
-
           node --version
           npm.cmd --version
 


### PR DESCRIPTION
Installing the ruby provider takes anything between 1 and 1.5 minutes on
Windows, which is a big drain on our CI. Remove it until we find a more
sustainable solution.
