### PR TITLE
docs: fix misleading help about number of actually used terminal colors

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -115,7 +115,7 @@ You can change the defaults with a TermOpen autocommand: >vim
 TERMINAL COLORS ~
 
 The `{g,b}:terminal_color_x` variables control the terminal color palette,
-where `x` is the color index between 0 and 255 inclusive.  The variables are
+where `x` is the color index between 0 and 15 inclusive.  The variables are
 read during |TermOpen|. The value must be a color name or hexadecimal string.
 Example: >vim
     let g:terminal_color_4 = '#ff0000'


### PR DESCRIPTION
Based on [this source code](https://github.com/neovim/neovim/blob/master/src/nvim/terminal.c#L271) it only respects `vim.g.terminal_color_{i}` for i from 0 to 15 inclusive.