### PR TITLE
build: make required parsers actually required by erroring if not found

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -400,7 +400,8 @@ jobs:
           # later on.
           cmake -S cmake.deps -B .deps -G Ninja -D USE_BUNDLED=OFF \
             -D USE_BUNDLED_LIBVTERM=ON \
-            -D USE_BUNDLED_TS=ON
+            -D USE_BUNDLED_TS=ON \
+            -D USE_BUNDLED_TS_PARSERS=ON
           cmake --build .deps
 
       - name: Build

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -32,6 +32,19 @@ find_package(Msgpack 1.0.0 REQUIRED)
 find_package(Treesitter 0.20.8 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 
+function(FindParsers lang)
+  string(TOUPPER "PARSER_${lang}" PARSER_NAME)
+  set(CMAKE_FIND_LIBRARY_PREFIXES "")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_SHARED_MODULE_SUFFIX})
+  find_library(${PARSER_NAME} NAMES ${lang} PATH_SUFFIXES nvim/parser)
+  if(NOT ${PARSER_NAME})
+    message(FATAL_ERROR "${lang} parser not found")
+  endif()
+endfunction()
+foreach(lang c lua vim vimdoc query)
+  FindParsers(${lang})
+endforeach()
+
 target_link_libraries(main_lib INTERFACE
   iconv
   libtermkey


### PR DESCRIPTION
Previously, neovim built without errors even if required parsers aren't
found. This tricked people into believing they had a functional version
of neovim even though it was technically broken. Having proper existence
check during build times prevents this scenario.
