### PR TITLE
vim-patch:9.0.0194: cursor displayed in wrong position after removing text prop

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -446,6 +446,7 @@ void deleted_lines_mark(linenr_T lnum, long count)
 }
 
 /// Marks the area to be redrawn after a change.
+/// Consider also calling changed_line_display_buf().
 ///
 /// @param buf the buffer where lines were changed
 /// @param lnum first line with change

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -11,6 +11,7 @@
 #include "nvim/highlight.h"
 #include "nvim/highlight_group.h"
 #include "nvim/memory.h"
+#include "nvim/move.h"
 #include "nvim/pos.h"
 #include "nvim/sign_defs.h"
 
@@ -86,6 +87,7 @@ void decor_redraw(buf_T *buf, int row1, int row2, Decoration *decor)
 
   if (decor && kv_size(decor->virt_lines)) {
     redraw_buf_line_later(buf, row1 + 1 + (decor->virt_lines_above?0:1), true);
+    changed_line_display_buf(buf);
   }
 }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -471,6 +471,19 @@ void changed_line_abv_curs_win(win_T *wp)
                    |VALID_CHEIGHT|VALID_TOPLINE);
 }
 
+/// Display of line has changed for "buf", invalidate cursor position and
+/// w_botline.
+void changed_line_display_buf(buf_T *buf)
+{
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_buffer == buf) {
+      wp->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL
+                       |VALID_CROW|VALID_CHEIGHT
+                       |VALID_TOPLINE|VALID_BOTLINE|VALID_BOTLINE_AP);
+    }
+  }
+}
+
 // Make sure the value of curwin->w_botline is valid.
 void validate_botline(win_T *wp)
 {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1247,6 +1247,7 @@ if (h->n_buckets < new_n_buckets) { // expand
     ]]}
 
     meths.buf_clear_namespace(0, ns, 0, -1)
+    -- Cursor should be drawn on the correct line. #22704
     screen:expect{grid=[[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)                 |
@@ -1254,15 +1255,14 @@ if (h->n_buckets < new_n_buckets) { // expand
       hkey_t));                                         |
         h->keys = new_keys;                             |
         if (kh_is_map && val_size) {                    |
-          char *new_vals = {3:krealloc}( h->vals_buf, new_n_|
-      buck^ets * val_size);                              |
+          ^char *new_vals = {3:krealloc}( h->vals_buf, new_n_|
+      buckets * val_size);                              |
           h->vals_buf = new_vals;                       |
         }                                               |
       }                                                 |
                                                         |
     ]]}
   end)
-
 
   it('works with text at the beginning of the buffer', function()
     insert(example_text)


### PR DESCRIPTION
Fix #22704

#### vim-patch:9.0.0194: cursor displayed in wrong position after removing text prop

Problem:    Cursor displayed in wrong position after removing text prop. (Ben
            Jackson)
Solution:   Invalidate the cursor position.

https://github.com/vim/vim/commit/326c5d36e7cb8526330565109c17b4a13ff790ae

Co-authored-by: Bram Moolenaar <Bram@vim.org>