### PR TITLE
vim-patch:8.2.{2094,2141},9.0.1508

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2367,7 +2367,10 @@ int eval0(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *const evalarg)
         semsg(_(e_invexpr2), arg);
       }
     }
-    ret = FAIL;
+
+    // Some of the expression may not have been consumed.  Do not check for
+    // a next command to avoid more errors.
+    return FAIL;
   }
 
   if (eap != NULL) {

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2368,11 +2368,14 @@ int eval0(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *const evalarg)
       }
     }
 
-    // Some of the expression may not have been consumed.  Do not check for
-    // a next command to avoid more errors, unless "|" is following, which
-    // could only be a command separator.
-    if (eap != NULL && skipwhite(p)[0] == '|' && skipwhite(p)[1] != '|') {
-      eap->nextcmd = check_nextcmd(p);
+    if (eap != NULL && p != NULL) {
+      // Some of the expression may not have been consumed.
+      // Only execute a next command if it cannot be a "||" operator.
+      // The next command may be "catch".
+      char *nextcmd = check_nextcmd(p);
+      if (nextcmd != NULL && *nextcmd != '|') {
+        eap->nextcmd = nextcmd;
+      }
     }
     return FAIL;
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2369,7 +2369,11 @@ int eval0(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *const evalarg)
     }
 
     // Some of the expression may not have been consumed.  Do not check for
-    // a next command to avoid more errors.
+    // a next command to avoid more errors, unless "|" is following, which
+    // could only be a command separator.
+    if (eap != NULL && skipwhite(p)[0] == '|' && skipwhite(p)[1] != '|') {
+      eap->nextcmd = check_nextcmd(p);
+    }
     return FAIL;
   }
 

--- a/test/old/testdir/test_trycatch.vim
+++ b/test/old/testdir/test_trycatch.vim
@@ -2220,6 +2220,36 @@ func Test_BufEnter_exception()
   %bwipe!
 endfunc
 
+" Test for using try/catch when lines are joined by "|" or "\n"           {{{1
+func Test_try_catch_nextcmd()
+  func Throw()
+    throw "Failure"
+  endfunc
+
+  let lines =<< trim END
+    try
+      let s:x = Throw()
+    catch
+      let g:caught = 1
+    endtry
+  END
+
+  let g:caught = 0
+  call execute(lines)
+  call assert_equal(1, g:caught)
+
+  let g:caught = 0
+  call execute(join(lines, '|'))
+  call assert_equal(1, g:caught)
+
+  let g:caught = 0
+  call execute(join(lines, "\n"))
+  call assert_equal(1, g:caught)
+
+  unlet g:caught
+  delfunc Throw
+endfunc
+
 " Test for using try/catch in a user command with a failing expression    {{{1
 func Test_user_command_try_catch()
   let lines =<< trim END

--- a/test/old/testdir/test_trycatch.vim
+++ b/test/old/testdir/test_trycatch.vim
@@ -2220,6 +2220,31 @@ func Test_BufEnter_exception()
   %bwipe!
 endfunc
 
+" Test for using try/catch in a user command with a failing expression    {{{1
+func Test_user_command_try_catch()
+  let lines =<< trim END
+      function s:throw() abort
+        throw 'error'
+      endfunction
+
+      command! Execute
+      \   try
+      \ |   let s:x = s:throw()
+      \ | catch
+      \ |   let g:caught = 'caught'
+      \ | endtry
+
+      let g:caught = 'no'
+      Execute
+      call assert_equal('caught', g:caught)
+  END
+  call writefile(lines, 'XtestTryCatch')
+  source XtestTryCatch
+
+  call delete('XtestTryCatch')
+  unlet g:caught
+endfunc
+
 " Test for using throw in a called function with following error    {{{1
 func Test_user_command_throw_in_function_call()
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:8.2.2094: when an expression fails getting next command may be wrong

Problem:    When an expression fails getting the next command may be wrong.
Solution:   Do not check for a next command after :eval fails.

https://github.com/vim/vim/commit/d0fe620cbbf5f5e00446efa89893036265c5c302

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2141: a user command with try/catch may not catch an expression error

Problem:    A user command with try/catch may not catch an expression error.
Solution:   When an expression fails check for following "|".

https://github.com/vim/vim/commit/8143a53c533bc7776c57e5db063d185bdd5750f3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1508: catch does not work when lines are joined with a newline

Problem:    Catch does not work when lines are joined with a newline.
Solution:   Set "nextcmd" appropriately. (closes vim/vim#12348)

https://github.com/vim/vim/commit/f2588b6fc90ba85b333ee8f747e8d1ebbc7e6300