### PR TITLE
fix(ftplugin): source Lua files after Vimscript files per directory

### DIFF
--- a/runtime/ftplugin.vim
+++ b/runtime/ftplugin.vim
@@ -28,9 +28,11 @@ augroup filetypeplugin
       " When there is a dot it is used to separate filetype names.  Thus for
       " "aaa.bbb" load "aaa" and then "bbb".
       for name in split(s, '\.')
-        exe 'runtime! ftplugin/' . name . '.vim ftplugin/' . name . '_*.vim ftplugin/' . name . '/*.vim'
-        " Load lua ftplugins
-        exe printf('runtime! ftplugin/%s.lua ftplugin/%s_*.lua ftplugin/%s/*.lua', name, name, name)
+        " Load Lua ftplugins after Vim ftplugins _per directory_
+        " TODO(clason): use nvim__get_runtime when supports globs and modeline
+        exe printf('runtime! ftplugin/%s.vim ftplugin/%s.lua', name, name)
+        exe printf('runtime! ftplugin/%s_*.vim ftplugin/%s_*.lua', name, name)
+        exe printf('runtime! ftplugin/%s/*.vim ftplugin/%s/*.lua', name, name)
       endfor
     endif
   endfunc


### PR DESCRIPTION
Problem: Lua ftplugins in runtime take precedence over Vim ftplugins in
user configs (even in `after/`).
Solution: Source ftplugins separately per directory, Vim then Lua.

fixes https://github.com/neovim/neovim/issues/16928

Alternative to #23202, which is blocked by improvements to `nvim__get_runtime`. That PR also fixes a similar issue for syntax files, but I think it's safe to assume that this is such an uncommon scenario that it can wait.
