### PR TITLE
fix(folds): handle visual blockwise indent insertion correctly

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -623,9 +623,9 @@ static void block_insert(oparg_T *oap, char *s, int b_insert, struct block_def *
     }
   }   // for all lnum
 
-  changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L, true);
-
   State = oldstate;
+
+  changed_lines(oap->start.lnum + 1, 0, oap->end.lnum + 1, 0L, true);
 }
 
 /// Handle reindenting a block of lines.

--- a/test/functional/editor/fold_spec.lua
+++ b/test/functional/editor/fold_spec.lua
@@ -359,4 +359,14 @@ a]], '13m7')
     eq(10, funcs.foldclosedend(7))
     eq(14, funcs.foldclosedend(11))
   end)
+  it('updates correctly with indent method and visual blockwise insertion', function()
+    insert([[
+    a
+    b
+    ]])
+    feed_command('set foldmethod=indent', 'set shiftwidth=2')
+    feed('gg0<C-v>jI  <Esc>') -- indent both lines using visual blockwise mode
+    eq(1, funcs.foldlevel(1))
+    eq(1, funcs.foldlevel(2))
+  end)
 end)


### PR DESCRIPTION
This commit fixes a bug that is not in Vim, where indenting multiple lines with Visual blockwise mode (when using the "indent" foldmethod) does not correctly update folds:

Bug Reproduction Steps:
1. Run `:set foldmethod=indent shiftwidth=2`.
3. Make 2 non-indented lines. Example: `afoo\<CR\>foo\<Esc\>`
5. Indent the 2 lines at the same time by inserting 2 spaces using Visual blockwise mode (CTRL-V). Example: `gg0\<C-V\>jI\<Space\>\<Space\>\<Esc\>`
7. Try to close the fold by typing `zc`.
9. See that the fold didn't close (even though the 2 lines were indented correctly).
11. Run `:set foldignore=` or `:set foldmethod=indent` to force the folds to update.
13. See that the fold is now closed.

I believe that the optimization in [this commit](https://github.com/neovim/neovim/commit/6e9f329d051cf6bf6d83dbe5335f86a1752ec45a) caused this bug, because removing the ` || State & MODE_INSERT` from the condition at [the start of foldUpdate()](https://github.com/neovim/neovim/blob/56e4d79b280b2da1c8d9705d2f300cd93e955f53/src/nvim/fold.c#L774) fixes the bug. I cannot build that old version, though, to truly confirm a regression.

My solution keeps the optimization but adds a call to `foldUpdateAfterInsert()`, which is a function that seems to be used in other places for a similar reason.

All tests pass when I run `make oldtest`. However, when I run `make test` at least 1 test fails. This even happens on the master branch. Is this ok?

Thanks.

```
"make test" Output:
     40 SKIPPED TESTS
     1 FAILED TEST
    ------------------------------------------------------------------------------
    $NVIM_LOG_FILE: /home/brandon/Downloads/neovim/build/.nvimlog
    (last 10 lines)
    ERR 2023-04-05T10:57:18.696 nvim.31322.0 tui_mode_change:1144: uv_tty_set_mode failed: inappropriate ioctl for device
    ERR 2023-04-05T10:57:32.375 T4637.31622.0 os_set_cloexec:495: Failed to get flags on descriptor 3: Bad file descriptor
    ERR 2023-04-05T10:58:36.237 T6045.33131.0 libuv_process_spawn:97: uv_spawn(fake_shell) failed: no such file or directory
    ERR 2023-04-05T11:00:20.041 T1211.34918.0 libuv_process_spawn:97: uv_spawn(/usr/bin/pwd) failed: permission denied
    ERR 2023-04-05T11:00:24.743 T1252.35061.0 libuv_process_spawn:97: uv_spawn(nosuchshell) failed: no such file or directory
    ERR 2023-04-05T11:00:24.744 T1252.35061.0 libuv_process_spawn:97: uv_spawn(nosuchshell) failed: no such file or directory
    ERR 2023-04-05T11:00:27.317 T1301.35186.0/c os_set_cloexec:495: Failed to get flags on descriptor 3: Bad file descriptor
    ERR 2023-04-05T11:03:22.229 nvim.39338.0 tui_mode_change:1144: uv_tty_set_mode failed: inappropriate ioctl for device
    ERR 2023-04-05T11:03:35.419 T4637.39638.0 os_set_cloexec:495: Failed to get flags on descriptor 3: Bad file descriptor
    ERR 2023-04-05T11:04:40.965 T6045.41156.0 libuv_process_spawn:97: uv_spawn(fake_shell) failed: no such file or directory
    ------------------------------------------------------------------------------
    -- Tests exited non-zero: Segmentation fault
    -- No output to stderr.
    CMake Error at /home/brandon/Downloads/neovim/cmake/RunTests.cmake:101 (message):
      functional tests failed with error: Segmentation fault
```