### PR TITLE
fix(lsp): Fix error in remove_workspace_folders when client has no workspace_folders 

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -523,7 +523,7 @@ function M.remove_workspace_folder(workspace_folder)
     { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } }
   )
   for _, client in pairs(vim.lsp.get_active_clients({ bufnr = 0 })) do
-    for idx, folder in pairs(client.workspace_folders) do
+    for idx, folder in pairs(client.workspace_folders or {}) do
       if folder.name == workspace_folder then
         vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
         client.workspace_folders[idx] = nil


### PR DESCRIPTION
When a client has no workspace_folders, (e.g., copilot), the `pairs` code would crash.

Unfortunately I didn't manage to produce better tests for this, since I'm not very familiar with Neovims test setup. I added some bare-bones tests as scaffolding for another, brave person to improve on on the future.