### PR TITLE
vim-patch:8.1.{partial:1155,1160,1165,1167,1175,1176,1178,1179,1181,1216,1223,1244,1247,1248,.2106,2148,2306},9.0.0825

### DIFF
--- a/test/old/testdir/mouse.vim
+++ b/test/old/testdir/mouse.vim
@@ -1,5 +1,9 @@
 " Helper functions for generating mouse events
 
+let g:Ttymouse_values = ['sgr']
+let g:Ttymouse_dec = []
+let g:Ttymouse_netterm = []
+
 func MouseLeftClick(row, col)
   call nvim_input_mouse('left', 'press', '', 0, a:row - 1, a:col - 1)
   call getchar(1)

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -12,6 +12,7 @@ if exists('s:did_load')
   set laststatus=1
   set listchars=eol:$
   set joinspaces
+  set mousemodel=extend
   set nohidden nosmarttab noautoindent noautoread noruler noshowcmd
   set nohlsearch noincsearch
   set nrformats=bin,octal,hex

--- a/test/old/testdir/test_selectmode.vim
+++ b/test/old/testdir/test_selectmode.vim
@@ -163,7 +163,7 @@ endfunc
 " Test double/triple/quadruple click to start 'select' mode
 func Test_term_mouse_multiple_clicks_to_select_mode()
   let save_mouse = &mouse
-  " let save_term = &term
+  let save_term = &term
   " let save_ttymouse = &ttymouse
   " call test_override('no_query_mouse', 1)
   " set mouse=a term=xterm mousetime=200
@@ -171,10 +171,9 @@ func Test_term_mouse_multiple_clicks_to_select_mode()
   set selectmode=mouse
   new
 
-  " for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
-  "   let msg = 'ttymouse=' .. ttymouse_val
-  "   exe 'set ttymouse=' .. ttymouse_val
-  let msg = ''
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
+    let msg = 'ttymouse=' .. ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
 
     " Single-click and drag should 'select' the characters
     call setline(1, ['foo [foo bar] foo', 'foo'])
@@ -247,7 +246,7 @@ func Test_term_mouse_multiple_clicks_to_select_mode()
     call assert_equal("\<c-s>", mode(), msg)
     norm! x
     call assert_equal(['axaa', 'bxbb'], getline(1, '$'), msg)
-  " endfor
+  endfor
 
   let &mouse = save_mouse
   " let &term = save_term

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -8,11 +8,12 @@ source mouse.vim
 source view_util.vim
 source term_util.vim
 
-func Test_xterm_mouse_left_click()
+func Test_term_mouse_left_click()
   new
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " set mouse=a term=xterm
   set mouse=a
   call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
@@ -31,6 +32,7 @@ func Test_xterm_mouse_left_click()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
   bwipe!
 endfunc
 
@@ -57,7 +59,7 @@ func Test_xterm_mouse_ctrl_click()
     call assert_equal('*usr_02.txt*', expand('<cWORD>'))
 
     call MouseCtrlRightClick(row, col)
-    call MouseLeftRelease(row, col)
+    call MouseRightRelease(row, col)
     " call assert_match('help.txt$', bufname('%'), msg)
     call assert_match('usr_toc.txt$', bufname('%'), msg)
     call assert_equal('|usr_02.txt|', expand('<cWORD>'))
@@ -70,13 +72,14 @@ func Test_xterm_mouse_ctrl_click()
   " let &ttymouse = save_ttymouse
 endfunc
 
-func Test_xterm_mouse_middle_click()
+func Test_term_mouse_middle_click()
   CheckFeature clipboard_working
 
   new
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   let save_quotestar = @*
   let @* = 'abc'
   " set mouse=a term=xterm
@@ -111,11 +114,14 @@ func Test_xterm_mouse_middle_click()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
   let @* = save_quotestar
   bwipe!
 endfunc
 
-func Test_xterm_mouse_wheel()
+" TODO: for unclear reasons this test fails if it comes after
+" Test_xterm_mouse_ctrl_click()
+func Test_1xterm_mouse_wheel()
   new
   let save_mouse = &mouse
   let save_term = &term
@@ -154,10 +160,11 @@ func Test_xterm_mouse_wheel()
   bwipe!
 endfunc
 
-func Test_xterm_mouse_drag_window_separator()
+func Test_term_mouse_drag_window_separator()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " set mouse=a term=xterm
   set mouse=a
 
@@ -209,12 +216,14 @@ func Test_xterm_mouse_drag_window_separator()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
 endfunc
 
-func Test_xterm_mouse_drag_statusline()
+func Test_term_mouse_drag_statusline()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   let save_laststatus = &laststatus
   " set mouse=a term=xterm laststatus=2
   set mouse=a laststatus=2
@@ -250,13 +259,15 @@ func Test_xterm_mouse_drag_statusline()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
   let &laststatus = save_laststatus
 endfunc
 
-func Test_xterm_mouse_click_tab()
+func Test_term_mouse_click_tab()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " set mouse=a term=xterm
   set mouse=a
   let row = 1
@@ -299,12 +310,14 @@ func Test_xterm_mouse_click_tab()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
 endfunc
 
-func Test_xterm_mouse_click_X_to_close_tab()
+func Test_term_mouse_click_X_to_close_tab()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " set mouse=a term=xterm
   set mouse=a
   let row = 1
@@ -346,12 +359,14 @@ func Test_xterm_mouse_click_X_to_close_tab()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
 endfunc
 
-func Test_xterm_mouse_drag_to_move_tab()
+func Test_term_mouse_drag_to_move_tab()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " Set 'mousetime' to 1 to avoid recognizing a double-click in the loop
   " set mouse=a term=xterm mousetime=1
   set mouse=a mousetime=0
@@ -393,13 +408,15 @@ func Test_xterm_mouse_drag_to_move_tab()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
   set mousetime&
 endfunc
 
-func Test_xterm_mouse_double_click_to_create_tab()
+func Test_term_mouse_double_click_to_create_tab()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
+  " call test_override('no_query_mouse', 1)
   " Set 'mousetime' to a small value, so that double-click works but we don't
   " have to wait long to avoid a triple-click.
   " set mouse=a term=xterm mousetime=100
@@ -450,6 +467,7 @@ func Test_xterm_mouse_double_click_to_create_tab()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  " call test_override('no_query_mouse', 0)
   set mousetime&
 endfunc
 

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -297,6 +297,8 @@ func Test_xterm_mouse_drag_to_move_tab()
         \              'Tab page 2',
         \              '#   Xtab1'], a)
 
+    " brief sleep to avoid causing a double-click
+    sleep 20m
     %bwipe!
   endfor
 

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -1,4 +1,161 @@
 
+source check.vim
+" CheckNotGui
+" CheckUnix
+
+source shared.vim
+source mouse.vim
+source view_util.vim
+source term_util.vim
+
+func Test_xterm_mouse_click()
+  new
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+  call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+    go
+    call assert_equal([0, 1, 1, 0], getpos('.'))
+    let row = 2
+    let col = 6
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    call assert_equal([0, 2, 6, 0], getpos('.'))
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  bwipe!
+endfunc
+
+func Test_xterm_mouse_wheel()
+  new
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+  call setline(1, range(1, 100))
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+    go
+    call assert_equal(1, line('w0'))
+    call assert_equal([0, 1, 1, 0], getpos('.'))
+
+    call MouseWheelDown(1, 1)
+    call assert_equal(4, line('w0'))
+    call assert_equal([0, 4, 1, 0], getpos('.'))
+
+    call MouseWheelDown(1, 1)
+    call assert_equal(7, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
+
+    call MouseWheelUp(1, 1)
+    call assert_equal(4, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
+
+    call MouseWheelUp(1, 1)
+    call assert_equal(1, line('w0'))
+    call assert_equal([0, 7, 1, 0], getpos('.'))
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  bwipe!
+endfunc
+
+func Test_xterm_mouse_drag_window_separator()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+
+    " Split horizontally and test dragging the horizontal window separator.
+    split
+    let rowseparator = winheight(0) + 1
+    let row = rowseparator
+    let col = 1
+    call MouseLeftClick(row, col)
+
+    let row -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(rowseparator - 1, winheight(0) + 1)
+    let row += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(rowseparator, winheight(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(rowseparator, winheight(0) + 1)
+
+    bwipe!
+
+    " Split vertically and test dragging the vertical window separator.
+    vsplit
+    let colseparator = winwidth(0) + 1
+
+    let row = 1
+    let col = colseparator
+    call MouseLeftClick(row, col)
+    let col -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(colseparator - 1, winwidth(0) + 1)
+    let col += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(colseparator, winwidth(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(colseparator, winwidth(0) + 1)
+
+    bwipe!
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+endfunc
+
+func Test_xterm_mouse_drag_statusline()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+
+    call assert_equal(1, &cmdheight)
+    let rowstatusline = winheight(0) + 1
+    let row = rowstatusline
+    let col = 1
+    call MouseLeftClick(row, col)
+    let row -= 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(2, &cmdheight)
+    call assert_equal(rowstatusline - 1, winheight(0) + 1)
+    let row += 1
+    call MouseLeftDrag(row, col)
+    call assert_equal(1, &cmdheight)
+    call assert_equal(rowstatusline, winheight(0) + 1)
+    call MouseLeftRelease(row, col)
+    call assert_equal(1, &cmdheight)
+    call assert_equal(rowstatusline, winheight(0) + 1)
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+endfunc
+
 " Test for translation of special key codes (<xF1>, <xF2>, etc.)
 func Test_Keycode_Translation()
   let keycodes = [

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -86,6 +86,12 @@ func Test_xterm_mouse_drag_window_separator()
     let rowseparator = winheight(0) + 1
     let row = rowseparator
     let col = 1
+
+    if ttymouse_val ==# 'xterm' && row > 223
+      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+      continue
+    endif
+
     call MouseLeftClick(row, col)
 
     let row -= 1
@@ -137,6 +143,12 @@ func Test_xterm_mouse_drag_statusline()
     let rowstatusline = winheight(0) + 1
     let row = rowstatusline
     let col = 1
+
+    if ttymouse_val ==# 'xterm' && row > 223
+      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+      continue
+    endif
+
     call MouseLeftClick(row, col)
     let row -= 1
     call MouseLeftDrag(row, col)

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -17,14 +17,15 @@ func Test_xterm_mouse_click()
   set mouse=a
   call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     go
-    call assert_equal([0, 1, 1, 0], getpos('.'))
+    call assert_equal([0, 1, 1, 0], getpos('.'), msg)
     let row = 2
     let col = 6
     call MouseLeftClick(row, col)
     call MouseLeftRelease(row, col)
-    call assert_equal([0, 2, 6, 0], getpos('.'))
+    call assert_equal([0, 2, 6, 0], getpos('.'), msg)
   endfor
 
   let &mouse = save_mouse
@@ -43,26 +44,27 @@ func Test_xterm_mouse_wheel()
   call setline(1, range(1, 100))
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     go
-    call assert_equal(1, line('w0'))
-    call assert_equal([0, 1, 1, 0], getpos('.'))
+    call assert_equal(1, line('w0'), msg)
+    call assert_equal([0, 1, 1, 0], getpos('.'), msg)
 
     call MouseWheelDown(1, 1)
-    call assert_equal(4, line('w0'))
-    call assert_equal([0, 4, 1, 0], getpos('.'))
+    call assert_equal(4, line('w0'), msg)
+    call assert_equal([0, 4, 1, 0], getpos('.'), msg)
 
     call MouseWheelDown(1, 1)
-    call assert_equal(7, line('w0'))
-    call assert_equal([0, 7, 1, 0], getpos('.'))
+    call assert_equal(7, line('w0'), msg)
+    call assert_equal([0, 7, 1, 0], getpos('.'), msg)
 
     call MouseWheelUp(1, 1)
-    call assert_equal(4, line('w0'))
-    call assert_equal([0, 7, 1, 0], getpos('.'))
+    call assert_equal(4, line('w0'), msg)
+    call assert_equal([0, 7, 1, 0], getpos('.'), msg)
 
     call MouseWheelUp(1, 1)
-    call assert_equal(1, line('w0'))
-    call assert_equal([0, 7, 1, 0], getpos('.'))
+    call assert_equal(1, line('w0'), msg)
+    call assert_equal([0, 7, 1, 0], getpos('.'), msg)
   endfor
 
   let &mouse = save_mouse
@@ -79,6 +81,7 @@ func Test_xterm_mouse_drag_window_separator()
   set mouse=a
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
 
     " Split horizontally and test dragging the horizontal window separator.
@@ -92,12 +95,12 @@ func Test_xterm_mouse_drag_window_separator()
       call MouseLeftClick(row, col)
       let row -= 1
       call MouseLeftDrag(row, col)
-      call assert_equal(rowseparator - 1, winheight(0) + 1)
+      call assert_equal(rowseparator - 1, winheight(0) + 1, msg)
       let row += 1
       call MouseLeftDrag(row, col)
-      call assert_equal(rowseparator, winheight(0) + 1)
+      call assert_equal(rowseparator, winheight(0) + 1, msg)
       call MouseLeftRelease(row, col)
-      call assert_equal(rowseparator, winheight(0) + 1)
+      call assert_equal(rowseparator, winheight(0) + 1, msg)
     endif
     bwipe!
 
@@ -112,12 +115,12 @@ func Test_xterm_mouse_drag_window_separator()
       call MouseLeftClick(row, col)
       let col -= 1
       call MouseLeftDrag(row, col)
-      call assert_equal(colseparator - 1, winwidth(0) + 1)
+      call assert_equal(colseparator - 1, winwidth(0) + 1, msg)
       let col += 1
       call MouseLeftDrag(row, col)
-      call assert_equal(colseparator, winwidth(0) + 1)
+      call assert_equal(colseparator, winwidth(0) + 1, msg)
       call MouseLeftRelease(row, col)
-      call assert_equal(colseparator, winwidth(0) + 1)
+      call assert_equal(colseparator, winwidth(0) + 1, msg)
     endif
     bwipe!
   endfor
@@ -136,9 +139,10 @@ func Test_xterm_mouse_drag_statusline()
   set mouse=a laststatus=2
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
 
-    call assert_equal(1, &cmdheight)
+    call assert_equal(1, &cmdheight, msg)
     let rowstatusline = winheight(0) + 1
     let row = rowstatusline
     let col = 1
@@ -151,15 +155,15 @@ func Test_xterm_mouse_drag_statusline()
     call MouseLeftClick(row, col)
     let row -= 1
     call MouseLeftDrag(row, col)
-    call assert_equal(2, &cmdheight)
-    call assert_equal(rowstatusline - 1, winheight(0) + 1)
+    call assert_equal(2, &cmdheight, msg)
+    call assert_equal(rowstatusline - 1, winheight(0) + 1, msg)
     let row += 1
     call MouseLeftDrag(row, col)
-    call assert_equal(1, &cmdheight)
-    call assert_equal(rowstatusline, winheight(0) + 1)
+    call assert_equal(1, &cmdheight, msg)
+    call assert_equal(rowstatusline, winheight(0) + 1, msg)
     call MouseLeftRelease(row, col)
-    call assert_equal(1, &cmdheight)
-    call assert_equal(rowstatusline, winheight(0) + 1)
+    call assert_equal(1, &cmdheight, msg)
+    call assert_equal(rowstatusline, winheight(0) + 1, msg)
   endfor
 
   let &mouse = save_mouse
@@ -177,6 +181,7 @@ func Test_xterm_mouse_click_tab()
   let row = 1
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     e Xfoo
     tabnew Xbar
@@ -185,7 +190,7 @@ func Test_xterm_mouse_click_tab()
     call assert_equal(['Tab page 1',
         \              '#   Xfoo',
         \              'Tab page 2',
-        \              '>   Xbar'], a)
+        \              '>   Xbar'], a, msg)
 
     " Test clicking on tab names in the tabline at the top.
     let col = 2
@@ -196,7 +201,7 @@ func Test_xterm_mouse_click_tab()
     call assert_equal(['Tab page 1',
         \              '>   Xfoo',
         \              'Tab page 2',
-        \              '#   Xbar'], a)
+        \              '#   Xbar'], a, msg)
 
     let col = 9
     call MouseLeftClick(row, col)
@@ -205,7 +210,7 @@ func Test_xterm_mouse_click_tab()
     call assert_equal(['Tab page 1',
         \              '#   Xfoo',
         \              'Tab page 2',
-        \              '>   Xbar'], a)
+        \              '>   Xbar'], a, msg)
 
     %bwipe!
   endfor
@@ -229,6 +234,7 @@ func Test_xterm_mouse_click_X_to_close_tab()
       " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
       continue
     endif
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     e Xtab1
     tabnew Xtab2
@@ -241,7 +247,7 @@ func Test_xterm_mouse_click_X_to_close_tab()
         \              'Tab page 2',
         \              '>   Xtab2',
         \              'Tab page 3',
-        \              '#   Xtab3'], a)
+        \              '#   Xtab3'], a, msg)
 
     " Click on "X" in tabline to close current tab i.e. Xtab2.
     redraw
@@ -251,7 +257,7 @@ func Test_xterm_mouse_click_X_to_close_tab()
     call assert_equal(['Tab page 1',
         \              '    Xtab1',
         \              'Tab page 2',
-        \              '>   Xtab3'], a)
+        \              '>   Xtab3'], a, msg)
 
     %bwipe!
   endfor
@@ -271,6 +277,7 @@ func Test_xterm_mouse_drag_to_move_tab()
   let row = 1
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     e Xtab1
     tabnew Xtab2
@@ -279,14 +286,14 @@ func Test_xterm_mouse_drag_to_move_tab()
     call assert_equal(['Tab page 1',
         \              '#   Xtab1',
         \              'Tab page 2',
-        \              '>   Xtab2'], a)
+        \              '>   Xtab2'], a, msg)
     redraw
 
     " Click in tab2 and drag it to tab1.
     " Check getcharmod() to verify that click is not
     " interpreted as a spurious double-click.
     call MouseLeftClick(row, 10)
-    call assert_equal(0, getcharmod())
+    call assert_equal(0, getcharmod(), msg)
     for col in [9, 8, 7, 6]
       call MouseLeftDrag(row, col)
     endfor
@@ -295,7 +302,7 @@ func Test_xterm_mouse_drag_to_move_tab()
     call assert_equal(['Tab page 1',
         \              '>   Xtab2',
         \              'Tab page 2',
-        \              '#   Xtab1'], a)
+        \              '#   Xtab1'], a, msg)
 
     " brief sleep to avoid causing a double-click
     sleep 20m
@@ -320,6 +327,7 @@ func Test_xterm_mouse_double_click_to_create_tab()
   let col = 10
 
   for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' . ttymouse_val
     e Xtab1
     tabnew Xtab2
@@ -328,16 +336,16 @@ func Test_xterm_mouse_double_click_to_create_tab()
     call assert_equal(['Tab page 1',
         \              '#   Xtab1',
         \              'Tab page 2',
-        \              '>   Xtab2'], a)
+        \              '>   Xtab2'], a, msg)
 
     redraw
     call MouseLeftClick(row, col)
     " Check getcharmod() to verify that first click is not
     " interpreted as a spurious double-click.
-    call assert_equal(0, getcharmod())
+    call assert_equal(0, getcharmod(), msg)
     call MouseLeftRelease(row, col)
     call MouseLeftClick(row, col)
-    call assert_equal(32, getcharmod()) " double-click
+    call assert_equal(32, getcharmod(), msg) " double-click
     call MouseLeftRelease(row, col)
     let a = split(execute(':tabs'), "\n")
     call assert_equal(['Tab page 1',
@@ -345,7 +353,7 @@ func Test_xterm_mouse_double_click_to_create_tab()
         \              'Tab page 2',
         \              '>   [No Name]',
         \              'Tab page 3',
-        \              '#   Xtab2'], a)
+        \              '#   Xtab2'], a, msg)
 
     if ttymouse_val !=# 'sgr'
       " We need to sleep, or else MouseLeftClick() in next loop

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -261,6 +261,104 @@ func Test_xterm_mouse_click_X_to_close_tab()
   " let &ttymouse = save_ttymouse
 endfunc
 
+func Test_xterm_mouse_drag_to_move_tab()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " Set 'mousetime' to 1 to avoid recognizing a double-click in the loop
+  " set mouse=a term=xterm mousetime=1
+  set mouse=a mousetime=0
+  let row = 1
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+    e Xtab1
+    tabnew Xtab2
+
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xtab1',
+        \              'Tab page 2',
+        \              '>   Xtab2'], a)
+    redraw
+
+    " Click in tab2 and drag it to tab1.
+    " Check getcharmod() to verify that click is not
+    " interpreted as a spurious double-click.
+    call MouseLeftClick(row, 10)
+    call assert_equal(0, getcharmod())
+    for col in [9, 8, 7, 6]
+      call MouseLeftDrag(row, col)
+    endfor
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '>   Xtab2',
+        \              'Tab page 2',
+        \              '#   Xtab1'], a)
+
+    %bwipe!
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  set mousetime&
+endfunc
+
+func Test_xterm_mouse_double_click_to_create_tab()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " Set 'mousetime' to a small value, so that double-click works but we don't
+  " have to wait long to avoid a triple-click.
+  " set mouse=a term=xterm mousetime=100
+  set mouse=a mousetime=100
+  let row = 1
+  let col = 10
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+    e Xtab1
+    tabnew Xtab2
+
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xtab1',
+        \              'Tab page 2',
+        \              '>   Xtab2'], a)
+
+    redraw
+    call MouseLeftClick(row, col)
+    " Check getcharmod() to verify that first click is not
+    " interpreted as a spurious double-click.
+    call assert_equal(0, getcharmod())
+    call MouseLeftRelease(row, col)
+    call MouseLeftClick(row, col)
+    call assert_equal(32, getcharmod()) " double-click
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '    Xtab1',
+        \              'Tab page 2',
+        \              '>   [No Name]',
+        \              'Tab page 3',
+        \              '#   Xtab2'], a)
+
+    if ttymouse_val !=# 'sgr'
+      " We need to sleep, or else MouseLeftClick() in next loop
+      " iteration will be interpreted as a spurious triple-click.
+      sleep 100m
+    endif
+    %bwipe!
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  set mousetime&
+endfunc
+
 " Test for translation of special key codes (<xF1>, <xF2>, etc.)
 func Test_Keycode_Translation()
   let keycodes = [

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -133,8 +133,9 @@ func Test_xterm_mouse_drag_statusline()
   let save_mouse = &mouse
   let save_term = &term
   " let save_ttymouse = &ttymouse
-  " set mouse=a term=xterm
-  set mouse=a
+  let save_laststatus = &laststatus
+  " set mouse=a term=xterm laststatus=2
+  set mouse=a laststatus=2
 
   for ttymouse_val in ['sgr']
     " exe 'set ttymouse=' . ttymouse_val
@@ -161,6 +162,54 @@ func Test_xterm_mouse_drag_statusline()
     call MouseLeftRelease(row, col)
     call assert_equal(1, &cmdheight)
     call assert_equal(rowstatusline, winheight(0) + 1)
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  let &laststatus = save_laststatus
+endfunc
+
+func Test_xterm_mouse_click_tab()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+  let row = 1
+
+  for ttymouse_val in ['sgr']
+    " exe 'set ttymouse=' . ttymouse_val
+    e Xfoo
+    tabnew Xbar
+
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xfoo',
+        \              'Tab page 2',
+        \              '>   Xbar'], a)
+
+    " Test clicking on tab names in the tabline at the top.
+    let col = 2
+    redraw!
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '>   Xfoo',
+        \              'Tab page 2',
+        \              '#   Xbar'], a)
+
+    let col = 9
+    call MouseLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xfoo',
+        \              'Tab page 2',
+        \              '>   Xbar'], a)
+
+    %bwipe!
   endfor
 
   let &mouse = save_mouse

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -35,6 +35,8 @@ func Test_xterm_mouse_left_click()
 endfunc
 
 func Test_xterm_mouse_middle_click()
+  CheckFeature clipboard_working
+
   new
   let save_mouse = &mouse
   let save_term = &term

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -369,6 +369,58 @@ func Test_xterm_mouse_double_click_to_create_tab()
   set mousetime&
 endfunc
 
+func Test_xterm_mouse_click_in_fold_columns()
+  new
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  let save_foldcolumn = &foldcolumn
+  " set mouse=a term=xterm foldcolumn=3
+  set mouse=a foldcolumn=3
+
+  " Create 2 nested folds.
+  call setline(1, range(1, 7))
+  2,6fold
+  norm! zR
+  4,5fold
+  call assert_equal([-1, -1, -1, 4, 4, -1, -1],
+        \           map(range(1, 7), 'foldclosed(v:val)'))
+
+  " Click in "+" of inner fold in foldcolumn should open it.
+  redraw
+  let row = 4
+  let col = 2
+  call MouseLeftClick(row, col)
+  call MouseLeftRelease(row, col)
+  call assert_equal([-1, -1, -1, -1, -1, -1, -1],
+        \           map(range(1, 7), 'foldclosed(v:val)'))
+
+  " Click in "-" of outer fold in foldcolumn should close it.
+  redraw
+  let row = 2
+  let col = 1
+  call MouseLeftClick(row, col)
+  call MouseLeftRelease(row, col)
+  call assert_equal([-1, 2, 2, 2, 2, 2, -1],
+        \           map(range(1, 7), 'foldclosed(v:val)'))
+  norm! zR
+
+  " Click in "|" of inner fold in foldcolumn should close it.
+  redraw
+  let row = 5
+  let col = 2
+  call MouseLeftClick(row, col)
+  call MouseLeftRelease(row, col)
+  call assert_equal([-1, -1, -1, 4, 4, -1, -1],
+        \           map(range(1, 7), 'foldclosed(v:val)'))
+
+  let &foldcolumn = save_foldcolumn
+  " let &ttymouse = save_ttymouse
+  " let &term = save_term
+  let &mouse = save_mouse
+  bwipe!
+endfunc
+
 " Test for translation of special key codes (<xF1>, <xF2>, etc.)
 func Test_Keycode_Translation()
   let keycodes = [

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -16,7 +16,7 @@ func Test_xterm_mouse_left_click()
   " set mouse=a term=xterm
   set mouse=a
   call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec + g:Ttymouse_netterm
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     go
@@ -42,7 +42,7 @@ func Test_xterm_mouse_ctrl_click()
   " set mouse=a term=xterm
   set mouse=a
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     " help
@@ -82,7 +82,7 @@ func Test_xterm_mouse_middle_click()
   " set mouse=a term=xterm
   set mouse=a
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     call setline(1, ['123456789', '123456789'])
@@ -124,7 +124,7 @@ func Test_xterm_mouse_wheel()
   set mouse=a
   call setline(1, range(1, 100))
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     go
@@ -161,7 +161,7 @@ func Test_xterm_mouse_drag_window_separator()
   " set mouse=a term=xterm
   set mouse=a
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
 
@@ -219,7 +219,7 @@ func Test_xterm_mouse_drag_statusline()
   " set mouse=a term=xterm laststatus=2
   set mouse=a laststatus=2
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
 
@@ -261,7 +261,7 @@ func Test_xterm_mouse_click_tab()
   set mouse=a
   let row = 1
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec + g:Ttymouse_netterm
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     e Xfoo
@@ -310,7 +310,7 @@ func Test_xterm_mouse_click_X_to_close_tab()
   let row = 1
   let col = &columns
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec + g:Ttymouse_netterm
     if ttymouse_val ==# 'xterm2' && col > 223
       " When 'ttymouse' is 'xterm2', row/col bigger than 223 are not supported.
       continue
@@ -357,7 +357,7 @@ func Test_xterm_mouse_drag_to_move_tab()
   set mouse=a mousetime=0
   let row = 1
 
-  for ttymouse_val in ['sgr']
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
@@ -407,11 +407,19 @@ func Test_xterm_mouse_double_click_to_create_tab()
   let row = 1
   let col = 10
 
-  for ttymouse_val in ['sgr']
+  let round = 0
+  for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec
     let msg = 'ttymouse=' .. ttymouse_val
     " exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
     tabnew Xtab2
+
+    if round > 0
+      " We need to sleep, or else the first MouseLeftClick() will be
+      " interpreted as a spurious triple-click.
+      sleep 100m
+    endif
+    let round += 1
 
     let a = split(execute(':tabs'), "\n")
     call assert_equal(['Tab page 1',
@@ -436,11 +444,6 @@ func Test_xterm_mouse_double_click_to_create_tab()
         \              'Tab page 3',
         \              '#   Xtab2'], a, msg)
 
-    if ttymouse_val !=# 'sgr'
-      " We need to sleep, or else MouseLeftClick() in next loop
-      " iteration will be interpreted as a spurious triple-click.
-      sleep 100m
-    endif
     %bwipe!
   endfor
 

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -18,7 +18,7 @@ func Test_xterm_mouse_left_click()
   call setline(1, ['line 1', 'line 2', 'line 3 is a bit longer'])
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     go
     call assert_equal([0, 1, 1, 0], getpos('.'), msg)
     let row = 2
@@ -32,6 +32,42 @@ func Test_xterm_mouse_left_click()
   " let &term = save_term
   " let &ttymouse = save_ttymouse
   bwipe!
+endfunc
+
+" Test that <C-LeftMouse> jumps to help tag and <C-RightMouse> jumps back.
+func Test_xterm_mouse_ctrl_click()
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  " set mouse=a term=xterm
+  set mouse=a
+
+  for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
+    " help
+    help usr_toc.txt
+    /usr_02.txt
+    norm! zt
+    let row = 1
+    let col = 1
+    call MouseCtrlLeftClick(row, col)
+    call MouseLeftRelease(row, col)
+    call assert_match('usr_02.txt$', bufname('%'), msg)
+    call assert_equal('*usr_02.txt*', expand('<cWORD>'))
+
+    call MouseCtrlRightClick(row, col)
+    call MouseLeftRelease(row, col)
+    " call assert_match('help.txt$', bufname('%'), msg)
+    call assert_match('usr_toc.txt$', bufname('%'), msg)
+    call assert_equal('|usr_02.txt|', expand('<cWORD>'))
+
+    helpclose
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
 endfunc
 
 func Test_xterm_mouse_middle_click()
@@ -48,7 +84,7 @@ func Test_xterm_mouse_middle_click()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     call setline(1, ['123456789', '123456789'])
 
     " Middle-click in the middle of the line pastes text where clicked.
@@ -90,7 +126,7 @@ func Test_xterm_mouse_wheel()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     go
     call assert_equal(1, line('w0'), msg)
     call assert_equal([0, 1, 1, 0], getpos('.'), msg)
@@ -127,7 +163,7 @@ func Test_xterm_mouse_drag_window_separator()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
 
     " Split horizontally and test dragging the horizontal window separator.
     split
@@ -185,7 +221,7 @@ func Test_xterm_mouse_drag_statusline()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
 
     call assert_equal(1, &cmdheight, msg)
     let rowstatusline = winheight(0) + 1
@@ -227,7 +263,7 @@ func Test_xterm_mouse_click_tab()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     e Xfoo
     tabnew Xbar
 
@@ -280,7 +316,7 @@ func Test_xterm_mouse_click_X_to_close_tab()
       continue
     endif
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
     tabnew Xtab2
     tabnew Xtab3
@@ -323,7 +359,7 @@ func Test_xterm_mouse_drag_to_move_tab()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
     tabnew Xtab2
 
@@ -373,7 +409,7 @@ func Test_xterm_mouse_double_click_to_create_tab()
 
   for ttymouse_val in ['sgr']
     let msg = 'ttymouse=' .. ttymouse_val
-    " exe 'set ttymouse=' . ttymouse_val
+    " exe 'set ttymouse=' .. ttymouse_val
     e Xtab1
     tabnew Xtab2
 

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -562,6 +562,28 @@ func Test_term_mouse_drag_to_move_tab()
         \              'Tab page 2',
         \              '#   Xtab1'], a, msg)
 
+    " Switch to tab1
+    tabnext
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xtab2',
+        \              'Tab page 2',
+        \              '>   Xtab1'], a, msg)
+
+    " Click in tab2 and drag it to tab1.
+    " This time it is non-current tab.
+    call MouseLeftClick(row, 6)
+    call assert_equal(0, getcharmod(), msg)
+    for col in [7, 8, 9, 10]
+      call MouseLeftDrag(row, col)
+    endfor
+    call MouseLeftRelease(row, col)
+    let a = split(execute(':tabs'), "\n")
+    call assert_equal(['Tab page 1',
+        \              '#   Xtab1',
+        \              'Tab page 2',
+        \              '>   Xtab2'], a, msg)
+
     " Click elsewhere so that click in next iteration is not
     " interpreted as unwanted double-click.
     call MouseLeftClick(row, 11)

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -90,8 +90,8 @@ func Test_xterm_mouse_drag_window_separator()
     let row = rowseparator
     let col = 1
 
-    " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
-    if ttymouse_val !=# 'xterm' || row <= 223
+    " When 'ttymouse' is 'xterm2', row/col bigger than 223 are not supported.
+    if ttymouse_val !=# 'xterm2' || row <= 223
       call MouseLeftClick(row, col)
       let row -= 1
       call MouseLeftDrag(row, col)
@@ -110,8 +110,8 @@ func Test_xterm_mouse_drag_window_separator()
     let row = 1
     let col = colseparator
 
-    " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
-    if ttymouse_val !=# 'xterm' || col <= 223
+    " When 'ttymouse' is 'xterm2', row/col bigger than 223 are not supported.
+    if ttymouse_val !=# 'xterm2' || col <= 223
       call MouseLeftClick(row, col)
       let col -= 1
       call MouseLeftDrag(row, col)
@@ -147,8 +147,8 @@ func Test_xterm_mouse_drag_statusline()
     let row = rowstatusline
     let col = 1
 
-    if ttymouse_val ==# 'xterm' && row > 223
-      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+    if ttymouse_val ==# 'xterm2' && row > 223
+      " When 'ttymouse' is 'xterm2', row/col bigger than 223 are not supported.
       continue
     endif
 
@@ -230,8 +230,8 @@ func Test_xterm_mouse_click_X_to_close_tab()
   let col = &columns
 
   for ttymouse_val in ['sgr']
-    if ttymouse_val ==# 'xterm' && col > 223
-      " When 'ttymouse' is 'xterm', row/col bigger than 223 are not supported.
+    if ttymouse_val ==# 'xterm2' && col > 223
+      " When 'ttymouse' is 'xterm2', row/col bigger than 223 are not supported.
       continue
     endif
     let msg = 'ttymouse=' .. ttymouse_val
@@ -375,7 +375,7 @@ func Test_xterm_mouse_click_in_fold_columns()
   let save_term = &term
   " let save_ttymouse = &ttymouse
   let save_foldcolumn = &foldcolumn
-  " set mouse=a term=xterm foldcolumn=3
+  " set mouse=a term=xterm foldcolumn=3 ttymouse=xterm2
   set mouse=a foldcolumn=3
 
   " Create 2 nested folds.

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -8,7 +8,7 @@ source mouse.vim
 source view_util.vim
 source term_util.vim
 
-func Test_xterm_mouse_click()
+func Test_xterm_mouse_left_click()
   new
   let save_mouse = &mouse
   let save_term = &term
@@ -31,6 +31,49 @@ func Test_xterm_mouse_click()
   let &mouse = save_mouse
   " let &term = save_term
   " let &ttymouse = save_ttymouse
+  bwipe!
+endfunc
+
+func Test_xterm_mouse_middle_click()
+  new
+  let save_mouse = &mouse
+  let save_term = &term
+  " let save_ttymouse = &ttymouse
+  let save_quotestar = @*
+  let @* = 'abc'
+  " set mouse=a term=xterm
+  set mouse=a
+
+  for ttymouse_val in ['sgr']
+    let msg = 'ttymouse=' .. ttymouse_val
+    " exe 'set ttymouse=' . ttymouse_val
+    call setline(1, ['123456789', '123456789'])
+
+    " Middle-click in the middle of the line pastes text where clicked.
+    let row = 1
+    let col = 6
+    call MouseMiddleClick(row, col)
+    call MouseMiddleRelease(row, col)
+    call assert_equal(['12345abc6789', '123456789'], getline(1, '$'), msg)
+
+    " Middle-click beyond end of the line pastes text at the end of the line.
+    let col = 20
+    call MouseMiddleClick(row, col)
+    call MouseMiddleRelease(row, col)
+    call assert_equal(['12345abc6789abc', '123456789'], getline(1, '$'), msg)
+
+    " Middle-click beyond the last line pastes in the last line.
+    let row = 5
+    let col = 3
+    call MouseMiddleClick(row, col)
+    call MouseMiddleRelease(row, col)
+    call assert_equal(['12345abc6789abc', '12abc3456789'], getline(1, '$'), msg)
+  endfor
+
+  let &mouse = save_mouse
+  " let &term = save_term
+  " let &ttymouse = save_ttymouse
+  let @* = save_quotestar
   bwipe!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:partial:8.1.1155: termcodes tests can be improved

Problem:    Termcodes tests can be improved.
Solution:   Add helper functions to simplify tests.  Dragging statusline for
            xterm and sgr. (Dominique Pelle, closes vim/vim#4237)

https://github.com/vim/vim/commit/3fbd2d7c316eaeea463b2f84f29b36d439306bf9

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1160: termcodes test would fail in a very big terminal

Problem:    Termcodes test would fail in a very big terminal.
Solution:   Bail out when the row is larger than what will work. (Dominique
            Pelle, closes vim/vim#4246)

https://github.com/vim/vim/commit/c8b3ddab51cd2901d5946949d02c96e1035b25c0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1165: no test for mouse clicks in the terminal tabpage line

Problem:    No test for mouse clicks in the terminal tabpage line.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#4247).  Also init
            TabPageIdxs[], in case it's used before a redraw.

https://github.com/vim/vim/commit/ca57ab54d759a3e265b19bbe31b57dfed00bbdd0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1167: no test for closing tab by click in tabline

Problem:    No test for closing tab by click in tabline.
Solution:   Add a test.  Also fix that dragging window separator could fail in
            a large terminal. (Dominique Pelle, closes vim/vim#4253)

https://github.com/vim/vim/commit/39f76c6ac0f5e07a0e608ddf920a67702ec83824

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1175: no test for dragging a tab and double click for new tab

Problem:    No test for dragging a tab with the mouse and for creating a new
            tab by double clicking in the tabline.
Solution:   Add two tests. (Dominique Pelle, closes vim/vim#4258)

https://github.com/vim/vim/commit/e3e3828f935392bb3c2147a000db1c7b094a4360

Set 'mousetime' to 0 instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1176: test for dragging a tab is flaky

Problem:    Test for dragging a tab is flaky.
Solution:   Add a brief sleep.

https://github.com/vim/vim/commit/7f27976589f075d591d54f754be257b5f6e6fd92

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1178: when mouse click tests fails value of 'ttytype' is unknown

Problem:    When mouse click tests fails value of 'ttytype' is unknown.
Solution:   Add a message to the assert.

https://github.com/vim/vim/commit/4945219b99f8e191c599f80dedc0c4be02ed821e

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1179: no test for mouse clicks in the fold column

Problem:    No test for mouse clicks in the fold column.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#4261)

https://github.com/vim/vim/commit/696d6377289eb7c703263aaabe58134968335c4b

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1181: tests for mouse clicks are a bit flaky

Problem:    Tests for mouse clicks are a bit flaky when run in an interactive
            terminal.
Solution:   Use "xterm2" instead of "xterm" for 'ttymouse' to avoid spurious
            drag events.

https://github.com/vim/vim/commit/2b00b9b0f355421fdb49e3a15f5a62af657d1922

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1216: mouse middle click is not tested

Problem:    Mouse middle click is not tested.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#4310)

https://github.com/vim/vim/commit/c1b8160b44b43cca3acd7a47c1b85350cb648fe5

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1223: middle mouse click test fails without a clipboard

Problem:    Middle mouse click test fails without a clipboard.
Solution:   Check if the clipboard can be used. (Dominique Pelle, Christian
            Brabandt)  Also use WorkingClipboard() instead of checking for the
            "clipboard" feature.

https://github.com/vim/vim/commit/564344ace9ef06b22e4e60a0196c41b410ac27da

Use CheckFeature clipboard_working from latest test instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1244: no tests for CTRL-mouse-click

Problem:    No tests for CTRL-mouse-click.
Solution:   Add a few tests. (Dominique Pelle, closes vim/vim#4323)

https://github.com/vim/vim/commit/1ee36d6ff5bc51a1ecb5631c3e5bb632b5d1bcfc

Use usr_toc.txt instead of help.txt.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1247: urxvt mouse codes are not tested

Problem:    Urxvt mouse codes are not tested.
Solution:   Also set 'ttymouse' to "urxvt" in the termcodes test.

https://github.com/vim/vim/commit/d0621d85a6ceb17e1e6fb17415c3f94a755aaafa

Use code from latest tests instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.1248: no test for dec mouse

Problem:    No test for dec mouse.
Solution:   Add some tests for dec mouse.  Add "no_query_mouse".

https://github.com/vim/vim/commit/92fd599e0d85bdd7462926b2e5bcf7ce65fccc50


#### vim-patch:8.1.2106: no tests for dragging the mouse beyond the window

Problem:    No tests for dragging the mouse beyond the window.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#5004)

https://github.com/vim/vim/commit/b4367b7fb65f6a88f76ef99f79342341af0b1017

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.2148: no test for right click extending Visual area

Problem:    No test for right click extending Visual area.
Solution:   Add a test. (Dominique Pelle, closes vim/vim#5018)

https://github.com/vim/vim/commit/6aa7523b9642a752ab879131d4b159635207d9f2

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.1.2306: double and triple clicks are not tested

Problem:    Double and triple clicks are not tested.
Solution:   Test mouse clicks to select text. (closes vim/vim#5226)

https://github.com/vim/vim/commit/f36a2c7e60d86b1a1733a8f51ed72da9c6f76eb8

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0825: cannot drag an entry in the tabpage line

Problem:    Cannot drag an entry in the tabpage line.
Solution:   Clear dragwin instead of got_click. (closes vim/vim#11483)

https://github.com/vim/vim/commit/8e0ccb6bc21a446e5c6375b7fdf200fb53a129da