### PR TITLE
fix(fs.lua): normalize slash truncation

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -348,7 +348,11 @@ function M.normalize(path, opts)
     path = path:gsub('%$([%w_]+)', vim.uv.os_getenv)
   end
 
-  return (path:gsub('\\', '/'):gsub('/+', '/'):gsub('(.)/$', '%1'))
+  path = path:gsub('\\', '/'):gsub('/+', '/')
+  if iswin and path:match('^%w:/$') then
+    return path
+  end
+  return (path:gsub('(.)/$', '%1'))
 end
 
 return M

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -301,5 +301,10 @@ describe('vim.fs', function()
         return vim.fs.normalize('$XDG_CONFIG_HOME/nvim')
       ]], xdg_config_home))
     end)
+    if is_os('win') then
+      it('Last slash is not truncated from root drive', function()
+        eq('C:/', exec_lua [[ return vim.fs.normalize('C:/') ]])
+      end)
+    end
   end)
 end)


### PR DESCRIPTION
Preserve last slash in windows' root drive directories

fixes #23733 