### PR TITLE
revert: "build: enable cmake workflow presets (#21860)"

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 3,
   "configurePresets": [
     {
       "name": "base",
@@ -93,21 +93,6 @@
     {
       "name": "iwyu",
       "configurePreset": "iwyu"
-    }
-  ],
-  "workflowPresets": [
-    {
-      "name": "iwyu",
-      "steps": [
-        {
-          "type": "configure",
-          "name": "iwyu"
-        },
-        {
-          "type": "build",
-          "name": "iwyu"
-        }
-      ]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,8 @@ For managing includes in C files, use [include-what-you-use].
 - [Install include-what-you-use][include-what-you-use-install]
 - To see which includes needs fixing use the cmake preset `iwyu`:
   ```
-  cmake --workflow --preset iwyu
+  cmake --preset iwyu
+  cmake --build --preset iwyu
   ```
 - There's also a make target that automatically fixes the suggestions from
   IWYU:

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,8 @@ generated-sources benchmark uninstall $(FORMAT) $(LINT) $(TEST): | build/.ran-cm
 test: $(TEST)
 
 iwyu: build/.ran-cmake
-	cmake --workflow --fresh --preset iwyu > build/iwyu.log
+	cmake --preset iwyu
+	cmake --build --preset iwyu > build/iwyu.log
 	iwyu-fix-includes --only_re="src/nvim" --ignore_re="src/nvim/(auto|map.h|eval/encode.c)" --safe_headers < build/iwyu.log
 	cmake -B build -U ENABLE_IWYU
 


### PR DESCRIPTION
This reverts commit 00a976129b603b60f1e309ee7484cb0f4b5a9792.

Visual Studio fails the build if the CMakePresets.json version is too
high and the CMakePresets.json integration is enabled.

Closes https://github.com/neovim/neovim/issues/22608.
