### PR TITLE
vim-patch:9.0.1518: search stats not always visible when searching backwards

### DIFF
--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -259,7 +259,7 @@ enum {
   SHM_COMPLETIONSCAN = 'C',  ///< Completion scanning messages.
   SHM_RECORDING      = 'q',  ///< Short recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
-  SHM_SEARCHCOUNT    = 'S',  ///< Search stats: '[1/10]'
+  SHM_SEARCHCOUNT    = 'S',  ///< No search stats: '[1/10]'
   SHM_LEN            = 30,   ///< Max length of all flags together plus a NUL character.
 };
 /// Represented by 'a' flag.

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -913,19 +913,22 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
           || found || loop) {
         break;
       }
-      //
+
       // If 'wrapscan' is set we continue at the other end of the file.
-      // If 'shortmess' does not contain 's', we give a message.
+      // If 'shortmess' does not contain 's', we give a message, but
+      // only, if we won't show the search stat later anyhow,
+      // (so SEARCH_COUNT must be absent).
       // This message is also remembered in keep_msg for when the screen
       // is redrawn. The keep_msg is cleared whenever another message is
       // written.
-      //
       if (dir == BACKWARD) {        // start second loop at the other end
         lnum = buf->b_ml.ml_line_count;
       } else {
         lnum = 1;
       }
-      if (!shortmess(SHM_SEARCH) && (options & SEARCH_MSG)) {
+      if (!shortmess(SHM_SEARCH)
+          && shortmess(SHM_SEARCHCOUNT)
+          && (options & SEARCH_MSG)) {
         give_warning(_(dir == BACKWARD ? top_bot_msg : bot_top_msg), true);
       }
       if (extra_arg != NULL) {
@@ -2702,8 +2705,10 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, searchst
     lbuf = curbuf;
   }
 
+  // when searching backwards and having jumped to the first occurrence,
+  // cur must remain greater than 1
   if (equalpos(lastpos, *cursor_pos) && !wraparound
-      && (dirc == 0 || dirc == '/' ? cur < cnt : cur > 0)) {
+      && (dirc == 0 || dirc == '/' ? cur < cnt : cur > 1)) {
     cur += dirc == 0 ? 0 : dirc == '/' ? 1 : -1;
   } else {
     proftime_T start;

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -10,8 +10,9 @@ describe('search stat', function()
     screen:set_default_attr_ids({
       [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
       [2] = {background = Screen.colors.Yellow},  -- Search
-      [3] = {foreground = Screen.colors.Blue4, background = Screen.colors.LightGrey},  -- Folded
+      [3] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},  -- Folded
       [4] = {reverse = true},  -- IncSearch, TabLineFill
+      [5] = {foreground = Screen.colors.Red},  -- WarningMsg
     })
     screen:attach()
   end)
@@ -181,6 +182,59 @@ describe('search stat', function()
       {1:~                             }|
       {1:~                             }|
       /abc^                          |
+    ]])
+  end)
+
+  -- oldtest: Test_search_stat_backwards()
+  it('when searching backwards', function()
+    screen:try_resize(60, 10)
+    exec([[
+      set shm-=S
+      call setline(1, ['test', ''])
+    ]])
+
+    feed('*')
+    screen:expect([[
+      {2:^test}                                                        |
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      /\<test\>                                            [1/1]  |
+    ]])
+
+    feed('N')
+    screen:expect([[
+      {2:^test}                                                        |
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      ?\<test\>                                            [1/1]  |
+    ]])
+
+    command('set shm+=S')
+    feed('N')
+    -- shows "Search Hit Bottom.."
+    screen:expect([[
+      {2:^test}                                                        |
+                                                                  |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {5:search hit TOP, continuing at BOTTOM}                        |
     ]])
   end)
 end)


### PR DESCRIPTION
#### vim-patch:9.0.1518: search stats not always visible when searching backwards

Problem:    Search stats not always visible when searching backwards.
Solution:   Do not display the top/bot message on top of the search stats.
            (Christian Brabandt, closes vim/vim#12322)

https://github.com/vim/vim/commit/34a6a3617b5b6ce11372439f14762caddc4b0cea

Co-authored-by: Christian Brabandt <cb@256bit.org>