### PR TITLE
refactor: remove use of reserved c++ keywords

### DIFF
--- a/src/klib/klist.h
+++ b/src/klib/klist.h
@@ -38,7 +38,7 @@
     kmptype_t **buf; \
   } kmp_##name##_t; \
   static inline kmp_##name##_t *kmp_init_##name(void) { \
-    return xcalloc(1, sizeof(kmp_##name##_t)); \
+    return (kmp_##name##_t *)xcalloc(1, sizeof(kmp_##name##_t)); \
   } \
   static inline void kmp_destroy_##name(kmp_##name##_t *mp) \
   REAL_FATTR_UNUSED; \
@@ -52,7 +52,7 @@
   static inline kmptype_t *kmp_alloc_##name(kmp_##name##_t *mp) { \
     mp->cnt++; \
     if (mp->n == 0) { \
-      return xcalloc(1, sizeof(kmptype_t)); \
+      return (kmptype_t *)xcalloc(1, sizeof(kmptype_t)); \
     } \
     return mp->buf[--mp->n]; \
   } \
@@ -60,7 +60,7 @@
     mp->cnt--; \
     if (mp->n == mp->max) { \
       mp->max = mp->max ? (mp->max << 1) : 16; \
-      mp->buf = xrealloc(mp->buf, sizeof(kmptype_t *) * mp->max); \
+      mp->buf = (kmptype_t **)xrealloc(mp->buf, sizeof(kmptype_t *) * mp->max); \
     } \
     mp->buf[mp->n++] = p; \
   }
@@ -84,7 +84,7 @@
     size_t size; \
   } kl_##name##_t; \
   static inline kl_##name##_t *kl_init_##name(void) { \
-    kl_##name##_t *kl = xcalloc(1, sizeof(kl_##name##_t)); \
+    kl_##name##_t *kl = (kl_##name##_t *)xcalloc(1, sizeof(kl_##name##_t)); \
     kl->mp = kmp_init(name); \
     kl->head = kl->tail = kmp_alloc(name, kl->mp); \
     kl->head->next = 0; \

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1015,11 +1015,11 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   uint32_t argt = 0;
   int64_t def = -1;
   cmd_addr_T addr_type_arg = ADDR_NONE;
-  int comp = EXPAND_NOTHING;
-  char *comp_arg = NULL;
+  int context = EXPAND_NOTHING;
+  char *compl_arg = NULL;
   const char *rep = NULL;
   LuaRef luaref = LUA_NOREF;
-  LuaRef comp_luaref = LUA_NOREF;
+  LuaRef compl_luaref = LUA_NOREF;
   LuaRef preview_luaref = LUA_NOREF;
 
   VALIDATE_S(uc_validate_name(name.data), "command name", name.data, {
@@ -1161,12 +1161,12 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   }
 
   if (opts->complete.type == kObjectTypeLuaRef) {
-    comp = EXPAND_USER_LUA;
-    comp_luaref = api_new_luaref(opts->complete.data.luaref);
+    context = EXPAND_USER_LUA;
+    compl_luaref = api_new_luaref(opts->complete.data.luaref);
   } else if (opts->complete.type == kObjectTypeString) {
     VALIDATE_S(OK == parse_compl_arg(opts->complete.data.string.data,
-                                     (int)opts->complete.data.string.size, &comp, &argt,
-                                     &comp_arg),
+                                     (int)opts->complete.data.string.size, &context, &argt,
+                                     &compl_arg),
                "complete", opts->complete.data.string.data, {
       goto err;
     });
@@ -1204,10 +1204,10 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   }
 
   WITH_SCRIPT_CONTEXT(channel_id, {
-    if (uc_add_command(name.data, name.size, rep, argt, def, flags, comp, comp_arg, comp_luaref,
-                       preview_luaref, addr_type_arg, luaref, force) != OK) {
+    if (uc_add_command(name.data, name.size, rep, argt, def, flags, context, compl_arg,
+                       compl_luaref, preview_luaref, addr_type_arg, luaref, force) != OK) {
       api_set_error(err, kErrorTypeException, "Failed to create user command");
-      // Do not goto err, since uc_add_command now owns luaref, comp_luaref, and comp_arg
+      // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
     }
   });
 
@@ -1215,8 +1215,8 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
 
 err:
   NLUA_CLEAR_REF(luaref);
-  NLUA_CLEAR_REF(comp_luaref);
-  xfree(comp_arg);
+  NLUA_CLEAR_REF(compl_luaref);
+  xfree(compl_arg);
 }
 /// Gets a map of global (non-buffer-local) Ex commands.
 ///

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1015,11 +1015,11 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   uint32_t argt = 0;
   int64_t def = -1;
   cmd_addr_T addr_type_arg = ADDR_NONE;
-  int compl = EXPAND_NOTHING;
-  char *compl_arg = NULL;
+  int comp = EXPAND_NOTHING;
+  char *comp_arg = NULL;
   const char *rep = NULL;
   LuaRef luaref = LUA_NOREF;
-  LuaRef compl_luaref = LUA_NOREF;
+  LuaRef comp_luaref = LUA_NOREF;
   LuaRef preview_luaref = LUA_NOREF;
 
   VALIDATE_S(uc_validate_name(name.data), "command name", name.data, {
@@ -1161,12 +1161,12 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   }
 
   if (opts->complete.type == kObjectTypeLuaRef) {
-    compl = EXPAND_USER_LUA;
-    compl_luaref = api_new_luaref(opts->complete.data.luaref);
+    comp = EXPAND_USER_LUA;
+    comp_luaref = api_new_luaref(opts->complete.data.luaref);
   } else if (opts->complete.type == kObjectTypeString) {
     VALIDATE_S(OK == parse_compl_arg(opts->complete.data.string.data,
-                                     (int)opts->complete.data.string.size, &compl, &argt,
-                                     &compl_arg),
+                                     (int)opts->complete.data.string.size, &comp, &argt,
+                                     &comp_arg),
                "complete", opts->complete.data.string.data, {
       goto err;
     });
@@ -1204,10 +1204,10 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
   }
 
   WITH_SCRIPT_CONTEXT(channel_id, {
-    if (uc_add_command(name.data, name.size, rep, argt, def, flags, compl, compl_arg, compl_luaref,
+    if (uc_add_command(name.data, name.size, rep, argt, def, flags, comp, comp_arg, comp_luaref,
                        preview_luaref, addr_type_arg, luaref, force) != OK) {
       api_set_error(err, kErrorTypeException, "Failed to create user command");
-      // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
+      // Do not goto err, since uc_add_command now owns luaref, comp_luaref, and comp_arg
     }
   });
 
@@ -1215,8 +1215,8 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
 
 err:
   NLUA_CLEAR_REF(luaref);
-  NLUA_CLEAR_REF(compl_luaref);
-  xfree(compl_arg);
+  NLUA_CLEAR_REF(comp_luaref);
+  xfree(comp_arg);
 }
 /// Gets a map of global (non-buffer-local) Ex commands.
 ///

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -939,10 +939,10 @@ void do_autocmd(exarg_T *eap, char *arg_in, int forceit)
   xfree(envpat);
 }
 
-void do_all_autocmd_events(char *pat, bool once, int nested, char *cmd, bool delete, int group)
+void do_all_autocmd_events(char *pat, bool once, int nested, char *cmd, bool del, int group)
 {
   FOR_ALL_AUEVENTS(event) {
-    if (do_autocmd_event(event, pat, once, nested, cmd, delete, group)
+    if (do_autocmd_event(event, pat, once, nested, cmd, del, group)
         == FAIL) {
       return;
     }
@@ -956,12 +956,12 @@ void do_all_autocmd_events(char *pat, bool once, int nested, char *cmd, bool del
 // If *cmd == NUL: show entries.
 // If forceit == true: delete entries.
 // If group is not AUGROUP_ALL: only use this group.
-int do_autocmd_event(event_T event, char *pat, bool once, int nested, char *cmd, bool delete,
+int do_autocmd_event(event_T event, char *pat, bool once, int nested, char *cmd, bool del,
                      int group)
   FUNC_ATTR_NONNULL_ALL
 {
   // Cannot be used to show all patterns. See au_show_for_event or au_show_for_all_events
-  assert(*pat != NUL || delete);
+  assert(*pat != NUL || del);
 
   AutoPat *ap;
   AutoPat **prev_ap;
@@ -978,7 +978,7 @@ int do_autocmd_event(event_T event, char *pat, bool once, int nested, char *cmd,
   }
 
   // Delete all aupat for an event.
-  if (*pat == NUL && delete) {
+  if (*pat == NUL && del) {
     aupat_del_for_event_and_group(event, findgroup);
     return OK;
   }
@@ -999,7 +999,7 @@ int do_autocmd_event(event_T event, char *pat, bool once, int nested, char *cmd,
       patlen = (int)strlen(buflocal_pat);
     }
 
-    if (delete) {
+    if (del) {
       assert(*pat != NUL);
 
       // Find AutoPat entries with this pattern.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -399,13 +399,13 @@ void changed_bytes(linenr_T lnum, colnr_T col)
 /// insert/delete bytes at column
 ///
 /// Like changed_bytes() but also adjust extmark for "new" bytes.
-void inserted_bytes(linenr_T lnum, colnr_T col, int old, int new)
+void inserted_bytes(linenr_T lnum, colnr_T start_col, int old_col, int new_col)
 {
   if (curbuf_splice_pending == 0) {
-    extmark_splice_cols(curbuf, (int)lnum - 1, col, old, new, kExtmarkUndo);
+    extmark_splice_cols(curbuf, (int)lnum - 1, start_col, old_col, new_col, kExtmarkUndo);
   }
 
-  changed_bytes(lnum, col);
+  changed_bytes(lnum, start_col);
 }
 
 /// Appended "count" lines below line "lnum" in the current buffer.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -831,13 +831,12 @@ static void term_close(void *data)
   multiqueue_put(chan->events, term_delayed_free, 1, data);
 }
 
-void channel_info_changed(Channel *chan, bool new)
+void channel_info_changed(Channel *chan, bool new_chan)
 {
-  event_T event = new ? EVENT_CHANOPEN : EVENT_CHANINFO;
+  event_T event = new_chan ? EVENT_CHANOPEN : EVENT_CHANINFO;
   if (has_event(event)) {
     channel_incref(chan);
-    multiqueue_put(main_loop.events, set_info_event,
-                   2, chan, event);
+    multiqueue_put(main_loop.events, set_info_event, 2, chan, event);
   }
 }
 

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -121,7 +121,7 @@ EXTERN Callback on_print INIT(= CALLBACK_INIT);
 /// @returns Channel with the id or NULL if not found
 static inline Channel *find_channel(uint64_t id)
 {
-  return pmap_get(uint64_t)(&channels, id);
+  return (Channel *)pmap_get(uint64_t)(&channels, id);
 }
 
 static inline Stream *channel_instream(Channel *chan)

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3996,7 +3996,7 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
 
   if (!clear_env) {
     typval_T temp_env = TV_INITIAL_VALUE;
-    f_environ(NULL, &temp_env, (EvalFuncData){ .nullptr = NULL });
+    f_environ(NULL, &temp_env, (EvalFuncData){ .null = NULL });
     tv_dict_extend(env, temp_env.vval.v_dict, "force");
     tv_dict_free(temp_env.vval.v_dict);
 

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1117,28 +1117,28 @@ static int ff_check_visited(ff_visited_T **visited_list, char *fname, char *wc_p
 static ff_stack_T *ff_create_stack_element(char *fix_part, char *wc_part, int level,
                                            int star_star_empty)
 {
-  ff_stack_T *new = xmalloc(sizeof(ff_stack_T));
+  ff_stack_T *stack = xmalloc(sizeof(ff_stack_T));
 
-  new->ffs_prev          = NULL;
-  new->ffs_filearray     = NULL;
-  new->ffs_filearray_size = 0;
-  new->ffs_filearray_cur  = 0;
-  new->ffs_stage         = 0;
-  new->ffs_level         = level;
-  new->ffs_star_star_empty = star_star_empty;
+  stack->ffs_prev          = NULL;
+  stack->ffs_filearray     = NULL;
+  stack->ffs_filearray_size = 0;
+  stack->ffs_filearray_cur  = 0;
+  stack->ffs_stage         = 0;
+  stack->ffs_level         = level;
+  stack->ffs_star_star_empty = star_star_empty;
 
   // the following saves NULL pointer checks in vim_findfile
   if (fix_part == NULL) {
     fix_part = "";
   }
-  new->ffs_fix_path = xstrdup(fix_part);
+  stack->ffs_fix_path = xstrdup(fix_part);
 
   if (wc_part == NULL) {
     wc_part = "";
   }
-  new->ffs_wc_path = xstrdup(wc_part);
+  stack->ffs_wc_path = xstrdup(wc_part);
 
-  return new;
+  return stack;
 }
 
 /// Push a dir on the directory stack.

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -5428,10 +5428,9 @@ char *vim_tempname(void)
 
   // There is no need to check if the file exists, because we own the directory
   // and nobody else creates a file in it.
-  char template[TEMP_FILE_PATH_MAXLEN];
-  snprintf(template, TEMP_FILE_PATH_MAXLEN,
-           "%s%" PRIu64, tempdir, temp_count++);
-  return xstrdup(template);
+  char templ[TEMP_FILE_PATH_MAXLEN];
+  snprintf(templ, TEMP_FILE_PATH_MAXLEN, "%s%" PRIu64, tempdir, temp_count++);
+  return xstrdup(templ);
 }
 
 /// Tries matching a filename with a "pattern" ("prog" is NULL), or use the

--- a/src/nvim/generators/gen_eval.lua
+++ b/src/nvim/generators/gen_eval.lua
@@ -94,12 +94,12 @@ for _, name in ipairs(neworder) do
   end
   local base = def.base or "BASE_NONE"
   local func = def.func or ('f_' .. name)
-  local data = def.data or "{ .nullptr = NULL }"
+  local data = def.data or "{ .null = NULL }"
   local fast = def.fast and 'true' or 'false'
   hashpipe:write(('  { "%s", %s, %s, %s, %s, &%s, %s },\n')
                   :format(name, args[1], args[2], base, fast, func, data))
 end
-hashpipe:write('  { NULL, 0, 0, BASE_NONE, false, NULL, { .nullptr = NULL } },\n')
+hashpipe:write('  { NULL, 0, 0, BASE_NONE, false, NULL, { .null = NULL } },\n')
 hashpipe:write("};\n\n")
 hashpipe:write(hashfun)
 hashpipe:close()

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -657,22 +657,22 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, int cle
 void grid_alloc(ScreenGrid *grid, int rows, int columns, bool copy, bool valid)
 {
   int new_row;
-  ScreenGrid new = *grid;
+  ScreenGrid ngrid = *grid;
   assert(rows >= 0 && columns >= 0);
   size_t ncells = (size_t)rows * (size_t)columns;
-  new.chars = xmalloc(ncells * sizeof(schar_T));
-  new.attrs = xmalloc(ncells * sizeof(sattr_T));
-  new.line_offset = xmalloc((size_t)rows * sizeof(*new.line_offset));
-  new.line_wraps = xmalloc((size_t)rows * sizeof(*new.line_wraps));
+  ngrid.chars = xmalloc(ncells * sizeof(schar_T));
+  ngrid.attrs = xmalloc(ncells * sizeof(sattr_T));
+  ngrid.line_offset = xmalloc((size_t)rows * sizeof(*ngrid.line_offset));
+  ngrid.line_wraps = xmalloc((size_t)rows * sizeof(*ngrid.line_wraps));
 
-  new.rows = rows;
-  new.cols = columns;
+  ngrid.rows = rows;
+  ngrid.cols = columns;
 
-  for (new_row = 0; new_row < new.rows; new_row++) {
-    new.line_offset[new_row] = (size_t)new_row * (size_t)new.cols;
-    new.line_wraps[new_row] = false;
+  for (new_row = 0; new_row < ngrid.rows; new_row++) {
+    ngrid.line_offset[new_row] = (size_t)new_row * (size_t)ngrid.cols;
+    ngrid.line_wraps[new_row] = false;
 
-    grid_clear_line(&new, new.line_offset[new_row], columns, valid);
+    grid_clear_line(&ngrid, ngrid.line_offset[new_row], columns, valid);
 
     if (copy) {
       // If the screen is not going to be cleared, copy as much as
@@ -680,18 +680,18 @@ void grid_alloc(ScreenGrid *grid, int rows, int columns, bool copy, bool valid)
       // (used when resizing the window at the "--more--" prompt or when
       // executing an external command, for the GUI).
       if (new_row < grid->rows && grid->chars != NULL) {
-        int len = MIN(grid->cols, new.cols);
-        memmove(new.chars + new.line_offset[new_row],
+        int len = MIN(grid->cols, ngrid.cols);
+        memmove(ngrid.chars + ngrid.line_offset[new_row],
                 grid->chars + grid->line_offset[new_row],
                 (size_t)len * sizeof(schar_T));
-        memmove(new.attrs + new.line_offset[new_row],
+        memmove(ngrid.attrs + ngrid.line_offset[new_row],
                 grid->attrs + grid->line_offset[new_row],
                 (size_t)len * sizeof(sattr_T));
       }
     }
   }
   grid_free(grid);
-  *grid = new;
+  *grid = ngrid;
 
   // Share a single scratch buffer for all grids, by
   // ensuring it is as wide as the widest grid.

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1067,14 +1067,14 @@ static bool pum_enough_matches(void)
 {
   // Don't display the popup menu if there are no matches or there is only
   // one (ignoring the original text).
-  compl_T *compl = compl_first_match;
+  compl_T *comp = compl_first_match;
   int i = 0;
   do {
-    if (compl == NULL || (!match_at_original_text(compl) && ++i == 2)) {
+    if (comp == NULL || (!match_at_original_text(comp) && ++i == 2)) {
       break;
     }
-    compl = compl->cp_next;
-  } while (!is_first_match(compl));
+    comp = comp->cp_next;
+  } while (!is_first_match(comp));
 
   if (strstr(p_cot, "menuone") != NULL) {
     return i >= 1;
@@ -1138,7 +1138,7 @@ static int ins_compl_build_pum(void)
 {
   // Need to build the popup menu list.
   compl_match_arraysize = 0;
-  compl_T *compl = compl_first_match;
+  compl_T *comp = compl_first_match;
 
   // If it's user complete function and refresh_always,
   // do not use "compl_leader" as prefix filter.
@@ -1149,13 +1149,13 @@ static int ins_compl_build_pum(void)
   const int lead_len = compl_leader != NULL ? (int)strlen(compl_leader) : 0;
 
   do {
-    if (!match_at_original_text(compl)
+    if (!match_at_original_text(comp)
         && (compl_leader == NULL
-            || ins_compl_equal(compl, compl_leader, (size_t)lead_len))) {
+            || ins_compl_equal(comp, compl_leader, (size_t)lead_len))) {
       compl_match_arraysize++;
     }
-    compl = compl->cp_next;
-  } while (compl != NULL && !is_first_match(compl));
+    comp = comp->cp_next;
+  } while (comp != NULL && !is_first_match(comp));
 
   if (compl_match_arraysize == 0) {
     return -1;
@@ -1172,46 +1172,46 @@ static int ins_compl_build_pum(void)
   bool did_find_shown_match = false;
   int cur = -1;
   int i = 0;
-  compl = compl_first_match;
+  comp = compl_first_match;
   do {
-    if (!match_at_original_text(compl)
+    if (!match_at_original_text(comp)
         && (compl_leader == NULL
-            || ins_compl_equal(compl, compl_leader, (size_t)lead_len))) {
+            || ins_compl_equal(comp, compl_leader, (size_t)lead_len))) {
       if (!shown_match_ok) {
-        if (compl == compl_shown_match || did_find_shown_match) {
+        if (comp == compl_shown_match || did_find_shown_match) {
           // This item is the shown match or this is the
           // first displayed item after the shown match.
-          compl_shown_match = compl;
+          compl_shown_match = comp;
           did_find_shown_match = true;
           shown_match_ok = true;
         } else {
           // Remember this displayed match for when the
           // shown match is just below it.
-          shown_compl = compl;
+          shown_compl = comp;
         }
         cur = i;
       }
 
-      if (compl->cp_text[CPT_ABBR] != NULL) {
-        compl_match_array[i].pum_text = compl->cp_text[CPT_ABBR];
+      if (comp->cp_text[CPT_ABBR] != NULL) {
+        compl_match_array[i].pum_text = comp->cp_text[CPT_ABBR];
       } else {
-        compl_match_array[i].pum_text = compl->cp_str;
+        compl_match_array[i].pum_text = comp->cp_str;
       }
-      compl_match_array[i].pum_kind = compl->cp_text[CPT_KIND];
-      compl_match_array[i].pum_info = compl->cp_text[CPT_INFO];
-      if (compl->cp_text[CPT_MENU] != NULL) {
-        compl_match_array[i++].pum_extra = compl->cp_text[CPT_MENU];
+      compl_match_array[i].pum_kind = comp->cp_text[CPT_KIND];
+      compl_match_array[i].pum_info = comp->cp_text[CPT_INFO];
+      if (comp->cp_text[CPT_MENU] != NULL) {
+        compl_match_array[i++].pum_extra = comp->cp_text[CPT_MENU];
       } else {
-        compl_match_array[i++].pum_extra = compl->cp_fname;
+        compl_match_array[i++].pum_extra = comp->cp_fname;
       }
     }
 
-    if (compl == compl_shown_match) {
+    if (comp == compl_shown_match) {
       did_find_shown_match = true;
 
       // When the original text is the shown match don't set
       // compl_shown_match.
-      if (match_at_original_text(compl)) {
+      if (match_at_original_text(comp)) {
         shown_match_ok = true;
       }
 
@@ -1222,8 +1222,8 @@ static int ins_compl_build_pum(void)
         shown_match_ok = true;
       }
     }
-    compl = compl->cp_next;
-  } while (compl != NULL && !is_first_match(compl));
+    comp = comp->cp_next;
+  } while (comp != NULL && !is_first_match(comp));
 
   if (!shown_match_ok) {  // no displayed match at all
     cur = -1;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1053,7 +1053,7 @@ int utf_class_tab(const int c, const uint64_t *const chartab)
   static struct clinterval {
     unsigned int first;
     unsigned int last;
-    unsigned int class;
+    unsigned int cls;
   } classes[] = {
     { 0x037e, 0x037e, 1 },              // Greek question mark
     { 0x0387, 0x0387, 1 },              // Greek ano teleia
@@ -1154,7 +1154,7 @@ int utf_class_tab(const int c, const uint64_t *const chartab)
     } else if (classes[mid].first > (unsigned int)c) {
       top = mid - 1;
     } else {
-      return (int)classes[mid].class;
+      return (int)classes[mid].cls;
     }
   }
 

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -1014,17 +1014,17 @@ int os_file_mkdir(char *fname, int32_t mode)
 
 /// Create a unique temporary directory.
 ///
-/// @param[in] template Template of the path to the directory with XXXXXX
-///                     which would be replaced by random chars.
+/// @param[in] templ Template of the path to the directory with XXXXXX
+///                  which would be replaced by random chars.
 /// @param[out] path Path to created directory for success, undefined for
 ///                  failure.
 /// @return `0` for success, non-zero for failure.
-int os_mkdtemp(const char *template, char *path)
+int os_mkdtemp(const char *templ, char *path)
   FUNC_ATTR_NONNULL_ALL
 {
   uv_fs_t request;
   fs_loop_lock();
-  int result = uv_fs_mkdtemp(&fs_loop, &request, template, NULL);
+  int result = uv_fs_mkdtemp(&fs_loop, &request, templ, NULL);
   fs_loop_unlock();
   if (result == kLibuvSuccess) {
     xstrlcpy(path, request.path, TEMP_FILE_PATH_MAXLEN);

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -5252,9 +5252,9 @@ static regsubs_T *addstate_here(nfa_list_T *l, nfa_state_T *state, regsubs_T *su
 }
 
 // Check character class "class" against current character c.
-static int check_char_class(int class, int c)
+static int check_char_class(int cls, int c)
 {
-  switch (class) {
+  switch (cls) {
   case NFA_CLASS_ALNUM:
     if (c >= 1 && c < 128 && isalnum(c)) {
       return OK;
@@ -5353,7 +5353,7 @@ static int check_char_class(int class, int c)
 
   default:
     // should not be here :P
-    siemsg(_(e_ill_char_class), (int64_t)class);
+    siemsg(_(e_ill_char_class), (int64_t)cls);
     return FAIL;
   }
   return FAIL;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -896,13 +896,13 @@ static int term_moverect(VTermRect dest, VTermRect src, void *data)
   return 1;
 }
 
-static int term_movecursor(VTermPos new, VTermPos old, int visible, void *data)
+static int term_movecursor(VTermPos new_pos, VTermPos old_pos, int visible, void *data)
 {
   Terminal *term = data;
-  term->cursor.row = new.row;
-  term->cursor.col = new.col;
-  invalidate_terminal(term, old.row, old.row + 1);
-  invalidate_terminal(term, new.row, new.row + 1);
+  term->cursor.row = new_pos.row;
+  term->cursor.col = new_pos.col;
+  invalidate_terminal(term, old_pos.row, old_pos.row + 1);
+  invalidate_terminal(term, new_pos.row, new_pos.row + 1);
   return 1;
 }
 

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -634,7 +634,7 @@ static bool paragraph_start(linenr_T lnum)
 void auto_format(bool trailblank, bool prev_line)
 {
   colnr_T len;
-  char *new, *pnew;
+  char *linep, *plinep;
   int cc;
 
   if (!has_format_option(FO_AUTO)) {
@@ -705,13 +705,13 @@ void auto_format(bool trailblank, bool prev_line)
   // need to add a space when 'w' is in 'formatoptions' to keep a paragraph
   // formatted.
   if (!wasatend && has_format_option(FO_WHITE_PAR)) {
-    new = get_cursor_line_ptr();
-    len = (colnr_T)strlen(new);
+    linep = get_cursor_line_ptr();
+    len = (colnr_T)strlen(linep);
     if (curwin->w_cursor.col == len) {
-      pnew = xstrnsave(new, (size_t)len + 2);
-      pnew[len] = ' ';
-      pnew[len + 1] = NUL;
-      ml_replace(curwin->w_cursor.lnum, pnew, false);
+      plinep = xstrnsave(linep, (size_t)len + 2);
+      plinep[len] = ' ';
+      plinep[len + 1] = NUL;
+      ml_replace(curwin->w_cursor.lnum, plinep, false);
       // remove the space later
       did_add_space = true;
     } else {

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -30,7 +30,7 @@ typedef struct MsgpackRpcRequestHandler MsgpackRpcRequestHandler;
 typedef union {
   float_T (*float_func)(float_T);
   const MsgpackRpcRequestHandler *api_handler;
-  void *nullptr;
+  void *null;
 } EvalFuncData;
 
 typedef handle_T NS;

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -637,10 +637,10 @@ int parse_addr_type_arg(char *value, int vallen, cmd_addr_T *addr_type_arg)
 /// Parse a completion argument "value[vallen]".
 /// The detected completion goes in "*complp", argument type in "*argt".
 /// When there is an argument, for function and user defined completion, it's
-/// copied to allocated memory and stored in "*comp_arg".
+/// copied to allocated memory and stored in "*compl_arg".
 ///
 /// @return  FAIL if something is wrong.
-int parse_compl_arg(const char *value, int vallen, int *complp, uint32_t *argt, char **comp_arg)
+int parse_compl_arg(const char *value, int vallen, int *complp, uint32_t *argt, char **compl_arg)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *arg = NULL;
@@ -692,13 +692,13 @@ int parse_compl_arg(const char *value, int vallen, int *complp, uint32_t *argt, 
   }
 
   if (arg != NULL) {
-    *comp_arg = xstrnsave(arg, arglen);
+    *compl_arg = xstrnsave(arg, arglen);
   }
   return OK;
 }
 
 static int uc_scan_attr(char *attr, size_t len, uint32_t *argt, long *def, int *flags, int *complp,
-                        char **comp_arg, cmd_addr_T *addr_type_arg)
+                        char **compl_arg, cmd_addr_T *addr_type_arg)
   FUNC_ATTR_NONNULL_ALL
 {
   char *p;
@@ -809,7 +809,7 @@ invalid_count:
         return FAIL;
       }
 
-      if (parse_compl_arg(val, (int)vallen, complp, argt, comp_arg)
+      if (parse_compl_arg(val, (int)vallen, complp, argt, compl_arg)
           == FAIL) {
         return FAIL;
       }
@@ -857,12 +857,12 @@ char *uc_validate_name(char *name)
 
 /// Create a new user command {name}, if one doesn't already exist.
 ///
-/// This function takes ownership of comp_arg, comp_luaref, and luaref.
+/// This function takes ownership of compl_arg, compl_luaref, and luaref.
 ///
 /// @return  OK if the command is created, FAIL otherwise.
 int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, int64_t def,
-                   int flags, int comp, char *comp_arg, LuaRef comp_luaref, LuaRef preview_luaref,
-                   cmd_addr_T addr_type, LuaRef luaref, bool force)
+                   int flags, int context, char *compl_arg, LuaRef compl_luaref,
+                   LuaRef preview_luaref, cmd_addr_T addr_type, LuaRef luaref, bool force)
   FUNC_ATTR_NONNULL_ARG(1, 3)
 {
   ucmd_T *cmd = NULL;
@@ -944,12 +944,12 @@ int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, 
   cmd->uc_rep = rep_buf;
   cmd->uc_argt = argt;
   cmd->uc_def = def;
-  cmd->uc_compl = comp;
+  cmd->uc_compl = context;
   cmd->uc_script_ctx = current_sctx;
   cmd->uc_script_ctx.sc_lnum += SOURCING_LNUM;
   nlua_set_sctx(&cmd->uc_script_ctx);
-  cmd->uc_compl_arg = comp_arg;
-  cmd->uc_compl_luaref = comp_luaref;
+  cmd->uc_compl_arg = compl_arg;
+  cmd->uc_compl_luaref = compl_luaref;
   cmd->uc_preview_luaref = preview_luaref;
   cmd->uc_addr_type = addr_type;
   cmd->uc_luaref = luaref;
@@ -958,9 +958,9 @@ int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, 
 
 fail:
   xfree(rep_buf);
-  xfree(comp_arg);
+  xfree(compl_arg);
   NLUA_CLEAR_REF(luaref);
-  NLUA_CLEAR_REF(comp_luaref);
+  NLUA_CLEAR_REF(compl_luaref);
   NLUA_CLEAR_REF(preview_luaref);
   return FAIL;
 }
@@ -974,8 +974,8 @@ void ex_command(exarg_T *eap)
   uint32_t argt = 0;
   long def = -1;
   int flags = 0;
-  int comp = EXPAND_NOTHING;
-  char *comp_arg = NULL;
+  int context = EXPAND_NOTHING;
+  char *compl_arg = NULL;
   cmd_addr_T addr_type_arg = ADDR_NONE;
   int has_attr = (eap->arg[0] == '-');
   size_t name_len;
@@ -986,7 +986,7 @@ void ex_command(exarg_T *eap)
   while (*p == '-') {
     p++;
     end = skiptowhite(p);
-    if (uc_scan_attr(p, (size_t)(end - p), &argt, &def, &flags, &comp, &comp_arg,
+    if (uc_scan_attr(p, (size_t)(end - p), &argt, &def, &flags, &context, &compl_arg,
                      &addr_type_arg) == FAIL) {
       goto theend;
     }
@@ -1011,17 +1011,17 @@ void ex_command(exarg_T *eap)
     emsg(_("E183: User defined commands must start with an uppercase letter"));
   } else if (name_len <= 4 && strncmp(name, "Next", name_len) == 0) {
     emsg(_("E841: Reserved name, cannot be used for user defined command"));
-  } else if (comp > 0 && (argt & EX_EXTRA) == 0) {
+  } else if (context > 0 && (argt & EX_EXTRA) == 0) {
     emsg(_(e_complete_used_without_allowing_arguments));
   } else {
-    uc_add_command(name, name_len, p, argt, def, flags, comp, comp_arg, LUA_NOREF, LUA_NOREF,
+    uc_add_command(name, name_len, p, argt, def, flags, context, compl_arg, LUA_NOREF, LUA_NOREF,
                    addr_type_arg, LUA_NOREF, eap->forceit);
 
     return;  // success
   }
 
 theend:
-  xfree(comp_arg);
+  xfree(compl_arg);
 }
 
 /// ":comclear"

--- a/test/unit/fixtures/multiqueue.c
+++ b/test/unit/fixtures/multiqueue.c
@@ -7,13 +7,13 @@
 #include "multiqueue.h"
 
 
-void ut_multiqueue_put(MultiQueue *this, const char *str)
+void ut_multiqueue_put(MultiQueue *self, const char *str)
 {
-  multiqueue_put(this, NULL, 1, str);
+  multiqueue_put(self, NULL, 1, str);
 }
 
-const char *ut_multiqueue_get(MultiQueue *this)
+const char *ut_multiqueue_get(MultiQueue *self)
 {
-  Event event = multiqueue_get(this);
+  Event event = multiqueue_get(self);
   return event.argv[0];
 }


### PR DESCRIPTION
libnvim couldn't be easily used in C++ due to the use of reserved keywords.

Additionally, add explicit casts to *alloc function calls used in inline functions, as C++ doesn't allow implicit casts from void pointers.