### PR TITLE
fix(api): extmark highlight groups not always included in details

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -208,7 +208,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
 
     // uncrustify:on
 
-    for (int j = 0; hls[j].name && hls[j].val; j++) {
+    for (int j = 0; hls[j].name; j++) {
       if (hls[j].val) {
         PUT(dict, hls[j].name, hl_group_name(hls[j].val, hl_name));
       }

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1541,6 +1541,12 @@ describe('API/extmarks', function()
       virt_text_pos = "win_col",
       virt_text_win_col = 1,
     } }, get_extmark_by_id(ns, marks[2], { details = true }))
+    set_extmark(ns, marks[3], 0, 0, { cursorline_hl_group = "Statement" })
+    eq({0, 0, {
+      ns_id = 1,
+      cursorline_hl_group = "Statement",
+      right_gravity = true,
+    } }, get_extmark_by_id(ns, marks[3], { details = true }))
   end)
 
   it('can get marks from anonymous namespaces', function()


### PR DESCRIPTION
Problem:    Erroneous for loop condition.
Solution:   Remove for loop condition.