### PR TITLE
vim-patch:9.0.{0138,0240}: two spell fixes

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5706,6 +5706,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Name of the word list file where words are added for the |zg| and |zw|
 	commands.  It must end in ".{encoding}.add".  You need to include the
 	path, otherwise the file is placed in the current directory.
+	The path may include characters from 'isfname', space, comma and '@'.
 								*E765*
 	It may also be a comma-separated list of names.  A count before the
 	|zg| and |zw| commands can be used to access each.  This allows using

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -858,14 +858,24 @@ bool vim_iswordp_buf(const char *const p, buf_T *const buf)
   return vim_iswordc_buf(c, buf);
 }
 
-/// Check that "c" is a valid file-name character.
+/// Check that "c" is a valid file-name character as specified with the
+/// 'isfname' option.
 /// Assume characters above 0x100 are valid (multi-byte).
+/// To be used for commands like "gf".
 ///
 /// @param  c  character to check
 bool vim_isfilec(int c)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return c >= 0x100 || (c > 0 && (g_chartab[c] & CT_FNAME_CHAR));
+}
+
+/// Check if "c" is a valid file-name character, including characters left
+/// out of 'isfname' to make "gf" work, such as comma, space, '@', etc.
+bool vim_is_fname_char(int c)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return vim_isfilec(c) || c == ',' || c == ' ' || c == '@';
 }
 
 /// Check that "c" is a valid file-name character or a wildcard character

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3621,7 +3621,7 @@ bool valid_spellfile(const char *val)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   for (const char *s = val; *s != NUL; s++) {
-    if (!vim_isfilec((uint8_t)(*s)) && *s != ',' && *s != ' ') {
+    if (!vim_is_fname_char((uint8_t)(*s))) {
       return false;
     }
   }

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -4971,9 +4971,12 @@ static int sug_filltree(spellinfo_T *spin, slang_T *slang)
   spin->si_sugtree = true;
 
   // Go through the whole case-folded tree, soundfold each word and put it
-  // in the trie.
+  // in the trie.  Bail out if the tree is empty.
   byts = slang->sl_fbyts;
   idxs = slang->sl_fidxs;
+  if (byts == NULL || idxs == NULL) {
+    return FAIL;
+  }
 
   arridx[0] = 0;
   curi[0] = 1;

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -1063,4 +1063,12 @@ func Test_mkspellmem_opt()
   call assert_fails('set mkspellmem=1000,50,0', 'E474:')
 endfunc
 
+" 'spellfile' accepts '@' on top of 'isfname'.
+func Test_spellfile_allow_at_character()
+  call mkdir('Xtest/the foo@bar,dir', 'p')
+  let &spellfile = './Xtest/the foo@bar,dir/Xspellfile.add'
+  let &spellfile = ''
+  call delete('Xtest', 'rf')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -1071,4 +1071,16 @@ func Test_spellfile_allow_at_character()
   call delete('Xtest', 'rf')
 endfunc
 
+" this was using a NULL pointer
+func Test_mkspell_empty_dic()
+  call writefile(['1'], 'XtestEmpty.dic')
+  call writefile(['SOFOFROM abcd', 'SOFOTO ABCD', 'SAL CIA X'], 'XtestEmpty.aff')
+  mkspell! XtestEmpty.spl XtestEmpty
+
+  call delete('XtestEmpty.dic')
+  call delete('XtestEmpty.aff')
+  call delete('XtestEmpty.spl')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0138: not enough characters accepted for 'spellfile'

Problem:    Not enough characters accepted for 'spellfile'.
Solution:   Add vim_is_fname_char() and use it for 'spellfile'.

https://github.com/vim/vim/commit/bc49c5f48f89c2d6f4d88ee77f44a11d68293be3

Cherry-pick related doc update from Vim runtime.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0240: crash when using ":mkspell" with an empty .dic file

Problem:    Crash when using ":mkspell" with an empty .dic file.
Solution:   Check for an empty word tree.

https://github.com/vim/vim/commit/6669de1b235843968e88844ca6d3c8dec4b01a9e

Co-authored-by: Bram Moolenaar <Bram@vim.org>