### PR TITLE
perf(events): store AutoCmds in a kvec_t

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -226,7 +226,7 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
     }
 
     for (AutoPat *ap = au_get_autopat_for_event(event); ap != NULL; ap = ap->next) {
-      if (ap->cmds == NULL) {
+      if (kv_size(ap->cmds) == 0) {
         continue;
       }
 
@@ -265,7 +265,8 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
         }
       }
 
-      for (AutoCmd *ac = ap->cmds; ac != NULL; ac = ac->next) {
+      for (size_t i = 0; i < kv_size(ap->cmds); i++) {
+        AutoCmd *const ac = &kv_A(ap->cmds, i);
         if (aucmd_exec_is_deleted(ac->exec)) {
           continue;
         }

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -40,11 +40,9 @@ struct AutoCmd_S {
   AucmdExecutable exec;
   bool once;                            // "One shot": removed after execution
   bool nested;                          // If autocommands nest here
-  bool last;                            // last command in list
   int64_t id;                           // ID used for uniquely tracking an autocmd.
   sctx_T script_ctx;                    // script context where it is defined
   char *desc;                           // Description for the autocmd.
-  AutoCmd *next;                        // Next AutoCmd in list
 };
 
 typedef struct AutoPat_S AutoPat;
@@ -54,19 +52,20 @@ struct AutoPat_S {
   char *pat;                            // pattern as typed (NULL when pattern
                                         // has been removed)
   regprog_T *reg_prog;                  // compiled regprog for pattern
-  AutoCmd *cmds;                        // list of commands to do
+  kvec_t(AutoCmd) cmds;                 // list of commands to do
   int group;                            // group ID
   int patlen;                           // strlen() of pat
   int buflocal_nr;                      // !=0 for buffer-local AutoPat
   char allow_dirs;                      // Pattern may match whole path
-  char last;                            // last pattern for apply_autocmds()
+  bool last;                            // last pattern for apply_autocmds()
 };
 
 /// Struct used to keep status while executing autocommands for an event.
 typedef struct AutoPatCmd_S AutoPatCmd;
 struct AutoPatCmd_S {
   AutoPat *curpat;          // next AutoPat to examine
-  AutoCmd *nextcmd;         // next AutoCmd to execute
+  size_t nextcmd;           // next AutoCmd index to execute
+  size_t last;              // last command index in list
   int group;                // group being used
   char *fname;              // fname to match with
   char *sfname;             // sfname to match with


### PR DESCRIPTION
Replace linked lists with kvec_t.

A quick benchmark on 10k autocommands of the same type and pattern (I doubt there is any performance gain with any other scenario, for now):
```
master:
nvim_create_autocmd     103.056ms
nvim_exec_autocmds      4.408ms
nvim_del_autocmd        273.789ms

refactor:
nvim_create_autocmd     10.079ms
nvim_exec_autocmds      4.420ms
nvim_del_autocmd        81.586ms
```

<details>

```lua
local api = vim.api
local hrtime = vim.loop.hrtime

require('jit').off()
require('jit').flush()

local N = 10000
local ts

local ids = {}
for i = 1, N do
  ids[i] = 0
end

local nvim_create_autocmd = api.nvim_create_autocmd
ts = hrtime()
for i = 1, N do
  ids[i] = nvim_create_autocmd('User', {
    pattern = 'Benchmark',
    command = 'eval ' .. i,
  })
end
print(('nvim_create_autocmd     %.3fms'):format((hrtime() - ts) / 1000000))

ts = hrtime()
api.nvim_exec_autocmds('User', { pattern = 'Benchmark', modeline = false })
print(('nvim_exec_autocmds      %.3fms'):format((hrtime() - ts) / 1000000))

local nvim_del_autocmd = api.nvim_del_autocmd
ts = hrtime()
for i = 1, N do
  nvim_del_autocmd(ids[i])
end
print(('nvim_del_autocmd        %.3fms'):format((hrtime() - ts) / 1000000))

vim.cmd('qa!')
```

`nvim --headless -c 'so benchmark.lua'`

</details>