### PR TITLE
vim-patch:9.0.1428: cursor in wrong position when leaving insert mode

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3457,6 +3457,7 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
       }
     } else {
       curwin->w_cursor.col--;
+      curwin->w_valid &= ~(VALID_WCOL|VALID_VIRTCOL);
       // Correct cursor for multi-byte character.
       mb_adjust_cursor();
     }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1377,6 +1377,7 @@ static int normal_check(VimState *state)
   // update cursor and redraw.
   if (skip_redraw || exmode_active) {
     skip_redraw = false;
+    setcursor();
   } else if (do_redraw || stuff_empty()) {
     // Ensure curwin->w_topline and curwin->w_leftcol are up to date
     // before triggering a WinScrolled autocommand.

--- a/test/functional/editor/mode_insert_spec.lua
+++ b/test/functional/editor/mode_insert_spec.lua
@@ -53,14 +53,13 @@ describe('insert-mode', function()
     it('double quote is removed after hit-enter prompt #22609', function()
       local screen = Screen.new(60, 6)
       screen:set_default_attr_ids({
-        [0] = {bold = true, foreground = Screen.colors.Blue},
-        [1] = {foreground = Screen.colors.Blue},
+        [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+        [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
         [2] = {foreground = Screen.colors.SlateBlue},
-        [3] = {bold = true},
-        [4] = {reverse = true, bold = true},
-        [5] = {background = Screen.colors.Red, foreground = Screen.colors.Red},
-        [6] = {background = Screen.colors.Red, foreground = Screen.colors.White},
-        [7] = {foreground = Screen.colors.SeaGreen, bold = true},
+        [3] = {bold = true},  -- ModeMsg
+        [4] = {reverse = true, bold = true},  -- MsgSeparator
+        [5] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+        [6] = {foreground = Screen.colors.SeaGreen, bold = true},  -- MoreMsg
       })
       screen:attach()
       feed('i<C-R>')
@@ -72,14 +71,23 @@ describe('insert-mode', function()
         {0:~                                                           }|
         {3:-- INSERT --}                                                |
       ]])
-      feed('={}<CR>')
+      feed('={}')
+      screen:expect([[
+        {1:"}                                                           |
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        {0:~                                                           }|
+        ={2:{}}^                                                         |
+      ]])
+      feed('<CR>')
       screen:expect([[
         {1:"}                                                           |
         {0:~                                                           }|
         {4:                                                            }|
-        ={5:{}{2:}}                                                         |
-        {6:E731: using Dictionary as a String}                          |
-        {7:Press ENTER or type command to continue}^                     |
+        ={2:{}}                                                         |
+        {5:E731: using Dictionary as a String}                          |
+        {6:Press ENTER or type command to continue}^                     |
       ]])
       feed('<CR>')
       screen:expect([[

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -55,4 +55,68 @@ describe('edit', function()
       =^           |
     ]])
   end)
+
+  -- oldtest: Test_edit_ctrl_r_failed()
+  it('positioning cursor after CTRL-R expression failed', function()
+    local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {foreground = Screen.colors.Blue},  -- SpecialKey
+      [2] = {foreground = Screen.colors.SlateBlue},
+      [3] = {bold = true},  -- ModeMsg
+      [4] = {reverse = true, bold = true},  -- MsgSeparator
+      [5] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
+      [6] = {foreground = Screen.colors.SeaGreen, bold = true},  -- MoreMsg
+    })
+    screen:attach()
+
+    feed('i<C-R>')
+    screen:expect([[
+      {1:^"}                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {3:-- INSERT --}                                                |
+    ]])
+    feed('={}')
+    screen:expect([[
+      {1:"}                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      ={2:{}}^                                                         |
+    ]])
+    -- trying to insert a dictionary produces an error
+    feed('<CR>')
+    screen:expect([[
+      {1:"}                                                           |
+      {0:~                                                           }|
+      {4:                                                            }|
+      ={2:{}}                                                         |
+      {5:E731: using Dictionary as a String}                          |
+      {6:Press ENTER or type command to continue}^                     |
+    ]])
+
+    feed(':')
+    screen:expect([[
+      :^                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {3:-- INSERT --}                                                |
+    ]])
+    -- ending Insert mode should put the cursor back on the ':'
+    feed('<Esc>')
+    screen:expect([[
+      ^:                                                           |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+                                                                  |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -5,6 +5,7 @@ if exists("+t_kD")
 endif
 
 source check.vim
+source screendump.vim
 
 " Needed for testing basic rightleft: Test_edit_rightleft
 source view_util.vim
@@ -1976,6 +1977,22 @@ func Test_edit_insert_reg()
   call assert_equal('"', g:Line)
   call test_override('ALL', 0)
   close!
+endfunc
+
+" Test for positioning cursor after CTRL-R expression failed
+func Test_edit_ctrl_r_failed()
+  CheckRunVimInTerminal
+
+  let buf = RunVimInTerminal('', #{rows: 6, cols: 60})
+
+  " trying to insert a dictionary produces an error
+  call term_sendkeys(buf, "i\<C-R>={}\<CR>")
+
+  " ending Insert mode should put the cursor back on the ':'
+  call term_sendkeys(buf, ":\<Esc>")
+  call VerifyScreenDump(buf, 'Test_edit_ctlr_r_failed_1', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " When a character is inserted at the last position of the last line in a


### PR DESCRIPTION
#### vim-patch:9.0.1428: cursor in wrong position when leaving insert mode

Problem:    Cursor in wrong position when leaving insert mode.
Solution:   Update the w_valid flags.  Position the cursor also when not
            redrawing.

https://github.com/vim/vim/commit/c174c2e58c9e24a75b189e01143e6d057b84e96e

Co-authored-by: Bram Moolenaar <Bram@vim.org>