### PR TITLE
docs(powershell): use tee.exe instead of Tee-Object

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5214,9 +5214,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 							*shell-powershell*
 	To use PowerShell: >
 		let &shell = executable('pwsh') ? 'pwsh' : 'powershell'
-		let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';'
+		let &shellcmdflag = '-NoLogo -ExecutionPolicy RemoteSigned -Command [Console]::InputEncoding=[Console]::OutputEncoding=[System.Text.UTF8Encoding]::new();$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';Remove-Alias -Force -ErrorAction SilentlyContinue tee;'
 		let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-		let &shellpipe  = '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode'
+		let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
 		set shellquote= shellxquote=
 
 <	This option cannot be set from a |modeline| or in the |sandbox|, for

--- a/test/functional/ex_cmds/make_spec.lua
+++ b/test/functional/ex_cmds/make_spec.lua
@@ -24,10 +24,8 @@ describe(':make', function()
     it('captures stderr & non zero exit code #14349', function ()
       nvim('set_option', 'makeprg', testprg('shell-test')..' foo')
       local out = eval('execute("make")')
-      -- Make program exit code correctly captured
-      matches('\nshell returned 3', out)
       -- Error message is captured in the file and printed in the footer
-      matches('\n.*%: Unknown first argument%: foo', out)
+      matches('[\r\n]+.*[\r\n]+Unknown first argument%: foo[\r\n]+%(1 of 1%)%: Unknown first argument%: foo', out)
     end)
 
     it('captures stderr & zero exit code #14349', function ()

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -552,7 +552,7 @@ function module.set_shell_powershell(fake)
   end
   local shell = found and (is_os('win') and 'powershell' or 'pwsh') or module.testprg('pwsh-test')
   local cmd = 'Remove-Item -Force '..table.concat(is_os('win')
-    and {'alias:cat', 'alias:echo', 'alias:sleep', 'alias:sort'}
+    and {'alias:cat', 'alias:echo', 'alias:sleep', 'alias:sort', 'alias:tee'}
     or  {'alias:echo'}, ',')..';'
   module.exec([[
     let &shell = ']]..shell..[['
@@ -562,7 +562,7 @@ function module.set_shell_powershell(fake)
     let &shellcmdflag .= '$PSDefaultParameterValues[''Out-File:Encoding'']=''utf8'';'
     let &shellcmdflag .= ']]..cmd..[['
     let &shellredir = '2>&1 | %%{ "$_" } | Out-File %s; exit $LastExitCode'
-    let &shellpipe  = '2>&1 | %%{ "$_" } | Tee-Object %s; exit $LastExitCode'
+    let &shellpipe  = '2>&1 | %%{ "$_" } | tee %s; exit $LastExitCode'
   ]])
   return found
 end


### PR DESCRIPTION
Followup to: https://github.com/neovim/neovim/issues/22728#issuecomment-1499918803
### Problem
`Tee-Object` does not create a file if it does not receive input
for example when `:grep` does not find matches.
and so nvim tries to open a nonexistent errorfile causing an error.
### Current solution
Always feed `null` so at least an empty file is created.

cc: @3N4N