### PR TITLE
fix(api): dont change curwin for nvim_win_set_height

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -209,13 +209,8 @@ void nvim_win_set_width(Window window, Integer width, Error *err)
     return;
   }
 
-  win_T *savewin = curwin;
-  curwin = win;
-  curbuf = curwin->w_buffer;
   try_start();
-  win_setwidth((int)width);
-  curwin = savewin;
-  curbuf = curwin->w_buffer;
+  win_setwidth_win((int)width, win);
   try_end(err);
 }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -167,13 +167,8 @@ void nvim_win_set_height(Window window, Integer height, Error *err)
     return;
   }
 
-  win_T *savewin = curwin;
-  curwin = win;
-  curbuf = curwin->w_buffer;
   try_start();
-  win_setheight((int)height);
-  curwin = savewin;
-  curbuf = curwin->w_buffer;
+  win_setheight_win((int)height, win);
   try_end(err);
 }
 

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -285,6 +285,22 @@ describe('API/win', function()
       eq(2, window('get_height', nvim('list_wins')[2]))
     end)
 
+    it('correctly handles height=1', function()
+      nvim('command', 'split')
+      nvim('set_current_win', nvim('list_wins')[1])
+      window('set_height', nvim('list_wins')[2], 1)
+      eq(1, window('get_height', nvim('list_wins')[2]))
+    end)
+
+    it('correctly handles height=1 with a winbar', function()
+      nvim('command', 'set winbar=foobar')
+      nvim('command', 'set winminheight=0')
+      nvim('command', 'split')
+      nvim('set_current_win', nvim('list_wins')[1])
+      window('set_height', nvim('list_wins')[2], 1)
+      eq(1, window('get_height', nvim('list_wins')[2]))
+    end)
+
     it('do not cause ml_get errors with foldmethod=expr #19989', function()
       insert([[
         aaaaa


### PR DESCRIPTION
Below is the code that calculates the minimum height.

When using `nvim_win_set_height`, `curwin` is temporarily changed to the window we're changing. This means that the code below will always set `height=2` when a winbar is active on the window.

This PR fixes that.

```
// Always keep current window at least one line high, even when 'winminheight' is zero.
  // Keep window at least two lines high if 'winbar' is enabled.
```

https://github.com/neovim/neovim/blob/2bdef6dd2a7572602aeb2efec76812769bcee246/src/nvim/window.c#L5788