### PR TITLE
vim-patch:8.2.{1062,1063,1064,1065,1068,1069,1070,1071,1073,1074,1075,1076,1079,1080,1098,1099,1100,1125,1161,1162,1163,1203,3216}

### DIFF
--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -173,6 +173,7 @@ Object nvim_eval(String expr, Error *err)
 
   TRY_WRAP(err, {
     ok = eval0(expr.data, &rettv, NULL, &EVALARG_EVALUATE);
+    clear_evalarg(&EVALARG_EVALUATE, NULL);
   });
 
   if (!ERROR_SET(err)) {
@@ -294,6 +295,7 @@ Object nvim_call_dict_function(Object dict, String fn, Array args, Error *err)
       api_set_error(err, kErrorTypeException,
                     "Failed to evaluate dict expression");
     }
+    clear_evalarg(&EVALARG_EVALUATE, NULL);
     if (try_end(err)) {
       return rv;
     }

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -494,7 +494,7 @@ static typval_T *eval_expr_no_emsg(struct debuggy *const bp)
 {
   // Disable error messages, a bad expression would make Vim unusable.
   emsg_off++;
-  typval_T *const tv = eval_expr(bp->dbg_name);
+  typval_T *const tv = eval_expr(bp->dbg_name, NULL);
   emsg_off--;
   return tv;
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7447,7 +7447,10 @@ void ex_echo(exarg_T *eap)
   const int did_emsg_before = did_emsg;
   const int called_emsg_before = called_emsg;
 
-  evalarg_T evalarg = { .eval_flags = eap->skip ? 0 : EVAL_EVALUATE };
+  evalarg_T evalarg = {
+    .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
+    .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
+  };
 
   if (eap->skip) {
     emsg_skip++;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7486,7 +7486,7 @@ void ex_echo(exarg_T *eap)
   const int called_emsg_before = called_emsg;
   evalarg_T evalarg;
 
-  fill_evalarg_from_eap(&evalarg, eap, eap != NULL && eap->skip);
+  fill_evalarg_from_eap(&evalarg, eap, eap->skip);
 
   if (eap->skip) {
     emsg_skip++;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2377,7 +2377,8 @@ static int eval2(char **arg, typval_T *rettv, evalarg_T *const evalarg)
   // Repeat until there is no following "||".
   bool first = true;
   bool result = false;
-  while ((*arg)[0] == '|' && (*arg)[1] == '|') {
+  char *p = *arg;
+  while (p[0] == '|' && p[1] == '|') {
     evalarg_T nested_evalarg = evalarg == NULL ? (evalarg_T){ 0 } : *evalarg;
     const int orig_flags = evalarg == NULL ? 0 : evalarg->eval_flags;
     const bool evaluate = orig_flags & EVAL_EVALUATE;
@@ -2414,6 +2415,8 @@ static int eval2(char **arg, typval_T *rettv, evalarg_T *const evalarg)
       rettv->v_type = VAR_NUMBER;
       rettv->vval.v_number = result;
     }
+
+    p = *arg;
   }
 
   return OK;
@@ -2439,7 +2442,8 @@ static int eval3(char **arg, typval_T *rettv, evalarg_T *const evalarg)
   // Repeat until there is no following "&&".
   bool first = true;
   bool result = true;
-  while ((*arg)[0] == '&' && (*arg)[1] == '&') {
+  char *p = *arg;
+  while (p[0] == '&' && p[1] == '&') {
     evalarg_T nested_evalarg = evalarg == NULL ? (evalarg_T){ 0 } : *evalarg;
     const int orig_flags = evalarg == NULL ? 0 : evalarg->eval_flags;
     const bool evaluate = orig_flags & EVAL_EVALUATE;
@@ -2476,6 +2480,8 @@ static int eval3(char **arg, typval_T *rettv, evalarg_T *const evalarg)
       rettv->v_type = VAR_NUMBER;
       rettv->vval.v_number = result;
     }
+
+    p = *arg;
   }
 
   return OK;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4003,7 +4003,7 @@ static int get_list_tv(char **arg, typval_T *rettv, evalarg_T *const evalarg)
       tv_list_append_owned_tv(l, tv);
     }
 
-    // the comma must comma after the value
+    // the comma must come after the value
     bool had_comma = **arg == ',';
     if (had_comma) {
       *arg = skipwhite(*arg + 1);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3023,7 +3023,6 @@ static int eval7(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool wan
     *arg = skipwhite(*arg + 1);
 
     ret = eval1(arg, rettv, evalarg);  // recursive!
-
     if (**arg == ')') {
       (*arg)++;
     } else if (ret == OK) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -695,9 +695,11 @@ void eval_patch(const char *const origfile, const char *const difffile, const ch
 void fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, bool skip)
 {
   *evalarg = (evalarg_T){ .eval_flags = skip ? 0 : EVAL_EVALUATE };
-  if (eap != NULL && getline_equal(eap->getline, eap->cookie, getsourceline)) {
-    evalarg->eval_getline = eap->getline;
-    evalarg->eval_cookie = eap->cookie;
+  if (eap != NULL) {
+    if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
+      evalarg->eval_getline = eap->getline;
+      evalarg->eval_cookie = eap->cookie;
+    }
   }
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -837,10 +837,17 @@ char *eval_to_string_skip(char *arg, exarg_T *eap, const bool skip)
   typval_T tv;
   char *retval;
 
+  evalarg_T evalarg = {
+    .eval_flags = skip ? 0 : EVAL_EVALUATE,
+  };
+  if (eap != NULL && getline_equal(eap->getline, eap->cookie, getsourceline)) {
+    evalarg.eval_getline = eap->getline;
+    evalarg.eval_cookie = eap->cookie;
+  }
   if (skip) {
     emsg_skip++;
   }
-  if (eval0(arg, &tv, eap, skip ? NULL : &EVALARG_EVALUATE) == FAIL || skip) {
+  if (eval0(arg, &tv, eap, &evalarg) == FAIL || skip) {
     retval = NULL;
   } else {
     retval = xstrdup(tv_get_string(&tv));
@@ -849,7 +856,7 @@ char *eval_to_string_skip(char *arg, exarg_T *eap, const bool skip)
   if (skip) {
     emsg_skip--;
   }
-  clear_evalarg(&EVALARG_EVALUATE, eap);
+  clear_evalarg(&evalarg, eap);
 
   return retval;
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4679,8 +4679,8 @@ static int get_literal_key(char **arg, typval_T *tv)
 
 /// Allocate a variable for a Dictionary and fill it from "*arg".
 ///
+/// @param arg  "*arg" points to the "{".
 /// @param literal  true for #{key: val}
-/// @param flags    can have EVAL_EVALUATE and other EVAL_ flags.
 ///
 /// @return  OK or FAIL.  Returns NOTDONE for {expr}.
 static int eval_dict(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool literal)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2259,21 +2259,23 @@ static int eval_func(char **const arg, evalarg_T *const evalarg, char *const nam
   return ret;
 }
 
-/// After using "evalarg" filled from "eap" free the memory.
+/// After using "evalarg" filled from "eap": free the memory.
 void clear_evalarg(evalarg_T *evalarg, exarg_T *eap)
 {
-  if (evalarg != NULL && evalarg->eval_tofree != NULL) {
-    if (eap != NULL) {
-      // We may need to keep the original command line, e.g. for
-      // ":let" it has the variable names.  But we may also need the
-      // new one, "nextcmd" points into it.  Keep both.
-      xfree(eap->cmdline_tofree);
-      eap->cmdline_tofree = *eap->cmdlinep;
-      *eap->cmdlinep = evalarg->eval_tofree;
-    } else {
-      xfree(evalarg->eval_tofree);
+  if (evalarg != NULL) {
+    if (evalarg->eval_tofree != NULL) {
+      if (eap != NULL) {
+        // We may need to keep the original command line, e.g. for
+        // ":let" it has the variable names.  But we may also need the
+        // new one, "nextcmd" points into it.  Keep both.
+        xfree(eap->cmdline_tofree);
+        eap->cmdline_tofree = *eap->cmdlinep;
+        *eap->cmdlinep = evalarg->eval_tofree;
+      } else {
+        xfree(evalarg->eval_tofree);
+      }
+      evalarg->eval_tofree = NULL;
     }
-    evalarg->eval_tofree = NULL;
   }
 }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2506,7 +2506,6 @@ static int eval3(char **arg, typval_T *rettv, evalarg_T *const evalarg)
 static int eval4(char **arg, typval_T *rettv, evalarg_T *const evalarg)
 {
   typval_T var2;
-  char *p;
   exprtype_T type = EXPR_UNKNOWN;
   int len = 2;
 
@@ -2515,7 +2514,7 @@ static int eval4(char **arg, typval_T *rettv, evalarg_T *const evalarg)
     return FAIL;
   }
 
-  p = *arg;
+  char *p = *arg;
   switch (p[0]) {
   case '=':
     if (p[1] == '=') {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2303,7 +2303,8 @@ int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
     return FAIL;
   }
 
-  if ((*arg)[0] == '?') {
+  char *p = *arg;
+  if (*p == '?') {
     evalarg_T nested_evalarg = evalarg == NULL ? (evalarg_T){ 0 } : *evalarg;
     const int orig_flags = evalarg == NULL ? 0 : evalarg->eval_flags;
     const bool evaluate = nested_evalarg.eval_flags & EVAL_EVALUATE;
@@ -2329,7 +2330,8 @@ int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
     }
 
     // Check for the ":".
-    if ((*arg)[0] != ':') {
+    p = *arg;
+    if (*p != ':') {
       emsg(_("E109: Missing ':' after '?'"));
       if (evaluate && result) {
         tv_clear(rettv);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3021,7 +3021,9 @@ static int eval7(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool wan
   // nested expression: (expression).
   case '(':
     *arg = skipwhite(*arg + 1);
+
     ret = eval1(arg, rettv, evalarg);  // recursive!
+
     if (**arg == ')') {
       (*arg)++;
     } else if (ret == OK) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -705,8 +705,11 @@ int eval_to_bool(char *arg, bool *error, exarg_T *eap, int skip)
 
   evalarg_T evalarg = {
     .eval_flags = skip ? 0 : EVAL_EVALUATE,
-    .eval_cookie = eap != NULL && eap->getline == getsourceline ? eap->cookie : NULL,
   };
+  if (eap != NULL && getline_equal(eap->getline, eap->cookie, getsourceline)) {
+    evalarg.eval_getline = eap->getline;
+    evalarg.eval_cookie = eap->cookie;
+  }
 
   if (skip) {
     emsg_skip++;
@@ -7461,8 +7464,11 @@ void ex_echo(exarg_T *eap)
 
   evalarg_T evalarg = {
     .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-    .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
   };
+  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
+    evalarg.eval_getline = eap->getline;
+    evalarg.eval_cookie = eap->cookie;
+  }
 
   if (eap->skip) {
     emsg_skip++;

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -275,7 +275,7 @@ typedef struct {
   LineGetter eval_getline;
   void *eval_cookie;  ///< argument for eval_getline()
 
-  /// pointer to the line obtained with getsourceline()
+  /// pointer to the last line obtained with getsourceline()
   char *eval_tofree;
 } evalarg_T;
 

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -272,7 +272,8 @@ typedef struct {
   int eval_flags;     ///< EVAL_ flag values below
 
   /// copied from exarg_T when "getline" is "getsourceline". Can be NULL.
-  void *eval_cookie;   // argument for getline()
+  LineGetter eval_getline;
+  void *eval_cookie;  ///< argument for eval_getline()
 
   /// pointer to the line obtained with getsourceline()
   char *eval_tofree;
@@ -284,7 +285,7 @@ enum {
 };
 
 /// Passed to an eval() function to enable evaluation.
-EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL, NULL });
+EXTERN evalarg_T EVALARG_EVALUATE INIT(= { EVAL_EVALUATE, NULL, NULL, NULL });
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval.h.generated.h"

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -366,7 +366,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, evalarg_T *evalarg)
   }
 
   eval_lavars_used = old_eval_lavars;
-  if (evalarg->eval_tofree == NULL) {
+  if (evalarg != NULL && evalarg->eval_tofree == NULL) {
     evalarg->eval_tofree = tofree;
   } else {
     xfree(tofree);
@@ -377,7 +377,7 @@ errret:
   ga_clear_strings(&newargs);
   xfree(fp);
   xfree(pt);
-  if (evalarg->eval_tofree == NULL) {
+  if (evalarg != NULL && evalarg->eval_tofree == NULL) {
     evalarg->eval_tofree = tofree;
   } else {
     xfree(tofree);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2996,6 +2996,7 @@ void ex_return(exarg_T *eap)
   if (eap->skip) {
     emsg_skip--;
   }
+  clear_evalarg(&evalarg, eap);
 }
 
 /// ":1,25call func(arg1, arg2)" function call.

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+#include "nvim/eval.h"
 #include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -267,7 +267,7 @@ void ex_let(exarg_T *eap)
   if (eap->skip) {
     emsg_skip--;
   }
-  xfree(evalarg.eval_tofree);
+  clear_evalarg(&evalarg, eap);
 
   if (!eap->skip && eval_res != FAIL) {
     (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count, is_const, op);

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -259,13 +259,8 @@ void ex_let(exarg_T *eap)
   if (eap->skip) {
     emsg_skip++;
   }
-  evalarg_T evalarg = {
-    .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-  };
-  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
-    evalarg.eval_getline = eap->getline;
-    evalarg.eval_cookie = eap->cookie;
-  }
+  evalarg_T evalarg;
+  fill_evalarg_from_eap(&evalarg, eap, eap->skip);
   int eval_res = eval0(expr, &rettv, eap, &evalarg);
   if (eap->skip) {
     emsg_skip--;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -267,6 +267,7 @@ void ex_let(exarg_T *eap)
   if (eap->skip) {
     emsg_skip--;
   }
+  xfree(evalarg.eval_tofree);
 
   if (!eap->skip && eval_res != FAIL) {
     (void)ex_let_vars(eap->arg, &rettv, false, semicolon, var_count, is_const, op);
@@ -510,7 +511,7 @@ static const char *list_arg_vars(exarg_T *eap, const char *arg, int *first)
         } else {
           // handle d.key, l[idx], f(expr)
           const char *const arg_subsc = arg;
-          if (handle_subscript(&arg, &tv, EVAL_EVALUATE, true) == FAIL) {
+          if (handle_subscript(&arg, &tv, &EVALARG_EVALUATE, true) == FAIL) {
             error = true;
           } else {
             if (arg == arg_subsc && len == 2 && name[1] == ':') {
@@ -1717,7 +1718,7 @@ bool var_exists(const char *var)
     n = get_var_tv(name, len, &tv, NULL, false, true) == OK;
     if (n) {
       // Handle d.key, l[idx], f(expr).
-      n = handle_subscript(&var, &tv, EVAL_EVALUATE, false) == OK;
+      n = handle_subscript(&var, &tv, &EVALARG_EVALUATE, false) == OK;
       if (n) {
         tv_clear(&tv);
       }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -261,8 +261,11 @@ void ex_let(exarg_T *eap)
   }
   evalarg_T evalarg = {
     .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-    .eval_cookie = eap->getline == getsourceline ? eap->cookie : NULL,
   };
+  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
+    evalarg.eval_getline = eap->getline;
+    evalarg.eval_cookie = eap->cookie;
+  }
   int eval_res = eval0(expr, &rettv, eap, &evalarg);
   if (eap->skip) {
     emsg_skip--;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3751,7 +3751,7 @@ int expand_filename(exarg_T *eap, char **cmdlinep, char **errormsgp)
     // Skip over `=expr`, wildcards in it are not expanded.
     if (p[0] == '`' && p[1] == '=') {
       p += 2;
-      (void)skip_expr(&p);
+      (void)skip_expr(&p, NULL);
       if (*p == '`') {
         p++;
       }
@@ -3970,7 +3970,7 @@ void separate_nextcmd(exarg_T *eap)
     } else if (p[0] == '`' && p[1] == '=' && (eap->argt & EX_XFILE)) {
       // Skip over `=expr` when wildcards are expanded.
       p += 2;
-      (void)skip_expr(&p);
+      (void)skip_expr(&p, NULL);
       if (*p == NUL) {  // stop at NUL after CTRL-V
         break;
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -484,24 +484,6 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       }
     }
 
-    if (cstack.cs_looplevel > 0) {
-      // Inside a while/for loop we need to store the lines and use them
-      // again.  Pass a different "fgetline" function to do_one_cmd()
-      // below, so that it stores lines in or reads them from
-      // "lines_ga".  Makes it possible to define a function inside a
-      // while/for loop.
-      cmd_getline = get_loop_line;
-      cmd_cookie = (void *)&cmd_loop_cookie;
-      cmd_loop_cookie.lines_gap = &lines_ga;
-      cmd_loop_cookie.current_line = current_line;
-      cmd_loop_cookie.getline = fgetline;
-      cmd_loop_cookie.cookie = cookie;
-      cmd_loop_cookie.repeating = (current_line < lines_ga.ga_len);
-    } else {
-      cmd_getline = fgetline;
-      cmd_cookie = cookie;
-    }
-
     // 2. If no line given, get an allocated line with fgetline().
     if (next_cmdline == NULL) {
       // Need to set msg_didout for the first line after an ":if",
@@ -540,15 +522,37 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
     }
     cmdline_copy = next_cmdline;
 
-    // Save the current line when inside a ":while" or ":for", and when
-    // the command looks like a ":while" or ":for", because we may need it
-    // later.  When there is a '|' and another command, it is stored
-    // separately, because we need to be able to jump back to it from an
+    int current_line_before = 0;
+    // Inside a while/for loop, and when the command looks like a ":while"
+    // or ":for", the line is stored, because we may need it later when
+    // looping.
+    //
+    // When there is a '|' and another command, it is stored separately,
+    // because we need to be able to jump back to it from an
     // :endwhile/:endfor.
-    if (current_line == lines_ga.ga_len
-        && (cstack.cs_looplevel || has_loop_cmd(next_cmdline))) {
-      store_loop_line(&lines_ga, next_cmdline);
+    //
+    // Pass a different "fgetline" function to do_one_cmd() below,
+    // that it stores lines in or reads them from "lines_ga".  Makes it
+    // possible to define a function inside a while/for loop.
+    if ((cstack.cs_looplevel > 0 || has_loop_cmd(next_cmdline))) {
+      cmd_getline = get_loop_line;
+      cmd_cookie = (void *)&cmd_loop_cookie;
+      cmd_loop_cookie.lines_gap = &lines_ga;
+      cmd_loop_cookie.current_line = current_line;
+      cmd_loop_cookie.getline = fgetline;
+      cmd_loop_cookie.cookie = cookie;
+      cmd_loop_cookie.repeating = (current_line < lines_ga.ga_len);
+
+      // Save the current line when encountering it the first time.
+      if (current_line == lines_ga.ga_len) {
+        store_loop_line(&lines_ga, next_cmdline);
+      }
+      current_line_before = current_line;
+    } else {
+      cmd_getline = fgetline;
+      cmd_cookie = cookie;
     }
+
     did_endif = false;
 
     if (count++ == 0) {
@@ -651,7 +655,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       } else if (cstack.cs_lflags & CSL_HAD_LOOP) {
         // For a ":while" or ":for" we need to remember the line number.
         cstack.cs_lflags &= ~CSL_HAD_LOOP;
-        cstack.cs_line[cstack.cs_idx] = current_line - 1;
+        cstack.cs_line[cstack.cs_idx] = current_line_before;
       }
     }
 

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -792,13 +792,9 @@ void report_discard_pending(int pending, void *value)
 void ex_eval(exarg_T *eap)
 {
   typval_T tv;
-  evalarg_T evalarg = {
-    .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-  };
-  if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
-    evalarg.eval_getline = eap->getline;
-    evalarg.eval_cookie = eap->cookie;
-  }
+  evalarg_T evalarg;
+
+  fill_evalarg_from_eap(&evalarg, eap, eap->skip);
 
   if (eval0(eap->arg, &tv, eap, &evalarg) == OK) {
     tv_clear(&tv);

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -957,21 +957,12 @@ void ex_while(exarg_T *eap)
       eap->cmdidx == CMD_while ? CSF_WHILE : CSF_FOR;
 
     int skip = CHECK_SKIP;
-    if (eap->cmdidx == CMD_while) {
-      // ":while bool-expr"
+    if (eap->cmdidx == CMD_while) {  // ":while bool-expr"
       result = eval_to_bool(eap->arg, &error, eap, skip);
-    } else {
+    } else {  // ":for var in list-expr"
+      evalarg_T evalarg;
+      fill_evalarg_from_eap(&evalarg, eap, skip);
       void *fi;
-
-      evalarg_T evalarg = {
-        .eval_flags = eap->skip ? 0 : EVAL_EVALUATE,
-      };
-      if (getline_equal(eap->getline, eap->cookie, getsourceline)) {
-        evalarg.eval_getline = eap->getline;
-        evalarg.eval_cookie = eap->cookie;
-      }
-
-      // ":for var in list-expr"
       if ((cstack->cs_lflags & CSL_HAD_LOOP) != 0) {
         // Jumping here from a ":continue" or ":endfor": use the
         // previously evaluated list.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5266,7 +5266,7 @@ int option_set_callback_func(char *optval, Callback *optcb)
       || (strncmp(optval, "function(", 9) == 0)
       || (strncmp(optval, "funcref(", 8) == 0)) {
     // Lambda expression or a funcref
-    tv = eval_expr(optval);
+    tv = eval_expr(optval, NULL);
     if (tv == NULL) {
       return FAIL;
     }

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -603,7 +603,7 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
     if (src[0] == '`' && src[1] == '=') {
       var = src;
       src += 2;
-      (void)skip_expr(&src);
+      (void)skip_expr(&src, NULL);
       if (*src == '`') {
         src++;
       }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6957,15 +6957,15 @@ void ex_cexpr(exarg_T *eap)
 
   // Evaluate the expression.  When the result is a string or a list we can
   // use it to fill the errorlist.
-  typval_T tv;
-  if (eval0(eap->arg, &tv, eap, &EVALARG_EVALUATE) == FAIL) {
+  typval_T *tv = eval_expr(eap->arg, eap);
+  if (tv == NULL) {
     return;
   }
 
-  if ((tv.v_type == VAR_STRING && tv.vval.v_string != NULL)
-      || tv.v_type == VAR_LIST) {
+  if ((tv->v_type == VAR_STRING && tv->vval.v_string != NULL)
+      || tv->v_type == VAR_LIST) {
     incr_quickfix_busy();
-    int res = qf_init_ext(qi, qi->qf_curlist, NULL, NULL, &tv, p_efm,
+    int res = qf_init_ext(qi, qi->qf_curlist, NULL, NULL, tv, p_efm,
                           (eap->cmdidx != CMD_caddexpr
                            && eap->cmdidx != CMD_laddexpr),
                           (linenr_T)0, (linenr_T)0,
@@ -6996,7 +6996,7 @@ void ex_cexpr(exarg_T *eap)
     emsg(_("E777: String or List expected"));
   }
 cleanup:
-  tv_clear(&tv);
+  tv_free(tv);
 }
 
 // Get the location list for ":lhelpgrep"

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -183,22 +183,25 @@ func Test_argument()
 
   let save_columns = &columns
   let &columns = 79
-  exe 'args ' .. join(range(1, 81))
-  call assert_equal(join([
-        \ '',
-        \ '[1] 6   11  16  21  26  31  36  41  46  51  56  61  66  71  76  81  ',
-        \ '2   7   12  17  22  27  32  37  42  47  52  57  62  67  72  77  ',
-        \ '3   8   13  18  23  28  33  38  43  48  53  58  63  68  73  78  ',
-        \ '4   9   14  19  24  29  34  39  44  49  54  59  64  69  74  79  ',
-        \ '5   10  15  20  25  30  35  40  45  50  55  60  65  70  75  80  ',
-        \ ], "\n"),
-        \ execute('args'))
+  try
+    exe 'args ' .. join(range(1, 81))
+    call assert_equal(join([
+          \ '',
+          \ '[1] 6   11  16  21  26  31  36  41  46  51  56  61  66  71  76  81  ',
+          \ '2   7   12  17  22  27  32  37  42  47  52  57  62  67  72  77  ',
+          \ '3   8   13  18  23  28  33  38  43  48  53  58  63  68  73  78  ',
+          \ '4   9   14  19  24  29  34  39  44  49  54  59  64  69  74  79  ',
+          \ '5   10  15  20  25  30  35  40  45  50  55  60  65  70  75  80  ',
+          \ ], "\n"),
+          \ execute('args'))
 
-  " No trailing newline with one item per row.
-  let long_arg = repeat('X', 81)
-  exe 'args ' .. long_arg
-  call assert_equal("\n[".long_arg.']', execute('args'))
-  let &columns = save_columns
+    " No trailing newline with one item per row.
+    let long_arg = repeat('X', 81)
+    exe 'args ' .. long_arg
+    call assert_equal("\n[".long_arg.']', execute('args'))
+  finally
+    let &columns = save_columns
+  endtry
 
   " Setting argument list should fail when the current buffer has unsaved
   " changes


### PR DESCRIPTION
#### vim-patch:8.2.1062: Vim9: no line break allowed inside "cond ? val1 : val2"

Problem:    Vim9: no line break allowed inside "cond ? val1 : val2".
Solution:   Check for operator after line break.

https://github.com/vim/vim/commit/793648fb563359396a23740c72a6e04cb64df3a9

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1063: Vim9: no line break allowed before || or &&

Problem:    Vim9: no line break allowed before || or &&.
Solution:   Check for operator after line break.

https://github.com/vim/vim/commit/be7ee488761a5582a5605197c3951a17f20d072e

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1064: Vim9: no line break allowed before comperators

Problem:    Vim9: no line break allowed before comperators.
Solution:   Check for comperator after line break.

https://github.com/vim/vim/commit/e6536aa766e95b6c64489678eb029e6909ee6a35

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1065: Vim9: no line break allowed inside a list

Problem:    Vim9: no line break allowed inside a list.
Solution:   Handle line break inside a list in Vim9 script.

https://github.com/vim/vim/commit/7147820cb978f5b179cfec2f9d8b7774e28d43e0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1068: Vim9: no line break allowed inside a dict

Problem:    Vim9: no line break allowed inside a dict.
Solution:   Handle line break inside a dict in Vim9 script.

https://github.com/vim/vim/commit/8ea9390b78da9e34a20e7418712921397c0c1989

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1069: Vim9: fail to check for white space in list

Problem:    Vim9: fail to check for white space in list.
Solution:   Add check for white space.

https://github.com/vim/vim/commit/e6e031739c9d0c4140e371031b58a249db0eb572

N/A patches for version.c:

vim-patch:8.2.1070: Vim9: leaking memory when lacking white space in dict

Problem:    Vim9: leaking memory when lacking white space in dict.
Solution:   Clear the typval.

https://github.com/vim/vim/commit/ab19d495fd880b25a38d58cbeb5b21e4d0ee5835

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1071: Vim9: no line break allowed inside a lambda

Problem:    Vim9: no line break allowed inside a lambda.
Solution:   Handle line break inside a lambda in Vim9 script.

https://github.com/vim/vim/commit/e40fbc2ca9fda07332a4da5af1fcaba91bed865b

Omit skip_expr_concatenate(). Apply the change to skip_expr() instead.
Omit eval_ga: Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1073: Vim9: no line break allowed in () expression

Problem:    Vim9: no line break allowed in () expression.
Solution:   Skip a line break.

https://github.com/vim/vim/commit/7a4981b93642b5b62018cd8150b3fb0dfa2417d4

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1074: Vim9: no line break allowed after some operators

Problem:    Vim9: no line break allowed after some operators.
Solution:   Skip a line break after the operator.  Add
            eval_may_get_next_line() to simplify checking for a line break.

https://github.com/vim/vim/commit/9215f01218b2ed2cfe49c1f43fcf342bd9ffdded

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1075: Vim9: no line break allowed in :echo expression

Problem:    Vim9: no line break allowed in :echo expression.
Solution:   Skip linebreak.

https://github.com/vim/vim/commit/7e8967fdcdf45caf08753bb791dc3779e78b34c8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1076: Vim9: no line break allowed in :if expression

Problem:    Vim9: no line break allowed in :if expression.
Solution:   Skip linebreak.

https://github.com/vim/vim/commit/faf8626b79e380fe81e7ae2439a535ed7619d27b

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1079: Vim9: no line break allowed in a while loop

Problem:    Vim9: no line break allowed in a while loop.
Solution:   Update stored loop lines when finding line breaks.

https://github.com/vim/vim/commit/d5053d015a957b343ad9c9e45e0abd2978f10cf0

Omit getline_peek(): Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1080: Vim9: no line break allowed in a for loop

Problem:    Vim9: no line break allowed in a for loop.
Solution:   Skip line breaks in for command.

https://github.com/vim/vim/commit/b7a78f7a6713f07d2fcad0b27dea22925c7b1cdf

Omit *_break_count and skip_for_lines(): Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1098: Vim9: cannot use line break in :throw argument

Problem:    Vim9: cannot use line break in :throw argument.
Solution:   Check for line break.

https://github.com/vim/vim/commit/006ad48b8a15c3bace741d8caaf3195e592fbe78

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1099: Vim9: cannot use line break in :cexpr argument

Problem:    Vim9: cannot use line break in :cexpr argument.
Solution:   Check for line break.

https://github.com/vim/vim/commit/37c837119579ff70b005a4e54c2e26ca42b74022

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1100: Vim9: cannot use line break in :execute argument

Problem:    Vim9: cannot use line break in :execute, :echomsg and :echoerr
            argument.
Solution:   Check for line break.

https://github.com/vim/vim/commit/47e880d6c13c3ec2888398fd9ba1f5a7180d791a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1103: Coverity reports an unnecessary NULL check

Problem:    Coverity reports an unnecessary NULL check.
Solution:   Remove the check for NULL.

https://github.com/vim/vim/commit/e707c882b23a53d2c1f0d1f7fc3a7be247aca614

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1110: Vim9: line continuation does not work in function arguments

Problem:    Vim9: line continuation does not work in function arguments.
Solution:   Pass "evalarg" to get_func_tv().  Fix seeing double quoted string
            as comment.

https://github.com/vim/vim/commit/e6b5324e3a3d354363f3c48e784c42ce3e77453f

Omit skipwhite_and_linebreak_keep_string(): Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1125: Vim9: double quote can be a string or a comment

Problem:    Vim9: double quote can be a string or a comment.
Solution:   Only support comments starting with # to avoid confusion.

https://github.com/vim/vim/commit/962d7213194647e90f9bdc608f693d39dd07cbd5

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1161: Vim9: using freed memory

Problem:    Vim9: using freed memory.
Solution:   Put pointer back in evalarg instead of freeing it.

https://github.com/vim/vim/commit/8e2730a315b8b06192f5fc822dc218dbb3cff7ae

Omit eval_tofree_lambda: Vim9 script only.

N/A patches for version.c:

vim-patch:8.2.1163: build error

Problem:    Build error.
Solution:   Add missing change to globals.

https://github.com/vim/vim/commit/6e13530ca03dd9cad245221177dd65f712211448

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1162: crash when using a lambda

Problem:    Crash when using a lambda.
Solution:   Check for evalarg to be NULL.

https://github.com/vim/vim/commit/efaaaa683b7b0cebc128be5c0c257b9d6578ac96

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1203: unused assignments in expression evaluation

Problem:    Unused assignments in expression evaluation.
Solution:   Move declarations and assignments to inner blocks where possible.

https://github.com/vim/vim/commit/3ac9c4701a5f1e39303ca2885956db92215966db

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3216: Vim9: crash when using variable in a loop at script level

Problem:    Vim9: crash when using variable in a loop at script level.
Solution:   Do not clear the variable if a function was defined.
            Do not create a new entry in sn_var_vals every time.

https://github.com/vim/vim/commit/2eb6fc3b52148f961e804ec2be361d531ff770d8

Omit eval_cstack: Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>