### PR TITLE
vim-patch:9.0.1505: error when heredoc content looks like heredoc

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2587,19 +2587,13 @@ void ex_function(exarg_T *eap)
 
       // Check for ":let v =<< [trim] EOF"
       //       and ":let [a, b] =<< [trim] EOF"
-      arg = skipwhite(skiptowhite(p));
-      if (*arg == '[') {
-        arg = vim_strchr(arg, ']');
-      }
-      if (arg != NULL) {
-        arg = skipwhite(skiptowhite(arg));
-        if (arg[0] == '='
-            && arg[1] == '<'
-            && arg[2] == '<'
-            && (p[0] == 'l'
-                && p[1] == 'e'
-                && (!ASCII_ISALNUM(p[2])
-                    || (p[2] == 't' && !ASCII_ISALNUM(p[3]))))) {
+      arg = p;
+      if (checkforcmd(&arg, "let", 2)) {
+        while (vim_strchr("$@&", *arg) != NULL) {
+          arg++;
+        }
+        arg = skipwhite(find_name_end(arg, NULL, NULL, FNE_INCL_BR));
+        if (arg[0] == '=' && arg[1] == '<' && arg[2] == '<') {
           p = skipwhite(arg + 3);
           while (true) {
             if (strncmp(p, "trim", 4) == 0) {

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -338,7 +338,43 @@ func Test_let_heredoc_fails()
     call assert_report('No exception thrown')
   catch /E488:/
   catch
-    call assert_report("Caught exception: " .. v:exception)
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let &commentstring =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E730:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let $SOME_ENV_VAR =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E730:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let @r =<< trim TEXT
+      change
+      insert
+      append
+    TEXT
+    call assert_report('No exception thrown')
+  catch /E730:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
   endtry
 
   let text =<< trim END
@@ -504,6 +540,32 @@ E
      z
 END
   call assert_equal(['     x', '     \y', '     z'], [a, b, c])
+
+  " unpack assignment without whitespace
+  let[a,b,c]=<<END
+change
+insert
+append
+END
+  call assert_equal(['change', 'insert', 'append'], [a, b, c])
+
+  " curly braces name and list slice assignment
+  let foo_3_bar = ['', '', '']
+  let foo_{1 + 2}_bar[ : ] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', 'insert', 'append'], foo_3_bar)
+
+  " dictionary key containing brackets and spaces
+  let d = {'abc] 123': 'baz'}
+  let d[d['abc] 123'] .. '{'] =<< END
+change
+insert
+append
+END
+  call assert_equal(['change', 'insert', 'append'], d['baz{'])
 endfunc
 
 " Test for evaluating Vim expressions in a heredoc using {expr}


### PR DESCRIPTION
#### vim-patch:9.0.1505: error when heredoc content looks like heredoc

Problem:    Error when heredoc content looks like heredoc.
Solution:   Handle curly expressions. (closes vim/vim#12325)

https://github.com/vim/vim/commit/a93d9cdc74f70ca2c85781496ffae4ca738fcd88
