### PR TITLE
fix(eval): fix out of bound write

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1850,7 +1850,7 @@ dictitem_T *tv_dict_item_alloc_len(const char *const key, const size_t key_len)
   FUNC_ATTR_NONNULL_RET FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
   FUNC_ATTR_MALLOC
 {
-  dictitem_T *const di = xmalloc(offsetof(dictitem_T, di_key) + key_len + 1);
+  dictitem_T *const di = xmalloc(sizeof(dictitem_T) + key_len + 1);
   memcpy(di->di_key, key, key_len);
   di->di_key[key_len] = NUL;
   di->di_flags = DI_FLAGS_ALLOC;


### PR DESCRIPTION
```
In function ‘tv_dict_item_alloc_len’,
    inlined from ‘tv_dict_watcher_notify’ at /home/asn/workspace/projects/neovim/src/nvim/eval/typval.c:1793:27:
/home/asn/workspace/projects/neovim/src/nvim/eval/typval.c:1855:23: warning: array subscript ‘dictitem_T[0]’ is partly outside array bounds of ‘unsigned char[21]’ [-Warray-bounds=]
 1855 |   di->di_key[key_len] = NUL;
/home/asn/workspace/projects/neovim/src/nvim/eval/typval.c:1853:26: note: object of size 21 allocated by ‘xmalloc’
 1853 |   dictitem_T *const di = xmalloc(offsetof(dictitem_T, di_key) + key_len + 1);
      |                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/asn/workspace/projects/neovim/src/nvim/eval/typval.c:1856:16: warning: array subscript ‘dictitem_T[0]’ is partly outside array bounds of ‘unsigned char[21]’ [-Warray-bounds=]
 1856 |   di->di_flags = DI_FLAGS_ALLOC;
      |   ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
```