### PR TITLE
fix(windows): consistent normalization in fs.find

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -216,7 +216,7 @@ function M.find(names, opts)
 
   ---@private
   local function add(match)
-    matches[#matches + 1] = match
+    matches[#matches + 1] = M.normalize(match)
     if #matches == limit then
       return true
     end

--- a/runtime/lua/vim/treesitter/playground.lua
+++ b/runtime/lua/vim/treesitter/playground.lua
@@ -265,7 +265,7 @@ function M.inspect_tree(opts)
 
   vim.wo[w].scrolloff = 5
   vim.wo[w].wrap = false
-  vim.wo[w].foldmethod = 'manual'  -- disable folding
+  vim.wo[w].foldmethod = 'manual' -- disable folding
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'


### PR DESCRIPTION
vim.fs.find(".luacheckrc")

```
c:\\projects\\neovim/.luacheckrc # before

c:/projects/neovim/.luacheckrc   # after
```
