### PR TITLE
vim-patch:9.0.1400: find_file_in_path() is not reentrant

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2146,6 +2146,9 @@ static void findfilendir(typval_T *argvars, typval_T *rettv, int find_what)
   }
 
   if (*fname != NUL && !error) {
+    char *file_to_find = NULL;
+    char *search_ctx = NULL;
+
     do {
       if (rettv->v_type == VAR_STRING || rettv->v_type == VAR_LIST) {
         xfree(fresult);
@@ -2156,13 +2159,17 @@ static void findfilendir(typval_T *argvars, typval_T *rettv, int find_what)
                                          find_what, curbuf->b_ffname,
                                          (find_what == FINDFILE_DIR
                                           ? ""
-                                          : curbuf->b_p_sua));
+                                          : curbuf->b_p_sua),
+                                         &file_to_find, &search_ctx);
       first = false;
 
       if (fresult != NULL && rettv->v_type == VAR_LIST) {
         tv_list_append_string(rettv->vval.v_list, fresult, -1);
       }
     } while ((rettv->v_type == VAR_LIST || --count > 0) && fresult != NULL);
+
+    xfree(file_to_find);
+    vim_findfile_cleanup(search_ctx);
   }
 
   if (rettv->v_type == VAR_STRING) {

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1690,8 +1690,11 @@ char *find_file_name_in_path(char *ptr, size_t len, int options, long count, cha
   }
 
   if (options & FNAME_EXP) {
-    file_name = find_file_in_path(ptr, len, options & ~FNAME_MESS, true,
-                                  rel_fname);
+    char *file_to_find = NULL;
+    char *search_ctx = NULL;
+
+    file_name = find_file_in_path(ptr, len, options & ~FNAME_MESS,
+                                  true, rel_fname, &file_to_find, &search_ctx);
 
     // If the file could not be found in a normal way, try applying
     // 'includeexpr' (unless done already).
@@ -1702,7 +1705,7 @@ char *find_file_name_in_path(char *ptr, size_t len, int options, long count, cha
         ptr = tofree;
         len = strlen(ptr);
         file_name = find_file_in_path(ptr, len, options & ~FNAME_MESS,
-                                      true, rel_fname);
+                                      true, rel_fname, &file_to_find, &search_ctx);
       }
     }
     if (file_name == NULL && (options & FNAME_MESS)) {
@@ -1716,9 +1719,12 @@ char *find_file_name_in_path(char *ptr, size_t len, int options, long count, cha
     // appears several times in the path.
     while (file_name != NULL && --count > 0) {
       xfree(file_name);
-      file_name =
-        find_file_in_path(ptr, len, options, false, rel_fname);
+      file_name = find_file_in_path(ptr, len, options, false, rel_fname,
+                                    &file_to_find, &search_ctx);
     }
+
+    xfree(file_to_find);
+    vim_findfile_cleanup(search_ctx);
   } else {
     file_name = xstrnsave(ptr, len);
   }


### PR DESCRIPTION
#### vim-patch:9.0.1400: find_file_in_path() is not reentrant

Problem:    find_file_in_path() is not reentrant.
Solution:   Instead of global variables pass pointers to the functions.

https://github.com/vim/vim/commit/5145c9a829cd43cb9e7962b181bf99226eb3a53f

Co-authored-by: Bram Moolenaar <Bram@vim.org>