### PR TITLE
defaults: shortmess+=C

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -58,12 +58,6 @@ The following new APIs or features were added.
 
 • Added |vim.keycode()| for translating keycodes in a string.
 
-• Added automatic linting of treesitter query files (see |ft-query-plugin|).
-  Automatic linting can be turned off via >lua
-      vim.g.query_lint_on = {}
-<
-• Enabled treesitter highlighting for treesitter query files by default.
-
 • Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
   default).
 
@@ -92,6 +86,13 @@ The following changes to existing APIs or features add new behavior.
 
 • vim.diagnostic.config() now accepts a function for the virtual_text.prefix
   option, which allows for rendering e.g., diagnostic severities differently.
+
+• Defaults:
+  • 'shortmess' includes the "C" flag.
+  • Automatic linting of treesitter query files (see |ft-query-plugin|).
+    Can be disabled via: >lua
+      vim.g.query_lint_on = {}
+< • Enabled treesitter highlighting for treesitter query files.
 
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
   by default.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -92,7 +92,7 @@ The following changes to existing APIs or features add new behavior.
   • Automatic linting of treesitter query files (see |ft-query-plugin|).
     Can be disabled via: >lua
       vim.g.query_lint_on = {}
-< • Enabled treesitter highlighting for treesitter query files.
+<  • Enabled treesitter highlighting for treesitter query files.
 
 • The `workspace/didChangeWatchedFiles` LSP client capability is now enabled
   by default.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5393,7 +5393,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 						*'shortmess'* *'shm'*
-'shortmess' 'shm'	string	(default "filnxtToOF")
+'shortmess' 'shm'	string	(default "filnxtToOCF")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -57,7 +57,7 @@ Defaults					            *nvim-defaults*
 - 'nrformats' defaults to "bin,hex"
 - 'ruler' is enabled
 - 'sessionoptions' includes "unix,slash", excludes "options"
-- 'shortmess' includes "F", excludes "S"
+- 'shortmess' includes "CF", excludes "S"
 - 'showcmd' is enabled
 - 'sidescroll' defaults to 1
 - 'smarttab' is enabled

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2233,7 +2233,7 @@ return {
       short_desc=N_("list of flags, reduce length of messages"),
       type='string', list='flags', scope={'global'},
       varname='p_shm',
-      defaults={if_true="filnxtToOF"},
+      defaults={if_true="filnxtToOCF"},
       cb='did_set_shortmess'
     },
     {


### PR DESCRIPTION
Problem:
Completion messages such as "scanning tags" are noisy and generally not useful on most systems. Most users probably aren't aware that this is configurable.

Solution:
Set `shortmess+=C`.

ref #19354