### PR TITLE
fix(colorscheme): try .lua files in 'rtp' before .vim files in 'pp'

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -697,10 +697,18 @@ int load_colors(char *name)
   char *buf = xmalloc(buflen);
   apply_autocmds(EVENT_COLORSCHEMEPRE, name, curbuf->b_fname, false, curbuf);
   snprintf(buf, buflen, "colors/%s.vim", name);
-  int retval = source_runtime(buf, DIP_START + DIP_OPT);
+  int retval = source_runtime(buf, 0);
   if (retval == FAIL) {
     snprintf(buf, buflen, "colors/%s.lua", name);
-    retval = source_runtime(buf, DIP_START + DIP_OPT);
+    retval = source_runtime(buf, 0);
+  }
+  if (retval == FAIL) {
+    snprintf(buf, buflen, "colors/%s.vim", name);
+    retval = source_runtime(buf, DIP_NORTP + DIP_START + DIP_OPT);
+  }
+  if (retval == FAIL) {
+    snprintf(buf, buflen, "colors/%s.lua", name);
+    retval = source_runtime(buf, DIP_NORTP + DIP_START + DIP_OPT);
   }
   xfree(buf);
   if (retval == OK) {

--- a/test/functional/lua/runtime_spec.lua
+++ b/test/functional/lua/runtime_spec.lua
@@ -61,6 +61,38 @@ describe('runtime:', function()
 
       eq('vim', eval('g:colorscheme'))
     end)
+
+    it("loads lua colorscheme in 'rtp' if vim version only exists in 'pp' #23724", function()
+      local pack_dir = 'Test_Pack'
+      mkdir_p(pack_dir)
+      finally(function()
+        rmdir(pack_dir)
+      end)
+      exec('set pp+=' .. pack_dir)
+
+      local pack_opt_dir = pack_dir .. sep .. 'pack' .. sep .. 'some_name' .. sep .. 'opt'
+      local colors_opt_dir = pack_opt_dir .. sep .. 'some_pack' .. sep .. 'colors'
+      mkdir_p(colors_opt_dir)
+
+      local rtp_colorscheme_file = colorscheme_folder .. sep .. 'new_colorscheme'
+      local pp_opt_colorscheme_file = colors_opt_dir .. sep .. 'new_colorscheme'
+
+      write_file(pp_opt_colorscheme_file .. '.lua', [[vim.g.colorscheme = 'lua_pp']])
+      exec('colorscheme new_colorscheme')
+      eq('lua_pp', eval('g:colorscheme'))
+
+      write_file(pp_opt_colorscheme_file .. '.vim', [[let g:colorscheme = 'vim_pp']])
+      exec('colorscheme new_colorscheme')
+      eq('vim_pp', eval('g:colorscheme'))
+
+      write_file(rtp_colorscheme_file .. '.lua', [[vim.g.colorscheme = 'lua_rtp']])
+      exec('colorscheme new_colorscheme')
+      eq('lua_rtp', eval('g:colorscheme'))
+
+      write_file(rtp_colorscheme_file .. '.vim', [[let g:colorscheme = 'vim_rtp']])
+      exec('colorscheme new_colorscheme')
+      eq('vim_rtp', eval('g:colorscheme'))
+    end)
   end)
 
   describe('compiler', function()


### PR DESCRIPTION
Fix #23724

This ensures that colorschemes in 'rtp' are tried before ones in 'pp',
because some colorschemes in 'pp' may not work if not added to 'rtp'.

This also matches the current documentation better.
