### PR TITLE
vim-patch:9.0.1538: :wqall does not trigger ExitPre

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1926,6 +1926,9 @@ void do_wqall(exarg_T *eap)
   int save_forceit = eap->forceit;
 
   if (eap->cmdidx == CMD_xall || eap->cmdidx == CMD_wqall) {
+    if (before_quit_all(eap) == FAIL) {
+      return;
+    }
     exiting = true;
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4589,8 +4589,9 @@ static void ex_cquit(exarg_T *eap)
   getout(eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE);
 }
 
-/// ":qall": try to quit all windows
-static void ex_quit_all(exarg_T *eap)
+/// Do preparations for "qall" and "wqall".
+/// Returns FAIL when quitting should be aborted.
+int before_quit_all(exarg_T *eap)
 {
   if (cmdwin_type != 0) {
     if (eap->forceit) {
@@ -4598,19 +4599,28 @@ static void ex_quit_all(exarg_T *eap)
     } else {
       cmdwin_result = K_XF2;
     }
-    return;
+    return FAIL;
   }
 
   // Don't quit while editing the command line.
   if (text_locked()) {
     text_locked_msg();
-    return;
+    return FAIL;
   }
 
   if (before_quit_autocmds(curwin, true, eap->forceit)) {
-    return;
+    return FAIL;
   }
 
+  return OK;
+}
+
+/// ":qall": try to quit all windows
+static void ex_quit_all(exarg_T *eap)
+{
+  if (before_quit_all(eap) == FAIL) {
+    return;
+  }
   exiting = true;
   if (eap->forceit || !check_changed_any(false, false)) {
     getout(0);

--- a/test/old/testdir/test_exit.vim
+++ b/test/old/testdir/test_exit.vim
@@ -81,6 +81,18 @@ func Test_exiting()
 	  \ readfile('Xtestout'))
   endif
   call delete('Xtestout')
+
+  " ExitPre autocommand also executed on :wqall
+  let after =<< trim [CODE]
+    au QuitPre * call writefile(["QuitPre"], "Xtestout", "a")
+    au ExitPre * call writefile(["ExitPre"], "Xtestout", "a")
+    wqall
+  [CODE]
+
+  if RunVim([], after, '')
+    call assert_equal(['QuitPre', 'ExitPre'], readfile('Xtestout'))
+  endif
+  call delete('Xtestout')
 endfunc
 
 " Test for getting the Vim exit code from v:exiting


### PR DESCRIPTION
#### vim-patch:9.0.1538: :wqall does not trigger ExitPre

Problem:    :wqall does not trigger ExitPre. (Bart Libert)
Solution:   Move preparations for :qall to a common function.

https://github.com/vim/vim/commit/411da64e77ef9d8edd1a5aa80fa5b9a4b159c93d

Co-authored-by: Bram Moolenaar <Bram@vim.org>