### PR TITLE
vim-patch:8.2.2138: Vim9: "exit_cb" causes Vim to exit

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2539,7 +2539,7 @@ This does NOT work: >
 			|List| item.
 
 						*:let=<<* *:let-heredoc*
-						*E990* *E991* *E172* *E221*
+					*E990* *E991* *E172* *E221* *E1145*
 :let {var-name} =<< [trim] {endmarker}
 text...
 text...

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -71,6 +71,8 @@ static const char *e_funcref = N_("E718: Funcref required");
 static const char *e_nofunc = N_("E130: Unknown function: %s");
 static const char e_no_white_space_allowed_before_str_str[]
   = N_("E1068: No white space allowed before '%s': %s");
+static const char e_missing_heredoc_end_marker_str[]
+  = N_("E1145: Missing heredoc end marker: %s");
 
 void func_init(void)
 {
@@ -2319,7 +2321,11 @@ void ex_function(exarg_T *eap)
       lines_left = Rows - 1;
     }
     if (theline == NULL) {
-      emsg(_("E126: Missing :endfunction"));
+      if (skip_until != NULL) {
+        semsg(_(e_missing_heredoc_end_marker_str), skip_until);
+      } else {
+        emsg(_("E126: Missing :endfunction"));
+      }
       goto erret;
     }
     if (show_block) {

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -327,7 +327,7 @@ func Test_let_heredoc_fails()
   endfunc
   END
   call writefile(text, 'XheredocFail')
-  call assert_fails('source XheredocFail', 'E126:')
+  call assert_fails('source XheredocFail', 'E1145:')
   call delete('XheredocFail')
 
   let text =<< trim CodeEnd
@@ -336,7 +336,7 @@ func Test_let_heredoc_fails()
   endfunc
   CodeEnd
   call writefile(text, 'XheredocWrong')
-  call assert_fails('source XheredocWrong', 'E126:')
+  call assert_fails('source XheredocWrong', 'E1145:')
   call delete('XheredocWrong')
 
   let text =<< trim TEXTend

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -6746,7 +6746,7 @@ func Test_script_lines()
 		    \ ])
 	call assert_report("Shouldn't be able to define function")
     catch
-	call assert_exception('Vim(function):E126: Missing :endfunction')
+	call assert_exception('Vim(function):E1145: Missing heredoc end marker: .')
     endtry
 
     " :change
@@ -6766,7 +6766,7 @@ func Test_script_lines()
 		    \ ])
 	call assert_report("Shouldn't be able to define function")
     catch
-	call assert_exception('Vim(function):E126: Missing :endfunction')
+	call assert_exception('Vim(function):E1145: Missing heredoc end marker: .')
     endtry
 
     " :insert
@@ -6786,7 +6786,7 @@ func Test_script_lines()
 		    \ ])
 	call assert_report("Shouldn't be able to define function")
     catch
-	call assert_exception('Vim(function):E126: Missing :endfunction')
+	call assert_exception('Vim(function):E1145: Missing heredoc end marker: .')
     endtry
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.2138: Vim9: "exit_cb" causes Vim to exit

Problem:    Vim9: "exit_cb" causes Vim to exit.
Solution:   Require white space after a command in Vim9 script.
            Also fix that Vim9 style heredoc was not always recognized.

https://github.com/vim/vim/commit/b5b9480ee936ef4cd0e350c468ef8c5f42fa398b

Omit EX_NONWHITE_OK, E1143, E1144: Vim9 script only.
Cherry-pick test_vimscript.vim changes from patch 8.2.2141.
Cherry-pick E1145 tag from Vim runtime.

N/A patches for version.c:

vim-patch:8.2.2140: build failure with tiny features

Problem:    Build failure with tiny features.
Solution:   Add #ifdef.

https://github.com/vim/vim/commit/2a3cd3af455973d678f70303ebdd486f3478bc0d