### PR TITLE
build: remove USE_BUNDLED_BUSTED option

### DIFF
--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -3,8 +3,6 @@
 #       running luarocks in parallel will break, e.g. when some rocks have
 #       the same dependency.
 
-option(USE_BUNDLED_BUSTED "Use the bundled version of busted to run tests." ON)
-
 # The luarocks binary location
 set(LUAROCKS_BINARY ${DEPS_BIN_DIR}/luarocks)
 
@@ -119,19 +117,17 @@ function(Download ROCK VER)
   set(CURRENT_DEP ${ROCK} PARENT_SCOPE)
 endfunction()
 
-if(USE_BUNDLED_BUSTED)
-  if(WIN32)
-    set(BUSTED_EXE "${DEPS_BIN_DIR}/busted.bat")
-    set(LUACHECK_EXE "${DEPS_BIN_DIR}/luacheck.bat")
-  else()
-    set(BUSTED_EXE "${DEPS_BIN_DIR}/busted")
-    set(LUACHECK_EXE "${DEPS_BIN_DIR}/luacheck")
-  endif()
+if(WIN32)
+  set(BUSTED_EXE "${DEPS_BIN_DIR}/busted.bat")
+  set(LUACHECK_EXE "${DEPS_BIN_DIR}/luacheck.bat")
+else()
+  set(BUSTED_EXE "${DEPS_BIN_DIR}/busted")
+  set(LUACHECK_EXE "${DEPS_BIN_DIR}/luacheck")
+endif()
 
-  Download(busted 2.1.1 ${BUSTED_EXE})
-  Download(luacheck 1.1.0-1 ${LUACHECK_EXE})
+Download(busted 2.1.1 ${BUSTED_EXE})
+Download(luacheck 1.1.0-1 ${LUACHECK_EXE})
 
-  if (USE_BUNDLED_LUA OR NOT USE_BUNDLED_LUAJIT)
-    Download(coxpcall 1.17.0-1)
-  endif()
+if (USE_BUNDLED_LUA OR NOT USE_BUNDLED_LUAJIT)
+  Download(coxpcall 1.17.0-1)
 endif()


### PR DESCRIPTION
The previous logic made it possible to install bundled luarocks, but
also use external rocks, making the luarocks installation unnecessary.
Instead, let's assume that if the user wants to use the bundled
luarocks, then they also want to use it to install necessary rocks.
