### PR TITLE
refactor: rename local API alias from a to api

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2570,17 +2570,17 @@ nvim_buf_get_extmarks({buffer}, {ns_id}, {start}, {end}, {opts})
     `limit`, to get the first marks prior to a given position.)
 
     Example: >lua
-      local a   = vim.api
-      local pos = a.nvim_win_get_cursor(0)
-      local ns  = a.nvim_create_namespace('my-plugin')
+      local api = vim.api
+      local pos = api.nvim_win_get_cursor(0)
+      local ns  = api.nvim_create_namespace('my-plugin')
       -- Create new extmark at line 1, column 1.
-      local m1  = a.nvim_buf_set_extmark(0, ns, 0, 0, {})
+      local m1  = api.nvim_buf_set_extmark(0, ns, 0, 0, {})
       -- Create new extmark at line 3, column 1.
-      local m2  = a.nvim_buf_set_extmark(0, ns, 2, 0, {})
+      local m2  = api.nvim_buf_set_extmark(0, ns, 2, 0, {})
       -- Get extmarks only from line 3.
-      local ms  = a.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
+      local ms  = api.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
       -- Get all marks in this buffer + namespace.
-      local all = a.nvim_buf_get_extmarks(0, ns, 0, -1, {})
+      local all = api.nvim_buf_get_extmarks(0, ns, 0, -1, {})
       print(vim.inspect(ms))
 <
 

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -1,4 +1,4 @@
-local a = vim.api
+local api = vim.api
 
 -- TODO(tjdevries): Improve option metadata so that this doesn't have to be hardcoded.
 --                  Can be done in a separate PR.
@@ -30,7 +30,7 @@ end
 
 local options_info = setmetatable({}, {
   __index = function(t, k)
-    local info = a.nvim_get_option_info(k)
+    local info = api.nvim_get_option_info(k)
     info.metatype = get_option_metatype(k, info)
     rawset(t, k, info)
     return rawget(t, k)
@@ -74,12 +74,12 @@ local function new_opt_accessor(handle, scope)
         return new_opt_accessor(k, scope)
       end
       opt_validate(k, scope)
-      return a.nvim_get_option_value(k, { [scope] = handle or 0 })
+      return api.nvim_get_option_value(k, { [scope] = handle or 0 })
     end,
 
     __newindex = function(_, k, v)
       opt_validate(k, scope)
-      return a.nvim_set_option_value(k, v, { [scope] = handle or 0 })
+      return api.nvim_set_option_value(k, v, { [scope] = handle or 0 })
     end,
   })
 end
@@ -91,10 +91,10 @@ vim.wo = new_opt_accessor(nil, 'win')
 --  this ONLY sets the global option. like `setglobal`
 vim.go = setmetatable({}, {
   __index = function(_, k)
-    return a.nvim_get_option_value(k, { scope = 'global' })
+    return api.nvim_get_option_value(k, { scope = 'global' })
   end,
   __newindex = function(_, k, v)
-    return a.nvim_set_option_value(k, v, { scope = 'global' })
+    return api.nvim_set_option_value(k, v, { scope = 'global' })
   end,
 })
 
@@ -102,10 +102,10 @@ vim.go = setmetatable({}, {
 --  it has no additional metamethod magic.
 vim.o = setmetatable({}, {
   __index = function(_, k)
-    return a.nvim_get_option_value(k, {})
+    return api.nvim_get_option_value(k, {})
   end,
   __newindex = function(_, k, v)
-    return a.nvim_set_option_value(k, v, {})
+    return api.nvim_set_option_value(k, v, {})
   end,
 })
 
@@ -488,7 +488,7 @@ local function create_option_accessor(scope)
     --  opt[my_option] = value
     _set = function(self)
       local value = convert_value_to_vim(self._name, self._info, self._value)
-      a.nvim_set_option_value(self._name, value, { scope = scope })
+      api.nvim_set_option_value(self._name, value, { scope = scope })
     end,
 
     get = function(self)
@@ -526,7 +526,7 @@ local function create_option_accessor(scope)
 
   return setmetatable({}, {
     __index = function(_, k)
-      return make_option(k, a.nvim_get_option_value(k, {}))
+      return make_option(k, api.nvim_get_option_value(k, {}))
     end,
 
     __newindex = function(_, k, v)

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -1,4 +1,4 @@
-local a = vim.api
+local api = vim.api
 local LanguageTree = require('vim.treesitter.languagetree')
 local Range = require('vim.treesitter._range')
 
@@ -80,7 +80,7 @@ function M._create_parser(bufnr, lang, opts)
 
   local source = self:source() --[[@as integer]]
 
-  a.nvim_buf_attach(
+  api.nvim_buf_attach(
     source,
     false,
     { on_bytes = bytes_cb, on_detach = detach_cb, on_reload = reload_cb, preview = true }
@@ -109,7 +109,7 @@ function M.get_parser(bufnr, lang, opts)
   opts = opts or {}
 
   if bufnr == nil or bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
+    bufnr = api.nvim_get_current_buf()
   end
 
   if not valid_lang(lang) then
@@ -141,7 +141,7 @@ end
 ---@return boolean
 function M._has_parser(bufnr)
   if bufnr == nil or bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
+    bufnr = api.nvim_get_current_buf()
   end
   return parsers[bufnr] ~= nil
 end
@@ -229,7 +229,7 @@ local function buf_range_get_text(buf, range)
     end_col = -1
     end_row = end_row - 1
   end
-  local lines = a.nvim_buf_get_text(buf, start_row, start_col, end_row, end_col, {})
+  local lines = api.nvim_buf_get_text(buf, start_row, start_col, end_row, end_col, {})
   return table.concat(lines, '\n')
 end
 
@@ -294,7 +294,7 @@ end
 ---@return table[] List of captures `{ capture = "name", metadata = { ... } }`
 function M.get_captures_at_pos(bufnr, row, col)
   if bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
+    bufnr = api.nvim_get_current_buf()
   end
   local buf_highlighter = M.highlighter.active[bufnr]
 
@@ -345,8 +345,8 @@ end
 ---@return string[] List of capture names
 function M.get_captures_at_cursor(winnr)
   winnr = winnr or 0
-  local bufnr = a.nvim_win_get_buf(winnr)
-  local cursor = a.nvim_win_get_cursor(winnr)
+  local bufnr = api.nvim_win_get_buf(winnr)
+  local cursor = api.nvim_win_get_cursor(winnr)
 
   local data = M.get_captures_at_pos(bufnr, cursor[1] - 1, cursor[2])
 
@@ -374,7 +374,7 @@ function M.get_node(opts)
   local bufnr = opts.bufnr
 
   if not bufnr or bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
+    bufnr = api.nvim_get_current_buf()
   end
 
   local row, col
@@ -383,10 +383,10 @@ function M.get_node(opts)
     row, col = opts.pos[1], opts.pos[2]
   else
     assert(
-      bufnr == a.nvim_get_current_buf(),
+      bufnr == api.nvim_get_current_buf(),
       'Position must be explicitly provided when not using the current buffer'
     )
-    local pos = a.nvim_win_get_cursor(0)
+    local pos = api.nvim_win_get_cursor(0)
     -- Subtract one to account for 1-based row indexing in nvim_win_get_cursor
     row, col = pos[1] - 1, pos[2]
   end
@@ -417,7 +417,7 @@ end
 function M.get_node_at_pos(bufnr, row, col, opts)
   vim.deprecate('vim.treesitter.get_node_at_pos()', 'vim.treesitter.get_node()', '0.10')
   if bufnr == 0 then
-    bufnr = a.nvim_get_current_buf()
+    bufnr = api.nvim_get_current_buf()
   end
   local ts_range = { row, col, row, col }
 
@@ -440,7 +440,7 @@ end
 function M.get_node_at_cursor(winnr)
   vim.deprecate('vim.treesitter.get_node_at_cursor()', 'vim.treesitter.get_node():type()', '0.10')
   winnr = winnr or 0
-  local bufnr = a.nvim_win_get_buf(winnr)
+  local bufnr = api.nvim_win_get_buf(winnr)
 
   return M.get_node({ bufnr = bufnr, ignore_injections = false }):type()
 end
@@ -465,7 +465,7 @@ end
 ---@param bufnr (integer|nil) Buffer to be highlighted (default: current buffer)
 ---@param lang (string|nil) Language of the parser (default: buffer filetype)
 function M.start(bufnr, lang)
-  bufnr = bufnr or a.nvim_get_current_buf()
+  bufnr = bufnr or api.nvim_get_current_buf()
   local parser = M.get_parser(bufnr, lang)
   M.highlighter.new(parser)
 end
@@ -474,7 +474,7 @@ end
 ---
 ---@param bufnr (integer|nil) Buffer to stop highlighting (default: current buffer)
 function M.stop(bufnr)
-  bufnr = bufnr or a.nvim_get_current_buf()
+  bufnr = bufnr or api.nvim_get_current_buf()
 
   if M.highlighter.active[bufnr] then
     M.highlighter.active[bufnr]:destroy()

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -1,4 +1,4 @@
-local a = vim.api
+local api = vim.api
 local query = vim.treesitter.query
 
 ---@alias TSHlIter fun(): integer, TSNode, TSMetadata
@@ -25,7 +25,7 @@ TSHighlighter.active = TSHighlighter.active or {}
 local TSHighlighterQuery = {}
 TSHighlighterQuery.__index = TSHighlighterQuery
 
-local ns = a.nvim_create_namespace('treesitter/highlighter')
+local ns = api.nvim_create_namespace('treesitter/highlighter')
 
 ---@private
 function TSHighlighterQuery.new(lang, query_string)
@@ -36,7 +36,7 @@ function TSHighlighterQuery.new(lang, query_string)
       local name = self._query.captures[capture]
       local id = 0
       if not vim.startswith(name, '_') then
-        id = a.nvim_get_hl_id_by_name('@' .. name .. '.' .. lang)
+        id = api.nvim_get_hl_id_by_name('@' .. name .. '.' .. lang)
       end
 
       rawset(table, capture, id)
@@ -121,7 +121,7 @@ function TSHighlighter.new(tree, opts)
     vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
   end
 
-  a.nvim_buf_call(self.bufnr, function()
+  api.nvim_buf_call(self.bufnr, function()
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
 
@@ -140,7 +140,7 @@ function TSHighlighter:destroy()
     vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
     vim.b[self.bufnr].ts_highlight = nil
     if vim.g.syntax_on == 1 then
-      a.nvim_exec_autocmds('FileType', { group = 'syntaxset', buffer = self.bufnr })
+      api.nvim_exec_autocmds('FileType', { group = 'syntaxset', buffer = self.bufnr })
     end
   end
 end
@@ -168,7 +168,7 @@ end
 ---@param start_row integer
 ---@param new_end integer
 function TSHighlighter:on_bytes(_, _, start_row, _, _, _, _, _, new_end)
-  a.nvim__buf_redraw_range(self.bufnr, start_row, start_row + new_end + 1)
+  api.nvim__buf_redraw_range(self.bufnr, start_row, start_row + new_end + 1)
 end
 
 ---@package
@@ -180,7 +180,7 @@ end
 ---@param changes integer[][]?
 function TSHighlighter:on_changedtree(changes)
   for _, ch in ipairs(changes or {}) do
-    a.nvim__buf_redraw_range(self.bufnr, ch[1], ch[3] + 1)
+    api.nvim__buf_redraw_range(self.bufnr, ch[1], ch[3] + 1)
   end
 end
 
@@ -252,7 +252,7 @@ local function on_line_impl(self, buf, line, is_spell_nav)
       local spell_pri_offset = capture_name == 'nospell' and 1 or 0
 
       if hl and end_row >= line and (not is_spell_nav or spell ~= nil) then
-        a.nvim_buf_set_extmark(buf, ns, start_row, start_col, {
+        api.nvim_buf_set_extmark(buf, ns, start_row, start_col, {
           end_line = end_row,
           end_col = end_col,
           hl_group = hl,
@@ -323,7 +323,7 @@ function TSHighlighter._on_win(_, _win, buf, _topline)
   return true
 end
 
-a.nvim_set_decoration_provider(ns, {
+api.nvim_set_decoration_provider(ns, {
   on_buf = TSHighlighter._on_buf,
   on_win = TSHighlighter._on_win,
   on_line = TSHighlighter._on_line,

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -1,4 +1,4 @@
-local a = vim.api
+local api = vim.api
 
 ---@class TSLanguageModule
 local M = {}
@@ -89,7 +89,7 @@ function M.add(lang, opts)
     end
 
     local fname = 'parser/' .. lang .. '.*'
-    local paths = a.nvim_get_runtime_file(fname, false)
+    local paths = api.nvim_get_runtime_file(fname, false)
     if #paths == 0 then
       error("no parser for '" .. lang .. "' language, see :help treesitter-parsers")
     end

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -32,7 +32,7 @@
 --- a plugin that does any kind of analysis on a tree should use a timer to throttle too frequent
 --- updates.
 
-local a = vim.api
+local api = vim.api
 local query = require('vim.treesitter.query')
 local language = require('vim.treesitter.language')
 local Range = require('vim.treesitter._range')
@@ -141,16 +141,16 @@ function LanguageTree:_log(...)
   local prefix =
     string.format('%s:%d: [%s:%d] ', info.name, info.currentline, self:lang(), nregions)
 
-  a.nvim_out_write(prefix)
+  api.nvim_out_write(prefix)
   for _, x in ipairs(args) do
     if type(x) == 'string' then
-      a.nvim_out_write(x)
+      api.nvim_out_write(x)
     else
-      a.nvim_out_write(vim.inspect(x, { newline = ' ', indent = '' }))
+      api.nvim_out_write(vim.inspect(x, { newline = ' ', indent = '' }))
     end
-    a.nvim_out_write(' ')
+    api.nvim_out_write(' ')
   end
-  a.nvim_out_write('\n')
+  api.nvim_out_write('\n')
 end
 
 --- Invalidates this parser and all its children

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1,4 +1,4 @@
-local a = vim.api
+local api = vim.api
 local language = require('vim.treesitter.language')
 
 ---@class Query
@@ -74,7 +74,7 @@ end
 ---@return string[] query_files List of files to load for given query and language
 function M.get_files(lang, query_name, is_included)
   local query_path = string.format('queries/%s/%s.scm', lang, query_name)
-  local lang_files = dedupe_files(a.nvim_get_runtime_file(query_path, true))
+  local lang_files = dedupe_files(api.nvim_get_runtime_file(query_path, true))
 
   if #lang_files == 0 then
     return {}
@@ -635,7 +635,7 @@ end
 ---@return (fun(): integer, TSNode, TSMetadata): capture id, capture node, metadata
 function Query:iter_captures(node, source, start, stop)
   if type(source) == 'number' and source == 0 then
-    source = vim.api.nvim_get_current_buf()
+    source = api.nvim_get_current_buf()
   end
 
   start, stop = value_or_node_range(start, stop, node)
@@ -690,7 +690,7 @@ end
 ---@return (fun(): integer, table<integer,TSNode>, table): pattern id, match, metadata
 function Query:iter_matches(node, source, start, stop)
   if type(source) == 'number' and source == 0 then
-    source = vim.api.nvim_get_current_buf()
+    source = api.nvim_get_current_buf()
   end
 
   start, stop = value_or_node_range(start, stop, node)

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -311,17 +311,17 @@ ArrayOf(Integer) nvim_buf_get_extmark_by_id(Buffer buffer, Integer ns_id,
 ///
 /// Example:
 /// <pre>lua
-///   local a   = vim.api
-///   local pos = a.nvim_win_get_cursor(0)
-///   local ns  = a.nvim_create_namespace('my-plugin')
+///   local api = vim.api
+///   local pos = api.nvim_win_get_cursor(0)
+///   local ns  = api.nvim_create_namespace('my-plugin')
 ///   -- Create new extmark at line 1, column 1.
-///   local m1  = a.nvim_buf_set_extmark(0, ns, 0, 0, {})
+///   local m1  = api.nvim_buf_set_extmark(0, ns, 0, 0, {})
 ///   -- Create new extmark at line 3, column 1.
-///   local m2  = a.nvim_buf_set_extmark(0, ns, 2, 0, {})
+///   local m2  = api.nvim_buf_set_extmark(0, ns, 2, 0, {})
 ///   -- Get extmarks only from line 3.
-///   local ms  = a.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
+///   local ms  = api.nvim_buf_get_extmarks(0, ns, {2,0}, {2,0}, {})
 ///   -- Get all marks in this buffer + namespace.
-///   local all = a.nvim_buf_get_extmarks(0, ns, 0, -1, {})
+///   local all = api.nvim_buf_get_extmarks(0, ns, 0, -1, {})
 ///   print(vim.inspect(ms))
 /// </pre>
 ///

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2721,11 +2721,11 @@ describe('lua stdlib', function()
     it('does not cause ml_get errors with invalid visual selection', function()
       -- Should be fixed by vim-patch:8.2.4028.
       exec_lua [[
-        local a = vim.api
-        local t = function(s) return a.nvim_replace_termcodes(s, true, true, true) end
-        a.nvim_buf_set_lines(0, 0, -1, true, {"a", "b", "c"})
-        a.nvim_feedkeys(t "G<C-V>", "txn", false)
-        a.nvim_buf_call(a.nvim_create_buf(false, true), function() vim.cmd "redraw" end)
+        local api = vim.api
+        local t = function(s) return api.nvim_replace_termcodes(s, true, true, true) end
+        api.nvim_buf_set_lines(0, 0, -1, true, {"a", "b", "c"})
+        api.nvim_feedkeys(t "G<C-V>", "txn", false)
+        api.nvim_buf_call(api.nvim_create_buf(false, true), function() vim.cmd "redraw" end)
       ]]
     end)
 
@@ -2800,29 +2800,29 @@ describe('lua stdlib', function()
     it('does not cause ml_get errors with invalid visual selection', function()
       -- Add lines to the current buffer and make another window looking into an empty buffer.
       exec_lua [[
-        _G.a = vim.api
-        _G.t = function(s) return a.nvim_replace_termcodes(s, true, true, true) end
-        _G.win_lines = a.nvim_get_current_win()
+        _G.api = vim.api
+        _G.t = function(s) return api.nvim_replace_termcodes(s, true, true, true) end
+        _G.win_lines = api.nvim_get_current_win()
         vim.cmd "new"
-        _G.win_empty = a.nvim_get_current_win()
-        a.nvim_set_current_win(win_lines)
-        a.nvim_buf_set_lines(0, 0, -1, true, {"a", "b", "c"})
+        _G.win_empty = api.nvim_get_current_win()
+        api.nvim_set_current_win(win_lines)
+        api.nvim_buf_set_lines(0, 0, -1, true, {"a", "b", "c"})
       ]]
 
       -- Start Visual in current window, redraw in other window with fewer lines.
       -- Should be fixed by vim-patch:8.2.4018.
       exec_lua [[
-        a.nvim_feedkeys(t "G<C-V>", "txn", false)
-        a.nvim_win_call(win_empty, function() vim.cmd "redraw" end)
+        api.nvim_feedkeys(t "G<C-V>", "txn", false)
+        api.nvim_win_call(win_empty, function() vim.cmd "redraw" end)
       ]]
 
       -- Start Visual in current window, extend it in other window with more lines.
       -- Fixed for win_execute by vim-patch:8.2.4026, but nvim_win_call should also not be affected.
       exec_lua [[
-        a.nvim_feedkeys(t "<Esc>gg", "txn", false)
-        a.nvim_set_current_win(win_empty)
-        a.nvim_feedkeys(t "gg<C-V>", "txn", false)
-        a.nvim_win_call(win_lines, function() a.nvim_feedkeys(t "G<C-V>", "txn", false) end)
+        api.nvim_feedkeys(t "<Esc>gg", "txn", false)
+        api.nvim_set_current_win(win_empty)
+        api.nvim_feedkeys(t "gg<C-V>", "txn", false)
+        api.nvim_win_call(win_lines, function() api.nvim_feedkeys(t "G<C-V>", "txn", false) end)
         vim.cmd "redraw"
       ]]
     end)
@@ -2836,14 +2836,14 @@ describe('lua stdlib', function()
       }
       screen:attach()
       exec_lua [[
-        _G.a = vim.api
+        _G.api = vim.api
         vim.opt.ruler = true
         local lines = {}
         for i = 0, 499 do lines[#lines + 1] = tostring(i) end
-        a.nvim_buf_set_lines(0, 0, -1, true, lines)
-        a.nvim_win_set_cursor(0, {20, 0})
+        api.nvim_buf_set_lines(0, 0, -1, true, lines)
+        api.nvim_win_set_cursor(0, {20, 0})
         vim.cmd "split"
-        _G.win = a.nvim_get_current_win()
+        _G.win = api.nvim_get_current_win()
         vim.cmd "wincmd w | redraw"
       ]]
       screen:expect [[
@@ -2854,7 +2854,7 @@ describe('lua stdlib', function()
                                       |
       ]]
       exec_lua [[
-        a.nvim_win_call(win, function() a.nvim_win_set_cursor(0, {100, 0}) end)
+        api.nvim_win_call(win, function() api.nvim_win_set_cursor(0, {100, 0}) end)
         vim.cmd "redraw"
       ]]
       screen:expect [[

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -575,12 +575,12 @@ describe("pending scrollback line handling", function()
 
   it("does not crash after setting 'number' #14891", function()
     exec_lua [[
-      local a = vim.api
-      local buf = a.nvim_create_buf(true, true)
-      local chan = a.nvim_open_term(buf, {})
-      a.nvim_win_set_option(0, "number", true)
-      a.nvim_chan_send(chan, ("a\n"):rep(11) .. "a")
-      a.nvim_win_set_buf(0, buf)
+      local api = vim.api
+      local buf = api.nvim_create_buf(true, true)
+      local chan = api.nvim_open_term(buf, {})
+      api.nvim_win_set_option(0, "number", true)
+      api.nvim_chan_send(chan, ("a\n"):rep(11) .. "a")
+      api.nvim_win_set_buf(0, buf)
     ]]
     screen:expect [[
       {1:  1 }^a                         |
@@ -607,12 +607,11 @@ describe("pending scrollback line handling", function()
   it("does not crash after nvim_buf_call #14891", function()
     skip(is_os('win'))
     exec_lua [[
-      local a = vim.api
-      local bufnr = a.nvim_create_buf(false, true)
-      a.nvim_buf_call(bufnr, function()
+      local bufnr = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_call(bufnr, function()
         vim.fn.termopen({"echo", ("hi\n"):rep(11)})
       end)
-      a.nvim_win_set_buf(0, bufnr)
+      vim.api.nvim_win_set_buf(0, bufnr)
       vim.cmd("startinsert")
     ]]
     screen:expect [[

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -47,15 +47,15 @@ describe('decorations providers', function()
 
   local function setup_provider(code)
     return exec_lua ([[
-      local a = vim.api
-      _G.ns1 = a.nvim_create_namespace "ns1"
+      local api = vim.api
+      _G.ns1 = api.nvim_create_namespace "ns1"
     ]] .. (code or [[
       beamtrace = {}
       local function on_do(kind, ...)
         table.insert(beamtrace, {kind, ...})
       end
     ]]) .. [[
-      a.nvim_set_decoration_provider(_G.ns1, {
+      api.nvim_set_decoration_provider(_G.ns1, {
         on_start = on_do; on_buf = on_do;
         on_win = on_do; on_line = on_do;
         on_end = on_do; _on_spell_nav = on_do;
@@ -75,8 +75,8 @@ describe('decorations providers', function()
     -- rather than append, which used to spin in an infinite loop allocating
     -- memory until nvim crashed/was killed.
     setup_provider([[
-      local ns2 = a.nvim_create_namespace "ns2"
-      a.nvim_set_decoration_provider(ns2, {})
+      local ns2 = api.nvim_create_namespace "ns2"
+      api.nvim_set_decoration_provider(ns2, {})
     ]])
     helpers.assert_alive()
   end)
@@ -132,12 +132,12 @@ describe('decorations providers', function()
   it('can have single provider', function()
     insert(mulholland)
     setup_provider [[
-      local hl = a.nvim_get_hl_id_by_name "ErrorMsg"
-      local test_ns = a.nvim_create_namespace "mulholland"
+      local hl = api.nvim_get_hl_id_by_name "ErrorMsg"
+      local test_ns = api.nvim_create_namespace "mulholland"
       function on_do(event, ...)
         if event == "line" then
           local win, buf, line = ...
-          a.nvim_buf_set_extmark(buf, test_ns, line, line,
+          api.nvim_buf_set_extmark(buf, test_ns, line, line,
                              { end_line = line, end_col = line+1,
                                hl_group = hl,
                                ephemeral = true
@@ -172,11 +172,11 @@ describe('decorations providers', function()
     ]]
 
     setup_provider [[
-      local ns = a.nvim_create_namespace "spell"
+      local ns = api.nvim_create_namespace "spell"
       beamtrace = {}
       local function on_do(kind, ...)
         if kind == 'win' or kind == 'spell' then
-          a.nvim_buf_set_extmark(0, ns, 0, 0, {
+          api.nvim_buf_set_extmark(0, ns, 0, 0, {
             end_row = 2,
             end_col = 23,
             spell = true,
@@ -330,12 +330,12 @@ describe('decorations providers', function()
     ]]}
 
     exec_lua [[
-      local a = vim.api
-      local thewin = a.nvim_get_current_win()
-      local ns2 = a.nvim_create_namespace 'ns2'
-      a.nvim_set_decoration_provider (ns2, {
+      local api = vim.api
+      local thewin = api.nvim_get_current_win()
+      local ns2 = api.nvim_create_namespace 'ns2'
+      api.nvim_set_decoration_provider (ns2, {
         on_win = function (_, win, buf)
-          a.nvim_set_hl_ns_fast(win == thewin and _G.ns1 or ns2)
+          api.nvim_set_hl_ns_fast(win == thewin and _G.ns1 or ns2)
         end;
       })
     ]]
@@ -436,12 +436,12 @@ describe('decorations providers', function()
   it('can have virtual text', function()
     insert(mulholland)
     setup_provider [[
-      local hl = a.nvim_get_hl_id_by_name "ErrorMsg"
-      local test_ns = a.nvim_create_namespace "mulholland"
+      local hl = api.nvim_get_hl_id_by_name "ErrorMsg"
+      local test_ns = api.nvim_create_namespace "mulholland"
       function on_do(event, ...)
         if event == "line" then
           local win, buf, line = ...
-          a.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
             virt_text = {{'+', 'ErrorMsg'}};
             virt_text_pos='overlay';
             ephemeral = true;
@@ -465,12 +465,12 @@ describe('decorations providers', function()
   it('can have virtual text of the style: right_align', function()
     insert(mulholland)
     setup_provider [[
-      local hl = a.nvim_get_hl_id_by_name "ErrorMsg"
-      local test_ns = a.nvim_create_namespace "mulholland"
+      local hl = api.nvim_get_hl_id_by_name "ErrorMsg"
+      local test_ns = api.nvim_create_namespace "mulholland"
       function on_do(event, ...)
         if event == "line" then
           local win, buf, line = ...
-          a.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+          api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
             virt_text = {{'+'}, {string.rep(' ', line+1), 'ErrorMsg'}};
             virt_text_pos='right_align';
             ephemeral = true;
@@ -494,12 +494,12 @@ describe('decorations providers', function()
   it('can highlight beyond EOL', function()
     insert(mulholland)
     setup_provider [[
-      local test_ns = a.nvim_create_namespace "veberod"
+      local test_ns = api.nvim_create_namespace "veberod"
       function on_do(event, ...)
         if event == "line" then
           local win, buf, line = ...
-          if string.find(a.nvim_buf_get_lines(buf, line, line+1, true)[1], "buf") then
-            a.nvim_buf_set_extmark(buf, test_ns, line, 0, {
+          if string.find(api.nvim_buf_get_lines(buf, line, line+1, true)[1], "buf") then
+            api.nvim_buf_set_extmark(buf, test_ns, line, 0, {
               end_line = line+1;
               hl_group = 'DiffAdd';
               hl_eol = true;
@@ -534,9 +534,9 @@ describe('decorations providers', function()
       local function on_do(kind, winid, bufnr, topline, botline_guess)
         if kind == 'win' then
           if topline < 100 and botline_guess > 100 then
-            vim.api.nvim_buf_set_extmark(bufnr, ns1, 99, -1, { sign_text = 'X' })
+            api.nvim_buf_set_extmark(bufnr, ns1, 99, -1, { sign_text = 'X' })
           else
-            vim.api.nvim_buf_clear_namespace(bufnr, ns1, 0, -1)
+            api.nvim_buf_clear_namespace(bufnr, ns1, 0, -1)
           end
         end
       end

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -65,20 +65,20 @@ describe('float window', function()
   it('closed immediately by autocmd #11383', function()
     eq('Window was closed immediately',
       pcall_err(exec_lua, [[
-        local a = vim.api
+        local api = vim.api
         local function crashes(contents)
-          local buf = a.nvim_create_buf(false, true)
-          local floatwin = a.nvim_open_win(buf, true, {
+          local buf = api.nvim_create_buf(false, true)
+          local floatwin = api.nvim_open_win(buf, true, {
             relative = 'cursor';
             style = 'minimal';
             row = 0; col = 0;
             height = #contents;
             width = 10;
           })
-          a.nvim_buf_set_lines(buf, 0, -1, true, contents)
+          api.nvim_buf_set_lines(buf, 0, -1, true, contents)
           local winnr = vim.fn.win_id2win(floatwin)
-          a.nvim_command('wincmd p')
-          a.nvim_command('autocmd CursorMoved * ++once '..winnr..'wincmd c')
+          api.nvim_command('wincmd p')
+          api.nvim_command('autocmd CursorMoved * ++once '..winnr..'wincmd c')
           return buf, floatwin
         end
         crashes{'foo'}


### PR DESCRIPTION
### Problem

Codebase inconsistently binds `vim.api` onto `a` or `api`.

### Solution
Use `api` everywhere. `a` as an identifier is too short to have at the module level.
