### PR TITLE
ci: remove team reviewers

### DIFF
--- a/.github/scripts/remove-reviewers.js
+++ b/.github/scripts/remove-reviewers.js
@@ -1,18 +1,16 @@
-module.exports = async ({github, context}) => {
+module.exports = async ({ github, context }) => {
   const requestedReviewers = await github.rest.pulls.listRequestedReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.issue.number
+    pull_number: context.issue.number,
   });
 
-  const reviewers = requestedReviewers.data.users.map(e => e.login)
-  const team_reviewers = requestedReviewers.data.teams.map(e => e.name);
+  const reviewers = requestedReviewers.data.users.map((e) => e.login);
 
   github.rest.pulls.removeRequestedReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.issue.number,
     reviewers: reviewers,
-    team_reviewers: team_reviewers
   });
-}
+};

--- a/.github/scripts/reviews.js
+++ b/.github/scripts/reviews.js
@@ -1,102 +1,108 @@
-module.exports = async ({github, context}) => {
+module.exports = async ({ github, context }) => {
   const pr_data = await github.rest.pulls.get({
     owner: context.repo.owner,
     repo: context.repo.repo,
-    pull_number: context.issue.number
-  })
-  const labels = pr_data.data.labels.map(e => e.name)
+    pull_number: context.issue.number,
+  });
+  const labels = pr_data.data.labels.map((e) => e.name);
 
-  const reviewers = new Set()
-  const team_reviewers = new Set()
-  if (labels.includes('api')) {
-    reviewers.add("bfredl")
+  const reviewers = new Set();
+  if (labels.includes("api")) {
+    reviewers.add("bfredl");
   }
 
-  if (labels.includes('build')) {
-    team_reviewers.add('ci');
+  if (labels.includes("build")) {
+    reviewers.add("dundargoc");
+    reviewers.add("jamessan");
+    reviewers.add("justinmk");
   }
 
-  if (labels.includes('ci')) {
-    team_reviewers.add('ci');
+  if (labels.includes("ci")) {
+    reviewers.add("dundargoc");
+    reviewers.add("jamessan");
+    reviewers.add("justinmk");
   }
 
-  if (labels.includes('column')) {
-    reviewers.add("lewis6991")
+  if (labels.includes("column")) {
+    reviewers.add("lewis6991");
   }
 
-  if (labels.includes('dependencies')) {
-    reviewers.add("jamessan")
+  if (labels.includes("dependencies")) {
+    reviewers.add("jamessan");
   }
 
-  if (labels.includes('diagnostic')) {
-    reviewers.add("gpanders")
+  if (labels.includes("diagnostic")) {
+    reviewers.add("gpanders");
   }
 
-  if (labels.includes('diff')) {
-    reviewers.add("lewis6991")
+  if (labels.includes("diff")) {
+    reviewers.add("lewis6991");
   }
 
-  if (labels.includes('distribution')) {
-    reviewers.add("jamessan")
+  if (labels.includes("distribution")) {
+    reviewers.add("jamessan");
   }
 
-  if (labels.includes('documentation')) {
-    reviewers.add("clason")
+  if (labels.includes("documentation")) {
+    reviewers.add("clason");
   }
 
-  if (labels.includes('extmarks')) {
-    reviewers.add("bfredl")
+  if (labels.includes("extmarks")) {
+    reviewers.add("bfredl");
   }
 
-  if (labels.includes('filetype')) {
-    reviewers.add("clason")
-    reviewers.add("gpanders")
-    reviewers.add("smjonas")
+  if (labels.includes("filetype")) {
+    reviewers.add("clason");
+    reviewers.add("gpanders");
+    reviewers.add("smjonas");
   }
 
-  if (labels.includes('lsp')) {
-    team_reviewers.add('lsp');
+  if (labels.includes("lsp")) {
+    reviewers.add("folke");
+    reviewers.add("glepnir");
+    reviewers.add("mfussenegger");
   }
 
-  if (labels.includes('platform:nix')) {
-    reviewers.add("teto")
+  if (labels.includes("platform:nix")) {
+    reviewers.add("teto");
   }
 
-  if (labels.includes('project-management')) {
-    reviewers.add("bfredl")
-    reviewers.add("justinmk")
+  if (labels.includes("project-management")) {
+    reviewers.add("bfredl");
+    reviewers.add("justinmk");
   }
 
-  if (labels.includes('test')) {
-    reviewers.add("justinmk")
+  if (labels.includes("test")) {
+    reviewers.add("justinmk");
   }
 
-  if (labels.includes('treesitter')) {
-    team_reviewers.add('treesitter');
+  if (labels.includes("treesitter")) {
+    reviewers.add("bfredl");
+    reviewers.add("clason");
+    reviewers.add("lewis6991");
   }
 
-  if (labels.includes('typo')) {
-    reviewers.add("dundargoc")
+  if (labels.includes("typo")) {
+    reviewers.add("dundargoc");
   }
 
-  if (labels.includes('ui')) {
-    reviewers.add("bfredl")
+  if (labels.includes("ui")) {
+    reviewers.add("bfredl");
   }
 
-  if (labels.includes('vim-patch')) {
-    reviewers.add("seandewar")
-    reviewers.add("zeertzjq")
+  if (labels.includes("vim-patch")) {
+    reviewers.add("seandewar");
+    reviewers.add("zeertzjq");
   }
 
   // Remove person that opened the PR since they can't review themselves
-  const pr_opener = pr_data.data.user.login
-  reviewers.delete(pr_opener)
+  const pr_opener = pr_data.data.user.login;
+  reviewers.delete(pr_opener);
 
   github.rest.pulls.requestReviewers({
     owner: context.repo.owner,
     repo: context.repo.repo,
     pull_number: context.issue.number,
     reviewers: Array.from(reviewers),
-    team_reviewers: Array.from(team_reviewers)
   });
-}
+};

--- a/.github/workflows/add-reviewers.yml
+++ b/.github/workflows/add-reviewers.yml
@@ -13,7 +13,6 @@ jobs:
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/reviews.js')
             await script({github, context})

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -43,7 +43,6 @@ jobs:
       - name: 'Request reviewers'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/reviews.js')
             await script({github, context})

--- a/.github/workflows/remove-reviewers.yml
+++ b/.github/workflows/remove-reviewers.yml
@@ -12,7 +12,6 @@ jobs:
       - name: 'Remove reviewers'
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.TEAM_REVIEW }}
           script: |
             const script = require('./.github/scripts/remove-reviewers.js')
             await script({github, context})


### PR DESCRIPTION
Team reviewers is a nice feature that comes with a severe drawback: it
makes testing the workflows incredibly difficult as they won't work
wihtout the exact same token for the tester.
