### PR TITLE
fix(colorscheme): link LSP semantic token groups to treesitter groups

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -286,22 +286,22 @@ static const char *highlight_init_both[] = {
   "default link @tag             Tag",
 
   // LSP semantic tokens
-  "default link @lsp.type.class         Structure",
-  "default link @lsp.type.comment       Comment",
-  "default link @lsp.type.decorator     Function",
-  "default link @lsp.type.enum          Structure",
-  "default link @lsp.type.enumMember    Constant",
-  "default link @lsp.type.function      Function",
-  "default link @lsp.type.interface     Structure",
-  "default link @lsp.type.macro         Macro",
-  "default link @lsp.type.method        Function",
-  "default link @lsp.type.namespace     Structure",
-  "default link @lsp.type.parameter     Identifier",
-  "default link @lsp.type.property      Identifier",
-  "default link @lsp.type.struct        Structure",
-  "default link @lsp.type.type          Type",
-  "default link @lsp.type.typeParameter TypeDef",
-  "default link @lsp.type.variable      NONE",  // don't highlight to reduce visual overload
+  "default link @lsp.type.class         @type",
+  "default link @lsp.type.comment       @comment",
+  "default link @lsp.type.decorator     @attribute",
+  "default link @lsp.type.enum          @type",
+  "default link @lsp.type.enumMember    @constant",
+  "default link @lsp.type.function      @function",
+  "default link @lsp.type.interface     @type",
+  "default link @lsp.type.macro         @constant.macro",
+  "default link @lsp.type.method        @function.method",
+  "default link @lsp.type.namespace     @module",
+  "default link @lsp.type.parameter     @variable.parameter",
+  "default link @lsp.type.property      @property",
+  "default link @lsp.type.struct        @type",
+  "default link @lsp.type.type          @type",
+  "default link @lsp.type.typeParameter @type.definition",
+  "default link @lsp.type.variable      @variable",
 
   NULL
 };


### PR DESCRIPTION
There has been a _lot_ of confusion around the new LSP semantic token highlighting. There has been at least one github issue[^1], many reddit posts[^2][^3][^4][^5], and the neovim chat questions with people who wonder why their syntax highlighting changes after a second or so with 0.9. Virtually all of the recommended "fixes" for these questions have been "just disable semantic tokens" without an explanation or reasoning as to why. It would be a shame for people to disable the feature entirely simply because their colorscheme didn't support LSP tokens when they first upgrade.

A large part of this confusion is that the default links bypass the `@` groups that many themes have catered for use with treesitter highlighting. When LSP's semantic tokens kick in, they apply a higher priority highlight that reverts back to basic (less expressive) groups, which most modern themes don't style the same. I can't say this is 100% the reason, but it definitely contributes to many people's desire to turn the feature off ("treesitter highlighting is better, it just gets worse after a second or so!" is a common theme).

I understand that the LSP semantic token highlighting and treesitter highlighting are orthogonal, but realistically, they are both there to do one thing--provide a good experience for syntax highlighting in our favorite editor. There's nothing about the `@type` groups that an internal implementation detail couldn't make use of. I agree that from a documentation and recommendation perspective, we shouldn't mix them. They are different. But for the built-in defaults (which are non-exposed implementation details), we can do pretty much whatever we want.

That being said, the _default_ links built in to the editor should provide the best out-of-the-box experience. Syntax highlighting (as a general "feature"--this includes all forms: syntax, treesitter, and LSP semantic tokens) priority is as follows: Syntax < treesitter < LSP semantic tokens. It makes sense that the link hierarchy should be the reverse: LSP -> treesitter -> syntax. This lets themes opt-in at any level to provide better/more fine tuned highlighting. The bonus is that many themes already have fine tuned treesitter groups, so if LSP semantic tokens kick in, it won't suddenly override all the colors everywhere, which has been a common complaint/source of confusion. For themes that don't color the `@` groups at all, this PR won't change much at all since the links will fall through to the base groups.

@swarn @mfussenegger @gpanders @clason @lewis6991 

As an aside, for the themes that _have_ added support for semantic tokens, they basically just add these links back to the `@` groups. I know `tokyonight`[^6], `catppuccin`[^7] and `kanagawa`[^8] have all needed to add some of these links back (with varying degrees of additional modifier groups they've tweaked).

[^1]: https://github.com/neovim/neovim/issues/22956
[^2]: https://www.reddit.com/r/neovim/comments/12g7ijr/treesitter_strange_highlighting_question/
[^3]: https://www.reddit.com/r/neovim/comments/12g5qk3/neovim_v090_is_very_slow_in/
[^4]: https://www.reddit.com/r/neovim/comments/12fidjh/treesitter_breaks_with_new_neovim_release/
[^5]: https://www.reddit.com/r/neovim/comments/12fdlac/neovim_error_after_upgrading_to_090/
[^6]: https://github.com/folke/tokyonight.nvim/blob/main/lua/tokyonight/theme.lua#L256-L264
[^7]: https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/groups/integrations/semantic_tokens.lua
[^8]: https://github.com/rebelot/kanagawa.nvim/blob/master/lua/kanagawa/highlights/lsp.lua