### PR TITLE
test(fs): use luv to fully implement rmdir

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -573,7 +573,7 @@ describe('API', function()
 
     before_each(function()
       clear()
-      funcs.mkdir("Xtestdir")
+      helpers.mkdir("Xtestdir")
       start_dir = funcs.getcwd()
     end)
 

--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -50,6 +50,7 @@ describe('oldtests', function()
   it('should fire on unload buf', function()
     funcs.writefile({'Test file Xxx1'}, 'Xxx1')
     funcs.writefile({'Test file Xxx2'}, 'Xxx2')
+    local fname = 'Xtest_functional_autocmd_unload'
 
     local content = [[
       func UnloadAllBufs()
@@ -69,15 +70,15 @@ describe('oldtests', function()
       q
     ]]
 
-    funcs.writefile(funcs.split(content, "\n"), 'Xtest')
+    funcs.writefile(funcs.split(content, "\n"), fname)
 
     funcs.delete('Xout')
-    funcs.system(meths.get_vvar('progpath') .. ' -u NORC -i NONE -N -S Xtest')
+    funcs.system(string.format('%s -u NORC -i NONE -N -S %s', meths.get_vvar('progpath'), fname))
     eq(1, funcs.filereadable('Xout'))
 
     funcs.delete('Xxx1')
     funcs.delete('Xxx2')
-    funcs.delete('Xtest')
+    funcs.delete(fname)
     funcs.delete('Xout')
   end)
 end)

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -266,9 +266,9 @@ describe('tmpdir', function()
 
   before_each(function()
     -- Fake /tmp dir so that we can mess it up.
-    os_tmpdir = tmpname()
-    os.remove(os_tmpdir)
-    mkdir(os_tmpdir)
+    os_tmpdir = vim.fs.dirname(tmpname())
+    helpers.rmdir(os_tmpdir)
+    helpers.mkdir_p(os_tmpdir)
   end)
 
   after_each(function()

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -776,10 +776,6 @@ function module.exec_lua(code, ...)
   return module.meths.exec_lua(code, {...})
 end
 
-function module.get_pathsep()
-  return is_os('win') and '\\' or '/'
-end
-
 --- Gets the filesystem root dir, namely "/" or "C:/".
 function module.pathroot()
   local pathsep = package.config:sub(1,1)

--- a/test/functional/legacy/061_undo_tree_spec.lua
+++ b/test/functional/legacy/061_undo_tree_spec.lua
@@ -22,29 +22,30 @@ end
 
 describe('undo tree:', function()
   before_each(clear)
+  local fname = 'Xtest_functional_legacy_undotree'
   teardown(function()
-    os.remove('Xtest.source')
+    os.remove(fname .. '.source')
   end)
 
   describe(':earlier and :later', function()
     before_each(function()
-      os.remove('Xtest')
+      os.remove(fname)
     end)
     teardown(function()
-      os.remove('Xtest')
+      os.remove(fname)
     end)
 
     it('time specifications, g- g+', function()
       -- We write the test text to a file in order to prevent nvim to record
       -- the inserting of the text into the undo history.
-      write_file('Xtest', '\n123456789\n')
+      write_file(fname, '\n123456789\n')
 
       -- `:earlier` and `:later` are (obviously) time-sensitive, so this test
       -- sometimes fails if the system is under load. It is wrapped in a local
       -- function to allow multiple attempts.
       local function test_earlier_later()
         clear()
-        feed_command('e Xtest')
+        feed_command('e ' .. fname)
         -- Assert that no undo history is present.
         eq({}, eval('undotree().entries'))
         -- Delete three characters and undo.
@@ -103,7 +104,7 @@ describe('undo tree:', function()
 
     it('file-write specifications', function()
       feed('ione one one<esc>')
-      feed_command('w Xtest')
+      feed_command('w ' .. fname)
       feed('otwo<esc>')
       feed('otwo<esc>')
       feed_command('w')
@@ -187,7 +188,7 @@ describe('undo tree:', function()
 
   it('undo an expression-register', function()
     local normal_commands = 'o1\027a2\018=string(123)\n\027'
-    write_file('Xtest.source', normal_commands)
+    write_file(fname .. '.source', normal_commands)
 
     feed('oa<esc>')
     feed('ob<esc>')
@@ -221,7 +222,7 @@ describe('undo tree:', function()
       c
       12]])
     feed('od<esc>')
-    feed_command('so! Xtest.source')
+    feed_command('so! ' .. fname .. '.source')
     expect([[
 
       a

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -11,11 +11,10 @@ describe('vim._watch', function()
   end)
 
   describe('watch', function()
+    local root_dir = vim.fs.dirname(helpers.tmpname())
+    helpers.rmdir(root_dir)
+    mkdir(root_dir)
     it('detects file changes', function()
-      local root_dir = helpers.tmpname()
-      os.remove(root_dir)
-      mkdir(root_dir)
-
       local result = exec_lua(
         [[
         local root_dir = ...
@@ -99,11 +98,10 @@ describe('vim._watch', function()
   end)
 
   describe('poll', function()
+    local root_dir = vim.fs.dirname(helpers.tmpname())
+    helpers.rmdir(root_dir)
+    mkdir(root_dir)
     it('detects file changes', function()
-      local root_dir = helpers.tmpname()
-      os.remove(root_dir)
-      mkdir(root_dir)
-
       local result = exec_lua(
         [[
         local root_dir = ...

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -22,6 +22,7 @@ local skip = helpers.skip
 
 describe('ui/ext_messages', function()
   local screen
+  local fname = 'Xtest_functional_ui_messages_spec'
 
   before_each(function()
     clear()
@@ -41,7 +42,7 @@ describe('ui/ext_messages', function()
     })
   end)
   after_each(function()
-    os.remove('Xtest')
+    os.remove(fname)
   end)
 
   it('msg_clear follows msg_show kind of confirm', function()
@@ -126,7 +127,7 @@ describe('ui/ext_messages', function()
     feed('nq')
 
     -- kind=wmsg (editing readonly file)
-    command('write Xtest')
+    command('write ' .. fname)
     command('set readonly nohls')
     feed('G$x')
     screen:expect{grid=[[
@@ -912,9 +913,9 @@ stack traceback:
   end)
 
   it('does not truncate messages', function()
-    command('write Xtest')
+    command('write '.. fname)
     screen:expect({messages={
-      {content = { { '"Xtest" [New] 0L, 0B written' } }, kind = "" }
+      {content = { { string.format('"%s" [New] 0L, 0B written', fname) } }, kind = "" }
     }})
   end)
 end)

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -393,7 +393,7 @@ describe('system()', function()
   end)
 
   describe('with output containing NULs', function()
-    local fname = 'Xtest'
+    local fname = 'Xtest_functional_vimscript_system_nuls'
 
     before_each(create_file_with_nuls(fname))
     after_each(delete_file(fname))
@@ -549,7 +549,7 @@ describe('systemlist()', function()
   end)
 
   describe('with output containing NULs', function()
-    local fname = 'Xtest'
+    local fname = 'Xtest_functional_vimscript_systemlist_nuls'
 
     before_each(function()
       command('set ff=unix')

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -906,6 +906,9 @@ function module.read_nvim_log(logfile, ci_rename)
 end
 
 function module.mkdir(path)
+  if module.isdir(path) then
+    return
+  end
   -- 493 is 0755 in decimal
   return luv.fs_mkdir(path, 493)
 end

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -21,6 +21,15 @@ local module = {
   REMOVE_THIS = {},
 }
 
+function module.get_pathsep()
+  return module.is_os('win') and '\\' or '/'
+end
+
+function module.join_paths(...)
+  local result = table.concat({ ... }, module.get_pathsep())
+  return result
+end
+
 function module.isdir(path)
   if not path then
     return false

--- a/test/helpers.lua
+++ b/test/helpers.lua
@@ -43,6 +43,38 @@ function module.isfile(path)
   return stat.type == 'file'
 end
 
+function module.rmdir(path)
+  if not module.isdir(path) then
+    return
+  end
+  local handle = luv.fs_scandir(path)
+  if type(handle) == 'string' then
+    error(handle)
+  end
+
+  while true do
+    local name, t = luv.fs_scandir_next(handle)
+    if not name then
+      break
+    end
+
+    local new_cwd = module.join_paths(path, name)
+    if t == 'directory' then
+      local success = module.rmdir(new_cwd)
+      if not success then
+        return false
+      end
+    else
+      local success = luv.fs_unlink(new_cwd)
+      if not success then
+        return false
+      end
+    end
+  end
+
+  return luv.fs_rmdir(path)
+end
+
 function module.argss_to_cmd(...)
   local cmd = ''
   for i = 1, select('#', ...) do


### PR DESCRIPTION
use luv for a performant cross-platform `rmdir` operation
- skip Lua's `os.remove` incompatibilities
- skip using nvim's process which might hang on Windows

credit: based on
[`nvim-tree.actions.remove_dir()`](https://github.com/kyazdani42/nvim-tree.lua/blob/d1410cb0896a3aad5d84ddc54284774a627c6d63/lua/nvim-tree/actions/fs/remove-file.lua#L42)
