### PR TITLE
feat: add `vim.treesitter.language.get_filetypes()`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -592,8 +592,7 @@ get_node_text({node}, {source}, {opts})
         (string)
 
 get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
-    Returns the parser for a specific buffer and filetype and attaches it to
-    the buffer
+    Returns the parser for a specific buffer and attaches it to the buffer
 
     If needed, this will create the parser.
 
@@ -728,29 +727,35 @@ stop({bufnr})                                          *vim.treesitter.stop()*
 Lua module: vim.treesitter.language                  *lua-treesitter-language*
 
 add({lang}, {opts})                            *vim.treesitter.language.add()*
-    Asserts that a parser for the language {lang} is installed.
+    Load parser with name {lang}
 
     Parsers are searched in the `parser` runtime directory, or the provided
     {path}
 
     Parameters: ~
-      • {lang}  (string) Language the parser should parse (alphanumerical and
-                `_` only)
+      • {lang}  (string) Name of the parser (alphanumerical and `_` only)
       • {opts}  (table|nil) Options:
-                • filetype (string|string[]) Filetype(s) that lang can be
-                  parsed with. Note this is not strictly the same as lang
-                  since a single lang can parse multiple filetypes. Defaults
-                  to lang.
+                • filetype (string|string[]) Default filetype the parser
+                  should be associated with. Defaults to {lang}.
                 • path (string|nil) Optional path the parser is located at
                 • symbol_name (string|nil) Internal symbol name for the
                   language to load
 
-get_lang({filetype})                      *vim.treesitter.language.get_lang()*
+get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
+    Get the filetypes associated with the parser named {lang}.
+
     Parameters: ~
-      • {filetype}  (string)
+      • {lang}  string Name of parser
 
     Return: ~
-        (string|nil)
+        string[] filetypes
+
+get_lang({filetype})                      *vim.treesitter.language.get_lang()*
+    Parameters: ~
+      • {filetype}  string
+
+    Return: ~
+        string|nil
 
 inspect({lang})                            *vim.treesitter.language.inspect()*
     Inspects the provided language.
@@ -765,10 +770,10 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
         (table)
 
 register({lang}, {filetype})              *vim.treesitter.language.register()*
-    Register a lang to be used for a filetype (or list of filetypes).
+    Register a parser named {lang} to be used for {filetype}(s).
 
     Parameters: ~
-      • {lang}      (string) Language to register
+      • {lang}      string Name of parser
       • {filetype}  string|string[] Filetype(s) to associate with lang
 
 

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -58,9 +58,6 @@ function M._create_parser(bufnr, lang, opts)
 
   vim.fn.bufload(bufnr)
 
-  local ft = vim.bo[bufnr].filetype
-  M.language.add(lang, { filetype = ft ~= '' and ft or nil })
-
   local self = LanguageTree.new(bufnr, lang, opts)
 
   ---@private
@@ -94,7 +91,12 @@ function M._create_parser(bufnr, lang, opts)
   return self
 end
 
---- Returns the parser for a specific buffer and filetype and attaches it to the buffer
+--- @private
+local function valid_lang(lang)
+  return lang and lang ~= ''
+end
+
+--- Returns the parser for a specific buffer and attaches it to the buffer
 ---
 --- If needed, this will create the parser.
 ---
@@ -110,18 +112,12 @@ function M.get_parser(bufnr, lang, opts)
     bufnr = a.nvim_get_current_buf()
   end
 
-  if lang == nil then
-    local ft = vim.bo[bufnr].filetype
-    if ft ~= '' then
-      lang = M.language.get_lang(ft) or ft
-      -- TODO(lewis6991): we should error here and not default to ft
-      -- if not lang then
-      --   error(string.format('filetype %s of buffer %d is not associated with any lang', ft, bufnr))
-      -- end
-    else
-      if parsers[bufnr] then
-        return parsers[bufnr]
-      end
+  if !valid_lang(lang) then
+    lang = M.language.get_lang(vim.bo[bufnr].filetype) or vim.bo[bufnr].filetype
+  end
+
+  if !valid_lang(lang) then
+    if not parsers[bufnr] then
       error(
         string.format(
           'There is no parser available for buffer %d and one could not be'
@@ -131,9 +127,7 @@ function M.get_parser(bufnr, lang, opts)
         )
       )
     end
-  end
-
-  if parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
+  elseif parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
     parsers[bufnr] = M._create_parser(bufnr, lang, opts)
   end
 
@@ -164,7 +158,6 @@ function M.get_string_parser(str, lang, opts)
     str = { str, 'string' },
     lang = { lang, 'string' },
   })
-  M.language.add(lang)
 
   return LanguageTree.new(str, lang, opts)
 end

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -116,7 +116,7 @@ function M.get_parser(bufnr, lang, opts)
     lang = M.language.get_lang(vim.bo[bufnr].filetype) or vim.bo[bufnr].filetype
   end
 
-  if !valid_lang(lang) then
+  if not valid_lang(lang) then
     if not parsers[bufnr] then
       error(
         string.format(

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -112,7 +112,7 @@ function M.get_parser(bufnr, lang, opts)
     bufnr = a.nvim_get_current_buf()
   end
 
-  if !valid_lang(lang) then
+  if not valid_lang(lang) then
     lang = M.language.get_lang(vim.bo[bufnr].filetype) or vim.bo[bufnr].filetype
   end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -76,7 +76,7 @@ LanguageTree.__index = LanguageTree
 --- "injected" language parsers, which themselves may inject other languages, recursively.
 ---
 ---@param source (integer|string) Buffer or text string to parse
----@param lang string Root language of this tree
+---@param lang string|nil Root language of this tree
 ---@param opts (table|nil) Optional arguments:
 ---             - injections table Map of language to injection query strings. Overrides the
 ---                                built-in runtime file searching for language injections.
@@ -85,11 +85,6 @@ function LanguageTree.new(source, lang, opts)
   language.add(lang)
   ---@type LanguageTreeOpts
   opts = opts or {}
-
-  if opts.queries then
-    a.nvim_err_writeln("'queries' is no longer supported. Use 'injections' now")
-    opts.injections = opts.queries
-  end
 
   local injections = opts.injections or {}
   local self = setmetatable({


### PR DESCRIPTION
## Problem

Cannot not determine what filetypes can be used for a treesitter language

## Solution

- Add `vim.treesitter.language.get_filetypes()`