### PR TITLE
feat(api): evaluate 'statuscolumn' with nvim_eval_statusline()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -773,6 +773,8 @@ nvim_eval_statusline({str}, {*opts})                  *nvim_eval_statusline()*
                 • use_tabline: (boolean) Evaluate tabline instead of
                   statusline. When true, {winid} is ignored. Mutually
                   exclusive with {use_winbar}.
+                • use_statuscol: (boolean) Evaluate statuscolumn instead of
+                  statusline.
 
     Return: ~
         Dictionary containing statusline information, with these keys:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -73,6 +73,9 @@ NEW FEATURES                                                    *news-features*
 
 The following new APIs or features were added.
 
+• |nvim_eval_statusline()| supports evaluating the |'statuscolumn'| through a
+  new `opts` field: `use_statuscol`.
+
 • |nvim_buf_get_extmarks()| now accepts a -1 `ns_id` to request extmarks from
   all namespaces and adds the namespace id to the details array.
   Other missing properties have been added to the details array and marks can

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -97,6 +97,7 @@ return {
     "highlights";
     "use_winbar";
     "use_tabline";
+    "use_statuscol";
   }};
   { 'option', {
     "scope";

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -959,12 +959,14 @@ bool set_mark(buf_T *buf, String name, Integer line, Integer col, Error *err)
 }
 
 /// Get default statusline highlight for window
-const char *get_default_stl_hl(win_T *wp, bool use_winbar)
+const char *get_default_stl_hl(win_T *wp, bool use_winbar, int stc_hl_id)
 {
   if (wp == NULL) {
     return "TabLineFill";
   } else if (use_winbar) {
     return (wp == curwin) ? "WinBar" : "WinBarNC";
+  } else if (stc_hl_id > 0) {
+    return syn_id2name(stc_hl_id);
   } else {
     return (wp == curwin) ? "StatusLine" : "StatusLineNC";
   }

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -386,7 +386,7 @@ next_mark:
 }
 
 void decor_redraw_signs(buf_T *buf, int row, int *num_signs, SignTextAttrs sattrs[],
-                        HlPriAttr *num_attrs, HlPriAttr *line_attrs, HlPriAttr *cul_attrs)
+                        HlPriId *num_id, HlPriId *line_id, HlPriId *cul_id)
 {
   if (!buf->b_signs) {
     return;
@@ -422,23 +422,23 @@ void decor_redraw_signs(buf_T *buf, int row, int *num_signs, SignTextAttrs sattr
       if (j < SIGN_SHOW_MAX) {
         sattrs[j] = (SignTextAttrs) {
           .text = decor->sign_text,
-          .hl_attr_id = decor->sign_hl_id == 0 ? 0 : syn_id2attr(decor->sign_hl_id),
+          .hl_id = decor->sign_hl_id,
           .priority = decor->priority
         };
         (*num_signs)++;
       }
     }
 
-    struct { HlPriAttr *dest; int hl; } cattrs[] = {
-      { line_attrs, decor->line_hl_id        },
-      { num_attrs,  decor->number_hl_id      },
-      { cul_attrs,  decor->cursorline_hl_id  },
+    struct { HlPriId *dest; int hl; } cattrs[] = {
+      { line_id, decor->line_hl_id        },
+      { num_id,  decor->number_hl_id      },
+      { cul_id,  decor->cursorline_hl_id  },
       { NULL, -1 },
     };
     for (int i = 0; cattrs[i].dest; i++) {
       if (cattrs[i].hl != 0 && decor->priority >= cattrs[i].dest->priority) {
-        *cattrs[i].dest = (HlPriAttr) {
-          .attr_id = syn_id2attr(cattrs[i].hl),
+        *cattrs[i].dest = (HlPriId) {
+          .hl_id = cattrs[i].hl,
           .priority = decor->priority
         };
       }

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -247,8 +247,8 @@ typedef struct {
 
 /// highlight attributes with associated priorities
 typedef struct {
-  int attr_id;
+  int hl_id;
   int priority;
-} HlPriAttr;
+} HlPriId;
 
 #endif  // NVIM_HIGHLIGHT_DEFS_H

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -491,8 +491,8 @@ SignTextAttrs *sign_get_attr(int idx, SignTextAttrs sattrs[], int max_signs)
 /// @param lnum Line in which to search
 /// @param sattrs Output array for attrs
 /// @return Number of signs of which attrs were found
-int buf_get_signattrs(buf_T *buf, linenr_T lnum, SignTextAttrs sattrs[], HlPriAttr *num_attrs,
-                      HlPriAttr *line_attrs, HlPriAttr *cul_attrs)
+int buf_get_signattrs(buf_T *buf, linenr_T lnum, SignTextAttrs sattrs[], HlPriId *num_id,
+                      HlPriId *line_id, HlPriId *cul_id)
 {
   sign_entry_T *sign;
 
@@ -517,21 +517,21 @@ int buf_get_signattrs(buf_T *buf, linenr_T lnum, SignTextAttrs sattrs[], HlPriAt
     if (sp->sn_text != NULL && sattr_matches < SIGN_SHOW_MAX) {
       sattrs[sattr_matches++] = (SignTextAttrs) {
         .text = sp->sn_text,
-        .hl_attr_id = sp->sn_text_hl == 0 ? 0 : syn_id2attr(sp->sn_text_hl),
+        .hl_id = sp->sn_text_hl,
         .priority = sign->se_priority
       };
     }
 
-    struct { HlPriAttr *dest; int hl; } cattrs[] = {
-      { line_attrs, sp->sn_line_hl },
-      { num_attrs,  sp->sn_num_hl  },
-      { cul_attrs,  sp->sn_cul_hl  },
+    struct { HlPriId *dest; int hl; } cattrs[] = {
+      { line_id, sp->sn_line_hl },
+      { num_id,  sp->sn_num_hl  },
+      { cul_id,  sp->sn_cul_hl  },
       { NULL, -1 },
     };
     for (int i = 0; cattrs[i].dest; i++) {
       if (cattrs[i].hl != 0 && sign->se_priority >= cattrs[i].dest->priority) {
-        *cattrs[i].dest = (HlPriAttr) {
-          .attr_id = syn_id2attr(cattrs[i].hl),
+        *cattrs[i].dest = (HlPriId) {
+          .hl_id = cattrs[i].hl,
           .priority = sign->se_priority
         };
       }

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -35,7 +35,7 @@ struct sign_entry {
 /// Sign attributes. Used by the screen refresh routines.
 typedef struct {
   char *text;
-  int hl_attr_id;
+  int hl_id;
   int priority;
 } SignTextAttrs;
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1512,7 +1512,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
 
     case STL_LINE:
       // Overload %l with v:lnum for 'statuscolumn'
-      if (opt_name != NULL && strcmp(opt_name, "statuscolumn") == 0) {
+      if (stcp != NULL) {
         if (wp->w_p_nu && !get_vim_var_nr(VV_VIRTNUM)) {
           num = (int)get_vim_var_nr(VV_LNUM);
         }
@@ -1617,7 +1617,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
     case STL_ROFLAG:
     case STL_ROFLAG_ALT:
       // Overload %r with v:relnum for 'statuscolumn'
-      if (opt_name != NULL && strcmp(opt_name, "statuscolumn") == 0) {
+      if (stcp != NULL) {
         if (wp->w_p_rnu && !get_vim_var_nr(VV_VIRTNUM)) {
           num = (int)get_vim_var_nr(VV_RELNUM);
         }
@@ -1652,7 +1652,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       char *p;
       if (fold) {
         size_t n = fill_foldcolumn(out_p, wp, stcp->foldinfo, (linenr_T)get_vim_var_nr(VV_LNUM));
-        stl_items[curitem].minwid = win_hl_attr(wp, stcp->use_cul ? HLF_CLF : HLF_FC);
+        stl_items[curitem].minwid = -((stcp->use_cul ? HLF_CLF : HLF_FC) + 1);
         p = out_p;
         p[n] = NUL;
       }
@@ -1668,9 +1668,8 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
         } else if (!fold) {
           SignTextAttrs *sattr = virtnum ? NULL : sign_get_attr(i, stcp->sattrs, wp->w_scwidth);
           p = sattr && sattr->text ? sattr->text : "  ";
-          stl_items[curitem].minwid = sattr ? stcp->sign_cul_attr ? stcp->sign_cul_attr
-                                                                  : sattr->hl_attr_id
-                                            : win_hl_attr(wp, stcp->use_cul ? HLF_CLS : HLF_SC);
+          stl_items[curitem].minwid = -(sattr ? stcp->sign_cul_id ? stcp->sign_cul_id
+                                        : sattr->hl_id : (stcp->use_cul ? HLF_CLS : HLF_SC) + 1);
         }
         stl_items[curitem].type = Highlight;
         stl_items[curitem].start = out_p + strlen(buf_tmp);

--- a/src/nvim/statusline_defs.h
+++ b/src/nvim/statusline_defs.h
@@ -62,8 +62,8 @@ typedef struct statuscol statuscol_T;
 struct statuscol {
   int width;                           ///< width of the status column
   int cur_attr;                        ///< current attributes in text
-  int num_attr;                        ///< attributes used for line number
-  int sign_cul_attr;                   ///< cursorline sign attr
+  int num_attr;                        ///< default highlight attr
+  int sign_cul_id;                     ///< cursorline sign highlight id
   int truncate;                        ///< truncated width
   bool draw;                           ///< whether to draw the statuscolumn
   bool use_cul;                        ///< whether to use cursorline attrs

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3421,6 +3421,40 @@ describe('API', function()
             'TextWithNoHighlight%#WarningMsg#TextWithWarningHighlight',
             { use_winbar = true, highlights = true }))
       end)
+      it('works with statuscolumn', function()
+        command([[
+          let &stc='%C%s%=%l '
+          set cul nu nuw=3 scl=yes:2 fdc=2
+          call setline(1, repeat(['aaaaa'], 5))
+          let g:ns = nvim_create_namespace('')
+          call sign_define('a', {'text':'aa', 'texthl':'IncSearch', 'numhl':'Normal'})
+          call sign_place(2, 1, 'a', bufnr(), {'lnum':4})
+          call nvim_buf_set_extmark(0, g:ns, 3, 1, { 'sign_text':'bb', 'sign_hl_group':'ErrorMsg' })
+          1,5fold | 1,5 fold | foldopen!
+        ]])
+        command('norm 4G')
+        command('let v:lnum=4')
+        eq({
+          str = '││aabb 4 ',
+          width = 9,
+          highlights = {
+            { group = 'CursorLineFold', start = 0 },
+            { group = 'Normal', start = 6 },
+            { group = 'IncSearch', start = 6 },
+            { group = 'ErrorMsg', start = 8 },
+            { group = 'Normal', start = 10 }
+          }
+        }, meths.eval_statusline('%C%s%=%l ', { use_statuscol = true, highlights = true }))
+        command('let v:lnum=3')
+        eq({
+          str = '3 ' ,
+          width = 2,
+          highlights = {
+            { group = 'LineNr', start = 0 },
+            { group = 'ErrorMsg', start = 1 }
+          }
+        }, meths.eval_statusline('%l%#ErrorMsg# ', { use_statuscol = true, highlights = true }))
+      end)
       it('no memory leak with click functions', function()
         meths.eval_statusline('%@ClickFunc@StatusLineStringWithClickFunc%T', {})
         eq({


### PR DESCRIPTION
Also refactor `HlPriAttr` and `SignTextAttrs` to store the highlight id rather than the attrs to enable making statuscolumn highlight section handling more aligned with statusline.