### PR TITLE
refactor(api): new helper macros

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -293,17 +293,17 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
           break;
         case kCallbackFuncref:
         case kCallbackPartial:
-          PUT(autocmd_info, "callback", STRING_OBJ(cstr_as_string(callback_to_string(cb))));
+          PUT(autocmd_info, "callback", CSTR_AS_OBJ(callback_to_string(cb)));
           break;
         default:
           abort();
         }
       } else {
-        PUT(autocmd_info, "command", STRING_OBJ(cstr_as_string(xstrdup(ac->exec.callable.cmd))));
+        PUT(autocmd_info, "command", CSTR_TO_OBJ(ac->exec.callable.cmd));
       }
 
-      PUT(autocmd_info, "pattern", STRING_OBJ(cstr_to_string(ap->pat)));
-      PUT(autocmd_info, "event", STRING_OBJ(cstr_to_string(event_nr2name(event))));
+      PUT(autocmd_info, "pattern", CSTR_TO_OBJ(ap->pat));
+      PUT(autocmd_info, "event", CSTR_TO_OBJ(event_nr2name(event)));
       PUT(autocmd_info, "once", BOOLEAN_OBJ(ac->once));
 
       if (ap->buflocal_nr) {
@@ -475,7 +475,7 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
   }
 
   if (patterns.size == 0) {
-    ADD(patterns, STRING_OBJ(STATIC_CSTR_TO_STRING("*")));
+    ADD(patterns, STATIC_CSTR_TO_OBJ("*"));
   }
 
   VALIDATE_R((event_array.size > 0), "event", {
@@ -587,7 +587,7 @@ void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Error *err)
   // When we create the autocmds, we want to say that they are all matched, so that's *
   // but when we clear them, we want to say that we didn't pass a pattern, so that's NUL
   if (patterns.size == 0) {
-    ADD(patterns, STRING_OBJ(STATIC_CSTR_TO_STRING("")));
+    ADD(patterns, STATIC_CSTR_TO_OBJ(""));
   }
 
   // If we didn't pass any events, that means clear all events.
@@ -763,7 +763,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Error *err)
   }
 
   if (patterns.size == 0) {
-    ADD(patterns, STRING_OBJ(STATIC_CSTR_TO_STRING("")));
+    ADD(patterns, STATIC_CSTR_TO_OBJ(""));
   }
 
   if (HAS_KEY(opts->data)) {
@@ -894,7 +894,7 @@ static bool get_patterns_from_pattern_or_buf(Array *patterns, Object pattern, Ob
     }
 
     snprintf((char *)pattern_buflocal, BUFLOCAL_PAT_LEN, "<buffer=%d>", (int)buf->handle);
-    ADD(*patterns, STRING_OBJ(cstr_to_string(pattern_buflocal)));
+    ADD(*patterns, CSTR_TO_OBJ(pattern_buflocal));
   }
 
   return true;

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -518,7 +518,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
 {
   MAXSIZE_TEMP_ARRAY(scratch, 1);
   if (replacement.size == 0) {
-    ADD_C(scratch, STRING_OBJ(STATIC_CSTR_AS_STRING("")));
+    ADD_C(scratch, STATIC_CSTR_AS_OBJ(""));
     replacement = scratch;
   }
 

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -245,7 +245,7 @@ Dictionary nvim_parse_cmd(String str, Dictionary opts, Error *err)
   Dictionary filter = ARRAY_DICT_INIT;
   PUT(filter, "pattern", cmdinfo.cmdmod.cmod_filter_pat
       ? CSTR_TO_OBJ(cmdinfo.cmdmod.cmod_filter_pat)
-      : STRING_OBJ(STATIC_CSTR_TO_STRING("")));
+      : STATIC_CSTR_TO_OBJ(""));
   PUT(filter, "force", BOOLEAN_OBJ(cmdinfo.cmdmod.cmod_filter_force));
   PUT(mods, "filter", DICTIONARY_OBJ(filter));
 
@@ -438,7 +438,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Error
         break;
       }
 
-      ADD(args, STRING_OBJ(cstr_as_string(data_str)));
+      ADD(args, CSTR_AS_OBJ(data_str));
     }
 
     bool argc_valid;

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -106,7 +106,7 @@ bool ns_initialized(uint32_t ns)
 static Object hl_group_name(int hl_id, bool hl_name)
 {
   if (hl_name) {
-    return STRING_OBJ(cstr_to_string(syn_id2name(hl_id)));
+    return CSTR_TO_OBJ(syn_id2name(hl_id));
   } else {
     return INTEGER_OBJ(hl_id);
   }
@@ -140,7 +140,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
       PUT(dict, "hl_eol", BOOLEAN_OBJ(decor->hl_eol));
     }
     if (decor->hl_mode) {
-      PUT(dict, "hl_mode", STRING_OBJ(cstr_to_string(hl_mode_str[decor->hl_mode])));
+      PUT(dict, "hl_mode", CSTR_TO_OBJ(hl_mode_str[decor->hl_mode]));
     }
 
     if (kv_size(decor->virt_text)) {
@@ -148,7 +148,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
       for (size_t i = 0; i < decor->virt_text.size; i++) {
         Array chunk = ARRAY_DICT_INIT;
         VirtTextChunk *vtc = &decor->virt_text.items[i];
-        ADD(chunk, STRING_OBJ(cstr_to_string(vtc->text)));
+        ADD(chunk, CSTR_TO_OBJ(vtc->text));
         if (vtc->hl_id > 0) {
           ADD(chunk, hl_group_name(vtc->hl_id, hl_name));
         }
@@ -160,7 +160,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
         PUT(dict, "virt_text_win_col", INTEGER_OBJ(decor->col));
       }
       PUT(dict, "virt_text_pos",
-          STRING_OBJ(cstr_to_string(virt_text_pos_str[decor->virt_text_pos])));
+          CSTR_TO_OBJ(virt_text_pos_str[decor->virt_text_pos]));
     }
 
     if (decor->ui_watched) {
@@ -177,7 +177,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
         for (size_t j = 0; j < vt->size; j++) {
           Array chunk = ARRAY_DICT_INIT;
           VirtTextChunk *vtc = &vt->items[j];
-          ADD(chunk, STRING_OBJ(cstr_to_string(vtc->text)));
+          ADD(chunk, CSTR_TO_OBJ(vtc->text));
           if (vtc->hl_id > 0) {
             ADD(chunk, hl_group_name(vtc->hl_id, hl_name));
           }
@@ -191,7 +191,7 @@ static Array extmark_to_array(const ExtmarkInfo *extmark, bool id, bool add_dict
     }
 
     if (decor->sign_text) {
-      PUT(dict, "sign_text", STRING_OBJ(cstr_to_string(decor->sign_text)));
+      PUT(dict, "sign_text", CSTR_TO_OBJ(decor->sign_text));
     }
 
     // uncrustify:off

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -188,7 +188,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
 
   switch (result) {
   case gov_string:
-    rv = STRING_OBJ(cstr_as_string(stringval));
+    rv = CSTR_AS_OBJ(stringval);
     break;
   case gov_number:
     rv = INTEGER_OBJ(numval);

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -660,10 +660,10 @@ static void init_ui_event_metadata(Dictionary *metadata)
   msgpack_unpacked_destroy(&unpacked);
   PUT(*metadata, "ui_events", ui_events);
   Array ui_options = ARRAY_DICT_INIT;
-  ADD(ui_options, STRING_OBJ(cstr_to_string("rgb")));
+  ADD(ui_options, CSTR_TO_OBJ("rgb"));
   for (UIExtension i = 0; i < kUIExtCount; i++) {
     if (ui_ext_names[i][0] != '_') {
-      ADD(ui_options, STRING_OBJ(cstr_to_string(ui_ext_names[i])));
+      ADD(ui_options, CSTR_TO_OBJ(ui_ext_names[i]));
     }
   }
   PUT(*metadata, "ui_options", ARRAY_OBJ(ui_options));
@@ -692,17 +692,17 @@ static void init_type_metadata(Dictionary *metadata)
   Dictionary buffer_metadata = ARRAY_DICT_INIT;
   PUT(buffer_metadata, "id",
       INTEGER_OBJ(kObjectTypeBuffer - EXT_OBJECT_TYPE_SHIFT));
-  PUT(buffer_metadata, "prefix", STRING_OBJ(cstr_to_string("nvim_buf_")));
+  PUT(buffer_metadata, "prefix", CSTR_TO_OBJ("nvim_buf_"));
 
   Dictionary window_metadata = ARRAY_DICT_INIT;
   PUT(window_metadata, "id",
       INTEGER_OBJ(kObjectTypeWindow - EXT_OBJECT_TYPE_SHIFT));
-  PUT(window_metadata, "prefix", STRING_OBJ(cstr_to_string("nvim_win_")));
+  PUT(window_metadata, "prefix", CSTR_TO_OBJ("nvim_win_"));
 
   Dictionary tabpage_metadata = ARRAY_DICT_INIT;
   PUT(tabpage_metadata, "id",
       INTEGER_OBJ(kObjectTypeTabpage - EXT_OBJECT_TYPE_SHIFT));
-  PUT(tabpage_metadata, "prefix", STRING_OBJ(cstr_to_string("nvim_tabpage_")));
+  PUT(tabpage_metadata, "prefix", CSTR_TO_OBJ("nvim_tabpage_"));
 
   PUT(types, "Buffer", DICTIONARY_OBJ(buffer_metadata));
   PUT(types, "Window", DICTIONARY_OBJ(window_metadata));

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -34,6 +34,7 @@
     .type = kObjectTypeString, \
     .data.string = s })
 
+#define CSTR_AS_OBJ(s) STRING_OBJ(cstr_as_string(s))
 #define CSTR_TO_OBJ(s) STRING_OBJ(cstr_to_string(s))
 
 #define BUFFER_OBJ(s) ((Object) { \
@@ -102,6 +103,9 @@
 #define STATIC_CSTR_TO_STRING(s) ((String){ \
     .data = xmemdupz(s, sizeof(s) - 1), \
     .size = sizeof(s) - 1 })
+
+#define STATIC_CSTR_AS_OBJ(s) STRING_OBJ(STATIC_CSTR_AS_STRING(s))
+#define STATIC_CSTR_TO_OBJ(s) STRING_OBJ(STATIC_CSTR_TO_STRING(s))
 
 // Helpers used by the generated msgpack-rpc api wrappers
 #define api_init_boolean

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -795,7 +795,7 @@ void remote_ui_put(UI *ui, const char *cell)
   UIData *data = ui->data;
   data->client_col++;
   Array args = data->call_buf;
-  ADD_C(args, STRING_OBJ(cstr_as_string((char *)cell)));
+  ADD_C(args, CSTR_AS_OBJ((char *)cell));
   push_call(ui, "put", args);
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -531,7 +531,7 @@ static void find_runtime_cb(char *fname, void *cookie)
 {
   Array *rv = (Array *)cookie;
   if (fname != NULL) {
-    ADD(*rv, STRING_OBJ(cstr_to_string(fname)));
+    ADD(*rv, CSTR_TO_OBJ(fname));
   }
 }
 
@@ -1383,7 +1383,7 @@ Dictionary nvim_get_mode(void)
   get_mode(modestr);
   bool blocked = input_blocking();
 
-  PUT(rv, "mode", STRING_OBJ(cstr_to_string(modestr)));
+  PUT(rv, "mode", CSTR_TO_OBJ(modestr));
   PUT(rv, "blocking", BOOLEAN_OBJ(blocked));
 
   return rv;
@@ -1926,7 +1926,7 @@ Array nvim__inspect_cell(Integer grid, Integer row, Integer col, Arena *arena, E
   }
   ret = arena_array(arena, 3);
   size_t off = g->line_offset[(size_t)row] + (size_t)col;
-  ADD_C(ret, STRING_OBJ(cstr_as_string((char *)g->chars[off])));
+  ADD_C(ret, CSTR_AS_OBJ((char *)g->chars[off]));
   int attr = g->attrs[off];
   ADD_C(ret, DICTIONARY_OBJ(hl_get_attr_by_id(attr, true, arena, err)));
   // will not work first time
@@ -2035,7 +2035,7 @@ Array nvim_get_mark(String name, Dictionary opts, Error *err)
   ADD(rv, INTEGER_OBJ(row));
   ADD(rv, INTEGER_OBJ(col));
   ADD(rv, INTEGER_OBJ(bufnr));
-  ADD(rv, STRING_OBJ(cstr_to_string(filename)));
+  ADD(rv, CSTR_TO_OBJ(filename));
 
   if (allocated) {
     xfree(filename);

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -502,7 +502,7 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, E
     };
     err_dict.items[0] = (KeyValuePair) {
       .key = STATIC_CSTR_TO_STRING("message"),
-      .value = STRING_OBJ(cstr_to_string(east.err.msg)),
+      .value = CSTR_TO_OBJ(east.err.msg),
     };
     if (east.err.arg == NULL) {
       err_dict.items[1] = (KeyValuePair) {
@@ -539,7 +539,7 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, E
       chunk_arr.items[0] = INTEGER_OBJ((Integer)chunk.start.line);
       chunk_arr.items[1] = INTEGER_OBJ((Integer)chunk.start.col);
       chunk_arr.items[2] = INTEGER_OBJ((Integer)chunk.end_col);
-      chunk_arr.items[3] = STRING_OBJ(cstr_to_string(chunk.group));
+      chunk_arr.items[3] = CSTR_TO_OBJ(chunk.group);
       hl.items[i] = ARRAY_OBJ(chunk_arr);
     }
     ret.items[ret.size++] = (KeyValuePair) {
@@ -616,7 +616,7 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, E
         kv_drop(ast_conv_stack, 1);
         ret_node->items[ret_node->size++] = (KeyValuePair) {
           .key = STATIC_CSTR_TO_STRING("type"),
-          .value = STRING_OBJ(cstr_to_string(east_node_type_tab[node->type])),
+          .value = CSTR_TO_OBJ(east_node_type_tab[node->type]),
         };
         Array start_array = {
           .items = xmalloc(2 * sizeof(start_array.items[0])),
@@ -701,11 +701,11 @@ Dictionary nvim_parse_expression(String expr, String flags, Boolean highlight, E
         case kExprNodeComparison:
           ret_node->items[ret_node->size++] = (KeyValuePair) {
             .key = STATIC_CSTR_TO_STRING("cmp_type"),
-            .value = STRING_OBJ(cstr_to_string(eltkn_cmp_type_tab[node->data.cmp.type])),
+            .value = CSTR_TO_OBJ(eltkn_cmp_type_tab[node->data.cmp.type]),
           };
           ret_node->items[ret_node->size++] = (KeyValuePair) {
             .key = STATIC_CSTR_TO_STRING("ccs_strategy"),
-            .value = STRING_OBJ(cstr_to_string(ccs_tab[node->data.cmp.ccs])),
+            .value = CSTR_TO_OBJ(ccs_tab[node->data.cmp.ccs]),
           };
           ret_node->items[ret_node->size++] = (KeyValuePair) {
             .key = STATIC_CSTR_TO_STRING("invert"),

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -267,7 +267,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
           PUT(rv, "bufpos", ARRAY_OBJ(pos));
         }
       }
-      PUT(rv, "anchor", STRING_OBJ(cstr_to_string(float_anchor_str[config->anchor])));
+      PUT(rv, "anchor", CSTR_TO_OBJ(float_anchor_str[config->anchor]));
       PUT(rv, "row", FLOAT_OBJ(config->row));
       PUT(rv, "col", FLOAT_OBJ(config->col));
       PUT(rv, "zindex", INTEGER_OBJ(config->zindex));
@@ -283,7 +283,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
         char *hi_name = syn_id2name(hi_id);
         if (hi_name[0]) {
           ADD(tuple, STRING_OBJ(s));
-          ADD(tuple, STRING_OBJ(cstr_to_string(hi_name)));
+          ADD(tuple, CSTR_TO_OBJ(hi_name));
           ADD(border, ARRAY_OBJ(tuple));
         } else {
           ADD(border, STRING_OBJ(s));
@@ -297,7 +297,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
           Array tuple = ARRAY_DICT_INIT;
           ADD(tuple, CSTR_TO_OBJ(title_datas.items[i].text));
           if (title_datas.items[i].hl_id > 0) {
-            ADD(tuple, STRING_OBJ(cstr_to_string(syn_id2name(title_datas.items[i].hl_id))));
+            ADD(tuple, CSTR_TO_OBJ(syn_id2name(title_datas.items[i].hl_id)));
           }
           ADD(titles, ARRAY_OBJ(tuple));
         }
@@ -317,7 +317,7 @@ Dictionary nvim_win_get_config(Window window, Error *err)
 
   const char *rel = (wp->w_floating && !config->external
                      ? float_relative_str[config->relative] : "");
-  PUT(rv, "relative", STRING_OBJ(cstr_to_string(rel)));
+  PUT(rv, "relative", CSTR_TO_OBJ(rel));
 
   return rv;
 }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -884,14 +884,14 @@ Dictionary channel_info(uint64_t id)
     stream_desc = "job";
     if (chan->stream.proc.type == kProcessTypePty) {
       const char *name = pty_process_tty_name(&chan->stream.pty);
-      PUT(info, "pty", STRING_OBJ(cstr_to_string(name)));
+      PUT(info, "pty", CSTR_TO_OBJ(name));
     }
 
     char **p = chan->stream.proc.argv;
     Array argv = ARRAY_DICT_INIT;
     if (p != NULL) {
       while (*p != NULL) {
-        ADD(argv, STRING_OBJ(cstr_to_string(*p)));
+        ADD(argv, CSTR_TO_OBJ(*p));
         p++;
       }
     }
@@ -918,7 +918,7 @@ Dictionary channel_info(uint64_t id)
   default:
     abort();
   }
-  PUT(info, "stream", STRING_OBJ(cstr_to_string(stream_desc)));
+  PUT(info, "stream", CSTR_TO_OBJ(stream_desc));
 
   if (chan->is_rpc) {
     mode_desc = "rpc";
@@ -929,7 +929,7 @@ Dictionary channel_info(uint64_t id)
   } else {
     mode_desc = "bytes";
   }
-  PUT(info, "mode", STRING_OBJ(cstr_to_string(mode_desc)));
+  PUT(info, "mode", CSTR_TO_OBJ(mode_desc));
 
   return info;
 }

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -62,8 +62,8 @@ Array mode_style_array(Arena *arena)
   for (int i = 0; i < SHAPE_IDX_COUNT; i++) {
     cursorentry_T *cur = &shape_table[i];
     Dictionary dic = arena_dict(arena, 3 + ((cur->used_for & SHAPE_CURSOR) ? 9 : 0));
-    PUT_C(dic, "name", STRING_OBJ(cstr_as_string(cur->full_name)));
-    PUT_C(dic, "short_name", STRING_OBJ(cstr_as_string(cur->name)));
+    PUT_C(dic, "name", CSTR_AS_OBJ(cur->full_name));
+    PUT_C(dic, "short_name", CSTR_AS_OBJ(cur->name));
     if (cur->used_for & SHAPE_MOUSE) {
       PUT_C(dic, "mouse_shape", INTEGER_OBJ(cur->mshape));
     }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8712,7 +8712,7 @@ void ex_checkhealth(exarg_T *eap)
 {
   Error err = ERROR_INIT;
   MAXSIZE_TEMP_ARRAY(args, 1);
-  ADD_C(args, STRING_OBJ(cstr_as_string(eap->arg)));
+  ADD_C(args, CSTR_AS_OBJ(eap->arg));
   NLUA_EXEC_STATIC("return vim.health._check(...)", args, &err);
   if (!ERROR_SET(&err)) {
     return;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3387,7 +3387,7 @@ static void ui_ext_cmdline_show(CmdlineInfo *line)
   } else {
     Array item = arena_array(&arena, 2);
     ADD_C(item, INTEGER_OBJ(0));
-    ADD_C(item, STRING_OBJ(cstr_as_string(line->cmdbuff)));
+    ADD_C(item, CSTR_AS_OBJ(line->cmdbuff));
     content = arena_array(&arena, 1);
     ADD_C(content, ARRAY_OBJ(item));
   }
@@ -3414,7 +3414,7 @@ void ui_ext_cmdline_block_append(size_t indent, const char *line)
 
   Array item = ARRAY_DICT_INIT;
   ADD(item, INTEGER_OBJ(0));
-  ADD(item, STRING_OBJ(cstr_as_string(buf)));
+  ADD(item, CSTR_AS_OBJ(buf));
   Array content = ARRAY_DICT_INIT;
   ADD(content, ARRAY_OBJ(item));
   ADD(cmdline_block, ARRAY_OBJ(content));

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -207,7 +207,7 @@ int ns_get_hl(NS *ns_hl, int hl_id, bool link, bool nodefault)
   if (!valid_item && p->hl_def != LUA_NOREF && !recursive) {
     MAXSIZE_TEMP_ARRAY(args, 3);
     ADD_C(args, INTEGER_OBJ((Integer)ns_id));
-    ADD_C(args, STRING_OBJ(cstr_to_string(syn_id2name(hl_id))));
+    ADD_C(args, CSTR_TO_OBJ(syn_id2name(hl_id)));
     ADD_C(args, BOOLEAN_OBJ(link));
     // TODO(bfredl): preload the "global" attr dict?
 
@@ -1141,21 +1141,21 @@ static void hl_inspect_impl(Array *arr, int attr)
   HlEntry e = kv_A(attr_entries, attr);
   switch (e.kind) {
   case kHlSyntax:
-    PUT(item, "kind", STRING_OBJ(cstr_to_string("syntax")));
+    PUT(item, "kind", CSTR_TO_OBJ("syntax"));
     PUT(item, "hi_name",
-        STRING_OBJ(cstr_to_string(syn_id2name(e.id1))));
+        CSTR_TO_OBJ(syn_id2name(e.id1)));
     break;
 
   case kHlUI:
-    PUT(item, "kind", STRING_OBJ(cstr_to_string("ui")));
+    PUT(item, "kind", CSTR_TO_OBJ("ui"));
     const char *ui_name = (e.id1 == -1) ? "Normal" : hlf_names[e.id1];
-    PUT(item, "ui_name", STRING_OBJ(cstr_to_string(ui_name)));
+    PUT(item, "ui_name", CSTR_TO_OBJ(ui_name));
     PUT(item, "hi_name",
-        STRING_OBJ(cstr_to_string(syn_id2name(e.id2))));
+        CSTR_TO_OBJ(syn_id2name(e.id2)));
     break;
 
   case kHlTerminal:
-    PUT(item, "kind", STRING_OBJ(cstr_to_string("term")));
+    PUT(item, "kind", CSTR_TO_OBJ("term"));
     break;
 
   case kHlCombine:

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1549,7 +1549,7 @@ static bool hlgroup2dict(Dictionary *hl, NS ns_id, int hl_id, Arena *arena)
     syn_attr2entry(ns_id == 0 ? sgp->sg_attr : ns_get_hl(&ns_id, hl_id, false, sgp->sg_set));
   *hl = arena_dict(arena, HLATTRS_DICT_SIZE + 1);
   if (link > 0) {
-    PUT_C(*hl, "link", STRING_OBJ(cstr_as_string(hl_table[link - 1].sg_name)));
+    PUT_C(*hl, "link", CSTR_AS_OBJ(hl_table[link - 1].sg_name));
   }
   Dictionary hl_cterm = arena_dict(arena, HLATTRS_DICT_SIZE);
   hlattrs2dict(hl, NULL, attr, true, true);

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2096,13 +2096,13 @@ static Dictionary mapblock_fill_dict(const mapblock_T *const mp, const char *lhs
                                 : cstr_as_string(str2special_save(mp->m_str, false, true))));
   }
   if (mp->m_desc != NULL) {
-    PUT(dict, "desc", STRING_OBJ(cstr_to_string(mp->m_desc)));
+    PUT(dict, "desc", CSTR_TO_OBJ(mp->m_desc));
   }
-  PUT(dict, "lhs", STRING_OBJ(cstr_as_string(lhs)));
-  PUT(dict, "lhsraw", STRING_OBJ(cstr_to_string(mp->m_keys)));
+  PUT(dict, "lhs", CSTR_AS_OBJ(lhs));
+  PUT(dict, "lhsraw", CSTR_TO_OBJ(mp->m_keys));
   if (lhsrawalt != NULL) {
     // Also add the value for the simplified entry.
-    PUT(dict, "lhsrawalt", STRING_OBJ(cstr_to_string(lhsrawalt)));
+    PUT(dict, "lhsrawalt", CSTR_TO_OBJ(lhsrawalt));
   }
   PUT(dict, "noremap", INTEGER_OBJ(noremap_value));
   PUT(dict, "script", INTEGER_OBJ(mp->m_noremap == REMAP_SCRIPT ? 1 : 0));
@@ -2115,7 +2115,7 @@ static Dictionary mapblock_fill_dict(const mapblock_T *const mp, const char *lhs
   if (mp->m_replace_keycodes) {
     PUT(dict, "replace_keycodes", INTEGER_OBJ(1));
   }
-  PUT(dict, "mode", STRING_OBJ(cstr_as_string(mapmode)));
+  PUT(dict, "mode", CSTR_AS_OBJ(mapmode));
 
   return dict;
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1069,7 +1069,7 @@ void ex_messages(void *const eap_p)
     for (; p != NULL; p = p->next) {
       if (kv_size(p->multiattr) || (p->msg && p->msg[0])) {
         Array entry = ARRAY_DICT_INIT;
-        ADD(entry, STRING_OBJ(cstr_to_string(p->kind)));
+        ADD(entry, CSTR_TO_OBJ(p->kind));
         Array content = ARRAY_DICT_INIT;
         if (kv_size(p->multiattr)) {
           for (uint32_t i = 0; i < kv_size(p->multiattr); i++) {
@@ -1082,7 +1082,7 @@ void ex_messages(void *const eap_p)
         } else if (p->msg && p->msg[0]) {
           Array content_entry = ARRAY_DICT_INIT;
           ADD(content_entry, INTEGER_OBJ(p->attr));
-          ADD(content_entry, STRING_OBJ(cstr_to_string(p->msg)));
+          ADD(content_entry, CSTR_TO_OBJ(p->msg));
           ADD(content, ARRAY_OBJ(content_entry));
         }
         ADD(entry, ARRAY_OBJ(content));

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -628,7 +628,7 @@ static void chan_close_with_error(Channel *channel, char *msg, int loglevel)
     ChannelCallFrame *frame = kv_A(channel->rpc.call_stack, i);
     frame->returned = true;
     frame->errored = true;
-    frame->result = STRING_OBJ(cstr_to_string(msg));
+    frame->result = CSTR_TO_OBJ(msg);
   }
 
   channel_close(channel->id, kChannelPartRpc, NULL);
@@ -665,7 +665,7 @@ static WBuffer *serialize_response(uint64_t channel_id, MsgpackRpcRequestHandler
     } else {
       Array args = ARRAY_DICT_INIT;
       ADD(args, INTEGER_OBJ(err->type));
-      ADD(args, STRING_OBJ(cstr_to_string(err->msg)));
+      ADD(args, CSTR_TO_OBJ(err->msg));
       msgpack_rpc_serialize_request(0, cstr_as_string("nvim_error_event"),
                                     args, &pac);
       api_free_array(args);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2031,7 +2031,7 @@ static void display_showcmd(void)
     if (len > 0) {
       // placeholder for future highlight support
       ADD_C(chunk, INTEGER_OBJ(0));
-      ADD_C(chunk, STRING_OBJ(cstr_as_string(showcmd_buf)));
+      ADD_C(chunk, CSTR_AS_OBJ(showcmd_buf));
       ADD_C(content, ARRAY_OBJ(chunk));
     }
     ui_call_msg_showcmd(content);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1252,7 +1252,7 @@ static void do_set_option_string(int opt_idx, int opt_flags, char **argp, int ne
     }
     if (options[opt_idx].flags & P_UI_OPTION) {
       ui_call_option_set(cstr_as_string(options[opt_idx].fullname),
-                         STRING_OBJ(cstr_as_string(saved_newval)));
+                         CSTR_AS_OBJ(saved_newval));
     }
   }
   xfree(saved_origval);
@@ -3803,7 +3803,7 @@ void ui_refresh_options(void)
       value = INTEGER_OBJ(*(long *)varp);
     } else if (flags & P_STRING) {
       // cstr_as_string handles NULL string
-      value = STRING_OBJ(cstr_as_string(*(char **)varp));
+      value = CSTR_AS_OBJ(*(char **)varp);
     }
     ui_call_option_set(name, value);
   }

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -254,7 +254,7 @@ Dictionary os_proc_info(int pid)
   if (pe.th32ProcessID == (DWORD)pid) {
     PUT(pinfo, "pid", INTEGER_OBJ(pid));
     PUT(pinfo, "ppid", INTEGER_OBJ((int)pe.th32ParentProcessID));
-    PUT(pinfo, "name", STRING_OBJ(cstr_to_string(pe.szExeFile)));
+    PUT(pinfo, "name", CSTR_TO_OBJ(pe.szExeFile));
   }
 
   return pinfo;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -164,10 +164,10 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
         Array arr = arena_array(&arena, (size_t)size);
         for (int i = 0; i < size; i++) {
           Array item = arena_array(&arena, 4);
-          ADD_C(item, STRING_OBJ(cstr_as_string(array[i].pum_text)));
-          ADD_C(item, STRING_OBJ(cstr_as_string(array[i].pum_kind)));
-          ADD_C(item, STRING_OBJ(cstr_as_string(array[i].pum_extra)));
-          ADD_C(item, STRING_OBJ(cstr_as_string(array[i].pum_info)));
+          ADD_C(item, CSTR_AS_OBJ(array[i].pum_text));
+          ADD_C(item, CSTR_AS_OBJ(array[i].pum_kind));
+          ADD_C(item, CSTR_AS_OBJ(array[i].pum_extra));
+          ADD_C(item, CSTR_AS_OBJ(array[i].pum_info));
           ADD_C(arr, ARRAY_OBJ(item));
         }
         ui_call_popupmenu_show(arr, selected, pum_win_row, cursor_col,

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -512,7 +512,7 @@ Array runtime_inspect(void)
   for (size_t i = 0; i < kv_size(path); i++) {
     SearchPathItem *item = &kv_A(path, i);
     Array entry = ARRAY_DICT_INIT;
-    ADD(entry, STRING_OBJ(cstr_to_string(item->path)));
+    ADD(entry, CSTR_TO_OBJ(item->path));
     ADD(entry, BOOLEAN_OBJ(item->after));
     if (item->has_lua != kNone) {
       ADD(entry, BOOLEAN_OBJ(item->has_lua == kTrue));
@@ -568,7 +568,7 @@ ArrayOf(String) runtime_get_named_common(bool lua, Array pat, bool all,
                                        item->path, pat_item.data.string.data);
         if (size < buf_len) {
           if (os_file_is_readable(buf)) {
-            ADD(rv, STRING_OBJ(cstr_to_string(buf)));
+            ADD(rv, CSTR_TO_OBJ(buf));
             if (!all) {
               goto done;
             }

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -2529,15 +2529,15 @@ static ShaDaWriteResult shada_write(ShaDaWriteDef *const sd_writer, ShaDaReadDef
         .capacity = 5,
         .items = ((KeyValuePair[]) {
           { STATIC_CSTR_AS_STRING("generator"),
-            STRING_OBJ(STATIC_CSTR_AS_STRING("nvim")) },
+            STATIC_CSTR_AS_OBJ("nvim") },
           { STATIC_CSTR_AS_STRING("version"),
-            STRING_OBJ(cstr_as_string(longVersion)) },
+            CSTR_AS_OBJ(longVersion) },
           { STATIC_CSTR_AS_STRING("max_kbyte"),
             INTEGER_OBJ((Integer)max_kbyte) },
           { STATIC_CSTR_AS_STRING("pid"),
             INTEGER_OBJ((Integer)os_get_pid()) },
           { STATIC_CSTR_AS_STRING("encoding"),
-            STRING_OBJ(cstr_as_string(p_enc)) },
+            CSTR_AS_OBJ(p_enc) },
         }),
       }
     }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -596,7 +596,7 @@ void win_redr_ruler(win_T *wp)
     MAXSIZE_TEMP_ARRAY(content, 1);
     MAXSIZE_TEMP_ARRAY(chunk, 2);
     ADD_C(chunk, INTEGER_OBJ(attr));
-    ADD_C(chunk, STRING_OBJ(cstr_as_string(buffer)));
+    ADD_C(chunk, CSTR_AS_OBJ(buffer));
     ADD_C(content, ARRAY_OBJ(chunk));
     ui_call_msg_ruler(content);
     did_show_ext_ruler = true;

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -547,8 +547,8 @@ static void set_bg(char *bgvalue)
 {
   if (ui_client_attached) {
     MAXSIZE_TEMP_ARRAY(args, 2);
-    ADD_C(args, STRING_OBJ(cstr_as_string("term_background")));
-    ADD_C(args, STRING_OBJ(cstr_as_string(bgvalue)));
+    ADD_C(args, CSTR_AS_OBJ("term_background"));
+    ADD_C(args, CSTR_AS_OBJ(bgvalue));
     rpc_send_event(ui_client_channel_id, "nvim_ui_set_option", args);
   }
 }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1302,16 +1302,16 @@ static void show_verbose_terminfo(TUIData *tui)
 
   Array chunks = ARRAY_DICT_INIT;
   Array title = ARRAY_DICT_INIT;
-  ADD(title, STRING_OBJ(cstr_to_string("\n\n--- Terminal info --- {{{\n")));
-  ADD(title, STRING_OBJ(cstr_to_string("Title")));
+  ADD(title, CSTR_TO_OBJ("\n\n--- Terminal info --- {{{\n"));
+  ADD(title, CSTR_TO_OBJ("Title"));
   ADD(chunks, ARRAY_OBJ(title));
   Array info = ARRAY_DICT_INIT;
   String str = terminfo_info_msg(ut, tui->term);
   ADD(info, STRING_OBJ(str));
   ADD(chunks, ARRAY_OBJ(info));
   Array end_fold = ARRAY_DICT_INIT;
-  ADD(end_fold, STRING_OBJ(cstr_to_string("}}}\n")));
-  ADD(end_fold, STRING_OBJ(cstr_to_string("Title")));
+  ADD(end_fold, CSTR_TO_OBJ("}}}\n"));
+  ADD(end_fold, CSTR_TO_OBJ("Title"));
   ADD(chunks, ARRAY_OBJ(end_fold));
 
   Array args = ARRAY_DICT_INIT;
@@ -1425,7 +1425,7 @@ void tui_option_set(TUIData *tui, String name, Object value)
 
     if (ui_client_channel_id) {
       MAXSIZE_TEMP_ARRAY(args, 2);
-      ADD_C(args, STRING_OBJ(cstr_as_string("rgb")));
+      ADD_C(args, CSTR_AS_OBJ("rgb"));
       ADD_C(args, BOOLEAN_OBJ(value.data.boolean));
       rpc_send_event(ui_client_channel_id, "nvim_ui_set_option", args);
     }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -613,8 +613,8 @@ Array ui_array(void)
     PUT(info, "override", BOOLEAN_OBJ(ui->override));
 
     // TUI fields. (`stdin_fd` is intentionally omitted.)
-    PUT(info, "term_name", STRING_OBJ(cstr_to_string(ui->term_name)));
-    PUT(info, "term_background", STRING_OBJ(cstr_to_string(ui->term_background)));
+    PUT(info, "term_name", CSTR_TO_OBJ(ui->term_name));
+    PUT(info, "term_background", CSTR_TO_OBJ(ui->term_background));
     PUT(info, "term_colors", INTEGER_OBJ(ui->term_colors));
     PUT(info, "stdin_tty", BOOLEAN_OBJ(ui->stdin_tty));
     PUT(info, "stdout_tty", BOOLEAN_OBJ(ui->stdout_tty));

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -83,11 +83,11 @@ void ui_client_attach(int width, int height, char *term)
   PUT_C(opts, "ext_linegrid", BOOLEAN_OBJ(true));
   PUT_C(opts, "ext_termcolors", BOOLEAN_OBJ(true));
   if (term) {
-    PUT_C(opts, "term_name", STRING_OBJ(cstr_as_string(term)));
+    PUT_C(opts, "term_name", CSTR_AS_OBJ(term));
   }
   if (ui_client_bg_response != kNone) {
     bool is_dark = (ui_client_bg_response == kTrue);
-    PUT_C(opts, "term_background", STRING_OBJ(cstr_as_string(is_dark ? "dark" : "light")));
+    PUT_C(opts, "term_background", CSTR_AS_OBJ(is_dark ? "dark" : "light"));
   }
   PUT_C(opts, "term_colors", INTEGER_OBJ(t_colors));
   if (!ui_client_is_remote) {

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -1754,8 +1754,8 @@ Dictionary commands_array(buf_T *buf)
     Dictionary d = ARRAY_DICT_INIT;
     ucmd_T *cmd = USER_CMD_GA(gap, i);
 
-    PUT(d, "name", STRING_OBJ(cstr_to_string(cmd->uc_name)));
-    PUT(d, "definition", STRING_OBJ(cstr_to_string(cmd->uc_rep)));
+    PUT(d, "name", CSTR_TO_OBJ(cmd->uc_name));
+    PUT(d, "definition", CSTR_TO_OBJ(cmd->uc_rep));
     PUT(d, "script_id", INTEGER_OBJ(cmd->uc_script_ctx.sc_sid));
     PUT(d, "bang", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_BANG)));
     PUT(d, "bar", BOOLEAN_OBJ(!!(cmd->uc_argt & EX_TRLBAR)));
@@ -1775,21 +1775,21 @@ Dictionary commands_array(buf_T *buf)
     case (EX_EXTRA | EX_NOSPC | EX_NEEDARG):
       arg[0] = '1'; break;
     }
-    PUT(d, "nargs", STRING_OBJ(cstr_to_string(arg)));
+    PUT(d, "nargs", CSTR_TO_OBJ(arg));
 
     char *cmd_compl = get_command_complete(cmd->uc_compl);
     PUT(d, "complete", (cmd_compl == NULL
-                        ? NIL : STRING_OBJ(cstr_to_string(cmd_compl))));
+                        ? NIL : CSTR_TO_OBJ(cmd_compl)));
     PUT(d, "complete_arg", cmd->uc_compl_arg == NULL
-        ? NIL : STRING_OBJ(cstr_to_string(cmd->uc_compl_arg)));
+        ? NIL : CSTR_TO_OBJ(cmd->uc_compl_arg));
 
     Object obj = NIL;
     if (cmd->uc_argt & EX_COUNT) {
       if (cmd->uc_def >= 0) {
         snprintf(str, sizeof(str), "%" PRId64, cmd->uc_def);
-        obj = STRING_OBJ(cstr_to_string(str));    // -count=N
+        obj = CSTR_TO_OBJ(str);    // -count=N
       } else {
-        obj = STRING_OBJ(cstr_to_string("0"));    // -count
+        obj = CSTR_TO_OBJ("0");    // -count
       }
     }
     PUT(d, "count", obj);
@@ -1797,12 +1797,12 @@ Dictionary commands_array(buf_T *buf)
     obj = NIL;
     if (cmd->uc_argt & EX_RANGE) {
       if (cmd->uc_argt & EX_DFLALL) {
-        obj = STRING_OBJ(cstr_to_string("%"));    // -range=%
+        obj = CSTR_TO_OBJ("%");    // -range=%
       } else if (cmd->uc_def >= 0) {
         snprintf(str, sizeof(str), "%" PRId64, cmd->uc_def);
-        obj = STRING_OBJ(cstr_to_string(str));    // -range=N
+        obj = CSTR_TO_OBJ(str);    // -range=N
       } else {
-        obj = STRING_OBJ(cstr_to_string("."));    // -range
+        obj = CSTR_TO_OBJ(".");    // -range
       }
     }
     PUT(d, "range", obj);
@@ -1811,7 +1811,7 @@ Dictionary commands_array(buf_T *buf)
     for (int j = 0; addr_type_complete[j].expand != ADDR_NONE; j++) {
       if (addr_type_complete[j].expand != ADDR_LINES
           && addr_type_complete[j].expand == cmd->uc_addr_type) {
-        obj = STRING_OBJ(cstr_to_string(addr_type_complete[j].name));
+        obj = CSTR_TO_OBJ(addr_type_complete[j].name);
         break;
       }
     }


### PR DESCRIPTION
Adds new API helper macros `CSTR_AS_OBJ()`, `STATIC_CSTR_AS_OBJ()`, and `STATIC_CSTR_TO_OBJ()`, which cleans up a lot of the current code. These macros will also be used extensively in the upcoming option refactor PRs because then API Objects will be used to get/set options. This PR also modifies pre-existing code to use old API helper macros like `CSTR_TO_OBJ()` to make them cleaner.