### PR TITLE
fix(lsp): fix vim.lsp.util.apply_text_edits's cursor position validation

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -436,7 +436,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
 
   -- Some LSP servers are depending on the VSCode behavior.
   -- The VSCode will re-locate the cursor position after applying TextEdit so we also do it.
-  local is_current_buf = api.nvim_get_current_buf() == bufnr
+  local is_current_buf = api.nvim_get_current_buf() == bufnr or bufnr == 0
   local cursor = (function()
     if not is_current_buf then
       return {
@@ -464,7 +464,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
       start_col = get_line_byte_from_position(bufnr, text_edit.range.start, offset_encoding),
       end_row = text_edit.range['end'].line,
       end_col = get_line_byte_from_position(bufnr, text_edit.range['end'], offset_encoding),
-      text = split(text_edit.newText, '\n', true),
+      text = split(text_edit.newText, '\n', { plain = true }),
     }
 
     local max = api.nvim_buf_line_count(bufnr)
@@ -522,7 +522,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
   if is_cursor_fixed then
     local is_valid_cursor = true
     is_valid_cursor = is_valid_cursor and cursor.row < max
-    is_valid_cursor = is_valid_cursor and cursor.col <= #(get_line(bufnr, max - 1) or '')
+    is_valid_cursor = is_valid_cursor and cursor.col <= #(get_line(bufnr, cursor.row) or '')
     if is_valid_cursor then
       api.nvim_win_set_cursor(0, { cursor.row + 1, cursor.col })
     end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1714,6 +1714,9 @@ describe('LSP', function()
       end)
 
       it('fix the cursor col', function()
+        -- append empty last line. See #22636
+        exec_lua('vim.api.nvim_buf_set_lines(...)', 1, -1, -1, true, {''})
+
         funcs.nvim_win_set_cursor(0, { 2, 11 })
         local edits = {
           make_edit(1, 7, 1, 11, '')
@@ -1725,6 +1728,7 @@ describe('LSP', function()
           'Third line of text';
           'Fourth line of text';
           'å å ɧ 汉语 ↥ 🤦 🦄';
+          '';
         }, buf_lines(1))
         eq({ 2, 7 }, funcs.nvim_win_get_cursor(0))
       end)


### PR DESCRIPTION
### Problem

Fix using wrong variable when checking the cursor position is valid or not in vim.lsp.util.apply_text_edits.

### Solution

Change to use correct variable.