### PR TITLE
fix(lsp): fixed dynamic registration of code actions

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -681,9 +681,16 @@ local function on_code_action_results(results, ctx, options)
     --  command: string
     --  arguments?: any[]
     --
+    ---@type lsp.Client
     local client = vim.lsp.get_client_by_id(action_tuple[1])
     local action = action_tuple[2]
-    if not action.edit and client and client.supports_method('codeAction/resolve') then
+
+    local reg = client.dynamic_capabilities:get('textDocument/codeAction', { bufnr = ctx.bufnr })
+
+    local supports_resolve = vim.tbl_get(reg or {}, 'registerOptions', 'resolveProvider')
+      or client.supports_method('codeAction/resolve')
+
+    if not action.edit and client and supports_resolve then
       client.request('codeAction/resolve', action, function(err, resolved_action)
         if err then
           vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)


### PR DESCRIPTION
@mfussenegger this should fix it specifically for the code-action resolve case.

I wasn't able to test this, since the servers I work with don't have resolve.

I feel like eventually we should have an easier way to work with dynamic registrations `registerOptions`. Will re-read the spec and see how we can further improve this.