### PR TITLE
fix(highlight): remove unnecessary assignment to char_attr for 'spell'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2046,9 +2046,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool nochange, 
         v = (ptr - line);
         if (has_spell && v >= word_end && v > cur_checked_col) {
           spell_attr = 0;
-          if (!attr_pri) {
-            wlv.char_attr = hl_combine_attr(wlv.char_attr, syntax_attr);
-          }
           if (c != 0 && ((!has_syntax && !no_plain_buffer) || can_spell)) {
             char *prev_ptr;
             char *p;

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -254,4 +254,19 @@ describe("'spell'", function()
     ]])
   end)
 
+  it('and syntax does not clear extmark highlighting at the start of a word', function()
+    screen:try_resize(43, 3)
+    command([[
+      set spell
+      syntax match Constant "^.*$"
+      call setline(1, "This is some text without any spell errors.")
+    ]])
+    local ns = meths.create_namespace("spell")
+    curbufmeths.set_extmark(ns, 0, 0, { hl_group = 'WarningMsg', end_col = 43 })
+    screen:expect([[
+      {6:^This is some text without any spell errors.}|
+      {0:~                                          }|
+                                                 |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Fix #23153

This text prop vim patch also removed the assignment but is otherwise N/A so marking this as a partial patch seemed unnecessary: https://github.com/vim/vim/commit/c6d86dccc4edff8627e309fb23dc8f810ef36b28.