### PR TITLE
docs(treesitter): add gsub! directive document

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -292,6 +292,18 @@ The following directives are built in:
         Example: >query
             ((identifier) @constant (#offset! @constant 0 1 0 -1))
 <
+    `gsub!`                                        *treesitter-directive-gsub!*
+        Transform the text of the node like |string.gsub()|. This will set the
+        transformed text as `metadata[capture_id].text`.
+
+        Parameters: ~
+            {capture_id}
+            {pattern}
+            {replacement}
+
+        Example: >query
+            ((identifier) @node (#gsub! @node ".*%.(.*)" "%1"))
+<
 
 Further directives can be added via |vim.treesitter.query.add_directive()|.
 Use |vim.treesitter.query.list_directives()| to list all available directives.


### PR DESCRIPTION
This adds missing gsub! directive doc.

related: https://github.com/neovim/neovim/pull/21548