### PR TITLE
vim-patch:8.2.{1047,1048,1049,1050,1052},9.0.1447

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -172,7 +172,7 @@ Object nvim_eval(String expr, Error *err)
   int ok;
 
   TRY_WRAP(err, {
-    ok = eval0(expr.data, &rettv, NULL, EVAL_EVALUATE);
+    ok = eval0(expr.data, &rettv, NULL, &EVALARG_EVALUATE);
   });
 
   if (!ERROR_SET(err)) {
@@ -290,7 +290,7 @@ Object nvim_call_dict_function(Object dict, String fn, Array args, Error *err)
   switch (dict.type) {
   case kObjectTypeString:
     try_start();
-    if (eval0(dict.data.string.data, &rettv, NULL, EVAL_EVALUATE) == FAIL) {
+    if (eval0(dict.data.string.data, &rettv, NULL, &EVALARG_EVALUATE) == FAIL) {
       api_set_error(err, kErrorTypeException,
                     "Failed to evaluate dict expression");
     }

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2203,7 +2203,7 @@ bool get_keymap_str(win_T *wp, char *fmt, char *buf, int len)
   curwin = wp;
   STRCPY(buf, "b:keymap_name");       // must be writable
   emsg_skip++;
-  s = p = eval_to_string(buf, NULL, false);
+  s = p = eval_to_string(buf, false);
   emsg_skip--;
   curbuf = old_curbuf;
   curwin = old_curwin;

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -266,10 +266,22 @@ typedef int (*ex_unletlock_callback)(lval_T *, char *, exarg_T *, int);
 // Used for checking if local variables or arguments used in a lambda.
 extern bool *eval_lavars_used;
 
+/// Struct passed through eval() functions.
+/// See EVALARG_EVALUATE for a fixed value with eval_flags set to EVAL_EVALUATE.
+typedef struct {
+  int eval_flags;     ///< EVAL_ flag values below
+
+  /// copied from exarg_T when "getline" is "getsourceline". Can be NULL.
+  void *eval_cookie;   // argument for getline()
+} evalarg_T;
+
 /// Flag for expression evaluation.
 enum {
   EVAL_EVALUATE = 1,  ///< when missing don't actually evaluate
 };
+
+/// Passed to an eval() function to enable evaluation.
+EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval.h.generated.h"

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -273,6 +273,9 @@ typedef struct {
 
   /// copied from exarg_T when "getline" is "getsourceline". Can be NULL.
   void *eval_cookie;   // argument for getline()
+
+  /// pointer to the line obtained with getsourceline()
+  char *eval_tofree;
 } evalarg_T;
 
 /// Flag for expression evaluation.
@@ -281,7 +284,7 @@ enum {
 };
 
 /// Passed to an eval() function to enable evaluation.
-EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL });
+EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL, NULL });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval.h.generated.h"

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1550,7 +1550,7 @@ static void f_eval(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   const char *const expr_start = s;
-  if (s == NULL || eval1((char **)&s, rettv, EVAL_EVALUATE) == FAIL) {
+  if (s == NULL || eval1((char **)&s, rettv, &EVALARG_EVALUATE) == FAIL) {
     if (expr_start != NULL && !aborting()) {
       semsg(_(e_invexpr2), expr_start);
     }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2957,7 +2957,7 @@ void ex_return(exarg_T *eap)
 
   eap->nextcmd = NULL;
   if ((*arg != NUL && *arg != '|' && *arg != '\n')
-      && eval0(arg, &rettv, &eap->nextcmd, &evalarg) != FAIL) {
+      && eval0(arg, &rettv, eap, &evalarg) != FAIL) {
     if (!eap->skip) {
       returning = do_return(eap, false, true, &rettv);
     } else {
@@ -3008,7 +3008,7 @@ void ex_call(exarg_T *eap)
     // instead to skip to any following command, e.g. for:
     //   :if 0 | call dict.foo().bar() | endif.
     emsg_skip++;
-    if (eval0(eap->arg, &rettv, &eap->nextcmd, NULL) != FAIL) {
+    if (eval0(eap->arg, &rettv, eap, NULL) != FAIL) {
       tv_clear(&rettv);
     }
     emsg_skip--;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -152,7 +152,7 @@ static int get_function_args(char **argp, char endchar, garray_T *newargs, int *
         p = skipwhite(p) + 1;
         p = skipwhite(p);
         char *expr = p;
-        if (eval1(&p, &rettv, 0) != FAIL) {
+        if (eval1(&p, &rettv, NULL) != FAIL) {
           ga_grow(default_args, 1);
 
           // trim trailing whitespace
@@ -455,6 +455,8 @@ int get_func_tv(const char *name, int len, typval_T *rettv, char **arg, funcexe_
   typval_T argvars[MAX_FUNC_ARGS + 1];          // vars for arguments
   int argcount = 0;                     // number of arguments found
 
+  evalarg_T evalarg = { .eval_flags = funcexe->fe_evaluate ? EVAL_EVALUATE : 0 };
+
   // Get the arguments.
   argp = *arg;
   while (argcount < MAX_FUNC_ARGS
@@ -463,8 +465,7 @@ int get_func_tv(const char *name, int len, typval_T *rettv, char **arg, funcexe_
     if (*argp == ')' || *argp == ',' || *argp == NUL) {
       break;
     }
-    if (eval1(&argp, &argvars[argcount],
-              funcexe->fe_evaluate ? EVAL_EVALUATE : 0) == FAIL) {
+    if (eval1(&argp, &argvars[argcount], &evalarg) == FAIL) {
       ret = FAIL;
       break;
     }
@@ -973,7 +974,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
 
         default_expr = ((char **)(fp->uf_def_args.ga_data))
                        [ai + fp->uf_def_args.ga_len];
-        if (eval1(&default_expr, &def_rettv, EVAL_EVALUATE) == FAIL) {
+        if (eval1(&default_expr, &def_rettv, &EVALARG_EVALUATE) == FAIL) {
           default_arg_err = true;
           break;
         }
@@ -1110,7 +1111,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     // A Lambda always has the command "return {expr}".  It is much faster
     // to evaluate {expr} directly.
     ex_nesting_level++;
-    (void)eval1(&p, rettv, EVAL_EVALUATE);
+    (void)eval1(&p, rettv, &EVALARG_EVALUATE);
     ex_nesting_level--;
   } else {
     // call do_cmdline() to execute the lines
@@ -2948,13 +2949,15 @@ void ex_return(exarg_T *eap)
     return;
   }
 
+  evalarg_T evalarg = { .eval_flags = eap->skip ? 0 : EVAL_EVALUATE };
+
   if (eap->skip) {
     emsg_skip++;
   }
 
   eap->nextcmd = NULL;
   if ((*arg != NUL && *arg != '|' && *arg != '\n')
-      && eval0(arg, &rettv, &eap->nextcmd, eap->skip ? 0 : EVAL_EVALUATE) != FAIL) {
+      && eval0(arg, &rettv, &eap->nextcmd, &evalarg) != FAIL) {
     if (!eap->skip) {
       returning = do_return(eap, false, true, &rettv);
     } else {
@@ -3005,7 +3008,7 @@ void ex_call(exarg_T *eap)
     // instead to skip to any following command, e.g. for:
     //   :if 0 | call dict.foo().bar() | endif.
     emsg_skip++;
-    if (eval0(eap->arg, &rettv, &eap->nextcmd, 0) != FAIL) {
+    if (eval0(eap->arg, &rettv, &eap->nextcmd, NULL) != FAIL) {
       tv_clear(&rettv);
     }
     emsg_skip--;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -255,13 +255,18 @@ void ex_let(exarg_T *eap)
     if (eap->skip) {
       emsg_skip++;
     }
-    int eval_flags = eap->skip ? 0 : EVAL_EVALUATE;
-    i = eval0(expr, &rettv, &eap->nextcmd, eval_flags);
+    evalarg_T evalarg = {
+      .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
+      .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
+    };
+    i = eval0(expr, &rettv, &eap->nextcmd, &evalarg);
+    if (eap->skip) {
+      emsg_skip--;
+    }
     if (eap->skip) {
       if (i != FAIL) {
         tv_clear(&rettv);
       }
-      emsg_skip--;
     } else if (i != FAIL) {
       (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count, is_const, op);
       tv_clear(&rettv);

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -185,7 +185,6 @@ void ex_let(exarg_T *eap)
   char *arg = eap->arg;
   char *expr = NULL;
   typval_T rettv;
-  int i;
   int var_count = 0;
   int semicolon = 0;
   char op[2];
@@ -221,7 +220,10 @@ void ex_let(exarg_T *eap)
       list_vim_vars(&first);
     }
     eap->nextcmd = check_nextcmd(arg);
-  } else if (expr[0] == '=' && expr[1] == '<' && expr[2] == '<') {
+    return;
+  }
+
+  if (expr[0] == '=' && expr[1] == '<' && expr[2] == '<') {
     // HERE document
     list_T *l = heredoc_get(eap, expr + 3);
     if (l != NULL) {
@@ -233,44 +235,44 @@ void ex_let(exarg_T *eap)
       }
       tv_clear(&rettv);
     }
+    return;
+  }
+
+  rettv.v_type = VAR_UNKNOWN;
+
+  op[0] = '=';
+  op[1] = NUL;
+  if (*expr != '=') {
+    if (vim_strchr("+-*/%.", (uint8_t)(*expr)) != NULL) {
+      op[0] = *expr;  // +=, -=, *=, /=, %= or .=
+      if (expr[0] == '.' && expr[1] == '.') {  // ..=
+        expr++;
+      }
+    }
+    expr += 2;
   } else {
-    rettv.v_type = VAR_UNKNOWN;
+    expr += 1;
+  }
 
-    op[0] = '=';
-    op[1] = NUL;
-    if (*expr != '=') {
-      if (vim_strchr("+-*/%.", (uint8_t)(*expr)) != NULL) {
-        op[0] = *expr;  // +=, -=, *=, /=, %= or .=
-        if (expr[0] == '.' && expr[1] == '.') {  // ..=
-          expr++;
-        }
-      }
-      expr += 2;
-    } else {
-      expr += 1;
-    }
+  expr = skipwhite(expr);
 
-    expr = skipwhite(expr);
+  if (eap->skip) {
+    emsg_skip++;
+  }
+  evalarg_T evalarg = {
+    .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
+    .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
+  };
+  int eval_res = eval0(expr, &rettv, eap, &evalarg);
+  if (eap->skip) {
+    emsg_skip--;
+  }
 
-    if (eap->skip) {
-      emsg_skip++;
-    }
-    evalarg_T evalarg = {
-      .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-      .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
-    };
-    i = eval0(expr, &rettv, eap, &evalarg);
-    if (eap->skip) {
-      emsg_skip--;
-    }
-    if (eap->skip) {
-      if (i != FAIL) {
-        tv_clear(&rettv);
-      }
-    } else if (i != FAIL) {
-      (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count, is_const, op);
-      tv_clear(&rettv);
-    }
+  if (!eap->skip && eval_res != FAIL) {
+    (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count, is_const, op);
+  }
+  if (eval_res != FAIL) {
+    tv_clear(&rettv);
   }
 }
 

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -259,7 +259,7 @@ void ex_let(exarg_T *eap)
       .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
       .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
     };
-    i = eval0(expr, &rettv, &eap->nextcmd, &evalarg);
+    i = eval0(expr, &rettv, eap, &evalarg);
     if (eap->skip) {
       emsg_skip--;
     }

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -185,6 +185,7 @@ struct exarg {
   char *nextcmd;                ///< next command (NULL if none)
   char *cmd;                    ///< the name of the command (except for :make)
   char **cmdlinep;              ///< pointer to pointer of allocated cmdline
+  char *cmdline_tofree;         ///< free later
   cmdidx_T cmdidx;              ///< the index for the command
   uint32_t argt;                ///< flags for the command
   int skip;                     ///< don't execute the command, only parse it

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2328,6 +2328,7 @@ doend:
   }
 
   ex_nesting_level--;
+  xfree(ea.cmdline_tofree);
 
   return ea.nextcmd;
 }
@@ -4432,7 +4433,7 @@ static void ex_colorscheme(exarg_T *eap)
     char *expr = xstrdup("g:colors_name");
 
     emsg_off++;
-    char *p = eval_to_string(expr, NULL, false);
+    char *p = eval_to_string(expr, false);
     emsg_off--;
     xfree(expr);
 

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -792,8 +792,11 @@ void report_discard_pending(int pending, void *value)
 void ex_eval(exarg_T *eap)
 {
   typval_T tv;
-
-  if (eval0(eap->arg, &tv, &eap->nextcmd, eap->skip ? 0 : EVAL_EVALUATE) == OK) {
+  evalarg_T evalarg = {
+    .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
+    .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
+  };
+  if (eval0(eap->arg, &tv, &eap->nextcmd, &evalarg) == OK) {
     tv_clear(&tv);
   }
 }

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -796,7 +796,7 @@ void ex_eval(exarg_T *eap)
     .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
     .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
   };
-  if (eval0(eap->arg, &tv, &eap->nextcmd, &evalarg) == OK) {
+  if (eval0(eap->arg, &tv, eap, &evalarg) == OK) {
     tv_clear(&tv);
   }
 }
@@ -815,7 +815,7 @@ void ex_if(exarg_T *eap)
     int skip = CHECK_SKIP;
 
     bool error;
-    int result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);
+    int result = eval_to_bool(eap->arg, &error, eap, skip);
 
     if (!skip && !error) {
       if (result) {
@@ -910,7 +910,7 @@ void ex_else(exarg_T *eap)
     if (skip && *eap->arg != '"' && ends_excmd(*eap->arg)) {
       semsg(_(e_invexpr2), eap->arg);
     } else {
-      result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);
+      result = eval_to_bool(eap->arg, &error, eap, skip);
     }
 
     // When throwing error exceptions, we want to throw always the first
@@ -957,7 +957,7 @@ void ex_while(exarg_T *eap)
     int skip = CHECK_SKIP;
     if (eap->cmdidx == CMD_while) {
       // ":while bool-expr"
-      result = eval_to_bool(eap->arg, &error, &eap->nextcmd, skip);
+      result = eval_to_bool(eap->arg, &error, eap, skip);
     } else {
       void *fi;
 
@@ -969,7 +969,7 @@ void ex_while(exarg_T *eap)
         error = false;
       } else {
         // Evaluate the argument and get the info in a structure.
-        fi = eval_for_line(eap->arg, &error, &eap->nextcmd, skip);
+        fi = eval_for_line(eap->arg, &error, eap, skip);
         cstack->cs_forinfo[cstack->cs_idx] = fi;
       }
 
@@ -1128,12 +1128,11 @@ void ex_endwhile(exarg_T *eap)
 /// Handle ":throw expr"
 void ex_throw(exarg_T *eap)
 {
-  const char *arg = eap->arg;
+  char *arg = eap->arg;
   char *value;
 
   if (*arg != NUL && *arg != '|' && *arg != '\n') {
-    value = eval_to_string_skip(arg, (const char **)&eap->nextcmd,
-                                (bool)eap->skip);
+    value = eval_to_string_skip(arg, eap, eap->skip);
   } else {
     emsg(_(e_argreq));
     value = NULL;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1749,7 +1749,8 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
       curbuf = wp->w_buffer;
 
       emsg_silent++;       // handle exceptions, but don't display errors
-      text = eval_to_string_safe(wp->w_p_fdt, NULL, was_set_insecurely(wp, "foldtext", OPT_LOCAL));
+      text = eval_to_string_safe(wp->w_p_fdt,
+                                 was_set_insecurely(wp, "foldtext", OPT_LOCAL));
       emsg_silent--;
 
       if (text == NULL || did_emsg) {

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1632,7 +1632,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
       api_clear_error(&err);
     }
   } else {
-    p = eval_to_string(expr, NULL, false);
+    p = eval_to_string(expr, false);
     xfree(expr);
   }
   expr_map_lock--;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -763,7 +763,7 @@ char *get_expr_line(void)
   }
 
   nested++;
-  rv = eval_to_string(expr_copy, NULL, true);
+  rv = eval_to_string(expr_copy, true);
   nested--;
   xfree(expr_copy);
   return rv;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1371,7 +1371,7 @@ static int expand_backtick(garray_T *gap, char *pat, int flags)
   char *cmd = xstrnsave(pat + 1, strlen(pat) - 2);
 
   if (*cmd == '=') {          // `={expr}`: Expand expression
-    buffer = eval_to_string(cmd + 1, &p, true);
+    buffer = eval_to_string(cmd + 1, true);
   } else {
     buffer = get_cmd_output(cmd, NULL, (flags & EW_SILENT) ? kShellOptSilent : 0, NULL);
   }
@@ -1662,7 +1662,7 @@ void simplify_filename(char *filename)
 static char *eval_includeexpr(const char *const ptr, const size_t len)
 {
   set_vim_var_string(VV_FNAME, ptr, (ptrdiff_t)len);
-  char *res = eval_to_string_safe(curbuf->b_p_inex, NULL,
+  char *res = eval_to_string_safe(curbuf->b_p_inex,
                                   was_set_insecurely(curwin, "includeexpr", OPT_LOCAL));
   set_vim_var_string(VV_FNAME, NULL, 0);
   return res;

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6958,7 +6958,7 @@ void ex_cexpr(exarg_T *eap)
   // Evaluate the expression.  When the result is a string or a list we can
   // use it to fill the errorlist.
   typval_T tv;
-  if (eval0(eap->arg, &tv, &eap->nextcmd, EVAL_EVALUATE) == FAIL) {
+  if (eval0(eap->arg, &tv, &eap->nextcmd, &EVALARG_EVALUATE) == FAIL) {
     return;
   }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6958,7 +6958,7 @@ void ex_cexpr(exarg_T *eap)
   // Evaluate the expression.  When the result is a string or a list we can
   // use it to fill the errorlist.
   typval_T tv;
-  if (eval0(eap->arg, &tv, &eap->nextcmd, &EVALARG_EVALUATE) == FAIL) {
+  if (eval0(eap->arg, &tv, eap, &EVALARG_EVALUATE) == FAIL) {
     return;
   }
 

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1812,7 +1812,7 @@ static int vim_regsub_both(char *source, typval_T *expr, char *dest, int destlen
         }
         tv_clear(&rettv);
       } else {
-        eval_result[nested] = eval_to_string(source + 2, NULL, true);
+        eval_result[nested] = eval_to_string(source + 2, true);
       }
       nesting--;
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -985,7 +985,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
     };
     set_var(S_LEN("g:statusline_winid"), &tv, false);
 
-    usefmt = eval_to_string_safe(fmt + 2, NULL, use_sandbox);
+    usefmt = eval_to_string_safe(fmt + 2, use_sandbox);
     if (usefmt == NULL) {
       usefmt = fmt;
     }
@@ -1457,7 +1457,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
       }
 
       // Note: The result stored in `t` is unused.
-      str = eval_to_string_safe(out_p, &t, use_sandbox);
+      str = eval_to_string_safe(out_p, use_sandbox);
 
       curwin = save_curwin;
       curbuf = save_curbuf;

--- a/test/unit/eval/helpers.lua
+++ b/test/unit/eval/helpers.lua
@@ -512,7 +512,8 @@ end
 local function eval0(expr)
   local tv = ffi.gc(ffi.new('typval_T', {v_type=eval.VAR_UNKNOWN}),
                     eval.tv_clear)
-  if eval.eval0(to_cstr(expr), tv, nil, eval.EVAL_EVALUATE) == 0 then
+  local evalarg = ffi.new('evalarg_T', {eval_flags = eval.EVAL_EVALUATE})
+  if eval.eval0(to_cstr(expr), tv, nil, evalarg) == 0 then
     return nil
   else
     return tv


### PR DESCRIPTION
#### vim-patch:8.2.1047: Vim9: script cannot use line continuation like :def function

Problem:    Vim9: script cannot use line continuation like in a :def function.
Solution:   Pass the getline function pointer to the eval() functions.  Use it
            for addition and multiplication operators.

https://github.com/vim/vim/commit/5409f5d8c95007216ae1190565a7a8ee9ebd7100

Omit source_nextline() and eval_next_non_blank(): Vim9 script only.

N/A patches for version.c:

vim-patch:8.2.1048: build failure without the eval feature

Problem:    Build failure without the eval feature.
Solution:   Add dummy typedef.

https://github.com/vim/vim/commit/9d40c63c7dc8c3eb3886c58dcd334bc7f37eceba

vim-patch:8.2.1052: build failure with older compilers

Problem:    Build failure with older compilers.
Solution:   Move declaration to start of block.

https://github.com/vim/vim/commit/7acde51832f383f9a6d2e740cd0420b433ea841a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1049: Vim9: leaking memory when using continuation line

Problem:    Vim9: leaking memory when using continuation line.
Solution:   Keep a pointer to the continuation line in evalarg_T.  Centralize
            checking for a next command.

https://github.com/vim/vim/commit/b171fb179053fa631fec74911b5fb9374cb6a8a1

Omit eval_next_line(): Vim9 script only.

vim-patch:8.2.1050: missing change in struct

Problem:    Missing change in struct.
Solution:   Add missing change.

https://github.com/vim/vim/commit/65a8ed37f7bc61fbe5c612a7b0eb0dfc16ad3e11

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1447: condition is always true

Problem:    Condition is always true.
Solution:   Remove the useless condition. (closes vim/vim#12253)

https://github.com/vim/vim/commit/474891bc89e657100bd37c29129451a0e601879d