### PR TITLE
docs(iter): add emmylua type to iter module

### DIFF
--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -51,6 +51,8 @@
 --- In addition to the |vim.iter()| function, the |vim.iter| module provides
 --- convenience functions like |vim.iter.filter()| and |vim.iter.totable()|.
 
+---@class IterMod
+---@operator call:Iter
 local M = {}
 
 ---@class Iter
@@ -974,6 +976,7 @@ function M.map(f, src, ...)
   return Iter.new(src, ...):map(f):totable()
 end
 
+---@type IterMod
 return setmetatable(M, {
   __call = function(_, ...)
     return Iter.new(...)


### PR DESCRIPTION
This adds an emmylua annotation for the call operator on the Iter module. This makes it possible to get completion both when indexing `vim.iter`, and when calling it

See this for context: https://github.com/folke/neodev.nvim/issues/153