### PR TITLE
vim-patch:9.0.1439: start Insert mode when accessing a hidden prompt buffer

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1495,7 +1495,9 @@ void aucmd_restbuf(aco_save_T *aco)
       }
     }
 win_found:
-
+    // May need to stop Insert mode if we were in a prompt buffer.
+    leaving_window(curwin);
+    // Remove the window.
     win_remove(curwin, NULL);
     pmap_del(handle_T)(&window_handles, curwin->handle);
     if (curwin->w_grid_alloc.chars != NULL) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2417,7 +2417,7 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
   }
 }
 
-static void leaving_window(win_T *const win)
+void leaving_window(win_T *const win)
   FUNC_ATTR_NONNULL_ALL
 {
   // Only matters for a prompt window.


### PR DESCRIPTION
#### vim-patch:9.0.1439: start Insert mode when accessing a hidden prompt buffer

Problem:    Start Insert mode when accessing a hidden prompt buffer.
Solution:   Call leaving_window() in aucmd_restbuf(). (Thorben Tröbst,
            closes vim/vim#12148)

https://github.com/vim/vim/commit/cde8de034524d00aba4ff4142e658baff511e12d

Cherry-pick test_prompt_buffer.vim changes from patch 9.0.0631.

Co-authored-by: orbital <orbital@holgerines.de>