### PR TITLE
 perf(treesitter): only run injection query on tree changes

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -740,7 +740,16 @@ function LanguageTree:_do_callback(cb_name, ...)
   end
 end
 
----@package
+--- @package
+--- @param start_byte integer
+--- @param end_byte_old integer
+--- @param end_byte_new integer
+--- @param start_row integer
+--- @param start_col integer
+--- @param end_row_old integer
+--- @param end_col_old integer
+--- @param end_row_new integer
+--- @param end_col_new integer
 function LanguageTree:_edit(
   start_byte,
   end_byte_old,

--- a/test/benchmark/treesitter_spec.lua
+++ b/test/benchmark/treesitter_spec.lua
@@ -5,9 +5,9 @@ local exec_lua = helpers.exec_lua
 
 local function tcall(f, ...)
   local start = vim.loop.hrtime()
-  f(...)
+  local stats = f(...)
   local d = vim.loop.hrtime() - start
-  return d / 1000000
+  return d / 1000000, stats
 end
 
 describe('treesitter perf', function()
@@ -75,26 +75,40 @@ describe('treesitter perf', function()
     print('Without injections:')
 
     local function step(what, t)
-      print('    - ' .. what .. ':\t', t)
+      local t2, stats = tcall(exec_lua, [[
+        parser:parse()
+        return parser:_get_stats()
+      ]])
+
+      print('\t- ' .. what .. ':')
+      print(string.format('\t  - total : %8.2fms', t + t2))
+      for k, s in pairs(stats) do
+        print(string.format('\t  - %s:', k))
+        for lang, v in pairs(s) do
+          if type(v) == 'number' and helpers.endswith(k, '_time') then
+            print(string.format('\t    - %-8s : %8.2fms', lang, v))
+          else
+            print(string.format('\t    - %-8s : %s', lang, vim.inspect(v)))
+          end
+        end
+      end
     end
 
     step('Initial parse', tcall(exec_lua, [[
+      vim.treesitter.query.set('c', 'injections', '')
       parser = vim.treesitter._create_parser(0, 'c')
     ]]))
 
     step('Edit (modify comment)', tcall(exec_lua, [[
       vim.cmd('normal gg3jx')
-      parser:parse()
     ]]))
 
     step('Edit (delete line)', tcall(exec_lua, [[
       vim.cmd('28d')
-      parser:parse()
     ]]))
 
     step('Edit (undo)', tcall(exec_lua, [[
       vim.cmd('u')
-      parser:parse()
     ]]))
 
     print('With injections:')
@@ -106,17 +120,15 @@ describe('treesitter perf', function()
 
     step('Edit (modify commment)', tcall(exec_lua, [[
       vim.cmd('normal gg3jx')
-      parser:parse()
+     return parser:_get_stats()
     ]]))
 
     step('Edit (delete line)', tcall(exec_lua, [[
       vim.cmd('28d')
-      parser:parse()
     ]]))
 
     step('Edit (undo)', tcall(exec_lua, [[
       vim.cmd('u')
-      parser:parse()
     ]]))
 
   end)


### PR DESCRIPTION
### Problem

The injection query is run too often causing large files to be very slow.

### Solution

Only run injections when the tree actually changes.

### Benchmark
- File:  https://raw.githubusercontent.com/torvalds/linux/master/drivers/gpu/drm/amd/include/asic_reg/dcn/dcn_3_2_0_sh_mask.h
- LOC: ~220k
- No. of C injections: ~200K

(times in ms)

Before:
```
Without injections:
    - Initial parse:            1672.091875
    - Edit (modify comment):    615.265166
    - Edit (delete line):       1104.628875
    - Edit (undo):              1095.763959
With injections:
    - Initial parse:            10009.997375
    - Edit (modify commment):   1555.78325
    - Edit (delete line):       10197.952
    - Edit (undo):              10545.194
```

After:
```
Without injections:
    - Initial parse:            1670.346708
    - Edit (modify comment):    0.683375
    - Edit (delete line):       445.935334
    - Edit (undo):              1085.54875
With injections:
    - Initial parse:            10075.066667
    - Edit (modify commment):   478.498916
    - Edit (delete line):       843.765334
    - Edit (undo):              2283.085208
```