### PR TITLE
vim-patch:9.0.{0269,0303,1431}: more getscriptinfo() features

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3578,21 +3578,40 @@ getregtype([{regname}])					*getregtype()*
 
 getscriptinfo([{opts}])					*getscriptinfo()*
 		Returns a |List| with information about all the sourced Vim
-		scripts in the order they were sourced.
+		scripts in the order they were sourced, like what
+		`:scriptnames` shows.
+
+		The optional Dict argument {opts} supports the following
+		optional items:
+		    name	Script name match pattern. If specified,
+				and "sid" is not specified, information about
+				scripts with name that match the pattern
+				"name" are returned.
+		    sid		Script ID |<SID>|.  If specified, only
+				information about the script with ID "sid" is
+				returned and "name" is ignored.
 
 		Each item in the returned List is a |Dict| with the following
 		items:
-		    autoload	always set to FALSE.
-		    name	vim script file name.
-		    sid		script ID |<SID>|.
-		    version	vimscript version, always 1
+		    autoload	Always set to FALSE.
+		    functions   List of script-local function names defined in
+				the script.  Present only when a particular
+				script is specified using the "sid" item in
+				{opts}.
+		    name	Vim script file name.
+		    sid		Script ID |<SID>|.
+		    variables   A dictionary with the script-local variables.
+				Present only when the a particular script is
+				specified using the "sid" item in {opts}.
+				Note that this is a copy, the value of
+				script-local variables cannot be changed using
+				this dictionary.
+		    version	Vimscript version, always 1
 
-		The optional Dict argument {opts} supports the following
-		items:
-		    name	script name match pattern. If specified,
-				information about scripts with name
-				that match the pattern "name" are returned.
-
+		Examples: >
+			:echo getscriptinfo({'name': 'myscript'})
+			:echo getscriptinfo({'sid': 15}).variables
+<
 gettabinfo([{tabnr}])					*gettabinfo()*
 		If {tabnr} is not specified, then information about all the
 		tab pages is returned as a |List|. Each List item is a

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -223,7 +223,7 @@ getreg([{regname} [, 1 [, {list}]]])
 				String or List   contents of a register
 getreginfo([{regname}])		Dict	information about a register
 getregtype([{regname}])		String	type of a register
-getscriptinfo()		List	list of sourced scripts
+getscriptinfo([{opts}])		List	list of sourced scripts
 gettabinfo([{expr}])		List	list of tab pages
 gettabvar({nr}, {varname} [, {def}])
 				any	variable {varname} in tab {nr} or {def}
@@ -3576,7 +3576,7 @@ getregtype([{regname}])					*getregtype()*
 		Can also be used as a |method|: >
 			GetRegname()->getregtype()
 
-getscriptinfo()					*getscriptinfo()*
+getscriptinfo([{opts}])					*getscriptinfo()*
 		Returns a |List| with information about all the sourced Vim
 		scripts in the order they were sourced.
 
@@ -3585,6 +3585,13 @@ getscriptinfo()					*getscriptinfo()*
 		    autoload	always set to FALSE.
 		    name	vim script file name.
 		    sid		script ID |<SID>|.
+		    version	vimscript version, always 1
+
+		The optional Dict argument {opts} supports the following
+		items:
+		    name	script name match pattern. If specified,
+				information about scripts with name
+				that match the pattern "name" are returned.
 
 gettabinfo([{tabnr}])					*gettabinfo()*
 		If {tabnr} is not specified, then information about all the

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -189,7 +189,7 @@ return {
     gettabinfo={args={0, 1}, base=1},
     gettabvar={args={2, 3}, base=1},
     gettabwinvar={args={3, 4}, base=1},
-    getscriptinfo={},
+    getscriptinfo={args={0, 1}},
     gettagstack={args={0, 1}, base=1},
     gettext={args=1, base=1},
     getwininfo={args={0, 1}, base=1},

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2015,12 +2015,11 @@ static void list_functions(regmatch_T *regmatch)
     if (!HASHITEM_EMPTY(hi)) {
       ufunc_T *fp = HI2UF(hi);
       todo--;
-      if ((fp->uf_flags & FC_DEAD) == 0
-          && (regmatch == NULL
-              ? (!message_filtered(fp->uf_name)
-                 && !func_name_refcount(fp->uf_name))
-              : (!isdigit((uint8_t)(*fp->uf_name))
-                 && vim_regexec(regmatch, fp->uf_name, 0)))) {
+      if (regmatch == NULL
+          ? (!message_filtered(fp->uf_name)
+             && !func_name_refcount(fp->uf_name))
+          : (!isdigit((uint8_t)(*fp->uf_name))
+             && vim_regexec(regmatch, fp->uf_name, 0))) {
         list_func_head(fp, false, false);
         if (changed != func_hashtab.ht_changed) {
           emsg(_("E454: function list was modified"));

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -28,10 +28,10 @@ struct funccal_entry;
 #define FC_DELETED  0x10          // :delfunction used while uf_refcount > 0
 #define FC_REMOVED  0x20          // function redefined while uf_refcount > 0
 #define FC_SANDBOX  0x40          // function defined in the sandbox
-#define FC_DEAD     0x80          // function kept only for reference to dfunc
-#define FC_EXPORT   0x100         // "export def Func()"
+// #define FC_DEAD     0x80          // function kept only for reference to dfunc
+// #define FC_EXPORT   0x100         // "export def Func()"
 #define FC_NOARGS   0x200         // no a: variables in lambda
-#define FC_VIM9     0x400         // defined in vim9 script file
+// #define FC_VIM9     0x400         // defined in vim9 script file
 #define FC_LUAREF  0x800          // luaref callback
 
 /// Structure used by trans_function_name()

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2368,8 +2368,8 @@ static list_T *get_script_local_funcs(scid_T sid)
   // looking for functions with script ID "sid".
   HASHTAB_ITER(functbl, hi, {
     const ufunc_T *const fp = HI2UF(hi);
-    // Add active functions with script id == "sid"
-    if (!(fp->uf_flags & FC_DEAD) && (fp->uf_script_ctx.sc_sid == sid)) {
+    // Add functions with script id == "sid"
+    if (fp->uf_script_ctx.sc_sid == sid) {
       const char *const name = fp->uf_name_exp != NULL ? fp->uf_name_exp : fp->uf_name;
       tv_list_append_string(l, name, -1);
     }

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -31,12 +31,34 @@ endfunc
 
 " Test for the getscriptinfo() function
 func Test_getscriptinfo()
-  call writefile(['let loaded_script_id = expand("<SID>")'], 'Xscript')
-  source Xscript
+  let lines =<< trim END
+    let g:loaded_script_id = expand("<SID>")
+    let s:XscriptVar = [1, #{v: 2}]
+    func s:XscriptFunc()
+    endfunc
+  END
+  call writefile(lines, 'X22script91')
+  source X22script91
   let l = getscriptinfo()
-  call assert_match('Xscript$', l[-1].name)
+  call assert_match('X22script91$', l[-1].name)
   call assert_equal(g:loaded_script_id, $"<SNR>{l[-1].sid}_")
-  call delete('Xscript')
+
+  let l = getscriptinfo({'name': '22script91'})
+  call assert_equal(1, len(l))
+  call assert_match('22script91$', l[0].name)
+
+  let l = getscriptinfo({'name': 'foobar'})
+  call assert_equal(0, len(l))
+  let l = getscriptinfo({'name': ''})
+  call assert_true(len(l) > 1)
+
+  call assert_fails("echo getscriptinfo({'name': []})", 'E730:')
+  call assert_fails("echo getscriptinfo({'name': '\\@'})", 'E866:')
+  let l = getscriptinfo({'name': v:_null_string})
+  call assert_true(len(l) > 1)
+  call assert_fails("echo getscriptinfo('foobar')", 'E1206:')
+
+  call delete('X22script91')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -32,20 +32,54 @@ endfunc
 " Test for the getscriptinfo() function
 func Test_getscriptinfo()
   let lines =<< trim END
+    " scriptversion 3
     let g:loaded_script_id = expand("<SID>")
     let s:XscriptVar = [1, #{v: 2}]
-    func s:XscriptFunc()
+    func s:XgetScriptVar()
+      return s:XscriptVar
     endfunc
+    func s:Xscript_legacy_func1()
+    endfunc
+    " def s:Xscript_def_func1()
+    " enddef
+    func Xscript_legacy_func2()
+    endfunc
+    " def Xscript_def_func2()
+    " enddef
   END
   call writefile(lines, 'X22script91')
   source X22script91
   let l = getscriptinfo()
   call assert_match('X22script91$', l[-1].name)
   call assert_equal(g:loaded_script_id, $"<SNR>{l[-1].sid}_")
+  " call assert_equal(3, l[-1].version)
+  call assert_equal(1, l[-1].version)
+  call assert_equal(0, has_key(l[-1], 'variables'))
+  call assert_equal(0, has_key(l[-1], 'functions'))
 
-  let l = getscriptinfo({'name': '22script91'})
+  " Get script information using script name
+  let l = getscriptinfo(#{name: '22script91'})
   call assert_equal(1, len(l))
   call assert_match('22script91$', l[0].name)
+  let sid = l[0].sid
+
+  " Get script information using script-ID
+  let l = getscriptinfo({'sid': sid})
+  call assert_equal(#{XscriptVar: [1, {'v': 2}]}, l[0].variables)
+  let funcs = ['Xscript_legacy_func2',
+        \ $"<SNR>{sid}_Xscript_legacy_func1",
+        "\ $"<SNR>{sid}_Xscript_def_func1",
+        "\ 'Xscript_def_func2',
+        \ $"<SNR>{sid}_XgetScriptVar"]
+  for f in funcs
+    call assert_true(index(l[0].functions, f) != -1)
+  endfor
+
+  " Verify that a script-local variable cannot be modified using the dict
+  " returned by getscriptinfo()
+  let l[0].variables.XscriptVar = ['n']
+  let funcname = $"<SNR>{sid}_XgetScriptVar"
+  call assert_equal([1, {'v': 2}], call(funcname, []))
 
   let l = getscriptinfo({'name': 'foobar'})
   call assert_equal(0, len(l))
@@ -57,6 +91,8 @@ func Test_getscriptinfo()
   let l = getscriptinfo({'name': v:_null_string})
   call assert_true(len(l) > 1)
   call assert_fails("echo getscriptinfo('foobar')", 'E1206:')
+
+  call assert_fails("echo getscriptinfo({'sid': []})", 'E745:')
 
   call delete('X22script91')
 endfunc

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -93,6 +93,16 @@ func Test_getscriptinfo()
   call assert_fails("echo getscriptinfo('foobar')", 'E1206:')
 
   call assert_fails("echo getscriptinfo({'sid': []})", 'E745:')
+  call assert_fails("echo getscriptinfo({'sid': {}})", 'E728:')
+  call assert_fails("echo getscriptinfo({'sid': 0})", 'E475:')
+  call assert_fails("echo getscriptinfo({'sid': -1})", 'E475:')
+  call assert_fails("echo getscriptinfo({'sid': -999})", 'E475:')
+
+  echo getscriptinfo({'sid': '1'})
+  " call assert_fails("vim9cmd echo getscriptinfo({'sid': '1'})", 'E1030:')
+
+  let max_sid = max(map(getscriptinfo(), { k, v -> v.sid }))
+  call assert_equal([], getscriptinfo({'sid': max_sid + 1}))
 
   call delete('X22script91')
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.0269: getscriptinfo() does not include the version

Problem:    getscriptinfo() does not include the version.  Cannot select
            entries by script name.
Solution:   Add the "version" item and the "name" argument. (Yegappan
            Lakshmanan, closes vim/vim#10962)

https://github.com/vim/vim/commit/520f6ef60a59f7b5f3da9199999d13dbe817d3ce

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0303: it is not easy to get information about a script

Problem:    It is not easy to get information about a script.
Solution:   Make getscriptinf() return the version.  When selecting a specific
            script return functions and variables. (Yegappan Lakshmanan,
            closes vim/vim#10991)

https://github.com/vim/vim/commit/2f892d8663498c21296ad6661dac1bb8372cfd10

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.1431: getscriptinfo() loops even when specific SID is given

Problem:    getscriptinfo() loops even when specific SID is given.
Solution:   Only loop when needed.  Give a clearer error message.
            (closes vim/vim#12207)

https://github.com/vim/vim/commit/2d68b722e3bca7532eb0d83ce773934618f12db5