### PR TITLE
vim-patch:9.0.1554: code for handling 'switchbuf' is repeated

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1459,16 +1459,11 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
 
   // make "buf" the current buffer
   if (action == DOBUF_SPLIT) {      // split window first
-    // If 'switchbuf' contains "useopen": jump to first window containing
-    // "buf" if one exists
-    if ((swb_flags & SWB_USEOPEN) && buf_jump_open_win(buf)) {
+    // If 'switchbuf' is set jump to the window containing "buf".
+    if (swbuf_goto_win_with_buf(buf) != NULL) {
       return OK;
     }
-    // If 'switchbuf' contains "usetab": jump to first window in any tab
-    // page containing "buf" if one exists
-    if ((swb_flags & SWB_USETAB) && buf_jump_open_tab(buf)) {
-      return OK;
-    }
+
     if (win_split(0, 0) == FAIL) {
       return FAIL;
     }
@@ -2072,17 +2067,8 @@ int buflist_getfile(int n, linenr_T lnum, int options, int forceit)
   }
 
   if (options & GETF_SWITCH) {
-    // If 'switchbuf' contains "useopen": jump to first window containing
-    // "buf" if one exists
-    if (swb_flags & SWB_USEOPEN) {
-      wp = buf_jump_open_win(buf);
-    }
-
-    // If 'switchbuf' contains "usetab": jump to first window in any tab
-    // page containing "buf" if one exists
-    if (wp == NULL && (swb_flags & SWB_USETAB)) {
-      wp = buf_jump_open_tab(buf);
-    }
+    // If 'switchbuf' is set jump to the window containing "buf".
+    wp = swbuf_goto_win_with_buf(buf);
 
     // If 'switchbuf' contains "split", "vsplit" or "newtab" and the
     // current buffer isn't empty: open new tab or window

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2901,21 +2901,10 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, int keep_help)
     buf_T *const existing_buf = buflist_findname_exp(fname);
 
     if (existing_buf != NULL) {
-      const win_T *wp = NULL;
-
-      if (swb_flags & SWB_USEOPEN) {
-        wp = buf_jump_open_win(existing_buf);
-      }
-
-      // If 'switchbuf' contains "usetab": jump to first window in any tab
-      // page containing "existing_buf" if one exists
-      if (wp == NULL && (swb_flags & SWB_USETAB)) {
-        wp = buf_jump_open_tab(existing_buf);
-      }
-
-      // We've switched to the buffer, the usual loading of the file must
-      // be skipped.
-      if (wp != NULL) {
+      // If 'switchbuf' is set jump to the window containing "buf".
+      if (swbuf_goto_win_with_buf(existing_buf) != NULL) {
+        // We've switched to the buffer, the usual loading of the file
+        // must be skipped.
         getfile_result = GETFILE_SAME_FILE;
       }
     }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -139,6 +139,32 @@ win_T *prevwin_curwin(void)
   return is_in_cmdwin() && prevwin != NULL ? prevwin : curwin;
 }
 
+/// If the 'switchbuf' option contains "useopen" or "usetab", then try to jump
+/// to a window containing "buf".
+/// Returns the pointer to the window that was jumped to or NULL.
+win_T *swbuf_goto_win_with_buf(buf_T *buf)
+{
+  win_T *wp = NULL;
+
+  if (buf == NULL) {
+    return wp;
+  }
+
+  // If 'switchbuf' contains "useopen": jump to first window in the current
+  // tab page containing "buf" if one exists.
+  if (swb_flags & SWB_USEOPEN) {
+    wp = buf_jump_open_win(buf);
+  }
+
+  // If 'switchbuf' contains "usetab": jump to first window in any tab page
+  // containing "buf" if one exists.
+  if (wp == NULL && (swb_flags & SWB_USETAB)) {
+    wp = buf_jump_open_tab(buf);
+  }
+
+  return wp;
+}
+
 /// all CTRL-W window commands are handled here, called from normal_cmd().
 ///
 /// @param xchar  extra char from ":wincmd gx" or NUL
@@ -520,20 +546,7 @@ wingotofile:
       win_T *wp = NULL;
       if ((swb_flags & (SWB_USEOPEN | SWB_USETAB))
           && cmdmod.cmod_tab == 0) {
-        buf_T *existing_buf = buflist_findname_exp(ptr);
-
-        if (existing_buf != NULL) {
-          if (swb_flags & SWB_USEOPEN) {
-            wp = buf_jump_open_win(existing_buf);
-          }
-
-          // If 'switchbuf' contains "usetab": jump to first
-          // window in any tab page containing "existing_buf"
-          // if one exists.
-          if (wp == NULL && (swb_flags & SWB_USETAB)) {
-            wp = buf_jump_open_tab(existing_buf);
-          }
-        }
+        wp = swbuf_goto_win_with_buf(buflist_findname_exp(ptr));
       }
 
       if (wp == NULL && win_split(0, 0) == OK) {


### PR DESCRIPTION
#### vim-patch:9.0.1554: code for handling 'switchbuf' is repeated

Problem:    Code for handling 'switchbuf' is repeated.
Solution:   Add a function to handle 'switchbuf'. (Yegappan Lakshmanan,
            closes vim/vim#12397)

https://github.com/vim/vim/commit/e42c27d9e8a18e3786f13f17663914cdd0f63f9e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>