### PR TITLE
fix(highlight): add missing g: prefix for colors_name

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1003,7 +1003,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     // ":highlight clear [group]" command.
     line = linep;
     if (ends_excmd((uint8_t)(*line))) {
-      do_unlet(S_LEN("colors_name"), true);
+      do_unlet(S_LEN("g:colors_name"), true);
       restore_cterm_colors();
 
       // Clear all default highlight groups and load the defaults.

--- a/test/functional/ex_cmds/highlight_spec.lua
+++ b/test/functional/ex_cmds/highlight_spec.lua
@@ -3,6 +3,9 @@ local helpers = require("test.functional.helpers")(after_each)
 local eq, command = helpers.eq, helpers.command
 local clear = helpers.clear
 local eval, exc_exec = helpers.eval, helpers.exc_exec
+local exec = helpers.exec
+local funcs = helpers.funcs
+local meths = helpers.meths
 
 describe(':highlight', function()
   local screen
@@ -44,5 +47,21 @@ describe(':highlight', function()
     command('highlight NonText gui=undercurl,underline')
     eq('', eval('synIDattr(hlID("NonText"), "undercurl", "gui")'))
     eq('1', eval('synIDattr(hlID("NonText"), "underline", "gui")'))
+  end)
+
+  it('clear', function()
+    meths.set_var('colors_name', 'foo')
+    eq(1, funcs.exists('g:colors_name'))
+    command('hi clear')
+    eq(0, funcs.exists('g:colors_name'))
+    meths.set_var('colors_name', 'foo')
+    eq(1, funcs.exists('g:colors_name'))
+    exec([[
+      func HiClear()
+        hi clear
+      endfunc
+    ]])
+    funcs.HiClear()
+    eq(0, funcs.exists('g:colors_name'))
   end)
 end)


### PR DESCRIPTION
Fix #22951.
This was fixed in Vim in patch 8.2.0613.
