### PR TITLE
refactor(loader): cache hash information

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2065,7 +2065,7 @@ find({modname}, {opts})                                    *vim.loader.find()*
           for `modname="*"`
 
 reset({path})                                             *vim.loader.reset()*
-    Resets the topmods cache for the path, or all the paths if path is nil.
+    Resets the cache for the path, or all the paths if path is nil.
 
     Parameters: ~
       • {path}  string? path to reset


### PR DESCRIPTION
Whenever we run fs_stat() on a path, save this information in the loader so it can be re-used.

- Loader.loadfile: Remove arguments `hash` as it is no longer needed.

- Loader.loader: Use _G.loadstring instead of Loader.load
  This allows plugins to wrap loadstring to inspection and profiling
