### PR TITLE
build(nix): upgrade nixpkgs to resolve link error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Tools
+/.direnv/
 /venv/
 compile_commands.json
 /.luarc.json
+/.envrc
 
 # IDEs
 /.vs/

--- a/contrib/flake.lock
+++ b/contrib/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1671983799,
-        "narHash": "sha256-Z2Ro6hFPZHkBqkVXY5/aBUzxi5xizQGvuHQ9+T5B/ks=",
+        "lastModified": 1681465517,
+        "narHash": "sha256-EasJh15/jcJNAHtq2SGbiADRXteURAnQbj1NqBoKkzU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fad51abd42ca17a60fc1d4cb9382e2d79ae31836",
+        "rev": "abe7316dd51a313ce528972b104f4f04f56eefc4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Resolves link error due to outdated nixpkgs#tree-sitter:

```
❯ nix build ./contrib
error: builder for '/nix/store/cvy6vcx3dppvq0ny88dyrm5145qjff4h-neovim-unwrapped-1ca77c2.drv' failed with exit code 2;
       last 10 log lines:
       >     inlined from 'disp_sb_line' at /build/by8brpnhzxcp645yiqb393xj3asqm4i3-source/src/nvim/message.c:2666:5:
       > /build/by8brpnhzxcp645yiqb393xj3asqm4i3-source/src/nvim/message.c:2158:18: warning: 'strnlen' specified bound 18446744073709551615 may exceed maximum object size 9223372036854775807 [-Wstringop-overread]
       >  2158 |     size_t len = strnlen(str, (size_t)maxlen);  // -V781
       >       |                  ^
       > /nix/store/frh9l9nrdysasdi2gs7i241s241ngjw2-binutils-2.39/bin/ld: /build/cc1jCXfr.ltrans38.ltrans.o: in function `tree_get_ranges':
       > <artificial>:(.text+0x1034): undefined reference to `ts_tree_included_ranges'
       > collect2: error: ld returned 1 exit status
       > make[2]: *** [src/nvim/CMakeFiles/nvim.dir/build.make:4627: bin/nvim] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:529: src/nvim/CMakeFiles/nvim.dir/all] Error 2
       > make: *** [Makefile:156: all] Error 2
       For full logs, run 'nix log /nix/store/cvy6vcx3dppvq0ny88dyrm5145qjff4h-neovim-unwrapped-1ca77c2.drv'.
```
