### PR TITLE
vim-patch:8.2.{2249,2610}: mouse click test fails over ssh

### DIFF
--- a/test/old/testdir/test_selectmode.vim
+++ b/test/old/testdir/test_selectmode.vim
@@ -166,8 +166,11 @@ func Test_term_mouse_multiple_clicks_to_select_mode()
   let save_term = &term
   " let save_ttymouse = &ttymouse
   " call test_override('no_query_mouse', 1)
-  " set mouse=a term=xterm mousetime=200
-  set mouse=a mousetime=200
+
+  " 'mousetime' must be sufficiently large, or else the test is flaky when
+  " using a ssh connection with X forwarding; i.e. ssh -X.
+  " set mouse=a term=xterm mousetime=1000
+  set mouse=a mousetime=1000
   set selectmode=mouse
   new
 

--- a/test/old/testdir/test_termcodes.vim
+++ b/test/old/testdir/test_termcodes.vim
@@ -680,8 +680,11 @@ func Test_term_mouse_multiple_clicks_to_visually_select()
   let save_term = &term
   " let save_ttymouse = &ttymouse
   " call test_override('no_query_mouse', 1)
-  " set mouse=a term=xterm mousetime=200
-  set mouse=a mousetime=200
+
+  " 'mousetime' must be sufficiently large, or else the test is flaky when
+  " using a ssh connection with X forwarding; i.e. ssh -X (issue #7563).
+  " set mouse=a term=xterm mousetime=600
+  set mouse=a mousetime=600
   new
 
   for ttymouse_val in g:Ttymouse_values + g:Ttymouse_dec


### PR DESCRIPTION
#### vim-patch:8.2.2249: termcodes test is flaky when used over ssh

Problem:    Termcodes test is flaky when used over ssh with X forwarding.
Solution:   Set 'mousetime' to a larger value. (Dominique Pellé, closes vim/vim#7576)

https://github.com/vim/vim/commit/2a5c61a0196d2d67313f5b3189974211e6f33562


#### vim-patch:8.2.2610: mouse click test fails when using remote connection

Problem:    Mouse click test fails when using remote connection.
Solution:   Use a larger 'mousetime'. (Dominique Pellé, closes vim/vim#7968)

https://github.com/vim/vim/commit/1e448465e1281eeb379f75fe848cbb47fe1be1d