### PR TITLE
feat(lua): allow `:=expr` as a shorter version of `:lua =expr`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -233,11 +233,11 @@ command calls. The |lua-stdlib| modules, user modules, and anything else on
 The Lua print() function redirects its output to the Nvim message area, with
 arguments separated by " " (space) instead of "\t" (tab).
 
-                                                                        *:lua*
+                                                                  *:lua=* *:lua*
 :lua {chunk}
     Executes Lua chunk {chunk}. If {chunk} starts with "=" the rest of the
-    chunk is evaluated as an expression and printed. `:lua =expr` is
-    equivalent to `:lua print(vim.inspect(expr))`
+    chunk is evaluated as an expression and printed. `:lua =expr` or `:=expr` is
+    equivalent to `:lua print(vim.inspect(expr))`.
 
     Examples: >vim
         :lua vim.api.nvim_command('echo "Hello, Nvim!"')

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -237,6 +237,11 @@ The following changes to existing APIs or features add new behavior.
 • The `win_viewport` UI event now contains information about virtual lines,
   meaning that smooth scrolling can now be implemented more consistenlty.
 
+• The `:= {expr}` syntax can be used to evaluate a lua expression, as
+  a shorter form of `:lua ={expr}`. `:=` and `:[range]=` without argument
+  are unchanged. However `:=#` and similar variants using |ex-flags|
+  are no longer supported.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -173,13 +173,12 @@ g8			Print the hex values of the bytes used in the
 			Like ":z" or ":z!", but number the lines.
 
 							*:=*
-:= [flags]		Print the last line number.
-			See |ex-flags| for [flags].
+:=			Without arg: Print the last line number.
+			with args: equivalent to `:lua ={expr}`. see |:lua|
 
-:{range}= [flags]	Prints the last line number in {range}.  For example,
+:{range}=		Prints the last line number in {range}.  For example,
 			this prints the current line number: >
 				:.=
-<			See |ex-flags| for [flags].
 
 :norm[al][!] {commands}					*:norm* *:normal*
 			Execute Normal mode commands {commands}.  This makes

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -460,6 +460,7 @@ Commands:
   |:doautocmd| does not warn about "No matching autocommands".
   |:wincmd| accepts a count.
   `:write!` does not show a prompt if the file was updated externally.
+  |:=| does not accept |ex-flags|. With an arg it is equivalent to |:lua=|
 
 Command-line:
   The meanings of arrow keys do not change depending on 'wildoptions'.

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2141,6 +2141,7 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
     return set_context_in_scriptnames_cmd(xp, arg);
 
   case CMD_lua:
+  case CMD_equal:
     xp->xp_context = EXPAND_LUA;
     break;
 

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -3319,7 +3319,7 @@ module.cmds = {
   {
     command='=',
     enum='CMD_equal',
-    flags=bit.bor(RANGE, TRLBAR, DFLALL, FLAGS, CMDWIN, LOCK_OK),
+    flags=bit.bor(RANGE, EXTRA, DFLALL, ARGOPT, CMDWIN, LOCK_OK),
     addr_type='ADDR_LINES',
     func='ex_equal',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5658,8 +5658,13 @@ static void ex_pwd(exarg_T *eap)
 /// ":=".
 static void ex_equal(exarg_T *eap)
 {
-  smsg("%" PRId64, (int64_t)eap->line2);
-  ex_may_print(eap);
+  if (*eap->arg != NUL && *eap->arg != '|') {
+    // equivalent to :lua= expr
+    ex_lua(eap);
+  } else {
+    eap->nextcmd = find_nextcmd(eap->arg);
+    smsg("%" PRId64, (int64_t)eap->line2);
+  }
 }
 
 static void ex_sleep(exarg_T *eap)

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1621,14 +1621,15 @@ void ex_lua(exarg_T *const eap)
     xfree(code);
     return;
   }
-  // When =expr is used transform it to print(vim.inspect(expr))
-  if (code[0] == '=') {
-    len += sizeof("vim.print()") - sizeof("=");
+  // When =expr is used transform it to vim.print(expr)
+  if (eap->cmdidx == CMD_equal || code[0] == '=') {
+    size_t off = (eap->cmdidx == CMD_equal) ? 0 : 1;
+    len += sizeof("vim.print()") - 1 - off;
     // code_buf needs to be 1 char larger then len for null byte in the end.
     // lua nlua_typval_exec doesn't expect null terminated string so len
     // needs to end before null byte.
     char *code_buf = xmallocz(len);
-    vim_snprintf(code_buf, len + 1, "vim.print(%s)", code + 1);
+    vim_snprintf(code_buf, len + 1, "vim.print(%s)", code + off);
     xfree(code);
     code = code_buf;
   }

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -146,6 +146,7 @@ describe(':lua command', function()
   it('prints result of =expr', function()
     exec_lua("x = 5")
     eq("5", exec_capture(':lua =x'))
+    eq("5", exec_capture('=x'))
     exec_lua("function x() return 'hello' end")
     eq('hello', exec_capture(':lua = x()'))
     exec_lua("x = {a = 1, b = 2}")
@@ -165,7 +166,7 @@ describe(':lua command', function()
       false
       nil
       Error message]],
-    exec_capture(':lua  =x(false)'))
+    exec_capture('=x(false)'))
   end)
 end)
 

--- a/test/old/testdir/test_ex_equal.vim
+++ b/test/old/testdir/test_ex_equal.vim
@@ -7,6 +7,19 @@ func Test_ex_equal()
   let a = execute('=')
   call assert_equal("\n2", a)
 
+  let a = execute('.=')
+  call assert_equal("\n1", a)
+
+  call assert_fails('3=', 'E16:')
+  bwipe!
+endfunc
+
+func Test_ex_equal_arg()
+  throw 'skipped: Nvim evaluates lua with := [arg]'
+
+  new
+  call setline(1, ["foo\tbar", "bar\tfoo"])
+
   let a = execute('=#')
   call assert_equal("\n2\n  1 foo     bar", a)
 
@@ -22,10 +35,6 @@ func Test_ex_equal()
   let a = execute('=p#')
   call assert_equal("\n2\n  1 foo     bar", a)
 
-  let a = execute('.=')
-  call assert_equal("\n1", a)
-
-  call assert_fails('3=', 'E16:')
   call assert_fails('=x', 'E488:')
 
   bwipe!


### PR DESCRIPTION
existing behavior of

    :=

and

    :[range]=

are unchanged. `|` is still allowed with this usage.

However,

     :=p

is changed in a way which could be construed as a breaking change. Allowing `|ex-flags|` for `:=` in the first place was a mistake as any form of `:=` **does not move the cursor**. So it would print one line number and then print a completely different line contents after that.