### PR TITLE
feat(diagnostic): specify diagnostic virtual text prefix as a function

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -392,8 +392,11 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                          always show the diagnostic source.
                        • spacing: (number) Amount of empty spaces inserted at
                          the beginning of the virtual text.
-                       • prefix: (string) Prepend diagnostic message with
-                         prefix.
+                       • prefix: (string or function) prepend diagnostic
+                         message with prefix. If a function, it must have the
+                         signature (diagnostic) -> string, where {diagnostic}
+                         is of type |diagnostic-structure|. This can be used
+                         to render diagnostic symbols or error codes.
                        • suffix: (string or function) Append diagnostic
                          message with suffix. If a function, it must have the
                          signature (diagnostic) -> string, where {diagnostic}

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -48,6 +48,9 @@ The following changes to existing APIs or features add new behavior.
 
 • |vim.region()| can use a string accepted by |getpos()| as position.
 
+• vim.diagnostic.config() now accepts a function for the virtual_text.prefix
+  option, which allows for rendering e.g., diagnostic severities differently.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1042,7 +1042,7 @@ end)
           local virt_text = get_virt_text_extmarks(diagnostic_ns)[1][4].virt_text
 
           local virt_texts = {}
-          for i = 2, #virt_text do
+          for i = 2, #virt_text - 1 do
             table.insert(virt_texts, (string.gsub(virt_text[i][2], "DiagnosticVirtualText", "")))
           end
 
@@ -1086,7 +1086,7 @@ end)
         })
 
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[2][1]
+        local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
       ]]
       eq(' source x: Some error', result)
@@ -1101,7 +1101,7 @@ end)
         }, diagnostic_ns)
 
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[2][1]
+        local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
       ]]
       eq(' Some error', result)
@@ -1121,7 +1121,7 @@ end)
         })
 
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = {extmarks[1][4].virt_text[2][1], extmarks[2][4].virt_text[2][1]}
+        local virt_text = {extmarks[1][4].virt_text[3][1], extmarks[2][4].virt_text[3][1]}
         return virt_text
       ]]
       eq(' source x: Some error', result[1])
@@ -1151,8 +1151,8 @@ end)
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
         return {extmarks[1][4].virt_text, extmarks[2][4].virt_text}
       ]]
-      eq(" 👀 Warning", result[1][2][1])
-      eq(" 🔥 Error", result[2][2][1])
+      eq(" 👀 Warning", result[1][3][1])
+      eq(" 🔥 Error", result[2][3][1])
     end)
 
     it('includes source for formatted diagnostics', function()
@@ -1179,8 +1179,48 @@ end)
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
         return {extmarks[1][4].virt_text, extmarks[2][4].virt_text}
       ]]
-      eq(" some_linter: 👀 Warning", result[1][2][1])
-      eq(" another_linter: 🔥 Error", result[2][2][1])
+      eq(" some_linter: 👀 Warning", result[1][3][1])
+      eq(" another_linter: 🔥 Error", result[2][3][1])
+    end)
+
+    it('can add a prefix to virtual text', function()
+      eq('E Some error',  exec_lua [[
+        local diagnostics = {
+          make_error('Some error', 0, 0, 0, 0),
+        }
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
+          underline = false,
+          virtual_text = {
+            prefix = 'E',
+            suffix = '',
+          }
+        })
+
+        local extmarks = get_virt_text_extmarks(diagnostic_ns)
+        local prefix = extmarks[1][4].virt_text[2][1]
+        local message = extmarks[1][4].virt_text[3][1]
+        return prefix .. message
+      ]])
+
+      eq('[err-code] Some error',  exec_lua [[
+        local diagnostics = {
+          make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
+        }
+
+        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
+          underline = false,
+          virtual_text = {
+            prefix = function(diag) return string.format('[%s]', diag.code) end,
+            suffix = '',
+          }
+        })
+
+        local extmarks = get_virt_text_extmarks(diagnostic_ns)
+        local prefix = extmarks[1][4].virt_text[2][1]
+        local message = extmarks[1][4].virt_text[3][1]
+        return prefix .. message
+      ]])
     end)
 
     it('can add a suffix to virtual text', function()
@@ -1198,7 +1238,7 @@ end)
         })
 
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[2][1]
+        local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
       ]])
 
@@ -1216,7 +1256,7 @@ end)
         })
 
         local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[2][1]
+        local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
       ]])
     end)


### PR DESCRIPTION
**Disclaimer** This is my first pull-request. Please correct and advice if there are additional changes that must be applied. I tried to figure out how to make the change follow existing conventions, but there might be things missing or incorrect.

# What the change does
The change introduces the option of specifying the `prefix` option of the diagnostic virtual text as a function, to allow the prefix to vary depending on e.g., diagnostic severity. For instance, we could specify the prefix as:

```lua
prefix = function(diagnostic)
  local icons = require("config.icons").diagnostics
  if diagnostic.severity == vim.diagnostic.severity.ERROR then
    return icons.error
  elseif diagnostic.severity == vim.diagnostic.severity.WARN then
    return icons.warn
  elseif diagnostic.severity == vim.diagnostic.severity.INFO then
    return icons.info
  else
    return icons.hint
  end
end,
```

and, setting up highlights it would be rendered as:

<img width="603" alt="Screenshot 2023-04-08 at 21 51 31" src="https://user-images.githubusercontent.com/167128/230740122-1522a8fb-c86f-4be0-97b5-fb63b1490c0f.png">


The pull-request also Introduce five new highlight groups for the virtual text prefix `DiagnosticVirtualTextPrefix...` (`Error`, `Warn`, etc)  to allow the prefix to be highlighted differently than the virtual text. By default all prefix highlights are linked to the corresponding virtual text highlight.

## Drabacks
None that I can see. Or perhaps added complexity.
The change should be silent and all existing configuratons should contiune to work as before.

Looking forward to feedback!
