### PR TITLE
fix(statusline): bail out properly on negative row

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -336,7 +336,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
     grid_adjust(&grid, &row, &col);
 
     if (row < 0) {
-      return;
+      goto theend;
     }
 
     fillchar = wp->w_p_fcs_chars.wbr;

--- a/test/functional/ui/winbar_spec.lua
+++ b/test/functional/ui/winbar_spec.lua
@@ -713,3 +713,26 @@ describe('local winbar with tabs', function()
     ]]}
   end)
 end)
+
+it('winbar works properly when redrawing is postponed #23534', function()
+  clear({args = {
+    '-c', 'set laststatus=2 lazyredraw',
+    '-c', 'setlocal statusline=(statusline) winbar=(winbar)',
+    '-c', 'call nvim_input(":<Esc>")',
+  }})
+  local screen = Screen.new(60, 6)
+  screen:attach()
+  screen:set_default_attr_ids({
+    [0] = {foreground = Screen.colors.Blue, bold = true},
+    [1] = {bold = true},
+    [2] = {bold = true, reverse = true},
+  })
+  screen:expect([[
+    {1:(winbar)                                                    }|
+    ^                                                            |
+    {0:~                                                           }|
+    {0:~                                                           }|
+    {2:(statusline)                                                }|
+                                                                |
+  ]])
+end)


### PR DESCRIPTION
Fix #23534
