### PR TITLE
docs(lsp): fix type of `config.cmd` argument for `vim.lsp.start_client`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -942,7 +942,7 @@ start_client({config})                                *vim.lsp.start_client()*
 
     Parameters: ~
       • {config}  (table) Configuration for the server:
-                  • cmd: (table|string|fun(dispatchers: table):table) command
+                  • cmd: (string[]|fun(dispatchers: table):table) command
                     string or list treated like |jobstart()|. The command must
                     launch the language server process. `cmd` can also be a
                     function that creates an RPC client. The function receives

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -901,7 +901,7 @@ end
 --- Field `cmd` in {config} is required.
 ---
 ---@param config (table) Configuration for the server:
---- - cmd: (table|string|fun(dispatchers: table):table) command string or
+--- - cmd: (string[]|fun(dispatchers: table):table) command string or
 ---       list treated like |jobstart()|. The command must launch the language server
 ---       process. `cmd` can also be a function that creates an RPC client.
 ---       The function receives a dispatchers table and must return a table with the


### PR DESCRIPTION
The argument `config.cmd` of `vim.lsp.start_client` is validated by `lsp._cmd_parts`.
List of string is valid.
String is invalid.

https://github.com/neovim/neovim/blob/84378c4dd56db9846b70a333530505a8048bd26e/runtime/lua/vim/lsp.lua#L1013-L1014

https://github.com/neovim/neovim/blob/84378c4dd56db9846b70a333530505a8048bd26e/runtime/lua/vim/lsp.lua#L297-L301

https://github.com/neovim/neovim/blob/84378c4dd56db9846b70a333530505a8048bd26e/runtime/lua/vim/lsp.lua#L222-L245