### PR TITLE
fix(build): distinguish vim.mpack from global require'mpack'

### DIFF
--- a/scripts/genvimvim.lua
+++ b/scripts/genvimvim.lua
@@ -1,4 +1,4 @@
-local mpack = require('mpack')
+local mpack = vim.mpack
 
 if arg[1] == '--help' then
   print('Usage: lua genvimvim.lua src/nvim runtime/syntax/vim/generated.vim')

--- a/src/mpack/lmpack.c
+++ b/src/mpack/lmpack.c
@@ -1171,9 +1171,6 @@ static const luaL_reg mpack_functions[] = {
   {NULL, NULL}
 };
 
-#ifdef NLUA_WIN32
-  __declspec(dllexport)
-#endif
 int luaopen_mpack(lua_State *L)
 {
   /* Unpacker */

--- a/src/mpack/lmpack.h
+++ b/src/mpack/lmpack.h
@@ -1,6 +1,3 @@
 #include <lua.h>
 
-#ifdef NLUA_WIN32
-  __declspec(dllexport)
-#endif
 int luaopen_mpack(lua_State *L);

--- a/src/nlua0.c
+++ b/src/nlua0.c
@@ -1,0 +1,13 @@
+#include <lua.h>
+
+#include "mpack/lmpack.h"
+
+LUA_API int luaopen_nlua0(lua_State* L);
+
+LUA_API int luaopen_nlua0(lua_State* L) {
+  lua_getglobal(L, "vim");
+  luaopen_mpack(L);
+  lua_setfield(L, -2, "mpack");
+
+  return 1;
+}

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 add_library(nlua0 MODULE)
 if(WIN32)
-  target_compile_definitions(nlua0 PUBLIC LUA_BUILD_AS_DLL NLUA_WIN32)
+  target_compile_definitions(nlua0 PUBLIC LUA_BUILD_AS_DLL LUA_LIB)
   set_target_properties(nlua0 PROPERTIES ENABLE_EXPORTS TRUE)
 elseif(APPLE)
   set_target_properties(nlua0 PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
@@ -322,6 +322,7 @@ if(PREFER_LUA)
   target_compile_definitions(main_lib INTERFACE NVIM_VENDOR_BIT)
 endif()
 
+list(APPEND NLUA0_SOURCES ${PROJECT_SOURCE_DIR}/src/nlua0.c)
 foreach(subdir
         os
         api

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -1,4 +1,4 @@
-local mpack = require('mpack')
+local mpack = vim.mpack
 
 local hashy = require'generators.hashy'
 

--- a/src/nvim/generators/gen_api_ui_events.lua
+++ b/src/nvim/generators/gen_api_ui_events.lua
@@ -1,4 +1,4 @@
-local mpack = require('mpack')
+local mpack = vim.mpack
 
 assert(#arg == 5)
 local input = io.open(arg[1], 'rb')

--- a/src/nvim/generators/gen_eval.lua
+++ b/src/nvim/generators/gen_eval.lua
@@ -1,4 +1,4 @@
-local mpack = require('mpack')
+local mpack = vim.mpack
 
 local autodir = arg[1]
 local metadata_file = arg[2]

--- a/src/nvim/generators/preload.lua
+++ b/src/nvim/generators/preload.lua
@@ -4,6 +4,7 @@ package.path = srcdir .. '/src/nvim/?.lua;' ..srcdir .. '/runtime/lua/?.lua;' ..
 _G.vim = require'vim.shared'
 _G.vim.inspect = require 'vim.inspect'
 package.cpath = package.cpath .. ';' .. nlualib
+require 'nlua0'
 
 arg[0] = table.remove(arg, 1)
 return loadfile(arg[0])()


### PR DESCRIPTION
problem: the api of vim.mpack is not compatible with a system provided mpack
solution: don't require 'mpack' directly from he system path

fixes #23213 (hopefully, with distros you can never be really sure)