### PR TITLE
vim-patch:9.0.1598: screenchar() and others are wrong with DBCS 'encoding'

### DIFF
--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -138,8 +138,9 @@ void grid_putchar(ScreenGrid *grid, int c, int row, int col, int attr)
   grid_puts(grid, buf, row, col, attr);
 }
 
-/// get a single character directly from grid.chars into "bytes[]".
-/// Also return its attribute in *attrp;
+/// Get a single character directly from grid.chars into "bytes", which must
+/// have a size of "MB_MAXBYTES + 1".
+/// If "attrp" is not NULL, return the character's attribute in "*attrp".
 void grid_getbytes(ScreenGrid *grid, int row, int col, char *bytes, int *attrp)
 {
   grid_adjust(&grid, &row, &col);
@@ -150,7 +151,9 @@ void grid_getbytes(ScreenGrid *grid, int row, int col, char *bytes, int *attrp)
   }
 
   size_t off = grid->line_offset[row] + (size_t)col;
-  *attrp = grid->attrs[off];
+  if (attrp != NULL) {
+    *attrp = grid->attrs[off];
+  }
   schar_copy(bytes, grid->chars[off]);
 }
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2834,6 +2834,34 @@ func Test_screen_functions()
   call assert_equal(-1, screenattr(-1, -1))
   call assert_equal(-1, screenchar(-1, -1))
   call assert_equal([], screenchars(-1, -1))
+
+  " Run this in a separate Vim instance to avoid messing up.
+  let after =<< trim [CODE]
+    scriptencoding utf-8
+    call setline(1, '口')
+    redraw
+    call assert_equal(0, screenattr(1, 1))
+    call assert_equal(char2nr('口'), screenchar(1, 1))
+    call assert_equal([char2nr('口')], screenchars(1, 1))
+    call assert_equal('口', screenstring(1, 1))
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [CODE]
+
+  let encodings = ['utf-8', 'cp932', 'cp936', 'cp949', 'cp950']
+  if !has('win32')
+    let encodings += ['euc-jp']
+  endif
+  if has('nvim')
+    let encodings = ['utf-8']
+  endif
+  for enc in encodings
+    let msg = 'enc=' .. enc
+    if RunVim([], after, $'--clean --cmd "set encoding={enc}"')
+      call assert_equal([], readfile('Xresult'), msg)
+    endif
+    call delete('Xresult')
+  endfor
 endfunc
 
 " Test for getcurpos() and setpos()

--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -88,7 +88,20 @@ func Test_screenchar_utf8()
   call assert_equal("B", screenstring(1, 2))
   call assert_equal("C\u0308", screenstring(1, 3))
 
-  " 2-cells, with composing characters 
+  " 1-cell, with 6 composing characters
+  set maxcombine=6
+  call setline(1, ["ABC" .. repeat("\u0308", 6)])
+  redraw
+  call assert_equal([0x0041], screenchars(1, 1))
+  call assert_equal([0x0042], 1->screenchars(2))
+  " This should not use uninitialized memory
+  call assert_equal([0x0043] + repeat([0x0308], 6), screenchars(1, 3))
+  call assert_equal("A", screenstring(1, 1))
+  call assert_equal("B", screenstring(1, 2))
+  call assert_equal("C" .. repeat("\u0308", 6), screenstring(1, 3))
+  set maxcombine&
+
+  " 2-cells, with composing characters
   let text = "\u3042\u3044\u3046\u3099"
   call setline(1, text)
   redraw


### PR DESCRIPTION
#### vim-patch:9.0.1598: screenchar() and others are wrong with DBCS 'encoding'

Problem:    screenchar(), screenchars() and screenstring() do not work
            properly when 'encoding' is set to a double-byte encoding.
Solution:   Fix the way the bytes of the characters are obtained.
            (issue vim/vim#12469)

https://github.com/vim/vim/commit/47eec6716b8621fd43bac8ecc9c19089df26705e