### PR TITLE
ci: make install_deps.sh more flexible

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
 
+SUDO="sudo"
+
+while (($# > 0)); do
+  case $1 in
+  --test) # install test dependencies
+    TEST=1
+    shift
+    ;;
+  --container) # don't use sudo
+    SUDO=""
+    shift
+    ;;
+  esac
+done
+
 os=$(uname -s)
 if [[ $os == Linux ]]; then
-  sudo apt-get update
-  sudo apt-get install -y build-essential cmake curl gettext locales-all ninja-build pkg-config unzip "$@"
+  $SUDO apt-get update
+  $SUDO apt-get install -y build-essential cmake curl gettext ninja-build pkg-config unzip
+  if [[ -n $TEST ]]; then
+    $SUDO apt-get install -y locales-all cpanminus
+  fi
 elif [[ $os == Darwin ]]; then
   brew update --quiet
-  brew install ninja "$@"
+  brew install ninja
+  if [[ -n $TEST ]]; then
+    brew install cpanminus
+  fi
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y build-essential cmake gettext ninja-build unzip
+      - run: ./.github/scripts/install_deps.sh --container
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: |
           echo 'NVIM_BUILD_TYPE=Release' >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ./.github/scripts/install_deps.sh lua-check
+          ./.github/scripts/install_deps.sh
           brew install stylua uncrustify
 
       - uses: ./.github/actions/cache
@@ -141,7 +141,7 @@ jobs:
         run: mkdir -p "$LOG_DIR"
 
       - name: Install dependencies
-        run: ./.github/scripts/install_deps.sh cpanminus
+        run: ./.github/scripts/install_deps.sh --test
 
       - name: Setup interpreter packages
         run: |


### PR DESCRIPTION
This will allow us to use it in containers as well as specify whether we
want to install test dependencies.
