### PR TITLE
fix(tui): grid_clear properly clears the screen

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -977,7 +977,7 @@ void tui_grid_clear(TUIData *tui, Integer g)
   UGrid *grid = &tui->grid;
   ugrid_clear(grid);
   kv_size(tui->invalid_regions) = 0;
-  clear_region(tui, 0, grid->height, 0, grid->width, 0);
+  clear_region(tui, 0, tui->height, 0, tui->width, 0);
 }
 
 void tui_grid_cursor_goto(TUIData *tui, Integer grid, Integer row, Integer col)

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -66,10 +66,10 @@ describe('api', function()
 
     screen:expect([[
       [tui] insert-mode                                 |
-      [socket 1] this is more t{4:                         }|
-      han 25 columns           {4:                         }|
-      [socket 2] input{1: }        {4:                         }|
-      {4:~                                                 }|
+      [socket 1] this is more t                         |
+      han 25 columns                                    |
+      [socket 2] input{1: }                                 |
+      {4:~                        }                         |
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
     ]])

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2422,6 +2422,19 @@ describe("TUI as a client", function()
       {3:-- TERMINAL --}                                    |
     ]]}
 
+    -- grid smaller than containing terminal window is cleared properly
+    feed_data(":call setline(1,['a'->repeat(&columns)]->repeat(&lines))\n")
+    feed_data("0:set lines=2\n")
+    screen_server:expect{grid=[[
+      {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      {5:[No Name] [+]                                     }|
+                                                        |
+                                                        |
+                                                        |
+                                                        |
+      {3:-- TERMINAL --}                                    |
+    ]]}
+
     feed_data(":q!\n")
 
     server_super:close()


### PR DESCRIPTION
Problem:    When setting a shell size smaller than the containing
            terminal window through `:winsize` or `:set lines/columns`
            the screen is not properly cleared.
Solution:   Clear the tui dimensions rather than the grid dimensions.
