### PR TITLE
fix(typval): don't treat v:null as truthy

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -4224,7 +4224,7 @@ bool tv2bool(const typval_T *const tv)
   case VAR_BOOL:
     return tv->vval.v_bool == kBoolVarTrue;
   case VAR_SPECIAL:
-    return tv->vval.v_special == kSpecialVarNull;
+    return tv->vval.v_special != kSpecialVarNull;
   case VAR_BLOB:
     return tv->vval.v_blob != NULL && tv->vval.v_blob->bv_ga.ga_len > 0;
   case VAR_UNKNOWN:

--- a/test/functional/vimscript/special_vars_spec.lua
+++ b/test/functional/vimscript/special_vars_spec.lua
@@ -130,6 +130,12 @@ describe('Special values', function()
     eq("v:false", eval('"" . v:false'))
   end)
 
+  it('work with ?? (falsy operator)', function()
+    eq(true, eval('v:true ?? 42'))
+    eq(42, eval('v:false ?? 42'))
+    eq(42, eval('v:null ?? 42'))
+  end)
+
   it('work with type()', function()
     eq(6, funcs.type(true))
     eq(6, funcs.type(false))


### PR DESCRIPTION
Fix #23279
