### PR TITLE
feat(runtime): add version checker

### DIFF
--- a/runtime/lua/versioncheck.lua
+++ b/runtime/lua/versioncheck.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+---@private
+---Reads version stored in $XDG_CACHE_HOME/nvim/version
+---
+---@return (table) Contents of version file or empty table.
+local function read_version()
+  local version = {}
+  local f = io.open(vim.fn.stdpath('state') .. '/version', 'r')
+  if f then
+    local contents = f:read('*a')
+    if contents then
+      for line in vim.gsplit(contents, '\n') do
+        local key, value = string.match(line, '^(%S+) = (.+)$')
+        if key and value then
+          version[key] = value
+        end
+      end
+    end
+    f:close()
+  end
+  return version
+end
+
+---@private
+--- Writes provided {version} table to the version file at
+--- $XDG_CACHE_HOME/nvim/version.
+---
+---@params version (table) A version table to write.
+local function write_version(version)
+  vim.validate({
+    api_compatible = { version.api_compatible, 'number' },
+    api_level = { version.api_level, 'number' },
+    api_prerelease = { version.api_prerelease, 'boolean' },
+    major = { version.major, 'number' },
+    minor = { version.minor, 'number' },
+    patch = { version.patch, 'number' },
+    prerelease = { version.prerelease, 'boolean' },
+  })
+  local f = assert(io.open(vim.fn.stdpath('state') .. '/version', 'w'))
+
+  local v = {}
+  for key, value in pairs(version) do
+    v[#v + 1] = string.format('%s = %s\n', key, value)
+  end
+  f:write(table.concat(v))
+  f:close()
+end
+
+M.check = function(version)
+  local current_version = version or vim.version()
+  local cached_version = read_version()
+
+  -- nothing in cache case: we write current_version to cache and end
+  if vim.tbl_isempty(cached_version) then
+      write_version(current_version)
+      return
+  end
+
+  -- Q: Should we compare version only on major/minor/patch?
+  local v1 = { tonumber(cached_version.major), tonumber(cached_version.minor), tonumber(cached_version.patch) }
+  local v2 = { current_version.major, current_version.minor, current_version.patch }
+
+  -- if cache version is equal or greater than current, do nothing
+  if vim.version.cmp(v1, v2) >= 0 then return end
+
+  write_version(current_version)
+
+  vim.notify_once(
+  "New version of Neovim detected! See what's new with `:help news.txt`",
+  vim.log.levels.WARN, {})
+end
+
+return M

--- a/runtime/plugin/versioncheck.lua
+++ b/runtime/plugin/versioncheck.lua
@@ -67,11 +67,6 @@ end
 local v1 = { tonumber(cached_version.major), tonumber(cached_version.minor), tonumber(cached_version.patch) }
 local v2 = { current_version.major, current_version.minor, current_version.patch }
 
-print('Cached version is:')
-vim.print(v1)
-print('Current version is:')
-vim.print(v2)
-
 -- if cache version is equal or greater than current, do nothing
 if vim.version.cmp(v1, v2) >= 0 then return end
 

--- a/runtime/plugin/versioncheck.lua
+++ b/runtime/plugin/versioncheck.lua
@@ -1,3 +1,6 @@
+-- skip if nvim started non-interactively
+if vim.tbl_contains(vim.v.argv, '-l') then return end
+
 ---@private
 ---Reads version stored in $XDG_CACHE_HOME/nvim/version
 ---

--- a/runtime/plugin/versioncheck.lua
+++ b/runtime/plugin/versioncheck.lua
@@ -4,7 +4,7 @@
 ---@return (table) Contents of version file or empty table.
 local function read_version()
   local version = {}
-  local f = io.open(vim.fn.stdpath('cache') .. '/version', 'r')
+  local f = io.open(vim.fn.stdpath('state') .. '/version', 'r')
   if f then
     local contents = f:read('*a')
     if contents then
@@ -38,7 +38,7 @@ local function write_version(version)
     patch = { version.patch, 'number' },
     prerelease = { version.prerelease, 'boolean' },
   })
-  local f = assert(io.open(vim.fn.stdpath('cache') .. '/version', 'w'))
+  local f = assert(io.open(vim.fn.stdpath('state') .. '/version', 'w'))
 
   local v = {}
   for key, value in pairs(version) do

--- a/runtime/plugin/versioncheck.lua
+++ b/runtime/plugin/versioncheck.lua
@@ -1,0 +1,89 @@
+---@private
+---Reads version stored in $XDG_CACHE_HOME/nvim/version
+---
+---@return (table) Contents of version file or empty table.
+local function read_version()
+  local version = {}
+  local f = io.open(vim.fn.stdpath('cache') .. '/version', 'r')
+  if f then
+    local contents = f:read('*a')
+    if contents then
+      for line in vim.gsplit(contents, '\n') do
+        local key, value = string.match(line, '^(%S+) = (.+)$')
+        if key and value then
+          version[key] = value
+        end
+      end
+    end
+    f:close()
+  end
+  return version
+end
+
+---@private
+--- Writes provided {version} table to the version file at
+--- $XDG_CACHE_HOME/nvim/version.
+---
+---@see |:vim.version|
+---
+---@params version (table) A version table to write.
+--- See vim.version() for table details.
+local function write_version(version)
+  vim.validate({
+    api_compatible = { version.api_compatible, 'number' },
+    api_level = { version.api_level, 'number' },
+    api_prerelease = { version.api_prerelease, 'boolean' },
+    major = { version.major, 'number' },
+    minor = { version.minor, 'number' },
+    patch = { version.patch, 'number' },
+    prerelease = { version.prerelease, 'boolean' },
+  })
+  local f = assert(io.open(vim.fn.stdpath('cache') .. '/version', 'w'))
+
+  local v = {}
+  for key, value in pairs(version) do
+    v[#v + 1] = string.format('%s = %s\n', key, value)
+  end
+  f:write(table.concat(v))
+  f:close()
+end
+
+-- so user can opt-out of being notified
+if vim.g.NVIM_NO_NEWS then return end
+
+local cached_version = read_version()
+local current_version = vim.version()
+
+-- branch 1: if nothing was stored in cache, we write current_version and end here
+if vim.tbl_isempty(cached_version) then
+    write_version(current_version)
+    return
+end
+
+-- Skip prereleases or make another option for it? Probably annoying on HEAD!
+-- if current_version.prerelease == true then return end
+
+-- Should we compare on anything else?
+local v1 = { tonumber(cached_version.major), tonumber(cached_version.minor), tonumber(cached_version.patch) }
+local v2 = { current_version.major, current_version.minor, current_version.patch }
+
+print('Cached version is:')
+vim.print(v1)
+print('Current version is:')
+vim.print(v2)
+
+-- if cache version is equal or greater than current, do nothing
+if vim.version.cmp(v1, v2) >= 0 then return end
+
+write_version(current_version)
+
+-- use vim.notify to tell user how to see news.txt for the updates
+vim.api.nvim_create_autocmd('CursorHold', {
+  group = vim.api.nvim_create_augroup('NvimVersionCheck', {}),
+  desc = 'Tells user how to see changes when a new nvim version is detected.',
+  callback = function()
+    vim.notify_once("New version of Neovim detected! See what's new with `:help news.txt`",
+                    vim.log.levels.WARN, {})
+  end,
+})
+

--- a/runtime/plugin/versioncheck.lua
+++ b/runtime/plugin/versioncheck.lua
@@ -1,87 +1,18 @@
 -- skip if nvim started non-interactively
 if vim.tbl_contains(vim.v.argv, '-l') then return end
 
----@private
----Reads version stored in $XDG_CACHE_HOME/nvim/version
----
----@return (table) Contents of version file or empty table.
-local function read_version()
-  local version = {}
-  local f = io.open(vim.fn.stdpath('state') .. '/version', 'r')
-  if f then
-    local contents = f:read('*a')
-    if contents then
-      for line in vim.gsplit(contents, '\n') do
-        local key, value = string.match(line, '^(%S+) = (.+)$')
-        if key and value then
-          version[key] = value
-        end
-      end
-    end
-    f:close()
-  end
-  return version
-end
-
----@private
---- Writes provided {version} table to the version file at
---- $XDG_CACHE_HOME/nvim/version.
----
----@see |:vim.version|
----
----@params version (table) A version table to write.
---- See vim.version() for table details.
-local function write_version(version)
-  vim.validate({
-    api_compatible = { version.api_compatible, 'number' },
-    api_level = { version.api_level, 'number' },
-    api_prerelease = { version.api_prerelease, 'boolean' },
-    major = { version.major, 'number' },
-    minor = { version.minor, 'number' },
-    patch = { version.patch, 'number' },
-    prerelease = { version.prerelease, 'boolean' },
-  })
-  local f = assert(io.open(vim.fn.stdpath('state') .. '/version', 'w'))
-
-  local v = {}
-  for key, value in pairs(version) do
-    v[#v + 1] = string.format('%s = %s\n', key, value)
-  end
-  f:write(table.concat(v))
-  f:close()
-end
-
--- so user can opt-out of being notified
+-- skip if user opts out of checking versions
 if vim.g.NVIM_NO_NEWS then return end
 
-local cached_version = read_version()
-local current_version = vim.version()
+-- skip prereleases altogether
+if vim.version().prerelease == true then return end
 
--- branch 1: if nothing was stored in cache, we write current_version and end here
-if vim.tbl_isempty(cached_version) then
-    write_version(current_version)
-    return
-end
-
--- Skip prereleases or make another option for it? Probably annoying on HEAD!
--- if current_version.prerelease == true then return end
-
--- Should we compare on anything else?
-local v1 = { tonumber(cached_version.major), tonumber(cached_version.minor), tonumber(cached_version.patch) }
-local v2 = { current_version.major, current_version.minor, current_version.patch }
-
--- if cache version is equal or greater than current, do nothing
-if vim.version.cmp(v1, v2) >= 0 then return end
-
-write_version(current_version)
-
--- use vim.notify to tell user how to see news.txt for the updates
+local group = vim.api.nvim_create_augroup('versioncheck', {})
 vim.api.nvim_create_autocmd('CursorHold', {
-  group = vim.api.nvim_create_augroup('NvimVersionCheck', {}),
-  desc = 'Tells user how to see changes when a new nvim version is detected.',
+  group = group,
+  desc = 'Tells user how to see changes when a new version is detected.',
   callback = function()
-    vim.notify_once("New version of Neovim detected! See what's new with `:help news.txt`",
-                    vim.log.levels.WARN, {})
+    require('versioncheck').check()
   end,
 })
 

--- a/test/functional/plugin/versioncheck_spec.lua
+++ b/test/functional/plugin/versioncheck_spec.lua
@@ -1,0 +1,65 @@
+-- to run this test:
+-- TEST_FILE=test/functional/plugin/versioncheck_spec.lua make functionaltest
+
+local helpers = require('test.functional.helpers')(after_each)
+local clear = helpers.clear
+local eq = helpers.eq
+local pathsep = helpers.get_pathsep()
+local is_os = helpers.is_os
+
+local testdir = 'Xstate'
+local test_version = [[
+api_compatible = 0
+api_level = 11
+api_prerelease = true
+major = 0
+minor = 8
+patch = 0
+prerelease = true
+]]
+local vc = require('versioncheck')
+
+setup(function()
+  helpers.mkdir_p(testdir .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
+  helpers.write_file(testdir .. pathsep .. 'version', test_version)
+end)
+
+teardown(function()
+  helpers.rmdir(testdir)
+end)
+
+describe('checkversion', function()
+
+    after_each(function()
+      os.remove('version')
+      helpers.rmdir(testdir)
+    end)
+
+    before_each(function()
+      clear({
+        env = { XDG_STATE_HOME=testdir },
+        -- removes -u NONE so runtime/plugin/versioncheck.lua runs
+        args_rm = { '-u' }
+      })
+
+      helpers.write_file(testdir .. pathsep .. 'version', test_version)
+    end)
+
+    it("updates cached version value when current newer", function()
+      eq(1, 1)
+      -- require('versioncheck').check({
+      --   api_compatible = 0,
+      --   api_level = 11,
+      --   api_prerelease = true,
+      --   major = 0,
+      --   minor = 8,
+      --   patch = 2,
+      --   prerelease = true,
+      -- })
+    end)
+     -- read and check that version is now 0.8.2 and not 0.7.0
+     -- helpers.read_file()
+
+end)
+
+


### PR DESCRIPTION
Adds a `versioncheck.lua` script in core runtime that checks whether
the current version running on startup is newer than the cached
version, and if so notifies the user to check the `news.txt`, in hopefully
a non-intrusive way.

Respects a global option to not notify when using a newer release,
which will help those building from HEAD often (or just don't want
to be notified of the new version).

Closes #21431

No tests done yet, just wondering if this is the right approach, first!
