### PR TITLE
build(windows): work around luarocks not finding its own md5sum

### DIFF
--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -13,6 +13,9 @@ if(NOT MSVC)
   # In MSVC don't pass the compiler/linker to luarocks, the bundled
   # version already knows, and passing them here breaks the build
   set(LUAROCKS_BUILDARGS CC=${DEPS_C_COMPILER} LD=${DEPS_C_COMPILER})
+else()
+  # Workaround for luarocks failing to find the md5sum.exe it is shipped with.
+  set(LUAROCKS_BUILDARGS MD5SUM=md5sum)
 endif()
 
 # Lua version, used with rocks directories.


### PR DESCRIPTION
Luarocks is unable to find its own md5sum due to these reasons listed in
the comment https://github.com/luarocks/luarocks/issues/1443.

The pull request https://github.com/luarocks/luarocks/pull/1498 resolves
this issue, but in the meantime we can work around it by resetting the
value of MD5sum to "md5sum".