### PR TITLE
fix(treesitter): reset cursor max_start_depth

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1349,6 +1349,11 @@ static int node_rawquery(lua_State *L)
   } else {
     cursor = ts_query_cursor_new();
   }
+
+#ifdef NVIM_TS_HAS_SET_MAX_START_DEPTH
+  // reset the start depth
+  ts_query_cursor_set_max_start_depth(cursor, 0);
+#endif
   ts_query_cursor_set_match_limit(cursor, 256);
   ts_query_cursor_exec(cursor, query, node);
 


### PR DESCRIPTION
Quick fixup after integrating with nvim-tressitter-context.