### PR TITLE
vim-patch:partial:9.0.0364: clang static analyzer gives warnings

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3322,11 +3322,10 @@ int get_tags(list_T *list, char *pat, char *buf_fname)
   }
 
   for (i = 0; i < num_matches; i++) {
-    int parse_result = parse_match(matches[i], &tp);
-
-    // Avoid an unused variable warning in release builds.
-    (void)parse_result;
-    assert(parse_result == OK);
+    if (parse_match(matches[i], &tp) == FAIL) {
+      xfree(matches[i]);
+      continue;
+    }
 
     bool is_static = test_for_static(&tp);
 


### PR DESCRIPTION
Fix #23057

#### vim-patch:partial:9.0.0364: clang static analyzer gives warnings

Problem:    Clang static analyzer gives warnings.
Solution:   Avoid the warnings. (Yegappan Lakshmanan, closes vim/vim#11043)

https://github.com/vim/vim/commit/c99e182e1fb54e39540d25d0ccd8dcdde25bb96c

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>