### PR TITLE
fix(lsp): add missing silent check in lsp hover handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -364,7 +364,9 @@ function M.hover(_, result, ctx, config)
   local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
   markdown_lines = util.trim_empty_lines(markdown_lines)
   if vim.tbl_isempty(markdown_lines) then
-    vim.notify('No information available')
+    if config.silent ~= true then
+      vim.notify('No information available')
+    end
     return
   end
   return util.open_floating_preview(markdown_lines, 'markdown', config)


### PR DESCRIPTION
If I use the `silent = true` option in the configuration for the LSP hover handler then it should silence all of the `"No information available"` messages. This adds a missing silent check that results in some `"No information available"` messages in some  tested language servers.