### PR TITLE
vim-patch:9.0.1578: SpellCap highlight not always updated when needed

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2222,9 +2222,8 @@ static void win_update(win_T *wp, DecorProviders *providers)
         }
 
         // Display one line
-        row = win_line(wp, lnum, srow,
-                       foldinfo.fi_lines ? srow : wp->w_grid.rows,
-                       mod_top == 0, false, foldinfo, &line_providers, &provider_err);
+        row = win_line(wp, lnum, srow, foldinfo.fi_lines ? srow : wp->w_grid.rows,
+                       mod_top, false, foldinfo, &line_providers, &provider_err);
 
         if (foldinfo.fi_lines == 0) {
           wp->w_lines[idx].wl_folded = false;
@@ -2261,7 +2260,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
         // text doesn't need to be drawn, but the number column does.
         foldinfo_T info = wp->w_p_cul && lnum == wp->w_cursor.lnum ?
                           cursorline_fi : fold_info(wp, lnum);
-        (void)win_line(wp, lnum, srow, wp->w_grid.rows, true, true,
+        (void)win_line(wp, lnum, srow, wp->w_grid.rows, mod_top, true,
                        info, &line_providers, &provider_err);
       }
 
@@ -2359,7 +2358,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
         // for ml_line_count+1 and only draw filler lines
         foldinfo_T info = { 0 };
         row = win_line(wp, wp->w_botline, row, wp->w_grid.rows,
-                       false, false, info, &line_providers, &provider_err);
+                       mod_top, false, info, &line_providers, &provider_err);
       }
     } else if (dollar_vcol == -1) {
       wp->w_botline = lnum;

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -509,7 +509,7 @@ void spell_suggest(int count)
   // Get the word and its length.
 
   // Figure out if the word should be capitalised.
-  int need_cap = check_need_cap(curwin->w_cursor.lnum, curwin->w_cursor.col);
+  int need_cap = check_need_cap(curwin, curwin->w_cursor.lnum, curwin->w_cursor.col);
 
   // Make a copy of current line since autocommands may free the line.
   line = xstrdup(get_cursor_line_ptr());

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -28,6 +28,7 @@ describe("'spell'", function()
       [7] = {foreground = Screen.colors.Blue},
       [8] = {foreground = Screen.colors.Blue, special = Screen.colors.Red, undercurl = true},
       [9] = {bold = true},
+      [10] = {background = Screen.colors.LightGrey, foreground = Screen.colors.DarkBlue},
     })
   end)
 
@@ -82,7 +83,7 @@ describe("'spell'", function()
   end)
 
   -- oldtest: Test_spell_screendump_spellcap()
-  it('has correct highlight at start of line with trailing space', function()
+  it('SpellCap highlight at start of line', function()
     exec([=[
       call setline(1, [
         \"   This line has a sepll error. and missing caps and trailing spaces.   ",
@@ -117,7 +118,7 @@ describe("'spell'", function()
                                                                                       |
     ]])
     -- Deleting a full stop removes missing Cap in next line
-    feed('5Gddk$x')
+    feed('5Gdd<C-L>k$x')
     screen:expect([[
          This line has a {1:sepll} error. {2:and} missing caps and trailing spaces.           |
       {2:another} missing cap here.                                                       |
@@ -136,6 +137,43 @@ describe("'spell'", function()
       Not                                                                             |
       and here^.                                                                       |
       {2:and} here.                                                                       |
+      {0:~                                                                               }|
+      {0:~                                                                               }|
+                                                                                      |
+    ]])
+    -- Folding an empty line does not remove Cap in next line
+    feed('uzfk:<Esc>')
+    screen:expect([[
+         This line has a {1:sepll} error. {2:and} missing caps and trailing spaces.           |
+      {2:another} missing cap here.                                                       |
+      Not                                                                             |
+      {10:^+--  2 lines: and here.·························································}|
+      {2:and} here.                                                                       |
+      {0:~                                                                               }|
+      {0:~                                                                               }|
+                                                                                      |
+    ]])
+    -- Folding the end of a sentence does not remove Cap in next line
+    -- and editing a line does not remove Cap in current line
+    feed('Jzfkk$x')
+    screen:expect([[
+         This line has a {1:sepll} error. {2:and} missing caps and trailing spaces.           |
+      {2:another} missing cap her^e                                                        |
+      {10:+--  2 lines: Not·······························································}|
+      {2:and} here.                                                                       |
+      {0:~                                                                               }|
+      {0:~                                                                               }|
+      {0:~                                                                               }|
+                                                                                      |
+    ]])
+    -- Cap is correctly applied in the first row of a window
+    feed('<C-E><C-L>')
+    screen:expect([[
+      {2:another} missing cap her^e                                                        |
+      {10:+--  2 lines: Not·······························································}|
+      {2:and} here.                                                                       |
+      {0:~                                                                               }|
+      {0:~                                                                               }|
       {0:~                                                                               }|
       {0:~                                                                               }|
                                                                                       |

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -1003,12 +1003,25 @@ func Test_spell_screendump_spellcap()
   call VerifyScreenDump(buf, 'Test_spell_3', {})
 
   " Deleting a full stop removes missing Cap in next line
-  call term_sendkeys(buf, "5Gddk$x")
+  call term_sendkeys(buf, "5Gdd\<C-L>k$x")
   call VerifyScreenDump(buf, 'Test_spell_4', {})
 
   " Undo also updates the next line (go to command line to remove message)
   call term_sendkeys(buf, "u:\<Esc>")
   call VerifyScreenDump(buf, 'Test_spell_5', {})
+
+  " Folding an empty line does not remove Cap in next line
+  call term_sendkeys(buf, "uzfk:\<Esc>")
+  call VerifyScreenDump(buf, 'Test_spell_6', {})
+
+  " Folding the end of a sentence does not remove Cap in next line
+  " and editing a line does not remove Cap in current line
+  call term_sendkeys(buf, "Jzfkk$x")
+  call VerifyScreenDump(buf, 'Test_spell_7', {})
+
+  " Cap is correctly applied in the first row of a window
+  call term_sendkeys(buf, "\<C-E>\<C-L>")
+  call VerifyScreenDump(buf, 'Test_spell_8', {})
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:    SpellCap highlight not always updated when needed.
Solution:   Handle updating line below closed fold and other situations where
            only part of the window is redrawn. (Luuk van Baal, closes vim/vim#12428,
            closes vim/vim#12420)

https://github.com/vim/vim/commit/2ac6497f0ef186f0e3ba67d7f0a485bfb612bb08