### PR TITLE
docs(lua): fix unnecessarily long lines in lua.txt

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1373,8 +1373,8 @@ connection_failure_errmsg({consequence})
 defer_fn({fn}, {timeout})                                     *vim.defer_fn()*
     Defers calling `fn` until `timeout` ms passes.
 
-    Use to do a one-shot timer that calls `fn` Note: The {fn} is |vim.schedule_wrap()|ped automatically, so API functions
-    are safe to call.
+    Use to do a one-shot timer that calls `fn` Note: The {fn} is
+    |vim.schedule_wrap()|ped automatically, so API functions are safe to call.
 
     Parameters: ~
       • {fn}       (function) Callback to call once `timeout` expires
@@ -1598,7 +1598,8 @@ show_pos({bufnr}, {row}, {col}, {filter})                     *vim.show_pos()*
 deep_equal({a}, {b})                                        *vim.deep_equal()*
     Deep compare values for equality
 
-    Tables are compared recursively unless they both provide the `eq` metamethod. All other types are compared using the equality `==` operator.
+    Tables are compared recursively unless they both provide the `eq`
+    metamethod. All other types are compared using the equality `==` operator.
 
     Parameters: ~
       • {a}  any First value
@@ -2567,8 +2568,10 @@ parse({version}, {opts})                                 *vim.version.parse()*
     Parameters: ~
       • {version}  (string) Version string to be parsed.
       • {opts}     (table|nil) Optional keyword arguments:
-                   • strict (boolean): Default false. If `true` , no coercion is attempted on input not strictly
-                     conforming to semver v2.0.0 ( https://semver.org/spec/v2.0.0.html ). E.g. `parse("v1.2")` returns nil.
+                   • strict (boolean): Default false. If `true` , no coercion
+                     is attempted on input not strictly conforming to
+                     semver v2.0.0 ( https://semver.org/spec/v2.0.0.html ).
+                     E.g. `parse("v1.2")` returns nil.
 
     Return: ~
         (table|nil) parsed_version Parsed version table or `nil` if `version`

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1151,7 +1151,7 @@ vim.go                                                                *vim.go*
         print(vim.go.columns)
         print(vim.go.bar)     -- error: invalid key
 <
-vim.bo[{bufnr}]                                                                *vim.bo*
+vim.bo[{bufnr}]                                                       *vim.bo*
     Get or set buffer-scoped |options| for the buffer with number {bufnr}.
     Like `:set` and `:setlocal`. If [{bufnr}] is omitted then the current
     buffer is used. Invalid {bufnr} or key is an error.
@@ -1164,7 +1164,7 @@ vim.bo[{bufnr}]                                                                *
         print(vim.bo.comments)
         print(vim.bo.baz)                 -- error: invalid key
 <
-vim.wo[{winid}]                                                                *vim.wo*
+vim.wo[{winid}]                                                       *vim.wo*
     Get or set window-scoped |options| for the window with handle {winid}.
     Like `:set`. If [{winid}] is omitted then the current window is used.
     Invalid {winid} or key is an error.
@@ -1182,9 +1182,9 @@ vim.wo[{winid}]                                                                *
 
 
 
-                                                                        *vim.opt_local*
-                                                                       *vim.opt_global*
-                                                                              *vim.opt*
+                                                               *vim.opt_local*
+                                                              *vim.opt_global*
+                                                                     *vim.opt*
 
 
 A special interface |vim.opt| exists for conveniently interacting with list-


### PR DESCRIPTION
Found a couple of places in the lua.txt docs which felt that they were easy to
shorten and improve the reading experience in split views:

- docs(lua): labels pushed past 78 chars
- docs(lua): unnecessarily long descriptions
