### PR TITLE
build: add "ci" configure preset to reduce verbosity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,7 +199,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake -B build -G Ninja -D CMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX ${{ matrix.flags }} -D CI_BUILD=ON
+          cmake --preset ci -D CMAKE_INSTALL_PREFIX:PATH=$INSTALL_PREFIX ${{ matrix.flags }}
           cmake --build build
 
       - if: "!cancelled()"
@@ -315,7 +315,7 @@ jobs:
 
       - name: Build
         run: |
-          cmake -B build -G Ninja -D CMAKE_BUILD_TYPE='RelWithDebInfo' -D CI_BUILD=ON
+          cmake --preset ci -D CMAKE_BUILD_TYPE='RelWithDebInfo'
           cmake --build build
 
       - name: Install test deps
@@ -405,5 +405,5 @@ jobs:
 
       - name: Build
         run: |
-          cmake -B build -G Ninja -D CI_BUILD=ON
+          cmake --preset ci
           cmake --build build

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,64 +35,20 @@
       "inherits": ["base"]
     },
     {
-      "name": "windows-default",
-      "displayName": "Windows x64 RelWithDebInfo",
-      "description": "Sets Ninja generator, enables optimizations with debug information for x64",
-      "generator": "Ninja",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-      },
-      "architecture": {
-        "value": "x64",
-        "strategy": "external"
-      },
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "hostOS": ["Windows"]
-        }
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      },
-      "inherits": ["base"]
-    },
-    {
       "name": "iwyu",
       "displayName": "IWYU",
-      "description": "Run include-what-you-use with the compiler",
+      "description": "Run include-what-you-use",
       "cacheVariables": {
         "ENABLE_IWYU": "ON"
       },
       "inherits": ["base"]
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "default",
-      "configurePreset": "default"
     },
     {
-      "name": "debug",
-      "configurePreset": "debug"
-    },
-    {
-      "name": "release",
-      "configurePreset": "release"
-    },
-    {
-      "name": "windows-default",
-      "configurePreset": "windows-default",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    },
-    {
-      "name": "iwyu",
-      "configurePreset": "iwyu"
+      "name": "ci",
+      "cacheVariables": {
+        "CI_BUILD": "ON"
+      },
+      "inherits": ["base"]
     }
   ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,7 +254,7 @@ For managing includes in C files, use [include-what-you-use].
 - To see which includes needs fixing use the cmake preset `iwyu`:
   ```
   cmake --preset iwyu
-  cmake --build --preset iwyu
+  cmake --build build iwyu
   ```
 - There's also a make target that automatically fixes the suggestions from
   IWYU:


### PR DESCRIPTION
`cmake --preset ci`

is equivalent to

`cmake -B build -G Ninja -D CI_BUILD=ON`

Also remove build presets as they're not very useful without workflow
presets, which are only available in schema versions 6 and above.
