### PR TITLE
refactor: remove typval.h from most header files

### DIFF
--- a/src/nvim/api/private/converter.h
+++ b/src/nvim/api/private/converter.h
@@ -2,7 +2,7 @@
 #define NVIM_API_PRIVATE_CONVERTER_H
 
 #include "nvim/api/private/defs.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/converter.h.generated.h"

--- a/src/nvim/arglist.h
+++ b/src/nvim/arglist.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_ARGLIST_H
 #define NVIM_ARGLIST_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -17,7 +17,7 @@ typedef struct {
 
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/garray.h"
 #include "nvim/grid_defs.h"
 #include "nvim/hashtab.h"

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/event/libuv_process.h"
 #include "nvim/event/multiqueue.h"

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/option_defs.h"
 #include "nvim/pos.h"
 #include "nvim/strings.h"

--- a/src/nvim/cmdexpand.h
+++ b/src/nvim/cmdexpand.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_CMDEXPAND_H
 #define NVIM_CMDEXPAND_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/ex_getln.h"
 #include "nvim/garray.h"
 #include "nvim/types.h"

--- a/src/nvim/cmdhist.h
+++ b/src/nvim/cmdhist.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_CMDHIST_H
 #define NVIM_CMDHIST_H
 
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/os/time.h"

--- a/src/nvim/eval/decode.h
+++ b/src/nvim/eval/decode.h
@@ -4,8 +4,8 @@
 #include <msgpack.h>
 #include <stddef.h>
 
-#include "nvim/eval/typval.h"
-#include "nvim/globals.h"
+#include "nvim/eval/typval_defs.h"
+#include "nvim/types.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval/decode.h.generated.h"

--- a/src/nvim/eval/executor.h
+++ b/src/nvim/eval/executor.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_EVAL_EXECUTOR_H
 #define NVIM_EVAL_EXECUTOR_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 
 extern char *e_list_index_out_of_range_nr;
 

--- a/src/nvim/eval/funcs.h
+++ b/src/nvim/eval/funcs.h
@@ -6,7 +6,6 @@
 
 #include "nvim/api/private/dispatch.h"
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/types.h"
 

--- a/src/nvim/eval/gc.h
+++ b/src/nvim/eval/gc.h
@@ -1,7 +1,6 @@
 #ifndef NVIM_EVAL_GC_H
 #define NVIM_EVAL_GC_H
 
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 
 extern dict_T *gc_first_dict;

--- a/src/nvim/eval/typval_encode.h
+++ b/src/nvim/eval/typval_encode.h
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #include "klib/kvec.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/func_attr.h"
 
 /// Type of the stack entry

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -5,7 +5,6 @@
 #include <stddef.h>
 
 #include "nvim/eval.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/garray.h"

--- a/src/nvim/event/process.h
+++ b/src/nvim/event/process.h
@@ -5,7 +5,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/os/time.h"

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/normal.h"
 #include "nvim/pos.h"
 #include "nvim/regexp_defs.h"

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -4,7 +4,6 @@
 #include <stdbool.h>
 
 #include "klib/kvec.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/types.h"

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -2,7 +2,6 @@
 #define NVIM_FILEIO_H
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/garray.h"
 #include "nvim/os/os.h"

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -22,6 +22,7 @@
 #include "nvim/globals.h"
 #include "nvim/help.h"
 #include "nvim/macros.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"

--- a/src/nvim/lua/converter.h
+++ b/src/nvim/lua/converter.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #include "nvim/api/private/defs.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/func_attr.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -8,7 +8,7 @@
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/assert.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/func_attr.h"
 #include "nvim/lua/converter.h"

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_MARK_DEFS_H
 #define NVIM_MARK_DEFS_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/os/time.h"
 #include "nvim/pos.h"
 

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/func_attr.h"
 #include "nvim/mbyte_defs.h"
 #include "nvim/os/os_defs.h"

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -6,7 +6,6 @@
 
 #include "lauxlib.h"
 #include "nvim/ascii.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/extmark.h"

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_OPTION_DEFS_H
 #define NVIM_OPTION_DEFS_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/macros.h"
 #include "nvim/types.h"
 

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 
 #include "nvim/ascii.h"
+#include "nvim/eval/typval.h"
 #include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
 #include "nvim/memory.h"
 #include "nvim/os/os.h"

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -5,7 +5,6 @@
 
 #include "klib/kvec.h"
 #include "nvim/autocmd.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/ex_eval_defs.h"

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -5,7 +5,6 @@
 #include <stdint.h>
 
 #include "nvim/buffer_defs.h"
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/normal.h"
 #include "nvim/os/time.h"

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -6,7 +6,7 @@
 #include <string.h>
 
 #include "klib/kvec.h"
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/types.h"
 
 /// Append string to string and return pointer to the next byte

--- a/src/nvim/testing.h
+++ b/src/nvim/testing.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_TESTING_H
 #define NVIM_TESTING_H
 
-#include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "testing.h.generated.h"

--- a/src/nvim/viml/parser/expressions.h
+++ b/src/nvim/viml/parser/expressions.h
@@ -5,7 +5,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/types.h"
 #include "nvim/viml/parser/parser.h"

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -4,13 +4,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/macros.h"
-#include "nvim/mark.h"
-#include "nvim/os/os.h"
-#include "nvim/os/os_defs.h"
-#include "nvim/vim.h"
+#include "nvim/option_defs.h"
 
 // Values for file_name_in_line()
 #define FNAME_MESS      1       // give error message


### PR DESCRIPTION
Because typval_defs.h is enough for most of them.
