### PR TITLE
vim-patch:8.2.1746: Vim9: cannot use "fina" for "finally"

### DIFF
--- a/test/old/testdir/test_trycatch.vim
+++ b/test/old/testdir/test_trycatch.vim
@@ -38,7 +38,7 @@ func T25_F()
         if loops == 2
           try
             Xpath 'f' . loops
-          finally
+          final
             Xpath 'g' . loops
           endtry
         endif
@@ -50,19 +50,20 @@ func T25_F()
   Xpath 'i'
 endfunc
 
+" Also try using "fina" and "final" and "finall" as abbraviations.
 func T25_G()
   if 1
     try
       Xpath 'A'
       call T25_F()
       Xpath 'B'
-    finally
+    fina
       Xpath 'C'
     endtry
   else
     try
       Xpath 'D'
-    finally
+    finall
       Xpath 'E'
     endtry
   endif


### PR DESCRIPTION
#### vim-patch:8.2.1746: Vim9: cannot use "fina" for "finally"

Problem:    Vim9: Cannot use "fina" for "finally". (Naruhiko Nishino)
Solution:   Specifically check for "fina".

https://github.com/vim/vim/commit/373863ed48c02b5df52574aa7d50aeecb1037d40

:final is N/A.

Co-authored-by: Bram Moolenaar <Bram@vim.org>