### PR TITLE
move ignore white up stack for linematch

### DIFF
--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -32,38 +32,6 @@ static size_t line_len(const char *s)
   return strlen(s);
 }
 
-/// Same as matching_chars but ignore whitespace
-///
-/// @param s1
-/// @param s2
-static int matching_chars_iwhite(const char *s1, const char *s2)
-{
-  // the newly processed strings that will be compared
-  // delete the white space characters, and/or replace all upper case with lower
-  char *strsproc[2];
-  const char *strsorig[2] = { s1, s2 };
-  for (int k = 0; k < 2; k++) {
-    size_t d = 0;
-    size_t i = 0;
-    size_t slen = line_len(strsorig[k]);
-    strsproc[k] = xmalloc((slen + 1) * sizeof(char));
-    while (d + i < slen) {
-      char e = strsorig[k][i + d];
-      if (e != ' ' && e != '\t') {
-        strsproc[k][i] = e;
-        i++;
-      } else {
-        d++;
-      }
-    }
-    strsproc[k][i] = '\0';
-  }
-  int matching = matching_chars(strsproc[0], strsproc[1]);
-  xfree(strsproc[0]);
-  xfree(strsproc[1]);
-  return matching;
-}
-
 /// update the path of a point in the diff linematch algorithm
 /// @param diffcmppath
 /// @param score
@@ -133,7 +101,7 @@ static int matching_chars(const char *s1, const char *s2)
 /// @param sp
 /// @param fomvals
 /// @param n
-static int count_n_matched_chars(const char **sp, const size_t n, bool iwhite)
+static int count_n_matched_chars(const char **sp, const size_t n)
 {
   int matched_chars = 0;
   int matched = 0;
@@ -141,9 +109,7 @@ static int count_n_matched_chars(const char **sp, const size_t n, bool iwhite)
     for (size_t j = i + 1; j < n; j++) {
       if (sp[i] != NULL && sp[j] != NULL) {
         matched++;
-        // TODO(lewis6991): handle whitespace ignoring higher up in the stack
-        matched_chars += iwhite ? matching_chars_iwhite(sp[i], sp[j])
-                                : matching_chars(sp[i], sp[j]);
+        matched_chars += matching_chars(sp[i], sp[j]);
       }
     }
   }
@@ -181,8 +147,7 @@ void fastforward_buf_to_lnum(const char **s, long lnum)
 /// @param diff_blk
 static void try_possible_paths(const int *df_iters, const size_t *paths, const int npaths,
                                const int path_idx, int *choice, diffcmppath_T *diffcmppath,
-                               const int *diff_len, const size_t ndiffs, const char **diff_blk,
-                               bool iwhite)
+                               const int *diff_len, const size_t ndiffs, const char **diff_blk)
 {
   if (path_idx == npaths) {
     if ((*choice) > 0) {
@@ -203,7 +168,7 @@ static void try_possible_paths(const int *df_iters, const size_t *paths, const i
       }
       size_t unwrapped_idx_from = unwrap_indexes(from_vals, diff_len, ndiffs);
       size_t unwrapped_idx_to = unwrap_indexes(to_vals, diff_len, ndiffs);
-      int matched_chars = count_n_matched_chars(current_lines, ndiffs, iwhite);
+      int matched_chars = count_n_matched_chars(current_lines, ndiffs);
       int score = diffcmppath[unwrapped_idx_from].df_lev_score + matched_chars;
       if (score > diffcmppath[unwrapped_idx_to].df_lev_score) {
         update_path_flat(diffcmppath, score, unwrapped_idx_to, unwrapped_idx_from, *choice);
@@ -224,10 +189,10 @@ static void try_possible_paths(const int *df_iters, const size_t *paths, const i
   size_t bit_place = paths[path_idx];
   *(choice) |= (1 << bit_place);  // set it to 1
   try_possible_paths(df_iters, paths, npaths, path_idx + 1, choice,
-                     diffcmppath, diff_len, ndiffs, diff_blk, iwhite);
+                     diffcmppath, diff_len, ndiffs, diff_blk);
   *(choice) &= ~(1 << bit_place);  // set it to 0
   try_possible_paths(df_iters, paths, npaths, path_idx + 1, choice,
-                     diffcmppath, diff_len, ndiffs, diff_blk, iwhite);
+                     diffcmppath, diff_len, ndiffs, diff_blk);
 }
 
 /// unwrap indexes to access n dimensional tensor
@@ -262,8 +227,7 @@ static size_t unwrap_indexes(const int *values, const int *diff_len, const size_
 /// @param ndiffs
 /// @param diff_blk
 static void populate_tensor(int *df_iters, const size_t ch_dim, diffcmppath_T *diffcmppath,
-                            const int *diff_len, const size_t ndiffs, const char **diff_blk,
-                            bool iwhite)
+                            const int *diff_len, const size_t ndiffs, const char **diff_blk)
 {
   if (ch_dim == ndiffs) {
     int npaths = 0;
@@ -279,14 +243,14 @@ static void populate_tensor(int *df_iters, const size_t ch_dim, diffcmppath_T *d
     size_t unwrapper_idx_to = unwrap_indexes(df_iters, diff_len, ndiffs);
     diffcmppath[unwrapper_idx_to].df_lev_score = -1;
     try_possible_paths(df_iters, paths, npaths, 0, &choice, diffcmppath,
-                       diff_len, ndiffs, diff_blk, iwhite);
+                       diff_len, ndiffs, diff_blk);
     return;
   }
 
   for (int i = 0; i <= diff_len[ch_dim]; i++) {
     df_iters[ch_dim] = i;
     populate_tensor(df_iters, ch_dim + 1, diffcmppath, diff_len,
-                    ndiffs, diff_blk, iwhite);
+                    ndiffs, diff_blk);
   }
 }
 
@@ -346,7 +310,7 @@ static void populate_tensor(int *df_iters, const size_t ch_dim, diffcmppath_T *d
 /// @param [out] [allocated] decisions
 /// @return the length of decisions
 size_t linematch_nbuffers(const char **diff_blk, const int *diff_len, const size_t ndiffs,
-                          int **decisions, bool iwhite)
+                          int **decisions)
 {
   assert(ndiffs <= LN_MAX_BUFS);
 
@@ -367,7 +331,7 @@ size_t linematch_nbuffers(const char **diff_blk, const int *diff_len, const size
 
   // memory for avoiding repetitive calculations of score
   int df_iters[LN_MAX_BUFS];
-  populate_tensor(df_iters, 0, diffcmppath, diff_len, ndiffs, diff_blk, iwhite);
+  populate_tensor(df_iters, 0, diffcmppath, diff_len, ndiffs, diff_blk);
 
   const size_t u = unwrap_indexes(diff_len, diff_len, ndiffs);
   const size_t best_path_idx = diffcmppath[u].df_path_idx;

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -67,14 +67,28 @@ static void get_linematch_results(lua_State *lstate, mmfile_t *ma, mmfile_t *mb,
                                   long count_a, long start_b, long count_b, bool iwhite)
 {
   // get the pointer to char of the start of the diff to pass it to linematch algorithm
-  const char *diff_begin[2] = { ma->ptr, mb->ptr };
+  char *diff_begin[2] = { ma->ptr, mb->ptr };
   int diff_length[2] = { (int)count_a, (int)count_b };
 
   fastforward_buf_to_lnum(&diff_begin[0], start_a + 1);
   fastforward_buf_to_lnum(&diff_begin[1], start_b + 1);
 
+  if (iwhite) {
+    for (int i = 0; i < 2; i++) {
+      size_t j = 0, k = 0, lines = diff_length[i];
+      while (lines > 0) {
+        if (diff_begin[i][j] != ' ' && diff_begin[i][j] != '\t') {
+          diff_begin[i][k++] = diff_begin[i][j];
+        }
+        if (diff_begin[i][j++] == '\n') {
+          lines--;
+        }
+      }
+    }
+  }
+
   int *decisions = NULL;
-  size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions, iwhite);
+  size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions);
 
   long lnuma = start_a, lnumb = start_b;
 


### PR DESCRIPTION
@lewis6991 
removes the 'iwhite' parameter from all the linematch functions, and many xmalloc calls when 'iwhite' is enabled