### PR TITLE
fix runtime/syntax/hitest.vim

### DIFF
--- a/runtime/syntax/hitest.vim
+++ b/runtime/syntax/hitest.vim
@@ -62,7 +62,7 @@ global /links to/ move $
 " move linked group names to the matching preferred groups
 " TODO: this fails if the group linked to isn't defined
 % substitute /^\(\w\+\)\s*\(links to\)\s*\(\w\+\)$/\3\t\2 \1/e
-silent! global /links to/ normal mz3ElD0#$p'zdd
+silent! global /links to/ normal! mz3ElD0#$p'zdd
 
 " delete empty lines
 global /^ *$/ delete
@@ -79,7 +79,7 @@ syntax clear
 % substitute /^syn keyword //
 
 " pretty formatting
-global /^/ exe "normal Wi\<CR>\t\eAA\ex"
+global /^/ exe "normal! Wi\<CR>\t\eAA\ex"
 global /^\S/ join
 
 " find out first syntax highlighting


### PR DESCRIPTION
There were two normal commands without bang(!), so it didn't work when mappings were present.

The vim is now pending [a pr](https://github.com/vim/vim/pull/10379) that completely rewrite it on vim9script, so we can fix it without fear of vim patch conflicts