### PR TITLE
feat(lsp): create default link from @lsp.type.comment to Comment

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -278,6 +278,7 @@ static const char *highlight_init_both[] = {
 
   // LSP semantic tokens
   "default link @lsp.type.class Structure",
+  "default link @lsp.type.comment Comment",
   "default link @lsp.type.decorator Function",
   "default link @lsp.type.enum Structure",
   "default link @lsp.type.enumMember Constant",


### PR DESCRIPTION
This adds a new default highlight link from `@lsp.type.comment` to `Comment`.

One useful use case for `@lsp.type.comment`: clangd uses this token to highlight preprocessor branches which are not taken (e.g. an `#ifdef` that is false). Without this default link, there is no visual indication that this token is being applied.

The only reference I can find on why this was not added originally is [here](https://github.com/neovim/neovim/pull/22022#discussion_r1090844216), which says that:

>[@lsp.type.comment] overrides @text.todo and other useful marks inside comments

I think this is a subjective tradeoff; personally, I don't use whatever Tree-sitter parser provides that highlight group. I propose enabling the `Comment` link by default, and users who find issues with `@text.todo` can adjust the priority as they wish.