### PR TITLE
build(uninstall): don't build if installation manifest not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,16 @@ functionaltest-lua: | nvim
 FORMAT=formatc formatlua format
 LINT=lintlua lintsh lintc clang-tidy lintcommit lint
 TEST=functionaltest unittest
-generated-sources benchmark uninstall $(FORMAT) $(LINT) $(TEST): | build/.ran-cmake
+generated-sources benchmark $(FORMAT) $(LINT) $(TEST): | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@
+
+uninstall:
+ifneq (,$(wildcard build/install_manifest.txt))
+	$(CMAKE_PRG) --build build --target $@
+else
+	@echo Install manifest file not found. You need to build and install \
+	neovim to generate the manifest file.
+endif
 
 test: $(TEST)
 


### PR DESCRIPTION
Due to the way neovim project is set up, running `make uninstall` would
previously build neovim in order to determine whether neovim was
installed. Instead, check if installation manifest file exists and if
not then skip building entirely.
