### PR TITLE
fix(editorconfig): also check same line comments when matching lines

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -157,7 +157,7 @@ local function parse_line(line)
       return glob, nil, nil
     end
 
-    local key, val = line:match('^%s*([^:= ][^:=]-)%s*[:=]%s*(.-)%s*$')
+    local key, val = line:match('^%s*([^:= ][^:=]-)%s*[:=]%s*([^#;%s]+).*$')
     if key ~= nil and val ~= nil then
       return nil, key:lower(), val:lower()
     end

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -22,7 +22,7 @@ setup(function()
   helpers.write_file(
     testdir .. pathsep .. '.editorconfig',
     [[
-    root = true
+    root = true ; semicolon comment
 
     [3_space.txt]
     indent_style = space
@@ -39,7 +39,7 @@ setup(function()
     indent_size = tab
 
     [tab.txt]
-    indent_style = tab
+    indent_style = tab # hashtag comment
 
     [4_tab.txt]
     indent_style = tab


### PR DESCRIPTION
I noticed that key, value parsing was not correct in `.editorconfig` files if the line contained an inline comment (# or ;).
`root = true ; semicolon comment` would result in: `key = "root"` and `value = "true ; semicolon comment"`.
