### PR TITLE
vim-patch:8.2.3969: value of MAXCOL not available in Vim script

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2890,6 +2890,9 @@ getcharpos({expr})
 		Get the position for String {expr}. Same as |getpos()| but the
 		column number in the returned List is a character index
 		instead of a byte index.
+		If |getpos()| returns a very large column number, equal to
+		|v:maxcol|, then getcharpos() will return the character index
+		of the last character.
 
 		Example:
 		With the cursor on '세' in line 5 with text "여보세요": >
@@ -3064,10 +3067,11 @@ getcompletion({pat}, {type} [, {filtered}])		*getcompletion()*
 							*getcurpos()*
 getcurpos([{winid}])
 		Get the position of the cursor.  This is like getpos('.'), but
-		includes an extra "curswant" in the list:
+		includes an extra "curswant" item in the list:
 		    [0, lnum, col, off, curswant] ~
 		The "curswant" number is the preferred column when moving the
-		cursor vertically.  Also see |getcursorcharpos()| and
+		cursor vertically.  After |$| command it will be a very large
+		number equal to |v:maxcol|.  Also see |getcursorcharpos()| and
 		|getpos()|.
 		The first "bufnum" item is always zero. The byte position of
 		the cursor is returned in "col". To get the character
@@ -3389,12 +3393,12 @@ getpos({expr})	Get the position for String {expr}.  For possible values of
 		character.
 		Note that for '< and '> Visual mode matters: when it is "V"
 		(visual line mode) the column of '< is zero and the column of
-		'> is a large number.
+		'> is a large number equal to |v:maxcol|.
 		The column number in the returned List is the byte position
 		within the line. To get the character position in the line,
 		use |getcharpos()|.
-		The column number can be very large, e.g. 2147483647, in which
-		case it means "after the end of the line".
+		A very large column number equal to |v:maxcol| can be returned,
+		in which case it means "after the end of the line".
 		If {expr} is invalid, returns a list with all zeros.
 		This can be used to save and restore the position of a mark: >
 			let save_a_mark = getpos("'a")
@@ -9407,10 +9411,14 @@ winsaveview()	Returns a |Dictionary| that contains information to restore
 		The return value includes:
 			lnum		cursor line number
 			col		cursor column (Note: the first column
-					zero, as opposed to what getpos()
+					zero, as opposed to what |getcurpos()|
 					returns)
 			coladd		cursor column offset for 'virtualedit'
-			curswant	column for vertical movement
+			curswant	column for vertical movement (Note:
+					the first column is zero, as opposed
+					to what |getcurpos()| returns).  After
+					|$| command it will be a very large
+					number equal to |v:maxcol|.
 			topline		first line in the window
 			topfill		filler lines, only in diff mode
 			leftcol		first column displayed; only used when

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6574,6 +6574,8 @@ screenpos({winid}, {lnum}, {col})				*screenpos()*
 		as if 'conceallevel' is zero.  You can set the cursor to the
 		right position and use |screencol()| to get the value with
 		|conceal| taken into account.
+		If the position is in a closed fold the screen position of the
+		first character is returned, {col} is not used.
 		Returns an empty Dict if {winid} is invalid.
 
 		Can also be used as a |method|: >

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1979,6 +1979,9 @@ v:lnum		Line number for the 'foldexpr' |fold-expr|, 'formatexpr',
 v:lua		Prefix for calling Lua functions from expressions.
 		See |v:lua-call| for more information.
 
+						*v:maxcol* *maxcol-variable*
+v:maxcol	Maximum line length.
+
 					*v:mouse_win* *mouse_win-variable*
 v:mouse_win	Window number for a mouse click obtained with |getchar()|.
 		First window has number 1, like with |winnr()|.  The value is

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1980,7 +1980,9 @@ v:lua		Prefix for calling Lua functions from expressions.
 		See |v:lua-call| for more information.
 
 						*v:maxcol* *maxcol-variable*
-v:maxcol	Maximum line length.
+v:maxcol	Maximum line length.  Depending on where it is used it can be
+		screen columns, characters or bytes.  The value currently is
+		2147483647 on all systems.
 
 					*v:mouse_win* *mouse_win-variable*
 v:mouse_win	Window number for a mouse click obtained with |getchar()|.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -251,6 +251,7 @@ static struct vimvar {
   VV(VV_ARGV,             "argv",             VAR_LIST, VV_RO),
   VV(VV_COLLATE,          "collate",          VAR_STRING, VV_RO),
   VV(VV_EXITING,          "exiting",          VAR_NUMBER, VV_RO),
+  VV(VV_MAXCOL,           "maxcol",           VAR_NUMBER, VV_RO),
   // Neovim
   VV(VV_STDERR,           "stderr",           VAR_NUMBER, VV_RO),
   VV(VV_MSGPACK_TYPES,    "msgpack_types",    VAR_DICT, VV_RO),
@@ -451,6 +452,7 @@ void eval_init(void)
   set_vim_var_nr(VV_NUMBERMIN, VARNUMBER_MIN);
   set_vim_var_nr(VV_NUMBERSIZE, sizeof(varnumber_T) * 8);
   set_vim_var_special(VV_EXITING, kSpecialVarNull);
+  set_vim_var_nr(VV_MAXCOL, MAXCOL);
 
   set_vim_var_nr(VV_ECHOSPACE,    sc_col - 1);
 

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -157,6 +157,7 @@ typedef enum {
   VV_ARGV,
   VV_COLLATE,
   VV_EXITING,
+  VV_MAXCOL,
   // Nvim
   VV_STDERR,
   VV_MSGPACK_TYPES,

--- a/test/old/testdir/test_cursor_func.vim
+++ b/test/old/testdir/test_cursor_func.vim
@@ -40,6 +40,18 @@ func Test_move_cursor()
   quit!
 endfunc
 
+func Test_curswant_maxcol()
+  new
+  call setline(1, 'foo')
+
+  " Test that after "$" command curswant is set to the same value as v:maxcol.
+  normal! 1G$
+  call assert_equal(v:maxcol, getcurpos()[4])
+  call assert_equal(v:maxcol, winsaveview().curswant)
+
+  quit!
+endfunc
+
 " Very short version of what matchparen does.
 function s:Highlight_Matching_Pair()
   let save_cursor = getcurpos()

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -921,7 +921,7 @@ func Test_normal14_page()
   set nostartofline
   exe "norm! $\<c-b>"
   call assert_equal('92', getline('.'))
-  call assert_equal([0, 92, 2, 0, 2147483647], getcurpos())
+  call assert_equal([0, 92, 2, 0, v:maxcol], getcurpos())
   " cleanup
   set startofline
   bw!
@@ -966,7 +966,7 @@ func Test_normal15_z_scroll_vert()
   norm! >>$ztzb
   call assert_equal('	30', getline('.'))
   call assert_equal(30, winsaveview()['topline']+winheight(0)-1)
-  call assert_equal([0, 30, 3, 0, 2147483647], getcurpos())
+  call assert_equal([0, 30, 3, 0, v:maxcol], getcurpos())
 
   " Test for z-
   1
@@ -2917,7 +2917,7 @@ func Test_normal36_g_cmd5()
   call assert_equal([0, 14, 1, 0, 1], getcurpos())
   " count > buffer content
   norm! 120go
-  call assert_equal([0, 14, 1, 0, 2147483647], getcurpos())
+  call assert_equal([0, 14, 1, 0, v:maxcol], getcurpos())
   " clean up
   bw!
 endfunc
@@ -3097,7 +3097,7 @@ func Test_normal42_halfpage()
   set nostartofline
   exe "norm! $\<c-u>"
   call assert_equal('95', getline('.'))
-  call assert_equal([0, 95, 2, 0, 2147483647], getcurpos())
+  call assert_equal([0, 95, 2, 0, v:maxcol], getcurpos())
   " cleanup
   set startofline
   bw!

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -209,7 +209,7 @@ func Test_multibyte_op_end_mark()
   call assert_equal([0, 1, 7, 0], getpos("']"))
 
   normal Vyp
-  call assert_equal([0, 1, 2147483647, 0], getpos("'>"))
+  call assert_equal([0, 1, v:maxcol, 0], getpos("'>"))
   call assert_equal([0, 2, 7, 0], getpos("']"))
   bwipe!
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.3969: value of MAXCOL not available in Vim script

Problem:    Value of MAXCOL not available in Vim script.
Solution:   Add v:maxcol. (Naohiro Ono, closes vim/vim#9451)

https://github.com/vim/vim/commit/56200eed62e59ad831f6564dcafe346e6f97ac20

The variable is always 2147483647, but introducing it makes functions
easier to document.

Co-authored-by: naohiro ono <obcat@icloud.com>