### PR TITLE
ci(labeler): don't automatically add "lua" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,10 +2,6 @@
   - runtime/lua/vim/lsp.lua
   - runtime/lua/vim/lsp/*
 
-"lua":
-  - runtime/lua/**/*
-  - src/nvim/lua/*
-
 "tui":
   - src/nvim/tui/tui.*
 


### PR DESCRIPTION
The labeler adds "lua" label to too many files. When there is already
a "treesitter" or "lsp" label, a "lua" label isn't useful. Instead it's
better to add the label manually to PRs for general Lua support.
