### PR TITLE
vim-patch:9.0.1551: position of marker for 'smoothscroll' not computed correctly

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -257,7 +257,8 @@ static void changed_common(linenr_T lnum, colnr_T col, linenr_T lnume, linenr_T 
               || (wp->w_topline >= lnum
                   && wp->w_topline < lnume
                   && win_linetabsize(wp, wp->w_topline, ml_get(wp->w_topline), (colnr_T)MAXCOL)
-                  <= (unsigned)wp->w_skipcol + (wp->w_p_list && wp->w_p_lcs_chars.prec ? 1 : 3)))) {
+                  <= (unsigned)(wp->w_skipcol + sms_marker_overlap(wp, win_col_off(wp)
+                                                                   - win_col_off2(wp)))))) {
         wp->w_skipcol = 0;
       }
 

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -426,8 +426,7 @@ func Test_smoothscroll_cursor_position()
 
   " Test moving the cursor behind the <<< display with 'virtualedit'
   set virtualedit=all
-  exe "normal \<C-E>"
-  norm 3lgkh
+  exe "normal \<C-E>3lgkh"
   call s:check_col_calc(3, 2, 23)
   set virtualedit&
 
@@ -497,6 +496,16 @@ func Test_smoothscroll_cursor_position()
   call s:check_col_calc(1, 2, 37)
   exe "normal \<C-Y>"
   call s:check_col_calc(1, 3, 37)
+  normal gg
+
+  " Test list + listchars "precedes", where there is always 1 overlap
+  " regardless of number and cpo-=n.
+  setl number list listchars=precedes:< cpo-=n
+  call s:check_col_calc(5, 1, 1)
+  exe "normal 2|\<C-E>"
+  call s:check_col_calc(6, 1, 18)
+  norm h
+  call s:check_col_calc(5, 2, 17)
   normal gg
 
   bwipe!


### PR DESCRIPTION
Problem:    Position of marker for 'smoothscroll' not computed correctly.
Solution:   Take 'list' and other options into account. (Luuk van Baal,
            closes vim/vim#12393)

https://github.com/vim/vim/commit/24b62ec8258cc7c9ca2c09f645f7f6b02584c892