### PR TITLE
fix(spell): properly source spell/LANG.{vim,lua}

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1578,7 +1578,9 @@ static void do_spelllang_source(win_T *win)
     }
   }
   if (p > q) {
-    vim_snprintf(fname, sizeof(fname), "spell/%.*s.\\(vim\\|lua\\)", (int)(p - q), q);
+    vim_snprintf(fname, sizeof(fname), "spell/%.*s.vim", (int)(p - q), q);
+    source_runtime(fname, DIP_ALL);
+    vim_snprintf(fname, sizeof(fname), "spell/%.*s.lua", (int)(p - q), q);
     source_runtime(fname, DIP_ALL);
   }
 }

--- a/test/functional/lua/runtime_spec.lua
+++ b/test/functional/lua/runtime_spec.lua
@@ -36,10 +36,12 @@ describe('runtime:', function()
 
   describe('colors', function()
     local colorscheme_folder = plug_dir .. sep .. 'colors'
+    before_each(function()
+      mkdir_p(colorscheme_folder)
+    end)
 
     it('loads lua colorscheme', function()
       local colorscheme_file = colorscheme_folder .. sep .. 'new_colorscheme.lua'
-      mkdir_p(colorscheme_folder)
       write_file(colorscheme_file, [[vim.g.lua_colorscheme = 1]])
 
       eq({'new_colorscheme'}, funcs.getcompletion('new_c', 'color'))
@@ -48,28 +50,27 @@ describe('runtime:', function()
       exec('colorscheme new_colorscheme')
 
       eq(1, eval('g:lua_colorscheme'))
-      rmdir(colorscheme_folder)
     end)
 
     it('loads vim colorscheme when both lua and vim version exist', function()
       local colorscheme_file = colorscheme_folder .. sep .. 'new_colorscheme'
-      mkdir_p(colorscheme_folder)
       write_file(colorscheme_file..'.vim', [[let g:colorscheme = 'vim']])
       write_file(colorscheme_file..'.lua', [[vim.g.colorscheme = 'lua']])
 
       exec('colorscheme new_colorscheme')
 
       eq('vim', eval('g:colorscheme'))
-      rmdir(colorscheme_folder)
     end)
   end)
 
   describe('compiler', function()
     local compiler_folder = plug_dir .. sep .. 'compiler'
+    before_each(function()
+      mkdir_p(compiler_folder)
+    end)
 
     it('loads lua compilers', function()
       local compiler_file = compiler_folder .. sep .. 'new_compiler.lua'
-      mkdir_p(compiler_folder)
       write_file(compiler_file, [[vim.b.lua_compiler = 1]])
 
       eq({'new_compiler'}, funcs.getcompletion('new_c', 'compiler'))
@@ -78,19 +79,16 @@ describe('runtime:', function()
       exec('compiler new_compiler')
 
       eq(1, eval('b:lua_compiler'))
-      rmdir(compiler_folder)
     end)
 
     it('loads vim compilers when both lua and vim version exist', function()
       local compiler_file = compiler_folder .. sep .. 'new_compiler'
-      mkdir_p(compiler_folder)
       write_file(compiler_file..'.vim', [[let b:compiler = 'vim']])
       write_file(compiler_file..'.lua', [[vim.b.compiler = 'lua']])
 
       exec('compiler new_compiler')
 
       eq('vim', eval('b:compiler'))
-      rmdir(compiler_folder)
     end)
   end)
 
@@ -98,8 +96,8 @@ describe('runtime:', function()
     local ftplugin_folder = table.concat({plug_dir, 'ftplugin'}, sep)
 
     it('loads lua ftplugins', function()
-      local ftplugin_file = table.concat({ftplugin_folder , 'new-ft.lua'}, sep)
       mkdir_p(ftplugin_folder)
+      local ftplugin_file = table.concat({ftplugin_folder , 'new-ft.lua'}, sep)
       write_file(ftplugin_file , [[vim.b.lua_ftplugin = 1]])
 
       eq({'new-ft'}, funcs.getcompletion('new-f', 'filetype'))
@@ -107,7 +105,6 @@ describe('runtime:', function()
 
       exec [[set filetype=new-ft]]
       eq(1, eval('b:lua_ftplugin'))
-      rmdir(ftplugin_folder)
     end)
   end)
 
@@ -115,8 +112,8 @@ describe('runtime:', function()
     local indent_folder = table.concat({plug_dir, 'indent'}, sep)
 
     it('loads lua indents', function()
-      local indent_file = table.concat({indent_folder , 'new-ft.lua'}, sep)
       mkdir_p(indent_folder)
+      local indent_file = table.concat({indent_folder , 'new-ft.lua'}, sep)
       write_file(indent_file , [[vim.b.lua_indent = 1]])
 
       eq({'new-ft'}, funcs.getcompletion('new-f', 'filetype'))
@@ -124,7 +121,6 @@ describe('runtime:', function()
 
       exec [[set filetype=new-ft]]
       eq(1, eval('b:lua_indent'))
-      rmdir(indent_folder)
     end)
   end)
 
@@ -132,8 +128,8 @@ describe('runtime:', function()
     local syntax_folder = table.concat({plug_dir, 'syntax'}, sep)
 
     before_each(function()
-      local syntax_file = table.concat({syntax_folder , 'my-lang.lua'}, sep)
       mkdir_p(syntax_folder)
+      local syntax_file = table.concat({syntax_folder , 'my-lang.lua'}, sep)
       write_file(syntax_file , [[vim.b.current_syntax = 'my-lang']])
       exec([[let b:current_syntax = '']])
     end)
@@ -158,6 +154,21 @@ describe('runtime:', function()
       eq({'my-lang'}, funcs.getcompletion('my-l', 'filetype'))
       eq({'my-lang'}, funcs.getcompletion('my-l', 'syntax'))
       eq({'syntax/my-lang.lua'}, funcs.getcompletion('syntax/my-l', 'runtime'))
+    end)
+  end)
+
+  describe('spell', function()
+    local spell_folder = table.concat({plug_dir, 'spell'}, sep)
+
+    it('loads spell/LANG.{vim,lua}', function()
+      mkdir_p(spell_folder)
+      local spell_vim = table.concat({spell_folder , 'Xtest.vim'}, sep)
+      write_file(spell_vim , [[let b:spell_vim = 1]])
+      local spell_lua = table.concat({spell_folder , 'Xtest.lua'}, sep)
+      write_file(spell_lua , [[vim.b.spell_lua = 1]])
+      exec('set spelllang=Xtest')
+      eq(1, eval('b:spell_vim'))
+      eq(1, eval('b:spell_lua'))
     end)
   end)
 


### PR DESCRIPTION
Fix #22715
Fix #22110

Using regexp doesn't work here because there are no wildcards.
