### PR TITLE
vim-patch:9.0.{1462,1468,1469}: :defer fixes

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3270,8 +3270,14 @@ static void handle_defer_one(funccall_T *funccal)
 /// Called when exiting: call all defer functions.
 void invoke_all_defer(void)
 {
-  for (funccall_T *funccal = current_funccal; funccal != NULL; funccal = funccal->fc_caller) {
-    handle_defer_one(funccal);
+  for (funccal_entry_T *fce = funccal_stack; fce != NULL; fce = fce->next) {
+    for (funccall_T *fc = fce->top_funccal; fc != NULL; fc = fc->fc_caller) {
+      handle_defer_one(fc);
+    }
+  }
+
+  for (funccall_T *fc = current_funccal; fc != NULL; fc = fc->fc_caller) {
+    handle_defer_one(fc);
   }
 }
 

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -661,6 +661,35 @@ func Test_defer_quitall_def()
   call delete('XQuitallDefThree')
 endfunc
 
+func Test_defer_quitall_autocmd()
+  let lines =<< trim END
+      autocmd User DeferAutocmdThree qa!
+
+      func DeferLevelTwo()
+        call writefile(['text'], 'XQuitallAutocmdTwo', 'D')
+        doautocmd User DeferAutocmdThree
+      endfunc
+
+      autocmd User DeferAutocmdTwo ++nested call DeferLevelTwo()
+
+      " def DeferLevelOne()
+      func DeferLevelOne()
+        call writefile(['text'], 'XQuitallAutocmdOne', 'D')
+        doautocmd User DeferAutocmdTwo
+      " enddef
+      endfunc
+
+      autocmd User DeferAutocmdOne ++nested call DeferLevelOne()
+
+      doautocmd User DeferAutocmdOne
+  END
+  call writefile(lines, 'XdeferQuitallAutocmd', 'D')
+  let res = system(GetVimCommand() .. ' -X -S XdeferQuitallAutocmd')
+  call assert_equal(0, v:shell_error)
+  call assert_false(filereadable('XQuitallAutocmdOne'))
+  call assert_false(filereadable('XQuitallAutocmdTwo'))
+endfunc
+
 func Test_defer_quitall_in_expr_func()
   throw 'Skipped: Vim9 script is N/A'
   let lines =<< trim END

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -609,33 +609,56 @@ func Test_defer_throw()
   call assert_false(filereadable('XDeleteTwo'))
 endfunc
 
-func Test_defer_quitall()
+func Test_defer_quitall_func()
   let lines =<< trim END
-      " vim9script
       func DeferLevelTwo()
-        call writefile(['text'], 'XQuitallTwo', 'D')
-        call writefile(['quit'], 'XQuitallThree', 'a')
+        call writefile(['text'], 'XQuitallFuncTwo', 'D')
+        call writefile(['quit'], 'XQuitallFuncThree', 'a')
         qa!
       endfunc
 
-      " def DeferLevelOne()
       func DeferLevelOne()
-        call writefile(['text'], 'XQuitallOne', 'D')
-        call DeferLevelTwo()
-      " enddef
+        call writefile(['text'], 'XQuitalFunclOne', 'D')
+        defer DeferLevelTwo()
       endfunc
 
-      " DeferLevelOne()
       call DeferLevelOne()
   END
-  call writefile(lines, 'XdeferQuitall', 'D')
-  let res = system(GetVimCommand() .. ' -X -S XdeferQuitall')
+  call writefile(lines, 'XdeferQuitallFunc', 'D')
+  call system(GetVimCommand() .. ' -X -S XdeferQuitallFunc')
   call assert_equal(0, v:shell_error)
-  call assert_false(filereadable('XQuitallOne'))
-  call assert_false(filereadable('XQuitallTwo'))
-  call assert_equal(['quit'], readfile('XQuitallThree'))
+  call assert_false(filereadable('XQuitallFuncOne'))
+  call assert_false(filereadable('XQuitallFuncTwo'))
+  call assert_equal(['quit'], readfile('XQuitallFuncThree'))
 
-  call delete('XQuitallThree')
+  call delete('XQuitallFuncThree')
+endfunc
+
+func Test_defer_quitall_def()
+  throw 'Skipped: Vim9 script is N/A'
+  let lines =<< trim END
+      vim9script
+      def DeferLevelTwo()
+        call writefile(['text'], 'XQuitallDefTwo', 'D')
+        call writefile(['quit'], 'XQuitallDefThree', 'a')
+        qa!
+      enddef
+
+      def DeferLevelOne()
+        call writefile(['text'], 'XQuitallDefOne', 'D')
+        defer DeferLevelTwo()
+      enddef
+
+      DeferLevelOne()
+  END
+  call writefile(lines, 'XdeferQuitallDef', 'D')
+  call system(GetVimCommand() .. ' -X -S XdeferQuitallDef')
+  call assert_equal(0, v:shell_error)
+  call assert_false(filereadable('XQuitallDefOne'))
+  call assert_false(filereadable('XQuitallDefTwo'))
+  call assert_equal(['quit'], readfile('XQuitallDefThree'))
+
+  call delete('XQuitallDefThree')
 endfunc
 
 func Test_defer_quitall_in_expr_func()
@@ -655,7 +678,7 @@ func Test_defer_quitall_in_expr_func()
       call Test_defer_in_funcref()
   END
   call writefile(lines, 'XdeferQuitallExpr', 'D')
-  let res = system(GetVimCommand() .. ' -X -S XdeferQuitallExpr')
+  call system(GetVimCommand() .. ' -X -S XdeferQuitallExpr')
   call assert_equal(0, v:shell_error)
   call assert_false(filereadable('Xentry0'))
   call assert_false(filereadable('Xentry1'))

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -614,6 +614,7 @@ func Test_defer_quitall()
       " vim9script
       func DeferLevelTwo()
         call writefile(['text'], 'XQuitallTwo', 'D')
+        call writefile(['quit'], 'XQuitallThree', 'a')
         qa!
       endfunc
 
@@ -632,6 +633,9 @@ func Test_defer_quitall()
   call assert_equal(0, v:shell_error)
   call assert_false(filereadable('XQuitallOne'))
   call assert_false(filereadable('XQuitallTwo'))
+  call assert_equal(['quit'], readfile('XQuitallThree'))
+
+  call delete('XQuitallThree')
 endfunc
 
 func Test_defer_quitall_in_expr_func()


### PR DESCRIPTION
#### vim-patch:9.0.1462: recursively calling :defer function if it does :qa

Problem:    Recursively calling :defer function if it does :qa.
Solution:   Clear the defer entry before calling the function.

https://github.com/vim/vim/commit/42994bf678f46dc9ca66e49f512261da8864fff6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1468: recursively calling :defer function if it does :qa

Problem:    Recursively calling :defer function if it does :qa in a compiled
            function.
Solution:   Clear the defer entry before calling the function. (closes vim/vim#12271)

https://github.com/vim/vim/commit/a1f2b5ddc63d4e2b6ab047d8c839dd8477b36aba


#### vim-patch:9.0.1469: deferred functions not called from autocommands

Problem:    Deferred functions not called from autocommands.
Solution:   Also go through the funccal_stack. (closes vim/vim#12267)

https://github.com/vim/vim/commit/960cf9119e3f4922ca9719feb5e0c0bc5e3b9840