### PR TITLE
feat(lua): add Iter:join()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3055,6 +3055,40 @@ Iter:fold({self}, {init}, {f})                                   *Iter:fold()*
     Return: ~
         any
 
+Iter:join({self}, {sep}, {i}, {j})                               *Iter:join()*
+    Each element of iter is concatenated and returned. sep, i, j are the same
+    as the arguments to |table.concat()|.
+
+    The following two are equivalent
+
+    Use table.concat() >
+
+     table.concat(vim
+       .iter({ 1, 2, 3 })
+       :map(function(v)
+         return v * 2
+       end)
+       :totable(), ', ')
+<
+
+    Use Iter :join() >
+
+     vim
+       .iter({ 1, 2, 3 })
+       :map(function(v)
+         return v * 2
+       end)
+       :join(', ')
+<
+
+    Parameters: ~
+      • {sep}  (string|nil)
+      • {i}    (integer|nil)
+      • {j}    (integer|nil)
+
+    Return: ~
+        (string)
+
 Iter:last({self})                                                *Iter:last()*
     Return the last item in the iterator.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -56,6 +56,8 @@ The following new APIs or features were added.
 • |Query:iter_matches()| now has the ability to set the maximum start depth
   for matches.
 
+• |Iter:join()| combines each element of iterators.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -863,7 +863,6 @@ function ListIter.enumerate(self)
   return self
 end
 
-
 --- Each element of iter is concatenated and returned.
 --- sep, i, j are the same as the arguments to |table.concat()|.
 ---

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -871,20 +871,11 @@ end
 function Iter.new(src, ...)
   local it = {}
   if type(src) == 'table' then
-    local t = {}
-
-    -- Check if source table can be treated like a list (indices are consecutive integers
-    -- starting from 1)
-    local count = 0
-    for _ in pairs(src) do
-      count = count + 1
-      local v = src[count]
-      if v == nil then
-        return Iter.new(pairs(src))
-      end
-      t[count] = v
+    if vim.tbl_islist(src) then
+      return ListIter.new(src)
+    else
+      return Iter.new(src)
     end
-    return ListIter.new(t)
   end
 
   if type(src) == 'function' then

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -863,6 +863,49 @@ function ListIter.enumerate(self)
   return self
 end
 
+
+--- Each element of iter is concatenated and returned.
+--- sep, i, j are the same as the arguments to |table.concat()|.
+---
+--- The following two are equivalent
+---
+--- Use table.concat()
+--- <pre>
+--- table.concat(vim
+---   .iter({ 1, 2, 3 })
+---   :map(function(v)
+---     return v * 2
+---   end)
+---   :totable(), ', ')
+--- </pre>
+---
+--- Use Iter:join()
+--- <pre>
+--- vim
+---   .iter({ 1, 2, 3 })
+---   :map(function(v)
+---     return v * 2
+---   end)
+---   :join(', ')
+--- </pre>
+---@param sep string|nil
+---@param i integer|nil
+---@param j integer|nil
+---@return string
+function Iter.join(self, sep, i, j)
+  local t = self
+    :map(function(_, v)
+      return v
+    end)
+    :totable()
+  return table.concat(t, sep, i, j)
+end
+
+---@private
+function ListIter.join(self, sep, i, j)
+  return table.concat(self._table, sep, i, j)
+end
+
 --- Create a new Iter object from a table or iterator.
 ---
 ---@param src table|function Table or iterator to drain values from

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -346,6 +346,12 @@ describe('vim.iter', function()
     end))
   end)
 
+  it('join()', function()
+    local t = {1, 2, 3, 4, 5}
+    eq("12345", vim.iter(t):join())
+    eq("2, 3, 4", vim.iter(t):join(", ", 2, 4))
+  end)
+
   it('handles map-like tables', function()
     local it = vim.iter({ a = 1, b = 2, c = 3 }):map(function(k, v)
       if v % 2 ~= 0 then


### PR DESCRIPTION
Add `Iter:join()` such that the following two are equivalent.

```lua
table.concat(vim
  .iter({ 1, 2, 3 })
  :map(function(v)
    return v * 2
  end)
  :totable(), ', ')
```

```lua
vim
  .iter({ 1, 2, 3 })
  :map(function(v)
    return v * 2
  end)
  :join(', ')
```
