### PR TITLE
feat(lua): allow vim.F.if_nil to take multiple arguments

### DIFF
--- a/runtime/lua/vim/F.lua
+++ b/runtime/lua/vim/F.lua
@@ -1,18 +1,29 @@
 local F = {}
 
---- Returns {a} if it is not nil, otherwise returns {b}.
+--- Returns the first argument which is not nil.
 ---
----@generic A
----@generic B
+--- If all arguments are nil, returns nil.
 ---
----@param a A
----@param b B
----@return A | B
-function F.if_nil(a, b)
-  if a == nil then
-    return b
+--- Examples:
+--- <pre>
+--- local a = nil
+--- local b = nil
+--- local c = 42
+--- local d = true
+--- assert(vim.F.if_nil(a, b, c, d) == 42)
+--- </pre>
+---
+---@param ... any
+---@return any
+function F.if_nil(...)
+  local nargs = select('#', ...)
+  for i = 1, nargs do
+    local v = select(i, ...)
+    if v ~= nil then
+      return v
+    end
   end
-  return a
+  return nil
 end
 
 -- Use in combination with pcall

--- a/runtime/plugin/editorconfig.lua
+++ b/runtime/plugin/editorconfig.lua
@@ -3,7 +3,7 @@ vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead', 'BufFilePost' }, {
   group = group,
   callback = function(args)
     -- Buffer-local enable has higher priority
-    local enable = vim.F.if_nil(vim.b.editorconfig, vim.F.if_nil(vim.g.editorconfig, true))
+    local enable = vim.F.if_nil(vim.b.editorconfig, vim.g.editorconfig, true)
     if not enable then
       return
     end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2967,6 +2967,32 @@ describe('lua stdlib', function()
       }]],
       eval[[execute('lua vim.print(42, "abc", { a = { b = 77 }})')]])
   end)
+
+  it('vim.F.if_nil', function()
+    local function if_nil(...)
+      return exec_lua([[
+        local args = {...}
+        local nargs = select('#', ...)
+        for i = 1, nargs do
+          if args[i] == vim.NIL then
+            args[i] = nil
+          end
+        end
+        return vim.F.if_nil(unpack(args, 1, nargs))
+      ]], ...)
+    end
+
+    local a = NIL
+    local b = NIL
+    local c = 42
+    local d = false
+    eq(42, if_nil(a, c))
+    eq(false, if_nil(d, b))
+    eq(42, if_nil(a, b, c, d))
+    eq(false, if_nil(d))
+    eq(false, if_nil(d, c))
+    eq(NIL, if_nil(a))
+  end)
 end)
 
 describe('lua: builtin modules', function()


### PR DESCRIPTION
The first argument which is non-nil is returned. This is useful when
using nested default values (e.g. in the EditorConfig plugin).

Before:

    local enable = vim.F.if_nil(vim.b.editorconfig, vim.F.if_nil(vim.g.editorconfig, true))

After:

    local enable = vim.F.if_nil(vim.b.editorconfig, vim.g.editorconfig, true)
