### PR TITLE
feat(filetype): detect v files

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1091,7 +1091,9 @@ local extension = {
   vr = 'vera',
   vri = 'vera',
   vrh = 'vera',
-  v = 'verilog',
+  v = function(path, bufnr)
+    return require('vim.filetype.detect').v(bufnr)
+  end,
   va = 'verilogams',
   vams = 'verilogams',
   vhdl = 'vhdl',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1322,6 +1322,15 @@ function M.txt(bufnr)
   end
 end
 
+function M.v(bufnr)
+  for _, line in ipairs(getlines(bufnr)) do
+    if not line:find(';$') then
+      return 'v'
+    end
+  end
+  return 'verilog'
+end
+
 -- WEB (*.web is also used for Winbatch: Guess, based on expecting "%" comment
 -- lines in a WEB file).
 function M.web(bufnr)


### PR DESCRIPTION
V files don't end lines with semicolons while verilog files do. I'm assuming this is a reliable filetype detection.