### PR TITLE
fix(startup): don't crash with start packages' after/ already in &rtp

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -914,19 +914,6 @@ static int add_pack_dir_to_rtp(char *fname, bool is_pack)
     const char *cur_entry = entry;
 
     copy_option_part((char **)&entry, buf, MAXPATHL, ",");
-    if (insp == NULL) {
-      add_pathsep(buf);
-      char *const rtp_ffname = fix_fname(buf);
-      if (rtp_ffname == NULL) {
-        goto theend;
-      }
-      bool match = path_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
-      xfree(rtp_ffname);
-      if (match) {
-        // Insert "ffname" after this entry (and comma).
-        insp = entry;
-      }
-    }
 
     if ((p = strstr(buf, "after")) != NULL
         && p > buf
@@ -939,6 +926,20 @@ static int add_pack_dir_to_rtp(char *fname, bool is_pack)
       }
       after_insp = cur_entry;
       break;
+    }
+
+    if (insp == NULL) {
+      add_pathsep(buf);
+      char *const rtp_ffname = fix_fname(buf);
+      if (rtp_ffname == NULL) {
+        goto theend;
+      }
+      bool match = path_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
+      xfree(rtp_ffname);
+      if (match) {
+        // Insert "ffname" after this entry (and comma).
+        insp = entry;
+      }
     }
   }
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -577,6 +577,12 @@ describe('startup', function()
     eq({'ordinary', 'FANCY', 'mittel', 'FANCY after', 'ordinary after'}, exec_lua [[ return _G.test_loadorder ]])
   end)
 
+  it("no crash with start packages' after/ already in &rtp #18240", function()
+    pack_clear [[ set loadplugins rtp=nosuchdir,test/functional/fixtures/pack/*/start/*/after | lua _G.test_loadorder = {} ]]
+    command [[ runtime! filen.lua ]]
+    eq({'FANCY', 'FANCY after'}, exec_lua [[ return _G.test_loadorder ]])
+  end)
+
   it("handles the correct order with globpath(&rtp, ...)", function()
     pack_clear [[ set loadplugins | lua _G.test_loadorder = {} ]]
     command [[


### PR DESCRIPTION
Problem:
Crash on startup with start packages' after/ already in &rtp.

Solution:
Check for after/ before matching directory name.

Fix #18240
