### PR TITLE
vim-patch:9.0.1394: Unx Tal files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1015,6 +1015,7 @@ local extension = {
   svh = 'systemverilog',
   sv = 'systemverilog',
   tak = 'tak',
+  tal = 'tal',
   task = 'taskedit',
   tm = 'tcl',
   tcl = 'tcl',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -581,6 +581,7 @@ let s:filename_checks = {
     \ 'systemverilog': ['file.sv', 'file.svh'],
     \ 'tags': ['tags'],
     \ 'tak': ['file.tak'],
+    \ 'tal': ['file.tal'],
     \ 'taskdata': ['pending.data', 'completed.data', 'undo.data'],
     \ 'taskedit': ['file.task'],
     \ 'tcl': ['file.tcl', 'file.tm', 'file.tk', 'file.itcl', 'file.itk', 'file.jacl', '.tclshrc', 'tclsh.rc', '.wishrc'],


### PR DESCRIPTION
Problem:    Unx Tal files are not recognized.
Solution:   Add a pattern for Unx Tal files. (Amaan Qureshi, closes vim/vim#12117)

https://github.com/vim/vim/commit/cde1f8714ed2c046aa770c46229e781380122bd7