### PR TITLE
feat(extmarks): extend nvim_buf_get_extmarks()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2527,6 +2527,8 @@ nvim_buf_get_extmark_by_id({buffer}, {ns_id}, {id}, {opts})
       • {id}      Extmark id
       • {opts}    Optional parameters. Keys:
                   • details: Whether to include the details dict
+                  • hl_name: Whether to include highlight group name instead
+                    of id, true if omitted
 
     Return: ~
         0-indexed (row, col) tuple or empty list () if extmark id was absent
@@ -2563,7 +2565,8 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
 
     Parameters: ~
       • {buffer}  Buffer handle, or 0 for current buffer
-      • {ns_id}   Namespace id from |nvim_create_namespace()|
+      • {ns_id}   Namespace id from |nvim_create_namespace()| or -1 for all
+                  namespaces
       • {start}   Start of range: a 0-indexed (row, col) or valid extmark id
                   (whose position defines the bound). |api-indexing|
       • {end}     End of range (inclusive): a 0-indexed (row, col) or valid
@@ -2571,7 +2574,11 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
                   |api-indexing|
       • {opts}    Optional parameters. Keys:
                   • limit: Maximum number of marks to return
-                  • details Whether to include the details dict
+                  • details: Whether to include the details dict
+                  • hl_name: Whether to include highlight group name instead
+                    of id, true if omitted
+                  • type: Filter marks by type: "highlight", "sign",
+                    "virt_text" and "virt_lines"
 
     Return: ~
         List of [extmark_id, row, col] tuples in "traversal order".

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -67,6 +67,11 @@ NEW FEATURES                                                    *news-features*
 
 The following new APIs or features were added.
 
+• |nvim_buf_get_extmarks()| now accepts a -1 `ns_id` to request extmarks from
+  all namespaces and adds the namespace id to the details array.
+  Other missing properties have been added to the details array and marks can
+  be filtered by type.
+
 • Added a new experimental |lua-loader| that byte-compiles and caches lua files.
   To enable the new loader, add the following at the top of your |init.lua|: >lua
     vim.loader.enable()

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -76,6 +76,14 @@ typedef enum {
   kExtmarkClear,
 } UndoObjectType;
 
+typedef enum {
+  kExtmarkNone = 0x1,
+  kExtmarkSign = 0x2,
+  kExtmarkVirtText = 0x4,
+  kExtmarkVirtLines = 0x8,
+  kExtmarkHighlight = 0x10,
+} ExtmarkType;
+
 // TODO(bfredl): reduce the number of undo action types
 struct undo_object {
   UndoObjectType type;

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1463,6 +1463,7 @@ describe('API/extmarks', function()
       end_line = 1
     })
     eq({ {1, 0, 0, {
+      ns_id = 1,
       end_col = 0,
       end_row = 1,
       right_gravity = true,
@@ -1480,20 +1481,27 @@ describe('API/extmarks', function()
 
   it('can get details', function()
     set_extmark(ns, marks[1], 0, 0, {
+      conceal = "c",
+      cursorline_hl_group = "Statement",
       end_col = 0,
-      end_row = 1,
-      right_gravity = false,
       end_right_gravity = true,
-      priority = 0,
+      end_row = 1,
       hl_eol = true,
-      hl_mode = "blend",
       hl_group = "String",
-      virt_text = { { "text", "Statement" } },
-      virt_text_pos = "right_align",
-      virt_text_hide = true,
+      hl_mode = "blend",
+      line_hl_group = "Statement",
+      number_hl_group = "Statement",
+      priority = 0,
+      right_gravity = false,
+      sign_hl_group = "Statement",
+      sign_text = ">>",
+      spell = true,
       virt_lines = { { { "lines", "Statement" } }},
       virt_lines_above = true,
       virt_lines_leftcol = true,
+      virt_text = { { "text", "Statement" } },
+      virt_text_hide = true,
+      virt_text_pos = "right_align",
     })
     set_extmark(ns, marks[2], 0, 0, {
       priority = 0,
@@ -1501,22 +1509,31 @@ describe('API/extmarks', function()
       virt_text_win_col = 1,
     })
     eq({0, 0, {
+      conceal = "c",
+      cursorline_hl_group = "Statement",
       end_col = 0,
-      end_row = 1,
-      right_gravity = false,
       end_right_gravity = true,
-      priority = 0,
+      end_row = 1,
       hl_eol = true,
-      hl_mode = "blend",
       hl_group = "String",
-      virt_text = { { "text", "Statement" } },
-      virt_text_pos = "right_align",
-      virt_text_hide = true,
+      hl_mode = "blend",
+      line_hl_group = "Statement",
+      ns_id = 1,
+      number_hl_group = "Statement",
+      priority = 0,
+      right_gravity = false,
+      sign_hl_group = "Statement",
+      sign_text = ">>",
+      spell = true,
       virt_lines = { { { "lines", "Statement" } }},
       virt_lines_above = true,
       virt_lines_leftcol = true,
+      virt_text = { { "text", "Statement" } },
+      virt_text_hide = true,
+      virt_text_pos = "right_align",
     } }, get_extmark_by_id(ns, marks[1], { details = true }))
     eq({0, 0, {
+      ns_id = 1,
       right_gravity = true,
       priority = 0,
       virt_text = { { "text", "Statement" } },
@@ -1524,6 +1541,29 @@ describe('API/extmarks', function()
       virt_text_pos = "win_col",
       virt_text_win_col = 1,
     } }, get_extmark_by_id(ns, marks[2], { details = true }))
+  end)
+
+  it('can get marks from anonymous namespaces', function()
+    ns = request('nvim_create_namespace', "")
+    ns2 = request('nvim_create_namespace', "")
+    set_extmark(ns, 1, 0, 0, {})
+    set_extmark(ns2, 2, 1, 0, {})
+    eq({{ 1, 0, 0, { ns_id = ns, right_gravity = true }},
+        { 2, 1, 0, { ns_id = ns2, right_gravity = true }}},
+        get_extmarks(-1, 0, -1, { details = true }))
+  end)
+
+  it('can filter by extmark properties', function()
+    set_extmark(ns, 1, 0, 0, {})
+    set_extmark(ns, 2, 0, 0, { hl_group = 'Normal' })
+    set_extmark(ns, 3, 0, 0, { sign_text = '>>' })
+    set_extmark(ns, 4, 0, 0, { virt_text = {{'text', 'Normal'}}})
+    set_extmark(ns, 5, 0, 0, { virt_lines = {{{ 'line', 'Normal' }}}})
+    eq(5, #get_extmarks(-1, 0, -1, { details = true }))
+    eq({{ 2, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'highlight' }))
+    eq({{ 3, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'sign' }))
+    eq({{ 4, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'virt_text' }))
+    eq({{ 5, 0, 0 }}, get_extmarks(-1, 0, -1, { type = 'virt_lines' }))
   end)
 end)
 

--- a/test/functional/ui/bufhl_spec.lua
+++ b/test/functional/ui/bufhl_spec.lua
@@ -766,6 +766,7 @@ describe('Buffer highlighting', function()
       -- an existing virtual text. We might add a prioritation system.
       set_virtual_text(id1, 0, s1, {})
       eq({{1, 0, 0, {
+        ns_id = 1,
         priority = 0,
         virt_text = s1,
         -- other details
@@ -778,6 +779,7 @@ describe('Buffer highlighting', function()
       local lastline = line_count()
       set_virtual_text(id1, line_count(), s2, {})
       eq({{3, lastline, 0, {
+        ns_id = 1,
         priority = 0,
         virt_text = s2,
         -- other details


### PR DESCRIPTION
Problem:    Can not get all extmarks in a buffer. Properties are missing
            from the details array.
Solution:   Allow getting all extmarks in a buffer by supplying a -1
            "ns_id". Add missing properties to the details array.