### PR TITLE
fix(checkhealth): shell_error and cpanm module

### DIFF
--- a/runtime/lua/provider/health.lua
+++ b/runtime/lua/provider/health.lua
@@ -850,7 +850,7 @@ local function perl()
 
   local latest_cpan_cmd = {
     perl_exec,
-    '-MApp::cpanminus::fatscript',
+    '-MApp::cpanminus::script',
     '-e',
     'my $app = App::cpanminus::script->new; $app->parse_options ("--info", "-q", "Neovim::Ext"); exit $app->doit',
   }
@@ -886,7 +886,7 @@ local function perl()
 
   local current_cpan_cmd = { perl_exec, '-W', '-MNeovim::Ext', '-e', 'print $Neovim::Ext::VERSION' }
   local current_cpan = system(current_cpan_cmd)
-  if shell_error then
+  if shell_error() then
     error(
       'Failed to run: ' .. table.concat(current_cpan_cmd, ' '),
       { 'Report this issue with the output of: ', table.concat(current_cpan_cmd, ' ') }


### PR DESCRIPTION
The perl module healthcheck contains two obvious bugs, and wasn't fixed for a long time.
I have been waiting for others to fix this for a long time.
Finally, it seems that I should pull my own local fix.