### PR TITLE
build: make lpeg an imported library

### DIFF
--- a/cmake/FindLpeg.cmake
+++ b/cmake/FindLpeg.cmake
@@ -10,5 +10,7 @@ ubuntu()
 find_package_handle_standard_args(Lpeg DEFAULT_MSG LPEG_LIBRARY)
 mark_as_advanced(LPEG_LIBRARY)
 
-add_library(lpeg INTERFACE)
-target_link_libraries(lpeg INTERFACE ${LPEG_LIBRARY})
+# Workaround: use an imported library to prevent cmake from modifying library
+# link path. See #23395.
+add_library(lpeg UNKNOWN IMPORTED)
+set_target_properties(lpeg PROPERTIES IMPORTED_LOCATION ${LPEG_LIBRARY})


### PR DESCRIPTION
Cmake truncates the full link path to a shared library if it is missing
an SONAME in some undocumented scenarios. This causes builds in some
systems to fail if "lpeg" isn't a library on the system path.

The path of imported libraries aren't modified by cmake, so we can use
that as a workaround until a proper solution for this has been
identified.

Closes https://github.com/neovim/neovim/issues/23395.
