### PR TITLE
fix(treesitter): use capture metadata range if exists

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -236,7 +236,8 @@ local function on_line_impl(self, buf, line, is_spell_nav)
         break
       end
 
-      local start_row, start_col, end_row, end_col = node:range()
+      local range = metadata[capture] and metadata[capture].range or { node:range() }
+      local start_row, start_col, end_row, end_col = unpack(range)
       local hl = highlighter_query.hl_cache[capture]
 
       local capture_name = highlighter_query:query().captures[capture]

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -236,8 +236,8 @@ local function on_line_impl(self, buf, line, is_spell_nav)
         break
       end
 
-      local range = metadata[capture] and metadata[capture].range or { node:range() }
-      local start_row, start_col, end_row, end_col = unpack(range)
+      local range = vim.treesitter.get_range(node, buf, metadata[capture])
+      local start_row, start_col, _, end_row, end_col, _ = unpack(range)
       local hl = highlighter_query.hl_cache[capture]
 
       local capture_name = highlighter_query:query().captures[capture]


### PR DESCRIPTION
Fixes nvim-treesitter/nvim-treesitter#4181