### PR TITLE
ci: replace stylua action with our own lint target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Install dependencies
         run: ./.github/scripts/install_deps.sh lua-check
 
+      - name: Set up Homebrew
+        id: homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - run: |
+          brew install stylua
+
       - name: Cache uncrustify
         id: cache-uncrustify
         uses: actions/cache@v3
@@ -84,12 +91,8 @@ jobs:
         run: echo "status=${{ job.status }}" >> $GITHUB_OUTPUT
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
-        name: lintstylua
-        uses: JohnnyMorganz/stylua-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          version: latest
-          args: --check runtime/
+        name: stylua
+        run: cmake --build build --target lintlua-stylua
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: luacheck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,8 @@ add_glob_target(
   FLAGS --color=always --check
   GLOB_DIRS runtime/
   GLOB_PAT *.lua
+  EXCLUDE
+    /runtime/lua/vim/re.lua
   TOUCH_STRATEGY SINGLE)
 
 add_custom_target(lintlua)


### PR DESCRIPTION
This will prevent situations where the linting works on CI but not locally, at the cost of increased CI time.

Also manually ignore `runtime/vim/lua/re.lua`, as the .styluaignore isn't respected when specifying a file instead of a directory.