### PR TITLE
fix(runtime): add commentstring for C# ftplugin

### DIFF
--- a/runtime/ftplugin/cs.lua
+++ b/runtime/ftplugin/cs.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'


### PR DESCRIPTION
Problem: No commentstring is set for C# buffers after removing the
default C-style commentstring

Solution: Add `ftplugin/cs.lua` with C-style commentstring
