### PR TITLE
vim-patch:9.0.1401: condition is always true

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6951,14 +6951,12 @@ int handle_subscript(const char **const arg, typval_T *rettv, int evaluate, int 
       tv_dict_unref(selfdict);
       selfdict = NULL;
     } else if (**arg == '-') {
-      if (ret == OK) {
-        if ((*arg)[2] == '{') {
-          // expr->{lambda}()
-          ret = eval_lambda((char **)arg, rettv, evaluate, verbose);
-        } else {
-          // expr->name()
-          ret = eval_method((char **)arg, rettv, evaluate, verbose);
-        }
+      if ((*arg)[2] == '{') {
+        // expr->{lambda}()
+        ret = eval_lambda((char **)arg, rettv, evaluate, verbose);
+      } else {
+        // expr->name()
+        ret = eval_method((char **)arg, rettv, evaluate, verbose);
       }
     } else {  // **arg == '[' || **arg == '.'
       tv_dict_unref(selfdict);


### PR DESCRIPTION
#### vim-patch:9.0.1401: condition is always true

Problem:    Condition is always true.
Solution:   Remove the condition. (closes vim/vim#12139)

https://github.com/vim/vim/commit/c481ad38f05c9f759ca7fd01a54c78acad794e85