### PR TITLE
vim-patch:9.0.{1330,1345,1353,1359,1369,1374}: handling new value of an option has a long "else if" chain

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1687,7 +1687,7 @@ void enter_buffer(buf_T *buf)
   // May need to set the spell language.  Can only do this after the buffer
   // has been properly setup.
   if (!curbuf->b_help && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL) {
-    (void)did_set_spelllang(curwin);
+    (void)parse_spelllang(curwin);
   }
   curbuf->b_last_used = time(NULL);
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7711,7 +7711,7 @@ static void f_spellbadword(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
   const int wo_spell_save = curwin->w_p_spell;
 
   if (!curwin->w_p_spell) {
-    did_set_spelllang(curwin);
+    parse_spelllang(curwin);
     curwin->w_p_spell = true;
   }
 
@@ -7768,7 +7768,7 @@ static void f_spellsuggest(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
   const int wo_spell_save = curwin->w_p_spell;
 
   if (!curwin->w_p_spell) {
-    did_set_spelllang(curwin);
+    parse_spelllang(curwin);
     curwin->w_p_spell = true;
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2640,7 +2640,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
   // If the window options were changed may need to set the spell language.
   // Can only do this after the buffer has been properly setup.
   if (did_get_winopts && curwin->w_p_spell && *curwin->w_s->b_p_spl != NUL) {
-    (void)did_set_spelllang(curwin);
+    (void)parse_spelllang(curwin);
   }
 
   if (command == NULL) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4277,7 +4277,7 @@ void cmdline_init(void)
 
 /// Check value of 'cedit' and set cedit_key.
 /// Returns NULL if value is OK, error message otherwise.
-const char *check_cedit(void)
+const char *did_set_cedit(optset_T *args)
 {
   if (*p_cedit == NUL) {
     cedit_key = -1;

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -154,6 +154,9 @@ local dump_option = function(i, o)
     table.insert(defines,  { 'PV_' .. varname:sub(3):upper() , pv_name})
     w('    .indir=' .. pv_name)
   end
+  if o.cb then
+    w('    .opt_did_set_cb=' .. o.cb)
+  end
   if o.enable_if then
     w('#else')
     w('    .var=NULL')

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2257,14 +2257,14 @@ static void copy_global_to_buflocal_cb(Callback *globcb, Callback *bufcb)
 /// Invoked when the 'completefunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-void set_completefunc_option(const char **errmsg)
+const char *did_set_completefunc(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (option_set_callback_func(curbuf->b_p_cfu, &cfu_cb) == FAIL) {
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
 
   set_buflocal_cfu_callback(curbuf);
+  return NULL;
 }
 
 /// Copy the global 'completefunc' callback function to the buffer-local
@@ -2278,13 +2278,14 @@ void set_buflocal_cfu_callback(buf_T *buf)
 /// Invoked when the 'omnifunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-void set_omnifunc_option(buf_T *buf, const char **errmsg)
+const char *did_set_omnifunc(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
   if (option_set_callback_func(buf->b_p_ofu, &ofu_cb) == FAIL) {
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
   set_buflocal_ofu_callback(buf);
+  return NULL;
 }
 
 /// Copy the global 'omnifunc' callback function to the buffer-local 'omnifunc'
@@ -2298,7 +2299,7 @@ void set_buflocal_ofu_callback(buf_T *buf)
 /// Invoked when the 'thesaurusfunc' option is set. The option value can be a
 /// name of a function (string), or function(<name>) or funcref(<name>) or a
 /// lambda expression.
-void set_thesaurusfunc_option(const char **errmsg)
+const char *did_set_thesaurusfunc(optset_T *args FUNC_ATTR_UNUSED)
 {
   int retval;
 
@@ -2310,9 +2311,7 @@ void set_thesaurusfunc_option(const char **errmsg)
     retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
   }
 
-  if (retval == FAIL) {
-    *errmsg = e_invarg;
-  }
+  return retval == FAIL ? e_invarg : NULL;
 }
 
 /// Mark the global 'completefunc' 'omnifunc' and 'thesaurusfunc' callbacks with

--- a/src/nvim/lua/spell.c
+++ b/src/nvim/lua/spell.c
@@ -39,7 +39,7 @@ int nlua_spell_check(lua_State *lstate)
   const int wo_spell_save = curwin->w_p_spell;
 
   if (!curwin->w_p_spell) {
-    did_set_spelllang(curwin);
+    parse_spelllang(curwin);
     curwin->w_p_spell = true;
   }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2386,7 +2386,7 @@ void langmap_init(void)
 
 /// Called when langmap option is set; the language map can be
 /// changed at any time!
-void langmap_set(void)
+const char *did_set_langmap(optset_T *args FUNC_ATTR_UNUSED)
 {
   char *p;
   char *p2;
@@ -2434,9 +2434,11 @@ void langmap_set(void)
         }
       }
       if (to == NUL) {
+        // TODO(vim): Need to use errbuf argument for this error message
+        // and return it.
         semsg(_("E357: 'langmap': Matching character missing for %s"),
               transchar(from));
-        return;
+        return NULL;
       }
 
       if (from >= 256) {
@@ -2454,8 +2456,10 @@ void langmap_set(void)
           p = p2;
           if (p[0] != NUL) {
             if (p[0] != ',') {
+              // TODO(vim): Need to use errbuf argument for this error
+              // message and return it.
               semsg(_("E358: 'langmap': Extra characters after semicolon: %s"), p);
-              return;
+              return NULL;
             }
             p++;
           }
@@ -2464,6 +2468,8 @@ void langmap_set(void)
       }
     }
   }
+
+  return NULL;
 }
 
 static void do_exmap(exarg_T *eap, int isabbrev)

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2386,7 +2386,7 @@ void langmap_init(void)
 
 /// Called when langmap option is set; the language map can be
 /// changed at any time!
-const char *did_set_langmap(optset_T *args FUNC_ATTR_UNUSED)
+const char *did_set_langmap(optset_T *args)
 {
   char *p;
   char *p2;
@@ -2434,11 +2434,10 @@ const char *did_set_langmap(optset_T *args FUNC_ATTR_UNUSED)
         }
       }
       if (to == NUL) {
-        // TODO(vim): Need to use errbuf argument for this error message
-        // and return it.
-        semsg(_("E357: 'langmap': Matching character missing for %s"),
-              transchar(from));
-        return NULL;
+        snprintf(args->os_errbuf, args->os_errbuflen,
+                 _("E357: 'langmap': Matching character missing for %s"),
+                 transchar(from));
+        return args->os_errbuf;
       }
 
       if (from >= 256) {
@@ -2456,10 +2455,10 @@ const char *did_set_langmap(optset_T *args FUNC_ATTR_UNUSED)
           p = p2;
           if (p[0] != NUL) {
             if (p[0] != ',') {
-              // TODO(vim): Need to use errbuf argument for this error
-              // message and return it.
-              semsg(_("E358: 'langmap': Extra characters after semicolon: %s"), p);
-              return NULL;
+              snprintf(args->os_errbuf, args->os_errbuflen,
+                       _("E358: 'langmap': Extra characters after semicolon: %s"),
+                       p);
+              return args->os_errbuf;
             }
             p++;
           }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5628,11 +5628,12 @@ static void op_colon(oparg_T *oap)
 static Callback opfunc_cb;
 
 /// Process the 'operatorfunc' option value.
-void set_operatorfunc_option(const char **errmsg)
+const char *did_set_operatorfunc(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (option_set_callback_func(p_opfunc, &opfunc_cb) == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
 #if defined(EXITFREE)

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1854,10 +1854,10 @@ static void didset_options2(void)
   highlight_changed();
 
   // Parse default for 'fillchars'.
-  (void)set_chars_option(curwin, &curwin->w_p_fcs, true);
+  (void)set_fillchars_option(curwin, curwin->w_p_fcs, true);
 
   // Parse default for 'listchars'.
-  (void)set_chars_option(curwin, &curwin->w_p_lcs, true);
+  (void)set_listchars_option(curwin, curwin->w_p_lcs, true);
 
   // Parse default for 'wildmode'.
   check_opt_wim();
@@ -4164,12 +4164,12 @@ void unset_global_local_option(char *name, void *from)
     break;
   case PV_LCS:
     clear_string_option(&((win_T *)from)->w_p_lcs);
-    set_chars_option((win_T *)from, &((win_T *)from)->w_p_lcs, true);
+    set_listchars_option((win_T *)from, ((win_T *)from)->w_p_lcs, true);
     redraw_later((win_T *)from, UPD_NOT_VALID);
     break;
   case PV_FCS:
     clear_string_option(&((win_T *)from)->w_p_fcs);
-    set_chars_option((win_T *)from, &((win_T *)from)->w_p_fcs, true);
+    set_fillchars_option((win_T *)from, ((win_T *)from)->w_p_fcs, true);
     redraw_later((win_T *)from, UPD_NOT_VALID);
     break;
   case PV_VE:
@@ -4749,8 +4749,8 @@ void didset_window_options(win_T *wp, bool valid_cursor)
   check_colorcolumn(wp);
   briopt_check(wp);
   fill_culopt_flags(NULL, wp);
-  set_chars_option(wp, &wp->w_p_fcs, true);
-  set_chars_option(wp, &wp->w_p_lcs, true);
+  set_fillchars_option(wp, wp->w_p_fcs, true);
+  set_listchars_option(wp, wp->w_p_lcs, true);
   parse_winhl_opt(wp);  // sets w_hl_needs_update also for w_p_winbl
   check_blending(wp);
   set_winbar_win(wp, false, valid_cursor);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -136,17 +136,6 @@ static long p_tw_nopaste;
 static long p_wm_nopaste;
 static char *p_vsts_nopaste;
 
-// options[] is initialized here.
-// The order of the options MUST be alphabetic for ":set all" and findoption().
-// All option names MUST start with a lowercase letter (for findoption()).
-// Exception: "t_" options are at the end.
-// The options with a NULL variable are 'hidden': a set command for them is
-// ignored and they are not printed.
-
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "options.generated.h"
-#endif
-
 #define OPTION_COUNT ARRAY_SIZE(options)
 
 typedef enum {
@@ -158,6 +147,17 @@ typedef enum {
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "option.c.generated.h"
+#endif
+
+// options[] is initialized here.
+// The order of the options MUST be alphabetic for ":set all" and findoption().
+// All option names MUST start with a lowercase letter (for findoption()).
+// Exception: "t_" options are at the end.
+// The options with a NULL variable are 'hidden': a set command for them is
+// ignored and they are not printed.
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "options.generated.h"
 #endif
 
 void set_init_tablocal(void)
@@ -2102,7 +2102,7 @@ static const char *did_set_force_off(bool *doskip)
 }
 
 /// Process the updated 'langremap' option value.
-const char *did_set_langremap(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_langremap(optset_T *args FUNC_ATTR_UNUSED)
 {
   // 'langremap' -> !'langnoremap'
   p_lnr = !p_lrm;
@@ -2110,7 +2110,7 @@ const char *did_set_langremap(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'langnoremap' option value.
-const char *did_set_langnoremap(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_langnoremap(optset_T *args FUNC_ATTR_UNUSED)
 {
   // 'langnoremap' -> !'langremap'
   p_lrm = !p_lnr;
@@ -2118,7 +2118,7 @@ const char *did_set_langnoremap(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'undofile' option value.
-const char *did_set_undofile(optset_T *args)
+static const char *did_set_undofile(optset_T *args)
 {
   // Only take action when the option was set.
   if (!curbuf->b_p_udf && !p_udf) {
@@ -2146,7 +2146,7 @@ const char *did_set_undofile(optset_T *args)
 }
 
 /// Process the updated 'readonly' option value.
-const char *did_set_readonly(optset_T *args)
+static const char *did_set_readonly(optset_T *args)
 {
   // when 'readonly' is reset globally, also reset readonlymode
   if (!curbuf->b_p_ro && (args->os_flags & OPT_LOCAL) == 0) {
@@ -2164,7 +2164,7 @@ const char *did_set_readonly(optset_T *args)
 }
 
 /// Process the updated 'modifiable' option value.
-const char *did_set_modifiable(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_modifiable(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'modifiable' is changed, redraw the window title
   redraw_titles();
@@ -2174,7 +2174,7 @@ const char *did_set_modifiable(optset_T *args FUNC_ATTR_UNUSED)
 
 /// Process the updated 'endoffile' or 'endofline' or 'fixendofline' or 'bomb'
 /// option value.
-const char *did_set_eof_eol_fixeol_bomb(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_eof_eol_fixeol_bomb(optset_T *args FUNC_ATTR_UNUSED)
 {
   // redraw the window title and tab page text
   redraw_titles();
@@ -2182,7 +2182,7 @@ const char *did_set_eof_eol_fixeol_bomb(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'binary' option value.
-const char *did_set_binary(optset_T *args)
+static const char *did_set_binary(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
 
@@ -2194,7 +2194,7 @@ const char *did_set_binary(optset_T *args)
 }
 
 /// Process the updated 'buflisted' option value.
-const char *did_set_buflisted(optset_T *args)
+static const char *did_set_buflisted(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
 
@@ -2207,7 +2207,7 @@ const char *did_set_buflisted(optset_T *args)
 }
 
 /// Process the updated 'swapfile' option value.
-const char *did_set_swapfile(optset_T *args)
+static const char *did_set_swapfile(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   // when 'swf' is set, create swapfile, when reset remove swapfile
@@ -2222,7 +2222,7 @@ const char *did_set_swapfile(optset_T *args)
 }
 
 /// Process the updated 'paste' option value.
-const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'paste' is set or reset also change other options
   paste_option_changed();
@@ -2230,7 +2230,7 @@ const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'ignorecase' option value.
-const char *did_set_ignorecase(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_ignorecase(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'ignorecase' is set or reset and 'hlsearch' is set, redraw
   if (p_hls) {
@@ -2240,7 +2240,7 @@ const char *did_set_ignorecase(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'hlsearch' option value.
-const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'hlsearch' is set or reset: reset no_hlsearch
   set_no_hlsearch(false);
@@ -2248,7 +2248,7 @@ const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'scrollbind' option value.
-const char *did_set_scrollbind(optset_T *args)
+static const char *did_set_scrollbind(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
 
@@ -2263,7 +2263,7 @@ const char *did_set_scrollbind(optset_T *args)
 }
 
 /// Process the updated 'previewwindow' option value.
-const char *did_set_previewwindow(optset_T *args)
+static const char *did_set_previewwindow(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
 
@@ -2284,7 +2284,7 @@ const char *did_set_previewwindow(optset_T *args)
 }
 
 /// Process the updated 'lisp' option value.
-const char *did_set_lisp(optset_T *args)
+static const char *did_set_lisp(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   // When 'lisp' option changes include/exclude '-' in keyword characters.
@@ -2293,7 +2293,7 @@ const char *did_set_lisp(optset_T *args)
 }
 
 /// Process the updated 'title' or the 'icon' option value.
-const char *did_set_title_icon(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_title_icon(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'title' changed, may need to change the title; same for 'icon'
   did_set_title();
@@ -2301,7 +2301,7 @@ const char *did_set_title_icon(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'modified' option value.
-const char *did_set_modified(optset_T *args)
+static const char *did_set_modified(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   if (!args->os_newval.boolean) {
@@ -2314,7 +2314,7 @@ const char *did_set_modified(optset_T *args)
 
 #ifdef BACKSLASH_IN_FILENAME
 /// Process the updated 'shellslash' option value.
-const char *did_set_shellslash(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_shellslash(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (p_ssl) {
     psepc = '/';
@@ -2335,7 +2335,7 @@ const char *did_set_shellslash(optset_T *args FUNC_ATTR_UNUSED)
 #endif
 
 /// Process the updated 'wrap' option value.
-const char *did_set_wrap(optset_T *args)
+static const char *did_set_wrap(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
 
@@ -2347,7 +2347,7 @@ const char *did_set_wrap(optset_T *args)
 }
 
 /// Process the updated 'equalalways' option value.
-const char *did_set_equalalways(optset_T *args)
+static const char *did_set_equalalways(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   if (p_ea && !args->os_oldval.boolean) {
@@ -2358,7 +2358,7 @@ const char *did_set_equalalways(optset_T *args)
 }
 
 /// Process the updated 'autochdir' option value.
-const char *did_set_autochdir(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_autochdir(optset_T *args FUNC_ATTR_UNUSED)
 {
   // Change directories when the 'acd' option is set now.
   do_autochdir();
@@ -2366,7 +2366,7 @@ const char *did_set_autochdir(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the updated 'diff' option value.
-const char *did_set_diff(optset_T *args)
+static const char *did_set_diff(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   // May add or remove the buffer from the list of diff buffers.
@@ -2378,7 +2378,7 @@ const char *did_set_diff(optset_T *args)
 }
 
 /// Process the updated 'spell' option value.
-const char *did_set_spell(optset_T *args)
+static const char *did_set_spell(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   if (win->w_p_spell) {
@@ -2389,7 +2389,7 @@ const char *did_set_spell(optset_T *args)
 }
 
 /// Process the updated 'arabic' option value.
-const char *did_set_arabic(optset_T *args)
+static const char *did_set_arabic(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   const char *errmsg = NULL;
@@ -2450,7 +2450,7 @@ const char *did_set_arabic(optset_T *args)
 }
 
 /// Process the updated 'number' or 'relativenumber' option value.
-const char *did_set_number_relativenumber(optset_T *args)
+static const char *did_set_number_relativenumber(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   if (*win->w_p_stc != NUL) {
@@ -2550,7 +2550,7 @@ static const char *set_bool_option(const int opt_idx, char *const varp, const in
 }
 
 /// Process the new 'winheight' value.
-const char *did_set_winheight(optset_T *args)
+static const char *did_set_winheight(optset_T *args)
 {
   // Change window height NOW
   if (!ONE_WINDOW) {
@@ -2564,7 +2564,7 @@ const char *did_set_winheight(optset_T *args)
 }
 
 /// Process the new 'helpheight' option value.
-const char *did_set_helpheight(optset_T *args)
+static const char *did_set_helpheight(optset_T *args)
 {
   // Change window height NOW
   if (!ONE_WINDOW) {
@@ -2579,7 +2579,7 @@ const char *did_set_helpheight(optset_T *args)
 }
 
 /// Process the new 'winwidth' option value.
-const char *did_set_winwidth(optset_T *args)
+static const char *did_set_winwidth(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
 
@@ -2590,7 +2590,7 @@ const char *did_set_winwidth(optset_T *args)
 }
 
 /// Process the new 'laststatus' option value.
-const char *did_set_laststatus(optset_T *args)
+static const char *did_set_laststatus(optset_T *args)
 {
   long old_value = args->os_oldval.number;
   long value = args->os_newval.number;
@@ -2614,7 +2614,7 @@ const char *did_set_laststatus(optset_T *args)
 }
 
 /// Process the new 'showtabline' option value.
-const char *did_set_showtabline(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_showtabline(optset_T *args FUNC_ATTR_UNUSED)
 {
   // (re)set tab page line
   win_new_screen_rows();  // recompute window positions and heights
@@ -2622,14 +2622,14 @@ const char *did_set_showtabline(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the new 'foldlevel' option value.
-const char *did_set_foldlevel(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_foldlevel(optset_T *args FUNC_ATTR_UNUSED)
 {
   newFoldLevel();
   return NULL;
 }
 
 /// Process the new 'foldminlines' option value.
-const char *did_set_foldminlines(optset_T *args)
+static const char *did_set_foldminlines(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   foldUpdateAll(win);
@@ -2637,7 +2637,7 @@ const char *did_set_foldminlines(optset_T *args)
 }
 
 /// Process the new 'foldnestmax' option value.
-const char *did_set_foldnestmax(optset_T *args)
+static const char *did_set_foldnestmax(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   if (foldmethodIsSyntax(win) || foldmethodIsIndent(win)) {
@@ -2647,7 +2647,7 @@ const char *did_set_foldnestmax(optset_T *args)
 }
 
 /// Process the new 'shiftwidth' or the 'tabstop' option value.
-const char *did_set_shiftwidth_tabstop(optset_T *args)
+static const char *did_set_shiftwidth_tabstop(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   win_T *win = (win_T *)args->os_win;
@@ -2666,7 +2666,7 @@ const char *did_set_shiftwidth_tabstop(optset_T *args)
 }
 
 /// Process the new 'iminset' option value.
-const char *did_set_iminsert(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_iminsert(optset_T *args FUNC_ATTR_UNUSED)
 {
   showmode();
   // Show/unshow value of 'keymap' in status lines.
@@ -2676,7 +2676,7 @@ const char *did_set_iminsert(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the new 'window' option value.
-const char *did_set_window(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_window(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (p_window < 1) {
     p_window = Rows - 1;
@@ -2687,7 +2687,7 @@ const char *did_set_window(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the new 'titlelen' option value.
-const char *did_set_titlelen(optset_T *args)
+static const char *did_set_titlelen(optset_T *args)
 {
   long old_value = args->os_oldval.number;
 
@@ -2700,7 +2700,7 @@ const char *did_set_titlelen(optset_T *args)
 }
 
 /// Process the new 'cmdheight' option value.
-const char *did_set_cmdheight(optset_T *args)
+static const char *did_set_cmdheight(optset_T *args)
 {
   long old_value = args->os_oldval.number;
 
@@ -2724,7 +2724,7 @@ const char *did_set_cmdheight(optset_T *args)
 }
 
 /// Process the new 'updatecount' option value.
-const char *did_set_updatecount(optset_T *args)
+static const char *did_set_updatecount(optset_T *args)
 {
   long old_value = args->os_oldval.number;
 
@@ -2737,7 +2737,7 @@ const char *did_set_updatecount(optset_T *args)
 }
 
 /// Process the new 'pumblend' option value.
-const char *did_set_pumblend(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_pumblend(optset_T *args FUNC_ATTR_UNUSED)
 {
   p_pb = MAX(MIN(p_pb, 100), 0);
   hl_invalidate_blends();
@@ -2771,7 +2771,7 @@ const char *did_set_buflocal_undolevels(buf_T *buf, long value, long old_value)
 }
 
 /// Process the new 'scrollback' option value.
-const char *did_set_scrollback(optset_T *args)
+static const char *did_set_scrollback(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   long old_value = args->os_oldval.number;
@@ -2785,7 +2785,7 @@ const char *did_set_scrollback(optset_T *args)
 }
 
 /// Process the new 'numberwidth' option value.
-const char *did_set_numberwidth(optset_T *args)
+static const char *did_set_numberwidth(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   win->w_nrwidth_line_count = 0;  // trigger a redraw
@@ -2794,7 +2794,7 @@ const char *did_set_numberwidth(optset_T *args)
 }
 
 /// Process the new 'textwidth' option value.
-const char *did_set_textwidth(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_textwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     check_colorcolumn(wp);
@@ -2804,7 +2804,7 @@ const char *did_set_textwidth(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// Process the new 'winblend' option value.
-const char *did_set_winblend(optset_T *args)
+static const char *did_set_winblend(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   long old_value = args->os_oldval.number;
@@ -2820,7 +2820,7 @@ const char *did_set_winblend(optset_T *args)
 }
 
 /// Process the new 'undolevels' option value.
-const char *did_set_undolevels(optset_T *args)
+static const char *did_set_undolevels(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   long *pp = (long *)args->os_varp;
@@ -5655,7 +5655,7 @@ void reset_option_was_set(const char *name)
 }
 
 /// Called when the 'breakat' option changes value.
-const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
+static const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
 {
   for (int i = 0; i < 256; i++) {
     breakat_flags[i] = false;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2510,6 +2510,8 @@ static const char *set_bool_option(const int opt_idx, char *const varp, const in
       .os_oldval.boolean = old_value,
       .os_newval.boolean = value,
       .os_doskip = false,
+      .os_errbuf = NULL,
+      .os_errbuflen = 0,
       .os_buf = curbuf,
       .os_win = curwin
     };
@@ -3100,6 +3102,8 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
       .os_flags = opt_flags,
       .os_oldval.number = old_value,
       .os_newval.number = value,
+      .os_errbuf = NULL,
+      .os_errbuflen = 0,
       .os_buf = curbuf,
       .os_win = curwin
     };

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -84,6 +84,7 @@
 #include "nvim/path.h"
 #include "nvim/popupmenu.h"
 #include "nvim/pos.h"
+#include "nvim/quickfix.h"
 #include "nvim/regexp.h"
 #include "nvim/runtime.h"
 #include "nvim/search.h"
@@ -1237,7 +1238,7 @@ static void do_set_option_string(int opt_idx, int opt_flags, char **argp, int ne
     // Handle side effects, and set the global value for ":set" on local
     // options. Note: when setting 'syntax' or 'filetype' autocommands may
     // be triggered that can cause havoc.
-    *errmsg = did_set_string_option(opt_idx, (char **)varp, oldval,
+    *errmsg = did_set_string_option(opt_idx, (char **)varp, oldval, newval,
                                     errbuf, errbuflen,
                                     opt_flags, value_checked);
 
@@ -1840,9 +1841,9 @@ static void didset_options(void)
   (void)compile_cap_prog(curwin->w_s);
   (void)did_set_spell_option(true);
   // set cedit_key
-  (void)check_cedit();
+  (void)did_set_cedit(NULL);
   // initialize the table for 'breakat'.
-  fill_breakat_flags();
+  (void)did_set_breakat(NULL);
   didset_window_options(curwin, true);
 }
 
@@ -2101,25 +2102,27 @@ static const char *did_set_force_off(bool *doskip)
 }
 
 /// Process the updated 'langremap' option value.
-static void did_set_langremap(void)
+const char *did_set_langremap(optset_T *args FUNC_ATTR_UNUSED)
 {
   // 'langremap' -> !'langnoremap'
   p_lnr = !p_lrm;
+  return NULL;
 }
 
 /// Process the updated 'langnoremap' option value.
-static void did_set_langnoremap(void)
+const char *did_set_langnoremap(optset_T *args FUNC_ATTR_UNUSED)
 {
   // 'langnoremap' -> !'langremap'
   p_lrm = !p_lnr;
+  return NULL;
 }
 
 /// Process the updated 'undofile' option value.
-static void did_set_undofile(int opt_flags)
+const char *did_set_undofile(optset_T *args)
 {
   // Only take action when the option was set.
   if (!curbuf->b_p_udf && !p_udf) {
-    return;
+    return NULL;
   }
 
   // When reset we do not delete the undo file, the option may be set again
@@ -2132,19 +2135,21 @@ static void did_set_undofile(int opt_flags)
     // if one exists, the buffer wasn't changed and the buffer was
     // loaded
     if ((curbuf == bp
-         || (opt_flags & OPT_GLOBAL) || opt_flags == 0)
+         || (args->os_flags & OPT_GLOBAL) || args->os_flags == 0)
         && !bufIsChanged(bp) && bp->b_ml.ml_mfp != NULL) {
       u_compute_hash(bp, hash);
       u_read_undo(NULL, hash, bp->b_fname);
     }
   }
+
+  return NULL;
 }
 
 /// Process the updated 'readonly' option value.
-static void did_set_readonly(int opt_flags)
+const char *did_set_readonly(optset_T *args)
 {
   // when 'readonly' is reset globally, also reset readonlymode
-  if (!curbuf->b_p_ro && (opt_flags & OPT_LOCAL) == 0) {
+  if (!curbuf->b_p_ro && (args->os_flags & OPT_LOCAL) == 0) {
     readonlymode = false;
   }
 
@@ -2154,10 +2159,12 @@ static void did_set_readonly(int opt_flags)
   }
 
   redraw_titles();
+
+  return NULL;
 }
 
 /// Process the updated 'modifiable' option value.
-static char *did_set_modifiable(void)
+const char *did_set_modifiable(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'modifiable' is changed, redraw the window title
   redraw_titles();
@@ -2167,90 +2174,108 @@ static char *did_set_modifiable(void)
 
 /// Process the updated 'endoffile' or 'endofline' or 'fixendofline' or 'bomb'
 /// option value.
-static void did_set_eof_eol_fixeol_bomb(void)
+const char *did_set_eof_eol_fixeol_bomb(optset_T *args FUNC_ATTR_UNUSED)
 {
   // redraw the window title and tab page text
   redraw_titles();
+  return NULL;
 }
 
 /// Process the updated 'binary' option value.
-static void did_set_binary(int opt_flags, long old_value)
+const char *did_set_binary(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+
   // when 'bin' is set also set some other options
-  set_options_bin((int)old_value, curbuf->b_p_bin, opt_flags);
+  set_options_bin((int)args->os_oldval.boolean, buf->b_p_bin, args->os_flags);
   redraw_titles();
+
+  return NULL;
 }
 
 /// Process the updated 'buflisted' option value.
-static void did_set_buflisted(long old_value)
+const char *did_set_buflisted(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+
   // when 'buflisted' changes, trigger autocommands
-  if (old_value != curbuf->b_p_bl) {
-    apply_autocmds(curbuf->b_p_bl ? EVENT_BUFADD : EVENT_BUFDELETE,
-                   NULL, NULL, true, curbuf);
+  if (args->os_oldval.boolean != buf->b_p_bl) {
+    apply_autocmds(buf->b_p_bl ? EVENT_BUFADD : EVENT_BUFDELETE,
+                   NULL, NULL, true, buf);
   }
+  return NULL;
 }
 
 /// Process the updated 'swapfile' option value.
-static void did_set_swapfile(void)
+const char *did_set_swapfile(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
   // when 'swf' is set, create swapfile, when reset remove swapfile
-  if (curbuf->b_p_swf && p_uc) {
-    ml_open_file(curbuf);                     // create the swap file
+  if (buf->b_p_swf && p_uc) {
+    ml_open_file(buf);                     // create the swap file
   } else {
     // no need to reset curbuf->b_may_swap, ml_open_file() will check
     // buf->b_p_swf
-    mf_close_file(curbuf, true);              // remove the swap file
+    mf_close_file(buf, true);              // remove the swap file
   }
+  return NULL;
 }
 
 /// Process the updated 'paste' option value.
-static void did_set_paste(void)
+const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'paste' is set or reset also change other options
   paste_option_changed();
+  return NULL;
 }
 
 /// Process the updated 'ignorecase' option value.
-static void did_set_ignorecase(void)
+const char *did_set_ignorecase(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'ignorecase' is set or reset and 'hlsearch' is set, redraw
   if (p_hls) {
     redraw_all_later(UPD_SOME_VALID);
   }
+  return NULL;
 }
 
 /// Process the updated 'hlsearch' option value.
-static void did_set_hlsearch(void)
+const char *did_set_hlsearch(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'hlsearch' is set or reset: reset no_hlsearch
   set_no_hlsearch(false);
+  return NULL;
 }
 
 /// Process the updated 'scrollbind' option value.
-static void did_set_scrollbind(void)
+const char *did_set_scrollbind(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
+
   // when 'scrollbind' is set: snapshot the current position to avoid a jump
   // at the end of normal_cmd()
-  if (!curwin->w_p_scb) {
-    return;
+  if (!win->w_p_scb) {
+    return NULL;
   }
   do_check_scrollbind(false);
-  curwin->w_scbind_pos = curwin->w_topline;
+  win->w_scbind_pos = win->w_topline;
+  return NULL;
 }
 
 /// Process the updated 'previewwindow' option value.
-static const char *did_set_previewwindow(bool *doskip)
+const char *did_set_previewwindow(optset_T *args)
 {
-  if (!curwin->w_p_pvw) {
+  win_T *win = (win_T *)args->os_win;
+
+  if (!win->w_p_pvw) {
     return NULL;
   }
 
   // There can be only one window with 'previewwindow' set.
-  FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
-    if (win->w_p_pvw && win != curwin) {
-      curwin->w_p_pvw = false;
-      *doskip = true;
+  FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    if (wp->w_p_pvw && wp != win) {
+      win->w_p_pvw = false;
+      args->os_doskip = true;
       return e_preview_window_already_exists;
     }
   }
@@ -2259,32 +2284,37 @@ static const char *did_set_previewwindow(bool *doskip)
 }
 
 /// Process the updated 'lisp' option value.
-static void did_set_lisp(void)
+const char *did_set_lisp(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
   // When 'lisp' option changes include/exclude '-' in keyword characters.
-  (void)buf_init_chartab(curbuf, false);          // ignore errors
+  (void)buf_init_chartab(buf, false);          // ignore errors
+  return NULL;
 }
 
 /// Process the updated 'title' or the 'icon' option value.
-static void did_set_title_icon(void)
+const char *did_set_title_icon(optset_T *args FUNC_ATTR_UNUSED)
 {
   // when 'title' changed, may need to change the title; same for 'icon'
   did_set_title();
+  return NULL;
 }
 
 /// Process the updated 'modified' option value.
-static void did_set_modified(long value)
+const char *did_set_modified(optset_T *args)
 {
-  if (!value) {
-    save_file_ff(curbuf);  // Buffer is unchanged
+  buf_T *buf = (buf_T *)args->os_buf;
+  if (!args->os_newval.boolean) {
+    save_file_ff(buf);  // Buffer is unchanged
   }
   redraw_titles();
-  modified_was_set = (int)value;
+  modified_was_set = (int)args->os_newval.boolean;
+  return NULL;
 }
 
 #ifdef BACKSLASH_IN_FILENAME
 /// Process the updated 'shellslash' option value.
-static void did_set_shellslash(void)
+const char *did_set_shellslash(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (p_ssl) {
     psepc = '/';
@@ -2300,63 +2330,76 @@ static void did_set_shellslash(void)
   buflist_slash_adjust();
   alist_slash_adjust();
   scriptnames_slash_adjust();
+  return NULL;
 }
 #endif
 
 /// Process the updated 'wrap' option value.
-static void did_set_wrap(void)
+const char *did_set_wrap(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
+
   // If 'wrap' is set, set w_leftcol to zero.
-  if (curwin->w_p_wrap) {
-    curwin->w_leftcol = 0;
+  if (win->w_p_wrap) {
+    win->w_leftcol = 0;
   }
+  return NULL;
 }
 
 /// Process the updated 'equalalways' option value.
-static void did_set_equalalways(long old_value)
+const char *did_set_equalalways(optset_T *args)
 {
-  if (p_ea && !old_value) {
-    win_equal(curwin, false, 0);
+  win_T *win = (win_T *)args->os_win;
+  if (p_ea && !args->os_oldval.boolean) {
+    win_equal(win, false, 0);
   }
+
+  return NULL;
 }
 
 /// Process the updated 'autochdir' option value.
-static void did_set_autochdir(void)
+const char *did_set_autochdir(optset_T *args FUNC_ATTR_UNUSED)
 {
   // Change directories when the 'acd' option is set now.
   do_autochdir();
+  return NULL;
 }
 
 /// Process the updated 'diff' option value.
-static void did_set_diff(void)
+const char *did_set_diff(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   // May add or remove the buffer from the list of diff buffers.
-  diff_buf_adjust(curwin);
-  if (foldmethodIsDiff(curwin)) {
-    foldUpdateAll(curwin);
+  diff_buf_adjust(win);
+  if (foldmethodIsDiff(win)) {
+    foldUpdateAll(win);
   }
+  return NULL;
 }
 
 /// Process the updated 'spell' option value.
-static char *did_set_spell(void)
+const char *did_set_spell(optset_T *args)
 {
-  if (curwin->w_p_spell) {
-    return did_set_spelllang(curwin);
+  win_T *win = (win_T *)args->os_win;
+  if (win->w_p_spell) {
+    return parse_spelllang(win);
   }
 
   return NULL;
 }
 
 /// Process the updated 'arabic' option value.
-static const char *did_set_arabic(void)
+const char *did_set_arabic(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   const char *errmsg = NULL;
-  if (curwin->w_p_arab) {
+
+  if (win->w_p_arab) {
     // 'arabic' is set, handle various sub-settings.
     if (!p_tbidi) {
       // set rightleft mode
-      if (!curwin->w_p_rl) {
-        curwin->w_p_rl = true;
+      if (!win->w_p_rl) {
+        win->w_p_rl = true;
         changed_window_setting();
       }
 
@@ -2386,8 +2429,8 @@ static const char *did_set_arabic(void)
     // 'arabic' is reset, handle various sub-settings.
     if (!p_tbidi) {
       // reset rightleft mode
-      if (curwin->w_p_rl) {
-        curwin->w_p_rl = false;
+      if (win->w_p_rl) {
+        win->w_p_rl = false;
         changed_window_setting();
       }
 
@@ -2406,85 +2449,15 @@ static const char *did_set_arabic(void)
   return errmsg;
 }
 
-static void did_set_number_relativenumber(void)
+/// Process the updated 'number' or 'relativenumber' option value.
+const char *did_set_number_relativenumber(optset_T *args)
 {
-  if (*curwin->w_p_stc != NUL) {
+  win_T *win = (win_T *)args->os_win;
+  if (*win->w_p_stc != NUL) {
     // When 'relativenumber'/'number' is changed and 'statuscolumn' is set, reset width.
-    curwin->w_nrwidth_line_count = 0;
+    win->w_nrwidth_line_count = 0;
   }
-}
-
-/// When some boolean options are changed, need to take some action.
-static const char *did_set_bool_option(const char *varp, int opt_flags, long value, long old_value,
-                                       bool *doskip)
-{
-  const char *errmsg = NULL;
-
-  if ((int *)varp == &p_force_on) {
-    errmsg = did_set_force_on(doskip);
-  } else if ((int *)varp == &p_force_off) {
-    errmsg = did_set_force_off(doskip);
-  } else if ((int *)varp == &p_lrm) {              // 'langremap'
-    did_set_langremap();
-  } else if ((int *)varp == &p_lnr) {              // 'langnoremap'
-    did_set_langnoremap();
-  } else if ((int *)varp == &curbuf->b_p_udf      // buffer local 'undofile'
-             || (int *)varp == &p_udf) {         // 'undofile'
-    did_set_undofile(opt_flags);
-  } else if ((int *)varp == &curbuf->b_p_ro) {     // 'readonly'
-    did_set_readonly(opt_flags);
-  } else if ((int *)varp == &curbuf->b_p_ma) {
-    errmsg = did_set_modifiable();        // 'modifiable'
-  } else if ((int *)varp == &curbuf->b_p_eof      // 'endoffile'
-             || (int *)varp == &curbuf->b_p_eol  // 'endofline'
-             || (int *)varp == &curbuf->b_p_fixeol       // 'fixendofline'
-             || (int *)varp == &curbuf->b_p_bomb) {      // 'bomb'
-    did_set_eof_eol_fixeol_bomb();
-  } else if ((int *)varp == &curbuf->b_p_bin) {    // 'binary'
-    did_set_binary(opt_flags, old_value);
-  } else if ((int *)varp == &curbuf->b_p_bl) {     // 'buflisted'
-    did_set_buflisted(old_value);
-  } else if ((int *)varp == &curbuf->b_p_swf) {    // 'swapfile'
-    did_set_swapfile();
-  } else if ((int *)varp == &p_paste) {            // 'paste'
-    did_set_paste();
-  } else if ((int *)varp == &p_ic) {       // 'ignorecase'
-    did_set_ignorecase();
-  } else if ((int *)varp == &p_hls) {      // 'hlsearch'
-    did_set_hlsearch();
-  } else if ((int *)varp == &curwin->w_p_scb) {    // 'scrollbind'
-    did_set_scrollbind();
-  } else if ((int *)varp == &curwin->w_p_pvw) {    // 'previewwindow'
-    errmsg = did_set_previewwindow(doskip);
-  } else if (varp == (char *)&(curbuf->b_p_lisp)) {      // 'lisp'
-    did_set_lisp();
-  } else if ((int *)varp == &p_title            // 'title'
-             || (int *)varp == &p_icon) {        // 'icon'
-    did_set_title_icon();
-  } else if ((int *)varp == &curbuf->b_changed) {  // 'modified'
-    did_set_modified(value);
-#ifdef BACKSLASH_IN_FILENAME
-  } else if ((int *)varp == &p_ssl) {              // 'shellslash'
-    did_set_shellslash();
-#endif
-  } else if ((int *)varp == &curwin->w_p_wrap) {   // 'wrap'
-    did_set_wrap();
-  } else if ((int *)varp == &p_ea) {               // 'equalalways'
-    did_set_equalalways(old_value);
-  } else if ((int *)varp == &p_acd) {              // 'autochdir'
-    did_set_autochdir();
-  } else if ((int *)varp == &curwin->w_p_diff) {   // 'diff'
-    did_set_diff();
-  } else if ((int *)varp == &curwin->w_p_spell) {  // 'spell'
-    errmsg = did_set_spell();
-  } else if ((int *)varp == &curwin->w_p_arab) {   // 'arabic'
-    errmsg = did_set_arabic();
-  } else if ((int *)varp == &curwin->w_p_nu        // 'number'
-             || (int *)varp == &curwin->w_p_rnu) {  // 'relativenumber'
-    did_set_number_relativenumber();
-  }
-
-  return errmsg;
+  return NULL;
 }
 
 /// Set the value of a boolean option, taking care of side effects
@@ -2524,8 +2497,26 @@ static const char *set_bool_option(const int opt_idx, char *const varp, const in
   }
 
   // Handle side effects for changing a bool option.
+  const char *errmsg = NULL;
   bool doskip = false;
-  const char *errmsg = did_set_bool_option(varp, opt_flags, value, old_value, &doskip);
+  if ((int *)varp == &p_force_on) {
+    errmsg = did_set_force_on(&doskip);
+  } else if ((int *)varp == &p_force_off) {
+    errmsg = did_set_force_off(&doskip);
+  } else if (options[opt_idx].opt_did_set_cb != NULL) {
+    optset_T args = {
+      .os_varp = varp,
+      .os_flags = opt_flags,
+      .os_oldval.boolean = old_value,
+      .os_newval.boolean = value,
+      .os_doskip = false,
+      .os_buf = curbuf,
+      .os_win = curwin
+    };
+
+    errmsg = options[opt_idx].opt_did_set_cb(&args);
+    doskip = args.os_doskip;
+  }
   if (doskip) {
     return errmsg;
   }
@@ -2557,38 +2548,51 @@ static const char *set_bool_option(const int opt_idx, char *const varp, const in
 }
 
 /// Process the new 'winheight' value.
-static void did_set_winheight(win_T *win, long value)
+const char *did_set_winheight(optset_T *args)
 {
   // Change window height NOW
   if (!ONE_WINDOW) {
-    if (win->w_height < value) {
-      win_setheight((int)value);
+    win_T *win = (win_T *)args->os_win;
+    if (win->w_height < p_wh) {
+      win_setheight((int)p_wh);
     }
   }
+
+  return NULL;
 }
 
 /// Process the new 'helpheight' option value.
-static void did_set_helpheight(buf_T *buf, win_T *win, long value)
+const char *did_set_helpheight(optset_T *args)
 {
   // Change window height NOW
   if (!ONE_WINDOW) {
-    if (buf->b_help && win->w_height < value) {
-      win_setheight((int)value);
+    buf_T *buf = (buf_T *)args->os_buf;
+    win_T *win = (win_T *)args->os_win;
+    if (buf->b_help && win->w_height < p_hh) {
+      win_setheight((int)p_hh);
     }
   }
+
+  return NULL;
 }
 
 /// Process the new 'winwidth' option value.
-static void did_set_winwidth(win_T *win, long value)
+const char *did_set_winwidth(optset_T *args)
 {
-  if (!ONE_WINDOW && win->w_width < value) {
-    win_setwidth((int)value);
+  win_T *win = (win_T *)args->os_win;
+
+  if (!ONE_WINDOW && win->w_width < p_wiw) {
+    win_setwidth((int)p_wiw);
   }
+  return NULL;
 }
 
 /// Process the new 'laststatus' option value.
-static void did_set_laststatus(long value, long old_value)
+const char *did_set_laststatus(optset_T *args)
 {
+  long old_value = args->os_oldval.number;
+  long value = args->os_newval.number;
+
   // When switching to global statusline, decrease topframe height
   // Also clear the cmdline to remove the ruler if there is one
   if (value == 3 && old_value != 3) {
@@ -2604,38 +2608,49 @@ static void did_set_laststatus(long value, long old_value)
   }
 
   last_status(false);  // (re)set last window status line.
+  return NULL;
 }
 
 /// Process the new 'showtabline' option value.
-static void did_set_showtabline(void)
+const char *did_set_showtabline(optset_T *args FUNC_ATTR_UNUSED)
 {
   // (re)set tab page line
   win_new_screen_rows();  // recompute window positions and heights
+  return NULL;
 }
 
 /// Process the new 'foldlevel' option value.
-static void did_set_foldlevel(void)
+const char *did_set_foldlevel(optset_T *args FUNC_ATTR_UNUSED)
 {
   newFoldLevel();
+  return NULL;
 }
 
 /// Process the new 'foldminlines' option value.
-static void did_set_foldminlines(win_T *win)
+const char *did_set_foldminlines(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   foldUpdateAll(win);
+  return NULL;
 }
 
 /// Process the new 'foldnestmax' option value.
-static void did_set_foldnestmax(win_T *win)
+const char *did_set_foldnestmax(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   if (foldmethodIsSyntax(win) || foldmethodIsIndent(win)) {
     foldUpdateAll(win);
   }
+  return NULL;
 }
 
 /// Process the new 'shiftwidth' or the 'tabstop' option value.
-static void did_set_shiftwidth_tabstop(buf_T *buf, win_T *win, const long *pp)
+const char *did_set_shiftwidth_tabstop(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  win_T *win = (win_T *)args->os_win;
+  long *pp = (long *)args->os_varp;
+
   if (foldmethodIsIndent(win)) {
     foldUpdateAll(win);
   }
@@ -2644,38 +2659,49 @@ static void did_set_shiftwidth_tabstop(buf_T *buf, win_T *win, const long *pp)
   if (pp == &buf->b_p_sw || buf->b_p_sw == 0) {
     parse_cino(buf);
   }
+
+  return NULL;
 }
 
 /// Process the new 'iminset' option value.
-static void did_set_iminsert(void)
+const char *did_set_iminsert(optset_T *args FUNC_ATTR_UNUSED)
 {
   showmode();
   // Show/unshow value of 'keymap' in status lines.
   status_redraw_curbuf();
+
+  return NULL;
 }
 
 /// Process the new 'window' option value.
-static void did_set_window(void)
+const char *did_set_window(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (p_window < 1) {
     p_window = Rows - 1;
   } else if (p_window >= Rows) {
     p_window = Rows - 1;
   }
+  return NULL;
 }
 
 /// Process the new 'titlelen' option value.
-static void did_set_titlelen(long old_value)
+const char *did_set_titlelen(optset_T *args)
 {
+  long old_value = args->os_oldval.number;
+
   // if 'titlelen' has changed, redraw the title
   if (starting != NO_SCREEN && old_value != p_titlelen) {
     need_maketitle = true;
   }
+
+  return NULL;
 }
 
 /// Process the new 'cmdheight' option value.
-static void did_set_cmdheight(long old_value)
+const char *did_set_cmdheight(optset_T *args)
 {
+  long old_value = args->os_oldval.number;
+
   if (ui_has(kUIMessages)) {
     p_ch = 0;
   }
@@ -2691,19 +2717,25 @@ static void did_set_cmdheight(long old_value)
       && full_screen) {
     command_height();
   }
+
+  return NULL;
 }
 
 /// Process the new 'updatecount' option value.
-static void did_set_updatecount(long old_value)
+const char *did_set_updatecount(optset_T *args)
 {
+  long old_value = args->os_oldval.number;
+
   // when 'updatecount' changes from zero to non-zero, open swap files
   if (p_uc && !old_value) {
     ml_open_files();
   }
+
+  return NULL;
 }
 
 /// Process the new 'pumblend' option value.
-static void did_set_pumblend(void)
+const char *did_set_pumblend(optset_T *args FUNC_ATTR_UNUSED)
 {
   p_pb = MAX(MIN(p_pb, 100), 0);
   hl_invalidate_blends();
@@ -2711,113 +2743,93 @@ static void did_set_pumblend(void)
   if (pum_drawn()) {
     pum_redraw();
   }
+
+  return NULL;
 }
 
 /// Process the new global 'undolevels' option value.
-static void did_set_global_undolevels(long value, long old_value)
+const char *did_set_global_undolevels(long value, long old_value)
 {
   // sync undo before 'undolevels' changes
   // use the old value, otherwise u_sync() may not work properly
   p_ul = old_value;
   u_sync(true);
   p_ul = value;
+  return NULL;
 }
 
 /// Process the new buffer local 'undolevels' option value.
-static void did_set_buflocal_undolevels(buf_T *buf, long value, long old_value)
+const char *did_set_buflocal_undolevels(buf_T *buf, long value, long old_value)
 {
   // use the old value, otherwise u_sync() may not work properly
   buf->b_p_ul = old_value;
   u_sync(true);
   buf->b_p_ul = value;
+  return NULL;
 }
 
 /// Process the new 'scrollback' option value.
-static void did_set_scrollback(buf_T *buf, long value, long old_value)
+const char *did_set_scrollback(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  long old_value = args->os_oldval.number;
+  long value = args->os_newval.number;
+
   if (buf->terminal && value < old_value) {
     // Force the scrollback to take immediate effect only when decreasing it.
     on_scrollback_option_changed(buf->terminal);
   }
+  return NULL;
 }
 
 /// Process the new 'numberwidth' option value.
-static void did_set_numberwidth(void)
+const char *did_set_numberwidth(optset_T *args)
 {
-  curwin->w_nrwidth_line_count = 0;  // trigger a redraw
+  win_T *win = (win_T *)args->os_win;
+  win->w_nrwidth_line_count = 0;  // trigger a redraw
+
+  return NULL;
 }
 
 /// Process the new 'textwidth' option value.
-static void did_set_textwidth(void)
+const char *did_set_textwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     check_colorcolumn(wp);
   }
+
+  return NULL;
 }
 
 /// Process the new 'winblend' option value.
-static void did_set_winblend(win_T *win, long value, long old_value)
+const char *did_set_winblend(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
+  long old_value = args->os_oldval.number;
+  long value = args->os_newval.number;
+
   if (value != old_value) {
     win->w_p_winbl = MAX(MIN(win->w_p_winbl, 100), 0);
     win->w_hl_needs_update = true;
     check_blending(curwin);
   }
+
+  return NULL;
 }
 
-/// When some number options are changed, need to take some action.
-static const char *did_set_num_option(long *pp, long value, long old_value, const char *errmsg)
+/// Process the new 'undolevels' option value.
+const char *did_set_undolevels(optset_T *args)
 {
-  if (pp == &p_wh) {      // 'winheight'
-    did_set_winheight(curwin, value);
-  } else if (pp == &p_hh) {  // 'helpheight'
-    did_set_helpheight(curbuf, curwin, value);
-  } else if (pp == &p_wmh) {  // 'winminheight'
-    did_set_winminheight();
-  } else if (pp == &p_wiw) {  // 'winwidth'
-    did_set_winwidth(curwin, value);
-  } else if (pp == &p_wmw) {  // 'winminwidth'
-    did_set_winminwidth();
-  } else if (pp == &p_window) {  // 'window'
-    did_set_window();
-  } else if (pp == &p_ls) {  // 'laststatus'
-    did_set_laststatus(value, old_value);
-  } else if (pp == &p_stal) {
-    did_set_showtabline();  // 'showtabline'
-  } else if (pp == &curwin->w_p_fdl) {
-    did_set_foldlevel();
-  } else if (pp == &curwin->w_p_fml) {
-    did_set_foldminlines(curwin);
-  } else if (pp == &curwin->w_p_fdn) {
-    did_set_foldnestmax(curwin);
-  } else if (pp == &curbuf->b_p_sw        // 'shiftwidth'
-             || pp == &curbuf->b_p_ts) {  // 'tabstop'
-    did_set_shiftwidth_tabstop(curbuf, curwin, pp);
-  } else if (pp == &curbuf->b_p_iminsert) {  // 'iminsert'
-    did_set_iminsert();
-  } else if (pp == &p_titlelen) {  // 'titlelen'
-    did_set_titlelen(old_value);
-  } else if (pp == &p_ch) {  // 'cmdheight'
-    did_set_cmdheight(old_value);
-  } else if (pp == &p_uc) {  // 'updatecount'
-    did_set_updatecount(old_value);
-  } else if (pp == &p_pb) {  // 'pumblend
-    did_set_pumblend();
-  } else if (pp == &p_ul) {  // global 'undolevels'
-    did_set_global_undolevels(value, old_value);
-  } else if (pp == &curbuf->b_p_ul) {  // buffer local 'undolevels'
-    did_set_buflocal_undolevels(curbuf, value, old_value);
-  } else if (pp == &curbuf->b_p_scbk || pp == &p_scbk) {
-    did_set_scrollback(curbuf, value, old_value);
-  } else if (pp == &curwin->w_p_nuw) {  // 'numberwidth'
-    did_set_numberwidth();
-  } else if (pp == &curbuf->b_p_tw) {  // 'textwidth'
-    did_set_textwidth();
-  } else if (pp == &curwin->w_p_winbl) {
-    did_set_winblend(curwin, value, old_value);
+  buf_T *buf = (buf_T *)args->os_buf;
+  long *pp = (long *)args->os_varp;
+
+  if (pp == &p_ul) {                  // global 'undolevels'
+    did_set_global_undolevels(args->os_newval.number, args->os_oldval.number);
+  } else if (pp == &curbuf->b_p_ul) {      // buffer local 'undolevels'
+    did_set_buflocal_undolevels(buf, args->os_newval.number, args->os_oldval.number);
   }
 
-  return errmsg;
+  return NULL;
 }
 
 /// Check the bounds of numeric options.
@@ -3080,8 +3092,19 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
   // Remember where the option was set.
   set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 
-  // Number options that need some action when changed
-  errmsg = did_set_num_option(pp, value, old_value, errmsg);
+  // Invoke the option specific callback function to validate and apply the
+  // new value.
+  if (options[opt_idx].opt_did_set_cb != NULL) {
+    optset_T args = {
+      .os_varp = varp,
+      .os_flags = opt_flags,
+      .os_oldval.number = old_value,
+      .os_newval.number = value,
+      .os_buf = curbuf,
+      .os_win = curwin
+    };
+    errmsg = options[opt_idx].opt_did_set_cb(&args);
+  }
 
   // Check the bounds for numeric options here
   errmsg = check_num_option_bounds(pp, old_value, old_Rows, errbuf, errbuflen, errmsg);
@@ -4562,6 +4585,12 @@ static inline char *get_varp(vimoption_T *p)
   return get_varp_from(p, curbuf, curwin);
 }
 
+/// Return the did_set callback function for the option at 'opt_idx'
+opt_did_set_cb_T get_option_did_set_cb(int opt_idx)
+{
+  return options[opt_idx].opt_did_set_cb;
+}
+
 /// Get the value of 'equalprg', either the buffer-local one or the global one.
 char *get_equalprg(void)
 {
@@ -5621,8 +5650,8 @@ void reset_option_was_set(const char *name)
   options[idx].flags &= ~P_WAS_SET;
 }
 
-/// fill_breakat_flags() -- called when 'breakat' changes value.
-void fill_breakat_flags(void)
+/// Called when the 'breakat' option changes value.
+const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
 {
   for (int i = 0; i < 256; i++) {
     breakat_flags[i] = false;
@@ -5633,6 +5662,8 @@ void fill_breakat_flags(void)
       breakat_flags[(uint8_t)(*p)] = true;
     }
   }
+
+  return NULL;
 }
 
 /// fill_culopt_flags() -- called when 'culopt' changes value

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -290,7 +290,7 @@ enum {
 #define GO_FOOTER       'F'             // add footer
 #define GO_VERTICAL     'v'             // arrange dialog buttons vertically
 #define GO_KEEPWINSIZE  'k'             // keep GUI window size
-#define GO_ALL "aAbcdefFghilmMprTvk"    // all possible flags for 'go'
+#define GO_ALL "!aAbcdefFghilLmMpPrRtTvk"  // all possible flags for 'go'
 
 // flags for 'comments' option
 #define COM_NEST        'n'             // comments strings nest
@@ -1001,6 +1001,12 @@ typedef struct {
   // When set by the called function: Stop processing the option further.
   // Currently only used for boolean options.
   int os_doskip;
+
+  // If the value specified for an option is not valid and the error message
+  // is parameterized, then the "os_errbuf" buffer is used to store the error
+  // message (when it is not NULL).
+  char *os_errbuf;
+  size_t os_errbuflen;
 
   void *os_win;
   void *os_buf;

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -1002,6 +1002,17 @@ typedef struct {
   // Currently only used for boolean options.
   int os_doskip;
 
+  // Option value was checked to be safe, no need to set P_INSECURE
+  // Used for the 'keymap', 'filetype' and 'syntax' options.
+  int os_value_checked;
+  // Option value changed.  Used for the 'filetype' and 'syntax' options.
+  int os_value_changed;
+
+  // Used by the 'isident', 'iskeyword', 'isprint' and 'isfname' options.
+  // Set to true if the character table is modified when processing the
+  // option and need to be restored because of a failure.
+  int os_restore_chartab;
+
   // If the value specified for an option is not valid and the error message
   // is parameterized, then the "os_errbuf" buffer is used to store the error
   // message (when it is not NULL).

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -981,8 +981,11 @@ enum {
 // Argument for the callback function (opt_did_set_cb_T) invoked after an
 // option value is modified.
 typedef struct {
+  // Pointer to the option variable.  The variable can be a long (numeric
+  // option), an int (boolean option) or a char pointer (string option).
+  char *os_varp;
+  int os_idx;
   int os_flags;
-  char *os_varp;  // pointer to the option variable
 
   // old value of the option (can be a string, number or a boolean)
   union {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -821,7 +821,8 @@ return {
       alloced=true,
       expand=true,
       varname='p_ft',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_filetype_or_syntax'
     },
     {
       full_name='fillchars', abbreviation='fcs',
@@ -1287,7 +1288,8 @@ return {
         -- ( and ) are used in text separating fnames */
         if_true="@,48-57,/,\\,.,-,_,+,,,#,$,%,{,},[,],:,@-@,!,~,=",
         if_false="@,48-57,/,.,-,_,+,,,#,$,%,~,="
-      }
+      },
+      cb='did_set_isopt'
     },
     {
       full_name='isident', abbreviation='isi',
@@ -1299,7 +1301,8 @@ return {
         condition='MSWIN',
         if_true="@,48-57,_,128-167,224-235",
         if_false="@,48-57,_,192-255"
-      }
+      },
+      cb='did_set_isopt'
     },
     {
       full_name='iskeyword', abbreviation='isk',
@@ -1308,7 +1311,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_isk',
-      defaults={if_true="@,48-57,_,192-255"}
+      defaults={if_true="@,48-57,_,192-255"},
+      cb='did_set_isopt'
     },
     {
       full_name='isprint', abbreviation='isp',
@@ -1317,7 +1321,8 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_isp',
-      defaults={if_true="@,161-255"}
+      defaults={if_true="@,161-255"},
+      cb='did_set_isopt'
     },
     {
       full_name='joinspaces', abbreviation='js',
@@ -1344,7 +1349,8 @@ return {
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_keymap', pv_name='p_kmap',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_keymap'
     },
     {
       full_name='keymodel', abbreviation='km',
@@ -1959,7 +1965,8 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="search"}
+      defaults={if_true="search"},
+      cb='did_set_rightleftcmd'
     },
     {
       full_name='ruler', abbreviation='ru',
@@ -2486,7 +2493,8 @@ return {
       normal_fname_chars=true,
       alloced=true,
       varname='p_syn',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_filetype_or_syntax'
     },
     {
       full_name='tagfunc', abbreviation='tfu',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -329,7 +329,8 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_ccv',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='cindent', abbreviation='cin',
@@ -425,7 +426,8 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_com',
-      defaults={if_true="s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"}
+      defaults={if_true="s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"},
+      cb='did_set_comments'
     },
     {
       full_name='commentstring', abbreviation='cms',
@@ -453,7 +455,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cpt',
-      defaults={if_true=".,w,b,u,t"}
+      defaults={if_true=".,w,b,u,t"},
+      cb='did_set_complete'
     },
     {
       full_name='concealcursor', abbreviation='cocu',
@@ -461,7 +464,8 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_concealcursor'
     },
     {
       full_name='conceallevel', abbreviation='cole',
@@ -518,7 +522,8 @@ return {
       type='string', list='flags', scope={'global'},
       redraw={'all_windows'},
       varname='p_cpo',
-      defaults={if_true=macros('CPO_VIM')}
+      defaults={if_true=macros('CPO_VIM')},
+      cb='did_set_cpoptions'
     },
     {
       full_name='cursorbind', abbreviation='crb',
@@ -600,7 +605,8 @@ return {
       secure=true,
       redraw={'curswant'},
       varname='p_dex',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='diffopt', abbreviation='dip',
@@ -869,7 +875,8 @@ return {
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="0"}
+      defaults={if_true="0"},
+      cb='did_set_foldexpr'
     },
     {
       full_name='foldignore', abbreviation='fdi',
@@ -948,7 +955,8 @@ return {
       modelineexpr=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="foldtext()"}
+      defaults={if_true="foldtext()"},
+      cb='did_set_optexpr'
     },
     {
       full_name='formatexpr', abbreviation='fex',
@@ -957,7 +965,8 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_fex',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='formatoptions', abbreviation='fo',
@@ -965,7 +974,8 @@ return {
       type='string', list='flags', scope={'buffer'},
       alloced=true,
       varname='p_fo',
-      defaults={if_true=macros('DFLT_FO_VIM')}
+      defaults={if_true=macros('DFLT_FO_VIM')},
+      cb='did_set_formatoptions'
     },
     {
       full_name='formatlistpat', abbreviation='flp',
@@ -1222,7 +1232,8 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_inex',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='incsearch', abbreviation='is',
@@ -1238,7 +1249,8 @@ return {
       modelineexpr=true,
       alloced=true,
       varname='p_inde',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='indentkeys', abbreviation='indk',
@@ -1623,7 +1635,8 @@ return {
       short_desc=N_("the use of mouse clicks"),
       type='string', list='flags', scope={'global'},
       varname='p_mouse',
-      defaults={if_true="nvi"}
+      defaults={if_true="nvi"},
+      cb='did_set_mouse'
     },
     {
       full_name='mousefocus', abbreviation='mousef',
@@ -1686,7 +1699,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_nf',
-      defaults={if_true="bin,hex"}
+      defaults={if_true="bin,hex"},
+      cb='did_set_nrformats'
     },
     {
       full_name='number', abbreviation='nu',
@@ -1771,7 +1785,8 @@ return {
       type='string', scope={'global'},
       secure=true,
       varname='p_pex',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_optexpr'
     },
     {
       full_name='patchmode', abbreviation='pm',
@@ -2197,7 +2212,8 @@ return {
       short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
       varname='p_shm',
-      defaults={if_true="filnxtToOF"}
+      defaults={if_true="filnxtToOF"},
+      cb='did_set_shortmess'
     },
     {
       full_name='showbreak', abbreviation='sbr',
@@ -2839,7 +2855,8 @@ return {
       short_desc=N_("allow specified keys to cross line boundaries"),
       type='string', list='flagscomma', scope={'global'},
       varname='p_ww',
-      defaults={if_true="b,s"}
+      defaults={if_true="b,s"},
+      cb='did_set_whichwrap'
     },
     {
       full_name='wildchar', abbreviation='wc',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -832,7 +832,8 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_fcs',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_chars_option'
     },
     {
       full_name='fixendofline', abbreviation='fixeol',
@@ -1485,7 +1486,8 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_lcs',
-      defaults={if_true="tab:> ,trail:-,nbsp:+"}
+      defaults={if_true="tab:> ,trail:-,nbsp:+"},
+      cb='did_set_chars_option'
     },
     {
       full_name='loadplugins', abbreviation='lpl',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -62,7 +62,8 @@ return {
       short_desc=N_("Arabic as a default second language"),
       type='bool', scope={'window'},
       redraw={'curswant'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_arabic'
     },
     {
       full_name='arabicshape', abbreviation='arshape',
@@ -86,14 +87,16 @@ return {
       type='string', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_ambw',
-      defaults={if_true="single"}
+      defaults={if_true="single"},
+      cb='did_set_ambiwidth'
     },
     {
       full_name='autochdir', abbreviation='acd',
       short_desc=N_("change directory to the file in the current window"),
       type='bool', scope={'global'},
       varname='p_acd',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_autochdir'
     },
     {
       full_name='autoindent', abbreviation='ai',
@@ -128,7 +131,8 @@ return {
       short_desc=N_("\"dark\" or \"light\", used for highlight colors"),
       type='string', scope={'global'},
       varname='p_bg',
-      defaults={if_true="dark"}
+      defaults={if_true="dark"},
+      cb='did_set_background'
     },
     {
       full_name='backspace', abbreviation='bs',
@@ -136,7 +140,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_bs',
-      defaults={if_true="indent,eol,start"}
+      defaults={if_true="indent,eol,start"},
+      cb='did_set_backspace'
     },
     {
       full_name='backup', abbreviation='bk',
@@ -156,6 +161,7 @@ return {
         if_true="auto",
         if_false="auto"
       },
+      cb='did_set_backupcopy'
     },
     {
       full_name='backupdir', abbreviation='bdir',
@@ -173,7 +179,8 @@ return {
       type='string', scope={'global'},
       normal_fname_chars=true,
       varname='p_bex',
-      defaults={if_true="~"}
+      defaults={if_true="~"},
+      cb='did_set_backupext_or_patchmode'
     },
     {
       full_name='backupskip', abbreviation='bsk',
@@ -197,7 +204,8 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_bin',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_binary'
     },
     {
       full_name='bomb',
@@ -206,7 +214,8 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_bomb',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_eof_eol_fixeol_bomb'
     },
     {
       full_name='breakat', abbreviation='brk',
@@ -214,7 +223,8 @@ return {
       type='string', list='flags', scope={'global'},
       redraw={'all_windows'},
       varname='p_breakat',
-      defaults={if_true=" \t!@*-+;:,./?"}
+      defaults={if_true=" \t!@*-+;:,./?"},
+      cb='did_set_breakat'
     },
     {
       full_name='breakindent', abbreviation='bri',
@@ -231,6 +241,7 @@ return {
       alloced=true,
       redraw={'current_buffer'},
       defaults={if_true=""},
+      cb='did_set_breakindentopt'
     },
     {
       full_name='browsedir', abbreviation='bsdir',
@@ -253,7 +264,8 @@ return {
       type='bool', scope={'buffer'},
       noglob=true,
       varname='p_bl',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_buflisted'
     },
     {
       full_name='buftype', abbreviation='bt',
@@ -262,7 +274,8 @@ return {
       noglob=true,
       alloced=true,
       varname='p_bt',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_buftype'
     },
     {
       full_name='casemap', abbreviation='cmp',
@@ -295,7 +308,8 @@ return {
       short_desc=N_("used to open the command-line window"),
       type='string', scope={'global'},
       varname='p_cedit',
-      defaults={if_true=macros('CTRL_F_STR')}
+      defaults={if_true=macros('CTRL_F_STR')},
+      cb='did_set_cedit'
     },
     {
       full_name='channel',
@@ -337,7 +351,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_cino',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_cinoptions'
     },
     {
       full_name='cinwords', abbreviation='cinw',
@@ -371,7 +386,8 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows'},
       varname='p_ch',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_cmdheight'
     },
     {
       full_name='cmdwinheight', abbreviation='cwh',
@@ -413,7 +429,8 @@ return {
       alloced=true,
       redraw={'curswant'},
       varname='p_cms',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_commentstring'
     },
     {
       full_name='compatible', abbreviation='cp',
@@ -456,7 +473,8 @@ return {
       alloced=true,
       func=true,
       varname='p_cfu',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_completefunc'
     },
     {
       full_name='completeopt', abbreviation='cot',
@@ -464,14 +482,16 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cot',
-      defaults={if_true="menu,preview"}
+      defaults={if_true="menu,preview"},
+      cb='did_set_completeopt'
     },
     {
       full_name='completeslash', abbreviation='csl',
       type='string', scope={'buffer'},
       varname='p_csl',
       enable_if='BACKSLASH_IN_FILENAME',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_completeslash'
     },
     {
       full_name='confirm', abbreviation='cf',
@@ -563,7 +583,8 @@ return {
       type='bool', scope={'window'},
       noglob=true,
       redraw={'current_window'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_diff'
     },
     {
       full_name='diffexpr', abbreviation='dex',
@@ -582,7 +603,8 @@ return {
       alloced=true,
       redraw={'current_window'},
       varname='p_dip',
-      defaults={if_true="internal,filler,closeoff"}
+      defaults={if_true="internal,filler,closeoff"},
+      cb='did_set_diffopt'
     },
     {
       full_name='digraph', abbreviation='dg',
@@ -608,7 +630,8 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_dy',
-      defaults={if_true="lastline"}
+      defaults={if_true="lastline"},
+      cb='did_set_display'
     },
     {
       full_name='eadirection', abbreviation='ead',
@@ -630,7 +653,8 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_emoji',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_ambiwidth'
     },
     {
       full_name='encoding', abbreviation='enc',
@@ -647,7 +671,8 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_eof',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_eof_eol_fixeol_bomb'
     },
     {
       full_name='endofline', abbreviation='eol',
@@ -656,14 +681,16 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_eol',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_eof_eol_fixeol_bomb'
     },
     {
       full_name='equalalways', abbreviation='ea',
       short_desc=N_("windows are automatically made the same size"),
       type='bool', scope={'global'},
       varname='p_ea',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_equalalways'
     },
     {
       full_name='equalprg', abbreviation='ep',
@@ -704,7 +731,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ei',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_eventignore'
     },
     {
       full_name='expandtab', abbreviation='et',
@@ -747,7 +775,8 @@ return {
       alloced=true,
       redraw={'curswant', 'statuslines'},
       varname='p_ff',
-      defaults={if_true=macros('DFLT_FF')}
+      defaults={if_true=macros('DFLT_FF')},
+      cb='did_set_fileformat'
     },
     {
       full_name='fileformats', abbreviation='ffs',
@@ -795,7 +824,8 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_fixeol',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_eof_eol_fixeol_bomb'
     },
     {
       full_name='foldclose', abbreviation='fcl',
@@ -812,7 +842,8 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="0"}
+      defaults={if_true="0"},
+      cb='did_set_foldcolumn'
     },
     {
       full_name='foldenable', abbreviation='fen',
@@ -836,14 +867,16 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="#"}
+      defaults={if_true="#"},
+      cb='did_set_foldignore'
     },
     {
       full_name='foldlevel', abbreviation='fdl',
       short_desc=N_("close folds with a level higher than this"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=0}
+      defaults={if_true=0},
+      cb='did_set_foldlevel'
     },
     {
       full_name='foldlevelstart', abbreviation='fdls',
@@ -860,7 +893,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="{{{,}}}"}
+      defaults={if_true="{{{,}}}"},
+      cb='did_set_foldmarker'
     },
     {
       full_name='foldmethod', abbreviation='fdm',
@@ -868,21 +902,24 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="manual"}
+      defaults={if_true="manual"},
+      cb='did_set_foldmethod'
     },
     {
       full_name='foldminlines', abbreviation='fml',
       short_desc=N_("minimum number of lines for a fold to be closed"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_foldminlines'
     },
     {
       full_name='foldnestmax', abbreviation='fdn',
       short_desc=N_("maximum fold depth"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=20}
+      defaults={if_true=20},
+      cb='did_set_foldnestmax'
     },
     {
       full_name='foldopen', abbreviation='fdo',
@@ -980,7 +1017,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_guicursor',
-      defaults={if_true="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"}
+      defaults={if_true="n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"},
+      cb='did_set_guicursor'
     },
     {
       full_name='guifont', abbreviation='gfn',
@@ -1028,14 +1066,16 @@ return {
       secure=true,
       expand=true,
       varname='p_hf',
-      defaults={if_true=macros('DFLT_HELPFILE')}
+      defaults={if_true=macros('DFLT_HELPFILE')},
+      cb='did_set_helpfile'
     },
     {
       full_name='helpheight', abbreviation='hh',
       short_desc=N_("minimum height of a new help window"),
       type='number', scope={'global'},
       varname='p_hh',
-      defaults={if_true=20}
+      defaults={if_true=20},
+      cb='did_set_helpheight'
     },
     {
       full_name='helplang', abbreviation='hlg',
@@ -1043,7 +1083,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_hlg',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_helplang'
     },
     {
       full_name='hidden', abbreviation='hid',
@@ -1058,7 +1099,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_hl',
-      defaults={if_true=macros('HIGHLIGHT_INIT')}
+      defaults={if_true=macros('HIGHLIGHT_INIT')},
+      cb='did_set_highlight'
     },
     {
       full_name='history', abbreviation='hi',
@@ -1087,14 +1129,16 @@ return {
       type='bool', scope={'global'},
       redraw={'all_windows'},
       varname='p_hls',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_hlsearch'
     },
     {
       full_name='icon',
       short_desc=N_("Vim set the text of the window icon"),
       type='bool', scope={'global'},
       varname='p_icon',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_title_icon'
     },
     {
       full_name='iconstring',
@@ -1102,14 +1146,16 @@ return {
       type='string', scope={'global'},
       modelineexpr=true,
       varname='p_iconstring',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_iconstring'
     },
     {
       full_name='ignorecase', abbreviation='ic',
       short_desc=N_("ignore case in search patterns"),
       type='bool', scope={'global'},
       varname='p_ic',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_ignorecase'
     },
     {
       full_name='imcmdline', abbreviation='imc',
@@ -1130,9 +1176,8 @@ return {
       short_desc=N_("use :lmap or IM in Insert mode"),
       type='number', scope={'buffer'},
       varname='p_iminsert', pv_name='p_imi',
-      defaults={
-        if_true=macros('B_IMODE_NONE'),
-      }
+      defaults={if_true=macros('B_IMODE_NONE')},
+      cb='did_set_iminsert'
     },
     {
       full_name='imsearch', abbreviation='ims',
@@ -1248,8 +1293,7 @@ return {
       deny_duplicates=true,
       redraw={'all_windows'},
       varname='p_isp',
-      defaults={if_true="@,161-255"
-      }
+      defaults={if_true="@,161-255"}
     },
     {
       full_name='joinspaces', abbreviation='js',
@@ -1283,7 +1327,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_km',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_keymodel'
     },
     {
       full_name='keywordprg', abbreviation='kp',
@@ -1303,7 +1348,8 @@ return {
       deny_duplicates=true,
       secure=true,
       varname='p_langmap',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_langmap'
     },
     {
       full_name='langmenu', abbreviation='lm',
@@ -1318,14 +1364,16 @@ return {
       short_desc=N_("do not apply 'langmap' to mapped characters"),
       type='bool', scope={'global'},
       varname='p_lnr',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_langnoremap'
     },
     {
       full_name='langremap', abbreviation='lrm',
       short_desc=N_('No description'),
       type='bool', scope={'global'},
       varname='p_lrm',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_langremap'
     },
     {
       full_name='laststatus', abbreviation='ls',
@@ -1333,7 +1381,8 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows'},
       varname='p_ls',
-      defaults={if_true=2}
+      defaults={if_true=2},
+      cb='did_set_laststatus'
     },
     {
       full_name='lazyredraw', abbreviation='lz',
@@ -1370,7 +1419,8 @@ return {
       short_desc=N_("indenting for Lisp"),
       type='bool', scope={'buffer'},
       varname='p_lisp',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_lisp'
     },
     {
       full_name='lispoptions', abbreviation='lop',
@@ -1378,7 +1428,8 @@ return {
       type='string', list='onecomma', scope={'buffer'},
       deny_duplicates=true,
       varname='p_lop', pv_name='p_lop',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_lispoptions'
     },
     {
       full_name='lispwords', abbreviation='lw',
@@ -1451,7 +1502,8 @@ return {
       deny_duplicates=true,
       alloced=true,
       varname='p_mps',
-      defaults={if_true="(:),{:},[:]"}
+      defaults={if_true="(:),{:},[:]"},
+      cb='did_set_matchpairs'
     },
     {
       full_name='matchtime', abbreviation='mat',
@@ -1502,7 +1554,8 @@ return {
       secure=true,
       expand=true,
       varname='p_msm',
-      defaults={if_true="460000,2000,500"}
+      defaults={if_true="460000,2000,500"},
+      cb='did_set_mkspellmem'
     },
     {
       full_name='modeline', abbreviation='ml',
@@ -1532,7 +1585,8 @@ return {
       type='bool', scope={'buffer'},
       noglob=true,
       varname='p_ma',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_modifiable'
     },
     {
       full_name='modified', abbreviation='mod',
@@ -1541,7 +1595,8 @@ return {
       no_mkrc=true,
       redraw={'statuslines'},
       varname='p_mod',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_modified'
     },
     {
       full_name='more',
@@ -1593,7 +1648,8 @@ return {
       type='string', list='comma', scope={'global'},
       vi_def=true,
       varname='p_mousescroll',
-      defaults={if_true="ver:3,hor:6"}
+      defaults={if_true="ver:3,hor:6"},
+      cb='did_set_mousescroll'
     },
     {
       full_name='mouseshape', abbreviation='mouses',
@@ -1623,14 +1679,16 @@ return {
       short_desc=N_("print the line number in front of each line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_number_relativenumber'
     },
     {
       full_name='numberwidth', abbreviation='nuw',
       short_desc=N_("number of columns used for the line number"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=4}
+      defaults={if_true=4},
+      cb='did_set_numberwidth'
     },
     {
       full_name='omnifunc', abbreviation='ofu',
@@ -1640,7 +1698,8 @@ return {
       alloced=true,
       func=true,
       varname='p_ofu',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_omnifunc'
     },
     {
       full_name='opendevice', abbreviation='odev',
@@ -1656,7 +1715,8 @@ return {
       secure=true,
       func=true,
       varname='p_opfunc',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_operatorfunc'
     },
     {
       full_name='packpath', abbreviation='pp',
@@ -1666,7 +1726,8 @@ return {
       secure=true,
       expand=true,
       varname='p_pp',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_runtimepackpath'
     },
     {
       full_name='paragraphs', abbreviation='para',
@@ -1681,7 +1742,8 @@ return {
       type='bool', scope={'global'},
       pri_mkrc=true,
       varname='p_paste',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_paste'
     },
     {
       full_name='pastetoggle', abbreviation='pt',
@@ -1703,7 +1765,8 @@ return {
       type='string', scope={'global'},
       normal_fname_chars=true,
       varname='p_pm',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_backupext_or_patchmode'
     },
     {
       full_name='path', abbreviation='pa',
@@ -1734,7 +1797,8 @@ return {
       type='bool', scope={'window'},
       noglob=true,
       redraw={'statuslines'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_previewwindow'
     },
     {
       full_name='prompt',
@@ -1749,7 +1813,8 @@ return {
       type='number', scope={'global'},
       redraw={'ui_option'},
       varname='p_pb',
-      defaults={if_true=0}
+      defaults={if_true=0},
+      cb='did_set_pumblend'
     },
     {
       full_name='pumheight', abbreviation='ph',
@@ -1780,7 +1845,8 @@ return {
       secure=true,
       func=true,
       varname='p_qftf',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_quickfixtextfunc'
     },
     {
       full_name='quoteescape', abbreviation='qe',
@@ -1797,7 +1863,8 @@ return {
       noglob=true,
       redraw={'statuslines'},
       varname='p_ro',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_readonly'
     },
     {
       full_name='redrawdebug', abbreviation='rdb',
@@ -1825,7 +1892,8 @@ return {
       short_desc=N_("show relative line number in front of each line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_number_relativenumber'
     },
     {
       full_name='remap',
@@ -1879,7 +1947,8 @@ return {
       modelineexpr=true,
       redraw={'statuslines'},
       varname='p_ruf',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_rulerformat'
     },
     {
       full_name='runtimepath', abbreviation='rtp',
@@ -1889,7 +1958,8 @@ return {
       secure=true,
       expand='nodefault',
       varname='p_rtp',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_runtimepackpath'
     },
     {
       full_name='scroll', abbreviation='scr',
@@ -1905,14 +1975,16 @@ return {
       type='number', scope={'buffer'},
       varname='p_scbk',
       redraw={'current_buffer'},
-      defaults={if_true=-1}
+      defaults={if_true=-1},
+      cb='did_set_scrollback'
     },
     {
       full_name='scrollbind', abbreviation='scb',
       short_desc=N_("scroll in window as other windows scroll"),
       type='bool', scope={'window'},
       pv_name='p_scbind',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_scrollbind'
     },
     {
       full_name='scrolljump', abbreviation='sj',
@@ -1956,7 +2028,8 @@ return {
       short_desc=N_("what type of selection to use"),
       type='string', scope={'global'},
       varname='p_sel',
-      defaults={if_true="inclusive"}
+      defaults={if_true="inclusive"},
+      cb='did_set_selection'
     },
     {
       full_name='selectmode', abbreviation='slm',
@@ -1972,7 +2045,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ssop',
-      defaults={if_true="blank,buffers,curdir,folds,help,tabpages,winsize,terminal"}
+      defaults={if_true="blank,buffers,curdir,folds,help,tabpages,winsize,terminal"},
+      cb='did_set_sessionoptions',
     },
     {
       full_name='shada', abbreviation='sd',
@@ -2056,7 +2130,8 @@ return {
       type='bool', scope={'global'},
       varname='p_ssl',
       enable_if='BACKSLASH_IN_FILENAME',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_shellslash'
     },
     {
       full_name='shelltemp', abbreviation='stmp',
@@ -2097,7 +2172,8 @@ return {
       short_desc=N_("number of spaces to use for (auto)indent step"),
       type='number', scope={'buffer'},
       varname='p_sw',
-      defaults={if_true=8}
+      defaults={if_true=8},
+      cb='did_set_shiftwidth_tabstop'
     },
     {
       full_name='shortmess', abbreviation='shm',
@@ -2112,7 +2188,8 @@ return {
       type='string', scope={'global', 'window'},
       redraw={'all_windows'},
       varname='p_sbr',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_showbreak'
     },
     {
       full_name='showcmd', abbreviation='sc',
@@ -2155,7 +2232,8 @@ return {
       type='number', scope={'global'},
       redraw={'all_windows', 'ui_option'},
       varname='p_stal',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_showtabline'
     },
     {
       full_name='sidescroll', abbreviation='ss',
@@ -2177,7 +2255,8 @@ return {
       type='string', scope={'window'},
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true="auto"}
+      defaults={if_true="auto"},
+      cb='did_set_signcolumn'
     },
     {
       full_name='smartcase', abbreviation='scs',
@@ -2212,7 +2291,8 @@ return {
       short_desc=N_("spell checking"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_spell'
     },
     {
       full_name='spellcapcheck', abbreviation='spc',
@@ -2221,7 +2301,8 @@ return {
       alloced=true,
       redraw={'current_buffer'},
       varname='p_spc',
-      defaults={if_true="[.?!]\\_[\\])'\"	 ]\\+"}
+      defaults={if_true="[.?!]\\_[\\])'\"	 ]\\+"},
+      cb='did_set_spellcapcheck'
     },
     {
       full_name='spellfile', abbreviation='spf',
@@ -2232,7 +2313,8 @@ return {
       alloced=true,
       expand=true,
       varname='p_spf',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_spellfile'
     },
     {
       full_name='spelllang', abbreviation='spl',
@@ -2243,7 +2325,8 @@ return {
       expand=true,
       redraw={'current_buffer'},
       varname='p_spl',
-      defaults={if_true="en"}
+      defaults={if_true="en"},
+      cb='did_set_spelllang'
     },
     {
       full_name='spellsuggest', abbreviation='sps',
@@ -2253,7 +2336,8 @@ return {
       secure=true,
       expand=true,
       varname='p_sps',
-      defaults={if_true="best"}
+      defaults={if_true="best"},
+      cb='did_set_spellsuggest'
     },
     {
       full_name='spelloptions', abbreviation='spo',
@@ -2263,7 +2347,8 @@ return {
       expand=true,
       varname='p_spo',
       redraw={'current_buffer'},
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_spelloptions'
     },
     {
       full_name='splitbelow', abbreviation='sb',
@@ -2301,7 +2386,8 @@ return {
       redraw={'current_window'},
       secure=true,
       alloced=true,
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_statuscolumn'
     },
     {
       full_name='statusline', abbreviation='stl',
@@ -2311,7 +2397,8 @@ return {
       modelineexpr=true,
       redraw={'statuslines'},
       varname='p_stl',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_statusline'
     },
     {
       full_name='suffixes', abbreviation='su',
@@ -2336,7 +2423,8 @@ return {
       type='bool', scope={'buffer'},
       redraw={'statuslines'},
       varname='p_swf',
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_swapfile'
     },
     {
       full_name='switchbuf', abbreviation='swb',
@@ -2371,7 +2459,8 @@ return {
       secure=true,
       func=true,
       varname='p_tfu',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_tagfunc'
     },
     {
       full_name='tabline', abbreviation='tal',
@@ -2380,7 +2469,8 @@ return {
       modelineexpr=true,
       redraw={'tabline'},
       varname='p_tal',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_tabline'
     },
     {
       full_name='tabpagemax', abbreviation='tpm',
@@ -2395,7 +2485,8 @@ return {
       type='number', scope={'buffer'},
       redraw={'current_buffer'},
       varname='p_ts',
-      defaults={if_true=8}
+      defaults={if_true=8},
+      cb='did_set_shiftwidth_tabstop'
     },
     {
       full_name='tagbsearch', abbreviation='tbs',
@@ -2409,7 +2500,8 @@ return {
       short_desc=N_("how to handle case when searching in tags files"),
       type='string', scope={'global', 'buffer'},
       varname='p_tc',
-      defaults={if_true="followic"}
+      defaults={if_true="followic"},
+      cb='did_set_tagcase'
     },
     {
       full_name='taglength', abbreviation='tl',
@@ -2482,7 +2574,8 @@ return {
       type='number', scope={'buffer'},
       redraw={'current_buffer'},
       varname='p_tw',
-      defaults={if_true=0}
+      defaults={if_true=0},
+      cb='did_set_textwidth'
     },
     {
       full_name='thesaurus', abbreviation='tsr',
@@ -2502,7 +2595,8 @@ return {
       alloced=true,
       func=true,
       varname='p_tsrfu',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_thesaurusfunc'
     },
     {
       full_name='tildeop', abbreviation='top',
@@ -2530,14 +2624,16 @@ return {
       short_desc=N_("Vim set the title of the window"),
       type='bool', scope={'global'},
       varname='p_title',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_title_icon'
     },
     {
       full_name='titlelen',
       short_desc=N_("of 'columns' used for window title"),
       type='number', scope={'global'},
       varname='p_titlelen',
-      defaults={if_true=85}
+      defaults={if_true=85},
+      cb='did_set_titlelen'
     },
     {
       full_name='titleold',
@@ -2554,7 +2650,8 @@ return {
       type='string', scope={'global'},
       modelineexpr=true,
       varname='p_titlestring',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_titlestring'
     },
     {
       full_name='ttimeout',
@@ -2595,14 +2692,16 @@ return {
       short_desc=N_("save undo information in a file"),
       type='bool', scope={'buffer'},
       varname='p_udf',
-      defaults={if_true=false}
+      defaults={if_true=false},
+      cb='did_set_undofile'
     },
     {
       full_name='undolevels', abbreviation='ul',
       short_desc=N_("maximum number of changes that can be undone"),
       type='number', scope={'global', 'buffer'},
       varname='p_ul',
-      defaults={if_true=1000}
+      defaults={if_true=1000},
+      cb='did_set_undolevels'
     },
     {
       full_name='undoreload', abbreviation='ur',
@@ -2616,7 +2715,8 @@ return {
       short_desc=N_("after this many characters flush swap file"),
       type='number', scope={'global'},
       varname='p_uc',
-      defaults={if_true=200}
+      defaults={if_true=200},
+      cb='did_set_updatecount'
     },
     {
       full_name='updatetime', abbreviation='ut',
@@ -2630,7 +2730,8 @@ return {
       short_desc=N_("list of numbers of spaces that <Tab> uses while editing"),
       type='string', list='comma', scope={'buffer'},
       varname='p_vsts',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_varsofttabstop'
     },
     {
       full_name='vartabstop', abbreviation='vts',
@@ -2638,7 +2739,8 @@ return {
       type='string', list='comma', scope={'buffer'},
       varname='p_vts',
       redraw={'current_buffer'},
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_vartabstop'
     },
     {
       full_name='verbose', abbreviation='vbs',
@@ -2654,7 +2756,8 @@ return {
       secure=true,
       expand=true,
       varname='p_vfile',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_verbosefile'
     },
     {
       full_name='viewdir', abbreviation='vdir',
@@ -2692,7 +2795,8 @@ return {
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_ve',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_virtualedit'
     },
     {
       full_name='visualbell', abbreviation='vb',
@@ -2757,7 +2861,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=false,
       varname='p_wim',
-      defaults={if_true="full"}
+      defaults={if_true="full"},
+      cb='did_set_wildmode'
     },
     {
       full_name='wildoptions', abbreviation='wop',
@@ -2772,7 +2877,8 @@ return {
       short_desc=N_("when the windows system handles ALT keys"),
       type='string', scope={'global'},
       varname='p_wak',
-      defaults={if_true="menu"}
+      defaults={if_true="menu"},
+      cb='did_set_winaltkeys'
     },
     {
       full_name='winbar', abbreviation='wbr',
@@ -2782,14 +2888,16 @@ return {
       modelineexpr=true,
       redraw={'statuslines'},
       varname='p_wbr',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_winbar'
     },
     {
       full_name='winblend', abbreviation='winbl',
       short_desc=N_("Controls transparency level for floating windows"),
       type='number', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=0}
+      defaults={if_true=0},
+      cb='did_set_winblend'
     },
     {
       full_name='winhighlight', abbreviation='winhl',
@@ -2798,21 +2906,24 @@ return {
       deny_duplicates=true,
       alloced=true,
       redraw={'current_window'},
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_winhl'
     },
     {
       full_name='window', abbreviation='wi',
       short_desc=N_("nr of lines to scroll for CTRL-F and CTRL-B"),
       type='number', scope={'global'},
       varname='p_window',
-      defaults={if_true=0}
+      defaults={if_true=0},
+      cb='did_set_window'
     },
     {
       full_name='winheight', abbreviation='wh',
       short_desc=N_("minimum number of lines for the current window"),
       type='number', scope={'global'},
       varname='p_wh',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_winheight'
     },
     {
       full_name='winfixheight', abbreviation='wfh',
@@ -2833,28 +2944,32 @@ return {
       short_desc=N_("minimum number of lines for any window"),
       type='number', scope={'global'},
       varname='p_wmh',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_winminheight'
     },
     {
       full_name='winminwidth', abbreviation='wmw',
       short_desc=N_("minimal number of columns for any window"),
       type='number', scope={'global'},
       varname='p_wmw',
-      defaults={if_true=1}
+      defaults={if_true=1},
+      cb='did_set_winminwidth'
     },
     {
       full_name='winwidth', abbreviation='wiw',
       short_desc=N_("minimal number of columns for current window"),
       type='number', scope={'global'},
       varname='p_wiw',
-      defaults={if_true=20}
+      defaults={if_true=20},
+      cb='did_set_winwidth'
     },
     {
       full_name='wrap',
       short_desc=N_("lines wrap and continue on the next line"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_wrap'
     },
     {
       full_name='wrapmargin', abbreviation='wm',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -676,7 +676,8 @@ return {
       type='string', scope={'global'},
       deny_in_modelines=true,
       varname='p_enc',
-      defaults={if_true=macros('ENC_DFLT')}
+      defaults={if_true=macros('ENC_DFLT')},
+      cb='did_set_encoding'
     },
     {
       full_name='endoffile', abbreviation='eof',
@@ -771,7 +772,8 @@ return {
       alloced=true,
       redraw={'statuslines', 'current_buffer'},
       varname='p_fenc',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_encoding'
     },
     {
       full_name='fileencodings', abbreviation='fencs',
@@ -1517,7 +1519,8 @@ return {
       short_desc=N_("Converts the output of external commands"),
       type='string', scope={'global', 'buffer'},
       varname='p_menc',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_encoding'
     },
     {
       full_name='makeprg', abbreviation='mp',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -196,7 +196,8 @@ return {
       type='string', list='comma', scope={'global'},
       deny_duplicates=true,
       varname='p_bo',
-      defaults={if_true="all"}
+      defaults={if_true="all"},
+      cb='did_set_belloff'
     },
     {
       full_name='binary', abbreviation='bin',
@@ -256,7 +257,8 @@ return {
       noglob=true,
       alloced=true,
       varname='p_bh',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_bufhidden'
     },
     {
       full_name='buflisted', abbreviation='bl',
@@ -283,7 +285,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cmp',
-      defaults={if_true="internal,keepascii"}
+      defaults={if_true="internal,keepascii"},
+      cb='did_set_casemap'
     },
     {
       full_name='cdhome', abbreviation='cdh',
@@ -378,7 +381,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_cb',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_clipboard'
     },
     {
       full_name='cmdheight', abbreviation='ch',
@@ -402,7 +406,8 @@ return {
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       redraw={'current_window'},
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_colorcolumn'
     },
     {
       full_name='columns', abbreviation='co',
@@ -542,14 +547,16 @@ return {
       type='string', list='onecomma', scope={'window'},
       deny_duplicates=true,
       redraw={'current_window_only'},
-      defaults={if_true="both"}
+      defaults={if_true="both"},
+      cb='did_set_cursorlineopt'
     },
     {
       full_name='debug',
       short_desc=N_("to \"msg\" to see all error messages"),
       type='string', scope={'global'},
       varname='p_debug',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_debug'
     },
     {
       full_name='define', abbreviation='def',
@@ -638,7 +645,8 @@ return {
       short_desc=N_("in which direction 'equalalways' works"),
       type='string', scope={'global'},
       varname='p_ead',
-      defaults={if_true="both"}
+      defaults={if_true="both"},
+      cb='did_set_eadirection'
     },
     {
       full_name='edcompatible', abbreviation='ed',
@@ -784,7 +792,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_ffs',
-      defaults={if_true=macros('DFLT_FFS_VIM')}
+      defaults={if_true=macros('DFLT_FFS_VIM')},
+      cb='did_set_fileformats'
     },
     {
       full_name='fileignorecase', abbreviation='fic',
@@ -834,7 +843,8 @@ return {
       deny_duplicates=true,
       redraw={'current_window'},
       varname='p_fcl',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_foldclose'
     },
     {
       full_name='foldcolumn', abbreviation='fdc',
@@ -928,7 +938,8 @@ return {
       deny_duplicates=true,
       redraw={'curswant'},
       varname='p_fdo',
-      defaults={if_true="block,hor,mark,percent,quickfix,search,tag,undo"}
+      defaults={if_true="block,hor,mark,percent,quickfix,search,tag,undo"},
+      cb='did_set_foldopen'
     },
     {
       full_name='foldtext', abbreviation='fdt',
@@ -1193,7 +1204,8 @@ return {
       short_desc=N_("Live preview of substitution"),
       type='string', scope={'global'},
       varname='p_icm',
-      defaults={if_true="nosplit"}
+      defaults={if_true="nosplit"},
+      cb='did_set_inccommand'
     },
     {
       full_name='include', abbreviation='inc',
@@ -1308,7 +1320,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_jop',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_jumpoptions'
     },
     {
       full_name='keymap', abbreviation='kmp',
@@ -1632,7 +1645,8 @@ return {
       short_desc=N_("changes meaning of mouse buttons"),
       type='string', scope={'global'},
       varname='p_mousem',
-      defaults={if_true="popup_setpos"}
+      defaults={if_true="popup_setpos"},
+      cb='did_set_mousemodel'
     },
     {
       full_name='mousemoveevent', abbreviation='mousemev',
@@ -1871,7 +1885,8 @@ return {
       short_desc=N_("Changes the way redrawing works (debug)"),
       type='string', list='onecomma', scope={'global'},
       varname='p_rdb',
-      defaults={if_true=''}
+      defaults={if_true=''},
+      cb='did_set_redrawdebug'
     },
     {
       full_name='redrawtime', abbreviation='rdt',
@@ -2006,7 +2021,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_sbo',
-      defaults={if_true="ver,jump"}
+      defaults={if_true="ver,jump"},
+      cb='did_set_scrollopt'
     },
     {
       full_name='sections', abbreviation='sect',
@@ -2037,7 +2053,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_slm',
-      defaults={if_true=""}
+      defaults={if_true=""},
+      cb='did_set_selectmode'
     },
     {
       full_name='sessionoptions', abbreviation='ssop',
@@ -2203,7 +2220,8 @@ return {
       short_desc=N_("change location of partial command"),
       type='string', scope={'global'},
       varname='p_sloc',
-      defaults={if_true="last"}
+      defaults={if_true="last"},
+      cb='did_set_showcmdloc'
     },
     {
       full_name='showfulltag', abbreviation='sft',
@@ -2362,7 +2380,8 @@ return {
       short_desc=N_("determines scroll behavior for split windows"),
       type='string', scope={'global'},
       varname='p_spk',
-      defaults={if_true='cursor'}
+      defaults={if_true='cursor'},
+      cb='did_set_splitkeep'
     },
     {
       full_name='splitright', abbreviation='spr',
@@ -2432,7 +2451,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_swb',
-      defaults={if_true="uselast"}
+      defaults={if_true="uselast"},
+      cb='did_set_switchbuf'
     },
     {
       full_name='synmaxcol', abbreviation='smc',
@@ -2559,7 +2579,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_tpf',
-      defaults={if_true="BS,HT,ESC,DEL"}
+      defaults={if_true="BS,HT,ESC,DEL"},
+      cb='did_set_termpastefilter'
     },
     {
       full_name='terse',
@@ -2774,7 +2795,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_vop',
-      defaults={if_true="folds,cursor,curdir"}
+      defaults={if_true="folds,cursor,curdir"},
+      cb='did_set_viewoptions'
     },
     {
       -- Alias for "shada".
@@ -2870,7 +2892,8 @@ return {
       type='string', list='onecomma', scope={'global'},
       deny_duplicates=true,
       varname='p_wop',
-      defaults={if_true='pum,tagfile'}
+      defaults={if_true='pum,tagfile'},
+      cb='did_set_wildoptions'
     },
     {
       full_name='winaltkeys', abbreviation='wak',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -444,7 +444,7 @@ const char *set_string_option(const int opt_idx, const char *const value, const 
   char *const saved_newval = xstrdup(s);
 
   int value_checked = false;
-  const char *const errmsg = did_set_string_option(opt_idx, varp, oldval, errbuf, errbuflen,
+  const char *const errmsg = did_set_string_option(opt_idx, varp, oldval, s, errbuf, errbuflen,
                                                    opt_flags, &value_checked);
   if (errmsg == NULL) {
     did_set_option(opt_idx, opt_flags, true, value_checked);
@@ -479,10 +479,12 @@ static bool valid_filetype(const char *val)
 
 /// Handle setting 'mousescroll'.
 /// @return error message, NULL if it's OK.
-static const char *check_mousescroll(char *string)
+const char *did_set_mousescroll(optset_T *args FUNC_ATTR_UNUSED)
 {
   long vertical = -1;
   long horizontal = -1;
+
+  char *string = p_mousescroll;
 
   while (true) {
     char *end = vim_strchr(string, ',');
@@ -651,8 +653,12 @@ static bool check_illegal_path_names(char *val, uint32_t flags)
               && strpbrk(val, "*?[|;&<>\r\n") != NULL));
 }
 
-static void did_set_backupcopy(buf_T *buf, char *oldval, int opt_flags, const char **errmsg)
+/// The 'backupcopy' option is changed.
+const char *did_set_backupcopy(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  const char *oldval = args->os_oldval.string;
+  int opt_flags = args->os_flags;
   char *bkc = p_bkc;
   unsigned *flags = &bkc_flags;
 
@@ -666,7 +672,7 @@ static void did_set_backupcopy(buf_T *buf, char *oldval, int opt_flags, const ch
     *flags = 0;
   } else {
     if (opt_strings_flags(bkc, p_bkc_values, flags, true) != OK) {
-      *errmsg = e_invarg;
+      return e_invarg;
     }
 
     if (((*flags & BKC_AUTO) != 0)
@@ -674,30 +680,41 @@ static void did_set_backupcopy(buf_T *buf, char *oldval, int opt_flags, const ch
         + ((*flags & BKC_NO) != 0) != 1) {
       // Must have exactly one of "auto", "yes"  and "no".
       (void)opt_strings_flags(oldval, p_bkc_values, flags, true);
-      *errmsg = e_invarg;
+      return e_invarg;
     }
   }
+
+  return NULL;
 }
 
-static void did_set_backupext_or_patchmode(const char **errmsg)
+/// The 'backupext' or the 'patchmode' option is changed.
+const char *did_set_backupext_or_patchmode(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (strcmp(*p_bex == '.' ? p_bex + 1 : p_bex,
              *p_pm == '.' ? p_pm + 1 : p_pm) == 0) {
-    *errmsg = e_backupext_and_patchmode_are_equal;
+    return e_backupext_and_patchmode_are_equal;
   }
+
+  return NULL;
 }
 
-static void did_set_breakindentopt(win_T *win, const char **errmsg)
+/// The 'breakindentopt' option is changed.
+const char *did_set_breakindentopt(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   if (briopt_check(win) == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
   // list setting requires a redraw
   if (win == curwin && win->w_briopt_list) {
     redraw_all_later(UPD_NOT_VALID);
   }
+
+  return NULL;
 }
 
+/// The 'isident' or the 'iskeyword' or the 'isprint' or the 'isfname' option is
+/// changed.
 static void did_set_isopt(buf_T *buf, bool *did_chartab, const char **errmsg)
 {
   // 'isident', 'iskeyword', 'isprint or 'isfname' option: refill g_chartab[]
@@ -709,7 +726,8 @@ static void did_set_isopt(buf_T *buf, bool *did_chartab, const char **errmsg)
   }
 }
 
-static void did_set_helpfile(void)
+/// The 'helpfile' option is changed.
+const char *did_set_helpfile(optset_T *args FUNC_ATTR_UNUSED)
 {
   // May compute new values for $VIM and $VIMRUNTIME
   if (didset_vim) {
@@ -718,8 +736,10 @@ static void did_set_helpfile(void)
   if (didset_vimruntime) {
     vim_unsetenv_ext("VIMRUNTIME");
   }
+  return NULL;
 }
 
+/// The 'cursorlineopt' option is changed.
 static void did_set_cursorlineopt(win_T *win, char **varp, const char **errmsg)
 {
   if (**varp == NUL || fill_culopt_flags(*varp, win) != OK) {
@@ -727,25 +747,28 @@ static void did_set_cursorlineopt(win_T *win, char **varp, const char **errmsg)
   }
 }
 
-static void did_set_helplang(const char **errmsg)
+/// The 'helplang' option is changed.
+const char *did_set_helplang(optset_T *args FUNC_ATTR_UNUSED)
 {
   // Check for "", "ab", "ab,cd", etc.
   for (char *s = p_hlg; *s != NUL; s += 3) {
     if (s[1] == NUL || ((s[2] != ',' || s[3] == NUL) && s[2] != NUL)) {
-      *errmsg = e_invarg;
-      break;
+      return e_invarg;
     }
     if (s[2] == NUL) {
       break;
     }
   }
+  return NULL;
 }
 
-static void did_set_highlight(char **varp, const char **errmsg)
+/// The 'highlight' option is changed.
+const char *did_set_highlight(optset_T *args)
 {
-  if (strcmp(*varp, HIGHLIGHT_INIT) != 0) {
-    *errmsg = e_unsupportedoption;
+  if (strcmp(args->os_varp, HIGHLIGHT_INIT) != 0) {
+    return e_unsupportedoption;
   }
+  return NULL;
 }
 
 static void did_set_opt_flags(char *val, char **values, unsigned *flagp, bool list,
@@ -761,32 +784,35 @@ static void did_set_opt_strings(char *val, char **values, bool list, const char 
   did_set_opt_flags(val, values, NULL, list, errmsg);
 }
 
-static void did_set_sessionoptions(char *oldval, const char **errmsg)
+/// The 'sessionoptions' option is changed.
+const char *did_set_sessionoptions(optset_T *args)
 {
   if (opt_strings_flags(p_ssop, p_ssop_values, &ssop_flags, true) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
   if ((ssop_flags & SSOP_CURDIR) && (ssop_flags & SSOP_SESDIR)) {
     // Don't allow both "sesdir" and "curdir".
+    const char *oldval = args->os_oldval.string;
     (void)opt_strings_flags(oldval, p_ssop_values, &ssop_flags, true);
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_ambiwidth(const char **errmsg)
+/// The 'ambiwidth' option is changed.
+const char *did_set_ambiwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_opt_strings(p_ambw, p_ambw_values, false) != OK) {
-    *errmsg = e_invarg;
-  } else {
-    *errmsg = check_chars_options();
+    return e_invarg;
   }
+  return check_chars_options();
 }
 
-static void did_set_background(const char **errmsg)
+/// The 'background' option is changed.
+const char *did_set_background(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_opt_strings(p_bg, p_bg_values, false) != OK) {
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
 
   int dark = (*p_bg == 'd');
@@ -803,27 +829,34 @@ static void did_set_background(const char **errmsg)
     check_string_option(&p_bg);
     init_highlight(false, false);
   }
+  return NULL;
 }
 
-static void did_set_wildmode(const char **errmsg)
+/// The 'wildmode' option is changed.
+const char *did_set_wildmode(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_opt_wim() == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_winaltkeys(const char **errmsg)
+/// The 'winaltkeys' option is changed.
+const char *did_set_winaltkeys(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (*p_wak == NUL || check_opt_strings(p_wak, p_wak_values, false) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_eventignore(const char **errmsg)
+/// The 'eventignore' option is changed.
+const char *did_set_eventignore(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_ei() == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
 // 'encoding', 'fileencoding' and 'makeencoding'
@@ -886,7 +919,7 @@ static void did_set_keymap(buf_T *buf, char **varp, int opt_flags, int *value_ch
   // even when the value comes from a modeline.
   *value_checked = true;
 
-  if (*errmsg == NULL) {
+  if (errmsg == NULL) {
     if (*buf->b_p_keymap != NUL) {
       // Installed a new keymap, switch on using it.
       buf->b_p_iminsert = B_IMODE_LMAP;
@@ -910,28 +943,32 @@ static void did_set_keymap(buf_T *buf, char **varp, int opt_flags, int *value_ch
   }
 }
 
-static void did_set_fileformat(buf_T *buf, char **varp, const char *oldval, int opt_flags,
-                               const char **errmsg)
+/// The 'fileformat' option is changed.
+const char *did_set_fileformat(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  const char *oldval = args->os_oldval.string;
+  int opt_flags = args->os_flags;
   if (!MODIFIABLE(buf) && !(opt_flags & OPT_GLOBAL)) {
-    *errmsg = e_modifiable;
-  } else if (check_opt_strings(*varp, p_ff_values, false) != OK) {
-    *errmsg = e_invarg;
-  } else {
-    redraw_titles();
-    // update flag in swap file
-    ml_setflags(buf);
-    // Redraw needed when switching to/from "mac": a CR in the text
-    // will be displayed differently.
-    if (get_fileformat(buf) == EOL_MAC || *oldval == 'm') {
-      redraw_buf_later(buf, UPD_NOT_VALID);
-    }
+    return e_modifiable;
+  } else if (check_opt_strings(args->os_varp, p_ff_values, false) != OK) {
+    return e_invarg;
   }
+  redraw_titles();
+  // update flag in swap file
+  ml_setflags(buf);
+  // Redraw needed when switching to/from "mac": a CR in the text
+  // will be displayed differently.
+  if (get_fileformat(buf) == EOL_MAC || *oldval == 'm') {
+    redraw_buf_later(buf, UPD_NOT_VALID);
+  }
+  return NULL;
 }
 
-static void did_set_matchpairs(char **varp, const char **errmsg)
+/// The 'matchpairs' option is changed.
+const char *did_set_matchpairs(optset_T *args)
 {
-  for (char *p = *varp; *p != NUL; p++) {
+  for (char *p = args->os_varp; *p != NUL; p++) {
     int x2 = -1;
     int x3 = -1;
 
@@ -944,13 +981,22 @@ static void did_set_matchpairs(char **varp, const char **errmsg)
       p += utfc_ptr2len(p);
     }
     if (x2 != ':' || x3 == -1 || (*p != NUL && *p != ',')) {
-      *errmsg = e_invarg;
-      break;
+      return e_invarg;
     }
     if (*p == NUL) {
       break;
     }
   }
+  return NULL;
+}
+
+/// The 'cinoptions' option is changed.
+const char *did_set_cinoptions(optset_T *args FUNC_ATTR_UNUSED)
+{
+  // TODO(vim): recognize errors
+  parse_cino(curbuf);
+
+  return NULL;
 }
 
 static void did_set_comments(char **varp, char *errbuf, size_t errbuflen, const char **errmsg)
@@ -1008,18 +1054,20 @@ static void did_set_global_listfillchars(win_T *win, char **varp, int opt_flags,
   }
 }
 
-static void did_set_verbosefile(const char **errmsg)
+/// The 'verbosefile' option is changed.
+const char *did_set_verbosefile(optset_T *args)
 {
   verbose_stop();
   if (*p_vfile != NUL && verbose_open() == FAIL) {
-    *errmsg = e_invarg;
+    return (char *)e_invarg;
   }
+  return NULL;
 }
 
 static int shada_idx = -1;
 
-static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, char *errbuf,
-                          size_t errbuflen, const char **errmsg)
+static const char *did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, char *errbuf,
+                                 size_t errbuflen)
 {
   // TODO(ZyX-I): Remove this code in the future, alongside with &viminfo
   //              option.
@@ -1034,8 +1082,7 @@ static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, ch
   for (char *s = p_shada; *s;) {
     // Check it's a valid character
     if (vim_strchr("!\"%'/:<@cfhnrs", (uint8_t)(*s)) == NULL) {
-      *errmsg = illegal_char(errbuf, errbuflen, (uint8_t)(*s));
-      break;
+      return illegal_char(errbuf, errbuflen, (uint8_t)(*s));
     }
     if (*s == 'n') {          // name is always last one
       break;
@@ -1054,181 +1101,241 @@ static void did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, ch
           vim_snprintf(errbuf, errbuflen,
                        _("E526: Missing number after <%s>"),
                        transchar_byte((uint8_t)(*(s - 1))));
-          *errmsg = errbuf;
+          return errbuf;
         } else {
-          *errmsg = "";
+          return "";
         }
-        break;
       }
     }
     if (*s == ',') {
       s++;
     } else if (*s) {
       if (errbuf != NULL) {
-        *errmsg = N_("E527: Missing comma");
+        return N_("E527: Missing comma");
       } else {
-        *errmsg = "";
+        return "";
       }
-      break;
     }
   }
-  if (*p_shada && *errmsg == NULL && get_shada_parameter('\'') < 0) {
-    *errmsg = N_("E528: Must specify a ' value");
+  if (*p_shada && get_shada_parameter('\'') < 0) {
+    return N_("E528: Must specify a ' value");
   }
+  return NULL;
 }
 
-static void did_set_showbreak(char **varp, const char **errmsg)
+/// The 'showbreak' option is changed.
+const char *did_set_showbreak(optset_T *args)
 {
-  for (char *s = *varp; *s;) {
+  for (char *s = args->os_varp; *s;) {
     if (ptr2cells(s) != 1) {
-      *errmsg = e_showbreak_contains_unprintable_or_wide_character;
+      return e_showbreak_contains_unprintable_or_wide_character;
     }
     MB_PTR_ADV(s);
   }
+  return NULL;
 }
 
-static void did_set_titleiconstring(char **varp)
+/// The 'titlestring' or the 'iconstring' option is changed.
+static const char *did_set_titleiconstring(optset_T *args, int flagval)
 {
-  // 'titlestring' and 'iconstring'
-  int flagval = (varp == &p_titlestring) ? STL_IN_TITLE : STL_IN_ICON;
-
   // NULL => statusline syntax
-  if (vim_strchr(*varp, '%') && check_stl_option(*varp) == NULL) {
+  if (vim_strchr(args->os_varp, '%') && check_stl_option(args->os_varp) == NULL) {
     stl_syntax |= flagval;
   } else {
     stl_syntax &= ~flagval;
   }
   did_set_title();
+
+  return NULL;
 }
 
-static void did_set_selection(const char **errmsg)
+/// The 'titlestring' option is changed.
+const char *did_set_titlestring(optset_T *args)
+{
+  return did_set_titleiconstring(args, STL_IN_TITLE);
+}
+
+/// The 'iconstring' option is changed.
+const char *did_set_iconstring(optset_T *args)
+{
+  return did_set_titleiconstring(args, STL_IN_ICON);
+}
+
+/// The 'selection' option is changed.
+const char *did_set_selection(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (*p_sel == NUL || check_opt_strings(p_sel, p_sel_values, false) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_keymodel(const char **errmsg)
+/// The 'keymodel' option is changed.
+const char *did_set_keymodel(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_opt_strings(p_km, p_km_values, true) != OK) {
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
   km_stopsel = (vim_strchr(p_km, 'o') != NULL);
   km_startsel = (vim_strchr(p_km, 'a') != NULL);
+  return NULL;
 }
 
-static void did_set_display(const char **errmsg)
+/// The 'display' option is changed.
+const char *did_set_display(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (opt_strings_flags(p_dy, p_dy_values, &dy_flags, true) != OK) {
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
   (void)init_chartab();
   msg_grid_validate();
+  return NULL;
 }
 
-static void did_set_spellfile(char **varp, const char **errmsg)
+/// The 'spellfile' option is changed.
+const char *did_set_spellfile(optset_T *args)
 {
   // When there is a window for this buffer in which 'spell'
   // is set load the wordlists.
-
-  if ((!valid_spellfile(*varp))) {
-    *errmsg = e_invarg;
-  } else {
-    *errmsg = did_set_spell_option(true);
+  if ((!valid_spellfile(args->os_varp))) {
+    return e_invarg;
   }
+  return did_set_spell_option(true);
 }
 
-static void did_set_spell(char **varp, const char **errmsg)
+const char *did_set_spelllang(optset_T *args)
 {
   // When there is a window for this buffer in which 'spell'
   // is set load the wordlists.
-  if (!valid_spelllang(*varp)) {
-    *errmsg = e_invarg;
-  } else {
-    *errmsg = did_set_spell_option(false);
+  if (!valid_spelllang(args->os_varp)) {
+    return e_invarg;
   }
+  return did_set_spell_option(false);
 }
 
-static void did_set_spellcapcheck(win_T *win, const char **errmsg)
+/// The 'spellcapcheck' option is changed.
+const char *did_set_spellcapcheck(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   // When 'spellcapcheck' is set compile the regexp program.
-  *errmsg = compile_cap_prog(win->w_s);
+  return compile_cap_prog(win->w_s);
 }
 
-static void did_set_spelloptions(win_T *win, const char **errmsg)
+/// The 'spelloptions' option is changed.
+const char *did_set_spelloptions(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   if (opt_strings_flags(win->w_s->b_p_spo, p_spo_values, &(win->w_s->b_p_spo_flags),
                         true) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_spellsuggest(const char **errmsg)
+/// The 'spellsuggest' option is changed.
+const char *did_set_spellsuggest(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (spell_check_sps() != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_mkspellmem(const char **errmsg)
+ /// The 'mkspellmem' option is changed.
+const char *did_set_mkspellmem(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (spell_check_msm() != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_buftype(buf_T *buf, win_T *win, const char **errmsg)
+/// The 'buftype' option is changed.
+const char *did_set_buftype(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  win_T *win = (win_T *)args->os_win;
   // When 'buftype' is set, check for valid value.
   if ((buf->terminal && buf->b_p_bt[0] != 't')
       || (!buf->terminal && buf->b_p_bt[0] == 't')
       || check_opt_strings(buf->b_p_bt, p_buftype_values, false) != OK) {
-    *errmsg = e_invarg;
-  } else {
-    if (win->w_status_height || global_stl_height()) {
-      win->w_redr_status = true;
-      redraw_later(win, UPD_VALID);
-    }
-    buf->b_help = (buf->b_p_bt[0] == 'h');
-    redraw_titles();
+    return e_invarg;
   }
+  if (win->w_status_height || global_stl_height()) {
+    win->w_redr_status = true;
+    redraw_later(win, UPD_VALID);
+  }
+  buf->b_help = (buf->b_p_bt[0] == 'h');
+  redraw_titles();
+  return NULL;
 }
 
-// 'statusline', 'winbar', 'tabline', 'rulerformat' or 'statuscolumn'
-static void did_set_statusline(win_T *win, char **varp, char **gvarp, const char **errmsg)
+/// The 'statusline', 'winbar', 'tabline', 'rulerformat' or 'statuscolumn' option is changed.
+///
+/// @param rulerformat  true if the 'rulerformat' option is changed
+/// @param statuscolumn  true if the 'statuscolumn' option is changed
+static const char *did_set_statustabline_rulerformat(optset_T *args, bool rulerformat,
+                                                     bool statuscolumn)
 {
-  if (varp == &p_ruf) {       // reset ru_wid first
+  win_T *win = (win_T *)args->os_win;
+  if (rulerformat) {       // reset ru_wid first
     ru_wid = 0;
-  } else if (varp == &win->w_p_stc) {
+  } else if (statuscolumn) {
     // reset 'statuscolumn' width
     win->w_nrwidth_line_count = 0;
   }
-  char *s = *varp;
-  if (varp == &p_ruf && *s == '%') {
+  const char *errmsg = NULL;
+  char *s = args->os_varp;
+  if (rulerformat && *s == '%') {
     // set ru_wid if 'ruf' starts with "%99("
     if (*++s == '-') {        // ignore a '-'
       s++;
     }
     int wid = getdigits_int(&s, true, 0);
-    if (wid && *s == '(' && (*errmsg = check_stl_option(p_ruf)) == NULL) {
+    if (wid && *s == '(' && (errmsg = check_stl_option(p_ruf)) == NULL) {
       ru_wid = wid;
     } else {
-      *errmsg = check_stl_option(p_ruf);
+      errmsg = check_stl_option(p_ruf);
     }
-  } else if (varp == &p_ruf || s[0] != '%' || s[1] != '!') {
+  } else if (rulerformat || s[0] != '%' || s[1] != '!') {
     // check 'statusline', 'winbar', 'tabline' or 'statuscolumn'
     // only if it doesn't start with "%!"
-    *errmsg = check_stl_option(s);
+    errmsg = check_stl_option(s);
   }
-  if (varp == &p_ruf && *errmsg == NULL) {
+  if (rulerformat && errmsg == NULL) {
     comp_col();
   }
-  // add / remove window bars for 'winbar'
-  if (gvarp == &p_wbr) {
-    set_winbar(true);
-  }
+  return errmsg;
+}
+
+/// The 'statusline' option is changed.
+const char *did_set_statusline(optset_T *args)
+{
+  return did_set_statustabline_rulerformat(args, false, false);
+}
+
+/// The 'tabline' option is changed.
+const char *did_set_tabline(optset_T *args)
+{
+  return did_set_statustabline_rulerformat(args, false, false);
+}
+
+/// The 'rulerformat' option is changed.
+const char *did_set_rulerformat(optset_T *args)
+{
+  return did_set_statustabline_rulerformat(args, true, false);
+}
+
+/// The 'winbar' option is changed.
+const char *did_set_winbar(optset_T *args)
+{
+  return did_set_statustabline_rulerformat(args, false, false);
+}
+
+/// The 'statuscolumn' option is changed.
+const char *did_set_statuscolumn(optset_T *args)
+{
+  return did_set_statustabline_rulerformat(args, false, true);
 }
 
 static void did_set_complete(char **varp, char *errbuf, size_t errbuflen, const char **errmsg)
@@ -1269,29 +1376,36 @@ static void did_set_complete(char **varp, char *errbuf, size_t errbuflen, const 
   }
 }
 
-static void did_set_completeopt(const char **errmsg)
+/// The 'completeopt' option is changed.
+const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (check_opt_strings(p_cot, p_cot_values, true) != OK) {
-    *errmsg = e_invarg;
-  } else {
-    completeopt_was_set();
+    return e_invarg;
   }
+  completeopt_was_set();
+  return NULL;
 }
 
 #ifdef BACKSLASH_IN_FILENAME
-static void did_set_completeslash(buf_T *buf, const char **errmsg)
+/// The 'completeslash' option is changed.
+const char *did_set_completeslash(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
   if (check_opt_strings(p_csl, p_csl_values, false) != OK
       || check_opt_strings(buf->b_p_csl, p_csl_values, false) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 #endif
 
-static void did_set_signcolumn(win_T *win, char **varp, const char *oldval, const char **errmsg)
+/// The 'signcolumn' option is changed.
+const char *did_set_signcolumn(optset_T *args)
 {
-  if (check_signcolumn(*varp) != OK) {
-    *errmsg = e_invarg;
+  win_T *win = (win_T *)args->os_win;
+  const char *oldval = args->os_oldval.string;
+  if (check_signcolumn(args->os_varp) != OK) {
+    return e_invarg;
   }
   // When changing the 'signcolumn' to or from 'number', recompute the
   // width of the number column if 'number' or 'relativenumber' is set.
@@ -1300,28 +1414,37 @@ static void did_set_signcolumn(win_T *win, char **varp, const char *oldval, cons
       && (win->w_p_nu || win->w_p_rnu)) {
     win->w_nrwidth_line_count = 0;
   }
+  return NULL;
 }
 
-static void did_set_foldcolumn(char **varp, const char **errmsg)
+/// The 'foldcolumn' option is changed.
+const char *did_set_foldcolumn(optset_T *args)
 {
-  if (**varp == NUL || check_opt_strings(*varp, p_fdc_values, false) != OK) {
-    *errmsg = e_invarg;
+  if (*args->os_varp == NUL || check_opt_strings(args->os_varp, p_fdc_values, false) != OK) {
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_backspace(const char **errmsg)
+/// The 'backspace' option is changed.
+const char *did_set_backspace(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (ascii_isdigit(*p_bs)) {
     if (*p_bs > '3' || p_bs[1] != NUL) {
-      *errmsg = e_invarg;
+      return e_invarg;
     }
   } else if (check_opt_strings(p_bs, p_bs_values, true) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_tagcase(buf_T *buf, int opt_flags, const char **errmsg)
+/// The 'tagcase' option is changed.
+const char *did_set_tagcase(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+  int opt_flags = args->os_flags;
+
   unsigned *flags;
   char *p;
 
@@ -1338,73 +1461,95 @@ static void did_set_tagcase(buf_T *buf, int opt_flags, const char **errmsg)
     *flags = 0;
   } else if (*p == NUL
              || opt_strings_flags(p, p_tc_values, flags, false) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_diffopt(const char **errmsg)
+/// The 'diffopt' option is changed.
+const char *did_set_diffopt(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (diffopt_changed() == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_foldmethod(win_T *win, char **varp, const char **errmsg)
+/// The 'foldmethod' option is changed.
+const char *did_set_foldmethod(optset_T *args)
 {
-  if (check_opt_strings(*varp, p_fdm_values, false) != OK
+  win_T *win = (win_T *)args->os_win;
+  if (check_opt_strings(args->os_varp, p_fdm_values, false) != OK
       || *win->w_p_fdm == NUL) {
-    *errmsg = e_invarg;
-  } else {
-    foldUpdateAll(win);
-    if (foldmethodIsDiff(win)) {
-      newFoldLevel();
-    }
+    return e_invarg;
   }
+  foldUpdateAll(win);
+  if (foldmethodIsDiff(win)) {
+    newFoldLevel();
+  }
+  return NULL;
 }
 
-static void did_set_foldmarker(win_T *win, char **varp, const char **errmsg)
+/// The 'foldmarker' option is changed.
+const char *did_set_foldmarker(optset_T *args)
 {
-  char *p = vim_strchr(*varp, ',');
+  win_T *win = (win_T *)args->os_win;
+  char *p = vim_strchr(args->os_varp, ',');
+
   if (p == NULL) {
-    *errmsg = N_("E536: comma required");
-  } else if (p == *varp || p[1] == NUL) {
-    *errmsg = e_invarg;
-  } else if (foldmethodIsMarker(win)) {
+    return N_("E536: comma required");
+  }
+
+  if (p == args->os_varp || p[1] == NUL) {
+    return e_invarg;
+  }
+
+  if (foldmethodIsMarker(win)) {
     foldUpdateAll(win);
   }
+
+  return NULL;
 }
 
-static void did_set_commentstring(char **varp, const char **errmsg)
+/// The 'commentstring' option is changed.
+const char *did_set_commentstring(optset_T *args)
 {
-  if (**varp != NUL && strstr(*varp, "%s") == NULL) {
-    *errmsg = N_("E537: 'commentstring' must be empty or contain %s");
+  if (*args->os_varp != NUL && strstr(args->os_varp, "%s") == NULL) {
+    return N_("E537: 'commentstring' must be empty or contain %s");
   }
+  return NULL;
 }
 
-static void did_set_foldignore(win_T *win)
+/// The 'foldignore' option is changed.
+const char *did_set_foldignore(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   if (foldmethodIsIndent(win)) {
     foldUpdateAll(win);
   }
+  return NULL;
 }
 
-static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, const char **errmsg)
+/// The 'virtualedit' option is changed.
+const char *did_set_virtualedit(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
+
   char *ve = p_ve;
   unsigned *flags = &ve_flags;
 
-  if (opt_flags & OPT_LOCAL) {
+  if (args->os_flags & OPT_LOCAL) {
     ve = win->w_p_ve;
     flags = &win->w_ve_flags;
   }
 
-  if ((opt_flags & OPT_LOCAL) && *ve == NUL) {
+  if ((args->os_flags & OPT_LOCAL) && *ve == NUL) {
     // make the local value empty: use the global value
     *flags = 0;
   } else {
     if (opt_strings_flags(ve, p_ve_values, flags, true) != OK) {
-      *errmsg = e_invarg;
-    } else if (strcmp(ve, oldval) != 0) {
+      return e_invarg;
+    } else if (strcmp(ve, args->os_oldval.string) != 0) {
       // Recompute cursor position in case the new 've' setting
       // changes something.
       validate_virtcol_win(win);
@@ -1412,15 +1557,20 @@ static void did_set_virtualedit(win_T *win, int opt_flags, char *oldval, const c
       coladvance(win->w_virtcol);
     }
   }
+  return NULL;
 }
 
-static void did_set_lispoptions(char **varp, const char **errmsg)
+/// The 'lispoptions' option is changed.
+const char *did_set_lispoptions(optset_T *args)
 {
-  if (**varp != NUL && strcmp(*varp, "expr:0") != 0 && strcmp(*varp, "expr:1") != 0) {
-    *errmsg = e_invarg;
+  if (*args->os_varp != NUL
+      && strcmp(args->os_varp, "expr:0") != 0 && strcmp(args->os_varp, "expr:1") != 0) {
+    return e_invarg;
   }
+  return NULL;
 }
 
+/// The 'filetype' or the 'syntax' option is changed.
 static void did_set_filetype_or_syntax(char **varp, char *oldval, int *value_checked,
                                        bool *value_changed, const char **errmsg)
 {
@@ -1436,66 +1586,75 @@ static void did_set_filetype_or_syntax(char **varp, char *oldval, int *value_che
   *value_checked = true;
 }
 
-static void did_set_winhl(win_T *win, const char **errmsg)
+const char *did_set_winhl(optset_T *args)
 {
+  win_T *win = (win_T *)args->os_win;
   if (!parse_winhl_opt(win)) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_varsoftabstop(buf_T *buf, char **varp, const char **errmsg)
+/// The 'varsofttabstop' option is changed.
+const char *did_set_varsofttabstop(optset_T *args)
 {
-  if (!(*varp)[0] || ((*varp)[0] == '0' && !(*varp)[1])) {
+  buf_T *buf = (buf_T *)args->os_buf;
+
+  if (!(args->os_varp[0]) || ((args->os_varp[0]) == '0' && !(args->os_varp[1]))) {
     XFREE_CLEAR(buf->b_p_vsts_array);
-    return;
+    return NULL;
   }
 
-  for (char *cp = *varp; *cp; cp++) {
+  for (char *cp = args->os_varp; *cp; cp++) {
     if (ascii_isdigit(*cp)) {
       continue;
     }
-    if (*cp == ',' && cp > *varp && *(cp - 1) != ',') {
+    if (*cp == ',' && cp > args->os_varp && *(cp - 1) != ',') {
       continue;
     }
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
 
   long *oldarray = buf->b_p_vsts_array;
-  if (tabstop_set(*varp, &(buf->b_p_vsts_array))) {
+  if (tabstop_set(args->os_varp, &(buf->b_p_vsts_array))) {
     xfree(oldarray);
   } else {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_vartabstop(buf_T *buf, win_T *win, char **varp, const char **errmsg)
+/// The 'varstabstop' option is changed.
+const char *did_set_vartabstop(optset_T *args)
 {
-  if (!(*varp)[0] || ((*varp)[0] == '0' && !(*varp)[1])) {
+  buf_T *buf = (buf_T *)args->os_buf;
+  win_T *win = (win_T *)args->os_win;
+
+  if (!(args->os_varp[0]) || ((args->os_varp[0]) == '0' && !(args->os_varp[1]))) {
     XFREE_CLEAR(buf->b_p_vts_array);
-    return;
+    return NULL;
   }
 
-  for (char *cp = *varp; *cp; cp++) {
+  for (char *cp = args->os_varp; *cp; cp++) {
     if (ascii_isdigit(*cp)) {
       continue;
     }
-    if (*cp == ',' && cp > *varp && *(cp - 1) != ',') {
+    if (*cp == ',' && cp > args->os_varp && *(cp - 1) != ',') {
       continue;
     }
-    *errmsg = e_invarg;
-    return;
+    return e_invarg;
   }
 
   long *oldarray = buf->b_p_vts_array;
-  if (tabstop_set(*varp, &(buf->b_p_vts_array))) {
+  if (tabstop_set(args->os_varp, &(buf->b_p_vts_array))) {
     xfree(oldarray);
     if (foldmethodIsIndent(win)) {
       foldUpdateAll(win);
     }
   } else {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
 static void did_set_optexpr(char **varp)
@@ -1517,6 +1676,11 @@ static void did_set_option_listflag(char **varp, char *flags, char *errbuf, size
       break;
     }
   }
+}
+
+const char *did_set_guicursor(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return parse_shape_opt(SHAPE_CURSOR);
 }
 
 // When 'syntax' is set, load the syntax of that name
@@ -1574,18 +1738,28 @@ static void do_spelllang_source(win_T *win)
 ///
 /// @return  NULL for success, or an untranslated error message for an error
 static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx, char **varp,
-                                             char *oldval, char *errbuf, size_t errbuflen,
-                                             int opt_flags, int *value_checked)
+                                             char *oldval, const char *value, char *errbuf,
+                                             size_t errbuflen, int opt_flags, int *value_checked)
 {
   const char *errmsg = NULL;
   bool did_chartab = false;
   vimoption_T *opt = get_option(opt_idx);
   bool free_oldval = (opt->flags & P_ALLOCED);
+  opt_did_set_cb_T did_set_cb = get_option_did_set_cb(opt_idx);
   bool value_changed = false;
 
   // Get the global option to compare with, otherwise we would have to check
   // two values for all local options.
   char **gvarp = (char **)get_varp_scope(opt, OPT_GLOBAL);
+
+  optset_T args = {
+    .os_varp = *varp,
+    .os_flags = opt_flags,
+    .os_oldval.string = oldval,
+    .os_newval.string = value,
+    .os_win = curwin,
+    .os_buf = curbuf,
+  };
 
   // Disallow changing some options from secure mode
   if ((secure || sandbox != 0) && (opt->flags & P_SECURE)) {
@@ -1593,68 +1767,39 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     // Check for a "normal" directory or file name in some options.
   } else if (check_illegal_path_names(*varp, opt->flags)) {
     errmsg = e_invarg;
-  } else if (gvarp == &p_bkc) {                         // 'backupcopy'
-    did_set_backupcopy(buf, oldval, opt_flags, &errmsg);
-  } else if (varp == &p_bex                             // 'backupext'
-             || varp == &p_pm) {                        // 'patchmode'
-    did_set_backupext_or_patchmode(&errmsg);
-  } else if (varp == &win->w_p_briopt) {                // 'breakindentopt'
-    did_set_breakindentopt(win, &errmsg);
+  } else if (did_set_cb != NULL) {
+    // Invoke the option specific callback function to validate and apply
+    // the new option value.
+    errmsg = did_set_cb(&args);
   } else if (varp == &p_isi                             // 'isident'
              || varp == &buf->b_p_isk                   // 'iskeyword'
              || varp == &p_isp                          // 'isprint'
              || varp == &p_isf) {                       // 'isfname'
     did_set_isopt(buf, &did_chartab, &errmsg);
-  } else if (varp == &p_hf) {                           // 'helpfile'
-    did_set_helpfile();
-  } else if (varp == &p_rtp                             // 'runtimepath'
-             || varp == &p_pp) {                        // 'packpath'
-    runtime_search_path_invalidate();
   } else if (gvarp == &win->w_allbuf_opt.wo_culopt) {   // 'cursorlineopt'
     did_set_cursorlineopt(win, varp, &errmsg);
   } else if (varp == &win->w_p_cc) {                    // 'colorcolumn'
     errmsg = check_colorcolumn(win);
-  } else if (varp == &p_hlg) {                          // 'helplang'
-    did_set_helplang(&errmsg);
-  } else if (varp == &p_hl) {                           // 'highlight'
-    did_set_highlight(varp, &errmsg);
   } else if (varp == &p_jop) {                          // 'jumpoptions'
     did_set_opt_flags(p_jop, p_jop_values, &jop_flags, true, &errmsg);
   } else if (gvarp == &p_nf) {                          // 'nrformats'
     did_set_opt_strings(*varp, p_nf_values, true, &errmsg);
-  } else if (varp == &p_ssop) {                         // 'sessionoptions'
-    did_set_sessionoptions(oldval, &errmsg);
   } else if (varp == &p_vop) {                          // 'viewoptions'
     did_set_opt_flags(p_vop, p_ssop_values, &vop_flags, true, &errmsg);
   } else if (varp == &p_rdb) {                          // 'redrawdebug'
     did_set_opt_flags(p_rdb, p_rdb_values, &rdb_flags, true, &errmsg);
   } else if (varp == &p_sbo) {                          // 'scrollopt'
     did_set_opt_strings(p_sbo, p_scbopt_values, true, &errmsg);
-  } else if (varp == &p_ambw                            // 'ambiwidth'
-             || (int *)varp == &p_emoji) {              // 'emoji'
-    did_set_ambiwidth(&errmsg);
-  } else if (varp == &p_bg) {                           // 'background'
-    did_set_background(&errmsg);
-  } else if (varp == &p_wim) {                          // 'wildmode'
-    did_set_wildmode(&errmsg);
   } else if (varp == &p_wop) {                          // 'wildoptions'
     did_set_opt_flags(p_wop, p_wop_values, &wop_flags, true, &errmsg);
-  } else if (varp == &p_wak) {                          // 'winaltkeys'
-    did_set_winaltkeys(&errmsg);
-  } else if (varp == &p_ei) {                           // 'eventignore'
-    did_set_eventignore(&errmsg);
   } else if (varp == &p_enc                             // 'encoding'
              || gvarp == &p_fenc                        // 'fileencoding'
              || gvarp == &p_menc) {                     // 'makeencoding'
     did_set_encoding(buf, varp, gvarp, opt_flags, &errmsg);
   } else if (varp == &buf->b_p_keymap) {                // 'keymap'
     did_set_keymap(buf, varp, opt_flags, value_checked, &errmsg);
-  } else if (gvarp == &p_ff) {                          // 'fileformat'
-    did_set_fileformat(buf, varp, oldval, opt_flags, &errmsg);
   } else if (varp == &p_ffs) {                          // 'fileformats'
     did_set_opt_strings(p_ffs, p_ff_values, true, &errmsg);
-  } else if (gvarp == &p_mps) {                         // 'matchpairs'
-    did_set_matchpairs(varp, &errmsg);
   } else if (gvarp == &p_com) {                         // 'comments'
     did_set_comments(varp, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_lcs                             // global 'listchars'
@@ -1664,123 +1809,43 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     errmsg = set_chars_option(win, varp, true);
   } else if (varp == &win->w_p_fcs) {                   // local 'fillchars'
     errmsg = set_chars_option(win, varp, true);
-  } else if (varp == &p_cedit) {                        // 'cedit'
-    errmsg = check_cedit();
-  } else if (varp == &p_vfile) {                        // 'verbosefile'
-    did_set_verbosefile(&errmsg);
   } else if (varp == &p_shada) {                        // 'shada'
-    did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen, &errmsg);
-  } else if (gvarp == &p_sbr) {                         // 'showbreak'
-    did_set_showbreak(varp, &errmsg);
-  } else if (varp == &p_guicursor) {                    // 'guicursor'
-    errmsg = parse_shape_opt(SHAPE_CURSOR);
-  } else if (varp == &p_langmap) {                      // 'langmap'
-    langmap_set();
-  } else if (varp == &p_breakat) {                      // 'breakat'
-    fill_breakat_flags();
-  } else if (varp == &p_titlestring                     // 'titlestring'
-             || varp == &p_iconstring) {                // 'iconstring'
-    did_set_titleiconstring(varp);
-  } else if (varp == &p_sel) {                          // 'selection'
-    did_set_selection(&errmsg);
+    errmsg = did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen);
   } else if (varp == &p_slm) {                          // 'selectmode'
     did_set_opt_strings(p_slm, p_slm_values, true, &errmsg);
-  } else if (varp == &p_km) {                           // 'keymodel'
-    did_set_keymodel(&errmsg);
   } else if (varp == &p_mousem) {                       // 'mousemodel'
     did_set_opt_strings(p_mousem, p_mousem_values, false, &errmsg);
-  } else if (varp == &p_mousescroll) {                  // 'mousescroll'
-    errmsg = check_mousescroll(p_mousescroll);
   } else if (varp == &p_swb) {                          // 'switchbuf'
     did_set_opt_flags(p_swb, p_swb_values, &swb_flags, true, &errmsg);
   } else if (varp == &p_spk) {                          // 'splitkeep'
     did_set_opt_strings(p_spk, p_spk_values, false, &errmsg);
   } else if (varp == &p_debug) {                        // 'debug'
     did_set_opt_strings(p_debug, p_debug_values, true, &errmsg);
-  } else if (varp == &p_dy) {                           // 'display'
-    did_set_display(&errmsg);
   } else if (varp == &p_ead) {                          // 'eadirection'
     did_set_opt_strings(p_ead, p_ead_values, false, &errmsg);
   } else if (varp == &p_cb) {                           // 'clipboard'
     did_set_opt_flags(p_cb, p_cb_values, &cb_flags, true, &errmsg);
-  } else if (varp == &win->w_s->b_p_spf) {              // 'spellfile'
-    did_set_spellfile(varp, &errmsg);
-  } else if (varp == &win->w_s->b_p_spl) {              // 'spell'
-    did_set_spell(varp, &errmsg);
-  } else if (varp == &win->w_s->b_p_spc) {              // 'spellcapcheck'
-    did_set_spellcapcheck(win, &errmsg);
-  } else if (varp == &win->w_s->b_p_spo) {              // 'spelloptions'
-    did_set_spelloptions(win, &errmsg);
-  } else if (varp == &p_sps) {                          // 'spellsuggest'
-    did_set_spellsuggest(&errmsg);
-  } else if (varp == &p_msm) {                          // 'mkspellmem'
-    did_set_mkspellmem(&errmsg);
   } else if (gvarp == &p_bh) {                          // 'bufhidden'
     did_set_opt_strings(buf->b_p_bh, p_bufhidden_values, false, &errmsg);
-  } else if (gvarp == &p_bt) {                          // 'buftype'
-    did_set_buftype(buf, win, &errmsg);
-  } else if (gvarp == &p_stl                            // 'statusline'
-             || gvarp == &p_wbr                         // 'winbar'
-             || varp == &p_tal                          // 'tabline'
-             || varp == &p_ruf                          // 'rulerformat'
-             || varp == &win->w_p_stc) {                // 'statuscolumn'
-    did_set_statusline(win, varp, gvarp, &errmsg);
   } else if (gvarp == &p_cpt) {                         // 'complete'
     did_set_complete(varp, errbuf, errbuflen, &errmsg);
-  } else if (varp == &p_cot) {                          // 'completeopt'
-    did_set_completeopt(&errmsg);
-#ifdef BACKSLASH_IN_FILENAME
-  } else if (gvarp == &p_csl) {                         // 'completeslash'
-    did_set_completeslash(buf, &errmsg);
-#endif
-  } else if (varp == &win->w_p_scl) {                   // 'signcolumn'
-    did_set_signcolumn(win, varp, oldval, &errmsg);
   } else if (varp == &p_sloc) {                         // 'showcmdloc'
     did_set_opt_strings(*varp, p_sloc_values, false, &errmsg);
-  } else if (gvarp == &win->w_allbuf_opt.wo_fdc) {      // 'foldcolumn'
-    did_set_foldcolumn(varp, &errmsg);
-  } else if (varp == &p_bs) {                           // 'backspace'
-    did_set_backspace(&errmsg);
   } else if (varp == &p_bo) {
     did_set_opt_flags(p_bo, p_bo_values, &bo_flags, true, &errmsg);
-  } else if (gvarp == &p_tc) {                          // 'tagcase'
-    did_set_tagcase(buf, opt_flags, &errmsg);
   } else if (varp == &p_cmp) {                          // 'casemap'
     did_set_opt_flags(p_cmp, p_cmp_values, &cmp_flags, true, &errmsg);
-  } else if (varp == &p_dip) {                          // 'diffopt'
-    did_set_diffopt(&errmsg);
-  } else if (gvarp == &win->w_allbuf_opt.wo_fdm) {      // 'foldmethod'
-    did_set_foldmethod(win, varp, &errmsg);
-  } else if (gvarp == &win->w_allbuf_opt.wo_fmr) {      // 'foldmarker'
-    did_set_foldmarker(win, varp, &errmsg);
-  } else if (gvarp == &p_cms) {                         // 'commentstring'
-    did_set_commentstring(varp, &errmsg);
   } else if (varp == &p_fdo) {                          // 'foldopen'
     did_set_opt_flags(p_fdo, p_fdo_values, &fdo_flags, true, &errmsg);
   } else if (varp == &p_fcl) {                          // 'foldclose'
     did_set_opt_strings(*varp, p_fcl_values, true, &errmsg);
-  } else if (gvarp == &win->w_allbuf_opt.wo_fdi) {      // 'foldignore'
-    did_set_foldignore(win);
-  } else if (gvarp == &p_ve) {                          // 'virtualedit'
-    did_set_virtualedit(win, opt_flags, oldval, &errmsg);
-  } else if (gvarp == &p_cino) {                        // 'cinoptions'
-    // TODO(vim): recognize errors
-    parse_cino(buf);
-  } else if (gvarp == &p_lop) {                         // 'lispoptions'
-    did_set_lispoptions(varp, &errmsg);
   } else if (varp == &p_icm) {                          // 'inccommand'
     did_set_opt_strings(*varp, p_icm_values, false, &errmsg);
   } else if (gvarp == &p_ft                             // 'filetype'
              || gvarp == &p_syn) {                      // 'syntax'
     did_set_filetype_or_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
-  } else if (varp == &win->w_p_winhl) {                 // 'winhighlight'
-    did_set_winhl(win, &errmsg);
   } else if (varp == &p_tpf) {
     did_set_opt_flags(p_tpf, p_tpf_values, &tpf_flags, true, &errmsg);
-  } else if (varp == &buf->b_p_vsts) {                  // 'varsofttabstop'
-    did_set_varsoftabstop(buf, varp, &errmsg);
-  } else if (varp == &buf->b_p_vts) {                   // 'vartabstop'
-    did_set_vartabstop(buf, win, varp, &errmsg);
   } else if (varp == &p_dex                             // 'diffexpr'
              || gvarp == &win->w_allbuf_opt.wo_fde      // 'foldexpr'
              || gvarp == &win->w_allbuf_opt.wo_fdt      // 'foldtext'
@@ -1793,18 +1858,6 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     if (varp == &win->w_p_fde && foldmethodIsExpr(win)) {
       foldUpdateAll(win);
     }
-  } else if (gvarp == &p_cfu) {                         // 'completefunc'
-    set_completefunc_option(&errmsg);
-  } else if (gvarp == &p_ofu) {                         // 'omnifunc'
-    set_omnifunc_option(buf, &errmsg);
-  } else if (gvarp == &p_tsrfu) {                       // 'thesaurusfunc'
-    set_thesaurusfunc_option(&errmsg);
-  } else if (varp == &p_opfunc) {                       // 'operatorfunc'
-    set_operatorfunc_option(&errmsg);
-  } else if (varp == &p_qftf) {                         // 'quickfixtextfunc'
-    qf_process_qftf_option(&errmsg);
-  } else if (gvarp == &p_tfu) {                         // 'tagfunc'
-    set_tagfunc_option(&errmsg);
   } else if (varp == &p_ww) {                           // 'whichwrap'
     did_set_option_listflag(varp, WW_ALL, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_shm) {                          // 'shortmess'
@@ -1817,12 +1870,6 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     did_set_option_listflag(varp, COCU_ALL, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_mouse) {                        // 'mouse'
     did_set_option_listflag(varp, MOUSE_ALL, errbuf, errbuflen, &errmsg);
-  } else if (gvarp == &p_flp) {                         // 'formatlistpat'
-    if (win->w_briopt_list) {
-      // Changing Formatlistpattern when briopt includes the list setting:
-      // redraw
-      redraw_all_later(UPD_NOT_VALID);
-    }
   }
 
   // If an error is detected, restore the previous value.
@@ -1875,6 +1922,16 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     setmouse();  // in case 'mouse' changed
   }
 
+  if ((varp == &p_flp || varp == &(buf->b_p_flp))
+      && win->w_briopt_list) {
+    // Changing Formatlistpattern when briopt includes the list setting:
+    // redraw
+    redraw_all_later(UPD_NOT_VALID);
+  } else if (varp == &p_wbr || varp == &(win->w_p_wbr)) {
+    // add / remove window bars for 'winbar'
+    set_winbar(true);
+  }
+
   if (win->w_curswant != MAXCOL
       && (opt->flags & (P_CURSWANT | P_RALL)) != 0) {
     win->w_set_curswant = true;
@@ -1885,11 +1942,11 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
   return errmsg;
 }
 
-const char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *errbuf,
+const char *did_set_string_option(int opt_idx, char **varp, char *oldval, char *value, char *errbuf,
                                   size_t errbuflen, int opt_flags, int *value_checked)
 {
-  return did_set_string_option_for(curbuf, curwin, opt_idx, varp, oldval, errbuf, errbuflen,
-                                   opt_flags, value_checked);
+  return did_set_string_option_for(curbuf, curwin, opt_idx, varp, oldval, value, errbuf,
+                                   errbuflen, opt_flags, value_checked);
 }
 
 /// Check an option that can be a range of string values.
@@ -1910,7 +1967,7 @@ static int check_opt_strings(char *val, char **values, int list)
 /// @param list  when true: accept a list of values
 ///
 /// @return  OK for correct value, FAIL otherwise. Empty is always OK.
-static int opt_strings_flags(char *val, char **values, unsigned *flagp, bool list)
+static int opt_strings_flags(const char *val, char **values, unsigned *flagp, bool list)
 {
   unsigned new_flags = 0;
 
@@ -1946,9 +2003,8 @@ int check_ff_value(char *p)
 static char shm_buf[SHM_LEN];
 static int set_shm_recursive = 0;
 
-/// Save the acutal shortmess Flags and clear them
-/// temporarily to avoid that file messages
-/// overwrites any output from the following commands.
+/// Save the actual shortmess Flags and clear them temporarily to avoid that
+/// file messages overwrites any output from the following commands.
 ///
 /// Caller must make sure to first call save_clear_shm_value() and then
 /// restore_shm_value() exactly the same number of times.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -698,6 +698,18 @@ const char *did_set_backupext_or_patchmode(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
+/// The 'belloff' option is changed.
+const char *did_set_belloff(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_bo, p_bo_values, &bo_flags, true);
+}
+
+/// The 'termpastefilter' option is changed.
+const char *did_set_termpastefilter(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_tpf, p_tpf_values, &tpf_flags, true);
+}
+
 /// The 'breakindentopt' option is changed.
 const char *did_set_breakindentopt(optset_T *args)
 {
@@ -740,11 +752,15 @@ const char *did_set_helpfile(optset_T *args FUNC_ATTR_UNUSED)
 }
 
 /// The 'cursorlineopt' option is changed.
-static void did_set_cursorlineopt(win_T *win, char **varp, const char **errmsg)
+const char *did_set_cursorlineopt(optset_T *args)
 {
-  if (**varp == NUL || fill_culopt_flags(*varp, win) != OK) {
-    *errmsg = e_invarg;
+  win_T *win = (win_T *)args->os_win;
+
+  if (*args->os_varp == NUL || fill_culopt_flags(args->os_varp, win) != OK) {
+    return e_invarg;
   }
+
+  return NULL;
 }
 
 /// The 'helplang' option is changed.
@@ -771,17 +787,29 @@ const char *did_set_highlight(optset_T *args)
   return NULL;
 }
 
-static void did_set_opt_flags(char *val, char **values, unsigned *flagp, bool list,
-                              const char **errmsg)
+static const char *did_set_opt_flags(char *val, char **values, unsigned *flagp, bool list)
 {
   if (opt_strings_flags(val, values, flagp, list) != OK) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
-static void did_set_opt_strings(char *val, char **values, bool list, const char **errmsg)
+static const char *did_set_opt_strings(char *val, char **values, bool list)
 {
-  did_set_opt_flags(val, values, NULL, list, errmsg);
+  return did_set_opt_flags(val, values, NULL, list);
+}
+
+/// The 'selectmode' option is changed.
+const char *did_set_selectmode(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_slm, p_slm_values, true);
+}
+
+/// The 'inccommand' option is changed.
+const char *did_set_inccommand(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_icm, p_icm_values, false);
 }
 
 /// The 'sessionoptions' option is changed.
@@ -832,6 +860,18 @@ const char *did_set_background(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
+/// The 'clipboard' option is changed.
+const char *did_set_clipboard(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_cb, p_cb_values, &cb_flags, true);
+}
+
+/// The 'foldopen' option is changed.
+const char *did_set_foldopen(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_fdo, p_fdo_values, &fdo_flags, true);
+}
+
 /// The 'wildmode' option is changed.
 const char *did_set_wildmode(optset_T *args FUNC_ATTR_UNUSED)
 {
@@ -857,6 +897,12 @@ const char *did_set_eventignore(optset_T *args FUNC_ATTR_UNUSED)
     return e_invarg;
   }
   return NULL;
+}
+
+/// The 'eadirection' option is changed.
+const char *did_set_eadirection(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_ead, p_ead_values, false);
 }
 
 // 'encoding', 'fileencoding' and 'makeencoding'
@@ -965,6 +1011,12 @@ const char *did_set_fileformat(optset_T *args)
   return NULL;
 }
 
+/// The 'fileformats' option is changed.
+const char *did_set_fileformats(optset_T *args)
+{
+  return did_set_opt_strings(p_ffs, p_ff_values, true);
+}
+
 /// The 'matchpairs' option is changed.
 const char *did_set_matchpairs(optset_T *args)
 {
@@ -997,6 +1049,13 @@ const char *did_set_cinoptions(optset_T *args FUNC_ATTR_UNUSED)
   parse_cino(curbuf);
 
   return NULL;
+}
+
+/// The 'colorcolumn' option is changed.
+const char *did_set_colorcolumn(optset_T *args)
+{
+  win_T *win = (win_T *)args->os_win;
+  return check_colorcolumn(win);
 }
 
 static void did_set_comments(char **varp, char *errbuf, size_t errbuflen, const char **errmsg)
@@ -1062,6 +1121,12 @@ const char *did_set_verbosefile(optset_T *args)
     return (char *)e_invarg;
   }
   return NULL;
+}
+
+/// The 'viewoptions' option is changed.
+const char *did_set_viewoptions(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_vop, p_ssop_values, &vop_flags, true);
 }
 
 static int shada_idx = -1;
@@ -1241,13 +1306,32 @@ const char *did_set_spellsuggest(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
- /// The 'mkspellmem' option is changed.
+/// The 'splitkeep' option is changed.
+const char *did_set_splitkeep(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_spk, p_spk_values, false);
+}
+
+/// The 'mkspellmem' option is changed.
 const char *did_set_mkspellmem(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (spell_check_msm() != OK) {
     return e_invarg;
   }
   return NULL;
+}
+
+/// The 'mousemodel' option is changed.
+const char *did_set_mousemodel(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_mousem, p_mousem_values, false);
+}
+
+/// The 'bufhidden' option is changed.
+const char *did_set_bufhidden(optset_T *args)
+{
+  buf_T *buf = (buf_T *)args->os_buf;
+  return did_set_opt_strings(buf->b_p_bh, p_bufhidden_values, false);
 }
 
 /// The 'buftype' option is changed.
@@ -1268,6 +1352,12 @@ const char *did_set_buftype(optset_T *args)
   buf->b_help = (buf->b_p_bt[0] == 'h');
   redraw_titles();
   return NULL;
+}
+
+/// The 'casemap' option is changed.
+const char *did_set_casemap(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_cmp, p_cmp_values, &cmp_flags, true);
 }
 
 /// The 'statusline', 'winbar', 'tabline', 'rulerformat' or 'statuscolumn' option is changed.
@@ -1338,6 +1428,12 @@ const char *did_set_statuscolumn(optset_T *args)
   return did_set_statustabline_rulerformat(args, false, true);
 }
 
+/// The 'scrollopt' option is changed.
+const char *did_set_scrollopt(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_sbo, p_scbopt_values, true);
+}
+
 static void did_set_complete(char **varp, char *errbuf, size_t errbuflen, const char **errmsg)
 {
   // check if it is a valid value for 'complete' -- Acevedo
@@ -1399,6 +1495,12 @@ const char *did_set_completeslash(optset_T *args)
 }
 #endif
 
+/// The 'showcmdloc' option is changed.
+const char *did_set_showcmdloc(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_sloc, p_sloc_values, true);
+}
+
 /// The 'signcolumn' option is changed.
 const char *did_set_signcolumn(optset_T *args)
 {
@@ -1439,6 +1541,12 @@ const char *did_set_backspace(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
+/// The 'switchbuf' option is changed.
+const char *did_set_switchbuf(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_swb, p_swb_values, &swb_flags, true);
+}
+
 /// The 'tagcase' option is changed.
 const char *did_set_tagcase(optset_T *args)
 {
@@ -1464,6 +1572,12 @@ const char *did_set_tagcase(optset_T *args)
     return e_invarg;
   }
   return NULL;
+}
+
+/// The 'debug' option is changed.
+const char *did_set_debug(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_debug, p_debug_values, false);
 }
 
 /// The 'diffopt' option is changed.
@@ -1558,6 +1672,24 @@ const char *did_set_virtualedit(optset_T *args)
     }
   }
   return NULL;
+}
+
+/// The 'jumpoptions' option is changed.
+const char *did_set_jumpoptions(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_jop, p_jop_values, &jop_flags, true);
+}
+
+/// The 'redrawdebug' option is changed.
+const char *did_set_redrawdebug(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_rdb, p_rdb_values, &rdb_flags, true);
+}
+
+/// The 'wildoptions' option is changed.
+const char *did_set_wildoptions(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_flags(p_wop, p_wop_values, &wop_flags, true);
 }
 
 /// The 'lispoptions' option is changed.
@@ -1657,6 +1789,12 @@ const char *did_set_vartabstop(optset_T *args)
   return NULL;
 }
 
+/// The 'nrformats' option is changed.
+const char *did_set_nrformats(optset_T *args)
+{
+  return did_set_opt_strings(args->os_varp, p_nf_values, true);
+}
+
 static void did_set_optexpr(char **varp)
 {
   char *name = get_scriptlocal_funcname(*varp);
@@ -1664,6 +1802,12 @@ static void did_set_optexpr(char **varp)
     free_string_option(*varp);
     *varp = name;
   }
+}
+
+/// The 'foldclose' option is changed.
+const char *did_set_foldclose(optset_T *args FUNC_ATTR_UNUSED)
+{
+  return did_set_opt_strings(p_fcl, p_fcl_values, true);
 }
 
 // handle option that is a list of flags.
@@ -1776,30 +1920,12 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
              || varp == &p_isp                          // 'isprint'
              || varp == &p_isf) {                       // 'isfname'
     did_set_isopt(buf, &did_chartab, &errmsg);
-  } else if (gvarp == &win->w_allbuf_opt.wo_culopt) {   // 'cursorlineopt'
-    did_set_cursorlineopt(win, varp, &errmsg);
-  } else if (varp == &win->w_p_cc) {                    // 'colorcolumn'
-    errmsg = check_colorcolumn(win);
-  } else if (varp == &p_jop) {                          // 'jumpoptions'
-    did_set_opt_flags(p_jop, p_jop_values, &jop_flags, true, &errmsg);
-  } else if (gvarp == &p_nf) {                          // 'nrformats'
-    did_set_opt_strings(*varp, p_nf_values, true, &errmsg);
-  } else if (varp == &p_vop) {                          // 'viewoptions'
-    did_set_opt_flags(p_vop, p_ssop_values, &vop_flags, true, &errmsg);
-  } else if (varp == &p_rdb) {                          // 'redrawdebug'
-    did_set_opt_flags(p_rdb, p_rdb_values, &rdb_flags, true, &errmsg);
-  } else if (varp == &p_sbo) {                          // 'scrollopt'
-    did_set_opt_strings(p_sbo, p_scbopt_values, true, &errmsg);
-  } else if (varp == &p_wop) {                          // 'wildoptions'
-    did_set_opt_flags(p_wop, p_wop_values, &wop_flags, true, &errmsg);
   } else if (varp == &p_enc                             // 'encoding'
              || gvarp == &p_fenc                        // 'fileencoding'
              || gvarp == &p_menc) {                     // 'makeencoding'
     did_set_encoding(buf, varp, gvarp, opt_flags, &errmsg);
   } else if (varp == &buf->b_p_keymap) {                // 'keymap'
     did_set_keymap(buf, varp, opt_flags, value_checked, &errmsg);
-  } else if (varp == &p_ffs) {                          // 'fileformats'
-    did_set_opt_strings(p_ffs, p_ff_values, true, &errmsg);
   } else if (gvarp == &p_com) {                         // 'comments'
     did_set_comments(varp, errbuf, errbuflen, &errmsg);
   } else if (varp == &p_lcs                             // global 'listchars'
@@ -1811,41 +1937,11 @@ static const char *did_set_string_option_for(buf_T *buf, win_T *win, int opt_idx
     errmsg = set_chars_option(win, varp, true);
   } else if (varp == &p_shada) {                        // 'shada'
     errmsg = did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen);
-  } else if (varp == &p_slm) {                          // 'selectmode'
-    did_set_opt_strings(p_slm, p_slm_values, true, &errmsg);
-  } else if (varp == &p_mousem) {                       // 'mousemodel'
-    did_set_opt_strings(p_mousem, p_mousem_values, false, &errmsg);
-  } else if (varp == &p_swb) {                          // 'switchbuf'
-    did_set_opt_flags(p_swb, p_swb_values, &swb_flags, true, &errmsg);
-  } else if (varp == &p_spk) {                          // 'splitkeep'
-    did_set_opt_strings(p_spk, p_spk_values, false, &errmsg);
-  } else if (varp == &p_debug) {                        // 'debug'
-    did_set_opt_strings(p_debug, p_debug_values, true, &errmsg);
-  } else if (varp == &p_ead) {                          // 'eadirection'
-    did_set_opt_strings(p_ead, p_ead_values, false, &errmsg);
-  } else if (varp == &p_cb) {                           // 'clipboard'
-    did_set_opt_flags(p_cb, p_cb_values, &cb_flags, true, &errmsg);
-  } else if (gvarp == &p_bh) {                          // 'bufhidden'
-    did_set_opt_strings(buf->b_p_bh, p_bufhidden_values, false, &errmsg);
   } else if (gvarp == &p_cpt) {                         // 'complete'
     did_set_complete(varp, errbuf, errbuflen, &errmsg);
-  } else if (varp == &p_sloc) {                         // 'showcmdloc'
-    did_set_opt_strings(*varp, p_sloc_values, false, &errmsg);
-  } else if (varp == &p_bo) {
-    did_set_opt_flags(p_bo, p_bo_values, &bo_flags, true, &errmsg);
-  } else if (varp == &p_cmp) {                          // 'casemap'
-    did_set_opt_flags(p_cmp, p_cmp_values, &cmp_flags, true, &errmsg);
-  } else if (varp == &p_fdo) {                          // 'foldopen'
-    did_set_opt_flags(p_fdo, p_fdo_values, &fdo_flags, true, &errmsg);
-  } else if (varp == &p_fcl) {                          // 'foldclose'
-    did_set_opt_strings(*varp, p_fcl_values, true, &errmsg);
-  } else if (varp == &p_icm) {                          // 'inccommand'
-    did_set_opt_strings(*varp, p_icm_values, false, &errmsg);
   } else if (gvarp == &p_ft                             // 'filetype'
              || gvarp == &p_syn) {                      // 'syntax'
     did_set_filetype_or_syntax(varp, oldval, value_checked, &value_changed, &errmsg);
-  } else if (varp == &p_tpf) {
-    did_set_opt_flags(p_tpf, p_tpf_values, &tpf_flags, true, &errmsg);
   } else if (varp == &p_dex                             // 'diffexpr'
              || gvarp == &win->w_allbuf_opt.wo_fde      // 'foldexpr'
              || gvarp == &win->w_allbuf_opt.wo_fdt      // 'foldtext'

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3885,11 +3885,12 @@ static buf_T *qf_find_buf(qf_info_T *qi)
 }
 
 /// Process the 'quickfixtextfunc' option value.
-void qf_process_qftf_option(const char **errmsg)
+const char *did_set_quickfixtextfunc(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (option_set_callback_func(p_qftf, &qftf_cb) == FAIL) {
-    *errmsg = e_invarg;
+    return e_invarg;
   }
+  return NULL;
 }
 
 /// Update the w:quickfix_title variable in the quickfix/location list window in

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -780,9 +780,10 @@ RuntimeSearchPath runtime_search_path_build(void)
   return search_path;
 }
 
-void runtime_search_path_invalidate(void)
+const char *did_set_runtimepackpath(optset_T *args)
 {
   runtime_search_path_valid = false;
+  return NULL;
 }
 
 void runtime_search_path_free(RuntimeSearchPath path)

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1851,7 +1851,7 @@ static int count_syllables(slang_T *slang, const char *word)
 
 /// Parse 'spelllang' and set w_s->b_langp accordingly.
 /// @return  NULL if it's OK, an untranslated error message otherwise.
-char *did_set_spelllang(win_T *wp)
+char *parse_spelllang(win_T *wp)
 {
   garray_T ga;
   char *splp;
@@ -2309,7 +2309,7 @@ void spell_reload(void)
     // window for this buffer in which 'spell' is set.
     if (*wp->w_s->b_p_spl != NUL) {
       if (wp->w_p_spell) {
-        (void)did_set_spelllang(wp);
+        (void)parse_spelllang(wp);
         break;
       }
     }
@@ -3637,7 +3637,7 @@ const char *did_set_spell_option(bool is_spellfile)
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == curbuf && wp->w_p_spell) {
-      errmsg = did_set_spelllang(wp);
+      errmsg = parse_spelllang(wp);
       break;
     }
   }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1851,7 +1851,7 @@ static void spell_reload_one(char *fname, bool added_word)
   // When "zg" was used and the file wasn't loaded yet, should redo
   // 'spelllang' to load it now.
   if (added_word && !didit) {
-    did_set_spelllang(curwin);
+    parse_spelllang(curwin);
   }
 }
 

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -453,7 +453,7 @@ void spell_suggest(int count)
   const int wo_spell_save = curwin->w_p_spell;
 
   if (!curwin->w_p_spell) {
-    did_set_spelllang(curwin);
+    parse_spelllang(curwin);
     curwin->w_p_spell = true;
   }
 

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -210,20 +210,23 @@ static Callback tfu_cb;         // 'tagfunc' callback function
 /// Reads the 'tagfunc' option value and convert that to a callback value.
 /// Invoked when the 'tagfunc' option is set. The option value can be a name of
 /// a function (string), or function(<name>) or funcref(<name>) or a lambda.
-void set_tagfunc_option(const char **errmsg)
+const char *did_set_tagfunc(optset_T *args)
 {
+  buf_T *buf = (buf_T *)args->os_buf;
+
   callback_free(&tfu_cb);
-  callback_free(&curbuf->b_tfu_cb);
+  callback_free(&buf->b_tfu_cb);
 
-  if (*curbuf->b_p_tfu == NUL) {
-    return;
+  if (*buf->b_p_tfu == NUL) {
+    return NULL;
   }
 
-  if (option_set_callback_func(curbuf->b_p_tfu, &tfu_cb) == FAIL) {
-    *errmsg = e_invarg;
+  if (option_set_callback_func(buf->b_p_tfu, &tfu_cb) == FAIL) {
+    return e_invarg;
   }
 
-  callback_copy(&curbuf->b_tfu_cb, &tfu_cb);
+  callback_copy(&buf->b_tfu_cb, &tfu_cb);
+  return NULL;
 }
 
 #if defined(EXITFREE)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6089,7 +6089,7 @@ static void frame_setwidth(frame_T *curfrp, int width)
 }
 
 // Check 'winminheight' for a valid value and reduce it if needed.
-void did_set_winminheight(void)
+const char *did_set_winminheight(optset_T *args FUNC_ATTR_UNUSED)
 {
   bool first = true;
 
@@ -6106,10 +6106,11 @@ void did_set_winminheight(void)
       first = false;
     }
   }
+  return NULL;
 }
 
 // Check 'winminwidth' for a valid value and reduce it if needed.
-void did_set_winminwidth(void)
+const char *did_set_winminwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
   bool first = true;
 
@@ -6126,6 +6127,7 @@ void did_set_winminwidth(void)
       first = false;
     }
   }
+  return NULL;
 }
 
 /// Status line of dragwin is dragged "offset" lines down (negative is up).

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1480,18 +1480,18 @@ func Test_string_option_revert_on_failure()
   if has('win32') && has('terminal')
     call add(optlist, ['termwintype', 'winpty', 'a123'])
   endif
-  if has('+toolbar')
+  if exists('+toolbar')
     call add(optlist, ['toolbar', 'text', 'a123'])
     call add(optlist, ['toolbariconsize', 'medium', 'a123'])
   endif
-  if has('+mouse')
+  if exists('+ttymouse') && !has('gui')
     call add(optlist, ['ttymouse', 'xterm', 'a123'])
   endif
-  if has('+vartabs')
+  if exists('+vartabs')
     call add(optlist, ['varsofttabstop', '12', 'a123'])
     call add(optlist, ['vartabstop', '4,20', '4,'])
   endif
-  if has('gui')
+  if exists('+winaltkeys')
     call add(optlist, ['winaltkeys', 'no', 'a123'])
   endif
   for opt in optlist


### PR DESCRIPTION
### vim-patch:9.0.1330: handling new value of an option has a long "else if" chain

    Problem:    Handling new value of an option has a long "else if" chain.
    Solution:   Use a function pointer. (Yegappan Lakshmanan, closes vim/vim#12015)

https://github.com/vim/vim/commit/af93691b53f38784efce0b93fe7644c44a7e382e

### vim-patch:9.0.1345: too many "else if" statements for handling options

    Problem:    Too many "else if" statements for handling options.
    Solution:   Add more functions to handle options. (Yegappan Lakshmanan,
                closes vim/vim#12051)

https://github.com/vim/vim/commit/8ad862a1f9d6f4128de856ccfabbeb7546d33b98

### vim-patch:9.0.1353: too many "else if" statements to handle option values

    Problem:    Too many "else if" statements to handle option values.
    Solution:   Add more functions to handle option value changes. (Yegappan
                Lakshmanan, closes vim/vim#12058)

https://github.com/vim/vim/commit/6d611de58c8e324491415da8e79c6bd3faa3e848

### vim-patch:9.0.1359: too many "else if" statements in handling options

    Problem:    Too many "else if" statements in handling options.
    Solution:   Add more functions for handling option changes. (Yegappan
                Lakshmanan, closes vim/vim#12060)

https://github.com/vim/vim/commit/5da901bb68717b2baff6e971c1517219b6ee3a67

### vim-patch:9.0.1369: still some "else if" constructs for setting options

    Problem:    Still some "else if" constructs for setting options.
    Solution:   Add a few more functions for handling options. (Yegappan
                Lakshmanan, closes vim/vim#12090)

https://github.com/vim/vim/commit/c6ff21e876af0e3ad59664dd0f69359c4b6e9f1d

### vim-patch:9.0.1374: function for setting options not used consistently

    Problem:    Function for setting options not used consistently.
    Solution:   Use a function for 'encoding' and terminal options. (Yegappan
                Lakshmanan, closes vim/vim#12099)

https://github.com/vim/vim/commit/c727b19e9f1df36e44321d933334c7b4961daa54

### Notes
- Added `os_buf` and `os_win` to the `optset_T` and use these fields instead of `curwin`/`curbuf` in callbacks.
- Made all the `did_set_*` callbacks in `option.c` static.
