### PR TITLE
feat: add vim.filetype.get_option()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1969,6 +1969,10 @@ nvim_get_option_value({name}, {*opts})               *nvim_get_option_value()*
                 • win: |window-ID|. Used for getting window local options.
                 • buf: Buffer number. Used for getting buffer local options.
                   Implies {scope} is "local".
+                • filetype: |filetype|. Used to get the default option for a
+                  specific filetype. Cannot be used with any other option.
+                  Note: this is expensive, it is recommended to cache this
+                  value.
 
     Return: ~
         Option value

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1971,8 +1971,8 @@ nvim_get_option_value({name}, {*opts})               *nvim_get_option_value()*
                   Implies {scope} is "local".
                 • filetype: |filetype|. Used to get the default option for a
                   specific filetype. Cannot be used with any other option.
-                  Note: this is expensive, it is recommended to cache this
-                  value.
+                  Note: this will trigger |ftplugin| and all |FileType|
+                  autocommands for the corresponding filetype.
 
     Return: ~
         Option value

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2206,6 +2206,28 @@ add({filetypes})                                          *vim.filetype.add()*
       • {filetypes}  (table) A table containing new filetype maps (see
                      example).
 
+get_option({filetype}, {option})                   *vim.filetype.get_option()*
+    Get the default option value for a {filetype}.
+
+    The returned value is what would be set in a new buffer after 'filetype'
+    is set, meaning it should respect all FileType autocmds and ftplugin
+    files.
+
+    Example: >lua
+      vim.filetype.get_option('vim', 'commentstring')
+<
+
+    Note: this uses |nvim_get_option_value()| but caches the result. This
+    means |ftplugin| and |FileType| autocommands are only triggered once and
+    may not reflect later changes.
+
+    Parameters: ~
+      • {filetype}  string Filetype
+      • {option}    string Option name
+
+    Return: ~
+        string|boolean|integer: Option value
+
 match({args})                                           *vim.filetype.match()*
     Perform filetype detection.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -213,6 +213,9 @@ The following new APIs or features were added.
 • |nvim_get_option_value()| now has a `filetype` option so it can return the
   default option for a specific filetype.
 
+• |vim.filetype.get_option()| to get the default option value for a specific
+  filetype. This is a wrapper around |nvim_get_option_value()| with caching.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -210,6 +210,9 @@ The following new APIs or features were added.
   https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection .
   Support for the previous format will be removed in a future release.
 
+• |nvim_get_option_value()| now has a `filetype` option so it can return the
+  default option for a specific filetype.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2631,4 +2631,24 @@ function M.match(args)
   end
 end
 
+--- Get the default option value for a {filetype}.
+---
+--- The returned value is what would be set in a new buffer after 'filetype'
+--- is set, meaning it should respect all FileType autocmds and ftplugin files.
+---
+--- Example:
+--- <pre>lua
+---   vim.filetype.get_option('vim', 'commentstring')
+--- </pre>
+---
+--- Note: this uses |nvim_get_option_value()| but caches the result.
+--- This means |ftplugin| and |FileType| autocommands are only
+--- triggered once and may not reflect later changes.
+--- @param filetype string Filetype
+--- @param option string Option name
+--- @return string|boolean|integer: Option value
+function M.get_option(filetype, option)
+  return require('vim.filetype.options').get_option(filetype, option)
+end
+
 return M

--- a/runtime/lua/vim/filetype/options.lua
+++ b/runtime/lua/vim/filetype/options.lua
@@ -1,0 +1,82 @@
+local api = vim.api
+
+local M = {}
+
+local function get_ftplugin_runtime(filetype)
+  return api.nvim__get_runtime({
+    string.format('ftplugin/%s.vim', filetype),
+    string.format('ftplugin/%s_*.vim', filetype),
+    string.format('ftplugin/%s/*.vim', filetype),
+    string.format('ftplugin/%s.lua', filetype),
+    string.format('ftplugin/%s_*.lua', filetype),
+    string.format('ftplugin/%s/*.lua', filetype),
+  }, true, {}) --[[@as string[] ]]
+end
+
+-- Keep track of ftplugin files
+local ftplugin_cache = {} ---@type table<string,table<string,integer>>
+
+-- Keep track of total number of FileType autocmds
+local ft_autocmd_num ---@type integer?
+
+-- Keep track of filetype options
+local ft_option_cache = {} ---@type table<string,table<string,any>>
+
+--- @param path string
+--- @return integer
+local function hash(path)
+  local mtime0 = vim.loop.fs_stat(path).mtime
+  return mtime0.sec * 1000000000 + mtime0.nsec
+end
+
+--- Only update the cache on changes to the number of FileType autocmds
+--- and changes to any ftplugin/ file. This isn't guaranteed to catch everything
+--- but should be good enough.
+--- @param filetype string
+local function update_ft_option_cache(filetype)
+  local new_ftautos = #api.nvim_get_autocmds({ event = 'FileType' })
+  if new_ftautos ~= ft_autocmd_num then
+    -- invalidate
+    ft_option_cache[filetype] = nil
+    ft_autocmd_num = new_ftautos
+  end
+
+  local files = get_ftplugin_runtime(filetype)
+
+  ftplugin_cache[filetype] = ftplugin_cache[filetype] or {}
+
+  if #files ~= #vim.tbl_keys(ftplugin_cache[filetype]) then
+    -- invalidate
+    ft_option_cache[filetype] = nil
+    ftplugin_cache[filetype] = {}
+  end
+
+  for _, f in ipairs(files) do
+    -- VIMRUNTIME should be static so shouldn't need to worry about it changing
+    if not vim.startswith(f, vim.env.VIMRUNTIME) then
+      local mtime = hash(f)
+      if ftplugin_cache[filetype][f] ~= mtime then
+        -- invalidate
+        ft_option_cache[filetype] = nil
+        ftplugin_cache[filetype][f] = mtime
+      end
+    end
+  end
+end
+
+--- @private
+--- @param filetype string Filetype
+--- @param option string Option name
+--- @return string|integer|boolean
+function M.get_option(filetype, option)
+  update_ft_option_cache(filetype)
+
+  if not ft_option_cache[filetype] or not ft_option_cache[filetype][option] then
+    ft_option_cache[filetype] = ft_option_cache[filetype] or {}
+    ft_option_cache[filetype][option] = api.nvim_get_option_value(option, { filetype = filetype })
+  end
+
+  return ft_option_cache[filetype][option]
+end
+
+return M

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -102,6 +102,7 @@ return {
     "scope";
     "win";
     "buf";
+    "filetype";
   }};
   { 'highlight', {
     "bold";

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -114,7 +114,11 @@ static buf_T *do_ft_buf(char *filetype, aco_save_T *aco, Error *err)
 
   ftbuf->b_p_ft = xstrdup(filetype);
 
-  apply_autocmds(EVENT_FILETYPE, ftbuf->b_p_ft, ftbuf->b_fname, true, ftbuf);
+  TRY_WRAP({
+    try_start();
+    apply_autocmds(EVENT_FILETYPE, ftbuf->b_p_ft, ftbuf->b_fname, true, ftbuf);
+    try_end(err);
+  });
 
   return ftbuf;
 }
@@ -133,8 +137,8 @@ static buf_T *do_ft_buf(char *filetype, aco_save_T *aco, Error *err)
 ///                         Implies {scope} is "local".
 ///                  - filetype: |filetype|. Used to get the default option for a
 ///                    specific filetype. Cannot be used with any other option.
-///                    Note: this is expensive, it is recommended to cache this
-///                    value.
+///                    Note: this will trigger |ftplugin| and all |FileType|
+///                    autocommands for the corresponding filetype.
 /// @param[out] err  Error details, if any
 /// @return          Option value
 Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -24,7 +24,7 @@
 #endif
 
 static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_type, void **from,
-                                      Error *err)
+                                      char **filetype, Error *err)
 {
   if (HAS_KEY(opts->scope)) {
     VALIDATE_T("scope", kObjectTypeString, opts->scope.type, {
@@ -43,6 +43,14 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
   }
 
   *opt_type = SREQ_GLOBAL;
+
+  if (filetype != NULL && HAS_KEY(opts->filetype)) {
+    VALIDATE_T("scope", kObjectTypeString, opts->filetype.type, {
+      return FAIL;
+    });
+
+    *filetype = opts->filetype.data.string.data;
+  }
 
   if (HAS_KEY(opts->win)) {
     VALIDATE_T("win", kObjectTypeInteger, opts->win.type, {
@@ -69,15 +77,46 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
     }
   }
 
+  VALIDATE((!HAS_KEY(opts->filetype)
+            || !(HAS_KEY(opts->buf) || HAS_KEY(opts->scope) || HAS_KEY(opts->win))),
+           "%s", "cannot use 'filetype' with 'scope', 'buf' or 'win'", {
+    return FAIL;
+  });
+
   VALIDATE((!HAS_KEY(opts->scope) || !HAS_KEY(opts->buf)), "%s",
            "cannot use both 'scope' and 'buf'", {
     return FAIL;
   });
+
   VALIDATE((!HAS_KEY(opts->win) || !HAS_KEY(opts->buf)), "%s", "cannot use both 'buf' and 'win'", {
     return FAIL;
   });
 
   return OK;
+}
+
+/// Create a dummy buffer and run the FileType autocmd on it.
+static buf_T *do_ft_buf(char *filetype, aco_save_T *aco, Error *err)
+{
+  if (filetype == NULL) {
+    return NULL;
+  }
+
+  // Allocate a buffer without putting it in the buffer list.
+  buf_T *ftbuf = buflist_new(NULL, NULL, 1, BLN_DUMMY);
+  if (ftbuf == NULL) {
+    api_set_error(err, kErrorTypeException, "Could not create internal buffer");
+    return NULL;
+  }
+
+  // Set curwin/curbuf to buf and save a few things.
+  aucmd_prepbuf(aco, ftbuf);
+
+  ftbuf->b_p_ft = xstrdup(filetype);
+
+  apply_autocmds(EVENT_FILETYPE, ftbuf->b_p_ft, ftbuf->b_fname, true, ftbuf);
+
+  return ftbuf;
 }
 
 /// Gets the value of an option. The behavior of this function matches that of
@@ -92,6 +131,10 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
 ///                  - win: |window-ID|. Used for getting window local options.
 ///                  - buf: Buffer number. Used for getting buffer local options.
 ///                         Implies {scope} is "local".
+///                  - filetype: |filetype|. Used to get the default option for a
+///                    specific filetype. Cannot be used with any other option.
+///                    Note: this is expensive, it is recommended to cache this
+///                    value.
 /// @param[out] err  Error details, if any
 /// @return          Option value
 Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
@@ -102,14 +145,37 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   int scope = 0;
   int opt_type = SREQ_GLOBAL;
   void *from = NULL;
-  if (!validate_option_value_args(opts, &scope, &opt_type, &from, err)) {
+  char *filetype = NULL;
+
+  if (!validate_option_value_args(opts, &scope, &opt_type, &from, &filetype, err)) {
     return rv;
+  }
+
+  aco_save_T aco;
+
+  buf_T *ftbuf = do_ft_buf(filetype, &aco, err);
+  if (ERROR_SET(err)) {
+    return rv;
+  }
+
+  if (ftbuf != NULL) {
+    assert(!from);
+    from = ftbuf;
   }
 
   long numval = 0;
   char *stringval = NULL;
   getoption_T result = access_option_value_for(name.data, &numval, &stringval, scope, opt_type,
                                                from, true, err);
+
+  if (ftbuf != NULL) {
+    // restore curwin/curbuf and a few other things
+    aucmd_restbuf(&aco);
+
+    assert(curbuf != ftbuf);  // safety check
+    wipe_buffer(ftbuf, false);
+  }
+
   if (ERROR_SET(err)) {
     return rv;
   }
@@ -164,7 +230,7 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
   int scope = 0;
   int opt_type = SREQ_GLOBAL;
   void *to = NULL;
-  if (!validate_option_value_args(opts, &scope, &opt_type, &to, err)) {
+  if (!validate_option_value_args(opts, &scope, &opt_type, &to, NULL, err)) {
     return;
   }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1245,7 +1245,9 @@ bool edit(int cmdchar, bool startln, long count)
   // Don't allow changes in the buffer while editing the cmdline.  The
   // caller of getcmdline() may get confused.
   // Don't allow recursive insert mode when busy with completion.
-  if (textlock != 0 || ins_compl_active() || compl_busy || pum_visible()) {
+  // Allow in dummy buffers since they are only used internally
+  if (textlock != 0 || ins_compl_active() || compl_busy || pum_visible()
+      || expr_map_locked()) {
     emsg(_(e_textlock));
     return false;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6326,6 +6326,11 @@ void restore_current_state(save_state_T *sst)
   ui_cursor_shape();  // may show different cursor shape
 }
 
+bool expr_map_locked(void)
+{
+  return expr_map_lock > 0 && !(curbuf->b_flags & BF_DUMMY);
+}
+
 /// ":normal[!] {commands}": Execute normal mode commands.
 static void ex_normal(exarg_T *eap)
 {
@@ -6335,10 +6340,11 @@ static void ex_normal(exarg_T *eap)
   }
   char *arg = NULL;
 
-  if (ex_normal_lock > 0) {
+  if (expr_map_locked()) {
     emsg(_(e_secure));
     return;
   }
+
   if (ex_normal_busy >= p_mmd) {
     emsg(_("E192: Recursive use of :normal too deep"));
     return;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2740,6 +2740,9 @@ bool text_locked(void)
   if (cmdwin_type != 0) {
     return true;
   }
+  if (expr_map_locked()) {
+    return true;
+  }
   return textlock != 0;
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -715,7 +715,7 @@ EXTERN typebuf_T typebuf INIT(= { NULL, NULL, 0, 0, 0, 0, 0, 0, 0 });
 EXTERN bool typebuf_was_empty INIT(= false);
 
 EXTERN int ex_normal_busy INIT(= 0);     // recursiveness of ex_normal()
-EXTERN int ex_normal_lock INIT(= 0);     // forbid use of ex_normal()
+EXTERN int expr_map_lock INIT(= 0);      // running expr mapping, prevent use of ex_normal() and text changes
 EXTERN int ignore_script INIT(= false);  // ignore script input
 EXTERN int stop_insert_mode;             // for ":stopinsert"
 EXTERN bool KeyTyped;                    // true if user typed current char

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1615,8 +1615,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
 
   // Forbid changing text or using ":normal" to avoid most of the bad side
   // effects.  Also restore the cursor position.
-  textlock++;
-  ex_normal_lock++;
+  expr_map_lock++;
   set_vim_var_char(c);    // set v:char to the typed character
   const pos_T save_cursor = curwin->w_cursor;
   const int save_msg_col = msg_col;
@@ -1637,8 +1636,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
     p = eval_to_string(expr, NULL, false);
     xfree(expr);
   }
-  textlock--;
-  ex_normal_lock--;
+  expr_map_lock--;
   curwin->w_cursor = save_cursor;
   msg_col = save_msg_col;
   msg_row = save_msg_row;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -96,6 +96,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/ex_docmd.h"
 #include "nvim/ex_getln.h"
 #include "nvim/extmark.h"
 #include "nvim/fileio.h"
@@ -300,7 +301,7 @@ bool undo_allowed(buf_T *buf)
 
   // Don't allow changes in the buffer while editing the cmdline.  The
   // caller of getcmdline() may get confused.
-  if (textlock != 0) {
+  if (textlock != 0 || expr_map_locked()) {
     emsg(_(e_textlock));
     return false;
   }

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -114,6 +114,21 @@ describe('vim.filetype', function()
     ]])
   end)
 
+  it('can get default option values for filetypes via vim.filetype.get_option()', function()
+    command('filetype plugin on')
+
+    for ft, opts in pairs {
+      lua = { commentstring = '-- %s' },
+      vim = { commentstring = '"%s' },
+      man = { tagfunc = 'v:lua.require\'man\'.goto_tag' },
+      xml = { formatexpr = 'xmlformat#Format()' }
+    } do
+      for option, value in pairs(opts) do
+        eq(value, exec_lua([[ return vim.filetype.get_option(...) ]], ft, option))
+      end
+    end
+
+  end)
 end)
 
 describe('filetype.lua', function()


### PR DESCRIPTION
### Problem

It is not possible to get the default option value for a specific filetype. This is required for a number of applications, including working with treesitter injections, e.g: automatically updating `'commentstring'` based on cursor position.

### Solution

- Add `filetype` option to `nvim_get_option_value()`  to get the default option value for a specific filetype.
- Add `vim.filetype.get_option(filetype, option)` as a wrapper around `nvim_get_option_value()` with caching.

---

<details>
<summary>Use this to set a context aware commentstring</summary>

```lua

local function get_lang()
  local ok, parser = pcall(vim.treesitter.get_parser)
  if not ok then
    return
  end

  local cpos = api.nvim_win_get_cursor(0)
  local row, col = cpos[1] - 1, cpos[2]
  local range = { row, col, row, col + 1 }

  local lang ---@type string?
  parser:for_each_child(function(tree, lang_)
    if tree:contains(range) then
      lang = lang_
      return
    end
  end)

  return lang
end

local function enable_commenstrings()
  -- Any better events?
  api.nvim_create_autocmd({'CursorMoved', 'CursorMovedI'}, {
    buffer = 0,
    callback = function()
      local lang = get_lang() or vim.bo.filetype
      if lang == 'comment' then
        lang = vim.bo.filetype   -- Exclude this
      end

      local commentstring = vim.filetype.get_option(lang, 'commentstring')

      if commentstring ~= vim.bo.commentstring then
        vim.bo.commentstring = commentstring
      end
    end
  })
end

api.nvim_create_autocmd('FileType', {
  callback = function()
    if not pcall(vim.treesitter.start) then
      return
    end

    enable_commenstrings()
  end
})

```

</details>