### PR TITLE
perf(lsp): better binary search mid calculation in semantic token

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -44,7 +44,7 @@ local STHighlighter = { active = {} }
 ---@private
 local function lower_bound(tokens, line, lo, hi)
   while lo < hi do
-    local mid = bit.rshift(lo + hi, 1)
+    local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2).
     if tokens[mid].line < line then
       lo = mid + 1
     else
@@ -62,7 +62,7 @@ end
 ---@private
 local function upper_bound(tokens, line, lo, hi)
   while lo < hi do
-    local mid = bit.rshift(lo + hi, 1)
+    local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2).
     if line < tokens[mid].line then
       hi = mid
     else

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -44,7 +44,7 @@ local STHighlighter = { active = {} }
 ---@private
 local function lower_bound(tokens, line, lo, hi)
   while lo < hi do
-    local mid = math.floor((lo + hi) / 2)
+    local mid = bit.rshift(lo + hi, 1)
     if tokens[mid].line < line then
       lo = mid + 1
     else
@@ -62,7 +62,7 @@ end
 ---@private
 local function upper_bound(tokens, line, lo, hi)
   while lo < hi do
-    local mid = math.floor((lo + hi) / 2)
+    local mid = bit.rshift(lo + hi, 1)
     if line < tokens[mid].line then
       hi = mid
     else


### PR DESCRIPTION
This commit replaces the usage of `math.floor((lo + hi) / 2)` with the faster and equivalent `bit.rshift(lo + hi, 1)` for calculating the midpoint in binary search.