### PR TITLE
vim-patch:9.0.1477: crash when recovering from corrupted swap file

### DIFF
--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -300,7 +300,12 @@ bhdr_T *mf_get(memfile_T *mfp, blocknr_T nr, unsigned page_count)
 
     // could check here if the block is in the free list
 
-    hp = mf_alloc_bhdr(mfp, page_count);
+    if (page_count > 0) {
+      hp = mf_alloc_bhdr(mfp, page_count);
+    }
+    if (hp == NULL) {
+      return NULL;
+    }
 
     hp->bh_bnum = nr;
     hp->bh_flags = 0;

--- a/test/old/testdir/test_recover.vim
+++ b/test/old/testdir/test_recover.vim
@@ -259,6 +259,14 @@ func Test_recover_corrupted_swap_file()
   call assert_equal(['???EMPTY BLOCK'], getline(1, '$'))
   bw!
 
+  " set the number of pointers in a pointer block to a large value
+  let b = copy(save_b)
+  let b[4098:4099] = 0zFFFF
+  call writefile(b, sn)
+  call assert_fails('recover Xfile1', 'E1364:')
+  call assert_equal('Xfile1', @%)
+  bw!
+
   " set the block number in a pointer entry to a negative number
   let b = copy(save_b)
   if system_64bit


### PR DESCRIPTION
#### vim-patch:9.0.1477: crash when recovering from corrupted swap file

Problem:    Crash when recovering from corrupted swap file.
Solution:   Check for a valid page count.

https://github.com/vim/vim/commit/b67ba03d3ef2e6c5f207d508e85fc6906f938028

Co-authored-by: Bram Moolenaar <Bram@vim.org>