### PR TITLE
fix(api): update "w_scwidth" in nvim_eval_statusline()

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2173,6 +2173,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
       linenr_T lnum = statuscol_lnum;
       int num_signs = buf_get_signattrs(wp->w_buffer, lnum, sattrs, &num, &line, &cul);
       decor_redraw_signs(wp->w_buffer, lnum - 1, &num_signs, sattrs, &num, &line, &cul);
+      wp->w_scwidth = win_signcol_count(wp);
 
       statuscol.sattrs = sattrs;
       statuscol.foldinfo = fold_info(wp, lnum);


### PR DESCRIPTION
Problem:    `w_scwidth` may be outdated in `nvim_eval_statusline()`, causing
            `build_stl_str_hl()` to return an incorrect `%s` sign segment.
Solution:   Update `w_scwidth` for `'statuscolumn'` evaluation.