### PR TITLE
fix(diff): trigger on_bytes only once after diffget/diffput

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -3136,7 +3136,7 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
 
       if (added != 0) {
         // Adjust marks.  This will change the following entries!
-        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, added, kExtmarkUndo);
+        mark_adjust(lnum, lnum + count - 1, (long)MAXLNUM, added, kExtmarkNOOP);
         if (curwin->w_cursor.lnum >= lnum) {
           // Adjust the cursor position if it's in/after the changed
           // lines.

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -1171,6 +1171,25 @@ describe('lua: nvim_buf_attach on_bytes', function()
       }
     end)
 
+    it('works with :diffput and :diffget', function()
+      local check_events = setup_eventcheck(verify, {"AAA"})
+      command('diffthis')
+      command('new')
+      command('diffthis')
+      meths.buf_set_lines(0, 0, -1, true, {"AAA", "BBB"})
+      feed('G')
+      command('diffput')
+      check_events {
+        { "test1", "bytes", 1, 3, 1, 0, 4, 0, 0, 0, 1, 0, 4 };
+      }
+      meths.buf_set_lines(0, 0, -1, true, {"AAA", "CCC"})
+      feed('<C-w>pG')
+      command('diffget')
+      check_events {
+        { "test1", "bytes", 1, 4, 1, 0, 4, 1, 0, 4, 1, 0, 4 };
+      }
+    end)
+
     local function test_lockmarks(mode)
       local description = (mode ~= "") and mode or "(baseline)"
       it("test_lockmarks " .. description .. " %delete _", function()


### PR DESCRIPTION
Problem: The fix from b50ee4a8dc4306e4be78ac33fb74b21dc6be5538 may adjust extmark twice, triggering on_bytes callback twice.

Solution: Don't let mark_adjust adjust extmark.