### PR TITLE
vim-patch:partial:9.0.1570: some tests are slow

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -719,7 +719,7 @@ endfunc
 func Test_shellcmd_completion()
   let save_path = $PATH
 
-  call mkdir('Xpathdir/Xpathsubdir', 'p')
+  call mkdir('Xpathdir/Xpathsubdir', 'pR')
   call writefile([''], 'Xpathdir/Xfile.exe')
   call setfperm('Xpathdir/Xfile.exe', 'rwx------')
 
@@ -735,17 +735,15 @@ func Test_shellcmd_completion()
   call insert(expected, 'Xfile.exe')
   call assert_equal(expected, actual)
 
-  call delete('Xpathdir', 'rf')
   let $PATH = save_path
 endfunc
 
 func Test_expand_star_star()
-  call mkdir('a/b', 'p')
-  call writefile(['asdfasdf'], 'a/b/fileXname')
-  call feedkeys(":find **/fileXname\<Tab>\<CR>", 'xt')
-  call assert_equal('find a/b/fileXname', @:)
+  call mkdir('a/b/c', 'pR')
+  call writefile(['asdfasdf'], 'a/b/c/fileXname')
+  call feedkeys(":find a/**/fileXname\<Tab>\<CR>", 'xt')
+  call assert_equal('find a/b/c/fileXname', @:)
   bwipe!
-  call delete('a', 'rf')
 endfunc
 
 func Test_cmdline_paste()

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -710,19 +710,20 @@ func CheckItems(checks)
     for i in range(0, len(names) - 1)
       new
       try
-        exe 'edit ' . fnameescape(names[i])
+        exe 'edit ' .. fnameescape(names[i])
       catch
-	call assert_report('cannot edit "' . names[i] . '": ' . v:exception)
+	call assert_report('cannot edit "' .. names[i] .. '": ' .. v:exception)
       endtry
       if &filetype == '' && &readonly
 	" File exists but not able to edit it (permission denied)
       else
         let expected = ft == 'none' ? '' : ft
-	call assert_equal(expected, &filetype, 'with file name: ' . names[i])
+	call assert_equal(expected, &filetype, 'with file name: ' .. names[i])
       endif
       bwipe!
     endfor
   endfor
+
   set swapfile&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:partial:9.0.1570: some tests are slow

Problem:    Some tests are slow.
Solution:   Make a few test cases faster.

https://github.com/vim/vim/commit/bf63011a52a3cc32609ae5945665875062a5ae50

Cherry-pick related test_cmdline.vim changes from patch 9.0.0418.

Co-authored-by: Bram Moolenaar <Bram@vim.org>