### PR TITLE
vim-patch:9.0.1523: some error messages are not marked for translation

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -993,7 +993,8 @@ EXTERN const char e_notset[] INIT(= N_("E764: Option '%s' is not set"));
 EXTERN const char e_invalidreg[] INIT(= N_("E850: Invalid register name"));
 EXTERN const char e_dirnotf[] INIT(= N_("E919: Directory not found in '%s': \"%s\""));
 EXTERN const char e_au_recursive[] INIT(= N_("E952: Autocommand caused recursive behavior"));
-EXTERN const char e_menuothermode[] INIT(= N_("E328: Menu only exists in another mode"));
+EXTERN const char e_menu_only_exists_in_another_mode[]
+INIT(= N_("E328: Menu only exists in another mode"));
 EXTERN const char e_autocmd_close[] INIT(= N_("E813: Cannot close autocmd window"));
 EXTERN const char e_listarg[] INIT(= N_("E686: Argument of %s must be a List"));
 EXTERN const char e_unsupportedoption[] INIT(= N_("E519: Option not supported"));

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -559,7 +559,7 @@ static int remove_menu(vimmenu_T **menup, char *name, int modes, bool silent)
         }
       } else if (*name != NUL) {
         if (!silent) {
-          emsg(_(e_menuothermode));
+          emsg(_(e_menu_only_exists_in_another_mode));
         }
         return FAIL;
       }
@@ -760,7 +760,7 @@ static vimmenu_T *find_menu(vimmenu_T *menu, char *name, int modes)
           emsg(_(e_notsubmenu));
           return NULL;
         } else if ((menu->modes & modes) == 0x0) {
-          emsg(_(e_menuothermode));
+          emsg(_(e_menu_only_exists_in_another_mode));
           return NULL;
         } else if (*p == NUL) {  // found a full match
           return menu;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1083,7 +1083,7 @@ void pum_show_popupmenu(vimmenu_T *menu)
   // When there are only Terminal mode menus, using "popup Edit" results in
   // pum_size being zero.
   if (pum_size <= 0) {
-    emsg(e_menuothermode);
+    emsg(_(e_menu_only_exists_in_another_mode));
     return;
   }
 

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2409,7 +2409,7 @@ void f_getscriptinfo(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         return;
       }
       if (sid <= 0) {
-        semsg(e_invargNval, "sid", tv_get_string(&sid_di->di_tv));
+        semsg(_(e_invargNval), "sid", tv_get_string(&sid_di->di_tv));
         return;
       }
     } else {


### PR DESCRIPTION
#### vim-patch:9.0.1523: some error messages are not marked for translation

Problem:    Some error messages are not marked for translation.
Solution:   Surround the messages in _(). (closes vim/vim#12356)

https://github.com/vim/vim/commit/276410e78f0b82e3123059383994d2f4c578dfbd