### PR TITLE
vim-patch:9.0.0947: invalid memory access in substitute with function

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -462,7 +462,7 @@ static bool check_text_locked(oparg_T *oap)
 /// If text is locked, "curbuf->b_ro_locked" or "allbuf_lock" is set:
 /// Give an error message, possibly beep and return true.
 /// "oap" may be NULL.
-static bool check_text_or_curbuf_locked(oparg_T *oap)
+bool check_text_or_curbuf_locked(oparg_T *oap)
 {
   if (check_text_locked(oap)) {
     return true;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -504,6 +504,9 @@ newwindow:
   case Ctrl_F: {
 wingotofile:
     CHECK_CMDWIN;
+    if (check_text_or_curbuf_locked(NULL)) {
+      break;
+    }
 
     linenr_T lnum = -1;
     char *ptr = grab_file_name(Prenum1, &lnum);
@@ -1068,10 +1071,10 @@ int win_split(int size, int flags)
   return win_split_ins(size, flags, NULL, 0);
 }
 
-// When "new_wp" is NULL: split the current window in two.
-// When "new_wp" is not NULL: insert this window at the far
-// top/left/right/bottom.
-// return FAIL for failure, OK otherwise
+/// When "new_wp" is NULL: split the current window in two.
+/// When "new_wp" is not NULL: insert this window at the far
+/// top/left/right/bottom.
+/// @return  FAIL for failure, OK otherwise
 int win_split_ins(int size, int flags, win_T *new_wp, int dir)
 {
   win_T *wp = new_wp;

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -1090,6 +1090,25 @@ func Test_sub_edit_scriptfile()
   bwipe!
 endfunc
 
+" This was editing another file from the expression.
+func Test_sub_expr_goto_other_file()
+  call writefile([''], 'Xfileone', 'D')
+  enew!
+  call setline(1, ['a', 'b', 'c', 'd',
+	\ 'Xfileone zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'])
+
+  func g:SplitGotoFile()
+    exe "sil! norm 0\<C-W>gf"
+    return ''
+  endfunc
+
+  $
+  s/\%')/\=g:SplitGotoFile()
+
+  delfunc g:SplitGotoFile
+  bwipe!
+endfunc
+
 " Test for the 2-letter and 3-letter :substitute commands
 func Test_substitute_short_cmd()
   new


### PR DESCRIPTION
#### vim-patch:9.0.0947: invalid memory access in substitute with function

Problem:    Invalid memory access in substitute with function that goes to
            another file.
Solution:   Check for text locked in CTRL-W gf.

https://github.com/vim/vim/commit/cc762a48d42b579fb7bdec2c614636b830342dd5

Co-authored-by: Bram Moolenaar <Bram@vim.org>