### PR TITLE
fix(lsp): Jump to tag locations reliably when :ltag is used

### DIFF
--- a/runtime/lua/vim/lsp/tagfunc.lua
+++ b/runtime/lua/vim/lsp/tagfunc.lua
@@ -9,7 +9,7 @@ local function mk_tag_item(name, range, uri, offset_encoding)
   return {
     name = name,
     filename = vim.uri_to_fname(uri),
-    cmd = string.format('call cursor(%d, %d)|', range.start.line + 1, byte),
+    cmd = string.format([[/\%%%dl\%%%dc/]], range.start.line + 1, byte),
   }
 end
 


### PR DESCRIPTION
The current `vim.lsp.tagfunc` works fine for a `<C-]>` jump to tag, but with `:ltag`, the style of `cmd` it returns gets you a location list that can only open the files, not consistently jump to each location.  This can be tested using `:ltag` then `:lnext` and `:lprev` a few times.  It seems like it can only make the very first jump, then it only switches buffers without moving the cursor.

This PR changes the `cmd` given in tag items to use a regex with unusual pair of terms: `\%nnnl` line and `\%nnnc` col, which keeps direct tag jumps working and fixes `:ltag`.