### PR TITLE
vim-patch:9.0.1475: busted configuration files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1522,6 +1522,7 @@ local filename = {
   ['.lsl'] = function(path, bufnr)
     return require('vim.filetype.detect').lsl(bufnr)
   end,
+  ['.busted'] = 'lua',
   ['.luacheckrc'] = 'lua',
   ['lynx.cfg'] = 'lynx',
   ['m3overrides'] = 'm3build',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -345,7 +345,7 @@ let s:filename_checks = {
     \ 'lpc': ['file.lpc', 'file.ulpc'],
     \ 'lsl': ['file.lsl'],
     \ 'lss': ['file.lss'],
-    \ 'lua': ['file.lua', 'file.rockspec', 'file.nse', '.luacheckrc'],
+    \ 'lua': ['file.lua', 'file.rockspec', 'file.nse', '.luacheckrc', '.busted'],
     \ 'lynx': ['lynx.cfg'],
     \ 'lyrics': ['file.lrc'],
     \ 'm3build': ['m3makefile', 'm3overrides'],


### PR DESCRIPTION
#### vim-patch:9.0.1475: busted configuration files are not recognized

Problem:    Busted configuration files are not recognized.
Solution:   Recognize busted configuration files as Lua. (Craig MacEachern,
            closes vim/vim#12209)

Co-authored-by: C.D. MacEachern <craig.daniel.maceachern@gmail.com>