### PR TITLE
build: remove functionaltest-lua target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,15 +179,10 @@ jobs:
         timeout-minutes: 5
         run: cmake --build build --target unittest
 
-      - if: matrix.flavor != 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
+      - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: Functionaltest
         timeout-minutes: 20
         run: cmake --build build --target functionaltest
-
-      - if: matrix.flavor == 'functionaltest-lua' && (success() || failure() && steps.abort_job.outputs.status == 'success')
-        name: Functionaltest with PUC Lua
-        timeout-minutes: 20
-        run: cmake --build build --target functionaltest-lua
 
       - if: matrix.flavor != 'tsan' && (success() || failure() && steps.abort_job.outputs.status == 'success')
         name: Oldtest

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ test/old/testdir/%.vim: phony_force nvim
 	+$(SINGLE_MAKE) -C test/old/testdir NVIM_PRG=$(NVIM_PRG) SCRIPTS= $(MAKEOVERRIDES) $(patsubst test/old/testdir/%.vim,%,$@)
 
 functionaltest-lua: | nvim
-	$(BUILD_TOOL) -C build $@
+	$(BUILD_TOOL) -C build functionaltest
 
 FORMAT=formatc formatlua format
 LINT=lintlua lintsh lintc clang-tidy lintcommit lint

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,21 +66,5 @@ add_custom_target(benchmark
   DEPENDS ${BENCHMARK_PREREQS}
   USES_TERMINAL)
 
-add_custom_target(functionaltest-lua
-  COMMAND ${CMAKE_COMMAND}
-    -D NVIM_PRG=$<TARGET_FILE:nvim>
-    -D WORKING_DIR=${PROJECT_SOURCE_DIR}
-    -D BUSTED_OUTPUT_TYPE=${BUSTED_OUTPUT_TYPE}
-    -D TEST_DIR=${CMAKE_CURRENT_SOURCE_DIR}
-    -D BUILD_DIR=${CMAKE_BINARY_DIR}
-    -D DEPS_INSTALL_DIR=${DEPS_INSTALL_DIR}
-    -D TEST_TYPE=functional
-    -D CIRRUS_CI=$ENV{CIRRUS_CI}
-    -D CI_BUILD=${CI_BUILD}
-    -P ${PROJECT_SOURCE_DIR}/cmake/RunTests.cmake
-  DEPENDS ${FUNCTIONALTEST_PREREQS}
-  USES_TERMINAL)
-
 add_dependencies(functionaltest test_deps)
 add_dependencies(benchmark test_deps)
-add_dependencies(functionaltest-lua test_deps)


### PR DESCRIPTION
It's not needed anymore as it does the exact same thing as
functionaltest. The functionaltest target will test the lua type neovim
was built with, which can be toggled with the PREFER_LUA option.