### PR TITLE
fix(treesitter): redraw added/removed injections properly

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1120,21 +1120,24 @@ LanguageTree:parse({self})                              *LanguageTree:parse()*
     Return: ~
         TSTree[]
 
-LanguageTree:register_cbs({self}, {cbs})         *LanguageTree:register_cbs()*
+                                                 *LanguageTree:register_cbs()*
+LanguageTree:register_cbs({self}, {cbs}, {recursive})
     Registers callbacks for the |LanguageTree|.
 
     Parameters: ~
-      • {cbs}   (table) An |nvim_buf_attach()|-like table argument with the
-                following handlers:
-                • `on_bytes` : see |nvim_buf_attach()|, but this will be called after the parsers callback.
-                • `on_changedtree` : a callback that will be called every time
-                  the tree has syntactical changes. It will only be passed one
-                  argument, which is a table of the ranges (as node ranges)
-                  that changed.
-                • `on_child_added` : emitted when a child is added to the
-                  tree.
-                • `on_child_removed` : emitted when a child is removed from
-                  the tree.
+      • {cbs}         (table) An |nvim_buf_attach()|-like table argument with
+                      the following handlers:
+                      • `on_bytes` : see |nvim_buf_attach()|, but this will be called after the parsers callback.
+                      • `on_changedtree` : a callback that will be called
+                        every time the tree has syntactical changes. It will
+                        only be passed one argument, which is a table of the
+                        ranges (as node ranges) that changed.
+                      • `on_child_added` : emitted when a child is added to
+                        the tree.
+                      • `on_child_removed` : emitted when a child is removed
+                        from the tree.
+      • {recursive?}  boolean Apply callbacks recursively for all children.
+                      Any new children will also inherit the callbacks.
       • {self}
 
 LanguageTree:source({self})                            *LanguageTree:source()*

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -76,9 +76,6 @@ function TSHighlighter.new(tree, opts)
   opts = opts or {} ---@type { queries: table<string,string> }
   self.tree = tree
   tree:register_cbs({
-    on_changedtree = function(...)
-      self:on_changedtree(...)
-    end,
     on_bytes = function(...)
       self:on_bytes(...)
     end,
@@ -86,6 +83,17 @@ function TSHighlighter.new(tree, opts)
       self:on_detach()
     end,
   })
+
+  tree:register_cbs({
+    on_changedtree = function(...)
+      self:on_changedtree(...)
+    end,
+    on_child_removed = function(child)
+      child:for_each_tree(function(t)
+        self:on_changedtree(t:included_ranges(true))
+      end)
+    end,
+  }, true)
 
   self.bufnr = tree:source() --[[@as integer]]
   self.edit_count = 0
@@ -177,10 +185,10 @@ function TSHighlighter:on_detach()
 end
 
 ---@package
----@param changes integer[][]?
+---@param changes Range6[][]
 function TSHighlighter:on_changedtree(changes)
-  for _, ch in ipairs(changes or {}) do
-    api.nvim__buf_redraw_range(self.bufnr, ch[1], ch[3] + 1)
+  for _, ch in ipairs(changes) do
+    api.nvim__buf_redraw_range(self.bufnr, ch[1], ch[4] + 1)
   end
 end
 


### PR DESCRIPTION
When injections are added or removed make sure to:
    - invoke 'changedtree' callbacks for when new trees are added.
    - invoke 'changedtree' callbacks for when trees are invalidated
    - redraw regions when languagetree children are removed
