### PR TITLE
feat(health): remove deprecation warnings

### DIFF
--- a/runtime/autoload/health.vim
+++ b/runtime/autoload/health.vim
@@ -1,24 +1,13 @@
-function! s:deprecate(type) abort
-  let deprecate = v:lua.vim.deprecate('health#report_' . a:type, 'vim.health.' . a:type, '0.11')
-  redraw | echo 'Running healthchecks...'
-  if deprecate isnot v:null
-    call v:lua.vim.health.warn(deprecate)
-  endif
-endfunction
-
 function! health#report_start(name) abort
   call v:lua.vim.health.start(a:name)
-  call s:deprecate('start')
 endfunction
 
 function! health#report_info(msg) abort
   call v:lua.vim.health.info(a:msg)
-  call s:deprecate('info')
 endfunction
 
 function! health#report_ok(msg) abort
   call v:lua.vim.health.ok(a:msg)
-  call s:deprecate('ok')
 endfunction
 
 function! health#report_warn(msg, ...) abort
@@ -27,7 +16,6 @@ function! health#report_warn(msg, ...) abort
   else
     call v:lua.vim.health.warn(a:msg)
   endif
-  call s:deprecate('warn')
 endfunction
 
 function! health#report_error(msg, ...) abort
@@ -36,5 +24,4 @@ function! health#report_error(msg, ...) abort
   else
     call v:lua.vim.health.error(a:msg)
   endif
-  call s:deprecate('error')
 endfunction


### PR DESCRIPTION
Remove deprecation warnings in vim script interface for checkhealth. It's still deprecated and undocumented, but it will remain working for backwards compatibility.