### PR TITLE
refactor(defaults)!: change default 'commentstring' value to empty

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -66,6 +66,8 @@ The following changes may require adaptations in user config or plugins.
   change is that language-specific highlight groups need to be renamed from
   `@foo.help` to `@foo.vimdoc`.
 
+• The default value of 'commentstring' is now empty instead of "/*%s*/".
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1390,7 +1390,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	insert a space.
 
 					*'commentstring'* *'cms'* *E537*
-'commentstring' 'cms'	string	(default "/*%s*/")
+'commentstring' 'cms'	string	(default "")
 			local to buffer
 	A template for a comment.  The "%s" in the value is replaced with the
 	comment text.  Currently only used to add markers for folding, see

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -34,6 +34,7 @@ Defaults					            *nvim-defaults*
 - 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/state/nvim/backup// (|xdg|), auto-created
 - 'belloff' defaults to "all"
+- 'commentstring' defaults to ""
 - 'compatible' is always disabled
 - 'complete' excludes "i"
 - 'directory' defaults to ~/.local/state/nvim/swap// (|xdg|), auto-created

--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'

--- a/runtime/ftplugin/calender.lua
+++ b/runtime/ftplugin/calender.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'

--- a/runtime/ftplugin/css.lua
+++ b/runtime/ftplugin/css.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'

--- a/runtime/ftplugin/indent.lua
+++ b/runtime/ftplugin/indent.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'

--- a/runtime/ftplugin/xdefaults.lua
+++ b/runtime/ftplugin/xdefaults.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -413,7 +413,7 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_cms',
-      defaults={if_true="/*%s*/"}
+      defaults={if_true=""}
     },
     {
       full_name='compatible', abbreviation='cp',

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -75,7 +75,7 @@ local function reopenwithfolds(b)
   local tick = reopen(b, origlines)
 
   -- use markers for folds, make all folds open by default
-  command('setlocal foldmethod=marker foldlevel=20')
+  command('setlocal foldmethod=marker foldlevel=20 commentstring=/*%s*/')
 
   -- add a fold
   command('2,4fold')

--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -116,6 +116,7 @@ describe('splitkeep', function()
   -- oldtest: Test_splitkeep_fold()
   it('does not scroll when window has closed folds', function()
     exec([[
+      set commentstring=/*%s*/
       set splitkeep=screen
       set foldmethod=marker
       set number

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -2032,8 +2032,11 @@ describe("folded lines", function()
   end)
 
   it('multibyte fold markers work #20438', function()
-    meths.win_set_option(0, 'foldmethod', 'marker')
-    meths.win_set_option(0, 'foldmarker', '«,»')
+    exec([[
+      setlocal foldmethod=marker
+      setlocal foldmarker=«,»
+      setlocal commentstring=/*%s*/
+    ]])
     insert([[
       bbbbb
       bbbbb

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -1,6 +1,7 @@
 if exists('s:did_load')
   " Align Nvim defaults to Vim.
   set backspace=
+  set commentstring=/*%s*/
   set complete=.,w,b,u,t,i
   set directory&
   set directory^=.


### PR DESCRIPTION
This will break the following ftplugins:
- c.vim
- calender.vim
- css.vim
- indent.vim
- xdefaults.vim
