### PR TITLE
feat(lua): vim.keycode

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1404,6 +1404,23 @@ inspect({object}, {options})                                   *vim.inspect()*
       • https://github.com/kikito/inspect.lua
       • https://github.com/mpeterv/vinspect
 
+keycode({str})                                                 *vim.keycode()*
+    Translate keycodes.
+
+    Example: >lua
+      local k = vim.keycode
+      vim.g.mapleader = k'<bs>'
+<
+
+    Parameters: ~
+      • {str}  string String to be converted.
+
+    Return: ~
+        string
+
+    See also: ~
+      • |nvim_replace_termcodes()|
+
 lua_omnifunc({find_start}, {_})                           *vim.lua_omnifunc()*
     Omnifunc for completing lua values from from the runtime lua interpreter,
     similar to the builtin completion for the `:lua` command.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -37,6 +37,7 @@ The following new APIs or features were added.
 
 • |vim.iter()| provides a generic iterator interface for tables and Lua
 iterators |luaref-in|.
+• Added |vim.keycode()| for translating keycodes in a string.
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -829,6 +829,20 @@ function vim.print(...)
   return ...
 end
 
+--- Translate keycodes.
+---
+--- Example:
+--- <pre>lua
+---   local k = vim.keycode
+---   vim.g.mapleader = k'<bs>'
+--- </pre>
+--- @param str string String to be converted.
+--- @return string
+--- @see |nvim_replace_termcodes()|
+function vim.keycode(str)
+  return vim.api.nvim_replace_termcodes(str, true, true, true)
+end
+
 function vim._cs_remote(rcid, server_addr, connect_error, args)
   local function connection_failure_errmsg(consequence)
     local explanation


### PR DESCRIPTION
Using nvim_replace_termcodes is too verbose, add vim.keycode for translating keycodes.