### PR TITLE
vim-patch:8.2.1398: autoload script sourced twice if sourced directly

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -579,7 +579,7 @@ ArrayOf(String) nvim__get_runtime(Array pat, Boolean all, Dict(runtime) *opts, E
   if (source) {
     for (size_t i = 0; i < res.size; i++) {
       String name = res.items[i].data.string;
-      (void)do_source(name.data, false, DOSO_NONE);
+      (void)do_source(name.data, false, DOSO_NONE, NULL);
     }
   }
 

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -909,7 +909,7 @@ void ex_loadview(exarg_T *eap)
     return;
   }
 
-  if (do_source(fname, false, DOSO_NONE) == FAIL) {
+  if (do_source(fname, false, DOSO_NONE, NULL) == FAIL) {
     semsg(_(e_notopen), fname);
   }
   xfree(fname);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2061,10 +2061,15 @@ void nlua_set_sctx(sctx_T *current)
     break;
   }
   char *source_path = fix_fname(info->source + 1);
-  get_current_script_id(&source_path, current);
-  xfree(source_path);
-  current->sc_lnum = info->currentline;
+  int sid = find_script_by_name(source_path);
+  if (sid > 0) {
+    xfree(source_path);
+  } else {
+    new_script_item(source_path, &sid);
+  }
+  current->sc_sid = sid;
   current->sc_seq = -1;
+  current->sc_lnum = info->currentline;
 
 cleanup:
   xfree(info);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1937,7 +1937,7 @@ static void do_system_initialization(void)
         dir_len += 1;
       }
       memcpy(vimrc + dir_len, path_tail, sizeof(path_tail));
-      if (do_source(vimrc, false, DOSO_NONE) != FAIL) {
+      if (do_source(vimrc, false, DOSO_NONE, NULL) != FAIL) {
         xfree(vimrc);
         xfree(config_dirs);
         return;
@@ -1949,7 +1949,7 @@ static void do_system_initialization(void)
 
 #ifdef SYS_VIMRC_FILE
   // Get system wide defaults, if the file name is defined.
-  (void)do_source(SYS_VIMRC_FILE, false, DOSO_NONE);
+  (void)do_source(SYS_VIMRC_FILE, false, DOSO_NONE, NULL);
 #endif
 }
 
@@ -1978,7 +1978,7 @@ static bool do_user_initialization(void)
 
   // init.lua
   if (os_path_exists(init_lua_path)
-      && do_source(init_lua_path, true, DOSO_VIMRC)) {
+      && do_source(init_lua_path, true, DOSO_VIMRC, NULL)) {
     if (os_path_exists(user_vimrc)) {
       semsg(_("E5422: Conflicting configs: \"%s\" \"%s\""), init_lua_path,
             user_vimrc);
@@ -1992,7 +1992,7 @@ static bool do_user_initialization(void)
   xfree(init_lua_path);
 
   // init.vim
-  if (do_source(user_vimrc, true, DOSO_VIMRC) != FAIL) {
+  if (do_source(user_vimrc, true, DOSO_VIMRC, NULL) != FAIL) {
     do_exrc = p_exrc;
     if (do_exrc) {
       do_exrc = (path_full_compare(VIMRC_FILE, user_vimrc, false, true) != kEqualFiles);
@@ -2018,7 +2018,7 @@ static bool do_user_initialization(void)
       memmove(vimrc, dir, dir_len);
       vimrc[dir_len] = PATHSEP;
       memmove(vimrc + dir_len + 1, path_tail, sizeof(path_tail));
-      if (do_source(vimrc, true, DOSO_VIMRC) != FAIL) {
+      if (do_source(vimrc, true, DOSO_VIMRC, NULL) != FAIL) {
         do_exrc = p_exrc;
         if (do_exrc) {
           do_exrc = (path_full_compare(VIMRC_FILE, vimrc, false, true) != kEqualFiles);
@@ -2084,7 +2084,7 @@ static void source_startup_scripts(const mparm_T *const parmp)
         || strequal(parmp->use_vimrc, "NORC")) {
       // Do nothing.
     } else {
-      if (do_source(parmp->use_vimrc, false, DOSO_NONE) != OK) {
+      if (do_source(parmp->use_vimrc, false, DOSO_NONE, NULL) != OK) {
         semsg(_("E282: Cannot read from \"%s\""), parmp->use_vimrc);
       }
     }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -4026,7 +4026,7 @@ static void syn_cmd_include(exarg_T *eap, int syncing)
   prev_toplvl_grp = curwin->w_s->b_syn_topgrp;
   curwin->w_s->b_syn_topgrp = sgl_id;
   if (source
-      ? do_source(eap->arg, false, DOSO_NONE) == FAIL
+      ? do_source(eap->arg, false, DOSO_NONE, NULL) == FAIL
       : source_runtime(eap->arg, DIP_ALL) == FAIL) {
     semsg(_(e_notopen), eap->arg);
   }

--- a/test/old/testdir/sautest/autoload/sourced.vim
+++ b/test/old/testdir/sautest/autoload/sourced.vim
@@ -1,3 +1,4 @@
 let g:loaded_sourced_vim += 1
-func! sourced#something()
+func sourced#something()
 endfunc
+call sourced#something()


### PR DESCRIPTION
#### vim-patch:8.2.1398: autoload script sourced twice if sourced directly

Problem:    Autoload script sourced twice if sourced directly.
Solution:   Do not source an autoload script again. (issue vim/vim#6644)

https://github.com/vim/vim/commit/daa2f36573db3e1df7eb1fdbc3a09a2815644048

Cherry-pick ret_sid changes from patch 8.2.0149.
Use do_in_runtimepath() as that's what source_runtime() calls in Nvim.

Co-authored-by: Bram Moolenaar <Bram@vim.org>
