### PR TITLE
test: Windows not detected in msys shells

### DIFF
--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -312,7 +312,7 @@ function module.is_os(s)
     or s == 'bsd') then
     error('unknown platform: '..tostring(s))
   end
-  return not not ((s == 'win' and module.sysname():find('windows'))
+  return not not ((s == 'win' and (module.sysname():find('windows') or module.sysname():find('mingw')))
     or (s == 'mac' and module.sysname() == 'darwin')
     or (s == 'freebsd' and module.sysname() == 'freebsd')
     or (s == 'openbsd' and module.sysname() == 'openbsd')


### PR DESCRIPTION
test: luv sysname is not 'windows' in msys shells

Problem:
The functional tests have a function 'is_os(s)' to determine if the
current os is s.  E.g., 'is_os("win")' returns true if the current os is
Windows.  This is done by checking if the sysname as detected by luv
contains the substring 'windows'.  The issue is, in MSYS shells, the
sysname is determined to be MINGWXX_NT, where XX is either 32 or 64.  So
if you're using busted or luv that you built separately, not the
nvim-bundled versions, then for you 'is_os(s)' won't work.

Solution:
If param 's' is 'win', return true if luv-detected sysname contains
either the substring 'windows' or 'mingw'.