### PR TITLE
fix(highlight): use winhl=Foo:Bar even when Bar is empty

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -53,7 +53,7 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
   }
 
   if (HAS_KEY(opts->win)) {
-    VALIDATE_T("win", kObjectTypeInteger, opts->win.type, {
+    VALIDATE_T_HANDLE("win", kObjectTypeWindow, opts->win.type, {
       return FAIL;
     });
 
@@ -65,7 +65,7 @@ static int validate_option_value_args(Dict(option) *opts, int *scope, int *opt_t
   }
 
   if (HAS_KEY(opts->buf)) {
-    VALIDATE_T("buf", kObjectTypeInteger, opts->buf.type, {
+    VALIDATE_T_HANDLE("buf", kObjectTypeBuffer, opts->buf.type, {
       return FAIL;
     });
 

--- a/src/nvim/api/private/validate.h
+++ b/src/nvim/api/private/validate.h
@@ -67,6 +67,15 @@
     } \
   } while (0)
 
+/// Checks that actual_t is either the correct handle type or a type erased handle (integer)
+#define VALIDATE_T_HANDLE(name, expected_t, actual_t, code) \
+  do { \
+    if (expected_t != actual_t && kObjectTypeInteger != actual_t) { \
+      api_err_exp(err, name, api_typename(expected_t), api_typename(actual_t)); \
+      code; \
+    } \
+  } while (0)
+
 #define VALIDATE_RANGE(cond, name, code) \
   do { \
     if (!(cond)) { \

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -303,7 +303,7 @@ int hl_get_ui_attr(int ns_id, int idx, int final_id, bool optional)
   bool available = false;
 
   if (final_id > 0) {
-    int syn_attr = syn_ns_id2attr(ns_id, final_id, optional);
+    int syn_attr = syn_ns_id2attr(ns_id, final_id, &optional);
     if (syn_attr > 0) {
       attrs = syn_attr2entry(syn_attr);
       available = true;

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -4935,6 +4935,53 @@ describe('float window', function()
       end)
     end)
 
+    it("can use Normal as background", function()
+      local buf = meths.create_buf(false,false)
+      meths.buf_set_lines(buf,0,-1,true,{"here", "float"})
+      local win = meths.open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
+      meths.set_option_value('winhl', 'Normal:Normal', {win=win})
+
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 5
+          here                |
+          float               |
+        ]], float_pos={
+          [5] = {{id = 1002}, "NW", 1, 2, 5, true, 50};
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [5] = {win = {id = 1002}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
+        }}
+      else
+        screen:expect{grid=[[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }here                {0:               }|
+          {0:~    }float               {0:               }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+        ]]}
+      end
+    end)
+
     describe("handles :wincmd", function()
       local win
       local expected_pos

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -2432,6 +2432,23 @@ describe("'winhighlight' highlight", function()
                                               |
     ]]}
   end)
+
+  it('can link to empty highlight group', function()
+    command 'hi NormalNC guibg=Red' -- czerwone time
+    command 'set winhl=NormalNC:Normal'
+    command 'split'
+
+    screen:expect{grid=[[
+      ^                    |
+      {0:~                   }|
+      {0:~                   }|
+      {3:[No Name]           }|
+                          |
+      {0:~                   }|
+      {4:[No Name]           }|
+                          |
+    ]]}
+  end)
 end)
 
 describe('highlight namespaces', function()


### PR DESCRIPTION
fixes #22906