### PR TITLE
build(win): export extern symbols for use in FFI

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1,7 +1,12 @@
 // This is an open source non-commercial project. Dear PVS-Studio, please check
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
-#define EXTERN
+// Make sure extern symbols are exported on Windows
+#ifdef WIN32
+# define EXTERN __declspec(dllexport)
+#else
+# define EXTERN
+#endif
 #include <assert.h>
 #include <limits.h>
 #include <msgpack/pack.h>

--- a/test/functional/lua/ffi_spec.lua
+++ b/test/functional/lua/ffi_spec.lua
@@ -63,5 +63,14 @@ describe('ffi.cdef', function()
         nil
       )
     ]=])
+
+    -- Check that extern symbols are exported and accessible
+    eq(true, exec_lua[[
+      local ffi = require('ffi')
+
+      ffi.cdef('uint64_t display_tick;')
+
+      return ffi.C.display_tick >= 0
+    ]])
   end)
 end)


### PR DESCRIPTION
Follow-up to https://github.com/neovim/neovim/pull/15999. This makes `extern` variables accessible through ffi on Windows.