### PR TITLE
fix(column): add truncated width during estimation for 'statuscolumn'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -656,7 +656,15 @@ static void get_statuscol_str(win_T *wp, linenr_T lnum, int virtnum, statuscol_T
     wp->w_statuscol_line_count = wp->w_nrwidth_line_count;
     set_vim_var_nr(VV_VIRTNUM, 0);
     build_statuscol_str(wp, wp->w_nrwidth_line_count, 0, stcp);
-    stcp->width += stcp->truncate;
+    if (stcp->truncate > 0) {
+      // Add truncated width to avoid unnecessary redraws
+      int addwidth = MIN(stcp->truncate, MAX_NUMBERWIDTH - wp->w_nrwidth);
+      stcp->truncate = 0;
+      stcp->width += addwidth;
+      wp->w_nrwidth += addwidth;
+      wp->w_nrwidth_width = wp->w_nrwidth;
+      wp->w_valid &= ~VALID_WCOL;
+    }
   }
   set_vim_var_nr(VV_VIRTNUM, virtnum);
 

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -593,4 +593,17 @@ describe('statuscolumn', function()
                                                            |
     ]])
   end)
+
+  it("is only evaluated twice, once to estimate and once to draw", function()
+    command([[
+      let g:stcnr = 0
+      func! Stc()
+        let g:stcnr += 1
+        return '12345'
+      endfunc
+      set stc=%!Stc()
+      norm ggdG
+    ]])
+    eq(2, eval('g:stcnr'))
+  end)
 end)


### PR DESCRIPTION
Problem:    Estimated 'statuscolumn' width is not properly used,
            executing the `w_redr_statuscol` path unnecessarily.
Solution:   Adjust `w_nrwidth` and 'statuscolumn' width before anything
            is actually drawn in a `win_update()`.