### PR TITLE
vim-patch:9.0.0904: various comment and indent flaws

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1506,18 +1506,16 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
       // g: dictionary). Disallow overwriting a builtin function.
       if (rettv != NULL && lp->ll_dict->dv_scope != 0) {
         char prevval;
-        int wrong;
-
         if (len != -1) {
           prevval = key[len];
           key[len] = NUL;
         } else {
           prevval = 0;  // Avoid compiler warning.
         }
-        wrong = ((lp->ll_dict->dv_scope == VAR_DEF_SCOPE
-                  && tv_is_func(*rettv)
-                  && var_wrong_func_name(key, lp->ll_di == NULL))
-                 || !valid_varname(key));
+        bool wrong = ((lp->ll_dict->dv_scope == VAR_DEF_SCOPE
+                       && tv_is_func(*rettv)
+                       && var_wrong_func_name(key, lp->ll_di == NULL))
+                      || !valid_varname(key));
         if (len != -1) {
           key[len] = prevval;
         }

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -98,6 +98,7 @@ win_T *win_id2wp(int id)
 }
 
 /// Return the window and tab pointer of window "id".
+/// Returns NULL when not found.
 win_T *win_id2wp_tp(int id, tabpage_T **tpp)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -93,7 +93,7 @@ static const char e_not_an_editor_command[]
   = N_("E492: Not an editor command");
 static const char e_no_autocommand_file_name_to_substitute_for_afile[]
   = N_("E495: No autocommand file name to substitute for \"<afile>\"");
-static const char e_no_autocommand_buffer_name_to_substitute_for_abuf[]
+static const char e_no_autocommand_buffer_number_to_substitute_for_abuf[]
   = N_("E496: No autocommand buffer number to substitute for \"<abuf>\"");
 static const char e_no_autocommand_match_name_to_substitute_for_amatch[]
   = N_("E497: No autocommand match name to substitute for \"<amatch>\"");
@@ -6913,7 +6913,7 @@ char *eval_vars(char *src, const char *srcstart, size_t *usedlen, linenr_T *lnum
 
     case SPEC_ABUF:             // buffer number for autocommand
       if (autocmd_bufnr <= 0) {
-        *errormsg = _(e_no_autocommand_buffer_name_to_substitute_for_abuf);
+        *errormsg = _(e_no_autocommand_buffer_number_to_substitute_for_abuf);
         return NULL;
       }
       snprintf(strbuf, sizeof(strbuf), "%d", autocmd_bufnr);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -834,23 +834,23 @@ bool noremap_keys(void)
   return KeyNoremap & (RM_NONE|RM_SCRIPT);
 }
 
-// Insert a string in position 'offset' in the typeahead buffer (for "@r"
-// and ":normal" command, vgetorpeek() and check_termcode())
-//
-// If noremap is REMAP_YES, new string can be mapped again.
-// If noremap is REMAP_NONE, new string cannot be mapped again.
-// If noremap is REMAP_SKIP, first char of new string cannot be mapped again,
-// but abbreviations are allowed.
-// If noremap is REMAP_SCRIPT, new string cannot be mapped again, except for
-//                             script-local mappings.
-// If noremap is > 0, that many characters of the new string cannot be mapped.
-//
-// If nottyped is true, the string does not return KeyTyped (don't use when
-// offset is non-zero!).
-//
-// If silent is true, cmd_silent is set when the characters are obtained.
-//
-// return FAIL for failure, OK otherwise
+/// Insert a string in position "offset" in the typeahead buffer (for "@r"
+/// and ":normal" command, vgetorpeek() and check_termcode())
+///
+/// If "noremap" is REMAP_YES, new string can be mapped again.
+/// If "noremap" is REMAP_NONE, new string cannot be mapped again.
+/// If "noremap" is REMAP_SKIP, first char of new string cannot be mapped again,
+/// but abbreviations are allowed.
+/// If "noremap" is REMAP_SCRIPT, new string cannot be mapped again, except for
+///                               script-local mappings.
+/// If "noremap" is > 0, that many characters of the new string cannot be mapped.
+///
+/// If "nottyped" is true, the string does not return KeyTyped (don't use when
+/// "offset" is non-zero!).
+///
+/// If "silent" is true, cmd_silent is set when the characters are obtained.
+///
+/// @return  FAIL for failure, OK otherwise
 int ins_typebuf(char *str, int noremap, int offset, bool nottyped, bool silent)
 {
   uint8_t *s1, *s2;
@@ -1351,8 +1351,8 @@ void before_blocking(void)
   }
 }
 
-/// updatescript() is called when a character can be written to the script file
-/// or when we have waited some time for a character (c == 0).
+/// updatescript() is called when a character can be written to the script
+/// file or when we have waited some time for a character (c == 0).
 ///
 /// All the changed memfiles are synced if c == 0 or when the number of typed
 /// characters reaches 'updatecount' and 'updatecount' is non-zero.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1250,6 +1250,7 @@ void wait_return(int redraw)
              || c == K_MOUSEDOWN || c == K_MOUSEUP
              || c == K_MOUSEMOVE);
     os_breakcheck();
+
     // Avoid that the mouse-up event causes visual mode to start.
     if (c == K_LEFTMOUSE || c == K_MIDDLEMOUSE || c == K_RIGHTMOUSE
         || c == K_X1MOUSE || c == K_X2MOUSE) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2328,9 +2328,10 @@ void cursor_correct(void)
   curwin->w_viewport_invalid = true;
 }
 
-// Move screen "count" pages up or down and update screen.
-//
-// Return FAIL for failure, OK otherwise.
+/// Move screen "count" pages up ("dir" is BACKWARD) or down ("dir" is FORWARD)
+/// and update the screen.
+///
+/// @return  FAIL for failure, OK otherwise.
 int onepage(Direction dir, long count)
 {
   long n;

--- a/test/old/testdir/test_fileformat.vim
+++ b/test/old/testdir/test_fileformat.vim
@@ -73,7 +73,12 @@ func Test_fileformats()
   call s:concat_files('XXMac', 'XXEol', 'XXMacEol')
   call s:concat_files('XXUxDs', 'XXMac', 'XXUxDsMc')
 
-  new
+  " The :bwipe commands below cause us to get back to the current buffer.
+  " Avoid stray errors for various 'fileformat' values which may cause a
+  " modeline to be misinterpreted by wiping the buffer and editing a new one.
+  only!
+  bwipe!
+  enew
 
   " Test 1: try reading and writing with 'fileformats' empty
   set fileformats=


### PR DESCRIPTION
#### vim-patch:9.0.0904: various comment and indent flaws

Problem:    Various comment and indent flaws.
Solution:   Improve comments and indenting.

https://github.com/vim/vim/commit/88456cd3c49a3dd1fda17cf350daa9b8216b1aa6

Omit test_function_lists.vim change as that file is likely not
applicable to Nvim due to the existence of Nvim-only functions.

Co-authored-by: Bram Moolenaar <Bram@vim.org>