### PR TITLE
vim-patch:9.0.1520: completion for option name includes all bool options

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -897,12 +897,27 @@ char *ExpandOne(expand_T *xp, char *str, char *orig, int options, int mode)
   if (mode == WILD_ALL && xp->xp_numfiles > 0 && !got_int) {
     size_t len = 0;
     for (int i = 0; i < xp->xp_numfiles; i++) {
+      if (i > 0) {
+        if (xp->xp_prefix == XP_PREFIX_NO) {
+          len += 2;   // prefix "no"
+        } else if (xp->xp_prefix == XP_PREFIX_INV) {
+          len += 3;   // prefix "inv"
+        }
+      }
       len += strlen(xp->xp_files[i]) + 1;
     }
     ss = xmalloc(len);
     *ss = NUL;
     for (int i = 0; i < xp->xp_numfiles; i++) {
+      if (i > 0) {
+        if (xp->xp_prefix == XP_PREFIX_NO) {
+          STRCAT(ss, "no");
+        } else if (xp->xp_prefix == XP_PREFIX_INV) {
+          STRCAT(ss, "inv");
+        }
+      }
       STRCAT(ss, xp->xp_files[i]);
+
       if (i != xp->xp_numfiles - 1) {
         STRCAT(ss, (options & WILD_USE_NL) ? "\n" : " ");
       }
@@ -927,6 +942,7 @@ void ExpandInit(expand_T *xp)
 {
   CLEAR_POINTER(xp);
   xp->xp_backslash = XP_BS_NONE;
+  xp->xp_prefix = XP_PREFIX_NONE;
   xp->xp_numfiles = -1;
 }
 

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -222,11 +222,18 @@ struct exarg {
 #define EXFLAG_NR       0x02    // '#': number
 #define EXFLAG_PRINT    0x04    // 'p': print
 
+typedef enum {
+  XP_PREFIX_NONE,  ///< prefix not used
+  XP_PREFIX_NO,    ///< "no" prefix for bool option
+  XP_PREFIX_INV,   ///< "inv" prefix for bool option
+} xp_prefix_T;
+
 // used for completion on the command line
 struct expand {
   char *xp_pattern;             // start of item to expand
   int xp_context;               // type of expansion
   size_t xp_pattern_len;        // bytes in xp_pattern before cursor
+  xp_prefix_T xp_prefix;
   char *xp_arg;                 // completion function
   LuaRef xp_luaref;             // Ref to Lua completion function
   sctx_T xp_script_ctx;         // SCTX for completion function

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5133,10 +5133,11 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
   }
   if (strncmp(p, "no", 2) == 0) {
     xp->xp_context = EXPAND_BOOL_SETTINGS;
+    xp->xp_prefix = XP_PREFIX_NO;
     p += 2;
-  }
-  if (strncmp(p, "inv", 3) == 0) {
+  } else if (strncmp(p, "inv", 3) == 0) {
     xp->xp_context = EXPAND_BOOL_SETTINGS;
+    xp->xp_prefix = XP_PREFIX_INV;
     p += 3;
   }
   xp->xp_pattern = p;

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -282,13 +282,17 @@ func Test_set_completion()
   call feedkeys(":setglobal di\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"setglobal dictionary diff diffexpr diffopt digraph directory display', @:)
 
-  " Expand boolean options. When doing :set no<Tab>
-  " vim displays the options names without "no" but completion uses "no...".
+  " Expand boolean options. When doing :set no<Tab> Vim prefixes the option
+  " names with "no".
   call feedkeys(":set nodi\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set nodiff digraph', @:)
+  call assert_equal('"set nodiff nodigraph', @:)
 
   call feedkeys(":set invdi\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"set invdiff digraph', @:)
+  call assert_equal('"set invdiff invdigraph', @:)
+
+  " Expanding "set noinv" does nothing.
+  call feedkeys(":set noinv\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set noinv', @:)
 
   " Expand abbreviation of options.
   call feedkeys(":set ts\<C-A>\<C-B>\"\<CR>", 'tx')


### PR DESCRIPTION
#### vim-patch:9.0.1520: completion for option name includes all bool options

Problem:    Completion for option name includes all bool options.
Solution:   Do not recognize the "noinv" prefix.  Prefix "no" or "inv" when
            appropriate.

https://github.com/vim/vim/commit/048d9d25214049dfde04c468c14bd1708fb692b8

Co-authored-by: Bram Moolenaar <Bram@vim.org>