### PR TITLE
feat(mouse): improve scrolling when mouse dragging

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -632,6 +632,11 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     jump_flags |= MOUSE_RELEASED;
   }
 
+  if (is_drag) {
+    jump_flags &= ~MOUSE_DID_MOVE;
+    jump_flags |= MOUSE_FOCUS;
+  }
+
   // JUMP!
   jump_flags = jump_to_mouse(jump_flags,
                              oap == NULL ? NULL : &(oap->inclusive),
@@ -714,12 +719,6 @@ bool do_mouse(oparg_T *oap, int c, int dir, long count, bool fixindent)
     } else {
       mouse_dragging = 1;
     }
-  }
-
-  // When dragging the mouse above the window, scroll down.
-  if (is_drag && mouse_row < 0 && !in_status_line) {
-    scroll_redraw(false, 1L);
-    mouse_row = 0;
   }
 
   if (start_visual.lnum) {              // right click in visual mode
@@ -1087,7 +1086,8 @@ retnomove:
   old_curwin = curwin;
   old_cursor = curwin->w_cursor;
 
-  if (row < 0 || col < 0) {                   // check if it makes sense
+  // check if it makes sense
+  if (!(flags & MOUSE_FOCUS) && (row < 0 || col < 0)) {
     return IN_UNKNOWN;
   }
 
@@ -1257,6 +1257,11 @@ retnomove:
     } else if (grid != DEFAULT_GRID_HANDLE) {
       row -= curwin->w_grid.row_offset;
       col -= curwin->w_grid.col_offset;
+    }
+
+    if (col < 0 && curwin->w_leftcol > 0) {
+      curwin->w_leftcol = MAX(0, curwin->w_leftcol + col);
+      leftcol_changed();
     }
 
     // When clicking beyond the end of the window, scroll the screen.


### PR DESCRIPTION
## When dragging with the mouse
- Allow negative `mouse_row` and `mouse_col` values. These should cause the window to scroll up or scroll to the left respectively.
- Unset `MOUSE_DID_MOVE` `jump_to_mouse ` flag . Repeated mouse drag events beyond the window should continue to scroll the window even when the mouse has not moved.
- Scroll the window leftward when no `nowrap` is set and `mouse_col` is less than `0`.
- Remove unnecessary scrolling logic in `do_mouse` function.