### PR TITLE
vim-patch:8.2.1067: expression "!expr->func()" does not work

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3075,8 +3075,7 @@ void ex_call(exarg_T *eap)
     }
 
     // Handle a function returning a Funcref, Dictionary or List.
-    if (handle_subscript((const char **)&arg, &rettv, true, true,
-                         (const char *)name, (const char **)&name)
+    if (handle_subscript((const char **)&arg, &rettv, true, true)
         == FAIL) {
       failed = true;
       break;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -508,7 +508,7 @@ static const char *list_arg_vars(exarg_T *eap, const char *arg, int *first)
         } else {
           // handle d.key, l[idx], f(expr)
           const char *const arg_subsc = arg;
-          if (handle_subscript(&arg, &tv, true, true, name, &name) == FAIL) {
+          if (handle_subscript(&arg, &tv, true, true) == FAIL) {
             error = true;
           } else {
             if (arg == arg_subsc && len == 2 && name[1] == ':') {
@@ -1715,7 +1715,7 @@ bool var_exists(const char *var)
     n = get_var_tv(name, len, &tv, NULL, false, true) == OK;
     if (n) {
       // Handle d.key, l[idx], f(expr).
-      n = handle_subscript(&var, &tv, true, false, name, &name) == OK;
+      n = handle_subscript(&var, &tv, true, false) == OK;
       if (n) {
         tv_clear(&tv);
       }

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -111,6 +111,13 @@ func Test_special_char()
   call assert_fails('echo "\<C-">')
 endfunc
 
+func Test_method_with_prefix()
+  call assert_equal(1, !range(5)->empty())
+  call assert_equal([0, 1, 2], --3->range())
+  call assert_equal(0, !-3)
+  call assert_equal(1, !+-+0)
+endfunc
+
 func Test_option_value()
   " boolean
   set bri


### PR DESCRIPTION
#### vim-patch:8.2.1067: expression "!expr->func()" does not work

Problem:    Expression "!expr->func()" does not work.
Solution:   Apply plus and minus earlier.

https://github.com/vim/vim/commit/0b1cd52ff6bf690388f892be686a91721a082e55

Co-authored-by: Bram Moolenaar <Bram@vim.org>