### PR TITLE
perf(treesitter): more efficient foldexpr

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -99,13 +99,28 @@ function M.get_parser(bufnr, lang, opts)
   if bufnr == nil or bufnr == 0 then
     bufnr = a.nvim_get_current_buf()
   end
+
   if lang == nil then
     local ft = vim.bo[bufnr].filetype
-    lang = language.get_lang(ft) or ft
-    -- TODO(lewis6991): we should error here and not default to ft
-    -- if not lang then
-    --   error(string.format('filetype %s of buffer %d is not associated with any lang', ft, bufnr))
-    -- end
+    if ft ~= '' then
+      lang = language.get_lang(ft) or ft
+      -- TODO(lewis6991): we should error here and not default to ft
+      -- if not lang then
+      --   error(string.format('filetype %s of buffer %d is not associated with any lang', ft, bufnr))
+      -- end
+    else
+      if parsers[bufnr] then
+        return parsers[bufnr]
+      end
+      error(
+        string.format(
+          'There is no parser available for buffer %d and one could not be'
+            .. ' created because lang could not be determined. Either pass lang'
+            .. ' or set the buffer filetype',
+          bufnr
+        )
+      )
+    end
   end
 
   if parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -60,16 +60,6 @@ function M.add(lang, opts)
     filetype = { filetype, { 'string', 'table' }, true },
   })
 
-  if filetype == '' then
-    error(string.format("'%s' is not a valid filetype", filetype))
-  elseif type(filetype) == 'table' then
-    for _, f in ipairs(filetype) do
-      if f == '' then
-        error(string.format("'%s' is not a valid filetype", filetype))
-      end
-    end
-  end
-
   M.register(lang, filetype or lang)
 
   if vim._ts_has_language(lang) then
@@ -109,7 +99,9 @@ function M.register(lang, filetype)
   end
 
   for _, f in ipairs(filetypes) do
-    ft_to_lang[f] = lang
+    if f ~= '' then
+      ft_to_lang[f] = lang
+    end
   end
 end
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -405,8 +405,6 @@ static int parser_parse(lua_State *L)
     old_tree = tmp ? *tmp : NULL;
   }
 
-  bool include_bytes = (lua_gettop(L) >= 3) && lua_toboolean(L, 3);
-
   TSTree *new_tree = NULL;
   size_t len;
   const char *str;
@@ -442,6 +440,8 @@ static int parser_parse(lua_State *L)
   default:
     return luaL_argerror(L, 3, "expected either string or buffer handle");
   }
+
+  bool include_bytes = (lua_gettop(L) >= 4) && lua_toboolean(L, 4);
 
   // Sometimes parsing fails (timeout, or wrong parser ABI)
   // In those case, just return an error.

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -36,11 +36,6 @@ describe('treesitter language API', function()
       pcall_err(exec_lua, 'vim.treesitter.add("/foo/")'))
   end)
 
-  it('shows error for invalid filetype', function()
-    eq('.../language.lua:0: \'\' is not a valid filetype',
-      pcall_err(exec_lua, [[vim.treesitter.add('foo', { filetype = '' })]]))
-  end)
-
   it('inspects language', function()
     local keys, fields, symbols = unpack(exec_lua([[
       local lang = vim.treesitter.inspect_language('c')

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -888,18 +888,20 @@ int x = INT_MAX;
   it("can fold via foldexpr", function()
     insert(test_text)
 
-    local levels = exec_lua([[
-      vim.opt.filetype = 'c'
-      vim.treesitter.get_parser(0, "c")
-      local res = {}
-      for i = 1, vim.api.nvim_buf_line_count(0) do
-        res[i] = vim.treesitter.foldexpr(i)
-      end
-      return res
-    ]])
+    local function get_fold_levels()
+      return exec_lua([[
+        local res = {}
+        for i = 1, vim.api.nvim_buf_line_count(0) do
+          res[i] = vim.treesitter.foldexpr(i)
+        end
+        return res
+      ]])
+    end
+
+    exec_lua([[vim.treesitter.get_parser(0, "c")]])
 
     eq({
-     [1] = '>1',
+      [1] = '>1',
       [2] = '1',
       [3] = '1',
       [4] = '1',
@@ -917,6 +919,33 @@ int x = INT_MAX;
       [16] = '3',
       [17] = '3',
       [18] = '2',
-      [19] = '1' }, levels)
+      [19] = '1' }, get_fold_levels())
+
+    helpers.command('1,2d')
+    helpers.poke_eventloop()
+
+    exec_lua([[vim.treesitter.get_parser():parse()]])
+
+    helpers.poke_eventloop()
+    helpers.sleep(100)
+
+    eq({
+      [1] = '0',
+      [2] = '0',
+      [3] = '>1',
+      [4] = '1',
+      [5] = '1',
+      [6] = '0',
+      [7] = '0',
+      [8] = '>1',
+      [9] = '1',
+      [10] = '1',
+      [11] = '1',
+      [12] = '1',
+      [13] = '>2',
+      [14] = '2',
+      [15] = '2',
+      [16] = '1',
+      [17] = '0' }, get_fold_levels())
   end)
 end)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -128,7 +128,9 @@ void ui_refresh(void)
   it('does not get parser for empty filetype', function()
     insert(test_text);
 
-    eq(".../language.lua:0: '' is not a valid filetype",
+    eq('.../treesitter.lua:0: There is no parser available for buffer 1 and one'
+         .. ' could not be created because lang could not be determined. Either'
+         .. ' pass lang or set the buffer filetype',
       pcall_err(exec_lua, 'vim.treesitter.get_parser(0)'))
 
     -- Must provide language for buffers with an empty filetype


### PR DESCRIPTION
Invalidating on changedtick is horrendously expensive and slow. Instead, update the foldinfo incrementally using `on_changedtree` callbacks.

Plus other fixes:
- better lang handling in `get_parser()`
- do not error on empty filetype
- correct include_bytes arg for `parse()`
