### PR TITLE
test(fs): get tmpdir correctly

### DIFF
--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -19,7 +19,6 @@ local meths = helpers.meths
 local mkdir = helpers.mkdir
 local sleep = helpers.sleep
 local read_file = helpers.read_file
-local tmpname = helpers.tmpname
 local trim = helpers.trim
 local currentdir = helpers.funcs.getcwd
 local assert_alive = helpers.assert_alive
@@ -266,9 +265,7 @@ describe('tmpdir', function()
 
   before_each(function()
     -- Fake /tmp dir so that we can mess it up.
-    os_tmpdir = tmpname()
-    os.remove(os_tmpdir)
-    mkdir(os_tmpdir)
+    os_tmpdir = vim.loop.fs_mkdtemp(vim.fs.dirname(helpers.tmpname()) .. '/nvim_XXXXXXXXXX')
   end)
 
   after_each(function()

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -3,7 +3,6 @@ local eq = helpers.eq
 local exec_lua = helpers.exec_lua
 local clear = helpers.clear
 local is_os = helpers.is_os
-local mkdir = helpers.mkdir
 
 describe('vim._watch', function()
   before_each(function()
@@ -12,9 +11,7 @@ describe('vim._watch', function()
 
   describe('watch', function()
     it('detects file changes', function()
-      local root_dir = helpers.tmpname()
-      os.remove(root_dir)
-      mkdir(root_dir)
+      local root_dir = vim.loop.fs_mkdtemp(vim.fs.dirname(helpers.tmpname()) .. '/nvim_XXXXXXXXXX')
 
       local result = exec_lua(
         [[
@@ -100,9 +97,7 @@ describe('vim._watch', function()
 
   describe('poll', function()
     it('detects file changes', function()
-      local root_dir = helpers.tmpname()
-      os.remove(root_dir)
-      mkdir(root_dir)
+      local root_dir = vim.loop.fs_mkdtemp(vim.fs.dirname(helpers.tmpname()) .. '/nvim_XXXXXXXXXX')
 
       local result = exec_lua(
         [[


### PR DESCRIPTION
Use `dirname` to get the parent folder from `helpers.tmpname()`, since it's _possible_ that the
function will create a local file depending on the tests execution order[^1], see:

https://github.com/neovim/neovim/blob/ccc0980f86c6ef9a86b0e5a3a691f37cea8eb776/test/helpers.lua#L357-L364

[^1]: some tests will create an `Xtest` dir, see https://github.com/neovim/neovim/blob/ccc0980f86c6ef9a86b0e5a3a691f37cea8eb776/test/functional/api/vim_spec.lua#L2352-L2356
