### PR TITLE
Resolving issue for ':substitute with expression replacement containi…

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -287,13 +287,16 @@ int call_internal_method(const char *const fname, const int argcount, typval_T *
 
   typval_T argv[MAX_FUNC_ARGS + 1];
   const ptrdiff_t base_index = fdef->base_arg == BASE_LAST ? argcount : fdef->base_arg - 1;
-  memcpy(argv, argvars, (size_t)base_index * sizeof(typval_T));
-  argv[base_index] = *basetv;
-  memcpy(argv + base_index + 1, argvars + base_index,
-         (size_t)(argcount - base_index) * sizeof(typval_T));
-  argv[argcount + 1].v_type = VAR_UNKNOWN;
-
-  fdef->func(argv, rettv, fdef->data);
+  if((base_index > 0 && base_index < argcount) && argcount > 0) {
+    memcpy(argv, argvars, (size_t)base_index * sizeof(typval_T));
+    argv[base_index] = *basetv;
+    size_t copy_size =  (size_t)(argcount - base_index) * sizeof(typval_T);
+    if(copy_size > 0) {
+      memcpy(argv + base_index + 1, argvars + base_index, copy_size);
+    }
+    argv[argcount + 1].v_type = VAR_UNKNOWN;
+    fdef->func(argv, rettv, fdef->data);
+  }
   return FCERR_NONE;
 }
 

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -287,11 +287,11 @@ int call_internal_method(const char *const fname, const int argcount, typval_T *
 
   typval_T argv[MAX_FUNC_ARGS + 1];
   const ptrdiff_t base_index = fdef->base_arg == BASE_LAST ? argcount : fdef->base_arg - 1;
-  if((base_index > 0 && base_index < argcount) && argcount > 0) {
+  if ((base_index > 0 && base_index < argcount) && argcount > 0) {
     memcpy(argv, argvars, (size_t)base_index * sizeof(typval_T));
     argv[base_index] = *basetv;
     size_t copy_size =  (size_t)(argcount - base_index) * sizeof(typval_T);
-    if(copy_size > 0) {
+    if (copy_size > 0) {
       memcpy(argv + base_index + 1, argvars + base_index, copy_size);
     }
     argv[argcount + 1].v_type = VAR_UNKNOWN;


### PR DESCRIPTION
neovim was crashing due to following steps

- Type in :s/^/\=submatch(0)->printf(.
- Now type in ) and nvim will crash.

cause of that was found to be due `ERROR: AddressSanitizer: negative-size-param: (size=-16)` memcpy failure
resolved by checking if the size is valid between base_index and argcount