### PR TITLE
fix(treesitter): Use the correct replacement args for #gsub! directive

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -458,7 +458,7 @@ local directive_handlers = {
       metadata[id] = {}
     end
 
-    local pattern, replacement = pred[3], pred[3]
+    local pattern, replacement = pred[3], pred[4]
     assert(type(pattern) == 'string')
     assert(type(replacement) == 'string')
 


### PR DESCRIPTION

<img width="517" alt="image" src="https://user-images.githubusercontent.com/12830256/231048912-61fd29ca-9142-454d-ac21-57a9d7b5d0d5.png">

```lua
local t = { "#gsub!", "@alias_args", ".*%.(.*)", "%1" }
print(t[3], t[4])
local text = "MyApp.MyModule"

-- current behavior
local new_text = text:gsub(t[3], t[3])
print(new_text)

-- expected behavior
local new_text = text:gsub(t[3], t[4])
print(new_text)
```
