### PR TITLE
fix(api): make nvim_get_hl return 'cterm' attrs properly

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -727,8 +727,8 @@ void remote_ui_hl_attr_define(UI *ui, Integer id, HlAttrs rgb_attrs, HlAttrs cte
   ADD_C(args, INTEGER_OBJ(id));
   MAXSIZE_TEMP_DICT(rgb, HLATTRS_DICT_SIZE);
   MAXSIZE_TEMP_DICT(cterm, HLATTRS_DICT_SIZE);
-  hlattrs2dict(&rgb, rgb_attrs, true, false);
-  hlattrs2dict(&cterm, rgb_attrs, false, false);
+  hlattrs2dict(&rgb, NULL, rgb_attrs, true, false);
+  hlattrs2dict(&cterm, NULL, rgb_attrs, false, false);
   ADD_C(args, DICTIONARY_OBJ(rgb));
   ADD_C(args, DICTIONARY_OBJ(cterm));
 
@@ -751,7 +751,7 @@ void remote_ui_highlight_set(UI *ui, int id)
   }
   data->hl_id = id;
   MAXSIZE_TEMP_DICT(dict, HLATTRS_DICT_SIZE);
-  hlattrs2dict(&dict, syn_attr2entry(id), ui->rgb, false);
+  hlattrs2dict(&dict, NULL, syn_attr2entry(id), ui->rgb, false);
   ADD_C(args, DICTIONARY_OBJ(dict));
   push_call(ui, "highlight_set", args);
 }
@@ -950,7 +950,7 @@ static Array translate_contents(UI *ui, Array contents, Arena *arena)
     int attr = (int)item.items[0].data.integer;
     if (attr) {
       Dictionary rgb_attrs = arena_dict(arena, HLATTRS_DICT_SIZE);
-      hlattrs2dict(&rgb_attrs, syn_attr2entry(attr), ui->rgb, false);
+      hlattrs2dict(&rgb_attrs, NULL, syn_attr2entry(attr), ui->rgb, false);
       ADD(new_item, DICTIONARY_OBJ(rgb_attrs));
     } else {
       ADD(new_item, DICTIONARY_OBJ((Dictionary)ARRAY_DICT_INIT));

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -207,7 +207,7 @@ int hash_add(hashtab_T *ht, char *key)
   hash_T hash = hash_hash(key);
   hashitem_T *hi = hash_lookup(ht, key, strlen(key), hash);
   if (!HASHITEM_EMPTY(hi)) {
-    internal_error("hash_add()");
+    siemsg(_("E685: Internal error: hash_add(): duplicate key \"%s\""), key);
     return FAIL;
   }
   hash_add_item(ht, hi, key, hash);

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1536,8 +1536,12 @@ static bool hlgroup2dict(Dictionary *hl, NS ns_id, int hl_id, Arena *arena)
     PUT_C(*hl, "link", STRING_OBJ(cstr_as_string(hl_table[link - 1].sg_name)));
   } else {
     *hl = arena_dict(arena, HLATTRS_DICT_SIZE);
-    hlattrs2dict(hl, attr, true, true);
-    hlattrs2dict(hl, attr, false, true);
+    Dictionary hl_cterm = arena_dict(arena, HLATTRS_DICT_SIZE);
+    hlattrs2dict(hl, NULL, attr, true, true);
+    hlattrs2dict(hl, &hl_cterm, attr, false, true);
+    if (kv_size(hl_cterm)) {
+      PUT_C(*hl, "cterm", DICTIONARY_OBJ(hl_cterm));
+    }
   }
   return true;
 }

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -380,14 +380,14 @@ describe('API: get highlight', function()
   local highlight1 = {
     bg = highlight_color.bg,
     fg = highlight_color.fg,
-    bold = true,
-    italic = true,
+    bold = true, italic = true,
+    cterm = {bold = true, italic = true},
   }
   local highlight2 = {
     ctermbg = highlight_color.ctermbg,
     ctermfg = highlight_color.ctermfg,
-    underline = true,
-    reverse = true,
+    underline = true, reverse = true,
+    cterm = {underline = true, reverse = true},
   }
   local highlight3_config = {
     bg = highlight_color.bg,
@@ -413,13 +413,8 @@ describe('API: get highlight', function()
     fg = highlight_color.fg,
     ctermbg = highlight_color.ctermbg,
     ctermfg = highlight_color.ctermfg,
-    bold = true,
-    italic = true,
-    nocombine = true,
-    reverse = true,
-    underdashed = true,
-    strikethrough = true,
-    altfont = true,
+    bold = true, italic = true, reverse = true, underdashed = true, strikethrough = true, altfont = true,
+    cterm = {italic = true, nocombine = true, reverse = true, strikethrough = true, altfont = true}
   }
 
   local function get_ns()
@@ -500,7 +495,8 @@ describe('API: get highlight', function()
         undercurl = true,
       },
     })
-    eq({ undercurl = true, underdotted = true }, meths.get_hl(ns, { name = 'Test_hl' }))
+    eq({ underdotted = true, cterm = { undercurl = true} },
+       meths.get_hl(ns, { name = 'Test_hl' }))
   end)
 
   it('can get a highlight in the global namespace', function()
@@ -524,43 +520,15 @@ describe('API: get highlight', function()
     }, meths.get_hl(0, { name = 'Test_hl3' }))
   end)
 
-  local expected_rgb = {
-    altfont = true,
-    bg = 16776960,
-    bold = true,
-    ctermbg = 10,
-    fg = 16711680,
-    italic = true,
-    nocombine = true,
-    reverse = true,
-    sp = 255,
-    strikethrough = true,
-    underline = true,
-  }
-  local expected = {
-    bg = 16776960,
-    bold = true,
-    ctermbg = 10,
-    fg = 16711680,
-    sp = 255,
-    underline = true,
-  }
-  local expected_undercurl = {
-    bg = 16776960,
-    ctermbg = 10,
-    fg = 16711680,
-    sp = 255,
-    undercurl = true,
-    underline = true,
-  }
-
   it('nvim_get_hl by id', function()
     local hl_id = meths.get_hl_id_by_name('NewHighlight')
 
     command(
       'hi NewHighlight cterm=underline ctermbg=green guifg=red guibg=yellow guisp=blue gui=bold'
     )
-    eq(expected, meths.get_hl(0, { id = hl_id }))
+    eq({ fg = 16711680, bg = 16776960, sp = 255, bold = true,
+         ctermbg = 10, cterm = { underline = true },
+    }, meths.get_hl(0, { id = hl_id }))
 
     -- Test 0 argument
     eq('Highlight id out of bounds', pcall_err(meths.get_hl, 0, { id = 0 }))
@@ -572,11 +540,17 @@ describe('API: get highlight', function()
 
     -- Test all highlight properties.
     command('hi NewHighlight gui=underline,bold,italic,reverse,strikethrough,altfont,nocombine')
-    eq(expected_rgb, meths.get_hl(0, { id = hl_id }))
+    eq({ fg = 16711680, bg = 16776960, sp = 255,
+         altfont = true, bold = true, italic = true, nocombine = true, reverse = true, strikethrough = true, underline = true,
+         ctermbg = 10, cterm = {underline = true},
+    }, meths.get_hl(0, { id = hl_id }))
 
     -- Test undercurl
     command('hi NewHighlight gui=undercurl')
-    eq(expected_undercurl, meths.get_hl(0, { id = hl_id }))
+    eq({ fg = 16711680, bg = 16776960, sp = 255, undercurl = true,
+         ctermbg = 10,
+         cterm = {underline = true},
+    }, meths.get_hl(0, { id = hl_id }))
   end)
 
   it('can correctly detect links', function()

--- a/test/unit/eval/typval_spec.lua
+++ b/test/unit/eval/typval_spec.lua
@@ -1653,7 +1653,7 @@ describe('typval.c', function()
           eq(OK, lib.tv_dict_add(d, di))
           alloc_log:check({})
           eq(FAIL, check_emsg(function() return lib.tv_dict_add(d, di) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key ""'))
           alloc_log:clear()
           lib.tv_dict_item_remove(d, di)
           alloc_log:check({
@@ -1947,7 +1947,7 @@ describe('typval.c', function()
           alloc_log:check({})
           eq({test=10, ['t-est']=int(42)}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add(d, di) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "t-est"'))
         end)
       end)
       describe('list()', function()
@@ -1964,7 +1964,7 @@ describe('typval.c', function()
           eq({test=10, tes={1, 2, 3}}, dct2tbl(d))
           eq(2, l.lv_refcount)
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_list(d, 'testt', 3, l) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           eq(2, l.lv_refcount)
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
@@ -1990,7 +1990,7 @@ describe('typval.c', function()
           eq({test=10, tes={foo=42}}, dct2tbl(d))
           eq(2, d2.dv_refcount)
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_dict(d, 'testt', 3, d2) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           eq(2, d2.dv_refcount)
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
@@ -2012,7 +2012,7 @@ describe('typval.c', function()
           alloc_log:check({a.di(dis.tes, 'tes')})
           eq({test=10, tes=int(2)}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_nr(d, 'testt', 3, 2) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_nr(d, 'testt', 3, 2) end,
@@ -2032,7 +2032,7 @@ describe('typval.c', function()
           alloc_log:check({a.di(dis.tes, 'tes')})
           eq({test=10, tes=1.5}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_float(d, 'testt', 3, 1.5) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_float(d, 'testt', 3, 1.5) end,
@@ -2055,7 +2055,7 @@ describe('typval.c', function()
           })
           eq({test=10, tes='TEST'}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_str(d, 'testt', 3, 'TEST') end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_str(d, 'testt', 3, 'TEST') end,
@@ -2085,7 +2085,7 @@ describe('typval.c', function()
           })
           eq({test=10, tes='TEST'}, dct2tbl(d))
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_allocated_str(d, 'testt', 3, s2) end,
-                              'E685: Internal error: hash_add()'))
+                              'E685: Internal error: hash_add(): duplicate key "tes"'))
           alloc_log:clear()
           lib.emsg_skip = lib.emsg_skip + 1
           eq(FAIL, check_emsg(function() return lib.tv_dict_add_allocated_str(d, 'testt', 3, s3) end,


### PR DESCRIPTION
fixup to #22693 . cterm attributes would've get showed in the same dict which gives duplicate keys in the Dictionary which (1) is no bueno (2) loses info if cterm attrs are different.