### PR TITLE
fix(treesitter): allow foldexpr without highlights

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -136,16 +136,6 @@ function M.get_parser(bufnr, lang, opts)
   return parsers[bufnr]
 end
 
----@package
----@param bufnr (integer|nil) Buffer number
----@return boolean
-function M._has_parser(bufnr)
-  if bufnr == nil or bufnr == 0 then
-    bufnr = api.nvim_get_current_buf()
-  end
-  return parsers[bufnr] ~= nil
-end
-
 --- Returns a string parser
 ---
 ---@param str string Text to parse

--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -301,7 +301,8 @@ function M.foldexpr(lnum)
   lnum = lnum or vim.v.lnum
   local bufnr = api.nvim_get_current_buf()
 
-  if not ts._has_parser(bufnr) or not lnum then
+  local parser = vim.F.npcall(ts.get_parser, bufnr)
+  if not parser then
     return '0'
   end
 
@@ -309,7 +310,6 @@ function M.foldexpr(lnum)
     foldinfos[bufnr] = FoldInfo.new()
     get_folds_levels(bufnr, foldinfos[bufnr])
 
-    local parser = ts.get_parser(bufnr)
     parser:register_cbs({
       on_changedtree = function(tree_changes)
         on_changedtree(bufnr, foldinfos[bufnr], tree_changes)


### PR DESCRIPTION
Ref nvim-treesitter/nvim-treesitter#4748
