### PR TITLE
feat(vim.gsplit): gain features of vim.split

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1659,12 +1659,18 @@ gsplit({s}, {sep}, {opts})                                      *vim.gsplit()*
        end
 <
 
+    If you want to also inspect the separator itself (instead of discarding
+    it), use |string.gmatch()|. Example: >lua
+
+       for word, num in ('foo111bar222'):gmatch('([^0-9]*)(d*)') do
+         print(('word: s num: s'):format(word, num))
+       end
+<
+
     Parameters: ~
-      • {s}     (string) String to split
-      • {sep}   (string) Separator or pattern
+      • {s}     string String to split
+      • {sep}   string Separator or pattern
       • {opts}  (table|nil) Keyword arguments |kwargs|:
-                • keepsep: (boolean) Return segments matching `sep` instead of
-                  discarding them.
                 • plain: (boolean) Use `sep` literally (as in string.find).
                 • trimempty: (boolean) Discard empty segments at start and end
                   of the sequence.
@@ -1673,6 +1679,7 @@ gsplit({s}, {sep}, {opts})                                      *vim.gsplit()*
         (function) Iterator over the split components
 
     See also: ~
+      • |string.gmatch()|
       • |vim.split()|
       • |luaref-patterns|
       • https://www.lua.org/pil/20.2.html
@@ -1749,7 +1756,6 @@ split({s}, {sep}, {opts})                                        *vim.split()*
       split("axaby", "ab?")                   --> {'','x','y'}
       split("x*yz*o", "*", {plain=true})      --> {'x','yz','o'}
       split("|x|y|z|", "|", {trimempty=true}) --> {'x', 'y', 'z'}
-      split("|x|y|z|", "|", {keepsep=true})   --> {'|', 'x', '|', 'y', '|', 'z', '|'}
 <
 
     Parameters: ~
@@ -1763,6 +1769,7 @@ split({s}, {sep}, {opts})                                        *vim.split()*
 
     See also: ~
       • |vim.gsplit()|
+      • |string.gmatch()|
 
 startswith({s}, {prefix})                                   *vim.startswith()*
     Tests if `s` starts with `prefix`.
@@ -2625,7 +2632,7 @@ cmp({v1}, {v2})                                            *vim.version.cmp()*
         (integer) -1 if `v1 < v2`, 0 if `v1 == v2`, 1 if `v1 > v2`.
 
 eq({v1}, {v2})                                              *vim.version.eq()*
-    Returns `true` if the given versions are equal.
+    Returns `true` if the given versions are equal. See |vim.version.cmp()| for usage.
 
     Parameters: ~
       • {v1}  Version|number[]
@@ -2635,7 +2642,7 @@ eq({v1}, {v2})                                              *vim.version.eq()*
         (boolean)
 
 gt({v1}, {v2})                                              *vim.version.gt()*
-    Returns `true` if `v1 > v2` .
+    Returns `true` if `v1 > v2` . See |vim.version.cmp()| for usage.
 
     Parameters: ~
       • {v1}  Version|number[]
@@ -2654,7 +2661,7 @@ last({versions})                                          *vim.version.last()*
         Version ?|ni
 
 lt({v1}, {v2})                                              *vim.version.lt()*
-    Returns `true` if `v1 < v2` .
+    Returns `true` if `v1 < v2` . See |vim.version.cmp()| for usage.
 
     Parameters: ~
       • {v1}  Version|number[]

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1649,14 +1649,25 @@ endswith({s}, {suffix})                                       *vim.endswith()*
     Return: ~
         (boolean) `true` if `suffix` is a suffix of `s`
 
-gsplit({s}, {sep}, {plain})                                     *vim.gsplit()*
+gsplit({s}, {sep}, {opts})                                      *vim.gsplit()*
     Splits a string at each instance of a separator.
 
+    Example: >lua
+
+       for s in vim.gsplit(':aa::b:', ':', {plain=true}) do
+         print(s)
+       end
+<
+
     Parameters: ~
-      • {s}      (string) String to split
-      • {sep}    (string) Separator or pattern
-      • {plain}  (boolean|nil) If `true` use `sep` literally (passed to
-                 string.find)
+      • {s}     (string) String to split
+      • {sep}   (string) Separator or pattern
+      • {opts}  (table|nil) Keyword arguments |kwargs|:
+                • keepsep: (boolean) Return segments matching `sep` instead of
+                  discarding them.
+                • plain: (boolean) Use `sep` literally (as in string.find).
+                • trimempty: (boolean) Discard empty segments at start and end
+                  of the sequence.
 
     Return: ~
         (function) Iterator over the split components
@@ -1729,7 +1740,7 @@ spairs({t})                                                     *vim.spairs()*
     See also: ~
       • Based on https://github.com/premake/premake-core/blob/master/src/base/table.lua
 
-split({s}, {sep}, {kwargs})                                      *vim.split()*
+split({s}, {sep}, {opts})                                        *vim.split()*
     Splits a string at each instance of a separator.
 
     Examples: >lua
@@ -1738,16 +1749,14 @@ split({s}, {sep}, {kwargs})                                      *vim.split()*
       split("axaby", "ab?")                   --> {'','x','y'}
       split("x*yz*o", "*", {plain=true})      --> {'x','yz','o'}
       split("|x|y|z|", "|", {trimempty=true}) --> {'x', 'y', 'z'}
+      split("|x|y|z|", "|", {keepsep=true})   --> {'|', 'x', '|', 'y', '|', 'z', '|'}
 <
 
     Parameters: ~
-      • {s}       (string) String to split
-      • {sep}     (string) Separator or pattern
-      • {kwargs}  (table|nil) Keyword arguments:
-                  • plain: (boolean) If `true` use `sep` literally (passed to
-                    string.find)
-                  • trimempty: (boolean) If `true` remove empty items from the
-                    front and back of the list
+      • {s}     (string) String to split
+      • {sep}   (string) Separator or pattern
+      • {opts}  (table|nil) Keyword arguments |kwargs| accepted by
+                |vim.gsplit()|
 
     Return: ~
         string[] List of split components

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -132,6 +132,8 @@ The following new APIs or features were added.
 • |vim.fs.dir()| now has a `opts` argument with a depth field to allow
   recursively searching a directory tree.
 
+• |vim.gsplit()| supports all features of |vim.split()|.
+
 • |vim.secure.read()| reads a file and prompts the user if it should be
   trusted and, if so, returns the file's contents.
 

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -66,14 +66,15 @@ end)()
 ---   end
 ---   </pre>
 ---
----@see |vim.split()|
----@see |luaref-patterns|
----@see https://www.lua.org/pil/20.2.html
----@see http://lua-users.org/wiki/StringLibraryTutorial
+--- @see |string.gmatch()|
+--- @see |vim.split()|
+--- @see |luaref-patterns|
+--- @see https://www.lua.org/pil/20.2.html
+--- @see http://lua-users.org/wiki/StringLibraryTutorial
 ---
----@param s string String to split
----@param sep string Separator or pattern
----@param opts (table|nil) Keyword arguments |kwargs|:
+--- @param s string String to split
+--- @param sep string Separator or pattern
+--- @param opts (table|nil) Keyword arguments |kwargs|:
 ---       - keepsep: (boolean) Include segments matching `sep` instead of discarding them.
 ---       - plain: (boolean) Use `sep` literally (as in string.find).
 ---       - trimempty: (boolean) Discard empty segments at start and end of the sequence.

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -65,6 +65,33 @@ local M = {}
 local Version = {}
 Version.__index = Version
 
+--- Compares prerelease strings: per semver, number parts must be must be treated as numbers:
+--- "pre1.10" is greater than "pre1.2". https://semver.org/#spec-item-11
+local function cmp_prerel(prerel1, prerel2)
+  if not prerel1 or not prerel2 then
+    return prerel1 and -1 or (prerel2 and 1 or 0)
+  end
+  -- TODO(justinmk): not fully spec-compliant; this treats non-dot-delimited digit sequences as
+  -- numbers. Maybe better: "(.-)(%.%d*)".
+  local iter1 = prerel1:gmatch('([^0-9]*)(%d*)')
+  local iter2 = prerel2:gmatch('([^0-9]*)(%d*)')
+  while true do
+    local word1, n1 = iter1()
+    local word2, n2 = iter2()
+    if word1 == nil and word2 == nil then -- Done iterating.
+      return 0
+    end
+    word1, n1, word2, n2 =
+      word1 or '', n1 and tonumber(n1) or 0, word2 or '', n2 and tonumber(n2) or 0
+    if word1 ~= word2 then
+      return word1 < word2 and -1 or 1
+    end
+    if n1 ~= n2 then
+      return n1 < n2 and -1 or 1
+    end
+  end
+end
+
 function Version:__index(key)
   return type(key) == 'number' and ({ self.major, self.minor, self.patch })[key] or Version[key]
 end
@@ -88,7 +115,7 @@ function Version:__eq(other)
       return false
     end
   end
-  return self.prerelease == other.prerelease
+  return 0 == cmp_prerel(self.prerelease, other.prerelease)
 end
 
 function Version:__tostring()
@@ -111,13 +138,7 @@ function Version:__lt(other)
       return true
     end
   end
-  if self.prerelease and not other.prerelease then
-    return true
-  end
-  if other.prerelease and not self.prerelease then
-    return false
-  end
-  return (self.prerelease or '') < (other.prerelease or '')
+  return -1 == cmp_prerel(self.prerelease, other.prerelease)
 end
 
 ---@param other Version
@@ -127,7 +148,7 @@ end
 
 --- @private
 ---
---- Creates a new Version object. Not public currently.
+--- Creates a new Version object, or returns `nil` if `version` is invalid.
 ---
 --- @param version string|number[]|Version
 --- @param strict? boolean Reject "1.0", "0-x", "3.2a" or other non-conforming version strings
@@ -173,6 +194,7 @@ function M._version(version, strict) -- Adapted from https://github.com/folke/la
       build = build ~= '' and build or nil,
     }, Version)
   end
+  return nil -- Invalid version string.
 end
 
 ---TODO: generalize this, move to func.lua
@@ -341,7 +363,7 @@ function M.cmp(v1, v2)
   return -1
 end
 
----Returns `true` if the given versions are equal.
+---Returns `true` if the given versions are equal. See |vim.version.cmp()| for usage.
 ---@param v1 Version|number[]
 ---@param v2 Version|number[]
 ---@return boolean
@@ -349,7 +371,7 @@ function M.eq(v1, v2)
   return M.cmp(v1, v2) == 0
 end
 
----Returns `true` if `v1 < v2`.
+---Returns `true` if `v1 < v2`. See |vim.version.cmp()| for usage.
 ---@param v1 Version|number[]
 ---@param v2 Version|number[]
 ---@return boolean
@@ -357,7 +379,7 @@ function M.lt(v1, v2)
   return M.cmp(v1, v2) == -1
 end
 
----Returns `true` if `v1 > v2`.
+---Returns `true` if `v1 > v2`. See |vim.version.cmp()| for usage.
 ---@param v1 Version|number[]
 ---@param v2 Version|number[]
 ---@return boolean

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -65,6 +65,8 @@ local M = {}
 local Version = {}
 Version.__index = Version
 
+--- @private
+---
 --- Compares prerelease strings: per semver, number parts must be must be treated as numbers:
 --- "pre1.10" is greater than "pre1.2". https://semver.org/#spec-item-11
 local function cmp_prerel(prerel1, prerel2)

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -101,6 +101,9 @@ describe('version', function()
       { v1 = 'v9.0.0',           v2 = 'v0.9.0',           want = 1, },
       { v1 = 'v0.9.0',           v2 = 'v0.0.0',           want = 1, },
       { v1 = 'v0.0.9',           v2 = 'v0.0.0',           want = 1, },
+      { v1 = 'v0.0.9+aaa',       v2 = 'v0.0.9+bbb',       want = 0, },
+
+      -- prerelease 💩 https://semver.org/#spec-item-11
       { v1 = 'v1.0.0-alpha',     v2 = 'v1.0.0',           want = -1, },
       { v1 = '1.0.0',            v2 = '1.0.0-alpha',      want = 1, },
       { v1 = '1.0.0-2',          v2 = '1.0.0-1',          want = 1, },
@@ -116,11 +119,11 @@ describe('version', function()
       { v1 = '1.0.0-alpha.beta', v2 = '1.0.0-alpha',      want = 1, },
       { v1 = '1.0.0-alpha',      v2 = '1.0.0-alpha.beta', want = -1, },
       { v1 = '1.0.0-alpha.beta', v2 = '1.0.0-beta',       want = -1, },
-      { v1 = '1.0.0-beta',       v2 = '1.0.0-alpha.beta', want = 1, },
-      { v1 = '1.0.0-beta',       v2 = '1.0.0-beta.2',     want = -1, },
-      -- TODO
-      -- { v1 = '1.0.0-beta.2',     v2 = '1.0.0-beta.11',    want = -1, },
-      { v1 = '1.0.0-beta.11',    v2 = '1.0.0-rc.1',       want = -1, },
+      { v1 = '1.0.0-beta.2',     v2 = '1.0.0-beta.11',    want = -1, },
+      { v1 = '1.0.0-beta.20',    v2 = '1.0.0-beta.11',    want = 1, },
+      { v1 = '1.0.0-alpha.20',   v2 = '1.0.0-beta.11',    want = -1, },
+      { v1 = '1.0.0-a.01.x.3',   v2 = '1.0.0-a.1.x.003',  want = 0, },
+      { v1 = 'v0.9.0-dev-92+9',  v2 = 'v0.9.0-dev-120+3', want = -1, },
     }
     for _, tc in ipairs(testcases) do
       local msg = function(s) return ('v1 %s v2'):format(s == 0 and '==' or (s == 1 and '>' or '<')) end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -329,14 +329,6 @@ describe('lua stdlib', function()
       matches("Infinite loop detected", pcall_err(vim.split, t[1], t[2]))
     end
 
-    -- `keepsep`
-    eq({ '', '.', '', '.', 'aa', '.', 'bb', '.', 'cc', '.', 'dd', '.', 'ee', '.', '', },
-      vim.split('..aa.bb.cc.dd.ee.', '%.', {keepsep=true}))
-    eq({ '..aa', '1', '.bb', '2', '', '2', '.cc.', '9', '', },
-      vim.split('..aa1.bb22.cc.9', '%d', {keepsep=true}))
-    eq({ '..aa', '1', '.bb', '22', '.cc.', '9', '', },
-      vim.split('..aa1.bb22.cc.9', '%d+', {keepsep=true}))
-
     -- Validates args.
     eq(true, pcall(vim.split, 'string', 'string'))
     matches('s: expected string, got number',
@@ -345,9 +337,6 @@ describe('lua stdlib', function()
       pcall_err(vim.split, 'string', 1))
     matches('opts: expected table, got number',
       pcall_err(vim.split, 'string', 'string', 1))
-    -- Not supported (yet).
-    matches('keepsep%+trimempty not supported',
-      pcall_err(vim.split, 'foo bar', ' ', {keepsep=true, trimempty=true}))
   end)
 
   it('vim.trim', function()


### PR DESCRIPTION
# Problem:
- `vim.version.cmp()` does not treat digit sequences in a _prerelease_ string
- ~~Cannot inspect the "separator" segments of vim.split or vim.gsplit.~~
    - EDIT: this can be done with `string.gmatch()`.

# Solution:
- Fix `vim.version.cmp()` using `string.gmatch()`.
- Move common implementation from vim.split into vim.gsplit.
    - ~~TODO: deprecate vim.split in favor of vim.totable(vim.gsplit())?~~
- ~~Introduce `keepsep` parameter.~~

# Todo

- generalize `vim.version.last()` => `vim.?.last()`
- ~~use `gsplit({keepsep=true})` to fix `vim.version` handling of `...-beta.1.2` prerelease semvers~~
    - `string.gmatch()` is a better fit.