### PR TITLE
fix(health): replace healthFoo with DiagnosticFoo

### DIFF
--- a/runtime/doc/pi_health.txt
+++ b/runtime/doc/pi_health.txt
@@ -12,7 +12,7 @@ any other environment conditions that a plugin might care about. Nvim ships
 with healthchecks for configuration, performance, python support, ruby
 support, clipboard support, and more.
 
-To run all healthchecks, use: >
+To run all healthchecks, use: >vim
 
         :checkhealth
 <
@@ -32,17 +32,17 @@ Commands                                *health-commands*
 
 :che[ckhealth] {plugins}
                 Run healthcheck(s) for one or more plugins. E.g. to run only
-                the standard Nvim healthcheck: >
+                the standard Nvim healthcheck: >vim
                         :checkhealth nvim
 <
                 To run the healthchecks for the "foo" and "bar" plugins
                 (assuming they are on 'runtimepath' and they have implemented
-                the Lua `require("foo.health").check()` interface): >
+                the Lua `require("foo.health").check()` interface): >vim
                         :checkhealth foo bar
 <
                 To run healthchecks for Lua submodules, use dot notation or
                 "*" to refer to all submodules. For example Nvim provides
-                `vim.lsp` and `vim.treesitter`:  >
+                `vim.lsp` and `vim.treesitter`:  >vim
                         :checkhealth vim.lsp vim.treesitter
                         :checkhealth vim*
 <
@@ -100,7 +100,7 @@ All such health modules must return a Lua table containing a `check()`
 function.
 
 Copy this sample code into `lua/foo/health.lua`, replacing "foo" in the path
-with your plugin name: >
+with your plugin name: >lua
 
         local M = {}
 

--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -11,15 +11,10 @@ unlet! b:current_syntax
 
 syn case match
 
-syn keyword healthError ERROR[:]
-syn keyword healthWarning WARNING[:]
-syn keyword healthSuccess OK[:]
+syn keyword DiagnosticError ERROR[:]
+syn keyword DiagnosticWarning WARNING[:]
+syn keyword DiagnosticOk OK[:]
 syn match helpSectionDelim "^======*\n.*$"
 syn match healthHeadingChar "=" conceal cchar=─ contained containedin=helpSectionDelim
-
-hi def link healthError Error
-hi def link healthWarning WarningMsg
-hi def healthSuccess guibg=#5fff00 guifg=#080808 ctermbg=82 ctermfg=232
-hi def link healthHelp Identifier
 
 let b:current_syntax = "checkhealth"

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -130,8 +130,8 @@ describe('health.vim', function()
       local screen = Screen.new(50, 12)
       screen:attach()
       screen:set_default_attr_ids({
-        Ok = { foreground = Screen.colors.Grey3, background = 6291200 },
-        Error = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
+        Ok = { foreground = Screen.colors.LightGreen },
+        Error = { foreground = Screen.colors.Red },
         Heading = { foreground = tonumber('0x6a0dad') },
         Bar = { foreground = Screen.colors.LightGrey, background = Screen.colors.DarkGrey },
       })


### PR DESCRIPTION
This replaces the custom `health{Error,Warning,Success}` highlight groups with `Diagnostic{Error,Warning,Ok}`, which are defined by default. Removes the link for `healthHelp`, which wasn't actually used in the syntax file.

followup to https://github.com/neovim/neovim/pull/21286
