### PR TITLE
vim-patch:9.0.1143: invalid memory access with bad 'statusline' value

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1373,6 +1373,9 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
     // An invalid item was specified.
     // Continue processing on the next character of the format string.
     if (vim_strchr(STL_ALL, (uint8_t)(*fmt_p)) == NULL) {
+      if (*fmt_p == NUL) {  // can happen with "%0"
+        break;
+      }
       fmt_p++;
       continue;
     }

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -444,6 +444,13 @@ func Test_statusline()
   set splitbelow&
 endfunc
 
+func Test_statusline_trailing_percent_zero()
+  " this was causing illegal memory access
+  set laststatus=2 stl=%!%0
+  call assert_fails('redraw', 'E15: Invalid expression: "%0"')
+  set laststatus& stl&
+endfunc
+
 func Test_statusline_visual()
   func CallWordcount()
     call wordcount()


### PR DESCRIPTION
#### vim-patch:9.0.1143: invalid memory access with bad 'statusline' value

Problem:    Invalid memory access with bad 'statusline' value.
Solution:   Avoid going over the NUL at the end.

https://github.com/vim/vim/commit/7b17eb4b063a234376c1ec909ee293e42cff290c

Co-authored-by: Bram Moolenaar <Bram@vim.org>