### PR TITLE
vim-patch:9.0.{0064,0218,0249,0490,0492,0598}: cmdwin fixes

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1528,8 +1528,9 @@ void edit_unputchar(void)
 
 // Called when p_dollar is set: display a '$' at the end of the changed text
 // Only works when cursor is in the line that changes.
-void display_dollar(colnr_T col)
+void display_dollar(colnr_T col_arg)
 {
+  colnr_T col = col_arg < 0 ? 0 : col_arg;
   colnr_T save_col;
 
   if (!redrawing()) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -107,6 +107,8 @@ static int VIsual_mode_orig = NUL;              // saved Visual mode
 #endif
 
 static const char e_changelist_is_empty[] = N_("E664: Changelist is empty");
+static const char e_cmdline_window_already_open[]
+  = N_("E1292: Command-line window is already open");
 
 static inline void normal_state_init(NormalState *s)
 {
@@ -6372,6 +6374,10 @@ static void nv_record(cmdarg_T *cap)
   }
 
   if (cap->nchar == ':' || cap->nchar == '/' || cap->nchar == '?') {
+    if (cmdwin_type != 0) {
+      emsg(_(e_cmdline_window_already_open));
+      return;
+    }
     stuffcharReadbuff(cap->nchar);
     stuffcharReadbuff(K_CMDWIN);
   } else {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2304,6 +2304,9 @@ static void win_equal_rec(win_T *next_curwin, bool current, frame_T *topfr, int 
         }
         if (hnc) {                  // add next_curwin size
           next_curwin_size -= (int)p_wiw - (m - n);
+          if (next_curwin_size < 0) {
+            next_curwin_size = 0;
+          }
           new_size += next_curwin_size;
           room -= new_size - next_curwin_size;
         } else {
@@ -6686,7 +6689,8 @@ static int win_border_width(win_T *wp)
 /// Set the width of a window.
 void win_new_width(win_T *wp, int width)
 {
-  wp->w_width = width;
+  // Should we give an error if width < 0?
+  wp->w_width = width < 0 ? 0 : width;
   wp->w_pos_changed = true;
   win_set_inner_size(wp, true);
 }

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -30,6 +30,9 @@ endfunc
 
 " This was using a pointer to a freed buffer
 func Test_cmdwin_freed_buffer_ptr()
+  " this does not work on MS-Windows because renaming an open file fails
+  CheckNotMSWindows
+
   au BufEnter * next 0| file 
   edit 0
   silent! norm q/

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -28,5 +28,15 @@ func Test_normal_escape()
   call assert_equal('" bar', @:)
 endfunc
 
+" This was using a pointer to a freed buffer
+func Test_cmdwin_freed_buffer_ptr()
+  au BufEnter * next 0| file 
+  edit 0
+  silent! norm q/
+
+  au! BufEnter
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -41,5 +41,27 @@ func Test_cmdwin_freed_buffer_ptr()
   bwipe!
 endfunc
 
+" This was resulting in a window with negative width.
+" The test doesn't reproduce the illegal memory access though...
+func Test_cmdwin_split_often()
+  let lines = &lines
+  let columns = &columns
+  set t_WS=
+
+  try
+    " set encoding=iso8859
+    set ruler
+    winsize 0 0
+    noremap 0 H
+    sil norm 0000000q:
+  catch /E36:/
+  endtry
+
+  bwipe!
+  set encoding=utf8
+  let &lines = lines
+  let &columns = columns
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -1,0 +1,17 @@
+" Tests for editing the command line.
+
+source check.vim
+source screendump.vim
+
+
+func Test_cant_open_cmdwin_in_cmdwin()
+  try
+    call feedkeys("q:q::q\<CR>", "x!")
+  catch
+    let caught = v:exception
+  endtry
+  call assert_match('E1292:', caught)
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -13,5 +13,13 @@ func Test_cant_open_cmdwin_in_cmdwin()
   call assert_match('E1292:', caught)
 endfunc
 
+func Test_cmdwin_virtual_edit()
+  enew!
+  set ve=all cpo+=$
+  silent normal q/s
+
+  set ve= cpo-=$
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -21,5 +21,12 @@ func Test_cmdwin_virtual_edit()
   set ve= cpo-=$
 endfunc
 
+" Check that a :normal command can be used to stop Visual mode without side
+" effects.
+func Test_normal_escape()
+  call feedkeys("q:i\" foo\<Esc>:normal! \<C-V>\<Esc>\<CR>:\" bar\<CR>", 'ntx')
+  call assert_equal('" bar', @:)
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0064: confusing error when using "q:" in command line window

Problem:    Confusing error when using "q:" in command line window.
Solution:   Check for the situation and give a better error message.

https://github.com/vim/vim/commit/c963ec31a0c293d629e40cb082d4bfb1651def49

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0218: reading before the start of the line

Problem:    Reading before the start of the line.
Solution:   When displaying "$" check the column is not negative.

https://github.com/vim/vim/commit/e98c88c44c308edaea5994b8ad4363e65030968c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0249: no test for what 9.0.0234 fixes

Problem:    No test for what 9.0.0234 fixes.
Solution:   Add a test. (issue vim/vim#10950)

https://github.com/vim/vim/commit/3a7ad904d27d904e57f7a22eb33872a587ae6673

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0490: using freed memory with cmdwin and BufEnter autocmd

Problem:    Using freed memory with cmdwin and BufEnter autocmd.
Solution:   Make sure pointer to b_p_iminsert is still valid.

https://github.com/vim/vim/commit/1c3dd8ddcba63c1af5112e567215b3cec2de11d0

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0492: cmdwin test fails on MS-Windows

Problem:    Cmdwin test fails on MS-Windows.
Solution:   Skip test on MS-Windows.

https://github.com/vim/vim/commit/312af65d1ac763c060cb5adfcf8ae5beeec97f59

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0598: using negative array index with negative width window

Problem:    Using negative array index with negative width window.
Solution:   Make sure the window width does not become negative.

https://github.com/vim/vim/commit/8279af514ca7e5fd3c31cf13b0864163d1a0bfeb

Co-authored-by: Bram Moolenaar <Bram@vim.org>