### PR TITLE
fix(folds): allow overlay virtual text on folded line

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2180,7 +2180,7 @@ Dictionary nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Error *
       wp->w_cursorline = win_cursorline_standout(wp) ? wp->w_cursor.lnum : 0;
 
       if (wp->w_p_cul) {
-        if (statuscol.foldinfo.fi_level > 0 && statuscol.foldinfo.fi_lines > 0) {
+        if (statuscol.foldinfo.fi_level != 0 && statuscol.foldinfo.fi_lines > 0) {
           wp->w_cursorline = statuscol.foldinfo.fi_lnum;
         }
         statuscol.use_cul = lnum == wp->w_cursorline && (wp->w_p_culopt_flags & CULOPT_NBR);

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1985,7 +1985,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
   if (wp->w_p_cul) {
     // Make sure that the cursorline on a closed fold is redrawn
     cursorline_fi = fold_info(wp, wp->w_cursor.lnum);
-    if (cursorline_fi.fi_level > 0 && cursorline_fi.fi_lines > 0) {
+    if (cursorline_fi.fi_level != 0 && cursorline_fi.fi_lines > 0) {
       wp->w_cursorline = cursorline_fi.fi_lnum;
     }
   }
@@ -2231,8 +2231,8 @@ static void win_update(win_T *wp, DecorProviders *providers)
 
         // Display one line
         spellvars_T zero_spv = { 0 };
-        row = win_line(wp, lnum, srow, foldinfo.fi_lines ? srow : wp->w_grid.rows, false,
-                       foldinfo.fi_lines ? &zero_spv : &spv,
+        row = win_line(wp, lnum, srow, foldinfo.fi_lines > 0 ? srow : wp->w_grid.rows, false,
+                       foldinfo.fi_lines > 0 ? &zero_spv : &spv,
                        foldinfo, &line_providers, &provider_err);
 
         if (foldinfo.fi_lines == 0) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -666,6 +666,7 @@ describe('extmark decorations', function()
       [30] = {foreground = Screen.colors.DarkCyan, background = Screen.colors.LightGray, underline = true};
       [31] = {underline = true, foreground = Screen.colors.DarkCyan};
       [32] = {underline = true};
+      [33] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGray};
     }
 
     ns = meths.create_namespace 'test'
@@ -1143,6 +1144,46 @@ describe('extmark decorations', function()
                                                         |
                                                         |
       {1:~                                                 }|
+                                                        |
+    ]]}
+  end)
+
+  it('can have virtual text on folded line', function()
+    insert([[
+      11111
+      22222
+      33333]])
+    command('1,2fold')
+    command('set nowrap')
+    screen:try_resize(50, 3)
+    feed('zb')
+    -- XXX: the behavior of overlay virtual text at non-zero column is strange:
+    -- 1. With 'wrap' it is never shown.
+    -- 2. With 'nowrap' it is shown only if the extmark is hidden before leftcol.
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = {{'AA', 'Underlined'}}, hl_mode = 'combine', virt_text_pos = 'overlay' })
+    meths.buf_set_extmark(0, ns, 0, 1, { virt_text = {{'BB', 'Underlined'}}, hl_mode = 'combine', virt_text_win_col = 10 })
+    meths.buf_set_extmark(0, ns, 0, 2, { virt_text = {{'CC', 'Underlined'}}, hl_mode = 'combine', virt_text_pos = 'right_align' })
+    screen:expect{grid=[[
+      {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
+      3333^3                                             |
+                                                        |
+    ]]}
+    feed('zl')
+    screen:expect{grid=[[
+      {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
+      333^3                                              |
+                                                        |
+    ]]}
+    feed('zl')
+    screen:expect{grid=[[
+      {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
+      33^3                                               |
+                                                        |
+    ]]}
+    feed('zl')
+    screen:expect{grid=[[
+      {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
+      3^3                                                |
                                                         |
     ]]}
   end)


### PR DESCRIPTION
Fix #23831

Also always check for fi_level before fi_lines.