### PR TITLE
feat(vim.net): `fetch()`, `download()`, and `:e URL` in lua

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3450,8 +3450,8 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                   following keys:
                   • ok boolean Whether the request was successful (status
                     within 2XX range).
-                  • headers fun(): table<string, string> Function returning a
-                    table of response headers.
+                  • headers fun(): table<string, string[]> Function returning
+                    a table of response headers.
                   • body fun(): string|nil Function returning response body.
                     If method was HEAD, this is nil.
                   • json fun(opts: table|nil): table Read the body as JSON.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3357,7 +3357,8 @@ download({url}, {path}, {opts})                           *vim.net.download()*
     Asynchronously download a file. To read the response metadata, such as
     headers and body, use |vim.net.fetch()|.
 
-    Shares a few options with |vim.net.fetch()|, but not all of them.
+    Please carefully note the option differences with |vim.net.fetch()|,
+    notably `redirect`.
 
     Example: >lua
 
@@ -3375,8 +3376,12 @@ download({url}, {path}, {opts})                           *vim.net.download()*
                 • method string|nil HTTP method to use. Defaults to GET.
                 • headers table<string, string>|nil A table of key-value
                   headers.
-                • follow_redirects boolean|nil Will follow redirects by
-                  default.
+                • redirect string|nil Redirect mode. Defaults to "follow".
+                  Possible values are:
+                  • "follow": Follow all redirects incurred when fetching a
+                    resource.
+                  • "none": Ignores redirect status.
+
                 • data string|table|nil Data to send with the request. If a
                   table, it will be JSON encoded. vim.net does not currently
                   support form encoding.
@@ -3392,11 +3397,15 @@ download({url}, {path}, {opts})                           *vim.net.download()*
         (number) jobid A job id. See |job-control|.
 
     See also: ~
+      • |vim.net.fetch()|
       • |job-control|
       • man://curl
 
 fetch({url}, {opts})                                         *vim.net.fetch()*
     Asynchronously make HTTP requests.
+
+    Please carefully note the option differences with |vim.net.download()|,
+    notably `redirect`.
 
     Example: >lua
 
@@ -3440,8 +3449,13 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
                 • headers table|nil A table of key-value headers.
-                • follow_redirects boolean|nil Whether to follow redirects.
-                  Defaults to true.
+                • redirect string|nil Redirect mode. Defaults to "follow".
+                  Possible values are:
+                  • "follow": Follow all redirects incurred when fetching a
+                    resource.
+                  • "error": Throw an error using on_err or vim.notify when
+                    status is 3XX.
+
                 • data string|table|nil Data to send with the request. If a
                   table, it will be JSON-encoded. vim.net does not currently
                   support form encoding.
@@ -3465,16 +3479,17 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                     transferred, excluding headers.
                   • http_version number HTTP version used in the request.
 
-                • on_err fun(err: string[])|nil An optional function recieving
-                  a `stderr_buffered` string[] of curl stderr. Without
-                  providing this function, |vim.net.fetch()| will
-                  automatically raise an error to the user. See |on_stderr|
-                  and `stderr_buffered`.
+                • on_err fun(err: string[])|nil Function recieving a
+                  `stderr_buffered` string[] of error. err is either curl
+                  stderr or internal fetch() error. Without providing this
+                  function, |vim.net.fetch()| will automatically raise the
+                  error to the user. See |on_stderr| and `stderr_buffered`.
 
     Return: ~
         (number) jobid A job id.
 
     See also: ~
+      • |vim.net.download()|
       • https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
       • |job-control|
       • man://curl

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3406,8 +3406,8 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
          -- Lets read the response!
 
          if response.ok then
-           -- Read response body
-           local body = response.body()
+           -- Read response text
+           local body = response.text()
          else
        end
      })
@@ -3452,7 +3452,7 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                     within 2XX range).
                   • headers fun(): table<string, string[]> Function returning
                     a table of response headers.
-                  • body fun(): string|nil Function returning response body.
+                  • text fun(): string|nil Function returning response body.
                     If method was HEAD, this is nil.
                   • json fun(opts: table|nil): table Read the body as JSON.
                     Optionally accepts opts from |vim.json.decode|. Will throw

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3379,6 +3379,8 @@ download({url}, {path}, {opts})                           *vim.net.download()*
                 • method string|nil HTTP method to use. Defaults to GET.
                 • headers HeaderTable | table<string, string | string[]> | nil Headers to set on
                   the request
+                • user string|nil String in "username:password" format. Prefer
+                  over passing in url.
                 • redirect string|nil Redirect mode. Defaults to "follow".
                   Possible values are:
                   • "follow": Follow all redirects incurred when fetching a
@@ -3390,11 +3392,11 @@ download({url}, {path}, {opts})                           *vim.net.download()*
                   support form encoding.
                 • on_complete fun()|nil Callback function when download
                   successfully completed.
-                • on_err fun(err: string[])|nil An optional function recieving
-                  a `stderr_buffered` string[] of curl stderr. Without
-                  providing this function, |vim.net.download()| will
-                  automatically raise an error to the user. See |on_stderr|
-                  and `stderr_buffered`.
+                • on_err fun(err: string[], exit_code: number)|nil An optional
+                  function recieving a `stderr_buffered` string[] of curl
+                  stderr. Without providing this function,
+                  |vim.net.download()| will automatically raise an error to
+                  the user. See |on_stderr| and `stderr_buffered`.
 
     Return: ~
         (number) jobid A job id. See |job-control|.
@@ -3465,6 +3467,8 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
 
                 • upload_file string|nil Path to an upload_file. Can be
                   relative.
+                • user string|nil String in "username:password" format. Prefer
+                  over passing in url.
                 • data string|table|nil Data to send with the request. If a
                   table, it will be JSON-encoded. vim.net does not currently
                   support form encoding.
@@ -3488,11 +3492,12 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                     transferred, excluding headers.
                   • http_version number HTTP version used in the request.
 
-                • on_err fun(err: string[])|nil Function recieving a
-                  `stderr_buffered` string[] of error. err is either curl
-                  stderr or internal fetch() error. Without providing this
-                  function, |vim.net.fetch()| will automatically raise the
-                  error to the user. See |on_stderr| and `stderr_buffered`.
+                • on_err fun(err: string[], exit_code: number|nil)|nil
+                  Function recieving a `stderr_buffered` string[] of error.
+                  err is either curl stderr or internal fetch() error. Without
+                  providing this function, |vim.net.fetch()| will
+                  automatically raise the error to the user. See |on_stderr|
+                  and `stderr_buffered`.
 
     Return: ~
         (number) jobid A job id.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3384,9 +3384,9 @@ download({url}, {path}, {opts})                           *vim.net.download()*
                   successfully completed.
                 • on_err fun(err: string[])|nil An optional function recieving
                   a `stderr_buffered` string[] of curl stderr. Without
-                  providing this function, |download()| will automatically
-                  raise an error to the user. See |on_stderr| and
-                  `stderr_buffered`.
+                  providing this function, |vim.net.download()| will
+                  automatically raise an error to the user. See |on_stderr|
+                  and `stderr_buffered`.
 
     Return: ~
         (number) jobid A job id. See |job-control|.
@@ -3467,8 +3467,9 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
 
                 • on_err fun(err: string[])|nil An optional function recieving
                   a `stderr_buffered` string[] of curl stderr. Without
-                  providing this function, |fetch()| will automatically raise
-                  an error to the user. See |on_stderr| and `stderr_buffered`.
+                  providing this function, |vim.net.fetch()| will
+                  automatically raise an error to the user. See |on_stderr|
+                  and `stderr_buffered`.
 
     Return: ~
         (number) jobid A job id.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3460,8 +3460,6 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                   • method string The http method used in the most recent HTTP
                     request.
                   • status number The numerical response code.
-                  • status_text string The status text returned with the
-                    response.
                   • size number The total amount of bytes that were
                     downloaded. This is the size of the body/data that was
                     transferred, excluding headers.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3468,9 +3468,10 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                   • headers fun(): HeaderTable Function returning a HeaderTable of response headers.
                   • text fun(): string|nil Function returning response body.
                     If method was HEAD, this is nil.
-                  • json fun(opts: table|nil): table Read the body as JSON.
-                    Optionally accepts opts from |vim.json.decode|. Will throw
-                    errors if body is not JSON-decodable.
+                  • json fun(opts: table|nil): table|nil Read the body as
+                    JSON. Optionally accepts opts from |vim.json.decode|. Will
+                    throw errors if body is not JSON-decodable. Nil if method
+                    is HEAD.
                   • method string The http method used in the most recent HTTP
                     request.
                   • status number The numerical response code.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3518,7 +3518,7 @@ HeaderTable:get({self}, {key})                             *HeaderTable:get()*
       • {key}   (string) Non case-sensitive header name.
 
     Return: ~
-        string[]
+        string[] | string | nil
 
 HeaderTable:has({self}, {key})                             *HeaderTable:has()*
     Parameters: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3349,4 +3349,121 @@ totable({f}, {...})                                       *vim.iter.totable()*
     Return: ~
         (table)
 
+
+==============================================================================
+Lua module: net                                                      *lua-net*
+
+download({url}, {path}, {opts})                               *net.download()*
+    Asynchronously download a file. To read the response metadata, such as
+    headers and body, use |fetch()|. Accepts shares a few options with
+    |vim.net.fetch()|, but not all of them.
+
+    Example: >lua
+
+     vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md",
+     ".cache/download/location/readme.md", {
+       on_complete = function ()
+         vim.notify("File Downloaded", vim.log.levels.INFO)
+       end
+     })
+<
+
+    Parameters: ~
+      • {url}   (string) url
+      • {path}  (string) A FULL download path. This function does not modify
+                the path, you should use |fnnamemodify| with relative paths.
+      • {opts}  (table|nil) Optional keyword arguments:
+                • method string|nil HTTP method to use. Defaults to GET.
+                • headers table|nil A table of key-value headers.
+                • follow_redirects boolean|nil Will follow redirects by
+                  default.
+                • data string|table|nil Data to send with the request. If a
+                  table, it will be json encoded.
+                • on_complete nil|fun() Callback function when download is
+                  complete.
+                • on_err nil|fun(errr: string[]) An optional function
+                  recieving a `stderr_buffered` string[] of curl stderr.
+                  Without providing this function, fetch() will automatically
+                  raise an error to the user. See |on_stderr| and
+                  `stderr_buffered`.
+
+fetch({url}, {opts})                                             *net.fetch()*
+    Asynchronously make HTTP requests.
+
+    Example: >lua
+
+     -- GET a url
+     vim.net.fetch("https://example.com/api/data", {
+       on_complete = function (response)
+         -- Lets read the response!
+
+         if response.ok then
+           -- Read response body
+           local body = response.body()
+         else
+       end
+     })
+
+     -- POST to a url, sending json and providing an authorization header
+     vim.net.fetch("https://example.com/api/data", {
+       method = "POST",
+       data = {
+         key = value
+       },
+       headers = {
+         Authorization = "Bearer " .. token
+       },
+       on_complete = function (response)
+         -- Lets read the response!
+
+         if response.ok then
+           -- Read json response
+           local table = response.json()
+         else
+
+         -- What went wrong?
+         vim.print(response.status)
+       end
+     })
+<
+
+    Parameters: ~
+      • {url}   (string) url
+      • {opts}  (table|nil) Optional keyword arguments:
+                • method string|nil HTTP method to use. Defaults to GET.
+                • headers table|nil A table of key-value headers.
+                • follow_redirects boolean|nil Will follow redirects by
+                  default.
+                • data string|table|nil Data to send with the request. If a
+                  table, it will be json encoded.
+                • on_complete nil|fun(response: table) Callback function when
+                  request is completed. The response has the following keys:
+                  • ok boolean Convience field showing whether or not the
+                    request was successful (status within 2XX range).
+                  • headers fun(): table<string, string> Function returning a
+                    table of response headers.
+                  • body fun(): string|nil Function returning response body.
+                    If method was HEAD, this is likely nil.
+                  • json fun(opts: table|nil): table Read the body as json.
+                    Optionally accepts opts from |vim.json.decode|. Will throw
+                    errors if body is not json-decodable.
+                  • method string The http method used in the most recent HTTP
+                    request.
+                  • status number The numerical response code. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+                  • status_text string The status text returned with the
+                    response.
+                  • size number The total amount of bytes that were
+                    downloaded. This is the size of the body/data that was
+                    transferred, excluding headers.
+                  • http_version number HTTP version used in the request.
+
+                • on_err nil|fun(errr: string[]) An optional function
+                  recieving a `stderr_buffered` string[] of curl stderr.
+                  Without providing this function, fetch() will automatically
+                  raise an error to the user. See |on_stderr| and
+                  `stderr_buffered`.
+
+    Return: ~
+        (number) jobid A job id. See |job-control|.
+
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3355,12 +3355,13 @@ Lua module: net                                                      *lua-net*
 
 download({url}, {path}, {opts})                           *vim.net.download()*
     Asynchronously download a file. To read the response metadata, such as
-    headers and body, use |fetch()|. Accepts shares a few options with
-    |vim.net.fetch()|, but not all of them.
+    headers and body, use |vim.net.fetch()|.
+
+    Shares a few options with |vim.net.fetch()|, but not all of them.
 
     Example: >lua
 
-     vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md", "~/.cache/download/location", {
+     vim.net.download("https://.../path/file", "~/.cache/download/location", {
        on_complete = function ()
          vim.notify("File Downloaded", vim.log.levels.INFO)
        end
@@ -3369,21 +3370,30 @@ download({url}, {path}, {opts})                           *vim.net.download()*
 
     Parameters: ~
       • {url}   (string) url
-      • {path}  (string) A download path. Can be relative.
+      • {path}  (string) A download path, can be relative.
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
-                • headers table|nil A table of key-value headers.
+                • headers table<string, string>|nil A table of key-value
+                  headers.
                 • follow_redirects boolean|nil Will follow redirects by
                   default.
                 • data string|table|nil Data to send with the request. If a
-                  table, it will be json encoded.
-                • on_complete nil|fun() Callback function when download
+                  table, it will be JSON encoded. vim.net does not currently
+                  support form encoding.
+                • on_complete fun()|nil Callback function when download
                   successfully completed.
-                • on_err nil|fun(errr: string[]) An optional function
-                  recieving a `stderr_buffered` string[] of curl stderr.
-                  Without providing this function, fetch() will automatically
+                • on_err fun(err: string[])|nil An optional function recieving
+                  a `stderr_buffered` string[] of curl stderr. Without
+                  providing this function, |download()| will automatically
                   raise an error to the user. See |on_stderr| and
                   `stderr_buffered`.
+
+    Return: ~
+        (number) jobid A job id. See |job-control|.
+
+    See also: ~
+      • |job-control|
+      • man://curl
 
 fetch({url}, {opts})                                         *vim.net.fetch()*
     Asynchronously make HTTP requests.
@@ -3402,7 +3412,7 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
        end
      })
 
-     -- POST to a url, sending json and providing an authorization header
+     -- POST to a url, sending a table as JSON and providing an authorization header
      vim.net.fetch("https://example.com/api/data", {
        method = "POST",
        data = {
@@ -3415,7 +3425,7 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
          -- Lets read the response!
 
          if response.ok then
-           -- Read json response
+           -- Read JSON response
            local table = response.json()
          else
 
@@ -3426,29 +3436,30 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
 <
 
     Parameters: ~
-      • {url}   (string) url
+      • {url}   (string) The request URL.
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
                 • headers table|nil A table of key-value headers.
-                • follow_redirects boolean|nil Will follow redirects by
-                  default.
+                • follow_redirects boolean|nil Whether to follow redirects.
+                  Defaults to true.
                 • data string|table|nil Data to send with the request. If a
-                  table, it will be json encoded.
-                • on_complete nil|fun(response: table) Callback function when
-                  request is successfully completed. The response has the
+                  table, it will be JSON-encoded. vim.net does not currently
+                  support form encoding.
+                • on_complete fun(response: table)|nil Callback function when
+                  request is completed successfully. The response has the
                   following keys:
-                  • ok boolean Convience field showing whether or not the
-                    request was successful (status within 2XX range).
+                  • ok boolean Whether the request was successful (status
+                    within 2XX range).
                   • headers fun(): table<string, string> Function returning a
                     table of response headers.
                   • body fun(): string|nil Function returning response body.
-                    If method was HEAD, this is likely nil.
-                  • json fun(opts: table|nil): table Read the body as json.
+                    If method was HEAD, this is nil.
+                  • json fun(opts: table|nil): table Read the body as JSON.
                     Optionally accepts opts from |vim.json.decode|. Will throw
-                    errors if body is not json-decodable.
+                    errors if body is not JSON-decodable.
                   • method string The http method used in the most recent HTTP
                     request.
-                  • status number The numerical response code. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+                  • status number The numerical response code.
                   • status_text string The status text returned with the
                     response.
                   • size number The total amount of bytes that were
@@ -3456,13 +3467,17 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                     transferred, excluding headers.
                   • http_version number HTTP version used in the request.
 
-                • on_err nil|fun(errr: string[]) An optional function
-                  recieving a `stderr_buffered` string[] of curl stderr.
-                  Without providing this function, fetch() will automatically
-                  raise an error to the user. See |on_stderr| and
-                  `stderr_buffered`.
+                • on_err fun(err: string[])|nil An optional function recieving
+                  a `stderr_buffered` string[] of curl stderr. Without
+                  providing this function, |fetch()| will automatically raise
+                  an error to the user. See |on_stderr| and `stderr_buffered`.
 
     Return: ~
-        (number) jobid A job id. See |job-control|.
+        (number) jobid A job id.
+
+    See also: ~
+      • https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+      • |job-control|
+      • man://curl
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3374,8 +3374,8 @@ download({url}, {path}, {opts})                           *vim.net.download()*
       • {path}  (string) A download path, can be relative.
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
-                • headers table<string, string>|nil A table of key-value
-                  headers.
+                • headers HeaderTable | table<string, string | string[]> | nil Headers to set on
+                  the request
                 • redirect string|nil Redirect mode. Defaults to "follow".
                   Possible values are:
                   • "follow": Follow all redirects incurred when fetching a
@@ -3448,7 +3448,8 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
       • {url}   (string) The request URL.
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
-                • headers table|nil A table of key-value headers.
+                • headers HeaderTable | table<string, string | string[]> | nil Headers to set on
+                  the request
                 • redirect string|nil Redirect mode. Defaults to "follow".
                   Possible values are:
                   • "follow": Follow all redirects incurred when fetching a
@@ -3464,8 +3465,7 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                   following keys:
                   • ok boolean Whether the request was successful (status
                     within 2XX range).
-                  • headers fun(): table<string, string[]> Function returning
-                    a table of response headers.
+                  • headers fun(): HeaderTable Function returning a HeaderTable of response headers.
                   • text fun(): string|nil Function returning response body.
                     If method was HEAD, this is nil.
                   • json fun(opts: table|nil): table Read the body as JSON.
@@ -3493,5 +3493,49 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
       • https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
       • |job-control|
       • man://curl
+
+HeaderTable:append({self}, {key}, {value})              *HeaderTable:append()*
+    Append value to header.
+
+    Parameters: ~
+      • {self}  
+      • {key}   (string) Non case-sensitive header name.
+
+HeaderTable:get({self}, {key})                             *HeaderTable:get()*
+    Get header values.
+
+    Parameters: ~
+      • {self}  
+      • {key}   (string) Non case-sensitive header name.
+
+    Return: ~
+        string[]
+
+HeaderTable:has({self}, {key})                             *HeaderTable:has()*
+    Parameters: ~
+      • {self}  
+      • {key}   (string) Non case-sensitive header name.
+
+    Return: ~
+        (boolean) has true if the HeaderTable contains key.
+
+HeaderTable:set({self}, {key}, {value})                    *HeaderTable:set()*
+    Set value of header.
+
+    Parameters: ~
+      • {self}   
+      • {value}  string[] | string Header value.
+      • {key}    (string) Non case-sensitive header name.
+
+new_headers({input_table})                             *vim.net.new_headers()*
+    Create a non-case sensitive table of headers that can contain multiple
+    values per header.
+
+    Parameters: ~
+      • {input_table}  table<string, string[] | string> | nil Optional input
+                       table.
+
+    Return: ~
+        HeaderTable
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3516,14 +3516,25 @@ HeaderTable:append({self}, {key}, {value})              *HeaderTable:append()*
       • {key}   (string) Non case-sensitive header name.
 
 HeaderTable:get({self}, {key})                             *HeaderTable:get()*
-    Get header values.
+    Get first header value. For headers like Cookies, use
+    |HeaderTable:get_all|.
 
     Parameters: ~
       • {self}  
       • {key}   (string) Non case-sensitive header name.
 
     Return: ~
-        string[] | string | nil
+        (string) | nil
+
+HeaderTable:get_all({self}, {key})                     *HeaderTable:get_all()*
+    Get all header values.
+
+    Parameters: ~
+      • {self}  
+      • {key}   (string) Non case-sensitive header name.
+
+    Return: ~
+        string[] | nil
 
 HeaderTable:has({self}, {key})                             *HeaderTable:has()*
     Parameters: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3353,15 +3353,14 @@ totable({f}, {...})                                       *vim.iter.totable()*
 ==============================================================================
 Lua module: net                                                      *lua-net*
 
-download({url}, {path}, {opts})                               *net.download()*
+download({url}, {path}, {opts})                           *vim.net.download()*
     Asynchronously download a file. To read the response metadata, such as
     headers and body, use |fetch()|. Accepts shares a few options with
     |vim.net.fetch()|, but not all of them.
 
     Example: >lua
 
-     vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md",
-     ".cache/download/location/readme.md", {
+     vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md", "~/.cache/download/location", {
        on_complete = function ()
          vim.notify("File Downloaded", vim.log.levels.INFO)
        end
@@ -3370,8 +3369,7 @@ download({url}, {path}, {opts})                               *net.download()*
 
     Parameters: ~
       • {url}   (string) url
-      • {path}  (string) A FULL download path. This function does not modify
-                the path, you should use |fnnamemodify| with relative paths.
+      • {path}  (string) A download path. Can be relative.
       • {opts}  (table|nil) Optional keyword arguments:
                 • method string|nil HTTP method to use. Defaults to GET.
                 • headers table|nil A table of key-value headers.
@@ -3387,7 +3385,7 @@ download({url}, {path}, {opts})                               *net.download()*
                   raise an error to the user. See |on_stderr| and
                   `stderr_buffered`.
 
-fetch({url}, {opts})                                             *net.fetch()*
+fetch({url}, {opts})                                         *vim.net.fetch()*
     Asynchronously make HTTP requests.
 
     Example: >lua

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3357,6 +3357,9 @@ download({url}, {path}, {opts})                           *vim.net.download()*
     Asynchronously download a file. To read the response metadata, such as
     headers and body, use |vim.net.fetch()|.
 
+    See man://curl for supported protocols. Not all protocols are fully
+    tested.
+
     Please carefully note the option differences with |vim.net.fetch()|,
     notably `redirect`.
 
@@ -3402,7 +3405,10 @@ download({url}, {path}, {opts})                           *vim.net.download()*
       • man://curl
 
 fetch({url}, {opts})                                         *vim.net.fetch()*
-    Asynchronously make HTTP requests.
+    Asynchronously make network requests.
+
+    See man://curl for supported protocols. Not all protocols are fully
+    tested.
 
     Please carefully note the option differences with |vim.net.download()|,
     notably `redirect`.
@@ -3457,6 +3463,8 @@ fetch({url}, {opts})                                         *vim.net.fetch()*
                   • "error": Throw an error using on_err or vim.notify when
                     status is 3XX.
 
+                • upload_file string|nil Path to an upload_file. Can be
+                  relative.
                 • data string|table|nil Data to send with the request. If a
                   table, it will be JSON-encoded. vim.net does not currently
                   support form encoding.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3379,8 +3379,8 @@ download({url}, {path}, {opts})                               *net.download()*
                   default.
                 • data string|table|nil Data to send with the request. If a
                   table, it will be json encoded.
-                • on_complete nil|fun() Callback function when download is
-                  complete.
+                • on_complete nil|fun() Callback function when download
+                  successfully completed.
                 • on_err nil|fun(errr: string[]) An optional function
                   recieving a `stderr_buffered` string[] of curl stderr.
                   Without providing this function, fetch() will automatically
@@ -3437,7 +3437,8 @@ fetch({url}, {opts})                                             *net.fetch()*
                 • data string|table|nil Data to send with the request. If a
                   table, it will be json encoded.
                 • on_complete nil|fun(response: table) Callback function when
-                  request is completed. The response has the following keys:
+                  request is successfully completed. The response has the
+                  following keys:
                   • ok boolean Convience field showing whether or not the
                     request was successful (status within 2XX range).
                   • headers fun(): table<string, string> Function returning a

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -49,6 +49,10 @@ iterators |luaref-in|.
 • Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
   default).
 
+• Added |vim.net.fetch()| for requests.
+
+• Added |vim.net.download()| for file downloads.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 
@@ -66,6 +70,16 @@ The following changes to existing APIs or features add new behavior.
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
   by default.
 
+• `:e, :w, :[range]w!, and :r https://*,http://*,ftp://*,scp://*` can now
+  use |vim.net.fetch()|. Opt-in via >lua
+      vim.g.lua_net_enable = true
+<
+• `:e https://*,http://*,ftp://*,scp://*` now automatically matches
+  filetype using the url. Optionally, you can enable (slower) automatic
+  full-text filetype matching for editing remote files that don't have an
+  extension (for example https://neovim.io/ -> `ft=html`) via >lua
+      vim.g.lua_net_ft_full = true
+<
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/nvim/health.lua
+++ b/runtime/lua/nvim/health.lua
@@ -394,6 +394,23 @@ local function check_terminal()
   end
 end
 
+local function check_network()
+  vim.health.start('Network (vim.net)')
+
+  if executable('curl') then
+    vim.health.ok('curl found')
+
+    local version = vim.split(vim.fn.systemlist({ 'curl', '--version' })[1], ' ')[2]
+
+    vim.health.info('curl version ' .. version .. ' was found.')
+  else
+    vim.health.error(
+      'curl could not be found. Cannot use |vim.net|.',
+      'Follow this guide to install curl https://everything.curl.dev/get.'
+    )
+  end
+end
+
 function M.check()
   check_config()
   check_runtime()
@@ -401,6 +418,7 @@ function M.check()
   check_rplugin_manifest()
   check_terminal()
   check_tmux()
+  check_network()
 end
 
 return M

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -38,6 +38,7 @@ for k, v in pairs({
   health = true,
   secure = true,
   _watch = true,
+  net = true,
 }) do
   vim._submodules[k] = v
 end

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -261,8 +261,13 @@ function M.fetch(url, opts)
       out = data
     end,
     on_stderr = function(_, data)
-      if #data == 1 and data[1] == '' then
-        -- Data is nothing but a EOL
+      if data[#data] == '' then
+        -- strip EOL
+        table.remove(data, #data)
+      end
+
+      if vim.tbl_isempty(data) then
+        -- Data was nothing but a EOL
         return
       end
 
@@ -276,7 +281,6 @@ function M.fetch(url, opts)
       if opts.on_complete and code == 0 then
         local res = process_stdout(out)
 
-        -- Since we use stdout_buffered, it is actually most safe to call on_compete from on_stdout.
         opts.on_complete(res)
       end
     end,
@@ -337,8 +341,13 @@ function M.download(url, path, opts)
       end
     end,
     on_stderr = function(_, data)
-      if #data == 1 and data[1] == '' then
-        -- Data is nothing but a EOL
+      if data[#data] == '' then
+        -- strip EOL
+        table.remove(data, #data)
+      end
+
+      if vim.tbl_isempty(data) then
+        -- Data was nothing but a EOL
         return
       end
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -252,6 +252,10 @@ function M.fetch(url, opts)
 
   local out = {}
 
+  if opts._dry then
+    return args
+  end
+
   local job = vim.fn.jobstart(args, {
     on_stdout = function(_, data)
       out = data

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -91,7 +91,7 @@ local function header_table_to_curl_arg_list(header_table)
   for key, values in pairs(header_table._storage) do
     for _, value in ipairs(values) do
       vim.list_extend(arg_list, {
-        '---header',
+        '--header',
         key .. ': ' .. value,
       })
     end

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -22,7 +22,7 @@ end
 ---@param url string The request URL.
 ---@param opts table Keyword arguments:
 ---             - method string|nil Http method.
----             - follow_redirects boolean|nil Follow redirects.
+---             - redirect string|nil Redirect mode.
 ---             - data string|table|nil Data to send with the request. If a table, it will be JSON
 ---             encoded.
 ---             - headers table<string, string>|nil Headers to set on the request
@@ -44,8 +44,8 @@ local function createCurlArgs(url, opts)
   -- Set http method.
   vim.list_extend(args, createMethodArgs(opts.method))
 
-  -- Follow redirects by default.
-  if opts.follow_redirects or opts.follow_redirects == nil then
+  -- redirect mode
+  if opts.redirect == 'follow' or opts.redirect == nil then
     table.insert(args, '--location')
   end
 
@@ -165,6 +165,10 @@ end
 
 --- Asynchronously make HTTP requests.
 ---
+--- Please carefully note the option differences with |vim.net.download()|, notably
+--- `redirect`.
+---
+---@see |vim.net.download()|
 ---@see https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 ---@see |job-control|
 ---@see man://curl
@@ -173,7 +177,9 @@ end
 ---@param opts table|nil Optional keyword arguments:
 ---             - method string|nil HTTP method to use. Defaults to GET.
 ---             - headers table|nil A table of key-value headers.
----             - follow_redirects boolean|nil Whether to follow redirects. Defaults to true.
+---             - redirect string|nil Redirect mode. Defaults to "follow". Possible values are:
+---                 - "follow": Follow all redirects incurred when fetching a resource.
+---                 - "error": Throw an error using on_err or vim.notify when status is 3XX.
 ---             - data string|table|nil Data to send with the request. If a table, it will be
 ---             JSON-encoded. vim.net does not currently support form encoding.
 ---
@@ -190,9 +196,10 @@ end
 ---                 - size number The total amount of bytes that were downloaded. This
 ---                 is the size of the body/data that was transferred, excluding headers.
 ---                 - http_version number HTTP version used in the request.
----             - on_err fun(err: string[])|nil An optional function recieving a `stderr_buffered` string[] of curl
----             stderr. Without providing this function, |vim.net.fetch()| will automatically raise an error
----             to the user. See |on_stderr| and `stderr_buffered`.
+---             - on_err fun(err: string[])|nil Function recieving a `stderr_buffered` string[] of error. 
+---             err is either curl stderr or internal fetch() error. Without providing this
+---             function, |vim.net.fetch()| will automatically raise the error to the user.
+---             See |on_stderr| and `stderr_buffered`.
 ---@return number jobid A job id.
 ---
 --- Example:
@@ -271,8 +278,24 @@ function M.fetch(url, opts)
       vim.notify('Failed to fetch: ' .. table.concat(data, '\n'), vim.log.levels.ERROR)
     end,
     on_exit = function(_, code)
+      local res
+
+      if opts.redirect == 'error' then
+        res = process_stdout(out)
+
+        if res.status >= 300 and res.status <= 399 then
+          local str = 'Fetch redirected to ' .. res._raw_write_out.redirect_url
+
+          if opts.on_err ~= nil then
+            return vim.notify(str, vim.log.levels.ERROR)
+          end
+
+          return opts.on_err({ str })
+        end
+      end
+
       if opts.on_complete and code == 0 then
-        local res = process_stdout(out)
+        res = res == nil and process_stdout(out) or res
 
         opts.on_complete(res)
       end
@@ -287,8 +310,10 @@ end
 --- Asynchronously download a file.
 --- To read the response metadata, such as headers and body, use |vim.net.fetch()|.
 ---
---- Shares a few options with |vim.net.fetch()|, but not all of them.
+--- Please carefully note the option differences with |vim.net.fetch()|, notably
+--- `redirect`.
 ---
+---@see |vim.net.fetch()|
 ---@see |job-control|
 ---@see man://curl
 ---
@@ -297,7 +322,9 @@ end
 ---@param opts table|nil Optional keyword arguments:
 ---             - method string|nil HTTP method to use. Defaults to GET.
 ---             - headers table<string, string>|nil A table of key-value headers.
----             - follow_redirects boolean|nil Will follow redirects by default.
+---             - redirect string|nil Redirect mode. Defaults to "follow". Possible values are:
+---                 - "follow": Follow all redirects incurred when fetching a resource.
+---                 - "none": Ignores redirect status.
 ---             - data string|table|nil Data to send with the request. If a table, it will be JSON
 ---             encoded. vim.net does not currently support form encoding.
 ---             - on_complete fun()|nil Callback function when download successfully completed.

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -275,8 +275,7 @@ end
 --- Accepts shares a few options with |vim.net.fetch()|, but not all of them.
 ---
 ---@param url string url
----@param path string A FULL download path. This function does not modify the path, you should use
----|fnnamemodify| with relative paths.
+---@param path string A download path. Can be relative.
 ---@param opts table|nil Optional keyword arguments:
 ---             - method string|nil HTTP method to use. Defaults to GET.
 ---             - headers table|nil A table of key-value headers.
@@ -291,8 +290,7 @@ end
 --- Example:
 --- <pre>lua
 ---
---- vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md",
---- ".cache/download/location/readme.md", {
+--- vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md", "~/.cache/download/location", {
 ---   on_complete = function ()
 ---     vim.notify("File Downloaded", vim.log.levels.INFO)
 ---   end
@@ -305,6 +303,8 @@ function M.download(url, path, opts)
   })
 
   opts = opts or {}
+
+  path = vim.fn.fnameescape(vim.fn.fnamemodify(path, ":p"))
 
   opts.download_location = path
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -60,7 +60,7 @@ function HeaderTable:append(key, value)
   end
 end
 
----Get first header value.
+---Get header value.
 ---For headers like cookies, use |HeaderTable:get_all|.
 ---@param self HeaderTable HeaderTable Instance.
 ---@param key string Non case-sensitive header name.
@@ -72,7 +72,7 @@ function HeaderTable:get(key)
   if value == nil then
     return nil
   elseif #value == 1 then
-    return value[1]
+    return table.concat(value, ", ")
   end
 end
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -180,7 +180,7 @@ end
 ---             - on_complete fun(response: table)|nil Callback function when request is
 ---             completed successfully. The response has the following keys:
 ---                 - ok boolean Whether the request was successful (status within 2XX range).
----                 - headers fun(): table<string, string> Function returning a table of response headers.
+---                 - headers fun(): table<string, string[]> Function returning a table of response headers.
 ---                 - body fun(): string|nil Function returning response body. If method was HEAD,
 ---                 this is nil.
 ---                 - json fun(opts: table|nil): table Read the body as JSON. Optionally accepts

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -63,10 +63,18 @@ end
 ---Get header values.
 ---@param self HeaderTable HeaderTable Instance.
 ---@param key string Non case-sensitive header name.
----@return string[]
+---@return string[] | string | nil
 function HeaderTable:get(key)
   local normalized_key = self:_normalize_key(key)
-  return self._storage[normalized_key]
+  local value = self._storage[normalized_key]
+
+  if value == nil then
+    return nil
+  elseif #value == 1 then
+    return value[1]
+  else
+    return value
+  end
 end
 
 ---@param self HeaderTable HeaderTable Instance.

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -166,7 +166,7 @@ local function createCurlArgs(url, opts)
   end
 
   if opts.headers ~= nil then
-    local headers
+    local headers = opts.headers
 
     if opts.headers._storage == nil then
       headers = HeaderTable.new(opts.headers)

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -191,7 +191,7 @@ end
 ---                 is the size of the body/data that was transferred, excluding headers.
 ---                 - http_version number HTTP version used in the request.
 ---             - on_err fun(err: string[])|nil An optional function recieving a `stderr_buffered` string[] of curl
----             stderr. Without providing this function, |fetch()| will automatically raise an error
+---             stderr. Without providing this function, |vim.net.fetch()| will automatically raise an error
 ---             to the user. See |on_stderr| and `stderr_buffered`.
 ---@return number jobid A job id.
 ---
@@ -302,7 +302,7 @@ end
 ---             encoded. vim.net does not currently support form encoding.
 ---             - on_complete fun()|nil Callback function when download successfully completed.
 ---             - on_err fun(err: string[])|nil An optional function recieving a `stderr_buffered` string[] of curl
----             stderr. Without providing this function, |download()| will automatically raise an error
+---             stderr. Without providing this function, |vim.net.download()| will automatically raise an error
 ---             to the user. See |on_stderr| and `stderr_buffered`.
 ---@return number jobid A job id. See |job-control|.
 ---

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -38,7 +38,6 @@ local function createCurlArgs(url, opts)
     'curl',
 
     -- Blocks progress bars and other non-parsable things
-    -- TODO: Allow stderr
     '--no-progress-meter',
   }
 

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -60,10 +60,11 @@ function HeaderTable:append(key, value)
   end
 end
 
----Get header values.
+---Get first header value.
+---For headers like cookies, use |HeaderTable:get_all|.
 ---@param self HeaderTable HeaderTable Instance.
 ---@param key string Non case-sensitive header name.
----@return string[] | string | nil
+---@return string | nil
 function HeaderTable:get(key)
   local normalized_key = self:_normalize_key(key)
   local value = self._storage[normalized_key]
@@ -72,10 +73,24 @@ function HeaderTable:get(key)
     return nil
   elseif #value == 1 then
     return value[1]
+  end
+end
+
+---Get all header values.
+---@param self HeaderTable HeaderTable Instance.
+---@param key string Non case-sensitive header name.
+---@return string[] | nil
+function HeaderTable:get_all(key)
+  local normalized_key = self:_normalize_key(key)
+  local value = self._storage[normalized_key]
+
+  if value == nil then
+    return nil
   else
     return value
   end
 end
+
 
 ---@param self HeaderTable HeaderTable Instance.
 ---@param key string Non case-sensitive header name.

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -137,7 +137,7 @@ local function process_stdout(data)
   end
 
   ---@private
-  local function read_body()
+  local function read_text()
     -- check cache, return nil if method is HEAD
     if cache.body == nil and extra.method ~= 'HEAD' then
       local body = table.concat(data, '\n', 1, began_headers_at - 1)
@@ -150,9 +150,9 @@ local function process_stdout(data)
 
   return {
     headers = read_headers,
-    body = read_body,
+    text = read_text,
     json = function(opts)
-      return vim.json.decode(read_body(), opts and opts or {})
+      return vim.json.decode(read_text(), opts and opts or {})
     end,
     method = extra.method,
     status = status,
@@ -181,7 +181,7 @@ end
 ---             completed successfully. The response has the following keys:
 ---                 - ok boolean Whether the request was successful (status within 2XX range).
 ---                 - headers fun(): table<string, string[]> Function returning a table of response headers.
----                 - body fun(): string|nil Function returning response body. If method was HEAD,
+---                 - text fun(): string|nil Function returning response body. If method was HEAD,
 ---                 this is nil.
 ---                 - json fun(opts: table|nil): table Read the body as JSON. Optionally accepts
 ---                 opts from |vim.json.decode|. Will throw errors if body is not JSON-decodable.
@@ -203,8 +203,8 @@ end
 ---     -- Lets read the response!
 ---
 ---     if response.ok then
----       -- Read response body
----       local body = response.body()
+---       -- Read response text
+---       local body = response.text()
 ---     else
 ---   end
 --- })

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -252,7 +252,8 @@ local function process_stdout(data)
     headers = read_headers,
     text = read_text,
     json = function(opts)
-      return vim.json.decode(read_text(), opts and opts or {})
+      local text = read_text()
+      return text and vim.json.decode(text, opts and opts or {}) or nil
     end,
     method = extra.method,
     status = status,
@@ -288,8 +289,9 @@ end
 ---                 - headers fun(): HeaderTable Function returning a HeaderTable of response headers.
 ---                 - text fun(): string|nil Function returning response body. If method was HEAD,
 ---                 this is nil.
----                 - json fun(opts: table|nil): table Read the body as JSON. Optionally accepts
+---                 - json fun(opts: table|nil): table|nil Read the body as JSON. Optionally accepts
 ---                 opts from |vim.json.decode|. Will throw errors if body is not JSON-decodable.
+---                 Nil if method is HEAD.
 ---                 - method string The http method used in the most recent HTTP request.
 ---                 - status number The numerical response code.
 ---                 - size number The total amount of bytes that were downloaded. This

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -334,6 +334,10 @@ function M.download(url, path, opts)
 
   local args = createCurlArgs(url, opts)
 
+  if opts._dry then
+    return args
+  end
+
   local job = vim.fn.jobstart(args, {
     on_exit = function(_, code)
       if opts.on_complete and code == 0 then

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -1,0 +1,328 @@
+local M = {}
+
+---@private Function to create method arguments. Method defaults to GET.
+---@param method string|nil Http method.
+---@return string[]
+local function createMethodArgs(method)
+  method = method and method:lower() or 'get'
+
+  if method == 'head' then
+    return { '--head' }
+  elseif method == 'get' then
+    return { '--get' }
+  end
+
+  return {
+    '--request',
+    method,
+  }
+end
+
+---@private Create curl args for a given request.
+---
+---@param url string Request URL.
+---@param opts table Keyword arguments:
+---             - method string|nil Http method.
+---             - follow_redirects boolean|nil Follow redirects.
+---             - data string|table|nil Data to send with the request. If a table, it will be json
+---             encoded.
+---             - headers table<string, string>|nil Headers to set on the request
+---             - download_location string|nil
+---
+---@return string[] args Curl command.
+local function createCurlArgs(url, opts)
+  vim.validate({
+    opts = { opts, 'table', true },
+  })
+
+  local args = {
+    'curl',
+
+    -- Blocks progress bars and other non-parsable things
+    -- TODO: Allow stderr
+    '--no-progress-meter',
+  }
+
+  if opts.download_location == nil then
+    -- Include header information when not downloading
+    table.insert(args, '--include')
+  end
+
+  -- Set http method.
+  vim.list_extend(args, createMethodArgs(opts.method))
+
+  -- Follow redirects by default.
+  if opts.follow_redirects or opts.follow_redirects == nil then
+    table.insert(args, '--location')
+  end
+
+  if opts.data ~= nil then
+    if type(opts.data) == 'table' then
+      vim.list_extend(args, {
+        -- Let curl do some extra stuff for json
+        '--json',
+        vim.json.encode(opts.data),
+      })
+    else
+      vim.list_extend(args, {
+        -- Otherwise, just pass the string as data
+        -- --data-raw does not give @ any special meaning
+        '--data-raw',
+        opts.data,
+      })
+    end
+  end
+
+  if opts.headers ~= nil then
+    for key, value in pairs(opts.headers) do
+      vim.list_extend(args, {
+        '--header',
+        key .. ': ' .. value,
+      })
+    end
+  end
+
+  if opts.download_location == nil then
+    -- Write additonal request metadata after the body.
+    vim.list_extend(args, {
+      '--write-out',
+      '\\n%{json}',
+    })
+  else
+    -- Write body contents to file.
+    vim.list_extend(args, {
+      '--output',
+      opts.download_location,
+    })
+  end
+
+  -- Finally, insert the request url.
+  table.insert(args, url)
+
+  return args
+end
+
+--- @private Process a stdout_buffered list of data into a response
+--- @param data string[] Data recieved from stdout
+local function process_stdout(data)
+  local cache = {}
+
+  -- Parse status string
+  local status_string = data[1]
+  -- Ignore these in favor of --write-out output i think
+  local _, _, status_text = status_string:match('(%S+)%s(%d+)%s(.+)\r')
+
+  local extra = {}
+
+  extra = vim.json.decode(data[#data])
+
+  ---@private
+  local function read_headers()
+    if cache.headers == nil then
+      local headers = {}
+
+      -- Plus one to account for status line
+      for i = 2, extra.num_headers + 1 do
+        local header_line = data[i]
+        local header_key, header_value = header_line:match('^(.-):%s*(.*)$')
+        headers[header_key] = header_value
+      end
+
+      cache.headers = headers
+    end
+
+    return cache.headers
+  end
+
+  ---@private
+  local function read_body()
+    if cache.body == nil then
+      local body_start = extra.num_headers + 2
+      local body_end = #data - 1
+      local body = table.concat(data, '\n', body_start, body_end)
+      cache.body = body
+    end
+
+    return cache.body
+  end
+
+  local status = extra.http_code and tonumber(extra.http_code) or nil
+
+  return {
+    headers = read_headers,
+    body = read_body,
+    json = function(opts)
+      return vim.json.decode(read_body(), opts and opts or {})
+    end,
+    method = extra.method,
+    status = status,
+    status_text = status_text,
+    ok = status and (status >= 200 and status <= 299) or false,
+    size = extra.size_download and tonumber(extra.size_download) or nil,
+    http_version = extra.http_version and tonumber(extra.http_version) or nil,
+    _raw_write_out = extra,
+  }
+end
+
+--- Asynchronously make HTTP requests.
+---
+---@param url string url
+---@param opts table|nil Optional keyword arguments:
+---             - method string|nil HTTP method to use. Defaults to GET.
+---             - headers table|nil A table of key-value headers.
+---             - follow_redirects boolean|nil Will follow redirects by default.
+---             - data string|table|nil Data to send with the request. If a table, it will be json
+---             encoded.
+---
+---             - on_complete nil|fun(response: table) Callback function when request is completed.
+---             The response has the following keys:
+---                 - ok boolean Convience field showing whether or not the request
+---                 was successful (status within 2XX range).
+---                 - headers fun(): table<string, string> Function returning a table of response headers.
+---                 - body fun(): string|nil Function returning response body. If method was HEAD,
+---                 this is likely nil.
+---                 - json fun(opts: table|nil): table Read the body as json. Optionally accepts
+---                 opts from |vim.json.decode|. Will throw errors if body is not json-decodable.
+---                 - method string The http method used in the most recent HTTP request.
+---                 - status number The numerical response code. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+---                 - status_text string The status text returned with the response.
+---                 - size number The total amount of bytes that were downloaded. This
+---                 is the size of the body/data that was transferred, excluding headers.
+---                 - http_version number HTTP version used in the request.
+---             - on_err nil|fun(errr: string[]) An optional function recieving a `stderr_buffered` string[] of curl
+---             stderr. Without providing this function, fetch() will automatically raise an error
+---             to the user. See |on_stderr| and `stderr_buffered`.
+---@return number jobid A job id. See |job-control|.
+---
+--- Example:
+--- <pre>lua
+--- -- GET a url
+--- vim.net.fetch("https://example.com/api/data", {
+---   on_complete = function (response)
+---     -- Lets read the response!
+---
+---     if response.ok then
+---       -- Read response body
+---       local body = response.body()
+---     else
+---   end
+--- })
+---
+--- -- POST to a url, sending json and providing an authorization header
+--- vim.net.fetch("https://example.com/api/data", {
+---   method = "POST",
+---   data = {
+---     key = value
+---   },
+---   headers = {
+---     Authorization = "Bearer " .. token
+---   },
+---   on_complete = function (response)
+---     -- Lets read the response!
+---
+---     if response.ok then
+---       -- Read json response
+---       local table = response.json()
+---     else
+---
+---     -- What went wrong?
+---     vim.print(response.status)
+---   end
+--- })
+--- </pre>
+function M.fetch(url, opts)
+  vim.validate({
+    opts = { opts, 'table', true },
+  })
+
+  opts = opts or {}
+
+  -- Ensure that we dont download to a file in fetch()
+  opts.download_location = nil
+
+  local args = createCurlArgs(url, opts)
+
+  local job = vim.fn.jobstart(args, {
+    on_stdout = function(_, data)
+      if opts.on_complete then
+        local res = process_stdout(data)
+
+        -- Since we use stdout_buffered, it is actually most safe to call on_compete from on_stdout.
+        opts.on_complete(res)
+      end
+    end,
+    on_stderr = function(_, data)
+      if opts.on_err ~= nil then
+        return opts.on_err(data)
+      end
+
+      vim.notify('Failed to fetch: ' .. table.concat(data, '\n'), vim.log.levels.ERROR)
+    end,
+    on_exit = function() end,
+    stdout_buffered = true,
+    stderr_buffered = true,
+  })
+
+  return job
+end
+
+--- Asynchronously download a file.
+--- To read the response metadata, such as headers and body, use |fetch()|.
+--- Accepts shares a few options with |vim.net.fetch()|, but not all of them.
+---
+---@param url string url
+---@param path string A FULL download path. This function does not modify the path, you should use
+---|fnnamemodify| with relative paths.
+---@param opts table|nil Optional keyword arguments:
+---             - method string|nil HTTP method to use. Defaults to GET.
+---             - headers table|nil A table of key-value headers.
+---             - follow_redirects boolean|nil Will follow redirects by default.
+---             - data string|table|nil Data to send with the request. If a table, it will be json
+---             encoded.
+---             - on_complete nil|fun() Callback function when download is complete.
+---             - on_err nil|fun(errr: string[]) An optional function recieving a `stderr_buffered` string[] of curl
+---             stderr. Without providing this function, fetch() will automatically raise an error
+---             to the user. See |on_stderr| and `stderr_buffered`.
+---
+--- Example:
+--- <pre>lua
+---
+--- vim.net.download("https://raw.githubusercontent.com/neovim/neovim/master/README.md",
+--- ".cache/download/location/readme.md", {
+---   on_complete = function ()
+---     vim.notify("File Downloaded", vim.log.levels.INFO)
+---   end
+--- })
+---
+--- </pre>
+function M.download(url, path, opts)
+  vim.validate({
+    opts = { opts, 'table', true },
+  })
+
+  opts = opts or {}
+
+  opts.download_location = path
+
+  local args = createCurlArgs(url, opts)
+
+  local job = vim.fn.jobstart(args, {
+    on_exit = function()
+      if opts.on_complete then
+        opts.on_complete()
+      end
+    end,
+    on_stderr = function(_, data)
+      if opts.on_err ~= nil then
+        return opts.on_err(data)
+      end
+
+      vim.notify('Failed to download file: ' .. table.concat(data, '\n'), vim.log.levels.ERROR)
+    end,
+    stderr_buffered = true,
+  })
+
+  return job
+end
+
+return M

--- a/runtime/plugin/net.lua
+++ b/runtime/plugin/net.lua
@@ -1,13 +1,48 @@
+if not vim.g.lua_net_enable then
+  return
+end
+
+local function url_safe_encode_byte(byte)
+  local char_map = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+  return char_map:sub(byte % 64 + 1, byte % 64 + 1)
+end
+
+-- The main function to generate a path-safe string
+local function generate_path_safe_string(len)
+  local path_safe_string = ''
+  local bytes = vim.loop.random(len)
+
+  for i = 1, len do
+    local encoded_byte = url_safe_encode_byte(bytes:byte(i))
+    path_safe_string = path_safe_string .. encoded_byte
+  end
+
+  return path_safe_string
+end
+
+local function get_buf_tmp_path()
+  if vim.b.lua_net_buf_id == nil then
+    vim.b.lua_net_buf_id = generate_path_safe_string(8)
+  end
+
+  local username = vim.fn.expand('$USER')
+  local root = '/tmp/nvim.' .. username
+
+  if vim.fn.isdirectory(root) == 0 then
+    vim.fn.mkdir(root)
+  end
+
+  return root .. '/' .. vim.b.lua_net_buf_id
+end
+
 local id = vim.api.nvim_create_augroup('LuaNetwork', {
   clear = true,
 })
 
-local namespace = vim.api.nvim_create_namespace('LuaNetwork')
-
 vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
-  pattern = { 'https://*', 'http://*' },
+  pattern = { 'https://*', 'http://*', 'ftp://*', 'scp://*' },
   group = id,
-  desc = 'Lua Network File Handler',
+  desc = 'Lua Network Buffer Read Handler',
   callback = function(ev)
     local view = vim.fn.winsaveview()
     local buf = ev.buf
@@ -16,11 +51,7 @@ vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
     local complete = false
     local err
 
-    local mark = vim.api.nvim_buf_set_extmark(buf, namespace, 0, 0, {
-      virt_text = {
-        { 'Loading ' .. file .. '...', 'Comment' },
-      },
-    })
+    vim.b.lua_net_buf_id = generate_path_safe_string(8)
 
     vim.net.fetch(file, {
       on_complete = function(result)
@@ -32,11 +63,106 @@ vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
 
         local ft = vim.filetype.match({
           filename = file,
-          contents = vim.g.net_ft_full and text or nil,
+          contents = vim.g.lua_net_ft_full and text or nil,
         })
 
         if ft then
           vim.cmd(':set ft=' .. ft)
+        end
+
+        complete = true
+      end,
+      on_err = function(data)
+        err = data
+        complete = true
+      end,
+    })
+
+    -- block until complete
+    local block, code = vim.wait(10000, function()
+      return complete
+    end)
+
+    if block == false and code == -2 then
+      return
+    end
+
+    if block == false and code == -1 and err then
+      vim.notify(
+        'Failed to fetch ' .. file .. ': ' .. table.concat(err, '\n'),
+        vim.log.levels.ERROR
+      )
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd({ 'FileReadCmd' }, {
+  pattern = { 'https://*', 'http://*', 'ftp://*', 'scp://*' },
+  group = id,
+  desc = 'Lua Network File Read Handler',
+  callback = function(ev)
+    local view = vim.fn.winsaveview()
+    local buf = ev.buf
+    local file = ev.file
+
+    local complete = false
+    local err
+
+    vim.net.fetch(file, {
+      on_complete = function(result)
+        local text = vim.split(result.text(), '\n')
+
+        local pos = vim.api.nvim_win_get_cursor(0)
+
+        vim.api.nvim_buf_set_lines(buf, pos[1], pos[1], false, text)
+
+        vim.fn.winrestview(view)
+
+        complete = true
+      end,
+      on_err = function(data)
+        err = data
+        complete = true
+      end,
+    })
+
+    -- block until complete
+    local block, code = vim.wait(10000, function()
+      return complete
+    end)
+
+    if block == false and code == -2 then
+      return
+    end
+
+    if block == false and code == -1 and err then
+      vim.notify('Failed to read ' .. file .. ': ' .. table.concat(err, '\n'), vim.log.levels.ERROR)
+    end
+  end,
+})
+
+vim.api.nvim_create_autocmd({ 'BufWriteCmd' }, {
+  pattern = { 'scp://*' },
+  group = id,
+  desc = 'Lua Network Write Handler',
+  callback = function(ev)
+    local buf = ev.buf
+    local file = ev.file
+
+    local complete = false
+    local err
+
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+
+    local path = get_buf_tmp_path()
+
+    vim.fn.writefile(lines, path)
+
+    vim.net.fetch(file, {
+      upload_file = path,
+      on_complete = function()
+        if not string.find(vim.o.cpo, '+') then
+          vim.cmd(':set modified&vim')
         end
 
         complete = true
@@ -51,14 +177,63 @@ vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
       return complete
     end)
 
-    -- Block timed out
-    if block == false and code == -1 then
+    if block == false and code == -2 then
+      return
+    end
+
+    if block == false and code == -1 and err then
       vim.notify(
-        'Failed to fetch ' .. file .. ': ' .. table.concat(err, '\n'),
+        'Failed to write to ' .. file .. ': ' .. table.concat(err, '\n'),
         vim.log.levels.ERROR
       )
     end
+  end,
+})
 
-    vim.api.nvim_buf_del_extmark(buf, namespace, mark)
+vim.api.nvim_create_autocmd({ 'FileWriteCmd' }, {
+  pattern = { 'scp://*' },
+  group = id,
+  desc = 'Lua Network Partial Write Handler',
+  callback = function(ev)
+    local buf = ev.buf
+    local file = ev.file
+
+    local complete = false
+    local err
+
+    local mark_start = vim.api.nvim_buf_get_mark(buf, '[')
+    local mark_end = vim.api.nvim_buf_get_mark(buf, ']')
+
+    local lines = vim.api.nvim_buf_get_lines(buf, mark_start[1] - 1, mark_end[1], true)
+
+    local path = get_buf_tmp_path()
+
+    vim.fn.writefile(lines, path)
+
+    vim.net.fetch(file, {
+      upload_file = path,
+      on_complete = function()
+        complete = true
+      end,
+      on_err = function(data)
+        err = data
+      end,
+    })
+
+    -- block until complete
+    local block, code = vim.wait(10000, function()
+      return complete
+    end)
+
+    if block == false and code == -2 then
+      return
+    end
+
+    if block == false and code == -1 and err then
+      vim.notify(
+        'Failed to partially write ' .. file .. ': ' .. table.concat(err, '\n'),
+        vim.log.levels.ERROR
+      )
+    end
   end,
 })

--- a/runtime/plugin/net.lua
+++ b/runtime/plugin/net.lua
@@ -24,9 +24,9 @@ vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
 
       vim.net.fetch(file, {
           on_complete = function(result)
-            local body = vim.split(result.body(), '\n')
+            local text = vim.split(result.text(), '\n')
 
-            vim.api.nvim_buf_set_lines(buf, -2, -1, false, body)
+            vim.api.nvim_buf_set_lines(buf, -2, -1, false, text)
 
             vim.fn.winrestview(view)
 

--- a/runtime/plugin/net.lua
+++ b/runtime/plugin/net.lua
@@ -30,6 +30,15 @@ vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
 
             vim.fn.winrestview(view)
 
+            local ft = vim.filetype.match({
+                    filename = file,
+                    contents = vim.g.net_ft_full and text or nil
+                })
+
+            if ft then
+              vim.cmd(':set ft=' .. ft)
+            end
+
             complete = true
           end,
           on_err = function(data)

--- a/runtime/plugin/net.lua
+++ b/runtime/plugin/net.lua
@@ -1,0 +1,55 @@
+local id = vim.api.nvim_create_augroup('LuaNetwork', {
+        clear = true,
+    })
+
+local namespace = vim.api.nvim_create_namespace('LuaNetwork')
+
+vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
+    pattern = { 'https://*', 'http://*' },
+    group = id,
+    desc = 'Lua Network File Handler',
+    callback = function(ev)
+      local view = vim.fn.winsaveview()
+      local buf = ev.buf
+      local file = ev.file
+
+      local complete = false
+      local err
+
+      local mark = vim.api.nvim_buf_set_extmark(buf, namespace, 0, 0, {
+              virt_text = {
+                  { 'Loading ' .. file .. '...', 'Comment' },
+              },
+          })
+
+      vim.net.fetch(file, {
+          on_complete = function(result)
+            local body = vim.split(result.body(), '\n')
+
+            vim.api.nvim_buf_set_lines(buf, -2, -1, false, body)
+
+            vim.fn.winrestview(view)
+
+            complete = true
+          end,
+          on_err = function(data)
+            err = data
+          end,
+      })
+
+      -- block until complete
+      local block, code = vim.wait(10000, function()
+            return complete
+          end)
+
+      -- Block timed out
+      if block == false and code == -1 then
+        vim.notify(
+            'Failed to fetch ' .. file .. ': ' .. table.concat(err, '\n'),
+            vim.log.levels.ERROR
+        )
+      end
+
+      vim.api.nvim_buf_del_extmark(buf, namespace, mark)
+    end,
+})

--- a/runtime/plugin/net.lua
+++ b/runtime/plugin/net.lua
@@ -1,64 +1,64 @@
 local id = vim.api.nvim_create_augroup('LuaNetwork', {
-        clear = true,
-    })
+  clear = true,
+})
 
 local namespace = vim.api.nvim_create_namespace('LuaNetwork')
 
 vim.api.nvim_create_autocmd({ 'BufReadCmd' }, {
-    pattern = { 'https://*', 'http://*' },
-    group = id,
-    desc = 'Lua Network File Handler',
-    callback = function(ev)
-      local view = vim.fn.winsaveview()
-      local buf = ev.buf
-      local file = ev.file
+  pattern = { 'https://*', 'http://*' },
+  group = id,
+  desc = 'Lua Network File Handler',
+  callback = function(ev)
+    local view = vim.fn.winsaveview()
+    local buf = ev.buf
+    local file = ev.file
 
-      local complete = false
-      local err
+    local complete = false
+    local err
 
-      local mark = vim.api.nvim_buf_set_extmark(buf, namespace, 0, 0, {
-              virt_text = {
-                  { 'Loading ' .. file .. '...', 'Comment' },
-              },
-          })
+    local mark = vim.api.nvim_buf_set_extmark(buf, namespace, 0, 0, {
+      virt_text = {
+        { 'Loading ' .. file .. '...', 'Comment' },
+      },
+    })
 
-      vim.net.fetch(file, {
-          on_complete = function(result)
-            local text = vim.split(result.text(), '\n')
+    vim.net.fetch(file, {
+      on_complete = function(result)
+        local text = vim.split(result.text(), '\n')
 
-            vim.api.nvim_buf_set_lines(buf, -2, -1, false, text)
+        vim.api.nvim_buf_set_lines(buf, -2, -1, false, text)
 
-            vim.fn.winrestview(view)
+        vim.fn.winrestview(view)
 
-            local ft = vim.filetype.match({
-                    filename = file,
-                    contents = vim.g.net_ft_full and text or nil
-                })
+        local ft = vim.filetype.match({
+          filename = file,
+          contents = vim.g.net_ft_full and text or nil,
+        })
 
-            if ft then
-              vim.cmd(':set ft=' .. ft)
-            end
+        if ft then
+          vim.cmd(':set ft=' .. ft)
+        end
 
-            complete = true
-          end,
-          on_err = function(data)
-            err = data
-          end,
-      })
+        complete = true
+      end,
+      on_err = function(data)
+        err = data
+      end,
+    })
 
-      -- block until complete
-      local block, code = vim.wait(10000, function()
-            return complete
-          end)
+    -- block until complete
+    local block, code = vim.wait(10000, function()
+      return complete
+    end)
 
-      -- Block timed out
-      if block == false and code == -1 then
-        vim.notify(
-            'Failed to fetch ' .. file .. ': ' .. table.concat(err, '\n'),
-            vim.log.levels.ERROR
-        )
-      end
+    -- Block timed out
+    if block == false and code == -1 then
+      vim.notify(
+        'Failed to fetch ' .. file .. ': ' .. table.concat(err, '\n'),
+        vim.log.levels.ERROR
+      )
+    end
 
-      vim.api.nvim_buf_del_extmark(buf, namespace, mark)
-    end,
+    vim.api.nvim_buf_del_extmark(buf, namespace, mark)
+  end,
 })

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -43,11 +43,17 @@ augroup END
 augroup Network
  au!
  au BufReadCmd   file://*											call netrw#FileUrlEdit(expand("<amatch>"))
-" TODO: Remove this modification, and provide an opt-in option
- au BufReadCmd   ftp://*,rcp://*,scp://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
- au FileReadCmd  ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
- au BufWriteCmd  ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
- au FileWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
+ " Disable non-lua implementations if user opts-in
+ if exists("g:lua_net_enable")
+  au BufReadCmd rcp://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
+  au BufWriteCmd  rcp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
+  au FileReadCmd  rcp://*,file://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
+ else
+  au BufReadCmd ftp://*,rcp://*,scp://*,http://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
+  au BufWriteCmd  ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
+  au FileReadCmd  ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
+ endif
+ au FileWriteCmd ftp://*,rcp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
  try
   au SourceCmd   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe 'Nsource '.fnameescape(expand("<amatch>"))
  catch /^Vim\%((\a\+)\)\=:E216/

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -48,12 +48,13 @@ augroup Network
   au BufReadCmd rcp://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
   au BufWriteCmd  rcp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
   au FileReadCmd  rcp://*,file://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
+  au FileWriteCmd rcp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
  else
   au BufReadCmd ftp://*,rcp://*,scp://*,http://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
   au BufWriteCmd  ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
   au FileReadCmd  ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
+   au FileWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
  endif
- au FileWriteCmd ftp://*,rcp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
  try
   au SourceCmd   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe 'Nsource '.fnameescape(expand("<amatch>"))
  catch /^Vim\%((\a\+)\)\=:E216/

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -43,7 +43,8 @@ augroup END
 augroup Network
  au!
  au BufReadCmd   file://*											call netrw#FileUrlEdit(expand("<amatch>"))
- au BufReadCmd   ftp://*,rcp://*,scp://*,http://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
+" TODO: Remove this modification, and provide an opt-in option
+ au BufReadCmd   ftp://*,rcp://*,scp://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
  au FileReadCmd  ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*	exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
  au BufWriteCmd  ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
  au FileWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*			exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -205,6 +205,7 @@ CONFIG = {
             'secure': 'vim.secure',
             'version': 'vim.version',
             'iter': 'vim.iter',
+            'net': 'vim.net',
         },
         'append_only': [
             'shared.lua',

--- a/scripts/gen_vimdoc.py
+++ b/scripts/gen_vimdoc.py
@@ -155,6 +155,7 @@ CONFIG = {
             'secure.lua',
             'version.lua',
             'iter.lua',
+            'net.lua',
         ],
         'files': [
             'runtime/lua/vim/iter.lua',
@@ -163,6 +164,7 @@ CONFIG = {
             'runtime/lua/vim/loader.lua',
             'runtime/lua/vim/uri.lua',
             'runtime/lua/vim/ui.lua',
+            'runtime/lua/vim/net.lua',
             'runtime/lua/vim/filetype.lua',
             'runtime/lua/vim/keymap.lua',
             'runtime/lua/vim/fs.lua',

--- a/test/functional/helpers.lua
+++ b/test/functional/helpers.lua
@@ -727,6 +727,15 @@ function module.assert_visible(bufnr, visible)
   end
 end
 
+function module.file_exists(path)
+  local stat, err = luv.fs_stat(path)
+  if stat then
+    return true
+  else
+    return false, err
+  end
+end
+
 local function do_rmdir(path)
   local stat = luv.fs_stat(path)
   if stat == nil then

--- a/test/functional/lua/net.lua
+++ b/test/functional/lua/net.lua
@@ -40,7 +40,6 @@ describe('vim.net', function()
             'curl',
             '--no-progress-meter',
             '--head',
-            '--location',
             '--write-out',
             '\\nBEGIN_HEADERS\\n%{header_json}\\n%{json}',
             'https://httpbin.org/head',
@@ -48,6 +47,7 @@ describe('vim.net', function()
           exec_lua([[
             return vim.net.fetch("https://httpbin.org/head", {
               method = "head",
+              redirect = "error",
               _dry = true
             })
           ]])
@@ -92,7 +92,7 @@ describe('vim.net', function()
           },
           exec_lua([[
             return vim.net.download("https://httpbin.org/get", "./download_file", {
-              follow_redirects = false,
+              redirect = "error",
               data = "hi",
               _dry = true
             })

--- a/test/functional/lua/net.lua
+++ b/test/functional/lua/net.lua
@@ -1,0 +1,164 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local clear = helpers.clear
+local exec_lua = helpers.exec_lua
+local next_msg = helpers.next_msg
+local meths = helpers.meths
+local eq = helpers.eq
+
+describe('vim.net methods', function()
+  before_each(clear)
+
+  describe('createCurlArgs', function()
+    it('should use args', function()
+      eq(
+        {
+          'curl',
+          '--no-progress-meter',
+          '--include',
+          '--get',
+          '--location',
+          '--write-out',
+          '\\n%{json}',
+          'https://httpbin.org/get',
+        },
+        exec_lua([[
+        return vim.net.fetch("https://httpbin.org/get", {
+          _dry = true
+        })
+      ]])
+      )
+
+      eq(
+        {
+          'curl',
+          '--no-progress-meter',
+          '--include',
+          '--head',
+          '--location',
+          '--write-out',
+          '\\n%{json}',
+          'https://httpbin.org/head',
+        },
+        exec_lua([[
+        return vim.net.fetch("https://httpbin.org/head", {
+          method = "head",
+          _dry = true
+        })
+      ]])
+      )
+
+      eq(
+        {
+          'curl',
+          '--no-progress-meter',
+          '--include',
+          '--request',
+          'DELETE',
+          '--location',
+          '--write-out',
+          '\\n%{json}',
+          'https://httpbin.org/delete',
+        },
+        exec_lua([[
+        return vim.net.fetch("https://httpbin.org/delete", {
+          method = "DELETE",
+          _dry = true
+        })
+      ]])
+      )
+    end)
+  end)
+
+  describe('fetch()', function()
+    before_each(function ()
+      local channel = meths.get_api_info()[1]
+      meths.set_var('channel', channel)
+    end)
+
+    it('should read status', function()
+      exec_lua([[
+        local result
+
+        vim.net.fetch("https://httpbingo.org/status/999", {
+          on_complete = function (res)
+            result = res
+          end
+        })
+
+        -- wait 10 seconds and time-out
+        local _, interrupted = vim.wait(10000, function()
+          return result ~= nil
+        end)
+
+        vim.rpcnotify(vim.g.channel, 'method', result.method == "GET")
+        vim.rpcnotify(vim.g.channel, 'ok', result.ok == false)
+        vim.rpcnotify(vim.g.channel, 'status', result.status)
+      ]])
+
+      eq({ 'notification', 'method', { true } }, next_msg(500))
+      eq({ 'notification', 'ok', { true } }, next_msg(500))
+      eq({ 'notification', 'status', { 999 } }, next_msg(500))
+    end)
+
+    it('should post & read JSON', function()
+      exec_lua([[
+        local result
+
+        vim.net.fetch("https://httpbingo.org/anything", {
+          method = "POST",
+          data = {
+            A = "b"
+          },
+          on_complete = function(res)
+            result = res
+          end
+        })
+
+        -- wait 10 seconds and time-out
+        local _, interrupted = vim.wait(10000, function()
+          return result ~= nil
+        end)
+
+        vim.rpcnotify(vim.g.channel, 'method', result.method == "POST")
+        vim.rpcnotify(vim.g.channel, 'ok', result.ok == true)
+        vim.rpcnotify(vim.g.channel, 'json', result.json().json)
+      ]])
+
+      eq({ 'notification', 'method', { true } }, next_msg(500))
+      eq({ 'notification', 'ok', { true } }, next_msg(500))
+      eq({ 'notification', 'json', { { A = 'b' } } }, next_msg(500))
+    end)
+
+    it('should set headers', function()
+      exec_lua([[
+        local result
+
+        vim.net.fetch("https://httpbingo.org/headers", {
+          headers = {
+            test_header = "value",
+            NIL_HEADER = nil
+          },
+          on_complete = function(res)
+            result = res
+          end
+        })
+
+        -- wait 10 seconds and time-out
+        local _, interrupted = vim.wait(10000, function()
+          return result ~= nil
+        end)
+
+        vim.rpcnotify(vim.g.channel, 'method', result.method == "GET")
+        vim.rpcnotify(vim.g.channel, 'ok', result.ok == true)
+        vim.rpcnotify(vim.g.channel, 'headers.TEST_HEADER', result.json().headers["Test_header"][1] == "value")
+        vim.rpcnotify(vim.g.channel, 'headers.NIL_HEADER', result.json().headers["Nil_header"] == nil)
+      ]])
+
+      eq({ 'notification', 'method', { true } }, next_msg(500))
+      eq({ 'notification', 'ok', { true } }, next_msg(500))
+      eq({ 'notification', 'headers.TEST_HEADER', { true } }, next_msg(500))
+      eq({ 'notification', 'headers.NIL_HEADER', { true } }, next_msg(500))
+    end)
+  end)
+end)

--- a/test/functional/lua/net.lua
+++ b/test/functional/lua/net.lua
@@ -3,79 +3,109 @@ local helpers = require('test.functional.helpers')(after_each)
 local clear = helpers.clear
 local exec_lua = helpers.exec_lua
 local next_msg = helpers.next_msg
+local file_exists = helpers.file_exists
+local read_file = helpers.read_file
 local meths = helpers.meths
 local eq = helpers.eq
 
-describe('vim.net methods', function()
-  before_each(clear)
+describe('vim.net', function()
+  before_each(function()
+    clear()
+    local channel = meths.get_api_info()[1]
+    meths.set_var('channel', channel)
+  end)
 
-  describe('createCurlArgs', function()
-    it('should use args', function()
-      eq(
-        {
-          'curl',
-          '--no-progress-meter',
-          '--include',
-          '--get',
-          '--location',
-          '--write-out',
-          '\\n%{json}',
-          'https://httpbin.org/get',
-        },
-        exec_lua([[
-        return vim.net.fetch("https://httpbin.org/get", {
-          _dry = true
-        })
-      ]])
-      )
+  describe('create args', function()
+    describe('fetch()', function()
+      it('valid', function()
+        eq(
+          {
+            'curl',
+            '--no-progress-meter',
+            '--include',
+            '--get',
+            '--location',
+            '--write-out',
+            '\\n%{json}',
+            'https://httpbin.org/get',
+          },
+          exec_lua([[
+            return vim.net.fetch("https://httpbin.org/get", {
+              _dry = true
+            })
+          ]])
+        )
 
-      eq(
-        {
-          'curl',
-          '--no-progress-meter',
-          '--include',
-          '--head',
-          '--location',
-          '--write-out',
-          '\\n%{json}',
-          'https://httpbin.org/head',
-        },
-        exec_lua([[
-        return vim.net.fetch("https://httpbin.org/head", {
-          method = "head",
-          _dry = true
-        })
-      ]])
-      )
+        eq(
+          {
+            'curl',
+            '--no-progress-meter',
+            '--include',
+            '--head',
+            '--location',
+            '--write-out',
+            '\\n%{json}',
+            'https://httpbin.org/head',
+          },
+          exec_lua([[
+            return vim.net.fetch("https://httpbin.org/head", {
+              method = "head",
+              _dry = true
+            })
+          ]])
+        )
 
-      eq(
-        {
-          'curl',
-          '--no-progress-meter',
-          '--include',
-          '--request',
-          'DELETE',
-          '--location',
-          '--write-out',
-          '\\n%{json}',
-          'https://httpbin.org/delete',
-        },
-        exec_lua([[
-        return vim.net.fetch("https://httpbin.org/delete", {
-          method = "DELETE",
-          _dry = true
-        })
-      ]])
-      )
+        eq(
+          {
+            'curl',
+            '--no-progress-meter',
+            '--include',
+            '--request',
+            'DELETE',
+            '--location',
+            '--write-out',
+            '\\n%{json}',
+            'https://httpbin.org/delete',
+          },
+          exec_lua([[
+            return vim.net.fetch("https://httpbin.org/delete", {
+              method = "DELETE",
+              _dry = true
+            })
+          ]])
+        )
+      end)
+    end)
+
+    describe('download()', function()
+      it('valid', function()
+        local path =
+          exec_lua([[return vim.fn.fnameescape(vim.fn.fnamemodify("./download_file", ":p"))]])
+
+        eq(
+          {
+            'curl',
+            '--no-progress-meter',
+            '--get',
+            '--data-raw',
+            'hi',
+            '--output',
+            path,
+            'https://httpbin.org/get',
+          },
+          exec_lua([[
+            return vim.net.download("https://httpbin.org/get", "./download_file", {
+              follow_redirects = false,
+              data = "hi",
+              _dry = true
+            })
+          ]])
+        )
+      end)
     end)
   end)
 
   describe('fetch()', function()
-    before_each(function ()
-      local channel = meths.get_api_info()[1]
-      meths.set_var('channel', channel)
-    end)
-
     it('should read status', function()
       exec_lua([[
         local result
@@ -159,6 +189,49 @@ describe('vim.net methods', function()
       eq({ 'notification', 'ok', { true } }, next_msg(500))
       eq({ 'notification', 'headers.TEST_HEADER', { true } }, next_msg(500))
       eq({ 'notification', 'headers.NIL_HEADER', { true } }, next_msg(500))
+    end)
+  end)
+
+  describe('download()', function()
+    before_each(function()
+      os.remove('./downloaded_file')
+    end)
+
+    it('saves files', function()
+      eq(false, file_exists('./downloaded_file'))
+
+      exec_lua([[
+        local done
+
+        vim.net.download("https://httpbingo.org/anything", "./download_file", {
+          headers = {
+            test_header = "value",
+          },
+          on_complete = function()
+            done = true
+          end
+        })
+
+        -- wait 10 seconds and time-out
+        local _, interrupted = vim.wait(10000, function()
+          return done
+        end)
+
+        vim.rpcnotify(vim.g.channel, 'done', done)
+        vim.rpcnotify(vim.g.channel, 'path', "./download_file")
+      ]])
+
+      eq({ 'notification', 'done', { true } }, next_msg(500))
+
+      local path = next_msg(500)[3][1]
+      local data = read_file(path)
+
+      eq(true, file_exists(path))
+      eq('https://httpbingo.org/anything', vim.json.decode(data).url)
+      eq({ 'value' }, vim.json.decode(data).headers['Test_header'])
+
+      -- Just to be safe - can contain header information
+      os.remove('./downloaded_file')
     end)
   end)
 end)

--- a/test/functional/lua/net.lua
+++ b/test/functional/lua/net.lua
@@ -22,11 +22,10 @@ describe('vim.net', function()
           {
             'curl',
             '--no-progress-meter',
-            '--include',
             '--get',
             '--location',
             '--write-out',
-            '\\n%{json}',
+            '\\nBEGIN_HEADERS\\n%{header_json}\\n%{json}',
             'https://httpbin.org/get',
           },
           exec_lua([[
@@ -40,11 +39,10 @@ describe('vim.net', function()
           {
             'curl',
             '--no-progress-meter',
-            '--include',
             '--head',
             '--location',
             '--write-out',
-            '\\n%{json}',
+            '\\nBEGIN_HEADERS\\n%{header_json}\\n%{json}',
             'https://httpbin.org/head',
           },
           exec_lua([[
@@ -59,12 +57,11 @@ describe('vim.net', function()
           {
             'curl',
             '--no-progress-meter',
-            '--include',
             '--request',
             'DELETE',
             '--location',
             '--write-out',
-            '\\n%{json}',
+            '\\nBEGIN_HEADERS\\n%{header_json}\\n%{json}',
             'https://httpbin.org/delete',
           },
           exec_lua([[


### PR DESCRIPTION
This PR closes #23232. Implements `vim.net.fetch()` and `vim.net.download()`. Wraps CURL.

I am asking everyone for their thoughts on the interface and implementation, I decided this would be a fun project to write over a few days.

It wraps curl's stdout, somewhat "handles" errors, and has some tests written. It is implemented in the best way I could think, please let me know if there is a smarter way to wrap curl.

Not everything is fully covered in the tests, however ive made many requests using it and ironed out a ridiculous amount of bugs. Even with `vim.json.encod`'ing entire certificates its still somehow faster than netrw.

### `vim.net.fetch()`
Asynchronously make HTTP requests. I took some inspiration from Javascript's `fetch()`.

It is likely that it will have to be expanded to other protocols. It is also likely that some already work, but they are entirely untested.

<details>
  <summary>Code Example</summary>
  
```lua
-- GET a url
vim.net.fetch("https://example.com/api/data", {
 on_complete = function (response)
   -- Lets read the response!

   if response.ok then
     -- Read response body
     local body = response.body()
   else
 end
})

-- POST to a url, sending a table as JSON and providing an authorization header
vim.net.fetch("https://example.com/api/data", {
 method = "POST",
 data = {
   key = value
 },
 headers = {
   Authorization = "Bearer " .. token
 },
 on_complete = function (response)
   -- Lets read the response!

   if response.ok then
     -- Read JSON response
     local table = response.json()
   else

   -- What went wrong?
   vim.print(response.status)
 end
})

```
</details>

### `vim.net.download()`
Asynchronously download a file. To read the response metadata, such as headers and body, use `vi.net.fetch()`.

Shares a few options with `vim.net.fetch()`, but not all of them.

It is entirely possible that this function gets removed, as the `:edit URL` implementation saves the file contents to memory. (Unlike netrw's `wget` implementation).

<details>
  <summary>Code Example</summary>

```lua
 vim.net.download("https://.../path/file", "~/.cache/download/location", {
   on_complete = function ()
     vim.notify("File Downloaded", vim.log.levels.INFO)
   end
 })
```

</details>

### `HeaderTable`

Helper class to deal with header operations, both internal and external plugins can benefit from its methods. See `:help vim.net`. 

### `:e, :w, :[range]w!, :r  URL`

Currently, this PR only handles `https://*,http://*,scp://*,ftp://*`. 

[Screencast from 2023-05-04 11-44-45.webm](https://user-images.githubusercontent.com/40532058/236091188-a1150780-b780-4789-b20c-eb7dd7045d52.webm)

### **Benchmarks**

Using this command, we can benchmark the time it takes to "read" a readme. This isnt proper benchmark, more data is required, but I think it might be enough.

```vim
:let start_time = reltime() | edit https://raw.githubusercontent.com/neovim/neovim/master/README.md | let end_time = reltime() | echo reltimestr(reltime(start_time, end_time))
```

`nvim --clean` on **vim.net** it took about `0.08` seconds.

![image](https://user-images.githubusercontent.com/40532058/235909157-0ceba42a-19a7-4831-9fe2-e82ea07394b4.png)

Stock `nvim --clean` on **master**.

![image](https://user-images.githubusercontent.com/40532058/235908873-e7d6b111-1e97-424b-9f0b-3f04927e2463.png)

`vim --clean` (for fun) (also showing that master is pretty similar)

![image](https://user-images.githubusercontent.com/40532058/235909266-42918a8b-9d3f-421f-ad31-9acddaf83d5f.png)

