### PR TITLE
vim-patch:9.0.1506: line number not displayed when using 'smoothscroll'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -609,7 +609,7 @@ static void handle_lnum_col(win_T *wp, winlinevars_T *wlv, int num_signs, int si
     } else {
       // Draw the line number (empty space after wrapping).
       if (wlv->row == wlv->startrow + wlv->filler_lines
-          && (wp->w_skipcol == 0 || wlv->row > wp->w_winrow || (wp->w_p_nu && wp->w_p_rnu))) {
+          && (wp->w_skipcol == 0 || wlv->row > 0 || (wp->w_p_nu && wp->w_p_rnu))) {
         get_line_number_str(wp, wlv->lnum, wlv->extra, sizeof(wlv->extra));
         if (wp->w_skipcol > 0 && wlv->startrow == 0) {
           for (wlv->p_extra = wlv->extra; *wlv->p_extra == ' '; wlv->p_extra++) {

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -195,7 +195,7 @@ describe('display', function()
     run_test_display_lastline(true)
   end)
 
-  -- oldtest: Test_display_long_lastline
+  -- oldtest: Test_display_long_lastline()
   it('display "lastline" shows correct text when end of wrapped line is deleted', function()
     local screen = Screen.new(35, 14)
     screen:attach()

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -179,6 +179,7 @@ describe('smoothscroll', function()
     exec([[
       call setline(1, [ 'one ' .. 'word '->repeat(20), 'two ' .. 'long word '->repeat(7), 'line', 'line', 'line', ])
       set smoothscroll scrolloff=5
+      set splitkeep=topline
       set number cpo+=n
       :3
       func g:DoRel()
@@ -277,6 +278,53 @@ describe('smoothscroll', function()
       ~                                       |
                                               |
     ]])
+    exec('botright split')
+    feed('gg')
+    screen:expect([[
+        1 one word word word word word word wo|
+          rd word word word word word word wor|
+          d word word word word word word     |
+        2 two long word long word long word@@@|
+      [No Name] [+]                           |
+        1 ^one word word word word word word wo|
+          rd word word word word word word wor|
+          d word word word word word word     |
+        2 two long word long word long word lo|
+          ng word long word long word long @@@|
+      [No Name] [+]                           |
+                                              |
+    ]])
+    feed('<C-E>')
+    screen:expect([[
+        1 one word word word word word word wo|
+          rd word word word word word word wor|
+          d word word word word word word     |
+        2 two long word long word long word@@@|
+      [No Name] [+]                           |
+      <<< rd word word word word word word wor|
+          d word word word word word word^     |
+        2 two long word long word long word lo|
+          ng word long word long word long wor|
+          d                                   |
+      [No Name] [+]                           |
+                                              |
+    ]])
+    feed('<C-E>')
+    screen:expect([[
+        1 one word word word word word word wo|
+          rd word word word word word word wor|
+          d word word word word word word     |
+        2 two long word long word long word@@@|
+      [No Name] [+]                           |
+      <<< d word word word word word word^     |
+        2 two long word long word long word lo|
+          ng word long word long word long wor|
+          d                                   |
+        3 line                                |
+      [No Name] [+]                           |
+                                              |
+    ]])
+    exec('close')
     exec('call DoRel()')
     screen:expect([[
       2<<<^ong text very long text very long te|

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -1325,6 +1325,7 @@ it('win_update redraws lines properly', function()
   ]]}
 end)
 
+-- oldtest: Test_diff_rnu()
 it('diff updates line numbers below filler lines', function()
   clear()
   local screen = Screen.new(40, 14)
@@ -1401,6 +1402,7 @@ it('diff updates line numbers below filler lines', function()
   ]])
 end)
 
+-- oldtest: Test_diff_with_scroll_and_change()
 it('Align the filler lines when changing text in diff mode', function()
   clear()
   local screen = Screen.new(40, 20)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -137,6 +137,7 @@ func Test_smoothscroll_number()
         'line',
       ])
       set smoothscroll
+      set splitkeep=topline
       set number cpo+=n
       :3
 
@@ -167,8 +168,16 @@ func Test_smoothscroll_number()
   call term_sendkeys(buf, "\<C-Y>")
   call VerifyScreenDump(buf, 'Test_smooth_number_6', {})
 
-  call term_sendkeys(buf, ":call DoRel()\<CR>")
+  call term_sendkeys(buf, ":botright split\<CR>gg")
   call VerifyScreenDump(buf, 'Test_smooth_number_7', {})
+  call term_sendkeys(buf, "\<C-E>")
+  call VerifyScreenDump(buf, 'Test_smooth_number_8', {})
+  call term_sendkeys(buf, "\<C-E>")
+  call VerifyScreenDump(buf, 'Test_smooth_number_9', {})
+  call term_sendkeys(buf, ":close\<CR>")
+
+  call term_sendkeys(buf, ":call DoRel()\<CR>")
+  call VerifyScreenDump(buf, 'Test_smooth_number_10', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1506: line number not displayed when using 'smoothscroll'

Problem:    Line number not displayed when using 'smoothscroll'.
Solution:   Adjust condition for showing the line number. (closes vim/vim#12333)

https://github.com/vim/vim/commit/88bb3e0a48f160134bdea98cd2b8bd3af86f9d6f