### PR TITLE
vim-patch:9.0.1476: lines put in non-current window are not displayed

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1100,12 +1100,12 @@ void ex_changes(exarg_T *eap)
     } \
   }
 
-// Adjust marks between line1 and line2 (inclusive) to move 'amount' lines.
+// Adjust marks between "line1" and "line2" (inclusive) to move "amount" lines.
 // Must be called before changed_*(), appended_lines() or deleted_lines().
 // May be called before or after changing the text.
-// When deleting lines line1 to line2, use an 'amount' of MAXLNUM: The marks
-// within this range are made invalid.
-// If 'amount_after' is non-zero adjust marks after line2.
+// When deleting lines "line1" to "line2", use an "amount" of MAXLNUM: The
+// marks within this range are made invalid.
+// If "amount_after" is non-zero adjust marks after "line2".
 // Example: Delete lines 34 and 35: mark_adjust(34, 35, MAXLNUM, -2);
 // Example: Insert two lines below 55: mark_adjust(56, MAXLNUM, 2, 0);
 //                                 or: mark_adjust(56, 55, MAXLNUM, 2);
@@ -1240,7 +1240,9 @@ static void mark_adjust_internal(linenr_T line1, linenr_T line2, linenr_T amount
             } else {
               win->w_topline = line1 - 1;
             }
-          } else {                      // keep topline on the same line
+          } else if (win->w_topline > line1) {
+            // keep topline on the same line, unless inserting just
+            // above it (we probably want to see that line then)
             win->w_topline += amount;
           }
           win->w_topfill = 0;

--- a/test/functional/legacy/put_spec.lua
+++ b/test/functional/legacy/put_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('test.functional.helpers')(after_each)
+local Screen = require('test.functional.ui.screen')
 local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local meths = helpers.meths
@@ -41,5 +42,32 @@ describe('put', function()
       call assert_fails('norm 999999999p', 'E1240:')
       bwipe!
     ]]
+  end)
+
+  -- oldtest: Test_put_other_window()
+  it('above topline in buffer in two splits', function()
+    local screen = Screen.new(80, 10)
+    screen:attach()
+    source([[
+      40vsplit
+      0put ='some text at the top'
+      put ='  one more text'
+      put ='  two more text'
+      put ='  three more text'
+      put ='  four more text'
+    ]])
+
+    screen:expect([[
+      some text at the top                    │some text at the top                   |
+        one more text                         │  one more text                        |
+        two more text                         │  two more text                        |
+        three more text                       │  three more text                      |
+        ^four more text                        │  four more text                       |
+                                              │                                       |
+      ~                                       │~                                      |
+      ~                                       │~                                      |
+      [No Name] [+]                            [No Name] [+]                          |
+                                                                                      |
+    ]])
   end)
 end)

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1372,11 +1372,11 @@ describe('builtin popupmenu', function()
         U{n: qui            }{s: }eniam, quis nostrud                     |
         e{n: officia        }{s: }co laboris nisi ut aliquip ex           |
       {4:[No}{n: deserunt       }{s: }{4:                                        }|
-        L{n: mollit         }{s: }sit amet, consectetur                   |
-        a{n: anim           }{s: }sed do eiusmod tempor                   |
-        i{n: id             }{s: }re et dolore magna aliqua.              |
-        U{n: est            }{s: }eniam, quis nostrud                     |
-        e{n: laborum        }{c: }co laboris nisi ut aliquip ex           |
+      Est{n: mollit         }{s: }                                        |
+        L{n: anim           }{s: }sit amet, consectetur                   |
+        a{n: id             }{s: }sed do eiusmod tempor                   |
+        i{n: est            }{s: }re et dolore magna aliqua.              |
+        U{n: laborum        }{c: }eniam, quis nostrud                     |
       {3:[No}{s: Est            }{c: }{3:                                        }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1390,11 +1390,11 @@ describe('builtin popupmenu', function()
         U{n: qui            }{s: }eniam, quis nostrud                     |
         e{n: officia        }{s: }co laboris nisi ut aliquip ex           |
       {4:[No}{n: deserunt       }{s: }{4:                                        }|
-        U{n: mollit         }{s: }eniam, quis nostrud                     |
-        e{n: anim           }{s: }co laboris nisi ut aliquip ex           |
-        e{n: id             }{s: }at. Duis aute irure dolor in            |
-        r{n: est            }{s: }oluptate velit esse cillum              |
-        d{n: laborum        }{c: }ulla pariatur. Excepteur sint           |
+        i{n: mollit         }{s: }re et dolore magna aliqua.              |
+        U{n: anim           }{s: }eniam, quis nostrud                     |
+        e{n: id             }{s: }co laboris nisi ut aliquip ex           |
+        e{n: est            }{s: }at. Duis aute irure dolor in            |
+        r{n: laborum        }{c: }oluptate velit esse cillum              |
       {3:[No}{s: Est            }{c: }{3:                                        }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1408,11 +1408,11 @@ describe('builtin popupmenu', function()
         U{n: enim           }veniam, quis nostrud                     |
         e{n: exercitation   }mco laboris nisi ut aliquip ex           |
       {4:[No}{n: ex             }{4:                                         }|
-        U{n: ea             }veniam, quis nostrud                     |
-        e{n: esse           }mco laboris nisi ut aliquip ex           |
-        e{n: eu             }uat. Duis aute irure dolor in            |
-        r{s: est            }voluptate velit esse cillum              |
-        dolore eu fugiat nulla pariatur. Excepteur sint           |
+        i{n: ea             }ore et dolore magna aliqua.              |
+        U{n: esse           }veniam, quis nostrud                     |
+        e{n: eu             }mco laboris nisi ut aliquip ex           |
+        e{s: est            }uat. Duis aute irure dolor in            |
+        reprehenderit in voluptate velit esse cillum              |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1426,11 +1426,11 @@ describe('builtin popupmenu', function()
         U{n: enim           }veniam, quis nostrud                     |
         e{n: exercitation   }mco laboris nisi ut aliquip ex           |
       {4:[No}{n: ex             }{4:                                         }|
-        L{n: ea             } sit amet, consectetur                   |
-        a{n: esse           } sed do eiusmod tempor                   |
-        i{n: eu             }ore et dolore magna aliqua.              |
-        U{s: est            }veniam, quis nostrud                     |
-        exercitation ullamco laboris nisi ut aliquip ex           |
+      Est{n: ea             }                                         |
+        L{n: esse           } sit amet, consectetur                   |
+        a{n: eu             } sed do eiusmod tempor                   |
+        i{s: est            }ore et dolore magna aliqua.              |
+        Ut enim ad minim veniam, quis nostrud                     |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1444,11 +1444,11 @@ describe('builtin popupmenu', function()
         Ut enim ad minim veniam, quis nostrud                     |
         exercitation ullamco laboris nisi ut aliquip ex           |
       {4:[No Name] [+]                                               }|
+      Est es                                                      |
         Lorem ipsum dolor sit amet, consectetur                   |
         adipisicing elit, sed do eiusmod tempor                   |
         incididunt ut labore et dolore magna aliqua.              |
         Ut enim ad minim veniam, quis nostrud                     |
-        exercitation ullamco laboris nisi ut aliquip ex           |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1462,11 +1462,11 @@ describe('builtin popupmenu', function()
         Ut enim ad minim veniam, quis nostrud                     |
         exercitation ullamco laboris nisi ut aliquip ex           |
       {4:[No Name] [+]                                               }|
+        incididunt ut labore et dolore magna aliqua.              |
         Ut enim ad minim veniam, quis nostrud                     |
         exercitation ullamco laboris nisi ut aliquip ex           |
         ea commodo consequat. Duis aute irure dolor in            |
         reprehenderit in voluptate velit esse cillum              |
-        dolore eu fugiat nulla pariatur. Excepteur sint           |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1480,11 +1480,11 @@ describe('builtin popupmenu', function()
         U{n: enim           }veniam, quis nostrud                     |
         e{n: exercitation   }mco laboris nisi ut aliquip ex           |
       {4:[No}{n: ex             }{4:                                         }|
-        U{n: ea             }veniam, quis nostrud                     |
-        e{n: esse           }mco laboris nisi ut aliquip ex           |
-        e{n: eu             }uat. Duis aute irure dolor in            |
-        r{s: est            }voluptate velit esse cillum              |
-        dolore eu fugiat nulla pariatur. Excepteur sint           |
+        i{n: ea             }ore et dolore magna aliqua.              |
+        U{n: esse           }veniam, quis nostrud                     |
+        e{n: eu             }mco laboris nisi ut aliquip ex           |
+        e{s: est            }uat. Duis aute irure dolor in            |
+        reprehenderit in voluptate velit esse cillum              |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
     ]])
@@ -1498,11 +1498,11 @@ describe('builtin popupmenu', function()
         U{n: enim           }veniam, quis nostrud                     |
         e{n: exercitation   }mco laboris nisi ut aliquip ex           |
       {4:[No}{n: ex             }{4:                                         }|
-        U{n: ea             }veniam, quis nostrud                     |
-        e{n: esse           }mco laboris nisi ut aliquip ex           |
-        e{s: eu             }uat. Duis aute irure dolor in            |
-        r{n: est            }voluptate velit esse cillum              |
-        dolore eu fugiat nulla pariatur. Excepteur sint           |
+        i{n: ea             }ore et dolore magna aliqua.              |
+        U{n: esse           }veniam, quis nostrud                     |
+        e{s: eu             }mco laboris nisi ut aliquip ex           |
+        e{n: est            }uat. Duis aute irure dolor in            |
+        reprehenderit in voluptate velit esse cillum              |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
     ]])
@@ -1516,15 +1516,14 @@ describe('builtin popupmenu', function()
         U{n: enim           }veniam, quis nostrud                     |
         e{n: exercitation   }mco laboris nisi ut aliquip ex           |
       {4:[No}{n: ex             }{4:                                         }|
-        r{n: ea             }voluptate velit esse cillum              |
-        d{n: esse           }nulla pariatur. Excepteur sint           |
-        o{s: eu             }t non proident, sunt in culpa            |
-        q{n: est            }unt mollit anim id est                   |
-        laborum.                                                  |
+        e{n: ea             }uat. Duis aute irure dolor in            |
+        r{n: esse           }voluptate velit esse cillum              |
+        d{s: eu             }nulla pariatur. Excepteur sint           |
+        o{n: est            }t non proident, sunt in culpa            |
+        qui officia deserunt mollit anim id est                   |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
     ]])
-
 
     funcs.complete(4, {'ea', 'eeeeeeeeeeeeeeeeee', 'ei', 'eo', 'eu', 'ey', 'eå', 'eä', 'eö'})
     screen:expect([[
@@ -1535,11 +1534,11 @@ describe('builtin popupmenu', function()
         {n: eo                 }iam, quis nostrud                     |
         {n: eu                 } laboris nisi ut aliquip ex           |
       {4:[N}{n: ey                 }{4:                                      }|
-        {n: eå                 }uptate velit esse cillum              |
-        {n: eä                 }la pariatur. Excepteur sint           |
-        {n: eö                 }on proident, sunt in culpa            |
+        {n: eå                 }. Duis aute irure dolor in            |
+        {n: eä                 }uptate velit esse cillum              |
+        {n: eö                 }la pariatur. Excepteur sint           |
+        occaecat cupidatat non proident, sunt in culpa            |
         qui officia deserunt mollit anim id est                   |
-        laborum.                                                  |
       {3:[No Name] [+]                                               }|
       {2:-- Keyword Local completion (^N^P) }{5:match 1 of 9}             |
     ]])
@@ -1553,11 +1552,11 @@ describe('builtin popupmenu', function()
         {n: eo             } veniam, quis nostrud                     |
         {n: eu             }amco laboris nisi ut aliquip ex           |
       {4:[N}{n: ey             }{4:                                          }|
-        {n: eå             } voluptate velit esse cillum              |
-        {n: eä             } nulla pariatur. Excepteur sint           |
-        {n: eö             }at non proident, sunt in culpa            |
+        {n: eå             }quat. Duis aute irure dolor in            |
+        {n: eä             } voluptate velit esse cillum              |
+        {n: eö             } nulla pariatur. Excepteur sint           |
+        occaecat cupidatat non proident, sunt in culpa            |
         qui officia deserunt mollit anim id est                   |
-        laborum.                                                  |
       {3:[No Name] [+]                                               }|
       {2:-- INSERT --}                                                |
     ]])
@@ -1571,11 +1570,11 @@ describe('builtin popupmenu', function()
         {n: eo             } veniam, quis nostrud                     |
         {n: eu             }amco laboris nisi ut aliquip ex           |
       {4:[N}{n: ey             }{4:                                          }|
-        {n: eå             } voluptate velit esse cillum              |
-        {n: eä             } nulla pariatur. Excepteur sint           |
-        {n: eö             }at non proident, sunt in culpa            |
+        {n: eå             }quat. Duis aute irure dolor in            |
+        {n: eä             } voluptate velit esse cillum              |
+        {n: eö             } nulla pariatur. Excepteur sint           |
+        occaecat cupidatat non proident, sunt in culpa            |
         qui officia deserunt mollit anim id est                   |
-        laborum.                                                  |
       {3:[No Name] [+]                                               }|
       {2:-- INSERT --}                                                |
     ]])
@@ -1589,11 +1588,11 @@ describe('builtin popupmenu', function()
         Ut enim ad minim veniam, quis nostrud                     |
         exercitation ullamco laboris nisi ut aliquip ex           |
       {4:[No Name] [+]                                               }|
+        ea commodo consequat. Duis aute irure dolor in            |
         reprehenderit in voluptate velit esse cillum              |
         dolore eu fugiat nulla pariatur. Excepteur sint           |
         occaecat cupidatat non proident, sunt in culpa            |
         qui officia deserunt mollit anim id est                   |
-        laborum.                                                  |
       {3:[No Name] [+]                                               }|
       {2:-- INSERT --}                                                |
     ]])
@@ -1607,11 +1606,11 @@ describe('builtin popupmenu', function()
         Ut enim ad minim veniam, quis nostrud                     |
         exercitation ullamco laboris nisi ut aliquip ex           |
       {4:[No Name] [+]                                               }|
+        ea commodo consequat. Duis aute irure dolor in            |
         reprehenderit in voluptate velit esse cillum              |
         dolore eu fugiat nulla pariatur. Excepteur sint           |
         occaecat cupidatat non proident, sunt in culpa            |
         qui officia deserunt mollit anim id est                   |
-        laborum.                                                  |
       {3:[No Name] [+]                                               }|
       {2:-- INSERT --}                                                |
     ]])

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -1,6 +1,7 @@
 " Tests for put commands, e.g. ":put", "p", "gp", "P", "gP", etc.
 
 source check.vim
+source screendump.vim
 
 func Test_put_block()
   new
@@ -244,6 +245,25 @@ func Test_put_visual_block_mode()
 
   bwipe!
   set ve=
+endfunc
+
+func Test_put_other_window()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      40vsplit
+      0put ='some text at the top'
+      put ='  one more text'
+      put ='  two more text'
+      put ='  three more text'
+      put ='  four more text'
+  END
+  call writefile(lines, 'Xtest_put_other', 'D')
+  let buf = RunVimInTerminal('-S Xtest_put_other', #{rows: 10})
+
+  call VerifyScreenDump(buf, 'Test_put_other_window_1', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 


### PR DESCRIPTION
#### vim-patch:9.0.1476: lines put in non-current window are not displayed

Problem:    Lines put in non-current window are not displayed. (Marius
            Gedminas)
Solution:   Don't increment the topline when inserting just above it.

https://github.com/vim/vim/commit/e7f05a8780426dc7af247419c6d02d5f1e896689

Co-authored-by: Bram Moolenaar <Bram@vim.org>