### PR TITLE
vim-patch:8.2.4397: crash when using many composing characters in error message

### DIFF
--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -121,7 +121,7 @@ static void ga_concat_shorten_esc(garray_T *gap, const char *str)
   for (const char *p = str; *p != NUL; p++) {
     int same_len = 1;
     const char *s = p;
-    const int c = mb_ptr2char_adv(&s);
+    const int c = mb_cptr2char_adv(&s);
     const int clen = (int)(s - p);
     while (*s != NUL && c == utf_ptr2char(s)) {
       same_len++;

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -53,6 +53,14 @@ func Test_assert_equal()
   call assert_equal("\b\e\f\n\t\r\\\x01\x7f", 'x')
   call assert_match('Expected ''\\b\\e\\f\\n\\t\\r\\\\\\x01\\x7f'' but got ''x''', v:errors[0])
   call remove(v:errors, 0)
+
+  " many composing characters are handled properly
+  call setline(1, ' ')
+  norm 100gr݀
+  call assert_equal(1, getline(1))
+  call assert_match("Expected 1 but got '.* occurs 100 times]'", v:errors[0])
+  call remove(v:errors, 0)
+  bwipe!
 endfunc
 
 func Test_assert_equal_dict()


### PR DESCRIPTION
#### vim-patch:8.2.4397: crash when using many composing characters in error message

Problem:    Crash when using many composing characters in error message.
Solution:   Use mb_cptr2char_adv() instead of mb_ptr2char_adv().

https://github.com/vim/vim/commit/34f8117dec685ace52cd9e578e2729db278163fc

Co-authored-by: Bram Moolenaar <Bram@vim.org>