### PR TITLE
fix: winbar is not redrawn on window change when 'showcmdloc' is "statusline"

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1173,7 +1173,7 @@ static int normal_execute(VimState *state, int key)
     msg_col = 0;
   }
 
-  s->old_pos = curwin->w_cursor;           // remember where cursor was
+  s->old_pos = curwin->w_cursor;           // remember where the cursor was
 
   // When 'keymodel' contains "startsel" some keys start Select/Visual
   // mode.
@@ -1997,13 +1997,21 @@ static void display_showcmd(void)
   showcmd_is_clear = (len == 0);
 
   if (*p_sloc == 's') {
-    win_redr_status(curwin);
-    setcursor();  // put cursor back where it belongs
+    if (showcmd_is_clear) {
+      curwin->w_redr_status = true;
+    } else {
+      win_redr_status(curwin);
+      setcursor();  // put cursor back where it belongs
+    }
     return;
   }
   if (*p_sloc == 't') {
-    draw_tabline();
-    setcursor();  // put cursor back where it belongs
+    if (showcmd_is_clear) {
+      redraw_tabline = true;
+    } else {
+      draw_tabline();
+      setcursor();  // put cursor back where it belongs
+    }
     return;
   }
   // 'showcmdloc' is "last" or empty

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -114,6 +114,41 @@ describe('winbar', function()
       {2:[No Name]                     [No Name]                     }|
                                                                   |
     ]])
+    -- 'showcmdloc' "statusline" should not interfere with winbar redrawing #23030
+    command('set showcmd showcmdloc=statusline')
+    feed('<C-W>w')
+    feed('<C-W>')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{4:[No Name]          ^W         }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     [No Name]                     }|
+                                                                  |
+    ]])
+    feed('w<C-W>W')
+    screen:expect([[
+      {6:Set Up The Bars              }│{6:Set Up The Bars               }|
+                                   │                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{2:[No Name]                     }|
+      {3:~                            }│{5:Set Up The Bars               }|
+      {3:~                            }│^                              |
+      {3:~                            }│{3:~                             }|
+      {3:~                            }│{4:[No Name]                     }|
+      {3:~                            }│{6:Set Up The Bars               }|
+      {3:~                            }│                              |
+      {3:~                            }│{3:~                             }|
+      {2:[No Name]                     [No Name]                     }|
+                                                                  |
+    ]])
   end)
 
   it('works when switching value of \'winbar\'', function()


### PR DESCRIPTION
**vim-patch:9.0.1451: unnecessary redrawing when 'showcmdloc' is not "last"**

Problem:    Unnecessary redrawing when 'showcmdloc' is not "last".
Solution:   Redraw later when "showcmd_is_clear" is set. (Luuk van Baal,
            closes https://github.com/vim/vim/pull/12260)

https://github.com/vim/vim/commit/aa7f25ebf16b8be99239af1134b441e3da93060a

**test(winbar_spec): properly update winbar when 'showcmdloc' is "statusline"**

Co-authored-by: zeertzjq <zeertzjq@outlook.com>

Fix #23030
Close #23058 (superseded)