### PR TITLE
feat(health): show attached buffers in LSP report

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -32,8 +32,15 @@ function M.check()
   vim.health.start('vim.lsp: Active Clients')
   if next(clients) then
     for _, client in pairs(clients) do
+      local attached_to = table.concat(vim.tbl_keys(client.attached_buffers or {}), ',')
       report_info(
-        string.format('%s (id=%s, root_dir=%s)', client.name, client.id, client.config.root_dir)
+        string.format(
+          '%s (id=%s, root_dir=%s, attached_to=[%s])',
+          client.name,
+          client.id,
+          vim.fn.fnamemodify(client.config.root_dir, ':~'),
+          attached_to
+        )
       )
     end
   else


### PR DESCRIPTION
Problem:
Users using `vim.lsp.start` directly (instead of nvim-lspconfig) need
more visibility for troubleshooting. For example, troubleshooting
unnecesary servers or servers that aren't attaching to expected buffers.

Solution:
Mention attached buffers in the `:checkhealth lsp` report.

Example:

    vim.lsp: Active Clients ~
    - clangd (id=1, root_dir=~/dev/neovim, attached_to=[7])
    - lua_ls (id=2, root_dir=~/dev/neovim, attached_to=[10])
