### PR TITLE
docs: fix `string.gsub()` examples

### DIFF
--- a/runtime/doc/luaref.txt
+++ b/runtime/doc/luaref.txt
@@ -4101,16 +4101,16 @@ string.gsub({s}, {pattern}, {repl} [, {n}])                    *string.gsub()*
            x = string.gsub("hello world from Lua", "(%w+)%s*(%w+)", "%2 %1")
            --> x="world hello Lua from"
 
-           x = string.gsub("home =  `HOME, user = ` USER", "%$(%w+)", os.getenv)
+           x = string.gsub("home = $HOME, user = $USER", "%$(%w+)", os.getenv)
            --> x="home = /home/roberto, user = roberto"
 
-           x = string.gsub("4+5 =  `return 4+5` ", "% `(.-)%` ", function (s)
+           x = string.gsub("4+5 = $return 4+5$", "%$(.-)%$", function (s)
                  return loadstring(s)()
                end)
            --> x="4+5 = 9"
 
            local t = {name="lua", version="5.1"}
-           x = string.gsub(" `name%-` version.tar.gz", "%$(%w+)", t)
+           x = string.gsub("$name%-$version.tar.gz", "%$(%w+)", t)
            --> x="lua-5.1.tar.gz"
 <
 


### PR DESCRIPTION
This makes `string.gsub()` examples correct making them the same as in [original source](https://www.lua.org/manual/5.1/manual.html#5.4).