### PR TITLE
feat(lsp): add original LSP Location as item's user_data in locations_to_items

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1751,6 +1751,9 @@ locations_to_items({locations}, {offset_encoding})
     Returns the items with the byte position calculated correctly and in
     sorted order, for display in quickfix and location lists.
 
+    The `user_data` field of each resulting item will contain the original
+    `Location` or `LocationLink` it was computed from.
+
     The result can be passed to the {list} argument of |setqflist()| or
     |setloclist()|.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -161,6 +161,9 @@ The following new APIs and features were added.
 • The |:terminal| command now accepts some |:command-modifiers| (specifically
   |:horizontal| and those that affect splitting a window).
 
+• |vim.lsp.util.locations_to_items()| sets the `user_data` of each item to the
+  original LSP `Location` or `LocationLink`.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1812,6 +1812,9 @@ end)
 --- Returns the items with the byte position calculated correctly and in sorted
 --- order, for display in quickfix and location lists.
 ---
+--- The `user_data` field of each resulting item will contain the original
+--- `Location` or `LocationLink` it was computed from.
+---
 --- The result can be passed to the {list} argument of |setqflist()| or
 --- |setloclist()|.
 ---
@@ -1840,7 +1843,7 @@ function M.locations_to_items(locations, offset_encoding)
     -- locations may be Location or LocationLink
     local uri = d.uri or d.targetUri
     local range = d.range or d.targetSelectionRange
-    table.insert(grouped[uri], { start = range.start })
+    table.insert(grouped[uri], { start = range.start, location = d })
   end
 
   local keys = vim.tbl_keys(grouped)
@@ -1872,6 +1875,7 @@ function M.locations_to_items(locations, offset_encoding)
         lnum = row + 1,
         col = col + 1,
         text = line,
+        user_data = temp.location,
       })
     end
   end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -2387,7 +2387,14 @@ describe('LSP', function()
           filename = '/fake/uri',
           lnum = 1,
           col = 3,
-          text = 'testing'
+          text = 'testing',
+          user_data = {
+            uri = 'file:///fake/uri',
+            range = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            }
+          }
         },
       }
       local actual = exec_lua [[
@@ -2413,7 +2420,18 @@ describe('LSP', function()
           filename = '/fake/uri',
           lnum = 1,
           col = 3,
-          text = 'testing'
+          text = 'testing',
+          user_data = {
+            targetUri = "file:///fake/uri",
+            targetRange = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            },
+            targetSelectionRange = {
+              start = { line = 0, character = 2 },
+              ['end'] = { line = 0, character = 3 },
+            }
+          }
         },
       }
       local actual = exec_lua [[


### PR DESCRIPTION
While this depends on this open (but approved) vim PR: https://github.com/vim/vim/pull/11818, I figured I'd already open the PR here to get some feedback on the lua API. Here are some open questions:

1) Do we want this to be opt-in? Should we add a flag to location_to_items that explicitly enabled this?
2) Should user_data directly be the LSP Location/LocationLink, or do we rather want something like `user_data = { lsp = { ... } }` ?

Update: vim-patch is merged in https://github.com/neovim/neovim/pull/24673

