### PR TITLE
perf(lsp): load buffer contents once when processing semantic tokens responses

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -253,10 +253,15 @@ local function get_lines(bufnr, rows)
   ---@private
   local function buf_lines()
     local lines = {}
-    for _, row in pairs(rows) do
+    for _, row in ipairs(rows) do
       lines[row] = (api.nvim_buf_get_lines(bufnr, row, row + 1, false) or { '' })[1]
     end
     return lines
+  end
+
+  -- use loaded buffers if available
+  if vim.fn.bufloaded(bufnr) == 1 then
+    return buf_lines()
   end
 
   local uri = vim.uri_from_bufnr(bufnr)
@@ -265,11 +270,6 @@ local function get_lines(bufnr, rows)
   -- Custom language server protocol extensions can result in servers sending URIs with custom schemes. Plugins are able to load these via `BufReadCmd` autocmds.
   if uri:sub(1, 4) ~= 'file' then
     vim.fn.bufload(bufnr)
-    return buf_lines()
-  end
-
-  -- use loaded buffers if available
-  if vim.fn.bufloaded(bufnr) == 1 then
     return buf_lines()
   end
 


### PR DESCRIPTION
I couldn't help myself, I had to profile this and make it as fast as possible. :smile:

Using `_get_line_byte_from_position()` for each token's boundaries was a pretty huge bottleneck, since that function would load individual buffer lines via `nvim_buf_get_lines()` (plus a lot of extra overhead). So each token was calling `nvim_buf_get_lines()` twice (once for the start position, and once for the end position).

For semantic tokens, we only attach to buffers that have already been loaded, so we can safely just get all the lines for the entire buffer at once, and lift the rest of the `_get_line_byte_from_position()` implementation directly, bypassing the part that loads the buffer line.

While I was looking at get_lines (used by `_get_line_byte_from_position()`), I noticed that we were checking for non-file URIs before we even looked to see if we already had the buffer loaded. Moving the buffer-already-loaded check to be the first thing done in `get_lines()` more than halved the average time spent for the semantic token list -> highlight range loop to run vs when it was still using `_get_line_byte_from_position()`. I ended up improving that loop more by not using `get_lines()` any longer, but figured the performance improvement it provided was worth leaving there.


<details benchmarks>
<summary>Here are some benchmarks using the same slow/large response from #23375 (and #23164). 
</summary>
<br>
"count" is the number of vim loop iterations it took to get the work done. "elapsed time" is total time to process the response. Each line is one response from the server. I was simply typing some code around the middle of the file to get new requests sent to the server.

#### Before this PR:
```
encoding: utf-16, count = 20, elapsed time: 96.717500 ms
encoding: utf-16, count = 23, elapsed time: 128.576500 ms
encoding: utf-16, count = 21, elapsed time: 102.536583 ms
encoding: utf-16, count = 23, elapsed time: 111.578375 ms
encoding: utf-16, count = 25, elapsed time: 123.191375 ms
encoding: utf-16, count = 21, elapsed time: 107.540500 ms
encoding: utf-16, count = 22, elapsed time: 112.200000 ms
encoding: utf-16, count = 23, elapsed time: 113.242375 ms
encoding: utf-16, count = 21, elapsed time: 105.465542 ms
encoding: utf-16, count = 20, elapsed time: 120.421042 ms
encoding: utf-16, count = 22, elapsed time: 109.167000 ms
encoding: utf-16, count = 22, elapsed time: 125.637625 ms
encoding: utf-16, count = 25, elapsed time: 121.411542 ms
encoding: utf-16, count = 22, elapsed time: 109.782209 ms
encoding: utf-16, count = 22, elapsed time: 114.396500 ms
encoding: utf-16, count = 22, elapsed time: 111.972584 ms
encoding: utf-16, count = 23, elapsed time: 115.726084 ms
```

#### After moving the buffer-already-loaded check in `vim.lsp.util.get_lines()` to go before the file URI check:
```
encoding: utf-16, count = 7, elapsed time: 33.936875 ms
encoding: utf-16, count = 8, elapsed time: 50.870500 ms
encoding: utf-16, count = 6, elapsed time: 27.025208 ms
encoding: utf-16, count = 10, elapsed time: 46.023792 ms
encoding: utf-16, count = 8, elapsed time: 48.982917 ms
encoding: utf-16, count = 10, elapsed time: 50.552792 ms
encoding: utf-16, count = 11, elapsed time: 53.209375 ms
encoding: utf-16, count = 6, elapsed time: 26.147750 ms
encoding: utf-16, count = 9, elapsed time: 44.670542 ms
encoding: utf-16, count = 9, elapsed time: 42.571833 ms
encoding: utf-16, count = 9, elapsed time: 41.352708 ms
encoding: utf-16, count = 9, elapsed time: 42.916208 ms
encoding: utf-16, count = 9, elapsed time: 44.721584 ms
encoding: utf-16, count = 8, elapsed time: 40.068583 ms
```

#### With this PR:
```
encoding: utf-16, count = 3, elapsed time: 10.593833 ms
encoding: utf-16, count = 2, elapsed time: 9.624708 ms
encoding: utf-16, count = 2, elapsed time: 5.429417 ms
encoding: utf-16, count = 1, elapsed time: 4.867375 ms
encoding: utf-16, count = 5, elapsed time: 21.012875 ms
encoding: utf-16, count = 5, elapsed time: 24.002208 ms
encoding: utf-16, count = 2, elapsed time: 6.308292 ms
encoding: utf-16, count = 2, elapsed time: 6.355708 ms
encoding: utf-16, count = 2, elapsed time: 5.706834 ms
encoding: utf-16, count = 3, elapsed time: 11.899375 ms
encoding: utf-16, count = 2, elapsed time: 7.385458 ms
encoding: utf-16, count = 2, elapsed time: 6.158042 ms
encoding: utf-16, count = 2, elapsed time: 9.011459 ms
encoding: utf-16, count = 2, elapsed time: 6.021208 ms
encoding: utf-16, count = 3, elapsed time: 13.430000 ms
```
</details>

Followup to #23375