### PR TITLE
refactor: use xstrl{cpy,cat} on IObuff

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1084,11 +1084,11 @@ char *do_bufdel(int command, char *arg, int addr_count, int start_bnr, int end_b
 
     if (deleted == 0) {
       if (command == DOBUF_UNLOAD) {
-        STRCPY(IObuff, _("E515: No buffers were unloaded"));
+        xstrlcpy(IObuff, _("E515: No buffers were unloaded"), IOSIZE);
       } else if (command == DOBUF_DEL) {
-        STRCPY(IObuff, _("E516: No buffers were deleted"));
+        xstrlcpy(IObuff, _("E516: No buffers were deleted"), IOSIZE);
       } else {
-        STRCPY(IObuff, _("E517: No buffers were wiped out"));
+        xstrlcpy(IObuff, _("E517: No buffers were wiped out"), IOSIZE);
       }
       errormsg = IObuff;
     } else if (deleted >= p_report) {

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -745,7 +745,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
       // the ones from the original file.
       // First find a file name that doesn't exist yet (use some
       // arbitrary numbers).
-      STRCPY(IObuff, fname);
+      xstrlcpy(IObuff, fname, IOSIZE);
       for (int i = 4913;; i += 123) {
         char *tail = path_tail(IObuff);
         size_t size = (size_t)(tail - IObuff);
@@ -1749,24 +1749,24 @@ restore_backup:
     add_quoted_fname(IObuff, IOSIZE, buf, fname);
     bool insert_space = false;
     if (write_info.bw_conv_error) {
-      STRCAT(IObuff, _(" CONVERSION ERROR"));
+      xstrlcat(IObuff, _(" CONVERSION ERROR"), IOSIZE);
       insert_space = true;
       if (write_info.bw_conv_error_lnum != 0) {
         vim_snprintf_add(IObuff, IOSIZE, _(" in line %" PRId64 ";"),
                          (int64_t)write_info.bw_conv_error_lnum);
       }
     } else if (notconverted) {
-      STRCAT(IObuff, _("[NOT converted]"));
+      xstrlcat(IObuff, _("[NOT converted]"), IOSIZE);
       insert_space = true;
     } else if (converted) {
-      STRCAT(IObuff, _("[converted]"));
+      xstrlcat(IObuff, _("[converted]"), IOSIZE);
       insert_space = true;
     }
     if (device) {
-      STRCAT(IObuff, _("[Device]"));
+      xstrlcat(IObuff, _("[Device]"), IOSIZE);
       insert_space = true;
     } else if (newfile) {
-      STRCAT(IObuff, new_file_message());
+      xstrlcat(IObuff, new_file_message(), IOSIZE);
       insert_space = true;
     }
     if (no_eol) {
@@ -1780,9 +1780,9 @@ restore_backup:
     msg_add_lines(insert_space, (long)lnum, nchars);       // add line/char count
     if (!shortmess(SHM_WRITE)) {
       if (append) {
-        STRCAT(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"));
+        xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"), IOSIZE);
       } else {
-        STRCAT(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"));
+        xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"), IOSIZE);
       }
     }
 

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -641,9 +641,10 @@ void ex_history(exarg_T *eap)
   }
 
   for (; !got_int && histype1 <= histype2; histype1++) {
-    STRCPY(IObuff, "\n      #  ");
+    xstrlcpy(IObuff, "\n      #  ", IOSIZE);
     assert(history_names[histype1] != NULL);
-    STRCAT(STRCAT(IObuff, history_names[histype1]), " history");
+    xstrlcat(IObuff, history_names[histype1], IOSIZE);
+    xstrlcat(IObuff, " history", IOSIZE);
     msg_puts_title(IObuff);
     int idx = hisidx[histype1];
     histentry_T *hist = history[histype1];
@@ -669,7 +670,7 @@ void ex_history(exarg_T *eap)
             trunc_string(hist[i].hisstr, IObuff + strlen(IObuff),
                          Columns - 10, IOSIZE - (int)strlen(IObuff));
           } else {
-            STRCAT(IObuff, hist[i].hisstr);
+            xstrlcat(IObuff, hist[i].hisstr, IOSIZE);
           }
           msg_outtrans(IObuff);
         }

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2892,9 +2892,9 @@ char *get_user_func_name(expand_T *xp, int idx)
 
     cat_func_name(IObuff, IOSIZE, fp);
     if (xp->xp_context != EXPAND_USER_FUNC) {
-      STRCAT(IObuff, "(");
+      xstrlcat(IObuff, "(", IOSIZE);
       if (!fp->uf_varargs && GA_EMPTY(&fp->uf_args)) {
-        STRCAT(IObuff, ")");
+        xstrlcat(IObuff, ")", IOSIZE);
       }
     }
     return IObuff;
@@ -3505,7 +3505,7 @@ char *get_return_cmd(void *rettv)
     s = "";
   }
 
-  STRCPY(IObuff, ":return ");
+  xstrlcpy(IObuff, ":return ", IOSIZE);
   xstrlcpy(IObuff + 8, s, IOSIZE - 8);
   if (strlen(s) + 8 >= IOSIZE) {
     STRCPY(IObuff + IOSIZE - 4, "...");

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1454,7 +1454,7 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, char **er
   }
   // Fail if command is invalid
   if (eap->cmdidx == CMD_SIZE) {
-    STRCPY(IObuff, _(e_not_an_editor_command));
+    xstrlcpy(IObuff, _(e_not_an_editor_command), IOSIZE);
     // If the modifier was parsed OK the error must be in the following command
     char *cmdname = after_modifier ? after_modifier : cmdline;
     append_command(cmdname);
@@ -2044,7 +2044,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
   // Check for wrong commands.
   if (ea.cmdidx == CMD_SIZE) {
     if (!ea.skip) {
-      STRCPY(IObuff, _(e_not_an_editor_command));
+      xstrlcpy(IObuff, _(e_not_an_editor_command), IOSIZE);
       // If the modifier was parsed OK the error must be in the following
       // command
       char *cmdname = after_modifier ? after_modifier : *cmdlinep;
@@ -2321,7 +2321,7 @@ doend:
   if (errormsg != NULL && *errormsg != NUL && !did_emsg) {
     if (flags & DOCMD_VERBOSE) {
       if (errormsg != IObuff) {
-        STRCPY(IObuff, errormsg);
+        xstrlcpy(IObuff, errormsg, IOSIZE);
         errormsg = IObuff;
       }
       append_command(*ea.cmdlinep);
@@ -2888,7 +2888,7 @@ static void append_command(char *cmd)
     d -= utf_head_off(IObuff, d);
     STRCPY(d, "...");
   }
-  STRCAT(IObuff, ": ");
+  xstrlcat(IObuff, ": ", IOSIZE);
   d = IObuff + strlen(IObuff);
   while (*s != NUL && d - IObuff + 5 < IOSIZE) {
     if ((uint8_t)s[0] == 0xc2 && (uint8_t)s[1] == 0xa0) {

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1693,22 +1693,22 @@ failed:
 
 #ifdef UNIX
       if (S_ISFIFO(perm)) {             // fifo
-        STRCAT(IObuff, _("[fifo]"));
+        xstrlcat(IObuff, _("[fifo]"), IOSIZE);
         c = true;
       }
       if (S_ISSOCK(perm)) {            // or socket
-        STRCAT(IObuff, _("[socket]"));
+        xstrlcat(IObuff, _("[socket]"), IOSIZE);
         c = true;
       }
 # ifdef OPEN_CHR_FILES
       if (S_ISCHR(perm)) {                          // or character special
-        STRCAT(IObuff, _("[character special]"));
+        xstrlcat(IObuff, _("[character special]"), IOSIZE);
         c = true;
       }
 # endif
 #endif
       if (curbuf->b_p_ro) {
-        STRCAT(IObuff, shortmess(SHM_RO) ? _("[RO]") : _("[readonly]"));
+        xstrlcat(IObuff, shortmess(SHM_RO) ? _("[RO]") : _("[readonly]"), IOSIZE);
         c = true;
       }
       if (read_no_eol_lnum) {
@@ -1716,18 +1716,18 @@ failed:
         c = true;
       }
       if (ff_error == EOL_DOS) {
-        STRCAT(IObuff, _("[CR missing]"));
+        xstrlcat(IObuff, _("[CR missing]"), IOSIZE);
         c = true;
       }
       if (split) {
-        STRCAT(IObuff, _("[long lines split]"));
+        xstrlcat(IObuff, _("[long lines split]"), IOSIZE);
         c = true;
       }
       if (notconverted) {
-        STRCAT(IObuff, _("[NOT converted]"));
+        xstrlcat(IObuff, _("[NOT converted]"), IOSIZE);
         c = true;
       } else if (converted) {
-        STRCAT(IObuff, _("[converted]"));
+        xstrlcat(IObuff, _("[converted]"), IOSIZE);
         c = true;
       }
       if (conv_error != 0) {
@@ -1739,7 +1739,7 @@ failed:
                  _("[ILLEGAL BYTE in line %" PRId64 "]"), (int64_t)illegal_byte);
         c = true;
       } else if (error) {
-        STRCAT(IObuff, _("[READ ERRORS]"));
+        xstrlcat(IObuff, _("[READ ERRORS]"), IOSIZE);
         c = true;
       }
       if (msg_add_fileformat(fileformat)) {
@@ -2128,17 +2128,17 @@ bool msg_add_fileformat(int eol_type)
 {
 #ifndef USE_CRNL
   if (eol_type == EOL_DOS) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[dos]") : _("[dos format]"));
+    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[dos]") : _("[dos format]"), IOSIZE);
     return true;
   }
 #endif
   if (eol_type == EOL_MAC) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"));
+    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"), IOSIZE);
     return true;
   }
 #ifdef USE_CRNL
   if (eol_type == EOL_UNIX) {
-    STRCAT(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"));
+    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"), IOSIZE);
     return true;
   }
 #endif
@@ -2170,8 +2170,7 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
 /// Append message for missing line separator to IObuff.
 void msg_add_eol(void)
 {
-  STRCAT(IObuff,
-         shortmess(SHM_LAST) ? _("[noeol]") : _("[Incomplete last line]"));
+  xstrlcat(IObuff, shortmess(SHM_LAST) ? _("[noeol]") : _("[Incomplete last line]"), IOSIZE);
 }
 
 bool time_differs(const FileInfo *file_info, long mtime, long mtime_ns) FUNC_ATTR_CONST

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1626,7 +1626,7 @@ int do_set(char *arg, int opt_flags)
           int i = (int)strlen(IObuff) + 2;
           if (i + (arg - startarg) < IOSIZE) {
             // append the argument with the error
-            STRCAT(IObuff, ": ");
+            xstrlcat(IObuff, ": ", IOSIZE);
             assert(arg >= startarg);
             memmove(IObuff + i, startarg, (size_t)(arg - startarg));
             IObuff[i + (arg - startarg)] = NUL;

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -130,7 +130,7 @@ char *get_xdg_home(const XDGVarType idx)
     xstrlcpy(IObuff, appname, appname_len + 1);
 #if defined(MSWIN)
     if (idx == kXDGDataHome || idx == kXDGStateHome) {
-      STRCAT(IObuff, "-data");
+      xstrlcat(IObuff, "-data", IOSIZE);
     }
 #endif
     dir = concat_fnames_realloc(dir, IObuff, true);

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1547,7 +1547,7 @@ static inline char *add_dir(char *dest, const char *const dir, const size_t dir_
     xstrlcpy(IObuff, appname, appname_len + 1);
 #if defined(MSWIN)
     if (type == kXDGDataHome || type == kXDGStateHome) {
-      STRCAT(IObuff, "-data");
+      xstrlcat(IObuff, "-data", IOSIZE);
       appname_len += 5;
     }
 #endif

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -732,7 +732,7 @@ void do_tag(char *tag, int type, int count, int forceit, int verbose)
                  num_matches,
                  max_num_matches != MAXCOL ? _(" or more") : "");
         if (ic) {
-          STRCAT(IObuff, _("  Using tag with different case!"));
+          xstrlcat(IObuff, _("  Using tag with different case!"), IOSIZE);
         }
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -418,11 +418,11 @@ static int assert_equalfile(typval_T *argvars)
         const int c2 = fgetc(fd2);
         if (c1 == EOF) {
           if (c2 != EOF) {
-            STRCPY(IObuff, "first file is shorter");
+            xstrlcpy(IObuff, "first file is shorter", IOSIZE);
           }
           break;
         } else if (c2 == EOF) {
-          STRCPY(IObuff, "second file is shorter");
+          xstrlcpy(IObuff, "second file is shorter", IOSIZE);
           break;
         } else {
           line1[lineidx] = (char)c1;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2667,7 +2667,7 @@ void ex_undolist(exarg_T *eap)
       undo_fmt_time(IObuff + strlen(IObuff), IOSIZE - strlen(IObuff), uhp->uh_time);
       if (uhp->uh_save_nr > 0) {
         while (strlen(IObuff) < 33) {
-          STRCAT(IObuff, " ");
+          xstrlcat(IObuff, " ", IOSIZE);
         }
         vim_snprintf_add(IObuff, IOSIZE, "  %3ld", uhp->uh_save_nr);
       }


### PR DESCRIPTION
Replace usage of STR{CPY,CAT} with xstrl{cpy,cat} when using on IObuff