### PR TITLE
docs(html): right-align inline tags

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -927,6 +927,9 @@ local function gen_css(fname)
     /* Tag pseudo-header common in :help docs. */
     .help-tag-right {
       color: var(--tag-color);
+      margin-left: auto;
+      margin-right: 0;
+      float: right;
     }
     h1 .help-tag, h2 .help-tag, h3 .help-tag {
       font-size: smaller;


### PR DESCRIPTION
Before: 
<img width="768" alt="Screenshot 2023-04-30 at 13 36 00" src="https://user-images.githubusercontent.com/2361214/235350851-267ff8e1-a8b0-4cd4-a213-dc91a4516a49.png">

After (local html, so missing main CSS):
<img width="690" alt="Screenshot 2023-04-30 at 13 36 25" src="https://user-images.githubusercontent.com/2361214/235350869-f38d295f-99b5-43d8-8632-d505bddc7300.png">
