### PR TITLE
build: remove LOG_DEBUG option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,6 @@ endif()
 option(LOG_LIST_ACTIONS "Add list actions logging" OFF)
 
 option(ENABLE_ASAN_UBSAN "Enable Clang address & undefined behavior sanitizer for nvim binary." OFF)
-option(LOG_DEBUG "Enable debug log messages even in a release build" OFF)
 option(ENABLE_MSAN "Enable Clang memory sanitizer for nvim binary." OFF)
 option(ENABLE_TSAN "Enable Clang thread sanitizer for nvim binary." OFF)
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -394,9 +394,6 @@ endif()
 if($ENV{CI})
   # Don't debug log on CI, it gets too verbose in the main build log.
   # TODO(bfredl): debug log level also exposes some errors with EXITFREE in ASAN build.
-  set(LOG_DEBUG FALSE)
-elseif(LOG_DEBUG)
-  target_compile_definitions(nvim PRIVATE NVIM_LOG_DEBUG)
 else()
   # Minimize logging for release-type builds.
   target_compile_definitions(nvim PRIVATE $<$<CONFIG:Debug>:NVIM_LOG_DEBUG>)


### PR DESCRIPTION
Its usecase is too specific to warrant an option. The same effect can be
achieved by passing `-DCMAKE_C_FLAGS=-DNVIM_LOG_DEBUG` in the command
line when building neovim.
