### PR TITLE
fix(excmd): append original command to error message

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -288,7 +288,7 @@ static void msg_verbose_cmd(linenr_T lnum, char *cmd)
 /// Execute a simple command line.  Used for translated commands like "*".
 int do_cmdline_cmd(const char *cmd)
 {
-  return do_cmdline((char *)cmd, NULL, NULL, DOCMD_NOWAIT|DOCMD_KEYTYPED);
+  return do_cmdline((char *)cmd, NULL, NULL, DOCMD_VERBOSE|DOCMD_NOWAIT|DOCMD_KEYTYPED);
 }
 
 /// do_cmdline(): execute one Ex command line
@@ -1862,7 +1862,8 @@ static bool skip_cmd(const exarg_T *eap)
 
 /// Execute one Ex command.
 ///
-/// If 'sourcing' is true, the command will be included in the error message.
+/// If "flags" has DOCMD_VERBOSE, the command will be included in the error
+/// message.
 ///
 /// 1. skip comment lines and leading space
 /// 2. handle command modifiers

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -361,6 +361,12 @@ describe('API', function()
       eq('', eval('v:errmsg'))  -- v:errmsg was not updated.
       eq('', eval('v:exception'))
     end)
+
+    it('gives E493 instead of prompting on backwards range', function()
+      command('split')
+      eq('Vim(windo):E493: Backwards range given: 2,1windo echo',
+         pcall_err(command, '2,1windo echo'))
+    end)
   end)
 
   describe('nvim_command_output', function()

--- a/test/functional/ex_cmds/excmd_spec.lua
+++ b/test/functional/ex_cmds/excmd_spec.lua
@@ -11,20 +11,24 @@ describe('Ex cmds', function()
     clear()
   end)
 
+  local function check_excmd_err(cmd, err)
+    eq(err .. ': ' .. cmd, pcall_err(command, cmd))
+  end
+
   it('handle integer overflow from user-input #5555', function()
     command(':9999999999999999999999999999999999999999')
     command(':later 9999999999999999999999999999999999999999')
     command(':echo expand("#<9999999999999999999999999999999999999999")')
     command(':lockvar 9999999999999999999999999999999999999999')
     command(':winsize 9999999999999999999999999999999999999999 9999999999999999999999999999999999999999')
-    eq('Vim(tabnext):E475: Invalid argument: 9999999999999999999999999999999999999999',
-      pcall_err(command, ':tabnext 9999999999999999999999999999999999999999'))
-    eq('Vim(Next):E939: Positive count required',
-      pcall_err(command, ':N 9999999999999999999999999999999999999999'))
+    check_excmd_err(':tabnext 9999999999999999999999999999999999999999',
+                    'Vim(tabnext):E475: Invalid argument: 9999999999999999999999999999999999999999')
+    check_excmd_err(':N 9999999999999999999999999999999999999999',
+                    'Vim(Next):E939: Positive count required')
+    check_excmd_err(':bdelete 9999999999999999999999999999999999999999',
+                    'Vim(bdelete):E939: Positive count required')
     eq('Vim(menu):E329: No menu "9999999999999999999999999999999999999999"',
       pcall_err(command, ':menu 9999999999999999999999999999999999999999'))
-    eq('Vim(bdelete):E939: Positive count required',
-      pcall_err(command, ':bdelete 9999999999999999999999999999999999999999'))
     assert_alive()
   end)
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -214,7 +214,7 @@ describe(':luado command', function()
   end)
   it('fails in sandbox when needed', function()
     curbufmeths.set_lines(0, 1, false, {"ABC", "def", "gHi"})
-    eq('Vim(luado):E48: Not allowed in sandbox',
+    eq('Vim(luado):E48: Not allowed in sandbox: sandbox luado runs = (runs or 0) + 1',
        pcall_err(command, 'sandbox luado runs = (runs or 0) + 1'))
     eq(NIL, funcs.luaeval('runs'))
   end)

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -1720,7 +1720,7 @@ describe("'inccommand' and :cnoremap", function()
 
   local function refresh(case, visual)
     clear()
-    screen = visual and Screen.new(50,10) or nil
+    screen = visual and Screen.new(80,10) or nil
     common_setup(screen, case, default_text)
   end
 

--- a/test/functional/vimscript/execute_spec.lua
+++ b/test/functional/vimscript/execute_spec.lua
@@ -4,6 +4,7 @@ local eval = helpers.eval
 local clear = helpers.clear
 local source = helpers.source
 local exc_exec = helpers.exc_exec
+local pcall_err = helpers.pcall_err
 local funcs = helpers.funcs
 local Screen = require('test.functional.ui.screen')
 local command = helpers.command
@@ -282,6 +283,14 @@ describe('execute()', function()
       42                                      |
       ]])
       eq('42', eval('g:mes'))
+    end)
+
+    it('gives E493 instead of prompting on backwards range for ""', function()
+      command('split')
+      eq('Vim(windo):E493: Backwards range given: 2,1windo echo',
+         pcall_err(funcs.execute, '2,1windo echo', ''))
+      eq('Vim(windo):E493: Backwards range given: 2,1windo echo',
+         pcall_err(funcs.execute, {'2,1windo echo'}, ''))
     end)
 
     it('captures but does not display output for "silent"', function()


### PR DESCRIPTION
Revert the change to `do_cmdline_cmd()` from #5226.

This function is used in many places, so making it different from Vim
leads to small differences from Vim in the behavior of some functions
like `execute()` and `assert_fails()`. If `DOCMD_VERBOSE` really needs to be
removed somewhere, a `do_cmdline()` call without `DOCMD_VERBOSE` is also
shorter than a `do_cmdline()` call with `DOCMD_VERBOSE`.