### PR TITLE
vim-patch:9.0.{1585,1595}

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1403,16 +1403,16 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
       line = ml_get_buf(wp->w_buffer, lnum + 1, false);
       spell_cat_line(nextline + SPWORDLEN, line, SPWORDLEN);
     }
-    line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum, false);
+    assert(!end_fill);
+    line = ml_get_buf(wp->w_buffer, lnum, false);
 
     // If current line is empty, check first word in next line for capital.
     ptr = skipwhite(line);
     if (*ptr == NUL) {
       spv->spv_cap_col = 0;
       spv->spv_capcol_lnum = lnum + 1;
-    }
-    // For checking first word with a capital skip white space.
-    else if (spv->spv_cap_col == 0) {
+    } else if (spv->spv_cap_col == 0) {
+      // For checking first word with a capital skip white space.
       spv->spv_cap_col = (int)(ptr - line);
     }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1021,21 +1021,21 @@ static void win_line_continue(winlinevars_T *wlv)
   }
 }
 
-/// Display line "lnum" of window 'wp' on the screen.
+/// Display line "lnum" of window "wp" on the screen.
 /// wp->w_virtcol needs to be valid.
 ///
 /// @param lnum         line to display
 /// @param startrow     first row relative to window grid
 /// @param endrow       last grid row to be redrawn
-/// @param mod_top      top line updated for changed text
 /// @param number_only  only update the number column
+/// @param spv          'spell' related variables kept between calls for "wp"
 /// @param foldinfo     fold info for this line
 /// @param[in, out] providers  decoration providers active this line
 ///                            items will be disables if they cause errors
 ///                            or explicitly return `false`.
 ///
 /// @return             the number of last row the line occupies.
-int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bool number_only,
+int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_only, spellvars_T *spv,
              foldinfo_T foldinfo, DecorProviders *providers, char **provider_err)
 {
   winlinevars_T wlv;                  // variables passed between functions
@@ -1079,7 +1079,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
   int eol_hl_off = 0;                   // 1 if highlighted char after EOL
   bool draw_color_col = false;          // highlight colorcolumn
   int *color_cols = NULL;               // pointer to according columns array
-  bool has_spell = false;               // this buffer has spell checking
 #define SPWORDLEN 150
   char nextline[SPWORDLEN * 2];         // text with start of the next line
   int nextlinecol = 0;                  // column where nextline[] starts
@@ -1087,11 +1086,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
                                         // starts
   int spell_attr = 0;                   // attributes desired by spelling
   int word_end = 0;                     // last byte with same spell_attr
-  static linenr_T checked_lnum = 0;     // line number for "checked_col"
-  static int checked_col = 0;           // column in "checked_lnum" up to which
-                                        // there are no spell errors
-  static int cap_col = -1;              // column to check for Cap word
-  static linenr_T capcol_lnum = 0;      // line number where "cap_col"
   int cur_checked_col = 0;              // checked column for current line
   int extra_check = 0;                  // has syntax or linebreak
   int multi_attr = 0;                   // attributes desired by multibyte
@@ -1201,43 +1195,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
     color_cols = wp->w_buffer->terminal ? NULL : wp->w_p_cc_cols;
     if (color_cols != NULL) {
       draw_color_col = advance_color_col(VCOL_HLC, &color_cols);
-    }
-
-    if (!has_fold && !end_fill && spell_check_window(wp)) {
-      // Prepare for spell checking.
-      has_spell = true;
-      extra_check = true;
-
-      // Get the start of the next line, so that words that wrap to the next
-      // line are found too: "et<line-break>al.".
-      // Trick: skip a few chars for C/shell/Vim comments
-      nextline[SPWORDLEN] = NUL;
-      if (lnum < wp->w_buffer->b_ml.ml_line_count) {
-        line = ml_get_buf(wp->w_buffer, lnum + 1, false);
-        spell_cat_line(nextline + SPWORDLEN, line, SPWORDLEN);
-      }
-
-      // When a word wrapped from the previous line the start of the current
-      // line is valid.
-      if (lnum == checked_lnum) {
-        cur_checked_col = checked_col;
-      }
-      checked_lnum = 0;
-
-      // When there was a sentence end in the previous line may require a
-      // word starting with capital in this line.  In line 1 always check
-      // the first word.  Also check for sentence end in the line above
-      // when updating the first row in a window, the top line with
-      // changed text in a window, or if the previous line is folded.
-      if (lnum == 1
-          || ((startrow == 0 || mod_top == lnum
-               || hasFoldingWin(wp, lnum - 1, NULL, NULL, true, NULL))
-              && check_need_cap(wp, lnum, 0))) {
-        cap_col = 0;
-      } else if (lnum != capcol_lnum) {
-        cap_col = -1;
-      }
-      capcol_lnum = 0;
     }
 
     // handle Visual active in this window
@@ -1423,15 +1380,38 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
   line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum, false);
   ptr = line;
 
-  if (has_spell && !number_only) {
+  if (spv->spv_has_spell && !number_only) {
+    // Prepare for spell checking.
+    extra_check = true;
+
+    // When a word wrapped from the previous line the start of the
+    // current line is valid.
+    if (lnum == spv->spv_checked_lnum) {
+      cur_checked_col = spv->spv_checked_col;
+    }
+    if (lnum != spv->spv_capcol_lnum) {
+      spv->spv_cap_col = -1;
+    }
+    spv->spv_checked_lnum = 0;
+
     // For checking first word with a capital skip white space.
-    if (cap_col == 0) {
-      cap_col = (int)getwhitecols(line);
+    if (spv->spv_cap_col == 0) {
+      spv->spv_cap_col = (int)getwhitecols(line);
+    } else if (*skipwhite(line) == NUL) {
+      // If current line is empty, check first word in next line for capital.
+      spv->spv_cap_col = 0;
+      spv->spv_capcol_lnum = lnum + 1;
     }
 
-    // To be able to spell-check over line boundaries copy the end of the
-    // current line into nextline[].  Above the start of the next line was
-    // copied to nextline[SPWORDLEN].
+    // Get the start of the next line, so that words that wrap to the
+    // next line are found too: "et<line-break>al.".
+    // Trick: skip a few chars for C/shell/Vim comments
+    nextline[SPWORDLEN] = NUL;
+    if (lnum < wp->w_buffer->b_ml.ml_line_count) {
+      spell_cat_line(nextline + SPWORDLEN,
+                     ml_get_buf(wp->w_buffer, lnum + 1, false), SPWORDLEN);
+    }
+    // Copy the end of the current line into nextline[].
     if (nextline[SPWORDLEN] == NUL) {
       // No next line or it is empty.
       nextlinecol = MAXCOL;
@@ -1541,7 +1521,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
     }
     // When spell checking a word we need to figure out the start of the
     // word and if it's badly spelled or not.
-    if (has_spell) {
+    if (spv->spv_has_spell) {
       size_t len;
       colnr_T linecol = (colnr_T)(ptr - line);
       hlf_T spell_hlf = HLF_COUNT;
@@ -1807,7 +1787,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
 
     int extmark_attr = 0;
     if (wlv.draw_state == WL_LINE
-        && (area_highlighting || has_spell || extra_check)) {
+        && (area_highlighting || spv->spv_has_spell || extra_check)) {
       // handle Visual or match highlighting in this line
       if (wlv.vcol == wlv.fromcol
           || (wlv.vcol + 1 == wlv.fromcol && wlv.n_extra == 0
@@ -2126,7 +2106,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
           did_emsg = false;
 
           decor_attr = get_syntax_attr((colnr_T)v - 1,
-                                       has_spell ? &can_spell : NULL, false);
+                                       spv->spv_has_spell ? &can_spell : NULL, false);
 
           if (did_emsg) {  // -V547
             wp->w_s->b_syn_error = true;
@@ -2185,7 +2165,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
         // @Spell cluster is not used or the current syntax item
         // contains the @Spell cluster.
         v = (ptr - line);
-        if (has_spell && v >= word_end && v > cur_checked_col) {
+        if (spv->spv_has_spell && v >= word_end && v > cur_checked_col) {
           spell_attr = 0;
           char *prev_ptr = ptr - mb_l;
           // do not calculate cap_col at the end of the line or when
@@ -2202,8 +2182,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
             } else {
               p = prev_ptr;
             }
-            cap_col -= (int)(prev_ptr - line);
-            size_t tmplen = spell_check(wp, p, &spell_hlf, &cap_col, mod_top == 0);
+            spv->spv_cap_col -= (int)(prev_ptr - line);
+            size_t tmplen = spell_check(wp, p, &spell_hlf, &spv->spv_cap_col, spv->spv_unchanged);
             assert(tmplen <= INT_MAX);
             int len = (int)tmplen;
             word_end = (int)v + len;
@@ -2224,8 +2204,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
                 && (p - nextline) + len > nextline_idx) {
               // Remember that the good word continues at the
               // start of the next line.
-              checked_lnum = lnum + 1;
-              checked_col = (int)((p - nextline) + len - nextline_idx);
+              spv->spv_checked_lnum = lnum + 1;
+              spv->spv_checked_col = (int)((p - nextline) + len - nextline_idx);
             }
 
             // Turn index into actual attributes.
@@ -2233,17 +2213,15 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
               spell_attr = highlight_attr[spell_hlf];
             }
 
-            if (cap_col > 0) {
-              if (p != prev_ptr
-                  && (p - nextline) + cap_col >= nextline_idx) {
+            if (spv->spv_cap_col > 0) {
+              if (p != prev_ptr && (p - nextline) + spv->spv_cap_col >= nextline_idx) {
                 // Remember that the word in the next line
                 // must start with a capital.
-                capcol_lnum = lnum + 1;
-                cap_col = (int)((p - nextline) + cap_col
-                                - nextline_idx);
+                spv->spv_capcol_lnum = lnum + 1;
+                spv->spv_cap_col = (int)((p - nextline) + spv->spv_cap_col - nextline_idx);
               } else {
                 // Compute the actual column.
-                cap_col += (int)(prev_ptr - line);
+                spv->spv_cap_col += (int)(prev_ptr - line);
               }
             }
           }
@@ -3151,12 +3129,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int mod_top, bo
       }
     }
   }     // for every character in the line
-
-  // After an empty line check first word for capital.
-  if (*skipwhite(line) == NUL) {
-    capcol_lnum = lnum + 1;
-    cap_col = 0;
-  }
 
   kv_destroy(virt_lines);
   xfree(wlv.p_extra_free);

--- a/src/nvim/drawline.h
+++ b/src/nvim/drawline.h
@@ -23,6 +23,17 @@ EXTERN kvec_t(WinExtmark) win_extmark_arr INIT(= KV_INITIAL_VALUE);
 
 EXTERN bool conceal_cursor_used INIT(= false);
 
+// Spell checking variables passed from win_update() to win_line().
+typedef struct {
+  bool spv_has_spell;         ///< drawn window has spell checking
+  bool spv_unchanged;         ///< not updating for changed text
+  int spv_checked_col;        ///< column in "checked_lnum" up to
+                              ///< which there are no spell errors
+  linenr_T spv_checked_lnum;  ///< line number for "checked_col"
+  int spv_cap_col;            ///< column to check for Cap word
+  linenr_T spv_capcol_lnum;   ///< line number for "cap_col"
+} spellvars_T;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "drawline.h.generated.h"
 #endif

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2230,8 +2230,10 @@ static void win_update(win_T *wp, DecorProviders *providers)
         }
 
         // Display one line
-        row = win_line(wp, lnum, srow, foldinfo.fi_lines ? srow : wp->w_grid.rows,
-                       false, &spv, foldinfo, &line_providers, &provider_err);
+        spellvars_T zero_spv = { 0 };
+        row = win_line(wp, lnum, srow, foldinfo.fi_lines ? srow : wp->w_grid.rows, false,
+                       foldinfo.fi_lines ? &zero_spv : &spv,
+                       foldinfo, &line_providers, &provider_err);
 
         if (foldinfo.fi_lines == 0) {
           wp->w_lines[idx].wl_folded = false;
@@ -2366,9 +2368,10 @@ static void win_update(win_T *wp, DecorProviders *providers)
       if (j > 0 && !wp->w_botfill && row < wp->w_grid.rows) {
         // Display filler text below last line. win_line() will check
         // for ml_line_count+1 and only draw filler lines
-        foldinfo_T info = { 0 };
-        row = win_line(wp, wp->w_botline, row, wp->w_grid.rows,
-                       false, &spv, info, &line_providers, &provider_err);
+        spellvars_T zero_spv = { 0 };
+        foldinfo_T zero_foldinfo = { 0 };
+        row = win_line(wp, wp->w_botline, row, wp->w_grid.rows, false, &zero_spv,
+                       zero_foldinfo, &line_providers, &provider_err);
       }
     } else if (dollar_vcol == -1) {
       wp->w_botline = lnum;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1995,11 +1995,9 @@ static void win_update(win_T *wp, DecorProviders *providers)
   spellvars_T spv = { 0 };
   linenr_T lnum = wp->w_topline;  // first line shown in window
   // Initialize spell related variables for the first drawn line.
-  spv.spv_has_spell = spell_check_window(wp);
-  if (spv.spv_has_spell) {
+  if (spell_check_window(wp)) {
+    spv.spv_has_spell = true;
     spv.spv_unchanged = mod_top == 0;
-    spv.spv_capcol_lnum = mod_top ? mod_top : lnum;
-    spv.spv_cap_col = check_need_cap(wp, spv.spv_capcol_lnum, 0) ? 0 : -1;
   }
 
   // Update all the window rows.
@@ -2242,16 +2240,10 @@ static void win_update(win_T *wp, DecorProviders *providers)
           syntax_last_parsed = lnum;
         } else {
           foldinfo.fi_lines--;
-          linenr_T lnume = lnum + foldinfo.fi_lines;
           wp->w_lines[idx].wl_folded = true;
-          wp->w_lines[idx].wl_lastlnum = lnume;
-
-          // Check if the line after this fold requires a capital.
-          if (spv.spv_has_spell && check_need_cap(wp, lnume + 1, 0)) {
-            spv.spv_cap_col = 0;
-            spv.spv_capcol_lnum = lnume + 1;
-          }
+          wp->w_lines[idx].wl_lastlnum = lnum + foldinfo.fi_lines;
           did_update = DID_FOLD;
+          spv.spv_capcol_lnum = 0;
         }
       }
 
@@ -2288,6 +2280,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
       }
       lnum = wp->w_lines[idx - 1].wl_lastlnum + 1;
       did_update = DID_NONE;
+      spv.spv_capcol_lnum = 0;
     }
 
     // 'statuscolumn' width has changed or errored, start from the top.

--- a/test/functional/ui/spell_spec.lua
+++ b/test/functional/ui/spell_spec.lua
@@ -178,6 +178,30 @@ describe("'spell'", function()
       {0:~                                                                               }|
                                                                                       |
     ]])
+    -- Adding an empty line does not remove Cap in "mod_bot" area
+    feed('zbO<Esc>')
+    screen:expect([[
+         This line has a {1:sepll} error. {2:and} missing caps and trailing spaces.           |
+      ^                                                                                |
+      {2:another} missing cap here                                                        |
+      {10:+--  2 lines: Not·······························································}|
+      {2:and} here.                                                                       |
+      {0:~                                                                               }|
+      {0:~                                                                               }|
+                                                                                      |
+    ]])
+    -- Multiple empty lines does not remove Cap in the line after
+    feed('O<Esc><C-L>')
+    screen:expect([[
+         This line has a {1:sepll} error. {2:and} missing caps and trailing spaces.           |
+      ^                                                                                |
+                                                                                      |
+      {2:another} missing cap here                                                        |
+      {10:+--  2 lines: Not·······························································}|
+      {2:and} here.                                                                       |
+      {0:~                                                                               }|
+                                                                                      |
+    ]])
   end)
 
   -- oldtest: Test_spell_compatible()

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -962,6 +962,7 @@ func Test_spell_screendump()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "This is some text without any spell errors.  Everything",
              \ "should just be black, nothing wrong here.",
@@ -984,6 +985,7 @@ func Test_spell_screendump_spellcap()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "   This line has a sepll error. and missing caps and trailing spaces.   ",
              \ "another missing cap here.",
@@ -1023,6 +1025,14 @@ func Test_spell_screendump_spellcap()
   call term_sendkeys(buf, "\<C-E>\<C-L>")
   call VerifyScreenDump(buf, 'Test_spell_8', {})
 
+  " Adding an empty line does not remove Cap in "mod_bot" area
+  call term_sendkeys(buf, "zbO\<Esc>")
+  call VerifyScreenDump(buf, 'Test_spell_9', {})
+
+  " Multiple empty lines does not remove Cap in the line after
+  call term_sendkeys(buf, "O\<Esc>\<C-L>")
+  call VerifyScreenDump(buf, 'Test_spell_10', {})
+
   " clean up
   call StopVimInTerminal(buf)
 endfunc
@@ -1031,6 +1041,7 @@ func Test_spell_compatible()
   CheckScreendump
 
   let lines =<< trim END
+       call test_override('alloc_lines', 1)
        call setline(1, [
              \ "test "->repeat(20),
              \ "",


### PR DESCRIPTION
**vim-patch:9.0.1585: weird use of static variables for spell checking**


Problem:    Weird use of static variables for spell checking.
Solution:   Move the variables to a structure and pass them from win_update()
            to win_line(). (Luuk van Baal, closes vim/vim#12448)

https://github.com/vim/vim/commit/30805a1aba0067cf0087f9a0e5c184562433e2e7

**vim-patch:9.0.1595: line pointer becomes invalid when using spell checking**

Problem:    Line pointer becomes invalid when using spell checking.
Solution:   Call ml_get() at the right places. (Luuk van Baal, closes vim/vim#12456)

https://github.com/vim/vim/commit/e84c773d42e8b6ef0f8ae9b6c7312e0fd47909af