### PR TITLE
feat(ui): detach

### DIFF
--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -210,6 +210,8 @@ void nvim_ui_attach(uint64_t channel_id, Integer width, Integer height, Dictiona
 
   pmap_put(uint64_t)(&connected_uis, channel_id, ui);
   ui_attach_impl(ui, channel_id);
+
+  last_ui = channel_id;
 }
 
 /// @deprecated
@@ -230,6 +232,10 @@ void nvim_ui_set_focus(uint64_t channel_id, Boolean gained, Error *error)
     api_set_error(error, kErrorTypeException,
                   "UI not attached to channel: %" PRId64, channel_id);
     return;
+  }
+
+  if (gained) {
+    last_ui = channel_id;
   }
 
   do_autocmd_focusgained((bool)gained);
@@ -1045,4 +1051,12 @@ void remote_ui_inspect(UI *ui, Dictionary *info)
 {
   UIData *data = ui->data;
   PUT(*info, "chan", INTEGER_OBJ((Integer)data->channel_id));
+}
+
+void ui_request_detach(uint64_t chan, String msg)
+{
+  UI *ui = pmap_get(uint64_t)(&connected_uis, chan);
+  if (ui) {
+    remote_ui_detach(ui, msg);
+  }
 }

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -40,6 +40,9 @@ void screenshot(String path)
   FUNC_API_SINCE(7);
 void option_set(String name, Object value)
   FUNC_API_SINCE(4);
+void detach(String msg)
+  FUNC_API_SINCE(10);
+
 // Stop event is not exported as such, represented by EOF in the msgpack stream.
 void stop(void)
   FUNC_API_NOEXPORT;

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -733,6 +733,12 @@ module.cmds = {
     func='ex_delfunction',
   },
   {
+    command='detach',
+    flags=bit.bor(TRLBAR, BANG, CMDWIN, LOCK_OK),
+    addr_type='ADDR_NONE',
+    func='ex_detach',
+  },
+  {
     command='display',
     flags=bit.bor(EXTRA, NOTRLCOM, TRLBAR, SBOXOK, CMDWIN, LOCK_OK),
     addr_type='ADDR_NONE',

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -614,7 +614,7 @@ void rpc_close(Channel *channel)
   channel->rpc.closed = true;
   channel_decref(channel);
 
-  if (channel->streamtype == kChannelStreamStdio
+  if ((channel->streamtype == kChannelStreamStdio && !embed_ui_detached)
       || (channel->id == ui_client_channel_id && channel->streamtype != kChannelStreamProc)) {
     if (channel->streamtype == kChannelStreamStdio) {
       // Avoid hanging when there are no other UIs and a prompt is triggered on exit.

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -126,5 +126,8 @@ typedef struct ui_event_callback {
 #endif
 // uncrustify:on
 
-EXTERN MultiQueue *resize_events;
+EXTERN MultiQueue *resize_events INIT(= NULL);
+EXTERN uint64_t last_ui INIT(= 0);
+EXTERN bool embed_ui_detached INIT(= false);
+
 #endif  // NVIM_UI_H

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -55,7 +55,7 @@ uint64_t ui_client_start_server(int argc, char **argv)
 
   Channel *channel = channel_job_start(args, CALLBACK_READER_INIT,
                                        on_err, CALLBACK_NONE,
-                                       false, true, true, false, kChannelStdinPipe,
+                                       false, true, true, true, kChannelStdinPipe,
                                        NULL, 0, 0, NULL, &exit_status);
 
   // If stdin is not a pty, it is forwarded to the client.


### PR DESCRIPTION
    $ nvim
         (edit some text)
    :detach
         Server detached. Address: /server/name
    $ nvim --server /server/name
         (same instance restored)

note `:detach` should detach the current UI, while `:detach!` should detach all.
We need a way to guesstimate the "current UI" in the first place. For now I use FocusGained but this will not work with terminals without focus reporting. We could update the focused ui also on `nvim_input` .