### PR TITLE
fix(treesitter): remove incompatible c query

### DIFF
--- a/runtime/queries/c/highlights.scm
+++ b/runtime/queries/c/highlights.scm
@@ -117,15 +117,6 @@
  (preproc_defined)
 ]  @function.macro
 
-(((field_expression
-     (field_identifier) @property)) @_parent
- (#not-has-parent? @_parent template_method function_declarator call_expression))
-
-(field_designator) @property
-(((field_identifier) @property)
- (#has-ancestor? @property field_declaration)
- (#not-has-ancestor? @property function_declarator))
-
 (statement_identifier) @label
 
 [


### PR DESCRIPTION
`#has-parent?` and `#has-ancestor?` predicates were not backported

Fixes #23858

