### PR TITLE
feat(lsp): initial support for dynamic capabilities

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -36,8 +36,7 @@ ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
 
-• Dynamic registration of LSP capabilities
-
+• Dynamic registration of LSP capabilities. An implication of this change is that checking a client's `server_capabilities` is no longer a sufficient indicator to see if a server supports a feature. Instead use `client.supports_method(<method>)`. It considers both the dynamic capabilities and static `server_capabilities`.
 • |vim.iter()| provides a generic iterator interface for tables and Lua
   iterators |luaref-in|.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -36,6 +36,8 @@ ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
 
+• Dynamic registration of LSP capabilities
+
 • |vim.iter()| provides a generic iterator interface for tables and Lua
   iterators |luaref-in|.
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -50,6 +50,7 @@ lsp._request_name_to_capability = {
   ['textDocument/codeAction'] = { 'codeActionProvider' },
   ['textDocument/codeLens'] = { 'codeLensProvider' },
   ['codeLens/resolve'] = { 'codeLensProvider', 'resolveProvider' },
+  ['codeAction/resolve'] = { 'codeActionProvider', 'resolveProvider' },
   ['workspace/executeCommand'] = { 'executeCommandProvider' },
   ['workspace/symbol'] = { 'workspaceSymbolProvider' },
   ['textDocument/references'] = { 'referencesProvider' },

--- a/runtime/lua/vim/lsp/_dynamic.lua
+++ b/runtime/lua/vim/lsp/_dynamic.lua
@@ -1,0 +1,109 @@
+local wf = require('vim.lsp._watchfiles')
+
+--- @class lsp.DynamicCapabilities
+--- @field capabilities table<string, lsp.Registration[]>
+--- @field client_id number
+local M = {}
+
+--- @param client_id number
+function M.new(client_id)
+  return setmetatable({
+    capabilities = {},
+    client_id = client_id,
+  }, { __index = M })
+end
+
+function M:supports_registration(method)
+  local client = vim.lsp.get_client_by_id(self.client_id)
+  if not client then
+    return false
+  end
+  local capability = vim.tbl_get(client.config.capabilities, unpack(vim.split(method, '/')))
+  return type(capability) == 'table' and capability.dynamicRegistration
+end
+
+--- @param registrations lsp.Registration[]
+--- @private
+function M:register(registrations)
+  -- remove duplicates
+  self:unregister(registrations)
+  for _, reg in ipairs(registrations) do
+    local method = reg.method
+    if not self.capabilities[method] then
+      self.capabilities[method] = {}
+    end
+    table.insert(self.capabilities[method], reg)
+  end
+end
+
+--- @param unregisterations lsp.Unregistration[]
+--- @private
+function M:unregister(unregisterations)
+  for _, unreg in ipairs(unregisterations) do
+    local method = unreg.method
+    if not self.capabilities[method] then
+      return
+    end
+    local id = unreg.id
+    for i, reg in ipairs(self.capabilities[method]) do
+      if reg.id == id then
+        table.remove(self.capabilities[method], i)
+        break
+      end
+    end
+  end
+end
+
+--- @param method string
+--- @param opts? {bufnr?: number}
+--- @return lsp.Registration? (table|nil) the registration if found
+--- @private
+function M:get(method, opts)
+  opts = opts or {}
+  opts.bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
+  for _, reg in ipairs(self.capabilities[method] or {}) do
+    if not reg.registerOptions then
+      return reg
+    end
+    local documentSelector = reg.registerOptions.documentSelector
+    if not documentSelector then
+      return reg
+    end
+    if M.match(opts.bufnr, documentSelector) then
+      return reg
+    end
+  end
+end
+
+--- @param method string
+--- @param opts? {bufnr?: number}
+--- @private
+function M:supports(method, opts)
+  return self:get(method, opts) ~= nil
+end
+
+--- @param bufnr number
+--- @param documentSelector lsp.DocumentSelector
+--- @private
+function M.match(bufnr, documentSelector)
+  local ft = vim.bo[bufnr].filetype
+  local uri = vim.uri_from_bufnr(bufnr)
+  local fname = vim.uri_to_fname(uri)
+  for _, filter in ipairs(documentSelector) do
+    local matches = true
+    if filter.language and ft ~= filter.language then
+      matches = false
+    end
+    if matches and filter.scheme and not vim.startswith(uri, filter.scheme .. ':') then
+      matches = false
+    end
+    if matches and filter.pattern and not wf._match(filter.pattern, fname) then
+      matches = false
+    end
+    if matches then
+      return true
+    end
+  end
+end
+
+return M

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -683,11 +683,7 @@ local function on_code_action_results(results, ctx, options)
     --
     local client = vim.lsp.get_client_by_id(action_tuple[1])
     local action = action_tuple[2]
-    if
-      not action.edit
-      and client
-      and vim.tbl_get(client.server_capabilities, 'codeActionProvider', 'resolveProvider')
-    then
+    if not action.edit and client and client.supports_method('codeAction/resolve') then
       client.request('codeAction/resolve', action, function(err, resolved_action)
         if err then
           vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -118,22 +118,26 @@ end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_registerCapability
 M['client/registerCapability'] = function(_, result, ctx)
-  local log_unsupported = false
+  local client_id = ctx.client_id
+  local client = vim.lsp.get_client_by_id(client_id)
+
+  client.dynamic_capabilities:register(result.registrations)
+
+  ---@type string[]
+  local unsupported = {}
   for _, reg in ipairs(result.registrations) do
     if reg.method == 'workspace/didChangeWatchedFiles' then
       require('vim.lsp._watchfiles').register(reg, ctx)
-    else
-      log_unsupported = true
+    elseif not client.dynamic_capabilities:supports_registration(reg.method) then
+      unsupported[#unsupported + 1] = reg.method
     end
   end
-  if log_unsupported then
-    local client_id = ctx.client_id
+  if #unsupported > 0 then
     local warning_tpl = 'The language server %s triggers a registerCapability '
-      .. 'handler despite dynamicRegistration set to false. '
+      .. 'handler for %s despite dynamicRegistration set to false. '
       .. 'Report upstream, this warning is harmless'
-    local client = vim.lsp.get_client_by_id(client_id)
     local client_name = client and client.name or string.format('id=%d', client_id)
-    local warning = string.format(warning_tpl, client_name)
+    local warning = string.format(warning_tpl, client_name, table.concat(unsupported, ', '))
     log.warn(warning)
   end
   return vim.NIL
@@ -141,6 +145,10 @@ end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_unregisterCapability
 M['client/unregisterCapability'] = function(_, result, ctx)
+  local client_id = ctx.client_id
+  local client = vim.lsp.get_client_by_id(client_id)
+  client.dynamic_capabilities:unregister(result.unregisterations)
+
   for _, unreg in ipairs(result.unregisterations) do
     if unreg.method == 'workspace/didChangeWatchedFiles' then
       require('vim.lsp._watchfiles').unregister(unreg, ctx)

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -119,9 +119,13 @@ end
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#client_registerCapability
 M['client/registerCapability'] = function(_, result, ctx)
   local client_id = ctx.client_id
+  ---@type lsp.Client
   local client = vim.lsp.get_client_by_id(client_id)
 
   client.dynamic_capabilities:register(result.registrations)
+  for bufnr, _ in ipairs(client.attached_buffers) do
+    vim.lsp._set_defaults(client, bufnr)
+  end
 
   ---@type string[]
   local unsupported = {}

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -697,7 +697,7 @@ function protocol.make_client_capabilities()
         didSave = true,
       },
       codeAction = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
 
         codeActionLiteralSupport = {
           codeActionKind = {
@@ -713,6 +713,12 @@ function protocol.make_client_capabilities()
         resolveSupport = {
           properties = { 'edit' },
         },
+      },
+      formatting = {
+        dynamicRegistration = true,
+      },
+      rangeFormatting = {
+        dynamicRegistration = true,
       },
       completion = {
         dynamicRegistration = false,
@@ -755,7 +761,7 @@ function protocol.make_client_capabilities()
         linkSupport = true,
       },
       hover = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
         contentFormat = { protocol.MarkupKind.Markdown, protocol.MarkupKind.PlainText },
       },
       signatureHelp = {
@@ -790,7 +796,7 @@ function protocol.make_client_capabilities()
         hierarchicalDocumentSymbolSupport = true,
       },
       rename = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
         prepareSupport = true,
       },
       publishDiagnostics = {

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -753,6 +753,7 @@ function protocol.make_client_capabilities()
       },
       definition = {
         linkSupport = true,
+        dynamicRegistration = true,
       },
       implementation = {
         linkSupport = true,

--- a/runtime/lua/vim/lsp/types.lua
+++ b/runtime/lua/vim/lsp/types.lua
@@ -35,3 +35,31 @@
 ---@field source string
 ---@field tags? lsp.DiagnosticTag[]
 ---@field relatedInformation DiagnosticRelatedInformation[]
+
+--- @class lsp.DocumentFilter
+--- @field language? string
+--- @field scheme? string
+--- @field pattern? string
+
+--- @alias lsp.DocumentSelector lsp.DocumentFilter[]
+
+--- @alias lsp.RegisterOptions any | lsp.StaticRegistrationOptions | lsp.TextDocumentRegistrationOptions
+
+--- @class lsp.Registration
+--- @field id string
+--- @field method string
+--- @field registerOptions? lsp.RegisterOptions
+
+--- @alias lsp.RegistrationParams {registrations: lsp.Registration[]}
+
+--- @class lsp.StaticRegistrationOptions
+--- @field id? string
+
+--- @class lsp.TextDocumentRegistrationOptions
+--- @field documentSelector? lsp.DocumentSelector
+
+--- @class lsp.Unregistration
+--- @field id string
+--- @field method string
+
+--- @alias lsp.UnregistrationParams {unregisterations: lsp.Unregistration[]}

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3765,6 +3765,96 @@ describe('LSP', function()
     end)
   end)
 
+  describe('#dynamic vim.lsp._dynamic', function()
+    it('supports dynamic registration', function()
+      local root_dir = helpers.tmpname()
+      os.remove(root_dir)
+      mkdir(root_dir)
+      local tmpfile = root_dir .. '/dynamic.foo'
+      local file = io.open(tmpfile, 'w')
+      file:close()
+
+      exec_lua(create_server_definition)
+      local result = exec_lua([[
+        local root_dir, tmpfile = ...
+
+        local server = _create_server()
+        local client_id = vim.lsp.start({
+          name = 'dynamic-test',
+          cmd = server.cmd,
+          root_dir = root_dir,
+          capabilities = {
+            textDocument = {
+              formatting = {
+                dynamicRegistration = true,
+              },
+              rangeFormatting = {
+                dynamicRegistration = true,
+              },
+            },
+          },
+        })
+
+        local expected_messages = 2 -- initialize, initialized
+
+        vim.lsp.handlers['client/registerCapability'](nil, {
+          registrations = {
+            {
+              id = 'formatting',
+              method = 'textDocument/formatting',
+              registerOptions = {
+                documentSelector = {{
+                  pattern = root_dir .. '/*.foo',
+                }},
+              },
+            },
+          },
+        }, { client_id = client_id })
+
+        vim.lsp.handlers['client/registerCapability'](nil, {
+          registrations = {
+            {
+              id = 'range-formatting',
+              method = 'textDocument/rangeFormatting',
+            },
+          },
+        }, { client_id = client_id })
+
+        vim.lsp.handlers['client/registerCapability'](nil, {
+          registrations = {
+            {
+              id = 'completion',
+              method = 'textDocument/completion',
+            },
+          },
+        }, { client_id = client_id })
+
+        local result = {}
+        local function check(method, fname)
+          local bufnr = fname and vim.fn.bufadd(fname) or nil
+          local client = vim.lsp.get_client_by_id(client_id)
+          result[#result + 1] = {method = method, fname = fname, supported = client.supports_method(method, {bufnr = bufnr})}
+        end
+
+
+        check("textDocument/formatting")
+        check("textDocument/formatting", tmpfile)
+        check("textDocument/rangeFormatting")
+        check("textDocument/rangeFormatting", tmpfile)
+        check("textDocument/completion")
+
+        return result
+      ]], root_dir, tmpfile)
+
+      eq(5, #result)
+      eq({method = 'textDocument/formatting', supported = false}, result[1])
+      eq({method = 'textDocument/formatting', supported = true, fname = tmpfile}, result[2])
+      eq({method = 'textDocument/rangeFormatting', supported = true}, result[3])
+      eq({method = 'textDocument/rangeFormatting', supported = true, fname = tmpfile}, result[4])
+      eq({method = 'textDocument/completion', supported = false}, result[5])
+    end)
+  end)
+
   describe('vim.lsp._watchfiles', function()
     it('sends notifications when files change', function()
       local root_dir = helpers.tmpname()


### PR DESCRIPTION
Added initial support for [dynamic registration of capabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability)

- `client.dynamic_capabilities` is an object that tracks client register/unregister
- `client.supports_method` will additionally check if a dynamic capability supports the method, taking document filters into account. But **only** if the client enabled `dynamicRegistration` for the capability
- updated the default client capabilities to include dynamicRegistration for:
  - `formatting`
  - `rangeFormatting`
  - `hover`
  - `codeAction`
  - `hover`
  - `rename`

## Notes

- `client.server_capabilities` only contains the capabilities set during server initialization.
- Client code that wants to fully support dynamic capabilities should additionally check `client.dynamic_capabities:get(method, {bufnr=...})`
- Maybe I should add a `client.get_server_capability(method, {bufnr=...})` that combines both like with `client.supports_method`?
- I didnt enable `dynamicRegistration` by default for `completion` since that ***possibly*** requires extra processing of `registrationOptions` (see the point above)

## Examples

This opens up a lot of new functionality for existing lsp servers. Some examples:

- formatting now works with rome lsp, since they only advertise formatting with dynamic registration
- eslintls also has a formatter, which does the same as EslintFixAll, so that special handling in lspconfig would no longer be needed
- some lsps advertise additional code actions

Would be great to get some feedback if this is something we would like to have in core.