### PR TITLE
docs: fix incorrectly parsed tags

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1162,7 +1162,7 @@ Set the 'cindent' option for C files in the /vim/src directory. >
 If you have a link from "/tmp/test.c" to "/home/nobody/vim/src/test.c", and
 you start editing "/tmp/test.c", this autocommand will match.
 
-Note:  To match part of a path, but not from the root directory, use a '*' as
+Note:  To match part of a path, but not from the root directory, use a "*" as
 the first character.  Example: >
 	:autocmd BufRead */doc/*.txt	set tw=78
 This autocommand will for example be executed for "/tmp/doc/xx.txt" and

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6014,7 +6014,7 @@ printf({fmt}, {expr1} ...)				*printf()*
 			be applied, see below.
 
 		A field width or precision, or both, may be indicated by an
-		asterisk '*' instead of a digit string.  In this case, a
+		asterisk "*" instead of a digit string.  In this case, a
 		Number argument supplies the field width or precision.  A
 		negative field width is treated as a left adjustment flag
 		followed by a positive field width; a negative precision is

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -143,7 +143,7 @@ CTRL-R {register}					*c_CTRL-R* *c_<C-R>*
 				the last delete or yank
 			'%'	the current file name
 			'#'	the alternate file name
-			'*'	the clipboard contents (X11: primary selection)
+			"*"	the clipboard contents (X11: primary selection)
 			'+'	the clipboard contents
 			'/'	the last search pattern
 			':'	the last command-line
@@ -431,8 +431,8 @@ CTRL-T		When 'incsearch' is set, entering a search pattern for "/" or
 		keyboard T is above G.
 
 The 'wildchar' option defaults to <Tab> (CTRL-E when in Vi compatible mode; in
-a previous version <Esc> was used).  In the pattern standard wildcards '*' and
-'?' are accepted when matching file names.  '*' matches any string, '?'
+a previous version <Esc> was used).  In the pattern standard wildcards "*" and
+'?' are accepted when matching file names.  "*" matches any string, '?'
 matches exactly one character.
 
 When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1581,7 +1581,7 @@ There are three different types of searching:
    so they work on all operating systems.  Note that "**" only acts as a
    special wildcard when it is at the start of a name.
 
-   The usage of '*' is quite simple: It matches 0 or more characters.  In a
+   The usage of "*" is quite simple: It matches 0 or more characters.  In a
    search pattern this would be ".*".  Note that the "." is not used for file
    searching.
 

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -1087,7 +1087,7 @@ That works, since the String "190" is automatically converted to the Number
 	1 . 90 * 90.0
 Should be read as: >
 	1 . (90 * 90.0)
-Since '.' has lower precedence than '*'.  This does NOT work, since this
+Since '.' has lower precedence than "*".  This does NOT work, since this
 attempts to concatenate a Float and a String.
 
 When dividing a Number by zero the result depends on the value:
@@ -2210,7 +2210,7 @@ v:register	The name of the register in effect for the current normal mode
 		(use this in custom commands that take a register).
 		If none is supplied it is the default register '"', unless
 		'clipboard' contains "unnamed" or "unnamedplus", then it is
-		'*' or '+'.
+		"*" or '+'.
 		Also see |getreg()| and |setreg()|
 
 					*v:relnum* *relnum-variable*

--- a/runtime/doc/ft_raku.txt
+++ b/runtime/doc/ft_raku.txt
@@ -35,7 +35,7 @@ Some of them are available with standard Vim digraphs:
 	(- ∈    ?= ≅    != ≠  ~
 	-) ∋    ?- ≃  ~
 
-The Greek alphabet is available with '*' followed by a similar Latin symbol:
+The Greek alphabet is available with "*" followed by a similar Latin symbol:
 	*p π  ~
 	*t τ  ~
 	*X ×  ~

--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -167,7 +167,7 @@ The initial height of the help window can be set with the 'helpheight' option
 						*help-buffer-options*
 When the help buffer is created, several local options are set to make sure
 the help text is displayed as it was intended:
-    'iskeyword'		nearly all ASCII chars except ' ', '*', '"' and '|'
+    'iskeyword'		nearly all ASCII chars except ' ', "*", '"' and '|'
     'foldmethod'	"manual"
     'tabstop'		8
     'arabic'		off

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -112,7 +112,7 @@ e	Reindent a line that starts with "else" when you type the second 'e'.
 =~word	Like =word, but ignore case.
 
 If you really want to reindent when you type 'o', 'O', 'e', '0', '<', '>',
-'*', ':' or '!', use "<o>", "<O>", "<e>", "<0>", "<<>", "<>>", "<*>", "<:>" or
+"*", ':' or '!', use "<o>", "<O>", "<e>", "<0>", "<<>", "<>>", "<*>", "<:>" or
 "<!>", respectively, for those keys.
 
 For an emacs-style indent mode where lines aren't indented every time you

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -114,7 +114,7 @@ CTRL-R {register}				*i_CTRL-R*
 				the last delete or yank
 			'%'	the current file name
 			'#'	the alternate file name
-			'*'	the clipboard contents (X11: primary selection)
+			"*"	the clipboard contents (X11: primary selection)
 			'+'	the clipboard contents
 			'/'	the last search pattern
 			':'	the last command-line
@@ -1392,7 +1392,7 @@ other versions of HTML. Features:
 - after "<" complete tag name depending on context (no div suggestion inside
   of an a tag); '/>' indicates empty tags
 - inside of tag complete proper attributes (no width attribute for an a tag);
-  show also type of attribute; '*' indicates required attributes
+  show also type of attribute; "*" indicates required attributes
 - when attribute has limited number of possible values help to complete them
 - complete names of entities
 - complete values of "class" and "id" attributes with data obtained from

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1324,7 +1324,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			register.  When "unnamed" is also included to the
 			option, yank and delete operations (but not put)
 			will additionally copy the text into register
-			'*'. See |clipboard|.
+			"*". See |clipboard|.
 
 						*'cmdheight'* *'ch'*
 'cmdheight' 'ch'	number	(default 1)
@@ -3523,7 +3523,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	that is not white space or punctuation).
 	For C programs you could use "a-z,A-Z,48-57,_,.,-,>".
 	For a help file it is set to all non-blank printable characters except
-	'*', '"' and '|' (so that CTRL-] on a command finds the help for that
+	"*", '"' and '|' (so that CTRL-] on a command finds the help for that
 	command).
 	When the 'lisp' option is on the '-' character is always included.
 	This option also influences syntax highlighting, unless the syntax

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -182,7 +182,7 @@ the "+" and/or "*" registers explicitly): >vim
 See 'clipboard' for details and options.
 
 							      *clipboard-tool*
-The presence of a working clipboard tool implicitly enables the '+' and '*'
+The presence of a working clipboard tool implicitly enables the '+' and "*"
 registers. Nvim looks for these clipboard tools, in order of priority:
 
   - |g:clipboard|

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1615,7 +1615,7 @@ be escaped), meta symbols have to be written with leading '%':
 	%\		The single '\' character.  Note that this has to be
 			escaped ("%\\") in ":set errorformat=" definitions.
 	%.		The single '.' character.
-	%#		The single '*'(!) character.
+	%#		The single "*"(!) character.
 	%^		The single '^' character.  Note that this is not
 			useful, the pattern already matches start of line.
 	%$		The single '$' character.  Note that this is not

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -468,7 +468,7 @@ sign_getplaced([{buf} [, {dict}]])			*sign_getplaced()*
 		   id		select sign with this identifier
 		   lnum		select signs placed in this line. For the use
 				of {lnum}, see |line()|.
-		If {group} is '*', then signs in all the groups including the
+		If {group} is "*", then signs in all the groups including the
 		global group are returned. If {group} is not supplied or is an
 		empty string, then only signs in the global group are
 		returned.  If no arguments are supplied, then signs in the
@@ -683,7 +683,7 @@ sign_unplace({group} [, {dict}])			*sign_unplace()*
 		is similar to the |:sign-unplace| command.
 
 		{group} is the sign group name. To use the global sign group,
-		use an empty string.  If {group} is set to '*', then all the
+		use an empty string.  If {group} is set to "*", then all the
 		groups including the global group are used.
 		The signs in {group} are selected based on the entries in
 		{dict}.  The following optional entries in {dict} are
@@ -735,7 +735,7 @@ sign_unplacelist({list})				*sign_unplacelist()*
 				the buffers.
 		    group	sign group name. If not specified or set to an
 				empty string, then the global sign group is
-				used. If set to '*', then all the groups
+				used. If set to "*", then all the groups
 				including the global group are used.
 		    id		sign identifier. If not specified, then all
 				the signs in the specified group are removed.

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -409,7 +409,7 @@ of the previous line "al." will be flagged as an error.  And when you type
 Use |CTRL-L| to redraw right away.  "[s" will also stop at a word combination
 with a line break.
 
-When encountering a line break Vim skips characters such as '*', '>' and '"',
+When encountering a line break Vim skips characters such as "*", '>' and '"',
 so that comments in C, shell and Vim code can be spell checked.
 
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5058,10 +5058,10 @@ ctermbg={color-nr}				*ctermbg*
 
 	The number under "NR-16" is used for 16-color terminals ('t_Co'
 	greater than or equal to 16).  The number under "NR-8" is used for
-	8-color terminals ('t_Co' less than 16).  The '*' indicates that the
+	8-color terminals ('t_Co' less than 16).  The "*" indicates that the
 	bold attribute is set for ctermfg.  In many 8-color terminals (e.g.,
 	"linux"), this causes the bright colors to appear.  This doesn't work
-	for background colors!	Without the '*' the bold attribute is removed.
+	for background colors!	Without the "*" the bold attribute is removed.
 	If you want to set the bold attribute in a different way, put a
 	"cterm=" argument AFTER the "ctermfg=" or "ctermbg=" argument.	Or use
 	a number instead of a color name.

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -398,7 +398,7 @@ selected text: >
 (In the <> notation |<>|, when typing it you should type it literally; you
 need to remove the 'B' flag from 'cpoptions')
 
-Note that special characters (like '.' and '*') will cause problems.
+Note that special characters (like '.' and "*") will cause problems.
 
 Visual-block Examples					*blockwise-examples*
 With the following text, I will indicate the commands to produce the block and


### PR DESCRIPTION
# Problem
`'*'` gets parsed as a `tag` node by the vimdoc treesitter parser
# Solution
Replace `'*'` with `"*"`

ref: https://github.com/neovim/tree-sitter-vimdoc/issues/105

### Additional notes
- `provider.txt` line 185 actually gets parsed as `ERROR` instead
- I have not changed code blocks or surrounding context