### PR TITLE
docs(float): add missing highlight groups

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -452,6 +452,10 @@ Buffer text can be highlighted by typical mechanisms (syntax highlighting,
 options from the current window; specify `style=minimal` in |nvim_open_win()|
 to disable various visual features such as the 'number' column.
 
+Other highlight groups specific to floating windows:
+- |hl-FloatBorder| for window's border
+- |hl-FloatTitle| for window's title
+
 Currently, floating windows don't support some widgets like scrollbar.
 
 The output of |:mksession| does not include commands for restoring floating

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5268,6 +5268,10 @@ NonText		'@' at the end of the window, characters from 'showbreak'
 Normal		Normal text.
 							*hl-NormalFloat*
 NormalFloat	Normal text in floating windows.
+							*hl-FloatBorder*
+FloatBorder	Border of floating windows.
+							*hl-FloatTitle*
+FloatTitle	Title of floating windows.
 							*hl-NormalNC*
 NormalNC	Normal text in non-current windows.
 							*hl-Pmenu*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -243,6 +243,8 @@ Highlight groups:
   |highlight-blend| controls blend level for a highlight group
   |expr-highlight| highlight groups (prefixed with "Nvim")
   |hl-NormalFloat| highlights floating window
+  |hl-FloatBorder| highlights border of a floating window
+  |hl-FloatTitle| highlights title of a floating window
   |hl-NormalNC| highlights non-current windows
   |hl-MsgArea| highlights messages/cmdline area
   |hl-MsgSeparator| highlights separator for scrolled messages


### PR DESCRIPTION
There are missing tags for `FloatBorder` and `FloatTitle` highlight groups. This PR adds them in every place which mentions `hl-NormalFloat`.

There are also `FloatShadow` and `FloatShadowThrough` highlight groups in code, but they are not mentioned anywhere yet, so decided not to add them.