### PR TITLE
feat(api): set statuscolumn line number in nvim_eval_statusline()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -773,8 +773,8 @@ nvim_eval_statusline({str}, {*opts})                  *nvim_eval_statusline()*
                 • use_tabline: (boolean) Evaluate tabline instead of
                   statusline. When true, {winid} is ignored. Mutually
                   exclusive with {use_winbar}.
-                • use_statuscol: (boolean) Evaluate statuscolumn instead of
-                  statusline.
+                • use_statuscol_lnum: (number) Evaluate statuscolumn for this
+                  line number instead of statusline.
 
     Return: ~
         Dictionary containing statusline information, with these keys:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -74,7 +74,7 @@ NEW FEATURES                                                    *news-features*
 The following new APIs or features were added.
 
 • |nvim_eval_statusline()| supports evaluating the |'statuscolumn'| through a
-  new `opts` field: `use_statuscol`.
+  new `opts` field: `use_statuscol_lnum`.
 
 • |nvim_buf_get_extmarks()| now accepts a -1 `ns_id` to request extmarks from
   all namespaces and adds the namespace id to the details array.

--- a/src/nvim/api/keysets.lua
+++ b/src/nvim/api/keysets.lua
@@ -97,7 +97,7 @@ return {
     "highlights";
     "use_winbar";
     "use_tabline";
-    "use_statuscol";
+    "use_statuscol_lnum";
   }};
   { 'option', {
     "scope";

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3422,7 +3422,7 @@ describe('API', function()
             { use_winbar = true, highlights = true }))
       end)
       it('works with statuscolumn', function()
-        command([[
+        exec([[
           let &stc='%C%s%=%l '
           set cul nu nuw=3 scl=yes:2 fdc=2
           call setline(1, repeat(['aaaaa'], 5))
@@ -3431,9 +3431,8 @@ describe('API', function()
           call sign_place(2, 1, 'a', bufnr(), {'lnum':4})
           call nvim_buf_set_extmark(0, g:ns, 3, 1, { 'sign_text':'bb', 'sign_hl_group':'ErrorMsg' })
           1,5fold | 1,5 fold | foldopen!
+          norm 4G
         ]])
-        command('norm 4G')
-        command('let v:lnum=4')
         eq({
           str = '││aabb 4 ',
           width = 9,
@@ -3444,8 +3443,7 @@ describe('API', function()
             { group = 'ErrorMsg', start = 8 },
             { group = 'Normal', start = 10 }
           }
-        }, meths.eval_statusline('%C%s%=%l ', { use_statuscol = true, highlights = true }))
-        command('let v:lnum=3')
+        }, meths.eval_statusline('%C%s%=%l ', { use_statuscol_lnum = 4, highlights = true }))
         eq({
           str = '3 ' ,
           width = 2,
@@ -3453,7 +3451,7 @@ describe('API', function()
             { group = 'LineNr', start = 0 },
             { group = 'ErrorMsg', start = 1 }
           }
-        }, meths.eval_statusline('%l%#ErrorMsg# ', { use_statuscol = true, highlights = true }))
+        }, meths.eval_statusline('%l%#ErrorMsg# ', { use_statuscol_lnum = 3, highlights = true }))
       end)
       it('no memory leak with click functions', function()
         meths.eval_statusline('%@ClickFunc@StatusLineStringWithClickFunc%T', {})


### PR DESCRIPTION
Having the user set `v:lnum` before calling `nvim_eval_statusline()` is unnecesarily fragile. Redraws inbetween setting `v:lnum` and the `nvim_eval_statusline()` call will overwrite `v:lnum`.