### PR TITLE
fix: adds a special case in nvim_cmd for cmds that take a count arg, neovim#23121

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -459,11 +459,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
       break;
     default:
       // if the cmd can take a count argument, it optionally has 1 arg
-      if (ea.argt & EX_COUNT) {
-        argc_valid = args.size == 0 || args.size == 1;
-      } else {
-        argc_valid = args.size == 0;
-      }
+      argc_valid = args.size == 0 || ((ea.argt & EX_COUNT) && args.size == 1);
       break;
     }
 

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -458,7 +458,12 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
       argc_valid = true;
       break;
     default:
-      argc_valid = args.size == 0;
+      // if the cmd can take a count argument, it optionally has 1 arg
+      if (ea.argt & EX_COUNT) {
+        argc_valid = args.size == 0 || args.size == 1;
+      } else {
+        argc_valid = args.size == 0;
+      }
       break;
     }
 


### PR DESCRIPTION
This location in nvim_cmd seems like the most appropriate to handle this case. If it isn't please let me know.