### PR TITLE
refactor(fs): it's time: get rid of fs_loop and fs_loop_mutex

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -308,7 +308,7 @@ static int nlua_thr_api_nvim__get_runtime(lua_State *lstate)
     return lua_error(lstate);
   }
 
-  ArrayOf(String) ret = runtime_get_named_thread(is_lua, pat, all);
+  ArrayOf(String) ret = runtime_get_named_thread(luv_loop(lstate), is_lua, pat, all);
   nlua_push_Array(lstate, ret, true);
   api_free_array(ret);
   api_free_array(pat);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -266,10 +266,6 @@ int main(int argc, char **argv)
   // `argc` and `argv` are also copied, so that they can be changed.
   init_params(&params, argc, argv);
 
-  // Since os_open is called during the init_startuptime, we need to call
-  // fs_init before it.
-  fs_init();
-
   init_startuptime(&params);
 
   // Need to find "--clean" before actually parsing arguments.
@@ -1479,7 +1475,7 @@ static void init_startuptime(mparm_T *paramp)
 {
   for (int i = 1; i < paramp->argc - 1; i++) {
     if (STRICMP(paramp->argv[i], "--startuptime") == 0) {
-      time_fd = os_fopen(paramp->argv[i + 1], "a");
+      time_fd = fopen(paramp->argv[i + 1], "a");
       time_start("--- NVIM STARTING ---");
       break;
     }

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -97,7 +97,6 @@ local init = only_separate(function()
   for _, c in ipairs(child_calls_init) do
     c.func(unpack(c.args))
   end
-  libnvim.fs_init()
   libnvim.event_init()
   libnvim.early_init(nil)
   if child_calls_mod then


### PR DESCRIPTION
Here's the headline: when run in sync mode (last argument cb=NULL), these functions don't actually use the uv_loop_t. However this is not a documented guarantee.

The _vast_ majority of usecases of the functions run in the context of the main loop, so we can just pass in `main_loop.uv`, just in case. The only exceptions are:

- `os_fopen()` in `init_startuptime()` before main loop is initialized

We recently fixed fopen() to work in the windows build, so we can just use fopen(). Amazing!

- `nvim__get_runtime()` has an implementation for worker threads.

This is not as bad as it seems, as it only uses the last available cached path from the main thread. Thus, in only needs os_file_is_readable() and os_is_dir() functionality. We can create thread safe variants of these, which uses the luv_loop() private to each worker thread.

Again the headline: The uv_fs module does not use the loop parameter when running in sync mode. We could get rid of the extra bookkeeping and just pass in loop=NULL. This works in the current bundled version of libuv, but there is no guarntee this will keep working in a future libuv update.