### PR TITLE
fix: disallow removing extmarks in on_lines callbacks

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2763,10 +2763,13 @@ nvim_set_decoration_provider({ns_id}, {*opts})
     for the extmarks set/modified inside the callback anyway.
 
     Note: doing anything other than setting extmarks is considered
-    experimental. Doing things like changing options are not expliticly
+    experimental. Doing things like changing options are not explicitly
     forbidden, but is likely to have unexpected consequences (such as 100% CPU
     consumption). doing `vim.rpcnotify` should be OK, but `vim.rpcrequest` is
     quite dubious for the moment.
+
+    Note: It is not allowed to remove or update extmarks in 'on_line'
+    callbacks.
 
     Attributes: ~
         Lua |vim.api| only

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -172,7 +172,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
   decor.priority = 0;
 
   extmark_set(buf, ns_id, NULL, (int)line, 0, -1, -1, &decor, true,
-              false, kExtmarkNoUndo);
+              false, kExtmarkNoUndo, NULL);
   return src_id;
 }
 

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -65,7 +65,7 @@ void bufhl_add_hl_pos_offset(buf_T *buf, int src_id, int hl_id, lpos_T pos_start
     }
     extmark_set(buf, (uint32_t)src_id, NULL,
                 (int)lnum - 1, hl_start, (int)lnum - 1 + end_off, hl_end,
-                &decor, true, false, kExtmarkNoUndo);
+                &decor, true, false, kExtmarkNoUndo, NULL);
   }
 }
 

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -100,6 +100,11 @@ typedef struct {
   int conceal_attr;
 
   TriState spell;
+
+  // This is used to prevent removing/updating extmarks inside
+  // on_lines callbacks which is not allowed since it can lead to
+  // heap-use-after-free errors.
+  bool running_on_lines;
 } DecorState;
 
 EXTERN DecorState decor_state INIT(= { 0 });

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -150,6 +150,7 @@ void decor_providers_invoke_win(win_T *wp, DecorProviders *providers,
 void decor_providers_invoke_line(win_T *wp, DecorProviders *providers, int row, bool *has_decor,
                                  char **err)
 {
+  decor_state.running_on_lines = true;
   for (size_t k = 0; k < kv_size(*providers); k++) {
     DecorProvider *p = kv_A(*providers, k);
     if (p && p->redraw_line != LUA_NOREF) {
@@ -167,6 +168,7 @@ void decor_providers_invoke_line(win_T *wp, DecorProviders *providers, int row, 
       hl_check_ns();
     }
   }
+  decor_state.running_on_lines = false;
 }
 
 /// For each provider invoke the 'buf' callback for a given buffer.
@@ -179,8 +181,9 @@ void decor_providers_invoke_buf(buf_T *buf, DecorProviders *providers, char **er
   for (size_t i = 0; i < kv_size(*providers); i++) {
     DecorProvider *p = kv_A(*providers, i);
     if (p && p->redraw_buf != LUA_NOREF) {
-      MAXSIZE_TEMP_ARRAY(args, 1);
+      MAXSIZE_TEMP_ARRAY(args, 2);
       ADD_C(args, BUFFER_OBJ(buf->handle));
+      ADD_C(args, INTEGER_OBJ((int64_t)display_tick));
       decor_provider_invoke(p->ns_id, "buf", p->redraw_buf, args, true, err);
     }
   }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -122,7 +122,7 @@ describe('decorations providers', function()
     ]]}
     check_trace {
       { "start", 5 };
-      { "buf", 1 };
+      { "buf", 1, 5 };
       { "win", 1000, 1, 0, 8 };
       { "line", 1000, 1, 6 };
       { "end", 5 };
@@ -563,6 +563,23 @@ describe('decorations providers', function()
       hello6                                  |
       hello7                                  |
                                               |
+    ]])
+  end)
+
+  it('does not allow removing extmarks during on_line callbacks', function()
+    exec_lua([[
+      eok = true
+    ]])
+    setup_provider([[
+      local function on_do(kind, winid, bufnr, topline, botline_guess)
+        if kind == 'line' then
+          api.nvim_buf_set_extmark(bufnr, ns1, 1, -1, { sign_text = 'X' })
+          eok = pcall(api.nvim_buf_clear_namespace, bufnr, ns1, 0, -1)
+        end
+      end
+    ]])
+    exec_lua([[
+      assert(eok == false)
     ]])
   end)
 end)


### PR DESCRIPTION
decor_redraw_start (which runs before decor_providers_invoke_lines) gets
references for the extmarks on a specific line. If these extmarks are
deleted in on_lines callbacks then this results in a heap-use-after-free
error.

Fixes #22801
