### PR TITLE
vim-patch:9.0.1444: crash when passing NULL to setcmdline()

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4209,7 +4209,8 @@ void f_setcmdline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
   }
 
-  rettv->vval.v_number = set_cmdline_str(argvars[0].vval.v_string, pos);
+  // Use tv_get_string() to handle a NULL string like an empty string.
+  rettv->vval.v_number = set_cmdline_str(tv_get_string(&argvars[0]), pos);
 }
 
 /// "setcmdpos()" function

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3532,6 +3532,14 @@ endfunc
 
 func Test_setcmdline()
   func SetText(text, pos)
+    call assert_equal(0, setcmdline(v:_null_string))
+    call assert_equal('', getcmdline())
+    call assert_equal(1, getcmdpos())
+
+    call assert_equal(0, setcmdline(''[: -1]))
+    call assert_equal('', getcmdline())
+    call assert_equal(1, getcmdpos())
+
     autocmd CmdlineChanged * let g:cmdtype = expand('<afile>')
     call assert_equal(0, setcmdline(a:text))
     call assert_equal(a:text, getcmdline())


### PR DESCRIPTION
#### vim-patch:9.0.1444: crash when passing NULL to setcmdline()

Problem:    Crash when passing NULL to setcmdline(). (Andreas Louv)
Solution:   Use tv_get_string() instead of using v_string directly.
            (closes vim/vim#12231)

https://github.com/vim/vim/commit/ac6cd31afcbdd08bfa92ca33f7d4ce5773ba4353