### PR TITLE
vim-patch:9.0.{0783,0785,0815,0817,0820,0864}

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -248,6 +248,7 @@ g8			Print the hex values of the bytes used in the
 <
 							*:!cmd* *:!*
 :!{cmd}			Execute {cmd} with 'shell'. See also |:terminal|.
+			`:!` without a {cmd} is a no-op, it does nothing.
 
 			The command runs in a non-interactive shell connected
 			to a pipe (not a terminal). Use |:terminal| to run an

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -248,7 +248,6 @@ g8			Print the hex values of the bytes used in the
 <
 							*:!cmd* *:!*
 :!{cmd}			Execute {cmd} with 'shell'. See also |:terminal|.
-			`:!` without a {cmd} is a no-op, it does nothing.
 
 			The command runs in a non-interactive shell connected
 			to a pipe (not a terminal). Use |:terminal| to run an

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3207,7 +3207,7 @@ static int ex_defer_inner(char *name, char **arg, const partial_T *const partial
 }
 
 /// Return true if currently inside a function call.
-/// Give an error message and return FALSE when not.
+/// Give an error message and return false when not.
 bool can_add_defer(void)
 {
   if (get_current_funccal() == NULL) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1015,6 +1015,7 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
   // Don't do anything if there is no command as there isn't really anything
   // useful in running "sh -c ''".  Avoids changing "prevcmd".
   if (strlen(newcmd) == 0) {
+    xfree(newcmd);
     return;
   }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -988,6 +988,8 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     }
     if (ins_prevcmd) {
       STRCAT(t, prevcmd);
+    } else {
+      xfree(t);
     }
     p = t + strlen(t);
     STRCAT(t, trailarg);
@@ -1012,15 +1014,11 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     }
   } while (trailarg != NULL);
 
-  // Don't do anything if there is no command as there isn't really anything
-  // useful in running "sh -c ''".  Avoids changing "prevcmd".
-  if (strlen(newcmd) == 0) {
-    xfree(newcmd);
-    return;
+  // Don't clear "prevcmd" if there is no command to run.
+  if (strlen(newcmd) > 0) {
+    xfree(prevcmd);
+    prevcmd = newcmd;
   }
-
-  xfree(prevcmd);
-  prevcmd = newcmd;
 
   if (bangredo) {  // put cmd in redo buffer for ! command
     // If % or # appears in the command, it must have been escaped.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1012,6 +1012,12 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     }
   } while (trailarg != NULL);
 
+  // Don't do anything if there is no command as there isn't really anything
+  // useful in running "sh -c ''".  Avoids changing "prevcmd".
+  if (strlen(newcmd) == 0) {
+    return;
+  }
+
   xfree(prevcmd);
   prevcmd = newcmd;
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1012,10 +1012,13 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     }
   } while (trailarg != NULL);
 
-  // Don't clear "prevcmd" if there is no command to run.
+  // Only set "prevcmd" if there is a command to run, otherwise keep te one
+  // we have.
   if (strlen(newcmd) > 0) {
     xfree(prevcmd);
     prevcmd = newcmd;
+  } else {
+    free_newcmd = true;
   }
 
   if (bangredo) {  // put cmd in redo buffer for ! command
@@ -1031,6 +1034,9 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
   }
   // Add quotes around the command, for shells that need them.
   if (*p_shq != NUL) {
+    if (free_newcmd) {
+      xfree(newcmd);
+    }
     newcmd = xmalloc(strlen(prevcmd) + 2 * strlen(p_shq) + 1);
     STRCPY(newcmd, p_shq);
     STRCAT(newcmd, prevcmd);

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -988,8 +988,6 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     }
     if (ins_prevcmd) {
       STRCAT(t, prevcmd);
-    } else {
-      xfree(t);
     }
     p = t + strlen(t);
     STRCAT(t, trailarg);

--- a/test/old/testdir/test_shell.vim
+++ b/test/old/testdir/test_shell.vim
@@ -237,4 +237,17 @@ func Test_shell_repeat()
   let &shell = save_shell
 endfunc
 
+func Test_shell_no_prevcmd()
+  " this doesn't do anything, just check it doesn't crash
+  let after =<< trim END
+    exe "normal !!\<CR>"
+    call writefile([v:errmsg, 'done'], 'Xtestdone')
+    qall!
+  END
+  if RunVim([], after, '--clean')
+    call assert_equal(['E34: No previous command', 'done'], readfile('Xtestdone'))
+  endif
+  call delete('Xtestdone')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_shell.vim
+++ b/test/old/testdir/test_shell.vim
@@ -223,8 +223,8 @@ func Test_shell_repeat()
   call assert_equal(['Cmd: [-c echo coconut]'], readfile('Xlog'))
 
   call writefile(['empty'], 'Xlog')
-  call feedkeys(":!\<CR>", 'xt')               " :! is a no-op
-  call assert_equal(['empty'], readfile('Xlog'))
+  call feedkeys(":!\<CR>", 'xt')               " :!
+  call assert_equal(['Cmd: [-c ]'], readfile('Xlog'))
 
   call feedkeys(":!!\<CR>", 'xt')              " :! doesn't clear previous command
   call assert_equal(['Cmd: [-c echo coconut]'], readfile('Xlog'))


### PR DESCRIPTION
#### vim-patch:9.0.0783: ":!" doesn't do anything but does update the previous command

Problem:    ":!" doesn't do anything but does update the previous command.
Solution:   Do not have ":!" change the previous command. (Martin Tournoij,
            closes vim/vim#11372)

https://github.com/vim/vim/commit/8107a2a8af80a53a61734b600539c5beb4782991

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0785: memory leak with empty shell command

Problem:    Memory leak with empty shell command.
Solution:   Free the allocated memory when bailing out.

https://github.com/vim/vim/commit/9652249a2d02318a28a63a7b5711f25652e8f969

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0815

https://github.com/vim/vim/commit/9c50eeb40117413bf59a9da904c8d0921ed0a6e6

Co-authored-by: Martin Tournoij <martin@arp242.net>


#### vim-patch:9.0.0817

https://github.com/vim/vim/commit/fb0cf2357e0c85bbfd9f9178705ad8d77b6b3b4e

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0820: memory leak with empty shell command

Problem:    Memory leak with empty shell command.
Solution:   Free the empty string.

https://github.com/vim/vim/commit/03d6e6f42b0deeb02d52c8a48c14abe431370c1c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0864: crash when using "!!" without a previous shell command

Problem:    Crash when using "!!" without a previous shell command.
Solution:   Check "prevcmd" is not NULL.

https://github.com/vim/vim/commit/6600447c7b0a1be3a64d07a318bacdfaae0cac4b

Co-authored-by: Bram Moolenaar <Bram@vim.org>