### PR TITLE
vim-patch:9.0.1591: some "gomod" files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -771,14 +771,14 @@ end
 function M.mod(path, bufnr)
   if vim.g.filetype_mod then
     return vim.g.filetype_mod
+  elseif matchregex(path, [[\c\<go\.mod$]]) then
+    return 'gomod'
   elseif is_lprolog(bufnr) then
     return 'lprolog'
   elseif matchregex(nextnonblank(bufnr, 1), [[\%(\<MODULE\s\+\w\+\s*;\|^\s*(\*\)]]) then
     return 'modula2'
   elseif is_rapid(bufnr) then
     return 'rapid'
-  elseif matchregex(path, [[\c\<go\.mod$]]) then
-    return 'gomod'
   else
     -- Nothing recognized, assume modsim3
     return 'modsim3'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1450,6 +1450,12 @@ func Test_mod_file()
   bwipe!
   call delete('go.mod')
 
+  call writefile(['module M'], 'go.mod')
+  split go.mod
+  call assert_equal('gomod', &filetype)
+  bwipe!
+  call delete('go.mod')
+
   filetype off
 endfunc
 


### PR DESCRIPTION
Problem:    Some "gomod" files are not recognized.
Solution:   Check for "go.mod" file name before checking out the contents.
            (Omar El Halabi, closes vim/vim#12462)

https://github.com/vim/vim/commit/c9fbd2560f24180d2efa40028ed68427341d2d99

Co-authored-by: Bram Moolenaar <Bram@vim.org>