### PR TITLE
ci: enable colors by default when testing

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -285,7 +285,7 @@ Number; !must be defined to function properly):
 
 - `VALGRIND_LOG` (F) (S): overrides valgrind log file name used for `VALGRIND`.
 
-- `TEST_COLORS` (F) (U) (D): enable pretty colors in test runner.
+- `TEST_COLORS` (F) (U) (D): enable pretty colors in test runner. Set to true by default.
 
 - `TEST_SKIP_FRAGILE` (F) (D): makes test suite skip some fragile tests.
 

--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -1,9 +1,15 @@
 local pretty = require 'pl.pretty'
 local global_helpers = require('test.helpers')
 
--- Colors are disabled by default. #15610
 local colors = setmetatable({}, {__index = function() return function(s) return s == nil and '' or tostring(s) end end})
+
+local enable_colors = true
 if os.getenv "TEST_COLORS" then
+  local test_colors = os.getenv("TEST_COLORS"):lower()
+  local disable_colors = test_colors == 'false' or test_colors == '0' or test_colors == 'no' or test_colors == 'off'
+  enable_colors = not disable_colors
+end
+if enable_colors then
   colors = require 'term.colors'
 end
 


### PR DESCRIPTION
Test colors were disabled in be7290d214673287218dcbd1a6730961cc067190
due to color codes interfering with the logs. I believe the solution to
disable colors is too aggressive. Reading raw logs isn't common compared
to reading CI results from the github UI. We should optimize the most
common use case.

It is also possible to interpret the colors codes in logs from neovim
with a plugin that interprets ansi escape sequences.