### PR TITLE
fix(column): invalidate statuscolumn width when UPD_NOT_VALID

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4109,7 +4109,6 @@ void buf_signcols_del_check(buf_T *buf, linenr_T line1, linenr_T line2)
 
   if (!buf->b_signcols.sentinel) {
     buf->b_signcols.valid = false;
-    invalidate_statuscol(NULL, buf);
     return;
   }
 
@@ -4118,7 +4117,6 @@ void buf_signcols_del_check(buf_T *buf, linenr_T line1, linenr_T line2)
   if (sent >= line1 && sent <= line2) {
     // Only invalidate when removing signs at the sentinel line.
     buf->b_signcols.valid = false;
-    invalidate_statuscol(NULL, buf);
   }
 }
 
@@ -4134,7 +4132,6 @@ void buf_signcols_add_check(buf_T *buf, sign_entry_T *added)
 
   if (!added || !buf->b_signcols.sentinel) {
     buf->b_signcols.valid = false;
-    invalidate_statuscol(NULL, buf);
     return;
   }
 

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1153,6 +1153,7 @@ void comp_col(void)
   }
   set_vim_var_nr(VV_ECHOSPACE, sc_col - 1);
 }
+
 static void redraw_win_signcol(win_T *wp)
 {
   // If we can compute a change in the automatic sizing of the sign column
@@ -1392,10 +1393,12 @@ static void win_update(win_T *wp, DecorProviders *providers)
   int type = wp->w_redr_type;
 
   if (type >= UPD_NOT_VALID) {
-    // TODO(bfredl): should only be implied for CLEAR, not NOT_VALID!
     wp->w_redr_status = true;
-
     wp->w_lines_valid = 0;
+    if (*wp->w_p_stc != NUL) {
+      wp->w_nrwidth_line_count = 0;    // make sure width is reset
+      wp->w_statuscol_line_count = 0;  // make sure width is re-estimated
+    }
   }
 
   // Window is zero-height: Only need to draw the separator

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2176,8 +2176,10 @@ static char *set_bool_option(const int opt_idx, char *const varp, const int valu
     if (curwin->w_p_spell) {
       errmsg = did_set_spelllang(curwin);
     }
-  } else if ((int *)varp == &curwin->w_p_nu) {  // 'number'
-    invalidate_statuscol(curwin, NULL);
+  } else if ((int *)varp == &curwin->w_p_nu && *curwin->w_p_stc != NUL) {
+    // When 'statuscolumn' is set and 'number' is changed:
+    curwin->w_nrwidth_line_count = 0;    // make sure width is reset
+    curwin->w_statuscol_line_count = 0;  // make sure width is re-estimated
   }
 
   if ((int *)varp == &curwin->w_p_arab) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1198,8 +1198,8 @@ static void did_set_statusline(win_T *win, char **varp, char **gvarp, char **err
   if (varp == &p_ruf) {       // reset ru_wid first
     ru_wid = 0;
   } else if (varp == &win->w_p_stc) {
-    win->w_nrwidth_line_count = 0;
-    win->w_statuscol_line_count = 0;
+    win->w_nrwidth_line_count = 0;    // make sure width is reset
+    win->w_statuscol_line_count = 0;  // make sure width is re-estimated
   }
   char *s = *varp;
   if (varp == &p_ruf && *s == '%') {

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -909,25 +909,6 @@ int build_statuscol_str(win_T *wp, linenr_T lnum, long relnum, statuscol_T *stcp
   return width;
 }
 
-/// Force a reset and re-estimation of the status column width.
-///
-/// @param wp  The window for which to reset the status column (can be NULL if "buf" is not)
-/// @param buf  The buffer for which to reset the status column (can be NULL)
-void invalidate_statuscol(win_T *wp, buf_T *buf)
-{
-  if (buf != NULL) {
-    FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
-      if (*win->w_p_stc != NUL && win->w_buffer == buf) {
-        win->w_nrwidth_line_count = 0;
-        win->w_statuscol_line_count = 0;
-      }
-    }
-  } else if (*wp->w_p_stc != NUL) {
-    wp->w_nrwidth_line_count = 0;    // make sure width is reset
-    wp->w_statuscol_line_count = 0;  // make sure width is re-estimated
-  }
-}
-
 /// Build a string from the status line items in "fmt".
 /// Return length of string in screen cells.
 ///


### PR DESCRIPTION
Follow-up to #22690.

Invalidate statuscolumn width in `win_update()` when `w_redr_type >= UPD_NOT_VALID` and be done with it. I was reluctant to add this unconditionally because it may mean evaluating the statuscolumn twice even when only a single line is redrawn.
With `UPD_NOT_VALID` however we are already updating the entire window so a single extra evaluation seems insignificant relatively speaking. No tests fail and it may catch other cases not covered by tests yet. 