### PR TITLE
ci: run commitlinter with cmake

### DIFF
--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -13,7 +13,15 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: rhysd/action-setup-vim@v1
-        with:
-          neovim: true
-      - run: nvim --clean -l scripts/lintcommit.lua main
+
+      - run: ./.github/scripts/install_deps.sh
+      - uses: ./.github/actions/cache
+      - name: Build
+        run: |
+          cmake -S cmake.deps -B .deps -G Ninja
+          cmake --build .deps
+          cmake --preset ci
+          cmake --build build
+
+      - name: lintcommit
+        run: cmake --build build --target lintcommit


### PR DESCRIPTION
This increases CI time, but prevents situations where it works on CI but
not locally.
