### PR TITLE
vim-patch:9.0.1472: ":drop fname" may change the last used tab page

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -1071,12 +1071,19 @@ static void do_arg_all(int count, int forceit, int keep_tabs)
   aall.alist->al_refcount++;
   arglist_locked = true;
 
+  tabpage_T *const new_lu_tp = curtab;
+
   // Try closing all windows that are not in the argument list.
   // Also close windows that are not full width;
   // When 'hidden' or "forceit" set the buffer becomes hidden.
   // Windows that have a changed buffer and can't be hidden won't be closed.
   // When the ":tab" modifier was used do this for all tab pages.
   arg_all_close_unused_windows(&aall);
+
+  // Now set the last used tabpage to where we started.
+  if (valid_tabpage(new_lu_tp)) {
+    lastused_tabpage = new_lu_tp;
+  }
 
   // Open a window for files in the argument list that don't have one.
   // ARGCOUNT may change while doing this, because of autocommands.

--- a/test/old/testdir/test_tabpage.vim
+++ b/test/old/testdir/test_tabpage.vim
@@ -148,6 +148,22 @@ function Test_tabpage()
   tabonly!
 endfunc
 
+func Test_tabpage_drop()
+  edit f1
+  tab split f2
+  tab split f3
+  normal! gt
+  call assert_equal(1, tabpagenr())
+
+  tab drop f3
+  call assert_equal(3, tabpagenr())
+  call assert_equal(1, tabpagenr('#'))
+  bwipe!
+  bwipe!
+  bwipe!
+  call assert_equal(1, tabpagenr('$'))
+endfunc
+
 " Test autocommands
 function Test_tabpage_with_autocmd()
   command -nargs=1 -bar C :call add(s:li, '=== ' . <q-args> . ' ===')|<args>


### PR DESCRIPTION
#### vim-patch:9.0.1472: ":drop fname" may change the last used tab page

Problem:    ":drop fname" may change the last used tab page.
Solution:   Restore the last used tab page when :drop has changed it.

https://github.com/vim/vim/commit/8281a16efc76197f7b0b2a385dffb44fce66d33e

Co-authored-by: Bram Moolenaar <Bram@vim.org>