### PR TITLE
feat(packaging): add start menu and desktop shortcuts on Windows

### DIFF
--- a/cmake.packaging/CMakeLists.txt
+++ b/cmake.packaging/CMakeLists.txt
@@ -34,8 +34,13 @@ if(WIN32)
   set(CPACK_WIX_UPGRADE_GUID "207A1A70-7B0C-418A-A153-CA6883E38F4D")
   set(CPACK_WIX_PRODUCT_ICON ${PROJECT_SOURCE_DIR}/runtime/neovim.ico)
 
-  # We use a wix patch to add further options to the installer. At present, it's just to add neovim to the path
-  # on installation, however, it can be extended.
+  # Create start menu and desktop shortcuts
+  set(CPACK_WIX_PROGRAM_MENU_FOLDER "${CPACK_PACKAGE_NAME}")
+  set(CPACK_PACKAGE_EXECUTABLES "nvim" "Neovim" "nvim-qt" "Neovim Qt")
+  set(CPACK_CREATE_DESKTOP_LINKS "nvim-qt")
+
+  # We use a wix patch to add further options to the installer. At present, it just adds neovim to the path
+  # on installation and defines per-user installation, however, it can be extended.
   # See: https://cmake.org/cmake/help/v3.7/module/CPackWIX.html#variable:CPACK_WIX_PATCH_FILE
   list(APPEND CPACK_WIX_EXTENSIONS WixUtilExtension)
   list(APPEND CPACK_WIX_PATCH_FILE ${CMAKE_CURRENT_LIST_DIR}/WixPatch.xml)

--- a/cmake.packaging/WixPatch.xml
+++ b/cmake.packaging/WixPatch.xml
@@ -1,14 +1,21 @@
 <CPackWiXPatch>
-    <!--  Fragment ID is from: <your build dir>/_CPack_Packages/win64/WIX/files.wxs -->
-    <CPackWiXFragment Id="CM_CP_bin.nvim.exe">
-      <Environment
-        Id='UpdatePath'
-        Name='PATH'
-        Action='set'
-        Permanent='no'
-        System='yes'
-        Part='last'
-        Value='[INSTALL_ROOT]bin'
-      />
-    </CPackWiXFragment>
+  <!--  Fragment ID is from: <your build dir>/_CPack_Packages/win64/WIX/files.wxs -->
+  <CPackWiXFragment Id="CM_CP_bin.nvim.exe">
+    <Environment
+      Id='UpdatePath'
+      Name='PATH'
+      Action='set'
+      Permanent='no'
+      System='no'
+      Part='last'
+      Value='[INSTALL_ROOT]bin'
+    />
+  </CPackWiXFragment>
+
+  <!-- Allow installation by non-administrative users -->
+  <!-- https://learn.microsoft.com/windows/win32/msi/allusers -->
+  <CPackWiXFragment Id="#PRODUCT">
+    <Property Id="ALLUSERS" Value="2" />
+    <Property Id="MSIINSTALLPERUSER" Value="1" />
+  </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
- Create start menu and desktop shortcuts
- Set installation context to *per-user*, allowing non-administrative users to install the MSI package
    - <https://learn.microsoft.com/windows/win32/msi/installation-context>
    - <https://learn.microsoft.com/windows/win32/msi/allusers>

Resolves #18119