### PR TITLE
fix(treesitter playground): fix the wrong range of a node displayed i…

### DIFF
--- a/runtime/lua/vim/treesitter/playground.lua
+++ b/runtime/lua/vim/treesitter/playground.lua
@@ -147,7 +147,7 @@ local decor_ns = api.nvim_create_namespace('ts.playground')
 ---@param end_lnum integer
 ---@param end_col integer
 ---@return string
-local function get_range_str(lnum, col, end_col, end_lnum)
+local function get_range_str(lnum, col, end_lnum, end_col)
   if lnum == end_lnum then
     return string.format('[%d:%d - %d]', lnum + 1, col + 1, end_col)
   end


### PR DESCRIPTION
The call parameters order of the function `get_range_str` is flipped for the last two arguments compared to the declaration.

### Before
<img width="1207" alt="image" src="https://user-images.githubusercontent.com/50717946/233227473-de4e79c6-4af3-421b-be9c-6713c9c9b048.png">

### After
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/50717946/233227521-efbaeaab-1dec-4e06-944f-2e0f345bfb7a.png">

