### PR TITLE
vim-patch:9.0.1470: deferred functions invoked in unexpected order

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3270,14 +3270,14 @@ static void handle_defer_one(funccall_T *funccal)
 /// Called when exiting: call all defer functions.
 void invoke_all_defer(void)
 {
+  for (funccall_T *fc = current_funccal; fc != NULL; fc = fc->fc_caller) {
+    handle_defer_one(fc);
+  }
+
   for (funccal_entry_T *fce = funccal_stack; fce != NULL; fce = fce->next) {
     for (funccall_T *fc = fce->top_funccal; fc != NULL; fc = fc->fc_caller) {
       handle_defer_one(fc);
     }
-  }
-
-  for (funccall_T *fc = current_funccal; fc != NULL; fc = fc->fc_caller) {
-    handle_defer_one(fc);
   }
 }
 


### PR DESCRIPTION
#### vim-patch:9.0.1470: deferred functions invoked in unexpected order

Problem:    Deferred functions invoked in unexpected order when using :qa and
            autocommands.
Solution:   Call deferred functions for the current funccal before using the
            stack. (closes vim/vim#12278)

https://github.com/vim/vim/commit/1be4b81bfb3d7edf0e2ae41711d429e8fa5e0555