### PR TITLE
fix(winbar): properly redraw winbar when showcmdloc=statusline

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -121,6 +121,7 @@ typedef enum {
 static bool redraw_popupmenu = false;
 static bool msg_grid_invalid = false;
 static bool resizing_autocmd = false;
+static win_T *cursor_info_win = NULL;
 
 static char *provider_err = NULL;
 
@@ -828,6 +829,7 @@ void show_cursor_info_later(bool force)
       || curwin->w_topfill != curwin->w_stl_topfill
       || empty_line != curwin->w_stl_empty
       || reg_recording != curwin->w_stl_recording
+      || curwin != cursor_info_win
       || state != curwin->w_stl_state) {
     if (curwin->w_status_height || global_stl_height()) {
       curwin->w_redr_status = true;
@@ -853,6 +855,7 @@ void show_cursor_info_later(bool force)
   curwin->w_stl_topfill = curwin->w_topfill;
   curwin->w_stl_state = state;
   curwin->w_stl_recording = reg_recording;
+  cursor_info_win = curwin;
 }
 
 /// @return true when postponing displaying the mode message: when not redrawing

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -114,6 +114,73 @@ describe('winbar', function()
       {2:[No Name]                     [No Name]                     }|
                                                                   |
     ]])
+
+    feed('<C-W>w')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{4:[No Name]                     }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     [No Name]                     }|
+                                                                  |
+    ]])
+    -- 'showcmdloc' "statusline" should not interfere with winbar redrawing #23030
+    command('set showcmd showcmdloc=statusline')
+    feed('<C-W>')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{4:[No Name]          ^W         }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     [No Name]                     }|
+                                                                  |
+    ]])
+    feed('w')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     }{4:[No Name]                     }|
+                                                                  |
+    ]])
+    feed('<C-W>W')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{4:[No Name]                     }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     [No Name]                     }|
+                                                                  |
+    ]])
   end)
 
   it('works when switching value of \'winbar\'', function()


### PR DESCRIPTION
Fixes #23030. I just applied the changes suggested by @luukvbaal . I hope that's OK.