### PR TITLE
fix(treesitter): support subfiletypes in get_lang

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -27,6 +27,11 @@ function M.get_lang(filetype)
   if filetype == '' then
     return
   end
+  if ft_to_lang[filetype] then
+    return ft_to_lang[filetype]
+  end
+  -- support subfiletypes like html.glimmer
+  filetype = vim.split(filetype, '.', { plain = true })[1]
   return ft_to_lang[filetype]
 end
 


### PR DESCRIPTION
Needed for parsers that target template languages like `html.glimmer`

See https://github.com/nvim-treesitter/nvim-treesitter/pull/1974
