### PR TITLE
build: fix build warning when using gcc 4.9.2

### DIFF
--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 project(tree-sitter C)
-
+if(NOT MSVC)
+  add_compile_options(-std=c99)
+endif()
 add_library(tree-sitter lib/src/lib.c)
 target_include_directories(tree-sitter
   PRIVATE lib/src lib/include)

--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(tree-sitter C)
-if(NOT MSVC)
-  add_compile_options(-std=c99)
-endif()
+set(CMAKE_C_STANDARD 99)
 add_library(tree-sitter lib/src/lib.c)
 target_include_directories(tree-sitter
   PRIVATE lib/src lib/include)


### PR DESCRIPTION
Problem:
When build with gcc 4.9.2, tree-sitter throw error: 'for' loop initial declarations are only allowed in C99 or C11 mode

Solution:
Add compile flag `-std=c99` to fix it