### PR TITLE
Add missing on_detach documentation for `LanguageTree:register_cbs`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1170,6 +1170,9 @@ LanguageTree:register_cbs({self}, {cbs}, {recursive})
                         the tree.
                       • `on_child_removed` : emitted when a child is removed
                         from the tree.
+                      • `on_detach` : emitted when the buffer is detached, see
+                        |nvim_buf_detach_event|. Takes one argument, the
+                        number of the buffer.
       • {recursive?}  boolean Apply callbacks recursively for all children.
                       Any new children will also inherit the callbacks.
       • {self}

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -886,6 +886,8 @@ end
 ---              changed.
 ---           - `on_child_added` : emitted when a child is added to the tree.
 ---           - `on_child_removed` : emitted when a child is removed from the tree.
+---           - `on_detach` : emitted when the buffer is detached, see |nvim_buf_detach_event|.
+---              Takes one argument, the number of the buffer.
 --- @param recursive? boolean Apply callbacks recursively for all children. Any new children will
 ---                           also inherit the callbacks.
 function LanguageTree:register_cbs(cbs, recursive)


### PR DESCRIPTION
The `on_detach` callback is implemented, but it is missing in the documentation. From my understanding of the implementation this is the same as the `on_detach` callback of `nvim_buf_attach`, except that the first argument (the string `'detach'`) is dropped.
