### PR TITLE
feat(diagnostic): add support for tags

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1113,7 +1113,8 @@ code_action({options})                             *vim.lsp.buf.code_action()*
       • {options}  (table|nil) Optional table which holds the following
                    optional fields:
                    • context: (table|nil) Corresponds to `CodeActionContext` of the LSP specification:
-                     • diagnostics (table|nil): LSP`Diagnostic[]` . Inferred from the current position if not provided.
+                     • diagnostics (table|nil): LSP `Diagnostic[]`. Inferred
+                       from the current position if not provided.
                      • only (table|nil): List of LSP `CodeActionKind`s used to
                        filter the code actions. Most language servers support
                        values like `refactor` or `quickfix`.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -226,7 +226,7 @@ The following new APIs or features were added.
 
 • Added |nvim_get_hl()| for getting highlight group definitions in a format compatible with |nvim_set_hl()|.
 
-• |vim.diagnostic| not supports LSP DiagnosticsTag.
+• |vim.diagnostic| now supports LSP DiagnosticsTag.
   See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticTag
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -226,6 +226,9 @@ The following new APIs or features were added.
 
 • Added |nvim_get_hl()| for getting highlight group definitions in a format compatible with |nvim_set_hl()|.
 
+• |vim.diagnostic| not supports LSP DiagnosticsTag.
+  See: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnosticTag
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changes*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -483,6 +483,7 @@ local function next_diagnostic(position, search_forward, bufnr, opts, namespace)
   local diagnostics =
     get_diagnostics(bufnr, vim.tbl_extend('keep', opts, { namespace = namespace }), true)
   local line_diagnostics = diagnostic_lines(diagnostics)
+
   for i = 0, line_count do
     local offset = i * (search_forward and 1 or -1)
     local lnum = position[1] + offset
@@ -752,6 +753,7 @@ end
 ---@field message string
 ---@field source nil|string
 ---@field code nil|string
+---@field _tags { deprecated: boolean, unnecessary: boolean}
 ---@field user_data nil|any arbitrary data plugins can add
 
 --- Get current diagnostics.
@@ -946,6 +948,16 @@ M.handlers.underline = {
       if higroup == nil then
         -- Default to error if we don't have a highlight associated
         higroup = underline_highlight_map.Error
+      end
+
+      if diagnostic._tags then
+        -- TODO(lewis6991): we should be able to stack these.
+        if diagnostic._tags.unnecessary then
+          higroup = 'DiagnosticUnnecessary'
+        end
+        if diagnostic._tags.deprecated then
+          higroup = 'DiagnosticDeprecated'
+        end
       end
 
       vim.highlight.range(

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -21,6 +21,7 @@ end
 --]=]
 
 local constants = {
+  --- @enum lsp.DiagnosticSeverity
   DiagnosticSeverity = {
     -- Reports an error.
     Error = 1,
@@ -32,6 +33,7 @@ local constants = {
     Hint = 4,
   },
 
+  --- @enum lsp.DiagnosticTag
   DiagnosticTag = {
     -- Unused or unnecessary code
     Unnecessary = 1,

--- a/runtime/lua/vim/lsp/types.lua
+++ b/runtime/lua/vim/lsp/types.lua
@@ -18,3 +18,20 @@
 ---@class lsp.FileEvent
 ---@field uri string
 ---@field type lsp.FileChangeType
+
+---@class lsp.Position
+---@field line integer
+---@field character integer
+
+---@class lsp.Range
+---@field start lsp.Position
+---@field end lsp.Position
+
+---@class lsp.Diagnostic
+---@field range lsp.Range
+---@field message string
+---@field severity? lsp.DiagnosticSeverity
+---@field code integer | string
+---@field source string
+---@field tags? lsp.DiagnosticTag[]
+---@field relatedInformation DiagnosticRelatedInformation[]

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -218,6 +218,8 @@ static const char *highlight_init_both[] = {
   "default link DiagnosticSignInfo DiagnosticInfo",
   "default link DiagnosticSignHint DiagnosticHint",
   "default link DiagnosticSignOk DiagnosticOk",
+  "default DiagnosticDeprecated cterm=strikethrough gui=strikethrough guisp=Red",
+  "default link DiagnosticUnnecessary Comment",
 
   // Text
   "default link @text.literal Comment",

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -86,6 +86,7 @@ describe('vim.diagnostic', function()
   it('creates highlight groups', function()
     command('runtime plugin/diagnostic.vim')
     eq({
+      'DiagnosticDeprecated',
       'DiagnosticError',
       'DiagnosticFloatingError',
       'DiagnosticFloatingHint',
@@ -105,6 +106,7 @@ describe('vim.diagnostic', function()
       'DiagnosticUnderlineInfo',
       'DiagnosticUnderlineOk',
       'DiagnosticUnderlineWarn',
+      'DiagnosticUnnecessary',
       'DiagnosticVirtualTextError',
       'DiagnosticVirtualTextHint',
       'DiagnosticVirtualTextInfo',

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -97,7 +97,6 @@ describe('vim.lsp.diagnostic', function()
         }
 
         diagnostics[1].code = 42
-        diagnostics[1].tags = {"foo", "bar"}
         diagnostics[1].data = "Hello world"
 
         vim.lsp.diagnostic.on_publish_diagnostics(nil, {
@@ -110,10 +109,9 @@ describe('vim.lsp.diagnostic', function()
           vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)[1],
         }
       ]]
-      eq({code = 42, tags = {"foo", "bar"}, data = "Hello world"}, result[1].user_data.lsp)
+      eq({code = 42, data = "Hello world"}, result[1].user_data.lsp)
       eq(42, result[1].code)
       eq(42, result[2].code)
-      eq({"foo", "bar"}, result[2].tags)
       eq("Hello world", result[2].data)
     end)
   end)


### PR DESCRIPTION
The LSP spec supports two tags that can be added to diagnostics: `Unnecessary` and `Deprecated`. Extend vim.diagnostic to be able to handle these.
