### PR TITLE
feat(docs/hover): add support for some html escape sequences

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1378,6 +1378,20 @@ function M.stylize_markdown(bufnr, contents, opts)
     end
   end
 
+  -- Handle some common html escape sequences
+  stripped = vim.tbl_map(function(line)
+    local escapes = {
+      ['&gt;'] = '>',
+      ['&lt;'] = '<',
+      ['&quot;'] = '"',
+      ['&apos;'] = "'",
+      ['&ensp;'] = ' ',
+      ['&emsp;'] = ' ',
+      ['&amp;'] = '&',
+    }
+    return (string.gsub(line, '&[^ ;]+;', escapes))
+  end, stripped)
+
   -- Compute size of float needed to show (wrapped) lines
   opts.wrap_at = opts.wrap_at or (vim.wo['wrap'] and api.nvim_win_get_width(0))
   local width = M._make_floating_popup_size(stripped, opts)

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -1,0 +1,75 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local exec_lua = helpers.exec_lua
+
+describe('vim.lsp.util', function()
+  before_each(helpers.clear)
+
+  describe('stylize_markdown', function()
+    local stylize_markdown = function(content, opts)
+      return exec_lua([[
+        local bufnr = vim.uri_to_bufnr("file:///fake/uri")
+        vim.fn.bufload(bufnr)
+
+        local args = { ... }
+        local content = args[1]
+        local opts = args[2]
+        local stripped_content = vim.lsp.util.stylize_markdown(bufnr, content, opts)
+
+        return stripped_content
+      ]], content, opts)
+    end
+
+    it('should stylize markdown code fences', function()
+      local lines = {
+        "```lua",
+        "local hello = 'world'",
+        "```",
+      }
+      local expected = {
+        "local hello = 'world'",
+      }
+      local opts = {}
+      eq(expected, stylize_markdown(lines, opts))
+    end)
+
+    it('should add separator after code block', function()
+      local lines = {
+        "```lua",
+        "local hello = 'world'",
+        "```",
+        "",
+        "something",
+      }
+      local expected = {
+        "local hello = 'world'",
+        "─────────────────────",
+        "something",
+      }
+      local opts = { separator = true }
+      eq(expected, stylize_markdown(lines, opts))
+    end)
+
+    it('should replace supported HTML entities', function()
+      local lines = {
+        "1 &lt; 2",
+        "3 &gt; 2",
+        "&quot;quoted&quot;",
+        "&apos;apos&apos;",
+        "&ensp; &emsp;",
+        "&amp;",
+      }
+      local expected = {
+        "1 < 2",
+        "3 > 2",
+        '"quoted"',
+        "'apos'",
+        "   ",
+        "&",
+      }
+      local opts = {}
+      eq(expected, stylize_markdown(lines, opts))
+    end)
+  end)
+end)

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -21,7 +21,7 @@ describe('vim.lsp.util', function()
       ]], content, opts)
     end
 
-    it('should stylize markdown code fences', function()
+    it('code fences', function()
       local lines = {
         "```lua",
         "local hello = 'world'",

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -34,7 +34,7 @@ describe('vim.lsp.util', function()
       eq(expected, stylize_markdown(lines, opts))
     end)
 
-    it('should add separator after code block', function()
+    it('adds separator after code block', function()
       local lines = {
         "```lua",
         "local hello = 'world'",

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -51,7 +51,7 @@ describe('vim.lsp.util', function()
       eq(expected, stylize_markdown(lines, opts))
     end)
 
-    it('should replace supported HTML entities', function()
+    it('replaces supported HTML entities', function()
       local lines = {
         "1 &lt; 2",
         "3 &gt; 2",


### PR DESCRIPTION
Implements #22757

During handling of textDocument/hover, if the language server returns a payload containing markdown with some html escape sequences, the neovim handler will convert common ones to characters to display in the floating window's buffer.