### PR TITLE
vim-patch:9.0.1586: error for using two messages with ngettext() differing in "%"

### DIFF
--- a/src/nvim/po/check.vim
+++ b/src/nvim/po/check.vim
@@ -6,6 +6,9 @@
 
 if 1	" Only execute this if the eval feature is available.
 
+" using line continuation
+set cpo&vim
+
 let filename = "check-" . expand("%:t:r") . ".log"
 exe 'redir! > ' . filename
 
@@ -62,12 +65,18 @@ while 1
   if getline(line('.') - 1) !~ "no-c-format"
     " go over the "msgid" and "msgid_plural" lines
     let prevfromline = 'foobar'
+    let plural = 0
     while 1
+      if getline('.') =~ 'msgid_plural'
+	let plural += 1
+      endif
       let fromline = GetMline()
       if prevfromline != 'foobar' && prevfromline != fromline
+	    \ && (plural != 1
+	    \     || count(prevfromline, '%') + 1 != count(fromline, '%'))
 	echomsg 'Mismatching % in line ' . (line('.') - 1)
 	echomsg 'msgid: ' . prevfromline
-	echomsg 'msgid ' . fromline
+	echomsg 'msgid: ' . fromline
 	if error == 0
 	  let error = line('.')
 	endif
@@ -89,6 +98,7 @@ while 1
     while getline('.') =~ '^msgstr'
       let toline = GetMline()
       if fromline != toline
+	    \ && (plural == 0 || count(fromline, '%') != count(toline, '%') + 1)
 	echomsg 'Mismatching % in line ' . (line('.') - 1)
 	echomsg 'msgid: ' . fromline
 	echomsg 'msgstr: ' . toline


### PR DESCRIPTION
#### vim-patch:9.0.1586: error for using two messages with ngettext() differing in "%"

Problem:    Checking translations gives an error for using two messages with
            ngettext() that differ in "%" items.
Solution:   Adjust the check script to tolerate omitting one "%" item.

https://github.com/vim/vim/commit/78ee62563ea940086f094150f0356e38f780c580

Co-authored-by: Bram Moolenaar <Bram@vim.org>