### PR TITLE
fix(editorconfig): insert_final_newline=false

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -110,8 +110,12 @@ end
 
 function M.properties.insert_final_newline(bufnr, val)
   assert(val == 'true' or val == 'false', 'insert_final_newline must be either "true" or "false"')
-  vim.bo[bufnr].fixendofline = val == 'true'
-  vim.bo[bufnr].endofline = val == 'true'
+  -- Treat false as "leave untouched", not "remove trailing newline".
+  -- https://github.com/editorconfig/editorconfig/issues/475
+  if val == 'true' then
+    vim.bo[bufnr].fixendofline = true
+    vim.bo[bufnr].endofline = true
+  end
 end
 
 --- Modified version of |glob2regpat()| that does not match path separators on *.

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -160,8 +160,10 @@ describe('editorconfig', function()
   end)
 
   it('sets newline options', function()
+    local orig_endofline = curbufmeths.get_option('endofline')
+    local orig_fixendofline = curbufmeths.get_option('fixendofline')
     test_case('with_newline.txt', { fixendofline = true, endofline = true })
-    test_case('without_newline.txt', { fixendofline = false, endofline = false })
+    test_case('without_newline.txt', { fixendofline = orig_fixendofline, endofline = orig_endofline })
   end)
 
   it('respects trim_trailing_whitespace', function()


### PR DESCRIPTION
Problem:
Nvim editorconfig support actively removes a newline if `insert_final_newline=false`. This (apparently) contradicts the spec. https://github.com/editorconfig/editorconfig/issues/475

Solution:
Don't set options if `insert_final_newline=false`.

fix #21648