### PR TITLE
ci(lintcommit): fix error output

### DIFF
--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-      - run: nvim --clean -l scripts/lintcommit.lua main --notrace
+      - run: nvim --clean -l scripts/lintcommit.lua main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,9 +259,7 @@ add_glob_target(
   TOUCH_STRATEGY SINGLE)
 
 add_custom_target(lintcommit
-  COMMAND ${PROJECT_BINARY_DIR}/bin/nvim -u NONE -l scripts/lintcommit.lua  main --notrace
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  VERBATIM)
+  COMMAND $<TARGET_FILE:nvim> -u NONE -l ${PROJECT_SOURCE_DIR}/scripts/lintcommit.lua main)
 add_dependencies(lintcommit nvim)
 
 add_custom_target(lint)


### PR DESCRIPTION
Using print alone doesn't work properly, the toggling the verbose option
is still required.
