### PR TITLE
Add cmd mods and count to `:InspectTree`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -623,8 +623,8 @@ inspect_tree({opts})                           *vim.treesitter.inspect_tree()*
                 • winid (integer|nil): Window id to display the tree buffer
                   in. If omitted, a new window is created with {command}.
                 • command (string|nil): Vimscript command to create the
-                  window. Default value is "topleft 60vnew". Only used when
-                  {winid} is nil.
+                  window. Default value is "60vnew". Only used when {winid} is
+                  nil.
                 • title (string|fun(bufnr:integer):string|nil): Title of the
                   window. If a function, it accepts the buffer number of the
                   source buffer as its only argument and should return a

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -439,7 +439,7 @@ end
 ---                      - winid (integer|nil): Window id to display the tree buffer in. If omitted,
 ---                        a new window is created with {command}.
 ---                      - command (string|nil): Vimscript command to create the window. Default
----                        value is "topleft 60vnew". Only used when {winid} is nil.
+---                        value is "60vnew". Only used when {winid} is nil.
 ---                      - title (string|fun(bufnr:integer):string|nil): Title of the window. If a
 ---                        function, it accepts the buffer number of the source buffer as its only
 ---                        argument and should return a string.
@@ -465,7 +465,7 @@ function M.inspect_tree(opts)
 
   local w = opts.winid
   if not w then
-    vim.cmd(opts.command or 'topleft 60vnew')
+    vim.cmd(opts.command or '60vnew')
     w = a.nvim_get_current_win()
   end
 

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -6,6 +6,15 @@ vim.api.nvim_create_user_command('Inspect', function(cmd)
   end
 end, { desc = 'Inspect highlights and extmarks at the cursor', bang = true })
 
-vim.api.nvim_create_user_command('InspectTree', function()
-  vim.treesitter.inspect_tree()
-end, { desc = 'Inspect treesitter language tree for buffer' })
+vim.api.nvim_create_user_command('InspectTree', function(cmd)
+  if cmd.mods ~= '' or cmd.count ~= 0 then
+    local count = cmd.count ~= 0 and cmd.count or ''
+    local new = cmd.mods ~= '' and 'new' or 'vnew'
+
+    vim.treesitter.inspect_tree({
+      command = ('%s %s%s'):format(cmd.mods, count, new),
+    })
+  else
+    vim.treesitter.inspect_tree()
+  end
+end, { desc = 'Inspect treesitter language tree for buffer', count = true })


### PR DESCRIPTION
Also changes the default of the `command` option of `vim.treesitter.inspect_tree()` from `topleft 60vnew` to `60vnew`.

See discussion at #22656. Closes #22656.

Do I need to write documentation for `:InspectTree`? That it accepts a count as window size and the modifiers?