### PR TITLE
vim-patch:8.2.3314: behavior of exists() in a :def function is unpredictable

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -60,14 +60,14 @@ browse({save}, {title}, {initdir}, {default})
 				String	put up a file requester
 browsedir({title}, {initdir})	String	put up a directory requester
 bufadd({name})			Number	add a buffer to the buffer list
-bufexists({expr})		Number	|TRUE| if buffer {expr} exists
-buflisted({expr})		Number	|TRUE| if buffer {expr} is listed
-bufload({expr})			Number	load buffer {expr} if not loaded yet
-bufloaded({expr})		Number	|TRUE| if buffer {expr} is loaded
-bufname([{expr}])		String	Name of the buffer {expr}
-bufnr([{expr} [, {create}]])	Number	Number of the buffer {expr}
-bufwinid({expr})		Number	|window-ID| of buffer {expr}
-bufwinnr({expr})		Number	window number of buffer {expr}
+bufexists({buf})		Number	|TRUE| if buffer {buf} exists
+buflisted({buf})		Number	|TRUE| if buffer {buf} is listed
+bufload({buf})			Number	load buffer {buf} if not loaded yet
+bufloaded({buf})		Number	|TRUE| if buffer {buf} is loaded
+bufname([{buf}])		String	Name of the buffer {buf}
+bufnr([{buf} [, {create}]])	Number	Number of the buffer {buf}
+bufwinid({buf})			Number	window ID of buffer {buf}
+bufwinnr({buf})			Number	window number of buffer {buf}
 byte2line({byte})		Number	line number at byte count {byte}
 byteidx({expr}, {nr})		Number	byte index of {nr}th char in {expr}
 byteidxcomp({expr}, {nr})	Number	byte index of {nr}th char in {expr}
@@ -1971,7 +1971,7 @@ exists({expr})	The result is a Number, which is |TRUE| if {expr} is
 		Can also be used as a |method|: >
 			Varname()->exists()
 
-exp({expr})						*exp()*
+exp({expr})							*exp()*
 		Return the exponential of {expr} as a |Float| in the range
 		[0, inf].
 		{expr} must evaluate to a |Float| or a |Number|.


### PR DESCRIPTION
#### vim-patch:8.2.3314: behavior of exists() in a :def function is unpredictable

Problem:    Behavior of exists() in a :def function is unpredictable.
Solution:   Add exists_compiled().

https://github.com/vim/vim/commit/267359902c8792fed13543ddeb56c6df0ae74957

Co-authored-by: Bram Moolenaar <Bram@vim.org>