### PR TITLE
fix(redraw): multibyte characters are wrapped at the end of a line

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2,7 +2,7 @@
 // it. PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
 
 // drawline.c: Functions for drawing window lines on the screen.
-// This is the middle level, drawscreen.c is the top and grid.c/screen.c the lower level.
+// This is the middle level, drawscreen.c is the top and grid.c the lower level.
 
 #include <assert.h>
 #include <limits.h>
@@ -1594,6 +1594,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
         // Draw the 'statuscolumn' if option is set.
         if (statuscol.draw) {
           if (statuscol.textp == NULL) {
+            v = (ptr - line);
             get_statuscol_str(wp, lnum, wlv.row - startrow - wlv.filler_lines, &statuscol);
             if (!end_fill) {
               // Get the line again as evaluating 'statuscolumn' may free it.

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -674,4 +674,16 @@ describe('statuscolumn', function()
     ]])
     eq(2, eval('g:stcnr'))
   end)
+
+  it('does not wrap multibyte characters at the end of a line', function()
+    screen:try_resize(33, 4)
+    command([[set spell stc=%l\ ]])
+    command('call setline(8, "This is a line that contains ᶏ multibyte character.")')
+    screen:expect([[
+      8  ^This is a line that contains ᶏ|
+          multibyte character.         |
+      9  aaaaa                         |
+                                       |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:    Multibyte characters may be wrapped at the end of a line
            when 'statuscolumn' and 'spell' are set.
Solution:   Update line pointerdiff "v" before fetching the line pointer
            after evaluating 'statuscolumn'.