### PR TITLE
test(scroll_opt): fix typo in porting oldtest

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -411,7 +411,7 @@ use >lua
   extid = vim.api.nvim_buf_set_extmark(buf, ns_id, line, col_start, {end_col = col_end, hl_group = hl_group})
 
   -- example: modify the extmark's highlight group
-  vim.api.nvim_buf_set_extmark(buf, ns_id, NEW_HL_GROUP, line, col_start, {end_col = col_end, hl_group = hl_group, id = extid})
+  vim.api.nvim_buf_set_extmark(buf, ns_id, line, col_start, {end_col = col_end, hl_group = NEW_HL_GROUP, id = extid})
 
   -- example: change the highlight's position
   vim.api.nvim_buf_set_extmark(buf, ns_id, NEW_LINE, col_start, {end_col = col_end, hl_group = NEW_HL_GROUP, id = extid})

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -202,7 +202,7 @@ describe('display', function()
     exec([[
       set display=lastline smoothscroll scrolloff=0
       call setline(1, [
-        \'aaaaa'->repeat(500),
+        \'aaaaa'->repeat(150),
         \'bbbbb '->repeat(7) .. 'ccccc '->repeat(7) .. 'ddddd '->repeat(7)
       \])
     ]])
@@ -220,7 +220,7 @@ describe('display', function()
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
-      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      ^aaaaaaaaaaaaaaa                    |
                                          |
     ]])
     -- The correct part of the last line is moved into view.


### PR DESCRIPTION
Also include a doc typo fix that I didn't feel like opening a PR for after clason's snide comment in #23404. Including it here now anyways as it seems it won't get picked up otherwise. 