### PR TITLE
Revert "fix(lsp): use buffer scheme for files not stored on disk (#22407)"

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2032,12 +2032,7 @@ end
 ---@returns `TextDocumentIdentifier`
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier
 function M.make_text_document_params(bufnr)
-  bufnr = bufnr or 0
-  local uri = vim.uri_from_bufnr(bufnr)
-  if not uv.fs_stat(api.nvim_buf_get_name(bufnr)) then
-    uri = uri:gsub('^file://', 'buffer://')
-  end
-  return { uri = uri }
+  return { uri = vim.uri_from_bufnr(bufnr or 0) }
 end
 
 --- Create the workspace params
@@ -2070,7 +2065,7 @@ function M.make_formatting_params(options)
     insertSpaces = vim.bo.expandtab,
   })
   return {
-    textDocument = M.make_text_document_params(0),
+    textDocument = { uri = vim.uri_from_bufnr(0) },
     options = options,
   }
 end

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -272,7 +272,6 @@ function tests.text_document_save_did_open()
     end;
     body = function()
       notify('start')
-      expect_notification('textDocument/didClose')
       expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave')
       notify('shutdown')
@@ -293,8 +292,6 @@ function tests.text_document_sync_save_bool()
     end;
     body = function()
       notify('start')
-      expect_notification('textDocument/didClose')
-      expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave', {textDocument = { uri = "file://" }})
       notify('shutdown')
     end;
@@ -316,8 +313,6 @@ function tests.text_document_sync_save_includeText()
     end;
     body = function()
       notify('start')
-      expect_notification('textDocument/didClose')
-      expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave', {
         textDocument = {
           uri = "file://"
@@ -464,7 +459,7 @@ function tests.basic_check_buffer_open()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
@@ -491,13 +486,13 @@ function tests.basic_check_buffer_open_and_change()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {
@@ -527,13 +522,13 @@ function tests.basic_check_buffer_open_and_change_noeol()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n");
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {
@@ -562,13 +557,13 @@ function tests.basic_check_buffer_open_and_change_multi()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {
@@ -577,7 +572,7 @@ function tests.basic_check_buffer_open_and_change_multi()
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 4;
         };
         contentChanges = {
@@ -607,13 +602,13 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {
@@ -622,7 +617,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 4;
         };
         contentChanges = {
@@ -631,7 +626,7 @@ function tests.basic_check_buffer_open_and_change_multi_and_close()
       })
       expect_notification('textDocument/didClose', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
         };
       })
       expect_notification("finish")
@@ -665,13 +660,13 @@ function tests.basic_check_buffer_open_and_change_incremental()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n") .. '\n';
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {
@@ -708,13 +703,13 @@ function tests.basic_check_buffer_open_and_change_incremental_editing()
         textDocument = {
           languageId = "";
           text = table.concat({"testing"; "123"}, "\n");
-          uri = "buffer://";
+          uri = "file://";
           version = 0;
         };
       })
       expect_notification('textDocument/didChange', {
         textDocument = {
-          uri = "buffer://";
+          uri = "file://";
           version = 3;
         };
         contentChanges = {


### PR DESCRIPTION
Although using `buffer://` for unsaved file buffers fixes issues with
language servers like eclipse.jdt.ls or ansible-language-server, it
breaks completion and signature help for clangd.

A regression is worse than a fix for something else, so this reverts
commit 896d672736b32a8f4a4fa51844b44f266dcdcc6c.

The spec change is also still in dicussion, see
https://github.com/microsoft/language-server-protocol/pull/1679#discussion_r1130704886
