### PR TITLE
vim-patch:9.0.1601: filetype detection fails for *.conf file without comments

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -196,6 +196,9 @@ function M.conf(path, bufnr)
   if vim.fn.did_filetype() ~= 0 or path:find(vim.g.ft_ignore_pat) then
     return
   end
+  if path:find('%.conf$') then
+    return 'conf'
+  end
   for _, line in ipairs(getlines(bufnr, 1, 5)) do
     if line:find('^#') then
       return 'conf'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -121,7 +121,7 @@ let s:filename_checks = {
     \ 'cobol': ['file.cbl', 'file.cob', 'file.lib'],
     \ 'coco': ['file.atg'],
     \ 'conaryrecipe': ['file.recipe'],
-    \ 'conf': ['auto.master'],
+    \ 'conf': ['auto.master', 'file.conf'],
     \ 'config': ['configure.in', 'configure.ac', '/etc/hostname.file', 'any/etc/hostname.file'],
     \ 'confini': ['/etc/pacman.conf', 'any/etc/pacman.conf', 'mpv.conf', 'any/.aws/config', 'any/.aws/credentials', 'file.nmconnection'],
     \ 'context': ['tex/context/any/file.tex', 'file.mkii', 'file.mkiv', 'file.mkvi', 'file.mkxl', 'file.mklx'],


### PR DESCRIPTION
Problem:    Filetype detection fails for *.conf file without comments.
            (Dmitrii Tcyganok)
Solution:   Use "conf" filetype as a fallback for an empty .conf file.
            (closes vim/vim#12487, closes vim/vim#12483)

https://github.com/vim/vim/commit/664fd12aa27a3c6bd19cfa474c4630d6c03fcc61

Co-authored-by: zeertzjq <zeertzjq@outlook.com>
