### PR TITLE
vim-patch:8.2.4598: profile completion test sometimes fails

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -497,6 +497,9 @@ let s:flaky_tests = [
       \ 'Test_termwinscroll()',
       \ ]
 
+" Delete the .res file, it may change behavior for completion
+call delete(fnamemodify(g:testname, ':r') .. '.res')
+
 " Locate Test_ functions and execute them.
 redir @q
 silent function /^Test_


### PR DESCRIPTION
#### vim-patch:8.2.4598: profile completion test sometimes fails

Problem:    Profile completion test sometimes fails.
Solution:   Delete the .res file before running tests.

https://github.com/vim/vim/commit/7e0be3ea211748a77d32cb1d3d35ecfc246cf0f2

Co-authored-by: Bram Moolenaar <Bram@vim.org>