### PR TITLE
refactor: remove STRCPY and STRCAT

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1222,7 +1222,7 @@ static int init_sign_text(char **sign_text, char *text)
   *sign_text = xstrnsave(text, len);
 
   if (cells == 1) {
-    strcpy(*sign_text + len - 1, " ");
+    strcpy(*sign_text + len - 1, " ");  // NOLINT(runtime/printf)
   }
 
   return OK;

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1222,7 +1222,7 @@ static int init_sign_text(char **sign_text, char *text)
   *sign_text = xstrnsave(text, len);
 
   if (cells == 1) {
-    STRCPY(*sign_text + len - 1, " ");
+    strcpy(*sign_text + len - 1, " ");
   }
 
   return OK;

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -688,9 +688,9 @@ char *au_event_disable(char *what)
   char *save_ei = xstrdup(p_ei);
   char *new_ei = xstrnsave(p_ei, strlen(p_ei) + strlen(what));
   if (*what == ',' && *p_ei == NUL) {
-    strcpy(new_ei, what + 1);
+    strcpy(new_ei, what + 1);  // NOLINT(runtime/printf)
   } else {
-    strcat(new_ei, what);
+    strcat(new_ei, what);  // NOLINT(runtime/printf)
   }
   set_string_option_direct("ei", -1, new_ei, OPT_FREE, SID_NONE);
   xfree(new_ei);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -688,9 +688,9 @@ char *au_event_disable(char *what)
   char *save_ei = xstrdup(p_ei);
   char *new_ei = xstrnsave(p_ei, strlen(p_ei) + strlen(what));
   if (*what == ',' && *p_ei == NUL) {
-    STRCPY(new_ei, what + 1);
+    strcpy(new_ei, what + 1);
   } else {
-    STRCAT(new_ei, what);
+    strcat(new_ei, what);
   }
   set_string_option_direct("ei", -1, new_ei, OPT_FREE, SID_NONE);
   xfree(new_ei);

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1084,11 +1084,11 @@ char *do_bufdel(int command, char *arg, int addr_count, int start_bnr, int end_b
 
     if (deleted == 0) {
       if (command == DOBUF_UNLOAD) {
-        STRCPY(IObuff, _("E515: No buffers were unloaded"));
+        strcpy(IObuff, _("E515: No buffers were unloaded"));
       } else if (command == DOBUF_DEL) {
-        STRCPY(IObuff, _("E516: No buffers were deleted"));
+        strcpy(IObuff, _("E516: No buffers were deleted"));
       } else {
-        STRCPY(IObuff, _("E517: No buffers were wiped out"));
+        strcpy(IObuff, _("E517: No buffers were wiped out"));
       }
       errormsg = IObuff;
     } else if (deleted >= p_report) {
@@ -2341,8 +2341,8 @@ int ExpandBufnames(char *pat, int *num_file, char ***file, int options)
   if (!fuzzy) {
     if (*pat == '^') {
       patc = xmalloc(strlen(pat) + 11);
-      STRCPY(patc, "\\(^\\|[\\/]\\)");
-      STRCPY(patc + 11, pat + 1);
+      strcpy(patc, "\\(^\\|[\\/]\\)");
+      strcpy(patc + 11, pat + 1);
     } else {
       patc = pat;
     }
@@ -3402,7 +3402,7 @@ void maketitle(void)
         len += utf_cp_tail_off(buf_p, buf_p + len) + 1;
         buf_p += len;
       }
-      STRCPY(icon_str, buf_p);
+      strcpy(icon_str, buf_p);
       trans_characters(icon_str, IOSIZE);
     }
   }
@@ -3524,7 +3524,7 @@ bool append_arg_number(win_T *wp, char *buf, int buflen, bool add_file)
   *p++ = ' ';
   *p++ = '(';
   if (add_file) {
-    STRCPY(p, "file ");
+    strcpy(p, "file ");
     p += 5;
   }
   vim_snprintf(p, (size_t)(buflen - (p - buf)),

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1084,11 +1084,11 @@ char *do_bufdel(int command, char *arg, int addr_count, int start_bnr, int end_b
 
     if (deleted == 0) {
       if (command == DOBUF_UNLOAD) {
-        strcpy(IObuff, _("E515: No buffers were unloaded"));
+        xstrlcpy(IObuff, _("E515: No buffers were unloaded"), IOSIZE);
       } else if (command == DOBUF_DEL) {
-        strcpy(IObuff, _("E516: No buffers were deleted"));
+        xstrlcpy(IObuff, _("E516: No buffers were deleted"), IOSIZE);
       } else {
-        strcpy(IObuff, _("E517: No buffers were wiped out"));
+        xstrlcpy(IObuff, _("E517: No buffers were wiped out"), IOSIZE);
       }
       errormsg = IObuff;
     } else if (deleted >= p_report) {
@@ -2341,8 +2341,8 @@ int ExpandBufnames(char *pat, int *num_file, char ***file, int options)
   if (!fuzzy) {
     if (*pat == '^') {
       patc = xmalloc(strlen(pat) + 11);
-      strcpy(patc, "\\(^\\|[\\/]\\)");
-      strcpy(patc + 11, pat + 1);
+      strcpy(patc, "\\(^\\|[\\/]\\)");  // NOLINT(runtime/printf)
+      strcpy(patc + 11, pat + 1);  // NOLINT(runtime/printf)
     } else {
       patc = pat;
     }
@@ -3402,7 +3402,7 @@ void maketitle(void)
         len += utf_cp_tail_off(buf_p, buf_p + len) + 1;
         buf_p += len;
       }
-      strcpy(icon_str, buf_p);
+      strcpy(icon_str, buf_p);  // NOLINT(runtime/printf)
       trans_characters(icon_str, IOSIZE);
     }
   }
@@ -3524,7 +3524,7 @@ bool append_arg_number(win_T *wp, char *buf, int buflen, bool add_file)
   *p++ = ' ';
   *p++ = '(';
   if (add_file) {
-    strcpy(p, "file ");
+    strcpy(p, "file ");  // NOLINT(runtime/printf)
     p += 5;
   }
   vim_snprintf(p, (size_t)(buflen - (p - buf)),

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -745,7 +745,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
       // the ones from the original file.
       // First find a file name that doesn't exist yet (use some
       // arbitrary numbers).
-      strcpy(IObuff, fname);
+      xstrlcpy(IObuff, fname, IOSIZE);
       for (int i = 4913;; i += 123) {
         char *tail = path_tail(IObuff);
         size_t size = (size_t)(tail - IObuff);
@@ -1749,24 +1749,24 @@ restore_backup:
     add_quoted_fname(IObuff, IOSIZE, buf, fname);
     bool insert_space = false;
     if (write_info.bw_conv_error) {
-      strcat(IObuff, _(" CONVERSION ERROR"));
+      xstrlcat(IObuff, _(" CONVERSION ERROR"), IOSIZE);
       insert_space = true;
       if (write_info.bw_conv_error_lnum != 0) {
         vim_snprintf_add(IObuff, IOSIZE, _(" in line %" PRId64 ";"),
                          (int64_t)write_info.bw_conv_error_lnum);
       }
     } else if (notconverted) {
-      strcat(IObuff, _("[NOT converted]"));
+      xstrlcat(IObuff, _("[NOT converted]"), IOSIZE);
       insert_space = true;
     } else if (converted) {
-      strcat(IObuff, _("[converted]"));
+      xstrlcat(IObuff, _("[converted]"), IOSIZE);
       insert_space = true;
     }
     if (device) {
-      strcat(IObuff, _("[Device]"));
+      xstrlcat(IObuff, _("[Device]"), IOSIZE);
       insert_space = true;
     } else if (newfile) {
-      strcat(IObuff, new_file_message());
+      xstrlcat(IObuff, new_file_message(), IOSIZE);
       insert_space = true;
     }
     if (no_eol) {
@@ -1780,9 +1780,9 @@ restore_backup:
     msg_add_lines(insert_space, (long)lnum, nchars);       // add line/char count
     if (!shortmess(SHM_WRITE)) {
       if (append) {
-        strcat(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"));
+        xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"), IOSIZE);
       } else {
-        strcat(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"));
+        xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"), IOSIZE);
       }
     }
 

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -745,7 +745,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
       // the ones from the original file.
       // First find a file name that doesn't exist yet (use some
       // arbitrary numbers).
-      STRCPY(IObuff, fname);
+      strcpy(IObuff, fname);
       for (int i = 4913;; i += 123) {
         char *tail = path_tail(IObuff);
         size_t size = (size_t)(tail - IObuff);
@@ -1749,24 +1749,24 @@ restore_backup:
     add_quoted_fname(IObuff, IOSIZE, buf, fname);
     bool insert_space = false;
     if (write_info.bw_conv_error) {
-      STRCAT(IObuff, _(" CONVERSION ERROR"));
+      strcat(IObuff, _(" CONVERSION ERROR"));
       insert_space = true;
       if (write_info.bw_conv_error_lnum != 0) {
         vim_snprintf_add(IObuff, IOSIZE, _(" in line %" PRId64 ";"),
                          (int64_t)write_info.bw_conv_error_lnum);
       }
     } else if (notconverted) {
-      STRCAT(IObuff, _("[NOT converted]"));
+      strcat(IObuff, _("[NOT converted]"));
       insert_space = true;
     } else if (converted) {
-      STRCAT(IObuff, _("[converted]"));
+      strcat(IObuff, _("[converted]"));
       insert_space = true;
     }
     if (device) {
-      STRCAT(IObuff, _("[Device]"));
+      strcat(IObuff, _("[Device]"));
       insert_space = true;
     } else if (newfile) {
-      STRCAT(IObuff, new_file_message());
+      strcat(IObuff, new_file_message());
       insert_space = true;
     }
     if (no_eol) {
@@ -1780,9 +1780,9 @@ restore_backup:
     msg_add_lines(insert_space, (long)lnum, nchars);       // add line/char count
     if (!shortmess(SHM_WRITE)) {
       if (append) {
-        STRCAT(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"));
+        strcat(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"));
       } else {
-        STRCAT(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"));
+        strcat(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"));
       }
     }
 

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1682,12 +1682,12 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
       // Below, set_indent(newindent, SIN_INSERT) will insert the
       // whitespace needed before the comment char.
       for (i = 0; i < padding; i++) {
-        strcat(leader, " ");
+        strcat(leader, " ");  // NOLINT(runtime/printf)
         less_cols--;
         newcol++;
       }
     }
-    strcat(leader, p_extra);
+    strcat(leader, p_extra);  // NOLINT(runtime/printf)
     p_extra = leader;
     did_ai = true;          // So truncating blanks works with comments
     less_cols -= lead_len;

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1682,12 +1682,12 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
       // Below, set_indent(newindent, SIN_INSERT) will insert the
       // whitespace needed before the comment char.
       for (i = 0; i < padding; i++) {
-        STRCAT(leader, " ");
+        strcat(leader, " ");
         less_cols--;
         newcol++;
       }
     }
-    STRCAT(leader, p_extra);
+    strcat(leader, p_extra);
     p_extra = leader;
     did_ai = true;          // So truncating blanks works with comments
     less_cols -= lead_len;

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -514,7 +514,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
     *buf = NUL;
     len = 0;
   } else {
-    strcpy(buf, "< ");
+    strcpy(buf, "< ");  // NOLINT(runtime/printf)
     len = 2;
   }
   clen = len;
@@ -530,7 +530,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
     // Check for menu separators - replace with '|'
     int emenu = (xp->xp_context == EXPAND_MENUS || xp->xp_context == EXPAND_MENUNAMES);
     if (emenu && menu_is_separator(s)) {
-      strcpy(buf + len, transchar('|'));
+      strcpy(buf + len, transchar('|'));  // NOLINT(runtime/printf)
       l = (int)strlen(buf + len);
       len += l;
       clen += l;
@@ -543,7 +543,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
           s += l - 1;
           len += l;
         } else {
-          strcpy(buf + len, transchar_byte((uint8_t)(*s)));
+          strcpy(buf + len, transchar_byte((uint8_t)(*s)));  // NOLINT(runtime/printf)
           len += (int)strlen(buf + len);
         }
       }
@@ -911,15 +911,15 @@ char *ExpandOne(expand_T *xp, char *str, char *orig, int options, int mode)
     for (int i = 0; i < xp->xp_numfiles; i++) {
       if (i > 0) {
         if (xp->xp_prefix == XP_PREFIX_NO) {
-          strcat(ss, "no");
+          xstrlcat(ss, "no", len);
         } else if (xp->xp_prefix == XP_PREFIX_INV) {
-          strcat(ss, "inv");
+          xstrlcat(ss, "inv", len);
         }
       }
-      strcat(ss, xp->xp_files[i]);
+      xstrlcat(ss, xp->xp_files[i], len);
 
       if (i != xp->xp_numfiles - 1) {
-        strcat(ss, (options & WILD_USE_NL) ? "\n" : " ");
+        xstrlcat(ss, (options & WILD_USE_NL) ? "\n" : " ", len);
       }
     }
   }

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -514,7 +514,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
     *buf = NUL;
     len = 0;
   } else {
-    STRCPY(buf, "< ");
+    strcpy(buf, "< ");
     len = 2;
   }
   clen = len;
@@ -530,7 +530,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
     // Check for menu separators - replace with '|'
     int emenu = (xp->xp_context == EXPAND_MENUS || xp->xp_context == EXPAND_MENUNAMES);
     if (emenu && menu_is_separator(s)) {
-      STRCPY(buf + len, transchar('|'));
+      strcpy(buf + len, transchar('|'));
       l = (int)strlen(buf + len);
       len += l;
       clen += l;
@@ -543,7 +543,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
           s += l - 1;
           len += l;
         } else {
-          STRCPY(buf + len, transchar_byte((uint8_t)(*s)));
+          strcpy(buf + len, transchar_byte((uint8_t)(*s)));
           len += (int)strlen(buf + len);
         }
       }
@@ -911,15 +911,15 @@ char *ExpandOne(expand_T *xp, char *str, char *orig, int options, int mode)
     for (int i = 0; i < xp->xp_numfiles; i++) {
       if (i > 0) {
         if (xp->xp_prefix == XP_PREFIX_NO) {
-          STRCAT(ss, "no");
+          strcat(ss, "no");
         } else if (xp->xp_prefix == XP_PREFIX_INV) {
-          STRCAT(ss, "inv");
+          strcat(ss, "inv");
         }
       }
-      STRCAT(ss, xp->xp_files[i]);
+      strcat(ss, xp->xp_files[i]);
 
       if (i != xp->xp_numfiles - 1) {
-        STRCAT(ss, (options & WILD_USE_NL) ? "\n" : " ");
+        strcat(ss, (options & WILD_USE_NL) ? "\n" : " ");
       }
     }
   }
@@ -3218,7 +3218,7 @@ void globpath(char *path, char *file, garray_T *ga, int expand_options, bool dir
     copy_option_part(&path, buf, MAXPATHL, ",");
     if (strlen(buf) + strlen(file) + 2 < MAXPATHL) {
       add_pathsep(buf);
-      STRCAT(buf, file);  // NOLINT
+      strcat(buf, file);  // NOLINT
 
       char **p;
       int num_p = 0;

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -641,9 +641,10 @@ void ex_history(exarg_T *eap)
   }
 
   for (; !got_int && histype1 <= histype2; histype1++) {
-    strcpy(IObuff, "\n      #  ");
+    xstrlcpy(IObuff, "\n      #  ", IOSIZE);
     assert(history_names[histype1] != NULL);
-    strcat(strcat(IObuff, history_names[histype1]), " history");
+    xstrlcat(IObuff, history_names[histype1], IOSIZE);
+    xstrlcat(IObuff, " history", IOSIZE);
     msg_puts_title(IObuff);
     int idx = hisidx[histype1];
     histentry_T *hist = history[histype1];
@@ -669,7 +670,7 @@ void ex_history(exarg_T *eap)
             trunc_string(hist[i].hisstr, IObuff + strlen(IObuff),
                          Columns - 10, IOSIZE - (int)strlen(IObuff));
           } else {
-            strcat(IObuff, hist[i].hisstr);
+            xstrlcat(IObuff, hist[i].hisstr, IOSIZE);
           }
           msg_outtrans(IObuff);
         }

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -641,9 +641,9 @@ void ex_history(exarg_T *eap)
   }
 
   for (; !got_int && histype1 <= histype2; histype1++) {
-    STRCPY(IObuff, "\n      #  ");
+    strcpy(IObuff, "\n      #  ");
     assert(history_names[histype1] != NULL);
-    STRCAT(STRCAT(IObuff, history_names[histype1]), " history");
+    strcat(strcat(IObuff, history_names[histype1]), " history");
     msg_puts_title(IObuff);
     int idx = hisidx[histype1];
     histentry_T *hist = history[histype1];
@@ -669,7 +669,7 @@ void ex_history(exarg_T *eap)
             trunc_string(hist[i].hisstr, IObuff + strlen(IObuff),
                          Columns - 10, IOSIZE - (int)strlen(IObuff));
           } else {
-            STRCAT(IObuff, hist[i].hisstr);
+            strcat(IObuff, hist[i].hisstr);
           }
           msg_outtrans(IObuff);
         }

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -784,8 +784,8 @@ static linenr_T debuggy_find(bool file, char *fname, linenr_T after, garray_T *g
   // Replace K_SNR in function name with "<SNR>".
   if (!file && (uint8_t)fname[0] == K_SPECIAL) {
     name = xmalloc(strlen(fname) + 3);
-    strcpy(name, "<SNR>");
-    strcpy(name + 5, fname + 3);
+    strcpy(name, "<SNR>");  // NOLINT(runtime/printf)
+    strcpy(name + 5, fname + 3);  // NOLINT(runtime/printf)
   }
 
   for (int i = 0; i < gap->ga_len; i++) {

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -784,8 +784,8 @@ static linenr_T debuggy_find(bool file, char *fname, linenr_T after, garray_T *g
   // Replace K_SNR in function name with "<SNR>".
   if (!file && (uint8_t)fname[0] == K_SPECIAL) {
     name = xmalloc(strlen(fname) + 3);
-    STRCPY(name, "<SNR>");
-    STRCPY(name + 5, fname + 3);
+    strcpy(name, "<SNR>");
+    strcpy(name + 5, fname + 3);
   }
 
   for (int i = 0; i < gap->ga_len; i++) {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1271,11 +1271,11 @@ void ex_diffpatch(exarg_T *eap)
 #endif
 
   // Delete any .orig or .rej file created.
-  STRCPY(buf, tmp_new);
-  STRCAT(buf, ".orig");
+  strcpy(buf, tmp_new);
+  strcat(buf, ".orig");
   os_remove(buf);
-  STRCPY(buf, tmp_new);
-  STRCAT(buf, ".rej");
+  strcpy(buf, tmp_new);
+  strcat(buf, ".rej");
   os_remove(buf);
 
   // Only continue if the output file was created.
@@ -1287,7 +1287,7 @@ void ex_diffpatch(exarg_T *eap)
   } else {
     if (curbuf->b_fname != NULL) {
       newname = xstrnsave(curbuf->b_fname, strlen(curbuf->b_fname) + 4);
-      STRCAT(newname, ".new");
+      strcat(newname, ".new");
     }
 
     // don't use a new tab page, each tab page has its own diffs

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1271,11 +1271,11 @@ void ex_diffpatch(exarg_T *eap)
 #endif
 
   // Delete any .orig or .rej file created.
-  strcpy(buf, tmp_new);
-  strcat(buf, ".orig");
+  xstrlcpy(buf, tmp_new, buflen);
+  xstrlcat(buf, ".orig", buflen);
   os_remove(buf);
-  strcpy(buf, tmp_new);
-  strcat(buf, ".rej");
+  xstrlcpy(buf, tmp_new, buflen);
+  xstrlcat(buf, ".rej", buflen);
   os_remove(buf);
 
   // Only continue if the output file was created.
@@ -1287,7 +1287,7 @@ void ex_diffpatch(exarg_T *eap)
   } else {
     if (curbuf->b_fname != NULL) {
       newname = xstrnsave(curbuf->b_fname, strlen(curbuf->b_fname) + 4);
-      strcat(newname, ".new");
+      strcat(newname, ".new");  // NOLINT(runtime/printf)
     }
 
     // don't use a new tab page, each tab page has its own diffs

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2201,7 +2201,7 @@ bool get_keymap_str(win_T *wp, char *fmt, char *buf, int len)
 
   curbuf = wp->w_buffer;
   curwin = wp;
-  STRCPY(buf, "b:keymap_name");       // must be writable
+  strcpy(buf, "b:keymap_name");       // must be writable
   emsg_skip++;
   s = p = eval_to_string(buf, false);
   emsg_skip--;

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -2201,7 +2201,7 @@ bool get_keymap_str(win_T *wp, char *fmt, char *buf, int len)
 
   curbuf = wp->w_buffer;
   curwin = wp;
-  strcpy(buf, "b:keymap_name");       // must be writable
+  xstrlcpy(buf, "b:keymap_name", (size_t)len);       // must be writable
   emsg_skip++;
   s = p = eval_to_string(buf, false);
   emsg_skip--;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -391,7 +391,7 @@ void eval_init(void)
   for (size_t i = 0; i < ARRAY_SIZE(vimvars); i++) {
     struct vimvar *p = &vimvars[i];
     assert(strlen(p->vv_name) <= VIMVAR_KEY_LEN);
-    STRCPY(p->vv_di.di_key, p->vv_name);
+    strcpy(p->vv_di.di_key, p->vv_name);
     if (p->vv_flags & VV_RO) {
       p->vv_di.di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     } else if (p->vv_flags & VV_RO_SBX) {
@@ -2131,7 +2131,7 @@ char *cat_prefix_varname(int prefix, const char *name)
   }
   *varnamebuf = (char)prefix;
   varnamebuf[1] = ':';
-  STRCPY(varnamebuf + 2, name);
+  strcpy(varnamebuf + 2, name);
   return varnamebuf;
 }
 
@@ -6837,9 +6837,9 @@ static char *make_expanded_name(const char *in_start, char *expr_start, char *ex
   if (temp_result != NULL) {
     retval = xmalloc(strlen(temp_result) + (size_t)(expr_start - in_start)
                      + (size_t)(in_end - expr_end) + 1);
-    STRCPY(retval, in_start);
-    STRCAT(retval, temp_result);
-    STRCAT(retval, expr_end + 1);
+    strcpy(retval, in_start);
+    strcat(retval, temp_result);
+    strcat(retval, expr_end + 1);
   }
   xfree(temp_result);
 
@@ -8497,7 +8497,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char 
     }
 
     if (ga.ga_data != NULL) {
-      STRCPY((char *)ga.ga_data + ga.ga_len, tail);
+      strcpy((char *)ga.ga_data + ga.ga_len, tail);
     }
 
     vim_regfree(regmatch.regprog);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -391,7 +391,7 @@ void eval_init(void)
   for (size_t i = 0; i < ARRAY_SIZE(vimvars); i++) {
     struct vimvar *p = &vimvars[i];
     assert(strlen(p->vv_name) <= VIMVAR_KEY_LEN);
-    strcpy(p->vv_di.di_key, p->vv_name);
+    xstrlcpy(p->vv_di.di_key, p->vv_name, ARRAY_SIZE(p->vv_di.di_key));
     if (p->vv_flags & VV_RO) {
       p->vv_di.di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     } else if (p->vv_flags & VV_RO_SBX) {
@@ -2131,7 +2131,7 @@ char *cat_prefix_varname(int prefix, const char *name)
   }
   *varnamebuf = (char)prefix;
   varnamebuf[1] = ':';
-  strcpy(varnamebuf + 2, name);
+  strcpy(varnamebuf + 2, name);  // NOLINT(runtime/printf)
   return varnamebuf;
 }
 
@@ -6837,9 +6837,9 @@ static char *make_expanded_name(const char *in_start, char *expr_start, char *ex
   if (temp_result != NULL) {
     retval = xmalloc(strlen(temp_result) + (size_t)(expr_start - in_start)
                      + (size_t)(in_end - expr_end) + 1);
-    strcpy(retval, in_start);
-    strcat(retval, temp_result);
-    strcat(retval, expr_end + 1);
+    strcpy(retval, in_start);  // NOLINT(runtime/printf)
+    strcat(retval, temp_result);  // NOLINT(runtime/printf)
+    strcat(retval, expr_end + 1);  // NOLINT(runtime/printf)
   }
   xfree(temp_result);
 
@@ -8497,7 +8497,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char 
     }
 
     if (ga.ga_data != NULL) {
-      strcpy((char *)ga.ga_data + ga.ga_len, tail);
+      strcpy((char *)ga.ga_data + ga.ga_len, tail);  // NOLINT(runtime/printf)
     }
 
     vim_regfree(regmatch.regprog);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6974,7 +6974,7 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
   char *pat3 = xmalloc(pat3_len);
   snprintf(pat2, pat2_len, "\\m\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat);
   if (*mpat == NUL) {
-    STRCPY(pat3, pat2);
+    strcpy(pat3, pat2);
   } else {
     snprintf(pat3, pat3_len,
              "\\m\\(%s\\m\\)\\|\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat, mpat);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6974,7 +6974,7 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
   char *pat3 = xmalloc(pat3_len);
   snprintf(pat2, pat2_len, "\\m\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat);
   if (*mpat == NUL) {
-    strcpy(pat3, pat2);
+    xstrlcpy(pat3, pat2, pat3_len);
   } else {
     snprintf(pat3, pat3_len,
              "\\m\\(%s\\m\\)\\|\\(%s\\m\\)\\|\\(%s\\m\\)", spat, epat, mpat);

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -4361,10 +4361,10 @@ const char *tv_get_string_buf_chk(const typval_T *const tv, char *const buf)
     }
     return "";
   case VAR_BOOL:
-    strcpy(buf, encode_bool_var_names[tv->vval.v_bool]);
+    xstrlcpy(buf, encode_bool_var_names[tv->vval.v_bool], NUMBUFLEN);
     return buf;
   case VAR_SPECIAL:
-    strcpy(buf, encode_special_var_names[tv->vval.v_special]);
+    xstrlcpy(buf, encode_special_var_names[tv->vval.v_special], NUMBUFLEN);
     return buf;
   case VAR_PARTIAL:
   case VAR_FUNC:

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -4361,10 +4361,10 @@ const char *tv_get_string_buf_chk(const typval_T *const tv, char *const buf)
     }
     return "";
   case VAR_BOOL:
-    STRCPY(buf, encode_bool_var_names[tv->vval.v_bool]);
+    strcpy(buf, encode_bool_var_names[tv->vval.v_bool]);
     return buf;
   case VAR_SPECIAL:
-    STRCPY(buf, encode_special_var_names[tv->vval.v_special]);
+    strcpy(buf, encode_special_var_names[tv->vval.v_special]);
     return buf;
   case VAR_PARTIAL:
   case VAR_FUNC:

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -256,12 +256,12 @@ char *get_lambda_name(void)
 
 static void set_ufunc_name(ufunc_T *fp, char *name)
 {
-  strcpy(fp->uf_name, name);
+  strcpy(fp->uf_name, name);  // NOLINT(runtime/printf)
 
   if ((uint8_t)name[0] == K_SPECIAL) {
     fp->uf_name_exp = xmalloc(strlen(name) + 3);
-    strcpy(fp->uf_name_exp, "<SNR>");
-    strcat(fp->uf_name_exp, fp->uf_name + 3);
+    strcpy(fp->uf_name_exp, "<SNR>");  // NOLINT(runtime/printf)
+    strcat(fp->uf_name_exp, fp->uf_name + 3);  // NOLINT(runtime/printf)
   }
 }
 
@@ -343,7 +343,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, evalarg_T *evalarg)
     size_t len = (size_t)(7 + end - start + 1);
     p = xmalloc(len);
     ((char **)(newlines.ga_data))[newlines.ga_len++] = p;
-    strcpy(p, "return ");
+    xstrlcpy(p, "return ", len);
     xstrlcpy(p + 7, start, (size_t)(end - start) + 1);
     if (strstr(p + 7, "a:") == NULL) {
       // No a: variables are used for sure.
@@ -983,7 +983,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
 #ifndef __clang_analyzer__
     name = (char *)v->di_key;
-    strcpy(name, "self");
+    strcpy(name, "self");  // NOLINT(runtime/printf)
 #endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_vars.dv_hashtab, v->di_key);
@@ -1009,7 +1009,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
 #ifndef __clang_analyzer__
     name = (char *)v->di_key;
-    strcpy(name, "000");
+    strcpy(name, "000");  // NOLINT(runtime/printf)
 #endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_avars.dv_hashtab, v->di_key);
@@ -1074,7 +1074,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
       v = xmalloc(sizeof(dictitem_T) + strlen(name));
       v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX | DI_FLAGS_ALLOC;
     }
-    strcpy(v->di_key, name);
+    strcpy(v->di_key, name);  // NOLINT(runtime/printf)
 
     // Note: the values are copied directly to avoid alloc/free.
     // "argvars" must have VAR_FIXED for v_lock.
@@ -2072,8 +2072,8 @@ char *get_scriptlocal_funcname(char *funcname)
            (int64_t)current_sctx.sc_sid);
   const int off = *funcname == 's' ? 2 : 5;
   char *newname = xmalloc(strlen(sid_buf) + strlen(funcname + off) + 1);
-  strcpy(newname, sid_buf);
-  strcat(newname, funcname + off);
+  strcpy(newname, sid_buf);  // NOLINT(runtime/printf)
+  strcat(newname, funcname + off);  // NOLINT(runtime/printf)
 
   return newname;
 }
@@ -2892,9 +2892,9 @@ char *get_user_func_name(expand_T *xp, int idx)
 
     cat_func_name(IObuff, IOSIZE, fp);
     if (xp->xp_context != EXPAND_USER_FUNC) {
-      strcat(IObuff, "(");
+      xstrlcat(IObuff, "(", IOSIZE);
       if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args)) {
-        strcat(IObuff, ")");
+        xstrlcat(IObuff, ")", IOSIZE);
       }
     }
     return IObuff;
@@ -3505,10 +3505,10 @@ char *get_return_cmd(void *rettv)
     s = "";
   }
 
-  strcpy(IObuff, ":return ");
+  xstrlcpy(IObuff, ":return ", IOSIZE);
   xstrlcpy(IObuff + 8, s, IOSIZE - 8);
   if (strlen(s) + 8 >= IOSIZE) {
-    strcpy(IObuff + IOSIZE - 4, "...");
+    strcpy(IObuff + IOSIZE - 4, "...");  // NOLINT(runtime/printf)
   }
   xfree(tofree);
   return xstrdup(IObuff);
@@ -3969,7 +3969,7 @@ char *register_luafunc(LuaRef ref)
   fp->uf_script_ctx = current_sctx;
   fp->uf_luaref = ref;
 
-  strcpy(fp->uf_name, name);
+  strcpy(fp->uf_name, name);  // NOLINT(runtime/printf)
   hash_add(&func_hashtab, UF2HIKEY(fp));
 
   // coverity[leaked_storage]

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -256,12 +256,12 @@ char *get_lambda_name(void)
 
 static void set_ufunc_name(ufunc_T *fp, char *name)
 {
-  STRCPY(fp->uf_name, name);
+  strcpy(fp->uf_name, name);
 
   if ((uint8_t)name[0] == K_SPECIAL) {
     fp->uf_name_exp = xmalloc(strlen(name) + 3);
-    STRCPY(fp->uf_name_exp, "<SNR>");
-    STRCAT(fp->uf_name_exp, fp->uf_name + 3);
+    strcpy(fp->uf_name_exp, "<SNR>");
+    strcat(fp->uf_name_exp, fp->uf_name + 3);
   }
 }
 
@@ -343,7 +343,7 @@ int get_lambda_tv(char **arg, typval_T *rettv, evalarg_T *evalarg)
     size_t len = (size_t)(7 + end - start + 1);
     p = xmalloc(len);
     ((char **)(newlines.ga_data))[newlines.ga_len++] = p;
-    STRCPY(p, "return ");
+    strcpy(p, "return ");
     xstrlcpy(p + 7, start, (size_t)(end - start) + 1);
     if (strstr(p + 7, "a:") == NULL) {
       // No a: variables are used for sure.
@@ -629,13 +629,13 @@ static char *fname_trans_sid(const char *const name, char *const fname_buf, char
   }
   char *fname;
   if ((size_t)i + strlen(name + llen) < FLEN_FIXED) {
-    STRCPY(fname_buf + i, name + llen);
+    strcpy(fname_buf + i, name + llen);
     fname = fname_buf;
   } else {
     fname = xmalloc((size_t)i + strlen(name + llen) + 1);
     *tofree = fname;
     memmove(fname, fname_buf, (size_t)i);
-    STRCPY(fname + i, name + llen);
+    strcpy(fname + i, name + llen);
   }
   return fname;
 }
@@ -675,7 +675,7 @@ static void cat_func_name(char *buf, size_t buflen, ufunc_T *fp)
 static void add_nr_var(dict_T *dp, dictitem_T *v, char *name, varnumber_T nr)
 {
 #ifndef __clang_analyzer__
-  STRCPY(v->di_key, name);
+  strcpy(v->di_key, name);
 #endif
   v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
   hash_add(&dp->dv_hashtab, v->di_key);
@@ -983,7 +983,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
 #ifndef __clang_analyzer__
     name = (char *)v->di_key;
-    STRCPY(name, "self");
+    strcpy(name, "self");
 #endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_vars.dv_hashtab, v->di_key);
@@ -1009,7 +1009,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
     v = (dictitem_T *)&fc->fc_fixvar[fixvar_idx++];
 #ifndef __clang_analyzer__
     name = (char *)v->di_key;
-    STRCPY(name, "000");
+    strcpy(name, "000");
 #endif
     v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX;
     hash_add(&fc->fc_l_avars.dv_hashtab, v->di_key);
@@ -1074,7 +1074,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
       v = xmalloc(sizeof(dictitem_T) + strlen(name));
       v->di_flags = DI_FLAGS_RO | DI_FLAGS_FIX | DI_FLAGS_ALLOC;
     }
-    STRCPY(v->di_key, name);
+    strcpy(v->di_key, name);
 
     // Note: the values are copied directly to avoid alloc/free.
     // "argvars" must have VAR_FIXED for v_lock.
@@ -2072,8 +2072,8 @@ char *get_scriptlocal_funcname(char *funcname)
            (int64_t)current_sctx.sc_sid);
   const int off = *funcname == 's' ? 2 : 5;
   char *newname = xmalloc(strlen(sid_buf) + strlen(funcname + off) + 1);
-  STRCPY(newname, sid_buf);
-  STRCAT(newname, funcname + off);
+  strcpy(newname, sid_buf);
+  strcat(newname, funcname + off);
 
   return newname;
 }
@@ -2892,9 +2892,9 @@ char *get_user_func_name(expand_T *xp, int idx)
 
     cat_func_name(IObuff, IOSIZE, fp);
     if (xp->xp_context != EXPAND_USER_FUNC) {
-      STRCAT(IObuff, "(");
+      strcat(IObuff, "(");
       if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args)) {
-        STRCAT(IObuff, ")");
+        strcat(IObuff, ")");
       }
     }
     return IObuff;
@@ -3505,10 +3505,10 @@ char *get_return_cmd(void *rettv)
     s = "";
   }
 
-  STRCPY(IObuff, ":return ");
+  strcpy(IObuff, ":return ");
   xstrlcpy(IObuff + 8, s, IOSIZE - 8);
   if (strlen(s) + 8 >= IOSIZE) {
-    STRCPY(IObuff + IOSIZE - 4, "...");
+    strcpy(IObuff + IOSIZE - 4, "...");
   }
   xfree(tofree);
   return xstrdup(IObuff);
@@ -3969,7 +3969,7 @@ char *register_luafunc(LuaRef ref)
   fp->uf_script_ctx = current_sctx;
   fp->uf_luaref = ref;
 
-  STRCPY(fp->uf_name, name);
+  strcpy(fp->uf_name, name);
   hash_add(&func_hashtab, UF2HIKEY(fp));
 
   // coverity[leaked_storage]

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1486,7 +1486,7 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
     assert(dict != NULL);
 
     v = xmalloc(offsetof(dictitem_T, di_key) + strlen(varname) + 1);
-    strcpy(v->di_key, varname);
+    strcpy(v->di_key, varname);  // NOLINT(runtime/printf)
     if (hash_add(ht, v->di_key) == FAIL) {
       xfree(v);
       return;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1486,7 +1486,7 @@ void set_var_const(const char *name, const size_t name_len, typval_T *const tv, 
     assert(dict != NULL);
 
     v = xmalloc(offsetof(dictitem_T, di_key) + strlen(varname) + 1);
-    STRCPY(v->di_key, varname);
+    strcpy(v->di_key, varname);
     if (hash_add(ht, v->di_key) == FAIL) {
       xfree(v);
       return;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -668,7 +668,7 @@ void ex_sort(exarg_T *eap)
     if (!unique || i == 0 || string_compare(s, sortbuf1) != 0) {
       // Copy the line into a buffer, it may become invalid in
       // ml_append(). And it's needed for "unique".
-      STRCPY(sortbuf1, s);
+      strcpy(sortbuf1, s);
       if (ml_append(lnum++, sortbuf1, (colnr_T)0, false) == FAIL) {
         break;
       }
@@ -996,13 +996,13 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
     t = xmalloc(len);
     *t = NUL;
     if (newcmd != NULL) {
-      STRCAT(t, newcmd);
+      strcat(t, newcmd);
     }
     if (ins_prevcmd) {
-      STRCAT(t, prevcmd);
+      strcat(t, prevcmd);
     }
     p = t + strlen(t);
-    STRCAT(t, trailarg);
+    strcat(t, trailarg);
     xfree(newcmd);
     newcmd = t;
 
@@ -1054,9 +1054,9 @@ void do_bang(int addr_count, exarg_T *eap, bool forceit, bool do_in, bool do_out
       xfree(newcmd);
     }
     newcmd = xmalloc(strlen(prevcmd) + 2 * strlen(p_shq) + 1);
-    STRCPY(newcmd, p_shq);
-    STRCAT(newcmd, prevcmd);
-    STRCAT(newcmd, p_shq);
+    strcpy(newcmd, p_shq);
+    strcat(newcmd, prevcmd);
+    strcat(newcmd, p_shq);
     free_newcmd = true;
   }
   if (addr_count == 0) {                // :!
@@ -1868,7 +1868,7 @@ int check_overwrite(exarg_T *eap, buf_T *buf, char *fname, char *ffname, int oth
       // for the written file.
       if (*p_dir == NUL) {
         dir = xmalloc(5);
-        STRCPY(dir, ".");
+        strcpy(dir, ".");
       } else {
         dir = xmalloc(MAXPATHL);
         p = p_dir;
@@ -4078,7 +4078,7 @@ skip:
             // the line as reference, because the substitute may
             // have changed the number of characters.  Same for
             // "prev_matchcol".
-            STRCAT(new_start, sub_firstline + copycol);
+            strcat(new_start, sub_firstline + copycol);
             matchcol = (colnr_T)strlen(sub_firstline) - matchcol;
             prev_matchcol = (colnr_T)strlen(sub_firstline)
                             - prev_matchcol;
@@ -4303,7 +4303,7 @@ bool do_sub_msg(bool count_only)
        || count_only)
       && messaging()) {
     if (got_int) {
-      STRCPY(msg_buf, _("(Interrupted) "));
+      strcpy(msg_buf, _("(Interrupted) "));
     } else {
       *msg_buf = NUL;
     }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1454,7 +1454,7 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   }
   // Fail if command is invalid
   if (eap->cmdidx == CMD_SIZE) {
-    STRCPY(IObuff, _(e_not_an_editor_command));
+    strcpy(IObuff, _(e_not_an_editor_command));
     // If the modifier was parsed OK the error must be in the following command
     char *cmdname = after_modifier ? after_modifier : cmdline;
     append_command(cmdname);
@@ -2044,7 +2044,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
   // Check for wrong commands.
   if (ea.cmdidx == CMD_SIZE) {
     if (!ea.skip) {
-      STRCPY(IObuff, _(e_not_an_editor_command));
+      strcpy(IObuff, _(e_not_an_editor_command));
       // If the modifier was parsed OK the error must be in the following
       // command
       char *cmdname = after_modifier ? after_modifier : *cmdlinep;
@@ -2321,7 +2321,7 @@ doend:
   if (errormsg != NULL && *errormsg != NUL && !did_emsg) {
     if (flags & DOCMD_VERBOSE) {
       if (errormsg != IObuff) {
-        STRCPY(IObuff, errormsg);
+        strcpy(IObuff, errormsg);
         errormsg = IObuff;
       }
       append_command(*ea.cmdlinep);
@@ -2886,14 +2886,14 @@ static void append_command(char *cmd)
     // Not enough space, truncate and put in "...".
     d = IObuff + IOSIZE - 100;
     d -= utf_head_off(IObuff, d);
-    STRCPY(d, "...");
+    strcpy(d, "...");
   }
-  STRCAT(IObuff, ": ");
+  strcat(IObuff, ": ");
   d = IObuff + strlen(IObuff);
   while (*s != NUL && d - IObuff + 5 < IOSIZE) {
     if ((uint8_t)s[0] == 0xc2 && (uint8_t)s[1] == 0xa0) {
       s += 2;
-      STRCPY(d, "<a0>");
+      strcpy(d, "<a0>");
       d += 4;
     } else if (d - IObuff + utfc_ptr2len(s) + 1 >= IOSIZE) {
       break;
@@ -3743,9 +3743,9 @@ char *replace_makeprg(exarg_T *eap, char *arg, char **cmdlinep)
     if ((new_cmdline = strrep(program, "$*", arg)) == NULL) {
       // No $* in arg, build "<makeprg> <arg>" instead
       new_cmdline = xmalloc(strlen(program) + strlen(arg) + 2);
-      STRCPY(new_cmdline, program);
-      STRCAT(new_cmdline, " ");
-      STRCAT(new_cmdline, arg);
+      strcpy(new_cmdline, program);
+      strcat(new_cmdline, " ");
+      strcat(new_cmdline, arg);
     }
 
     msg_make(arg);
@@ -3943,12 +3943,12 @@ static char *repl_cmdline(exarg_T *eap, char *src, size_t srclen, char *repl, ch
 
   memmove(new_cmdline + i, repl, len);
   i += len;                             // remember the end of the string
-  STRCPY(new_cmdline + i, src + srclen);
+  strcpy(new_cmdline + i, src + srclen);
   src = new_cmdline + i;                // remember where to continue
 
   if (eap->nextcmd != NULL) {           // append next command
     i = strlen(new_cmdline) + 1;
-    STRCPY(new_cmdline + i, eap->nextcmd);
+    strcpy(new_cmdline + i, eap->nextcmd);
     eap->nextcmd = new_cmdline + i;
   }
   eap->cmd = new_cmdline + (eap->cmd - *cmdlinep);
@@ -7065,9 +7065,9 @@ char *expand_sfile(char *arg)
       size_t len = strlen(result) - srclen + strlen(repl) + 1;
       char *newres = xmalloc(len);
       memmove(newres, result, (size_t)(p - result));
-      STRCPY(newres + (p - result), repl);
+      strcpy(newres + (p - result), repl);
       len = strlen(newres);
-      STRCAT(newres, p + srclen);
+      strcat(newres, p + srclen);
       xfree(repl);
       xfree(result);
       result = newres;

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -390,8 +390,8 @@ char *get_exception_string(void *value, except_type_T type, char *cmdname, int *
     if (cmdname != NULL && *cmdname != NUL) {
       size_t cmdlen = strlen(cmdname);
       ret = xstrnsave("Vim(", 4 + cmdlen + 2 + strlen(mesg));
-      STRCPY(&ret[4], cmdname);
-      STRCPY(&ret[4 + cmdlen], "):");
+      strcpy(&ret[4], cmdname);
+      strcpy(&ret[4 + cmdlen], "):");
       val = ret + 4 + cmdlen + 2;
     } else {
       ret = xstrnsave("Vim:", 4 + strlen(mesg));
@@ -411,7 +411,7 @@ char *get_exception_string(void *value, except_type_T type, char *cmdname, int *
                           || (ascii_isdigit(p[3])
                               && p[4] == ':')))))) {
         if (*p == NUL || p == mesg) {
-          STRCAT(val, mesg);  // 'E123' missing or at beginning
+          strcat(val, mesg);  // 'E123' missing or at beginning
         } else {
           // '"filename" E123: message text'
           if (mesg[0] != '"' || p - 2 < &mesg[1]
@@ -420,7 +420,7 @@ char *get_exception_string(void *value, except_type_T type, char *cmdname, int *
             continue;
           }
 
-          STRCAT(val, p);
+          strcat(val, p);
           p[-2] = NUL;
           snprintf(val + strlen(p), strlen(" (%s)"), " (%s)", &mesg[1]);
           p[-2] = '"';

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -984,7 +984,7 @@ static int command_line_handle_ctrl_bsl(CommandLineState *s)
         int len = (int)strlen(p);
         realloc_cmdbuff(len + 1);
         ccline.cmdlen = len;
-        STRCPY(ccline.cmdbuff, p);
+        strcpy(ccline.cmdbuff, p);
         xfree(p);
 
         // Restore the cursor or use the position set with
@@ -1782,7 +1782,7 @@ static int command_line_browse_history(CommandLineState *s)
       ccline.cmdbuff[len] = NUL;
     } else {
       alloc_cmdbuff((int)strlen(p));
-      STRCPY(ccline.cmdbuff, p);
+      strcpy(ccline.cmdbuff, p);
     }
 
     ccline.cmdpos = ccline.cmdlen = (int)strlen(ccline.cmdbuff);
@@ -4008,7 +4008,7 @@ void escape_fname(char **pp)
 {
   char *p = xmalloc(strlen(*pp) + 2);
   p[0] = '\\';
-  STRCPY(p + 1, *pp);
+  strcpy(p + 1, *pp);
   xfree(*pp);
   *pp = p;
 }
@@ -4162,7 +4162,7 @@ static int set_cmdline_str(const char *str, int pos)
   int len = (int)strlen(str);
   realloc_cmdbuff(len + 1);
   p->cmdlen = len;
-  STRCPY(p->cmdbuff, str);
+  strcpy(p->cmdbuff, str);
 
   p->cmdpos = pos < 0 || pos > p->cmdlen ? p->cmdlen : pos;
   new_cmdpos = p->cmdpos;

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1100,7 +1100,7 @@ static char *get_view_file(int c)
     }
   }
   char *retval = xmalloc(strlen(sname) + len + strlen(p_vdir) + 9);
-  STRCPY(retval, p_vdir);
+  strcpy(retval, p_vdir);
   add_pathsep(retval);
   char *s = retval + strlen(retval);
   for (char *p = sname; *p; p++) {

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -442,16 +442,16 @@ void *vim_findfile_init(char *path, char *filename, char *stopdirs, int level, i
     emsg(_(e_path_too_long_for_completion));
     goto error_return;
   }
-  STRCPY(ff_expand_buffer, search_ctx->ffsc_start_dir);
+  strcpy(ff_expand_buffer, search_ctx->ffsc_start_dir);
   add_pathsep(ff_expand_buffer);
   {
     size_t eb_len = strlen(ff_expand_buffer);
     char *buf = xmalloc(eb_len + strlen(search_ctx->ffsc_fix_path) + 1);
 
-    STRCPY(buf, ff_expand_buffer);
-    STRCPY(buf + eb_len, search_ctx->ffsc_fix_path);
+    strcpy(buf, ff_expand_buffer);
+    strcpy(buf + eb_len, search_ctx->ffsc_fix_path);
     if (os_isdir(buf)) {
-      STRCAT(ff_expand_buffer, search_ctx->ffsc_fix_path);
+      strcat(ff_expand_buffer, search_ctx->ffsc_fix_path);
       add_pathsep(ff_expand_buffer);
     } else {
       char *p = path_tail(search_ctx->ffsc_fix_path);
@@ -478,8 +478,8 @@ void *vim_findfile_init(char *path, char *filename, char *stopdirs, int level, i
         temp = xmalloc(strlen(search_ctx->ffsc_wc_path)
                        + strlen(search_ctx->ffsc_fix_path + len)
                        + 1);
-        STRCPY(temp, search_ctx->ffsc_fix_path + len);
-        STRCAT(temp, search_ctx->ffsc_wc_path);
+        strcpy(temp, search_ctx->ffsc_fix_path + len);
+        strcat(temp, search_ctx->ffsc_wc_path);
         xfree(search_ctx->ffsc_wc_path);
         xfree(wc_path);
         search_ctx->ffsc_wc_path = temp;
@@ -659,7 +659,7 @@ char *vim_findfile(void *search_ctx_arg)
             ff_free_stack_element(stackp);
             goto fail;
           }
-          STRCPY(file_path, search_ctx->ffsc_start_dir);
+          strcpy(file_path, search_ctx->ffsc_start_dir);
           if (!add_pathsep(file_path)) {
             ff_free_stack_element(stackp);
             goto fail;
@@ -671,7 +671,7 @@ char *vim_findfile(void *search_ctx_arg)
           ff_free_stack_element(stackp);
           goto fail;
         }
-        STRCAT(file_path, stackp->ffs_fix_path);
+        strcat(file_path, stackp->ffs_fix_path);
         if (!add_pathsep(file_path)) {
           ff_free_stack_element(stackp);
           goto fail;
@@ -766,12 +766,12 @@ char *vim_findfile(void *search_ctx_arg)
               ff_free_stack_element(stackp);
               goto fail;
             }
-            STRCPY(file_path, stackp->ffs_filearray[i]);
+            strcpy(file_path, stackp->ffs_filearray[i]);
             if (!add_pathsep(file_path)) {
               ff_free_stack_element(stackp);
               goto fail;
             }
-            STRCAT(file_path, search_ctx->ffsc_file_to_search);
+            strcat(file_path, search_ctx->ffsc_file_to_search);
 
             // Try without extra suffix and then with suffixes
             // from 'suffixesadd'.
@@ -908,11 +908,11 @@ char *vim_findfile(void *search_ctx_arg)
           + strlen(search_ctx->ffsc_fix_path) >= MAXPATHL) {
         goto fail;
       }
-      STRCPY(file_path, search_ctx->ffsc_start_dir);
+      strcpy(file_path, search_ctx->ffsc_start_dir);
       if (!add_pathsep(file_path)) {
         goto fail;
       }
-      STRCAT(file_path, search_ctx->ffsc_fix_path);
+      strcat(file_path, search_ctx->ffsc_fix_path);
 
       // create a new stack entry
       sptr = ff_create_stack_element(file_path,
@@ -1099,7 +1099,7 @@ static int ff_check_visited(ff_visited_T **visited_list, char *fname, char *wc_p
     vp->ffv_fname[0] = NUL;
   } else {
     vp->file_id_valid = false;
-    STRCPY(vp->ffv_fname, ff_expand_buffer);
+    strcpy(vp->ffv_fname, ff_expand_buffer);
   }
 
   if (wc_path != NULL) {
@@ -1410,11 +1410,11 @@ char *find_file_in_path_option(char *ptr, size_t len, int options, int first, ch
             && (options & FNAME_REL)
             && rel_fname != NULL
             && strlen(rel_fname) + l < MAXPATHL) {
-          STRCPY(NameBuff, rel_fname);
-          STRCPY(path_tail(NameBuff), *file_to_find);
+          strcpy(NameBuff, rel_fname);
+          strcpy(path_tail(NameBuff), *file_to_find);
           l = strlen(NameBuff);
         } else {
-          STRCPY(NameBuff, *file_to_find);
+          strcpy(NameBuff, *file_to_find);
           run = 2;
         }
 
@@ -1538,7 +1538,7 @@ void do_autocmd_dirchanged(char *new_dir, CdScope scope, CdCause cause, bool pre
 
 #ifdef BACKSLASH_IN_FILENAME
   char new_dir_buf[MAXPATHL];
-  STRCPY(new_dir_buf, new_dir);
+  strcpy(new_dir_buf, new_dir);
   slash_adjust(new_dir_buf);
   new_dir = new_dir_buf;
 #endif

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1693,22 +1693,22 @@ failed:
 
 #ifdef UNIX
       if (S_ISFIFO(perm)) {             // fifo
-        STRCAT(IObuff, _("[fifo]"));
+        strcat(IObuff, _("[fifo]"));
         c = true;
       }
       if (S_ISSOCK(perm)) {            // or socket
-        STRCAT(IObuff, _("[socket]"));
+        strcat(IObuff, _("[socket]"));
         c = true;
       }
 # ifdef OPEN_CHR_FILES
       if (S_ISCHR(perm)) {                          // or character special
-        STRCAT(IObuff, _("[character special]"));
+        strcat(IObuff, _("[character special]"));
         c = true;
       }
 # endif
 #endif
       if (curbuf->b_p_ro) {
-        STRCAT(IObuff, shortmess(SHM_RO) ? _("[RO]") : _("[readonly]"));
+        strcat(IObuff, shortmess(SHM_RO) ? _("[RO]") : _("[readonly]"));
         c = true;
       }
       if (read_no_eol_lnum) {
@@ -1716,18 +1716,18 @@ failed:
         c = true;
       }
       if (ff_error == EOL_DOS) {
-        STRCAT(IObuff, _("[CR missing]"));
+        strcat(IObuff, _("[CR missing]"));
         c = true;
       }
       if (split) {
-        STRCAT(IObuff, _("[long lines split]"));
+        strcat(IObuff, _("[long lines split]"));
         c = true;
       }
       if (notconverted) {
-        STRCAT(IObuff, _("[NOT converted]"));
+        strcat(IObuff, _("[NOT converted]"));
         c = true;
       } else if (converted) {
-        STRCAT(IObuff, _("[converted]"));
+        strcat(IObuff, _("[converted]"));
         c = true;
       }
       if (conv_error != 0) {
@@ -1739,7 +1739,7 @@ failed:
                  _("[ILLEGAL BYTE in line %" PRId64 "]"), (int64_t)illegal_byte);
         c = true;
       } else if (error) {
-        STRCAT(IObuff, _("[READ ERRORS]"));
+        strcat(IObuff, _("[READ ERRORS]"));
         c = true;
       }
       if (msg_add_fileformat(fileformat)) {
@@ -2128,17 +2128,17 @@ bool msg_add_fileformat(int eol_type)
 {
 #ifndef USE_CRNL
   if (eol_type == EOL_DOS) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[dos]") : _("[dos format]"));
+    strcat(IObuff, shortmess(SHM_TEXT) ? _("[dos]") : _("[dos format]"));
     return true;
   }
 #endif
   if (eol_type == EOL_MAC) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"));
+    strcat(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"));
     return true;
   }
 #ifdef USE_CRNL
   if (eol_type == EOL_UNIX) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"));
+    strcat(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"));
     return true;
   }
 #endif
@@ -2170,7 +2170,7 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
 /// Append message for missing line separator to IObuff.
 void msg_add_eol(void)
 {
-  STRCAT(IObuff,
+  strcat(IObuff,
          shortmess(SHM_LAST) ? _("[noeol]") : _("[Incomplete last line]"));
 }
 
@@ -2623,7 +2623,7 @@ static int rename_with_tmp(const char *const from, const char *const to)
   }
 
   char tempname[MAXPATHL + 1];
-  STRCPY(tempname, from);
+  strcpy(tempname, from);
   for (int n = 123; n < 99999; n++) {
     char *tail = path_tail(tempname);
     snprintf(tail, (size_t)((MAXPATHL + 1) - (tail - tempname - 1)), "%d", n);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1612,15 +1612,15 @@ static void foldAddMarker(buf_T *buf, pos_T pos, const char *marker, size_t mark
   // Check if the line ends with an unclosed comment
   skip_comment(line, false, false, &line_is_comment);
   newline = xmalloc(line_len + markerlen + strlen(cms) + 1);
-  STRCPY(newline, line);
+  strcpy(newline, line);
   // Append the marker to the end of the line
   if (p == NULL || line_is_comment) {
     xstrlcpy(newline + line_len, marker, markerlen + 1);
     added = markerlen;
   } else {
-    STRCPY(newline + line_len, cms);
+    strcpy(newline + line_len, cms);
     memcpy(newline + line_len + (p - cms), marker, markerlen);
-    STRCPY(newline + line_len + (p - cms) + markerlen, p + 2);
+    strcpy(newline + line_len + (p - cms) + markerlen, p + 2);
     added = markerlen + strlen(cms) - 2;
   }
   ml_replace_buf(buf, lnum, newline, false);
@@ -1686,7 +1686,7 @@ static void foldDelMarker(buf_T *buf, linenr_T lnum, char *marker, size_t marker
       char *newline = xmalloc(strlen(line) - len + 1);
       assert(p >= line);
       memcpy(newline, line, (size_t)(p - line));
-      STRCPY(newline + (p - line), p + len);
+      strcpy(newline + (p - line), p + len);
       ml_replace_buf(buf, lnum, newline, false);
       extmark_splice_cols(buf, (int)lnum - 1, (int)(p - line),
                           (int)len, 0, kExtmarkUndo);
@@ -3295,7 +3295,7 @@ void f_foldtext(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     char *r = xmalloc(len);
     snprintf(r, len, txt, dashes, count);
     len = strlen(r);
-    STRCAT(r, s);
+    strcat(r, s);
     // remove 'foldmarker' and 'commentstring'
     foldtext_cleanup(r + len);
     rettv->vval.v_string = r;

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -387,7 +387,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
     // '*'are changed to "star", otherwise '*' is recognized as a wildcard.
     for (int i = 0; except_tbl[i][0] != NULL; i++) {
       if (strcmp(arg, except_tbl[i][0]) == 0) {
-        STRCPY(d, except_tbl[i][1]);
+        strcpy(d, except_tbl[i][1]);
         break;
       }
     }
@@ -406,7 +406,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
       vim_snprintf(d, IOSIZE, "/\\\\%s", arg + 1);
       // Check for "/\\_$", should be "/\\_\$"
       if (d[3] == '_' && d[4] == '$') {
-        STRCPY(d + 4, "\\$");
+        strcpy(d + 4, "\\$");
       }
     } else {
       // Replace:
@@ -435,11 +435,11 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
         }
         switch (*s) {
         case '|':
-          STRCPY(d, "bar");
+          strcpy(d, "bar");
           d += 3;
           continue;
         case '"':
-          STRCPY(d, "quote");
+          strcpy(d, "quote");
           d += 5;
           continue;
         case '*':
@@ -464,7 +464,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
           if (d > IObuff && d[-1] != '_' && d[-1] != '\\') {
             *d++ = '_';                 // prepend a '_' to make x_CTRL-x
           }
-          STRCPY(d, "CTRL-");
+          strcpy(d, "CTRL-");
           d += 5;
           if (*s < ' ') {
             *d++ = (char)(*s + '@');
@@ -489,7 +489,7 @@ int find_help_tags(const char *arg, int *num_matches, char ***matches, bool keep
         // "CTRL-\_" -> "CTRL-\\_" to avoid the special meaning of "\_" in
         // "CTRL-\_CTRL-N"
         if (STRNICMP(s, "CTRL-\\_", 7) == 0) {
-          STRCPY(d, "CTRL-\\\\");
+          strcpy(d, "CTRL-\\\\");
           d += 7;
           s += 6;
         }
@@ -1142,16 +1142,16 @@ static void do_helptags(char *dirname, bool add_help_tags, bool ignore_writeerr)
 
   // Loop over the found languages to generate a tags file for each one.
   for (j = 0; j < ga.ga_len; j += 2) {
-    STRCPY(fname, "tags-xx");
+    strcpy(fname, "tags-xx");
     fname[5] = ((char *)ga.ga_data)[j];
     fname[6] = ((char *)ga.ga_data)[j + 1];
     if (fname[5] == 'e' && fname[6] == 'n') {
       // English is an exception: use ".txt" and "tags".
       fname[4] = NUL;
-      STRCPY(ext, ".txt");
+      strcpy(ext, ".txt");
     } else {
       // Language "ab" uses ".abx" and "tags-ab".
-      STRCPY(ext, ".xxx");
+      strcpy(ext, ".xxx");
       ext[1] = fname[5];
       ext[2] = fname[6];
     }

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -2018,12 +2018,12 @@ int get_c_indent(void)
       }
       (void)copy_option_part(&p, lead_end, COM_MAX_LEN, ",");
       if (what == COM_START) {
-        STRCPY(lead_start, lead_end);
+        strcpy(lead_start, lead_end);
         lead_start_len = (int)strlen(lead_start);
         start_off = off;
         start_align = align;
       } else if (what == COM_MIDDLE) {
-        STRCPY(lead_middle, lead_end);
+        strcpy(lead_middle, lead_end);
         lead_middle_len = (int)strlen(lead_middle);
       } else if (what == COM_END) {
         // If our line starts with the middle comment string, line it

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -669,7 +669,7 @@ static char *ins_compl_infercase_gettext(const char *str, int char_len, int comp
       // growarray.  Add the character in the next round.
       ga_grow(&gap, IOSIZE);
       *p = NUL;
-      STRCPY(gap.ga_data, IObuff);
+      strcpy((char *)gap.ga_data, IObuff);
       gap.ga_len = (int)strlen(IObuff);
     } else {
       p += utf_char2bytes(wca[i++], p);
@@ -3832,7 +3832,7 @@ static int get_normal_compl_info(char *line, int startcol, colnr_T curs_col)
             && (vim_iswordp(mb_prevptr(line, line + compl_col))))) {
       prefix = "";
     }
-    STRCPY(compl_pattern, prefix);
+    strcpy(compl_pattern, prefix);
     (void)quote_meta(compl_pattern + strlen(prefix),
                      line + compl_col, compl_length);
   } else if (--startcol < 0
@@ -3860,12 +3860,12 @@ static int get_normal_compl_info(char *line, int startcol, colnr_T curs_col)
       // there's no need to call quote_meta,
       // xmalloc(7) is enough  -- Acevedo
       compl_pattern = xmalloc(7);
-      STRCPY(compl_pattern, "\\<");
+      strcpy(compl_pattern, "\\<");
       (void)quote_meta(compl_pattern + 2, line + compl_col, 1);
-      STRCAT(compl_pattern, "\\k");
+      strcat(compl_pattern, "\\k");
     } else {
       compl_pattern = xmalloc(quote_meta(NULL, line + compl_col, compl_length) + 2);
-      STRCPY(compl_pattern, "\\<");
+      strcpy(compl_pattern, "\\<");
       (void)quote_meta(compl_pattern + 2, line + compl_col, compl_length);
     }
   }

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -551,7 +551,7 @@ char *get_special_key_name(int c, int modifiers)
     size_t len = strlen(key_names_table[table_idx].name);
 
     if ((int)len + idx + 2 <= MAX_KEY_NAME_LEN) {
-      STRCPY(string + idx, key_names_table[table_idx].name);
+      strcpy(string + idx, key_names_table[table_idx].name);
       idx += (int)len;
     }
   }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1541,7 +1541,7 @@ void show_utf8(void)
     if (clen == 0) {
       // start of (composing) character, get its length
       if (i > 0) {
-        STRCPY(IObuff + rlen, "+ ");
+        strcpy(IObuff + rlen, "+ ");
         rlen += 2;
       }
       clen = utf_ptr2len(line + i);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1847,7 +1847,7 @@ char *ml_get_buf(buf_T *buf, linenr_T lnum, bool will_change)
     }
     ml_flush_line(buf);
 errorret:
-    STRCPY(questions, "???");
+    strcpy(questions, "???");
     buf->b_ml.ml_line_lnum = lnum;
     return questions;
   }
@@ -3084,13 +3084,13 @@ int resolve_symlink(const char *fname, char *buf)
     // portion of the filename (if any) and the path the symlink
     // points to.
     if (path_is_absolute(buf)) {
-      STRCPY(tmp, buf);
+      strcpy(tmp, buf);
     } else {
       char *tail = path_tail(tmp);
       if (strlen(tail) + strlen(buf) >= MAXPATHL) {
         return FAIL;
       }
-      STRCPY(tail, buf);
+      strcpy(tail, buf);
     }
   }
 

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -438,10 +438,10 @@ static int add_menu_path(const char *const menu_path, vimmenu_T *menuarg, const 
           menu->strings[i] = xmalloc(strlen(call_data) + 5);
           menu->strings[i][0] = c;
           if (d == 0) {
-            STRCPY(menu->strings[i] + 1, call_data);
+            strcpy(menu->strings[i] + 1, call_data);
           } else {
             menu->strings[i][1] = d;
-            STRCPY(menu->strings[i] + 2, call_data);
+            strcpy(menu->strings[i] + 2, call_data);
           }
           if (c == Ctrl_C) {
             int len = (int)strlen(menu->strings[i]);
@@ -1076,7 +1076,7 @@ char *get_menu_names(expand_T *xp, int idx)
       }
       // hack on menu separators:  use a 'magic' char for the separator
       // so that '.' in names gets escaped properly
-      STRCAT(tbuffer, "\001");
+      strcat(tbuffer, "\001");
       str = tbuffer;
     } else {
       if (should_advance) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3690,7 +3690,7 @@ static void copy_hotkeys_and_msg(const char *message, char *buttons, int default
                                  const bool has_hotkey[], char *hotkeys_ptr)
 {
   *confirm_msg = '\n';
-  STRCPY(confirm_msg + 1, message);
+  strcpy(confirm_msg + 1, message);
 
   char *msgp = confirm_msg + 1 + strlen(message);
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1931,7 +1931,7 @@ bool add_to_showcmd(int c)
 
   char *p = transchar(c);
   if (*p == ' ') {
-    STRCPY(p, "<20>");
+    strcpy(p, "<20>");
   }
   size_t old_len = strlen(showcmd_buf);
   size_t extra_len = strlen(p);
@@ -1940,7 +1940,7 @@ bool add_to_showcmd(int c)
     size_t overflow = old_len + extra_len - limit;
     memmove(showcmd_buf, showcmd_buf + overflow, old_len - overflow + 1);
   }
-  STRCAT(showcmd_buf, p);
+  strcat(showcmd_buf, p);
 
   if (char_avail()) {
     return false;
@@ -1982,7 +1982,7 @@ static void del_from_showcmd(int len)
 void push_showcmd(void)
 {
   if (p_sc) {
-    STRCPY(old_showcmd_buf, showcmd_buf);
+    strcpy(old_showcmd_buf, showcmd_buf);
   }
 }
 
@@ -1992,7 +1992,7 @@ void pop_showcmd(void)
     return;
   }
 
-  STRCPY(showcmd_buf, old_showcmd_buf);
+  strcpy(showcmd_buf, old_showcmd_buf);
 
   display_showcmd();
 }
@@ -3362,7 +3362,7 @@ static size_t nv_K_getcmd(cmdarg_T *cap, char *kp, bool kp_help, bool kp_ex, cha
 {
   if (kp_help) {
     // in the help buffer
-    STRCPY(buf, "he! ");
+    strcpy(buf, "he! ");
     return n;
   }
 
@@ -3371,8 +3371,8 @@ static size_t nv_K_getcmd(cmdarg_T *cap, char *kp, bool kp_help, bool kp_ex, cha
     if (cap->count0 != 0) {  // Send the count to the ex command.
       snprintf(buf, buf_size, "%" PRId64, (int64_t)(cap->count0));
     }
-    STRCAT(buf, kp);
-    STRCAT(buf, " ");
+    strcat(buf, kp);
+    strcat(buf, " ");
     return n;
   }
 
@@ -3401,17 +3401,17 @@ static size_t nv_K_getcmd(cmdarg_T *cap, char *kp, bool kp_help, bool kp_ex, cha
   }
 
   do_cmdline_cmd("tabnew");
-  STRCAT(buf, "terminal ");
+  strcat(buf, "terminal ");
   if (cap->count0 == 0 && isman_s) {
-    STRCAT(buf, "man");
+    strcat(buf, "man");
   } else {
-    STRCAT(buf, kp);
+    strcat(buf, kp);
   }
-  STRCAT(buf, " ");
+  strcat(buf, " ");
   if (cap->count0 != 0 && (isman || isman_s)) {
     snprintf(buf + strlen(buf), buf_size - strlen(buf), "%" PRId64,
              (int64_t)cap->count0);
-    STRCAT(buf, " ");
+    strcat(buf, " ");
   }
 
   *ptr_arg = ptr;
@@ -3489,7 +3489,7 @@ static void nv_ident(cmdarg_T *cap)
     curwin->w_cursor.col = (colnr_T)(ptr - get_cursor_line_ptr());
 
     if (!g_cmd && vim_iswordp(ptr)) {
-      STRCPY(buf, "\\<");
+      strcpy(buf, "\\<");
     }
     no_smartcase = true;                // don't use 'smartcase' now
     break;
@@ -3503,16 +3503,16 @@ static void nv_ident(cmdarg_T *cap)
 
   case ']':
     tag_cmd = true;
-    STRCPY(buf, "ts ");
+    strcpy(buf, "ts ");
     break;
 
   default:
     tag_cmd = true;
     if (curbuf->b_help) {
-      STRCPY(buf, "he! ");
+      strcpy(buf, "he! ");
     } else {
       if (g_cmd) {
-        STRCPY(buf, "tj ");
+        strcpy(buf, "tj ");
       } else {
         snprintf(buf, buf_size, "%" PRId64 "ta ", (int64_t)cap->count0);
       }
@@ -3532,7 +3532,7 @@ static void nv_ident(cmdarg_T *cap)
     xfree(ptr);
     char *newbuf = xrealloc(buf, strlen(buf) + strlen(p) + 1);
     buf = newbuf;
-    STRCAT(buf, p);
+    strcat(buf, p);
     xfree(p);
   } else {
     char *aux_ptr;
@@ -3572,7 +3572,7 @@ static void nv_ident(cmdarg_T *cap)
   if (cmdchar == '*' || cmdchar == '#') {
     if (!g_cmd
         && vim_iswordp(mb_prevptr(get_cursor_line_ptr(), ptr))) {
-      STRCAT(buf, "\\>");
+      strcat(buf, "\\>");
     }
 
     // put pattern in search history

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -995,9 +995,9 @@ static int stuff_yank(int regname, char *p)
   if (is_append_register(regname) && reg->y_array != NULL) {
     char **pp = &(reg->y_array[reg->y_size - 1]);
     char *lp = xmalloc(strlen(*pp) + strlen(p) + 1);
-    STRCPY(lp, *pp);
+    strcpy(lp, *pp);
     // TODO(philix): use xstpcpy() in stuff_yank()
-    STRCAT(lp, p);
+    strcat(lp, p);
     xfree(p);
     xfree(*pp);
     *pp = lp;
@@ -2758,8 +2758,8 @@ static void op_yank_reg(oparg_T *oap, bool message, yankreg_T *reg, bool append)
         && vim_strchr(p_cpo, CPO_REGAPPEND) == NULL) {
       pnew = xmalloc(strlen(curr->y_array[curr->y_size - 1])
                      + strlen(reg->y_array[0]) + 1);
-      STRCPY(pnew, curr->y_array[--j]);
-      STRCAT(pnew, reg->y_array[0]);
+      strcpy(pnew, curr->y_array[--j]);
+      strcat(pnew, reg->y_array[0]);
       xfree(curr->y_array[j]);
       xfree(reg->y_array[0]);
       curr->y_array[j++] = pnew;
@@ -3534,8 +3534,8 @@ void do_put(int regname, yankreg_T *reg, int dir, long count, int flags)
           ptr = ml_get(lnum) + col;
           totlen = strlen(y_array[y_size - 1]);
           newp = xmalloc((size_t)(strlen(ptr) + totlen + 1));
-          STRCPY(newp, y_array[y_size - 1]);
-          STRCAT(newp, ptr);
+          strcpy(newp, y_array[y_size - 1]);
+          strcat(newp, ptr);
           // insert second line
           ml_append(lnum, newp, (colnr_T)0, false);
           new_lnum++;
@@ -4806,7 +4806,7 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
       }
     }
     *ptr = NUL;
-    STRCAT(buf1, buf2);
+    strcat(buf1, buf2);
     ins_str(buf1);              // insert the new number
     endpos = curwin->w_cursor;
     if (curwin->w_cursor.col) {
@@ -4988,7 +4988,7 @@ void *get_reg_contents(int regname, int flags)
   // Copy the lines of the yank register into the string.
   len = 0;
   for (size_t i = 0; i < reg->y_size; i++) {
-    STRCPY(retval + len, reg->y_array[i]);
+    strcpy(retval + len, reg->y_array[i]);
     len += strlen(retval + len);
 
     // Insert a NL between lines and after the last line if y_type is

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -225,11 +225,11 @@ static void set_init_default_backupskip(void)
           == NULL) {
         ga_grow(&ga, (int)len);
         if (!GA_EMPTY(&ga)) {
-          STRCAT(ga.ga_data, ",");
+          strcat((char *)ga.ga_data, ",");
         }
-        STRCAT(ga.ga_data, p);
+        strcat((char *)ga.ga_data, p);
         add_pathsep(ga.ga_data);
-        STRCAT(ga.ga_data, "*");
+        strcat((char *)ga.ga_data, "*");
         ga.ga_len += (int)len;
       }
       xfree(item);
@@ -993,7 +993,7 @@ static char *stropt_expand_envvar(int opt_idx, char *origval, char *newval, set_
     newlen += (unsigned)strlen(origval) + 1;
   }
   newval = xmalloc(newlen);
-  STRCPY(newval, s);
+  strcpy(newval, s);
 
   return newval;
 }
@@ -1030,7 +1030,7 @@ static void stropt_remove_val(char *origval, char *newval, uint32_t flags, char 
 {
   // Remove newval[] from origval[]. (Note: "len" has been set above
   // and is used here).
-  STRCPY(newval, origval);
+  strcpy(newval, origval);
   if (*strval) {
     // may need to remove a comma
     if (flags & P_COMMA) {
@@ -1123,7 +1123,7 @@ static char *stropt_get_newval(int nextchar, int opt_idx, char **argp, char *var
       // do not add if already there
       if ((op == OP_ADDING || op == OP_PREPENDING) && s != NULL) {
         op = OP_NONE;
-        STRCPY(newval, origval);
+        strcpy(newval, origval);
       }
 
       // if no duplicate, move pointer to end of original value
@@ -1626,7 +1626,7 @@ int do_set(char *arg, int opt_flags)
           int i = (int)strlen(IObuff) + 2;
           if (i + (arg - startarg) < IOSIZE) {
             // append the argument with the error
-            STRCAT(IObuff, ": ");
+            strcat(IObuff, ": ");
             assert(arg >= startarg);
             memmove(IObuff + i, startarg, (size_t)(arg - startarg));
             IObuff[i + (arg - startarg)] = NUL;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2249,7 +2249,7 @@ void save_clear_shm_value(void)
   }
 
   if (++set_shm_recursive == 1) {
-    STRCPY(shm_buf, p_shm);
+    strcpy(shm_buf, p_shm);
     set_option_value_give_err("shm", 0L, "", 0);
   }
 }

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -699,7 +699,7 @@ void expand_env_esc(char *restrict srcp, char *restrict dst, int dstlen, bool es
 
       if (var != NULL && *var != NUL
           && (strlen(var) + strlen(tail) + 1 < (unsigned)dstlen)) {
-        STRCPY(dst, var);
+        strcpy(dst, var);
         dstlen -= (int)strlen(var);
         int c = (int)strlen(var);
         // if var[] ends in a path separator and tail[] starts

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -243,15 +243,15 @@ int os_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, in
   if (shell_style == STYLE_BT) {
     // change `command; command& ` to (command; command )
     if (is_fish_shell) {
-      STRCPY(command, "begin; ");
+      strcpy(command, "begin; ");
     } else {
-      STRCPY(command, "(");
+      strcpy(command, "(");
     }
-    STRCAT(command, pat[0] + 1);                // exclude first backtick
+    strcat(command, pat[0] + 1);                // exclude first backtick
     p = command + strlen(command) - 1;
     if (is_fish_shell) {
       *p-- = ';';
-      STRCAT(command, " end");
+      strcat(command, " end");
     } else {
       *p-- = ')';                                 // remove last backtick
     }
@@ -262,31 +262,31 @@ int os_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, in
       ampersand = true;
       *p = ' ';
     }
-    STRCAT(command, ">");
+    strcat(command, ">");
   } else {
-    STRCPY(command, "");
+    strcpy(command, "");
     if (shell_style == STYLE_GLOB) {
       // Assume the nonomatch option is valid only for csh like shells,
       // otherwise, this may set the positional parameters for the shell,
       // e.g. "$*".
       if (flags & EW_NOTFOUND) {
-        STRCAT(command, "set nonomatch; ");
+        strcat(command, "set nonomatch; ");
       } else {
-        STRCAT(command, "unset nonomatch; ");
+        strcat(command, "unset nonomatch; ");
       }
     }
     if (shell_style == STYLE_GLOB) {
-      STRCAT(command, "glob >");
+      strcat(command, "glob >");
     } else if (shell_style == STYLE_PRINT) {
-      STRCAT(command, "print -N >");
+      strcat(command, "print -N >");
     } else if (shell_style == STYLE_VIMGLOB) {
-      STRCAT(command, sh_vimglob_func);
+      strcat(command, sh_vimglob_func);
     } else {
-      STRCAT(command, "echo >");
+      strcat(command, "echo >");
     }
   }
 
-  STRCAT(command, tempname);
+  strcat(command, tempname);
 
   if (shell_style != STYLE_BT) {
     for (i = 0; i < num_pat; i++) {
@@ -330,7 +330,7 @@ int os_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, in
   }
 
   if (ampersand) {
-    STRCAT(command, "&");               // put the '&' after the redirection
+    strcat(command, "&");               // put the '&' after the redirection
   }
 
   // Using zsh -G: If a pattern has no matches, it is just deleted from
@@ -535,7 +535,7 @@ int os_expand_wildcards(int num_pat, char **pat, int *num_file, char ***file, in
     }
 
     p = xmalloc(strlen((*file)[i]) + 1 + dir);
-    STRCPY(p, (*file)[i]);
+    strcpy(p, (*file)[i]);
     if (dir) {
       add_pathsep(p);             // add '/' to a directory name
     }

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -130,7 +130,7 @@ char *get_xdg_home(const XDGVarType idx)
     xstrlcpy(IObuff, appname, appname_len + 1);
 #if defined(MSWIN)
     if (idx == kXDGDataHome || idx == kXDGStateHome) {
-      STRCAT(IObuff, "-data");
+      strcat(IObuff, "-data");
     }
 #endif
     dir = concat_fnames_realloc(dir, IObuff, true);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -717,7 +717,7 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
   // is following then find matches without any directory.
   if (!didstar && stardepth < 100 && starstar && e - s == 2
       && *path_end == '/') {
-    STRCPY(s, path_end + 1);
+    strcpy(s, path_end + 1);
     stardepth++;
     (void)do_path_expand(gap, buf, (size_t)(s - buf), flags, true);
     stardepth--;
@@ -739,20 +739,20 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
           && ((regmatch.regprog != NULL && vim_regexec(&regmatch, name, 0))
               || ((flags & EW_NOTWILD)
                   && path_fnamencmp(path + (s - buf), name, (size_t)(e - s)) == 0))) {
-        STRCPY(s, name);
+        strcpy(s, name);
         len = strlen(buf);
 
         if (starstar && stardepth < 100) {
           // For "**" in the pattern first go deeper in the tree to
           // find matches.
-          STRCPY(buf + len, "/**");  // NOLINT
-          STRCPY(buf + len + 3, path_end);
+          strcpy(buf + len, "/**");  // NOLINT
+          strcpy(buf + len + 3, path_end);
           stardepth++;
           (void)do_path_expand(gap, buf, len + 1, flags, true);
           stardepth--;
         }
 
-        STRCPY(buf + len, path_end);
+        strcpy(buf + len, path_end);
         if (path_has_exp_wildcard(path_end)) {      // handle more wildcards
           // need to expand another component of the path
           // remove backslashes for the remaining components only
@@ -869,7 +869,7 @@ static void expand_path_option(char *curdir, garray_T *gap)
       memmove(buf, curbuf->b_ffname, len);
       simplify_filename(buf);
     } else if (buf[0] == NUL) {
-      STRCPY(buf, curdir);  // relative to current directory
+      strcpy(buf, curdir);  // relative to current directory
     } else if (path_with_url(buf)) {
       continue;  // URL can't be used here
     } else if (!path_is_absolute(buf)) {
@@ -879,7 +879,7 @@ static void expand_path_option(char *curdir, garray_T *gap)
         continue;
       }
       STRMOVE(buf + len + 1, buf);
-      STRCPY(buf, curdir);
+      strcpy(buf, curdir);
       buf[len] = PATHSEP;
       simplify_filename(buf);
     }
@@ -951,7 +951,7 @@ static void uniquefy_paths(garray_T *gap, char *pattern)
   char *file_pattern = xmalloc(len + 2);
   file_pattern[0] = '*';
   file_pattern[1] = NUL;
-  STRCAT(file_pattern, pattern);
+  strcat(file_pattern, pattern);
   char *pat = file_pat_to_reg_pat(file_pattern, NULL, NULL, true);
   xfree(file_pattern);
   if (pat == NULL) {
@@ -1026,7 +1026,7 @@ static void uniquefy_paths(garray_T *gap, char *pattern)
       //     c:\file.txt           c:\           .\file.txt
       short_name = path_shorten_fname(path, curdir);
       if (short_name != NULL && short_name > path + 1) {
-        STRCPY(path, ".");
+        strcpy(path, ".");
         add_pathsep(path);
         STRMOVE(path + strlen(path), short_name);
       }
@@ -1050,14 +1050,14 @@ static void uniquefy_paths(garray_T *gap, char *pattern)
       short_name = path;
     }
     if (is_unique(short_name, gap, i)) {
-      STRCPY(fnames[i], short_name);
+      strcpy(fnames[i], short_name);
       continue;
     }
 
     rel_path = xmalloc(strlen(short_name) + strlen(PATHSEPSTR) + 2);
-    STRCPY(rel_path, ".");
+    strcpy(rel_path, ".");
     add_pathsep(rel_path);
-    STRCAT(rel_path, short_name);
+    strcat(rel_path, short_name);
 
     xfree(fnames[i]);
     fnames[i] = rel_path;
@@ -1481,7 +1481,7 @@ void addfile(garray_T *gap, char *f, int flags)
 
   char *p = xmalloc(strlen(f) + 1 + isdir);
 
-  STRCPY(p, f);
+  strcpy(p, f);
 #ifdef BACKSLASH_IN_FILENAME
   slash_adjust(p);
 #endif
@@ -1937,7 +1937,7 @@ void path_fix_case(char *name)
       FileInfo file_info_new;
       if (os_fileinfo_link(newname, &file_info_new)
           && os_fileinfo_id_equal(&file_info, &file_info_new)) {
-        STRCPY(tail, entry);
+        strcpy(tail, entry);
         break;
       }
     }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -430,7 +430,7 @@ static char *efmpat_to_regpat(const char *efmpat, char *regpat, efm_T *efminfo, 
     // Also match "c:" in the file name, even when
     // checking for a colon next: "%f:".
     // "\%(\a:\)\="
-    STRCPY(regpat, "\\%(\\a:\\)\\=");
+    strcpy(regpat, "\\%(\\a:\\)\\=");
     regpat += 10;
   }
 #endif
@@ -441,12 +441,12 @@ static char *efmpat_to_regpat(const char *efmpat, char *regpat, efm_T *efminfo, 
       // the file name.  Use ".\{-1,}x" instead (x is
       // the next character), the requirement that :999:
       // follows should work.
-      STRCPY(regpat, ".\\{-1,}");
+      strcpy(regpat, ".\\{-1,}");
       regpat += 7;
     } else {
       // File name followed by '\\' or '%': include as
       // many file name chars as possible.
-      STRCPY(regpat, "\\f\\+");
+      strcpy(regpat, "\\f\\+");
       regpat += 4;
     }
   } else {
@@ -1461,7 +1461,7 @@ static int qf_parse_fmt_s(regmatch_T *rmp, int midx, qffields_T *fields)
   if (len > CMDBUFFSIZE - 5) {
     len = CMDBUFFSIZE - 5;
   }
-  STRCPY(fields->pattern, "^\\V");
+  strcpy(fields->pattern, "^\\V");
   xstrlcat(fields->pattern, rmp->startp[midx], len + 4);
   fields->pattern[len + 3] = '\\';
   fields->pattern[len + 4] = '$';
@@ -1659,7 +1659,7 @@ static int qf_parse_multiline_pfx(int idx, qf_list_T *qfl, qffields_T *fields)
       size_t errlen  = strlen(fields->errmsg);
       qfprev->qf_text = xrealloc(qfprev->qf_text, textlen + errlen + 2);
       qfprev->qf_text[textlen] = '\n';
-      STRCPY(qfprev->qf_text + textlen + 1, fields->errmsg);
+      strcpy(qfprev->qf_text + textlen + 1, fields->errmsg);
     }
     if (qfprev->qf_nr == -1) {
       qfprev->qf_nr = fields->enr;
@@ -4422,9 +4422,9 @@ static char *get_mef_name(void)
       off += 19;
     }
     name = xmalloc(strlen(p_mef) + 30);
-    STRCPY(name, p_mef);
+    strcpy(name, p_mef);
     snprintf(name + (p - p_mef), strlen(name), "%d%d", start, off);
-    STRCAT(name, p + 2);
+    strcat(name, p + 2);
     // Don't accept a symbolic link, it's a security risk.
     FileInfo file_info;
     bool file_or_link_found = os_fileinfo_link(name, &file_info);
@@ -7086,7 +7086,7 @@ static void hgr_search_files_in_dir(qf_list_T *qfl, char *dirname, regmatch_T *p
 
   // Find all "*.txt" and "*.??x" files in the "doc" directory.
   add_pathsep(dirname);
-  STRCAT(dirname, "doc/*.\\(txt\\|??x\\)");  // NOLINT
+  strcat(dirname, "doc/*.\\(txt\\|??x\\)");  // NOLINT
   if (gen_expand_wildcards(1, &dirname, &fcount, &fnames, EW_FILE|EW_SILENT) == OK
       && fcount > 0) {
     for (int fi = 0; fi < fcount && !got_int; fi++) {

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1269,7 +1269,7 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
         reg_tofree = xmalloc((size_t)len);
         reg_tofreelen = (unsigned)len;
       }
-      STRCPY(reg_tofree, rex.line);
+      strcpy((char *)reg_tofree, (const char *)rex.line);
       rex.input = reg_tofree + (rex.input - rex.line);
       rex.line = reg_tofree;
     }
@@ -1557,7 +1557,7 @@ char *regtilde(char *source, int magic, bool preview)
         if (!magic) {
           p++;                                // back off backslash
         }
-        STRCPY(tmpsub + len + prevlen, p + 1);
+        strcpy(tmpsub + len + prevlen, p + 1);
 
         if (newsub != source) {               // already allocated newsub
           xfree(newsub);
@@ -1766,7 +1766,7 @@ static int vim_regsub_both(char *source, typval_T *expr, char *dest, int destlen
     // "flags & REGSUB_COPY" != 0.
     if (copy) {
       if (eval_result[nested] != NULL) {
-        STRCPY(dest, eval_result[nested]);
+        strcpy(dest, eval_result[nested]);
         dst += strlen(eval_result[nested]);
         XFREE_CLEAR(eval_result[nested]);
       }
@@ -2171,7 +2171,7 @@ char *reg_submatch(int no)
         // lines completely and end line up to end col.
         len = (ssize_t)strlen(s);
         if (round == 2) {
-          STRCPY(retval, s);
+          strcpy(retval, s);
           retval[len] = '\n';
         }
         len++;
@@ -2179,7 +2179,7 @@ char *reg_submatch(int no)
         while (lnum < rsm.sm_mmatch->endpos[no].lnum) {
           s = reg_getline_submatch(lnum++);
           if (round == 2) {
-            STRCPY(retval + len, s);
+            strcpy(retval + len, s);
           }
           len += (ssize_t)strlen(s);
           if (round == 2) {

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -5290,7 +5290,7 @@ static uint8_t *regprop(uint8_t *op)
   char *p;
   static char buf[50];
 
-  STRCPY(buf, ":");
+  strcpy(buf, ":");
 
   switch ((int)OP(op)) {
   case BOL:
@@ -5655,7 +5655,7 @@ static uint8_t *regprop(uint8_t *op)
     break;
   }
   if (p != NULL) {
-    STRCAT(buf, p);
+    strcat(buf, p);
   }
   return (uint8_t *)buf;
 }

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2937,106 +2937,106 @@ static void nfa_set_code(int c)
     c -= NFA_ADD_NL;
   }
 
-  STRCPY(code, "");
+  strcpy((char *)code, "");
   switch (c) {
   case NFA_MATCH:
-    STRCPY(code, "NFA_MATCH "); break;
+    strcpy((char *)code, "NFA_MATCH "); break;
   case NFA_SPLIT:
-    STRCPY(code, "NFA_SPLIT "); break;
+    strcpy((char *)code, "NFA_SPLIT "); break;
   case NFA_CONCAT:
-    STRCPY(code, "NFA_CONCAT "); break;
+    strcpy((char *)code, "NFA_CONCAT "); break;
   case NFA_NEWL:
-    STRCPY(code, "NFA_NEWL "); break;
+    strcpy((char *)code, "NFA_NEWL "); break;
   case NFA_ZSTART:
-    STRCPY(code, "NFA_ZSTART"); break;
+    strcpy((char *)code, "NFA_ZSTART"); break;
   case NFA_ZEND:
-    STRCPY(code, "NFA_ZEND"); break;
+    strcpy((char *)code, "NFA_ZEND"); break;
 
   case NFA_BACKREF1:
-    STRCPY(code, "NFA_BACKREF1"); break;
+    strcpy((char *)code, "NFA_BACKREF1"); break;
   case NFA_BACKREF2:
-    STRCPY(code, "NFA_BACKREF2"); break;
+    strcpy((char *)code, "NFA_BACKREF2"); break;
   case NFA_BACKREF3:
-    STRCPY(code, "NFA_BACKREF3"); break;
+    strcpy((char *)code, "NFA_BACKREF3"); break;
   case NFA_BACKREF4:
-    STRCPY(code, "NFA_BACKREF4"); break;
+    strcpy((char *)code, "NFA_BACKREF4"); break;
   case NFA_BACKREF5:
-    STRCPY(code, "NFA_BACKREF5"); break;
+    strcpy((char *)code, "NFA_BACKREF5"); break;
   case NFA_BACKREF6:
-    STRCPY(code, "NFA_BACKREF6"); break;
+    strcpy((char *)code, "NFA_BACKREF6"); break;
   case NFA_BACKREF7:
-    STRCPY(code, "NFA_BACKREF7"); break;
+    strcpy((char *)code, "NFA_BACKREF7"); break;
   case NFA_BACKREF8:
-    STRCPY(code, "NFA_BACKREF8"); break;
+    strcpy((char *)code, "NFA_BACKREF8"); break;
   case NFA_BACKREF9:
-    STRCPY(code, "NFA_BACKREF9"); break;
+    strcpy((char *)code, "NFA_BACKREF9"); break;
   case NFA_ZREF1:
-    STRCPY(code, "NFA_ZREF1"); break;
+    strcpy((char *)code, "NFA_ZREF1"); break;
   case NFA_ZREF2:
-    STRCPY(code, "NFA_ZREF2"); break;
+    strcpy((char *)code, "NFA_ZREF2"); break;
   case NFA_ZREF3:
-    STRCPY(code, "NFA_ZREF3"); break;
+    strcpy((char *)code, "NFA_ZREF3"); break;
   case NFA_ZREF4:
-    STRCPY(code, "NFA_ZREF4"); break;
+    strcpy((char *)code, "NFA_ZREF4"); break;
   case NFA_ZREF5:
-    STRCPY(code, "NFA_ZREF5"); break;
+    strcpy((char *)code, "NFA_ZREF5"); break;
   case NFA_ZREF6:
-    STRCPY(code, "NFA_ZREF6"); break;
+    strcpy((char *)code, "NFA_ZREF6"); break;
   case NFA_ZREF7:
-    STRCPY(code, "NFA_ZREF7"); break;
+    strcpy((char *)code, "NFA_ZREF7"); break;
   case NFA_ZREF8:
-    STRCPY(code, "NFA_ZREF8"); break;
+    strcpy((char *)code, "NFA_ZREF8"); break;
   case NFA_ZREF9:
-    STRCPY(code, "NFA_ZREF9"); break;
+    strcpy((char *)code, "NFA_ZREF9"); break;
   case NFA_SKIP:
-    STRCPY(code, "NFA_SKIP"); break;
+    strcpy((char *)code, "NFA_SKIP"); break;
 
   case NFA_PREV_ATOM_NO_WIDTH:
-    STRCPY(code, "NFA_PREV_ATOM_NO_WIDTH"); break;
+    strcpy((char *)code, "NFA_PREV_ATOM_NO_WIDTH"); break;
   case NFA_PREV_ATOM_NO_WIDTH_NEG:
-    STRCPY(code, "NFA_PREV_ATOM_NO_WIDTH_NEG"); break;
+    strcpy((char *)code, "NFA_PREV_ATOM_NO_WIDTH_NEG"); break;
   case NFA_PREV_ATOM_JUST_BEFORE:
-    STRCPY(code, "NFA_PREV_ATOM_JUST_BEFORE"); break;
+    strcpy((char *)code, "NFA_PREV_ATOM_JUST_BEFORE"); break;
   case NFA_PREV_ATOM_JUST_BEFORE_NEG:
-    STRCPY(code, "NFA_PREV_ATOM_JUST_BEFORE_NEG"); break;
+    strcpy((char *)code, "NFA_PREV_ATOM_JUST_BEFORE_NEG"); break;
   case NFA_PREV_ATOM_LIKE_PATTERN:
-    STRCPY(code, "NFA_PREV_ATOM_LIKE_PATTERN"); break;
+    strcpy((char *)code, "NFA_PREV_ATOM_LIKE_PATTERN"); break;
 
   case NFA_NOPEN:
-    STRCPY(code, "NFA_NOPEN"); break;
+    strcpy((char *)code, "NFA_NOPEN"); break;
   case NFA_NCLOSE:
-    STRCPY(code, "NFA_NCLOSE"); break;
+    strcpy((char *)code, "NFA_NCLOSE"); break;
   case NFA_START_INVISIBLE:
-    STRCPY(code, "NFA_START_INVISIBLE"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE"); break;
   case NFA_START_INVISIBLE_FIRST:
-    STRCPY(code, "NFA_START_INVISIBLE_FIRST"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_FIRST"); break;
   case NFA_START_INVISIBLE_NEG:
-    STRCPY(code, "NFA_START_INVISIBLE_NEG"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_NEG"); break;
   case NFA_START_INVISIBLE_NEG_FIRST:
-    STRCPY(code, "NFA_START_INVISIBLE_NEG_FIRST"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_NEG_FIRST"); break;
   case NFA_START_INVISIBLE_BEFORE:
-    STRCPY(code, "NFA_START_INVISIBLE_BEFORE"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_BEFORE"); break;
   case NFA_START_INVISIBLE_BEFORE_FIRST:
-    STRCPY(code, "NFA_START_INVISIBLE_BEFORE_FIRST"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_BEFORE_FIRST"); break;
   case NFA_START_INVISIBLE_BEFORE_NEG:
-    STRCPY(code, "NFA_START_INVISIBLE_BEFORE_NEG"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_BEFORE_NEG"); break;
   case NFA_START_INVISIBLE_BEFORE_NEG_FIRST:
-    STRCPY(code, "NFA_START_INVISIBLE_BEFORE_NEG_FIRST"); break;
+    strcpy((char *)code, "NFA_START_INVISIBLE_BEFORE_NEG_FIRST"); break;
   case NFA_START_PATTERN:
-    STRCPY(code, "NFA_START_PATTERN"); break;
+    strcpy((char *)code, "NFA_START_PATTERN"); break;
   case NFA_END_INVISIBLE:
-    STRCPY(code, "NFA_END_INVISIBLE"); break;
+    strcpy((char *)code, "NFA_END_INVISIBLE"); break;
   case NFA_END_INVISIBLE_NEG:
-    STRCPY(code, "NFA_END_INVISIBLE_NEG"); break;
+    strcpy((char *)code, "NFA_END_INVISIBLE_NEG"); break;
   case NFA_END_PATTERN:
-    STRCPY(code, "NFA_END_PATTERN"); break;
+    strcpy((char *)code, "NFA_END_PATTERN"); break;
 
   case NFA_COMPOSING:
-    STRCPY(code, "NFA_COMPOSING"); break;
+    strcpy((char *)code, "NFA_COMPOSING"); break;
   case NFA_END_COMPOSING:
-    STRCPY(code, "NFA_END_COMPOSING"); break;
+    strcpy((char *)code, "NFA_END_COMPOSING"); break;
   case NFA_OPT_CHARS:
-    STRCPY(code, "NFA_OPT_CHARS"); break;
+    strcpy((char *)code, "NFA_OPT_CHARS"); break;
 
   case NFA_MOPEN:
   case NFA_MOPEN1:
@@ -3048,7 +3048,7 @@ static void nfa_set_code(int c)
   case NFA_MOPEN7:
   case NFA_MOPEN8:
   case NFA_MOPEN9:
-    STRCPY(code, "NFA_MOPEN(x)");
+    strcpy((char *)code, "NFA_MOPEN(x)");
     code[10] = c - NFA_MOPEN + '0';
     break;
   case NFA_MCLOSE:
@@ -3061,7 +3061,7 @@ static void nfa_set_code(int c)
   case NFA_MCLOSE7:
   case NFA_MCLOSE8:
   case NFA_MCLOSE9:
-    STRCPY(code, "NFA_MCLOSE(x)");
+    strcpy((char *)code, "NFA_MCLOSE(x)");
     code[11] = c - NFA_MCLOSE + '0';
     break;
   case NFA_ZOPEN:
@@ -3074,7 +3074,7 @@ static void nfa_set_code(int c)
   case NFA_ZOPEN7:
   case NFA_ZOPEN8:
   case NFA_ZOPEN9:
-    STRCPY(code, "NFA_ZOPEN(x)");
+    strcpy((char *)code, "NFA_ZOPEN(x)");
     code[10] = c - NFA_ZOPEN + '0';
     break;
   case NFA_ZCLOSE:
@@ -3087,189 +3087,189 @@ static void nfa_set_code(int c)
   case NFA_ZCLOSE7:
   case NFA_ZCLOSE8:
   case NFA_ZCLOSE9:
-    STRCPY(code, "NFA_ZCLOSE(x)");
+    strcpy((char *)code, "NFA_ZCLOSE(x)");
     code[11] = c - NFA_ZCLOSE + '0';
     break;
   case NFA_EOL:
-    STRCPY(code, "NFA_EOL "); break;
+    strcpy((char *)code, "NFA_EOL "); break;
   case NFA_BOL:
-    STRCPY(code, "NFA_BOL "); break;
+    strcpy((char *)code, "NFA_BOL "); break;
   case NFA_EOW:
-    STRCPY(code, "NFA_EOW "); break;
+    strcpy((char *)code, "NFA_EOW "); break;
   case NFA_BOW:
-    STRCPY(code, "NFA_BOW "); break;
+    strcpy((char *)code, "NFA_BOW "); break;
   case NFA_EOF:
-    STRCPY(code, "NFA_EOF "); break;
+    strcpy((char *)code, "NFA_EOF "); break;
   case NFA_BOF:
-    STRCPY(code, "NFA_BOF "); break;
+    strcpy((char *)code, "NFA_BOF "); break;
   case NFA_LNUM:
-    STRCPY(code, "NFA_LNUM "); break;
+    strcpy((char *)code, "NFA_LNUM "); break;
   case NFA_LNUM_GT:
-    STRCPY(code, "NFA_LNUM_GT "); break;
+    strcpy((char *)code, "NFA_LNUM_GT "); break;
   case NFA_LNUM_LT:
-    STRCPY(code, "NFA_LNUM_LT "); break;
+    strcpy((char *)code, "NFA_LNUM_LT "); break;
   case NFA_COL:
-    STRCPY(code, "NFA_COL "); break;
+    strcpy((char *)code, "NFA_COL "); break;
   case NFA_COL_GT:
-    STRCPY(code, "NFA_COL_GT "); break;
+    strcpy((char *)code, "NFA_COL_GT "); break;
   case NFA_COL_LT:
-    STRCPY(code, "NFA_COL_LT "); break;
+    strcpy((char *)code, "NFA_COL_LT "); break;
   case NFA_VCOL:
-    STRCPY(code, "NFA_VCOL "); break;
+    strcpy((char *)code, "NFA_VCOL "); break;
   case NFA_VCOL_GT:
-    STRCPY(code, "NFA_VCOL_GT "); break;
+    strcpy((char *)code, "NFA_VCOL_GT "); break;
   case NFA_VCOL_LT:
-    STRCPY(code, "NFA_VCOL_LT "); break;
+    strcpy((char *)code, "NFA_VCOL_LT "); break;
   case NFA_MARK:
-    STRCPY(code, "NFA_MARK "); break;
+    strcpy((char *)code, "NFA_MARK "); break;
   case NFA_MARK_GT:
-    STRCPY(code, "NFA_MARK_GT "); break;
+    strcpy((char *)code, "NFA_MARK_GT "); break;
   case NFA_MARK_LT:
-    STRCPY(code, "NFA_MARK_LT "); break;
+    strcpy((char *)code, "NFA_MARK_LT "); break;
   case NFA_CURSOR:
-    STRCPY(code, "NFA_CURSOR "); break;
+    strcpy((char *)code, "NFA_CURSOR "); break;
   case NFA_VISUAL:
-    STRCPY(code, "NFA_VISUAL "); break;
+    strcpy((char *)code, "NFA_VISUAL "); break;
   case NFA_ANY_COMPOSING:
-    STRCPY(code, "NFA_ANY_COMPOSING "); break;
+    strcpy((char *)code, "NFA_ANY_COMPOSING "); break;
 
   case NFA_STAR:
-    STRCPY(code, "NFA_STAR "); break;
+    strcpy((char *)code, "NFA_STAR "); break;
   case NFA_STAR_NONGREEDY:
-    STRCPY(code, "NFA_STAR_NONGREEDY "); break;
+    strcpy((char *)code, "NFA_STAR_NONGREEDY "); break;
   case NFA_QUEST:
-    STRCPY(code, "NFA_QUEST"); break;
+    strcpy((char *)code, "NFA_QUEST"); break;
   case NFA_QUEST_NONGREEDY:
-    STRCPY(code, "NFA_QUEST_NON_GREEDY"); break;
+    strcpy((char *)code, "NFA_QUEST_NON_GREEDY"); break;
   case NFA_EMPTY:
-    STRCPY(code, "NFA_EMPTY"); break;
+    strcpy((char *)code, "NFA_EMPTY"); break;
   case NFA_OR:
-    STRCPY(code, "NFA_OR"); break;
+    strcpy((char *)code, "NFA_OR"); break;
 
   case NFA_START_COLL:
-    STRCPY(code, "NFA_START_COLL"); break;
+    strcpy((char *)code, "NFA_START_COLL"); break;
   case NFA_END_COLL:
-    STRCPY(code, "NFA_END_COLL"); break;
+    strcpy((char *)code, "NFA_END_COLL"); break;
   case NFA_START_NEG_COLL:
-    STRCPY(code, "NFA_START_NEG_COLL"); break;
+    strcpy((char *)code, "NFA_START_NEG_COLL"); break;
   case NFA_END_NEG_COLL:
-    STRCPY(code, "NFA_END_NEG_COLL"); break;
+    strcpy((char *)code, "NFA_END_NEG_COLL"); break;
   case NFA_RANGE:
-    STRCPY(code, "NFA_RANGE"); break;
+    strcpy((char *)code, "NFA_RANGE"); break;
   case NFA_RANGE_MIN:
-    STRCPY(code, "NFA_RANGE_MIN"); break;
+    strcpy((char *)code, "NFA_RANGE_MIN"); break;
   case NFA_RANGE_MAX:
-    STRCPY(code, "NFA_RANGE_MAX"); break;
+    strcpy((char *)code, "NFA_RANGE_MAX"); break;
 
   case NFA_CLASS_ALNUM:
-    STRCPY(code, "NFA_CLASS_ALNUM"); break;
+    strcpy((char *)code, "NFA_CLASS_ALNUM"); break;
   case NFA_CLASS_ALPHA:
-    STRCPY(code, "NFA_CLASS_ALPHA"); break;
+    strcpy((char *)code, "NFA_CLASS_ALPHA"); break;
   case NFA_CLASS_BLANK:
-    STRCPY(code, "NFA_CLASS_BLANK"); break;
+    strcpy((char *)code, "NFA_CLASS_BLANK"); break;
   case NFA_CLASS_CNTRL:
-    STRCPY(code, "NFA_CLASS_CNTRL"); break;
+    strcpy((char *)code, "NFA_CLASS_CNTRL"); break;
   case NFA_CLASS_DIGIT:
-    STRCPY(code, "NFA_CLASS_DIGIT"); break;
+    strcpy((char *)code, "NFA_CLASS_DIGIT"); break;
   case NFA_CLASS_GRAPH:
-    STRCPY(code, "NFA_CLASS_GRAPH"); break;
+    strcpy((char *)code, "NFA_CLASS_GRAPH"); break;
   case NFA_CLASS_LOWER:
-    STRCPY(code, "NFA_CLASS_LOWER"); break;
+    strcpy((char *)code, "NFA_CLASS_LOWER"); break;
   case NFA_CLASS_PRINT:
-    STRCPY(code, "NFA_CLASS_PRINT"); break;
+    strcpy((char *)code, "NFA_CLASS_PRINT"); break;
   case NFA_CLASS_PUNCT:
-    STRCPY(code, "NFA_CLASS_PUNCT"); break;
+    strcpy((char *)code, "NFA_CLASS_PUNCT"); break;
   case NFA_CLASS_SPACE:
-    STRCPY(code, "NFA_CLASS_SPACE"); break;
+    strcpy((char *)code, "NFA_CLASS_SPACE"); break;
   case NFA_CLASS_UPPER:
-    STRCPY(code, "NFA_CLASS_UPPER"); break;
+    strcpy((char *)code, "NFA_CLASS_UPPER"); break;
   case NFA_CLASS_XDIGIT:
-    STRCPY(code, "NFA_CLASS_XDIGIT"); break;
+    strcpy((char *)code, "NFA_CLASS_XDIGIT"); break;
   case NFA_CLASS_TAB:
-    STRCPY(code, "NFA_CLASS_TAB"); break;
+    strcpy((char *)code, "NFA_CLASS_TAB"); break;
   case NFA_CLASS_RETURN:
-    STRCPY(code, "NFA_CLASS_RETURN"); break;
+    strcpy((char *)code, "NFA_CLASS_RETURN"); break;
   case NFA_CLASS_BACKSPACE:
-    STRCPY(code, "NFA_CLASS_BACKSPACE"); break;
+    strcpy((char *)code, "NFA_CLASS_BACKSPACE"); break;
   case NFA_CLASS_ESCAPE:
-    STRCPY(code, "NFA_CLASS_ESCAPE"); break;
+    strcpy((char *)code, "NFA_CLASS_ESCAPE"); break;
   case NFA_CLASS_IDENT:
-    STRCPY(code, "NFA_CLASS_IDENT"); break;
+    strcpy((char *)code, "NFA_CLASS_IDENT"); break;
   case NFA_CLASS_KEYWORD:
-    STRCPY(code, "NFA_CLASS_KEYWORD"); break;
+    strcpy((char *)code, "NFA_CLASS_KEYWORD"); break;
   case NFA_CLASS_FNAME:
-    STRCPY(code, "NFA_CLASS_FNAME"); break;
+    strcpy((char *)code, "NFA_CLASS_FNAME"); break;
 
   case NFA_ANY:
-    STRCPY(code, "NFA_ANY"); break;
+    strcpy((char *)code, "NFA_ANY"); break;
   case NFA_IDENT:
-    STRCPY(code, "NFA_IDENT"); break;
+    strcpy((char *)code, "NFA_IDENT"); break;
   case NFA_SIDENT:
-    STRCPY(code, "NFA_SIDENT"); break;
+    strcpy((char *)code, "NFA_SIDENT"); break;
   case NFA_KWORD:
-    STRCPY(code, "NFA_KWORD"); break;
+    strcpy((char *)code, "NFA_KWORD"); break;
   case NFA_SKWORD:
-    STRCPY(code, "NFA_SKWORD"); break;
+    strcpy((char *)code, "NFA_SKWORD"); break;
   case NFA_FNAME:
-    STRCPY(code, "NFA_FNAME"); break;
+    strcpy((char *)code, "NFA_FNAME"); break;
   case NFA_SFNAME:
-    STRCPY(code, "NFA_SFNAME"); break;
+    strcpy((char *)code, "NFA_SFNAME"); break;
   case NFA_PRINT:
-    STRCPY(code, "NFA_PRINT"); break;
+    strcpy((char *)code, "NFA_PRINT"); break;
   case NFA_SPRINT:
-    STRCPY(code, "NFA_SPRINT"); break;
+    strcpy((char *)code, "NFA_SPRINT"); break;
   case NFA_WHITE:
-    STRCPY(code, "NFA_WHITE"); break;
+    strcpy((char *)code, "NFA_WHITE"); break;
   case NFA_NWHITE:
-    STRCPY(code, "NFA_NWHITE"); break;
+    strcpy((char *)code, "NFA_NWHITE"); break;
   case NFA_DIGIT:
-    STRCPY(code, "NFA_DIGIT"); break;
+    strcpy((char *)code, "NFA_DIGIT"); break;
   case NFA_NDIGIT:
-    STRCPY(code, "NFA_NDIGIT"); break;
+    strcpy((char *)code, "NFA_NDIGIT"); break;
   case NFA_HEX:
-    STRCPY(code, "NFA_HEX"); break;
+    strcpy((char *)code, "NFA_HEX"); break;
   case NFA_NHEX:
-    STRCPY(code, "NFA_NHEX"); break;
+    strcpy((char *)code, "NFA_NHEX"); break;
   case NFA_OCTAL:
-    STRCPY(code, "NFA_OCTAL"); break;
+    strcpy((char *)code, "NFA_OCTAL"); break;
   case NFA_NOCTAL:
-    STRCPY(code, "NFA_NOCTAL"); break;
+    strcpy((char *)code, "NFA_NOCTAL"); break;
   case NFA_WORD:
-    STRCPY(code, "NFA_WORD"); break;
+    strcpy((char *)code, "NFA_WORD"); break;
   case NFA_NWORD:
-    STRCPY(code, "NFA_NWORD"); break;
+    strcpy((char *)code, "NFA_NWORD"); break;
   case NFA_HEAD:
-    STRCPY(code, "NFA_HEAD"); break;
+    strcpy((char *)code, "NFA_HEAD"); break;
   case NFA_NHEAD:
-    STRCPY(code, "NFA_NHEAD"); break;
+    strcpy((char *)code, "NFA_NHEAD"); break;
   case NFA_ALPHA:
-    STRCPY(code, "NFA_ALPHA"); break;
+    strcpy((char *)code, "NFA_ALPHA"); break;
   case NFA_NALPHA:
-    STRCPY(code, "NFA_NALPHA"); break;
+    strcpy((char *)code, "NFA_NALPHA"); break;
   case NFA_LOWER:
-    STRCPY(code, "NFA_LOWER"); break;
+    strcpy((char *)code, "NFA_LOWER"); break;
   case NFA_NLOWER:
-    STRCPY(code, "NFA_NLOWER"); break;
+    strcpy((char *)code, "NFA_NLOWER"); break;
   case NFA_UPPER:
-    STRCPY(code, "NFA_UPPER"); break;
+    strcpy((char *)code, "NFA_UPPER"); break;
   case NFA_NUPPER:
-    STRCPY(code, "NFA_NUPPER"); break;
+    strcpy((char *)code, "NFA_NUPPER"); break;
   case NFA_LOWER_IC:
-    STRCPY(code, "NFA_LOWER_IC"); break;
+    strcpy((char *)code, "NFA_LOWER_IC"); break;
   case NFA_NLOWER_IC:
-    STRCPY(code, "NFA_NLOWER_IC"); break;
+    strcpy((char *)code, "NFA_NLOWER_IC"); break;
   case NFA_UPPER_IC:
-    STRCPY(code, "NFA_UPPER_IC"); break;
+    strcpy((char *)code, "NFA_UPPER_IC"); break;
   case NFA_NUPPER_IC:
-    STRCPY(code, "NFA_NUPPER_IC"); break;
+    strcpy((char *)code, "NFA_NUPPER_IC"); break;
 
   default:
-    STRCPY(code, "CHAR(x)");
+    strcpy((char *)code, "CHAR(x)");
     code[5] = c;
   }
 
   if (addnl == true) {
-    STRCAT(code, " + NEWLINE ");
+    strcat((char *)code, " + NEWLINE ");
   }
 }
 

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -452,7 +452,7 @@ int do_in_cached_path(char *name, int flags, DoInRuntimepathCB callback, void *c
     if (name == NULL) {
       (*callback)(item.path, cookie);
     } else if (buflen + strlen(name) + 2 < MAXPATHL) {
-      STRCPY(buf, item.path);
+      strcpy(buf, item.path);
       add_pathsep(buf);
       tail = buf + strlen(buf);
 
@@ -1547,7 +1547,7 @@ static inline char *add_dir(char *dest, const char *const dir, const size_t dir_
     xstrlcpy(IObuff, appname, appname_len + 1);
 #if defined(MSWIN)
     if (type == kXDGDataHome || type == kXDGStateHome) {
-      STRCAT(IObuff, "-data");
+      strcat(IObuff, "-data");
       appname_len += 5;
     }
 #endif

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -326,7 +326,7 @@ bool sha256_self_test(void)
       hexit = sha256_bytes((uint8_t *)sha_self_test_msg[i],
                            strlen(sha_self_test_msg[i]),
                            NULL, 0);
-      STRCPY(output, hexit);
+      strcpy(output, hexit);
     } else {
       sha256_start(&ctx);
       memset(buf, 'a', 1000);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -105,7 +105,7 @@ static signgroup_T *sign_group_ref(const char *groupname)
     // new group
     group = xmalloc(offsetof(signgroup_T, sg_name) + strlen(groupname) + 1);
 
-    STRCPY(group->sg_name, groupname);
+    strcpy(group->sg_name, groupname);
     group->sg_refcount = 1;
     group->sg_next_sign_id = 1;
     hash_add_item(&sg_table, hi, group->sg_name, hash);
@@ -944,7 +944,7 @@ static int sign_define_init_text(sign_T *sp, char *text)
   sp->sn_text = xstrnsave(text, len);
 
   if (cells == 1) {
-    STRCPY(sp->sn_text + len - 1, " ");
+    strcpy(sp->sn_text + len - 1, " ");
   }
 
   return OK;

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1317,7 +1317,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
     // possible.  Note: this ml_get_buf() may make "line" invalid, check
     // for empty line first.
     bool empty_line = *skipwhite(line) == NUL;
-    STRCPY(buf, line);
+    strcpy(buf, line);
     if (lnum < wp->w_buffer->b_ml.ml_line_count) {
       spell_cat_line(buf + strlen(buf),
                      ml_get_buf(wp->w_buffer, lnum + 1, false),
@@ -1520,7 +1520,7 @@ static void spell_load_lang(char *lang)
 
   // Copy the language name to pass it to spell_load_cb() as a cookie.
   // It's truncated when an error is detected.
-  STRCPY(sl.sl_lang, lang);
+  strcpy(sl.sl_lang, lang);
   sl.sl_slang = NULL;
   sl.sl_nobreak = false;
 
@@ -1567,7 +1567,7 @@ static void spell_load_lang(char *lang)
     }
   } else if (sl.sl_slang != NULL) {
     // At least one file was loaded, now load ALL the additions.
-    STRCPY(fname_enc + strlen(fname_enc) - 3, "add.spl");
+    strcpy(fname_enc + strlen(fname_enc) - 3, "add.spl");
     do_in_runtimepath(fname_enc, DIP_ALL, spell_load_cb, &sl);
   }
 
@@ -2040,7 +2040,7 @@ char *parse_spelllang(win_T *wp)
     } else {
       // One entry in 'spellfile'.
       copy_option_part(&spf, spf_name, MAXPATHL - 5, ",");
-      STRCAT(spf_name, ".spl");
+      strcat(spf_name, ".spl");
 
       // If it was already found above then skip it.
       for (c = 0; c < ga.ga_len; c++) {
@@ -2067,7 +2067,7 @@ char *parse_spelllang(win_T *wp)
       // region name, the region is ignored otherwise.  for int_wordlist
       // use an arbitrary name.
       if (round == 0) {
-        STRCPY(lang, "internal wordlist");
+        strcpy(lang, "internal wordlist");
       } else {
         xstrlcpy(lang, path_tail(spf_name), MAXWLEN + 1);
         p = vim_strchr(lang, '.');
@@ -2620,8 +2620,8 @@ void ex_spellrepall(exarg_T *eap)
                                repl_to, strlen(repl_to)) != 0) {
       char *p = xmalloc(strlen(line) + (size_t)addlen + 1);
       memmove(p, line, (size_t)curwin->w_cursor.col);
-      STRCPY(p + curwin->w_cursor.col, repl_to);
-      STRCAT(p, line + curwin->w_cursor.col + strlen(repl_from));
+      strcpy(p + curwin->w_cursor.col, repl_to);
+      strcat(p, line + curwin->w_cursor.col + strlen(repl_from));
       ml_replace(curwin->w_cursor.lnum, p, false);
       changed_bytes(curwin->w_cursor.lnum, curwin->w_cursor.col);
 
@@ -2718,7 +2718,7 @@ void make_case_word(char *fword, char *cword, int flags)
     onecap_copy(fword, cword, true);
   } else {
     // Use goodword as-is.
-    STRCPY(cword, fword);
+    strcpy(cword, fword);
   }
 }
 
@@ -3399,15 +3399,15 @@ static void dump_word(slang_T *slang, char *word, char *pat, Direction *dir, int
   if (pat == NULL) {
     // Add flags and regions after a slash.
     if ((flags & (WF_BANNED | WF_RARE | WF_REGION)) || keepcap) {
-      STRCPY(badword, p);
-      STRCAT(badword, "/");
+      strcpy(badword, p);
+      strcat(badword, "/");
       if (keepcap) {
-        STRCAT(badword, "=");
+        strcat(badword, "=");
       }
       if (flags & WF_BANNED) {
-        STRCAT(badword, "!");
+        strcat(badword, "!");
       } else if (flags & WF_RARE) {
-        STRCAT(badword, "?");
+        strcat(badword, "?");
       }
       if (flags & WF_REGION) {
         for (int i = 0; i < 7; i++) {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -920,7 +920,7 @@ void suggest_load_files(void)
       if (dotp == NULL || path_fnamecmp(dotp, ".spl") != 0) {
         continue;
       }
-      STRCPY(dotp, ".sug");
+      strcpy(dotp, ".sug");
       fd = os_fopen(slang->sl_fname, "r");
       if (fd == NULL) {
         goto nextone;
@@ -1010,7 +1010,7 @@ nextone:
       if (fd != NULL) {
         fclose(fd);
       }
-      STRCPY(dotp, ".spl");
+      strcpy(dotp, ".spl");
     }
   }
 }
@@ -1994,8 +1994,8 @@ static void spell_print_node(wordnode_T *node, int depth)
     // do the siblings
     if (node->wn_sibling != NULL) {
       // get rid of all parent details except |
-      STRCPY(line1, line3);
-      STRCPY(line2, line3);
+      strcpy(line1, line3);
+      strcpy(line2, line3);
       spell_print_node(node->wn_sibling, depth);
     }
   }
@@ -2180,12 +2180,12 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
                     + strlen(items[0])
                     + strlen(items[1]) + 3, false);
         if (spin->si_info != NULL) {
-          STRCPY(p, spin->si_info);
-          STRCAT(p, "\n");
+          strcpy(p, spin->si_info);
+          strcat(p, "\n");
         }
-        STRCAT(p, items[0]);
-        STRCAT(p, " ");
-        STRCAT(p, items[1]);
+        strcat(p, items[0]);
+        strcat(p, " ");
+        strcat(p, items[1]);
         spin->si_info = p;
       } else if (is_aff_rule(items, itemcnt, "MIDWORD", 2) && midword == NULL) {
         midword = getroom_save(spin, items[1]);
@@ -2238,8 +2238,8 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
         // Turn flag "c" into COMPOUNDRULE compatible string "c+",
         // "Na" into "Na+", "1234" into "1234+".
         p = getroom(spin, strlen(items[1]) + 2, false);
-        STRCPY(p, items[1]);
-        STRCAT(p, "+");
+        strcpy(p, items[1]);
+        strcat(p, "+");
         compflags = p;
       } else if (is_aff_rule(items, itemcnt, "COMPOUNDRULES", 2)) {
         // We don't use the count, but do check that it's a number and
@@ -2259,10 +2259,10 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
           }
           p = getroom(spin, (size_t)l, false);
           if (compflags != NULL) {
-            STRCPY(p, compflags);
-            STRCAT(p, "/");
+            strcpy(p, compflags);
+            strcat(p, "/");
           }
-          STRCAT(p, items[1]);
+          strcat(p, items[1]);
           compflags = p;
         }
       } else if (is_aff_rule(items, itemcnt, "COMPOUNDWORDMAX", 2)
@@ -2379,7 +2379,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
                    "in %s line %d: %s"),
                  fname, lnum, items[1]);
           }
-          STRCPY(cur_aff->ah_key, items[1]);
+          strcpy(cur_aff->ah_key, items[1]);
           hash_add(tp, cur_aff->ah_key);
 
           cur_aff->ah_combine = (*items[2] == 'Y');
@@ -2892,8 +2892,8 @@ static void process_compflags(spellinfo_T *spin, afffile_T *aff, char *compflags
   }
   char *p = getroom(spin, (size_t)len, false);
   if (spin->si_compflags != NULL) {
-    STRCPY(p, spin->si_compflags);
-    STRCAT(p, "/");
+    strcpy(p, spin->si_compflags);
+    strcat(p, "/");
   }
   spin->si_compflags = p;
   uint8_t *tp = (uint8_t *)p + strlen(p);
@@ -2915,7 +2915,7 @@ static void process_compflags(spellinfo_T *spin, afffile_T *aff, char *compflags
           id = HI2CI(hi)->ci_newID;
         } else {
           ci = getroom(spin, sizeof(compitem_T), true);
-          STRCPY(ci->ci_key, key);
+          strcpy(ci->ci_key, key);
           ci->ci_flag = flag;
           // Avoid using a flag ID that has a special meaning in a
           // regexp (also inside []).
@@ -3463,7 +3463,7 @@ static int store_aff_word(spellinfo_T *spin, char *word, char *afflist, afffile_
                   MB_PTR_ADV(p);
                 }
               }
-              STRCAT(newword, p);
+              strcat(newword, p);
             } else {
               // suffix: chop/add at the end of the word
               xstrlcpy(newword, word, MAXWLEN);
@@ -3477,7 +3477,7 @@ static int store_aff_word(spellinfo_T *spin, char *word, char *afflist, afffile_
                 *p = NUL;
               }
               if (ae->ae_add != NULL) {
-                STRCAT(newword, ae->ae_add);
+                strcat(newword, ae->ae_add);
               }
             }
 
@@ -3732,7 +3732,7 @@ static int spell_read_wordfile(spellinfo_T *spin, char *fname)
                  fname, lnum, line);
           } else {
             spin->si_region_count = (int)strlen(line) / 2;
-            STRCPY(spin->si_region_name, line);
+            strcpy(spin->si_region_name, line);
 
             // Adjust the mask for a word valid in all regions.
             spin->si_region = (1 << spin->si_region_count) - 1;

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -643,8 +643,8 @@ void spell_suggest(int count)
     p = xmalloc(strlen(line) - (size_t)stp->st_orglen + (size_t)stp->st_wordlen + 1);
     int c = (int)(sug.su_badptr - line);
     memmove(p, line, (size_t)c);
-    STRCPY(p + c, stp->st_word);
-    STRCAT(p, sug.su_badptr + stp->st_orglen);
+    strcpy(p + c, stp->st_word);
+    strcat(p, sug.su_badptr + stp->st_orglen);
 
     // For redo we use a change-word command.
     ResetRedobuff();
@@ -688,8 +688,8 @@ void spell_suggest_list(garray_T *gap, char *word, int maxcount, bool need_cap, 
     // The suggested word may replace only part of "word", add the not
     // replaced part.
     wcopy = xmalloc((size_t)stp->st_wordlen + strlen(sug.su_badptr + stp->st_orglen) + 1);
-    STRCPY(wcopy, stp->st_word);
-    STRCPY(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen);
+    strcpy(wcopy, stp->st_word);
+    strcpy(wcopy + stp->st_wordlen, sug.su_badptr + stp->st_orglen);
     ((char **)gap->ga_data)[gap->ga_len++] = wcopy;
   }
 
@@ -1071,7 +1071,7 @@ static void suggest_try_change(suginfo_T *su)
   // We make a copy of the case-folded bad word, so that we can modify it
   // to find matches (esp. REP items).  Append some more text, changing
   // chars after the bad word may help.
-  STRCPY(fword, su->su_fbadword);
+  strcpy(fword, su->su_fbadword);
   int n = (int)strlen(fword);
   char *p = su->su_badptr + su->su_badlen;
   (void)spell_casefold(curwin, p, (int)strlen(p), fword + n, MAXWLEN - n);
@@ -1412,7 +1412,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
       // If there is a word from a previous split, append.
       // For the soundfold tree don't change the case, simply append.
       if (soundfold) {
-        STRCPY(preword + sp->ts_prewordlen, tword + sp->ts_splitoff);
+        strcpy(preword + sp->ts_prewordlen, tword + sp->ts_splitoff);
       } else if (flags & WF_KEEPCAP) {
         // Must find the word in the keep-case tree.
         find_keepcap_word(slang, tword + sp->ts_splitoff, preword + sp->ts_prewordlen);
@@ -1649,7 +1649,7 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
 
             // Append a space to preword when splitting.
             if (!try_compound && !fword_ends) {
-              STRCAT(preword, " ");
+              strcat(preword, " ");
             }
             sp->ts_prewordlen = (uint8_t)strlen(preword);
             sp->ts_splitoff = sp->ts_twordlen;
@@ -2664,7 +2664,7 @@ static int stp_sal_score(suggest_T *stp, suginfo_T *su, slang_T *slang, char *ba
   if (lendiff > 0 && stp->st_wordlen + lendiff < MAXWLEN) {
     // Add part of the bad word to the good word, so that we soundfold
     // what replaces the bad word.
-    STRCPY(goodword, stp->st_word);
+    strcpy(goodword, stp->st_word);
     xstrlcpy(goodword + stp->st_wordlen,
              su->su_badptr + su->su_badlen - lendiff, (size_t)lendiff + 1);
     pgood = goodword;
@@ -2841,7 +2841,7 @@ static void add_sound_suggest(suginfo_T *su, char *goodword, int score, langp_T 
       // skip over the NUL bytes
       for (; byts[n + i] == NUL; i++) {
         if (i > byts[n]) {              // safety check
-          STRCPY(theword + wlen, "BAD");
+          strcpy(theword + wlen, "BAD");
           wlen += 3;
           goto badword;
         }

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -264,7 +264,7 @@ void may_trigger_modechanged(void)
   vim_snprintf(pattern_buf, sizeof(pattern_buf), "%s:%s", last_mode, curr_mode);
 
   apply_autocmds(EVENT_MODECHANGED, pattern_buf, NULL, false, curbuf);
-  STRCPY(last_mode, curr_mode);
+  strcpy(last_mode, curr_mode);
 
   restore_v_event(v_event, &save_v_event);
 }

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -327,7 +327,7 @@ char *strcase_save(const char *const orig, bool upper)
       // TODO(philix): use xrealloc() in strcase_save()
       char *s = xmalloc(strlen(res) + (size_t)(1 + newl - l));
       memcpy(s, res, (size_t)(p - res));
-      STRCPY(s + (p - res) + newl, p + l);
+      strcpy(s + (p - res) + newl, p + l);
       p = s + (p - res);
       xfree(res);
       res = s;
@@ -490,8 +490,8 @@ char *concat_str(const char *restrict str1, const char *restrict str2)
 {
   size_t l = strlen(str1);
   char *dest = xmalloc(l + strlen(str2) + 1);
-  STRCPY(dest, str1);
-  STRCPY(dest + l, str2);
+  strcpy(dest, str1);
+  strcpy(dest + l, str2);
   return dest;
 }
 
@@ -1491,13 +1491,13 @@ char *strrep(const char *src, const char *what, const char *rep)
     size_t idx = (size_t)(pos - src);
     memcpy(ptr, src, idx);
     ptr += idx;
-    STRCPY(ptr, rep);
+    strcpy(ptr, rep);
     ptr += replen;
     src = pos + whatlen;
   }
 
   // Copy remaining
-  STRCPY(ptr, src);
+  strcpy(ptr, src);
 
   return ret;
 }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3740,7 +3740,7 @@ static void add_keyword(char *const name, const int id, const int flags,
       : name;
 
   keyentry_T *const kp = xmalloc(offsetof(keyentry_T, keyword) + strlen(name_ic) + 1);
-  STRCPY(kp->keyword, name_ic);
+  strcpy(kp->keyword, name_ic);
   kp->k_syn.id = (int16_t)id;
   kp->k_syn.inc_tag = current_syn_inc_tag;
   kp->flags = flags;
@@ -5036,7 +5036,7 @@ static int get_id_list(char **const arg, const int keylen, int16_t **const list,
         } else {
           // Handle match of regexp with group names.
           *name = '^';
-          STRCAT(name, "$");
+          strcat(name, "$");
           regmatch.regprog = vim_regcomp(name, RE_MAGIC);
           if (regmatch.regprog == NULL) {
             failed = true;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -732,7 +732,7 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
                  num_matches,
                  max_num_matches != MAXCOL ? _(" or more") : "");
         if (ic) {
-          STRCAT(IObuff, _("  Using tag with different case!"));
+          strcat(IObuff, _("  Using tag with different case!"));
         }
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {
@@ -1059,14 +1059,14 @@ static int add_llist_tags(char *tag, int num_matches, char **matches)
       // If "^" is present in the tag search pattern, then
       // copy it first.
       if (*cmd_start == '^') {
-        STRCPY(cmd, "^");
+        strcpy(cmd, "^");
         cmd_start++;
         len++;
       }
 
       // Precede the tag pattern with \V to make it very
       // nomagic.
-      STRCAT(cmd, "\\V");
+      strcat(cmd, "\\V");
       len += 2;
 
       int cmd_len = (int)(cmd_end - cmd_start + 1);
@@ -1361,24 +1361,24 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
       *p++ = MT_GL_OTH + 1;   // mtt
       *p++ = TAG_SEP;     // no tag file name
 
-      STRCPY(p, res_name);
+      strcpy(p, res_name);
       p += strlen(p);
 
       *p++ = TAB;
-      STRCPY(p, res_fname);
+      strcpy(p, res_fname);
       p += strlen(p);
 
       *p++ = TAB;
-      STRCPY(p, res_cmd);
+      strcpy(p, res_cmd);
       p += strlen(p);
 
       if (has_extra) {
-        STRCPY(p, ";\"");
+        strcpy(p, ";\"");
         p += strlen(p);
 
         if (res_kind) {
           *p++ = TAB;
-          STRCPY(p, res_kind);
+          strcpy(p, res_kind);
           p += strlen(p);
         }
 
@@ -1403,11 +1403,11 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
           }
 
           *p++ = TAB;
-          STRCPY(p, dict_key);
+          strcpy(p, dict_key);
           p += strlen(p);
-          STRCPY(p, ":");
+          strcpy(p, ":");
           p += strlen(p);
-          STRCPY(p, tv->vval.v_string);
+          strcpy(p, tv->vval.v_string);
           p += strlen(p);
         });
       }
@@ -1474,7 +1474,7 @@ static bool findtags_in_help_init(findtags_state_T *st)
 
   // Keep "en" as the language if the file extension is ".txt"
   if (st->is_txt) {
-    STRCPY(st->help_lang, "en");
+    strcpy(st->help_lang, "en");
   } else {
     // Prefer help tags according to 'helplang'.  Put the two-letter
     // language name in help_lang[].
@@ -1482,7 +1482,7 @@ static bool findtags_in_help_init(findtags_state_T *st)
     if (i > 3 && st->tag_fname[i - 3] == '-') {
       xstrlcpy(st->help_lang, st->tag_fname + i - 2, 3);
     } else {
-      STRCPY(st->help_lang, "en");
+      strcpy(st->help_lang, "en");
     }
   }
   // When searching for a specific language skip tags files for other
@@ -1946,7 +1946,7 @@ static void findtags_string_convert(findtags_state_T *st)
     st->lbuf = conv_line;
     st->lbuf_size = len;
   } else {
-    STRCPY(st->lbuf, conv_line);
+    strcpy(st->lbuf, conv_line);
     xfree(conv_line);
   }
 }
@@ -2006,9 +2006,9 @@ static void findtags_add_match(findtags_state_T *st, tagptrs_T *tagpp, findtags_
     mfp = xmalloc(mfp_size);
 
     p = mfp;
-    STRCPY(p, tagpp->tagname);
+    strcpy(p, tagpp->tagname);
     p[len] = '@';
-    STRCPY(p + len + 1, st->help_lang);
+    strcpy(p + len + 1, st->help_lang);
     snprintf(p + len + 1 + ML_EXTRA, mfp_size - (len + 1 + ML_EXTRA), "%06d",
              help_heuristic(tagpp->tagname,
                             margs->match_re ? margs->matchoff : 0,
@@ -2058,7 +2058,7 @@ static void findtags_add_match(findtags_state_T *st, tagptrs_T *tagpp, findtags_
     mfp = xmalloc(sizeof(char) + len + 1);
     p = mfp;
     p[0] = (char)(mtt + 1);
-    STRCPY(p + 1, st->tag_fname);
+    strcpy(p + 1, st->tag_fname);
 #ifdef BACKSLASH_IN_FILENAME
     // Ignore differences in slashes, avoid adding
     // both path/file and path\file.
@@ -2066,7 +2066,7 @@ static void findtags_add_match(findtags_state_T *st, tagptrs_T *tagpp, findtags_
 #endif
     p[tag_fname_len + 1] = TAG_SEP;
     s = p + 1 + tag_fname_len + 1;
-    STRCPY(s, st->lbuf);
+    strcpy(s, st->lbuf);
   }
 
   if (mfp != NULL) {
@@ -2540,8 +2540,8 @@ int get_tagfname(tagname_T *tnp, int first, char *buf)
         return FAIL;
       }
       tnp->tn_hf_idx++;
-      STRCPY(buf, p_hf);
-      STRCPY(path_tail(buf), "tags");
+      strcpy(buf, p_hf);
+      strcpy(path_tail(buf), "tags");
 #ifdef BACKSLASH_IN_FILENAME
       slash_adjust(buf);
 #endif
@@ -2609,7 +2609,7 @@ int get_tagfname(tagname_T *tnp, int first, char *buf)
     }
   }
 
-  STRCPY(buf, fname);
+  strcpy(buf, fname);
   xfree(fname);
   return OK;
 }
@@ -3123,7 +3123,7 @@ static char *expand_tag_fname(char *fname, char *const tag_fname, const bool exp
       && !vim_isAbsName(fname)
       && (p = path_tail(tag_fname)) != tag_fname) {
     retval = xmalloc(MAXPATHL);
-    STRCPY(retval, tag_fname);
+    strcpy(retval, tag_fname);
     xstrlcpy(retval + (p - tag_fname), fname, (size_t)(MAXPATHL - (p - tag_fname)));
     // Translate names like "src/a/../b/file.c" into "src/b/file.c".
     simplify_filename(retval);

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -418,11 +418,11 @@ static int assert_equalfile(typval_T *argvars)
         const int c2 = fgetc(fd2);
         if (c1 == EOF) {
           if (c2 != EOF) {
-            STRCPY(IObuff, "first file is shorter");
+            strcpy(IObuff, "first file is shorter");
           }
           break;
         } else if (c2 == EOF) {
-          STRCPY(IObuff, "second file is shorter");
+          strcpy(IObuff, "second file is shorter");
           break;
         } else {
           line1[lineidx] = (char)c1;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2667,7 +2667,7 @@ void ex_undolist(exarg_T *eap)
       undo_fmt_time(IObuff + strlen(IObuff), IOSIZE - strlen(IObuff), uhp->uh_time);
       if (uhp->uh_save_nr > 0) {
         while (strlen(IObuff) < 33) {
-          STRCAT(IObuff, " ");
+          strcat(IObuff, " ");
         }
         vim_snprintf_add(IObuff, IOSIZE, "  %3ld", uhp->uh_save_nr);
       }

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1270,9 +1270,9 @@ static size_t add_cmd_modifier(char *buf, char *mod_str, bool *multi_mods)
 
   if (buf != NULL) {
     if (*multi_mods) {
-      STRCAT(buf, " ");
+      strcat(buf, " ");
     }
-    STRCAT(buf, mod_str);
+    strcat(buf, mod_str);
   }
 
   *multi_mods = true;
@@ -1464,7 +1464,7 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
       if (quote == 1) {
         result = 2;
         if (buf != NULL) {
-          STRCPY(buf, "''");
+          strcpy(buf, "''");
         }
       } else {
         result = 0;
@@ -1482,7 +1482,7 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
     case 0:     // No quoting, no splitting
       result = strlen(eap->arg);
       if (buf != NULL) {
-        STRCPY(buf, eap->arg);
+        strcpy(buf, eap->arg);
       }
       break;
     case 1:     // Quote, but don't split
@@ -1513,7 +1513,7 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
 
       result = *split_len;
       if (buf != NULL && result != 0) {
-        STRCPY(buf, *split_buf);
+        strcpy(buf, *split_buf);
       }
 
       break;
@@ -1561,7 +1561,7 @@ static size_t uc_check_code(char *code, size_t len, char *buf, ucmd_T *cmd, exar
       if (quote) {
         *buf++ = '"';
       }
-      STRCPY(buf, num_buf);
+      strcpy(buf, num_buf);
       buf += num_len;
       if (quote) {
         *buf = '"';
@@ -1708,7 +1708,7 @@ int do_ucmd(exarg_T *eap, bool preview)
       }
     }
     if (buf != NULL) {              // second time here, finished
-      STRCPY(q, p);
+      strcpy(q, p);
       break;
     }
 

--- a/src/nvim/vim.h
+++ b/src/nvim/vim.h
@@ -200,14 +200,13 @@ enum { FOLD_TEXT_LEN = 51, };  //!< buffer size for get_foldtext()
 # define strnlen xstrnlen  // Older versions of SunOS may not have strnlen
 #endif
 
-#define STRCPY(d, s)        strcpy((char *)(d), (char *)(s))  // NOLINT(runtime/printf)
 #ifdef HAVE_STRCASECMP
-# define STRICMP(d, s)      strcasecmp((char *)(d), (char *)(s))
+# define STRICMP(d, s)      strcasecmp((d), (s))
 #else
 # ifdef HAVE_STRICMP
-#  define STRICMP(d, s)     stricmp((char *)(d), (char *)(s))
+#  define STRICMP(d, s)     stricmp((d), (s))
 # else
-#  define STRICMP(d, s)     vim_stricmp((char *)(d), (char *)(s))
+#  define STRICMP(d, s)     vim_stricmp((d), (s))
 # endif
 #endif
 
@@ -215,16 +214,14 @@ enum { FOLD_TEXT_LEN = 51, };  //!< buffer size for get_foldtext()
 #define STRMOVE(d, s)       memmove((d), (s), strlen(s) + 1)
 
 #ifdef HAVE_STRNCASECMP
-# define STRNICMP(d, s, n)  strncasecmp((char *)(d), (char *)(s), (size_t)(n))
+# define STRNICMP(d, s, n)  strncasecmp((d), (s), (size_t)(n))
 #else
 # ifdef HAVE_STRNICMP
-#  define STRNICMP(d, s, n) strnicmp((char *)(d), (char *)(s), (size_t)(n))
+#  define STRNICMP(d, s, n) strnicmp((d), (s), (size_t)(n))
 # else
-#  define STRNICMP(d, s, n) vim_strnicmp((char *)(d), (char *)(s), (size_t)(n))
+#  define STRNICMP(d, s, n) vim_strnicmp((d), (s), (size_t)(n))
 # endif
 #endif
-
-#define STRCAT(d, s)        strcat((char *)(d), (char *)(s))  // NOLINT(runtime/printf)
 
 // Character used as separated in autoload function/variable names.
 #define AUTOLOAD_CHAR '#'


### PR DESCRIPTION
char_u is dead, STRCPY and STRCAT macros are no longer needed. Also remove char* casts in STRICMP and STRNICMP macros.