### PR TITLE
refactor(lua): get all extmarks instead of iterating over namespaces

### DIFF
--- a/test/functional/lua/inspector_spec.lua
+++ b/test/functional/lua/inspector_spec.lua
@@ -12,9 +12,13 @@ describe('vim.inspect_pos', function()
   it('it returns items', function()
     local ret = exec_lua([[
       local buf = vim.api.nvim_create_buf(true, false)
+      local ns1 = vim.api.nvim_create_namespace("ns1")
+      local ns2 = vim.api.nvim_create_namespace("")
       vim.api.nvim_set_current_buf(buf)
       vim.api.nvim_buf_set_lines(0, 0, -1, false, {"local a = 123"})
       vim.api.nvim_buf_set_option(buf, "filetype", "lua")
+      vim.api.nvim_buf_set_extmark(buf, ns1, 0, 10, { hl_group = "Normal" })
+      vim.api.nvim_buf_set_extmark(buf, ns2, 0, 10, { hl_group = "Normal" })
       vim.cmd("syntax on")
       return {buf, vim.inspect_pos(0, 0, 10)}
     ]])
@@ -24,7 +28,42 @@ describe('vim.inspect_pos', function()
       buffer = buf,
       col = 10,
       row = 0,
-      extmarks = {},
+      extmarks = {
+        {
+          col = 10,
+          end_col = 11,
+          end_row = 0,
+          id = 1,
+          ns = 'ns1',
+          ns_id = 1,
+          opts = {
+            hl_eol = false,
+            hl_group = 'Normal',
+            hl_group_link = 'Normal',
+            ns_id = 1,
+            priority = 4096,
+            right_gravity = true
+          },
+          row = 0
+        },
+        {
+          col = 10,
+          end_col = 11,
+          end_row = 0,
+          id = 1,
+          ns = '',
+          ns_id = 2,
+          opts = {
+            hl_eol = false,
+            hl_group = 'Normal',
+            hl_group_link = 'Normal',
+            ns_id = 2,
+            priority = 4096,
+            right_gravity = true
+          },
+          row = 0
+        }
+      },
       treesitter = {},
       semantic_tokens = {},
       syntax = {


### PR DESCRIPTION
Inspector now also includes highlights set in anonymous namespaces.

Close #22732