### PR TITLE
vim-patch:9.0.1442: mapset() does not restore non-script context

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -449,7 +449,7 @@ static int str_to_mapargs(const char *strargs, bool is_unmap, MapArguments *mapa
 /// @param args  "rhs", "rhs_lua", "orig_rhs", "expr", "silent", "nowait", "replace_keycodes" and
 ///              and "desc" fields are used.
 ///              "rhs", "rhs_lua", "orig_rhs" fields are cleared if "simplified" is false.
-/// @param sid  -1 to use current_sctx
+/// @param sid  0 to use current_sctx
 static void map_add(buf_T *buf, mapblock_T **map_table, mapblock_T **abbr_table, const char *keys,
                     MapArguments *args, int noremap, int mode, bool is_abbr, scid_T sid,
                     linenr_T lnum, bool simplified)
@@ -482,7 +482,7 @@ static void map_add(buf_T *buf, mapblock_T **map_table, mapblock_T **abbr_table,
   mp->m_simplified = simplified;
   mp->m_expr = args->expr;
   mp->m_replace_keycodes = args->replace_keycodes;
-  if (sid >= 0) {
+  if (sid != 0) {
     mp->m_script_ctx.sc_sid = sid;
     mp->m_script_ctx.sc_lnum = lnum;
   } else {
@@ -857,8 +857,8 @@ static int buf_do_map(int maptype, MapArguments *args, int mode, bool is_abbrev,
 
     // Get here when adding a new entry to the maphash[] list or abbrlist.
     map_add(buf, map_table, abbr_table, lhs, args, noremap, mode, is_abbrev,
-            -1,  // sid
-            0,   // lnum
+            0,  // sid
+            0,  // lnum
             keyround1_simplified);
   }
 

--- a/test/old/testdir/test_maparg.vim
+++ b/test/old/testdir/test_maparg.vim
@@ -1,8 +1,9 @@
 " Tests for maparg(), mapcheck() and mapset().
 " Also test utf8 map with a 0x80 byte.
-" Also test mapcheck()
 
-func s:SID()     
+source shared.vim
+
+func s:SID()
   return str2nr(matchstr(expand('<sfile>'), '<SNR>\zs\d\+\ze_SID$'))
 endfunc
 
@@ -319,7 +320,28 @@ func Test_map_restore()
   call Check_ctrlb_map(dsimp, 0)
 
   nunmap <C-B>
+endfunc
 
+" Test restoring the script context of a mapping
+func Test_map_restore_sid()
+  let after =<< trim [CODE]
+    call assert_equal("\tLast set from --cmd argument",
+          \ execute('verbose nmap ,n')->trim()->split("\n")[-1])
+    let d = maparg(',n', 'n', 0, 1)
+    nunmap ,n
+    call assert_equal('No mapping found',
+          \ execute('verbose nmap ,n')->trim()->split("\n")[-1])
+    call mapset('n', 0, d)
+    call assert_equal("\tLast set from --cmd argument",
+          \ execute('verbose nmap ,n')->trim()->split("\n")[-1])
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [CODE]
+
+  if RunVim([], after, '--clean --cmd "nmap ,n <Nop>"')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xresult')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1442: mapset() does not restore non-script context

Problem:    mapset() does not restore non-script context.
Solution:   Also accept negative sid. (closes vim/vim#12132)

https://github.com/vim/vim/commit/bfc7cbd1d44e53e844a079d8ad16ae990dad664d