### PR TITLE
fix(man.lua): return support of all sections

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -583,7 +583,7 @@ local function get_paths(sect, name)
 
   local mandirs = table.concat(vim.split(mandirs_raw, '[:\n]', { trimempty = true }), ',')
   ---@type string[]
-  local paths = fn.globpath(mandirs, 'man?/' .. name .. '*.' .. sect .. '*', false, true)
+  local paths = fn.globpath(mandirs, 'man[^\\/]*/' .. name .. '*.' .. sect .. '*', false, true)
 
   -- Prioritize the result from find_path as it obeys b:man_default_sects.
   local first = M.find_path(sect, name)
@@ -739,7 +739,12 @@ function M.open_page(count, smods, args)
   else
     -- Combine the name and sect into a manpage reference so that all
     -- verification/extraction can be kept in a single function.
-    if tonumber(args[1]) then
+    if args[1]:match('^%d$') or args[1]:match('^%d%a') or args[1]:match('^%a$') then
+      -- NB: Valid sections are not only digits, but also:
+      --  - <digit><word> (see POSIX mans),
+      --  - and even <letter> and <word> (see, for example, by tcl/tk)
+      -- NB2: don't optimize to :match("^%d"), as it will match manpages like
+      --    441toppm and others whose name starts with digit
       local sect = args[1]
       table.remove(args, 1)
       local name = table.concat(args, ' ')

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -20,10 +20,10 @@ local function get_search_history(name)
     local man = require('runtime.lua.man')
     local res = {}
     man.find_path = function(sect, name)
-      table.insert(res, name)
+      table.insert(res, {sect, name})
       return nil
     end
-    local ok, rv = pcall(man.open_page, 0, {tab = 0}, args)
+    local ok, rv = pcall(man.open_page, -1, {tab = 0}, args)
     assert(not ok)
     assert(rv and rv:match('no manual entry'))
     return res
@@ -196,16 +196,32 @@ describe(':Man', function()
 
   it('tries variants with spaces, underscores #22503', function()
     eq({
-       'NAME WITH SPACES',
-       'NAME_WITH_SPACES',
+       {'', 'NAME WITH SPACES'},
+       {'', 'NAME_WITH_SPACES'},
       }, get_search_history('NAME WITH SPACES'))
     eq({
-       'some other man',
-       'some_other_man',
+       {'3', 'some other man'},
+       {'3', 'some_other_man'},
       }, get_search_history('3 some other man'))
     eq({
-       'other_man',
-       'other_man',
+       {'3x', 'some other man'},
+       {'3x', 'some_other_man'},
+      }, get_search_history('3X some other man'))
+    eq({
+       {'3tcl', 'some other man'},
+       {'3tcl', 'some_other_man'},
+      }, get_search_history('3tcl some other man'))
+    eq({
+       {'n', 'some other man'},
+       {'n', 'some_other_man'},
+      }, get_search_history('n some other man'))
+    eq({
+       {'', '123some other man'},
+       {'', '123some_other_man'},
+      }, get_search_history('123some other man'))
+    eq({
+       {'1', 'other_man'},
+       {'1', 'other_man'},
       }, get_search_history('other_man(1)'))
   end)
 end)


### PR DESCRIPTION
Current behaviour of `:Man` is to only work with "number" sections. This is caused by wrong assumptions about existing man sections.

Also, there was similar assumption about dirs in paths. Although, it looks like it doesn't trigger on my system, it is still not right, so fixed too.

fixes #23485