### PR TITLE
vim-patch:9.0.1145: invalid memory access with recursive substitute expression

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8375,6 +8375,10 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char 
       // - The substituted text.
       // - The text after the match.
       sublen = vim_regsub(&regmatch, sub, expr, tail, 0, REGSUB_MAGIC);
+      if (sublen <= 0) {
+        ga_clear(&ga);
+        break;
+      }
       ga_grow(&ga, (int)((end - tail) + sublen -
                          (regmatch.endp[0] - regmatch.startp[0])));
 

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -1109,6 +1109,22 @@ func Test_sub_expr_goto_other_file()
   bwipe!
 endfunc
 
+func Test_recursive_expr_substitute()
+  " this was reading invalid memory
+  let lines =<< trim END
+      func Repl(g, n)
+        s
+        r%:s000
+      endfunc
+      next 0
+      let caught = 0
+      s/\%')/\=Repl(0, 0)
+      qall!
+  END
+  call writefile(lines, 'XexprSubst', 'D')
+  call RunVim([], [], '--clean -S XexprSubst')
+endfunc
+
 " Test for the 2-letter and 3-letter :substitute commands
 func Test_substitute_short_cmd()
   new


### PR DESCRIPTION
#### vim-patch:9.0.1145: invalid memory access with recursive substitute expression

Problem:    Invalid memory access with recursive substitute expression.
Solution:   Check the return value of vim_regsub().

https://github.com/vim/vim/commit/3ac1d97a1d9353490493d30088256360435f7731

Co-authored-by: Bram Moolenaar <Bram@vim.org>