### PR TITLE
test(highlight_spec): fix warning in Visual highlight test

### DIFF
--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -376,7 +376,6 @@ describe('highlight', function()
 
     -- Vertical cursor: highlights char-at-cursor. #8983
     command('set guicursor=a:block-blinkon175')
-    feed('<esc>gg$vhhh')
     screen:expect([[
         line1 foo{1:^ bar}     |
                           |


### PR DESCRIPTION
Problem:    Warning in Visual highlight test.
Solution:   Don't move cursor back and forth.
