### PR TITLE
docs(api.txt) fix string format in example

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3293,7 +3293,7 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
         vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
           pattern = {"*.c", "*.h"},
           callback = function(ev)
-            print(string.format('event fired: s', vim.inspect(ev)))
+            print(string.format("event fired: %s", vim.inspect(ev)))
           end
         })
 <

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3293,7 +3293,7 @@ nvim_create_autocmd({event}, {*opts})                  *nvim_create_autocmd()*
         vim.api.nvim_create_autocmd({"BufEnter", "BufWinEnter"}, {
           pattern = {"*.c", "*.h"},
           callback = function(ev)
-            print(string.format("event fired: %s", vim.inspect(ev)))
+            print(string.format('event fired: %s', vim.inspect(ev)))
           end
         })
 <


### PR DESCRIPTION
Fixes the example for `nvim_create_autocmd`.

I've also changed the string delimiter to use double quotes instead of single quotes to make it consistent with all the other strings around.
Let me know if you want me to change it back.

Also, apologies for keep sending tiny MRs with docs fixes.
I'm fixing stuff as I go through the docs, and would rather not keep changes on my side as I may forget to push them later.