### PR TITLE
refactor(iter): use metatable as packed table tag

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3416,6 +3416,41 @@ describe('lua stdlib', function()
         { item_3 = 'test' },
       }, output)
     end)
+
+    it('handles nil values', function()
+      local t = {1, 2, 3, 4, 5}
+      do
+        local it = vim.iter(t):enumerate():map(function(i, v)
+          if i % 2 == 0 then
+            return nil, v*v
+          end
+          return v, nil
+        end)
+        eq({
+          { [1] = 1 },
+          { [2] = 4 },
+          { [1] = 3 },
+          { [2] = 16 },
+          { [1] = 5 },
+        }, it:totable())
+      end
+
+      do
+        local it = vim.iter(ipairs(t)):map(function(i, v)
+          if i % 2 == 0 then
+            return nil, v*v
+          end
+          return v, nil
+        end)
+        eq({
+          { [1] = 1 },
+          { [2] = 4 },
+          { [1] = 3 },
+          { [2] = 16 },
+          { [1] = 5 },
+        }, it:totable())
+      end
+    end)
   end)
 end)
 


### PR DESCRIPTION
This is a more robust method for tagging a packed table and eliminates the need to manually remove the `__n` keys which were used as tags prior.
