### PR TITLE
build: download wintools executables separately

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -163,9 +163,15 @@ set(LUV_SHA256 16720d17b9e6d42a7008b902207ea2d61e3eeaef3cf358398dbbf3777867ec09)
 set(LUA_COMPAT53_URL https://github.com/keplerproject/lua-compat-5.3/archive/v0.9.tar.gz)
 set(LUA_COMPAT53_SHA256 ad05540d2d96a48725bb79a1def35cf6652a4e2ec26376e2617c8ce2baa6f416)
 
-# cat.exe curl.exe curl-ca-bundle.crt diff.exe tee.exe xxd.exe
-set(WINTOOLS_URL https://github.com/neovim/deps/raw/c1e7dd8de9e1b18d11dcfa0a192cd029262e5303/opt/win32tools.zip)
-set(WINTOOLS_SHA256 3c4c490a3d392ceeb1347cb77cc821a31900b688a2189276d3a1131a3f21daf1)
+# Windows only: cat.exe diff.exe tee.exe xxd.exe
+set(CAT_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/cat.exe)
+set(CAT_SHA256 93b8d307bb15af3968920bdea3beb869a49d166f9164853c58a4e6ffdcae61c6)
+set(DIFF_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/diff.exe)
+set(DIFF_SHA256 4ceceebc8150422c6d8d9a06c2e9686d5a5d90f1033f60ad92ab81fe810e2a28)
+set(TEE_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/tee.exe)
+set(TEE_SHA256 950eea4e17fa3a7e89fa2c55374037b5797b3f1a54fea1304634884ab42ec14d)
+set(XXD_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/xxd.exe)
+set(XXD_SHA256 7a581e3882d28161cc52850f9a11d634b3eaf2c029276f093c1ed4c90e45a10c)
 
 set(WINGUI_URL https://github.com/equalsraf/neovim-qt/releases/download/v0.2.17/neovim-qt.zip)
 set(WINGUI_SHA256 502e386eef677c2c2e0c11d8cbb27f3e12b4d96818369417e8da4129c4580c25)
@@ -264,8 +270,10 @@ endif()
 if(WIN32)
   include(GetBinaryDeps)
 
-  GetBinaryDep(TARGET wintools
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory . ${DEPS_BIN_DIR})
+  GetExecutable(TARGET cat)
+  GetExecutable(TARGET diff)
+  GetExecutable(TARGET tee)
+  GetExecutable(TARGET xxd)
 
   if(USE_BUNDLED_NVIMQT)
     GetBinaryDep(TARGET wingui

--- a/cmake.deps/cmake/GetBinaryDeps.cmake
+++ b/cmake.deps/cmake/GetBinaryDeps.cmake
@@ -10,17 +10,10 @@ function(GetBinaryDep)
     "INSTALL_COMMAND"
     ${ARGN})
 
-  if(NOT _gettool_TARGET OR NOT _gettool_INSTALL_COMMAND)
-    message(FATAL_ERROR "Must pass INSTALL_COMMAND and TARGET")
-  endif()
-
   string(TOUPPER "${_gettool_TARGET}_URL" URL_VARNAME)
   string(TOUPPER "${_gettool_TARGET}_SHA256" HASH_VARNAME)
   set(URL ${${URL_VARNAME}})
   set(HASH ${${HASH_VARNAME}})
-  if(NOT URL OR NOT HASH )
-    message(FATAL_ERROR "${URL_VARNAME} and ${HASH_VARNAME} must be set")
-  endif()
 
   ExternalProject_Add(${_gettool_TARGET}
     URL ${URL}
@@ -32,4 +25,29 @@ function(GetBinaryDep)
     BUILD_COMMAND ""
     INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_BIN_DIR}
     COMMAND "${_gettool_INSTALL_COMMAND}")
+endfunction()
+
+# Download executable and move it to DEPS_BIN_DIR
+function(GetExecutable)
+  cmake_parse_arguments(ARG
+    ""
+    "TARGET"
+    ""
+    ${ARGN})
+
+  string(TOUPPER "${ARG_TARGET}_URL" URL_VARNAME)
+  string(TOUPPER "${ARG_TARGET}_SHA256" HASH_VARNAME)
+  set(URL ${${URL_VARNAME}})
+  set(HASH ${${HASH_VARNAME}})
+
+  ExternalProject_Add(${ARG_TARGET}
+    URL ${URL}
+    URL_HASH SHA256=${HASH}
+    DOWNLOAD_NO_PROGRESS TRUE
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}
+    DOWNLOAD_NO_EXTRACT TRUE
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_BIN_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy <DOWNLOADED_FILE> ${DEPS_BIN_DIR})
 endfunction()

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -744,15 +744,12 @@ if(WIN32)
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
       cat.exe
-      curl-ca-bundle.crt
-      curl.exe
       diff.exe
       tee.exe
       win32yank.exe
       xxd.exe
 
-      ${NVIMQT_DEPS}
-      )
+      ${NVIMQT_DEPS})
   get_filename_component(DEP_FILE_DIR ${DEP_FILE} DIRECTORY)
   set(EXTERNAL_BLOBS_SCRIPT "${EXTERNAL_BLOBS_SCRIPT}\n"
     "file(COPY \"${DEPS_PREFIX}/bin/${DEP_FILE}\"


### PR DESCRIPTION
The wintools executables are stored in a zip file, making it
inconvenient to bump these during releases. Instead, unpack the
executables in the deps repository and download each executable
separately.
