### PR TITLE
vim-patch:9.0.1596: :registers command does not work in sandbox

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2212,7 +2212,7 @@ module.cmds = {
   },
   {
     command='registers',
-    flags=bit.bor(EXTRA, NOTRLCOM, TRLBAR, CMDWIN, LOCK_OK),
+    flags=bit.bor(EXTRA, NOTRLCOM, TRLBAR, SBOXOK, CMDWIN, LOCK_OK),
     addr_type='ADDR_NONE',
     func='ex_display',
   },

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -55,8 +55,9 @@ func Test_display_registers()
     call feedkeys("i\<C-R>=2*4\n\<esc>")
     call feedkeys(":ls\n", 'xt')
 
-    let a = execute('display')
-    let b = execute('registers')
+    " these commands work in the sandbox
+    let a = execute('sandbox display')
+    let b = execute('sandbox registers')
 
     call assert_equal(a, b)
     call assert_match('^\nType Name Content\n'


### PR DESCRIPTION
#### vim-patch:9.0.1596: :registers command does not work in sandbox

Problem:    :registers command does not work in sandbox.
Solution:   Add flag to the command. (closes vim/vim#12473)

https://github.com/vim/vim/commit/eb43b7f0531bd13d15580b5c262a25d6a52a0823

Co-authored-by: Julio B <julio.bacel@gmail.com>