### PR TITLE
build(deps): bump luarocks and bundled rocks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -19,8 +19,10 @@ cache = true
 ignore = {
   "631",  -- max_line_length
   "212/_.*",  -- unused argument, for vars with "_" prefix
+  "214", -- used variable with unused hint ("_" prefix)
   "121", -- setting read-only global variable 'vim'
   "122", -- setting read-only field of global variable 'vim'
+  "581", -- negation of a relational operator- operator can be flipped (not for tables)
 }
 
 -- Global objects defined by the C code

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -144,8 +144,8 @@ set(LUAJIT_SHA256 67c88399b901a22e9a236f4b77e6fe39af00f6b7144ce9dd6f51141d921f10
 set(LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz)
 set(LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333)
 
-set(LUAROCKS_URL https://github.com/luarocks/luarocks/archive/v3.8.0.tar.gz)
-set(LUAROCKS_SHA256 ab6612ca9ab87c6984871d2712d05525775e8b50172701a0a1cabddf76de2be7)
+set(LUAROCKS_URL https://github.com/luarocks/luarocks/archive/v3.9.2.tar.gz)
+set(LUAROCKS_SHA256 a0b36cd68586cd79966d0106bb2e5a4f5523327867995fd66bee4237062b3e3b)
 
 set(UNIBILIUM_URL https://github.com/neovim/unibilium/archive/d72c3598e7ac5d1ebf86ee268b8b4ed95c0fa628.tar.gz)
 set(UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b9536655596797487)

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -147,7 +147,7 @@ if(USE_BUNDLED_BUSTED)
   if (USE_BUNDLED_LUA OR NOT USE_BUNDLED_LUAJIT)
     # coxpcall
     add_custom_command(OUTPUT ${ROCKS_DIR}/coxpcall
-      COMMAND ${LUAROCKS_BINARY} build coxpcall 1.16.0-1 ${LUAROCKS_BUILDARGS}
+      COMMAND ${LUAROCKS_BINARY} build coxpcall 1.17.0-1 ${LUAROCKS_BUILDARGS}
       DEPENDS luarocks)
     add_custom_target(coxpcall ALL DEPENDS ${ROCKS_DIR}/coxpcall)
   endif()

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -100,7 +100,7 @@ set(ROCKS_DIR ${DEPS_LIB_DIR}/luarocks/rocks-${LUA_VERSION})
 
 # mpack
 add_custom_command(OUTPUT ${ROCKS_DIR}/mpack
-  COMMAND ${LUAROCKS_BINARY} build mpack 1.0.8-0 ${LUAROCKS_BUILDARGS}
+  COMMAND ${LUAROCKS_BINARY} build mpack 1.0.10-0 ${LUAROCKS_BUILDARGS}
   DEPENDS luarocks)
 add_custom_target(mpack ALL DEPENDS ${ROCKS_DIR}/mpack)
 

--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -140,7 +140,7 @@ if(USE_BUNDLED_BUSTED)
 
   # luacheck
   add_custom_command(OUTPUT ${LUACHECK_EXE}
-    COMMAND ${LUAROCKS_BINARY} build luacheck 0.23.0-1 ${LUAROCKS_BUILDARGS}
+    COMMAND ${LUAROCKS_BINARY} build luacheck 1.1.0-1 ${LUAROCKS_BUILDARGS}
     DEPENDS busted)
   add_custom_target(luacheck ALL DEPENDS ${LUACHECK_EXE})
 


### PR DESCRIPTION
Update Luarocks and all bundled rocks. I'll push each bump as a separate commit in order to see which if any break CI.

* [x] Luarocks: v3.8.0 -> v3.9.2 (@dundargoc see [changelog](https://github.com/luarocks/luarocks/blob/master/CHANGELOG.md), some changes may allow simplifying our cmake script)
* [x] coxpcall: 1.16.0-1 -> 1.17.0-1
* [x] luacheck: 0.23.0-1 -> 1.1.0-1
* [x] mpack: 1.0.8-0 -> 1.0.10-0
