### PR TITLE
fix(column): 'statuscolumn' not drawn after virt_lines with "n" in 'cpo'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2967,16 +2967,17 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
         wlv.need_showbreak = true;
       }
       if (statuscol.draw) {
-        if (wlv.row == startrow + wlv.filler_lines + 1
-            || wlv.row == startrow + wlv.filler_lines) {
-          // Re-evaluate 'statuscolumn' for the first wrapped row and non filler line
-          statuscol.textp = NULL;
-        } else if (statuscol.textp) {
+        if (wlv.row == startrow + wlv.filler_lines) {
+          statuscol.textp = NULL;  // re-evaluate for first non-filler line
+        } else if (vim_strchr(p_cpo, CPO_NUMCOL) && wlv.row > startrow + wlv.filler_lines) {
+          statuscol.draw = false;  // don't draw status column if "n" is in 'cpo'
+        } else if (wlv.row == startrow + wlv.filler_lines + 1) {
+          statuscol.textp = NULL;  // re-evaluate for first wrapped line
+        } else {
           // Draw the already built 'statuscolumn' on the next wrapped or filler line
           statuscol.textp = statuscol.text;
           statuscol.hlrecp = statuscol.hlrec;
-        }  // Fall back to default columns if the 'n' flag isn't in 'cpo'
-        statuscol.draw = vim_strchr(p_cpo, CPO_NUMCOL) == NULL;
+        }
       }
       wlv.filler_todo--;
       virt_line_offset = -1;

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -397,6 +397,29 @@ describe('statuscolumn', function()
       {0:~                                                    }|
                                                            |
     ]])
+    -- Also test virt_lines when 'cpoptions' includes "n"
+    exec_lua([[
+      vim.opt.cpoptions:append("n")
+      local ns = vim.api.nvim_create_namespace("ns")
+      vim.api.nvim_buf_set_extmark(0, ns, 14, 0, { virt_lines = {{{"virt_line1", ""}}} })
+      vim.api.nvim_buf_set_extmark(0, ns, 14, 0, { virt_lines = {{{"virt_line2", ""}}} })
+    ]])
+    screen:expect([[
+      {1:buffer  0 13}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaa                                            |
+      {1:buffer  0 14}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaa                                            |
+      {1:buffer  0 15}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaa                                            |
+      {1:virtual-2 15}virt_line1                               |
+      {1:virtual-2 15}virt_line2                               |
+      {1:buffer  0 16}{5:^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {5:aaaaaaaaa                                            }|
+      {1:virtual-1 16}END                                      |
+      {0:~                                                    }|
+      {0:~                                                    }|
+                                                           |
+    ]])
   end)
 
   it("works with 'statuscolumn' clicks", function()


### PR DESCRIPTION
Problem:    The 'statuscolumn' is not drawn and the line itself is drawn
            at an offset to the rest of the buffer after virt_lines if
            'cpoptions' includes "n".
Solution:   Make sure 'statuscolumn' is drawn.