### PR TITLE
vim-patch:9.0.1492: using uninitialized memory when argument is missing

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -287,6 +287,9 @@ int call_internal_method(const char *const fname, const int argcount, typval_T *
 
   typval_T argv[MAX_FUNC_ARGS + 1];
   const ptrdiff_t base_index = fdef->base_arg == BASE_LAST ? argcount : fdef->base_arg - 1;
+  if (argcount < base_index) {
+    return FCERR_TOOFEW;
+  }
   memcpy(argv, argvars, (size_t)base_index * sizeof(typval_T));
   argv[base_index] = *basetv;
   memcpy(argv + base_index + 1, argvars + base_index,

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -407,6 +407,9 @@ func Test_printf_misc()
   call CheckLegacyAndVim9Success(lines)
 
   call CheckLegacyAndVim9Failure(["call printf('123', 3)"], "E767:")
+
+  " this was using uninitialized memory
+  call CheckLegacyAndVim9Failure(["eval ''->printf()"], "E119:")
 endfunc
 
 func Test_printf_float()


### PR DESCRIPTION
Fix #23321
Close #23349

#### vim-patch:9.0.1492: using uninitialized memory when argument is missing

Problem:    Using uninitialized memory when argument is missing.
Solution:   Check there are sufficient arguments before the base.

https://github.com/vim/vim/commit/b7f2270bab102d68f83a6300699b7f98efad81f2

Co-authored-by: Bram Moolenaar <Bram@vim.org>