### PR TITLE
turn on severity_sort by default for LSP diagnostics

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -24,7 +24,7 @@ local global_diagnostic_options = {
   virtual_text = true,
   float = true,
   update_in_insert = false,
-  severity_sort = false,
+  severity_sort = true,
 }
 
 M.handlers = setmetatable({}, {


### PR DESCRIPTION
This is just a guess on my part, but I expect most people would prefer to have `severity_sort` turned on. The current default seems to result in info/help diagnostics covering the error messages that caused them, at least in my experience using rust-analyzer. Here's an example of the current default:

![image](https://user-images.githubusercontent.com/860932/230786269-d69b8ccd-f626-4e7c-b66c-b020e8a5fa84.png)

And here's the same example with `severity_sort` set to true:

![image](https://user-images.githubusercontent.com/860932/230786295-026239ad-3449-4148-b747-3492a0c4b3d2.png)