### PR TITLE
vim-patch:9.0.1580: CI: indent test hangs on FreeBSD

### DIFF
--- a/runtime/indent/testdir/runtest.vim
+++ b/runtime/indent/testdir/runtest.vim
@@ -12,6 +12,7 @@ set nowrapscan
 set report=9999
 set modeline
 set debug=throw
+set nomore
 
 au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()


### PR DESCRIPTION
#### vim-patch:9.0.1580: CI: indent test hangs on FreeBSD

Problem:    CI: indent test hangs on FreeBSD.
Solution:   Set 'nomore' when running the indent tests. (Ozaki Kiichi,
            closes vim/vim#12446)

https://github.com/vim/vim/commit/9f3afe7a70d50447424b8d7404aae0d641cd827c

Co-authored-by: ichizok <gclient.gaap@gmail.com>