### PR TITLE
fix(lsp): send didClose on buffer rename

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: invisible
 local default_handlers = require('vim.lsp.handlers')
 local log = require('vim.lsp.log')
 local lsp_rpc = require('vim.lsp.rpc')
@@ -1592,6 +1593,11 @@ local function text_document_did_save_handler(bufnr)
     local name = api.nvim_buf_get_name(bufnr)
     local old_name = changetracking._get_and_set_name(client, bufnr, name)
     if old_name and name ~= old_name then
+      client.notify('textDocument/didClose', {
+        textDocument = {
+          uri = vim.uri_from_fname(old_name),
+        },
+      })
       client.notify('textDocument/didOpen', {
         textDocument = {
           version = 0,

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -272,6 +272,7 @@ function tests.text_document_save_did_open()
     end;
     body = function()
       notify('start')
+      expect_notification('textDocument/didClose')
       expect_notification('textDocument/didOpen')
       expect_notification('textDocument/didSave')
       notify('shutdown')


### PR DESCRIPTION
Subset of https://github.com/neovim/neovim/pull/22407 that was reverted
in https://github.com/neovim/neovim/pull/22604

If a buffer is renamed sending `didClose` for the old buffer helps
ensure the language server doesn't keep a stale document in memory.
