### PR TITLE
vim-patch:8.2.{0987,1463}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3683,9 +3683,6 @@ static int eval_index(char **arg, typval_T *rettv, evalarg_T *const evalarg, boo
         n1 = (int)len;
       }
       if (range) {
-        list_T *l;
-        listitem_T *item;
-
         if (n2 < 0) {
           n2 = (int)len + n2;
         } else if (n2 >= len) {
@@ -3694,12 +3691,7 @@ static int eval_index(char **arg, typval_T *rettv, evalarg_T *const evalarg, boo
         if (!empty2 && (n2 < 0 || n2 + 1 < n1)) {
           n2 = -1;
         }
-        l = tv_list_alloc(n2 - n1 + 1);
-        item = tv_list_find(rettv->vval.v_list, n1);
-        while (n1++ <= n2) {
-          tv_list_append_tv(l, TV_LIST_ITEM_TV(item));
-          item = TV_LIST_ITEM_NEXT(rettv->vval.v_list, item);
-        }
+        list_T *l = tv_list_slice(rettv->vval.v_list, n1, n2);
         tv_clear(rettv);
         tv_list_set_ret(rettv, l);
       } else {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3470,7 +3470,7 @@ static int eval_index(char **arg, typval_T *rettv, evalarg_T *const evalarg, boo
   bool empty1 = false;
   bool empty2 = false;
   ptrdiff_t len = -1;
-  int range = false;
+  bool range = false;
   const char *key = NULL;
 
   switch (rettv->v_type) {
@@ -3667,37 +3667,15 @@ static int eval_index(char **arg, typval_T *rettv, evalarg_T *const evalarg, boo
       }
       break;
     case VAR_LIST:
-      len = tv_list_len(rettv->vval.v_list);
-      if (n1 < 0) {
-        n1 = (int)len + n1;
+      if (empty1) {
+        n1 = 0;
       }
-      if (!empty1 && (n1 < 0 || n1 >= len)) {
-        // For a range we allow invalid values and return an empty
-        // list.  A list index out of range is an error.
-        if (!range) {
-          if (verbose) {
-            semsg(_(e_listidx), (int64_t)n1);
-          }
-          return FAIL;
-        }
-        n1 = (int)len;
+      if (empty2) {
+        n2 = -1;
       }
-      if (range) {
-        if (n2 < 0) {
-          n2 = (int)len + n2;
-        } else if (n2 >= len) {
-          n2 = (int)len - 1;
-        }
-        if (!empty2 && (n2 < 0 || n2 + 1 < n1)) {
-          n2 = -1;
-        }
-        list_T *l = tv_list_slice(rettv->vval.v_list, n1, n2);
-        tv_clear(rettv);
-        tv_list_set_ret(rettv, l);
-      } else {
-        tv_copy(TV_LIST_ITEM_TV(tv_list_find(rettv->vval.v_list, (int)n1)), &var1);
-        tv_clear(rettv);
-        *rettv = var1;
+      if (tv_list_slice_or_index(rettv->vval.v_list,
+                                 range, n1, n2, rettv, verbose) == FAIL) {
+        return FAIL;
       }
       break;
     case VAR_DICT: {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -765,6 +765,17 @@ int tv_list_concat(list_T *const l1, list_T *const l2, typval_T *const tv)
   return OK;
 }
 
+list_T *tv_list_slice(list_T *ol, int n1, int n2)
+{
+  list_T *l = tv_list_alloc(n2 - n1 + 1);
+  listitem_T *item = tv_list_find(ol, n1);
+  for (; n1 <= n2; n1++) {
+    tv_list_append_tv(l, TV_LIST_ITEM_TV(item));
+    item = TV_LIST_ITEM_NEXT(rettv->vval.v_list, item);
+  }
+  return l;
+}
+
 typedef struct {
   char *s;
   char *tofree;

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -765,7 +765,7 @@ int tv_list_concat(list_T *const l1, list_T *const l2, typval_T *const tv)
   return OK;
 }
 
-list_T *tv_list_slice(list_T *ol, int n1, int n2)
+static list_T *tv_list_slice(list_T *ol, int n1, int n2)
 {
   list_T *l = tv_list_alloc(n2 - n1 + 1);
   listitem_T *item = tv_list_find(ol, n1);
@@ -774,6 +774,50 @@ list_T *tv_list_slice(list_T *ol, int n1, int n2)
     item = TV_LIST_ITEM_NEXT(rettv->vval.v_list, item);
   }
   return l;
+}
+
+int tv_list_slice_or_index(list_T *list, bool range, int n1_arg, int n2_arg, typval_T *rettv,
+                           bool verbose)
+{
+  int len = tv_list_len(rettv->vval.v_list);
+  int n1 = n1_arg;
+  int n2 = n2_arg;
+
+  if (n1 < 0) {
+    n1 = len + n1;
+  }
+  if (n1 < 0 || n1 >= len) {
+    // For a range we allow invalid values and return an empty
+    // list.  A list index out of range is an error.
+    if (!range) {
+      if (verbose) {
+        semsg(_(e_listidx), (int64_t)n1);
+      }
+      return FAIL;
+    }
+    n1 = len;
+  }
+  if (range) {
+    if (n2 < 0) {
+      n2 = len + n2;
+    } else if (n2 >= len) {
+      n2 = len - 1;
+    }
+    if (n2 < 0 || n2 + 1 < n1) {
+      n2 = -1;
+    }
+    list_T *l = tv_list_slice(rettv->vval.v_list, n1, n2);
+    tv_clear(rettv);
+    tv_list_set_ret(rettv, l);
+  } else {
+    // copy the item to "var1" to avoid that freeing the list makes it
+    // invalid.
+    typval_T var1;
+    tv_copy(TV_LIST_ITEM_TV(tv_list_find(rettv->vval.v_list, (int)n1)), &var1);
+    tv_clear(rettv);
+    *rettv = var1;
+  }
+  return OK;
 }
 
 typedef struct {


### PR DESCRIPTION
#### vim-patch:8.2.0987: Vim9: cannot assign to [var; var]

Problem:    Vim9: cannot assign to [var; var].
Solution:   Assign rest of items to a list.

https://github.com/vim/vim/commit/9af78769eeae0318e07aa8b6af4d6e2244481ca7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1463: Vim9: list slice not supported yet

Problem:    Vim9: list slice not supported yet.
Solution:   Add support for list slicing.

https://github.com/vim/vim/commit/ed5918771fcf9877d8445e74c62ab1ce6b8e28c1

Co-authored-by: Bram Moolenaar <Bram@vim.org>