### PR TITLE
vim-patch:8.2.3741: using freed memory in open command

### DIFF
--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -123,6 +123,20 @@ func Test_open_command()
   close!
 endfunc
 
+func Test_open_command_flush_line()
+  throw 'Skipped: Nvim does not have :open'
+  " this was accessing freed memory: the regexp match uses a pointer to the
+  " current line which becomes invalid when searching for the ') mark.
+  new
+  call setline(1, ['one', 'two. three'])
+  s/one/ONE
+  try
+    open /\%')/
+  catch /E479/
+  endtry
+  bwipe!
+endfunc
+
 " Test for :g/pat/visual to run vi commands in Ex mode
 " This used to hang Vim before 8.2.0274.
 func Test_Ex_global()


### PR DESCRIPTION
#### vim-patch:8.2.3741: using freed memory in open command

Problem:    Using freed memory in open command.
Solution:   Make a copy of the current line.

https://github.com/vim/vim/commit/e031fe90cf2e375ce861ff5e5e281e4ad229ebb9

Co-authored-by: Bram Moolenaar <Bram@vim.org>