### PR TITLE
vim-patch:8.2.{1014,3329}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4918,6 +4918,7 @@ static int eval_env_var(char **arg, typval_T *rettv, int evaluate)
     name[len] = (char)cc;
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = string;
+    rettv->v_lock = VAR_UNLOCKED;
   }
 
   return OK;


### PR DESCRIPTION
#### vim-patch:8.2.1014: using "name" for a string result is confusing

Problem:    Using "name" for a string result is confusing.
Solution:   Rename to "end".

https://github.com/vim/vim/commit/1e0b7b11db61bd906266d3174fee0bbaf20a101f

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3329: v_lock not set when getting value of environment variable

Problem:    v_lock not set when getting value of environment variable.
Solution:   Set v_lock to zero.

https://github.com/vim/vim/commit/16e63e6d353c8b7337470644ceac02dc5e569db9

Co-authored-by: Bram Moolenaar <Bram@vim.org>