### PR TITLE
test: use exec_capture() in more places

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -338,7 +338,8 @@ vim.cmd = setmetatable({}, {
     if type(command) == 'table' then
       return vim.api.nvim_cmd(command, {})
     else
-      return vim.api.nvim_exec2(command, { output = false }).output
+      vim.api.nvim_exec2(command, {})
+      return ''
     end
   end,
   __index = function(t, command)

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -11,6 +11,7 @@ local insert = helpers.insert
 local feed = helpers.feed
 local clear = helpers.clear
 local command = helpers.command
+local exec = helpers.exec
 local meths = helpers.meths
 local assert_alive = helpers.assert_alive
 
@@ -1413,12 +1414,12 @@ describe('API/extmarks', function()
   end)
 
   it('does not crash with append/delete/undo sequence', function()
-    meths.exec2([[
+    exec([[
       let ns = nvim_create_namespace('myplugin')
       call nvim_buf_set_extmark(0, ns, 0, 0, {})
       call append(0, '')
       %delete
-      undo]], { output = false })
+      undo]])
     assert_alive()
   end)
 
@@ -1450,7 +1451,7 @@ describe('API/extmarks', function()
 
     feed('u')
     -- handles pasting
-    meths.exec2([[let @a='asdfasdf']], { output = false })
+    exec([[let @a='asdfasdf']])
     feed([["ap]])
     eq({ {1, 0, 0}, {2, 0, 8} },
         meths.buf_get_extmarks(0, ns, 0, -1, {}))

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -681,13 +681,13 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
   end)
 
   it('can set <expr> mappings whose RHS change dynamically', function()
-    meths.exec2([[
+    exec([[
         function! FlipFlop() abort
           if !exists('g:flip') | let g:flip = 0 | endif
           let g:flip = !g:flip
           return g:flip
         endfunction
-        ]], { output = false })
+        ]])
     eq(1, meths.call_function('FlipFlop', {}))
     eq(0, meths.call_function('FlipFlop', {}))
     eq(1, meths.call_function('FlipFlop', {}))

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -9,6 +9,7 @@ local NIL = helpers.NIL
 local clear, nvim, eq, neq = helpers.clear, helpers.nvim, helpers.eq, helpers.neq
 local command = helpers.command
 local exec = helpers.exec
+local exec_capture = helpers.exec_capture
 local eval = helpers.eval
 local expect = helpers.expect
 local funcs = helpers.funcs
@@ -588,7 +589,7 @@ describe('API', function()
 
     it('sets previous directory', function()
       meths.set_current_dir("Xtestdir")
-      meths.exec2('cd -', { output = false })
+      command('cd -')
       eq(funcs.getcwd(), start_dir)
     end)
   end)
@@ -2687,7 +2688,7 @@ describe('API', function()
       eq('  1 %a   "[No Name]"                    line 1\n'..
          '  3  h   "[Scratch]"                    line 0\n'..
          '  4  h   "[Scratch]"                    line 0',
-         meths.exec2('ls', { output = true }).output)
+         exec_capture('ls'))
       -- current buffer didn't change
       eq({id=1}, meths.get_current_buf())
 
@@ -2954,13 +2955,13 @@ describe('API', function()
     it('can save message history', function()
       nvim('command', 'set cmdheight=2') -- suppress Press ENTER
       nvim("echo", {{"msg\nmsg"}, {"msg"}}, true, {})
-      eq("msg\nmsgmsg", meths.exec2('messages', { output = true }).output)
+      eq("msg\nmsgmsg", exec_capture('messages'))
     end)
 
     it('can disable saving message history', function()
       nvim('command', 'set cmdheight=2') -- suppress Press ENTER
       nvim_async("echo", {{"msg\nmsg"}, {"msg"}}, false, {})
-      eq("", meths.exec2("messages", { output = true }).output)
+      eq("", exec_capture('messages'))
     end)
   end)
 
@@ -3949,7 +3950,7 @@ describe('API', function()
 
     it('sets correct script context', function()
       meths.cmd({ cmd = "set", args = { "cursorline" } }, {})
-      local str = meths.exec2([[verbose set cursorline?]], { output = true }).output
+      local str = exec_capture([[verbose set cursorline?]])
       neq(nil, str:find("cursorline\n\tLast set from API client %(channel id %d+%)"))
     end)
 
@@ -3999,7 +4000,7 @@ describe('API', function()
         line6
       ]]
       meths.cmd({ cmd = "del", range = { 2, 4 }, reg = 'a' }, {})
-      meths.exec2("1put a", { output = false })
+      command('1put a')
       expect [[
         line1
         line2
@@ -4064,11 +4065,11 @@ describe('API', function()
                    { output = true }))
     end)
     it('splits arguments correctly', function()
-      meths.exec2([[
+      exec([[
         function! FooFunc(...)
           echo a:000
         endfunction
-      ]], { output = false })
+      ]])
       meths.create_user_command("Foo", "call FooFunc(<f-args>)", { nargs = '+' })
       eq([=[['a quick', 'brown fox', 'jumps over the', 'lazy dog']]=],
          meths.cmd({ cmd = "Foo", args = { "a quick", "brown fox", "jumps over the", "lazy dog"}},

--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -4,10 +4,7 @@ local clear = helpers.clear
 local eq = helpers.eq
 local meths = helpers.meths
 local funcs = helpers.funcs
-
-local exec = function(str)
-  meths.exec2(str, { output = false })
-end
+local exec = helpers.exec
 
 describe('oldtests', function()
   before_each(clear)

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -3,11 +3,11 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local command = helpers.command
 local eq = helpers.eq
+local exec_capture = helpers.exec_capture
 local exec_lua = helpers.exec_lua
 local expect = helpers.expect
 local funcs = helpers.funcs
 local insert = helpers.insert
-local meths = helpers.meths
 local new_argv = helpers.new_argv
 local neq = helpers.neq
 local set_session = helpers.set_session
@@ -101,7 +101,7 @@ describe('Remote', function()
     expect(contents)
     eq(1, #funcs.getbufinfo())
     -- Since we didn't pass silent, we should get a complaint
-    neq(nil, string.find(meths.exec2('messages', { output = true }).output, 'E247'))
+    neq(nil, string.find(exec_capture('messages'), 'E247:'))
   end)
 
   it('creates server if not found with tabs', function()
@@ -110,7 +110,7 @@ describe('Remote', function()
     eq(2, #funcs.gettabinfo())
     eq(2, #funcs.getbufinfo())
     -- We passed silent, so no message should be issued about the server not being found
-    eq(nil, string.find(meths.exec2('messages', { output = true }).output, 'E247'))
+    eq(nil, string.find(exec_capture('messages'), 'E247:'))
   end)
 
   pending('exits with error on', function()

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -9,6 +9,7 @@ local ok = helpers.ok
 local eq = helpers.eq
 local matches = helpers.matches
 local eval = helpers.eval
+local exec_capture = helpers.exec_capture
 local exec_lua = helpers.exec_lua
 local feed = helpers.feed
 local funcs = helpers.funcs
@@ -823,7 +824,7 @@ describe('user config init', function()
       clear{ args_rm={'-u'}, env=xenv }
       feed('<cr><c-c>')  -- Dismiss "Conflicting config …" message.
       eq(1, eval('g:lua_rc'))
-      matches('^E5422: Conflicting configs', meths.exec2('messages', { output = true }).output)
+      matches('^E5422: Conflicting configs', exec_capture('messages'))
     end)
   end)
 end)
@@ -872,7 +873,7 @@ describe('runtime:', function()
 
     eq(2, eval('g:lua_plugin'))
     -- Check if plugin_file_path is listed in :scriptname
-    local scripts = meths.exec2(':scriptnames', { output = true }).output
+    local scripts = exec_capture('scriptnames')
     assert(scripts:find(plugin_file_path))
 
     -- Check if plugin_file_path is listed in startup profile

--- a/test/functional/ex_cmds/script_spec.lua
+++ b/test/functional/ex_cmds/script_spec.lua
@@ -3,6 +3,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
 local neq = helpers.neq
 local command = helpers.command
+local exec_capture = helpers.exec_capture
 local write_file = helpers.write_file
 local meths = helpers.meths
 local clear = helpers.clear
@@ -34,7 +35,7 @@ describe('script_get-based command', function()
             %s %s
           endif
         ]])):format(cmd, garbage)))
-        eq('', meths.exec2('messages', { output = true }).output)
+        eq('', exec_capture('messages'))
         if check_neq then
           neq(0, exc_exec(dedent([[
             %s %s
@@ -49,7 +50,7 @@ describe('script_get-based command', function()
           EOF
           endif
         ]])):format(cmd, garbage)))
-        eq('', meths.exec2('messages', { output = true }).output)
+        eq('', exec_capture('messages'))
         if check_neq then
           eq(true, pcall(source, (dedent([[
             let g:exc = 0

--- a/test/functional/ex_cmds/source_spec.lua
+++ b/test/functional/ex_cmds/source_spec.lua
@@ -96,12 +96,12 @@ describe(':source', function()
       let d = s:s]])
 
     command('source')
-    eq('2', meths.exec2('echo a', { output = true }).output)
-    eq("{'k': 'v'}", meths.exec2('echo b', { output = true }).output)
+    eq('2', exec_capture('echo a'))
+    eq("{'k': 'v'}", exec_capture('echo b'))
 
     -- Script items are created only on script var access
-    eq("1", meths.exec2('echo c', { output = true }).output)
-    eq("0zBEEFCAFE", meths.exec2('echo d', { output = true }).output)
+    eq("1", exec_capture('echo c'))
+    eq("0zBEEFCAFE", exec_capture('echo d'))
 
     exec('set cpoptions+=C')
     eq('Vim(let):E723: Missing end of Dictionary \'}\': ', exc_exec('source'))
@@ -124,14 +124,14 @@ describe(':source', function()
     -- Source the 2nd line only
     feed('ggjV')
     feed_command(':source')
-    eq('3', meths.exec2('echo a', { output = true }).output)
+    eq('3', exec_capture('echo a'))
 
     -- Source from 2nd line to end of file
     feed('ggjVG')
     feed_command(':source')
-    eq('4', meths.exec2('echo a', { output = true }).output)
-    eq("{'K': 'V'}", meths.exec2('echo b', { output = true }).output)
-    eq("<SNR>1_C()", meths.exec2('echo D()', { output = true }).output)
+    eq('4', exec_capture('echo a'))
+    eq("{'K': 'V'}", exec_capture('echo b'))
+    eq("<SNR>1_C()", exec_capture('echo D()'))
 
     -- Source last line only
     feed_command(':$source')
@@ -147,7 +147,7 @@ describe(':source', function()
       let a = 123
     ]]
     command('source')
-    eq('123', meths.exec2('echo a', { output = true }).output)
+    eq('123', exec_capture('echo a'))
   end)
 
   it('multiline heredoc command', function()
@@ -157,7 +157,7 @@ describe(':source', function()
       EOF]])
 
     command('source')
-    eq('4', meths.exec2('echo luaeval("y")', { output = true }).output)
+    eq('4', exec_capture('echo luaeval("y")'))
   end)
 
   it('can source lua files', function()

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -28,7 +28,7 @@ vim.api.nvim_exec2("augroup test_group\
                      autocmd!\
                      autocmd FileType c setl cindent\
                      augroup END\
-                  ", { output = false })
+                  ", {})
 
 vim.api.nvim_command("command Bdelete :bd")
 vim.api.nvim_create_user_command("TestCommand", ":echo 'Hello'", {})

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -826,7 +826,7 @@ function module.skip_fragile(pending_fn, cond)
 end
 
 function module.exec(code)
-  module.meths.exec2(code, { output = false })
+  module.meths.exec2(code, {})
 end
 
 function module.exec_capture(code)

--- a/test/functional/options/keymap_spec.lua
+++ b/test/functional/options/keymap_spec.lua
@@ -2,7 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear, feed, eq = helpers.clear, helpers.feed, helpers.eq
 local expect, command, eval = helpers.expect,  helpers.command,  helpers.eval
 local insert, call = helpers.insert, helpers.call
-local funcs, dedent = helpers.funcs, helpers.dedent
+local exec_capture, dedent = helpers.exec_capture, helpers.dedent
 
 -- First test it's implemented using the :lmap and :lnoremap commands, then
 -- check those mappings behave as expected.
@@ -30,7 +30,7 @@ describe("'keymap' / :lmap", function()
       command('lmapclear <buffer>')
       command('set keymap=dvorak')
       command('set nomore')
-      local bindings = funcs.nvim_exec2('lmap', { output = true }).output
+      local bindings = exec_capture('lmap')
       eq(dedent([[
 
       l  "            @_

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -7,6 +7,7 @@ local clear = helpers.clear
 local meths = helpers.meths
 local funcs = helpers.funcs
 local source = helpers.source
+local exec_capture = helpers.exec_capture
 local dedent = helpers.dedent
 local command = helpers.command
 local curbufmeths = helpers.curbufmeths
@@ -362,7 +363,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
       :e^                                      |
     ]])
-    eq('', meths.exec2('messages', { output = true }).output)
+    eq('', exec_capture('messages'))
   end)
   it('silences :echon', function()
     set_color_cb('Echoning')
@@ -377,7 +378,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
       :e^                                      |
     ]])
-    eq('', meths.exec2('messages', { output = true }).output)
+    eq('', exec_capture('messages'))
   end)
   it('silences :echomsg', function()
     set_color_cb('Echomsging')
@@ -392,7 +393,7 @@ describe('Command-line coloring', function()
       {EOB:~                                       }|
       :e^                                      |
     ]])
-    eq('', meths.exec2('messages', { output = true }).output)
+    eq('', exec_capture('messages'))
   end)
   it('does the right thing when throwing', function()
     set_color_cb('Throwing')
@@ -858,7 +859,7 @@ describe('Ex commands coloring', function()
     ]])
     feed('<CR>')
     eq('Error detected while processing :\nE605: Exception not caught: 42\nE749: empty buffer',
-       meths.exec2('messages', { output = true }).output)
+       exec_capture('messages'))
   end)
   it('errors out when failing to get callback', function()
     meths.set_var('Nvim_color_cmdline', 42)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -10,6 +10,7 @@ local async_meths = helpers.async_meths
 local test_build_dir = helpers.test_build_dir
 local nvim_prog = helpers.nvim_prog
 local exec = helpers.exec
+local exec_capture = helpers.exec_capture
 local exc_exec = helpers.exc_exec
 local exec_lua = helpers.exec_lua
 local poke_eventloop = helpers.poke_eventloop
@@ -986,7 +987,7 @@ describe('ui/builtin messages', function()
 
     -- screen size doesn't affect internal output #10285
     eq('ErrorMsg       xxx ctermfg=15 ctermbg=1 guifg=White guibg=Red',
-       meths.exec2("hi ErrorMsg", { output = true }).output)
+       exec_capture("hi ErrorMsg"))
   end)
 
   it(':syntax list langGroup output', function()
@@ -1025,7 +1026,7 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
                    match /\<endif\s\+".*$/ms=s+5,lc=5  contains=@vimCommentGroup,vimCommentString 
                    match /\<else\s\+".*$/ms=s+4,lc=4  contains=@vimCommentGroup,vimCommentString 
                    links to Comment]],
-       meths.exec2('syntax list vimComment', { output = true }).output)
+       exec_capture('syntax list vimComment'))
     -- luacheck: pop
   end)
 


### PR DESCRIPTION
Problem:
Using `meths.exec2("code", { output = true })` is too verbose.

Solution:
Use exec_capture() in more places.
