### PR TITLE
fix(api): do not re-apply win_config.style when missing

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3066,8 +3066,8 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                       In general, values below 100 are recommended, unless
                       there is a good reason to overshadow builtin elements.
 
-                  • style: Configure the appearance of the window. Currently
-                    only takes one non-empty value:
+                  • style: (optional) Configure the appearance of the window.
+                    Currently only supports one value:
                     • "minimal" Nvim will display the window with many UI
                       options disabled. This is useful when displaying a
                       temporary float where the text should not be edited.

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -108,8 +108,8 @@
 ///     The default value for floats are 50.  In general, values below 100 are
 ///     recommended, unless there is a good reason to overshadow builtin
 ///     elements.
-///   - style: Configure the appearance of the window. Currently only takes
-///       one non-empty value:
+///   - style: (optional) Configure the appearance of the window. Currently
+///       only supports one value:
 ///       - "minimal"  Nvim will display the window with many UI options
 ///                    disabled. This is useful when displaying a temporary
 ///                    float where the text should not be edited. Disables
@@ -222,9 +222,11 @@ void nvim_win_set_config(Window window, Dict(float_config) *config, Error *err)
     win_config_float(win, fconfig);
     win->w_pos_changed = true;
   }
-  if (fconfig.style == kWinStyleMinimal) {
-    win_set_minimal_style(win);
-    didset_window_options(win, true);
+  if (HAS_KEY(config->style)) {
+    if (fconfig.style == kWinStyleMinimal) {
+      win_set_minimal_style(win);
+      didset_window_options(win, true);
+    }
   }
 }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -432,6 +432,25 @@ describe('float window', function()
     assert_alive()
   end)
 
+  it("should re-apply 'style' when present", function()
+    local float_opts = {style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_win = meths.open_win(0, true, float_opts)
+    meths.win_set_option(float_win, 'number', true)
+    float_opts.row = 2
+    meths.win_set_config(float_win, float_opts)
+    eq(false, meths.win_get_option(float_win, 'number'))
+  end)
+
+  it("should not re-apply 'style' when missing", function()
+    local float_opts = {style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_win = meths.open_win(0, true, float_opts)
+    meths.win_set_option(float_win, 'number', true)
+    float_opts.row = 2
+    float_opts.style = nil
+    meths.win_set_config(float_win, float_opts)
+    eq(true, meths.win_get_option(float_win, 'number'))
+  end)
+
   it("'scroll' is computed correctly when opening float with splitkeep=screen #20684", function()
     meths.set_option('splitkeep', 'screen')
     local float_opts = {relative = 'editor', row = 1, col = 1, width = 10, height = 10}


### PR DESCRIPTION
> **Note**
> For `0.10` release

resolves https://github.com/neovim/neovim/issues/20370