### PR TITLE
docs(CSS): Larger font size in output.

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -927,6 +927,7 @@ local function gen_css(fname)
     /* Tag pseudo-header common in :help docs. */
     .help-tag-right {
       color: var(--tag-color);
+      font-size: 19px;
     }
     h1 .help-tag, h2 .help-tag, h3 .help-tag {
       font-size: smaller;


### PR DESCRIPTION
### Problem
The font size of the API displayed on the web is too small.
### 
Changing the font size makes it even easier to read.

#### Before
![neovimHomepageBefore](https://user-images.githubusercontent.com/80927666/224684003-c9d3cd7a-5496-4173-babb-055e2a1a7e99.png)
#### After
![neovimHomepageAfter](https://user-images.githubusercontent.com/80927666/224684029-d48e2b2b-93ce-4f25-b2f3-f3b203a5c291.png)
