### PR TITLE
vim-patch:9.0.1546: some commands for opening a file don't use 'switchbuf'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6201,16 +6201,18 @@ A jump table for the options with a short description can be found at |Q_op|.
 'switchbuf' 'swb'	string	(default "uselast")
 			global
 	This option controls the behavior when switching between buffers.
-	Mostly for |quickfix| commands some values are also used for other
-	commands, as mentioned below.
+	This option is checked, when
+	- jumping to errors with the |quickfix| commands (|:cc|, |:cn|, |:cp|,
+	  etc.)
+	- jumping to a tag using the |:stag| command.
+	- opening a file using the |CTRL-W_f| or |CTRL-W_F| command.
+	- jumping to a buffer using a buffer split command (e.g.  |:sbuffer|,
+	  |:sbnext|, or |:sbrewind|).
 	Possible values (comma-separated list):
-	   useopen	If included, jump to the first open window that
-			contains the specified buffer (if there is one).
-			Otherwise: Do not examine other windows.
-			This setting is checked with |quickfix| commands, when
-			jumping to errors (":cc", ":cn", "cp", etc.).  It is
-			also used in all buffer related split commands, for
-			example ":sbuffer", ":sbnext", or ":sbrewind".
+	   useopen	If included, jump to the first open window in the
+			current tab page that contains the specified buffer
+			(if there is one).  Otherwise: Do not examine other
+			windows.
 	   usetab	Like "useopen", but also consider windows in other tab
 			pages.
 	   split	If included, split the current window before loading

--- a/test/old/testdir/test_gf.vim
+++ b/test/old/testdir/test_gf.vim
@@ -300,4 +300,65 @@ func Test_gf_subdirs_wildcard()
   set path&
 endfunc
 
+" Test for 'switchbuf' with gf and gF commands
+func Test_gf_switchbuf()
+  call writefile(repeat(["aaa"], 10), "Xtest1", 'D')
+  edit Xtest1
+  new
+  call setline(1, ['Xtest1'])
+
+  " Test for 'useopen'
+  set switchbuf=useopen
+  call cursor(1, 1)
+  exe "normal \<C-W>f"
+  call assert_equal([2, 2], [winnr(), winnr('$')])
+  close
+
+  " If the file is opened in another tabpage, then it should not be considered
+  tabedit Xtest1
+  tabfirst
+  exe "normal \<C-W>f"
+  call assert_equal([1, 2], [winnr(), winnr('$')])
+  call assert_equal([1, 2], [tabpagenr(), tabpagenr('$')])
+  close
+
+  " Test for 'usetab'
+  set switchbuf=usetab
+  exe "normal \<C-W>f"
+  call assert_equal([1, 1], [winnr(), winnr('$')])
+  call assert_equal([2, 2], [tabpagenr(), tabpagenr('$')])
+  %bw!
+
+  " Test for CTRL-W_F with 'useopen'
+  set isfname-=:
+  call setline(1, ['Xtest1:5'])
+  set switchbuf=useopen
+  split +1 Xtest1
+  wincmd b
+  exe "normal \<C-W>F"
+  call assert_equal([1, 2], [winnr(), winnr('$')])
+  call assert_equal(5, line('.'))
+  close
+
+  " If the file is opened in another tabpage, then it should not be considered
+  tabedit +1 Xtest1
+  tabfirst
+  exe "normal \<C-W>F"
+  call assert_equal([1, 2], [winnr(), winnr('$')])
+  call assert_equal(5, line('.'))
+  call assert_equal([1, 2], [tabpagenr(), tabpagenr('$')])
+  close
+
+  " Test for CTRL_W_F with 'usetab'
+  set switchbuf=usetab
+  exe "normal \<C-W>F"
+  call assert_equal([2, 2], [tabpagenr(), tabpagenr('$')])
+  call assert_equal([1, 1], [winnr(), winnr('$')])
+  call assert_equal(5, line('.'))
+
+  set switchbuf=
+  set isfname&
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1546: some commands for opening a file don't use 'switchbuf'

Problem:    Some commands for opening a file don't use 'switchbuf'.
Solution:   Use 'switchbuf' for more commands. (Yegappan Lakshmanan,
            closes vim/vim#12383)

https://github.com/vim/vim/commit/54be5fb382d2bf25fd1b17ddab8b21f599019b81

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>