### PR TITLE
fix(treesitter):  use 'tsinspector' filetype for InspectTree

### DIFF
--- a/runtime/ftplugin/tsinspector.lua
+++ b/runtime/ftplugin/tsinspector.lua
@@ -1,6 +1,0 @@
--- Neovim filetype plugin file
--- Language:    Tree-sitter playground
--- Last Change: 2023 Apr 4
-
--- it's a lisp!
-vim.cmd([[ runtime! ftplugin/lisp.vim ]])

--- a/runtime/ftplugin/tsinspector.lua
+++ b/runtime/ftplugin/tsinspector.lua
@@ -1,0 +1,6 @@
+-- Neovim filetype plugin file
+-- Language:    Tree-sitter playground
+-- Last Change: 2023 Apr 4
+
+-- it's a lisp!
+vim.cmd([[ runtime! ftplugin/lisp.vim ]])

--- a/runtime/indent/tsinspector.lua
+++ b/runtime/indent/tsinspector.lua
@@ -1,10 +1,13 @@
 -- Neovim indent file
--- Language:    Tree-sitter playground
--- Last Change: 2023 Apr 4
+-- Language:    Tree-sitter inspector
+-- Last Change: 2023 Nov 28
 
--- it's a lisp!
-vim.cmd([[ runtime! indent/lisp.vim ]])
+-- Only load this indent file when no other was loaded
+if vim.b.did_indent then
+  return
+end
+vim.b.did_indent = 1
 
 vim.bo.expandtab = true
 vim.bo.shiftwidth = 2
-vim.b.undo_indent = vim.b.undo_indent .. '|setl et< sw<'
+vim.b.undo_indent = 'setl et< sw<'

--- a/runtime/indent/tsinspector.lua
+++ b/runtime/indent/tsinspector.lua
@@ -1,0 +1,10 @@
+-- Neovim indent file
+-- Language:    Tree-sitter playground
+-- Last Change: 2023 Apr 4
+
+-- it's a lisp!
+vim.cmd([[ runtime! indent/lisp.vim ]])
+
+vim.bo.expandtab = true
+vim.bo.shiftwidth = 2
+vim.b.undo_indent = vim.b.undo_indent .. '|setl et< sw<'

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -225,7 +225,7 @@ function TSTreeView:draw(bufnr)
   local lines = {} ---@type string[]
   local lang_hl_marks = {} ---@type table[]
 
-  local indent  ---@type string
+  local indent ---@type string
   if vim.bo[bufnr].expandtab then
     local sw = vim.bo[bufnr].shiftwidth
     if sw == 0 then

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -178,19 +178,18 @@ local function set_dev_properties(w, b)
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'
-  vim.bo[b].filetype = 'query'
 end
 
 --- Updates the cursor position in the inspector to match the node under the cursor.
 ---
---- @param pg TSTreeView
+--- @param treeview TSTreeView
 --- @param lang string
 --- @param source_buf integer
 --- @param inspect_buf integer
 --- @param inspect_win integer
 --- @param pos? { [1]: integer, [2]: integer }
-local function set_inspector_cursor(pg, lang, source_buf, inspect_buf, inspect_win, pos)
-  api.nvim_buf_clear_namespace(inspect_buf, pg.ns, 0, -1)
+local function set_inspector_cursor(treeview, lang, source_buf, inspect_buf, inspect_win, pos)
+  api.nvim_buf_clear_namespace(inspect_buf, treeview.ns, 0, -1)
 
   local cursor_node = vim.treesitter.get_node({
     bufnr = source_buf,
@@ -203,11 +202,11 @@ local function set_inspector_cursor(pg, lang, source_buf, inspect_buf, inspect_w
   end
 
   local cursor_node_id = cursor_node:id()
-  for i, v in pg:iter() do
+  for i, v in treeview:iter() do
     if v.id == cursor_node_id then
       local start = v.depth
       local end_col = start + #v.text
-      api.nvim_buf_set_extmark(inspect_buf, pg.ns, i - 1, start, {
+      api.nvim_buf_set_extmark(inspect_buf, treeview.ns, i - 1, start, {
         end_col = end_col,
         hl_group = 'Visual',
       })
@@ -226,12 +225,23 @@ function TSTreeView:draw(bufnr)
   local lines = {} ---@type string[]
   local lang_hl_marks = {} ---@type table[]
 
+  local indent  ---@type string
+  if vim.bo[bufnr].expandtab then
+    local sw = vim.bo[bufnr].shiftwidth
+    if sw == 0 then
+      sw = vim.bo[bufnr].tabstop
+    end
+    indent = string.rep(' ', sw or 2)
+  else
+    indent = '\t'
+  end
+
   for _, item in self:iter() do
     local range_str = get_range_str(item.lnum, item.col, item.end_lnum, item.end_col)
     local lang_str = self.opts.lang and string.format(' %s', item.lang) or ''
     local text = item.named and item.text or escape_quotes(item.text)
     local line =
-      string.format('%s%s ; %s%s', string.rep(' ', item.depth), text, range_str, lang_str)
+      string.format('%s%s ; %s%s', string.rep(indent, item.depth), text, range_str, lang_str)
 
     if self.opts.lang then
       lang_hl_marks[#lang_hl_marks + 1] = {
@@ -304,7 +314,7 @@ function M.inspect_tree(opts)
 
   local buf = api.nvim_get_current_buf()
   local win = api.nvim_get_current_win()
-  local pg = assert(TSTreeView:new(buf, opts.lang))
+  local treeview = assert(TSTreeView:new(buf, opts.lang))
 
   -- Close any existing inspector window
   if vim.b[buf].dev_inspect then
@@ -328,6 +338,7 @@ function M.inspect_tree(opts)
   vim.b[b].dev_base = win -- base window handle
   vim.b[b].disable_query_linter = true
   set_dev_properties(w, b)
+  vim.bo[b].filetype = 'tsinspector'
 
   local title --- @type string?
   local opts_title = opts.title
@@ -341,17 +352,17 @@ function M.inspect_tree(opts)
   assert(type(title) == 'string', 'Window title must be a string')
   api.nvim_buf_set_name(b, title)
 
-  pg:draw(b)
+  treeview:draw(b)
 
   local cursor = api.nvim_win_get_cursor(win)
-  set_inspector_cursor(pg, opts.lang, buf, b, w, { cursor[1] - 1, cursor[2] })
+  set_inspector_cursor(treeview, opts.lang, buf, b, w, { cursor[1] - 1, cursor[2] })
 
-  api.nvim_buf_clear_namespace(buf, pg.ns, 0, -1)
+  api.nvim_buf_clear_namespace(buf, treeview.ns, 0, -1)
   api.nvim_buf_set_keymap(b, 'n', '<CR>', '', {
     desc = 'Jump to the node under the cursor in the source buffer',
     callback = function()
       local row = api.nvim_win_get_cursor(w)[1]
-      local pos = pg:get(row)
+      local pos = treeview:get(row)
       api.nvim_set_current_win(win)
       api.nvim_win_set_cursor(win, { pos.lnum + 1, pos.col })
     end,
@@ -360,21 +371,21 @@ function M.inspect_tree(opts)
     desc = 'Toggle anonymous nodes',
     callback = function()
       local row, col = unpack(api.nvim_win_get_cursor(w)) ---@type integer, integer
-      local curnode = pg:get(row)
+      local curnode = treeview:get(row)
       while curnode and not curnode.named do
         row = row - 1
-        curnode = pg:get(row)
+        curnode = treeview:get(row)
       end
 
-      pg.opts.anon = not pg.opts.anon
-      pg:draw(b)
+      treeview.opts.anon = not treeview.opts.anon
+      treeview:draw(b)
 
       if not curnode then
         return
       end
 
       local id = curnode.id
-      for i, node in pg:iter() do
+      for i, node in treeview:iter() do
         if node.id == id then
           api.nvim_win_set_cursor(w, { i, col })
           break
@@ -385,8 +396,8 @@ function M.inspect_tree(opts)
   api.nvim_buf_set_keymap(b, 'n', 'I', '', {
     desc = 'Toggle language display',
     callback = function()
-      pg.opts.lang = not pg.opts.lang
-      pg:draw(b)
+      treeview.opts.lang = not treeview.opts.lang
+      treeview:draw(b)
     end,
   })
   api.nvim_buf_set_keymap(b, 'n', 'o', '', {
@@ -409,10 +420,10 @@ function M.inspect_tree(opts)
         return true
       end
 
-      api.nvim_buf_clear_namespace(buf, pg.ns, 0, -1)
+      api.nvim_buf_clear_namespace(buf, treeview.ns, 0, -1)
       local row = api.nvim_win_get_cursor(w)[1]
-      local pos = pg:get(row)
-      api.nvim_buf_set_extmark(buf, pg.ns, pos.lnum, pos.col, {
+      local pos = treeview:get(row)
+      api.nvim_buf_set_extmark(buf, treeview.ns, pos.lnum, pos.col, {
         end_row = pos.end_lnum,
         end_col = math.max(0, pos.end_col),
         hl_group = 'Visual',
@@ -437,7 +448,7 @@ function M.inspect_tree(opts)
         return true
       end
 
-      set_inspector_cursor(pg, opts.lang, buf, b, w)
+      set_inspector_cursor(treeview, opts.lang, buf, b, w)
     end,
   })
 
@@ -449,8 +460,8 @@ function M.inspect_tree(opts)
         return true
       end
 
-      pg = assert(TSTreeView:new(buf, opts.lang))
-      pg:draw(b)
+      treeview = assert(TSTreeView:new(buf, opts.lang))
+      treeview:draw(b)
     end,
   })
 
@@ -461,7 +472,7 @@ function M.inspect_tree(opts)
       if not api.nvim_buf_is_loaded(buf) then
         return true
       end
-      api.nvim_buf_clear_namespace(buf, pg.ns, 0, -1)
+      api.nvim_buf_clear_namespace(buf, treeview.ns, 0, -1)
     end,
   })
 
@@ -472,7 +483,7 @@ function M.inspect_tree(opts)
       if not api.nvim_buf_is_loaded(b) then
         return true
       end
-      api.nvim_buf_clear_namespace(b, pg.ns, 0, -1)
+      api.nvim_buf_clear_namespace(b, treeview.ns, 0, -1)
     end,
   })
 
@@ -482,6 +493,14 @@ function M.inspect_tree(opts)
     once = true,
     callback = function()
       close_win(w)
+    end,
+  })
+
+  api.nvim_create_autocmd('OptionSet', {
+    group = group,
+    pattern = { 'expandtab', 'shiftwidth' },
+    callback = function()
+      treeview:draw(b)
     end,
   })
 end
@@ -563,6 +582,7 @@ function M.edit_query(lang)
   vim.b[buf].dev_edit = query_win
   vim.bo[query_buf].omnifunc = 'v:lua.vim.treesitter.query.omnifunc'
   set_dev_properties(query_win, query_buf)
+  vim.bo[query_buf].filetype = 'query'
 
   -- Note that omnifunc guesses the language based on the containing folder,
   -- so we add the parser's language to the buffer's name so that omnifunc

--- a/runtime/syntax/tsinspector.lua
+++ b/runtime/syntax/tsinspector.lua
@@ -1,8 +1,18 @@
 -- Neovim syntax file
--- Language:    Tree-sitter playground
--- Last Change: 2023 Apr 4
+-- Language:    Tree-sitter inspector
+-- Last Change: 2023 Nov 28
 
--- it's a lisp!
-vim.cmd([[ runtime! syntax/lisp.vim ]])
+-- Quit when a syntax file was already loaded
+if vim.b.current_syntax then
+  return
+end
+
+vim.cmd([[
+syn match tsInspectorComment /;.*$/
+syn region tsInspectorAnonymous start=/"/ end=/"/
+
+hi def link tsInspectorComment   Comment
+hi def link tsInspectorAnonymous String
+]])
 
 vim.b.current_syntax = 'tsinspector'

--- a/runtime/syntax/tsinspector.lua
+++ b/runtime/syntax/tsinspector.lua
@@ -1,0 +1,8 @@
+-- Neovim syntax file
+-- Language:    Tree-sitter playground
+-- Last Change: 2023 Apr 4
+
+-- it's a lisp!
+vim.cmd([[ runtime! syntax/lisp.vim ]])
+
+vim.b.current_syntax = 'tsinspector'

--- a/runtime/syntax/tsinspector.lua
+++ b/runtime/syntax/tsinspector.lua
@@ -9,7 +9,7 @@ end
 
 vim.cmd([[
 syn match tsInspectorComment /;.*$/
-syn region tsInspectorAnonymous start=/"/ end=/"/
+syn region tsInspectorAnonymous start=/"/ end=/"/ skip=/\\"/
 
 hi def link tsInspectorComment   Comment
 hi def link tsInspectorAnonymous String


### PR DESCRIPTION
This decouples the playground window from query buffers, which should not be treated the same (i.e. we do not want to run the query linter in the playground window). We also use the indentation settings for the 'playground' filetype to determine the indentation level in the :InspectTree window.

This obviously conflicts with https://github.com/neovim/neovim/pull/22848, but should be an easy merge conflict to resolve.

