### PR TITLE
fix(watchfiles): skip Created events when poll starts

### DIFF
--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -122,10 +122,6 @@ describe('vim._watch', function()
           table.insert(events, { path = path, change_type = change_type })
         end)
 
-        -- polling generates Created events for the existing entries when it starts.
-        expected_events = expected_events + 1
-        wait_for_events()
-
         vim.wait(100)
 
         local watched_path = root_dir .. '/file'
@@ -158,39 +154,35 @@ describe('vim._watch', function()
         root_dir
       )
 
-      eq(5, #result)
-      eq({
-        change_type = exec_lua([[return vim._watch.FileChangeType.Created]]),
-        path = root_dir,
-      }, result[1])
+      eq(4, #result)
       eq({
         change_type = exec_lua([[return vim._watch.FileChangeType.Created]]),
         path = root_dir .. '/file',
-      }, result[2])
+      }, result[1])
       eq({
         change_type = exec_lua([[return vim._watch.FileChangeType.Changed]]),
         path = root_dir,
-      }, result[3])
+      }, result[2])
       -- The file delete and corresponding directory change events do not happen in any
       -- particular order, so allow either
-      if result[4].path == root_dir then
+      if result[3].path == root_dir then
         eq({
           change_type = exec_lua([[return vim._watch.FileChangeType.Changed]]),
           path = root_dir,
-        }, result[4])
+        }, result[3])
         eq({
           change_type = exec_lua([[return vim._watch.FileChangeType.Deleted]]),
           path = root_dir .. '/file',
-        }, result[5])
+        }, result[4])
       else
         eq({
           change_type = exec_lua([[return vim._watch.FileChangeType.Deleted]]),
           path = root_dir .. '/file',
-        }, result[4])
+        }, result[3])
         eq({
           change_type = exec_lua([[return vim._watch.FileChangeType.Changed]]),
           path = root_dir,
-        }, result[5])
+        }, result[4])
       end
     end)
   end)


### PR DESCRIPTION
Previously, starting a `vim._watch.poll` would emit a `Created` event for every file and directory that already existed. For even moderately large file trees watched by the LSP client, sending all of those events at once would result in noticeable gaps in responsiveness by the rest of the editor.

This change skips sending those initial `Created` events to bring it more in line with the behavior of `vim._watch.watch` and reduce LSP overhead on both the client and server side when a watch is started using the polling implementation. 

Side note: this change doesn't seem to affect the flaky test behavior addressed in #22637, so that workaround is still necessary.