### PR TITLE
vim-patch:9.0.{1293,1308,1311}: refactor option.c

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1207,6 +1207,9 @@ static void do_set_option_string(int opt_idx, int opt_flags, char **argp, int ne
 
   // Set the new value.
   *(char **)(varp) = newval;
+  if (newval == NULL) {
+    *(char **)(varp) = empty_option;
+  }
 
   // origval may be freed by did_set_string_option(), make a copy.
   char *saved_origval = (origval != NULL) ? xstrdup(origval) : NULL;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2471,6 +2471,346 @@ static const char *set_bool_option(const int opt_idx, char *const varp, const in
   return errmsg;
 }
 
+/// Process the new 'winheight' value.
+static void did_set_winheight(win_T *win, long value)
+{
+  // Change window height NOW
+  if (!ONE_WINDOW) {
+    if (win->w_height < value) {
+      win_setheight((int)value);
+    }
+  }
+}
+
+/// Process the new 'helpheight' option value.
+static void did_set_helpheight(buf_T *buf, win_T *win, long value)
+{
+  // Change window height NOW
+  if (!ONE_WINDOW) {
+    if (buf->b_help && win->w_height < value) {
+      win_setheight((int)value);
+    }
+  }
+}
+
+/// Process the new 'winwidth' option value.
+static void did_set_winwidth(win_T *win, long value)
+{
+  if (!ONE_WINDOW && win->w_width < value) {
+    win_setwidth((int)value);
+  }
+}
+
+/// Process the new 'laststatus' option value.
+static void did_set_laststatus(long value, long old_value)
+{
+  // When switching to global statusline, decrease topframe height
+  // Also clear the cmdline to remove the ruler if there is one
+  if (value == 3 && old_value != 3) {
+    frame_new_height(topframe, topframe->fr_height - STATUS_HEIGHT, false, false);
+    (void)win_comp_pos();
+    clear_cmdline = true;
+  }
+  // When switching from global statusline, increase height of topframe by STATUS_HEIGHT
+  // in order to to re-add the space that was previously taken by the global statusline
+  if (old_value == 3 && value != 3) {
+    frame_new_height(topframe, topframe->fr_height + STATUS_HEIGHT, false, false);
+    (void)win_comp_pos();
+  }
+
+  last_status(false);  // (re)set last window status line.
+}
+
+/// Process the new 'showtabline' option value.
+static void did_set_showtabline(void)
+{
+  // (re)set tab page line
+  win_new_screen_rows();  // recompute window positions and heights
+}
+
+/// Process the new 'foldlevel' option value.
+static void did_set_foldlevel(void)
+{
+  newFoldLevel();
+}
+
+/// Process the new 'foldminlines' option value.
+static void did_set_foldminlines(win_T *win)
+{
+  foldUpdateAll(win);
+}
+
+/// Process the new 'foldnestmax' option value.
+static void did_set_foldnestmax(win_T *win)
+{
+  if (foldmethodIsSyntax(win) || foldmethodIsIndent(win)) {
+    foldUpdateAll(win);
+  }
+}
+
+/// Process the new 'shiftwidth' or the 'tabstop' option value.
+static void did_set_shiftwidth_tabstop(buf_T *buf, win_T *win, const long *pp)
+{
+  if (foldmethodIsIndent(win)) {
+    foldUpdateAll(win);
+  }
+  // When 'shiftwidth' changes, or it's zero and 'tabstop' changes:
+  // parse 'cinoptions'.
+  if (pp == &buf->b_p_sw || buf->b_p_sw == 0) {
+    parse_cino(buf);
+  }
+}
+
+/// Process the new 'iminset' option value.
+static void did_set_iminsert(void)
+{
+  showmode();
+  // Show/unshow value of 'keymap' in status lines.
+  status_redraw_curbuf();
+}
+
+/// Process the new 'window' option value.
+static void did_set_window(void)
+{
+  if (p_window < 1) {
+    p_window = Rows - 1;
+  } else if (p_window >= Rows) {
+    p_window = Rows - 1;
+  }
+}
+
+/// Process the new 'titlelen' option value.
+static void did_set_titlelen(long old_value)
+{
+  // if 'titlelen' has changed, redraw the title
+  if (starting != NO_SCREEN && old_value != p_titlelen) {
+    need_maketitle = true;
+  }
+}
+
+/// Process the new 'cmdheight' option value.
+static void did_set_cmdheight(long old_value)
+{
+  if (ui_has(kUIMessages)) {
+    p_ch = 0;
+  }
+  if (p_ch > Rows - min_rows() + 1) {
+    p_ch = Rows - min_rows() + 1;
+  }
+
+  // if p_ch changed value, change the command line height
+  // Only compute the new window layout when startup has been
+  // completed. Otherwise the frame sizes may be wrong.
+  if ((p_ch != old_value
+       || tabline_height() + global_stl_height() + topframe->fr_height != Rows - p_ch)
+      && full_screen) {
+    command_height();
+  }
+}
+
+/// Process the new 'updatecount' option value.
+static void did_set_updatecount(long old_value)
+{
+  // when 'updatecount' changes from zero to non-zero, open swap files
+  if (p_uc && !old_value) {
+    ml_open_files();
+  }
+}
+
+/// Process the new 'pumblend' option value.
+static void did_set_pumblend(void)
+{
+  p_pb = MAX(MIN(p_pb, 100), 0);
+  hl_invalidate_blends();
+  pum_grid.blending = (p_pb > 0);
+  if (pum_drawn()) {
+    pum_redraw();
+  }
+}
+
+/// Process the new global 'undolevels' option value.
+static void did_set_global_undolevels(long value, long old_value)
+{
+  // sync undo before 'undolevels' changes
+  // use the old value, otherwise u_sync() may not work properly
+  p_ul = old_value;
+  u_sync(true);
+  p_ul = value;
+}
+
+/// Process the new buffer local 'undolevels' option value.
+static void did_set_buflocal_undolevels(buf_T *buf, long value, long old_value)
+{
+  // use the old value, otherwise u_sync() may not work properly
+  buf->b_p_ul = old_value;
+  u_sync(true);
+  buf->b_p_ul = value;
+}
+
+/// Process the new 'scrollback' option value.
+static void did_set_scrollback(buf_T *buf, long value, long old_value)
+{
+  if (buf->terminal && value < old_value) {
+    // Force the scrollback to take immediate effect only when decreasing it.
+    on_scrollback_option_changed(buf->terminal);
+  }
+}
+
+/// Process the new 'numberwidth' option value.
+static void did_set_numberwidth(void)
+{
+  curwin->w_nrwidth_line_count = 0;  // trigger a redraw
+}
+
+/// Process the new 'textwidth' option value.
+static void did_set_textwidth(void)
+{
+  FOR_ALL_TAB_WINDOWS(tp, wp) {
+    check_colorcolumn(wp);
+  }
+}
+
+/// Process the new 'winblend' option value.
+static void did_set_winblend(win_T *win, long value, long old_value)
+{
+  if (value != old_value) {
+    win->w_p_winbl = MAX(MIN(win->w_p_winbl, 100), 0);
+    win->w_hl_needs_update = true;
+    check_blending(curwin);
+  }
+}
+
+/// When some number options are changed, need to take some action.
+static const char *did_set_num_option(long *pp, long value, long old_value, const char *errmsg)
+{
+  if (pp == &p_wh) {      // 'winheight'
+    did_set_winheight(curwin, value);
+  } else if (pp == &p_hh) {  // 'helpheight'
+    did_set_helpheight(curbuf, curwin, value);
+  } else if (pp == &p_wmh) {  // 'winminheight'
+    did_set_winminheight();
+  } else if (pp == &p_wiw) {  // 'winwidth'
+    did_set_winwidth(curwin, value);
+  } else if (pp == &p_wmw) {  // 'winminwidth'
+    did_set_winminwidth();
+  } else if (pp == &p_window) {  // 'window'
+    did_set_window();
+  } else if (pp == &p_ls) {  // 'laststatus'
+    did_set_laststatus(value, old_value);
+  } else if (pp == &p_stal) {
+    did_set_showtabline();  // 'showtabline'
+  } else if (pp == &curwin->w_p_fdl) {
+    did_set_foldlevel();
+  } else if (pp == &curwin->w_p_fml) {
+    did_set_foldminlines(curwin);
+  } else if (pp == &curwin->w_p_fdn) {
+    did_set_foldnestmax(curwin);
+  } else if (pp == &curbuf->b_p_sw        // 'shiftwidth'
+             || pp == &curbuf->b_p_ts) {  // 'tabstop'
+    did_set_shiftwidth_tabstop(curbuf, curwin, pp);
+  } else if (pp == &curbuf->b_p_iminsert) {  // 'iminsert'
+    did_set_iminsert();
+  } else if (pp == &p_titlelen) {  // 'titlelen'
+    did_set_titlelen(old_value);
+  } else if (pp == &p_ch) {  // 'cmdheight'
+    did_set_cmdheight(old_value);
+  } else if (pp == &p_uc) {  // 'updatecount'
+    did_set_updatecount(old_value);
+  } else if (pp == &p_pb) {  // 'pumblend
+    did_set_pumblend();
+  } else if (pp == &p_ul) {  // global 'undolevels'
+    did_set_global_undolevels(value, old_value);
+  } else if (pp == &curbuf->b_p_ul) {  // buffer local 'undolevels'
+    did_set_buflocal_undolevels(curbuf, value, old_value);
+  } else if (pp == &curbuf->b_p_scbk || pp == &p_scbk) {
+    did_set_scrollback(curbuf, value, old_value);
+  } else if (pp == &curwin->w_p_nuw) {  // 'numberwidth'
+    did_set_numberwidth();
+  } else if (pp == &curbuf->b_p_tw) {  // 'textwidth'
+    did_set_textwidth();
+  } else if (pp == &curwin->w_p_winbl) {
+    did_set_winblend(curwin, value, old_value);
+  }
+
+  return errmsg;
+}
+
+/// Check the bounds of numeric options.
+static const char *check_num_option_bounds(long *pp, long old_value, long old_Rows, char *errbuf,
+                                           size_t errbuflen, const char *errmsg)
+{
+  // Check the (new) bounds for Rows and Columns here.
+  if (p_lines < min_rows() && full_screen) {
+    if (errbuf != NULL) {
+      vim_snprintf(errbuf, errbuflen, _("E593: Need at least %d lines"), min_rows());
+      errmsg = errbuf;
+    }
+    p_lines = min_rows();
+  }
+  if (p_columns < MIN_COLUMNS && full_screen) {
+    if (errbuf != NULL) {
+      vim_snprintf(errbuf, errbuflen, _("E594: Need at least %d columns"), MIN_COLUMNS);
+      errmsg = errbuf;
+    }
+    p_columns = MIN_COLUMNS;
+  }
+
+  // True max size is defined by check_screensize()
+  p_lines = MIN(p_lines, INT_MAX);
+  p_columns = MIN(p_columns, INT_MAX);
+
+  // If the screen (shell) height has been changed, assume it is the
+  // physical screenheight.
+  if (p_lines != Rows || p_columns != Columns) {
+    // Changing the screen size is not allowed while updating the screen.
+    if (updating_screen) {
+      *pp = old_value;
+    } else if (full_screen) {
+      screen_resize((int)p_columns, (int)p_lines);
+    } else {
+      // TODO(bfredl): is this branch ever needed?
+      // Postpone the resizing; check the size and cmdline position for
+      // messages.
+      Rows = (int)p_lines;
+      Columns = (int)p_columns;
+      check_screensize();
+      int new_row = (int)(Rows - MAX(p_ch, 1));
+      if (cmdline_row > new_row && Rows > p_ch) {
+        assert(p_ch >= 0 && new_row <= INT_MAX);
+        cmdline_row = new_row;
+      }
+    }
+    if (p_window >= Rows || !option_was_set("window")) {
+      p_window = Rows - 1;
+    }
+  }
+
+  if ((curwin->w_p_scr <= 0 || (curwin->w_p_scr > curwin->w_height && curwin->w_height > 0))
+      && full_screen) {
+    if (pp == &(curwin->w_p_scr)) {
+      if (curwin->w_p_scr != 0) {
+        errmsg = e_scroll;
+      }
+      win_comp_scroll(curwin);
+    } else if (curwin->w_p_scr <= 0) {
+      // If 'scroll' became invalid because of a side effect silently adjust it.
+      curwin->w_p_scr = 1;
+    } else {  // curwin->w_p_scr > curwin->w_height
+      curwin->w_p_scr = curwin->w_height;
+    }
+  }
+  if ((p_sj < -100 || p_sj >= Rows) && full_screen) {
+    if (Rows != old_Rows) {  // Rows changed, just adjust p_sj
+      p_sj = Rows / 2;
+    } else {
+      errmsg = e_scroll;
+      p_sj = 1;
+    }
+  }
+
+  return errmsg;
+}
+
 /// Set the value of a number option, taking care of side effects
 ///
 /// @param[in]  opt_idx  Option index in options[] table.
@@ -2491,8 +2831,7 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
   long *pp = (long *)varp;
 
   // Disallow changing some options from secure mode.
-  if ((secure || sandbox != 0)
-      && (options[opt_idx].flags & P_SECURE)) {
+  if ((secure || sandbox != 0) && (options[opt_idx].flags & P_SECURE)) {
     return e_secure;
   }
 
@@ -2656,207 +2995,11 @@ static const char *set_num_option(int opt_idx, char *varp, long value, char *err
   // Remember where the option was set.
   set_option_sctx_idx(opt_idx, opt_flags, current_sctx);
 
-  // For these options we want to fix some invalid values.
-  if (pp == &p_window) {
-    if (p_window < 1) {
-      p_window = Rows - 1;
-    } else if (p_window >= Rows) {
-      p_window = Rows - 1;
-    }
-  } else if (pp == &p_ch) {
-    if (ui_has(kUIMessages)) {
-      p_ch = 0;
-    }
-    if (p_ch > Rows - min_rows() + 1) {
-      p_ch = Rows - min_rows() + 1;
-    }
-  }
-
   // Number options that need some action when changed
-  if (pp == &p_wh) {
-    // 'winheight'
-    if (!ONE_WINDOW && curwin->w_height < p_wh) {
-      win_setheight((int)p_wh);
-    }
-  } else if (pp == &p_hh) {
-    // 'helpheight'
-    if (!ONE_WINDOW && curbuf->b_help && curwin->w_height < p_hh) {
-      win_setheight((int)p_hh);
-    }
-  } else if (pp == &p_wmh) {
-    // 'winminheight'
-    win_setminheight();
-  } else if (pp == &p_wiw) {
-    // 'winwidth'
-    if (!ONE_WINDOW && curwin->w_width < p_wiw) {
-      win_setwidth((int)p_wiw);
-    }
-  } else if (pp == &p_wmw) {
-    // 'winminwidth'
-    win_setminwidth();
-  } else if (pp == &p_ls) {
-    // When switching to global statusline, decrease topframe height
-    // Also clear the cmdline to remove the ruler if there is one
-    if (value == 3 && old_value != 3) {
-      frame_new_height(topframe, topframe->fr_height - STATUS_HEIGHT, false, false);
-      (void)win_comp_pos();
-      clear_cmdline = true;
-    }
-    // When switching from global statusline, increase height of topframe by STATUS_HEIGHT
-    // in order to to re-add the space that was previously taken by the global statusline
-    if (old_value == 3 && value != 3) {
-      frame_new_height(topframe, topframe->fr_height + STATUS_HEIGHT, false, false);
-      (void)win_comp_pos();
-    }
+  errmsg = did_set_num_option(pp, value, old_value, errmsg);
 
-    last_status(false);  // (re)set last window status line.
-  } else if (pp == &p_stal) {
-    // (re)set tab page line
-    win_new_screen_rows();   // recompute window positions and heights
-  } else if (pp == &curwin->w_p_fdl) {
-    newFoldLevel();
-  } else if (pp == &curwin->w_p_fml) {
-    foldUpdateAll(curwin);
-  } else if (pp == &curwin->w_p_fdn) {
-    if (foldmethodIsSyntax(curwin) || foldmethodIsIndent(curwin)) {
-      foldUpdateAll(curwin);
-    }
-  } else if (pp == &curbuf->b_p_sw || pp == &curbuf->b_p_ts) {
-    // 'shiftwidth' or 'tabstop'
-    if (foldmethodIsIndent(curwin)) {
-      foldUpdateAll(curwin);
-    }
-    // When 'shiftwidth' changes, or it's zero and 'tabstop' changes:
-    // parse 'cinoptions'.
-    if (pp == &curbuf->b_p_sw || curbuf->b_p_sw == 0) {
-      parse_cino(curbuf);
-    }
-  } else if (pp == &curbuf->b_p_iminsert) {
-    showmode();
-    // Show/unshow value of 'keymap' in status lines.
-    status_redraw_curbuf();
-  } else if (pp == &p_titlelen) {
-    // if 'titlelen' has changed, redraw the title
-    if (starting != NO_SCREEN && old_value != p_titlelen) {
-      need_maketitle = true;
-    }
-  } else if (pp == &p_ch) {
-    // if p_ch changed value, change the command line height
-    // Only compute the new window layout when startup has been
-    // completed. Otherwise the frame sizes may be wrong.
-    if ((p_ch != old_value
-         || tabline_height() + global_stl_height() + topframe->fr_height != Rows - p_ch)
-        && full_screen) {
-      command_height();
-    }
-  } else if (pp == &p_uc) {
-    // when 'updatecount' changes from zero to non-zero, open swap files
-    if (p_uc && !old_value) {
-      ml_open_files();
-    }
-  } else if (pp == &p_pb) {
-    p_pb = MAX(MIN(p_pb, 100), 0);
-    hl_invalidate_blends();
-    pum_grid.blending = (p_pb > 0);
-    if (pum_drawn()) {
-      pum_redraw();
-    }
-  } else if (pp == &p_ul || pp == &curbuf->b_p_ul) {
-    // sync undo before 'undolevels' changes
-    // use the old value, otherwise u_sync() may not work properly
-    *pp = old_value;
-    u_sync(true);
-    *pp = value;
-  } else if (pp == &curbuf->b_p_tw) {
-    FOR_ALL_TAB_WINDOWS(tp, wp) {
-      check_colorcolumn(wp);
-    }
-  } else if (pp == &curbuf->b_p_scbk || pp == &p_scbk) {
-    if (curbuf->terminal && value < old_value) {
-      // Force the scrollback to take immediate effect only when decreasing it.
-      on_scrollback_option_changed(curbuf->terminal);
-    }
-  } else if (pp == &curwin->w_p_nuw) {
-    curwin->w_nrwidth_line_count = 0;
-  } else if (pp == &curwin->w_p_winbl && value != old_value) {
-    // 'winblend'
-    curwin->w_p_winbl = MAX(MIN(curwin->w_p_winbl, 100), 0);
-    curwin->w_hl_needs_update = true;
-    check_blending(curwin);
-  }
-
-  // Check the (new) bounds for Rows and Columns here.
-  if (p_lines < min_rows() && full_screen) {
-    if (errbuf != NULL) {
-      vim_snprintf(errbuf, errbuflen,
-                   _("E593: Need at least %d lines"), min_rows());
-      errmsg = errbuf;
-    }
-    p_lines = min_rows();
-  }
-  if (p_columns < MIN_COLUMNS && full_screen) {
-    if (errbuf != NULL) {
-      vim_snprintf(errbuf, errbuflen,
-                   _("E594: Need at least %d columns"), MIN_COLUMNS);
-      errmsg = errbuf;
-    }
-    p_columns = MIN_COLUMNS;
-  }
-
-  // True max size is defined by check_screensize()
-  p_lines = MIN(p_lines, INT_MAX);
-  p_columns = MIN(p_columns, INT_MAX);
-
-  // If the screen (shell) height has been changed, assume it is the
-  // physical screenheight.
-  if (p_lines != Rows || p_columns != Columns) {
-    // Changing the screen size is not allowed while updating the screen.
-    if (updating_screen) {
-      *pp = old_value;
-    } else if (full_screen) {
-      screen_resize((int)p_columns, (int)p_lines);
-    } else {
-      // TODO(bfredl): is this branch ever needed?
-      // Postpone the resizing; check the size and cmdline position for
-      // messages.
-      Rows = (int)p_lines;
-      Columns = (int)p_columns;
-      check_screensize();
-      int new_row = (int)(Rows - MAX(p_ch, 1));
-      if (cmdline_row > new_row && Rows > p_ch) {
-        assert(p_ch >= 0 && new_row <= INT_MAX);
-        cmdline_row = new_row;
-      }
-    }
-    if (p_window >= Rows || !option_was_set("window")) {
-      p_window = Rows - 1;
-    }
-  }
-
-  if ((curwin->w_p_scr <= 0
-       || (curwin->w_p_scr > curwin->w_height
-           && curwin->w_height > 0))
-      && full_screen) {
-    if (pp == &(curwin->w_p_scr)) {
-      if (curwin->w_p_scr != 0) {
-        errmsg = e_scroll;
-      }
-      win_comp_scroll(curwin);
-    } else if (curwin->w_p_scr <= 0) {
-      // If 'scroll' became invalid because of a side effect silently adjust it.
-      curwin->w_p_scr = 1;
-    } else {  // curwin->w_p_scr > curwin->w_height
-      curwin->w_p_scr = curwin->w_height;
-    }
-  }
-  if ((p_sj < -100 || p_sj >= Rows) && full_screen) {
-    if (Rows != old_Rows) {     // Rows changed, just adjust p_sj
-      p_sj = Rows / 2;
-    } else {
-      errmsg = e_scroll;
-      p_sj = 1;
-    }
-  }
+  // Check the bounds for numeric options here
+  errmsg = check_num_option_bounds(pp, old_value, old_Rows, errbuf, errbuflen, errmsg);
 
   // May set global value for local option.
   if ((opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6098,7 +6098,7 @@ static void frame_setwidth(frame_T *curfrp, int width)
 }
 
 // Check 'winminheight' for a valid value and reduce it if needed.
-void win_setminheight(void)
+void did_set_winminheight(void)
 {
   bool first = true;
 
@@ -6118,7 +6118,7 @@ void win_setminheight(void)
 }
 
 // Check 'winminwidth' for a valid value and reduce it if needed.
-void win_setminwidth(void)
+void did_set_winminwidth(void)
 {
   bool first = true;
 


### PR DESCRIPTION
#### vim-patch:9.0.1293: the set_num_option() is too long

Problem:    The set_num_option() is too long.
Solution:   Move code to separate functions. (Yegappan Lakshmanan, closes vim/vim#11954)

https://github.com/vim/vim/commit/0caaf1e46511f7a92e036f05e6aa9d5992540117

#### vim-patch:9.0.1308: the code for setting options is too complicated

Problem:    The code for setting options is too complicated.
Solution:   Refactor the code for setting options. (Yegappan Lakshmanan, closes vim/vim#11989)

https://github.com/vim/vim/commit/1a6476428f63e9fa0c2cbea296e475e60363af11

#### vim-patch:9.0.1311: Coverity warns for using a NULL pointer

Problem:    Coverity warns for using a NULL pointer.
Solution:   Use "empty_option" instead of NULL.

https://github.com/vim/vim/commit/339e114d70de3ec2b36edf37d7ba7a7cfdf9d1a6


#### (N/A) vim-patch:9.0.1405: missing check for out-of-memory

Problem:    Missing check for out-of-memory.
Solution:   Check for alloc() returning NULL pointer.

https://github.com/vim/vim/commit/14338024c131b71a337c2bb87cb5904f5a5782b8