### PR TITLE
vim-patch:9.0.1412: Pony files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -800,6 +800,7 @@ local extension = {
   pod = 'pod',
   filter = 'poefilter',
   pk = 'poke',
+  pony = 'pony',
   ps = 'postscr',
   epsi = 'postscr',
   afm = 'postscr',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -449,6 +449,7 @@ let s:filename_checks = {
     \ 'pod': ['file.pod'],
     \ 'poefilter': ['file.filter'],
     \ 'poke': ['file.pk'],
+    \ 'pony': ['file.pony'],
     \ 'postscr': ['file.ps', 'file.pfa', 'file.afm', 'file.eps', 'file.epsf', 'file.epsi', 'file.ai'],
     \ 'pov': ['file.pov'],
     \ 'povini': ['.povrayrc'],


### PR DESCRIPTION
Problem:    Pony files are not recognized.
Solution:   Add a pattern for Pony files. (Amaan Qureshi, closes vim/vim#12155)

https://github.com/vim/vim/commit/6e377eca8de4c0c0d25808beb7de7676194ebf1d