### PR TITLE
refactor(fs): get rid of fs_loop and fs_loop_mutex (YOLO EDITION)

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -266,10 +266,6 @@ int main(int argc, char **argv)
   // `argc` and `argv` are also copied, so that they can be changed.
   init_params(&params, argc, argv);
 
-  // Since os_open is called during the init_startuptime, we need to call
-  // fs_init before it.
-  fs_init();
-
   init_startuptime(&params);
 
   // Need to find "--clean" before actually parsing arguments.
@@ -1479,7 +1475,7 @@ static void init_startuptime(mparm_T *paramp)
 {
   for (int i = 1; i < paramp->argc - 1; i++) {
     if (STRICMP(paramp->argv[i], "--startuptime") == 0) {
-      time_fd = os_fopen(paramp->argv[i + 1], "a");
+      time_fd = fopen(paramp->argv[i + 1], "a");
       time_start("--- NVIM STARTING ---");
       break;
     }

--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -97,7 +97,6 @@ local init = only_separate(function()
   for _, c in ipairs(child_calls_init) do
     c.func(unpack(c.args))
   end
-  libnvim.fs_init()
   libnvim.event_init()
   libnvim.early_init(nil)
   if child_calls_mod then


### PR DESCRIPTION
This is a variant of #23307 but we just set uv_loop_t to NULL everywhere (fuck it we ball)

I think his works in the current bundled version of libuv, but there is no guarantee this will keep working in a future libuv update.

Should this turn out to work, it could be worth asking upstream for a documentation update where this is properly guaranteed to not break