### PR TITLE
vim-patch:9.0.1426: indent wrong after "export namespace" in C++

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -525,7 +525,9 @@ static bool cin_is_cpp_namespace(const char *s)
 
   s = cin_skipcomment(s);
 
-  if (strncmp(s, "inline", 6) == 0 && (s[6] == NUL || !vim_iswordc((uint8_t)s[6]))) {
+  // skip over "inline" and "export" in any order
+  while ((strncmp(s, "inline", 6) == 0 || strncmp(s, "export", 6) == 0)
+         && (s[6] == NUL || !vim_iswordc((uint8_t)s[6]))) {
     s = cin_skipcomment(skipwhite(s + 6));
   }
 

--- a/test/old/testdir/test_cindent.vim
+++ b/test/old/testdir/test_cindent.vim
@@ -4392,6 +4392,18 @@ func Test_cindent_47()
   inline/* test */namespace {
     111111111111111111;
   }
+  export namespace {
+    111111111111111111;
+  }
+  export inline namespace {
+    111111111111111111;
+  }
+  export/* test */inline namespace {
+    111111111111111111;
+  }
+  inline export namespace {
+    111111111111111111;
+  }
 
   /* invalid namespaces use block indent */
   namespace test test2 {
@@ -4493,6 +4505,18 @@ func Test_cindent_47()
   111111111111111111;
   }
   inline/* test */namespace {
+  111111111111111111;
+  }
+  export namespace {
+  111111111111111111;
+  }
+  export inline namespace {
+  111111111111111111;
+  }
+  export/* test */inline namespace {
+  111111111111111111;
+  }
+  inline export namespace {
   111111111111111111;
   }
 


### PR DESCRIPTION
#### vim-patch:9.0.1426: indent wrong after "export namespace" in C++

Problem:    Indent wrong after "export namespace" in C++.
Solution:   Skip over "inline" and "export" in any order. (Virginia Senioria,
            closes vim/vim#12134)

https://github.com/vim/vim/commit/99e4ab2a1e577ddb29030c09c308b67e16fd51c4

Co-authored-by: Virginia Senioria <91khr@users.noreply.github.com>