### PR TITLE
vim-patch:9.0.{0369,0372,0426,0514,0545,0560,0561,1005,1007,1008,1009,1010,1012,1020,1021,1034}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ compile_commands.json
 /test/old/testdir/test*.res
 /test/old/testdir/test*.log
 /test/old/testdir/messages
+/test/old/testdir/starttime
 /test/old/testdir/viminfo
 /test/old/testdir/test.ok
 /test/old/testdir/*.failed

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -506,6 +506,7 @@ submatch({nr} [, {list}])	String or List
 					specific match in ":s" or substitute()
 substitute({expr}, {pat}, {sub}, {flags})
 				String	all {pat} in {expr} replaced with {sub}
+swapfilelist()			List	swap files found in 'directory'
 swapinfo({fname})		Dict	information about swap file {fname}
 swapname({buf})			String	swap file of buffer {buf}
 synID({lnum}, {col}, {trans})	Number	syntax ID at {lnum} and {col}
@@ -8416,6 +8417,17 @@ substitute({string}, {pat}, {sub}, {flags})		*substitute()*
 
 		Can also be used as a |method|: >
 			GetString()->substitute(pat, sub, flags)
+
+swapfilelist()						*swapfilelist()*
+		Returns a list of swap file names, like what "vim -r" shows.
+		See the |-r| command argument.  The 'directory' option is used
+		for the directories to inspect.  If you only want to get a
+		list of swap files in the current directory then temporarily
+		set 'directory' to a dot: >
+			let save_dir = &directory
+			let &directory = '.'
+			let swapfiles = swapfilelist()
+			let &directory = save_dir
 
 swapinfo({fname})					*swapinfo()*
 		The result is a dictionary, which holds information about the

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -883,6 +883,7 @@ Buffers, windows and the argument list:
 	getwininfo()		get a list with window information
 	getchangelist()		get a list of change list entries
 	getjumplist()		get a list of jump list entries
+	swapfilelist()		list of existing swap files in 'directory'
 	swapinfo()		information about a swap file
 	swapname()		get the swap file path of a buffer
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5712,8 +5712,7 @@ void get_xdg_var_list(const XDGVarType xdg, typval_T *rettv)
     if (dir != NULL && dir_len > 0) {
       char *dir_with_nvim = xmemdupz(dir, dir_len);
       dir_with_nvim = concat_fnames_realloc(dir_with_nvim, appname, true);
-      tv_list_append_string(list, dir_with_nvim, (ssize_t)strlen(dir_with_nvim));
-      xfree(dir_with_nvim);
+      tv_list_append_allocated_string(list, dir_with_nvim);
     }
   } while (iter != NULL);
   xfree(dirs);

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -400,6 +400,7 @@ return {
     strwidth={args=1, base=1, fast=true},
     submatch={args={1, 2}, base=1},
     substitute={args=4, base=1},
+    swapfilelist={},
     swapinfo={args=1, base=1},
     swapname={args=1, base=1},
     synID={args=3},

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -44,6 +44,7 @@
 #include "nvim/eval/executor.h"
 #include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/eval/vars.h"
 #include "nvim/eval/window.h"
@@ -3850,8 +3851,7 @@ static void f_insert(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 }
 
 /// "interrupt()" function
-static void f_interrupt(typval_T *argvars FUNC_ATTR_UNUSED, typval_T *rettv FUNC_ATTR_UNUSED,
-                        EvalFuncData fptr FUNC_ATTR_UNUSED)
+static void f_interrupt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   got_int = true;
 }
@@ -8521,6 +8521,13 @@ static void f_substitute(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     rettv->vval.v_string = do_string_sub((char *)str, (char *)pat,
                                          (char *)sub, expr, (char *)flg);
   }
+}
+
+/// "swapfilelist()" function
+static void f_swapfilelist(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  tv_list_alloc_ret(rettv, kListLenUnknown);
+  recover_names(NULL, false, rettv->vval.v_list, 0, NULL);
 }
 
 /// "swapinfo(swap_filename)" function

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -466,7 +466,7 @@ int main(int argc, char **argv)
   // Recovery mode without a file name: List swap files.
   // Uses the 'dir' option, therefore it must be after the initializations.
   if (recoverymode && fname == NULL) {
-    recover_names(NULL, true, 0, NULL);
+    recover_names(NULL, true, NULL, 0, NULL);
     os_exit(0);
   }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -762,7 +762,7 @@ void ml_recover(bool checkext)
     directly = false;
 
     // count the number of matching swap files
-    len = recover_names(fname, false, 0, NULL);
+    len = recover_names(fname, false, NULL, 0, NULL);
     if (len == 0) {                 // no swap files found
       semsg(_("E305: No swap file found for %s"), fname);
       goto theend;
@@ -772,7 +772,7 @@ void ml_recover(bool checkext)
       i = 1;
     } else {                          // several swap files found, choose
       // list the names of the swap files
-      (void)recover_names(fname, true, 0, NULL);
+      (void)recover_names(fname, true, NULL, 0, NULL);
       msg_putchar('\n');
       msg_puts(_("Enter number of swap file to use (0 to quit): "));
       i = get_number(false, NULL);
@@ -781,7 +781,7 @@ void ml_recover(bool checkext)
       }
     }
     // get the swap file name that will be used
-    (void)recover_names(fname, false, i, &fname_used);
+    (void)recover_names(fname, false, NULL, i, &fname_used);
   }
   if (fname_used == NULL) {
     goto theend;  // user chose invalid number.
@@ -1200,13 +1200,15 @@ theend:
 /// - list the swap files for "vim -r"
 /// - count the number of swap files when recovering
 /// - list the swap files when recovering
+/// - list the swap files for swapfilelist()
 /// - find the name of the n'th swap file when recovering
 ///
 /// @param fname  base for swap file name
-/// @param list  when true, list the swap file names
+/// @param do_list  when true, list the swap file names
+/// @param ret_list  when not NULL add file names to it
 /// @param nr  when non-zero, return nr'th swap file name
 /// @param fname_out  result when "nr" > 0
-int recover_names(char *fname, int list, int nr, char **fname_out)
+int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fname_out)
 {
   int num_names;
   char *(names[6]);
@@ -1230,7 +1232,7 @@ int recover_names(char *fname, int list, int nr, char **fname_out)
     fname_res = fname;
   }
 
-  if (list) {
+  if (do_list) {
     // use msg() to start the scrolling properly
     msg(_("Swap files found:"));
     msg_putchar('\n');
@@ -1306,9 +1308,11 @@ int recover_names(char *fname, int list, int nr, char **fname_out)
       }
     }
 
-    // remove swapfile name of the current buffer, it must be ignored
+    // Remove swapfile name of the current buffer, it must be ignored.
+    // But keep it for swapfilelist().
     if (curbuf->b_ml.ml_mfp != NULL
-        && (p = curbuf->b_ml.ml_mfp->mf_fname) != NULL) {
+        && (p = curbuf->b_ml.ml_mfp->mf_fname) != NULL
+        && ret_list == NULL) {
       for (int i = 0; i < num_files; i++) {
         // Do not expand wildcards, on Windows would try to expand
         // "%tmp%" in "%tmp%file"
@@ -1333,7 +1337,7 @@ int recover_names(char *fname, int list, int nr, char **fname_out)
         *fname_out = xstrdup(files[nr - 1 + num_files - file_count]);
         dirp = "";                        // stop searching
       }
-    } else if (list) {
+    } else if (do_list) {
       if (dir_name[0] == '.' && dir_name[1] == NUL) {
         if (fname == NULL) {
           msg_puts(_("   In current directory:\n"));
@@ -1359,6 +1363,14 @@ int recover_names(char *fname, int list, int nr, char **fname_out)
         msg_puts(_("      -- none --\n"));
       }
       ui_flush();
+    } else if (ret_list != NULL) {
+      for (int i = 0; i < num_files; i++) {
+        char *name = concat_fnames(dir_name, files[i], true);
+        if (name != NULL) {
+          tv_list_append_string(ret_list, name, -1);
+          xfree(name);
+        }
+      }
     } else {
       file_count += num_files;
     }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1367,8 +1367,7 @@ int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fn
       for (int i = 0; i < num_files; i++) {
         char *name = concat_fnames(dir_name, files[i], true);
         if (name != NULL) {
-          tv_list_append_string(ret_list, name, -1);
-          xfree(name);
+          tv_list_append_allocated_string(ret_list, name);
         }
       }
     } else {

--- a/test/old/testdir/Makefile
+++ b/test/old/testdir/Makefile
@@ -70,6 +70,7 @@ report:
 		then echo TEST FAILURE; exit 1; \
 		else echo ALL DONE; \
 		fi"
+	@rm -f starttime
 
 test1.out: $(NVIM_PRG)
 
@@ -86,10 +87,13 @@ fixff:
 	-$(NVIM_PRG) $(NO_INITS) -u unix.vim "+argdo set ff=dos|upd" +q \
 	  dotest.in
 
+# File to delete when testing starts
+CLEANUP_FILES = test.log messages starttime
+
 # Execute an individual new style test, e.g.:
 # 	make test_largefile
 $(NEW_TESTS):
-	rm -f $@.res test.log messages
+	rm -f $@.res $(CLEANUP_FILES)
 	@MAKEFLAGS=--no-print-directory $(MAKE) -f Makefile $@.res
 	@cat messages
 	@if test -f test.log; then \
@@ -108,9 +112,8 @@ CLEAN_FILES := *.out \
   *.rej             \
   *.orig            \
   *.tlog            \
-  test.log          \
   test_result.log   \
-  messages          \
+  $(CLEANUP_FILES)  \
   $(RM_ON_RUN)      \
   $(RM_ON_START)    \
   valgrind.*        \
@@ -132,7 +135,7 @@ test1.out: .gdbinit test1.in
 
 nolog:
 	@echo "[OLDTEST-PREP] Removing test.log and messages"
-	@rm -f test.log messages
+	@rm -f test_result.log $(CLEANUP_FILES)
 
 
 # New style of tests uses Vim script with assert calls.  These are easier

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -323,7 +323,14 @@ func RunTheTest(test)
   " buffer, continue until we end up in an empty no-name buffer without a swap
   " file.
   while bufname() != '' || execute('swapname') !~ 'No swap file'
-    bwipe!
+    let bn = bufnr()
+
+    noswapfile bwipe!
+
+    if bn == bufnr()
+      " avoid getting stuck in the same buffer
+      break
+    endif
   endwhile
 
   " Check if the test has left any swap files behind.  Delete them before

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -434,7 +434,7 @@ for g:testfunc in sort(s:tests)
   " A test can set g:test_is_flaky to retry running the test.
   let g:test_is_flaky = 0
 
-  let starttime = strftime("%T")
+  let starttime = strftime("%H:%M:%S")
   call RunTheTest(g:testfunc)
 
   " Repeat a flaky test.  Give up when:
@@ -469,7 +469,7 @@ for g:testfunc in sort(s:tests)
       let v:errors = []
       let g:run_nr += 1
 
-      let starttime = strftime("%T")
+      let starttime = strftime("%H:%M:%S")
       call RunTheTest(g:testfunc)
 
       if len(v:errors) == 0

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -139,11 +139,15 @@ func GetAllocId(name)
   return lnum - top - 1
 endfunc
 
+let g:func_start = reltime()
+
 func RunTheTest(test)
-  echo 'Executing ' . a:test
+  let prefix = ''
   if has('reltime')
-    let func_start = reltime()
+    let prefix = 'took ' .. reltimestr(reltime(g:func_start)) .. '; now '
+    let g:func_start = reltime()
   endif
+  echo prefix .. 'Executing ' .. a:test
 
   " Avoid stopping at the "hit enter" prompt
   set nomore
@@ -247,12 +251,12 @@ func RunTheTest(test)
   let message = 'Executed ' . a:test
   if has('reltime')
     let message ..= repeat(' ', 50 - len(message))
-    let time = reltime(func_start)
-    if has('float') && reltimefloat(time) > 0.1
+    let time = reltime(g:func_start)
+    if reltimefloat(time) > 0.1
       let message = s:t_bold .. message
     endif
     let message ..= ' in ' .. reltimestr(time) .. ' seconds'
-    if has('float') && reltimefloat(time) > 0.1
+    if reltimefloat(time) > 0.1
       let message ..= s:t_normal
     endif
   endif

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -174,6 +174,7 @@ endfunc
 for name in s:GetSwapFileList()
   call delete(name)
 endfor
+unlet name
 
 
 " Invoked when a test takes too much time.

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -319,6 +319,13 @@ func RunTheTest(test)
   call add(s:messages, message)
   let s:done += 1
 
+  " May be editing some buffer, wipe it out.  Then we may end up in another
+  " buffer, continue until we end up in an empty no-name buffer without a swap
+  " file.
+  while bufname() != '' || execute('swapname') !~ 'No swap file'
+    bwipe!
+  endwhile
+
   " Check if the test has left any swap files behind.  Delete them before
   " running tests again, they might interfere.
   let swapfiles = s:GetSwapFileList()

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -320,6 +320,11 @@ func RunTheTest(test)
   call add(s:messages, message)
   let s:done += 1
 
+  " close any split windows
+  while winnr('$') > 1
+    bwipe!
+  endwhile
+
   " May be editing some buffer, wipe it out.  Then we may end up in another
   " buffer, continue until we end up in an empty no-name buffer without a swap
   " file.

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -193,6 +193,11 @@ func RunTheTest(test)
   endif
   au! VimLeavePre
 
+  if a:test =~ '_terminal_'
+    " Terminal tests sometimes hang, give extra information
+    echoconsole 'After executing ' .. a:test
+  endif
+
   " In case 'insertmode' was set and something went wrong, make sure it is
   " reset to avoid trouble with anything else.
   set noinsertmode
@@ -233,6 +238,11 @@ func RunTheTest(test)
   endwhile
 
   exe 'cd ' . save_cwd
+
+  if a:test =~ '_terminal_'
+    " Terminal tests sometimes hang, give extra information
+    echoconsole 'Finished ' . a:test
+  endif
 
   let message = 'Executed ' . a:test
   if has('reltime')

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -130,6 +130,14 @@ if has('mac')
   let $BASH_SILENCE_DEPRECATION_WARNING = 1
 endif
 
+
+" A previous (failed) test run may have left swap files behind.  Delete them
+" before running tests again, they might interfere.
+for name in s:GetSwapFileList()
+  call delete(name)
+endfor
+
+
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1
 
@@ -151,6 +159,22 @@ endfunc
 if has('reltime')
   let g:func_start = reltime()
 endif
+
+" Get the list of swap files in the current directory.
+func s:GetSwapFileList()
+  let save_dir = &directory
+  let &directory = '.'
+  let files = swapfilelist()
+  let &directory = save_dir
+
+  " remove a match with runtest.vim
+  let idx = indexof(files, 'v:val =~ "runtest.vim."')
+  if idx >= 0
+    call remove(files, idx)
+  endif
+
+  return files
+endfunc
 
 " Invoked when a test takes too much time.
 func TestTimeout(id)
@@ -294,6 +318,16 @@ func RunTheTest(test)
   endif
   call add(s:messages, message)
   let s:done += 1
+
+  " Check if the test has left any swap files behind.  Delete them before
+  " running tests again, they might interfere.
+  let swapfiles = s:GetSwapFileList()
+  if len(swapfiles) > 0
+    call add(s:messages, "Found swap files: " .. string(swapfiles))
+    for name in swapfiles
+      call delete(name)
+    endfor
+  endif
 endfunc
 
 func AfterTheTest(func_name)

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -449,7 +449,8 @@ for g:testfunc in sort(s:tests)
       call add(s:messages, 'Found errors in ' .. g:testfunc .. ':')
       call extend(s:messages, v:errors)
 
-      call add(total_errors, starttime .. ' Run ' .. g:run_nr .. ':')
+      let endtime = strftime("%H:%M:%S")
+      call add(total_errors, $'Run {g:run_nr}, {starttime} - {endtime}:')
       call extend(total_errors, v:errors)
 
       if g:run_nr >= 5 || prev_error == v:errors[0]

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -61,7 +61,16 @@ if &lines < 24 || &columns < 80
 endif
 
 if has('reltime')
-  let s:start_time = reltime()
+  let s:run_start_time = reltime()
+
+  if !filereadable('starttime')
+    " first test, store the overall test starting time
+    let s:test_start_time = localtime()
+    call writefile([string(s:test_start_time)], 'starttime')
+  else
+    " second or later test, read the overall test starting time
+    let s:test_start_time = readfile('starttime')[0]->str2nr()
+  endif
 endif
 
 " Always use forward slashes.
@@ -139,12 +148,14 @@ func GetAllocId(name)
   return lnum - top - 1
 endfunc
 
-let g:func_start = reltime()
+if has('reltime')
+  let g:func_start = reltime()
+endif
 
 func RunTheTest(test)
   let prefix = ''
   if has('reltime')
-    let prefix = 'took ' .. reltimestr(reltime(g:func_start)) .. '; now '
+    let prefix = strftime('%M:%S', localtime() - s:test_start_time) .. ' '
     let g:func_start = reltime()
   endif
   echo prefix .. 'Executing ' .. a:test
@@ -328,7 +339,7 @@ func FinishTesting()
   endif
   if s:done > 0 && has('reltime')
     let message = s:t_bold .. message .. repeat(' ', 40 - len(message))
-    let message ..= ' in ' .. reltimestr(reltime(s:start_time)) .. ' seconds'
+    let message ..= ' in ' .. reltimestr(reltime(s:run_start_time)) .. ' seconds'
     let message ..= s:t_normal
   endif
   echo message

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -131,13 +131,6 @@ if has('mac')
 endif
 
 
-" A previous (failed) test run may have left swap files behind.  Delete them
-" before running tests again, they might interfere.
-for name in s:GetSwapFileList()
-  call delete(name)
-endfor
-
-
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1
 
@@ -175,6 +168,13 @@ func s:GetSwapFileList()
 
   return files
 endfunc
+
+" A previous (failed) test run may have left swap files behind.  Delete them
+" before running tests again, they might interfere.
+for name in s:GetSwapFileList()
+  call delete(name)
+endfor
+
 
 " Invoked when a test takes too much time.
 func TestTimeout(id)

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -434,6 +434,7 @@ for g:testfunc in sort(s:tests)
   " A test can set g:test_is_flaky to retry running the test.
   let g:test_is_flaky = 0
 
+  let starttime = strftime("%T")
   call RunTheTest(g:testfunc)
 
   " Repeat a flaky test.  Give up when:
@@ -445,10 +446,10 @@ for g:testfunc in sort(s:tests)
         \ && (index(s:flaky_tests, g:testfunc) >= 0
         \      || g:test_is_flaky)
     while 1
-      call add(s:messages, 'Found errors in ' . g:testfunc . ':')
+      call add(s:messages, 'Found errors in ' .. g:testfunc .. ':')
       call extend(s:messages, v:errors)
 
-      call add(total_errors, 'Run ' . g:run_nr . ':')
+      call add(total_errors, starttime .. ' Run ' .. g:run_nr .. ':')
       call extend(total_errors, v:errors)
 
       if g:run_nr >= 5 || prev_error == v:errors[0]
@@ -468,6 +469,7 @@ for g:testfunc in sort(s:tests)
       let v:errors = []
       let g:run_nr += 1
 
+      let starttime = strftime("%T")
       call RunTheTest(g:testfunc)
 
       if len(v:errors) == 0

--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -110,16 +110,16 @@ func RunServer(cmd, testfunc, args)
   try
     let g:currentJob = RunCommand(pycmd)
 
-    " Wait for up to 2 seconds for the port number to be there.
+    " Wait for some time for the port number to be there.
     let port = GetPort()
     if port == 0
-      call assert_false(1, "Can't start " . a:cmd)
+      call assert_report(strftime("%T") .. " Can't start " .. a:cmd)
       return
     endif
 
     call call(function(a:testfunc), [port])
   catch
-    call assert_false(1, 'Caught exception: "' . v:exception . '" in ' . v:throwpoint)
+    call assert_report('Caught exception: "' . v:exception . '" in ' . v:throwpoint)
   finally
     call s:kill_server(a:cmd)
   endtry

--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -113,7 +113,7 @@ func RunServer(cmd, testfunc, args)
     " Wait for some time for the port number to be there.
     let port = GetPort()
     if port == 0
-      call assert_report(strftime("%T") .. " Can't start " .. a:cmd)
+      call assert_report(strftime("%H:%M:%S") .. " Can't start " .. a:cmd)
       return
     endif
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3156,7 +3156,7 @@ func Test_autocmd_FileReadCmd()
         \ 'v:cmdarg =  ++ff=mac',
         \ 'v:cmdarg =  ++enc=utf-8'], getline(1, '$'))
 
-  close!
+  bwipe!
   augroup FileReadCmdTest
     au!
   augroup END

--- a/test/old/testdir/test_swap.vim
+++ b/test/old/testdir/test_swap.vim
@@ -115,6 +115,15 @@ func Test_swapinfo()
   w
   let fname = s:swapname()
   call assert_match('Xswapinfo', fname)
+
+  let nr = 0
+  for name in swapfilelist()
+    if name =~ '[\\/]' .. fname .. '$'
+      let nr += 1
+    endif
+  endfor
+  call assert_equal(1, nr)
+
   let info = fname->swapinfo()
 
   let ver = printf('VIM %d.%d', v:version / 100, v:version % 100)

--- a/test/old/testdir/test_swap.vim
+++ b/test/old/testdir/test_swap.vim
@@ -116,16 +116,18 @@ func Test_swapinfo()
   let fname = s:swapname()
   call assert_match('Xswapinfo', fname)
 
+  " Check the tail appears in the list from swapfilelist().  The path depends
+  " on the system.
+  let tail = fnamemodify(fname, ":t")->fnameescape()
   let nr = 0
   for name in swapfilelist()
-    if name =~ '[\\/]' .. fname .. '$'
+    if name =~ tail .. '$'
       let nr += 1
     endif
   endfor
-  call assert_equal(1, nr)
+  call assert_equal(1, nr, 'not found in ' .. string(swapfilelist()))
 
   let info = fname->swapinfo()
-
   let ver = printf('VIM %d.%d', v:version / 100, v:version % 100)
   call assert_equal(ver, info.version)
 

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -460,7 +460,7 @@ func Test_invalid_name()
 endfunc
 
 func Test_ownsyntax()
-  new Xfoo
+  new XfooOwnSyntax
   call setline(1, '#define FOO')
   syntax on
   set filetype=c

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -5983,6 +5983,9 @@ endfunc
 
 " interrupt right before a catch is invoked in a script
 func Test_ignore_catch_after_intr_1()
+  " for unknown reasons this test sometimes fails on MS-Windows.
+  let g:test_is_flaky = 1
+
   XpathINIT
   let lines =<< trim [CODE]
     try

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -6024,6 +6024,9 @@ endfunc
 
 " interrupt right before a catch is invoked inside a function.
 func Test_ignore_catch_after_intr_2()
+  " for unknown reasons this test sometimes fails on MS-Windows.
+  let g:test_is_flaky = 1
+
   XpathINIT
   func F()
     try

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -119,10 +119,9 @@ endfunc
 
 " Test the ":wincmd ^" and "<C-W>^" commands.
 func Test_window_split_edit_alternate()
-
   " Test for failure when the alternate buffer/file no longer exists.
   edit Xfoo | %bw
-  call assert_fails(':wincmd ^', 'E23')
+  call assert_fails(':wincmd ^', 'E23:')
 
   " Test for the expected behavior when we have two named buffers.
   edit Xfoo | edit Xbar
@@ -152,12 +151,11 @@ endfunc
 
 " Test the ":[count]wincmd ^" and "[count]<C-W>^" commands.
 func Test_window_split_edit_bufnr()
-
   %bwipeout
   let l:nr = bufnr('%') + 1
-  call assert_fails(':execute "normal! ' . l:nr . '\<C-W>\<C-^>"', 'E92')
-  call assert_fails(':' . l:nr . 'wincmd ^', 'E16')
-  call assert_fails(':0wincmd ^', 'E16')
+  call assert_fails(':execute "normal! ' . l:nr . '\<C-W>\<C-^>"', 'E92:')
+  call assert_fails(':' . l:nr . 'wincmd ^', 'E16:')
+  call assert_fails(':0wincmd ^', 'E16:')
 
   edit Xfoo | edit Xbar | edit Xbaz
   let l:foo_nr = bufnr('Xfoo')


### PR DESCRIPTION
#### vim-patch:9.0.0369: a failing flaky test doesn't mention the time

Problem:    A failing flaky test doesn't mention the time.
Solution:   Add the time for debugging.  Improve error message.

https://github.com/vim/vim/commit/06d32a0c177e4166ff0491668cd459464bc2ef45

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0372: MS-Windows: "%T" time format does not appear to work

Problem:    MS-Windows: "%T" time format does not appear to work.
Solution:   Use "%H:%M:%S" instead.

https://github.com/vim/vim/commit/5fbbec180b623cd6ebfc9528be6fa70b4cf664d4

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0426: failed flaky tests reports only start time

Problem:    Failed flaky tests reports only start time.
Solution:   Also report the end time.

https://github.com/vim/vim/commit/65258d36ddfab371c7982343efc9b2533ba39075

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0514: terminal test sometimes hangs

Problem:    Terminal test sometimes hangs.
Solution:   Add a bit more information to the test output. (issue vim/vim#11179)

https://github.com/vim/vim/commit/a22c56a59a1e60f6976e61d16001623424a26b3a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0545: when a test is slow and CI times out there is no time info

Problem:    When a test is slow and CI times out there is no time info.
Solution:   Add the elapsed time to the "Executing" message.

https://github.com/vim/vim/commit/daaa3d9965d74faf1f75aea218822bfb7ba687a7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0560: elapsed time since testing started is not visible

Problem:    Elapsed time since testing started is not visible.
Solution:   Show the elapsed time while running tests.

https://github.com/vim/vim/commit/b9093d50098ccff3848c2a404b9d0324a074c7b7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0561: when a test gets stuck it just hangs forever

Problem:    When a test gets stuck it just hangs forever.
Solution:   Set a timeout of 30 seconds.

https://github.com/vim/vim/commit/3bcd0ddc2deb34794c735c6ea0b8f964b510c6db

Note: This doesn't cause test_timers.vim failures in Nvim because there
is a SetUp() function that calls timer_stopall().

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1007: there is no way to get a list of swap file names

Problem:    There is no way to get a list of swap file names.
Solution:   Add the swapfilelist() function.  Use it in the test script to
            clean up.  Remove deleting individual swap files.

https://github.com/vim/vim/commit/c216a7a21a25a701b84b79abc1ba6ab0baa3a311

vim-patch:9.0.1005: a failed test may leave a swap file behind

Problem:    A failed test may leave a swap file behind.
Solution:   Delete the swap file to avoid another test to fail.  Use another
            file name.

https://github.com/vim/vim/commit/d0f8d39d20f8d42f7451f781f7be0bcd20e06741

Cherry-pick test_window_cmd.vim changes from patch 8.2.1593.
Remove FUNC_ATTR_UNUSED from eval functions as fptr is always unused.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1008: test for swapfilelist() fails on MS-Windows

Problem:    Test for swapfilelist() fails on MS-Windows.
Solution:   Only check the tail of the path.  Mark a test as flaky.

https://github.com/vim/vim/commit/6cf3151f0e3839332c89367b7384c395a1185927

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1009: test for catch after interrupt is flaky on MS-Windows

Problem:    Test for catch after interrupt is flaky on MS-Windows.
Solution:   Mark the test as flaky.

https://github.com/vim/vim/commit/72b5b0d51aa9ddf8d338a5a133a667a3c2392ae1

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1010: stray warnings for existing swap files

Problem:    Stray warnings for existing swap files.
Solution:   Wipe out the buffer until it has no name and no swap file.

https://github.com/vim/vim/commit/23526d2539e8679ea8df14e3a018101dedc3f391

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1012: tests may get stuck in buffer with swap file

Problem:    Tests may get stuck in buffer with swap file.
Solution:   Bail out when bwipe! doesn't get another buffer.

https://github.com/vim/vim/commit/fa2533c8bb96abcec29b9dc6bd4fe7054c7c7e50

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1020: tests call GetSwapFileList() before it is defined

Problem:    Tests call GetSwapFileList() before it is defined.
Solution:   Move the call to after defining the function. (Christopher
            Plewright)

https://github.com/vim/vim/commit/6572a90287c7aa6e8042b18604891e9df3657245

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1021: test trips over g:name

Problem:    Test trips over g:name.
Solution:   Delete g:name after using it.

https://github.com/vim/vim/commit/d6e74f547910d5273a3b99c23fb3197131c7d379

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1034: reporting swap file when windows are split

Problem:    Reporting swap file when windows are split.
Solution:   Close extra windows after running a test.

https://github.com/vim/vim/commit/e5eae82bb7199bd71c6216269e78c69e9a793c8f

Co-authored-by: Bram Moolenaar <Bram@vim.org>