### PR TITLE
refactor: remove modelines from Lua files

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2384,4 +2384,3 @@ lsp.commands = setmetatable({}, {
 })
 
 return lsp
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -806,4 +806,3 @@ function M.execute_command(command_params)
 end
 
 return M
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -644,4 +644,3 @@ for k, fn in pairs(M) do
 end
 
 return M
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -174,4 +174,3 @@ function log.should_log(level)
 end
 
 return log
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -894,4 +894,3 @@ function protocol.resolve_capabilities(server_capabilities)
 end
 
 return protocol
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -753,4 +753,3 @@ return {
   client_errors = client_errors,
   create_read_loop = create_read_loop,
 }
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2154,4 +2154,3 @@ M._get_line_byte_from_position = get_line_byte_from_position
 M.buf_versions = {}
 
 return M
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -811,4 +811,3 @@ function vim.defaulttable(create)
 end
 
 return vim
--- vim:sw=2 ts=2 et

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -134,4 +134,3 @@ return {
   uri_to_fname = uri_to_fname,
   uri_to_bufnr = uri_to_bufnr,
 }
--- vim:sw=2 ts=2 et

--- a/test/functional/shada/merging_spec.lua
+++ b/test/functional/shada/merging_spec.lua
@@ -1115,5 +1115,3 @@ describe('ShaDa changes support code', function()
     eq(found, 100)
   end)
 end)
-
--- vim: ts=2 sw=2


### PR DESCRIPTION
Now that we have builtin EditorConfig support and a formatting check in
CI, these are not necessary.
