### PR TITLE
vim-patch:9.0.{1336,1372}

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -956,7 +956,7 @@ normal_end:
     set_reg_var(get_default_register_name());
   }
 
-  s->c = finish_op;
+  const bool prev_finish_op = finish_op;
   if (s->oa.op_type == OP_NOP) {
     // Reset finish_op, in case it was set
     finish_op = false;
@@ -964,7 +964,7 @@ normal_end:
   }
   // Redraw the cursor with another shape, if we were in Operator-pending
   // mode or did a replace command.
-  if (s->c || s->ca.cmdchar == 'r'
+  if (prev_finish_op || s->ca.cmdchar == 'r'
       || (s->ca.cmdchar == 'g' && s->ca.nchar == 'r')) {
     ui_cursor_shape();                  // may show different cursor shape
   }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -1026,6 +1026,11 @@ typedef struct {
   void *os_buf;
 } optset_T;
 
+/// Type for the callback function that is invoked after an option value is
+/// changed to validate and apply the new value.
+///
+/// Returns NULL if the option value is valid and successfully applied.
+/// Otherwise returns an error message.
 typedef const char *(*opt_did_set_cb_T)(optset_T *args);
 
 /// Stores an identifier of a script or channel that last set an option.

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1482,6 +1482,8 @@ func Test_string_option_revert_on_failure()
   endif
   if exists('+toolbar')
     call add(optlist, ['toolbar', 'text', 'a123'])
+  endif
+  if exists('+toolbariconsize')
     call add(optlist, ['toolbariconsize', 'medium', 'a123'])
   endif
   if exists('+ttymouse') && !has('gui')


### PR DESCRIPTION
#### vim-patch:9.0.1336: functions without arguments are not always declared properly

Problem:    Functions without arguments are not always declared properly.
Solution:   Use "(void)" instead of "()". (Yegappan Lakshmanan, closes vim/vim#12031)

https://github.com/vim/vim/commit/a23a11b5bf03454b71fdb5deac0d5f641e222160

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.1372: test for 'toolbariconsize' may fail

Problem:    Test for 'toolbariconsize' may fail.
Solution:   Only test 'toolbariconsize' when it is supported. (James McCoy,
            closes vim/vim#12095)

https://github.com/vim/vim/commit/db1887ce40452daea8c4e8734ec64202e5f24130

Co-authored-by: James McCoy <jamessan@jamessan.com>