### PR TITLE
fix(lsp): add silent options in code_action params table

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1027,6 +1027,8 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                      selection. Table must contain `start` and `end` keys with
                      {row, col} tuples using mark-like indexing. See
                      |api-indexing|
+                   • silent: (boolean|nil) when silent is true, if there is no
+                     available actions does not show notify.
 
     See also: ~
         https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -625,7 +625,7 @@ local function on_code_action_results(results, ctx, options)
       end
     end
   end
-  if #action_tuples == 0 then
+  if #action_tuples == 0 and not options.silent then
     vim.notify('No code actions available', vim.log.levels.INFO)
     return
   end
@@ -745,6 +745,9 @@ end
 ---           If in visual mode this defaults to the active selection.
 ---           Table must contain `start` and `end` keys with {row, col} tuples
 ---           using mark-like indexing. See |api-indexing|
+---  - silent: (boolean|nil)
+---            when silent is true, if there is no available actions does not
+---            show notify.
 ---
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 ---@see vim.lsp.protocol.constants.CodeActionTriggerKind


### PR DESCRIPTION
sometimes is annoying .  add a new field  `silent` in options table to disable run this notify when there is no code actions.