### PR TITLE
vim-patch:8.2.3509: undo file is not synced

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2774,8 +2774,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'fsync' 'fs'		boolean	(default off)
 			global
 	When on, the OS function fsync() will be called after saving a file
-	(|:write|, |writefile()|, …), |swap-file| and |shada-file|. This
-	flushes the file to disk, ensuring that it is safely written.
+	(|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
+	This flushes the file to disk, ensuring that it is safely written.
 	Slow on some systems: writing buffers, quitting Nvim, and other
 	operations may sometimes take a few seconds.
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1333,6 +1333,10 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   }
 #endif
 
+  if (p_fs && fflush(fp) == 0 && os_fsync(fd) != 0) {
+    write_ok = false;
+  }
+
 write_error:
   fclose(fp);
   if (!write_ok) {


### PR DESCRIPTION
#### vim-patch:8.2.3509: undo file is not synced

Problem:    Undo file is not synced. (Sami Farin)
Solution:   Sync the undo file if 'fsync' is set. (Christian Brabandt,
            closes vim/vim#8920)

https://github.com/vim/vim/commit/340dd0fbe462a15a9678cfba02085b4adcc45f02

Co-authored-by: Bram Moolenaar <Bram@vim.org>