### PR TITLE
ci: auto add label according title

### DIFF
--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -35,14 +35,3 @@ jobs:
           actions: 'add-labels'
           issue-number: ${{ github.event.issue.number }}
           labels: ${{ steps.check-issue.outputs.keyword }}
-
-      - name: check invalid
-        if: (contains(github.event.issue.body, 'Step to Reproduce') == false)  && (github.event.label.name != 'enhancement')
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'create-comment,add-labels,close-issue'
-          issue-number: ${{ github.event.issue.number }}
-          labels: 'closed:invalid'
-          body: |
-            Hello @${{ github.event.issue.user.login }}, your issue has been closed because it does not include reproduce step.
-

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -4,9 +4,6 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  contents: read
-
 jobs:
   issue-open-check:
     permissions:

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -1,0 +1,48 @@
+name: Issue Open Check
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  issue-open-check:
+    permissions:
+      issues: write  # for actions-cool/issues-helper to update issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: check issue title
+        id: check-issue
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const title = context.payload.issue.title;
+            const keywords = ['api', 'treesitter', 'ui', 'lsp', 'doc'];
+            const regex = new RegExp(`\\b(${keywords.join('|')})\\b`, 'i');
+            const match = title.match(regex);
+
+            if (match) {
+              core.setOutput('keyword', match[0]);
+            } else {
+              core.setOutput('keyword', 'bug');
+            }
+
+      - name: add label
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'add-labels'
+          issue-number: ${{ github.event.issue.number }}
+          labels: ${{ steps.check-issue.outputs.keyword }}
+
+      - name: check invalid
+        if: (contains(github.event.issue.body, 'Step to Reproduce') == false)  && (github.event.label.name != 'enhancement')
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'create-comment,add-labels,close-issue'
+          issue-number: ${{ github.event.issue.number }}
+          labels: 'closed:invalid'
+          body: |
+            Hello @${{ github.event.issue.user.login }}, your issue has been closed because it does not include reproduce step.
+

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -19,19 +19,19 @@ jobs:
         with:
           script: |
             const title = context.payload.issue.title;
+            const titleSplit = title.split(/\s+/).map(e => e.toLowerCase());
             const keywords = ['api', 'treesitter', 'ui', 'lsp', 'doc'];
-            const regex = new RegExp(`\\b(${keywords.join('|')})\\b`, 'i');
-            const match = title.match(regex);
-
-            if (match) {
-              core.setOutput('keyword', match[0]);
-            } else {
-              core.setOutput('keyword', 'bug');
+            var match = new Set();
+            for(const keyword of keywords) {
+              if(titleSplit.includes(keyword)) {
+                match.add(keyword)
+              }
             }
-
-      - name: add label
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'add-labels'
-          issue-number: ${{ github.event.issue.number }}
-          labels: ${{ steps.check-issue.outputs.keyword }}
+            if(match.size !== 0){
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: Array.from(match)
+              })
+            }

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   issue-open-check:
     permissions:
-      issues: write  # for actions-cool/issues-helper to update issues
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: check issue title

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: check issue title
         id: check-issue
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             const title = context.payload.issue.title;


### PR DESCRIPTION
Found this [action-cool/issue-helper](https://github.com/actions-cool/issues-helper) . Looks like it will be of some help to our issue tracking. Reduce manual label addition. There are various possibilities for title. Adding a standard title format would be more helpful for actions. For example `[api] issue description` `[doc] xxx` etc. Automatically missing reproduce step issue. Reduce maintainers' time wasting on some strange issues. Not very familiar with github actions. Just trying to add some test cases. It looks  good.

![image](https://user-images.githubusercontent.com/41671631/234792774-24da4ae3-34bb-49d6-94c0-5cd9961495b3.png)
