### PR TITLE
vim-patch:8.2.1111: inconsistent naming of get_list_tv() and eval_dict()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1722,7 +1722,7 @@ static void f_exists(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       xfree(exp);
     }
   } else if (*p == '&' || *p == '+') {  // Option.
-    n = (get_option_tv(&p, NULL, true) == OK);
+    n = (eval_option(&p, NULL, true) == OK);
     if (*skipwhite(p) != NUL) {
       n = false;  // Trailing garbage.
     }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -503,8 +503,7 @@ static const char *list_arg_vars(exarg_T *eap, const char *arg, int *first)
         if (tofree != NULL) {
           name = tofree;
         }
-        if (get_var_tv(name, len, &tv, NULL, true, false)
-            == FAIL) {
+        if (eval_variable(name, len, &tv, NULL, true, false) == FAIL) {
           error = true;
         } else {
           // handle d.key, l[idx], f(expr)
@@ -1076,8 +1075,8 @@ static int do_lock_var(lval_T *lp, char *name_end FUNC_ATTR_UNUSED, exarg_T *eap
 /// @param dip  non-NULL when typval's dict item is needed
 /// @param verbose  may give error message
 /// @param no_autoload  do not use script autoloading
-int get_var_tv(const char *name, int len, typval_T *rettv, dictitem_T **dip, bool verbose,
-               bool no_autoload)
+int eval_variable(const char *name, int len, typval_T *rettv, dictitem_T **dip, bool verbose,
+                  bool no_autoload)
 {
   int ret = OK;
   typval_T *tv = NULL;
@@ -1564,7 +1563,7 @@ static void get_var_from(const char *varname, typval_T *rettv, typval_T *deftv, 
             tv_dict_set_ret(rettv, opts);
             done = true;
           }
-        } else if (get_option_tv(&varname, rettv, true) == OK) {
+        } else if (eval_option(&varname, rettv, true) == OK) {
           // Local option
           done = true;
         }
@@ -1713,7 +1712,7 @@ bool var_exists(const char *var)
     if (tofree != NULL) {
       name = tofree;
     }
-    n = get_var_tv(name, len, &tv, NULL, false, true) == OK;
+    n = eval_variable(name, len, &tv, NULL, false, true) == OK;
     if (n) {
       // Handle d.key, l[idx], f(expr).
       n = handle_subscript(&var, &tv, &EVALARG_EVALUATE, false) == OK;


### PR DESCRIPTION
#### vim-patch:8.2.1111: inconsistent naming of get_list_tv() and eval_dict()

Problem:    Inconsistent naming of get_list_tv() and eval_dict().
Solution:   Rename get_list_tv() to eval_list().  Similarly for eval_number(),
            eval_string(), eval_lit_string() and a few others.

https://github.com/vim/vim/commit/9a78e6df17033223ebdf499f2b02b2538601c52d

Co-authored-by: Bram Moolenaar <Bram@vim.org>