### PR TITLE
vim-patch:8.2.1953,9.0.{0213,0404,0543,0846,0854,1507}: assert fixes

### DIFF
--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -229,16 +229,6 @@ typedef struct {
   Callback callback;
 } timer_T;
 
-/// Type of assert_* check being performed
-typedef enum {
-  ASSERT_EQUAL,
-  ASSERT_NOTEQUAL,
-  ASSERT_MATCH,
-  ASSERT_NOTMATCH,
-  ASSERT_INRANGE,
-  ASSERT_OTHER,
-} assert_type_T;
-
 /// types for expressions.
 typedef enum {
   EXPR_UNKNOWN = 0,

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -56,6 +56,8 @@ static const char e_list_required_for_argument_nr[]
   = N_("E1211: List required for argument %d");
 static const char e_bool_required_for_argument_nr[]
   = N_("E1212: Bool required for argument %d");
+static const char e_float_or_number_required_for_argument_nr[]
+  = N_("E1219: Float or Number required for argument %d");
 static const char e_string_or_number_required_for_argument_nr[]
   = N_("E1220: String or Number required for argument %d");
 static const char e_string_or_list_required_for_argument_nr[]
@@ -4171,7 +4173,7 @@ int tv_check_for_float_or_nr_arg(const typval_T *const args, const int idx)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
   if (args[idx].v_type != VAR_FLOAT && args[idx].v_type != VAR_NUMBER) {
-    semsg(_(e_number_required_for_argument_nr), idx + 1);
+    semsg(_(e_float_or_number_required_for_argument_nr), idx + 1);
     return FAIL;
   }
   return OK;

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -531,6 +531,11 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   no_wait_return++;
 
   do_cmdline_cmd(cmd);
+
+  // reset here for any errors reported below
+  trylevel = save_trylevel;
+  suppress_errthrow = false;
+
   if (called_emsg == called_emsg_before) {
     prepare_assert_error(&ga);
     ga_concat(&ga, "command did not fail: ");
@@ -557,6 +562,9 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       }
       const typval_T *tv = TV_LIST_ITEM_TV(tv_list_first(list));
       expected = tv_get_string_buf_chk(tv, buf);
+      if (expected == NULL) {
+        goto theend;
+      }
       if (!pattern_match(expected, actual, false)) {
         error_found = true;
         expected_str = expected;
@@ -565,6 +573,9 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         tofree = actual = xstrdup(get_vim_var_str(VV_ERRMSG));
         tv = TV_LIST_ITEM_TV(tv_list_last(list));
         expected = tv_get_string_buf_chk(tv, buf);
+        if (expected == NULL) {
+          goto theend;
+        }
         if (!pattern_match(expected, actual, false)) {
           error_found = true;
           expected_str = expected;

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -522,14 +522,13 @@ void f_assert_fails(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  const char *const cmd = tv_get_string_chk(&argvars[0]);
-
   // trylevel must be zero for a ":throw" command to be considered failed
   trylevel = 0;
   suppress_errthrow = true;
   in_assert_fails = true;
   no_wait_return++;
 
+  const char *const cmd = tv_get_string_chk(&argvars[0]);
   do_cmdline_cmd(cmd);
 
   // reset here for any errors reported below

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -258,6 +258,20 @@ func Test_assert_fail_fails()
   call assert_match("E856: \"assert_fails()\" second argument", exp)
 
   try
+    call assert_equal(1, assert_fails('xxx', v:_null_list))
+  catch
+    let exp = v:exception
+  endtry
+  call assert_match("E856: \"assert_fails()\" second argument", exp)
+
+  try
+    call assert_equal(1, assert_fails('xxx', []))
+  catch
+    let exp = v:exception
+  endtry
+  call assert_match("E856: \"assert_fails()\" second argument", exp)
+
+  try
     call assert_equal(1, assert_fails('xxx', #{one: 1}))
   catch
     let exp = v:exception
@@ -296,6 +310,15 @@ func Test_assert_fail_fails()
   call assert_equal(1, assert_fails('c0', ['', '\(.\)\1']))
   call assert_match("Expected '\\\\\\\\(.\\\\\\\\)\\\\\\\\1' but got 'E939: Positive count required: c0': c0", v:errors[0])
   call remove(v:errors, 0)
+
+  " Test for matching the line number and the script name in an error message
+  call writefile(['', 'call Xnonexisting()'], 'Xassertfails.vim', 'D')
+  call assert_fails('source Xassertfails.vim', 'E117:', '', 10)
+  call assert_match("Expected 10 but got 2", v:errors[0])
+  call remove(v:errors, 0)
+  call assert_fails('source Xassertfails.vim', 'E117:', '', 2, 'Xabc')
+  call assert_match("Expected 'Xabc' but got .*Xassertfails.vim", v:errors[0])
+  call remove(v:errors, 0)
 endfunc
 
 func Test_assert_fails_in_try_block()
@@ -320,6 +343,12 @@ func Test_assert_beeps()
   bwipe
 endfunc
 
+func Test_assert_nobeep()
+  call assert_equal(1, assert_nobeep('normal! cr'))
+  call assert_match("command did beep: normal! cr", v:errors[0])
+  call remove(v:errors, 0)
+endfunc
+
 func Test_assert_inrange()
   call assert_equal(0, assert_inrange(7, 7, 7))
   call assert_equal(0, assert_inrange(5, 7, 5))
@@ -341,21 +370,29 @@ func Test_assert_inrange()
 
   call assert_fails('call assert_inrange(1, 1)', 'E119:')
 
-  if has('float')
-    call assert_equal(0, assert_inrange(7.0, 7, 7))
-    call assert_equal(0, assert_inrange(7, 7.0, 7))
-    call assert_equal(0, assert_inrange(7, 7, 7.0))
-    call assert_equal(0, assert_inrange(5, 7, 5.0))
-    call assert_equal(0, assert_inrange(5, 7, 6.0))
-    call assert_equal(0, assert_inrange(5, 7, 7.0))
+  call assert_equal(0, assert_inrange(7.0, 7, 7))
+  call assert_equal(0, assert_inrange(7, 7.0, 7))
+  call assert_equal(0, assert_inrange(7, 7, 7.0))
+  call assert_equal(0, assert_inrange(5, 7, 5.0))
+  call assert_equal(0, assert_inrange(5, 7, 6.0))
+  call assert_equal(0, assert_inrange(5, 7, 7.0))
 
-    call assert_equal(1, assert_inrange(5, 7, 4.0))
-    call assert_match("Expected range 5.0 - 7.0, but got 4.0", v:errors[0])
-    call remove(v:errors, 0)
-    call assert_equal(1, assert_inrange(5, 7, 8.0))
-    call assert_match("Expected range 5.0 - 7.0, but got 8.0", v:errors[0])
-    call remove(v:errors, 0)
-  endif
+  call assert_equal(1, assert_inrange(5, 7, 4.0))
+  call assert_match("Expected range 5.0 - 7.0, but got 4.0", v:errors[0])
+  call remove(v:errors, 0)
+  call assert_equal(1, assert_inrange(5, 7, 8.0))
+  call assert_match("Expected range 5.0 - 7.0, but got 8.0", v:errors[0])
+  call remove(v:errors, 0)
+
+  " Use a custom message
+  call assert_equal(1, assert_inrange(5, 7, 8.0, "Higher"))
+  call assert_match("Higher", v:errors[0])
+  call remove(v:errors, 0)
+
+  " Invalid arguments
+  call assert_fails("call assert_inrange([], 2, 3)", 'E1219:')
+  call assert_fails("call assert_inrange(1, [], 3)", 'E1219:')
+  call assert_fails("call assert_inrange(1, 2, [])", 'E1219:')
 endfunc
 
 func Test_assert_with_msg()
@@ -391,6 +428,21 @@ func Test_mouse_position()
   call assert_equal([0, 2, 1, 0], getpos('.'))
   bwipe!
   let &mouse = save_mouse
+endfunc
+
+" Test for the test_alloc_fail() function
+func Test_test_alloc_fail()
+  throw 'Skipped: Nvim does not support test_alloc_fail()'
+  call assert_fails('call test_alloc_fail([], 1, 1)', 'E474:')
+  call assert_fails('call test_alloc_fail(10, [], 1)', 'E474:')
+  call assert_fails('call test_alloc_fail(10, 1, [])', 'E474:')
+  call assert_fails('call test_alloc_fail(999999, 1, 1)', 'E474:')
+endfunc
+
+" Test for the test_option_not_set() function
+func Test_test_option_not_set()
+  throw 'Skipped: Nvim does not support test_option_not_set()'
+  call assert_fails('call test_option_not_set("Xinvalidopt")', 'E475:')
 endfunc
 
 " Must be last.

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -265,6 +265,21 @@ func Test_assert_fail_fails()
   call assert_match("E1222: String or List required for argument 2", exp)
 
   try
+    call assert_equal(0, assert_fails('xxx', [#{one: 1}]))
+  catch
+    let exp = v:exception
+  endtry
+  call assert_match("E731: Using a Dictionary as a String", exp)
+
+  let exp = ''
+  try
+    call assert_equal(0, assert_fails('xxx', ['E492', #{one: 1}]))
+  catch
+    let exp = v:exception
+  endtry
+  call assert_match("E731: Using a Dictionary as a String", exp)
+
+  try
     call assert_equal(1, assert_fails('xxx', 'E492', '', 'burp'))
   catch
     let exp = v:exception
@@ -278,8 +293,8 @@ func Test_assert_fail_fails()
   endtry
   call assert_match("E1174: String required for argument 5", exp)
 
-  call assert_equal(1, assert_fails('c0', ['', '\1']))
-  call assert_match("Expected '\\\\\\\\1' but got 'E939: Positive count required: c0': c0", v:errors[0])
+  call assert_equal(1, assert_fails('c0', ['', '\(.\)\1']))
+  call assert_match("Expected '\\\\\\\\(.\\\\\\\\)\\\\\\\\1' but got 'E939: Positive count required: c0': c0", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -6,11 +6,11 @@ func Test_assert_false()
   call assert_equal(0, v:false->assert_false())
 
   call assert_equal(1, assert_false(123))
-  call assert_match("Expected False but got 123", v:errors[0])
+  call assert_match("Expected 'False' but got 123", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 123->assert_false())
-  call assert_match("Expected False but got 123", v:errors[0])
+  call assert_match("Expected 'False' but got 123", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -21,11 +21,11 @@ func Test_assert_true()
   call assert_equal(0, v:true->assert_true())
 
   call assert_equal(1, assert_true(0))
-  call assert_match("Expected True but got 0", v:errors[0])
+  call assert_match("Expected 'True' but got 0", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 0->assert_true())
-  call assert_match("Expected True but got 0", v:errors[0])
+  call assert_match("Expected 'True' but got 0", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -228,11 +228,11 @@ func Test_assert_fail_fails()
   call remove(v:errors, 0)
 
   call assert_equal(1, assert_fails('xxx', ['E9876']))
-  call assert_match("Expected \\['E9876'\\] but got 'E492:", v:errors[0])
+  call assert_match("Expected 'E9876' but got 'E492:", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, assert_fails('xxx', ['E492:', 'E9876']))
-  call assert_match("Expected \\['E492:', 'E9876'\\] but got 'E492:", v:errors[0])
+  call assert_match("Expected 'E9876' but got 'E492:", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, assert_fails('echo', '', 'echo command'))

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -327,6 +327,12 @@ func Test_assert_fails_in_try_block()
   endtry
 endfunc
 
+func Test_assert_fails_in_timer()
+  " should not cause a hit-enter prompt, which isn't actually checked here
+  call timer_start(0, {-> assert_fails('call', 'E471:')})
+  sleep 10m
+endfunc
+
 func Test_assert_beeps()
   new
   call assert_equal(0, assert_beeps('normal h'))

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -9,11 +9,11 @@ func Test_assert_false()
   call assert_equal(0, v:false->assert_false())
 
   call assert_equal(1, assert_false(123))
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 123->assert_false())
-  call assert_match("Expected 'False' but got 123", v:errors[0])
+  call assert_match("Expected False but got 123", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -24,11 +24,11 @@ func Test_assert_true()
   call assert_equal(0, v:true->assert_true())
 
   call assert_equal(1, assert_true(0))
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 
   call assert_equal(1, 0->assert_true())
-  call assert_match("Expected 'True' but got 0", v:errors[0])
+  call assert_match("Expected True but got 0", v:errors[0])
   call remove(v:errors, 0)
 endfunc
 
@@ -405,8 +405,11 @@ func Test_assert_inrange()
   call remove(v:errors, 0)
 
   " Use a custom message
+  call assert_equal(1, assert_inrange(5, 7, 8, "Higher"))
+  call assert_match("Higher: Expected range 5 - 7, but got 8", v:errors[0])
+  call remove(v:errors, 0)
   call assert_equal(1, assert_inrange(5, 7, 8.0, "Higher"))
-  call assert_match("Higher", v:errors[0])
+  call assert_match("Higher: Expected range 5.0 - 7.0, but got 8.0", v:errors[0])
   call remove(v:errors, 0)
 
   " Invalid arguments

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -277,6 +277,10 @@ func Test_assert_fail_fails()
     let exp = v:exception
   endtry
   call assert_match("E1174: String required for argument 5", exp)
+
+  call assert_equal(1, assert_fails('c0', ['', '\1']))
+  call assert_match("Expected '\\\\\\\\1' but got 'E939: Positive count required: c0': c0", v:errors[0])
+  call remove(v:errors, 0)
 endfunc
 
 func Test_assert_fails_in_try_block()

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -894,8 +894,6 @@ endfunc
 func Test_shortmess_F2()
   e file1
   e file2
-  " Accommodate Nvim default.
-  set shortmess-=F
   call assert_match('file1', execute('bn', ''))
   call assert_match('file2', execute('bn', ''))
   set shortmess+=F
@@ -913,12 +911,12 @@ func Test_shortmess_F2()
   " call assert_false(test_getvalue('need_fileinfo'))
   call assert_true(empty(execute('bn', '')))
   " call assert_false(test_getvalue('need_fileinfo'))
-  " Accommodate Nvim default.
-  set shortmess-=F
+  set shortmess-=F  " Accommodate Nvim default.
   call assert_match('file1', execute('bn', ''))
   call assert_match('file2', execute('bn', ''))
   bwipe
   bwipe
+  " call assert_fails('call test_getvalue("abc")', 'E475:')
 endfunc
 
 func Test_local_scrolloff()


### PR DESCRIPTION
#### vim-patch:8.2.1953: Vim9: extra "unknown" error after other error

Problem:    Vim9: extra "unknown" error after other error.
Solution:   Restore did_emsg count after EXEC instruction.
            Improve error message from assert_fails()

https://github.com/vim/vim/commit/631e8f93458b102091d54c502f489c03e454d4da

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0213: using freed memory with error in assert argument

Problem:    Using freed memory with error in assert argument.
Solution:   Make a copy of the error.

https://github.com/vim/vim/commit/249e1b903a9c0460d618f6dcc59aeb8c03b24b20

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0404: crash when passing invalid arguments to assert_fails()

Problem:    Crash when passing invalid arguments to assert_fails().
Solution:   Check for NULL string.

https://github.com/vim/vim/commit/1540d334a04d874c2aa9d26b82dbbcd4bc5a78de

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0543: insufficient testing for assert and test functions

Problem:    Insufficient testing for assert and test functions.
Solution:   Add a few more tests. (Yegappan Lakshmanan, closes vim/vim#11190)

https://github.com/vim/vim/commit/e24b5e0b0f5ab015215ef2761baa98ccb1ba8606

Cherry-pick E1219 from patch 8.2.3229.
Cherry-pick test_assert.vim change from patch 9.0.0491.
Cherry-pick the whole Test_refcount() function and skip it.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0846: using assert_fails() may cause hit-enter prompt

Problem:    Using assert_fails() may cause hit-enter prompt.
Solution:   Set no_wait_return.

https://github.com/vim/vim/commit/f220643c260d55d21a841a3c4032daadc41bc50b

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0854: no proper test for what 9.0.0846 fixes

Problem:    No proper test for what 9.0.0846 fixes.
Solution:   Run test in a terminal so that the hit-enter prompt can show up.
            (closes vim/vim#11523)

https://github.com/vim/vim/commit/7265851b2b4e5a63c0a02a9057dee237502ee557


#### vim-patch:9.0.1507: assert message is confusing with boolean result

Problem:    Assert message is confusing with boolean result.  assert_inrange()
            replaces message instead of adding it.
Solution:   Don't put quotes around expected boolean value.  Append message
            for assert_inrange(). (closes vim/vim#12342, closes vim/vim#12341)

https://github.com/vim/vim/commit/53f5e51628b56ef9171671cd6e9970374036a084

Move assert_type_T to testing.c and remove ASSERT_INRANGE.