### PR TITLE
fix(api): ensure scrolling when calling nvim_out_write

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1685,6 +1685,7 @@ static void write_msg(String message, bool to_err, bool writeln)
   } \
   if (c == NL) { \
     kv_push(line_buf, NUL); \
+    msg_scroll = true; \
     msg(line_buf.items); \
     kv_drop(line_buf, kv_size(line_buf)); \
     kv_resize(line_buf, LINE_BUFFER_MIN_SIZE); \


### PR DESCRIPTION
Fix #22878
Fix #22988

This can cause unwanted hit-enter prompts when cmdheight=0. Not sure if there's a better solution.