### PR TITLE
docs(lua-guide.txt): fix file tree indentation

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -114,10 +114,10 @@ Let's assume you have the following directory structure:
     |-- after/
     |-- ftplugin/
     |-- lua/
-    |  |-- myluamodule.lua
-    |  |-- other_modules/
-    |     |-- anothermodule.lua
-    |     |-- init.lua
+    |   |-- myluamodule.lua
+    |   |-- other_modules/
+    |       |-- anothermodule.lua
+    |       |-- init.lua
     |-- plugin/
     |-- syntax/
     |-- init.vim


### PR DESCRIPTION
This is a minor (nitpick) fix of the indentation in the file tree structure of the `lua-guide.txt` doc.