### PR TITLE
vim-patch:9.0.0244: cannot easily get the list of sourced scripts

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -223,6 +223,7 @@ getreg([{regname} [, 1 [, {list}]]])
 				String or List   contents of a register
 getreginfo([{regname}])		Dict	information about a register
 getregtype([{regname}])		String	type of a register
+getscriptinfo()		List	list of sourced scripts
 gettabinfo([{expr}])		List	list of tab pages
 gettabvar({nr}, {varname} [, {def}])
 				any	variable {varname} in tab {nr} or {def}
@@ -3575,6 +3576,16 @@ getregtype([{regname}])					*getregtype()*
 
 		Can also be used as a |method|: >
 			GetRegname()->getregtype()
+
+getscriptinfo()					*getscriptinfo()*
+		Returns a |List| with information about all the sourced Vim
+		scripts in the order they were sourced.
+
+		Each item in the returned List is a |Dict| with the following
+		items:
+		    autoload	always set to FALSE.
+		    name	vim script file name.
+		    sid		script ID |<SID>|.
 
 gettabinfo([{tabnr}])					*gettabinfo()*
 		If {tabnr} is not specified, then information about all the

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1056,6 +1056,14 @@ Prompt Buffer:					*promptbuffer-functions*
 	prompt_setinterrupt()	set interrupt callback for a buffer
 	prompt_setprompt()	set the prompt text for a buffer
 
+Registers:					*register-functions*
+	getreg()		get contents of a register
+	getreginfo()		get information about a register
+	getregtype()		get type of a register
+	setreg()		set contents and type of a register
+	reg_executing()		return the name of the register being executed
+	reg_recording()		return the name of the register being recorded
+
 Context Stack:					*ctx-functions*
 	ctxget()		return context at given index from top
 	ctxpop()		pop and restore top context
@@ -1072,19 +1080,13 @@ Various:					*various-functions*
 	did_filetype()		check if a FileType autocommand was used
 	eventhandler()		check if invoked by an event handler
 	getpid()		get process ID of Vim
+	getscriptinfo()		get list of sourced vim scripts
 
 	libcall()		call a function in an external library
 	libcallnr()		idem, returning a number
 
 	undofile()		get the name of the undo file
 	undotree()		return the state of the undo tree
-
-	getreg()		get contents of a register
-	getreginfo()		get information about a register
-	getregtype()		get type of a register
-	setreg()		set contents and type of a register
-	reg_executing()		return the name of the register being executed
-	reg_recording()		return the name of the register being recorded
 
 	shiftwidth()		effective value of 'shiftwidth'
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -189,6 +189,7 @@ return {
     gettabinfo={args={0, 1}, base=1},
     gettabvar={args={2, 3}, base=1},
     gettabwinvar={args={3, 4}, base=1},
+    getscriptinfo={},
     gettagstack={args={0, 1}, base=1},
     gettext={args=1, base=1},
     getwininfo={args={0, 1}, base=1},

--- a/src/nvim/generators/gen_eval.lua
+++ b/src/nvim/generators/gen_eval.lua
@@ -48,6 +48,7 @@ hashpipe:write([[
 #include "nvim/menu.h"
 #include "nvim/move.h"
 #include "nvim/quickfix.h"
+#include "nvim/runtime.h"
 #include "nvim/search.h"
 #include "nvim/sign.h"
 #include "nvim/testing.h"

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2337,6 +2337,29 @@ linenr_T get_sourced_lnum(LineGetter fgetline, void *cookie)
         : SOURCING_LNUM;
 }
 
+/// "getscriptinfo()" function
+void f_getscriptinfo(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  tv_list_alloc_ret(rettv, script_items.ga_len);
+
+  list_T *l = rettv->vval.v_list;
+
+  for (int i = 1; i <= script_items.ga_len; i++) {
+    scriptitem_T *si = SCRIPT_ITEM(i);
+
+    if (si->sn_name == NULL) {
+      continue;
+    }
+
+    dict_T *d = tv_dict_alloc();
+    tv_list_append_dict(l, d);
+    tv_dict_add_str(d, S_LEN("name"), si->sn_name);
+    tv_dict_add_nr(d, S_LEN("sid"), i);
+    // Vim9 autoload script (:h vim9-autoload), not applicable to Nvim.
+    tv_dict_add_bool(d, S_LEN("autoload"), false);
+  }
+}
+
 /// Get one full line from a sourced file.
 /// Called by do_cmdline() when it's called from do_source().
 ///

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -1,5 +1,5 @@
-" Test for :scriptnames
 
+" Test for the :scriptnames command
 func Test_scriptnames()
   call writefile(['let did_load_script = 123'], 'Xscripting')
   source Xscripting
@@ -27,6 +27,18 @@ func Test_scriptnames()
   let msgs = execute('messages')
   scriptnames
   call assert_equal(msgs, execute('messages'))
+endfunc
+
+" Test for the getscriptinfo() function
+func Test_getscriptinfo()
+  call writefile(['let loaded_script_id = expand("<SID>")'], 'Xscript')
+  source Xscript
+  let l = getscriptinfo()
+  call assert_match('Xscript$', l[-1].name)
+  " Nvim does not support interpolated strings yet.
+  " call assert_equal(g:loaded_script_id, $"<SNR>{l[-1].sid}_")
+  call assert_equal(g:loaded_script_id, '<SNR>' . l[-1].sid . '_')
+  call delete('Xscript')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    Cannot easily get the list of sourced scripts.
Solution:   Add the getscriptinfo() function. (Yegappan Lakshmanan,
            closes vim/vim#10957)

https://github.com/vim/vim/commit/f768c3d19c518822d89dec4cc3947ddeea249316