### PR TITLE
vim-patch:9.0.1539: typst filetype is not recognized

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -162,6 +162,7 @@ variables can be used to overrule the filetype used for certain extensions:
 	*.sys		g:filetype_sys
 	*.sh		g:bash_is_sh	|ft-sh-syntax|
 	*.tex		g:tex_flavor	|ft-tex-plugin|
+	*.typ		g:filetype_typ
 	*.w		g:filetype_w	|ft-cweb-syntax|
 
 For a few filetypes the global variable is used only when the filetype could

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -997,7 +997,9 @@ local extension = {
   spi = 'spyce',
   spy = 'spyce',
   tyc = 'sql',
-  typ = 'sql',
+  typ = function(path, bufnr)
+    return require('vim.filetype.detect').typ(bufnr)
+  end,
   pkb = 'sql',
   tyb = 'sql',
   pks = 'sql',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1322,6 +1322,28 @@ function M.txt(bufnr)
   end
 end
 
+function M.typ(bufnr)
+  if vim.g.filetype_typ then
+    return vim.g.filetype_typ
+  end
+
+  for _, line in ipairs(getlines(bufnr, 1, 200)) do
+    if
+      findany(line, {
+        '^CASE[%s]?=[%s]?SAME$',
+        '^CASE[%s]?=[%s]?LOWER$',
+        '^CASE[%s]?=[%s]?UPPER$',
+        '^CASE[%s]?=[%s]?OPPOSITE$',
+        '^TYPE%s',
+      })
+    then
+      return 'sql'
+    end
+  end
+
+  return 'typst'
+end
+
 -- Determine if a .v file is Verilog, V, or Coq
 function M.v(bufnr)
   if vim.fn.did_filetype() ~= 0 then

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -564,7 +564,7 @@ let s:filename_checks = {
     \ 'spice': ['file.sp', 'file.spice'],
     \ 'spup': ['file.speedup', 'file.spdata', 'file.spd'],
     \ 'spyce': ['file.spy', 'file.spi'],
-    \ 'sql': ['file.tyb', 'file.typ', 'file.tyc', 'file.pkb', 'file.pks'],
+    \ 'sql': ['file.tyb', 'file.tyc', 'file.pkb', 'file.pks'],
     \ 'sqlj': ['file.sqlj'],
     \ 'prql': ['file.prql'],
     \ 'sqr': ['file.sqr', 'file.sqi'],
@@ -2043,6 +2043,37 @@ func Test_lsl_file()
   split Xfile.lsl
   call assert_equal('larch', &filetype)
   bwipe!
+
+  filetype off
+endfunc
+
+func Test_typ_file()
+  filetype on
+
+  " SQL type file
+
+  call writefile(['CASE = LOWER'], 'Xfile.typ', 'D')
+  split Xfile.typ
+  call assert_equal('sql', &filetype)
+  bwipe!
+
+  call writefile(['TYPE foo'], 'Xfile.typ')
+  split Xfile.typ
+  call assert_equal('sql', &filetype)
+  bwipe!
+
+  " typst document
+
+  call writefile(['this is a fallback'], 'Xfile.typ')
+  split Xfile.typ
+  call assert_equal('typst', &filetype)
+  bwipe!
+
+  let g:filetype_typ = 'typst'
+  split test.typ
+  call assert_equal('typst', &filetype)
+  bwipe!
+  unlet g:filetype_typ
 
   filetype off
 endfunc


### PR DESCRIPTION
**vim-patch:9.0.1539: typst filetype is not recognized**

Problem:    Typst filetype is not recognized.
Solution:   Distinguish between sql and typst. (Gaetan Lepage, closes vim/vim#12363)

https://github.com/vim/vim/commit/4ce1bda869e4ec0152d7dcbe1e491ceac5341d5e