### PR TITLE
refactor!: remove deprecated functions

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -237,6 +237,10 @@ The following deprecated functions or APIs were removed.
 • |LanguageTree:parse()| no longer returns changed regions. Please use the
   `on_changedtree` callbacks instead.
 
+• `vim.highlight.create()`, `vim.highlight.link()` were removed, use |nvim_set_hl()| instead.
+
+• `require'health'` was removed. Use |vim.health| instead.
+
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 

--- a/runtime/lua/health.lua
+++ b/runtime/lua/health.lua
@@ -1,6 +1,0 @@
-return setmetatable({}, {
-  __index = function(_, k)
-    vim.deprecate("require('health')", 'vim.health', '0.9', false)
-    return vim.health[k]
-  end,
-})

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -10,30 +10,6 @@ M.priorities = {
   user = 200,
 }
 
----@private
-function M.create(higroup, hi_info, default)
-  vim.deprecate('vim.highlight.create', 'vim.api.nvim_set_hl', '0.9')
-  local options = {}
-  -- TODO: Add validation
-  for k, v in pairs(hi_info) do
-    table.insert(options, string.format('%s=%s', k, v))
-  end
-  vim.cmd(
-    string.format(
-      [[highlight %s %s %s]],
-      default and 'default' or '',
-      higroup,
-      table.concat(options, ' ')
-    )
-  )
-end
-
----@private
-function M.link(higroup, link_to, force)
-  vim.deprecate('vim.highlight.link', 'vim.api.nvim_set_hl', '0.9')
-  vim.cmd(string.format([[highlight%s link %s %s]], force and '!' or ' default', higroup, link_to))
-end
-
 --- Highlight range between two positions
 ---
 ---@param bufnr integer Buffer number to apply highlighting to

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -648,12 +648,6 @@ function M.inspect_tree(opts)
   })
 end
 
----@deprecated
----@private
-function M.show_tree()
-  vim.deprecate('show_tree', 'inspect_tree', '0.9', nil, false)
-end
-
 --- Returns the fold level for {lnum} in the current buffer. Can be set directly to 'foldexpr':
 --- <pre>lua
 --- vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'


### PR DESCRIPTION
- `vim.highlight.create()`, `vim.highlight.link()` were removed, use [|nvim_set_hl()|](https://neovim.io/doc/user/api.html#nvim_set_hl()) instead

- `require'health'` was removed. Use [|vim.health|](https://neovim.io/doc/user/pi_health.html#vim.health) instead