### PR TITLE
vim-patch:9.0.1588: Incsearch not triggered when pasting clipboard register

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1597,7 +1597,7 @@ static int command_line_insert_reg(CommandLineState *s)
 
   bool literally = false;
   if (s->c != ESC) {               // use ESC to cancel inserting register
-    literally = i == Ctrl_R;
+    literally = i == Ctrl_R || is_literal_register(s->c);
     cmdline_paste(s->c, literally, false);
 
     // When there was a serious error abort getting the

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -854,15 +854,6 @@ static bool is_append_register(int regname)
   return ASCII_ISUPPER(regname);
 }
 
-/// @see get_yank_register
-/// @returns true when register should be inserted literally
-/// (selection or clipboard)
-static inline bool is_literal_register(int regname)
-  FUNC_ATTR_CONST
-{
-  return regname == '*' || regname == '+';
-}
-
 /// @return  a copy of contents in register `name` for use in do_put. Should be
 ///          freed by caller.
 yankreg_T *copy_register(int name)

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -123,6 +123,15 @@ static inline int op_reg_index(const int regname)
   }
 }
 
+/// @see get_yank_register
+/// @return  true when register should be inserted literally
+/// (selection or clipboard)
+static inline bool is_literal_register(const int regname)
+  FUNC_ATTR_CONST
+{
+  return regname == '*' || regname == '+';
+}
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ops.h.generated.h"
 #endif

--- a/test/functional/autocmd/textyankpost_spec.lua
+++ b/test/functional/autocmd/textyankpost_spec.lua
@@ -8,7 +8,7 @@ describe('TextYankPost', function()
     clear()
 
     -- emulate the clipboard so system clipboard isn't affected
-    command('let &rtp = "test/functional/fixtures,".&rtp')
+    command('set rtp^=test/functional/fixtures')
 
     command('let g:count = 0')
     command('autocmd TextYankPost * let g:event = copy(v:event)')

--- a/test/functional/provider/clipboard_spec.lua
+++ b/test/functional/provider/clipboard_spec.lua
@@ -301,7 +301,7 @@ end)
 
 describe('clipboard (with fake clipboard.vim)', function()
   local function reset(...)
-    clear('--cmd', 'let &rtp = "test/functional/fixtures,".&rtp', ...)
+    clear('--cmd', 'set rtp^=test/functional/fixtures', ...)
   end
 
   before_each(function()

--- a/test/functional/provider/provider_spec.lua
+++ b/test/functional/provider/provider_spec.lua
@@ -7,7 +7,7 @@ local pcall_err = helpers.pcall_err
 
 describe('providers', function()
   before_each(function()
-    clear('--cmd', 'let &rtp = "test/functional/fixtures,".&rtp')
+    clear('--cmd', 'set rtp^=test/functional/fixtures')
   end)
 
   it('with #Call(), missing g:loaded_xx_provider', function()

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -512,6 +512,36 @@ describe('search highlighting', function()
       {1:~                   }│{1:~                  }|
       /file^                                   |
     ]])
+    feed('<Esc>')
+
+    command('set rtp^=test/functional/fixtures')
+    -- incsearch works after c_CTRL-R inserts clipboard register
+
+    command('let @* = "first"')
+    feed('/<C-R>*')
+    screen:expect([[
+      the {3:first} line      │the {2:first} line     |
+      in a little file    │in a little file   |
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      /first^                                  |
+    ]])
+    feed('<Esc>')
+
+    command('let @+ = "little"')
+    feed('/<C-R>+')
+    screen:expect([[
+      the first line      │the first line     |
+      in a {3:little} file    │in a {2:little} file   |
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      {1:~                   }│{1:~                  }|
+      /little^                                 |
+    ]])
+    feed('<Esc>')
   end)
 
   it('works with incsearch and offset', function()

--- a/test/functional/vimscript/api_functions_spec.lua
+++ b/test/functional/vimscript/api_functions_spec.lua
@@ -133,7 +133,7 @@ describe('eval-API', function()
     })
 
     command("set ft=vim")
-    command("let &rtp='build/runtime/,'.&rtp")
+    command("set rtp^=build/runtime/")
     command("syntax on")
     insert([[
       call bufnr('%')

--- a/test/old/testdir/test_hlsearch.vim
+++ b/test/old/testdir/test_hlsearch.vim
@@ -85,4 +85,23 @@ func Test_hlsearch_Ctrl_R()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_hlsearch_clipboard()
+  CheckRunVimInTerminal
+  CheckFeature clipboard_working
+
+  let lines =<< trim END
+      set incsearch hlsearch
+      let @* = "text"
+      put *
+  END
+  call writefile(lines, 'XhlsearchClipboard', 'D')
+  let buf = RunVimInTerminal('-S XhlsearchClipboard', #{rows: 6, cols: 60})
+
+  call term_sendkeys(buf, "/\<C-R>*")
+  call VerifyScreenDump(buf, 'Test_hlsearch_ctrlr_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1588: Incsearch not triggered when pasting clipboard register

Problem:    Incsearch not triggered when pasting clipboard register on the
            command line.
Solution:   Also set "literally" when using a clipboard register. (Ken Takata,
            closes vim/vim#12460)

https://github.com/vim/vim/commit/9cf6ab133227ac7e9169941752293bb7178d8e38

Co-authored-by: K.Takata <kentkt@csc.jp>