### PR TITLE
vim 9.0.1591

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -771,14 +771,14 @@ end
 function M.mod(path, bufnr)
   if vim.g.filetype_mod then
     return vim.g.filetype_mod
+  elseif matchregex(path, [[\c\<go\.mod$]]) then
+    return 'gomod'
   elseif is_lprolog(bufnr) then
     return 'lprolog'
   elseif matchregex(nextnonblank(bufnr, 1), [[\%(\<MODULE\s\+\w\+\s*;\|^\s*(\*\)]]) then
     return 'modula2'
   elseif is_rapid(bufnr) then
     return 'rapid'
-  elseif matchregex(path, [[\c\<go\.mod$]]) then
-    return 'gomod'
   else
     -- Nothing recognized, assume modsim3
     return 'modsim3'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1450,6 +1450,12 @@ func Test_mod_file()
   bwipe!
   call delete('go.mod')
 
+  call writefile(['module M'], 'go.mod')
+  split go.mod
+  call assert_equal('gomod', &filetype)
+  bwipe!
+  call delete('go.mod')
+
   filetype off
 endfunc
 


### PR DESCRIPTION
- fix(extmarks): don't show virt lines for end mark (#23792)
- fix(extmarks): fix virt_text_hide off-by-one hiding (#23795)
- vim-patch:9.0.1584: not all meson files are recognized (#23797)
- fix(ftplugin): source Lua files after Vimscript files per directory (#23801)
- build: remove LOG_DEBUG option
- build: align .clang-format rules with uncrustify config
- fix(NVIM_APPNAME): show error message if $NVIM_APPNAME is invalid
- build: remove LOG_LIST_ACTIONS option and related code
- fix(substitute): properly check if preview is needed (#23809)
- vim-patch:9.0.1587: Corn config files are not recognized (#23807)
- vim-patch:9.0.1586: error for using two messages with ngettext() differing in "%" (#23816)
- vim-patch:9.0.1591: some "gomod" files are not recognized
