### PR TITLE
vim-patch:8.2.{1378,3856,4361,4373,4476}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3149,8 +3149,9 @@ static int eval7(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool wan
       ret = FAIL;
     } else {
       const int flags = evalarg == NULL ? 0 : evalarg->eval_flags;
-      if (**arg == '(') {
+      if (*skipwhite(*arg) == '(') {
         // "name(..."  recursive!
+        *arg = skipwhite(*arg);
         ret = eval_func(arg, evalarg, s, len, rettv, flags, NULL);
       } else if (evaluate) {
         // get value of variable

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -45,7 +45,7 @@ func Test_version()
   call assert_false(has('patch-9.9.1'))
 endfunc
 
-func Test_op_trinary()
+func Test_op_ternary()
   let lines =<< trim END
       call assert_equal('yes', 1 ? 'yes' : 'no')
       call assert_equal('no', 0 ? 'yes' : 'no')

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -613,7 +613,8 @@ func Test_function_with_funcref()
       call assert_equal(4, Ref('text'))
   END
   call CheckTransLegacySuccess(lines)
-  " cannot create s: variable in :def function
+  " skip CheckTransDefSuccess(), cannot assign to script variable
+  call map(lines, {k, v -> v =~ 'legacy' ? v : substitute(v, 's:', '', 'g')})
   call CheckTransVim9Success(lines)
 endfunc
 

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -596,8 +596,8 @@ endfunc
 
 func Test_function_with_funcref()
   let lines =<< trim END
-      VAR s:F = function('type')
-      VAR s:Fref = function(s:F)
+      let s:F = function('type')
+      let s:Fref = function(s:F)
       call assert_equal(v:t_string, s:Fref('x'))
       call assert_fails("call function('s:F')", 'E700:')
 
@@ -605,17 +605,34 @@ func Test_function_with_funcref()
       call assert_fails("call function('foo()')", 'foo()')
       call assert_fails("function('')", 'E129:')
 
-      legacy let s:Len = {s -> strlen(s)}
+      let s:Len = {s -> strlen(s)}
       call assert_equal(6, s:Len('foobar'))
-      VAR name = string(s:Len)
-      #" can evaluate "function('<lambda>99')"
-      call execute('VAR Ref = ' .. name)
+      let name = string(s:Len)
+      " can evaluate "function('<lambda>99')"
+      call execute('let Ref = ' .. name)
       call assert_equal(4, Ref('text'))
   END
-  call CheckTransLegacySuccess(lines)
-  " skip CheckTransDefSuccess(), cannot assign to script variable
-  call map(lines, {k, v -> v =~ 'legacy' ? v : substitute(v, 's:', '', 'g')})
-  call CheckTransVim9Success(lines)
+  call CheckScriptSuccess(lines)
+
+  let lines =<< trim END
+      vim9script
+      var F = function('type')
+      var Fref = function(F)
+      call assert_equal(v:t_string, Fref('x'))
+      call assert_fails("call function('F')", 'E700:')
+
+      call assert_fails("call function('foo()')", 'E475:')
+      call assert_fails("call function('foo()')", 'foo()')
+      call assert_fails("function('')", 'E129:')
+
+      var Len = (s) => strlen(s)
+      call assert_equal(6, Len('foobar'))
+      var name = string(Len)
+      # can evaluate "function('<lambda>99')"
+      call execute('var Ref = ' .. name)
+      call assert_equal(4, Ref('text'))
+  END
+  call CheckScriptSuccess(lines)
 endfunc
 
 func Test_funcref()

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -1,6 +1,7 @@
 " Tests for expressions.
 
 source check.vim
+source vim9.vim
 
 func Test_equal()
   let base = {}
@@ -45,509 +46,575 @@ func Test_version()
 endfunc
 
 func Test_op_trinary()
-  call assert_equal('yes', 1 ? 'yes' : 'no')
-  call assert_equal('no', 0 ? 'yes' : 'no')
-  call assert_equal('no', 'x' ? 'yes' : 'no')
-  call assert_equal('yes', '1x' ? 'yes' : 'no')
+  let lines =<< trim END
+      call assert_equal('yes', 1 ? 'yes' : 'no')
+      call assert_equal('no', 0 ? 'yes' : 'no')
 
-  call assert_fails('echo [1] ? "yes" : "no"', 'E745:')
-  call assert_fails('echo {} ? "yes" : "no"', 'E728:')
+      call assert_fails('echo [1] ? "yes" : "no"', 'E745:')
+      call assert_fails('echo {} ? "yes" : "no"', 'E728:')
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call assert_equal('no', 'x' ? 'yes' : 'no')
+  call CheckDefAndScriptFailure(["'x' ? 'yes' : 'no'"], 'E1135:')
+  call assert_equal('yes', '1x' ? 'yes' : 'no')
+  call CheckDefAndScriptFailure(["'1x' ? 'yes' : 'no'"], 'E1135:')
 endfunc
 
 func Test_op_falsy()
-  call assert_equal(v:true, v:true ?? 456)
-  call assert_equal(123, 123 ?? 456)
-  call assert_equal('yes', 'yes' ?? 456)
-  call assert_equal(0z00, 0z00 ?? 456)
-  call assert_equal([1], [1] ?? 456)
-  call assert_equal(#{one: 1}, #{one: 1} ?? 456)
-  if has('float')
-    call assert_equal(0.1, 0.1 ?? 456)
-  endif
+  let lines =<< trim END
+      call assert_equal(v:true, v:true ?? 456)
+      call assert_equal(123, 123 ?? 456)
+      call assert_equal('yes', 'yes' ?? 456)
+      call assert_equal(0z00, 0z00 ?? 456)
+      call assert_equal([1], [1] ?? 456)
+      call assert_equal({'one': 1}, {'one': 1} ?? 456)
+      if has('float')
+        call assert_equal(0.1, 0.1 ?? 456)
+      endif
 
-  call assert_equal(456, v:false ?? 456)
-  call assert_equal(456, 0 ?? 456)
-  call assert_equal(456, '' ?? 456)
-  call assert_equal(456, 0z ?? 456)
-  call assert_equal(456, [] ?? 456)
-  call assert_equal(456, {} ?? 456)
-  if has('float')
-    call assert_equal(456, 0.0 ?? 456)
-  endif
+      call assert_equal(456, v:false ?? 456)
+      call assert_equal(456, 0 ?? 456)
+      call assert_equal(456, '' ?? 456)
+      call assert_equal(456, 0z ?? 456)
+      call assert_equal(456, [] ?? 456)
+      call assert_equal(456, {} ?? 456)
+      if has('float')
+        call assert_equal(456, 0.0 ?? 456)
+      endif
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_dict()
-  let d = {'': 'empty', 'a': 'a', 0: 'zero'}
-  call assert_equal('empty', d[''])
-  call assert_equal('a', d['a'])
-  call assert_equal('zero', d[0])
-  call assert_true(has_key(d, ''))
-  call assert_true(has_key(d, 'a'))
-  call assert_fails("let i = has_key([], 'a')", 'E715:')
+  let lines =<< trim END
+      VAR d = {'': 'empty', 'a': 'a', 0: 'zero'}
+      call assert_equal('empty', d[''])
+      call assert_equal('a', d['a'])
+      call assert_equal('zero', d[0])
+      call assert_true(has_key(d, ''))
+      call assert_true(has_key(d, 'a'))
 
-  let d[''] = 'none'
-  let d['a'] = 'aaa'
-  call assert_equal('none', d[''])
-  call assert_equal('aaa', d['a'])
+      LET d[''] = 'none'
+      LET d['a'] = 'aaa'
+      call assert_equal('none', d[''])
+      call assert_equal('aaa', d['a'])
 
-  let d[ 'b' ] = 'bbb'
-  call assert_equal('bbb', d[ 'b' ])
+      LET d[ 'b' ] = 'bbb'
+      call assert_equal('bbb', d[ 'b' ])
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call CheckLegacyAndVim9Failure(["VAR i = has_key([], 'a')"], ['E715:', 'E1013:', 'E1206:'])
 endfunc
 
 func Test_strgetchar()
-  call assert_equal(char2nr('a'), strgetchar('axb', 0))
-  call assert_equal(char2nr('x'), 'axb'->strgetchar(1))
-  call assert_equal(char2nr('b'), strgetchar('axb', 2))
+  let lines =<< trim END
+      call assert_equal(char2nr('a'), strgetchar('axb', 0))
+      call assert_equal(char2nr('x'), 'axb'->strgetchar(1))
+      call assert_equal(char2nr('b'), strgetchar('axb', 2))
 
-  call assert_equal(-1, strgetchar('axb', -1))
-  call assert_equal(-1, strgetchar('axb', 3))
-  call assert_equal(-1, strgetchar('', 0))
-  call assert_fails("let c=strgetchar([], 1)", 'E730:')
-  call assert_fails("let c=strgetchar('axb', [])", 'E745:')
+      call assert_equal(-1, strgetchar('axb', -1))
+      call assert_equal(-1, strgetchar('axb', 3))
+      call assert_equal(-1, strgetchar('', 0))
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call CheckLegacyAndVim9Failure(["VAR c = strgetchar([], 1)"], ['E730:', 'E1013:', 'E1174:'])
+  call CheckLegacyAndVim9Failure(["VAR c = strgetchar('axb', [])"], ['E745:', 'E1013:', 'E1210:'])
 endfunc
 
 func Test_strcharpart()
-  call assert_equal('a', strcharpart('axb', 0, 1))
-  call assert_equal('x', 'axb'->strcharpart(1, 1))
-  call assert_equal('b', strcharpart('axb', 2, 1))
-  call assert_equal('xb', strcharpart('axb', 1))
+  let lines =<< trim END
+      call assert_equal('a', strcharpart('axb', 0, 1))
+      call assert_equal('x', 'axb'->strcharpart(1, 1))
+      call assert_equal('b', strcharpart('axb', 2, 1))
+      call assert_equal('xb', strcharpart('axb', 1))
 
-  call assert_equal('', strcharpart('axb', 1, 0))
-  call assert_equal('', strcharpart('axb', 1, -1))
-  call assert_equal('', strcharpart('axb', -1, 1))
-  call assert_equal('', strcharpart('axb', -2, 2))
+      call assert_equal('', strcharpart('axb', 1, 0))
+      call assert_equal('', strcharpart('axb', 1, -1))
+      call assert_equal('', strcharpart('axb', -1, 1))
+      call assert_equal('', strcharpart('axb', -2, 2))
 
-  call assert_equal('a', strcharpart('axb', -1, 2))
+      call assert_equal('a', strcharpart('axb', -1, 2))
 
-  call assert_equal('edit', "editor"[-10:3])
+      call assert_equal('edit', "editor"[-10 : 3])
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_getreg_empty_list()
-  call assert_equal('', getreg('x'))
-  call assert_equal([], getreg('x', 1, 1))
-  let x = getreg('x', 1, 1)
-  let y = x
-  call add(x, 'foo')
-  call assert_equal(['foo'], y)
-  call assert_fails('call getreg([])', 'E730:')
+  let lines =<< trim END
+      call assert_equal('', getreg('x'))
+      call assert_equal([], getreg('x', 1, 1))
+      VAR x = getreg('x', 1, 1)
+      VAR y = x
+      call add(x, 'foo')
+      call assert_equal(['foo'], y)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call CheckLegacyAndVim9Failure(['call getreg([])'], ['E730:', 'E1013:', 'E1174:'])
 endfunc
 
 func Test_loop_over_null_list()
-  let null_list = v:_null_list
-  for i in null_list
-    call assert_report('should not get here')
-  endfor
+  let lines =<< trim END
+      VAR null_list = v:_null_list
+      for i in null_list
+        call assert_report('should not get here')
+      endfor
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_setreg_null_list()
-  call setreg('x', v:_null_list)
+  let lines =<< trim END
+      call setreg('x', v:_null_list)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_special_char()
   " The failure is only visible using valgrind.
-  call assert_fails('echo "\<C-">')
+  call CheckLegacyAndVim9Failure(['echo "\<C-">'], ['E15:', 'E1004:', 'E1004:'])
 endfunc
 
 func Test_method_with_prefix()
-  call assert_equal(1, !range(5)->empty())
+  let lines =<< trim END
+      call assert_equal(TRUE, !range(5)->empty())
+      call assert_equal(FALSE, !-3)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   call assert_equal([0, 1, 2], --3->range())
-  call assert_equal(0, !-3)
+  call CheckDefAndScriptFailure(['eval --3->range()'], 'E15')
+
   call assert_equal(1, !+-+0)
+  call CheckDefAndScriptFailure(['eval !+-+0'], 'E15')
 endfunc
 
 func Test_option_value()
-  " boolean
-  set bri
-  call assert_equal(1, &bri)
-  set nobri
-  call assert_equal(0, &bri)
+  let lines =<< trim END
+      #" boolean
+      set bri
+      call assert_equal(TRUE, &bri)
+      set nobri
+      call assert_equal(FALSE, &bri)
 
-  " number
-  set ts=1
-  call assert_equal(1, &ts)
-  set ts=8
-  call assert_equal(8, &ts)
+      #" number
+      set ts=1
+      call assert_equal(1, &ts)
+      set ts=8
+      call assert_equal(8, &ts)
 
-  " string
-  exe "set cedit=\<Esc>"
-  call assert_equal("\<Esc>", &cedit)
-  set cpo=
-  call assert_equal("", &cpo)
-  set cpo=abcdefi
-  call assert_equal("abcdefi", &cpo)
-  set cpo&vim
+      #" string
+      exe "set cedit=\<Esc>"
+      call assert_equal("\<Esc>", &cedit)
+      set cpo=
+      call assert_equal("", &cpo)
+      set cpo=abcdefi
+      call assert_equal("abcdefi", &cpo)
+      set cpo&vim
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
-function Test_printf_64bit()
-  call assert_equal("123456789012345", printf('%d', 123456789012345))
+func Test_printf_misc()
+  let lines =<< trim END
+      call assert_equal('123', printf('123'))
+
+      call assert_equal('123', printf('%d', 123))
+      call assert_equal('123', printf('%i', 123))
+      call assert_equal('123', printf('%D', 123))
+      call assert_equal('123', printf('%U', 123))
+      call assert_equal('173', printf('%o', 123))
+      call assert_equal('173', printf('%O', 123))
+      call assert_equal('7b', printf('%x', 123))
+      call assert_equal('7B', printf('%X', 123))
+
+      call assert_equal('123', printf('%hd', 123))
+      call assert_equal('-123', printf('%hd', -123))
+      call assert_equal('-1', printf('%hd', 0xFFFF))
+      call assert_equal('-1', printf('%hd', 0x1FFFFF))
+
+      call assert_equal('123', printf('%hu', 123))
+      call assert_equal('65413', printf('%hu', -123))
+      call assert_equal('65535', printf('%hu', 0xFFFF))
+      call assert_equal('65535', printf('%hu', 0x1FFFFF))
+
+      call assert_equal('123', printf('%ld', 123))
+      call assert_equal('-123', printf('%ld', -123))
+      call assert_equal('65535', printf('%ld', 0xFFFF))
+      call assert_equal('131071', printf('%ld', 0x1FFFF))
+
+      call assert_equal('{', printf('%c', 123))
+      call assert_equal('abc', printf('%s', 'abc'))
+      call assert_equal('abc', printf('%S', 'abc'))
+
+      call assert_equal('+123', printf('%+d', 123))
+      call assert_equal('-123', printf('%+d', -123))
+      call assert_equal('+123', printf('%+ d', 123))
+      call assert_equal(' 123', printf('% d', 123))
+      call assert_equal(' 123', printf('%  d', 123))
+      call assert_equal('-123', printf('% d', -123))
+
+      call assert_equal('123', printf('%2d', 123))
+      call assert_equal('   123', printf('%6d', 123))
+      call assert_equal('000123', printf('%06d', 123))
+      call assert_equal('+00123', printf('%+06d', 123))
+      call assert_equal(' 00123', printf('% 06d', 123))
+      call assert_equal('  +123', printf('%+6d', 123))
+      call assert_equal('   123', printf('% 6d', 123))
+      call assert_equal('  -123', printf('% 6d', -123))
+
+      #" Test left adjusted.
+      call assert_equal('123   ', printf('%-6d', 123))
+      call assert_equal('+123  ', printf('%-+6d', 123))
+      call assert_equal(' 123  ', printf('%- 6d', 123))
+      call assert_equal('-123  ', printf('%- 6d', -123))
+
+      call assert_equal('  00123', printf('%7.5d', 123))
+      call assert_equal(' -00123', printf('%7.5d', -123))
+      call assert_equal(' +00123', printf('%+7.5d', 123))
+
+      #" Precision field should not be used when combined with %0
+      call assert_equal('  00123', printf('%07.5d', 123))
+      call assert_equal(' -00123', printf('%07.5d', -123))
+
+      call assert_equal('  123', printf('%*d', 5, 123))
+      call assert_equal('123  ', printf('%*d', -5, 123))
+      call assert_equal('00123', printf('%.*d', 5, 123))
+      call assert_equal('  123', printf('% *d', 5, 123))
+      call assert_equal(' +123', printf('%+ *d', 5, 123))
+
+      call assert_equal('foobar', printf('%.*s',  9, 'foobar'))
+      call assert_equal('foo',    printf('%.*s',  3, 'foobar'))
+      call assert_equal('',       printf('%.*s',  0, 'foobar'))
+      call assert_equal('foobar', printf('%.*s', -1, 'foobar'))
+
+      #" Simple quote (thousand grouping char) is ignored.
+      call assert_equal('+00123456', printf("%+'09d", 123456))
+
+      #" Unrecognized format specifier kept as-is.
+      call assert_equal('_123', printf("%_%d", 123))
+
+      #" Test alternate forms.
+      call assert_equal('0x7b', printf('%#x', 123))
+      call assert_equal('0X7B', printf('%#X', 123))
+      call assert_equal('0173', printf('%#o', 123))
+      call assert_equal('0173', printf('%#O', 123))
+      call assert_equal('abc', printf('%#s', 'abc'))
+      call assert_equal('abc', printf('%#S', 'abc'))
+      call assert_equal('  0173', printf('%#6o', 123))
+      call assert_equal(' 00173', printf('%#6.5o', 123))
+      call assert_equal('  0173', printf('%#6.2o', 123))
+      call assert_equal('  0173', printf('%#6.2o', 123))
+      call assert_equal('0173', printf('%#2.2o', 123))
+
+      call assert_equal(' 00123', printf('%6.5d', 123))
+      call assert_equal(' 0007b', printf('%6.5x', 123))
+
+      call assert_equal('123', printf('%.2d', 123))
+      call assert_equal('0123', printf('%.4d', 123))
+      call assert_equal('0000000123', printf('%.10d', 123))
+      call assert_equal('123', printf('%.0d', 123))
+
+      call assert_equal('abc', printf('%2s', 'abc'))
+      call assert_equal('abc', printf('%2S', 'abc'))
+      call assert_equal('abc', printf('%.4s', 'abc'))
+      call assert_equal('abc', printf('%.4S', 'abc'))
+      call assert_equal('ab', printf('%.2s', 'abc'))
+      call assert_equal('ab', printf('%.2S', 'abc'))
+      call assert_equal('', printf('%.0s', 'abc'))
+      call assert_equal('', printf('%.s', 'abc'))
+      call assert_equal(' abc', printf('%4s', 'abc'))
+      call assert_equal(' abc', printf('%4S', 'abc'))
+      call assert_equal('0abc', printf('%04s', 'abc'))
+      call assert_equal('0abc', printf('%04S', 'abc'))
+      call assert_equal('abc ', printf('%-4s', 'abc'))
+      call assert_equal('abc ', printf('%-4S', 'abc'))
+
+      call assert_equal('🐍', printf('%.2S', '🐍🐍'))
+      call assert_equal('', printf('%.1S', '🐍🐍'))
+
+      call assert_equal('[    あいう]', printf('[%10.6S]', 'あいうえお'))
+      call assert_equal('[  あいうえ]', printf('[%10.8S]', 'あいうえお'))
+      call assert_equal('[あいうえお]', printf('[%10.10S]', 'あいうえお'))
+      call assert_equal('[あいうえお]', printf('[%10.12S]', 'あいうえお'))
+
+      call assert_equal('あいう', printf('%S', 'あいう'))
+      call assert_equal('あいう', printf('%#S', 'あいう'))
+
+      call assert_equal('あb', printf('%2S', 'あb'))
+      call assert_equal('あb', printf('%.4S', 'あb'))
+      call assert_equal('あ', printf('%.2S', 'あb'))
+      call assert_equal(' あb', printf('%4S', 'あb'))
+      call assert_equal('0あb', printf('%04S', 'あb'))
+      call assert_equal('あb ', printf('%-4S', 'あb'))
+      call assert_equal('あ  ', printf('%-4.2S', 'あb'))
+
+      call assert_equal('aい', printf('%2S', 'aい'))
+      call assert_equal('aい', printf('%.4S', 'aい'))
+      call assert_equal('a', printf('%.2S', 'aい'))
+      call assert_equal(' aい', printf('%4S', 'aい'))
+      call assert_equal('0aい', printf('%04S', 'aい'))
+      call assert_equal('aい ', printf('%-4S', 'aい'))
+      call assert_equal('a   ', printf('%-4.2S', 'aい'))
+
+      call assert_equal('[あいう]', printf('[%05S]', 'あいう'))
+      call assert_equal('[あいう]', printf('[%06S]', 'あいう'))
+      call assert_equal('[0あいう]', printf('[%07S]', 'あいう'))
+
+      call assert_equal('[あiう]', printf('[%05S]', 'あiう'))
+      call assert_equal('[0あiう]', printf('[%06S]', 'あiう'))
+      call assert_equal('[00あiう]', printf('[%07S]', 'あiう'))
+
+      call assert_equal('[0あい]', printf('[%05.4S]', 'あいう'))
+      call assert_equal('[00あい]', printf('[%06.4S]', 'あいう'))
+      call assert_equal('[000あい]', printf('[%07.4S]', 'あいう'))
+
+      call assert_equal('[00あi]', printf('[%05.4S]', 'あiう'))
+      call assert_equal('[000あi]', printf('[%06.4S]', 'あiう'))
+      call assert_equal('[0000あi]', printf('[%07.4S]', 'あiう'))
+
+      call assert_equal('[0あい]', printf('[%05.5S]', 'あいう'))
+      call assert_equal('[00あい]', printf('[%06.5S]', 'あいう'))
+      call assert_equal('[000あい]', printf('[%07.5S]', 'あいう'))
+
+      call assert_equal('[あiう]', printf('[%05.5S]', 'あiう'))
+      call assert_equal('[0あiう]', printf('[%06.5S]', 'あiう'))
+      call assert_equal('[00あiう]', printf('[%07.5S]', 'あiう'))
+
+      call assert_equal('[0000000000]', printf('[%010.0S]', 'あいう'))
+      call assert_equal('[0000000000]', printf('[%010.1S]', 'あいう'))
+      call assert_equal('[00000000あ]', printf('[%010.2S]', 'あいう'))
+      call assert_equal('[00000000あ]', printf('[%010.3S]', 'あいう'))
+      call assert_equal('[000000あい]', printf('[%010.4S]', 'あいう'))
+      call assert_equal('[000000あい]', printf('[%010.5S]', 'あいう'))
+      call assert_equal('[0000あいう]', printf('[%010.6S]', 'あいう'))
+      call assert_equal('[0000あいう]', printf('[%010.7S]', 'あいう'))
+
+      call assert_equal('[0000000000]', printf('[%010.1S]', 'あiう'))
+      call assert_equal('[00000000あ]', printf('[%010.2S]', 'あiう'))
+      call assert_equal('[0000000あi]', printf('[%010.3S]', 'あiう'))
+      call assert_equal('[0000000あi]', printf('[%010.4S]', 'あiう'))
+      call assert_equal('[00000あiう]', printf('[%010.5S]', 'あiう'))
+      call assert_equal('[00000あiう]', printf('[%010.6S]', 'あiう'))
+      call assert_equal('[00000あiう]', printf('[%010.7S]', 'あiう'))
+
+      call assert_equal('1%', printf('%d%%', 1))
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call CheckLegacyAndVim9Failure(["call printf('123', 3)"], "E767:")
 endfunc
 
-function Test_printf_spec_s()
-  " number
-  call assert_equal("1234567890", printf('%s', 1234567890))
-
-  " string
-  call assert_equal("abcdefgi", printf('%s', "abcdefgi"))
-
-  " float
-  call assert_equal("1.23", printf('%s', 1.23))
-
-  " list
-  let value = [1, 'two', ['three', 4]]
-  call assert_equal(string(value), printf('%s', value))
-
-  " dict
-  let value = {'key1' : 'value1', 'key2' : ['list', 'value'], 'key3' : {'dict' : 'value'}}
-  call assert_equal(string(value), printf('%s', value))
-
-  " funcref
-  call assert_equal('printf', printf('%s', 'printf'->function()))
-
-  " partial
-  call assert_equal(string(function('printf', ['%s'])), printf('%s', function('printf', ['%s'])))
-endfunc
-
-function Test_printf_spec_b()
-  call assert_equal("0", printf('%b', 0))
-  call assert_equal("00001100", printf('%08b', 12))
-  call assert_equal("11111111", printf('%08b', 0xff))
-  call assert_equal("   1111011", printf('%10b', 123))
-  call assert_equal("0001111011", printf('%010b', 123))
-  call assert_equal(" 0b1111011", printf('%#10b', 123))
-  call assert_equal("0B01111011", printf('%#010B', 123))
-  call assert_equal("1001001100101100000001011010010", printf('%b', 1234567890))
-  call assert_equal("11100000100100010000110000011011101111101111001", printf('%b', 123456789012345))
-  call assert_equal("1111111111111111111111111111111111111111111111111111111111111111", printf('%b', -1))
-endfunc
-
-function Test_printf_misc()
-  call assert_equal('123', printf('123'))
-  call assert_fails("call printf('123', 3)", "E767:")
-
-  call assert_equal('123', printf('%d', 123))
-  call assert_equal('123', printf('%i', 123))
-  call assert_equal('123', printf('%D', 123))
-  call assert_equal('123', printf('%U', 123))
-  call assert_equal('173', printf('%o', 123))
-  call assert_equal('173', printf('%O', 123))
-  call assert_equal('7b', printf('%x', 123))
-  call assert_equal('7B', printf('%X', 123))
-
-  call assert_equal('123', printf('%hd', 123))
-  call assert_equal('-123', printf('%hd', -123))
-  call assert_equal('-1', printf('%hd', 0xFFFF))
-  call assert_equal('-1', printf('%hd', 0x1FFFFF))
-
-  call assert_equal('123', printf('%hu', 123))
-  call assert_equal('65413', printf('%hu', -123))
-  call assert_equal('65535', printf('%hu', 0xFFFF))
-  call assert_equal('65535', printf('%hu', 0x1FFFFF))
-
-  call assert_equal('123', printf('%ld', 123))
-  call assert_equal('-123', printf('%ld', -123))
-  call assert_equal('65535', printf('%ld', 0xFFFF))
-  call assert_equal('131071', printf('%ld', 0x1FFFF))
-
-  call assert_equal('{', printf('%c', 123))
-  call assert_equal('abc', printf('%s', 'abc'))
-  call assert_equal('abc', printf('%S', 'abc'))
-
-  call assert_equal('+123', printf('%+d', 123))
-  call assert_equal('-123', printf('%+d', -123))
-  call assert_equal('+123', printf('%+ d', 123))
-  call assert_equal(' 123', printf('% d', 123))
-  call assert_equal(' 123', printf('%  d', 123))
-  call assert_equal('-123', printf('% d', -123))
-
-  call assert_equal('123', printf('%2d', 123))
-  call assert_equal('   123', printf('%6d', 123))
-  call assert_equal('000123', printf('%06d', 123))
-  call assert_equal('+00123', printf('%+06d', 123))
-  call assert_equal(' 00123', printf('% 06d', 123))
-  call assert_equal('  +123', printf('%+6d', 123))
-  call assert_equal('   123', printf('% 6d', 123))
-  call assert_equal('  -123', printf('% 6d', -123))
-
-  " Test left adjusted.
-  call assert_equal('123   ', printf('%-6d', 123))
-  call assert_equal('+123  ', printf('%-+6d', 123))
-  call assert_equal(' 123  ', printf('%- 6d', 123))
-  call assert_equal('-123  ', printf('%- 6d', -123))
-
-  call assert_equal('  00123', printf('%7.5d', 123))
-  call assert_equal(' -00123', printf('%7.5d', -123))
-  call assert_equal(' +00123', printf('%+7.5d', 123))
-  " Precision field should not be used when combined with %0
-  call assert_equal('  00123', printf('%07.5d', 123))
-  call assert_equal(' -00123', printf('%07.5d', -123))
-
-  call assert_equal('  123', printf('%*d', 5, 123))
-  call assert_equal('123  ', printf('%*d', -5, 123))
-  call assert_equal('00123', printf('%.*d', 5, 123))
-  call assert_equal('  123', printf('% *d', 5, 123))
-  call assert_equal(' +123', printf('%+ *d', 5, 123))
-
-  call assert_equal('foobar', printf('%.*s',  9, 'foobar'))
-  call assert_equal('foo',    printf('%.*s',  3, 'foobar'))
-  call assert_equal('',       printf('%.*s',  0, 'foobar'))
-  call assert_equal('foobar', printf('%.*s', -1, 'foobar'))
-
-  " Simple quote (thousand grouping char) is ignored.
-  call assert_equal('+00123456', printf("%+'09d", 123456))
-
-  " Unrecognized format specifier kept as-is.
-  call assert_equal('_123', printf("%_%d", 123))
-
-  " Test alternate forms.
-  call assert_equal('0x7b', printf('%#x', 123))
-  call assert_equal('0X7B', printf('%#X', 123))
-  call assert_equal('0173', printf('%#o', 123))
-  call assert_equal('0173', printf('%#O', 123))
-  call assert_equal('abc', printf('%#s', 'abc'))
-  call assert_equal('abc', printf('%#S', 'abc'))
-  call assert_equal('  0173', printf('%#6o', 123))
-  call assert_equal(' 00173', printf('%#6.5o', 123))
-  call assert_equal('  0173', printf('%#6.2o', 123))
-  call assert_equal('  0173', printf('%#6.2o', 123))
-  call assert_equal('0173', printf('%#2.2o', 123))
-
-  call assert_equal(' 00123', printf('%6.5d', 123))
-  call assert_equal(' 0007b', printf('%6.5x', 123))
-
-  call assert_equal('123', printf('%.2d', 123))
-  call assert_equal('0123', printf('%.4d', 123))
-  call assert_equal('0000000123', printf('%.10d', 123))
-  call assert_equal('123', printf('%.0d', 123))
-
-  call assert_equal('abc', printf('%2s', 'abc'))
-  call assert_equal('abc', printf('%2S', 'abc'))
-  call assert_equal('abc', printf('%.4s', 'abc'))
-  call assert_equal('abc', printf('%.4S', 'abc'))
-  call assert_equal('ab', printf('%.2s', 'abc'))
-  call assert_equal('ab', printf('%.2S', 'abc'))
-  call assert_equal('', printf('%.0s', 'abc'))
-  call assert_equal('', printf('%.s', 'abc'))
-  call assert_equal(' abc', printf('%4s', 'abc'))
-  call assert_equal(' abc', printf('%4S', 'abc'))
-  call assert_equal('0abc', printf('%04s', 'abc'))
-  call assert_equal('0abc', printf('%04S', 'abc'))
-  call assert_equal('abc ', printf('%-4s', 'abc'))
-  call assert_equal('abc ', printf('%-4S', 'abc'))
-
-  call assert_equal('🐍', printf('%.2S', '🐍🐍'))
-  call assert_equal('', printf('%.1S', '🐍🐍'))
-
-  call assert_equal('[    あいう]', printf('[%10.6S]', 'あいうえお'))
-  call assert_equal('[  あいうえ]', printf('[%10.8S]', 'あいうえお'))
-  call assert_equal('[あいうえお]', printf('[%10.10S]', 'あいうえお'))
-  call assert_equal('[あいうえお]', printf('[%10.12S]', 'あいうえお'))
-
-  call assert_equal('あいう', printf('%S', 'あいう'))
-  call assert_equal('あいう', printf('%#S', 'あいう'))
-
-  call assert_equal('あb', printf('%2S', 'あb'))
-  call assert_equal('あb', printf('%.4S', 'あb'))
-  call assert_equal('あ', printf('%.2S', 'あb'))
-  call assert_equal(' あb', printf('%4S', 'あb'))
-  call assert_equal('0あb', printf('%04S', 'あb'))
-  call assert_equal('あb ', printf('%-4S', 'あb'))
-  call assert_equal('あ  ', printf('%-4.2S', 'あb'))
-
-  call assert_equal('aい', printf('%2S', 'aい'))
-  call assert_equal('aい', printf('%.4S', 'aい'))
-  call assert_equal('a', printf('%.2S', 'aい'))
-  call assert_equal(' aい', printf('%4S', 'aい'))
-  call assert_equal('0aい', printf('%04S', 'aい'))
-  call assert_equal('aい ', printf('%-4S', 'aい'))
-  call assert_equal('a   ', printf('%-4.2S', 'aい'))
-
-  call assert_equal('[あいう]', printf('[%05S]', 'あいう'))
-  call assert_equal('[あいう]', printf('[%06S]', 'あいう'))
-  call assert_equal('[0あいう]', printf('[%07S]', 'あいう'))
-
-  call assert_equal('[あiう]', printf('[%05S]', 'あiう'))
-  call assert_equal('[0あiう]', printf('[%06S]', 'あiう'))
-  call assert_equal('[00あiう]', printf('[%07S]', 'あiう'))
-
-  call assert_equal('[0あい]', printf('[%05.4S]', 'あいう'))
-  call assert_equal('[00あい]', printf('[%06.4S]', 'あいう'))
-  call assert_equal('[000あい]', printf('[%07.4S]', 'あいう'))
-
-  call assert_equal('[00あi]', printf('[%05.4S]', 'あiう'))
-  call assert_equal('[000あi]', printf('[%06.4S]', 'あiう'))
-  call assert_equal('[0000あi]', printf('[%07.4S]', 'あiう'))
-
-  call assert_equal('[0あい]', printf('[%05.5S]', 'あいう'))
-  call assert_equal('[00あい]', printf('[%06.5S]', 'あいう'))
-  call assert_equal('[000あい]', printf('[%07.5S]', 'あいう'))
-
-  call assert_equal('[あiう]', printf('[%05.5S]', 'あiう'))
-  call assert_equal('[0あiう]', printf('[%06.5S]', 'あiう'))
-  call assert_equal('[00あiう]', printf('[%07.5S]', 'あiう'))
-
-  call assert_equal('[0000000000]', printf('[%010.0S]', 'あいう'))
-  call assert_equal('[0000000000]', printf('[%010.1S]', 'あいう'))
-  call assert_equal('[00000000あ]', printf('[%010.2S]', 'あいう'))
-  call assert_equal('[00000000あ]', printf('[%010.3S]', 'あいう'))
-  call assert_equal('[000000あい]', printf('[%010.4S]', 'あいう'))
-  call assert_equal('[000000あい]', printf('[%010.5S]', 'あいう'))
-  call assert_equal('[0000あいう]', printf('[%010.6S]', 'あいう'))
-  call assert_equal('[0000あいう]', printf('[%010.7S]', 'あいう'))
-
-  call assert_equal('[0000000000]', printf('[%010.1S]', 'あiう'))
-  call assert_equal('[00000000あ]', printf('[%010.2S]', 'あiう'))
-  call assert_equal('[0000000あi]', printf('[%010.3S]', 'あiう'))
-  call assert_equal('[0000000あi]', printf('[%010.4S]', 'あiう'))
-  call assert_equal('[00000あiう]', printf('[%010.5S]', 'あiう'))
-  call assert_equal('[00000あiう]', printf('[%010.6S]', 'あiう'))
-  call assert_equal('[00000あiう]', printf('[%010.7S]', 'あiう'))
-
-  call assert_equal('1%', printf('%d%%', 1))
-endfunc
-
-function Test_printf_float()
-  call assert_equal('1.000000', printf('%f', 1))
-  call assert_equal('1.230000', printf('%f', 1.23))
-  call assert_equal('1.230000', printf('%F', 1.23))
-  call assert_equal('9999999.9', printf('%g', 9999999.9))
-  call assert_equal('9999999.9', printf('%G', 9999999.9))
-  call assert_equal('1.00000001e7', printf('%.8g', 10000000.1))
-  call assert_equal('1.00000001E7', printf('%.8G', 10000000.1))
-  call assert_equal('1.230000e+00', printf('%e', 1.23))
-  call assert_equal('1.230000E+00', printf('%E', 1.23))
-  call assert_equal('1.200000e-02', printf('%e', 0.012))
-  call assert_equal('-1.200000e-02', printf('%e', -0.012))
-  call assert_equal('0.33', printf('%.2f', 1.0/3.0))
-  call assert_equal('  0.33', printf('%6.2f', 1.0/3.0))
-  call assert_equal(' -0.33', printf('%6.2f', -1.0/3.0))
-  call assert_equal('000.33', printf('%06.2f', 1.0/3.0))
-  call assert_equal('-00.33', printf('%06.2f', -1.0/3.0))
-  call assert_equal('-00.33', printf('%+06.2f', -1.0/3.0))
-  call assert_equal('+00.33', printf('%+06.2f', 1.0/3.0))
-  call assert_equal(' 00.33', printf('% 06.2f', 1.0/3.0))
-  call assert_equal('000.33', printf('%06.2g', 1.0/3.0))
-  call assert_equal('-00.33', printf('%06.2g', -1.0/3.0))
-  call assert_equal('0.33', printf('%3.2f', 1.0/3.0))
-  call assert_equal('003.33e-01', printf('%010.2e', 1.0/3.0))
-  call assert_equal(' 03.33e-01', printf('% 010.2e', 1.0/3.0))
-  call assert_equal('+03.33e-01', printf('%+010.2e', 1.0/3.0))
-  call assert_equal('-03.33e-01', printf('%010.2e', -1.0/3.0))
-
-  " When precision is 0, the dot should be omitted.
-  call assert_equal('  2', printf('%3.f', 7.0/3.0))
-  call assert_equal('  2', printf('%3.g', 7.0/3.0))
-  call assert_equal('  2e+00', printf('%7.e', 7.0/3.0))
-
-  " Float zero can be signed.
-  call assert_equal('+0.000000', printf('%+f', 0.0))
-  call assert_equal('0.000000', printf('%f', 1.0/(1.0/0.0)))
-  call assert_equal('-0.000000', printf('%f', 1.0/(-1.0/0.0)))
-  call assert_equal('0.0', printf('%s', 1.0/(1.0/0.0)))
-  call assert_equal('-0.0', printf('%s', 1.0/(-1.0/0.0)))
-  call assert_equal('0.0', printf('%S', 1.0/(1.0/0.0)))
-  call assert_equal('-0.0', printf('%S', 1.0/(-1.0/0.0)))
-
-  " Float infinity can be signed.
-  call assert_equal('inf', printf('%f', 1.0/0.0))
-  call assert_equal('-inf', printf('%f', -1.0/0.0))
-  call assert_equal('inf', printf('%g', 1.0/0.0))
-  call assert_equal('-inf', printf('%g', -1.0/0.0))
-  call assert_equal('inf', printf('%e', 1.0/0.0))
-  call assert_equal('-inf', printf('%e', -1.0/0.0))
-  call assert_equal('INF', printf('%F', 1.0/0.0))
-  call assert_equal('-INF', printf('%F', -1.0/0.0))
-  call assert_equal('INF', printf('%E', 1.0/0.0))
-  call assert_equal('-INF', printf('%E', -1.0/0.0))
-  call assert_equal('INF', printf('%E', 1.0/0.0))
-  call assert_equal('-INF', printf('%G', -1.0/0.0))
-  call assert_equal('+inf', printf('%+f', 1.0/0.0))
-  call assert_equal('-inf', printf('%+f', -1.0/0.0))
-  call assert_equal(' inf', printf('% f',  1.0/0.0))
-  call assert_equal('   inf', printf('%6f', 1.0/0.0))
-  call assert_equal('  -inf', printf('%6f', -1.0/0.0))
-  call assert_equal('   inf', printf('%6g', 1.0/0.0))
-  call assert_equal('  -inf', printf('%6g', -1.0/0.0))
-  call assert_equal('  +inf', printf('%+6f', 1.0/0.0))
-  call assert_equal('   inf', printf('% 6f', 1.0/0.0))
-  call assert_equal('  +inf', printf('%+06f', 1.0/0.0))
-  call assert_equal('inf   ', printf('%-6f', 1.0/0.0))
-  call assert_equal('-inf  ', printf('%-6f', -1.0/0.0))
-  call assert_equal('+inf  ', printf('%-+6f', 1.0/0.0))
-  call assert_equal(' inf  ', printf('%- 6f', 1.0/0.0))
-  call assert_equal('-INF  ', printf('%-6F', -1.0/0.0))
-  call assert_equal('+INF  ', printf('%-+6F', 1.0/0.0))
-  call assert_equal(' INF  ', printf('%- 6F', 1.0/0.0))
-  call assert_equal('INF   ', printf('%-6G', 1.0/0.0))
-  call assert_equal('-INF  ', printf('%-6G', -1.0/0.0))
-  call assert_equal('INF   ', printf('%-6E', 1.0/0.0))
-  call assert_equal('-INF  ', printf('%-6E', -1.0/0.0))
-  call assert_equal("str2float('inf')", printf('%s', 1.0/0.0))
-  call assert_equal("-str2float('inf')", printf('%s', -1.0/0.0))
-
-  " Test special case where max precision is truncated at 340.
-  call assert_equal('1.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.330f', 1.0))
-  call assert_equal('1.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.340f', 1.0))
-  call assert_equal('1.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.350f', 1.0))
-
-  " Float nan (not a number) has no sign.
-  call assert_equal('nan', printf('%f', sqrt(-1.0)))
-  call assert_equal('nan', printf('%f', 0.0/0.0))
-  call assert_equal('nan', printf('%f', -0.0/0.0))
-  call assert_equal('nan', printf('%g', 0.0/0.0))
-  call assert_equal('nan', printf('%e', 0.0/0.0))
-  call assert_equal('NAN', printf('%F', 0.0/0.0))
-  call assert_equal('NAN', printf('%G', 0.0/0.0))
-  call assert_equal('NAN', printf('%E', 0.0/0.0))
-  call assert_equal('NAN', printf('%F', -0.0/0.0))
-  call assert_equal('NAN', printf('%G', -0.0/0.0))
-  call assert_equal('NAN', printf('%E', -0.0/0.0))
-  call assert_equal('   nan', printf('%6f', 0.0/0.0))
-  call assert_equal('   nan', printf('%06f', 0.0/0.0))
-  call assert_equal('nan   ', printf('%-6f', 0.0/0.0))
-  call assert_equal('nan   ', printf('%- 6f', 0.0/0.0))
-  call assert_equal("str2float('nan')", printf('%s', 0.0/0.0))
-  call assert_equal("str2float('nan')", printf('%s', -0.0/0.0))
-  call assert_equal("str2float('nan')", printf('%S', 0.0/0.0))
-  call assert_equal("str2float('nan')", printf('%S', -0.0/0.0))
-
-  call assert_fails('echo printf("%f", "a")', 'E807:')
-endfunc
-
-function Test_printf_errors()
-  call assert_fails('echo printf("%d", {})', 'E728:')
-  call assert_fails('echo printf("%d", [])', 'E745:')
-  call assert_fails('echo printf("%d", 1, 2)', 'E767:')
-  call assert_fails('echo printf("%*d", 1)', 'E766:')
-  call assert_fails('echo printf("%s")', 'E766:')
+func Test_printf_float()
   if has('float')
-    call assert_fails('echo printf("%d", 1.2)', 'E805:')
-    call assert_fails('echo printf("%f")')
+    let lines =<< trim END
+        call assert_equal('1.000000', printf('%f', 1))
+        call assert_equal('1.230000', printf('%f', 1.23))
+        call assert_equal('1.230000', printf('%F', 1.23))
+        call assert_equal('9999999.9', printf('%g', 9999999.9))
+        call assert_equal('9999999.9', printf('%G', 9999999.9))
+        call assert_equal('1.00000001e7', printf('%.8g', 10000000.1))
+        call assert_equal('1.00000001E7', printf('%.8G', 10000000.1))
+        call assert_equal('1.230000e+00', printf('%e', 1.23))
+        call assert_equal('1.230000E+00', printf('%E', 1.23))
+        call assert_equal('1.200000e-02', printf('%e', 0.012))
+        call assert_equal('-1.200000e-02', printf('%e', -0.012))
+        call assert_equal('0.33', printf('%.2f', 1.0 / 3.0))
+        call assert_equal('  0.33', printf('%6.2f', 1.0 / 3.0))
+        call assert_equal(' -0.33', printf('%6.2f', -1.0 / 3.0))
+        call assert_equal('000.33', printf('%06.2f', 1.0 / 3.0))
+        call assert_equal('-00.33', printf('%06.2f', -1.0 / 3.0))
+        call assert_equal('-00.33', printf('%+06.2f', -1.0 / 3.0))
+        call assert_equal('+00.33', printf('%+06.2f', 1.0 / 3.0))
+        call assert_equal(' 00.33', printf('% 06.2f', 1.0 / 3.0))
+        call assert_equal('000.33', printf('%06.2g', 1.0 / 3.0))
+        call assert_equal('-00.33', printf('%06.2g', -1.0 / 3.0))
+        call assert_equal('0.33', printf('%3.2f', 1.0 / 3.0))
+        call assert_equal('003.33e-01', printf('%010.2e', 1.0 / 3.0))
+        call assert_equal(' 03.33e-01', printf('% 010.2e', 1.0 / 3.0))
+        call assert_equal('+03.33e-01', printf('%+010.2e', 1.0 / 3.0))
+        call assert_equal('-03.33e-01', printf('%010.2e', -1.0 / 3.0))
+
+        #" When precision is 0, the dot should be omitted.
+        call assert_equal('  2', printf('%3.f', 7.0 / 3.0))
+        call assert_equal('  2', printf('%3.g', 7.0 / 3.0))
+        call assert_equal('  2e+00', printf('%7.e', 7.0 / 3.0))
+
+        #" Float zero can be signed.
+        call assert_equal('+0.000000', printf('%+f', 0.0))
+        call assert_equal('0.000000', printf('%f', 1.0 / (1.0 / 0.0)))
+        call assert_equal('-0.000000', printf('%f', 1.0 / (-1.0 / 0.0)))
+        call assert_equal('0.0', printf('%s', 1.0 / (1.0 / 0.0)))
+        call assert_equal('-0.0', printf('%s', 1.0 / (-1.0 / 0.0)))
+        call assert_equal('0.0', printf('%S', 1.0 / (1.0 / 0.0)))
+        call assert_equal('-0.0', printf('%S', 1.0 / (-1.0 / 0.0)))
+
+        #" Float infinity can be signed.
+        call assert_equal('inf', printf('%f', 1.0 / 0.0))
+        call assert_equal('-inf', printf('%f', -1.0 / 0.0))
+        call assert_equal('inf', printf('%g', 1.0 / 0.0))
+        call assert_equal('-inf', printf('%g', -1.0 / 0.0))
+        call assert_equal('inf', printf('%e', 1.0 / 0.0))
+        call assert_equal('-inf', printf('%e', -1.0 / 0.0))
+        call assert_equal('INF', printf('%F', 1.0 / 0.0))
+        call assert_equal('-INF', printf('%F', -1.0 / 0.0))
+        call assert_equal('INF', printf('%E', 1.0 / 0.0))
+        call assert_equal('-INF', printf('%E', -1.0 / 0.0))
+        call assert_equal('INF', printf('%E', 1.0 / 0.0))
+        call assert_equal('-INF', printf('%G', -1.0 / 0.0))
+        call assert_equal('+inf', printf('%+f', 1.0 / 0.0))
+        call assert_equal('-inf', printf('%+f', -1.0 / 0.0))
+        call assert_equal(' inf', printf('% f',  1.0 / 0.0))
+        call assert_equal('   inf', printf('%6f', 1.0 / 0.0))
+        call assert_equal('  -inf', printf('%6f', -1.0 / 0.0))
+        call assert_equal('   inf', printf('%6g', 1.0 / 0.0))
+        call assert_equal('  -inf', printf('%6g', -1.0 / 0.0))
+        call assert_equal('  +inf', printf('%+6f', 1.0 / 0.0))
+        call assert_equal('   inf', printf('% 6f', 1.0 / 0.0))
+        call assert_equal('  +inf', printf('%+06f', 1.0 / 0.0))
+        call assert_equal('inf   ', printf('%-6f', 1.0 / 0.0))
+        call assert_equal('-inf  ', printf('%-6f', -1.0 / 0.0))
+        call assert_equal('+inf  ', printf('%-+6f', 1.0 / 0.0))
+        call assert_equal(' inf  ', printf('%- 6f', 1.0 / 0.0))
+        call assert_equal('-INF  ', printf('%-6F', -1.0 / 0.0))
+        call assert_equal('+INF  ', printf('%-+6F', 1.0 / 0.0))
+        call assert_equal(' INF  ', printf('%- 6F', 1.0 / 0.0))
+        call assert_equal('INF   ', printf('%-6G', 1.0 / 0.0))
+        call assert_equal('-INF  ', printf('%-6G', -1.0 / 0.0))
+        call assert_equal('INF   ', printf('%-6E', 1.0 / 0.0))
+        call assert_equal('-INF  ', printf('%-6E', -1.0 / 0.0))
+        call assert_equal("str2float('inf')", printf('%s', 1.0 / 0.0))
+        call assert_equal("-str2float('inf')", printf('%s', -1.0 / 0.0))
+
+        #" Test special case where max precision is truncated at 340.
+        call assert_equal('1.000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.330f', 1.0))
+        call assert_equal('1.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.340f', 1.0))
+        call assert_equal('1.0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000', printf('%.350f', 1.0))
+
+        #" Float nan (not a number) has no sign.
+        call assert_equal('nan', printf('%f', sqrt(-1.0)))
+        call assert_equal('nan', printf('%f', 0.0 / 0.0))
+        call assert_equal('nan', printf('%f', -0.0 / 0.0))
+        call assert_equal('nan', printf('%g', 0.0 / 0.0))
+        call assert_equal('nan', printf('%e', 0.0 / 0.0))
+        call assert_equal('NAN', printf('%F', 0.0 / 0.0))
+        call assert_equal('NAN', printf('%G', 0.0 / 0.0))
+        call assert_equal('NAN', printf('%E', 0.0 / 0.0))
+        call assert_equal('NAN', printf('%F', -0.0 / 0.0))
+        call assert_equal('NAN', printf('%G', -0.0 / 0.0))
+        call assert_equal('NAN', printf('%E', -0.0 / 0.0))
+        call assert_equal('   nan', printf('%6f', 0.0 / 0.0))
+        call assert_equal('   nan', printf('%06f', 0.0 / 0.0))
+        call assert_equal('nan   ', printf('%-6f', 0.0 / 0.0))
+        call assert_equal('nan   ', printf('%- 6f', 0.0 / 0.0))
+        call assert_equal("str2float('nan')", printf('%s', 0.0 / 0.0))
+        call assert_equal("str2float('nan')", printf('%s', -0.0 / 0.0))
+        call assert_equal("str2float('nan')", printf('%S', 0.0 / 0.0))
+        call assert_equal("str2float('nan')", printf('%S', -0.0 / 0.0))
+    END
+    call CheckLegacyAndVim9Success(lines)
+
+    call CheckLegacyAndVim9Failure(['echo printf("%f", "a")'], 'E807:')
   endif
 endfunc
 
-function Test_max_min_errors()
-  call assert_fails('call max(v:true)', 'E712:')
-  call assert_fails('call max(v:true)', 'max()')
-  call assert_fails('call min(v:true)', 'E712:')
-  call assert_fails('call min(v:true)', 'min()')
+func Test_printf_errors()
+  call CheckLegacyAndVim9Failure(['echo printf("%d", {})'], 'E728:')
+  call CheckLegacyAndVim9Failure(['echo printf("%d", [])'], 'E745:')
+  call CheckLegacyAndVim9Failure(['echo printf("%d", 1, 2)'], 'E767:')
+  call CheckLegacyAndVim9Failure(['echo printf("%*d", 1)'], 'E766:')
+  call CheckLegacyAndVim9Failure(['echo printf("%s")'], 'E766:')
+  if has('float')
+    call CheckLegacyAndVim9Failure(['echo printf("%d", 1.2)'], 'E805:')
+    call CheckLegacyAndVim9Failure(['echo printf("%f")'], 'E766:')
+  endif
+endfunc
+
+func Test_printf_64bit()
+  let lines =<< trim END
+      call assert_equal("123456789012345", printf('%d', 123456789012345))
+  END
+  call CheckLegacyAndVim9Success(lines)
+endfunc
+
+func Test_printf_spec_s()
+  let lines =<< trim END
+      #" number
+      call assert_equal("1234567890", printf('%s', 1234567890))
+
+      #" string
+      call assert_equal("abcdefgi", printf('%s', "abcdefgi"))
+
+      #" float
+      if has('float')
+        call assert_equal("1.23", printf('%s', 1.23))
+      endif
+
+      #" list
+      VAR lvalue = [1, 'two', ['three', 4]]
+      call assert_equal(string(lvalue), printf('%s', lvalue))
+
+      #" dict
+      VAR dvalue = {'key1': 'value1', 'key2': ['list', 'lvalue'], 'key3': {'dict': 'lvalue'}}
+      call assert_equal(string(dvalue), printf('%s', dvalue))
+
+      #" funcref
+      call assert_equal('printf', printf('%s', 'printf'->function()))
+
+      #" partial
+      call assert_equal(string(function('printf', ['%s'])), printf('%s', function('printf', ['%s'])))
+  END
+  call CheckLegacyAndVim9Success(lines)
+endfunc
+
+func Test_printf_spec_b()
+  let lines =<< trim END
+      call assert_equal("0", printf('%b', 0))
+      call assert_equal("00001100", printf('%08b', 12))
+      call assert_equal("11111111", printf('%08b', 0xff))
+      call assert_equal("   1111011", printf('%10b', 123))
+      call assert_equal("0001111011", printf('%010b', 123))
+      call assert_equal(" 0b1111011", printf('%#10b', 123))
+      call assert_equal("0B01111011", printf('%#010B', 123))
+      call assert_equal("1001001100101100000001011010010", printf('%b', 1234567890))
+      call assert_equal("11100000100100010000110000011011101111101111001", printf('%b', 123456789012345))
+      call assert_equal("1111111111111111111111111111111111111111111111111111111111111111", printf('%b', -1))
+  END
+  call CheckLegacyAndVim9Success(lines)
+endfunc
+
+func Test_max_min_errors()
+  call CheckLegacyAndVim9Failure(['call max(v:true)'], ['E712:', 'E1013:', 'E1227:'])
+  call CheckLegacyAndVim9Failure(['call max(v:true)'], ['max()', 'E1013:', 'E1227:'])
+  call CheckLegacyAndVim9Failure(['call min(v:true)'], ['E712:', 'E1013:', 'E1227:'])
+  call CheckLegacyAndVim9Failure(['call min(v:true)'], ['min()', 'E1013:', 'E1227:'])
 endfunc
 
 func Test_function_with_funcref()
-  let s:f = function('type')
-  let s:fref = function(s:f)
-  call assert_equal(v:t_string, s:fref('x'))
-  call assert_fails("call function('s:f')", 'E700:')
+  let lines =<< trim END
+      VAR s:F = function('type')
+      VAR s:Fref = function(s:F)
+      call assert_equal(v:t_string, s:Fref('x'))
+      call assert_fails("call function('s:F')", 'E700:')
 
-  call assert_fails("call function('foo()')", 'E475:')
-  call assert_fails("call function('foo()')", 'foo()')
-  call assert_fails("function('')", 'E129:')
+      call assert_fails("call function('foo()')", 'E475:')
+      call assert_fails("call function('foo()')", 'foo()')
+      call assert_fails("function('')", 'E129:')
 
-  let Len = {s -> strlen(s)}
-  call assert_equal(6, Len('foobar'))
-  let name = string(Len)
-  " can evaluate "function('<lambda>99')"
-  call execute('let Ref = ' .. name)
-  call assert_equal(4, Ref('text'))
+      legacy let s:Len = {s -> strlen(s)}
+      call assert_equal(6, s:Len('foobar'))
+      VAR name = string(s:Len)
+      #" can evaluate "function('<lambda>99')"
+      call execute('VAR Ref = ' .. name)
+      call assert_equal(4, Ref('text'))
+  END
+  call CheckTransLegacySuccess(lines)
+  " cannot create s: variable in :def function
+  call CheckTransVim9Success(lines)
 endfunc
 
 func Test_funcref()
@@ -585,33 +652,41 @@ func Test_function_outside_script()
 endfunc
 
 func Test_setmatches()
-  hi def link 1 Comment
-  hi def link 2 PreProc
-  let set = [{"group": 1, "pattern": 2, "id": 3, "priority": 4}]
-  let exp = [{"group": '1', "pattern": '2', "id": 3, "priority": 4}]
-  if has('conceal')
-    let set[0]['conceal'] = 5
-    let exp[0]['conceal'] = '5'
-  endif
-  eval set->setmatches()
-  call assert_equal(exp, getmatches())
-  call assert_fails('let m = setmatches([], [])', 'E745:')
+  let lines =<< trim END
+      hi def link 1 Comment
+      hi def link 2 PreProc
+      VAR set = [{"group": 1, "pattern": 2, "id": 3, "priority": 4}]
+      VAR exp = [{"group": '1', "pattern": '2', "id": 3, "priority": 4}]
+      if has('conceal')
+        LET set[0]['conceal'] = 5
+        LET exp[0]['conceal'] = '5'
+      endif
+      eval set->setmatches()
+      call assert_equal(exp, getmatches())
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call CheckLegacyAndVim9Failure(['VAR m = setmatches([], [])'], ['E745:', 'E1013:', 'E1210:'])
 endfunc
 
 func Test_empty_concatenate()
-  call assert_equal('b', 'a'[4:0] . 'b')
-  call assert_equal('b', 'b' . 'a'[4:0])
+  let lines =<< trim END
+      call assert_equal('b', 'a'[4 : 0] .. 'b')
+      call assert_equal('b', 'b' .. 'a'[4 : 0])
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_broken_number()
-  let X = 'bad'
-  call assert_fails('echo 1X', 'E15:')
-  call assert_fails('echo 0b1X', 'E15:')
-  call assert_fails('echo 0b12', 'E15:')
-  call assert_fails('echo 0x1X', 'E15:')
-  call assert_fails('echo 011X', 'E15:')
-  call assert_equal(2, str2nr('2a'))
-  call assert_fails('inoremap <Char-0b1z> b', 'E474:')
+  call CheckLegacyAndVim9Failure(['VAR X = "bad"', 'echo 1X'], 'E15:')
+  call CheckLegacyAndVim9Failure(['VAR X = "bad"', 'echo 0b1X'], 'E15:')
+  call CheckLegacyAndVim9Failure(['echo 0b12'], 'E15:')
+  call CheckLegacyAndVim9Failure(['VAR X = "bad"', 'echo 0x1X'], 'E15:')
+  call CheckLegacyAndVim9Failure(['VAR X = "bad"', 'echo 011X'], 'E15:')
+
+  call CheckLegacyAndVim9Success(['call assert_equal(2, str2nr("2a"))'])
+
+  call CheckLegacyAndVim9Failure(['inoremap <Char-0b1z> b'], 'E474:')
 endfunc
 
 func Test_eval_after_if()
@@ -710,36 +785,49 @@ endfunc
 
 " Test for errors in expression evaluation
 func Test_expr_eval_error()
-  call assert_fails("let i = 'abc' . []", 'E730:')
-  call assert_fails("let l = [] + 10", 'E745:')
-  call assert_fails("let v = 10 + []", 'E745:')
-  call assert_fails("let v = 10 / []", 'E745:')
-  call assert_fails("let v = -{}", 'E728:')
+  call CheckLegacyAndVim9Failure(["VAR i = 'abc' .. []"], ['E730:', 'E1105:', 'E730:'])
+  call CheckLegacyAndVim9Failure(["VAR l = [] + 10"], ['E745:', 'E1051:', 'E745'])
+  call CheckLegacyAndVim9Failure(["VAR v = 10 + []"], ['E745:', 'E1051:', 'E745:'])
+  call CheckLegacyAndVim9Failure(["VAR v = 10 / []"], ['E745:', 'E1036:', 'E745:'])
+  call CheckLegacyAndVim9Failure(["VAR v = -{}"], ['E728:', 'E1012:', 'E728:'])
 endfunc
 
 func Test_white_in_function_call()
-  let text = substitute ( 'some text' , 't' , 'T' , 'g' )
-  call assert_equal('some TexT', text)
+  let lines =<< trim END
+      VAR text = substitute ( 'some text' , 't' , 'T' , 'g' )
+      call assert_equal('some TexT', text)
+  END
+  call CheckTransLegacySuccess(lines)
+
+  let lines =<< trim END
+      var text = substitute ( 'some text' , 't' , 'T' , 'g' )
+      call assert_equal('some TexT', text)
+  END
+  call CheckDefAndScriptFailure(lines, ['E1001:', 'E121:'])
 endfunc
 
 " Test for float value comparison
 func Test_float_compare()
   CheckFeature float
-  call assert_true(1.2 == 1.2)
-  call assert_true(1.0 != 1.2)
-  call assert_true(1.2 > 1.0)
-  call assert_true(1.2 >= 1.2)
-  call assert_true(1.0 < 1.2)
-  call assert_true(1.2 <= 1.2)
-  call assert_true(+0.0 == -0.0)
-  " two NaNs (not a number) are not equal
-  call assert_true(sqrt(-4.01) != (0.0 / 0.0))
-  " two inf (infinity) are equal
-  call assert_true((1.0 / 0) == (2.0 / 0))
-  " two -inf (infinity) are equal
-  call assert_true(-(1.0 / 0) == -(2.0 / 0))
-  " +infinity != -infinity
-  call assert_true((1.0 / 0) != -(2.0 / 0))
+
+  let lines =<< trim END
+      call assert_true(1.2 == 1.2)
+      call assert_true(1.0 != 1.2)
+      call assert_true(1.2 > 1.0)
+      call assert_true(1.2 >= 1.2)
+      call assert_true(1.0 < 1.2)
+      call assert_true(1.2 <= 1.2)
+      call assert_true(+0.0 == -0.0)
+      #" two NaNs (not a number) are not equal
+      call assert_true(sqrt(-4.01) != (0.0 / 0.0))
+      #" two inf (infinity) are equal
+      call assert_true((1.0 / 0) == (2.0 / 0))
+      #" two -inf (infinity) are equal
+      call assert_true(-(1.0 / 0) == -(2.0 / 0))
+      #" +infinity != -infinity
+      call assert_true((1.0 / 0) != -(2.0 / 0))
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -717,6 +717,11 @@ func Test_expr_eval_error()
   call assert_fails("let v = -{}", 'E728:')
 endfunc
 
+func Test_white_in_function_call()
+  let text = substitute ( 'some text' , 't' , 'T' , 'g' )
+  call assert_equal('some TexT', text)
+endfunc
+
 " Test for float value comparison
 func Test_float_compare()
   CheckFeature float

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2561,7 +2561,7 @@ func Test_builtin_check()
   call assert_fails('let l:.trim = {x -> " " .. x}', 'E704:')
   let lines =<< trim END
     vim9script
-    var s:trim = (x) => " " .. x
+    var trim = (x) => " " .. x
   END
   call CheckScriptFailure(lines, 'E704:')
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1598,11 +1598,11 @@ func Test_completefunc_callback()
     bw!
 
     # Test for using a script-local function name
-    def s:LocalCompleteFunc(findstart: number, base: string): any
+    def LocalCompleteFunc(findstart: number, base: string): any
       add(g:LocalCompleteFuncArgs, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &completefunc = s:LocalCompleteFunc
+    &completefunc = LocalCompleteFunc
     new | only
     setline(1, 'three')
     g:LocalCompleteFuncArgs = []
@@ -1855,11 +1855,11 @@ func Test_omnifunc_callback()
     bw!
 
     # Test for using a script-local function name
-    def s:LocalOmniFunc(findstart: number, base: string): any
+    def LocalOmniFunc(findstart: number, base: string): any
       add(g:LocalOmniFuncArgs, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &omnifunc = s:LocalOmniFunc
+    &omnifunc = LocalOmniFunc
     new | only
     setline(1, 'three')
     g:LocalOmniFuncArgs = []
@@ -2148,11 +2148,11 @@ func Test_thesaurusfunc_callback()
     bw!
 
     # Test for using a script-local function name
-    def s:LocalTsrFunc(findstart: number, base: string): any
+    def LocalTsrFunc(findstart: number, base: string): any
       add(g:LocalTsrFuncArgs, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &thesaurusfunc = s:LocalTsrFunc
+    &thesaurusfunc = LocalTsrFunc
     new | only
     setline(1, 'three')
     g:LocalTsrFuncArgs = []

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -732,10 +732,10 @@ func Test_opfunc_callback()
     bw!
 
     # Test for using a script-local function name
-    def s:LocalOpFunc(type: string): void
+    def LocalOpFunc(type: string): void
       g:LocalOpFuncArgs = [type]
     enddef
-    &opfunc = s:LocalOpFunc
+    &opfunc = LocalOpFunc
     g:LocalOpFuncArgs = []
     normal! g@l
     assert_equal(['char'], g:LocalOpFuncArgs)

--- a/test/old/testdir/test_tagfunc.vim
+++ b/test/old/testdir/test_tagfunc.vim
@@ -369,11 +369,11 @@ func Test_tagfunc_callback()
     bw!
 
     # Test for using a script-local function name
-    def s:LocalTagFunc(pat: string, flags: string, info: dict<any> ): any
+    def LocalTagFunc(pat: string, flags: string, info: dict<any> ): any
       g:LocalTagFuncArgs = [pat, flags, info]
       return null
     enddef
-    &tagfunc = s:LocalTagFunc
+    &tagfunc = LocalTagFunc
     new
     g:LocalTagFuncArgs = []
     assert_fails('tag a12', 'E433:')

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7267,7 +7267,7 @@ func Test_typed_script_var()
 endfunc
 
 " Test for issue6776              {{{1
-func Test_trinary_expression()
+func Test_ternary_expression()
   try
     call eval('0 ? 0')
   catch

--- a/test/old/testdir/vim9.vim
+++ b/test/old/testdir/vim9.vim
@@ -34,6 +34,14 @@ func CheckScriptSuccess(lines)
   endtry
 endfunc
 
+func CheckDefAndScriptSuccess(lines)
+  return
+endfunc
+
+func CheckDefAndScriptFailure(lines, error, lnum = -3)
+  return
+endfunc
+
 func CheckDefExecAndScriptFailure(lines, error, lnum = -3)
   return
 endfunc
@@ -83,6 +91,14 @@ func CheckTransLegacySuccess(lines)
                               \  ->substitute('#"', ' "', 'g')
                               \ })
   call CheckLegacySuccess(legacylines)
+endfunc
+
+func CheckTransDefSuccess(lines)
+  return
+endfunc
+
+func CheckTransVim9Success(lines)
+  return
 endfunc
 
 " Execute "lines" in a legacy function


### PR DESCRIPTION
#### vim-patch:8.2.1378: cannot put space between function name and paren

Problem:    Cannot put space between function name and paren.
Solution:   Allow this for backwards compatibility.

https://github.com/vim/vim/commit/bbd3e3c357487f7a5bdc704a819f63a7dd0dd66e

This fixes a regression from patch 8.2.1365, which isn't ported yet.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3856: Vim9: not enough tests

Problem:    Vim9: not enough tests.
Solution:   Run more expression tests also with Vim9. Fix an uncovered
            problem.

https://github.com/vim/vim/commit/fea43e44c008a7ca73b506ddab0f47b63b5d2126

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4361: Vim9: some tests fail

Problem:    Vim9: some tests fail.
Solution:   Fix the tests, mostly by removing "s:".

https://github.com/vim/vim/commit/62b191c38758c835a577ef091a803b6dd4cd4f49

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4373: expression test fails

Problem:    Expression test fails.
Solution:   Make the test work with latest Vim9 syntax.

https://github.com/vim/vim/commit/c87aa34dfd68e95e4b1aac96d2274fcd672753ac

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4476: operator name spelled wrong

Problem:    Operator name spelled wrong.
Solution:   Change trinary to ternary. (Goc Dundar, closes vim/vim#9850)

https://github.com/vim/vim/commit/e41c1dd8890d3f701253255993f4e9af2d12225c

Co-authored-by: =?UTF-8?q?Dundar=20G=C3=B6c?= <gocdundar@gmail.com>