### PR TITLE
build: allow using system rocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,13 +286,18 @@ ExternalProject_Add(uncrustify
   CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS}
   EXCLUDE_FROM_ALL TRUE)
 
-ExternalProject_Add(lua-dev-deps
-  URL https://github.com/neovim/deps/raw/5a1f71cceb24990a0b15fd9a472a5f549f019248/opt/lua-dev-deps.tar.gz
-  URL_HASH SHA256=27db2495f5eddc7fc191701ec9b291486853530c6125609d3197d03481e8d5a2
-  DOWNLOAD_NO_PROGRESS TRUE
-  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/lua-dev-deps
-  SOURCE_DIR ${DEPS_SHARE_DIR}
-  CONFIGURE_COMMAND ""
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ""
-  EXCLUDE_FROM_ALL TRUE)
+option(USE_BUNDLED_BUSTED "Use bundled luarocks" ON)
+if(USE_BUNDLED_BUSTED)
+  ExternalProject_Add(lua-dev-deps
+    URL https://github.com/neovim/deps/raw/5a1f71cceb24990a0b15fd9a472a5f549f019248/opt/lua-dev-deps.tar.gz
+    URL_HASH SHA256=27db2495f5eddc7fc191701ec9b291486853530c6125609d3197d03481e8d5a2
+    DOWNLOAD_NO_PROGRESS TRUE
+    DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/lua-dev-deps
+    SOURCE_DIR ${DEPS_SHARE_DIR}
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    EXCLUDE_FROM_ALL TRUE)
+else()
+  add_custom_target(lua-dev-deps)
+endif()


### PR DESCRIPTION
This allow distributions and other interested parties to use a system
busted rather than the on neovim bundles by passing the
-D USE_BUNDLED_BUSTED=ON flag to cmake when building.

Closes https://github.com/neovim/neovim/issues/23814.