### PR TITLE
vim-patch:9.0.1514: test waits unnecessarily long before checking screendump

### DIFF
--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -604,7 +604,6 @@ func Test_smoothscrol_zero_width()
   END
   call writefile(lines, 'XSmoothScrollZero', 'D')
   let buf = RunVimInTerminal('-u NONE -i NONE -n -m -X -Z -e -s -S XSmoothScrollZero', #{rows: 6, cols: 60, wait_for_ruler: 0})
-  call TermWait(buf, 3000)
   call VerifyScreenDump(buf, 'Test_smoothscroll_zero_1', {})
 
   call term_sendkeys(buf, ":sil norm \<C-V>\<C-W>\<C-V>\<C-N>\<CR>")


### PR DESCRIPTION
#### vim-patch:9.0.1514: test waits unnecessarily long before checking screendump

Problem:    Test waits unnecessarily long before checking screendump.
Solution:   Remove TermWait() call.

https://github.com/vim/vim/commit/45fcb7928af8ac9bc5685ce7c804b8250866a874

Co-authored-by: Bram Moolenaar <Bram@vim.org>