### PR TITLE
vim-patch:8.2.{0101,0102,0103,0104,0633,0634}: null typval tests

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -789,6 +789,9 @@ int eval_expr_typval(const typval_T *expr, typval_T *argv, int argc, typval_T *r
     }
   } else if (expr->v_type == VAR_PARTIAL) {
     partial_T *const partial = expr->vval.v_partial;
+    if (partial == NULL) {
+      return FAIL;
+    }
     const char *const s = partial_name(partial);
     if (s == NULL || *s == NUL) {
       return FAIL;
@@ -8640,8 +8643,9 @@ int typval_compare(typval_T *typ1, typval_T *typ2, exprtype_T type, bool ic)
     }
     if ((typ1->v_type == VAR_PARTIAL && typ1->vval.v_partial == NULL)
         || (typ2->v_type == VAR_PARTIAL && typ2->vval.v_partial == NULL)) {
-      // when a partial is NULL assume not equal
-      n1 = false;
+      // When both partials are NULL, then they are equal.
+      // Otherwise they are not equal.
+      n1 = (typ1->vval.v_partial == typ2->vval.v_partial);
     } else if (type_is) {
       if (typ1->v_type == VAR_FUNC && typ2->v_type == VAR_FUNC) {
         // strings are considered the same if their value is

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4059,7 +4059,10 @@ char *partial_name(partial_T *pt)
   if (pt->pt_name != NULL) {
     return pt->pt_name;
   }
-  return pt->pt_func->uf_name;
+  if (pt->pt_func != NULL) {
+    return pt->pt_func->uf_name;
+  }
+  return "";
 }
 
 static void partial_free(partial_T *pt)

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3806,7 +3806,7 @@ static const char *const str_errors[] = {
   [VAR_DICT]= N_("E731: using Dictionary as a String"),
   [VAR_FLOAT]= e_float_as_string,
   [VAR_BLOB]= N_("E976: using Blob as a String"),
-  [VAR_UNKNOWN]= N_("E908: using an invalid value as a String"),
+  [VAR_UNKNOWN]= e_inval_string,
 };
 
 #undef FUNC_ERROR

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -998,6 +998,7 @@ EXTERN const char e_listarg[] INIT(= N_("E686: Argument of %s must be a List"));
 EXTERN const char e_unsupportedoption[] INIT(= N_("E519: Option not supported"));
 EXTERN const char e_fnametoolong[] INIT(= N_("E856: Filename too long"));
 EXTERN const char e_float_as_string[] INIT(= N_("E806: using Float as a String"));
+EXTERN const char e_inval_string[] INIT(= N_("E908: using an invalid value as a String"));
 EXTERN const char e_cannot_edit_other_buf[] INIT(= N_("E788: Not allowed to edit another buffer now"));
 
 EXTERN const char e_cmdmap_err[] INIT(= N_("E5520: <Cmd> mapping must end with <CR>"));

--- a/test/old/testdir/test_bufwintabinfo.vim
+++ b/test/old/testdir/test_bufwintabinfo.vim
@@ -42,6 +42,7 @@ function Test_getbufwintabinfo()
     sign undefine Mark
     enew!
   endif
+  call assert_notequal([], getbufinfo(v:_null_dict))
 
   only
   let w1_id = win_getid()

--- a/test/old/testdir/test_cd.vim
+++ b/test/old/testdir/test_cd.vim
@@ -106,6 +106,7 @@ func Test_chdir_func()
   call assert_equal("", d)
   " Should not crash
   call chdir(d)
+  call assert_equal('', chdir([]))
 
   only | tabonly
   call chdir(topdir)

--- a/test/old/testdir/test_eval_stuff.vim
+++ b/test/old/testdir/test_eval_stuff.vim
@@ -205,6 +205,19 @@ func Test_vvar_scriptversion1()
   call assert_equal(511, 0o777)
 endfunc
 
+func Test_excute_null()
+  call assert_fails('execute v:_null_list', 'E730:')
+  call assert_fails('execute v:_null_dict', 'E731:')
+  call assert_fails('execute v:_null_blob', 'E976:')
+  execute v:_null_string
+  " Nvim doesn't have null partials
+  " call assert_fails('execute test_null_partial()', 'E729:')
+  if has('job')
+    call assert_fails('execute test_null_job()', 'E908:')
+    call assert_fails('execute test_null_channel()', 'E908:')
+  endif
+endfunc
+
 func Test_number_max_min_size()
   " This will fail on systems without 64 bit number support or when not
   " configured correctly.

--- a/test/old/testdir/test_eval_stuff.vim
+++ b/test/old/testdir/test_eval_stuff.vim
@@ -39,6 +39,9 @@ func Test_mkdir_p()
   call assert_fails('call mkdir("Xfile", "p")', 'E739')
   call delete('Xfile')
   call delete('Xmkdir', 'rf')
+  call assert_equal(0, mkdir(v:_null_string))
+  call assert_fails('call mkdir([])', 'E730')
+  call assert_fails('call mkdir("abc", [], [])', 'E745')
 endfunc
 
 func Test_line_continuation()
@@ -212,6 +215,8 @@ func Test_execute_cmd_with_null()
   execute v:_null_string
   " Nvim doesn't have null partials
   " call assert_fails('execute test_null_partial()', 'E729:')
+  " Nvim doesn't have test_unknown()
+  " call assert_fails('execute test_unknown()', 'E908:')
   if has('job')
     call assert_fails('execute test_null_job()', 'E908:')
     call assert_fails('execute test_null_channel()', 'E908:')

--- a/test/old/testdir/test_eval_stuff.vim
+++ b/test/old/testdir/test_eval_stuff.vim
@@ -205,7 +205,7 @@ func Test_vvar_scriptversion1()
   call assert_equal(511, 0o777)
 endfunc
 
-func Test_excute_null()
+func Test_execute_cmd_with_null()
   call assert_fails('execute v:_null_list', 'E730:')
   call assert_fails('execute v:_null_dict', 'E731:')
   call assert_fails('execute v:_null_blob', 'E976:')

--- a/test/old/testdir/test_execute_func.vim
+++ b/test/old/testdir/test_execute_func.vim
@@ -41,8 +41,6 @@ func Test_execute_string()
   call assert_equal("\nsomething", execute('echo "something"', 'silent!'))
   call assert_equal("", execute('burp', 'silent!'))
   call assert_fails('call execute("echo \"x\"", 3.4)', 'E806:')
-
-  call assert_equal("", execute(""))
 endfunc
 
 func Test_execute_list()
@@ -53,7 +51,6 @@ func Test_execute_list()
   call assert_equal("\n0\n1\n2\n3", execute(l))
 
   call assert_equal("", execute([]))
-  call assert_equal("", execute(v:_null_list))
 endfunc
 
 func Test_execute_does_not_change_col()
@@ -171,6 +168,19 @@ func Test_win_execute_visual_redraw()
 
   bwipe!
   bwipe!
+endfunc
+
+func Test_execute_null()
+  call assert_equal("", execute(v:_null_string))
+  call assert_equal("", execute(v:_null_list))
+  call assert_fails('call execute(v:_null_dict)', 'E731:')
+  call assert_fails('call execute(v:_null_blob)', 'E976:')
+  " Nvim doesn't have null partials
+  " call assert_fails('call execute(test_null_partial())','E729:')
+  if has('job')
+    call assert_fails('call execute(test_null_job())', 'E908:')
+    call assert_fails('call execute(test_null_channel())', 'E908:')
+  endif
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_execute_func.vim
+++ b/test/old/testdir/test_execute_func.vim
@@ -170,7 +170,7 @@ func Test_win_execute_visual_redraw()
   bwipe!
 endfunc
 
-func Test_execute_null()
+func Test_execute_cmd_with_null()
   call assert_equal("", execute(v:_null_string))
   call assert_equal("", execute(v:_null_list))
   call assert_fails('call execute(v:_null_dict)', 'E731:')

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -22,6 +22,9 @@ func Test_equal()
   call assert_false([base.method] == [instance.other])
 
   call assert_fails('echo base.method > instance.method')
+  " Nvim doesn't have null functions
+  " call assert_equal(0, test_null_function() == function('min'))
+  " call assert_equal(1, test_null_function() == test_null_function())
 endfunc
 
 func Test_version()
@@ -710,6 +713,26 @@ func Test_expr_eval_error()
   call assert_fails("let v = 10 + []", 'E745:')
   call assert_fails("let v = 10 / []", 'E745:')
   call assert_fails("let v = -{}", 'E728:')
+endfunc
+
+" Test for float value comparison
+func Test_float_compare()
+  CheckFeature float
+  call assert_true(1.2 == 1.2)
+  call assert_true(1.0 != 1.2)
+  call assert_true(1.2 > 1.0)
+  call assert_true(1.2 >= 1.2)
+  call assert_true(1.0 < 1.2)
+  call assert_true(1.2 <= 1.2)
+  call assert_true(+0.0 == -0.0)
+  " two NaNs (not a number) are not equal
+  call assert_true(sqrt(-4.01) != (0.0 / 0.0))
+  " two inf (infinity) are equal
+  call assert_true((1.0 / 0) == (2.0 / 0))
+  " two -inf (infinity) are equal
+  call assert_true(-(1.0 / 0) == -(2.0 / 0))
+  " +infinity != -infinity
+  call assert_true((1.0 / 0) != -(2.0 / 0))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -25,6 +25,8 @@ func Test_equal()
   " Nvim doesn't have null functions
   " call assert_equal(0, test_null_function() == function('min'))
   " call assert_equal(1, test_null_function() == test_null_function())
+  " Nvim doesn't have test_unknown()
+  " call assert_fails('eval 10 == test_unknown()', 'E685:')
 endfunc
 
 func Test_version()
@@ -137,7 +139,7 @@ func Test_loop_over_null_list()
   endfor
 endfunc
 
-func Test_set_reg_null_list()
+func Test_setreg_null_list()
   call setreg('x', v:_null_list)
 endfunc
 

--- a/test/old/testdir/test_filter_map.vim
+++ b/test/old/testdir/test_filter_map.vim
@@ -93,6 +93,12 @@ func Test_map_filter_fails()
   call assert_equal(v:_null_dict, filter(v:_null_dict, 0))
   call assert_equal(v:_null_list, map(v:_null_list, '"> " .. v:val'))
   call assert_equal(v:_null_dict, map(v:_null_dict, '"> " .. v:val'))
+  " Nvim doesn't have null functions
+  " call assert_equal([1, 2, 3], filter([1, 2, 3], test_null_function()))
+  call assert_fails("let l = filter([1, 2], function('min'))", 'E118:')
+  " Nvim doesn't have null partials
+  " call assert_equal([1, 2, 3], filter([1, 2, 3], test_null_partial()))
+  call assert_fails("let l = filter([1, 2], {a, b, c -> 1})", 'E119:')
 endfunc
 
 func Test_map_and_modify()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -990,6 +990,7 @@ func Test_matchstrpos()
   call assert_equal(['', -1, -1], matchstrpos('testing', 'ing', 8))
   call assert_equal(['ing', 1, 4, 7], matchstrpos(['vim', 'testing', 'execute'], 'ing'))
   call assert_equal(['', -1, -1, -1], matchstrpos(['vim', 'testing', 'execute'], 'img'))
+  call assert_equal(['', -1, -1], matchstrpos(v:_null_list, '\a'))
 endfunc
 
 func Test_nextnonblank_prevnonblank()
@@ -1284,6 +1285,7 @@ func Test_hlexists()
   syntax off
 endfunc
 
+" Test for the col() function
 func Test_col()
   new
   call setline(1, 'abcdef')
@@ -1435,6 +1437,8 @@ func Test_inputlist()
   call assert_equal(-2, c)
 
   call assert_fails('call inputlist("")', 'E686:')
+  " Nvim accepts null list as empty list
+  " call assert_fails('call inputlist(v:_null_list)', 'E686:')
 endfunc
 
 func Test_range_inputlist()
@@ -2357,6 +2361,16 @@ func Test_garbagecollect_now_fails()
   let v:testing = 1
 endfunc
 
+" Test for echo highlighting
+func Test_echohl()
+  echohl Search
+  echo 'Vim'
+  call assert_equal('Vim', Screenline(&lines))
+  " TODO: How to check the highlight group used by echohl?
+  " ScreenAttrs() returns all zeros.
+  echohl None
+endfunc
+
 " Test for the eval() function
 func Test_eval()
   call assert_fails("call eval('5 a')", 'E488:')
@@ -2513,6 +2527,18 @@ func Test_glob()
   call delete('XGLOB2')
 
   call assert_fails("call glob('*', 0, {})", 'E728:')
+endfunc
+
+" Test for browse()
+func Test_browse()
+  CheckFeature browse
+  call assert_fails('call browse([], "open", "x", "a.c")', 'E745:')
+endfunc
+
+" Test for browsedir()
+func Test_browsedir()
+  CheckFeature browse
+  call assert_fails('call browsedir("open", [])', 'E730:')
 endfunc
 
 func HasDefault(msg = 'msg')

--- a/test/old/testdir/test_getvar.vim
+++ b/test/old/testdir/test_getvar.vim
@@ -150,6 +150,12 @@ func Test_get_func()
   call assert_equal({'func has': 'no dict'}, get(l:F, 'dict', {'func has': 'no dict'}))
   call assert_equal(0, get(l:F, 'dict'))
   call assert_equal([], get(l:F, 'args'))
+  " Nvim doesn't have null functions
+  " let NF = test_null_function()
+  " call assert_equal('', get(NF, 'name'))
+  " call assert_equal(NF, get(NF, 'func'))
+  " call assert_equal(0, get(NF, 'dict'))
+  " call assert_equal([], get(NF, 'args'))
 endfunc
 
 " get({partial}, {what} [, {default}]) - in test_partial.vim

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -85,6 +85,24 @@ func Test_let()
   let l:Test_Local_Var = {'k' : 5}
   call assert_match("\nl:Test_Local_Var      {'k': 5}", execute('let l:'))
   call assert_match("v:errors              []", execute('let v:'))
+
+  " Test for assigning multiple list items
+  let l = [1, 2, 3]
+  let [l[0], l[1]] = [10, 20]
+  call assert_equal([10, 20, 3], l)
+
+  " Test for errors in conditional expression
+  call assert_fails('let val = [] ? 1 : 2', 'E745:')
+  call assert_fails('let val = 1 ? 5+ : 6', 'E121:')
+  call assert_fails('let val = 1 ? 0 : 5+', 'E15:')
+  call assert_false(exists('val'))
+
+  " Test for errors in logical operators
+  let @a = 'if [] || 0 | let val = 2 | endif'
+  call assert_fails('exe @a', 'E745:')
+  call assert_fails('call feedkeys(":let val = 0 || []\<cr>", "xt")', 'E745:')
+  call assert_fails('exe "let val = [] && 5"', 'E745:')
+  call assert_fails('exe "let val = 6 && []"', 'E745:')
 endfunc
 
 func s:set_arg1(a) abort

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1081,6 +1081,7 @@ func Test_null_dict()
   call assert_equal('{}', string(d))
   call assert_fails('let x = v:_null_dict[10]')
   call assert_equal({}, {})
+  call assert_equal(0, len(copy(d)))
 endfunc
 
 " Test for the indexof() function

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -794,6 +794,7 @@ func Test_listdict_compare_complex()
   call assert_true(dict4 == dict4copy)
 endfunc
 
+" Test for extending lists and dictionaries
 func Test_listdict_extend()
   " Test extend() with lists
 
@@ -1028,6 +1029,9 @@ func Test_listdict_index()
   call assert_fails("let l[1.1] = 4", 'E806:')
   call assert_fails("let l[:i] = [4, 5]", 'E121:')
   call assert_fails("let l[:3.2] = [4, 5]", 'E806:')
+  " Nvim doesn't have test_unknown()
+  " let t = test_unknown()
+  " call assert_fails("echo t[0]", 'E685:')
 endfunc
 
 " Test for a null list
@@ -1079,9 +1083,20 @@ func Test_null_dict()
   call assert_equal(0, values(d))
   call assert_false(has_key(d, 'k'))
   call assert_equal('{}', string(d))
-  call assert_fails('let x = v:_null_dict[10]')
+  call assert_fails('let x = d[10]')
   call assert_equal({}, {})
   call assert_equal(0, len(copy(d)))
+  call assert_equal(0, count(d, 'k'))
+  call assert_equal({}, deepcopy(d))
+  call assert_equal(20, get(d, 'k', 20))
+  call assert_equal(0, min(d))
+  call assert_equal(0, max(d))
+  call assert_equal(0, remove(d, 'k'))
+  call assert_equal('{}', string(d))
+  " call assert_equal(0, extend(d, d, 0))
+  lockvar d
+  call assert_equal(1, islocked('d'))
+  unlockvar d
 endfunc
 
 " Test for the indexof() function

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -408,6 +408,8 @@ func Test_null()
   echom v:_null_dict
   echom v:_null_blob
   echom v:_null_string
+  " Nvim doesn't have NULL functions
+  " echom test_null_function()
   " Nvim doesn't have NULL partials
   " echom test_null_partial()
   if has('job')

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -404,13 +404,16 @@ func Test_ask_yesno()
 endfunc
 
 func Test_null()
-  echom test_null_list()
-  echom test_null_dict()
-  echom test_null_blob()
-  echom test_null_job()
-  echom test_null_string()
-  echom test_null_channel()
-  echom test_null_partial()
+  echom v:_null_list
+  echom v:_null_dict
+  echom v:_null_blob
+  echom v:_null_string
+  " Nvim doesn't have NULL partials
+  " echom test_null_partial()
+  if has('job')
+    echom test_null_job()
+    echom test_null_channel()
+  endif
 endfunc
 
 func Test_mapping_at_hit_return_prompt()

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -403,6 +403,16 @@ func Test_ask_yesno()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_null()
+  echom test_null_list()
+  echom test_null_dict()
+  echom test_null_blob()
+  echom test_null_job()
+  echom test_null_string()
+  echom test_null_channel()
+  echom test_null_partial()
+endfunc
+
 func Test_mapping_at_hit_return_prompt()
   nnoremap <C-B> :echo "hit ctrl-b"<CR>
   call feedkeys(":ls\<CR>", "xt")

--- a/test/old/testdir/test_partial.vim
+++ b/test/old/testdir/test_partial.vim
@@ -63,16 +63,18 @@ endfunc
 func Test_partial_dict()
   let dict = {'name': 'hello'}
   let Cb = function('MyDictFunc', ["foo", "bar"], dict)
+  call test_garbagecollect_now()
   call assert_equal("hello/foo/bar", Cb())
   call assert_fails('Cb("xxx")', 'E492:')
+
+  let Cb = function('MyDictFunc', ["foo"], dict)
+  call assert_equal("hello/foo/xxx", Cb("xxx"))
+  call assert_fails('Cb()', 'E492:')
 
   let Cb = function('MyDictFunc', [], dict)
   call assert_equal("hello/ttt/xxx", Cb("ttt", "xxx"))
   call assert_fails('Cb("yyy")', 'E492:')
 
-  let Cb = function('MyDictFunc', ["foo"], dict)
-  call assert_equal("hello/foo/xxx", Cb("xxx"))
-  call assert_fails('Cb()', 'E492:')
   let Cb = function('MyDictFunc', dict)
   call assert_equal("hello/xxx/yyy", Cb("xxx", "yyy"))
   call assert_fails('Cb("fff")', 'E492:')
@@ -238,17 +240,22 @@ endfunc
 func Ignored(job1, job2, status)
 endfunc
 
-" func Test_cycle_partial_job()
-"   let job = job_start('echo')
-"   call job_setoptions(job, {'exit_cb': function('Ignored', [job])})
-"   unlet job
-" endfunc
+func Test_cycle_partial_job()
+  if has('job')
+    let job = job_start('echo')
+    call job_setoptions(job, {'exit_cb': function('Ignored', [job])})
+    unlet job
+  endif
+endfunc
 
-" func Test_ref_job_partial_dict()
-"   let g:ref_job = job_start('echo')
-"   let d = {'a': 'b'}
-"   call job_setoptions(g:ref_job, {'exit_cb': function('string', [], d)})
-" endfunc
+func Test_ref_job_partial_dict()
+  if has('job')
+    let g:ref_job = job_start('echo')
+    let d = {'a': 'b'}
+    call job_setoptions(g:ref_job, {'exit_cb': function('string', [], d)})
+    call test_garbagecollect_now()
+  endif
+endfunc
 
 func Test_auto_partial_rebind()
   let dict1 = {'name': 'dict1'}
@@ -356,6 +363,18 @@ func Test_compare_partials()
   call assert_true(F1 isnot# F2)  " Different functions
   call assert_true(F1 isnot# F1d1)  " Partial /= non-partial
   call assert_true(d1.f1 isnot# d1.f1)  " handle_subscript creates new partial each time
+
+  " compare two null partials
+  " Nvim doesn't have null partials
+  " let N1 = test_null_partial()
+  let N1 = function('min')
+  let N2 = N1
+  call assert_true(N1 is N2)
+  call assert_true(N1 == N2)
+
+  " compare a partial and a null partial
+  call assert_false(N1 == F1)
+  call assert_false(F1 is N1)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_partial.vim
+++ b/test/old/testdir/test_partial.vim
@@ -194,6 +194,10 @@ func Test_partial_string()
   call assert_equal("function('MyFunc', {'one': 1})", string(F))
   let F = function('MyFunc', ['foo'], d)
   call assert_equal("function('MyFunc', ['foo'], {'one': 1})", string(F))
+  " Nvim doesn't have null functions
+  " call assert_equal("function('')", string(test_null_function()))
+  " Nvim doesn't have null partials
+  " call assert_equal("function('')", string(test_null_partial()))
 endfunc
 
 func Test_func_unref()

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -2425,6 +2425,16 @@ func Xproperty_tests(cchar)
     call assert_equal(246, d.context)
     " set other Vim data types as context
     call g:Xsetlist([], 'a', {'context' : v:_null_blob})
+    if has('channel')
+      call g:Xsetlist([], 'a', {'context' : test_null_channel()})
+    endif
+    if has('job')
+      call g:Xsetlist([], 'a', {'context' : test_null_job()})
+    endif
+    " Nvim doesn't have null functions
+    " call g:Xsetlist([], 'a', {'context' : test_null_function()})
+    " Nvim doesn't have null partials
+    " call g:Xsetlist([], 'a', {'context' : test_null_partial()})
     call g:Xsetlist([], 'a', {'context' : ''})
     call test_garbagecollect_now()
     if a:cchar == 'l'

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -6508,9 +6508,17 @@ func Test_type()
     call assert_equal(v:t_float, type(0.0))
     call assert_equal(v:t_bool, type(v:false))
     call assert_equal(v:t_bool, type(v:true))
+    " call assert_equal(v:t_none, type(v:none))
+    " call assert_equal(v:t_none, type(v:null))
     call assert_equal(v:t_string, type(v:_null_string))
     call assert_equal(v:t_list, type(v:_null_list))
     call assert_equal(v:t_dict, type(v:_null_dict))
+    if has('job')
+      call assert_equal(v:t_job, type(test_null_job()))
+    endif
+    if has('channel')
+      call assert_equal(v:t_channel, type(test_null_channel()))
+    endif
     call assert_equal(v:t_blob, type(v:_null_blob))
 
     call assert_equal(0, 0 + v:false)


### PR DESCRIPTION
#### vim-patch:8.2.0101: crash when passing null object to ":echomsg"

Problem:    Crash when passing null object to ":echomsg".
Solution:   Check for NULL pointer. (Yasuhiro Matsumoto, closes vim/vim#5460)

https://github.com/vim/vim/commit/9db2afe46d3208775d1c3075bbee073a17f8fdc6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0102: messages test fails in small version

Problem:    Messages test fails in small version.
Solution:   Only use test_null_job() when available.

https://github.com/vim/vim/commit/da292b07afb7ea5ec9f4b43a7326551922e29f3a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0103: using null object with execute() has strange effects

Problem:    Using null object with execute() has strange effects.
Solution:   Give an error message ofr Job and Channel.

https://github.com/vim/vim/commit/e2a8f0773e91685843c062b1e48259712d5f2213

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0104: using channel or job with ":execute" has strange effects

Problem:    Using channel or job with ":execute" has strange effects.
Solution:   Give an error message for Job and Channel.

https://github.com/vim/vim/commit/b662591e505e8523634a1c8ddfb7fe44fae880c6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0633: crash when using null partial in filter()

Problem:    Crash when using null partial in filter().
Solution:   Fix crash.  Add more tests. (Yegappan Lakshmanan, closes vim/vim#5976)

https://github.com/vim/vim/commit/9d8d0b5c644ea53364d04403740b3f23e57c1497

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0634: crash with null partial and blob

Problem:    Crash with null partial and blob.
Solution:   Check for NULL pointer.  Add more tests. (Yegappan Lakshmanan,
            closes vim/vim#5984)

https://github.com/vim/vim/commit/92b83ccfda7a1d654ccaaf161a9c8a8e01fbcf76

Co-authored-by: Bram Moolenaar <Bram@vim.org>