### PR TITLE
vim-patch:9.0.0662: concealed characters do not work correctly

### DIFF
--- a/test/functional/legacy/conceal_spec.lua
+++ b/test/functional/legacy/conceal_spec.lua
@@ -474,6 +474,39 @@ describe('Conceal', function()
     ]])
   end)
 
+  -- oldtest: Test_conceal_linebreak()
+  it('with linebreak', function()
+    local screen = Screen.new(75, 8)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      let &wrap = v:true
+      let &conceallevel = 2
+      let &concealcursor = 'nc'
+      let &linebreak = v:true
+      let &showbreak = '+ '
+      let line = 'a`a`a`a`'
+          \ .. 'a'->repeat(&columns - 15)
+          \ .. ' b`b`'
+          \ .. 'b'->repeat(&columns - 10)
+          \ .. ' cccccc'
+      eval ['x'->repeat(&columns), '', line]->setline(1)
+      syntax region CodeSpan matchgroup=Delimiter start=/\z(`\+\)/ end=/\z1/ concealends
+    ]])
+    screen:expect([[
+      ^xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+                                                                                 |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa           |
+      {0:+ }bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb      |
+      {0:+ }cccccc                                                                   |
+      {0:~                                                                          }|
+      {0:~                                                                          }|
+                                                                                 |
+    ]])
+  end)
+
   -- Tests for correct display (cursor column position) with +conceal and tabulators.
   -- oldtest: Test_conceal_cursor_pos()
   it('cursor and column position with conceal and tabulators', function()

--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -188,6 +188,32 @@ func Test_conceal_resize_term()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_conceal_linebreak()
+  CheckScreendump
+
+  let code =<< trim [CODE]
+      vim9script
+      &wrap = true
+      &conceallevel = 2
+      &concealcursor = 'nc'
+      &linebreak = true
+      &showbreak = '+ '
+      var line: string = 'a`a`a`a`'
+          .. 'a'->repeat(&columns - 15)
+          .. ' b`b`'
+          .. 'b'->repeat(&columns - 10)
+          .. ' cccccc'
+      ['x'->repeat(&columns), '', line]->setline(1)
+      syntax region CodeSpan matchgroup=Delimiter start=/\z(`\+\)/ end=/\z1/ concealends
+  [CODE]
+  call writefile(code, 'XTest_conceal_linebreak', 'D')
+  let buf = RunVimInTerminal('-S XTest_conceal_linebreak', {'rows': 8})
+  call VerifyScreenDump(buf, 'Test_conceal_linebreak_1', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 " Tests for correct display (cursor column position) with +conceal and
 " tabulators.  Need to run this test in a separate Vim instance. Otherwise the
 " screen is not updated (lazy redraw) and the cursor position is wrong.


### PR DESCRIPTION
#### vim-patch:9.0.0662: concealed characters do not work correctly

Problem:    Concealed characters do not work correctly.
Solution:   Subtract boguscols instead of adding them.

https://github.com/vim/vim/commit/75008661821eee6989476908feaf64a9dea03e05

Code change is N/A as Nvim has a draw_col variable instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>