### PR TITLE
build: make dependency URL variables non-cached

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -133,7 +133,9 @@ if(APPLE)
 endif()
 
 include(ExternalProject)
-set_directory_properties(PROPERTIES EP_PREFIX "${DEPS_BUILD_DIR}")
+set_directory_properties(PROPERTIES
+  EP_PREFIX "${DEPS_BUILD_DIR}"
+  CMAKE_CONFIGURE_DEPENDS deps.txt)
 
 file(READ deps.txt DEPENDENCIES)
 STRING(REGEX REPLACE "\n" ";" DEPENDENCIES "${DEPENDENCIES}")
@@ -141,16 +143,9 @@ foreach(dep ${DEPENDENCIES})
   STRING(REGEX REPLACE " " ";" dep "${dep}")
   list(GET dep 0 name)
   list(GET dep 1 value)
-
-  if(name MATCHES "^.*URL$")
-    mark_as_advanced(${name})
-    if(NOT USE_EXISTING_SRC_DIR)
-      set(${name} ${value} CACHE STRING "")
-    endif()
-  elseif(name MATCHES "^.*SHA256$")
+  if(NOT ${name})
     set(${name} ${value})
   endif()
-
 endforeach()
 
 if(USE_BUNDLED_UNIBILIUM)


### PR DESCRIPTION
Cmake won't rebuild with the new URL when bumping dependency version.
This is because the old URL is still cached, and won't be removed
automatically. The workaround for using non-cached variables, but also
let users specify an alternative URL is to only set the defined
variables in deps.txt if the corresponding variable hasn't already been
set by the user from the command line.

Also apply the CMAKE_CONFIFGURE_DEPENDS property to deps.txt, as we want
cmake to rebuild when changing this file.