### PR TITLE
vim-patch:9.0.1561: display wrong when moving cursor to above the top line

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1502,11 +1502,11 @@ void adjust_skipcol(void)
     } else {
       curwin->w_skipcol -= width1;
     }
-    redraw_later(curwin, UPD_NOT_VALID);
     scrolled = true;
-    validate_virtcol();
   }
   if (scrolled) {
+    validate_virtcol();
+    redraw_later(curwin, UPD_NOT_VALID);
     return;  // don't scroll in the other direction now
   }
   long col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -22,6 +22,7 @@
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
+#include "nvim/move.h"
 #include "nvim/normal.h"
 #include "nvim/option_defs.h"
 #include "nvim/pos.h"
@@ -414,6 +415,7 @@ int bck_word(long count, bool bigword, bool stop)
 finished:
     stop = false;
   }
+  adjust_skipcol();
   return OK;
 }
 
@@ -518,6 +520,7 @@ int bckend_word(long count, bool bigword, bool eol)
       }
     }
   }
+  adjust_skipcol();
   return OK;
 }
 

--- a/test/functional/legacy/display_spec.lua
+++ b/test/functional/legacy/display_spec.lua
@@ -286,17 +286,56 @@ describe('display', function()
     local screen = Screen.new(75, 8)
     screen:attach()
     exec([[
-      call setline(1, ['a', 'bbbbb '->repeat(100), 'c'])
+      call setline(1, ['a', 'b ' .. 'bbbbb'->repeat(150), 'c'])
       norm $j
     ]])
     screen:expect([[
-      <<<bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb |
-      bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbb|
-      bb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb |
-      bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbb|
-      bb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb |
-      bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbb|
-      bb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb bbbbb^ |
+      <<<bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      b^b                                                                         |
+                                                                                 |
+    ]])
+    -- FIXME: moving the cursor above the topline does not set w_skipcol
+    -- correctly with cpo+=n and zero scrolloff (curs_columns() extra == 1).
+    exec('set number cpo+=n scrolloff=0')
+    feed('$0')
+    screen:expect([[
+      <<<b^bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+                                                                                 |
+    ]])
+    -- Going to the start of the line with "b" did not set w_skipcol correctly with 'smoothscroll'.
+    exec('set smoothscroll')
+    feed('$b')
+    screen:expect([[
+        2 b ^bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+                                                                                 |
+    ]])
+    -- Same for "ge".
+    feed('$ge')
+    screen:expect([[
+        2 ^b bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
                                                                                  |
     ]])
   end)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -502,7 +502,7 @@ func Test_smoothscroll_cursor_position()
   " regardless of number and cpo-=n.
   setl number list listchars=precedes:< cpo-=n
   call s:check_col_calc(5, 1, 1)
-  exe "normal 2|\<C-E>"
+  exe "normal 3|\<C-E>h"
   call s:check_col_calc(6, 1, 18)
   norm h
   call s:check_col_calc(5, 2, 17)


### PR DESCRIPTION
Problem:    Display wrong when moving cursor to above the top line and
            'smoothscroll' is set.
Solution:   Call adjust_skipcol() in more places and make it work better.
            (Luuk van Baal, closes vim/vim#12395)

https://github.com/vim/vim/commit/798fa76dbf737f855e47b10bf326453866b429ab