### PR TITLE
feat(diagnostic): support get cursor and original lsp diagnostic in v…

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -464,7 +464,10 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                  • namespace: (number) Limit diagnostics to the given
                    namespace.
                  • lnum: (number) Limit diagnostics to the given line number.
+                 • col: (number) Limit diagnsotics to the given column number.
                  • severity: See |diagnostic-severity|.
+                 • original: (boolean) if true the diagnostic use lsp orignial
+                   format.
 
     Return: ~
         Diagnostic [] table A list of diagnostic items |diagnostic-structure|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -289,6 +289,8 @@ The following deprecated functions or APIs were removed.
 
 • `require'health'` was removed. Use |vim.health| instead.
 
+• `vim.diagnostic.get` support get diagnostic by using col and get original
+  sever format diagnostic.
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -769,7 +769,13 @@ function M.code_action(options)
   end
   if not context.diagnostics then
     local bufnr = api.nvim_get_current_buf()
-    context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)
+    local pos = api.nvim_win_get_cursor(0)
+    --when in normal mode use cursor diagnsotics in context
+    if api.nvim_get_mode().mode == 'n' then
+      context.diagnostics = vim.diagnostic.get(bufnr, { lnum = pos[1], col = pos[2], original = true })
+    else
+      context.diagnostics = vim.diagnostic.get(bufnr, { lnum = pos[1] })
+    end
   end
   local params
   local mode = api.nvim_get_mode().mode

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2149,6 +2149,35 @@ function M.lookup_section(settings, section)
   return settings
 end
 
+---@private
+---@param diagnostic Diagnostic
+---@return lsp.Diagnostic[]
+function M.diagnostic_vim_to_lsp(diagnostic)
+  local function severity_vim_to_lsp(severity)
+    if type(severity) == 'string' then
+      severity = vim.diagnostic.severity[severity]
+    end
+    return severity
+  end
+
+  return vim.tbl_extend('keep', {
+    range = {
+      start = {
+        line = diagnostic.lnum,
+        character = diagnostic.col,
+      },
+      ['end'] = {
+        line = diagnostic.end_lnum,
+        character = diagnostic.end_col,
+      },
+    },
+    severity = severity_vim_to_lsp(diagnostic.severity),
+    message = diagnostic.message,
+    source = diagnostic.source,
+    code = diagnostic.code,
+  }, diagnostic.user_data and (diagnostic.user_data.lsp or {}) or {})
+end
+
 M._get_line_byte_from_position = get_line_byte_from_position
 
 M.buf_versions = {}

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -340,6 +340,25 @@ describe('vim.diagnostic', function()
     ]])
   end)
 
+  it('get diagnostic by lnum and col get original lsp diagnostic', function()
+    local result = exec_lua [[
+      local ns_1_diags = {
+        make_error("Error 1", 1, 1, 1, 5),
+        make_warning("Warning on Server 1", 2, 1, 2, 3),
+      }
+      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
+      local diag = vim.diagnostic.get(diagnostic_bufnr, { lnum = 1, col = 3 })[1]
+      local original = vim.diagnostic.get(diagnostic_bufnr, { original = true })[1]
+      return {
+        { bufnr = diag.bufnr ,lnum = diag.lnum, col = diag.col },
+        { message = original.message, severity = original.severity }
+      }
+    ]]
+
+    eq({2, 1, 1}, {result[1].bufnr, result[1].lnum, result[1].col})
+    eq({"Error 1", 1}, {result[2].message, result[2].severity})
+  end)
+
   describe('show() and hide()', function()
     it('works', function()
       local result = exec_lua [[


### PR DESCRIPTION
We only suggest use `vim.diagnostic`  module for diagnostic relate usage. the `vim.lsp.diagnostic` module a little duplicate. now extend get line or cursor diagnostic in `vim.diagnostic.get`  function and support to get original lsp format diagnostic. 

when use `codeacton`  default  handler  in normal mode pass cursor diagnostic to  context.  mark `vim.lsp.diagnostic.get_line_diagnsotics` as `deprecated` and remove some private and not used functions. 

next step we can move some functions in `vim.lsp.diagnsotic` to `vim.lsp.handler` and  `vim.diagnostic` then maybe can remove `vim.lsp.diagnostic` ? keep one `diagnostic` module.

Fix #21985 