### PR TITLE
Add support for LSP positionEncoding capability

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -39,6 +39,12 @@ ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
 
+• Nvim's LSP client now advertises the general.positionEncodings client
+  capability to indicate to servers that it supports utf-8, utf-16, and utf-32
+  encodings. If the server responds with the positionEncoding capability in
+  its initialization response, Nvim automatically sets the client's
+  `offset_encoding` field.
+
 • Dynamic registration of LSP capabilities. An implication of this change is that checking a client's `server_capabilities` is no longer a sufficient indicator to see if a server supports a feature. Instead use `client.supports_method(<method>)`. It considers both the dynamic capabilities and static `server_capabilities`.
 • |vim.iter()| provides a generic iterator interface for tables and Lua
   iterators |luaref-in|.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1344,6 +1344,10 @@ function lsp.start_client(config)
         assert(result.capabilities, "initialize result doesn't contain capabilities")
       client.server_capabilities = protocol.resolve_capabilities(client.server_capabilities)
 
+      if client.server_capabilities.positionEncoding then
+        client.offset_encoding = client.server_capabilities.positionEncoding
+      end
+
       if next(config.settings) then
         client.notify('workspace/didChangeConfiguration', { settings = config.settings })
       end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -634,6 +634,13 @@ export interface WorkspaceClientCapabilities {
 --- capabilities.
 function protocol.make_client_capabilities()
   return {
+    general = {
+      positionEncodings = {
+        'utf-8',
+        'utf-16',
+        'utf-32',
+      },
+    },
     textDocument = {
       semanticTokens = {
         dynamicRegistration = false,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -218,6 +218,34 @@ describe('LSP', function()
       })
     end)
 
+    it("should set the client's offset_encoding when positionEncoding capability is supported", function()
+      clear()
+      exec_lua(create_server_definition)
+      local result = exec_lua([[
+        local server = _create_server({
+          capabilities = {
+            positionEncoding = "utf-8"
+          },
+        })
+
+        local client_id = vim.lsp.start({
+          name = 'dummy',
+          cmd = server.cmd,
+        })
+
+        if not client_id then
+          return 'vim.lsp.start did not return client_id'
+        end
+
+        local client = vim.lsp.get_client_by_id(client_id)
+        if not client then
+          return 'No client found with id ' .. client_id
+        end
+        return client.offset_encoding
+      ]])
+      eq('utf-8', result)
+    end)
+
     it('should succeed with manual shutdown', function()
       if is_ci() then
         pending('hangs the build on CI #14028, re-enable with freeze timeout #14204')


### PR DESCRIPTION
* feat(lsp): set client offset_encoding if server supports positionEncoding

If the server sends the positionEncoding capability in its initialization response, automatically set the client's `offset_encoding` to use the value provided.

* feat(lsp): include positionEncodings in default client capabilities