### PR TITLE
fix: pasting in terminal buffer on windows

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -724,7 +724,11 @@ void terminal_paste(long count, char **y_array, size_t y_size)
     for (size_t j = 0; j < y_size; j++) {
       if (j) {
         // terminate the previous line
+#ifdef MSWIN
+        terminal_send(curbuf->terminal, "\r\n", 2);
+#else
         terminal_send(curbuf->terminal, "\n", 1);
+#endif
       }
       size_t len = strlen(y_array[j]);
       if (len > buff_len) {

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -429,3 +429,71 @@ it('terminal truncates number of composing characters to 5', function()
   meths.chan_send(chan, 'a' .. composing:rep(8))
   retry(nil, nil, function() eq('a' .. composing:rep(5), meths.get_current_line()) end)
 end)
+
+if is_os('win') then
+  describe(':terminal in Windows', function()
+    local screen
+
+    before_each(function()
+      clear()
+      feed_command('set modifiable swapfile undolevels=20')
+      poke_eventloop()
+      local cmd = '["' .. 'cmd.exe' .. '","/K","PROMPT=$g$s"]'
+      screen = thelpers.screen_setup(nil, cmd)
+    end)
+
+    it('"put" operator sends data normally', function()
+      feed('<c-\\><c-n>G')
+      feed_command('let @a = ":: tty ready"')
+      feed_command('let @a = @a . "\\n:: appended " . @a . "\\n\\n"')
+      feed('"ap"ap')
+      screen:expect([[
+                                                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      ^> {2: }                                               |
+      :let @a = @a . "\n:: appended " . @a . "\n\n"     |
+      ]])
+      -- operator count is also taken into consideration
+      feed('3"ap')
+      screen:expect([[
+      > :: appended :: tty ready                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      ^> {2: }                                               |
+      :let @a = @a . "\n:: appended " . @a . "\n\n"     |
+      ]])
+    end)
+
+    it('":put" command sends data normally', function()
+      feed('<c-\\><c-n>G')
+      feed_command('let @a = ":: tty ready"')
+      feed_command('let @a = @a . "\\n:: appended " . @a . "\\n\\n"')
+      feed_command('put a')
+      screen:expect([[
+                                                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      > {2: }                                               |
+                                                        |
+      ^                                                  |
+      :put a                                            |
+      ]])
+      -- line argument is only used to move the cursor
+      feed_command('6put a')
+      screen:expect([[
+                                                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      > :: tty ready                                    |
+      > :: appended :: tty ready                        |
+      ^> {2: }                                               |
+      :6put a                                           |
+      ]])
+    end)
+  end)
+end

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -438,7 +438,7 @@ if is_os('win') then
       clear()
       feed_command('set modifiable swapfile undolevels=20')
       poke_eventloop()
-      local cmd = '["' .. 'cmd.exe' .. '","/K","PROMPT=$g$s"]'
+      local cmd = '["cmd.exe","/K","PROMPT=$g$s"]'
       screen = thelpers.screen_setup(nil, cmd)
     end)
 


### PR DESCRIPTION
fix: pasting in terminal buffer on windows

Problem:
On Windows, pasting multiple lines on a terminal buffer cause all the
lines to appear on the same line, i.e., the line breaks are lost.

Cause:
Windows shells expect '\r\n' as line break but 'terminal_paste' function
uses '\n'.

Solution:
Use '\r\n' as line break for pasting in terminal buffer on Windows.

Note:
Although this issue was reported with powershell set as 'shell', it
occurs in cmd too.

Fixes #14621