### PR TITLE
perf(runtime/filetype): simplify strace regex

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1550,7 +1550,7 @@ local patterns_text = {
   ['^SNNS pattern definition file'] = 'snnspat',
   ['^SNNS result file'] = 'snnsres',
   ['^%%.-[Vv]irata'] = { 'virata', { start_lnum = 1, end_lnum = 5 } },
-  ['[0-9:%.]* *execve%('] = 'strace',
+  ['execve%('] = 'strace',
   ['^__libc_start_main'] = 'strace',
   -- VSE JCL
   ['^\\* $$ JOB\\>'] = { 'vsejcl', { vim_regex = true } },


### PR DESCRIPTION
I noticed that for files containing a single large line, such as genome or bit string data, the `filetype` detection function feeds the entire line to a set of regular expressions, which can cause significant performance issues. 

To address this, I have added a change to cap the line length at 1000 characters, which should be sufficient to determine the file type based on the regex currently implemented. This fix will prevent it from hanging for extended periods of time when dealing with large, single-line files.