### PR TITLE
refactor(lsp): mark server_ready function as deprecated

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1299,13 +1299,6 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
                     • name (string|nil): Restrict clients used for rename to
                       ones where client.name matches this field.
 
-server_ready()                                    *vim.lsp.buf.server_ready()*
-    Checks whether the language servers attached to the current buffer are
-    ready.
-
-    Return: ~
-        `true` if server responds.
-
 signature_help()                                *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
     floating window.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -31,7 +31,9 @@ end
 --- ready.
 ---
 ---@returns `true` if server responds.
+---@deprecated
 function M.server_ready()
+  vim.deprecate('vim.lsp.buf.server_ready', nil, '0.10.0')
   return not not vim.lsp.buf_notify(0, 'window/progress', {})
 end
 


### PR DESCRIPTION
`window/progress` not part of lsp spec. we shouldn't have this handler.  Consider it already used in some user config or plugin. So mark as deprecated and remove in next version

Fix #23511