### PR TITLE
vim-patch:8.2.{4179,4180,4181,4182,4183,4184,4185,4186,4193,4197}

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -396,7 +396,9 @@ If the 'diffexpr' expression starts with s: or |<SID>|, then it is replaced
 with the script ID (|local-function|). Example: >
 		set diffexpr=s:MyDiffExpr()
 		set diffexpr=<SID>SomeDiffExpr()
-<
+Otherwise, the expression is evaluated in the context of the script where the
+option was set, thus script-local items are available.
+
 						*E810* *E97*
 Vim will do a test if the diff output looks alright.  If it doesn't, you will
 get an error message.  Possible causes:
@@ -452,5 +454,8 @@ If the 'patchexpr' expression starts with s: or |<SID>|, then it is replaced
 with the script ID (|local-function|). Example: >
 		set patchexpr=s:MyPatchExpr()
 		set patchexpr=<SID>SomePatchExpr()
-<
+Otherwise, the expression is evaluated in the context of the script where the
+option was set, thus script-local items are available.
+
+
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2563,7 +2563,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'foldexpr' 'fde'	string (default: "0")
 			local to window
 	The expression used for when 'foldmethod' is "expr".  It is evaluated
-	for each line to obtain its fold level.  See |fold-expr|.
+	for each line to obtain its fold level.  The context is set to the
+	script where 'foldexpr' was set, script-local items can be accessed.
+	See |fold-expr| for the usage.
 
 	The expression will be evaluated in the |sandbox| if set from a
 	modeline, see |sandbox-option|.
@@ -2679,7 +2681,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'foldtext' 'fdt'	string (default: "foldtext()")
 			local to window
 	An expression which is used to specify the text displayed for a closed
-	fold.  See |fold-foldtext|.
+	fold.  The context is set to the script where 'foldexpr' was set,
+	script-local items can be accessed.  See |fold-foldtext| for the
+	usage.
 
 	The expression will be evaluated in the |sandbox| if set from a
 	modeline, see |sandbox-option|.
@@ -2720,7 +2724,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the script ID (|local-function|). Example: >
 		set formatexpr=s:MyFormatExpr()
 		set formatexpr=<SID>SomeFormatExpr()
-<
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
+
 	The expression will be evaluated in the |sandbox| when set from a
 	modeline, see |sandbox-option|.  That stops the option from working,
 	since changing the buffer text is not allowed.
@@ -3334,7 +3340,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the script ID (|local-function|). Example: >
 		setlocal includeexpr=s:MyIncludeExpr(v:fname)
 		setlocal includeexpr=<SID>SomeIncludeExpr(v:fname)
-<
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
+
 	The expression will be evaluated in the |sandbox| when set from a
 	modeline, see |sandbox-option|.
 	This option cannot be set in a modeline when 'modelineexpr' is off.
@@ -3389,11 +3397,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The expression is evaluated with |v:lnum| set to the line number for
 	which the indent is to be computed.  The cursor is also in this line
 	when the expression is evaluated (but it may be moved around).
+
 	If the expression starts with s: or |<SID>|, then it is replaced with
 	the script ID (|local-function|). Example: >
 		set indentexpr=s:MyIndentExpr()
 		set indentexpr=<SID>SomeIndentExpr()
-<
+<	Otherwise, the expression is evaluated in the context of the script
+	where the option was set, thus script-local items are available.
+
 	The expression must return the number of spaces worth of indent.  It
 	can return "-1" to keep the current indent (this means 'autoindent' is
 	used for the indent).

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1085,6 +1085,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
   typval_T rettv;
   list_T *list = NULL;
   char *p = skipwhite(expr);
+  const sctx_T saved_sctx = current_sctx;
 
   // Set "v:val" to the bad word.
   prepare_vimvar(VV_VAL, &save_val);
@@ -1092,6 +1093,10 @@ list_T *eval_spell_expr(char *badword, char *expr)
   vimvars[VV_VAL].vv_str = badword;
   if (p_verbose == 0) {
     emsg_off++;
+  }
+  sctx_T *ctx = get_option_sctx("spellsuggest");
+  if (ctx != NULL) {
+    current_sctx = *ctx;
   }
 
   if (eval1(&p, &rettv, &EVALARG_EVALUATE) == OK) {
@@ -1106,6 +1111,7 @@ list_T *eval_spell_expr(char *badword, char *expr)
     emsg_off--;
   }
   restore_vimvar(VV_VAL, &save_val);
+  current_sctx = saved_sctx;
 
   return list;
 }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -669,15 +669,24 @@ int eval_charconvert(const char *const enc_from, const char *const enc_to,
 
 void eval_diff(const char *const origfile, const char *const newfile, const char *const outfile)
 {
-  bool err = false;
-
+  const sctx_T saved_sctx = current_sctx;
   set_vim_var_string(VV_FNAME_IN, origfile, -1);
   set_vim_var_string(VV_FNAME_NEW, newfile, -1);
   set_vim_var_string(VV_FNAME_OUT, outfile, -1);
-  (void)eval_to_bool(p_dex, &err, NULL, false);
+
+  sctx_T *ctx = get_option_sctx("diffexpr");
+  if (ctx != NULL) {
+    current_sctx = *ctx;
+  }
+
+  // errors are ignored
+  typval_T *tv = eval_expr(p_dex, NULL);
+  tv_clear(tv);
+
   set_vim_var_string(VV_FNAME_IN, NULL, -1);
   set_vim_var_string(VV_FNAME_NEW, NULL, -1);
   set_vim_var_string(VV_FNAME_OUT, NULL, -1);
+  current_sctx = saved_sctx;
 }
 
 void eval_patch(const char *const origfile, const char *const difffile, const char *const outfile)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -691,15 +691,24 @@ void eval_diff(const char *const origfile, const char *const newfile, const char
 
 void eval_patch(const char *const origfile, const char *const difffile, const char *const outfile)
 {
-  bool err = false;
-
+  const sctx_T saved_sctx = current_sctx;
   set_vim_var_string(VV_FNAME_IN, origfile, -1);
   set_vim_var_string(VV_FNAME_DIFF, difffile, -1);
   set_vim_var_string(VV_FNAME_OUT, outfile, -1);
-  (void)eval_to_bool(p_pex, &err, NULL, false);
+
+  sctx_T *ctx = get_option_sctx("patchexpr");
+  if (ctx != NULL) {
+    current_sctx = *ctx;
+  }
+
+  // errors are ignored
+  typval_T *tv = eval_expr(p_pex, NULL);
+  tv_free(tv);
+
   set_vim_var_string(VV_FNAME_IN, NULL, -1);
   set_vim_var_string(VV_FNAME_DIFF, NULL, -1);
   set_vim_var_string(VV_FNAME_OUT, NULL, -1);
+  current_sctx = saved_sctx;
 }
 
 void fill_evalarg_from_eap(evalarg_T *evalarg, exarg_T *eap, bool skip)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -681,7 +681,7 @@ void eval_diff(const char *const origfile, const char *const newfile, const char
 
   // errors are ignored
   typval_T *tv = eval_expr(p_dex, NULL);
-  tv_clear(tv);
+  tv_free(tv);
 
   set_vim_var_string(VV_FNAME_IN, NULL, -1);
   set_vim_var_string(VV_FNAME_NEW, NULL, -1);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -647,19 +647,27 @@ void var_redir_stop(void)
 int eval_charconvert(const char *const enc_from, const char *const enc_to,
                      const char *const fname_from, const char *const fname_to)
 {
-  bool err = false;
+  const sctx_T saved_sctx = current_sctx;
 
   set_vim_var_string(VV_CC_FROM, enc_from, -1);
   set_vim_var_string(VV_CC_TO, enc_to, -1);
   set_vim_var_string(VV_FNAME_IN, fname_from, -1);
   set_vim_var_string(VV_FNAME_OUT, fname_to, -1);
+  sctx_T *ctx = get_option_sctx("charconvert");
+  if (ctx != NULL) {
+    current_sctx = *ctx;
+  }
+
+  bool err = false;
   if (eval_to_bool(p_ccv, &err, NULL, false)) {
     err = true;
   }
+
   set_vim_var_string(VV_CC_FROM, NULL, -1);
   set_vim_var_string(VV_CC_TO, NULL, -1);
   set_vim_var_string(VV_FNAME_IN, NULL, -1);
   set_vim_var_string(VV_FNAME_OUT, NULL, -1);
+  current_sctx = saved_sctx;
 
   if (err) {
     return FAIL;

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1122,6 +1122,7 @@ int get_expr_indent(void)
   int save_set_curswant;
   int save_State;
   int use_sandbox = was_set_insecurely(curwin, "indentexpr", OPT_LOCAL);
+  const sctx_T save_sctx = current_sctx;
 
   // Save and restore cursor position and curswant, in case it was changed
   // * via :normal commands.
@@ -1134,6 +1135,7 @@ int get_expr_indent(void)
     sandbox++;
   }
   textlock++;
+  current_sctx = curbuf->b_p_script_ctx[BV_INDE].script_ctx;
 
   // Need to make a copy, the 'indentexpr' option could be changed while
   // evaluating it.
@@ -1145,6 +1147,7 @@ int get_expr_indent(void)
     sandbox--;
   }
   textlock--;
+  current_sctx = save_sctx;
 
   // Restore the cursor position so that 'indentexpr' doesn't need to.
   // Pretend to be in Insert mode, allow cursor past end of line for "o"

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1913,6 +1913,18 @@ bool parse_winhl_opt(win_T *wp)
   return true;
 }
 
+/// Get the script context of global option "name".
+sctx_T *get_option_sctx(const char *const name)
+{
+  int idx = findoption(name);
+
+  if (idx >= 0) {
+    return &options[idx].last_set.script_ctx;
+  }
+  siemsg("no such option: %s", name);
+  return NULL;
+}
+
 /// Set the script_ctx for an option, taking care of setting the buffer- or
 /// window-local value.
 void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1661,10 +1661,15 @@ void simplify_filename(char *filename)
 
 static char *eval_includeexpr(const char *const ptr, const size_t len)
 {
+  const sctx_T save_sctx = current_sctx;
   set_vim_var_string(VV_FNAME, ptr, (ptrdiff_t)len);
+  current_sctx = curbuf->b_p_script_ctx[BV_INEX].script_ctx;
+
   char *res = eval_to_string_safe(curbuf->b_p_inex,
                                   was_set_insecurely(curwin, "includeexpr", OPT_LOCAL));
+
   set_vim_var_string(VV_FNAME, NULL, 0);
+  current_sctx = save_sctx;
   return res;
 }
 

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -881,6 +881,7 @@ void op_formatexpr(oparg_T *oap)
 int fex_format(linenr_T lnum, long count, int c)
 {
   int use_sandbox = was_set_insecurely(curwin, "formatexpr", OPT_LOCAL);
+  const sctx_T save_sctx = current_sctx;
 
   // Set v:lnum to the first line number and v:count to the number of lines.
   // Set v:char to the character to be inserted (can be NUL).
@@ -890,6 +891,8 @@ int fex_format(linenr_T lnum, long count, int c)
 
   // Make a copy, the option could be changed while calling it.
   char *fex = xstrdup(curbuf->b_p_fex);
+  current_sctx = curbuf->b_p_script_ctx[BV_FEX].script_ctx;
+
   // Evaluate the function.
   if (use_sandbox) {
     sandbox++;
@@ -901,6 +904,7 @@ int fex_format(linenr_T lnum, long count, int c)
 
   set_vim_var_string(VV_CHAR, NULL, -1);
   xfree(fex);
+  current_sctx = save_sctx;
 
   return r;
 }


### PR DESCRIPTION
#### vim-patch:8.2.4179: 'foldtext' is evaluated in the current script context

Problem:    'foldtext' is evaluated in the current script context.
Solution:   Use the script context where the option was set.

https://github.com/vim/vim/commit/9530b580a7b71960dbbdb2b12a3aafeb540bd135

Script version is N/A.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4180: 'balloonexpr' is evaluated in the current script context

Problem:    'balloonexpr' is evaluated in the current script context.
Solution:   Use the script context where the option was set.

https://github.com/vim/vim/commit/5600a709f453045c80f92087acc0f855b4af377a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4181: Vim9: cannot use an import in 'diffexpr'

Problem:    Vim9: cannot use an import in 'diffexpr'.
Solution:   Set the script context when evaluating 'diffexpr'.  Do not require
            'diffexpr' to return a bool, it was ignored anyway.

https://github.com/vim/vim/commit/7b29f6a3949743914f08410b6f6bd6237c2f2038

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4182: memory leak when evaluating 'diffexpr'

Problem:    Memory leak when evaluating 'diffexpr'.
Solution:   Use free_tv() instead of clear_tv().

https://github.com/vim/vim/commit/39b8944539a9cde553fe709e535fdfd37d0f9307

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4183: cannot use an import in 'formatexpr'

Problem:    Cannot use an import in 'formatexpr'.
Solution:   Set the script context when evaluating 'formatexpr'.

https://github.com/vim/vim/commit/3ba685eeefcfbbf895d70664357ef05f252d7b21

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4184: cannot use an import in 'includeexpr'

Problem:    Cannot use an import in 'includeexpr'.
Solution:   Set the script context when evaluating 'includeexpr'

https://github.com/vim/vim/commit/47bcc5f4c83c158f43ac2ea7abfe99dbf5c2e098

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4185: cannot use an import in 'indentexpr'

Problem:    Cannot use an import in 'indentexpr'.
Solution:   Set the script context when evaluating 'indentexpr'

https://github.com/vim/vim/commit/28e60cc088cadd25afb69ee636f0e2e34233ba4e

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4186: cannot use an import in 'patchexpr'

Problem:    Cannot use an import in 'patchexpr'.
Solution:   Set the script context when evaluating 'patchexpr'.  Do not
            require 'patchexpr' to return a bool, it was ignored anyway.

https://github.com/vim/vim/commit/36c2add7f82bc5dbbfc45db31953ef9633c635b3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4193: cannot use an import in 'charconvert'

Problem:    Cannot use an import in 'charconvert'.
Solution:   Set the script context when evaluating 'charconvert'.  Also expand
            script-local functions in 'charconvert'.

https://github.com/vim/vim/commit/f4e88f2152c5975a6f4cfa7ccd745575fe4d1c78

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4197: cannot use an import in the "expr" part of 'spellsuggest'

Problem:    Cannot use an import in the "expr" part of 'spellsuggest'.
Solution:   Set the script context when evaluating "expr" of 'spellsuggest'.

https://github.com/vim/vim/commit/2a7aa834583dea157eccf3e69827d2ff1d9fe9c7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:partial:6f4754b9f725

Update runtime files

https://github.com/vim/vim/commit/6f4754b9f7253d7e4ba527064a24aff1acdb1e8f

Co-authored-by: Bram Moolenaar <Bram@vim.org>