### PR TITLE
vim-patch:9.0.1434: crash when adding package already in 'runtimepath'

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -914,19 +914,6 @@ static int add_pack_dir_to_rtp(char *fname, bool is_pack)
     const char *cur_entry = entry;
 
     copy_option_part((char **)&entry, buf, MAXPATHL, ",");
-    if (insp == NULL) {
-      add_pathsep(buf);
-      char *const rtp_ffname = fix_fname(buf);
-      if (rtp_ffname == NULL) {
-        goto theend;
-      }
-      bool match = path_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
-      xfree(rtp_ffname);
-      if (match) {
-        // Insert "ffname" after this entry (and comma).
-        insp = entry;
-      }
-    }
 
     if ((p = strstr(buf, "after")) != NULL
         && p > buf
@@ -939,6 +926,20 @@ static int add_pack_dir_to_rtp(char *fname, bool is_pack)
       }
       after_insp = cur_entry;
       break;
+    }
+
+    if (insp == NULL) {
+      add_pathsep(buf);
+      char *const rtp_ffname = fix_fname(buf);
+      if (rtp_ffname == NULL) {
+        goto theend;
+      }
+      bool match = path_fnamencmp(rtp_ffname, ffname, fname_len) == 0;
+      xfree(rtp_ffname);
+      if (match) {
+        // Insert "ffname" after this entry (and comma).
+        insp = entry;
+      }
     }
   }
 

--- a/test/old/testdir/test_packadd.vim
+++ b/test/old/testdir/test_packadd.vim
@@ -20,6 +20,13 @@ func Test_packadd()
   call mkdir(s:plugdir . '/plugin/also', 'p')
   call mkdir(s:plugdir . '/ftdetect', 'p')
   call mkdir(s:plugdir . '/after', 'p')
+
+  " This used to crash Vim
+  let &rtp = 'nosuchdir,' . s:plugdir . '/after'
+  packadd mytest
+  " plugdir should be inserted before plugdir/after
+  call assert_match('^nosuchdir,' . s:plugdir . ',', &rtp)
+
   set rtp&
   let rtp = &rtp
   filetype on


### PR DESCRIPTION
Fix #18240

#### vim-patch:9.0.1434: crash when adding package already in 'runtimepath'

Problem:    Crash when adding package already in 'runtimepath'.
Solution:   Change order for using 'runtimepath' entries. (closes vim/vim#12215)

https://github.com/vim/vim/commit/39c9ec16ea7ef13c5d783481542ee9aa6c05282c