### PR TITLE
vim-patch:8.2.2858: test fails because of changed error message

### DIFF
--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -218,9 +218,9 @@ func Test_Ex_echo_backslash()
   let bsl = '\\\\'
   let bsl2 = '\\\'
   call assert_fails('call feedkeys("Qecho " .. bsl .. "\nvisual\n", "xt")',
-        \ "E15: Invalid expression: \\\\")
+        \ 'E15: Invalid expression: "\\"')
   call assert_fails('call feedkeys("Qecho " .. bsl2 .. "\nm\nvisual\n", "xt")',
-        \ "E15: Invalid expression: \\\nm")
+        \ "E15: Invalid expression: \"\\\nm\"")
 endfunc
 
 func Test_ex_mode_errors()


### PR DESCRIPTION
#### vim-patch:8.2.2858: test fails because of changed error message

Problem:    Test fails because of changed error message.
Solution:   Adjust the expected error message.

https://github.com/vim/vim/commit/6b02b38ed06879f5e6befe2140aee11a6ad66884

Co-authored-by: Bram Moolenaar <Bram@vim.org>