### PR TITLE
refactor: remove :CheckHealth

### DIFF
--- a/runtime/doc/pi_health.txt
+++ b/runtime/doc/pi_health.txt
@@ -21,7 +21,7 @@ Plugin authors are encouraged to write new healthchecks. |health-dev|
 ==============================================================================
 Commands                                *health-commands*
 
-                                        *:che* *:checkhealth* *:CheckHealth*
+                                                             *:che* *:checkhealth*
 :che[ckhealth]  Run all healthchecks.
                                         *E5009*
                 Nvim depends on |$VIMRUNTIME|, 'runtimepath' and 'packpath' to

--- a/runtime/plugin/health.vim
+++ b/runtime/plugin/health.vim
@@ -1,1 +1,0 @@
-autocmd CmdUndefined CheckHealth checkhealth

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -5540,7 +5540,7 @@ msgstr "tekijät Bram Moolenaar et al."
 #~ msgstr "kirjoita :help iccf<Enter>    lisätietoa varten            "
 
 #, fuzzy
-#~ msgid "type  :CheckHealth<Enter>     to optimize Nvim"
+#~ msgid "type  :checkhealth<Enter>     to optimize Nvim"
 #~ msgstr "kirjoita :help iccf<Enter>    lisätietoa varten            "
 
 msgid "type  :q<Enter>               to exit         "

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -402,8 +402,6 @@ describe('startup', function()
       local line1 = string.match(out, '^.-\n')
       -- updatecount=0 means swapfile was disabled.
       eq("  swapfile  updatecount=0  shadafile=\n", line1)
-      -- Standard plugins were loaded, but not user config.
-      eq('health.vim', string.match(out, 'health.vim'))
       eq(nil, string.match(out, 'init.vim'))
     end
   end)


### PR DESCRIPTION
Using :CheckHealth invokes an error, and many of the features from
:checkhealth doesn't even work such as calling only a specific check.
It's clearly suffering, so let's put it out of its misery.
