### PR TITLE
vim-patch:9.0.1478: filetypes for *.v files not detected properly

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1091,7 +1091,9 @@ local extension = {
   vr = 'vera',
   vri = 'vera',
   vrh = 'vera',
-  v = 'verilog',
+  v = function(path, bufnr)
+    return require('vim.filetype.detect').v(bufnr)
+  end,
   va = 'verilogams',
   vams = 'verilogams',
   vhdl = 'vhdl',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1322,6 +1322,24 @@ function M.txt(bufnr)
   end
 end
 
+-- Determine if a .v file is Verilog, V, or Coq
+function M.v(bufnr)
+  if vim.fn.did_filetype() ~= 0 then
+    -- Filetype was already detected
+    return
+  end
+  for _, line in ipairs(getlines(bufnr, 1, 200)) do
+    if not line:find('^%s*/') then
+      if matchregex(line, [[;\(\s*\)\?\(/.*\)\?$]]) then
+        return 'verilog'
+      elseif matchregex(line, [[\.\(\s*\)\?\((\*.*\)\?$]]) then
+        return 'coq'
+      end
+    end
+  end
+  return 'v'
+end
+
 -- WEB (*.web is also used for Winbatch: Guess, based on expecting "%" comment
 -- lines in a WEB file).
 function M.web(bufnr)

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1332,7 +1332,7 @@ function M.v(bufnr)
     if not line:find('^%s*/') then
       if findany(line, { ";%s*$", ";%s*/" }) then
         return 'verilog'
-      elseif matchregex(line, [[\.\(\s*\)\?\((\*.*\)\?$]]) then
+      elseif findany(line, { "%.%s*$", "%.%s*%(%*" }) then
         return 'coq'
       end
     end

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1330,9 +1330,9 @@ function M.v(bufnr)
   end
   for _, line in ipairs(getlines(bufnr, 1, 200)) do
     if not line:find('^%s*/') then
-      if findany(line, { ";%s*$", ";%s*/" }) then
+      if findany(line, { ';%s*$', ';%s*/' }) then
         return 'verilog'
-      elseif findany(line, { "%.%s*$", "%.%s*%(%*" }) then
+      elseif findany(line, { '%.%s*$', '%.%s*%(%*' }) then
         return 'coq'
       end
     end

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1330,7 +1330,7 @@ function M.v(bufnr)
   end
   for _, line in ipairs(getlines(bufnr, 1, 200)) do
     if not line:find('^%s*/') then
-      if matchregex(line, [[;\(\s*\)\?\(/.*\)\?$]]) then
+      if findany(line, { ";%s*$", ";%s*/" }) then
         return 'verilog'
       elseif matchregex(line, [[\.\(\s*\)\?\((\*.*\)\?$]]) then
         return 'coq'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -646,7 +646,6 @@ let s:filename_checks = {
     \ 'vdmrt': ['file.vdmrt'],
     \ 'vdmsl': ['file.vdm', 'file.vdmsl'],
     \ 'vera': ['file.vr', 'file.vri', 'file.vrh'],
-    \ 'verilog': ['file.v'],
     \ 'verilogams': ['file.va', 'file.vams'],
     \ 'vgrindefs': ['vgrindefs'],
     \ 'vhdl': ['file.hdl', 'file.vhd', 'file.vhdl', 'file.vbe', 'file.vst', 'file.vhdl_123', 'file.vho', 'some.vhdl_1', 'some.vhdl_1-file'],
@@ -1766,6 +1765,27 @@ func Test_ttl_file()
   call writefile(['looks like Tera Term Language'], 'Xfile.ttl')
   split Xfile.ttl
   call assert_equal('teraterm', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_v_file()
+  filetype on
+
+  call writefile(['module tb; // Looks like a Verilog'], 'Xfile.v', 'D')
+  split Xfile.v
+  call assert_equal('verilog', &filetype)
+  bwipe!
+
+  call writefile(['module main'], 'Xfile.v')
+  split Xfile.v
+  call assert_equal('v', &filetype)
+  bwipe!
+
+  call writefile(['Definition x := 10.  (*'], 'Xfile.v')
+  split Xfile.v
+  call assert_equal('coq', &filetype)
   bwipe!
 
   filetype off


### PR DESCRIPTION
Problem:    Filetypes for *.v files not detected properly.
Solution:   Use the file contents to detect the filetype. (Turiiya,
            closes vim/vim#12281)

https://github.com/vim/vim/commit/80406c26188219f3773b2e9c49160caeeb386ee2

Co-authored-by: Turiiya <34311583+tobealive@users.noreply.github.com>
