### PR TITLE
vim-patch:9.0.1555: setcharsearch() does not clear last searched char properly

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1519,7 +1519,7 @@ int searchc(cmdarg_T *cap, int t_cmd)
       }
     }
   } else {            // repeat previous search
-    if (*lastc == NUL && lastc_bytelen == 1) {
+    if (*lastc == NUL && lastc_bytelen <= 1) {
       return FAIL;
     }
     if (dir) {        // repeat in opposite direction
@@ -1562,7 +1562,7 @@ int searchc(cmdarg_T *cap, int t_cmd)
         }
         col -= utf_head_off(p, p + col - 1) + 1;
       }
-      if (lastc_bytelen == 1) {
+      if (lastc_bytelen <= 1) {
         if (p[col] == c && stop) {
           break;
         }

--- a/test/old/testdir/test_charsearch.vim
+++ b/test/old/testdir/test_charsearch.vim
@@ -38,6 +38,8 @@ func Test_charsearch()
   " clear the character search
   call setcharsearch({'char' : ''})
   call assert_equal('', getcharsearch().char)
+  call assert_beeps('normal ;')
+  call assert_beeps('normal ,')
 
   call assert_fails("call setcharsearch([])", 'E1206:')
   enew!

--- a/test/old/testdir/test_charsearch_utf8.vim
+++ b/test/old/testdir/test_charsearch_utf8.vim
@@ -13,6 +13,13 @@ func Test_search_cmds()
   call assert_equal([0, 1, 43, 0], getpos('.'))
   normal! ,
   call assert_equal([0, 1, 28, 0], getpos('.'))
+  call assert_equal('最', getcharsearch().char)
+  call setcharsearch({'char' : ''})
+  call assert_equal('', getcharsearch().char)
+  call assert_beeps('normal ;')
+  call assert_equal([0, 1, 28, 0], getpos('.'))
+  call assert_beeps('normal ,')
+  call assert_equal([0, 1, 28, 0], getpos('.'))
   bw!
 endfunc
 


### PR DESCRIPTION
Fix #23625

#### vim-patch:9.0.1555: setcharsearch() does not clear last searched char properly

Problem:    setcharsearch() does not clear last searched char properly.
Solution:   Do not accept lastc_bytelen smaller than one. (closes vim/vim#12398)

https://github.com/vim/vim/commit/e5d91ba1de83949eb9357c0fb8cbd91e7e69be6f