### PR TITLE
vim-patch:9.0.{1512,1513}

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2101,7 +2101,12 @@ static void win_update(win_T *wp, DecorProviders *providers)
             if (hasFoldingWin(wp, l, NULL, &l, true, NULL)) {
               new_rows++;
             } else if (l == wp->w_topline) {
-              new_rows += plines_win_nofill(wp, l, true) + wp->w_topfill;
+              int n = plines_win_nofill(wp, l, false) + wp->w_topfill;
+              n = adjust_plines_for_skipcol(wp, n);
+              if (n > wp->w_height_inner) {
+                n = wp->w_height_inner;
+              }
+              new_rows += n;
             } else {
               new_rows += plines_win(wp, l, true);
             }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -58,7 +58,7 @@ typedef struct {
 #endif
 
 /// Reduce "n" for the screen lines skipped with "wp->w_skipcol".
-static int adjust_plines_for_skipcol(win_T *wp, int n)
+int adjust_plines_for_skipcol(win_T *wp, int n)
 {
   if (wp->w_skipcol == 0) {
     return n;
@@ -196,7 +196,7 @@ static int skipcol_from_plines(win_T *wp, int plines_off)
   return skipcol;
 }
 
-/// Set wp->s_skipcol to zero and redraw later if needed.
+/// Set wp->w_skipcol to zero and redraw later if needed.
 static void reset_skipcol(win_T *wp)
 {
   if (wp->w_skipcol != 0) {
@@ -2267,7 +2267,7 @@ void cursor_correct(void)
   }
 
   if (curwin->w_p_sms && !curwin->w_p_wrap) {
-    // 'smoothscroll is active
+    // 'smoothscroll' is active
     if (curwin->w_cline_height == curwin->w_height_inner) {
       // The cursor line just fits in the window, don't scroll.
       reset_skipcol(curwin);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1616,6 +1616,9 @@ static void win_init(win_T *newp, win_T *oldp, int flags)
                     ? NULL : xstrdup(oldp->w_prevdir);
 
   if (*p_spk != 'c') {
+    if (*p_spk == 't') {
+      newp->w_skipcol = oldp->w_skipcol;
+    }
     newp->w_botline = oldp->w_botline;
     newp->w_prev_height = oldp->w_height;
     newp->w_prev_winrow = oldp->w_winrow;
@@ -6605,13 +6608,13 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
         set_fraction(wp);
       }
     }
-    wp->w_skipcol = 0;
     wp->w_height_inner = height;
     win_comp_scroll(wp);
 
     // There is no point in adjusting the scroll position when exiting.  Some
     // values might be invalid.
     if (valid_cursor && !exiting && *p_spk == 'c') {
+      wp->w_skipcol = 0;
       scroll_to_fraction(wp, prev_height);
     }
     redraw_later(wp, UPD_SOME_VALID);

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -695,6 +695,30 @@ describe('smoothscroll', function()
     ]])
   end)
 
+  -- oldtest: Test_smoothscroll_ins_lines()
+  it("this was unnecessarily inserting lines", function()
+    screen:try_resize(40, 6)
+    exec([=[
+      set wrap smoothscroll scrolloff=0 conceallevel=2 concealcursor=nc
+      call setline(1, [
+        \'line one' .. 'with lots of text in one line '->repeat(2),
+        \'line two',
+        \'line three',
+        \'line four',
+        \'line five'
+      \])
+    ]=])
+    feed('<C-E>gjgk')
+    screen:expect([[
+      <<<lots of text in one line^             |
+      line two                                |
+      line three                              |
+      line four                               |
+      line five                               |
+                                              |
+    ]])
+  end)
+
   it("works with virt_lines above and below", function()
     screen:try_resize(55, 7)
     exec([=[

--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -254,4 +254,29 @@ describe('splitkeep', function()
                                                            |
     ]])
   end)
+
+  -- oldtest: Test_splitkeep_skipcol()
+  it('skipcol is not reset unnecessarily and is copied to new window', function()
+    screen:try_resize(40, 12)
+    exec([[
+      set splitkeep=topline smoothscroll splitbelow scrolloff=0
+      call setline(1, 'with lots of text in one line '->repeat(6))
+      norm 2
+      wincmd s
+    ]])
+    screen:expect([[
+      <<<e line with lots of text in one line |
+      with lots of text in one line with lots |
+      of text in one line                     |
+      ~                                       |
+      [No Name] [+]                           |
+      <<<e line with lots of text in one line |
+      ^with lots of text in one line with lots |
+      of text in one line                     |
+      ~                                       |
+      ~                                       |
+      [No Name] [+]                           |
+                                              |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -587,7 +587,7 @@ func Test_smoothscroll_mouse_pos()
 endfunc
 
 " this was dividing by zero
-func Test_smoothscrol_zero_width()
+func Test_smoothscroll_zero_width()
   CheckScreendump
 
   let lines =<< trim END
@@ -613,5 +613,30 @@ func Test_smoothscrol_zero_width()
   call StopVimInTerminal(buf)
 endfunc
 
+" this was unnecessarily inserting lines
+func Test_smoothscroll_ins_lines()
+  CheckScreendump
+
+  let lines =<< trim END
+      set wrap
+      set smoothscroll
+      set scrolloff=0
+      set conceallevel=2
+      call setline(1, [
+        \'line one' .. 'with lots of text in one line '->repeat(2),
+        \'line two',
+        \'line three',
+        \'line four',
+        \'line five'
+      \])
+  END
+  call writefile(lines, 'XSmoothScrollInsLines', 'D')
+  let buf = RunVimInTerminal('-S XSmoothScrollInsLines', #{rows: 6, cols: 40})
+
+  call term_sendkeys(buf, "\<C-E>gjgk")
+  call VerifyScreenDump(buf, 'Test_smooth_ins_lines', {})
+
+  call StopVimInTerminal(buf)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1879,6 +1879,23 @@ func Test_splitkeep_status()
   call StopVimInTerminal(buf)
 endfunc
 
+" skipcol is not reset unnecessarily and is copied to new window
+func Test_splitkeep_skipcol()
+  CheckScreendump
+
+  let lines =<< trim END
+    set splitkeep=topline smoothscroll splitbelow scrolloff=0
+    call setline(1, 'with lots of text in one line '->repeat(6))
+    norm 2
+    wincmd s
+  END
+
+  call writefile(lines, 'XTestSplitkeepSkipcol', 'D')
+  let buf = RunVimInTerminal('-S XTestSplitkeepSkipcol', #{rows: 12, cols: 40})
+
+  call VerifyScreenDump(buf, 'Test_splitkeep_skipcol_1', {})
+endfunc
+
 func Test_new_help_window_on_error()
   help change.txt
   execute "normal! /CTRL-@\<CR>"


### PR DESCRIPTION
Fix #23495

**vim-patch:9.0.1513: text scrolls unnecessarily when splitting**

Problem:    Text scrolls unnecessarily when splitting and 'splitkeep' is not
            "cursor".
Solution:   Avoid resetting w_skipcol. (Luuk van Baal, closes vim/vim#12334)

https://github.com/vim/vim/commit/b926bf47d61360a4ec5e4867714a08d70fd49965

**vim-patch:9.0.1512: inserting lines when scrolling with 'smoothscroll' set**

Problem:    Inserting lines when scrolling with 'smoothscroll' set.
Solution:   Adjust line height computation for w_skipcol. (Luuk van Baal,
            closes vim/vim#12350)

https://github.com/vim/vim/commit/c8502f9b880b6d23baa4f9d28b60e1ceb442e35f