### PR TITLE
vim-patch:8.2.2459: Coverity reports dead code

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3677,9 +3677,6 @@ static int eval_index_inner(typval_T *rettv, bool is_range, typval_T *var1, typv
       } else if (n2 >= len) {
         n2 = len;
       }
-      if (exclusive) {
-        n2--;
-      }
       if (n1 >= len || n2 < 0 || n1 > n2) {
         v = NULL;
       } else {


### PR DESCRIPTION
#### vim-patch:8.2.2459: Coverity reports dead code

Problem:    Coverity reports dead code.
Solution:   Remove the dead code.

https://github.com/vim/vim/commit/8bead9a058907e7f10ad25893d8475d2d9dd173c

Co-authored-by: Bram Moolenaar <Bram@vim.org>