### PR TITLE
vim-patch:9.0.1525: 'smoothscroll' does not always work properly

### DIFF
--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -548,11 +548,11 @@ describe('smoothscroll', function()
     exec('set scrolloff=0')
     feed('0j')
     screen:expect([[
-      <<<of text with lots of text with lots o|
+      <<<th lots of text with lots of text wit|
+      h lots of text with lots of text with lo|
+      ts of text with lots of text with lots o|
       f text with lots of text end            |
       ^four                                    |
-      ~                                       |
-      ~                                       |
                                               |
     ]])
     -- Test zt/zz/zb that they work properly when a long line is above it
@@ -696,7 +696,7 @@ describe('smoothscroll', function()
   end)
 
   -- oldtest: Test_smoothscroll_ins_lines()
-  it("this was unnecessarily inserting lines", function()
+  it("does not unnecessarily insert lines", function()
     screen:try_resize(40, 6)
     exec([=[
       set wrap smoothscroll scrolloff=0 conceallevel=2 concealcursor=nc
@@ -715,6 +715,67 @@ describe('smoothscroll', function()
       line three                              |
       line four                               |
       line five                               |
+                                              |
+    ]])
+  end)
+
+  -- oldtest: Test_smoothscroll_cursormoved_line()
+  it("does not place the cursor in the command line", function()
+    screen:try_resize(40, 6)
+    exec([=[
+      set smoothscroll
+      call setline(1, [
+        \'',
+        \'_'->repeat(&lines * &columns),
+        \(('_')->repeat(&columns - 2) .. 'xxx')->repeat(2)
+      \])
+      autocmd CursorMoved * eval [line('w0'), line('w$')]
+      call search('xxx')
+    ]=])
+    screen:expect([[
+      <<<_____________________________________|
+      ________________________________________|
+      ______________________________________^xx|
+      x______________________________________x|
+      xx                                      |
+                                              |
+    ]])
+  end)
+
+  -- oldtest: Test_smoothscroll_eob()
+  it("does not scroll halfway at end of buffer", function()
+    screen:try_resize(40, 10)
+    exec([[
+      set smoothscroll
+      call setline(1, ['']->repeat(100))
+      norm G
+    ]])
+    -- does not scroll halfway when scrolling to end of buffer
+    screen:expect([[
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+      ^                                        |
+                                              |
+    ]])
+    exec("call setline(92, 'a'->repeat(100))")
+    feed('<C-B>G')
+    -- cursor is not placed below window
+    screen:expect([[
+      <<<aaaaaaaaaaaaaaaaa                    |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+                                              |
+      ^                                        |
                                               |
     ]])
   end)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -638,4 +638,47 @@ func Test_smoothscroll_ins_lines()
   call StopVimInTerminal(buf)
 endfunc
 
+" this placed the cursor in the command line
+func Test_smoothscroll_cursormoved_line()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll
+      call setline(1, [
+        \'',
+        \'_'->repeat(&lines * &columns),
+        \(('_')->repeat(&columns - 2) .. 'xxx')->repeat(2)
+      \])
+      autocmd CursorMoved * eval [line('w0'), line('w$')]
+      call search('xxx')
+  END
+  call writefile(lines, 'XSmoothCursorMovedLine', 'D')
+  let buf = RunVimInTerminal('-S XSmoothCursorMovedLine', #{rows: 6})
+
+  call VerifyScreenDump(buf, 'Test_smooth_cursormoved_line', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_eob()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll
+      call setline(1, ['']->repeat(100))
+      norm G
+  END
+  call writefile(lines, 'XSmoothEob', 'D')
+  let buf = RunVimInTerminal('-S XSmoothEob', #{rows: 10})
+
+  " does not scroll halfway when scrolling to end of buffer
+  call VerifyScreenDump(buf, 'Test_smooth_eob_1', {})
+
+  " cursor is not placed below window
+  call term_sendkeys(buf, ":call setline(92, 'a'->repeat(100))\<CR>\<C-B>G")
+  call VerifyScreenDump(buf, 'Test_smooth_eob_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:    'smoothscroll' does not always work properly.
Solution:   Do not reset w_skipcol after it was intentionally set.  (Luuk van
            Baal, closes vim/vim#12360, closes vim/vim#12199, closes vim/vim#12323)

https://github.com/vim/vim/commit/3ce8c389155fc1257082cdb0cef7801b49f6aaf9