### PR TITLE
vim-patch:8.2.{4770,4783,4840,4883,4930,4934},9.0.0104: interpolated string

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2569,20 +2569,20 @@ text...
 			{endmarker}.
 
 			If "eval" is not specified, then each line of text is
-			used as a |literal-string|.  If "eval" is specified,
-			then any Vim expression in the form ``={expr}`` is
-			evaluated and the result replaces the expression.
+			used as a |literal-string|, except that single quotes
+			doe not need to be doubled.
+			If "eval" is specified, then any Vim expression in the
+			form {expr} is evaluated and the result replaces the
+			expression, like with |interp-string|.
 			Example where $HOME is expanded: >
 				let lines =<< trim eval END
 				  some text
-				  See the file `=$HOME`/.vimrc
+				  See the file {$HOME}/.vimrc
 				  more text
 				END
 <			There can be multiple Vim expressions in a single line
 			but an expression cannot span multiple lines.  If any
 			expression evaluation fails, then the assignment fails.
-			once the "`=" has been found {expr} and a backtick
-			must follow.  {expr} cannot be empty.
 
 			{endmarker} must not contain white space.
 			{endmarker} cannot start with a lower case character.
@@ -2635,10 +2635,10 @@ text...
 				DATA
 
 				let code =<< trim eval CODE
-				   let v = `=10 + 20`
-				   let h = "`=$HOME`"
-				   let s = "`=Str1()` abc `=Str2()`"
-				   let n = `=MyFunc(3, 4)`
+				   let v = {10 + 20}
+				   let h = "{$HOME}"
+				   let s = "{Str1()} abc {Str2()}"
+				   let n = {MyFunc(3, 4)}
 				CODE
 <
 								*E121*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2540,14 +2540,30 @@ This does NOT work: >
 
 						*:let=<<* *:let-heredoc*
 					*E990* *E991* *E172* *E221* *E1145*
-:let {var-name} =<< [trim] {endmarker}
+:let {var-name} =<< [trim] [eval] {endmarker}
 text...
 text...
 {endmarker}
 			Set internal variable {var-name} to a |List|
 			containing the lines of text bounded by the string
-			{endmarker}. The lines of text is used as a
-			|literal-string|.
+			{endmarker}.
+
+			If "eval" is not specified, then each line of text is
+			used as a |literal-string|.  If "eval" is specified,
+			then any Vim expression in the form ``={expr}`` is
+			evaluated and the result replaces the expression.
+			Example where $HOME is expanded: >
+				let lines =<< trim eval END
+				  some text
+				  See the file `=$HOME`/.vimrc
+				  more text
+				END
+<			There can be multiple Vim expressions in a single line
+			but an expression cannot span multiple lines.  If any
+			expression evaluation fails, then the assignment fails.
+			once the "`=" has been found {expr} and a backtick
+			must follow.  {expr} cannot be empty.
+
 			{endmarker} must not contain white space.
 			{endmarker} cannot start with a lower case character.
 			The last line should end only with the {endmarker}
@@ -2597,6 +2613,13 @@ text...
 					1 2 3 4
 					5 6 7 8
 				DATA
+
+				let code =<< trim eval CODE
+				   let v = `=10 + 20`
+				   let h = "`=$HOME`"
+				   let s = "`=Str1()` abc `=Str2()`"
+				   let n = `=MyFunc(3, 4)`
+				CODE
 <
 								*E121*
 :let {var-name}	..	List the value of variable {var-name}.  Multiple

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1407,6 +1407,26 @@ to be doubled.  These two commands are equivalent: >
 
 
 ------------------------------------------------------------------------------
+interpolated-string					*interp-string*
+
+$"string"		interpolated string constant		*expr-$quote*
+$'string'		interpolated literal string constant	*expr-$'*
+
+Interpolated strings are an extension of the |string| and |literal-string|,
+allowing the inclusion of Vim script expressions (see |expr1|).  Any
+expression returning a value can be enclosed between curly braces.  The value
+is converted to a string.  All the text and results of the expressions
+are concatenated to make a new string.
+
+To include an opening brace '{' or closing brace '}' in the string content
+double it.
+
+Examples: >
+	let your_name = input("What's your name? ")
+	echo $"Hello, {your_name}!"
+	echo $"The square root of 9 is {sqrt(9)}"
+
+------------------------------------------------------------------------------
 option						*expr-option* *E112* *E113*
 
 &option			option value, local value if possible

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1417,14 +1417,22 @@ allowing the inclusion of Vim script expressions (see |expr1|).  Any
 expression returning a value can be enclosed between curly braces.  The value
 is converted to a string.  All the text and results of the expressions
 are concatenated to make a new string.
-
+								*E1278*
 To include an opening brace '{' or closing brace '}' in the string content
-double it.
+double it.  For double quoted strings using a backslash also works.  A single
+closing brace '}' will result in an error.
 
 Examples: >
 	let your_name = input("What's your name? ")
+<	What's your name?  Peter ~
+>
+	echo
 	echo $"Hello, {your_name}!"
-	echo $"The square root of 9 is {sqrt(9)}"
+<	Hello, Peter! ~
+>
+	echo $"The square root of {{9}} is {sqrt(9)}"
+<	The square root of {9} is 3.0 ~
+
 
 ------------------------------------------------------------------------------
 option						*expr-option* *E112* *E113*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1407,7 +1407,7 @@ to be doubled.  These two commands are equivalent: >
 
 
 ------------------------------------------------------------------------------
-interpolated-string					*interp-string*
+interpolated-string				*$quote* *interpolated-string*
 
 $"string"		interpolated string constant		*expr-$quote*
 $'string'		interpolated literal string constant	*expr-$'*
@@ -2578,10 +2578,10 @@ text...
 
 			If "eval" is not specified, then each line of text is
 			used as a |literal-string|, except that single quotes
-			doe not need to be doubled.
+			does not need to be doubled.
 			If "eval" is specified, then any Vim expression in the
 			form {expr} is evaluated and the result replaces the
-			expression, like with |interp-string|.
+			expression, like with |interpolated-string|.
 			Example where $HOME is expanded: >
 				let lines =<< trim eval END
 				  some text

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3332,8 +3332,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	If the expression starts with s: or |<SID>|, then it is replaced with
 	the script ID (|local-function|). Example: >
-		set includeexpr=s:MyIncludeExpr(v:fname)
-		set includeexpr=<SID>SomeIncludeExpr(v:fname)
+		setlocal includeexpr=s:MyIncludeExpr(v:fname)
+		setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
 <
 	The expression will be evaluated in the |sandbox| when set from a
 	modeline, see |sandbox-option|.

--- a/runtime/syntax/modula3.vim
+++ b/runtime/syntax/modula3.vim
@@ -84,9 +84,7 @@ syn case ignore
 
   let s:digits = "0123456789ABCDEF"
   for s:radix in range(2, 16)
-    " Nvim does not support interpolated strings yet.
-    " exe $'syn match modula3Integer "\<{s:radix}_[{s:digits[:s:radix - 1]}]\+L\=\>"'
-    exe 'syn match modula3Integer "\<' .. s:radix .. '_[' .. s:digits[:s:radix - 1] .. ']\+L\=\>"'
+    exe $'syn match modula3Integer "\<{s:radix}_[{s:digits[:s:radix - 1]}]\+L\=\>"'
   endfor
   unlet s:digits s:radix
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4140,7 +4140,7 @@ int eval_interp_string(char **arg, typval_T *rettv, bool evaluate)
       (*arg)++;
       break;
     }
-    char *p = eval_one_expr_in_str(*arg, &ga);
+    char *p = eval_one_expr_in_str(*arg, &ga, evaluate);
     if (p == NULL) {
       ret = FAIL;
       break;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2483,10 +2483,19 @@ void ex_function(exarg_T *eap)
                 && (!ASCII_ISALNUM(p[2])
                     || (p[2] == 't' && !ASCII_ISALNUM(p[3]))))) {
           p = skipwhite(arg + 3);
-          if (strncmp(p, "trim", 4) == 0) {
-            // Ignore leading white space.
-            p = skipwhite(p + 4);
-            heredoc_trimmed = xstrnsave(theline, (size_t)(skipwhite(theline) - theline));
+          while (true) {
+            if (strncmp(p, "trim", 4) == 0) {
+              // Ignore leading white space.
+              p = skipwhite(p + 4);
+              heredoc_trimmed = xstrnsave(theline, (size_t)(skipwhite(theline) - theline));
+              continue;
+            }
+            if (strncmp(p, "eval", 4) == 0) {
+              // Ignore leading white space.
+              p = skipwhite(p + 4);
+              continue;
+            }
+            break;
           }
           skip_until = xstrnsave(p, (size_t)(skiptowhite(p) - p));
           do_concat = false;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -227,7 +227,7 @@ static list_T *heredoc_get(exarg_T *eap, char *cmd)
     }
 
     char *str = theline + ti;
-    if (evalstr) {
+    if (evalstr && !eap->skip) {
       str = eval_all_expr_in_str(str);
       if (str == NULL) {
         // expression evaluation failed

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -1024,6 +1024,11 @@ EXTERN const char e_highlight_group_name_too_long[] INIT(= N_("E1249: Highlight 
 
 EXTERN const char e_invalid_line_number_nr[] INIT(= N_("E966: Invalid line number: %ld"));
 
+EXTERN char e_stray_closing_curly_str[]
+INIT(= N_("E1278: Stray '}' without a matching '{': %s"));
+EXTERN char e_missing_close_curly_str[]
+INIT(= N_("E1279: Missing '}': %s"));
+
 EXTERN const char e_undobang_cannot_redo_or_move_branch[]
 INIT(= N_("E5767: Cannot use :undo! to redo or move to a different undo branch"));
 

--- a/test/old/testdir/test_eval_stuff.vim
+++ b/test/old/testdir/test_eval_stuff.vim
@@ -407,4 +407,9 @@ func Test_modified_char_no_escape_special()
   nunmap <M-…>
 endfunc
 
+func Test_eval_string_in_special_key()
+  " this was using the '{' inside <> as the start of an interpolated string
+  silent! echo 0{1-$"\<S--{>n|nö%
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -855,7 +855,7 @@ func Test_string_interp()
     #" Escaping rules.
     call assert_equal('"foo"{bar}', $"\"foo\"{{bar}}")
     call assert_equal('"foo"{bar}', $'"foo"{{bar}}')
-    call assert_equal('foobar', $"{\"foo\"}" .. $'{''bar''}')
+    call assert_equal('foobar', $"{"foo"}" .. $'{'bar'}')
     #" Whitespace before/after the expression.
     call assert_equal('3', $"{ 1 + 2 }")
     #" String conversion.
@@ -865,8 +865,8 @@ func Test_string_interp()
     call assert_equal(string(v:true), $"{v:true}")
     call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
     #" Hex-escaped opening brace: char2nr('{') == 0x7b
-    call assert_equal('esc123ape', $"esc\x7b123}ape")
-    call assert_equal('me{}me', $"me{\x7b}\x7dme")
+    call assert_equal('esc123ape', $"esc{123}ape")
+    call assert_equal('me{}me', $"me{"\x7b"}\x7dme")
     VAR var1 = "sun"
     VAR var2 = "shine"
     call assert_equal('sunshine', $"{var1}{var2}")
@@ -874,7 +874,7 @@ func Test_string_interp()
     #" Multibyte strings.
     call assert_equal('say ハロー・ワールド', $"say {'ハロー・ワールド'}")
     #" Nested.
-    call assert_equal('foobarbaz', $"foo{$\"{'bar'}\"}baz")
+    call assert_equal('foobarbaz', $"foo{$"{'bar'}"}baz")
     #" Do not evaluate blocks when the expr is skipped.
     VAR tmp = 0
     if v:false

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -848,4 +848,60 @@ func Test_float_compare()
   call CheckLegacyAndVim9Success(lines)
 endfunc
 
+func Test_string_interp()
+  let lines =<< trim END
+    call assert_equal('', $"")
+    call assert_equal('foobar', $"foobar")
+    #" Escaping rules.
+    call assert_equal('"foo"{bar}', $"\"foo\"{{bar}}")
+    call assert_equal('"foo"{bar}', $'"foo"{{bar}}')
+    call assert_equal('foobar', $"{\"foo\"}" .. $'{''bar''}')
+    #" Whitespace before/after the expression.
+    call assert_equal('3', $"{ 1 + 2 }")
+    #" String conversion.
+    call assert_equal('hello from ' .. v:version, $"hello from {v:version}")
+    call assert_equal('hello from ' .. v:version, $'hello from {v:version}')
+    #" Paper over a small difference between VimScript behaviour.
+    call assert_equal(string(v:true), $"{v:true}")
+    call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
+    #" Hex-escaped opening brace: char2nr('{') == 0x7b
+    call assert_equal('esc123ape', $"esc\x7b123}ape")
+    call assert_equal('me{}me', $"me{\x7b}\x7dme")
+    VAR var1 = "sun"
+    VAR var2 = "shine"
+    call assert_equal('sunshine', $"{var1}{var2}")
+    call assert_equal('sunsunsun', $"{var1->repeat(3)}")
+    #" Multibyte strings.
+    call assert_equal('say ハロー・ワールド', $"say {'ハロー・ワールド'}")
+    #" Nested.
+    call assert_equal('foobarbaz', $"foo{$\"{'bar'}\"}baz")
+    #" Do not evaluate blocks when the expr is skipped.
+    VAR tmp = 0
+    if v:false
+      echo "${ LET tmp += 1 }"
+    endif
+    call assert_equal(0, tmp)
+
+    #" Stray closing brace.
+    call assert_fails('echo $"moo}"', 'E1278:')
+    #" Undefined variable in expansion.
+    call assert_fails('echo $"{moo}"', 'E121:')
+    #" Empty blocks are rejected.
+    call assert_fails('echo $"{}"', 'E15:')
+    call assert_fails('echo $"{   }"', 'E15:')
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+    call assert_equal('5', $"{({x -> x + 1})(4)}")
+  END
+  call CheckLegacySuccess(lines)
+
+  let lines =<< trim END
+    call assert_equal('5', $"{((x) => x + 1)(4)}")
+    call assert_fails('echo $"{ # foo }"', 'E1279:')
+  END
+  call CheckDefAndScriptSuccess(lines)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -507,20 +507,24 @@ func Test_let_heredoc_eval()
     let c = "abc`=str`d"
   END
   call assert_equal(['let a = 15', 'let b = 6 + 6', '', 'let c = "abcd"'], code)
+
   let $TESTVAR = "Hello"
   let code =<< eval trim END
     let s = "`=$TESTVAR`"
   END
   call assert_equal(['let s = "Hello"'], code)
+
   let code =<< eval END
     let s = "`=$TESTVAR`"
 END
   call assert_equal(['    let s = "Hello"'], code)
+
   let a = 10
   let data =<< eval END
 `=a`
 END
   call assert_equal(['10'], data)
+
   let x = 'X'
   let code =<< eval trim END
     let a = `abc`
@@ -528,12 +532,14 @@ END
     let c = `
   END
   call assert_equal(['let a = `abc`', 'let b = X', 'let c = `'], code)
+
   let code = 'xxx'
   let code =<< eval trim END
     let n = `=5 +
     6`
   END
   call assert_equal('xxx', code)
+
   let code =<< eval trim END
      let n = `=min([1, 2]` + `=max([3, 4])`
   END
@@ -559,6 +565,13 @@ END
       END
   LINES
   call CheckScriptFailure(lines, 'E15:')
+
+  " skipped heredoc
+  if 0
+    let msg =<< trim eval END
+        n is: `=n`
+    END
+  endif
 
   " Test for sourcing a script containing a heredoc with invalid expression.
   " Variable assignment should fail, if expression evaluation fails

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -393,9 +393,8 @@ func Test_let_interpolated()
   let text = 'text'
   call assert_equal('text{{', $'{text .. "{{"}')
   call assert_equal('text{{', $"{text .. '{{'}")
-  " FIXME: should not need to escape quotes in the expression
-  call assert_equal('text{{', $'{text .. ''{{''}')
-  call assert_equal('text{{', $"{text .. \"{{\"}")
+  call assert_equal('text{{', $'{text .. '{{'}')
+  call assert_equal('text{{', $"{text .. "{{"}")
 endfunc
 
 " Test for the setting a variable using the heredoc syntax.

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -1,5 +1,7 @@
 " Tests for the :let command.
 
+source vim9.vim
+
 func Test_let()
   " Test to not autoload when assigning.  It causes internal error.
   set runtimepath+=./sautest
@@ -385,7 +387,8 @@ END
   call assert_equal(['Text', 'with', 'indent'], text)
 endfunc
 
-" Test for the setting a variable using the heredoc syntax
+" Test for the setting a variable using the heredoc syntax.
+" Keep near the end, this messes up highlighting.
 func Test_let_heredoc()
   let var1 =<< END
 Some sample text
@@ -491,6 +494,98 @@ E
      z
 END
   call assert_equal(['     x', '     \y', '     z'], [a, b, c])
+endfunc
+
+" Test for evaluating Vim expressions in a heredoc using `=expr`
+" Keep near the end, this messes up highlighting.
+func Test_let_heredoc_eval()
+  let str = ''
+  let code =<< trim eval END
+    let a = `=5 + 10`
+    let b = `=min([10, 6])` + `=max([4, 6])`
+    `=str`
+    let c = "abc`=str`d"
+  END
+  call assert_equal(['let a = 15', 'let b = 6 + 6', '', 'let c = "abcd"'], code)
+  let $TESTVAR = "Hello"
+  let code =<< eval trim END
+    let s = "`=$TESTVAR`"
+  END
+  call assert_equal(['let s = "Hello"'], code)
+  let code =<< eval END
+    let s = "`=$TESTVAR`"
+END
+  call assert_equal(['    let s = "Hello"'], code)
+  let a = 10
+  let data =<< eval END
+`=a`
+END
+  call assert_equal(['10'], data)
+  let x = 'X'
+  let code =<< eval trim END
+    let a = `abc`
+    let b = `=x`
+    let c = `
+  END
+  call assert_equal(['let a = `abc`', 'let b = X', 'let c = `'], code)
+  let code = 'xxx'
+  let code =<< eval trim END
+    let n = `=5 +
+    6`
+  END
+  call assert_equal('xxx', code)
+  let code =<< eval trim END
+     let n = `=min([1, 2]` + `=max([3, 4])`
+  END
+  call assert_equal('xxx', code)
+
+  let lines =<< trim LINES
+      let text =<< eval trim END
+        let b = `=
+      END
+  LINES
+  call CheckScriptFailure(lines, 'E1083:')
+
+  let lines =<< trim LINES
+      let text =<< eval trim END
+        let b = `=abc
+      END
+  LINES
+  call CheckScriptFailure(lines, 'E1083:')
+
+  let lines =<< trim LINES
+      let text =<< eval trim END
+        let b = `=`
+      END
+  LINES
+  call CheckScriptFailure(lines, 'E15:')
+
+  " Test for sourcing a script containing a heredoc with invalid expression.
+  " Variable assignment should fail, if expression evaluation fails
+  new
+  let g:Xvar = 'test'
+  let g:b = 10
+  let lines =<< trim END
+    let Xvar =<< eval CODE
+    let a = 1
+    let b = `=5+`
+    let c = 2
+    CODE
+    let g:Count += 1
+  END
+  call setline(1, lines)
+  let g:Count = 0
+  call assert_fails('source', 'E15:')
+  call assert_equal(1, g:Count)
+  call setline(3, 'let b = `=abc`')
+  call assert_fails('source', 'E121:')
+  call assert_equal(2, g:Count)
+  call setline(3, 'let b = `=abc` + `=min([9, 4])` + 2')
+  call assert_fails('source', 'E121:')
+  call assert_equal(3, g:Count)
+  call assert_equal('test', g:Xvar)
+  call assert_equal(10, g:b)
+  bw!
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -35,9 +35,7 @@ func Test_getscriptinfo()
   source Xscript
   let l = getscriptinfo()
   call assert_match('Xscript$', l[-1].name)
-  " Nvim does not support interpolated strings yet.
-  " call assert_equal(g:loaded_script_id, $"<SNR>{l[-1].sid}_")
-  call assert_equal(g:loaded_script_id, '<SNR>' . l[-1].sid . '_')
+  call assert_equal(g:loaded_script_id, $"<SNR>{l[-1].sid}_")
   call delete('Xscript')
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.4770: cannot easily mix expression and heredoc

Problem:    Cannot easily mix expression and heredoc.
Solution:   Support  in heredoc. (Yegappan Lakshmanan, closes vim/vim#10138)

https://github.com/vim/vim/commit/efbfa867a146fcd93fdec2435597aa4ae7f1325c

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:8.2.4783: Coverity warns for leaking memory

Problem:    Coverity warns for leaking memory.
Solution:   Use another strategy freeing "theline".

https://github.com/vim/vim/commit/42ccb8d74700506936567b0eb6d11def5e25e1dd

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4840: heredoc expression evaluated even when skipping

Problem:    Heredoc expression evaluated even when skipping.
Solution:   Don't evaluate when "skip" is set.

https://github.com/vim/vim/commit/05c7f5d3d03440da6f69604f8c06c4e3d90d2a26

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4883: string interpolation only works in heredoc

Problem:    String interpolation only works in heredoc.
Solution:   Support interpolated strings.  Use syntax for heredoc consistent
            with strings, similar to C#. (closes vim/vim#10327)

https://github.com/vim/vim/commit/2eaef106e4a7fc9dc74a7e672b5f550ec1f9786e

Cherry-pick Test_Debugger_breakadd_expr() from Vim.

Co-authored-by: LemonBoy <thatlemon@gmail.com>


#### vim-patch:8.2.4930: interpolated string expression requires escaping

Problem:    Interpolated string expression requires escaping.
Solution:   Do not require escaping in the expression.

https://github.com/vim/vim/commit/0abc2871c105882ed1c1effb9a7757fad8a395bd

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4934: string interpolation fails when not evaluating

Problem:    String interpolation fails when not evaluating.
Solution:   Skip the expression when not evaluating.

https://github.com/vim/vim/commit/70c41241c2701f26a99085e433925a206ca265a3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0104: going beyond allocated memory when evaluating string constant

Problem:    Going beyond allocated memory when evaluating string constant.
Solution:   Properly skip over <Key> form.

https://github.com/vim/vim/commit/1e56bda9048a9625bce6e660938c834c5c15b07d

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:partial:d899e5112079

Update runtime files

https://github.com/vim/vim/commit/d899e51120798d3fb5420abb1f19dddf3f014d05

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:3f32a5f1601a

Update runtime files and translations

https://github.com/vim/vim/commit/3f32a5f1601ab2b0eba0caad00d4c26fb86a02a2

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:b59ae59a5870

Update runtime files

https://github.com/vim/vim/commit/b59ae59a58706e454ef8c78276f021b1f58466e7

Co-authored-by: Bram Moolenaar <Bram@vim.org>