### PR TITLE
fix(lua): inspect_pos respect bufnr when get syntax info

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -70,15 +70,18 @@ function vim.inspect_pos(bufnr, row, col, filter)
   if filter.treesitter then
     for _, capture in pairs(vim.treesitter.get_captures_at_pos(bufnr, row, col)) do
       capture.hl_group = '@' .. capture.capture .. '.' .. capture.lang
-      table.insert(results.treesitter, resolve_hl(capture))
+      results.treesitter[#results.treesitter + 1] = resolve_hl(capture)
     end
   end
 
   -- syntax
-  if filter.syntax then
-    for _, i1 in ipairs(vim.fn.synstack(row + 1, col + 1)) do
-      table.insert(results.syntax, resolve_hl({ hl_group = vim.fn.synIDattr(i1, 'name') }))
-    end
+  if filter.syntax and vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_call(bufnr, function()
+      for _, i1 in ipairs(vim.fn.synstack(row + 1, col + 1)) do
+        results.syntax[#results.syntax + 1] =
+          resolve_hl({ hl_group = vim.fn.synIDattr(i1, 'name') })
+      end
+    end)
   end
 
   -- namespace id -> name map

--- a/test/functional/lua/inspector_spec.lua
+++ b/test/functional/lua/inspector_spec.lua
@@ -12,17 +12,21 @@ describe('vim.inspect_pos', function()
   it('it returns items', function()
     local ret = exec_lua([[
       local buf = vim.api.nvim_create_buf(true, false)
+      local buf1 = vim.api.nvim_create_buf(true, false)
       local ns1 = vim.api.nvim_create_namespace("ns1")
       local ns2 = vim.api.nvim_create_namespace("")
       vim.api.nvim_set_current_buf(buf)
       vim.api.nvim_buf_set_lines(0, 0, -1, false, {"local a = 123"})
+      vim.api.nvim_buf_set_lines(buf1, 0, -1, false, {"--commentline"})
       vim.api.nvim_buf_set_option(buf, "filetype", "lua")
+      vim.api.nvim_buf_set_option(buf1, "filetype", "lua")
       vim.api.nvim_buf_set_extmark(buf, ns1, 0, 10, { hl_group = "Normal" })
       vim.api.nvim_buf_set_extmark(buf, ns2, 0, 10, { hl_group = "Normal" })
       vim.cmd("syntax on")
-      return {buf, vim.inspect_pos(0, 0, 10)}
+      return {buf, vim.inspect_pos(0, 0, 10), vim.inspect_pos(buf1, 0, 10).syntax }
     ]])
-    local buf, items = unpack(ret)
+    local buf, items, other_buf_syntax = unpack(ret)
+
     eq('', eval('v:errmsg'))
     eq({
       buffer = buf,
@@ -73,6 +77,13 @@ describe('vim.inspect_pos', function()
         },
       },
     }, items)
+
+    eq({
+      {
+        hl_group = 'luaComment',
+        hl_group_link = 'Comment',
+      },
+    }, other_buf_syntax)
   end)
 end)
 


### PR DESCRIPTION
Problem: `synstack` get the syntax in current window this will ignore the `bufnr` param.
Solution: wrap `synstack` in `nvim_buf_call` to inspect `bufnr` .  
Chore: use set value to index instead invoke `table.insert` . in luajit  this is fast than `insert`.

Fix #23096 