### PR TITLE
vim-patch:9.0.1464: strace filetype detection is expensive

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1550,8 +1550,15 @@ local patterns_text = {
   ['^SNNS pattern definition file'] = 'snnspat',
   ['^SNNS result file'] = 'snnsres',
   ['^%%.-[Vv]irata'] = { 'virata', { start_lnum = 1, end_lnum = 5 } },
-  ['[0-9:%.]* *execve%('] = 'strace',
-  ['^__libc_start_main'] = 'strace',
+  function(lines)
+    if
+      -- inaccurate fast match first, then use accurate slow match
+      (lines[1]:find('execve%(') and lines[1]:find('^[0-9:%.]* *execve%('))
+      or lines[1]:find('^__libc_start_main')
+    then
+      return 'strace'
+    end
+  end,
   -- VSE JCL
   ['^\\* $$ JOB\\>'] = { 'vsejcl', { vim_regex = true } },
   ['^// *JOB\\>'] = { 'vsejcl', { vim_regex = true } },

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -733,6 +733,11 @@ func Test_filetype_detection()
   filetype off
 endfunc
 
+" Content lines that should not result in filetype detection
+let s:false_positive_checks = {
+      \ '': [['test execve("/usr/bin/pstree", ["pstree"], 0x7ff0 /* 63 vars */) = 0']],
+      \ }
+
 " Filetypes detected from the file contents by scripts.vim
 let s:script_checks = {
       \ 'virata': [['% Virata'],
@@ -824,6 +829,7 @@ func Run_script_detection(test_dict)
 endfunc
 
 func Test_script_detection()
+  call Run_script_detection(s:false_positive_checks)
   call Run_script_detection(s:script_checks)
   call Run_script_detection(s:script_env_checks)
 endfunc


### PR DESCRIPTION
Problem:    Strace filetype detection is expensive.
Solution:   Match with a cheap pattern first. (Federico Mengozzi,
            closes vim/vim#12220)

https://github.com/vim/vim/commit/6e5a9f948221b52caaaf106079cb3430c4dd7c77

Co-authored-by: Federico Mengozzi <19249682+fedemengo@users.noreply.github.com>
