### PR TITLE
build: align .clang-format rules with uncrustify config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ PenaltyReturnTypeOnItsOwnLine: 200
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-BinPackParameters: false
+BinPackParameters: true
 BreakBeforeBinaryOperators: true
 BreakBeforeTernaryOperators: true
 ContinuationIndentWidth: 2
@@ -23,7 +23,7 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: No
 AlwaysBreakTemplateDeclarations: No
 AlignEscapedNewlines: DontAlign
-BinPackArguments: false
+BinPackArguments: true
 BraceWrapping:
   AfterClass:      false
   AfterControlStatement: false


### PR DESCRIPTION
While clang-format is not the official code formatter, it's convenient to invoke via clangd, so I think it's valuable to keep it as close to the uncrustify config as possible.