### PR TITLE
fix(api): allow negative column arguments for nvim_buf_set_text

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -547,6 +547,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   // Another call to ml_get_buf() may free the line, so make a copy.
   str_at_start = xstrdup(ml_get_buf(buf, (linenr_T)start_row, false));
   size_t len_at_start = strlen(str_at_start);
+  start_col = start_col < 0 ? (int64_t)len_at_start + start_col + 1 : start_col;
   VALIDATE_RANGE((start_col >= 0 && (size_t)start_col <= len_at_start), "start_col", {
     goto early_end;
   });
@@ -554,6 +555,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   // Another call to ml_get_buf() may free the line, so make a copy.
   str_at_end = xstrdup(ml_get_buf(buf, (linenr_T)end_row, false));
   size_t len_at_end = strlen(str_at_end);
+  end_col = end_col < 0 ? (int64_t)len_at_end + end_col + 1 : end_col;
   VALIDATE_RANGE((end_col >= 0 && (size_t)end_col <= len_at_end), "end_col", {
     goto early_end;
   });

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -437,6 +437,10 @@ describe('api/buf', function()
       -- can append to a line
       set_text(1, 4, -1, 4, {' and', 'more'})
       eq({'goodbye bar', 'text and', 'more'}, get_lines(0, 3, true))
+
+      -- can use negative column numbers
+      set_text(0, -5, 0, -1, {'!'})
+      eq({'goodbye!'}, get_lines(0, 1, true))
     end)
 
     it('works with undo', function()


### PR DESCRIPTION
This PR allows `nvim_buf_set_text()` to use negative column arguments like `nvim_buf_get_text()`.
Currently, using negative columns raise out of range error.

📝 Example

```lua
--- test
local text = vim.api.nvim_buf_get_text(0, 0, -5, 0, -1, {})
vim.api.nvim_buf_set_text(0, 0, -5, 0, -1, { text[1] .. " ok" }) -- can use columns the same with nvim_buf_get_text
```
