### PR TITLE
fix(lsp): don't register didChangeWatchedFiles when capability not set

### DIFF
--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -193,7 +193,12 @@ local to_lsp_change_type = {
 function M.register(reg, ctx)
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  if not client.workspace_folders then
+  if
+    -- Ill-behaved servers may not honor the client capability and try to register
+    -- anyway, so ignore requests when the user has opted out of the feature.
+    not client.config.capabilities.workspace.didChangeWatchedFiles.dynamicRegistration
+    or not client.workspace_folders
+  then
     return
   end
   local watch_regs = {}


### PR DESCRIPTION
Some LSP servers (tailwindcss, rome) are known to request registration for `workspace/didChangeWatchedFiles` even when the corresponding client capability does not advertise support. This change adds an extra check in the `client/registerCapability` handler not to start a watch unless the client capability is set appropriately.

ref: https://github.com/neovim/neovim/pull/23500#issuecomment-1554237951