### PR TITLE
vim-patch:9.0.1429: invalid memory access when ending insert mode

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2294,11 +2294,11 @@ static void stop_insert(pos_T *end_insert_pos, int esc, int nomove)
   // Don't do it when "restart_edit" was set and nothing was inserted,
   // otherwise CTRL-O w and then <Left> will clear "last_insert".
   ptr = get_inserted();
-  if (did_restart_edit == 0 || (ptr != NULL
-                                && (int)strlen(ptr) > new_insert_skip)) {
+  int added = ptr == NULL ? 0 : (int)strlen(ptr) - new_insert_skip;
+  if (did_restart_edit == 0 || added > 0) {
     xfree(last_insert);
     last_insert = ptr;
-    last_insert_skip = new_insert_skip;
+    last_insert_skip = added < 0 ? 0 : new_insert_skip;
   } else {
     xfree(ptr);
   }


### PR DESCRIPTION
#### vim-patch:9.0.1429: invalid memory access when ending insert mode

Problem:    Invalid memory access when ending insert mode.
Solution:   Check if the insert_skip value is valid.

https://github.com/vim/vim/commit/1a08a3e2a584889f19b84a27672134649b73da58

Co-authored-by: Bram Moolenaar <Bram@vim.org>