### PR TITLE
fix(lua): vim.split may trim inner empty items

### DIFF
--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -100,10 +100,9 @@ function vim.gsplit(s, sep, opts)
   local start = 1
   local done = false
 
-  -- For `trimempty`:
+  -- For `trimempty`: queue of collected segments, to be emitted at next pass.
+  local segs = {}
   local empty_start = true -- Only empty segments seen so far.
-  local empty_segs = 0 -- Empty segments found between non-empty segments.
-  local nonemptyseg = nil
 
   local function _pass(i, j, ...)
     if i then
@@ -118,14 +117,9 @@ function vim.gsplit(s, sep, opts)
   end
 
   return function()
-    if trimempty and empty_segs > 0 then
-      -- trimempty: Pop the collected empty segments.
-      empty_segs = empty_segs - 1
-      return ''
-    elseif trimempty and nonemptyseg then
-      local seg = nonemptyseg
-      nonemptyseg = nil
-      return seg
+    if trimempty and #segs > 0 then
+      -- trimempty: Pop the collected segments.
+      return table.remove(segs)
     elseif done or (s == '' and sep == '') then
       return nil
     elseif sep == '' then
@@ -138,23 +132,24 @@ function vim.gsplit(s, sep, opts)
     local seg = _pass(s:find(sep, start, plain))
 
     -- Trim empty segments from start/end.
-    if seg ~= '' then
+    if trimempty and seg ~= '' then
       empty_start = false
-    elseif trimempty then
+    elseif trimempty and seg == '' then
       while not done and seg == '' do
-        empty_segs = empty_segs + 1
+        table.insert(segs, 1, '')
         seg = _pass(s:find(sep, start, plain))
       end
       if done and seg == '' then
         return nil
       elseif empty_start then
         empty_start = false
-        empty_segs = 0
+        segs = {}
         return seg
       end
-      nonemptyseg = seg ~= '' and seg or nil
-      seg = ''
-      empty_segs = empty_segs - 1
+      if seg ~= '' then
+        table.insert(segs, 1, seg)
+      end
+      return table.remove(segs)
     end
 
     return seg

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -138,7 +138,9 @@ function vim.gsplit(s, sep, opts)
     local seg = _pass(s:find(sep, start, plain))
 
     -- Trim empty segments from start/end.
-    if trimempty and seg == '' then
+    if seg ~= '' then
+      empty_start = false
+    elseif trimempty then
       while not done and seg == '' do
         empty_segs = empty_segs + 1
         seg = _pass(s:find(sep, start, plain))

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -294,9 +294,11 @@ describe('lua stdlib', function()
 
   it('vim.gsplit, vim.split', function()
     local tests = {
+      --                            plain  trimempty
       { 'a,b',             ',',     false, false, { 'a', 'b' } },
       { ':aa::::bb:',      ':',     false, false, { '', 'aa', '', '', '', 'bb', '' } },
       { ':aa::::bb:',      ':',     false, true,  { 'aa', '', '', '', 'bb' } },
+      { 'aa::::bb:',       ':',     false, true,  { 'aa', '', '', '', 'bb' } },
       { ':aa::bb:',        ':',     false, true,  { 'aa', '', 'bb' } },
       { '/a/b:/b/\n',      '[:\n]', false, true,  { '/a/b', '/b/' } },
       { '::ee::ff:',       ':',     false, false, { '', '', 'ee', '', 'ff', '' } },
@@ -315,7 +317,7 @@ describe('lua stdlib', function()
     }
 
     for _, t in ipairs(tests) do
-      eq(t[5], vim.split(t[1], t[2], {plain=t[3], trimempty=t[4]}))
+      eq(t[5], vim.split(t[1], t[2], {plain=t[3], trimempty=t[4]}), t[1])
     end
 
     -- Test old signature


### PR DESCRIPTION
Problem:
`vim.split('a:::b:', ':', {trimempty=true})` trims inner empty items.
Regression from 9c49c1047079427ff0a2356cb37302934845108e

Solution:
Set `empty_start=false` when first non-empty item is found.
close #23212
