### PR TITLE
fix(lsp): prevent lsp tests from picking up local user config

### DIFF
--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -13,6 +13,7 @@ function M.clear_notrace()
   -- solution: don't look too closely for dragons
   clear {env={
     NVIM_LUA_NOTRACK="1";
+    NVIM_APPNAME="nvim_lsp_test";
     VIMRUNTIME=os.getenv"VIMRUNTIME";
   }}
 end
@@ -85,6 +86,7 @@ local function fake_lsp_server_setup(test_name, timeout_ms, options, settings)
       cmd_env = {
         NVIM_LOG_FILE = fake_lsp_logfile;
         NVIM_LUA_NOTRACK = "1";
+        NVIM_APPNAME = "nvim_lsp_test";
       };
       cmd = {
         vim.v.progpath, '-l', fake_lsp_code, test_name, tostring(timeout),

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -57,6 +57,7 @@ describe('LSP', function()
         return lsp.start_client {
           cmd_env = {
             NVIM_LOG_FILE = fake_lsp_logfile;
+            NVIM_APPNAME = "nvim_lsp_test";
           };
           cmd = {
             vim.v.progpath, '-l', fake_lsp_code, test_name;


### PR DESCRIPTION
Sets `NVIM_APPNAME` for the lsp server instances and also for the
`exec_lua` environment to ensure local user config doesn't interfere
with the test cases.

My local `ftplugin/xml.lua` broke the LSP test cases about setting
`omnifunc` defaults.
