### PR TITLE
fix(mkspell): prevent Unicode character overflow

### DIFF
--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3131,7 +3131,7 @@ static int spell_read_dic(spellinfo_T *spin, char *fname, afffile_T *affile)
     // Remove CR, LF and white space from the end.  White space halfway through
     // the word is kept to allow multi-word terms like "et al.".
     l = (int)strlen(line);
-    while (l > 0 && line[l - 1] <= ' ') {
+    while (l > 0 && (uint8_t)line[l - 1] <= ' ') {
       l--;
     }
     if (l == 0) {


### PR DESCRIPTION
After hours in gdb i think i found the issue.
Commit bd22585061b6 changed `char_u line` to `char line` in function spell_read_dic. Greek Unicode block is encoded as `[\xce\x80-\xcf\xbf]`, which was always overflowing because char is at most 127 and the condition `line[x] <= ' '` was always true. With this fix .spl and .sug files are generated correctly.
fixes #23758