### PR TITLE
vim-patch:9.0.{1522,1524}: some functions give two error messages

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2166,6 +2166,16 @@ varnumber_T tv_dict_get_number_def(const dict_T *const d, const char *const key,
   return tv_get_number(&di->di_tv);
 }
 
+varnumber_T tv_dict_get_bool(const dict_T *const d, const char *const key, const int def)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  dictitem_T *const di = tv_dict_find(d, key, -1);
+  if (di == NULL) {
+    return def;
+  }
+  return tv_get_bool(&di->di_tv);
+}
+
 /// Converts a dict to an environment
 char **tv_dict_to_env(dict_T *denv)
 {
@@ -4047,6 +4057,18 @@ varnumber_T tv_get_number_chk(const typval_T *const tv, bool *const ret_error)
     *ret_error = true;
   }
   return (ret_error == NULL ? -1 : 0);
+}
+
+varnumber_T tv_get_bool(const typval_T *const tv)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  return tv_get_number_chk(tv, NULL);
+}
+
+varnumber_T tv_get_bool_chk(const typval_T *const tv, bool *const ret_error)
+  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
+{
+  return tv_get_number_chk(tv, ret_error);
 }
 
 /// Get the line number from VimL object

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -567,8 +567,4 @@ EXTERN const size_t kTVTranslate INIT(= TV_TRANSLATE);
 # include "eval/typval.h.generated.h"
 #endif
 
-#define tv_get_bool tv_get_number
-#define tv_get_bool_chk tv_get_number_chk
-#define tv_dict_get_bool tv_dict_get_number_def
-
 #endif  // NVIM_EVAL_TYPVAL_H

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1502,7 +1502,8 @@ char *strrep(const char *src, const char *what, const char *rep)
   return ret;
 }
 
-static void byteidx(typval_T *argvars, typval_T *rettv, int comp)
+/// Implementation of "byteidx()" and "byteidxcomp()" functions
+static void byteidx_common(typval_T *argvars, typval_T *rettv, int comp)
 {
   rettv->vval.v_number = -1;
 
@@ -1516,7 +1517,9 @@ static void byteidx(typval_T *argvars, typval_T *rettv, int comp)
   if (argvars[2].v_type != VAR_UNKNOWN) {
     utf16idx = tv_get_bool(&argvars[2]);
     if (utf16idx < 0 || utf16idx > 1) {
-      semsg(_(e_using_number_as_bool_nr), utf16idx);
+      if (utf16idx != -1) {
+        semsg(_(e_using_number_as_bool_nr), utf16idx);
+      }
       return;
     }
   }
@@ -1550,13 +1553,13 @@ static void byteidx(typval_T *argvars, typval_T *rettv, int comp)
 /// "byteidx()" function
 void f_byteidx(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  byteidx(argvars, rettv, false);
+  byteidx_common(argvars, rettv, false);
 }
 
 /// "byteidxcomp()" function
 void f_byteidxcomp(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  byteidx(argvars, rettv, true);
+  byteidx_common(argvars, rettv, true);
 }
 
 /// "charidx()" function
@@ -1770,7 +1773,9 @@ void f_strchars(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     skipcc = (int)tv_get_bool(&argvars[1]);
   }
   if (skipcc < 0 || skipcc > 1) {
-    semsg(_(e_using_number_as_bool_nr), skipcc);
+    if (skipcc != -1) {
+      semsg(_(e_using_number_as_bool_nr), skipcc);
+    }
   } else {
     strchar_common(argvars, rettv, skipcc);
   }
@@ -1842,7 +1847,9 @@ void f_strcharpart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         && argvars[3].v_type != VAR_UNKNOWN) {
       skipcc = tv_get_bool(&argvars[3]);
       if (skipcc < 0 || skipcc > 1) {
-        semsg(_(e_using_number_as_bool_nr), skipcc);
+        if (skipcc != -1) {
+          semsg(_(e_using_number_as_bool_nr), skipcc);
+        }
         return;
       }
     }

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1515,11 +1515,13 @@ static void byteidx_common(typval_T *argvars, typval_T *rettv, int comp)
 
   varnumber_T utf16idx = false;
   if (argvars[2].v_type != VAR_UNKNOWN) {
-    utf16idx = tv_get_bool(&argvars[2]);
+    bool error = false;
+    utf16idx = tv_get_bool_chk(&argvars[2], &error);
+    if (error) {
+      return;
+    }
     if (utf16idx < 0 || utf16idx > 1) {
-      if (utf16idx != -1) {
-        semsg(_(e_using_number_as_bool_nr), utf16idx);
-      }
+      semsg(_(e_using_number_as_bool_nr), utf16idx);
       return;
     }
   }
@@ -1767,18 +1769,21 @@ void f_strcharlen(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "strchars()" function
 void f_strchars(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  int skipcc = false;
+  varnumber_T skipcc = false;
 
   if (argvars[1].v_type != VAR_UNKNOWN) {
-    skipcc = (int)tv_get_bool(&argvars[1]);
-  }
-  if (skipcc < 0 || skipcc > 1) {
-    if (skipcc != -1) {
-      semsg(_(e_using_number_as_bool_nr), skipcc);
+    bool error = false;
+    skipcc = tv_get_bool_chk(&argvars[1], &error);
+    if (error) {
+      return;
     }
-  } else {
-    strchar_common(argvars, rettv, skipcc);
+    if (skipcc < 0 || skipcc > 1) {
+      semsg(_(e_using_number_as_bool_nr), skipcc);
+      return;
+    }
   }
+
+  strchar_common(argvars, rettv, skipcc);
 }
 
 /// "strutf16len()" function
@@ -1845,11 +1850,12 @@ void f_strcharpart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (!error) {
     if (argvars[2].v_type != VAR_UNKNOWN
         && argvars[3].v_type != VAR_UNKNOWN) {
-      skipcc = tv_get_bool(&argvars[3]);
+      skipcc = tv_get_bool_chk(&argvars[3], &error);
+      if (error) {
+        return;
+      }
       if (skipcc < 0 || skipcc > 1) {
-        if (skipcc != -1) {
-          semsg(_(e_using_number_as_bool_nr), skipcc);
-        }
+        semsg(_(e_using_number_as_bool_nr), skipcc);
         return;
       }
     }

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -154,6 +154,8 @@ func Test_strcharpart()
       call assert_equal('edit', "editor"[-10 : 3])
   END
   call CheckLegacyAndVim9Success(lines)
+
+  call assert_fails('echo strcharpart("", 0, 0, {})', ['E728:', 'E728:'])
 endfunc
 
 func Test_getreg_empty_list()

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -155,7 +155,8 @@ func Test_strcharpart()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails('echo strcharpart("", 0, 0, {})', ['E728:', 'E728:'])
+  call assert_fails('call strcharpart("", 0, 0, {})', ['E728:', 'E728:'])
+  call assert_fails('call strcharpart("", 0, 0, -1)', ['E1023:', 'E1023:'])
 endfunc
 
 func Test_getreg_empty_list()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -1097,6 +1097,7 @@ func Test_byteidx()
   call assert_fails("call byteidx([], 0)", 'E730:')
   call assert_fails("call byteidx('abc', [])", 'E745:')
   call assert_fails("call byteidx('abc', 0, {})", ['E728:', 'E728:'])
+  call assert_fails("call byteidx('abc', 0, -1)", ['E1023:', 'E1023:'])
 endfunc
 
 " Test for byteidxcomp() using a character index
@@ -1137,6 +1138,7 @@ func Test_byteidxcomp()
   call assert_fails("call byteidxcomp([], 0)", 'E730:')
   call assert_fails("call byteidxcomp('abc', [])", 'E745:')
   call assert_fails("call byteidxcomp('abc', 0, {})", ['E728:', 'E728:'])
+  call assert_fails("call byteidxcomp('abc', 0, -1)", ['E1023:', 'E1023:'])
 endfunc
 
 " Test for byteidx() using a UTF-16 index
@@ -1497,7 +1499,6 @@ func Test_utf16idx_from_charidx()
   " error cases
   call assert_equal(-1, utf16idx(v:_null_string, 0, v:true, v:true))
   call assert_fails('let l = utf16idx("ab", 0, v:false, [])', 'E1212:')
-  call assert_fails('echo strchars("", {})', ['E728:', 'E728:'])
 endfunc
 
 " Test for strutf16len()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -1096,6 +1096,7 @@ func Test_byteidx()
   " error cases
   call assert_fails("call byteidx([], 0)", 'E730:')
   call assert_fails("call byteidx('abc', [])", 'E745:')
+  call assert_fails("call byteidx('abc', 0, {})", ['E728:', 'E728:'])
 endfunc
 
 " Test for byteidxcomp() using a character index
@@ -1135,6 +1136,7 @@ func Test_byteidxcomp()
   " error cases
   call assert_fails("call byteidxcomp([], 0)", 'E730:')
   call assert_fails("call byteidxcomp('abc', [])", 'E745:')
+  call assert_fails("call byteidxcomp('abc', 0, {})", ['E728:', 'E728:'])
 endfunc
 
 " Test for byteidx() using a UTF-16 index
@@ -1495,6 +1497,7 @@ func Test_utf16idx_from_charidx()
   " error cases
   call assert_equal(-1, utf16idx(v:_null_string, 0, v:true, v:true))
   call assert_fails('let l = utf16idx("ab", 0, v:false, [])', 'E1212:')
+  call assert_fails('echo strchars("", {})', ['E728:', 'E728:'])
 endfunc
 
 " Test for strutf16len()

--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -29,8 +29,10 @@ func Test_strchars()
     call assert_equal(exp[i], strcharlen(inp[i]))
   endfor
 
-  call assert_fails("let v=strchars('abc', [])", 'E745:')
-  call assert_fails("let v=strchars('abc', 2)", 'E1023:')
+  call assert_fails("call strchars('abc', 2)", ['E1023:', 'E1023:'])
+  call assert_fails("call strchars('abc', -1)", ['E1023:', 'E1023:'])
+  call assert_fails("call strchars('abc', {})", ['E728:', 'E728:'])
+  call assert_fails("call strchars('abc', [])", ['E745:', 'E745:'])
 endfunc
 
 " Test for customlist completion


### PR DESCRIPTION
#### vim-patch:9.0.1522: some functions give two error messages

Problem:    Some functions give two error messages.
Solution:   Do not give a second error message.

https://github.com/vim/vim/commit/e4098457ab9c94225b1b0e3c5e06b82b75587971

It seems that tv_get_bool() is actually not exactly the same as
tv_get_number(), so change it to a function instead.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1524: passing -1 for bool is not always rejected

Problem:    Passing -1 for bool is not always rejected.
Solution:   Check for error in a better way. (closes vim/vim#12358)

https://github.com/vim/vim/commit/8cf51376b842e0060edf08bd2e5bd9933c552ecf