### PR TITLE
PTY madness

### DIFF
--- a/src/nvim/api/vim.h
+++ b/src/nvim/api/vim.h
@@ -4,6 +4,11 @@
 #include "nvim/api/keysets.h"
 #include "nvim/api/private/defs.h"
 
+typedef struct {
+  Object on_input;
+  Object pty;
+} Dict(open_term);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/vim.h.generated.h"
 #endif

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -29,6 +29,7 @@ typedef enum {
   kChannelStreamStdio,
   kChannelStreamStderr,
   kChannelStreamInternal,
+  kChannelStreamPty,  ///< only for raw pty, use Proc for process within pty
 } ChannelStreamType;
 
 typedef enum {
@@ -127,6 +128,7 @@ static inline Stream *channel_instream(Channel *chan)
 {
   switch (chan->streamtype) {
   case kChannelStreamProc:
+  case kChannelStreamPty:
     return &chan->stream.proc.in;
 
   case kChannelStreamSocket:
@@ -147,6 +149,7 @@ static inline Stream *channel_outstream(Channel *chan)
 {
   switch (chan->streamtype) {
   case kChannelStreamProc:
+  case kChannelStreamPty:
     return &chan->stream.proc.out;
 
   case kChannelStreamSocket:

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -76,7 +76,7 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
     status = libuv_process_spawn((LibuvProcess *)proc);
     break;
   case kProcessTypePty:
-    status = pty_process_spawn((PtyProcess *)proc);
+    status = pty_process_spawn((PtyProcess *)proc, true);
     break;
   default:
     abort();
@@ -134,6 +134,7 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
   DLOG("new: pid=%d argv=[%s]", proc->pid, proc->argv[0]);
   return 0;
 }
+
 
 void process_teardown(Loop *loop) FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -90,7 +90,6 @@ void stream_init(Loop *loop, Stream *stream, int fd, uv_stream_t *uvstream)
   stream->internal_data = NULL;
   stream->fpos = 0;
   stream->curmem = 0;
-  stream->maxmem = 0;
   stream->pending_reqs = 0;
   stream->read_cb = NULL;
   stream->write_cb = NULL;

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -52,7 +52,6 @@ struct stream {
   void *close_cb_data, *internal_data;
   size_t fpos;
   size_t curmem;
-  size_t maxmem;
   size_t pending_reqs;
   size_t num_bytes;
   MultiQueue *events;

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -160,8 +160,9 @@ static pid_t forkpty(int *amaster, char *name, struct termios *termp, struct win
 
 #endif
 
+/// @param process if true spawn procces, if false just open pty
 /// @returns zero on success, or negative error code
-int pty_process_spawn(PtyProcess *ptyproc)
+int pty_process_spawn(PtyProcess *pty, bool process)
   FUNC_ATTR_NONNULL_ALL
 {
   // termios initialized at first use
@@ -170,21 +171,33 @@ int pty_process_spawn(PtyProcess *ptyproc)
     init_termios(&termios_default);
   }
 
+  Process *proc = &pty->process;
   int status = 0;  // zero or negative error code (libuv convention)
-  Process *proc = (Process *)ptyproc;
   assert(proc->err.closed);
-  uv_signal_start(&proc->loop->children_watcher, chld_handler, SIGCHLD);
-  ptyproc->winsize = (struct winsize){ ptyproc->height, ptyproc->width, 0, 0 };
-  uv_disable_stdio_inheritance();
-  int master;
-  int pid = forkpty(&master, NULL, &termios_default, &ptyproc->winsize);
+  pty->winsize = (struct winsize){ pty->height, pty->width, 0, 0 };
 
-  if (pid < 0) {
-    status = -errno;
-    ELOG("forkpty failed: %s", strerror(errno));
-    return status;
-  } else if (pid == 0) {
-    init_child(ptyproc);  // never returns
+  int master, pid;
+  if (process) {
+    uv_signal_start(&proc->loop->children_watcher, chld_handler, SIGCHLD);
+    uv_disable_stdio_inheritance();
+    pid = forkpty(&master, NULL, &termios_default, &pty->winsize);
+
+    if (pid < 0) {
+      status = -errno;
+      ELOG("forkpty failed: %s", strerror(errno));
+      return status;
+    } else if (pid == 0) {
+      init_child(pty);  // never returns
+    }
+    proc->pid = pid;
+  } else {
+    int slave;
+    if (openpty(&master, &slave, NULL, &termios_default, &pty->winsize) == -1) {
+      status = -errno;
+      ELOG("openpty failed: %s", strerror(errno));
+      return status;
+    }
+    pty->slave_fd = slave;
   }
 
   // make sure the master file descriptor is non blocking
@@ -216,27 +229,28 @@ int pty_process_spawn(PtyProcess *ptyproc)
     goto error;
   }
 
-  ptyproc->tty_fd = master;
-  proc->pid = pid;
+  pty->master_fd = master;
   return 0;
 
 error:
   close(master);
-  kill(pid, SIGKILL);
-  waitpid(pid, NULL, 0);
+  if (process) {
+    kill(pid, SIGKILL);
+    waitpid(pid, NULL, 0);
+  }
   return status;
 }
 
 const char *pty_process_tty_name(PtyProcess *ptyproc)
 {
-  return ptsname(ptyproc->tty_fd);
+  return ptsname(ptyproc->master_fd);
 }
 
 void pty_process_resize(PtyProcess *ptyproc, uint16_t width, uint16_t height)
   FUNC_ATTR_NONNULL_ALL
 {
   ptyproc->winsize = (struct winsize){ height, width, 0, 0 };
-  ioctl(ptyproc->tty_fd, TIOCSWINSZ, &ptyproc->winsize);
+  ioctl(ptyproc->master_fd, TIOCSWINSZ, &ptyproc->winsize);
 }
 
 void pty_process_close(PtyProcess *ptyproc)
@@ -251,9 +265,9 @@ void pty_process_close(PtyProcess *ptyproc)
 
 void pty_process_close_master(PtyProcess *ptyproc) FUNC_ATTR_NONNULL_ALL
 {
-  if (ptyproc->tty_fd >= 0) {
-    close(ptyproc->tty_fd);
-    ptyproc->tty_fd = -1;
+  if (ptyproc->master_fd >= 0) {
+    close(ptyproc->master_fd);
+    ptyproc->master_fd = -1;
   }
 }
 

--- a/src/nvim/os/pty_process_unix.h
+++ b/src/nvim/os/pty_process_unix.h
@@ -11,16 +11,19 @@ typedef struct pty_process {
   Process process;
   uint16_t width, height;
   struct winsize winsize;
-  int tty_fd;
+  int master_fd;
+  int slave_fd;  ///< only set for kChannelStreamPty
 } PtyProcess;
 
-static inline PtyProcess pty_process_init(Loop *loop, void *data)
+static inline PtyProcess pty_process_init(Loop *loop, void *data, bool process)
 {
+  // TODO: if pty_process_win don't need this either,
+  (void)process;
   PtyProcess rv;
   rv.process = process_init(loop, kProcessTypePty, data);
   rv.width = 80;
   rv.height = 24;
-  rv.tty_fd = -1;
+  rv.master_fd = -1;
   return rv;
 }
 

--- a/src/nvim/os/pty_process_win.h
+++ b/src/nvim/os/pty_process_win.h
@@ -22,10 +22,12 @@ typedef struct arg_node {
   QUEUE node;  // QUEUE structure.
 } ArgNode;
 
-static inline PtyProcess pty_process_init(Loop *loop, void *data)
+static inline PtyProcess pty_process_init(Loop *loop, void *data, bool process)
 {
   PtyProcess rv;
-  rv.process = process_init(loop, kProcessTypePty, data);
+  if (process) {
+    rv.process = process_init(loop, kProcessTypePty, data);
+  }
   rv.width = 80;
   rv.height = 24;
   rv.conpty = NULL;

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -889,9 +889,6 @@ static int do_os_system(char **argv, const char *input, size_t len, char **outpu
   // deal with stream events as fast a possible.  It prevents closing the
   // streams while there's still data in the OS buffer (due to the process
   // exiting before all data is read).
-  if (has_input) {
-    wstream_init(&proc->in, 0);
-  }
   rstream_init(&proc->out, 0);
   rstream_start(&proc->out, data_cb, &buf);
   rstream_init(&proc->err, 0);


### PR DESCRIPTION
The idea is that you can open a bare PTY first like
```
x = vim.api.nvim_open_term(0, {pty=true})
fd = vim.api.nvim_get_chan_info(x).slave_fd
```

and then use it in `uv.spawn` with a mixture of other file descriptors

```
stdin = uv.new_pipe()
cmd = "less"
args = {}
handle, pid = uv.spawn(cmd, {
  args = args,
  stdio = {stdin, fd, fd},
  detach = true,
}, vim.schedule_wrap(function()
  print("is dead")
end))
```

But it will not work yet for many use-cases as we need to set the controlling tty (TIOCSCTTY) of the child properly.

Related issues: several