### PR TITLE
vim-patch:9.0.1393: Cairo files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -191,6 +191,7 @@ local extension = {
   BUILD = 'bzl',
   qc = 'c',
   cabal = 'cabal',
+  cairo = 'cairo',
   capnp = 'capnp',
   cdc = 'cdc',
   cdl = 'cdl',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -98,6 +98,7 @@ let s:filename_checks = {
     \ 'cabal': ['file.cabal'],
     \ 'cabalconfig': ['cabal.config'],
     \ 'cabalproject': ['cabal.project', 'cabal.project.local'],
+    \ 'cairo': ['file.cairo'],
     \ 'calendar': ['calendar', '/.calendar/file', '/share/calendar/any/calendar.file', '/share/calendar/calendar.file', 'any/share/calendar/any/calendar.file', 'any/share/calendar/calendar.file'],
     \ 'capnp': ['file.capnp'],
     \ 'catalog': ['catalog', 'sgml.catalogfile', 'sgml.catalog', 'sgml.catalog-file'],


### PR DESCRIPTION
Problem:    Cairo files are not recognized.
Solution:   Add a pattern for Cairo files. (Amaan Qureshi, closes vim/vim#12118)

https://github.com/vim/vim/commit/ff226d49fed2d8fc668084324c7b0f00117c5e74