### PR TITLE
vim-patch:9.0.{0609,0612}

### DIFF
--- a/test/old/testdir/test_blockedit.vim
+++ b/test/old/testdir/test_blockedit.vim
@@ -18,6 +18,7 @@ endfunc
 func Test_blockinsert_autoindent()
   new
   let lines =<< trim END
+      vim9script
       var d = {
       a: () => 0,
       b: () => 0,
@@ -28,42 +29,42 @@ func Test_blockinsert_autoindent()
   filetype plugin indent on
   setlocal sw=2 et ft=vim
   setlocal indentkeys+=:
-  exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
-  " FIXME: what do we really expect?
+  exe "norm! 3Gf)\<c-v>2jA: asdf\<esc>"
   let expected =<< trim END
+      vim9script
       var d = {
-      a: (): asdf => 0,
+        a: (): asdf => 0,
       b: (): asdf => 0,
       c: (): asdf => 0,
       }
   END
-  call assert_equal(expected, getline(1, 5))
+  call assert_equal(expected, getline(1, 6))
 
   " insert on the next column should do exactly the same
   :%dele
   call setline(1, lines)
-  exe "norm! 2Gf)l\<c-v>2jI: asdf\<esc>"
-  call assert_equal(expected, getline(1, 5))
+  exe "norm! 3Gf)l\<c-v>2jI: asdf\<esc>"
+  call assert_equal(expected, getline(1, 6))
 
   :%dele
   call setline(1, lines)
   setlocal sw=8 noet
-  exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
-  " FIXME: what do we really expect?
+  exe "norm! 3Gf)\<c-v>2jA: asdf\<esc>"
   let expected =<< trim END
+      vim9script
       var d = {
-      a: (): asdf => 0,
+      	a: (): asdf => 0,
       b: (): asdf => 0,
       c: (): asdf => 0,
       }
   END
-  call assert_equal(expected, getline(1, 5))
+  call assert_equal(expected, getline(1, 6))
 
   " insert on the next column should do exactly the same
   :%dele
   call setline(1, lines)
-  exe "norm! 2Gf)l\<c-v>2jI: asdf\<esc>"
-  call assert_equal(expected, getline(1, 5))
+  exe "norm! 3Gf)l\<c-v>2jI: asdf\<esc>"
+  call assert_equal(expected, getline(1, 6))
 
   filetype off
   bwipe!

--- a/test/old/testdir/test_blockedit.vim
+++ b/test/old/testdir/test_blockedit.vim
@@ -29,9 +29,10 @@ func Test_blockinsert_autoindent()
   setlocal sw=2 et ft=vim
   setlocal indentkeys+=:
   exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
+  " FIXME: what do we really expect?
   let expected =<< trim END
       var d = {
-        a: (): asdf => 0,
+      a: (): asdf => 0,
       b: (): asdf => 0,
       c: (): asdf => 0,
       }
@@ -48,9 +49,10 @@ func Test_blockinsert_autoindent()
   call setline(1, lines)
   setlocal sw=8 noet
   exe "norm! 2Gf)\<c-v>2jA: asdf\<esc>"
+  " FIXME: what do we really expect?
   let expected =<< trim END
       var d = {
-      	a: (): asdf => 0,
+      a: (): asdf => 0,
       b: (): asdf => 0,
       c: (): asdf => 0,
       }


### PR DESCRIPTION
#### vim-patch:9.0.0609: blockedit test fails because of wrong indent

Problem:    Blockedit test fails because of wrong indent.
Solution:   Adjust the expected text temporarily

https://github.com/vim/vim/commit/66000ff9af8e3de93825ce7baa0c43727465eca5

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0612: blockedit test passes with wrong result

Problem:    Blockedit test passes with wrong result.
Solution:   Add a "vim9script" line to make indenting work.

https://github.com/vim/vim/commit/47da934844afec7b04d94e0d1f8cf0a86e1b9bea

Co-authored-by: Bram Moolenaar <Bram@vim.org>