### PR TITLE
fix(lsp): add param assert in client_is_stopped

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2275,7 +2275,8 @@ end
 ---@param client_id (integer)
 ---@return boolean stopped true if client is stopped, false otherwise.
 function lsp.client_is_stopped(client_id)
-  return active_clients[client_id] == nil
+  assert(client_id, 'missing client_id param')
+  return active_clients[client_id] == nil and not uninitialized_clients[client_id]
 end
 
 --- Gets a map of client_id:client pairs for the given buffer, where each value


### PR DESCRIPTION
Problem: if not pass a `client_id` it always return true .  and there should check client is in `uninitialized_clients` table or not

Solution: add assertion for param `client_id` and check client in `uninitialized_clients` or not 

Fix #23853 