### PR TITLE
fix(diff): remove repetitive comparisons between strings with linematch

### DIFF
--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -328,9 +328,7 @@ int ***allocate_comparison_buffers(const int *diff_length, const size_t nDiffs)
           comparison_buffers[cpointer][k] = xmalloc(sizeof(int) * (size_t)diff_length[j]);
         }
         // initialize to -1
-        for (int l = 0; l < diff_length[j]; l++) {
-          comparison_buffers[cpointer][k][l] = -1;
-        }
+        memset(comparison_buffers[cpointer][k], -1, (size_t)diff_length[j]);
       }
       cpointer++;
     }


### PR DESCRIPTION
@lewis6991 

Add memory to avoid repetitive string comparisons

Why is this important?

take for example these files in 3 way diff mode with linematch enabled:
file 1:
1a
1b
1c

file 2:
2a
2b
2c

file 3:
3a
3b
3c

there are repetitive calls to matching_chars which are unecessary, and the amount of these calls increases rapidly with larger diffs with over 3 buffers open in diff mode.

with:
27 calls to `matching_chars`
without:
189 calls to `matching_chars`

add a single extra line to each file for 4 lines each:
with:
48 calls to `matching_chars`
without:
432 calls to `matching_chars`