### PR TITLE
fix(help): force tree reparse after local addition insertion

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -169,8 +169,8 @@ DEVELOPING NVIM
 |dev-style|		Development style guidelines
 |debug.txt|		Debugging Vim itself
 
-						*standard-plugin-list*
 Standard plugins ~
+						*standard-plugin-list*
 |matchit.txt|		Extended |%| matching
 |pi_gzip.txt|		Reading and writing compressed files
 |pi_health.txt|		Healthcheck framework
@@ -181,7 +181,8 @@ Standard plugins ~
 |pi_tar.txt|		Tar file explorer
 |pi_zip.txt|		Zip archive explorer
 
-LOCAL ADDITIONS:				*local-additions*
+Local additions ~
+							*local-additions*
 
 ------------------------------------------------------------------------------
 *bars*		Bars example

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -10,6 +10,7 @@
 
 #include "nvim/ascii.h"
 #include "nvim/buffer.h"
+#include "nvim/change.h"
 #include "nvim/charset.h"
 #include "nvim/cmdexpand.h"
 #include "nvim/ex_cmds.h"
@@ -699,6 +700,8 @@ void fix_help_buffer(void)
         continue;
       }
 
+      int lnum_start = lnum;
+
       // Go through all directories in 'runtimepath', skipping
       // $VIMRUNTIME.
       char *p = p_rtp;
@@ -828,6 +831,11 @@ void fix_help_buffer(void)
           }
         }
         xfree(rt);
+      }
+      linenr_T appended = lnum - lnum_start;
+      if (appended) {
+        mark_adjust(lnum_start + 1, (linenr_T)MAXLNUM, appended, 0L, kExtmarkUndo);
+        changed_lines_buf(curbuf, lnum_start + 1, lnum_start + 1, appended);
       }
       break;
     }


### PR DESCRIPTION
Problem: `*local-additions*` in `help.txt` are inserted via `ml_append`,
which messes up treesitter highlighting of this file as the buffer
becomes desynced from the tree.

Solution: Add hack on top of hack by explicitly calling `mark_adjust`
and `changed_lines_buf` after each insertion.

Should be covered by old `test_help.vim`.

Also massage the column headers in that section for consistency and correct vimdoc parsing.

Closes https://github.com/neovim/tree-sitter-vimdoc/issues/99

@bfredl 
