### PR TITLE
vim-patch:8.2.1697: inconsistent capitalization of error messages

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -89,7 +89,7 @@
 static const char *e_missbrac = N_("E111: Missing ']'");
 static const char *e_list_end = N_("E697: Missing end of List ']': %s");
 static const char *e_cannot_slice_dictionary
-  = N_("E719: cannot slice a Dictionary");
+  = N_("E719: Cannot slice a Dictionary");
 static const char e_cannot_index_special_variable[]
   = N_("E909: Cannot index a special variable");
 static const char *e_nowhitespace

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -79,6 +79,8 @@ static const char *e_funcref = N_("E718: Funcref required");
 static const char *e_nofunc = N_("E130: Unknown function: %s");
 static const char e_function_list_was_modified[]
   = N_("E454: Function list was modified");
+static const char e_function_nesting_too_deep[]
+  = N_("E1058: Function nesting too deep");
 static const char e_no_white_space_allowed_before_str_str[]
   = N_("E1068: No white space allowed before '%s': %s");
 static const char e_missing_heredoc_end_marker_str[]
@@ -2528,7 +2530,7 @@ void ex_function(exarg_T *eap)
         xfree(trans_function_name(&p, true, 0, NULL, NULL));
         if (*skipwhite(p) == '(') {
           if (nesting == MAX_FUNC_NESTING - 1) {
-            emsg(_("E1058: function nesting too deep"));
+            emsg(_(e_function_nesting_too_deep));
           } else {
             nesting++;
             indent += 2;

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -35,11 +35,11 @@
 #endif
 
 static const char e_assert_fails_second_arg[]
-  = N_("E856: assert_fails() second argument must be a string or a list with one or two strings");
+  = N_("E856: \"assert_fails()\" second argument must be a string or a list with one or two strings");
 static const char e_assert_fails_fourth_argument[]
-  = N_("E1115: assert_fails() fourth argument must be a number");
+  = N_("E1115: \"assert_fails()\" fourth argument must be a number");
 static const char e_assert_fails_fifth_argument[]
-  = N_("E1116: assert_fails() fifth argument must be a string");
+  = N_("E1116: \"assert_fails()\" fifth argument must be a string");
 static const char e_calling_test_garbagecollect_now_while_v_testing_is_not_set[]
   = N_("E1142: Calling test_garbagecollect_now() while v:testing is not set");
 

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -240,35 +240,35 @@ func Test_assert_fail_fails()
   catch
     let exp = v:exception
   endtry
-  call assert_match("E856: assert_fails() second argument", exp)
+  call assert_match("E856: \"assert_fails()\" second argument", exp)
 
   try
     call assert_equal(1, assert_fails('xxx', ['1', '2', '3']))
   catch
     let exp = v:exception
   endtry
-  call assert_match("E856: assert_fails() second argument", exp)
+  call assert_match("E856: \"assert_fails()\" second argument", exp)
 
   try
     call assert_equal(1, assert_fails('xxx', #{one: 1}))
   catch
     let exp = v:exception
   endtry
-  call assert_match("E856: assert_fails() second argument", exp)
+  call assert_match("E856: \"assert_fails()\" second argument", exp)
 
   try
     call assert_equal(1, assert_fails('xxx', 'E492', '', 'burp'))
   catch
     let exp = v:exception
   endtry
-  call assert_match("E1115: assert_fails() fourth argument must be a number", exp)
+  call assert_match("E1115: \"assert_fails()\" fourth argument must be a number", exp)
 
   try
     call assert_equal(1, assert_fails('xxx', 'E492', '', 54, 123))
   catch
     let exp = v:exception
   endtry
-  call assert_match("E1116: assert_fails() fifth argument must be a string", exp)
+  call assert_match("E1116: \"assert_fails()\" fifth argument must be a string", exp)
 endfunc
 
 func Test_assert_fails_in_try_block()


### PR DESCRIPTION
#### vim-patch:8.2.1697: inconsistent capitalization of error messages

Problem:    Inconsistent capitalization of error messages.
Solution:   Always start with a capital.

https://github.com/vim/vim/commit/7707228aace9aff16434edf5377a354c6ad07316

Most of these errors are Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>