### PR TITLE
build(clint): fix deprecation and linter warnings

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -42,7 +42,6 @@ import copy
 import getopt
 import os
 import re
-import sre_compile
 import string
 import sys
 import json
@@ -308,14 +307,14 @@ def Match(pattern, s):
     # performance reasons; factoring it out into a separate function turns out
     # to be noticeably expensive.
     if pattern not in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].match(s)
 
 
 def Search(pattern, s):
     """Searches the string for the pattern, caching the compiled regexp."""
     if pattern not in _regexp_compile_cache:
-        _regexp_compile_cache[pattern] = sre_compile.compile(pattern)
+        _regexp_compile_cache[pattern] = re.compile(pattern)
     return _regexp_compile_cache[pattern].search(s)
 
 
@@ -2810,6 +2809,8 @@ def ParseArguments(args):
     Returns:
       The list of filenames to lint.
     """
+    opts = []
+    filenames = []
     try:
         (opts, filenames) = getopt.getopt(args, '', ['help',
                                                      'output=',


### PR DESCRIPTION
`sre_compile` is deprecated in python 11, and gives warning when clint
is used.
