### PR TITLE
feat!: rename vim.loop -> vim.uv

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3927,8 +3927,8 @@ has({feature})	Returns 1 if {feature} is supported, 0 otherwise.  The
 		{feature} argument is a feature name like "nvim-0.2.1" or
 		"win32", see below.  See also |exists()|.
 
-		To get the system name use |vim.loop|.os_uname() in Lua: >
-			:lua print(vim.loop.os_uname().sysname)
+		To get the system name use |vim.uv|.os_uname() in Lua: >lua
+			print(vim.uv.os_uname().sysname)
 
 <		If the code has a syntax error then Vimscript may skip the
 		rest of the line.  Put |:if| and |:endif| on separate lines to

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -144,6 +144,7 @@ TREESITTER FUNCTIONS
 LUA
 - vim.register_keystroke_callback()	Use |vim.on_key()| instead.
 - *vim.pretty_print()*			Use |vim.print()| instead.
+- *vim.loop*				Use |vim.uv| instead.
 
 NORMAL COMMANDS
 - *]f* *[f*		Same as "gf".

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -105,7 +105,7 @@ API (EXTENSIBILITY/SCRIPTING/PLUGINS)
 |lua-guide|		Nvim Lua guide
 |lua|			Lua API
 |luaref|		Lua reference manual
-|luvref|		Luv (|vim.loop|) reference manual
+|luvref|		Luv (|vim.uv|) reference manual
 |autocmd|		Event handlers
 |job-control|		Spawn and control multiple processes
 |channel|		Nvim asynchronous IO

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -449,29 +449,24 @@ Note that underscore-prefixed functions (e.g. "_os_proc_children") are
 internal/private and must not be used by plugins.
 
 ------------------------------------------------------------------------------
-VIM.LOOP                                                   *lua-loop* *vim.loop*
+VIM.UV                                                   *lua-loop* *vim.uv*
 
-`vim.loop` exposes all features of the Nvim event-loop. This is a low-level
-API that provides functionality for networking, filesystem, and process
-management. Try this command to see available functions: >vim
-
-    :lua print(vim.inspect(vim.loop))
-<
-Internally, `vim.loop` wraps the "luv" Lua bindings for the LibUV library;
-see |luv-intro| for a full reference manual.
+`vim.uv` exposes the "luv" Lua bindings for the libUV library that Nvim uses
+for networking, filesystem, and process management, see |luvref.txt|.
+In particular, it allows interacting with the main Nvim |luv-event-loop|.
 
                                                     *E5560* *lua-loop-callbacks*
 It is an error to directly invoke `vim.api` functions (except |api-fast|) in
-`vim.loop` callbacks. For example, this is an error: >lua
+`vim.uv` callbacks. For example, this is an error: >lua
 
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     timer:start(1000, 0, function()
       vim.api.nvim_command('echomsg "test"')
     end)
 <
 To avoid the error use |vim.schedule_wrap()| to defer the callback: >lua
 
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     timer:start(1000, 0, vim.schedule_wrap(function()
       vim.api.nvim_command('echomsg "test"')
     end))
@@ -484,7 +479,7 @@ Example: repeating timer
     2. Execute it with ":luafile %". >lua
 
     -- Create a timer handle (implementation detail: uv_timer_t).
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     local i = 0
     -- Waits 1000ms, then repeats every 750ms until timer:close().
     timer:start(1000, 750, function()
@@ -504,7 +499,7 @@ Example: File-change detection                                    *watch-file*
     5. Observe that the file reloads in Nvim (because on_change() calls
        |:checktime|). >lua
 
-    local w = vim.loop.new_fs_event()
+    local w = vim.uv.new_fs_event()
     local function on_change(err, fname, status)
       -- Do work...
       vim.api.nvim_command('checktime')
@@ -528,11 +523,11 @@ Example: TCP echo-server                                          *tcp-server*
     4. Connect from any TCP client (e.g. "nc 0.0.0.0 36795"): >lua
 
     local function create_server(host, port, on_connect)
-      local server = vim.loop.new_tcp()
+      local server = vim.uv.new_tcp()
       server:bind(host, port)
       server:listen(128, function(err)
         assert(not err, err)  -- Check for errors.
-        local sock = vim.loop.new_tcp()
+        local sock = vim.uv.new_tcp()
         server:accept(sock)  -- Accept client connection.
         on_connect(sock)  -- Start reading messages.
       end)
@@ -553,14 +548,14 @@ Example: TCP echo-server                                          *tcp-server*
 Multithreading                                            *lua-loop-threading*
 
 Plugins can perform work in separate (os-level) threads using the threading
-APIs in luv, for instance `vim.loop.new_thread`. Note that every thread
+APIs in luv, for instance `vim.uv.new_thread`. Note that every thread
 gets its own separate lua interpreter state, with no access to lua globals
 in the main thread. Neither can the state of the editor (buffers, windows,
 etc) be directly accessed from threads.
 
 A subset of the `vim.*` API is available in threads. This includes:
 
-- `vim.loop` with a separate event loop per thread.
+- `vim.uv` with a separate event loop per thread.
 - `vim.mpack` and `vim.json` (useful for serializing messages between threads)
 - `require` in threads can use lua packages from the global |package.path|
 - `print()` and `vim.inspect`
@@ -885,7 +880,7 @@ vim.defer_fn({fn}, {timeout})                                   *vim.defer_fn*
       • {timeout}   Time in ms to wait before calling {fn}
 
     Returns: ~
-        |vim.loop|.new_timer() object
+        |vim.uv|.new_timer() object
 
 vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
     Wait for {time} in milliseconds until {callback} returns `true`.
@@ -2531,7 +2526,7 @@ find({names}, {opts})                                          *vim.fs.find()*
      -- location of Cargo.toml from the current buffer's path
      local cargo = vim.fs.find('Cargo.toml', {
        upward = true,
-       stop = vim.loop.os_homedir(),
+       stop = vim.uv.os_homedir(),
        path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
      })
 

--- a/runtime/doc/luvref.txt
+++ b/runtime/doc/luvref.txt
@@ -5,8 +5,8 @@
 
 								      *luvref*
 This file documents the Lua bindings for the LibUV library which is used for
-Nvim's event-loop and is accessible from Lua via |vim.loop| (e.g., |uv.version()|
-is exposed as `vim.loop.version()`).
+Nvim's event-loop and is accessible from Lua via |vim.uv| (e.g., |uv.version()|
+is exposed as `vim.uv.version()`).
 
 For information about this manual, see |luv-credits|.
 
@@ -29,7 +29,7 @@ TCP Echo Server Example ~
 Here is a small example showing a TCP echo server:
 
     >lua
-    local uv = vim.loop
+    local uv = vim.uv
 
     local server = uv.new_tcp()
     server:bind("127.0.0.1", 1337)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -109,4 +109,6 @@ release.
   - |nvim_win_get_option()|	Use |nvim_get_option_value()| instead.
   - |nvim_win_set_option()|	Use |nvim_set_option_value()| instead.
 
+• `vim.loop` has been renamed to `vim.uv`.
+
  vim:tw=78:ts=8:sw=2:et:ft=help:norl:

--- a/runtime/lua/_vim9script.lua
+++ b/runtime/lua/_vim9script.lua
@@ -513,7 +513,7 @@ vim9['import'] = (function()
 
   imported.absolute = setmetatable({}, {
     __index = function(self, name)
-      if vim.loop.fs_stat(name) then
+      if vim.uv.fs_stat(name) then
         local result = loadfile(name)()
         rawset(self, name, result)
 

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -21,13 +21,13 @@ end
 local function system(cmd_, silent, env)
   local stdout_data = {} ---@type string[]
   local stderr_data = {} ---@type string[]
-  local stdout = assert(vim.loop.new_pipe(false))
-  local stderr = assert(vim.loop.new_pipe(false))
+  local stdout = assert(vim.uv.new_pipe(false))
+  local stderr = assert(vim.uv.new_pipe(false))
 
   local done = false
   local exit_code ---@type integer?
 
-  -- We use the `env` command here rather than the env option to vim.loop.spawn since spawn will
+  -- We use the `env` command here rather than the env option to vim.uv.spawn since spawn will
   -- completely overwrite the environment when we just want to modify the existing one.
   --
   -- Overwriting mainly causes problems NixOS which relies heavily on a non-standard environment.
@@ -39,7 +39,7 @@ local function system(cmd_, silent, env)
   end
 
   local handle
-  handle = vim.loop.spawn(cmd[1], {
+  handle = vim.uv.spawn(cmd[1], {
     args = vim.list_slice(cmd, 2),
     stdio = { nil, stdout, stderr },
   }, function(code)

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -30,7 +30,7 @@ local function check_runtime()
   local bad_files_msg = ''
   for k, _ in pairs(bad_files) do
     local path = ('%s/%s'):format(vim.env.VIMRUNTIME, k)
-    if vim.loop.fs_stat(path) then
+    if vim.uv.fs_stat(path) then
       bad_files[k] = true
       bad_files_msg = ('%s%s\n'):format(bad_files_msg, path)
     end

--- a/runtime/lua/provider/health.lua
+++ b/runtime/lua/provider/health.lua
@@ -5,7 +5,7 @@ local ok = vim.health.ok
 local info = vim.health.info
 local warn = vim.health.warn
 local error = vim.health.error
-local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
+local iswin = vim.uv.os_uname().sysname == 'Windows_NT'
 
 local shell_error_code = 0
 local function shell_error()
@@ -30,7 +30,7 @@ local function isdir(path)
   if not path then
     return false
   end
-  local stat = vim.loop.fs_stat(path)
+  local stat = vim.uv.fs_stat(path)
   if not stat then
     return false
   end
@@ -41,7 +41,7 @@ local function isfile(path)
   if not path then
     return false
   end
-  local stat = vim.loop.fs_stat(path)
+  local stat = vim.uv.fs_stat(path)
   if not stat then
     return false
   end

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -42,6 +42,10 @@ for k, v in pairs({
   vim._submodules[k] = v
 end
 
+-- Remove at Nvim 1.0
+---@deprecated
+vim.loop = vim.uv
+
 -- There are things which have special rules in vim._init_packages
 -- for legacy reasons (uri) or for performance (_inspector).
 -- most new things should go into a submodule namespace ( vim.foobar.do_thing() )
@@ -159,7 +163,7 @@ do
   ---                - 3: ends the paste (exactly once)
   ---@returns boolean # false if client should cancel the paste.
   function vim.paste(lines, phase)
-    local now = vim.loop.now()
+    local now = vim.uv.now()
     local is_first_chunk = phase < 2
     local is_last_chunk = phase == -1 or phase == 3
     if is_first_chunk then -- Reset flags.
@@ -483,7 +487,7 @@ end
 ---@return table timer luv timer object
 function vim.defer_fn(fn, timeout)
   vim.validate({ fn = { fn, 'c', true } })
-  local timer = vim.loop.new_timer()
+  local timer = vim.uv.new_timer()
   timer:start(
     timeout,
     0,

--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -46,7 +46,7 @@ function M.watch(path, opts, callback)
 
   path = vim.fs.normalize(path)
   local uvflags = opts and opts.uvflags or {}
-  local handle, new_err = vim.loop.new_fs_event()
+  local handle, new_err = vim.uv.new_fs_event()
   assert(not new_err, new_err)
   local _, start_err = handle:start(path, uvflags, function(err, filename, events)
     assert(not err, err)
@@ -57,7 +57,7 @@ function M.watch(path, opts, callback)
     end
     local change_type = events.change and M.FileChangeType.Changed or 0
     if events.rename then
-      local _, staterr, staterrname = vim.loop.fs_stat(fullpath)
+      local _, staterr, staterrname = vim.uv.fs_stat(fullpath)
       if staterrname == 'ENOENT' then
         change_type = M.FileChangeType.Deleted
       else
@@ -99,7 +99,7 @@ local function poll_internal(path, opts, callback, watches)
   }
 
   if not watches.handle then
-    local poll, new_err = vim.loop.new_fs_poll()
+    local poll, new_err = vim.uv.new_fs_poll()
     assert(not new_err, new_err)
     watches.handle = poll
     local _, start_err = poll:start(

--- a/runtime/lua/vim/filetype/options.lua
+++ b/runtime/lua/vim/filetype/options.lua
@@ -34,7 +34,7 @@ local ft_option_cache = {} ---@type table<string,table<string,any>>
 --- @param path string
 --- @return integer
 local function hash(path)
-  local mtime0 = vim.loop.fs_stat(path).mtime
+  local mtime0 = vim.uv.fs_stat(path).mtime
   return mtime0.sec * 1000000000 + mtime0.nsec
 end
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local iswin = vim.loop.os_uname().sysname == 'Windows_NT'
+local iswin = vim.uv.os_uname().sysname == 'Windows_NT'
 
 --- Iterate over all the parents of the given file or directory.
 ---
@@ -106,12 +106,12 @@ function M.dir(path, opts)
   })
 
   if not opts.depth or opts.depth == 1 then
-    local fs = vim.loop.fs_scandir(M.normalize(path))
+    local fs = vim.uv.fs_scandir(M.normalize(path))
     return function()
       if not fs then
         return
       end
-      return vim.loop.fs_scandir_next(fs)
+      return vim.uv.fs_scandir_next(fs)
     end
   end
 
@@ -121,9 +121,9 @@ function M.dir(path, opts)
     while #dirs > 0 do
       local dir0, level = unpack(table.remove(dirs, 1))
       local dir = level == 1 and dir0 or M.joinpath(path, dir0)
-      local fs = vim.loop.fs_scandir(M.normalize(dir))
+      local fs = vim.uv.fs_scandir(M.normalize(dir))
       while fs do
-        local name, t = vim.loop.fs_scandir_next(fs)
+        local name, t = vim.uv.fs_scandir_next(fs)
         if not name then
           break
         end
@@ -158,7 +158,7 @@ end
 --- -- location of Cargo.toml from the current buffer's path
 --- local cargo = vim.fs.find('Cargo.toml', {
 ---   upward = true,
----   stop = vim.loop.os_homedir(),
+---   stop = vim.uv.os_homedir(),
 ---   path = vim.fs.dirname(vim.api.nvim_buf_get_name(0)),
 --- })
 ---
@@ -212,7 +212,7 @@ function M.find(names, opts)
 
   names = type(names) == 'string' and { names } or names
 
-  local path = opts.path or vim.loop.cwd()
+  local path = opts.path or vim.uv.cwd()
   local stop = opts.stop
   local limit = opts.limit or 1
 
@@ -244,7 +244,7 @@ function M.find(names, opts)
         local t = {}
         for _, name in ipairs(names) do
           local f = M.joinpath(p, name)
-          local stat = vim.loop.fs_stat(f)
+          local stat = vim.uv.fs_stat(f)
           if stat and (not opts.type or opts.type == stat.type) then
             t[#t + 1] = f
           end
@@ -337,7 +337,7 @@ function M.normalize(path, opts)
   })
 
   if path:sub(1, 1) == '~' then
-    local home = vim.loop.os_homedir() or '~'
+    local home = vim.uv.os_homedir() or '~'
     if home:sub(-1) == '\\' or home:sub(-1) == '/' then
       home = home:sub(1, -2)
     end
@@ -345,7 +345,7 @@ function M.normalize(path, opts)
   end
 
   if opts.expand_env == nil or opts.expand_env then
-    path = path:gsub('%$([%w_]+)', vim.loop.os_getenv)
+    path = path:gsub('%$([%w_]+)', vim.uv.os_getenv)
   end
 
   path = path:gsub('\\', '/'):gsub('/+', '/')

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv
 
 --- @type (fun(modename: string): fun()|string)[]
 local loaders = package.loaders
@@ -465,7 +465,7 @@ end
 --- @private
 function Loader.track(stat, f)
   return function(...)
-    local start = vim.loop.hrtime()
+    local start = vim.uv.hrtime()
     local r = { f(...) }
     Loader._stats[stat] = Loader._stats[stat] or { total = 0, time = 0 }
     Loader._stats[stat].total = Loader._stats[stat].total + 1

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -10,7 +10,7 @@ local semantic_tokens = require('vim.lsp.semantic_tokens')
 local api = vim.api
 local nvim_err_writeln, nvim_buf_get_lines, nvim_command, nvim_exec_autocmds =
   api.nvim_err_writeln, api.nvim_buf_get_lines, api.nvim_command, api.nvim_exec_autocmds
-local uv = vim.loop
+local uv = vim.uv
 local tbl_isempty, tbl_extend = vim.tbl_isempty, vim.tbl_extend
 local validate = vim.validate
 local if_nil = vim.F.if_nil

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -22,7 +22,7 @@ function M.check()
   local log_path = vim.lsp.get_log_path()
   report_info(string.format('Log path: %s', log_path))
 
-  local log_file = vim.loop.fs_stat(log_path)
+  local log_file = vim.uv.fs_stat(log_path)
   local log_size = log_file and log_file.size or 0
 
   local report_fn = (log_size / 1000000 > 100 and report_warn or report_info)

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -31,7 +31,7 @@ do
     end
   end
 
-  local path_sep = vim.loop.os_uname().version:match('Windows') and '\\' or '/'
+  local path_sep = vim.uv.os_uname().version:match('Windows') and '\\' or '/'
   ---@private
   local function path_join(...)
     return table.concat(vim.tbl_flatten({ ... }), path_sep)
@@ -68,7 +68,7 @@ do
       return false
     end
 
-    local log_info = vim.loop.fs_stat(logfilename)
+    local log_info = vim.uv.fs_stat(logfilename)
     if log_info and log_info.size > 1e9 then
       local warn_msg = string.format(
         'LSP client log is large (%d MB): %s',

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -1,4 +1,4 @@
-local uv = vim.loop
+local uv = vim.uv
 local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
 local validate, schedule, schedule_wrap = vim.validate, vim.schedule, vim.schedule_wrap
@@ -691,7 +691,7 @@ local function start(cmd, cmd_args, dispatchers, extra_spawn_params)
   })
 
   ---@private
-  --- Callback for |vim.loop.spawn()| Closes all streams and runs the `on_exit` dispatcher.
+  --- Callback for |vim.uv.spawn()| Closes all streams and runs the `on_exit` dispatcher.
   ---@param code (integer) Exit code
   ---@param signal (integer) Signal that was used to terminate (if any)
   local function onexit(code, signal)

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -2,7 +2,7 @@ local api = vim.api
 local bit = require('bit')
 local handlers = require('vim.lsp.handlers')
 local util = require('vim.lsp.util')
-local uv = vim.loop
+local uv = vim.uv
 
 --- @class STTokenRange
 --- @field line integer line number 0-based

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -4,7 +4,7 @@ local validate = vim.validate
 local api = vim.api
 local list_extend = vim.list_extend
 local highlight = require('vim.highlight')
-local uv = vim.loop
+local uv = vim.uv
 
 local npcall = vim.F.npcall
 local split = vim.split

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -51,7 +51,7 @@ end
 ---        trusted, or nil otherwise.
 function M.read(path)
   vim.validate({ path = { path, 's' } })
-  local fullpath = vim.loop.fs_realpath(vim.fs.normalize(path))
+  local fullpath = vim.uv.fs_realpath(vim.fs.normalize(path))
   if not fullpath then
     return nil
   end
@@ -149,13 +149,13 @@ function M.trust(opts)
 
   local fullpath
   if path then
-    fullpath = vim.loop.fs_realpath(vim.fs.normalize(path))
+    fullpath = vim.uv.fs_realpath(vim.fs.normalize(path))
   elseif bufnr then
     local bufname = vim.api.nvim_buf_get_name(bufnr)
     if bufname == '' then
       return false, 'buffer is not associated with a file'
     end
-    fullpath = vim.loop.fs_realpath(vim.fs.normalize(bufname))
+    fullpath = vim.uv.fs_realpath(vim.fs.normalize(bufname))
   else
     error('one of "path" or "bufnr" is required')
   end

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -170,11 +170,11 @@ end
 ---@param f fun(): R1, R2, R2
 ---@return integer, R1, R2, R3
 local function tcall(f, ...)
-  local start = vim.loop.hrtime()
+  local start = vim.uv.hrtime()
   ---@diagnostic disable-next-line
   local r = { f(...) }
   --- @type number
-  local duration = (vim.loop.hrtime() - start) / 1000000
+  local duration = (vim.uv.hrtime() - start) / 1000000
   return duration, unpack(r)
 end
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3238,7 +3238,7 @@ static bool has_wsl(void)
   static TriState has_wsl = kNone;
   if (has_wsl == kNone) {
     Error err = ERROR_INIT;
-    Object o = nlua_exec(STATIC_CSTR_AS_STRING("return vim.loop.os_uname()['release']:lower()"
+    Object o = nlua_exec(STATIC_CSTR_AS_STRING("return vim.uv.os_uname()['release']:lower()"
                                                ":match('microsoft') and true or false"),
                          (Array)ARRAY_DICT_INIT, &err);
     assert(!ERROR_SET(&err));

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -565,7 +565,7 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread, bool is_stan
   lua_setfield(lstate, LUA_REGISTRYINDEX, "mpack.empty_dict");
   lua_setfield(lstate, -2, "_empty_dict_mt");
 
-  // vim.loop
+  // vim.uv
   if (is_standalone) {
     // do nothing, use libluv like in a standalone interpreter
   } else if (is_thread) {
@@ -578,9 +578,9 @@ static void nlua_common_vim_init(lua_State *lstate, bool is_thread, bool is_stan
   }
   luaopen_luv(lstate);
   lua_pushvalue(lstate, -1);
-  lua_setfield(lstate, -3, "loop");
+  lua_setfield(lstate, -3, "uv");
 
-  // package.loaded.luv = vim.loop
+  // package.loaded.luv = vim.uv
   // otherwise luv will be reinitialized when require'luv'
   lua_getglobal(lstate, "package");
   lua_getfield(lstate, -1, "loaded");

--- a/test/benchmark/autocmd_spec.lua
+++ b/test/benchmark/autocmd_spec.lua
@@ -12,10 +12,10 @@ describe('autocmd perf', function()
     exec_lua([[
       out = {}
       function start()
-        ts = vim.loop.hrtime()
+        ts = vim.uv.hrtime()
       end
       function stop(name)
-        out[#out+1] = ('%14.6f ms - %s'):format((vim.loop.hrtime() - ts) / 1000000, name)
+        out[#out+1] = ('%14.6f ms - %s'):format((vim.uv.hrtime() - ts) / 1000000, name)
       end
     ]])
   end)

--- a/test/benchmark/iter_spec.lua
+++ b/test/benchmark/iter_spec.lua
@@ -35,9 +35,9 @@ describe('vim.iter perf', function()
     local stats = {}
     local result
     for _ = 1, N do
-      local tic = vim.loop.hrtime()
+      local tic = vim.uv.hrtime()
       result = f(input)
-      local toc = vim.loop.hrtime()
+      local toc = vim.uv.hrtime()
       stats[#stats + 1] = (toc - tic) / 1000000
     end
     table.sort(stats)

--- a/test/benchmark/treesitter_spec.lua
+++ b/test/benchmark/treesitter_spec.lua
@@ -37,7 +37,7 @@ describe('treesitter perf', function()
         return "qq" .. acc .. "q"
       end
 
-      local start = vim.loop.hrtime()
+      local start = vim.uv.hrtime()
       keys(mk_keys(10))
 
       for _ = 1, 100 do
@@ -45,7 +45,7 @@ describe('treesitter perf', function()
         vim.cmd'redraw!'
       end
 
-      return vim.loop.hrtime() - start
+      return vim.uv.hrtime() - start
     ]]
 
   end)

--- a/test/busted_runner.lua
+++ b/test/busted_runner.lua
@@ -1,4 +1,4 @@
-local platform = vim.loop.os_uname()
+local platform = vim.uv.os_uname()
 local deps_install_dir = os.getenv 'DEPS_INSTALL_DIR'
 local suffix = (platform and platform.sysname:lower():find'windows') and '.dll' or '.so'
 package.path = deps_install_dir.."/share/lua/5.1/?.lua;"..deps_install_dir.."/share/lua/5.1/?/init.lua;"..package.path

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -110,7 +110,7 @@ describe('startup', function()
       exec_lua [[
         local asan_options = os.getenv 'ASAN_OPTIONS'
         if asan_options ~= nil and asan_options ~= '' then
-          vim.loop.os_setenv('ASAN_OPTIONS', asan_options..':detect_leaks=0')
+          vim.uv.os_setenv('ASAN_OPTIONS', asan_options..':detect_leaks=0')
         end
       ]]
       -- nvim -l foo.lua -arg1 -- a b c

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -950,7 +950,7 @@ local test_name = arg[1]
 local timeout = arg[2]
 assert(type(test_name) == 'string', 'test_name must be specified as first arg.')
 
-local kill_timer = vim.loop.new_timer()
+local kill_timer = vim.uv.new_timer()
 kill_timer:start(timeout or 1e3, 0, function()
   kill_timer:stop()
   kill_timer:close()

--- a/test/functional/fixtures/start/nvim-leftpad/lua/async_leftpad.lua
+++ b/test/functional/fixtures/start/nvim-leftpad/lua/async_leftpad.lua
@@ -1,5 +1,5 @@
 return function (val, res)
   local handle
-  handle = vim.loop.new_async(function() _G[res] = require'leftpad'(val) handle:close() end)
+  handle = vim.uv.new_async(function() _G[res] = require'leftpad'(val) handle:close() end)
   handle:send()
 end

--- a/test/functional/lua/highlight_spec.lua
+++ b/test/functional/lua/highlight_spec.lua
@@ -24,7 +24,7 @@ describe('vim.highlight.on_yank', function()
   it('does not close timer twice', function()
     exec_lua([[
       vim.highlight.on_yank({timeout = 10, on_macro = true, event = {operator = "y"}})
-      vim.loop.sleep(10)
+      vim.uv.sleep(10)
       vim.schedule(function()
         vim.highlight.on_yank({timeout = 0, on_macro = true, event = {operator = "y"}})
       end)

--- a/test/functional/lua/loop_spec.lua
+++ b/test/functional/lua/loop_spec.lua
@@ -14,24 +14,24 @@ local retry = helpers.retry
 
 before_each(clear)
 
-describe('vim.loop', function()
+describe('vim.uv', function()
 
   it('version', function()
-    assert(funcs.luaeval('vim.loop.version()')>=72961, "libuv version too old")
-    matches("(%d+)%.(%d+)%.(%d+)", funcs.luaeval('vim.loop.version_string()'))
+    assert(funcs.luaeval('vim.uv.version()')>=72961, "libuv version too old")
+    matches("(%d+)%.(%d+)%.(%d+)", funcs.luaeval('vim.uv.version_string()'))
   end)
 
   it('timer', function()
     exec_lua('vim.api.nvim_set_var("coroutine_cnt", 0)', {})
 
     local code=[[
-      local loop = vim.loop
+      local uv = vim.uv
 
       local touch = 0
       local function wait(ms)
         local this = coroutine.running()
         assert(this)
-        local timer = loop.new_timer()
+        local timer = uv.new_timer()
         timer:start(ms, 0, vim.schedule_wrap(function ()
           timer:close()
           touch = touch + 1
@@ -73,7 +73,7 @@ describe('vim.loop', function()
 
     -- deferred API functions are disabled, as their safety can't be guaranteed
     exec_lua([[
-      local timer = vim.loop.new_timer()
+      local timer = vim.uv.new_timer()
       timer:start(20, 0, function ()
         _G.is_fast = vim.in_fast_event()
         timer:close()
@@ -101,7 +101,7 @@ describe('vim.loop', function()
     -- callbacks can be scheduled to be executed in the main event loop
     -- where the entire API is available
     exec_lua([[
-      local timer = vim.loop.new_timer()
+      local timer = vim.uv.new_timer()
       timer:start(20, 0, vim.schedule_wrap(function ()
         _G.is_fast = vim.in_fast_event()
         timer:close()
@@ -127,7 +127,7 @@ describe('vim.loop', function()
 
     -- fast (not deferred) API functions are allowed to be called directly
     exec_lua([[
-      local timer = vim.loop.new_timer()
+      local timer = vim.uv.new_timer()
       timer:start(20, 0, function ()
         timer:close()
         -- input is queued for processing after the callback returns
@@ -151,6 +151,6 @@ describe('vim.loop', function()
   end)
 
   it("is equal to require('luv')", function()
-    eq(true, exec_lua("return vim.loop == require('luv')"))
+    eq(true, exec_lua("return vim.uv == require('luv')"))
   end)
 end)

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -119,7 +119,7 @@ describe('print', function()
     exec_lua([[
       local cmd = ...
       function test()
-        local timer = vim.loop.new_timer()
+        local timer = vim.uv.new_timer()
         local done = false
         timer:start(10, 0, function()
           print("very fast")
@@ -130,7 +130,7 @@ describe('print', function()
         -- loop until we know for sure the callback has been executed
         while not done do
           os.execute(cmd)
-          vim.loop.run("nowait") -- fake os_breakcheck()
+          vim.uv.run("nowait") -- fake os_breakcheck()
         end
         print("very slow")
         vim.api.nvim_command("sleep 1m") -- force deferred event processing

--- a/test/functional/lua/thread_spec.lua
+++ b/test/functional/lua/thread_spec.lua
@@ -27,10 +27,10 @@ describe('thread', function()
 
   it('entry func is executed in protected mode', function()
     exec_lua [[
-      local thread = vim.loop.new_thread(function()
+      local thread = vim.uv.new_thread(function()
         error('Error in thread entry func')
       end)
-      vim.loop.thread_join(thread)
+      vim.uv.thread_join(thread)
     ]]
 
     screen:expect([[
@@ -51,17 +51,17 @@ describe('thread', function()
 
   it('callback is executed in protected mode', function()
     exec_lua [[
-      local thread = vim.loop.new_thread(function()
-        local timer = vim.loop.new_timer()
+      local thread = vim.uv.new_thread(function()
+        local timer = vim.uv.new_timer()
         local function ontimeout()
           timer:stop()
           timer:close()
           error('Error in thread callback')
         end
         timer:start(10, 0, ontimeout)
-        vim.loop.run()
+        vim.uv.run()
       end)
-      vim.loop.thread_join(thread)
+      vim.uv.thread_join(thread)
     ]]
 
     screen:expect([[
@@ -83,10 +83,10 @@ describe('thread', function()
   describe('print', function()
     it('works', function()
       exec_lua [[
-        local thread = vim.loop.new_thread(function()
+        local thread = vim.uv.new_thread(function()
           print('print in thread')
         end)
-        vim.loop.thread_join(thread)
+        vim.uv.thread_join(thread)
       ]]
 
       screen:expect([[
@@ -105,10 +105,10 @@ describe('thread', function()
 
     it('vim.inspect', function()
       exec_lua [[
-        local thread = vim.loop.new_thread(function()
+        local thread = vim.uv.new_thread(function()
           print(vim.inspect({1,2}))
         end)
-        vim.loop.thread_join(thread)
+        vim.uv.thread_join(thread)
       ]]
 
       screen:expect([[
@@ -140,13 +140,13 @@ describe('thread', function()
         function Thread_Test:do_test()
           local async
           local on_async = self.on_async
-          async = vim.loop.new_async(function(ret)
+          async = vim.uv.new_async(function(ret)
             on_async(ret)
             async:close()
           end)
           local thread =
-            vim.loop.new_thread(self.entry_func, async, self.entry_str, self.args)
-          vim.loop.thread_join(thread)
+            vim.uv.new_thread(self.entry_func, async, self.entry_str, self.args)
+          vim.uv.thread_join(thread)
         end
 
         Thread_Test.new = function(entry, on_async, ...)
@@ -175,10 +175,10 @@ describe('thread', function()
       eq({'notification', 'result', {true}}, next_msg())
     end)
 
-    it('loop', function()
+    it('uv', function()
       exec_lua [[
         local entry = function(async)
-          async:send(vim.loop.version())
+          async:send(vim.uv.version())
         end
         local on_async = function(ret)
           vim.rpcnotify(1, ret)
@@ -259,7 +259,7 @@ describe('threadpool', function()
       local after_work_fn = function(ret)
         vim.rpcnotify(1, 'result', ret)
       end
-      local work = vim.loop.new_work(work_fn, after_work_fn)
+      local work = vim.uv.new_work(work_fn, after_work_fn)
       work:queue()
     ]]
 
@@ -268,7 +268,7 @@ describe('threadpool', function()
 
   it('with invalid argument', function()
     local status = pcall_err(exec_lua, [[
-      local work = vim.loop.new_thread(function() end, function() end)
+      local work = vim.uv.new_thread(function() end, function() end)
       work:queue({})
     ]])
 
@@ -288,7 +288,7 @@ describe('threadpool', function()
     })
 
     exec_lua [[
-      local work = vim.loop.new_work(function() return {} end, function() end)
+      local work = vim.uv.new_work(function() return {} end, function() end)
       work:queue()
     ]]
 
@@ -319,7 +319,7 @@ describe('threadpool', function()
 
         function Threadpool_Test:do_test()
           local work =
-            vim.loop.new_work(self.work_fn, self.after_work)
+            vim.uv.new_work(self.work_fn, self.after_work)
           work:queue(self.work_fn_str, self.args)
         end
 
@@ -334,10 +334,10 @@ describe('threadpool', function()
       ]]
     end)
 
-    it('loop', function()
+    it('uv', function()
       exec_lua [[
         local work_fn = function()
-          return vim.loop.version()
+          return vim.uv.version()
         end
         local after_work_fn = function(ret)
           vim.rpcnotify(1, ret)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -882,7 +882,7 @@ describe('lua stdlib', function()
 
   it('vim.fn is allowed in "fast" context by some functions #18306', function()
     exec_lua([[
-      local timer = vim.loop.new_timer()
+      local timer = vim.uv.new_timer()
       timer:start(0, 0, function()
         timer:close()
         assert(vim.in_fast_event())
@@ -948,7 +948,7 @@ describe('lua stdlib', function()
     })
     screen:attach()
     exec_lua([[
-      timer = vim.loop.new_timer()
+      timer = vim.uv.new_timer()
       timer:start(20, 0, function ()
         -- notify ok (executed later when safe)
         vim.rpcnotify(chan, 'nvim_set_var', 'yy', {3, vim.NIL})
@@ -2481,7 +2481,7 @@ describe('lua stdlib', function()
         start_time = get_time()
 
         vim.g.timer_result = false
-        timer = vim.loop.new_timer()
+        timer = vim.uv.new_timer()
         timer:start(100, 0, vim.schedule_wrap(function()
           vim.g.timer_result = true
         end))
@@ -2503,7 +2503,7 @@ describe('lua stdlib', function()
         start_time = get_time()
 
         vim.g.timer_result = false
-        timer = vim.loop.new_timer()
+        timer = vim.uv.new_timer()
         timer:start(100, 0, vim.schedule_wrap(function()
           vim.g.timer_result = true
         end))
@@ -2546,17 +2546,17 @@ describe('lua stdlib', function()
 
     it('should allow waiting with no callback, explicit', function()
       eq(true, exec_lua [[
-        local start_time = vim.loop.hrtime()
+        local start_time = vim.uv.hrtime()
         vim.wait(50, nil)
-        return vim.loop.hrtime() - start_time > 25000
+        return vim.uv.hrtime() - start_time > 25000
       ]])
     end)
 
     it('should allow waiting with no callback, implicit', function()
       eq(true, exec_lua [[
-        local start_time = vim.loop.hrtime()
+        local start_time = vim.uv.hrtime()
         vim.wait(50)
-        return vim.loop.hrtime() - start_time > 25000
+        return vim.uv.hrtime() - start_time > 25000
       ]])
     end)
 

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -99,7 +99,7 @@ local function fake_lsp_server_setup(test_name, timeout_ms, options, settings)
         end;
       });
       workspace_folders = {{
-          uri = 'file://' .. vim.loop.cwd(),
+          uri = 'file://' .. vim.uv.cwd(),
           name = 'test_folder',
       }};
       on_init = function(client, result)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -65,7 +65,7 @@ describe('LSP', function()
             vim.v.progpath, '-l', fake_lsp_code, test_name;
           };
           workspace_folders = {{
-              uri = 'file://' .. vim.loop.cwd(),
+              uri = 'file://' .. vim.uv.cwd(),
               name = 'test_folder',
           }};
         }
@@ -2031,7 +2031,7 @@ describe('LSP', function()
         }
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
     end)
     it('Supports file creation in folder that needs to be created with CreateFile payload', function()
       local tmpfile = helpers.tmpname()
@@ -2047,7 +2047,7 @@ describe('LSP', function()
         }
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
     end)
     it('createFile does not touch file if it exists and ignoreIfExists is set', function()
       local tmpfile = helpers.tmpname()
@@ -2065,7 +2065,7 @@ describe('LSP', function()
         }
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
       eq('Dummy content', read_file(tmpfile))
     end)
     it('createFile overrides file if overwrite is set', function()
@@ -2085,7 +2085,7 @@ describe('LSP', function()
         }
       }
       exec_lua('vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16')
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
       eq('', read_file(tmpfile))
     end)
     it('DeleteFile delete file and buffer', function()
@@ -2106,7 +2106,7 @@ describe('LSP', function()
         }
       }
       eq(true, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit, 'utf-16'))
-      eq(false, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
       eq(false, exec_lua('return vim.api.nvim_buf_is_loaded(vim.fn.bufadd(...))', tmpfile))
     end)
     it('DeleteFile fails if file does not exist and ignoreIfNotExists is false', function()
@@ -2125,7 +2125,7 @@ describe('LSP', function()
         }
       }
       eq(false, pcall(exec_lua, 'vim.lsp.util.apply_workspace_edit(...)', edit))
-      eq(false, exec_lua('return vim.loop.fs_stat(...) ~= nil', tmpfile))
+      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', tmpfile))
     end)
   end)
 
@@ -2195,9 +2195,9 @@ describe('LSP', function()
         return vim.api.nvim_buf_get_lines(bufnr, 0, -1, true)
       ]], old, new)
       eq({'Test content'}, lines)
-      local exists = exec_lua('return vim.loop.fs_stat(...) ~= nil', old)
+      local exists = exec_lua('return vim.uv.fs_stat(...) ~= nil', old)
       eq(false, exists)
-      exists = exec_lua('return vim.loop.fs_stat(...) ~= nil', new)
+      exists = exec_lua('return vim.uv.fs_stat(...) ~= nil', new)
       eq(true, exists)
       os.remove(new)
     end)
@@ -2238,9 +2238,9 @@ describe('LSP', function()
 	return vim.fn.bufloaded(oldbufnr)
       ]], old_dir, new_dir, pathsep)
       eq(0, lines)
-      eq(false, exec_lua('return vim.loop.fs_stat(...) ~= nil', old_dir))
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', new_dir))
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', new_dir .. pathsep .. file))
+      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old_dir))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new_dir))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new_dir .. pathsep .. file))
       eq('Test content', read_file(new_dir .. pathsep .. file))
 
       os.remove(new_dir)
@@ -2258,7 +2258,7 @@ describe('LSP', function()
         vim.lsp.util.rename(old, new, { ignoreIfExists = true })
       ]], old, new)
 
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', old))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
       eq('New file', read_file(new))
 
       exec_lua([[
@@ -2268,7 +2268,7 @@ describe('LSP', function()
         vim.lsp.util.rename(old, new, { overwrite = false })
       ]], old, new)
 
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', old))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
       eq('New file', read_file(new))
     end)
     it('Does override target if overwrite is true', function()
@@ -2283,8 +2283,8 @@ describe('LSP', function()
         vim.lsp.util.rename(old, new, { overwrite = true })
       ]], old, new)
 
-      eq(false, exec_lua('return vim.loop.fs_stat(...) ~= nil', old))
-      eq(true, exec_lua('return vim.loop.fs_stat(...) ~= nil', new))
+      eq(false, exec_lua('return vim.uv.fs_stat(...) ~= nil', old))
+      eq(true, exec_lua('return vim.uv.fs_stat(...) ~= nil', new))
       eq('Old file\n', read_file(new))
     end)
   end)
@@ -3669,7 +3669,7 @@ describe('LSP', function()
   describe('cmd', function()
     it('can connect to lsp server via rpc.connect', function()
       local result = exec_lua [[
-        local uv = vim.loop
+        local uv = vim.uv
         local server = uv.new_tcp()
         local init = nil
         server:bind('127.0.0.1', 0)
@@ -3697,7 +3697,7 @@ describe('LSP', function()
   describe('handlers', function()
     it('handler can return false as response', function()
       local result = exec_lua [[
-        local uv = vim.loop
+        local uv = vim.uv
         local server = uv.new_tcp()
         local messages = {}
         local responses = {}

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1554,7 +1554,7 @@ describe('TUI', function()
   end)
 
   it('no assert failure on deadly signal #21896', function()
-    exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
+    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     screen:expect({any = '%[Process exited 1%]'})
   end)
 
@@ -1605,7 +1605,7 @@ describe('TUI', function()
       foo                                               |
       {3:-- TERMINAL --}                                    |
     ]])
-    exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigwinch')]])
+    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigwinch')]])
     screen:expect([[
       {1: }                                                 |
       {4:~                                                 }|
@@ -2517,7 +2517,7 @@ describe("TUI as a client", function()
 
     -- No heap-use-after-free when receiving UI events after deadly signal #22184
     server:request('nvim_input', ('a'):rep(1000))
-    exec_lua([[vim.loop.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
+    exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     screen:expect({any = '%[Process exited 1%]'})
 
     eq(0, meths.get_vvar('shell_error'))

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -182,11 +182,11 @@ void ui_refresh(void)
     local function q(n)
       return exec_lua ([[
         local query, n = ...
-        local before = vim.loop.hrtime()
+        local before = vim.uv.hrtime()
         for i=1,n,1 do
           cquery = vim.treesitter.query.parse("c", ...)
         end
-        local after = vim.loop.hrtime()
+        local after = vim.uv.hrtime()
         return after - before
       ]], long_query, n)
     end


### PR DESCRIPTION
## Problem

- `vim.loop` as a name is confusing and doesn't obviously map onto `uv`. This leads to a discontinuity in our docs since all luv functions are documented as `uv.*`.
- A common convention has developed to include `local uv = vim.loop` (even in our own codebase!). This makes searching for uv usages more difficult.

## Solution

- Rename `vim.loop` to `vim.uv`
- Add `vim.loop = vim.uv`
- Deprecate `vim.loop` (via emmy annotations only).

## Benefits

- Makes our documentation more consistent: references to `vim.uv.spawn` take you to the documentation of `uv.spawn`
- Makes searching for usages of `uv` easier: `grep uv\.spawn` vs `grep '(uv|loop)\.spawn)`
- Closer mapping to the backend API: `vim.uv.fs_stat()` -> `uv_fs_stat()`

## Cons

- More churn