### PR TITLE
refactor(env): remove unused mutex

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -176,7 +176,6 @@ bool event_teardown(void)
 /// Needed for unit tests. Must be called after `time_init()`.
 void early_init(mparm_T *paramp)
 {
-  env_init();
   estack_init();
   cmdline_init();
   eval_init();          // init global variables


### PR DESCRIPTION
This was needed when TUI was a thread.
lua code uses  :os_getenv:  only on the main thread.