### PR TITLE
fix(ui): don't send empty grid_line with redrawdebug=compositor

### DIFF
--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -439,7 +439,7 @@ static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlag
 static void compose_debug(Integer startrow, Integer endrow, Integer startcol, Integer endcol,
                           int syn_id, bool delay)
 {
-  if (!(rdb_flags & RDB_COMPOSITOR)) {
+  if (!(rdb_flags & RDB_COMPOSITOR) || startcol >= endcol) {
     return;
   }
 

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -947,6 +947,7 @@ end
 
 function Screen:_handle_grid_line(grid, row, col, items)
   assert(self._options.ext_linegrid)
+  assert(#items > 0)
   local line = self._grids[grid].rows[row+1]
   local colpos = col+1
   local hl_id = 0

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -1096,3 +1096,18 @@ it('CTRL-F or CTRL-B scrolls a page after UI attach/resize #20605', function()
   feed('<C-F>')
   eq(953, funcs.line('w0'))
 end)
+
+it("showcmd doesn't cause empty grid_line with redrawdebug=compositor #22593", function()
+  clear()
+  local screen = Screen.new(30, 2)
+  screen:set_default_attr_ids({
+    [0] = {bold = true, foreground = Screen.colors.Blue},
+  })
+  screen:attach()
+  command('set showcmd redrawdebug=compositor')
+  feed('d')
+  screen:expect{grid=[[
+    ^                              |
+                       d          |
+  ]]}
+end)


### PR DESCRIPTION
Fix #22593
