### PR TITLE
fix(column): don't reset 'statuscolumn' width after it has been drawn

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -574,9 +574,9 @@ int update_screen(void)
     draw_tabline();
   }
 
-  // Correct stored syntax highlighting info for changes in each displayed
-  // buffer.  Each buffer must only be done once.
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    // Correct stored syntax highlighting info for changes in each displayed
+    // buffer.  Each buffer must only be done once.
     update_window_hl(wp, type >= UPD_NOT_VALID || hl_changed);
 
     buf_T *buf = wp->w_buffer;
@@ -592,6 +592,11 @@ int update_screen(void)
         buf->b_mod_tick_decor = display_tick;
       }
     }
+
+    // Reset 'statuscolumn' if there is no dedicated signcolumn but it is invalid.
+    if (*wp->w_p_stc != NUL && !wp->w_buffer->b_signcols.valid && win_no_signcol(wp)) {
+      wp->w_nrwidth_line_count = 0;
+    }
   }
 
   // Go from top to bottom through the windows, redrawing the ones that need it.
@@ -599,6 +604,11 @@ int update_screen(void)
   screen_search_hl.rm.regprog = NULL;
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    // Validate b_signcols if there is no dedicated signcolumn but 'statuscolumn' is set.
+    if (*wp->w_p_stc != NUL && win_no_signcol(wp)) {
+      buf_signcols(wp->w_buffer, 0);
+    }
+
     if (wp->w_redr_type == UPD_CLEAR && wp->w_floating && wp->w_grid_alloc.chars) {
       grid_invalidate(&wp->w_grid_alloc);
       wp->w_redr_type = UPD_NOT_VALID;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5947,6 +5947,14 @@ int win_signcol_count(win_T *wp)
   return win_signcol_configured(wp, NULL);
 }
 
+/// Return true when window "wp" has no sign column.
+bool win_no_signcol(win_T *wp)
+{
+  const char *scl = wp->w_p_scl;
+  return (*scl == 'n' && (*(scl + 1) == 'o' || (*(scl + 1) == 'u'
+                                                && (wp->w_p_nu || wp->w_p_rnu))));
+}
+
 /// Return the number of requested sign columns, based on user / configuration.
 int win_signcol_configured(win_T *wp, int *is_fixed)
 {
@@ -5956,20 +5964,7 @@ int win_signcol_configured(win_T *wp, int *is_fixed)
     *is_fixed = 1;
   }
 
-  // Note: It checks "no" or "number" in 'signcolumn' option
-  if (*scl == 'n'
-      && (*(scl + 1) == 'o' || (*(scl + 1) == 'u'
-                                && (wp->w_p_nu || wp->w_p_rnu)))) {
-    if (!wp->w_buffer->b_signcols.valid) {
-      FOR_ALL_WINDOWS_IN_TAB(win, curtab) {
-        if (*win->w_p_stc != NUL) {
-          win->w_nrwidth_line_count = 0;
-        }
-      }
-    }
-    if (*wp->w_p_stc != NUL) {
-      buf_signcols(wp->w_buffer, 0);
-    }
+  if (win_no_signcol(wp)) {
     return 0;
   }
 


### PR DESCRIPTION
Problem:     'statuscolumn' width may be reset after it has been drawn
              when multiple windows contain the same buffer. This results
              in an offset for the drawn cursor position.
Solution:     Loop over all windows (twice) prior to drawing them to
              reset the 'statuscolumn' width and validate the sign
              column when necessary.