### PR TITLE
vimpatch/tests

### DIFF
--- a/test/old/testdir/test_filter_cmd.vim
+++ b/test/old/testdir/test_filter_cmd.vim
@@ -142,6 +142,11 @@ func Test_filter_commands()
   let res = split(execute("filter /\.c$/ marks"), "\n")[1:]
   call assert_equal([" A      1    0 file.c"], res)
 
+  " Test filtering :highlight command
+  highlight MyHlGroup ctermfg=10
+  let res = split(execute("filter /MyHlGroup/ highlight"), "\n")
+  call assert_equal(["MyHlGroup      xxx ctermfg=10"], res)
+
   call setline(1, ['one', 'two', 'three'])
   1mark a
   2mark b

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -766,6 +766,55 @@ func Test_xxlast_highlight_RGB_color()
   hi clear
 endfunc
 
+" Test for using default highlighting group
+func Test_highlight_default()
+  highlight MySearch ctermfg=7
+  highlight default MySearch ctermfg=5
+  let hlSearch = HighlightArgs('MySearch')
+  call assert_match('ctermfg=7', hlSearch)
+
+  highlight default QFName ctermfg=3
+  call assert_match('ctermfg=3', HighlightArgs('QFName'))
+  hi clear
+endfunc
+
+" Test for 'ctermul in a highlight group
+func Test_highlight_ctermul()
+  throw 'Skipped: Nvim does not have ctermul='
+
+  CheckNotGui
+  call assert_notmatch('ctermul=', HighlightArgs('Normal'))
+  highlight Normal ctermul=3
+  call assert_match('ctermul=3', HighlightArgs('Normal'))
+  highlight Normal ctermul=NONE
+endfunc
+
+" Test for specifying 'start' and 'stop' in a highlight group
+func Test_highlight_start_stop()
+  throw 'Skipped: Nvim does not have start= or stop='
+
+  hi HlGrp1 start=<Esc>[27h;<Esc>[<Space>r;
+  call assert_match("start=^[[27h;^[[ r;", HighlightArgs('HlGrp1'))
+  hi HlGrp1 start=NONE
+  call assert_notmatch("start=", HighlightArgs('HlGrp1'))
+  hi HlGrp2 stop=<Esc>[27h;<Esc>[<Space>r;
+  call assert_match("stop=^[[27h;^[[ r;", HighlightArgs('HlGrp2'))
+  hi HlGrp2 stop=NONE
+  call assert_notmatch("stop=", HighlightArgs('HlGrp2'))
+  hi clear
+endfunc
+
+" Test for setting various 'term' attributes
+func Test_highlight_term_attr()
+  throw 'Skipped: Nvim does not have underline, etc on term='
+
+  hi HlGrp3 term=bold,underline,undercurl,strikethrough,reverse,italic,standout
+  call assert_equal('hi HlGrp3          term=bold,standout,underline,undercurl,italic,reverse,strikethrough', HighlightArgs('HlGrp3'))
+  hi HlGrp3 term=NONE
+  call assert_equal('hi HlGrp3          cleared', HighlightArgs('HlGrp3'))
+  hi clear
+endfunc
+
 func Test_highlight_clear_restores_links()
   let aaa_id = hlID('aaa')
   call assert_equal(aaa_id, 0)

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -190,3 +190,50 @@ func Test_unicode()
 
   set encoding=utf8
 endfunc
+
+" Test range objects, see :help python-range
+func Test_range()
+  new
+  py3 b = vim.current.buffer
+
+  call setline(1, range(1, 6))
+  py3 r = b.range(2, 4)
+  call assert_equal(6, py3eval('len(b)'))
+  call assert_equal(3, py3eval('len(r)'))
+  call assert_equal('3', py3eval('b[2]'))
+  call assert_equal('4', py3eval('r[2]'))
+
+  call assert_fails('py3 r[3] = "x"', 'IndexError: line number out of range')
+  call assert_fails('py3 x = r[3]', 'IndexError: line number out of range')
+  call assert_fails('py3 r["a"] = "x"', 'TypeError')
+  call assert_fails('py3 x = r["a"]', 'TypeError')
+
+  py3 del r[:]
+  call assert_equal(['1', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 6))
+  py3 r = b.range(2, 5)
+  py3 del r[2]
+  call assert_equal(['1', '2', '3', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 6))
+  py3 r = b.range(2, 4)
+  py3 vim.command("%d,%dnorm Ax" % (r.start + 1, r.end + 1))
+  call assert_equal(['1', '2x', '3x', '4x', '5', '6'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 4))
+  py3 r = b.range(2, 3)
+  py3 r.append(['a', 'b'])
+  call assert_equal(['1', '2', '3', 'a', 'b', '4'], getline(1, '$'))
+  py3 r.append(['c', 'd'], 0)
+  call assert_equal(['1', 'c', 'd', '2', '3', 'a', 'b', '4'], getline(1, '$'))
+
+  %d | call setline(1, range(1, 5))
+  py3 r = b.range(2, 4)
+  py3 r.append('a')
+  call assert_equal(['1', '2', '3', '4', 'a', '5'], getline(1, '$'))
+  py3 r.append('b', 1)
+  call assert_equal(['1', '2', 'b', '3', '4', 'a', '5'], getline(1, '$'))
+
+  bwipe!
+endfunc


### PR DESCRIPTION
- vim-patch:8.2.0130: Python3 ranges are not tested
- vim-patch:8.2.1097: highlight code not sufficiently tested
