### PR TITLE
fix(test): fix C imports on macOS arm64

### DIFF
--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -148,7 +148,11 @@ local cdef = ffi.cdef
 
 local cimportstr
 
-local previous_defines_init = ''
+local previous_defines_init = [[
+typedef struct { char bytes[16]; } __attribute__((aligned(16))) __uint128_t;
+typedef struct { char bytes[16]; } __attribute__((aligned(16))) __float128;
+]]
+
 local preprocess_cache_init = {}
 local previous_defines_mod = ''
 local preprocess_cache_mod = nil


### PR DESCRIPTION
System headers on macOS arm64 contain 128-bit numeric types. These types are built into clang and GCC as extensions. Unfortunately, they break the LuaJIT C importer. This PR defines typedefs for the missing numeric types to satisfy the C importer.

Closes: #18176