### PR TITLE
feat(vim.diff): allow passing an integer for linematch

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -685,9 +685,10 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
                    • "unified": (default) String in unified format.
                    • "indices": Array of hunk locations.
                    Note: This option is ignored if `on_hunk` is used.
-                 • `linematch` (boolean): Run linematch on the resulting hunks
-                   from xdiff. Requires `result_type = indices`, ignored
-                   otherwise.
+                 • `linematch` (boolean|integer): Run linematch on the resulting hunks
+                   from xdiff. When integer, only hunks upto this size in
+                   lines are run through linematch. Requires `result_type = indices`,
+                   ignored otherwise.
                  • `algorithm` (string):
                    Diff algorithm to use. Values:
                    • "myers"      the default algorithm


### PR DESCRIPTION
Without this, Gitsigns literally explodes memory usage when opening this file: https://raw.githubusercontent.com/torvalds/linux/master/drivers/gpu/drm/amd/include/asic_reg/bif/bif_5_1_sh_mask.h