### PR TITLE
vim-patch:9.0.1503: Luau files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -637,6 +637,7 @@ local extension = {
   nse = 'lua',
   rockspec = 'lua',
   lua = 'lua',
+  luau = 'luau',
   lrc = 'lyrics',
   m = function(path, bufnr)
     return require('vim.filetype.detect').m(bufnr)

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -346,6 +346,7 @@ let s:filename_checks = {
     \ 'lsl': ['file.lsl'],
     \ 'lss': ['file.lss'],
     \ 'lua': ['file.lua', 'file.rockspec', 'file.nse', '.luacheckrc', '.busted'],
+    \ 'luau': ['file.luau'],
     \ 'lynx': ['lynx.cfg'],
     \ 'lyrics': ['file.lrc'],
     \ 'm3build': ['m3makefile', 'm3overrides'],


### PR DESCRIPTION
Problem:    Luau files are not recognized.
Solution:   Add a patter for Luau files. (Amaan Qureshi, closes vim/vim#12317)

https://github.com/vim/vim/commit/2dcfe9ae1df61e1249520ed435dd8cf60e157103

Co-authored-by: Amaan Qureshi <amaanq12@gmail.com>
