### PR TITLE
Update genappimage.sh

### DIFF
--- a/scripts/genappimage.sh
+++ b/scripts/genappimage.sh
@@ -52,7 +52,7 @@ fi
 chmod +x "$APP_BUILD_DIR"/linuxdeploy-x86_64.AppImage
 
 # metainfo is not packaged automatically by linuxdeploy
-mkdir "$APP_DIR/usr/share/metainfo/"
+mkdir -p "$APP_DIR/usr/share/metainfo/"
 cp "$ROOT_DIR/runtime/nvim.appdata.xml" "$APP_DIR/usr/share/metainfo/"
 
 cd "$APP_DIR" || exit


### PR DESCRIPTION
When the parent directory of $APP_DIR/usr/share/metainfo/ does not exist, a 'mkdir' failure error will occur, therefore the '-p' parameter is added.