### PR TITLE
vim-patch:8.2.{3768,3772}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6002,7 +6002,7 @@ void add_timer_info_all(typval_T *rettv)
   tv_list_alloc_ret(rettv, map_size(&timers));
   timer_T *timer;
   map_foreach_value(&timers, timer, {
-    if (!timer->stopped) {
+    if (!timer->stopped || timer->refcount > 1) {
       add_timer_info(rettv, timer);
     }
   })

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -8944,7 +8944,7 @@ static void f_timer_info(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
     tv_list_alloc_ret(rettv, 1);
     timer_T *timer = find_timer_by_nr(tv_get_number(&argvars[0]));
-    if (timer != NULL && !timer->stopped) {
+    if (timer != NULL && (!timer->stopped || timer->refcount > 1)) {
       add_timer_info(rettv, timer);
     }
   } else {

--- a/test/old/testdir/test_timers.vim
+++ b/test/old/testdir/test_timers.vim
@@ -94,6 +94,13 @@ func Test_timer_info()
   call assert_equal([], timer_info(id))
 
   call assert_fails('call timer_info("abc")', 'E39:')
+
+  " check repeat count inside the callback
+  let g:timer_repeat = []
+  let tid = timer_start(10, {tid -> execute("call add(g:timer_repeat, timer_info(tid)[0].repeat)")}, #{repeat: 3})
+  sleep 100m
+  call assert_equal([2, 1, 0], g:timer_repeat)
+  unlet g:timer_repeat
 endfunc
 
 func Test_timer_stopall()

--- a/test/old/testdir/test_timers.vim
+++ b/test/old/testdir/test_timers.vim
@@ -98,8 +98,7 @@ func Test_timer_info()
   " check repeat count inside the callback
   let g:timer_repeat = []
   let tid = timer_start(10, {tid -> execute("call add(g:timer_repeat, timer_info(tid)[0].repeat)")}, #{repeat: 3})
-  sleep 100m
-  call assert_equal([2, 1, 0], g:timer_repeat)
+  call WaitForAssert({-> assert_equal([2, 1, 0], g:timer_repeat)})
   unlet g:timer_repeat
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.3768: timer_info() has the wrong repeat value in a timer callback

Problem:    timer_info() has the wrong repeat value in a timer callback.
Solution:   Do not add one to the repeat value when in the callback.

https://github.com/vim/vim/commit/95b2dd0c008f0977ebb3cbe233a5064001a332e1

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3772: timer info test fails on slow machine

Problem:    Timer info test fails on slow machine.
Solution:   Use WaitForAssert().

https://github.com/vim/vim/commit/ff39a650b2bd31e30d1bb8766e8560f9a14a7137

Co-authored-by: Bram Moolenaar <Bram@vim.org>