### PR TITLE
test: avoid name collisions with Xtest directory

### DIFF
--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -50,6 +50,7 @@ describe('oldtests', function()
   it('should fire on unload buf', function()
     funcs.writefile({'Test file Xxx1'}, 'Xxx1')
     funcs.writefile({'Test file Xxx2'}, 'Xxx2')
+    local fname = 'Xtest_functional_autocmd_unload'
 
     local content = [[
       func UnloadAllBufs()
@@ -69,15 +70,15 @@ describe('oldtests', function()
       q
     ]]
 
-    funcs.writefile(funcs.split(content, "\n"), 'Xtest')
+    funcs.writefile(funcs.split(content, "\n"), fname)
 
     funcs.delete('Xout')
-    funcs.system(meths.get_vvar('progpath') .. ' -u NORC -i NONE -N -S Xtest')
+    funcs.system(string.format('%s -u NORC -i NONE -N -S %s', meths.get_vvar('progpath'), fname))
     eq(1, funcs.filereadable('Xout'))
 
     funcs.delete('Xxx1')
     funcs.delete('Xxx2')
-    funcs.delete('Xtest')
+    funcs.delete(fname)
     funcs.delete('Xout')
   end)
 end)

--- a/test/functional/legacy/061_undo_tree_spec.lua
+++ b/test/functional/legacy/061_undo_tree_spec.lua
@@ -22,29 +22,30 @@ end
 
 describe('undo tree:', function()
   before_each(clear)
+  local fname = 'Xtest_functional_legacy_undotree'
   teardown(function()
-    os.remove('Xtest.source')
+    os.remove(fname .. '.source')
   end)
 
   describe(':earlier and :later', function()
     before_each(function()
-      os.remove('Xtest')
+      os.remove(fname)
     end)
     teardown(function()
-      os.remove('Xtest')
+      os.remove(fname)
     end)
 
     it('time specifications, g- g+', function()
       -- We write the test text to a file in order to prevent nvim to record
       -- the inserting of the text into the undo history.
-      write_file('Xtest', '\n123456789\n')
+      write_file(fname, '\n123456789\n')
 
       -- `:earlier` and `:later` are (obviously) time-sensitive, so this test
       -- sometimes fails if the system is under load. It is wrapped in a local
       -- function to allow multiple attempts.
       local function test_earlier_later()
         clear()
-        feed_command('e Xtest')
+        feed_command('e ' .. fname)
         -- Assert that no undo history is present.
         eq({}, eval('undotree().entries'))
         -- Delete three characters and undo.
@@ -103,7 +104,7 @@ describe('undo tree:', function()
 
     it('file-write specifications', function()
       feed('ione one one<esc>')
-      feed_command('w Xtest')
+      feed_command('w ' .. fname)
       feed('otwo<esc>')
       feed('otwo<esc>')
       feed_command('w')
@@ -187,7 +188,7 @@ describe('undo tree:', function()
 
   it('undo an expression-register', function()
     local normal_commands = 'o1\027a2\018=string(123)\n\027'
-    write_file('Xtest.source', normal_commands)
+    write_file(fname .. '.source', normal_commands)
 
     feed('oa<esc>')
     feed('ob<esc>')
@@ -221,7 +222,7 @@ describe('undo tree:', function()
       c
       12]])
     feed('od<esc>')
-    feed_command('so! Xtest.source')
+    feed_command('so! ' .. fname .. '.source')
     expect([[
 
       a

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -22,6 +22,7 @@ local skip = helpers.skip
 
 describe('ui/ext_messages', function()
   local screen
+  local fname = 'Xtest_functional_ui_messages_spec'
 
   before_each(function()
     clear()
@@ -41,7 +42,7 @@ describe('ui/ext_messages', function()
     })
   end)
   after_each(function()
-    os.remove('Xtest')
+    os.remove(fname)
   end)
 
   it('msg_clear follows msg_show kind of confirm', function()
@@ -126,7 +127,7 @@ describe('ui/ext_messages', function()
     feed('nq')
 
     -- kind=wmsg (editing readonly file)
-    command('write Xtest')
+    command('write ' .. fname)
     command('set readonly nohls')
     feed('G$x')
     screen:expect{grid=[[
@@ -912,9 +913,9 @@ stack traceback:
   end)
 
   it('does not truncate messages', function()
-    command('write Xtest')
+    command('write '.. fname)
     screen:expect({messages={
-      {content = { { '"Xtest" [New] 0L, 0B written' } }, kind = "" }
+      {content = { { string.format('"%s" [New] 0L, 0B written', fname) } }, kind = "" }
     }})
   end)
 end)

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -393,7 +393,7 @@ describe('system()', function()
   end)
 
   describe('with output containing NULs', function()
-    local fname = 'Xtest'
+    local fname = 'Xtest_functional_vimscript_system_nuls'
 
     before_each(create_file_with_nuls(fname))
     after_each(delete_file(fname))
@@ -549,7 +549,7 @@ describe('systemlist()', function()
   end)
 
   describe('with output containing NULs', function()
-    local fname = 'Xtest'
+    local fname = 'Xtest_functional_vimscript_systemlist_nuls'
 
     before_each(function()
       command('set ff=unix')


### PR DESCRIPTION
Rename test-specific files to avoid name-collisions and for better tracebility.

The name `Xtest` has been (historically?) used as a tmpdir in some tests:
- https://github.com/neovim/neovim/blob/ccc0980f86c6ef9a86b0e5a3a691f37cea8eb776/test/functional/legacy/autochdir_spec.lua#L29
- https://github.com/neovim/neovim/blob/ccc0980f86c6ef9a86b0e5a3a691f37cea8eb776/test/functional/api/vim_spec.lua#L2354
