### PR TITLE
ci: prevent merging PRs with unwanted labels

### DIFF
--- a/.github/scripts/block_merge.js
+++ b/.github/scripts/block_merge.js
@@ -1,0 +1,14 @@
+module.exports = async ({ github, context }) => {
+  const issue = await github.rest.issues.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    issue_number: context.issue.number,
+  });
+  const labels = issue.data.labels.map((e) => e.name);
+
+  error = labels.includes("DO NOT MERGE") || labels.includes("typo");
+
+  if (error) {
+    process.exit(1);
+  }
+};

--- a/.github/workflows/block-merge.yml
+++ b/.github/workflows/block-merge.yml
@@ -1,0 +1,17 @@
+name: block-merge
+on:
+  pull_request:
+    types: [labeled, unlabeled, reopened]
+jobs:
+  block-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Request reviewers'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/block_merge.js')
+            await script({github, context})

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -48,3 +48,15 @@ jobs:
           script: |
             const script = require('./.github/scripts/reviews.js')
             await script({github, context})
+
+  block-merge:
+    runs-on: ubuntu-latest
+    needs: ["triage", "type-scope"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Request reviewers'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const script = require('./.github/scripts/block_merge.js')
+            await script({github, context})


### PR DESCRIPTION
This is meant as an extra precaution for contributors to not
accidentally merge pull requests when they shouldn't.
