### PR TITLE
vim-patch:9.0.1511: crash when using wrong arg types to assert_match()

### DIFF
--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -287,11 +287,10 @@ static int assert_match_common(typval_T *argvars, assert_type_T atype)
 {
   char buf1[NUMBUFLEN];
   char buf2[NUMBUFLEN];
-  const int called_emsg_before = called_emsg;
   const char *const pat = tv_get_string_buf_chk(&argvars[0], buf1);
   const char *const text = tv_get_string_buf_chk(&argvars[1], buf2);
 
-  if (called_emsg == called_emsg_before
+  if (pat != NULL && text != NULL
       && pattern_match(pat, text, false) != (atype == ASSERT_MATCH)) {
     garray_T ga;
     prepare_assert_error(&ga);
@@ -393,12 +392,10 @@ static int assert_equalfile(typval_T *argvars)
 {
   char buf1[NUMBUFLEN];
   char buf2[NUMBUFLEN];
-  const int called_emsg_before = called_emsg;
   const char *const fname1 = tv_get_string_buf_chk(&argvars[0], buf1);
   const char *const fname2 = tv_get_string_buf_chk(&argvars[1], buf2);
-  garray_T ga;
 
-  if (called_emsg > called_emsg_before) {
+  if (fname1 == NULL || fname2 == NULL) {
     return 0;
   }
 
@@ -451,7 +448,9 @@ static int assert_equalfile(typval_T *argvars)
       fclose(fd2);
     }
   }
+
   if (IObuff[0] != NUL) {
+    garray_T ga;
     prepare_assert_error(&ga);
     if (argvars[2].v_type != VAR_UNKNOWN) {
       char *const tofree = encode_tv2echo(&argvars[2], NULL);
@@ -475,6 +474,7 @@ static int assert_equalfile(typval_T *argvars)
     ga_clear(&ga);
     return 1;
   }
+
   return 0;
 }
 

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -324,6 +324,23 @@ func Test_assert_fail_fails()
   call remove(v:errors, 0)
 endfunc
 
+func Test_assert_wrong_arg_emsg_off()
+  CheckFeature folding
+
+  new
+  call setline(1, ['foo', 'bar'])
+  1,2fold
+
+  " This used to crash Vim
+  let &l:foldtext = 'assert_match({}, {})'
+  redraw!
+
+  let &l:foldtext = 'assert_equalfile({}, {})'
+  redraw!
+
+  bwipe!
+endfunc
+
 func Test_assert_fails_in_try_block()
   try
     call assert_equal(0, assert_fails('throw "error"'))


### PR DESCRIPTION
#### vim-patch:9.0.1511: crash when using wrong arg types to assert_match()

Problem:    Crash when using wrong arg types to assert_match().
Solution:   Check for NULL pointer. (closes vim/vim#12349)

https://github.com/vim/vim/commit/12e7a1fe7527e9e59adbe248a95b4b532e3ec58c