### PR TITLE
fix(api): return both link and attributes with nvim_get_hl

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -941,6 +941,10 @@ nvim_get_hl({ns_id}, {*opts})                                  *nvim_get_hl()*
         map as in |nvim_set_hl()|, or only a single highlight definition map
         if requested by name or id.
 
+    Note:
+        When the `link` attribute is defined in the highlight definition map,
+        other attributes will not be taking effect (see |:hi-link|).
+
 nvim_get_hl_id_by_name({name})                      *nvim_get_hl_id_by_name()*
     Gets a highlight group by name
 
@@ -1387,6 +1391,10 @@ nvim_set_hl({ns_id}, {name}, {*val})                           *nvim_set_hl()*
         which act as aliases to the corresponding foreground and background
         values of the Normal group. If the Normal group has not been defined,
         using these values results in an error.
+
+    Note:
+        If `link` is used in combination with other attributes; only the
+        `link` will take effect (see |:hi-link|).
 
     Parameters: ~
       • {ns_id}  Namespace id for this highlight |nvim_create_namespace()|.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -95,6 +95,9 @@ Integer nvim_get_hl_id_by_name(String name)
 /// @param[out] err Error details, if any.
 /// @return Highlight groups as a map from group name to a highlight definition map as in |nvim_set_hl()|,
 ///                   or only a single highlight definition map if requested by name or id.
+///
+/// @note When the `link` attribute is defined in the highlight definition
+///       map, other attributes will not be taking effect (see |:hi-link|).
 Dictionary nvim_get_hl(Integer ns_id, Dict(get_highlight) *opts, Arena *arena, Error *err)
   FUNC_API_SINCE(11)
 {
@@ -112,6 +115,10 @@ Dictionary nvim_get_hl(Integer ns_id, Dict(get_highlight) *opts, Arena *arena, E
 ///       which act as aliases to the corresponding foreground and background
 ///       values of the Normal group. If the Normal group has not been defined,
 ///       using these values results in an error.
+///
+///
+/// @note If `link` is used in combination with other attributes; only the
+///       `link` will take effect (see |:hi-link|).
 ///
 /// @param ns_id Namespace id for this highlight |nvim_create_namespace()|.
 ///              Use 0 to set a highlight group globally |:highlight|.

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -795,9 +795,9 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
   }
 
   HlGroup *g = &hl_table[idx];
+  g->sg_cleared = false;
 
   if (link_id > 0) {
-    g->sg_cleared = false;
     g->sg_link = link_id;
     g->sg_script_ctx = current_sctx;
     g->sg_script_ctx.sc_lnum += SOURCING_LNUM;
@@ -807,11 +807,10 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
       g->sg_deflink_sctx = current_sctx;
       g->sg_deflink_sctx.sc_lnum += SOURCING_LNUM;
     }
-    goto update;
+  } else {
+    g->sg_link = 0;
   }
 
-  g->sg_cleared = false;
-  g->sg_link = 0;
   g->sg_gui = attrs.rgb_ae_attr;
 
   g->sg_rgb_fg = attrs.rgb_fg_color;
@@ -863,7 +862,6 @@ void set_hl_group(int id, HlAttrs attrs, Dict(highlight) *dict, int link_id)
     }
   }
 
-update:
   if (!updating_screen) {
     redraw_all_later(UPD_NOT_VALID);
   }
@@ -1531,17 +1529,15 @@ static bool hlgroup2dict(Dictionary *hl, NS ns_id, int hl_id, Arena *arena)
   }
   HlAttrs attr =
     syn_attr2entry(ns_id == 0 ? sgp->sg_attr : ns_get_hl(&ns_id, hl_id, false, sgp->sg_set));
+  *hl = arena_dict(arena, HLATTRS_DICT_SIZE + 1);
   if (link > 0) {
-    *hl = arena_dict(arena, 1);
     PUT_C(*hl, "link", STRING_OBJ(cstr_as_string(hl_table[link - 1].sg_name)));
-  } else {
-    *hl = arena_dict(arena, HLATTRS_DICT_SIZE);
-    Dictionary hl_cterm = arena_dict(arena, HLATTRS_DICT_SIZE);
-    hlattrs2dict(hl, NULL, attr, true, true);
-    hlattrs2dict(hl, &hl_cterm, attr, false, true);
-    if (kv_size(hl_cterm)) {
-      PUT_C(*hl, "cterm", DICTIONARY_OBJ(hl_cterm));
-    }
+  }
+  Dictionary hl_cterm = arena_dict(arena, HLATTRS_DICT_SIZE);
+  hlattrs2dict(hl, NULL, attr, true, true);
+  hlattrs2dict(hl, &hl_cterm, attr, false, true);
+  if (kv_size(hl_cterm)) {
+    PUT_C(*hl, "cterm", DICTIONARY_OBJ(hl_cterm));
   }
   return true;
 }

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -561,4 +561,18 @@ describe('API: get highlight', function()
     eq({ link = 'String' }, meths.get_hl(0, { name = '@string' }))
     eq({ fg = 10937249 }, meths.get_hl(0, { name = '@string.cpp', link = false }))
   end)
+
+  it('can get all attributes for a linked group', function()
+    command('hi Bar guifg=red')
+    command('hi Foo guifg=#00ff00 gui=bold,underline')
+    command('hi! link Foo Bar')
+    eq({ link = 'Bar', fg = tonumber('00ff00', 16), bold = true, underline = true }, meths.get_hl(0, { name = 'Foo', link = true }))
+  end)
+
+  it('can set link as well as other attributes', function()
+    command('hi Bar guifg=red')
+    local hl = { link = 'Bar', fg = tonumber('00ff00', 16), bold = true, cterm = { bold = true } }
+    meths.set_hl(0, 'Foo', hl)
+    eq(hl, meths.get_hl(0, { name = 'Foo', link = true }))
+  end)
 end)


### PR DESCRIPTION
Highlight groups may have both their own attributes as well as being linked to another group. However, the new `nvim_get_hl(0, {link=true})` API will only show the link target name. The actual attributes for linked groups were previously still accessible through `nvim__get_hl_defs()`. And with its removal, the only way to find the actual attributes is through vimscript:

```vim
:hi Foo guifg=#ff0000 gui=bold,underline
:hi! link Foo Statement
:hi Foo
Foo            xxx gui=bold,underline guifg=#ff0000
                   links to Statement
```

This PR changes `hlgroup2dict()` such that it populates the dict with the hl group's actual attributes as well as the link target.

```vim
:lua =vim.api.nvim_get_hl(0, { name = "Foo", link = true })
{
  bold = true,
  fg = 16711680,
  link = "Statement",
  underline = true
}

" `link = false` still gets the effective attrs from the link target:
:lua =vim.api.nvim_get_hl(0, { name = "Foo", link = false })
{
  fg = 14192761
}
```

The PR also changes `set_hl_group()` such that one can set both a group's link target, as well as its attributes. ~~This makes it such that doing something like the following does *not* change a hl group:~~

```lua
vim.api.nvim_set_hl(0, "Foo", vim.api.nvim_get_hl(0, { name = "Foo", link = true }))
```

~~This seems like a desirable trait in my opinion, given the implied symmetry between these two API functions.~~

EDIT: This was a bad example, as it works the same currently, seeing as using `nvim_set_hl()` with `{link=...}` doesn't change the target's other attributes. However, I still think it's valuable to be able to set a group's attributes as well as it's link target, as this is possible in vimscript.
