### PR TITLE
vim.ui.open: "gx" without netrw

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2343,6 +2343,30 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                       typed (it might be an empty string if nothing was
                       entered), or `nil` if the user aborted the dialog.
 
+open({path})                                                   *vim.ui.open()*
+    Opens a path in the system's default handler. This function utilizes
+    `xdg-open`, `wslview`, `explorer`, or `open` commands depending on the
+    system to open the provided path.
+
+    Notifies the user if unsuccessful
+
+    Example: >lua
+
+     vim.ui.open("https://neovim.io/")
+
+     vim.ui.open("/path/to/file")
+<
+
+    Parameters: ~
+      • {path}  (string) Path to be opened
+
+    Return: ~
+        SystemCompleted|nil result Result of command, if an appropriate one
+        could be found.
+
+    See also: ~
+      • |vim.system|
+
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
     Prompts the user to pick from a list of items, allowing arbitrary
     (potentially asynchronous) work until `on_choice`.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2344,28 +2344,26 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
                       entered), or `nil` if the user aborted the dialog.
 
 open({path})                                                   *vim.ui.open()*
-    Opens a path in the system's default handler. This function utilizes
-    `xdg-open`, `wslview`, `explorer`, or `open` commands depending on the
-    system to open the provided path.
+    Opens `path` with the system default handler (macOS `open`, Windows
+    `explorer.exe`, Linux `xdg-open`, …), or shows a message on failure.
 
-    Notifies the user if unsuccessful
+    Expands "~/" and environment variables in filesystem paths.
 
-    Example: >lua
+    Examples: >lua
 
      vim.ui.open("https://neovim.io/")
-
-     vim.ui.open("/path/to/file")
+     vim.ui.open("~/path/to/file")
+     vim.ui.open("$VIMRUNTIME")
 <
 
     Parameters: ~
-      • {path}  (string) Path to be opened
+      • {path}  (string) Path or URL to open
 
     Return: ~
-        SystemCompleted|nil result Result of command, if an appropriate one
-        could be found.
+        SystemCompleted|nil result Command result, or nil if not found.
 
     See also: ~
-      • |vim.system|
+      • |vim.system()|
 
 select({items}, {opts}, {on_choice})                         *vim.ui.select()*
     Prompts the user to pick from a list of items, allowing arbitrary

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2345,7 +2345,8 @@ input({opts}, {on_confirm})                                   *vim.ui.input()*
 
 open({path})                                                   *vim.ui.open()*
     Opens `path` with the system default handler (macOS `open`, Windows
-    `explorer.exe`, Linux `xdg-open`, …), or shows a message on failure.
+    `explorer.exe`, Linux `xdg-open`, …), or returns (but does not show) an
+    error message on failure.
 
     Expands "~/" and environment variables in filesystem paths.
 
@@ -2360,7 +2361,8 @@ open({path})                                                   *vim.ui.open()*
       • {path}  (string) Path or URL to open
 
     Return: ~
-        SystemCompleted|nil result Command result, or nil if not found.
+        SystemCompleted|nil # Command result, or nil if not found.
+        (string|nil) # Error message on failure
 
     See also: ~
       • |vim.system()|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -107,6 +107,9 @@ The following new APIs and features were added.
 • Bundled treesitter parser and queries (highlight, folds) for Markdown,
 Python, and Bash.
 
+• |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
+Windows `explorer`, Linux `xdg-open`, etc.)
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 
@@ -142,6 +145,9 @@ The following changes to existing APIs or features add new behavior.
   defined by the 'foldenable' option.
 
 • |:Man| now respects 'wrapmargin'
+
+• The |gx| command now uses |vim.ui.open()| and not netrw. Continue using
+netrw with `vim.g.use_lua_gx = false`.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -105,10 +105,10 @@ The following new APIs and features were added.
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
 
 • Bundled treesitter parser and queries (highlight, folds) for Markdown,
-Python, and Bash.
+  Python, and Bash.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
-Windows `explorer`, Linux `xdg-open`, etc.)
+  Windows `explorer`, Linux `xdg-open`, etc.)
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
@@ -146,8 +146,9 @@ The following changes to existing APIs or features add new behavior.
 
 • |:Man| now respects 'wrapmargin'
 
-• The |gx| command now uses |vim.ui.open()| and not netrw. Continue using
-netrw with `vim.g.use_lua_gx = false`.
+• |gx| now uses |vim.ui.open()| and not netrw. To customize, you can redefine
+  `vim.ui.open` or remap `gx`. To continue using netrw (deprecated): >vim
+  :call netrw#BrowseX(expand(exists("g:netrw_gx")? g:netrw_gx : '<cfile>'), netrw#CheckIfRemote())<CR>
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -97,6 +97,14 @@ g8			Print the hex values of the bytes used in the
 			cursor is halfway through a multibyte character the
 			command won't move the cursor.
 
+							*gx*
+gx			Open the current path or URL under the cursor in the 
+			system's default handler with |vim.ui.open|.
+
+			To use the netrw keymap, set `use_lua_gx` to false:
+>lua
+    vim.g.use_lua_gx = false
+<
 						*:p* *:pr* *:print* *E749*
 :[range]p[rint] [flags]
 			Print [range] lines (default current line).

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -98,13 +98,14 @@ g8			Print the hex values of the bytes used in the
 			command won't move the cursor.
 
 							*gx*
-gx			Open the current path or URL under the cursor in the 
-			system's default handler with |vim.ui.open|.
+gx			Opens the current filepath or URL (decided by
+			|<cfile>|, 'isfname') at cursor using the system
+			default handler, by calling |vim.ui.open()|.
 
-			To use the netrw keymap, set `use_lua_gx` to false:
->lua
-    vim.g.use_lua_gx = false
-<
+							*v_gx*
+{Visual}gx		Opens the selected text using the system default
+			handler, by calling |vim.ui.open()|.
+
 						*:p* *:pr* *:print* *E749*
 :[range]p[rint] [flags]
 			Print [range] lines (default current line).

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -573,22 +573,15 @@ M['window/showDocument'] = function(_, result, ctx, _)
 
   if result.external then
     -- TODO(lvimuser): ask the user for confirmation
-    local cmd
-    if vim.fn.has('win32') == 1 then
-      cmd = { 'cmd.exe', '/c', 'start', '""', uri }
-    elseif vim.fn.has('macunix') == 1 then
-      cmd = { 'open', uri }
-    else
-      cmd = { 'xdg-open', uri }
-    end
 
-    local ret = vim.fn.system(cmd)
-    if vim.v.shell_error ~= 0 then
+    local ret = vim.ui.open(uri)
+
+    if ret.code ~= 0 or ret == nil then
       return {
         success = false,
         error = {
           code = protocol.ErrorCodes.UnknownErrorCode,
-          message = ret,
+          message = ret and ret.stderr or 'No handler could be found',
         },
       }
     end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -576,12 +576,12 @@ M['window/showDocument'] = function(_, result, ctx, _)
 
     local ret = vim.ui.open(uri)
 
-    if ret.code ~= 0 or ret == nil then
+    if ret == nil or ret.code ~= 0 then
       return {
         success = false,
         error = {
           code = protocol.ErrorCodes.UnknownErrorCode,
-          message = ret and ret.stderr or 'No handler could be found',
+          message = ret and ret.stderr or 'No handler found',
         },
       }
     end
@@ -593,7 +593,7 @@ M['window/showDocument'] = function(_, result, ctx, _)
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
-    err_message({ 'LSP[', client_name, '] client has shut down after sending ', ctx.method })
+    err_message('LSP[', client_name, '] client has shut down after sending ', ctx.method)
     return vim.NIL
   end
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -573,15 +573,14 @@ M['window/showDocument'] = function(_, result, ctx, _)
 
   if result.external then
     -- TODO(lvimuser): ask the user for confirmation
-
-    local ret = vim.ui.open(uri)
+    local ret, err = vim.ui.open(uri)
 
     if ret == nil or ret.code ~= 0 then
       return {
         success = false,
         error = {
           code = protocol.ErrorCodes.UnknownErrorCode,
-          message = ret and ret.stderr or 'No handler found',
+          message = ret and ret.stderr or err,
         },
       }
     end

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -19,10 +19,15 @@ vim.api.nvim_create_user_command('InspectTree', function(cmd)
   end
 end, { desc = 'Inspect treesitter language tree for buffer', count = true })
 
-if vim.g.use_lua_gx == nil or vim.g.use_lua_gx == true then
-  vim.keymap.set({ 'n', 'x' }, 'gx', function()
-    local uri = vim.fn.expand('<cfile>')
-
-    vim.ui.open(uri)
-  end, { desc = 'Open URI under cursor with system app' })
+-- TODO: use vim.region() when it lands... #13896 #16843
+local function get_visual_selection()
+  local save_a = vim.fn.getreginfo('a')
+  vim.cmd[[norm! "ay]]
+  local selection = vim.fn.getreg('a', 1)
+  vim.fn.setreg('a', save_a)
+  return selection
 end
+
+local gx_desc = 'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
+vim.keymap.set({ 'n' }, 'gx', function() vim.ui.open(vim.fn.expand('<cfile>')) end, { desc = gx_desc })
+vim.keymap.set({ 'x' }, 'gx', function() vim.ui.open(get_visual_selection()) end, { desc = gx_desc })

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -18,3 +18,11 @@ vim.api.nvim_create_user_command('InspectTree', function(cmd)
     vim.treesitter.inspect_tree()
   end
 end, { desc = 'Inspect treesitter language tree for buffer', count = true })
+
+if vim.g.use_lua_gx == nil or vim.g.use_lua_gx == true then
+  vim.keymap.set({ 'n', 'x' }, 'gx', function()
+    local uri = vim.fn.expand('<cfile>')
+
+    vim.ui.open(uri)
+  end, { desc = 'Open URI under cursor with system app' })
+end

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -22,12 +22,23 @@ end, { desc = 'Inspect treesitter language tree for buffer', count = true })
 -- TODO: use vim.region() when it lands... #13896 #16843
 local function get_visual_selection()
   local save_a = vim.fn.getreginfo('a')
-  vim.cmd[[norm! "ay]]
+  vim.cmd([[norm! "ay]])
   local selection = vim.fn.getreg('a', 1)
   vim.fn.setreg('a', save_a)
   return selection
 end
 
-local gx_desc = 'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
-vim.keymap.set({ 'n' }, 'gx', function() vim.ui.open(vim.fn.expand('<cfile>')) end, { desc = gx_desc })
-vim.keymap.set({ 'x' }, 'gx', function() vim.ui.open(get_visual_selection()) end, { desc = gx_desc })
+local gx_desc =
+  'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
+local function do_open(uri)
+  local _, err = vim.ui.open(uri)
+  if err then
+    vim.notify(err, vim.log.levels.ERROR)
+  end
+end
+vim.keymap.set({ 'n' }, 'gx', function()
+  do_open(vim.fn.expand('<cfile>'))
+end, { desc = gx_desc })
+vim.keymap.set({ 'x' }, 'gx', function()
+  do_open(get_visual_selection())
+end, { desc = gx_desc })

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -1,5 +1,6 @@
 local helpers = require('test.functional.helpers')(after_each)
 local eq = helpers.eq
+local matches = helpers.matches
 local exec_lua = helpers.exec_lua
 local clear = helpers.clear
 local feed = helpers.feed
@@ -11,8 +12,7 @@ describe('vim.ui', function()
     clear()
   end)
 
-
-  describe('select', function()
+  describe('select()', function()
     it('can select an item', function()
       local result = exec_lua[[
         local items = {
@@ -47,7 +47,7 @@ describe('vim.ui', function()
     end)
   end)
 
-  describe('input', function()
+  describe('input()', function()
     it('can input text', function()
       local result = exec_lua[[
         local opts = {
@@ -129,5 +129,19 @@ describe('vim.ui', function()
       eq(42, exec_lua('return result()'))
     end)
 
+  end)
+
+  describe('open()', function()
+    it('validation', function()
+      exec_lua[[vim.ui.open('non-existent-file')]]
+      matches('vim.ui.open: command failed %(%d%): { "[^"]+", "non%-existent%-file" }', eval('v:errmsg'))
+
+      exec_lua[[
+        vim.fn.has = function() return 0 end
+        vim.fn.executable = function() return 0 end
+      ]]
+      exec_lua[[vim.ui.open('foo')]]
+      eq('vim.ui.open: no handler found (tried: wslview, xdg-open)', eval('v:errmsg'))
+    end)
   end)
 end)

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -5,6 +5,7 @@ local exec_lua = helpers.exec_lua
 local clear = helpers.clear
 local feed = helpers.feed
 local eval = helpers.eval
+local is_os = helpers.is_os
 local poke_eventloop = helpers.poke_eventloop
 
 describe('vim.ui', function()
@@ -133,15 +134,17 @@ describe('vim.ui', function()
 
   describe('open()', function()
     it('validation', function()
-      exec_lua[[vim.ui.open('non-existent-file')]]
-      matches('vim.ui.open: command failed %(%d%): { "[^"]+", "non%-existent%-file" }', eval('v:errmsg'))
+      if not is_os('bsd') then
+        matches('vim.ui.open: command failed %(%d%): { "[^"]+", "non%-existent%-file" }',
+          exec_lua[[local _, err = vim.ui.open('non-existent-file') ; return err]])
+      end
 
       exec_lua[[
         vim.fn.has = function() return 0 end
         vim.fn.executable = function() return 0 end
       ]]
-      exec_lua[[vim.ui.open('foo')]]
-      eq('vim.ui.open: no handler found (tried: wslview, xdg-open)', eval('v:errmsg'))
+      eq('vim.ui.open: no handler found (tried: wslview, xdg-open)',
+        exec_lua[[local _, err = vim.ui.open('foo') ; return err]])
     end)
   end)
 end)


### PR DESCRIPTION
Fix #23231

`vim.ui.os_open` is partially based off https://github.com/folke/lazy.nvim/blob/main/lua/lazy/util.lua#L13-L44, as recommended by @folke on the original issue.

- [x] Implement `vim.ui.os_open(uri: string | vim.uri.Uri)`
    - [x] Accept a `string` as `uri`
    - [ ] ~~Accept a `vim.uri.Uri` as `uri`~~
- [x] Implement "gx" in lua. The implementation drops current netrw options, including `g:netrw_gx`.
- [ ] Ability to change impl by using `vim.func.on_func(vim.ui, 'open_uri', …)`