### PR TITLE
build: remove uninstall target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,14 +134,6 @@ TEST=functionaltest unittest
 generated-sources benchmark $(FORMAT) $(LINT) $(TEST): | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@
 
-uninstall:
-ifneq (,$(wildcard build/install_manifest.txt))
-	$(CMAKE_PRG) --build build --target $@
-else
-	@echo Install manifest file not found. You need to build and install \
-	neovim to generate the manifest file.
-endif
-
 test: $(TEST)
 
 iwyu: build/.ran-cmake


### PR DESCRIPTION
The `make uninstall` target can't be expected to find all files it
installs in many cases. It is therefore better to remove it rather than give
the impression to users that it is a robust.