### PR TITLE
refactor(redraw): make cursor position use the "redraw later" pattern

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1350,12 +1350,15 @@ void ins_redraw(bool ready)
   }
 
   pum_check_clear();
+  show_cursor_info_later(false);
   if (must_redraw) {
     update_screen();
-  } else if (clear_cmdline || redraw_cmdline) {
-    showmode();  // clear cmdline and show mode
+  } else {
+    redraw_statuslines();
+    if (clear_cmdline || redraw_cmdline || redraw_mode) {
+      showmode();  // clear cmdline and show mode
+    }
   }
-  show_cursor_info(false);
   setcursor();
   emsg_on_display = false;      // may remove error message now
 }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3747,6 +3747,7 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
               update_topline(curwin);
               validate_cursor();
               redraw_later(curwin, UPD_SOME_VALID);
+              show_cursor_info_later(true);
               update_screen();
               highlight_match = false;
               redraw_later(curwin, UPD_SOME_VALID);
@@ -3765,7 +3766,6 @@ static int do_sub(exarg_T *eap, proftime_T timeout, long cmdpreview_ns, handle_T
                         _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
               msg_no_more = false;
               msg_scroll = (int)i;
-              show_cursor_info(true);
               if (!ui_has(kUIMessages)) {
                 ui_cursor_goto(msg_row, msg_col);
               }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1306,16 +1306,20 @@ static void normal_redraw(NormalState *s)
   update_topline(curwin);
   validate_cursor();
 
+  show_cursor_info_later(false);
+
   if (VIsual_active) {
     redraw_curbuf_later(UPD_INVERTED);  // update inverted part
-    update_screen();
-  } else if (must_redraw) {
-    update_screen();
-  } else if (redraw_cmdline || clear_cmdline || redraw_mode) {
-    showmode();
   }
 
-  redraw_statuslines();
+  if (must_redraw) {
+    update_screen();
+  } else {
+    redraw_statuslines();
+    if (redraw_cmdline || clear_cmdline || redraw_mode) {
+      showmode();
+    }
+  }
 
   if (need_maketitle) {
     maketitle();
@@ -1348,7 +1352,6 @@ static void normal_redraw(NormalState *s)
   did_emsg = false;
   msg_didany = false;  // reset lines_left in msg_start()
   may_clear_sb_text();  // clear scroll-back text on next msg
-  show_cursor_info(false);
 
   setcursor();
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2255,9 +2255,6 @@ static char *set_bool_option(const int opt_idx, char *const varp, const int valu
   if ((int *)varp == &p_ru || (int *)varp == &p_sc) {
     // in case 'ruler' or 'showcmd' changed
     comp_col();
-    if ((int *)varp == &p_ru) {
-      win_redr_ruler(curwin);
-    }
   }
   if (curwin->w_curswant != MAXCOL
       && (options[opt_idx].flags & (P_CURSWANT | P_RALL)) != 0) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1221,7 +1221,6 @@ static void did_set_statusline(win_T *win, char **varp, char **gvarp, char **err
   }
   if (varp == &p_ruf && *errmsg == NULL) {
     comp_col();
-    win_redr_ruler(curwin);
   }
   // add / remove window bars for 'winbar'
   if (gvarp == &p_wbr) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2340,7 +2340,6 @@ void showmatch(int c)
     dollar_vcol = -1;
   }
   curwin->w_virtcol++;              // do display ')' just before "$"
-  update_screen();                  // show the new char first
 
   colnr_T save_dollar_vcol = dollar_vcol;
   int save_state = State;
@@ -2349,7 +2348,8 @@ void showmatch(int c)
   curwin->w_cursor = mpos;          // move to matching char
   *so = 0;                          // don't use 'scrolloff' here
   *siso = 0;                        // don't use 'sidescrolloff' here
-  show_cursor_info(false);
+  show_cursor_info_later(false);
+  update_screen();                  // show the new char
   setcursor();
   ui_flush();
   // Restore dollar_vcol(), because setcursor() may call curs_rows()

--- a/test/functional/ex_cmds/map_spec.lua
+++ b/test/functional/ex_cmds/map_spec.lua
@@ -152,7 +152,7 @@ describe('Screen', function()
       ~                   |
       ~                   |
       ~                   |
-      >                   |
+      -- INSERT --        |
     ]])
   end)
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -474,8 +474,7 @@ describe('ui/ext_messages', function()
     ]], msg_history={{
       content = {{ "stuff" }},
       kind = "echomsg",
-    }}, showmode={{ "-- INSERT --", 3 }},
-      messages={{
+    }}, messages={{
         content = {{ "Press ENTER or type command to continue", 4}},
         kind = "return_prompt"
     }}}


### PR DESCRIPTION
follow up to #22547 

Don't do an extra redraw just for cursor positions after the `update_screen()` call. instead use the standard "redraw later" code path. 