### PR TITLE
vim-patch:9.0.1582: :stopinsert may not work in a popup close handler

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1355,11 +1355,13 @@ void aucmd_restbuf(aco_save_T *aco)
       }
     }
 win_found:
+    ;
+    const bool save_stop_insert_mode = stop_insert_mode;
     // May need to stop Insert mode if we were in a prompt buffer.
     leaving_window(curwin);
     // Do not stop Insert mode when already in Insert mode before.
     if (aco->save_State & MODE_INSERT) {
-      stop_insert_mode = false;
+      stop_insert_mode = save_stop_insert_mode;
     }
     // Remove the window.
     win_remove(curwin, NULL);

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -6280,5 +6280,28 @@ func Test_setqflist_cb_arg()
   call setqflist([], 'f')
 endfunc
 
+" Test that setqflist() should not prevent :stopinsert from working
+func Test_setqflist_stopinsert()
+  new
+  call setqflist([], 'f')
+  copen
+  cclose
+  func StopInsert()
+    stopinsert
+    call setqflist([{'text': 'foo'}])
+    return ''
+  endfunc
+
+  call setline(1, 'abc')
+  call cursor(1, 1)
+  call feedkeys("i\<C-R>=StopInsert()\<CR>$", 'tnix')
+  call assert_equal('foo', getqflist()[0].text)
+  call assert_equal([0, 1, 3, 0, v:maxcol], getcurpos())
+  call assert_equal(['abc'], getline(1, '$'))
+
+  delfunc StopInsert
+  call setqflist([], 'f')
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1582: :stopinsert may not work in a popup close handler

Problem:    :stopinsert may not work in a popup close handler. (Ben Jackson)
Solution:   Restore stop_insert_mode when appropriate. (closes vim/vim#12452)

https://github.com/vim/vim/commit/a40c0bcc83c32da02869f59b10538d6327df61c5