### PR TITLE
ci!: remove the .deb release

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -33,12 +33,6 @@ ${NVIM_VERSION}
 2. Extract: `tar xzvf nvim-linux64.tar.gz`
 3. Run `./nvim-linux64/bin/nvim`
 
-#### Debian Package
-
-1. Download **nvim-linux64.deb**
-2. Install the package using `sudo apt install ./nvim-linux64.deb`
-3. Run `nvim`
-
 #### AppImage
 1. Download **nvim.appimage**
 2. Run `chmod u+x nvim.appimage && ./nvim.appimage`
@@ -56,7 +50,6 @@ ${NVIM_VERSION}
 
 ```
 ${SHA_LINUX_64_TAR}
-${SHA_LINUX_64_DEB}
 ${SHA_APP_IMAGE}
 ${SHA_APP_IMAGE_ZSYNC}
 ${SHA_MACOS}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
           name: nvim-linux64
           path: |
             build/nvim-linux64.tar.gz
-            build/nvim-linux64.deb
           retention-days: 1
 
   appimage:
@@ -182,8 +181,6 @@ jobs:
           cd ./nvim-linux64
           sha256sum nvim-linux64.tar.gz > nvim-linux64.tar.gz.sha256sum
           echo "SHA_LINUX_64_TAR=$(cat nvim-linux64.tar.gz.sha256sum)" >> $GITHUB_ENV
-          sha256sum nvim-linux64.deb > nvim-linux64.deb.sha256sum
-          echo "SHA_LINUX_64_DEB=$(cat nvim-linux64.deb.sha256sum)" >> $GITHUB_ENV
       - name: Generate App Image SHA256 checksums
         run: |
           cd ./appimage


### PR DESCRIPTION
Having multiple release artifacts per platform is a maintenance burden.
Furthermore, it is a maintenance burden that doesn't directly improve
the Nvim editor itself. The releases are meant to be a quick way for
users to try out and use neovim on their platform and was never intended
to be a buffet of releases for every conceivable setup.

Users are encouraged to the following replacements:

- Github action `action-setup-vim` to have neovim installed on their
  PATH for their CI jobs. See https://github.com/rhysd/action-setup-vim.
- Use the appimage, either as is or by extracting it
  - To use as is, run `chmod u+x nvim.appimage && ./nvim.appimage`
  - If your system does not have FUSE you can extract the appimage with
    `./nvim.appimage --appimage-extract && ./squashfs-root/usr/bin/nvim`
- Build it manually. See https://github.com/neovim/neovim/wiki/Building-Neovim.

Work on https://github.com/neovim/neovim/issues/22684
