### PR TITLE
refactor(treesitter): delegate region calculation to treesitter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -376,13 +376,13 @@ jobs:
             libluajit-5.1-dev \
             libmsgpack-dev \
             libtermkey-dev \
-            libtree-sitter-dev \
             libunibilium-dev \
             libuv1-dev \
             lua-filesystem \
             lua-lpeg \
             lua-mpack \
             luajit
+            # libtree-sitter-dev \
             # libvterm-dev \
             # lua-luv-dev
 
@@ -397,7 +397,10 @@ jobs:
           # dependencies don't have the required version available. We use the
           # bundled versions for these with the hopes of being able to remove them
           # later on.
-          cmake -S cmake.deps -B .deps -G Ninja -D USE_BUNDLED=OFF -D USE_BUNDLED_LUV=ON -D USE_BUNDLED_LIBVTERM=ON
+          cmake -S cmake.deps -B .deps -G Ninja -D USE_BUNDLED=OFF \
+            -D USE_BUNDLED_LUV=ON \
+            -D USE_BUNDLED_LIBVTERM=ON \
+            -D USE_BUNDLED_TS=ON
           cmake --build .deps
 
       - name: Build

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Iconv REQUIRED)
 find_package(Libtermkey 0.22 REQUIRED)
 find_package(Libvterm 0.3 REQUIRED)
 find_package(Msgpack 1.0.0 REQUIRED)
-find_package(Treesitter REQUIRED)
+find_package(Treesitter 0.20.8 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 
 target_link_libraries(main_lib INTERFACE

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -64,6 +64,7 @@ static struct luaL_Reg tree_meta[] = {
   { "__tostring", tree_tostring },
   { "root", tree_root },
   { "edit", tree_edit },
+  { "included_ranges", tree_get_ranges },
   { "copy", tree_copy },
   { NULL, NULL }
 };
@@ -510,6 +511,24 @@ static int tree_edit(lua_State *L)
   ts_tree_edit(*tree, &edit);
 
   return 0;
+}
+
+static int tree_get_ranges(lua_State *L)
+{
+  TSTree **tree = tree_check(L, 1);
+  if (!(*tree)) {
+    return 0;
+  }
+
+  bool include_bytes = (lua_gettop(L) >= 2) && lua_toboolean(L, 2);
+
+  uint32_t len;
+  TSRange *ranges = ts_tree_included_ranges(*tree, &len);
+
+  push_ranges(L, ranges, len, include_bytes);
+
+  xfree(ranges);
+  return 1;
 }
 
 // Use the top of the stack (without popping it) to create a TSRange, it can be


### PR DESCRIPTION
Treesitter can track regions for us. Repurpose `_regions` field from LanguageTree. This means regions will be automatically adjusted after calls to `tree:edit()` instead of trying to keep track of it ourselves.

This should allow us to more accurately validate regions (by doing less).

Also added some logging.

Requires new release of treesitter.

Revival to #22553
