### PR TITLE
Increase SEARCH_STAT_DEF_MAX_COUNT to 999

### DIFF
--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -54,7 +54,7 @@
 
 // Values for searchcount()
 #define SEARCH_STAT_DEF_TIMEOUT 40L
-#define SEARCH_STAT_DEF_MAX_COUNT 99
+#define SEARCH_STAT_DEF_MAX_COUNT 999
 #define SEARCH_STAT_BUF_LEN 12
 
 /// Maximum number of characters that can be fuzzy matched


### PR DESCRIPTION
Show up to 999 hits in `searchcount()`; previously was 99.

> Probably not necessary to update news.txt for this.