### PR TITLE
fix(health): stop using deprecated ts.language.inspect_language()

### DIFF
--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -22,7 +22,7 @@ function M.check()
         )
       )
     else
-      local lang = ts.language.inspect_language(parsername)
+      local lang = ts.language.inspect(parsername)
       health.report_ok(
         string.format('Parser: %-10s ABI: %d, path: %s', parsername, lang._abi_version, parser)
       )


### PR DESCRIPTION
This fixes a deprecation warning when running `:checkhealth vim.treesitter`.

```
vim.treesitter.language.inspect_language() is deprecated, use vim.treesitter.language.inspect() instead. :help deprecated
This feature will be removed in Nvim version 0.10
stack traceback:
        .../path/to/share/nvim/runtime/lua/vim/treesitter/language.lua:139: in function 'inspect_language'
        .../path/to/share/nvim/runtime/lua/vim/treesitter/health.lua:25: in function 'check'
        [string "luaeval()"]:1: in main chunk
```