### PR TITLE
build(nix): use clang14Stdenv on Darwin

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -10,7 +10,14 @@
     {
       overlay = final: prev: {
 
-        neovim = final.neovim-unwrapped.overrideAttrs (oa: rec {
+        neovim = let
+          stdenv = if final.stdenv.isDarwin then
+            final.clang14Stdenv
+          else
+            final.stdenv;
+        in (final.neovim-unwrapped.override {
+          inherit stdenv;
+        }).overrideAttrs (oa: rec {
           version = self.shortRev or "dirty";
           src = ../.;
           preConfigure = ''


### PR DESCRIPTION
Update the flake to the `clang14Stdenv` on Darwin, to bring it in line with what currently ships on macOS 13.

The `nix` default is currently `clang11Stdenv`.

~~This also takes into account that `nix` "forces" `cctools` as the linker, which expects certain flags (`--no-undefined`) in a different way.~~

~~Creating this as a draft, because I don't have a way to test my `src/nvim/CMakeLists.txt` change on a non-`nix` macOS installation.~~

/cc @teto @dundargoc 