### PR TITLE
feat: try to recover from missing tempdir

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8688,13 +8688,11 @@ taglist({expr} [, {filename}])				*taglist()*
 			GetTagpattern()->taglist()
 
 tempname()					*tempname()* *temp-file-name*
-		The result is a String, which is the name of a file that
-		doesn't exist.  It can be used for a temporary file.  Example: >
+		Generates a (non-existent) filename located in the Nvim root
+		|tempdir|. Scripts can use the filename as a temporary file.
+		Example: >
 			:let tmpfile = tempname()
 			:exe "redir > " .. tmpfile
-<		For Unix, the file will be in a private directory |tempfile|.
-		For MS-Windows forward slashes are used when the 'shellslash'
-		option is set or when 'shellcmdflag' starts with '-'.
 
 termopen({cmd} [, {opts}])			*termopen()*
 		Spawns {cmd} in a new pseudo-terminal session connected

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -576,18 +576,29 @@ with ".".  Vim does not recognize a comment (starting with '"') after the
 {Visual}=		Filter the highlighted lines like with ={motion}.
 
 
-						*tempfile* *setuid*
-Vim uses temporary files for filtering, generating diffs and also for
-tempname().  For Unix, the file will be in a private directory (only
-accessible by the current user) to avoid security problems (e.g., a symlink
-attack or other people reading your file).  When Vim exits the directory and
-all files in it are deleted.  When Vim has the setuid bit set this may cause
-problems, the temp file is owned by the setuid user but the filter command
-probably runs as the original user.
-Directory for temporary files is created in the first possible directory of:
+						*tempdir* *tempfile* *setuid*
+Nvim uses temporary files for filtering and generating diffs. Plugins also
+commonly use |tempname()| for their own purposes. On the first request for
+a temporary file, Nvim creates a common directory (the "Nvim tempdir"), to
+serve as storage for all temporary files (including `stdpath("run")` files
+|$XDG_RUNTIME_DIR|) in the current session.
+
+The Nvim tempdir is created in the first available system tempdir:
 	Unix:    $TMPDIR, /tmp, current-dir, $HOME.
 	Windows: $TMPDIR, $TMP, $TEMP, $USERPROFILE, current-dir.
 
+On unix the tempdir is created with permissions 0700 (only accessible by the
+current user) to avoid security problems (e.g. symlink attacks).  On exit,
+Nvim deletes the tempdir and its contents.
+							*E5431*
+If you see an error or |log| message like: >
+	E5431: tempdir disappeared (2 times)
+this means an external process on your system deleted the Nvim tempdir.
+Typically this is caused by "antivirus" or a misconfigured cleanup service.
+
+If Nvim has the setuid bit set this may cause problems: the temp file
+is owned by the setuid user but the filter command probably runs as the
+original user.
 
 
 4.2 Substitute						*:substitute*

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1397,7 +1397,7 @@ Note: Similarly to the $XDG environment variables, when
 `$XDG_CONFIG_HOME/nvim` is mentionned, it should be understood as
 `$XDG_CONFIG_HOME/$NVIM_APPNAME`.
 
-LOG FILE					*$NVIM_LOG_FILE* *E5430*
+LOG FILE					*log* *$NVIM_LOG_FILE* *E5430*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -237,6 +237,7 @@ Functions:
   |stdpath()|
   |system()|, |systemlist()| can run {cmd} directly (without 'shell')
   |matchadd()| can be called before highlight group is defined
+  |tempname()| tries to recover if the Nvim |tempdir| disappears.
   |writefile()| with "p" flag creates parent directories.
 
 Highlight groups:


### PR DESCRIPTION
Continues https://github.com/neovim/neovim/pull/11284


## Problem:
If vim_tempdir mysteriously goes missing (likely by "antivirus" on Windows), any plugins using tempname() will be broken for the rest of the session. #1432 #9833
https://groups.google.com/g/vim_use/c/ef55jNm5czI

### Steps:

    mkdir foo
    TMPDIR=./foo nvim
    :echo tempname()
    !rm -r foo
    :echo tempname()
    tempname() still uses the foo path even though it was deleted.

## Solution:

- Don't assume that vim_tempdir exists.
- If it goes missing, create a new one, and log a WARN message.
- If it goes missing again, create a new one and show an error.

Rejected in Vim for performance reasons:
https://groups.google.com/g/vim_use/c/qgRob9SWDv8/m/FAOFVVcDTv0J
https://groups.google.com/g/vim_dev/c/cogp-Vye4oo/m/d_SVFXBbnnoJ

Testing shows that `vim_gettempdir` is not called frequently.

Fixes #1432
Fixes #9833
Fixes #11250
Related: stdpath("run") f50135a32e11c535e1dc3a8e9460c5b4e640ee86
