### PR TITLE
ci: trigger tests when pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
 name: build
 on:
+  push:
+    paths:
+      - '**.cmake'
+      - '**/CMakeLists.txt'
+      - '**/CMakePresets.json'
+      - 'cmake.*/**'
+      - '.github/**'
   pull_request:
     branches:
       - 'master'
@@ -12,7 +19,7 @@ on:
       - '.github/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.repository_owner == 'neovim' && github.sha || github.ref_name }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - 'master'
-      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - 'master'
@@ -12,7 +9,7 @@ on:
       - 'contrib/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.repository_owner == 'neovim' && github.sha || github.ref_name }}
   cancel-in-progress: true
 
 env:
@@ -30,7 +27,6 @@ env:
 
 jobs:
   lint:
-    if: (github.event_name == 'pull_request' && github.base_ref == 'master') || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
This will allow contributors to test changes in their own fork when
pushing without needing to make a pull request. This can be useful when
wanting to test out an idea before initiating a review process.

Make the following assumptions when defining concurrency:
- Pull request will work the same.
- Pushes to the neovim repo will work the same: each unique commit will
  trigger a test run that won't cancel each other.
- Pushes to forks will cancel older CI runs on the same branch, similar
  to how pull requests work.

This will create duplicate CI runs when doing a pull request, one in the
neovim repo for the pull request event and one in the fork for the push
event. This is an acceptable trade as the runs in the fork doesn't count
towards the CI limit of neovim. Contributors are also free to disable
these actions in their own fork if they wish.