### PR TITLE
fix(api): Use local LastSet structure in nvim_get_option_info

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1912,7 +1912,7 @@ nvim_get_all_options_info()                      *nvim_get_all_options_info()*
     Gets the option information for all options.
 
     The dictionary has the full option names as keys and option metadata
-    dictionaries as detailed at |nvim_get_option_info()|.
+    dictionaries as detailed at |nvim_get_option_info2()|.
 
     Return: ~
         dictionary of all options
@@ -1926,8 +1926,8 @@ nvim_get_option({name})                                    *nvim_get_option()*
     Return: ~
         Option value (global)
 
-nvim_get_option_info({name})                          *nvim_get_option_info()*
-    Gets the option information for one option
+nvim_get_option_info2({name}, {*opts})               *nvim_get_option_info2()*
+    Gets the option information for one option from arbitrary buffer or window
 
     Resulting dictionary has keys:
     • name: Name of the option (like 'filetype')
@@ -1943,8 +1943,19 @@ nvim_get_option_info({name})                          *nvim_get_option_info()*
     • commalist: List of comma separated values
     • flaglist: List of single char flags
 
+    When {scope} is not provided, the last set information applies to the
+    local value in the current buffer or window if it is available, otherwise
+    the global value information is returned. This behavior can be disabled by
+    explicitly specifying {scope} in the {opts} table.
+
     Parameters: ~
       • {name}  Option name
+      • {opts}  Optional parameters
+                • scope: One of "global" or "local". Analogous to |:setglobal|
+                  and |:setlocal|, respectively.
+                • win: |window-ID|. Used for getting window local options.
+                • buf: Buffer number. Used for getting buffer local options.
+                  Implies {scope} is "local".
 
     Return: ~
         Option Information

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -20,6 +20,7 @@ API
 - *nvim_get_hl_by_name()*	Use |nvim_get_hl()| instead.
 - *nvim_get_hl_by_id()*		Use |nvim_get_hl()| instead.
 - *nvim_exec()*			Use |nvim_exec2()| instead.
+- *nvim_get_option_info()*	Use |nvim_get_option_info2()| instead.
 
 COMMANDS
 - *:rv* *:rviminfo*		Deprecated alias to |:rshada| command.

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -20,6 +20,7 @@
 #include "nvim/highlight_group.h"
 #include "nvim/lua/executor.h"
 #include "nvim/memory.h"
+#include "nvim/option.h"
 #include "nvim/pos.h"
 #include "nvim/types.h"
 
@@ -507,4 +508,17 @@ Object vim_del_var(String name, Error *err)
 static int64_t convert_index(int64_t index)
 {
   return index < 0 ? index - 1 : index;
+}
+
+/// Gets the option information for one option
+///
+/// @deprecated Use @ref nvim_get_option_info2 instead.
+///
+/// @param          name Option name
+/// @param[out] err Error details, if any
+/// @return         Option Information
+Dictionary nvim_get_option_info(String name, Error *err)
+  FUNC_API_SINCE(7)
+{
+  return get_vimoption(name, OPT_GLOBAL, curbuf, curwin, err);
 }


### PR DESCRIPTION
* nvim_get_option_info is changed to use the local LastSet information for the current buffer or window (if available). Fixes #15232.
* a new option is added that also accepts 'opts' table (scope, buf, win) allowing to query local options from another buffer or window.