### PR TITLE
feat(lsp): allow setting `select` and `silent` for code actions

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1128,9 +1128,12 @@ code_action({options})                             *vim.lsp.buf.code_action()*
                      is applied without user query.
                    • range: (table|nil) Range for which code actions should be
                      requested. If in visual mode this defaults to the active
-                     selection. Table must contain `start` and `end` keys with
-                     {row, col} tuples using mark-like indexing. See
+                     selection. Table must contain `start` and `end` keys with {row, col} tuples using mark-like indexing. See
                      |api-indexing|
+                     • silent: (boolean|nil) When `true`, don't show a
+                       notification when no code actions are available
+                     • select: (function|nil) See |vim.ui.select| Custom
+                       select function. Defaults to `vim.ui.select`
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -634,7 +634,7 @@ local function on_code_action_results(results, ctx, options)
       end
     end
   end
-  if #action_tuples == 0 then
+  if #action_tuples == 0 and not (options and options.silent) then
     vim.notify('No code actions available', vim.log.levels.INFO)
     return
   end
@@ -707,7 +707,7 @@ local function on_code_action_results(results, ctx, options)
     return
   end
 
-  vim.ui.select(action_tuples, {
+  (options and options.select or vim.ui.select)(action_tuples, {
     prompt = 'Code actions:',
     kind = 'codeaction',
     format_item = function(action_tuple)
@@ -754,6 +754,12 @@ end
 ---           If in visual mode this defaults to the active selection.
 ---           Table must contain `start` and `end` keys with {row, col} tuples
 ---           using mark-like indexing. See |api-indexing|
+---
+---   - silent: (boolean|nil)
+---             When `true`, don't show a notification when no code actions are available
+---
+---   - select: (function|nil) See |vim.ui.select|
+---             Custom select function. Defaults to `vim.ui.select`
 ---
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
 ---@see vim.lsp.protocol.constants.CodeActionTriggerKind


### PR DESCRIPTION
Small PR that adds two options to `vim.lsp.buf.code_action`

- `silent`: when `true`, don't show a notification when no code actions were found
- `select`: a custom `vim.ui.select` to be used instead of the default.

## Why `select`?

It allows to set a custom select ui specifically for code actions, but my main use-case is to show `vim.ui.select` for two different sets of code actions.

In the image below, the first two are the regular code actions and the three below that are the **source** code actions.

Up until now, I had source actions mapped to a different keymap, but it's much better to show all together in one list.

![image](https://github.com/neovim/neovim/assets/292349/3e032d0f-0145-4c99-9640-3cf9f8793aac)

## Example code to combine code actions with source actions

```lua
  local all = {}
  local select = function(items, opts, on_choice)
    vim.list_extend(all, items)
    vim.ui.select(all, opts, on_choice)
  end
  
  -- regular code actions
  vim.lsp.buf.code_action({
    select = select,
    silent = true,
  })

  -- source actions
  vim.lsp.buf.code_action({
    select = select,
    silent = true,
    context = {
      only = {
        "source",
      },
      diagnostics = {},
    },
  })
```

![image](https://github.com/neovim/neovim/assets/292349/3582c2b5-9672-4f3a-83a4-6b3384f00af9)
