### PR TITLE
vim-patch:9.0.1545: text not scrolled when cursor moved with "g0" and "h"

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2527,6 +2527,7 @@ int oneleft(void)
     }
 
     curwin->w_set_curswant = true;
+    adjust_skipcol();
     return OK;
   }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5272,6 +5272,7 @@ static void nv_g_home_m_cmd(cmdarg_T *cap)
     curwin->w_valid &= ~VALID_WCOL;
   }
   curwin->w_set_curswant = true;
+  adjust_skipcol();
 }
 
 /// "g_": to the last non-blank character in the line or <count> lines downward.

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -419,6 +419,18 @@ func Test_smoothscroll_cursor_position()
   exe "normal \<C-Y>"
   call s:check_col_calc(1, 3, 41)
 
+   " Test "g0/g<Home>"
+  exe "normal gg\<C-E>"
+  norm $gkg0
+  call s:check_col_calc(1, 2, 21)
+
+  " Test moving the cursor behind the <<< display with 'virtualedit'
+  set virtualedit=all
+  exe "normal \<C-E>"
+  norm 3lgkh
+  call s:check_col_calc(3, 2, 23)
+  set virtualedit&
+
   normal gg3l
   exe "normal \<C-E>"
 


### PR DESCRIPTION
Problem:    Text not scrolled when cursor moved with "g0" and "h".
Solution:   Adjust w_skipcol when needed. (Luuk van Baal, closes vim/vim#12387)

https://github.com/vim/vim/commit/8667a5678f983ba899825b810ab849952d49bcb8