### PR TITLE
vim-patch:9.0.1395: Odin files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -751,6 +751,7 @@ local extension = {
   mli = 'ocaml',
   ml = 'ocaml',
   occ = 'occam',
+  odin = 'odin',
   xom = 'omnimark',
   xin = 'omnimark',
   opam = 'opam',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -414,6 +414,7 @@ let s:filename_checks = {
     \ 'ocaml': ['file.ml', 'file.mli', 'file.mll', 'file.mly', '.ocamlinit', 'file.mlt', 'file.mlp', 'file.mlip', 'file.mli.cppo', 'file.ml.cppo'],
     \ 'occam': ['file.occ'],
     \ 'octave': ['octaverc', '.octaverc', 'octave.conf'],
+    \ 'odin': ['file.odin'],
     \ 'omnimark': ['file.xom', 'file.xin'],
     \ 'opam': ['opam', 'file.opam', 'file.opam.template'],
     \ 'openroad': ['file.or'],


### PR DESCRIPTION
Problem:    Odin files are not recognized.
Solution:   Add a pattern for Odin files. (Amaan Qureshi, closes vim/vim#12122)

https://github.com/vim/vim/commit/638388b8ef37684e36a7f5d9286bab2d31c28f36