### PR TITLE
vim-patch:9.0.{0406,0419}: the :defer command does not check the function arguments

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -228,6 +228,31 @@ const EvalFuncDef *find_internal_func(const char *const name)
   return index >= 0 ? &functions[index] : NULL;
 }
 
+/// Check the argument count to use for internal function "fdef".
+/// @return  -1 for failure, 0 if no method base accepted, 1 if method base is
+/// first argument, 2 if method base is second argument, etc.
+int check_internal_func(const EvalFuncDef *const fdef, const int argcount)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int res;
+
+  if (argcount < fdef->min_argc) {
+    res = FCERR_TOOFEW;
+  } else if (argcount > fdef->max_argc) {
+    res = FCERR_TOOMANY;
+  } else {
+    return fdef->base_arg;
+  }
+
+  const char *const name = fdef->name;
+  if (res == FCERR_TOOMANY) {
+    semsg(_(e_toomanyarg), name);
+  } else {
+    semsg(_(e_toofewarg), name);
+  }
+  return -1;
+}
+
 int call_internal_func(const char *const fname, const int argcount, typval_T *const argvars,
                        typval_T *const rettv)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -953,6 +953,7 @@ EXTERN const char e_dictreq[] INIT(= N_("E715: Dictionary required"));
 EXTERN const char e_blobidx[] INIT(= N_("E979: Blob index out of range: %" PRId64));
 EXTERN const char e_invalblob[] INIT(= N_("E978: Invalid operation for Blob"));
 EXTERN const char e_toomanyarg[] INIT(= N_("E118: Too many arguments for function: %s"));
+EXTERN const char e_toofewarg[] INIT(= N_("E119: Not enough arguments for function: %s"));
 EXTERN const char e_dictkey[] INIT(= N_("E716: Key not present in Dictionary: \"%s\""));
 EXTERN const char e_listreq[] INIT(= N_("E714: List required"));
 EXTERN const char e_listblobreq[] INIT(= N_("E897: List or Blob required"));

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -5,6 +5,7 @@
 
 source check.vim
 source shared.vim
+source vim9.vim
 
 func Table(title, ...)
   let ret = a:title
@@ -627,7 +628,7 @@ func Test_defer_quitall()
       call DeferLevelOne()
   END
   call writefile(lines, 'XdeferQuitall', 'D')
-  let res = system(GetVimCommandClean() .. ' -X -S XdeferQuitall')
+  let res = system(GetVimCommand() .. ' -X -S XdeferQuitall')
   call assert_equal(0, v:shell_error)
   call assert_false(filereadable('XQuitallOne'))
   call assert_false(filereadable('XQuitallTwo'))
@@ -650,7 +651,7 @@ func Test_defer_quitall_in_expr_func()
       call Test_defer_in_funcref()
   END
   call writefile(lines, 'XdeferQuitallExpr', 'D')
-  let res = system(GetVimCommandClean() .. ' -X -S XdeferQuitallExpr')
+  let res = system(GetVimCommand() .. ' -X -S XdeferQuitallExpr')
   call assert_equal(0, v:shell_error)
   call assert_false(filereadable('Xentry0'))
   call assert_false(filereadable('Xentry1'))
@@ -660,6 +661,62 @@ endfunc
 func FuncIndex(idx, val)
   call writefile([a:idx .. ': ' .. a:val], 'Xentry' .. a:idx, 'D')
   return a:val == 'c'
+endfunc
+
+func Test_defer_wrong_arguments()
+  call assert_fails('defer delete()', 'E119:')
+  call assert_fails('defer FuncIndex(1)', 'E119:')
+  call assert_fails('defer delete(1, 2, 3)', 'E118:')
+  call assert_fails('defer FuncIndex(1, 2, 3)', 'E118:')
+
+  throw 'Skipped: Vim9 script is N/A'
+  let lines =<< trim END
+      def DeferFunc0()
+        defer delete()
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E119:')
+  let lines =<< trim END
+      def DeferFunc3()
+        defer delete(1, 2, 3)
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E118:')
+  let lines =<< trim END
+      def DeferFunc2()
+        defer delete(1, 2)
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E1013: Argument 1: type mismatch, expected string but got number')
+
+  def g:FuncOneArg(arg: string)
+    echo arg
+  enddef
+
+  let lines =<< trim END
+      def DeferUserFunc0()
+        defer g:FuncOneArg()
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E119:')
+  let lines =<< trim END
+      def DeferUserFunc2()
+        defer g:FuncOneArg(1, 2)
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E118:')
+  let lines =<< trim END
+      def DeferUserFunc1()
+        defer g:FuncOneArg(1)
+      enddef
+      defcompile
+  END
+  call v9.CheckScriptFailure(lines, 'E1013: Argument 1: type mismatch, expected string but got number')
 endfunc
 
 

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -633,5 +633,34 @@ func Test_defer_quitall()
   call assert_false(filereadable('XQuitallTwo'))
 endfunc
 
+func Test_defer_quitall_in_expr_func()
+  throw 'Skipped: Vim9 script is N/A'
+  let lines =<< trim END
+      def DefIndex(idx: number, val: string): bool
+        call writefile([idx .. ': ' .. val], 'Xentry' .. idx, 'D')
+        if val == 'b'
+          qa!
+        endif
+        return val == 'c'
+      enddef
+
+      def Test_defer_in_funcref()
+        assert_equal(2, indexof(['a', 'b', 'c'], funcref('g:DefIndex')))
+      enddef
+      call Test_defer_in_funcref()
+  END
+  call writefile(lines, 'XdeferQuitallExpr', 'D')
+  let res = system(GetVimCommandClean() .. ' -X -S XdeferQuitallExpr')
+  call assert_equal(0, v:shell_error)
+  call assert_false(filereadable('Xentry0'))
+  call assert_false(filereadable('Xentry1'))
+  call assert_false(filereadable('Xentry2'))
+endfunc
+
+func FuncIndex(idx, val)
+  call writefile([a:idx .. ': ' .. a:val], 'Xentry' .. a:idx, 'D')
+  return a:val == 'c'
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0406: deferred functions not invoked when partial func exits

Problem:    Deferred functions not invoked when partial func exits.
Solution:   Create a funccall_T when calling a :def function.

https://github.com/vim/vim/commit/9667b2c888351b04751bdb43cba0d4ffc8c13ab1

The remove_funccal() function is currently unused, but it will be used
in patch 9.0.0618.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0419: the :defer command does not check the function arguments

Problem:    The :defer command does not check the function argument count and
            types.
Solution:   Check the function arguments when adding a deferred function.

https://github.com/vim/vim/commit/169003289fb4b2ad18fd7f5807e0d05efff0be85

Cherry-pick check_internal_func() from Vim, but use EvalFuncDef pointer
as first argument.

Co-authored-by: Bram Moolenaar <Bram@vim.org>