### PR TITLE
ci(news): don't run on draft

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -1,11 +1,13 @@
 name: "news.txt check"
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
     - 'master'
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
same as lintcommit: only becomes relevant when discussing merging, and is annoying while still working on the PR in draft.

@dundargoc
