### PR TITLE
vim-patch:8.2.{1466,3336}

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -795,7 +795,7 @@ int tv_list_slice_or_index(list_T *list, bool range, int n1_arg, int n2_arg, typ
       }
       return FAIL;
     }
-    n1 = len;
+    n1 = n1 < 0 ? 0 : len;
   }
   if (range) {
     if (n2 < 0) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -787,15 +787,15 @@ int tv_list_slice_or_index(list_T *list, bool range, int n1_arg, int n2_arg, typ
     n1 = len + n1;
   }
   if (n1 < 0 || n1 >= len) {
-    // For a range we allow invalid values and return an empty
-    // list.  A list index out of range is an error.
+    // For a range we allow invalid values and return an empty list.
+    // A list index out of range is an error.
     if (!range) {
       if (verbose) {
         semsg(_(e_listidx), (int64_t)n1);
       }
       return FAIL;
     }
-    n1 = n1 < 0 ? 0 : len;
+    n1 = len;
   }
   if (range) {
     if (n2 < 0) {

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1,5 +1,7 @@
 " Tests for the List and Dict types
 
+source vim9.vim
+
 func TearDown()
   " Run garbage collection after every test
   call test_garbagecollect_now()
@@ -37,6 +39,23 @@ func Test_list_slice()
   let l[:1] += [1, 2]
   let l[2:] -= [1]
   call assert_equal([2, 4, 2], l)
+
+  let lines =<< trim END
+      VAR l = [1, 2]
+      call assert_equal([1, 2], l[:])
+      call assert_equal([2], l[-1 : -1])
+      call assert_equal([1, 2], l[-2 : -1])
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let l = [1, 2]
+  call assert_equal([], l[-3 : -1])
+
+  let lines =<< trim END
+      var l = [1, 2]
+      assert_equal([1, 2], l[-3 : -1])
+  END
+  call CheckDefAndScriptSuccess(lines)
 endfunc
 
 " List identity


### PR DESCRIPTION
#### vim-patch:8.2.1466: Vim9: cannot index or slice a variable with type "any"

Problem:    Vim9: cannot index or slice a variable with type "any".
Solution:   Add runtime index and slice.

https://github.com/vim/vim/commit/cc673e746ab98566556ff964d7a76f2fb46d7f84

Omit E1024 and E1062: Vim9 script only.
Omit string_slice() and char_idx2byte(): Vim9 script only.
Remove the first tv_is_luafunc() check because it always returns false.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3336: behavior of negative index in list change changed

Problem:    Behavior of negative index in list change changed. (Naruhiko
            Nishino)
Solution:   Only change it for Vim9 script.

https://github.com/vim/vim/commit/92f05f21afdb8a43581554a252cb2fc050f9e03b

Co-authored-by: Bram Moolenaar <Bram@vim.org>