### PR TITLE
fix(buffer): mixed slashes in buffer name

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -1003,6 +1003,10 @@ String nvim_buf_get_name(Buffer buffer, Arena *arena, Error *err)
     return rv;
   }
 
+#if defined(BACKSLASH_IN_FILENAME)
+  slash_adjust(buf->b_ffname);
+#endif
+
   return cstr_as_string(buf->b_ffname);
 }
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -21,6 +21,7 @@
 #include "nvim/eval/typval.h"
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_eval.h"
+#include "nvim/fileio.h"
 #include "nvim/garray.h"
 #include "nvim/highlight_group.h"
 #include "nvim/lua/executor.h"
@@ -301,6 +302,12 @@ buf_T *find_buffer_by_handle(Buffer buffer, Error *err)
   if (!rv) {
     api_set_error(err, kErrorTypeValidation, "Invalid buffer id: %d", buffer);
   }
+
+#if defined(BACKSLASH_IN_FILENAME)
+  if (rv->b_ffname) {
+    forward_slash(rv->b_ffname);
+  }
+#endif
 
   return rv;
 }


### PR DESCRIPTION
Problem: 'nvim_buf_get_name' does not respect 'shellslash' option and returns path with mixed slashes.

Solution: Force forward slashes when loading the buffer, but adjust the slashes according to 'shellslash' option for 'nvim_buf_get_name' api.

Closes #23639