### PR TITLE
vim-patch:8.2.{1461,1462,1466,2344,2607,2756}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -486,7 +486,7 @@ str2list({expr} [, {utf8}])	List	convert each character of {expr} to
 str2nr({expr} [, {base} [, {quoted}]])
 				Number	convert String to Number
 strcharlen({expr})		Number	character length of the String {expr}
-strcharpart({str}, {start} [, {len}])
+strcharpart({str}, {start} [, {len} [, {skipcc}]])
 				String	{len} characters of {str} at
 					character {start}
 strchars({expr} [, {skipcc}])	Number	character count of the String {expr}
@@ -7779,6 +7779,7 @@ slice({expr}, {start} [, {end}])			*slice()*
 		Similar to using a |slice| "expr[start : end]", but "end" is
 		used exclusive.  And for a string the indexes are used as
 		character indexes instead of byte indexes.
+		Also, composing characters are not counted.
 		When {end} is omitted the slice continues to the last item.
 		When {end} is -1 the last item is omitted.
 		Returns an empty value if {start} or {end} are invalid.
@@ -8129,12 +8130,16 @@ strcharlen({string})					*strcharlen()*
 			GetText()->strcharlen()
 
 
-strcharpart({src}, {start} [, {len}])			*strcharpart()*
+strcharpart({src}, {start} [, {len} [, {skipcc}]])		*strcharpart()*
 		Like |strpart()| but using character index and length instead
-		of byte index and length.  Composing characters are counted
-		separately.
+		of byte index and length.
+		When {skipcc} is omitted or zero, composing characters are
+		counted separately.
+		When {skipcc} set to 1, Composing characters are ignored,
+		similar to  |slice()|.
 		When a character index is used where a character does not
-		exist it is assumed to be one character.  For example: >
+		exist it is omitted and counted as one character.  For
+		example: >
 			strcharpart('abc', -1, 2)
 <		results in 'a'.
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -464,6 +464,8 @@ sign_unplacelist({list})	List	unplace a list of signs
 simplify({filename})		String	simplify filename as much as possible
 sin({expr})			Float	sine of {expr}
 sinh({expr})			Float	hyperbolic sine of {expr}
+slice({expr}, {start} [, {end}])  String, List or Blob
+					slice of a String, List or Blob
 sockconnect({mode}, {address} [, {opts}])
 				Number	Connects to socket
 sort({list} [, {func} [, {dict}]])
@@ -7772,6 +7774,18 @@ sinh({expr})						*sinh()*
 
 		Can also be used as a |method|: >
 			Compute()->sinh()
+
+slice({expr}, {start} [, {end}])			*slice()*
+		Similar to using a |slice| "expr[start : end]", but "end" is
+		used exclusive.  And for a string the indexes are used as
+		character indexes instead of byte indexes.
+		When {end} is omitted the slice continues to the last item.
+		When {end} is -1 the last item is omitted.
+		Returns an empty value if {start} or {end} are invalid.
+
+		Can also be used as a |method|: >
+			GetList()->slice(offset)
+
 
 sockconnect({mode}, {address} [, {opts}])		 *sockconnect()*
 		Connect a socket to an address. If {mode} is "pipe" then

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1152,6 +1152,8 @@ text column numbers start with one!  Example, to get the byte under the
 cursor: >
 	:let c = getline(".")[col(".") - 1]
 
+Index zero gives the first byte.  Careful: text column numbers start with one!
+
 If the length of the String is less than the index, the result is an empty
 String.  A negative index always results in an empty string (reason: backward
 compatibility).  Use [-1:] to get the last byte.

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -270,6 +270,9 @@ similar to -1. >
 	:let shortlist = mylist[2:2]	" List with one item: [3]
 	:let otherlist = mylist[:]	" make a copy of the List
 
+Notice that the last index is inclusive.  If you prefer using an exclusive
+index use the |slice()| method.
+
 If the first index is beyond the last item of the List or the second item is
 before the first item, the result is an empty list.  There is no error
 message.
@@ -1177,6 +1180,9 @@ expr1a and expr1b are used as a Number.
 In legacy Vim script the indexes are byte indexes.  This doesn't recognize
 multibyte encodings, see |byteidx()| for computing the indexes.  If expr8 is
 a Number it is first converted to a String.
+
+The item at index expr1b is included, it is inclusive.  For an exclusive index
+use the |slice()| function.
 
 If expr1a is omitted zero is used.  If expr1b is omitted the length of the
 string minus one is used.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -630,6 +630,8 @@ String manipulation:					*string-functions*
 	submatch()		get a specific match in ":s" and substitute()
 	strpart()		get part of a string using byte index
 	strcharpart()		get part of a string using char index
+	slice()			take a slice of a string, using char index in
+				Vim9 script
 	strgetchar()		get character from a string using char index
 	expand()		expand special keywords
 	expandcmd()		expand a command like done for `:edit`
@@ -659,6 +661,7 @@ List manipulation:					*list-functions*
 	filter()		remove selected items from a List
 	map()			change each List item
 	reduce()		reduce a List to a value
+	slice()			take a slice of a List
 	sort()			sort a List
 	reverse()		reverse the order of a List or Blob
 	uniq()			remove copies of repeated adjacent items

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7264,6 +7264,27 @@ int check_luafunc_name(const char *const str, const bool paren)
   return (int)(p - str);
 }
 
+/// Return the character "str[index]" where "index" is the character index.  If
+/// "index" is out of range NULL is returned.
+char *char_from_string(char *str, varnumber_T index)
+{
+  size_t nbyte = 0;
+  varnumber_T nchar = index;
+
+  if (str == NULL || index < 0) {
+    return NULL;
+  }
+  size_t slen = strlen(str);
+  while (nchar > 0 && nbyte < slen) {
+    nbyte += (size_t)utf_ptr2len(str + nbyte);
+    nchar--;
+  }
+  if (nbyte >= slen) {
+    return NULL;
+  }
+  return xstrnsave(str + nbyte, (size_t)utf_ptr2len(str + nbyte));
+}
+
 /// Handle:
 /// - expr[expr], expr[expr:expr] subscript
 /// - ".name" lookup

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7285,6 +7285,58 @@ char *char_from_string(char *str, varnumber_T index)
   return xstrnsave(str + nbyte, (size_t)utf_ptr2len(str + nbyte));
 }
 
+/// Get the byte index for character index "idx" in string "str" with length
+/// "str_len".
+/// If going over the end return "str_len".
+/// If "idx" is negative count from the end, -1 is the last character.
+/// When going over the start return zero.
+static size_t char_idx2byte(char *str, size_t str_len, varnumber_T idx)
+{
+  varnumber_T nchar = idx;
+  size_t nbyte = 0;
+
+  if (nchar >= 0) {
+    while (nchar > 0 && nbyte < str_len) {
+      nbyte += (size_t)utf_ptr2len(str + nbyte);
+      nchar--;
+    }
+  } else {
+    nbyte = str_len;
+    while (nchar < 0 && nbyte > 0) {
+      nbyte--;
+      nbyte -= (size_t)utf_head_off(str, str + nbyte);
+      nchar++;
+    }
+  }
+  return nbyte;
+}
+
+/// Return the slice "str[first:last]" using character indexes.
+/// Return NULL when the result is empty.
+char *string_slice(char *str, varnumber_T first, varnumber_T last)
+{
+  if (str == NULL) {
+    return NULL;
+  }
+  size_t slen = strlen(str);
+  size_t start_byte = char_idx2byte(str, slen, first);
+  size_t end_byte;
+  if (last == -1) {
+    end_byte = slen;
+  } else {
+    end_byte = char_idx2byte(str, slen, last);
+    if (end_byte < slen) {
+      // end index is inclusive
+      end_byte += (size_t)utf_ptr2len(str + end_byte);
+    }
+  }
+
+  if (start_byte >= slen || end_byte <= start_byte) {
+    return NULL;
+  }
+  return xstrnsave(str + start_byte, end_byte - start_byte);
+}
+
 /// Handle:
 /// - expr[expr], expr[expr:expr] subscript
 /// - ".name" lookup

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -386,7 +386,7 @@ return {
     str2list={args={1, 2}, base=1},
     str2nr={args={1, 3}, base=1},
     strcharlen={args=1, base=1},
-    strcharpart={args={2, 3}, base=1, fast=true},
+    strcharpart={args={2, 4}, base=1, fast=true},
     strchars={args={1, 2}, base=1},
     strdisplaywidth={args={1, 2}, base=1},
     strftime={args={1, 2}, base=1},

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -371,6 +371,7 @@ return {
     simplify={args=1, base=1},
     sin={args=1, base=1, float_func="sin"},
     sinh={args=1, base=1, float_func="sinh"},
+    slice={args={2, 3}, base=1},
     sockconnect={args={2,3}},
     sort={args={1, 3}, base=1},
     soundfold={args=1, base=1},

--- a/src/nvim/generators/gen_eval.lua
+++ b/src/nvim/generators/gen_eval.lua
@@ -17,6 +17,7 @@ hashpipe:write([[
 #include "nvim/cmdexpand.h"
 #include "nvim/cmdhist.h"
 #include "nvim/digraph.h"
+#include "nvim/eval.h"
 #include "nvim/eval/buffer.h"
 #include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"

--- a/test/old/testdir/test_expr_utf8.vim
+++ b/test/old/testdir/test_expr_utf8.vim
@@ -31,4 +31,14 @@ func Test_strcharpart()
   call assert_equal('a', strcharpart('àxb', 0, 1))
   call assert_equal('̀', strcharpart('àxb', 1, 1))
   call assert_equal('x', strcharpart('àxb', 2, 1))
+
+
+  call assert_equal('a', strcharpart('àxb', 0, 1, 0))
+  call assert_equal('à', strcharpart('àxb', 0, 1, 1))
+  call assert_equal('x', strcharpart('àxb', 1, 1, 1))
+
+  call assert_fails("let v = strcharpart('abc', 0, 0, [])", 'E745:')
+  call assert_fails("let v = strcharpart('abc', 0, 0, 2)", 'E1023:')
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -935,7 +935,7 @@ func Test_visual_block_mode()
 endfunc
 
 func Test_visual_force_motion_feedkeys()
-    onoremap <expr> i- execute('let g:mode = mode(1)')
+    onoremap <expr> i- execute('let g:mode = mode(1)')->slice(0, 0)
     call feedkeys('dvi-', 'x')
     call assert_equal('nov', g:mode)
     call feedkeys('di-', 'x')


### PR DESCRIPTION
#### vim-patch:8.2.1461: Vim9: string indexes are counted in bytes

Problem:    Vim9: string indexes are counted in bytes.
Solution:   Use character indexes.

https://github.com/vim/vim/commit/e3c37d8ebf9dbbf210fde4a5fb28eb1f2a492a34

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1462: Vim9: string slice not supported yet

Problem:    Vim9: string slice not supported yet.
Solution:   Add support for string slicing.

https://github.com/vim/vim/commit/11107bab7ead9124f46a7ddf6aa3bb66b43a8246

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1466: Vim9: cannot index or slice a variable with type "any"

Problem:    Vim9: cannot index or slice a variable with type "any".
Solution:   Add runtime index and slice.

https://github.com/vim/vim/commit/cc673e746ab98566556ff964d7a76f2fb46d7f84

Missing changes from the last PR.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2344: using inclusive index for slice is not always desired

Problem:    Using inclusive index for slice is not always desired.
Solution:   Add the slice() method, which has an exclusive index. (closes
            vim/vim#7408)

https://github.com/vim/vim/commit/6601b62943a19d4f8818c3638440663d67a17b6a

Cherry-pick a line in docs added later.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2607: strcharpart() cannot include composing characters

Problem:    strcharpart() cannot include composing characters.
Solution:   Add the {skipcc} argument.

https://github.com/vim/vim/commit/02b4d9b18a03549b68e364e428392b7a62766c74

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2756: Vim9: blob index and slice not implemented yet

Problem:    Vim9: blob index and slice not implemented yet.
Solution:   Implement blob index and slice.

https://github.com/vim/vim/commit/cfc3023cb6ce5aaec13f49bc4b821feb05e3fb03

Co-authored-by: Bram Moolenaar <Bram@vim.org>