### PR TITLE
fix(lsp): avoid switching buffers on lsp attach

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1115,7 +1115,7 @@ function lsp.start_client(config)
       return false
     end
 
-    return vim.startswith(vim.fn.expand(scriptname), vim.fn.expand(vim.fn.getenv('VIMRUNTIME')))
+    return vim.startswith(vim.fn.expand(scriptname), vim.fn.expand('$VIMRUNTIME'))
   end
 
   ---@private

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1101,21 +1101,21 @@ function lsp.start_client(config)
       return true
     end
 
-    local old_bufnr = vim.fn.bufnr('')
     local last_set_from = vim.fn.gettext('\n\tLast set from ')
     local line = vim.fn.gettext(' line ')
+    local scriptname
 
-    vim.cmd.buffer(bufnr)
-    local scriptname = vim.fn
-      .execute('verbose set ' .. option .. '?')
-      :match(last_set_from .. '(.*)' .. line .. '%d+')
-    vim.cmd.buffer(old_bufnr)
+    vim.api.nvim_buf_call(bufnr, function()
+      scriptname = vim.fn
+        .execute('verbose set ' .. option .. '?')
+        :match(last_set_from .. '(.*)' .. line .. '%d+')
+    end)
 
     if not scriptname then
       return false
     end
-    local vimruntime = vim.fn.getenv('VIMRUNTIME')
-    return vim.startswith(vim.fn.expand(scriptname), vim.fn.expand(vimruntime))
+
+    return vim.startswith(vim.fn.expand(scriptname), vim.fn.expand(vim.fn.getenv('VIMRUNTIME')))
   end
 
   ---@private


### PR DESCRIPTION
I've been having issues where under some weird circumstances, certain window options are being turned off (namely `:h 'diff'`) when doing things like viewing changes with `vim-fugitive` after LSP server(s) are attached to a buffer with these options on. I was not quite able to pinpoint exactly what is going on, but was able to bisect this down to `9ef7297ef142354ace8b1f3f277d0eee3cfdc6d4` (#22267) and the fact that it actually switches buffers.

Altering this function to just always return `false` or ensuring that these options are empty (so it returns early) fixed the issue. Figured it would be worth submitting a patch to (theoretically) fix the issue I am seeing while maintaining the intended functionality.

Tagging those that were mostly involved on the original PR:
- @mliszcz 
- @justinmk

This might be worth waiting until #22634 is merged as @justinmk noted on the previous PR, but as long as the functionality still works as intended @mliszcz, it'd be awesome to merge this so I can avoid the issue I've been having lately. Either way, appreciate the time.