### PR TITLE
vim-patch:9.0.{1064,1456}

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -38,6 +38,7 @@
 #include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option.h"
+#include "nvim/optionstr.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/path.h"
 #include "nvim/pos.h"
@@ -467,7 +468,6 @@ void ex_listdo(exarg_T *eap)
                         | (eap->forceit ? CCGD_FORCEIT : 0)
                         | CCGD_EXCMD)) {
     int next_fnum = 0;
-    char *p_shm_save;
     int i = 0;
     // start at the eap->line1 argument/window/buffer
     wp = firstwin;
@@ -514,7 +514,9 @@ void ex_listdo(exarg_T *eap)
       if (qf_size == 0 || (size_t)eap->line1 > qf_size) {
         buf = NULL;
       } else {
+        save_clear_shm_value();
         ex_cc(eap);
+        restore_shm_value();
 
         buf = curbuf;
         i = (int)eap->line1 - 1;
@@ -541,11 +543,9 @@ void ex_listdo(exarg_T *eap)
         if (curwin->w_arg_idx != i || !editing_arg_idx(curwin)) {
           // Clear 'shm' to avoid that the file message overwrites
           // any output from the command.
-          p_shm_save = xstrdup(p_shm);
-          set_option_value_give_err("shm", 0L, "", 0);
+          save_clear_shm_value();
           do_argfile(eap, i);
-          set_option_value_give_err("shm", 0L, p_shm_save, 0);
-          xfree(p_shm_save);
+          restore_shm_value();
         }
         if (curwin->w_arg_idx != i) {
           break;
@@ -610,11 +610,9 @@ void ex_listdo(exarg_T *eap)
 
         // Go to the next buffer.  Clear 'shm' to avoid that the file
         // message overwrites any output from the command.
-        p_shm_save = xstrdup(p_shm);
-        set_option_value_give_err("shm", 0L, "", 0);
+        save_clear_shm_value();
         goto_buffer(eap, DOBUF_FIRST, FORWARD, next_fnum);
-        set_option_value_give_err("shm", 0L, p_shm_save, 0);
-        xfree(p_shm_save);
+        restore_shm_value();
 
         // If autocommands took us elsewhere, quit here.
         if (curbuf->b_fnum != next_fnum) {
@@ -633,11 +631,9 @@ void ex_listdo(exarg_T *eap)
 
         // Clear 'shm' to avoid that the file message overwrites
         // any output from the command.
-        p_shm_save = xstrdup(p_shm);
-        set_option_value_give_err("shm", 0L, "", 0);
+        save_clear_shm_value();
         ex_cnext(eap);
-        set_option_value_give_err("shm", 0L, p_shm_save, 0);
-        xfree(p_shm_save);
+        restore_shm_value();
 
         // If jumping to the next quickfix entry fails, quit here.
         if (qf_get_cur_idx(eap) == qf_idx) {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -260,6 +260,7 @@ enum {
   SHM_RECORDING      = 'q',  ///< Short recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
   SHM_SEARCHCOUNT    = 'S',  ///< Search stats: '[1/10]'
+  SHM_LEN            = 30,   ///< Max length of all flags together plus a NUL character.
 };
 /// Represented by 'a' flag.
 #define SHM_ALL_ABBREVIATIONS ((char[]) { \

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -56,6 +56,9 @@ if has('timers')
   endfunc
 
   func Test_cursorhold_insert()
+    " depends on timing
+    let g:test_is_flaky = 1
+
     " Need to move the cursor.
     call feedkeys("ggG", "xt")
 
@@ -3627,6 +3630,7 @@ func SetupVimTest_shm()
   let g:bwe = []
   let g:brp = []
   set shortmess+=F
+  messages clear
 
   let dirname='XVimTestSHM'
   call mkdir(dirname, 'R')


### PR DESCRIPTION
#### vim-patch:9.0.1064: code for making 'shortmess' temporarily empty is repeated

Problem:    Code for making 'shortmess' temporarily empty is repeated.
Solution:   Add functions for making 'shortmess' empty and restoring it.
            (Christian Brabandt, closes vim/vim#11709)

https://github.com/vim/vim/commit/9aee8ec400fe617f6d82441c46a22d0cef6fa3e6

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1456: shortmess test depends on order of test execution

Problem:    Shortmess test depends on order of test execution.
Solution:   Clear messages. (closes vim/vim#12264)

https://github.com/vim/vim/commit/657b31fa3bda2089fef18c30fc706abe5d57e865