### PR TITLE
vim-patch:8.2.{1189,1512}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2378,6 +2378,7 @@ int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
     *arg = skipwhite(*arg + 1);
     evalarg_used->eval_flags = result ? orig_flags : orig_flags & ~EVAL_EVALUATE;
     if (eval1(arg, rettv, evalarg_used) == FAIL) {
+      evalarg_used->eval_flags = orig_flags;
       return FAIL;
     }
 
@@ -2388,17 +2389,19 @@ int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
       if (evaluate && result) {
         tv_clear(rettv);
       }
+      evalarg_used->eval_flags = orig_flags;
       return FAIL;
     }
 
     // Get the third variable.  Recursive!
     *arg = skipwhite(*arg + 1);
-    typval_T var2;
     evalarg_used->eval_flags = !result ? orig_flags : orig_flags & ~EVAL_EVALUATE;
+    typval_T var2;
     if (eval1(arg, &var2, evalarg_used) == FAIL) {
       if (evaluate && result) {
         tv_clear(rettv);
       }
+      evalarg_used->eval_flags = orig_flags;
       return FAIL;
     }
     if (evaluate && !result) {

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7258,6 +7258,30 @@ func Test_typed_script_var()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for issue6776              {{{1
+func Test_trinary_expression()
+  try
+    call eval('0 ? 0')
+  catch
+  endtry
+  " previous failure should not cause next expression to fail
+  call assert_equal(v:false, eval(string(v:false)))
+
+  try
+    call eval('0 ? "burp')
+  catch
+  endtry
+  " previous failure should not cause next expression to fail
+  call assert_equal(v:false, eval(string(v:false)))
+
+  try
+    call eval('1 ? 0 : "burp')
+  catch
+  endtry
+  " previous failure should not cause next expression to fail
+  call assert_equal(v:false, eval(string(v:false)))
+endfunction
+
 func Test_for_over_string()
   let res = ''
   for c in 'aéc̀d'


### PR DESCRIPTION
#### vim-patch:8.2.1189: Vim9: line continuation in lambda doesn't always work

Problem:    Vim9: line continuation in lambda doesn't always work.
Solution:   Do not use a local evalarg unless there isn't one.

https://github.com/vim/vim/commit/8af81d656a4c501611f6211b6379ea9dd650c545

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1512: failure after trinary expression fails

Problem:    Failure after trinary expression fails.
Solution:   Restore eval_flags. (Yasuhiro Matsumoto, closes vim/vim#6776)

https://github.com/vim/vim/commit/69e44552c567ff25b363ba0790ad3d43fa0397a7

Co-authored-by: Bram Moolenaar <Bram@vim.org>