### PR TITLE
vim-patch:9.0.1430: Livebook files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -615,6 +615,7 @@ local extension = {
   asd = 'lisp',
   lt = 'lite',
   lite = 'lite',
+  livemd = 'livebook',
   lgt = 'logtalk',
   lotos = 'lotos',
   lot = 'lotos',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -338,6 +338,7 @@ let s:filename_checks = {
     \ 'lite': ['file.lite', 'file.lt'],
     \ 'litestep': ['/LiteStep/any/file.rc', 'any/LiteStep/any/file.rc'],
     \ 'logcheck': ['/etc/logcheck/file.d-some/file', '/etc/logcheck/file.d/file', 'any/etc/logcheck/file.d-some/file', 'any/etc/logcheck/file.d/file'],
+    \ 'livebook': ['file.livemd'],
     \ 'loginaccess': ['/etc/login.access', 'any/etc/login.access'],
     \ 'logindefs': ['/etc/login.defs', 'any/etc/login.defs'],
     \ 'logtalk': ['file.lgt'],


### PR DESCRIPTION
Problem:    Livebook files are not recognized.
Solution:   Add a pattern for Livebook files. (Mathias Jean Johansen,
            closes vim/vim#12203)

https://github.com/vim/vim/commit/64002035178ac3e0d9ab7269d1bf06c6ede5a854

Co-authored-by: Mathias Jean Johansen <mathias@mjj.io>
