### PR TITLE
vim-patch:8.2.{0551,0578,0672}: heredoc for interfaces does not support "trim"

### DIFF
--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -19,7 +19,7 @@ See |provider-perl| for more information.
 			working: >
 				:perl print "Hello"
 
-:[range]perl << [endmarker]
+:[range]perl << [trim] [{endmarker}]
 {script}
 {endmarker}
 			Execute perl script {script}.

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -19,17 +19,16 @@ Commands						*python-commands*
 			the `:python` command is working: >vim
 				:python print "Hello"
 
-:[range]py[thon] << [endmarker]
+:[range]py[thon] << [trim] [{endmarker}]
 {script}
 {endmarker}
 			Execute Python script {script}.  Useful for including
 			python code in Vim scripts.  Requires Python, see
 			|script-here|.
 
-The {endmarker} below the {script} must NOT be preceded by any white space.
-
 If [endmarker] is omitted from after the "<<", a dot '.' must be used after
-{script}, like for the |:append| and |:insert| commands.
+{script}, like for the |:append| and |:insert| commands.  Refer to
+|:let-heredoc| for more information.
 
 Example: >vim
 	function! IcecreamInitialize()
@@ -597,12 +596,12 @@ variants explicitly if Python 3 is required.
 
 							*:py3* *:python3*
 :[range]py3 {stmt}
-:[range]py3 << [endmarker]
+:[range]py3 << [trim] [{endmarker}]
 {script}
 {endmarker}
 
 :[range]python3 {stmt}
-:[range]python3 << [endmarker]
+:[range]python3 << [trim] [{endmarker}]
 {script}
 {endmarker}
 	The `:py3` and `:python3` commands work similar to `:python`.  A

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -19,15 +19,15 @@ downloading Ruby there.
 :rub[y] {cmd}		Execute Ruby command {cmd}.  A command to try it out: >
 				:ruby print "Hello"
 
-:rub[y] << [endmarker]
+:rub[y] << [trim] [{endmarker}]
 {script}
 {endmarker}
 			Execute Ruby script {script}.
-			The {endmarker} after {script} must NOT be preceded by
-			any white space.
 
 			If [endmarker] is omitted, it defaults to a dot '.'
-			like for the |:append| and |:insert| commands.
+			like for the |:append| and |:insert| commands.  Refer
+			to |:let-heredoc| for more information.
+
 
 			This form of the |:ruby| command is mainly useful for
 			including ruby code in vim scripts.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -247,12 +247,12 @@ arguments separated by " " (space) instead of "\t" (tab).
         :lua =jit.version
 <
                                                                 *:lua-heredoc*
-:lua << [endmarker]
+:lua << [trim] [{endmarker}]
 {script}
 {endmarker}
-    Executes Lua script {script} from within Vimscript. {endmarker} must NOT
-    be preceded by whitespace. You can omit [endmarker] after the "<<" and use
-    a dot "." after {script} (similar to |:append|, |:insert|).
+    Executes Lua script {script} from within Vimscript. You can omit
+    [endmarker] after the "<<" and use a dot "." after {script} (similar to
+    |:append|, |:insert|). Refer to |let-heredoc| for more information.
 
     Example: >vim
         function! CurrentLineInfo()

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2571,11 +2571,18 @@ void ex_function(exarg_T *eap)
                   && (!ASCII_ISALPHA(p[2]) || p[2] == 's')))) {
         // ":python <<" continues until a dot, like ":append"
         p = skipwhite(arg + 2);
+        if (strncmp(p, "trim", 4) == 0) {
+          // Ignore leading white space.
+          p = skipwhite(p + 4);
+          heredoc_trimmed = xstrnsave(theline, (size_t)(skipwhite(theline) - theline));
+        }
         if (*p == NUL) {
           skip_until = xstrdup(".");
         } else {
-          skip_until = xstrdup(p);
+          skip_until = xstrnsave(p, (size_t)(skiptowhite(p) - p));
         }
+        do_concat = false;
+        is_heredoc = true;
       }
 
       // Check for ":let v =<< [trim] EOF"

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -214,7 +214,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
       return NULL;
     }
     *p = NUL;
-    if (islower((uint8_t)(*marker))) {
+    if (!script_get && islower((uint8_t)(*marker))) {
       emsg(_("E221: Marker cannot start with lower case letter"));
       return NULL;
     }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -163,7 +163,6 @@ char *eval_all_expr_in_str(char *str)
 list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
 {
   char *marker;
-  char *p;
   int marker_indent_len = 0;
   int text_indent_len = 0;
   char *text_indent = NULL;
@@ -187,7 +186,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
       // The amount of indentation trimmed is the same as the indentation
       // of the first line after the :let command line.  To find the end
       // marker the indent of the :let command line is trimmed.
-      p = *eap->cmdlinep;
+      char *p = *eap->cmdlinep;
       while (ascii_iswhite(*p)) {
         p++;
         marker_indent_len++;
@@ -208,7 +207,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
   // The marker is the next word.
   if (*cmd != NUL && *cmd != '"') {
     marker = skipwhite(cmd);
-    p = skiptowhite(marker);
+    char *p = skiptowhite(marker);
     if (*skipwhite(p) != NUL && *skipwhite(p) != '"') {
       semsg(_(e_trailing_arg), p);
       return NULL;
@@ -238,7 +237,9 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
     xfree(theline);
     theline = eap->getline(NUL, eap->cookie, 0, false);
     if (theline == NULL) {
-      semsg(_("E990: Missing end marker '%s'"), marker);
+      if (!script_get) {
+        semsg(_("E990: Missing end marker '%s'"), marker);
+      }
       break;
     }
 
@@ -260,7 +261,7 @@ list_T *heredoc_get(exarg_T *eap, char *cmd, bool script_get)
 
     if (text_indent_len == -1 && *theline != NUL) {
       // set the text indent from the first line.
-      p = theline;
+      char *p = theline;
       text_indent_len = 0;
       while (ascii_iswhite(*p)) {
         p++;

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1619,7 +1619,7 @@ void ex_lua(exarg_T *const eap)
 {
   size_t len;
   char *code = script_get(eap, &len);
-  if (eap->skip) {
+  if (eap->skip || code == NULL) {
     xfree(code);
     return;
   }

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -7,6 +7,7 @@ local NIL = helpers.NIL
 local eval = helpers.eval
 local feed = helpers.feed
 local clear = helpers.clear
+local matches = helpers.matches
 local meths = helpers.meths
 local exec_lua = helpers.exec_lua
 local exec_capture = helpers.exec_capture
@@ -27,22 +28,27 @@ describe(':lua command', function()
     eq('', exec_capture(
       'lua vim.api.nvim_buf_set_lines(1, 1, 2, false, {"TEST"})'))
     eq({'', 'TEST'}, curbufmeths.get_lines(0, 100, false))
-    source(dedent([[
+    source([[
       lua << EOF
         vim.api.nvim_buf_set_lines(1, 1, 2, false, {"TSET"})
-      EOF]]))
+      EOF]])
     eq({'', 'TSET'}, curbufmeths.get_lines(0, 100, false))
-    source(dedent([[
+    source([[
       lua << EOF
-        vim.api.nvim_buf_set_lines(1, 1, 2, false, {"SETT"})]]))
+        vim.api.nvim_buf_set_lines(1, 1, 2, false, {"SETT"})]])
     eq({'', 'SETT'}, curbufmeths.get_lines(0, 100, false))
-    source(dedent([[
+    source([[
       lua << EOF
         vim.api.nvim_buf_set_lines(1, 1, 2, false, {"ETTS"})
         vim.api.nvim_buf_set_lines(1, 2, 3, false, {"TTSE"})
         vim.api.nvim_buf_set_lines(1, 3, 4, false, {"STTE"})
-      EOF]]))
+      EOF]])
     eq({'', 'ETTS', 'TTSE', 'STTE'}, curbufmeths.get_lines(0, 100, false))
+    matches('.*Vim%(lua%):E15: Invalid expression: .*', pcall_err(source, [[
+      lua << eval EOF
+        {}
+      EOF
+    ]]))
   end)
   it('throws catchable errors', function()
     eq([[Vim(lua):E5107: Error loading lua [string ":lua"]:0: unexpected symbol near ')']],

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -321,8 +321,53 @@ func Test_set_completion()
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
-
   set tags&
+
+  " Expanding the option names
+  call feedkeys(":set \<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set all', @:)
+
+  " Expanding a second set of option names
+  call feedkeys(":set wrapscan \<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set wrapscan all', @:)
+
+  " Expanding a special keycode
+  " call feedkeys(":set <Home>\<Tab>\<C-B>\"\<CR>", 'xt')
+  " call assert_equal('"set <Home>', @:)
+
+  " Expanding an invalid special keycode
+  call feedkeys(":set <abcd>\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set <abcd>\<Tab>", @:)
+
+  " Expanding a terminal keycode
+  " call feedkeys(":set t_AB\<Tab>\<C-B>\"\<CR>", 'xt')
+  " call assert_equal("\"set t_AB", @:)
+
+  " Expanding an invalid option name
+  call feedkeys(":set abcde=\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set abcde=\<Tab>", @:)
+
+  " Expanding after a = for a boolean option
+  call feedkeys(":set wrapscan=\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set wrapscan=\<Tab>", @:)
+
+  " Expanding a numeric option
+  call feedkeys(":set tabstop+=\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set tabstop+=" .. &tabstop, @:)
+
+  " Expanding a non-boolean option
+  call feedkeys(":set invtabstop=\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set invtabstop=", @:)
+
+  " Expand options for 'spellsuggest'
+  call feedkeys(":set spellsuggest=best,file:xyz\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"set spellsuggest=best,file:xyz", @:)
+
+  " Expand value for 'key'
+  " set key=abcd
+  " call feedkeys(":set key=\<Tab>\<C-B>\"\<CR>", 'xt')
+  " call assert_equal('"set key=*****', @:)
+  " set key=
 
   " Expand values for 'filetype'
   call feedkeys(":set filetype=sshdconfi\<Tab>\<C-B>\"\<CR>", 'xt')
@@ -411,7 +456,14 @@ func Test_set_errors()
   set backupext& patchmode&
 
   call assert_fails('set winminheight=10 winheight=9', 'E591:')
+  set winminheight& winheight&
+  set winheight=10 winminheight=10
+  call assert_fails('set winheight=9', 'E591:')
+  set winminheight& winheight&
   call assert_fails('set winminwidth=10 winwidth=9', 'E592:')
+  set winminwidth& winwidth&
+  call assert_fails('set winwidth=9 winminwidth=10', 'E592:')
+  set winwidth& winminwidth&
   call assert_fails("set showbreak=\x01", 'E595:')
   call assert_fails('set t_foo=', 'E846:')
   call assert_fails('set tabstop??', 'E488:')
@@ -944,7 +996,9 @@ endfunc
 func Test_opt_sandbox()
   for opt in ['backupdir', 'cdpath', 'exrc']
     call assert_fails('sandbox set ' .. opt .. '?', 'E48:')
+    call assert_fails('sandbox let &' .. opt .. ' = 1', 'E48:')
   endfor
+  call assert_fails('sandbox let &modelineexpr = 1', 'E48:')
 endfunc
 
 " Test for setting an option with local value to global value

--- a/test/old/testdir/test_perl.vim
+++ b/test/old/testdir/test_perl.vim
@@ -224,11 +224,11 @@ endfunc
 func Test_stdio()
   throw 'skipped: TODO: '
   redir =>l:out
-  perl <<EOF
+  perl << trim EOF
     VIM::Msg("&VIM::Msg");
     print "STDOUT";
     print STDERR "STDERR";
-EOF
+  EOF
   redir END
   call assert_equal(['&VIM::Msg', 'STDOUT', 'STDERR'], split(l:out, "\n"))
 endfunc
@@ -305,7 +305,13 @@ END
   perl <<
 VIM::DoCommand('let s ..= "B"')
 .
-  call assert_equal('AB', s)
+  perl << trim END
+    VIM::DoCommand('let s ..= "C"')
+  END
+  perl << trim
+    VIM::DoCommand('let s ..= "D"')
+  .
+  call assert_equal('ABCD', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_perl.vim
+++ b/test/old/testdir/test_perl.vim
@@ -311,7 +311,10 @@ VIM::DoCommand('let s ..= "B"')
   perl << trim
     VIM::DoCommand('let s ..= "D"')
   .
-  call assert_equal('ABCD', s)
+  perl << trim eof
+    VIM::DoCommand('let s ..= "E"')
+  eof
+  call assert_equal('ABCDE', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python2.vim
+++ b/test/old/testdir/test_python2.vim
@@ -40,7 +40,7 @@ func Test_set_cursor()
 endfunc
 
 func Test_vim_function()
-  throw 'skipped: Nvim does not support vim.bindeval()'
+  throw 'Skipped: Nvim does not support vim.bindeval()'
   " Check creating vim.Function object
   py import vim
 

--- a/test/old/testdir/test_python2.vim
+++ b/test/old/testdir/test_python2.vim
@@ -186,7 +186,10 @@ s+='B'
   python << trim
     s+='D'
   .
-  call assert_equal('ABCD', pyxeval('s'))
+  python << trim eof
+    s+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python2.vim
+++ b/test/old/testdir/test_python2.vim
@@ -171,3 +171,22 @@ func Test_Catch_Exception_Message()
     call assert_match('^Vim(.*):.*RuntimeError: TEST$', v:exception )
   endtry
 endfunc
+
+" Test for various heredoc syntax
+func Test_python_heredoc()
+  python << END
+s='A'
+END
+  python <<
+s+='B'
+.
+  python << trim END
+    s+='C'
+  END
+  python << trim
+    s+='D'
+  .
+  call assert_equal('ABCD', pyxeval('s'))
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -40,7 +40,7 @@ func Test_set_cursor()
 endfunc
 
 func Test_vim_function()
-  throw 'skipped: Nvim does not support vim.bindeval()'
+  throw 'Skipped: Nvim does not support vim.bindeval()'
   " Check creating vim.Function object
   py3 import vim
 
@@ -68,7 +68,7 @@ func Test_vim_function()
 endfunc
 
 func Test_skipped_python3_command_does_not_affect_pyxversion()
-  throw 'skipped: Nvim hardcodes pyxversion=3'
+  throw 'Skipped: Nvim hardcodes pyxversion=3'
   set pyxversion=0
   if 0
     python3 import vim
@@ -190,3 +190,77 @@ func Test_unicode()
 
   set encoding=utf8
 endfunc
+
+" Test for resetting options with local values to global values
+func Test_python3_opt_reset_local_to_global()
+  throw 'Skipped: Nvim does not support vim.bindeval()'
+  new
+
+  py3 curbuf = vim.current.buffer
+  py3 curwin = vim.current.window
+
+  " List of buffer-local options. Each list item has [option name, global
+  " value, buffer-local value, buffer-local value after reset] to use in the
+  " test.
+  let bopts = [
+        \ ['autoread', 1, 0, -1],
+        \ ['equalprg', 'geprg', 'leprg', ''],
+        \ ['keywordprg', 'gkprg', 'lkprg', ''],
+        \ ['path', 'gpath', 'lpath', ''],
+        \ ['backupcopy', 'yes', 'no', ''],
+        \ ['tags', 'gtags', 'ltags', ''],
+        \ ['tagcase', 'ignore', 'match', ''],
+        \ ['define', 'gdef', 'ldef', ''],
+        \ ['include', 'ginc', 'linc', ''],
+        \ ['dict', 'gdict', 'ldict', ''],
+        \ ['thesaurus', 'gtsr', 'ltsr', ''],
+        \ ['formatprg', 'gfprg', 'lfprg', ''],
+        \ ['errorformat', '%f:%l:%m', '%s-%l-%m', ''],
+        \ ['grepprg', 'ggprg', 'lgprg', ''],
+        \ ['makeprg', 'gmprg', 'lmprg', ''],
+        \ ['balloonexpr', 'gbexpr', 'lbexpr', ''],
+        \ ['cryptmethod', 'blowfish2', 'zip', ''],
+        \ ['lispwords', 'abc', 'xyz', ''],
+        \ ['makeencoding', 'utf-8', 'latin1', ''],
+        \ ['undolevels', 100, 200, -123456]]
+
+  " Set the global and buffer-local option values and then clear the
+  " buffer-local option value.
+  for opt in bopts
+    py3 pyopt = vim.bindeval("opt")
+    py3 vim.options[pyopt[0]] = pyopt[1]
+    py3 curbuf.options[pyopt[0]] = pyopt[2]
+    exe "call assert_equal(opt[2], &" .. opt[0] .. ")"
+    exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
+    exe "call assert_equal(opt[2], &l:" .. opt[0] .. ")"
+    py3 del curbuf.options[pyopt[0]]
+    exe "call assert_equal(opt[1], &" .. opt[0] .. ")"
+    exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
+    exe "call assert_equal(opt[3], &l:" .. opt[0] .. ")"
+    exe "set " .. opt[0] .. "&"
+  endfor
+
+  " Set the global and window-local option values and then clear the
+  " window-local option value.
+  let wopts = [
+        \ ['scrolloff', 5, 10, -1],
+        \ ['sidescrolloff', 6, 12, -1],
+        \ ['statusline', '%<%f', '%<%F', '']]
+  for opt in wopts
+    py3 pyopt = vim.bindeval("opt")
+    py3 vim.options[pyopt[0]] = pyopt[1]
+    py3 curwin.options[pyopt[0]] = pyopt[2]
+    exe "call assert_equal(opt[2], &" .. opt[0] .. ")"
+    exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
+    exe "call assert_equal(opt[2], &l:" .. opt[0] .. ")"
+    py3 del curwin.options[pyopt[0]]
+    exe "call assert_equal(opt[1], &" .. opt[0] .. ")"
+    exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
+    exe "call assert_equal(opt[3], &l:" .. opt[0] .. ")"
+    exe "set " .. opt[0] .. "&"
+  endfor
+
+  close!
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -281,7 +281,10 @@ s+='B'
   python3 << trim
     s+='D'
   .
-  call assert_equal('ABCD', pyxeval('s'))
+  python3 << trim eof
+    s+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -227,9 +227,11 @@ func Test_python3_opt_reset_local_to_global()
   " Set the global and buffer-local option values and then clear the
   " buffer-local option value.
   for opt in bopts
-    py3 pyopt = vim.bindeval("opt")
-    py3 vim.options[pyopt[0]] = pyopt[1]
-    py3 curbuf.options[pyopt[0]] = pyopt[2]
+    py3 << trim END
+      pyopt = vim.bindeval("opt")
+      vim.options[pyopt[0]] = pyopt[1]
+      curbuf.options[pyopt[0]] = pyopt[2]
+    END
     exe "call assert_equal(opt[2], &" .. opt[0] .. ")"
     exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
     exe "call assert_equal(opt[2], &l:" .. opt[0] .. ")"
@@ -247,9 +249,11 @@ func Test_python3_opt_reset_local_to_global()
         \ ['sidescrolloff', 6, 12, -1],
         \ ['statusline', '%<%f', '%<%F', '']]
   for opt in wopts
-    py3 pyopt = vim.bindeval("opt")
-    py3 vim.options[pyopt[0]] = pyopt[1]
-    py3 curwin.options[pyopt[0]] = pyopt[2]
+    py3 << trim
+      pyopt = vim.bindeval("opt")
+      vim.options[pyopt[0]] = pyopt[1]
+      curwin.options[pyopt[0]] = pyopt[2]
+    .
     exe "call assert_equal(opt[2], &" .. opt[0] .. ")"
     exe "call assert_equal(opt[1], &g:" .. opt[0] .. ")"
     exe "call assert_equal(opt[2], &l:" .. opt[0] .. ")"
@@ -261,6 +265,23 @@ func Test_python3_opt_reset_local_to_global()
   endfor
 
   close!
+endfunc
+
+" Test for various heredoc syntax
+func Test_python3_heredoc()
+  python3 << END
+s='A'
+END
+  python3 <<
+s+='B'
+.
+  python3 << trim END
+    s+='C'
+  END
+  python3 << trim
+    s+='D'
+  .
+  call assert_equal('ABCD', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_pyx2.vim
+++ b/test/old/testdir/test_pyx2.vim
@@ -94,7 +94,10 @@ result+='B'
   pyx << trim
     result+='D'
   .
-  call assert_equal('ABCD', pyxeval('result'))
+  pyx << trim eof
+    result+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('result'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_pyx2.vim
+++ b/test/old/testdir/test_pyx2.vim
@@ -15,10 +15,10 @@ endfunc
 
 func Test_pyx()
   redir => var
-  pyx << EOF
-import sys
-print(sys.version)
-EOF
+  pyx << trim EOF
+    import sys
+    print(sys.version)
+  EOF
   redir END
   call assert_match(s:py2pattern, split(var)[0])
 endfunc
@@ -79,3 +79,22 @@ func Test_Catch_Exception_Message()
     call assert_match('^Vim(.*):.*RuntimeError: TEST$', v:exception )
   endtry
 endfunc
+
+" Test for various heredoc syntaxes
+func Test_pyx2_heredoc()
+  pyx << END
+result='A'
+END
+  pyx <<
+result+='B'
+.
+  pyx << trim END
+    result+='C'
+  END
+  pyx << trim
+    result+='D'
+  .
+  call assert_equal('ABCD', pyxeval('result'))
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_pyx3.vim
+++ b/test/old/testdir/test_pyx3.vim
@@ -94,7 +94,10 @@ result+='B'
   pyx << trim
     result+='D'
   .
-  call assert_equal('ABCD', pyxeval('result'))
+  pyx << trim eof
+    result+='E'
+  eof
+  call assert_equal('ABCDE', pyxeval('result'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_pyx3.vim
+++ b/test/old/testdir/test_pyx3.vim
@@ -15,10 +15,10 @@ endfunc
 
 func Test_pyx()
   redir => var
-  pyx << EOF
-import sys
-print(sys.version)
-EOF
+  pyx << trim EOF
+    import sys
+    print(sys.version)
+  EOF
   redir END
   call assert_match(s:py3pattern, split(var)[0])
 endfunc
@@ -79,3 +79,22 @@ func Test_Catch_Exception_Message()
     call assert_match('^Vim(.*):.*RuntimeError: TEST$', v:exception )
   endtry
 endfunc
+
+" Test for various heredoc syntaxes
+func Test_pyx3_heredoc()
+  pyx << END
+result='A'
+END
+  pyx <<
+result+='B'
+.
+  pyx << trim END
+    result+='C'
+  END
+  pyx << trim
+    result+='D'
+  .
+  call assert_equal('ABCD', pyxeval('result'))
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ruby.vim
+++ b/test/old/testdir/test_ruby.vim
@@ -341,11 +341,11 @@ func Test_ruby_Vim_evaluate_list()
   call setline(line('$'), ['2 line 2'])
   ruby Vim.command("normal /^2\n")
   let l = ["abc", "def"]
-  ruby << EOF
-  curline = $curbuf.line_number
-  l = Vim.evaluate("l");
-  $curbuf.append(curline, l.join("|"))
-EOF
+  ruby << trim EOF
+    curline = $curbuf.line_number
+    l = Vim.evaluate("l");
+    $curbuf.append(curline, l.join("|"))
+  EOF
   normal j
   .rubydo $_ = $_.gsub(/\|/, '/')
   call assert_equal('abc/def', getline('$'))
@@ -412,6 +412,23 @@ func Test_rubyeval_error()
   "   "SyntaxError: array length must be 2"
   " Unclear why. The test does not check the error message.
   call assert_fails('call rubyeval("(")')
+endfunc
+
+" Test for various heredoc syntax
+func Test_ruby_heredoc()
+  ruby << END
+Vim.command('let s = "A"')
+END
+  ruby <<
+Vim.command('let s ..= "B"')
+.
+  ruby << trim END
+    Vim.command('let s ..= "C"')
+  END
+  ruby << trim
+    Vim.command('let s ..= "D"')
+  .
+  call assert_equal('ABCD', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ruby.vim
+++ b/test/old/testdir/test_ruby.vim
@@ -428,7 +428,10 @@ Vim.command('let s ..= "B"')
   ruby << trim
     Vim.command('let s ..= "D"')
   .
-  call assert_equal('ABCD', s)
+  ruby << trim eof
+    Vim.command('let s ..= "E"')
+  eof
+  call assert_equal('ABCDE', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -126,6 +126,11 @@ func Test_global_local_undolevels()
   call assert_equal(50, &g:undolevels)
   call assert_equal(-123456, &l:undolevels)
 
+  " Resetting the local 'undolevels' value to use the global value
+  setlocal undolevels=5
+  setlocal undolevels<
+  call assert_equal(-123456, &l:undolevels)
+
   " Drop created windows
   set ul&
   new

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -6705,6 +6705,11 @@ func Test_echo_and_string()
     let l = split(result, "\n")
     call assert_equal(["{'a': [], 'b': []}",
 		     \ "{'a': [], 'b': []}"], l)
+
+    call assert_fails('echo &:', 'E112:')
+    call assert_fails('echo &g:', 'E112:')
+    call assert_fails('echo &l:', 'E112:')
+
 endfunc
 
 "-------------------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:8.2.0551: not all code for options is tested

Problem:    Not all code for options is tested.
Solution:   Add more tests. (Yegappan Lakshmanan, closes vim/vim#5913)

https://github.com/vim/vim/commit/1363a30cef382b912bf092969e040333c5c293c6


#### vim-patch:8.2.0578: heredoc for interfaces does not support "trim"

Problem:    Heredoc for interfaces does not support "trim".
Solution:   Update the script heredoc support to be same as the :let command.
            (Yegappan Lakshmanan, closes vim/vim#5916)

https://github.com/vim/vim/commit/6c2b7b8055b96463f78abb70f58c4c6d6d4b9d55


#### vim-patch:8.2.0672: heredoc in scripts does not accept lower case marker

Problem:    Heredoc in scripts does not accept lower case marker.
Solution:   Allow lower case only in non-Vim scripts. (Ken Takata,
            closes vim/vim#6019)

https://github.com/vim/vim/commit/6ab0953fefe31fef91e40752a675ceb60fc2fe03