### PR TITLE
build: drop diff.exe from windows builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,7 +354,7 @@ jobs:
         with:
           update: true
           pacboy: >-
-            make:p gcc:p
+            make:p gcc:p diffutils:p
           release: false
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -164,11 +164,9 @@ set(LUV_SHA256 222b38b6425f0926218e14e7da81481fdde6f9660c1feac25a53e6fb52e886e6)
 set(LUA_COMPAT53_URL https://github.com/keplerproject/lua-compat-5.3/archive/v0.9.tar.gz)
 set(LUA_COMPAT53_SHA256 ad05540d2d96a48725bb79a1def35cf6652a4e2ec26376e2617c8ce2baa6f416)
 
-# Windows only: cat.exe diff.exe tee.exe xxd.exe
+# Windows only: cat.exe tee.exe xxd.exe
 set(CAT_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/cat.exe)
 set(CAT_SHA256 93b8d307bb15af3968920bdea3beb869a49d166f9164853c58a4e6ffdcae61c6)
-set(DIFF_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/diff.exe)
-set(DIFF_SHA256 4ceceebc8150422c6d8d9a06c2e9686d5a5d90f1033f60ad92ab81fe810e2a28)
 set(TEE_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/tee.exe)
 set(TEE_SHA256 950eea4e17fa3a7e89fa2c55374037b5797b3f1a54fea1304634884ab42ec14d)
 set(XXD_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/xxd.exe)
@@ -267,7 +265,6 @@ if(WIN32)
   include(GetBinaryDeps)
 
   GetExecutable(TARGET cat)
-  GetExecutable(TARGET diff)
   GetExecutable(TARGET tee)
   GetExecutable(TARGET xxd)
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -761,7 +761,6 @@ if(WIN32)
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
       cat.exe
-      diff.exe
       tee.exe
       win32yank.exe
       xxd.exe


### PR DESCRIPTION
The shipped versions of xdiff already does everything diff does, so this
duplication of tools isn't necessary. Furthermore, this setup is more
consistent overall, as the 'diffopt=external' option should be for
external programs rather than programs we bundle neovim with.

Install diffutils for oldtests in CI to avoid needing to modify tests.