### PR TITLE
vim-patch:9.0.{1564,1568}

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -415,6 +415,8 @@ void update_topline(win_T *wp)
     // When 'smoothscroll' is not set, should reset w_skipcol.
     if (!wp->w_p_sms) {
       reset_skipcol(wp);
+    } else if (wp->w_skipcol != 0) {
+      redraw_later(wp, UPD_SOME_VALID);
     }
 
     // May need to set w_skipcol when cursor in w_topline.
@@ -659,7 +661,7 @@ static void curs_rows(win_T *wp)
         i--;                            // hold at inserted lines
       }
     }
-    if (valid && (lnum != wp->w_topline || !win_may_fill(wp))) {
+    if (valid && (lnum != wp->w_topline || (wp->w_skipcol == 0 && !win_may_fill(wp)))) {
       lnum = wp->w_lines[i].wl_lastlnum + 1;
       // Cursor inside folded lines, don't count this row
       if (lnum > wp->w_cursor.lnum) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -248,7 +248,6 @@ void update_topline(win_T *wp)
   }
 
   linenr_T old_topline = wp->w_topline;
-  colnr_T old_skipcol = wp->w_skipcol;
   int old_topfill = wp->w_topfill;
 
   // If the buffer is empty, always set topline to 1.
@@ -413,8 +412,8 @@ void update_topline(win_T *wp)
     dollar_vcol = -1;
     redraw_later(wp, UPD_VALID);
 
-    // Only reset w_skipcol if it was not just set to make cursor visible.
-    if (wp->w_skipcol == old_skipcol) {
+    // When 'smoothscroll' is not set, should reset w_skipcol.
+    if (!wp->w_p_sms) {
       reset_skipcol(wp);
     }
 

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -422,12 +422,41 @@ describe('smoothscroll', function()
                                               |
     ]])
     feed('j')
-    screen:expect_unchanged()
+    screen:expect([[
+      Line with some text with some text with |
+      some text with some text with some text |
+      with some text with some text           |
+      ^Line with some text with some text with |
+      some text with some text with some text |
+      with some text with some text           |
+      @                                       |
+                                              |
+    ]])
     -- moving cursor down - whole bottom line shows
     feed('<C-E>j')
-    screen:expect_unchanged()
+    screen:expect([[
+      <<<h some text with some text           |
+      Line with some text with some text with |
+      some text with some text with some text |
+      with some text with some text           |
+      ^Line with some text with some text with |
+      some text with some text with some text |
+      with some text with some text           |
+                                              |
+    ]])
     feed('G')
-    screen:expect_unchanged()
+    -- FIXME: different from vim onwards, this had in incorrect cursor position
+    -- in vim but we show an eob line.
+    screen:expect([[
+      <<<h some text with some text           |
+      Line with some text with some text with |
+      some text with some text with some text |
+      with some text with some text           |
+      Line with some text with some text with |
+      some text with some text with some text |
+      ^with some text with some text           |
+                                              |
+    ]])
     -- moving cursor up right after the >>> marker - no need to show whole line
     feed('2gj3l2k')
     screen:expect([[

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -422,42 +422,15 @@ describe('smoothscroll', function()
                                               |
     ]])
     feed('j')
-    screen:expect([[
-      Line with some text with some text with |
-      some text with some text with some text |
-      with some text with some text           |
-      ^Line with some text with some text with |
-      some text with some text with some text |
-      with some text with some text           |
-      @                                       |
-                                              |
-    ]])
+    screen:expect_unchanged()
     -- moving cursor down - whole bottom line shows
     feed('<C-E>j')
-    screen:expect([[
-      <<<h some text with some text           |
-      Line with some text with some text with |
-      some text with some text with some text |
-      with some text with some text           |
-      ^Line with some text with some text with |
-      some text with some text with some text |
-      with some text with some text           |
-                                              |
-    ]])
+    screen:expect_unchanged()
     feed('G')
-    -- FIXME: different from vim onwards, this had in incorrect cursor position
-    -- in vim but we show an eob line.
-    screen:expect([[
-      <<<h some text with some text           |
-      Line with some text with some text with |
-      some text with some text with some text |
-      with some text with some text           |
-      Line with some text with some text with |
-      some text with some text with some text |
-      ^with some text with some text           |
-                                              |
-    ]])
-    -- moving cursor up right after the >>> marker - no need to show whole line
+    screen:expect_unchanged()
+    feed('4<C-Y>G')
+    screen:expect_unchanged()
+    -- moving cursor up right after the <<< marker - no need to show whole line
     feed('2gj3l2k')
     screen:expect([[
       <<<^h some text with some text           |
@@ -469,7 +442,7 @@ describe('smoothscroll', function()
       with some text with some text           |
                                               |
     ]])
-    -- moving cursor up where the >>> marker is - whole top line shows
+    -- moving cursor up where the <<< marker is - whole top line shows
     feed('2j02k')
     screen:expect([[
       ^Line with some text with some text with |
@@ -802,6 +775,67 @@ describe('smoothscroll', function()
                                               |
       ^                                        |
                                               |
+    ]])
+  end)
+
+  -- oldtest: Test_smoothscroll_incsearch()
+  it("does not reset skipcol when doing incremental search on the same word", function()
+    screen:try_resize(40, 8)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Brown},
+      [2] = {foreground = Screen.colors.Blue1, bold = true},
+      [3] = {background = Screen.colors.Yellow1},
+      [4] = {reverse = true},
+    })
+    exec([[
+      set smoothscroll number scrolloff=0 incsearch
+      call setline(1, repeat([''], 20))
+      call setline(11, repeat('a', 100))
+      call setline(14, 'bbbb')
+    ]])
+    feed('/b')
+    screen:expect([[
+      {2:<<<}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaa        |
+      {1: 12 }                                    |
+      {1: 13 }                                    |
+      {1: 14 }{4:b}{3:bbb}                                |
+      {1: 15 }                                    |
+      {1: 16 }                                    |
+      {1: 17 }                                    |
+      /b^                                      |
+    ]])
+    feed('b')
+    screen:expect([[
+      {2:<<<}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaa        |
+      {1: 12 }                                    |
+      {1: 13 }                                    |
+      {1: 14 }{4:bb}{3:bb}                                |
+      {1: 15 }                                    |
+      {1: 16 }                                    |
+      {1: 17 }                                    |
+      /bb^                                     |
+    ]])
+    feed('b')
+    screen:expect([[
+      {2:<<<}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaa        |
+      {1: 12 }                                    |
+      {1: 13 }                                    |
+      {1: 14 }{4:bbb}b                                |
+      {1: 15 }                                    |
+      {1: 16 }                                    |
+      {1: 17 }                                    |
+      /bbb^                                    |
+    ]])
+    feed('b')
+    screen:expect([[
+      {2:<<<}{1: }aaaaaaaaaaaaaaaaaaaaaaaaaaaa        |
+      {1: 12 }                                    |
+      {1: 13 }                                    |
+      {1: 14 }{4:bbbb}                                |
+      {1: 15 }                                    |
+      {1: 16 }                                    |
+      {1: 17 }                                    |
+      /bbbb^                                   |
     ]])
   end)
 

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -257,11 +257,14 @@ func Test_smoothscroll_wrap_scrolloff_zero()
   call term_sendkeys(buf, "G")
   call VerifyScreenDump(buf, 'Test_smooth_wrap_4', {})
 
-  " moving cursor up right after the >>> marker - no need to show whole line
+  call term_sendkeys(buf, "4\<C-Y>G")
+  call VerifyScreenDump(buf, 'Test_smooth_wrap_4', {})
+
+  " moving cursor up right after the <<< marker - no need to show whole line
   call term_sendkeys(buf, "2gj3l2k")
   call VerifyScreenDump(buf, 'Test_smooth_wrap_5', {})
 
-  " moving cursor up where the >>> marker is - whole top line shows
+  " moving cursor up where the <<< marker is - whole top line shows
   call term_sendkeys(buf, "2j02k")
   call VerifyScreenDump(buf, 'Test_smooth_wrap_6', {})
 
@@ -701,6 +704,32 @@ func Test_smoothscroll_eob()
   " cursor is not placed below window
   call term_sendkeys(buf, ":call setline(92, 'a'->repeat(100))\<CR>\<C-B>G")
   call VerifyScreenDump(buf, 'Test_smooth_eob_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+" skipcol should not reset when doing incremental search on the same word
+func Test_smoothscroll_incsearch()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll number scrolloff=0 incsearch
+      call setline(1, repeat([''], 20))
+      call setline(11, repeat('a', 100))
+      call setline(14, 'bbbb')
+  END
+  call writefile(lines, 'XSmoothIncsearch', 'D')
+  let buf = RunVimInTerminal('-S XSmoothIncsearch', #{rows: 8, cols:40})
+
+  call term_sendkeys(buf, "/b")
+  call VerifyScreenDump(buf, 'Test_smooth_incsearch_1', {})
+  call term_sendkeys(buf, "b")
+  call VerifyScreenDump(buf, 'Test_smooth_incsearch_2', {})
+  call term_sendkeys(buf, "b")
+  call VerifyScreenDump(buf, 'Test_smooth_incsearch_3', {})
+  call term_sendkeys(buf, "b")
+  call VerifyScreenDump(buf, 'Test_smooth_incsearch_4', {})
+  call term_sendkeys(buf, "\<CR>")
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
**vim-patch:9.0.1564: display moves up and down with 'incsearch' and 'smoothscroll'**

Problem:    Display moves up and down with 'incsearch' and 'smoothscroll'.
Solution:   Do not check if w_skipcol changed. (Luuk van Baal, closes vim/vim#12410,
            closes vim/vim#12409)

https://github.com/vim/vim/commit/0222c2d103ad9298bec4dc8864cd80b4e7559db1

**vim-patch:9.0.1568: with 'smoothscroll' cursor may move below botline**

Problem:    With 'smoothscroll' cursor may move below botline.
Solution:   Call redraw_later() if needed,  Compute cursor row with adjusted
            condition. (Luuk van Baal, closes vim/vim#12415)

https://github.com/vim/vim/commit/d49f646bf56b29d44bbb16e79bc877b59aab38ac
