### PR TITLE
feat(lua): represent empty Dictionary as vim.empty_dict() in new api functions

### DIFF
--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -619,9 +619,10 @@ local function process_function(fn)
     }
       ]], return_type))
     else
+      local special = (fn.since ~= nil and fn.since < 11)
       write_shifted_output(output, string.format([[
-    nlua_push_%s(lstate, ret, true);
-      ]], return_type))
+    nlua_push_%s(lstate, ret, %s);
+      ]], return_type, tostring(special)))
     end
 
     write_shifted_output(output, string.format([[


### PR DESCRIPTION
This addresses the concern that Dictionary api functions (of which there are many new in the works), return opaque `{ [true] = 6 }` values. These will now instead use the introspectible `vim.empty_dict()` value (whose `pairs()` enumeration is indeed empty, as well).

This is fully backwards compatible as stable API functions are not changed.

Related: #19032  https://github.com/neovim/neovim/pull/22693#issuecomment-1476212144 