### PR TITLE
fix(lsp): change LspTokenUpdate to use buffer instead of pattern when executing callbacks

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -435,7 +435,7 @@ function STHighlighter:on_win(topline, botline)
           token.marked = true
 
           api.nvim_exec_autocmds('LspTokenUpdate', {
-            pattern = vim.api.nvim_buf_get_name(self.bufnr),
+            buffer = self.bufnr,
             modeline = false,
             data = {
               token = token,


### PR DESCRIPTION
Follow up to #22022 to fix a minor bug with the `LspTokenUpdate` callback. It should be using the buffer argument to `nvim_exec_autocmds` instead of using the api to lookup the buffer's name and passing that as `pattern`. The current way (without this fix) doesn't actually work when defining a buffer-local autocmd for this event.

@swarn @mfussenegger 