### PR TITLE
vim-patch:9.0.1449: test for prompt buffer is flaky

### DIFF
--- a/test/old/testdir/test_prompt_buffer.vim
+++ b/test/old/testdir/test_prompt_buffer.vim
@@ -283,20 +283,16 @@ func Test_prompt_appending_while_hidden()
   call TermWait(buf)
 
   call term_sendkeys(buf, "exit\<CR>")
-  call TermWait(buf)
-  call assert_notmatch('-- INSERT --', term_getline(buf, 10))
+  call WaitForAssert({-> assert_notmatch('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, ":call DoAppend()\<CR>")
-  call TermWait(buf)
-  call assert_notmatch('-- INSERT --', term_getline(buf, 10))
+  call WaitForAssert({-> assert_notmatch('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, "i")
-  call TermWait(buf)
-  call assert_match('-- INSERT --', term_getline(buf, 10))
+  call WaitForAssert({-> assert_match('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, "\<C-R>=DoAppend()\<CR>")
-  call TermWait(buf)
-  call assert_match('-- INSERT --', term_getline(buf, 10))
+  call WaitForAssert({-> assert_match('-- INSERT --', term_getline(buf, 10))})
 
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)


### PR DESCRIPTION
#### vim-patch:9.0.1449: test for prompt buffer is flaky

Problem:    Test for prompt buffer is flaky.
Solution:   Use WaitForAssert() instead of TermWait(). (Ozaki Kiichi,
            closes vim/vim#12247)

https://github.com/vim/vim/commit/ff6c230051ed2a2dbbbd517f51fe00c8ea27961b