### PR TITLE
fix(packaging): revert installation context to per-machine on Windows

### DIFF
--- a/cmake.packaging/WixPatch.xml
+++ b/cmake.packaging/WixPatch.xml
@@ -11,11 +11,4 @@
       Value='[INSTALL_ROOT]bin'
     />
   </CPackWiXFragment>
-
-  <!-- Allow installation by non-administrative users -->
-  <!-- https://learn.microsoft.com/windows/win32/msi/allusers -->
-  <CPackWiXFragment Id="#PRODUCT">
-    <Property Id="ALLUSERS" Value="2" />
-    <Property Id="MSIINSTALLPERUSER" Value="1" />
-  </CPackWiXFragment>
 </CPackWiXPatch>


### PR DESCRIPTION
Fixes #22933. Revert this change until a proper solution is implemented, such as https://github.com/neovim/neovim/issues/22933#issuecomment-1500766519.

This change should also be backported to the https://github.com/neovim/neovim/tree/release-0.9 branch.