### PR TITLE
vim-patch:partial:8.2.0425: code for modeless selection not sufficiently tested

### DIFF
--- a/test/old/testdir/mouse.vim
+++ b/test/old/testdir/mouse.vim
@@ -1,0 +1,69 @@
+" Helper functions for generating mouse events
+
+func MouseLeftClick(row, col)
+  call nvim_input_mouse('left', 'press', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseMiddleClick(row, col)
+  call nvim_input_mouse('middle', 'press', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseRightClick(row, col)
+  call nvim_input_mouse('right', 'press', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseCtrlLeftClick(row, col)
+  call nvim_input_mouse('left', 'press', 'C', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseCtrlRightClick(row, col)
+  call nvim_input_mouse('right', 'press', 'C', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseLeftRelease(row, col)
+  call nvim_input_mouse('left', 'release', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseMiddleRelease(row, col)
+  call nvim_input_mouse('middle', 'release', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseRightRelease(row, col)
+  call nvim_input_mouse('right', 'release', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseLeftDrag(row, col)
+  call nvim_input_mouse('left', 'drag', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseWheelUp(row, col)
+  call nvim_input_mouse('wheel', 'up', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+func MouseWheelDown(row, col)
+  call nvim_input_mouse('wheel', 'down', '', 0, a:row - 1, a:col - 1)
+  call getchar(1)
+  call feedkeys('', 'x!')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_selectmode.vim
+++ b/test/old/testdir/test_selectmode.vim
@@ -1,6 +1,11 @@
 " Test for Select-mode
 
+source check.vim
+" CheckNotGui
+" CheckUnix
+
 source shared.vim
+source mouse.vim
 
 " Test for select mode
 func Test_selectmode_basic()
@@ -153,6 +158,104 @@ func Test_select_mode_map()
   set selectmode&
 
   close!
+endfunc
+
+" Test double/triple/quadruple click to start 'select' mode
+func Test_term_mouse_multiple_clicks_to_select_mode()
+  let save_mouse = &mouse
+  " let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
+  " set mouse=a term=xterm mousetime=200
+  set mouse=a mousetime=200
+  set selectmode=mouse
+  new
+
+  " for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
+  "   let msg = 'ttymouse=' .. ttymouse_val
+  "   exe 'set ttymouse=' .. ttymouse_val
+  let msg = ''
+
+    " Single-click and drag should 'select' the characters
+    call setline(1, ['foo [foo bar] foo', 'foo'])
+    call MouseLeftClick(1, 3)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftDrag(1, 13)
+    call MouseLeftRelease(1, 13)
+    norm! o
+    call assert_equal(['foo foo', 'foo'], getline(1, '$'), msg)
+
+    " Double-click on word should visually 'select' the word.
+    call setline(1, ['foo [foo bar] foo', 'foo'])
+    call MouseLeftClick(1, 2)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 2)
+    call assert_equal('s', mode(), msg)
+    norm! bar
+    call assert_equal(['bar [foo bar] foo', 'foo'], getline(1, '$'), msg)
+
+    " Double-click on opening square bracket should visually
+    " 'select' the whole [foo bar].
+    call setline(1, ['foo [foo bar] foo', 'foo'])
+    call MouseLeftClick(1, 5)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 5)
+    call MouseLeftClick(1, 5)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 5)
+    call assert_equal('s', mode(), msg)
+    norm! bar
+    call assert_equal(['foo bar foo', 'foo'], getline(1, '$'), msg)
+
+    " To guarantee that the next click is not counted as a triple click
+    call MouseRightClick(1, 1)
+    call MouseRightRelease(1, 1)
+
+    " Triple-click should visually 'select' the whole line.
+    call setline(1, ['foo [foo bar] foo', 'foo'])
+    call MouseLeftClick(1, 3)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 3)
+    call MouseLeftClick(1, 3)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 3)
+    call MouseLeftClick(1, 3)
+    call assert_equal(64, getcharmod(), msg) " triple-click
+    call MouseLeftRelease(1, 3)
+    call assert_equal('S', mode(), msg)
+    norm! baz
+    call assert_equal(['bazfoo'], getline(1, '$'), msg)
+
+    " Quadruple-click should start visual block 'select'.
+    call setline(1, ['aaaaaa', 'bbbbbb'])
+    call MouseLeftClick(1, 2)
+    call assert_equal(0, getcharmod(), msg)
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(32, getcharmod(), msg) " double-click
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(64, getcharmod(), msg) " triple-click
+    call MouseLeftRelease(1, 2)
+    call MouseLeftClick(1, 2)
+    call assert_equal(96, getcharmod(), msg) " quadruple-click
+    call MouseLeftDrag(2, 4)
+    call MouseLeftRelease(2, 4)
+    call assert_equal("\<c-s>", mode(), msg)
+    norm! x
+    call assert_equal(['axaa', 'bxbb'], getline(1, '$'), msg)
+  " endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  set mousetime&
+  set selectmode&
+  " call test_override('no_query_mouse', 0)
+  bwipe!
 endfunc
 
 " Test for selecting a register with CTRL-R


### PR DESCRIPTION
#### vim-patch:partial:8.2.0425: code for modeless selection not sufficiently tested

Problem:    Code for modeless selection not sufficiently tested.
Solution:   Add tests.  Move mouse code functionality to a common script file.
            (Yegappan Lakshmanan, closes vim/vim#5821)

Add some mouse.vim functions that can be made to work in Nvim.

https://github.com/vim/vim/commit/515545e11f523d14343b1e588dc0b9bd3d362bc2