### PR TITLE
fix(deps): restore functionality of USE_EXISTING_SRC_DIR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,3 +78,30 @@ jobs:
 
       - name: Install
         run: make install
+
+  use-existing-src:
+    name: Test USE_EXISTING_SRC_DIR=ON builds with no network access
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install build dependencies
+        run: ./.github/scripts/install_deps.sh
+
+      - name: Build bundled dependencies
+        run: make deps
+
+      - name: Clean bundled dependencies à la neovim/deps
+        run: |
+          rm -rf ./build
+          find .deps .deps/build -maxdepth 1 '!' \( -name .deps -o -name build -o -name src \) -exec rm -r '{}' +
+          cd .deps/build/src
+          rm -rf ./*-build
+          rm -rf ./*-stamp/*-{configure,build,install,done}
+          for d in *; do (cd "$d"; rm -rf ./autom4te.cache; make clean || true; make distclean || true); done
+
+      - name: Re-build bundled dependencies with no network access
+        run: unshare --map-root-user --net make deps DEPS_CMAKE_FLAGS=-DUSE_EXISTING_SRC_DIR=ON
+
+      - name: Build
+        run: make CMAKE_FLAGS="-D CI_BUILD=ON"

--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -88,7 +88,11 @@ foreach(dep ${DEPENDENCIES})
   list(GET dep 0 name)
   list(GET dep 1 value)
   if(NOT ${name})
-    set(${name} ${value})
+    # _URL variables must NOT be set when USE_EXISTING_SRC_DIR is set,
+    # otherwise ExternalProject will try to re-download the sources.
+    if(NOT USE_EXISTING_SRC_DIR)
+      set(${name} ${value})
+    endif()
   endif()
 endforeach()
 


### PR DESCRIPTION
30a0299bc removed the USE_EXISTING_SRC_DIR hack which broke building the
nightly PPA since ExternalProject tried to download the sources.
