### PR TITLE
fix(diagnostic): use correct field name for tags

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -119,7 +119,7 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
       message = diagnostic.message,
       source = diagnostic.source,
       code = diagnostic.code,
-      tags = tags_lsp_to_vim(diagnostic, client_id),
+      _tags = tags_lsp_to_vim(diagnostic, client_id),
       user_data = {
         lsp = {
           -- usage of user_data.lsp.code is deprecated in favor of the top-level code field


### PR DESCRIPTION
This PR fixes a small issue with #22747 where LSP tags were moved to the top level of the diagnostic under the `tags` field but referred to as "_tags" in the diagnostic underline handler. This meant that the original PR essentially wasn't working.

@lewis6991 tagging you (not sure of the custom for the project) since you have the most context on that change. It could very well be that the inverse is desirable i.e. the tags are referred to as `_tags` throughout.