### PR TITLE
feat(fold): colorful foldtext

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -52,6 +52,9 @@ iterators |luaref-in|.
 • |'smoothscroll'| option to scroll by screen line rather than by text line
 when |'wrap'| is set.
 
+• |'foldtext'| can be set to an empty string to disable and render the line
+as normal with regular highlighting.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2692,6 +2692,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	It is not allowed to change text or jump to another window while
 	evaluating 'foldtext' |textlock|.
 
+	When set to an empty string, foldtext is disabled, and the first line
+	of the fold is displayed with highlighting.
+
 						*'formatexpr'* *'fex'*
 'formatexpr' 'fex'	string (default "")
 			local to buffer

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1273,7 +1273,9 @@ VirtText parse_virt_text(Array chunks, Error *err, int *width)
     kv_push(virt_text, ((VirtTextChunk){ .text = text, .hl_id = hl_id }));
   }
 
-  *width = w;
+  if (width) {
+    *width = w;
+  }
   return virt_text;
 
 free_exit:

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1677,8 +1677,21 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
       wlv.char_attr = win_hl_attr(wp, HLF_FL);
       linenr_T lnume = lnum + foldinfo.fi_lines - 1;
       memset(buf_fold, ' ', FOLD_TEXT_LEN);
-      wlv.p_extra = get_foldtext(wp, lnum, lnume, foldinfo, buf_fold);
+      VirtText vt = KV_INITIAL_VALUE;
+      int vtwidth = 0;
+      wlv.p_extra = get_foldtext(wp, lnum, lnume, foldinfo, buf_fold, &vt, &vtwidth);
       wlv.n_extra = (int)strlen(wlv.p_extra);
+      if (vtwidth) {
+        for (int i = wlv.col; i < wlv.col + vtwidth; i++) {
+          linebuf_attr[i] = wlv.char_attr;
+        }
+
+        int col = draw_virt_text_item(buf, wlv.col, vt, kHlModeCombine, wlv.col + vtwidth, 0);
+
+        wlv.col = col;
+        wlv.off = col;
+      }
+      kv_destroy(vt);
 
       if (wlv.p_extra != buf_fold) {
         xfree(wlv.p_extra_free);


### PR DESCRIPTION
If `'foldtext'` begins with `=`, it will be evaluated as a Lua expression. This Lua expression can be a list of text-hl tuples (just like virtual text).

```lua
function FoldText()
  return { { 'hello', 'Title'}, {''..vim.v.foldstart, 'Error' }}
end

vim.o.foldtext='=FoldText()'
```

![image](https://user-images.githubusercontent.com/7904185/236177222-fc776416-0a73-4219-8928-8c89a246dd98.png)

Closes #12649