### PR TITLE
vim-patch:9.0.1438: .fs files are falsely recognized as forth files

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -473,12 +473,12 @@ function M.fs(bufnr)
   if vim.g.filetype_fs then
     return vim.g.filetype_fs
   end
-  local line = nextnonblank(bufnr, 1)
-  if findany(line, { '^%s*%.?%( ', '^%s*\\G? ', '^\\$', '^%s*: %S' }) then
-    return 'forth'
-  else
-    return 'fsharp'
+  for _, line in ipairs(getlines(bufnr, 1, 100)) do
+    if line:find('^[:(\\] ') then
+      return 'forth'
+    end
   end
+  return 'fsharp'
 end
 
 function M.git(bufnr)

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1227,23 +1227,7 @@ func Test_fs_file()
   call assert_equal('forth', &filetype)
   bwipe!
 
-  call writefile(['.( Forth displayed inline comment )'], 'Xfile.fs')
-  split Xfile.fs
-  call assert_equal('forth', &filetype)
-  bwipe!
-
   call writefile(['\ Forth line comment'], 'Xfile.fs')
-  split Xfile.fs
-  call assert_equal('forth', &filetype)
-  bwipe!
-
-  " empty line comment - no space required
-  call writefile(['\'], 'Xfile.fs')
-  split Xfile.fs
-  call assert_equal('forth', &filetype)
-  bwipe!
-
-  call writefile(['\G Forth documentation comment '], 'Xfile.fs')
   split Xfile.fs
   call assert_equal('forth', &filetype)
   bwipe!


### PR DESCRIPTION
Problem:    .fs files are falsely recognized as forth files.
Solution:   Check 100 lines for something that looks like forth. (Johan
            Kotlinski, closes vim/vim#12219, closes vim/vim#11988)

https://github.com/vim/vim/commit/065088d5549e7711668321cc5a77c9a9b684b142

Co-authored-by: Johan Kotlinski <kotlinski@gmail.com>
