### PR TITLE
fix(extmarks): fix heap buffer overflow caused by inline virtual text

### DIFF
--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2506,6 +2506,28 @@ bbbbbbb]])
                                                                                         |
     ]]}
   end)
+
+  it('list "extends" is drawn with only inline virtual text offscreen', function()
+    command('set nowrap')
+    command('set list')
+    command('set listchars+=extends:c')
+    meths.buf_set_extmark(0, ns, 0, 0,
+      { virt_text = { { 'test', 'Special' } }, virt_text_pos = 'inline' })
+    insert(string.rep('a', 50))
+    feed('gg0')
+    screen:expect { grid = [[
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:c}|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+      ]]}
+  end)
 end)
 
 describe('decorations: virtual lines', function()


### PR DESCRIPTION
fixes #23848, also fixes an edge case where the `extends` character would not be rendered if the real text was the exact length of the grid and was followed by inline virtual text. This seems to work, but can't be 100% sure of all edge cases. If there is any better way to do this, please let me know.

@zeertzjq could you confirm that this PR fixes the issue on your end?

Also is there a way to write a test for #23848?