### PR TITLE
test: fix flaky watchfiles tests

### DIFF
--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -126,6 +126,8 @@ describe('vim._watch', function()
         expected_events = expected_events + 1
         wait_for_events()
 
+        vim.wait(100)
+
         local watched_path = root_dir .. '/file'
         local watched, err = io.open(watched_path, 'w')
         assert(not err, err)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3714,7 +3714,8 @@ describe('LSP', function()
 
         local expected_messages = 2 -- initialize, initialized
 
-        local msg_wait_timeout = require('vim.lsp._watchfiles')._watchfunc == vim._watch.poll and 2500 or 200
+        local watchfunc = require('vim.lsp._watchfiles')._watchfunc
+        local msg_wait_timeout = watchfunc == vim._watch.poll and 2500 or 200
         local function wait_for_messages()
           assert(vim.wait(msg_wait_timeout, function() return #server.messages == expected_messages end), 'Timed out waiting for expected number of messages. Current messages seen so far: ' .. vim.inspect(server.messages))
         end
@@ -3737,6 +3738,10 @@ describe('LSP', function()
             },
           },
         }, { client_id = client_id })
+
+        if watchfunc == vim._watch.poll then
+          vim.wait(100)
+        end
 
         local path = root_dir .. '/watch'
         local file = io.open(path, 'w')


### PR DESCRIPTION
This PR aims to address the file watching test flakes described in this thread: https://github.com/neovim/neovim/pull/22405#issuecomment-1461119947. Specifically, the ones that surface as 
```
ERROR    test/functional/lua/watch_spec.lua @ 102: vim._watch poll detects file changes
test/functional/helpers.lua:103: Error executing lua: [string "<nvim>"]:10: Timed out waiting for expected number of events. Current events seen so far: { {
    change_type = 1,
    path = "/Users/runner/work/neovim/neovim/build/Xtest_tmpdir/T3131.65"
  } }
```
and
```
RUN      T3481 LSP vim.lsp._watchfiles sends notifications when files change: 2566.11 ms ERR
test/functional/helpers.lua:103: Error executing lua: [string "<nvim>"]:14: Timed out waiting for expected number of messages. Current messages seen so far: { {
    method = "initialize",
    params = { ... }
  }, {
    method = "initialized",
    params = vim.empty_dict()
  } }
stack traceback:
	[C]: in function 'assert'
	[string "<nvim>"]:14: in function 'wait_for_messages'
	[string "<nvim>"]:41: in main chunk

stack traceback:
	test/functional/helpers.lua:103: in function 'exec_lua'
	test/functional/plugin/lsp_spec.lua:3601: in function <test/functional/plugin/lsp_spec.lua:3595>
```

I think both of these are being caused by the same underlying issue where there's a race condition between when a `vim._watch.poll` is started and events start happening, so some events never come through for reasons I don't quite fully understand yet.

Currently, the fix is a hack to wait for some time between creating the poller and generating the first event afterward. I think I'll need some help coming up with a real fix, but hopefully this is a decent hint at least as to what's really going on.