### PR TITLE
docs: add vim.treesitter.query.get_query() to deprecated.txt

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -130,6 +130,8 @@ TREESITTER FUNCTIONS
 						instead.
 - *vim.treesitter.get_node_at_cursor()*		Use |vim.treesitter.get_node()|
 						and |TSNode:type()| instead.
+- *vim.treesitter.query.get_query()*		Use |vim.treesitter.query.get()|
+						instead.
 
 LUA
 - vim.register_keystroke_callback()	Use |vim.on_key()| instead.


### PR DESCRIPTION
Add details of deprecation to the correct spot in docs.
Current warning tells you to see `:help deprecate.txt` but the
details were not there.
