### PR TITLE
build!: remove neovim qt

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -10,13 +10,13 @@ ${NVIM_VERSION}
 
 1. Download **nvim-win64.zip**
 2. Extract the zip
-3. Run `nvim-qt.exe`
+3. Run `nvim.exe` on your CLI of choice
 
 #### MSI
 
 1. Download **nvim-win64.msi**
 2. Run the MSI
-3. Search and run `nvim-qt.exe` or run `nvim.exe` on your CLI of choice
+3. Run `nvim.exe` on your CLI of choice
 
 ### macOS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,21 +289,10 @@ install_helper(
   FILES ${CMAKE_SOURCE_DIR}/src/man/nvim.1
   DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 
-if(EXISTS "${DEPS_PREFIX}/share/nvim-qt")
-  option(USE_BUNDLED_NVIMQT "Bundle neovim-qt" ON)
-else()
-  option(USE_BUNDLED_NVIMQT "Bundle neovim-qt" OFF)
-endif()
-
 add_subdirectory(src/nvim)
 add_subdirectory(cmake.config)
 add_subdirectory(runtime)
 add_subdirectory(test)
-if(WIN32 AND USE_BUNDLED_NVIMQT)
-  install_helper(
-    FILES ${DEPS_PREFIX}/share/nvim-qt/runtime/plugin/nvim_gui_shim.vim
-    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/nvim-qt/runtime/plugin)
-endif()
 
 add_custom_target(uninstall
   COMMAND ${CMAKE_COMMAND} -P ${PROJECT_SOURCE_DIR}/cmake/UninstallHelper.cmake)

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -54,10 +54,6 @@ else()
   option(USE_BUNDLED_LIBICONV "Use the bundled version of libiconv." OFF)
 endif()
 
-if(WIN32)
-  option(USE_BUNDLED_NVIMQT "Bundle neovim-qt" ON)
-endif()
-
 option(USE_EXISTING_SRC_DIR "Skip download of deps sources in case of existing source directory." OFF)
 
 find_package(Git)
@@ -157,12 +153,6 @@ if(WIN32)
   GetExecutable(TARGET cat)
   GetExecutable(TARGET tee)
   GetExecutable(TARGET xxd)
-
-  if(USE_BUNDLED_NVIMQT)
-    GetBinaryDep(TARGET wingui
-      INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory bin ${DEPS_BIN_DIR}
-      COMMAND ${CMAKE_COMMAND} -E copy_directory share ${DEPS_INSTALL_DIR}/share)
-  endif()
 
   GetBinaryDep(TARGET win32yank_X86_64
     INSTALL_COMMAND ${CMAKE_COMMAND} -E copy win32yank.exe ${DEPS_BIN_DIR})

--- a/cmake.packaging/CMakeLists.txt
+++ b/cmake.packaging/CMakeLists.txt
@@ -37,8 +37,7 @@ if(WIN32)
 
   # Create start menu and desktop shortcuts
   set(CPACK_WIX_PROGRAM_MENU_FOLDER "${CPACK_PACKAGE_NAME}")
-  set(CPACK_PACKAGE_EXECUTABLES "nvim" "Neovim" "nvim-qt" "Neovim Qt")
-  set(CPACK_CREATE_DESKTOP_LINKS "nvim-qt")
+  set(CPACK_PACKAGE_EXECUTABLES "nvim" "Neovim")
 
   # We use a wix patch to add further options to the installer.
   # See: https://cmake.org/cmake/help/v3.7/module/CPackWIX.html#variable:CPACK_WIX_PATCH_FILE

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -703,59 +703,6 @@ if(WIN32)
       -P ${PROJECT_SOURCE_DIR}/cmake/WindowsDllCopy.cmake)
   add_dependencies(nvim_runtime_deps nvim_dll_deps)
 
-  if(USE_BUNDLED_NVIMQT)
-    set(NVIMQT_DEPS
-      # Dependencies for neovim-qt
-      bearer/qgenericbearer.dll
-      iconengines/qsvgicon.dll
-      imageformats/qgif.dll
-      imageformats/qicns.dll
-      imageformats/qico.dll
-      imageformats/qjpeg.dll
-      imageformats/qsvg.dll
-      imageformats/qtga.dll
-      imageformats/qtiff.dll
-      imageformats/qwbmp.dll
-      imageformats/qwebp.dll
-      platforms/qwindows.dll
-      styles/qwindowsvistastyle.dll
-      translations/qt_ar.qm
-      translations/qt_bg.qm
-      translations/qt_ca.qm
-      translations/qt_cs.qm
-      translations/qt_da.qm
-      translations/qt_de.qm
-      translations/qt_en.qm
-      translations/qt_es.qm
-      translations/qt_fi.qm
-      translations/qt_fr.qm
-      translations/qt_gd.qm
-      translations/qt_he.qm
-      translations/qt_hu.qm
-      translations/qt_it.qm
-      translations/qt_ja.qm
-      translations/qt_ko.qm
-      translations/qt_lv.qm
-      translations/qt_pl.qm
-      translations/qt_ru.qm
-      translations/qt_sk.qm
-      translations/qt_uk.qm
-      D3Dcompiler_47.dll
-      libEGL.dll
-      libgcc_s_seh-1.dll
-      libGLESv2.dll
-      libstdc++-6.dll
-      libwinpthread-1.dll
-      nvim-qt.exe
-      opengl32sw.dll
-      Qt5Core.dll
-      Qt5Gui.dll
-      Qt5Network.dll
-      Qt5Svg.dll
-      Qt5Widgets.dll
-      )
-  endif()
-
   # A CMake script is used for copying the files to avoid the
   # "command line is too long" error that occurs when Ninja tries running
   # a command that exceeds the length limit (8191 characters) on Windows.
@@ -766,9 +713,7 @@ if(WIN32)
       cat.exe
       tee.exe
       win32yank.exe
-      xxd.exe
-
-      ${NVIMQT_DEPS})
+      xxd.exe)
   get_filename_component(DEP_FILE_DIR ${DEP_FILE} DIRECTORY)
   set(EXTERNAL_BLOBS_SCRIPT "${EXTERNAL_BLOBS_SCRIPT}\n"
     "file(COPY \"${DEPS_PREFIX}/bin/${DEP_FILE}\"


### PR DESCRIPTION
Neovim QT was originally bundled on Windows as a response to the then
lackluster terminal options. The situation has dramatically changed,
with viable options such as Windows terminal, Alacritty and Wezterm to
name a few. The Windows build no longer needs this special treatment for
neovim to be usable.

Pros:
  - Release builds will be smaller.
  - Less maintenance burden.
  - Clearer separation of responsibility (neovim issues go to the neovim
    repo and neovim-qt issues to the neovim-qt repo).
  - More consistent treatment between platforms.

Cons:
  - Users who've come to expect neovim-qt to be bundled with nvim will
    need to adjust and download neovim-qt from
    https://github.com/equalsraf/neovim-qt instead.
  - Similarly, build scripts will need to be adjusted to reflect this
    change.

Closes https://github.com/neovim/neovim/issues/21209.