### PR TITLE
fix(iter): allow table values in iterator pipelines

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3037,6 +3037,19 @@ Iter:find({self}, {f})                                           *Iter:find()*
 Iter:fold({self}, {init}, {f})                                   *Iter:fold()*
     Fold an iterator or table into a single value.
 
+    Examples: >
+
+     -- Create a new table with only even values
+     local t = { a = 1, b = 2, c = 3, d = 4 }
+     local it = vim.iter(t)
+     it:filter(function(k, v) return v % 2 == 0 end)
+     it:fold({}, function(t, k, v)
+       t[k] = v
+       return t
+     end)
+     -- { b = 2, d = 4 }
+<
+
     Parameters: ~
       • {init}  any Initial value of the accumulator.
       • {f}     function(acc:any, ...):A Accumulation function.
@@ -3297,9 +3310,7 @@ Iter:totable({self})                                          *Iter:totable()*
     The resulting table depends on the initial source in the iterator
     pipeline. List-like tables and function iterators will be collected into a
     list-like table. If multiple values are returned from the final stage in
-    the iterator pipeline, each value will be included in a table. If a
-    map-like table was used as the initial source, then a map-like table is
-    returned.
+    the iterator pipeline, each value will be included in a table.
 
     Examples: >lua
 
@@ -3310,8 +3321,12 @@ Iter:totable({self})                                          *Iter:totable()*
      -- { { 1, 2 }, { 2, 4 }, { 3, 6 } }
 
      vim.iter({ a = 1, b = 2, c = 3 }):filter(function(k, v) return v % 2 ~= 0 end):totable()
-     -- { a = 1, c = 3 }
+     -- { { 'a', 1 }, { 'c', 3 } }
 <
+
+    The generated table is a list-like table with consecutive, numeric
+    indices. To create a map-like table with arbitrary keys, use
+    |Iter:fold()|.
 
     Return: ~
         (table)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3381,6 +3381,33 @@ describe('lua stdlib', function()
         end
       end)
       eq({ A = 2, C = 6 }, it:totable())
+
+    it('handles table values mid-pipeline', function()
+      local map = {
+        item = {
+          file = 'test',
+        },
+        item_2 = {
+          file = 'test',
+        },
+        item_3 = {
+          file = 'test',
+        },
+      }
+
+      local output = vim.iter(map):map(function(key, value)
+        return { [key] = value.file }
+      end):totable()
+
+      table.sort(output, function(a, b)
+        return next(a) < next(b)
+      end)
+
+      eq({
+        { item = 'test' },
+        { item_2 = 'test' },
+        { item_3 = 'test' },
+      }, output)
     end)
   end)
 end)

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3374,13 +3374,18 @@ describe('lua stdlib', function()
     end)
 
     it('handles map-like tables', function()
-      local t = { a = 1, b = 2, c = 3 }
-      local it = vim.iter(t):map(function(k, v)
+      local it = vim.iter({ a = 1, b = 2, c = 3 }):map(function(k, v)
         if v % 2 ~= 0 then
           return k:upper(), v * 2
         end
       end)
-      eq({ A = 2, C = 6 }, it:totable())
+
+      local t = it:fold({}, function(t, k, v)
+        t[k] = v
+        return t
+      end)
+      eq({ A = 2, C = 6 }, t)
+    end)
 
     it('handles table values mid-pipeline', function()
       local map = {


### PR DESCRIPTION
- fix(iter): add tag to packed table

If pack() is called with a single value, it does not create a table; it simply returns the value it is passed. When unpack is called with a table argument, it interprets that table as a list of values that were packed together into a table.

This causes a problem when the single value being packed is _itself_ a table. pack() will not place it into another table, but unpack() sees the table argument and tries to unpack it.

To fix this, we add a simple "tag" to packed table values so that unpack() only attempts to unpack tables that have this tag. Other tables are left alone. The tag is simply the length of the table.

---

- fix(iter): remove special case totable for map-like tables

This was originally meant as a convenience but prevents possible functionality. For example:

```lua
-- Get the keys of the table with even values
local t = { a = 1, b = 2, c = 3, d = 4 }
vim.iter(t):map(function(k, v)
  if v % 2 == 0 then return k end
end):totable()
```

The example above would not work, because the map() function returns only a single value, and cannot be converted back into a map-like table (there are many such examples like this).

Instead, to convert an iterator into a map-like table, users can use fold():

```lua
vim.iter(t):fold({}, function(t, k, v)
  t[k] = v
  return t
end)
```

Closes #23183.