### PR TITLE
vim-patch:9.0.{1600,1607}: screenpos() fixes

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1069,21 +1069,20 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
   bool visible_row = false;
   bool is_folded = false;
 
-  if (pos->lnum >= wp->w_topline && pos->lnum <= wp->w_botline) {
-    linenr_T lnum = pos->lnum;
+  linenr_T lnum = pos->lnum;
+  if (lnum >= wp->w_topline && lnum <= wp->w_botline) {
     is_folded = hasFoldingWin(wp, lnum, &lnum, NULL, true, NULL);
     row = plines_m_win(wp, wp->w_topline, lnum - 1) + 1;
     // Add filler lines above this buffer line.
-    row += win_get_fill(wp, lnum);
+    row += lnum == wp->w_topline ? wp->w_topfill : win_get_fill(wp, lnum);
     visible_row = true;
-  } else if (!local || pos->lnum < wp->w_topline) {
+  } else if (!local || lnum < wp->w_topline) {
     row = 0;
   } else {
     row = wp->w_height_inner;
   }
 
-  bool existing_row = (pos->lnum > 0
-                       && pos->lnum <= wp->w_buffer->b_ml.ml_line_count);
+  bool existing_row = (lnum > 0 && lnum <= wp->w_buffer->b_ml.ml_line_count);
 
   if ((local || visible_row) && existing_row) {
     const colnr_T off = win_col_off(wp);
@@ -1098,7 +1097,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       col += off;
       int width = wp->w_width_inner - off + win_col_off2(wp);
 
-      if (pos->lnum == wp->w_topline) {
+      if (lnum == wp->w_topline) {
         col -= wp->w_skipcol;
       }
 

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1098,6 +1098,10 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       col += off;
       int width = wp->w_width_inner - off + win_col_off2(wp);
 
+      if (pos->lnum == wp->w_topline) {
+        col -= wp->w_skipcol;
+      }
+
       // long line wrapping, adjust row
       if (wp->w_p_wrap && col >= (colnr_T)wp->w_width_inner && width > 0) {
         // use same formula as what is used in curs_columns()

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1090,6 +1090,7 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
       row += local ? 0 : wp->w_winrow + wp->w_winrow_off;
       coloff = (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1 + off;
     } else {
+      assert(lnum == pos->lnum);
       getvcol(wp, pos, &scol, &ccol, &ecol);
 
       // similar to what is done in validate_cursor_col()

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -38,8 +38,7 @@
 /// @param winheight when true limit to window height
 int plines_win(win_T *wp, linenr_T lnum, bool winheight)
 {
-  // Check for filler lines above this buffer line.  When folded the result
-  // is one line anyway.
+  // Check for filler lines above this buffer line.
   return plines_win_nofill(wp, lnum, winheight) + win_get_fill(wp, lnum);
 }
 
@@ -199,16 +198,12 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
 int plines_win_full(win_T *wp, linenr_T lnum, linenr_T *const nextp, bool *const foldedp,
                     const bool cache, const bool winheight)
 {
-  bool folded = hasFoldingWin(wp, lnum, NULL, nextp, cache, NULL);
-  if (foldedp) {
+  bool folded = hasFoldingWin(wp, lnum, &lnum, nextp, cache, NULL);
+  if (foldedp != NULL) {
     *foldedp = folded;
   }
-  if (folded) {
-    return 1;
-  } else if (lnum == wp->w_topline) {
-    return plines_win_nofill(wp, lnum, winheight) + wp->w_topfill;
-  }
-  return plines_win(wp, lnum, winheight);
+  return ((folded ? 1 : plines_win_nofill(wp, lnum, winheight)) +
+          (lnum == wp->w_topline ? wp->w_topfill : win_get_fill(wp, lnum)));
 }
 
 int plines_m_win(win_T *wp, linenr_T first, linenr_T last)

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -7,7 +7,6 @@ local insert = helpers.insert
 local funcs = helpers.funcs
 local meths = helpers.meths
 local exec = helpers.exec
-local exec_lua = helpers.exec_lua
 local assert_alive = helpers.assert_alive
 
 
@@ -1911,19 +1910,17 @@ describe("folded lines", function()
       end
     end)
 
-    it('fold attached virtual lines are drawn correctly #21837', function()
+    it('fold attached virtual lines are drawn and scrolled correctly #21837', function()
       funcs.setline(1, 'line 1')
       funcs.setline(2, 'line 2')
       funcs.setline(3, 'line 3')
       funcs.setline(4, 'line 4')
       feed("zfj")
-      exec_lua([[
-        local ns = vim.api.nvim_create_namespace("ns")
-        vim.api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines_above = true, virt_lines = {{{"virt_line above line 1", ""}}} })
-        vim.api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_lines = {{{"virt_line below line 2", ""}}} })
-        vim.api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_lines_above = true, virt_lines = {{{"virt_line above line 3", ""}}} })
-        vim.api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = {{{"virt_line below line 4", ""}}} })
-      ]])
+      local ns = meths.create_namespace('ns')
+      meths.buf_set_extmark(0, ns, 0, 0, { virt_lines_above = true, virt_lines = {{{"virt_line above line 1", ""}}} })
+      meths.buf_set_extmark(0, ns, 1, 0, { virt_lines = {{{"virt_line below line 2", ""}}} })
+      meths.buf_set_extmark(0, ns, 2, 0, { virt_lines_above = true, virt_lines = {{{"virt_line above line 3", ""}}} })
+      meths.buf_set_extmark(0, ns, 3, 0, { virt_lines = {{{"virt_line below line 4", ""}}} })
       if multigrid then
         screen:expect([[
         ## grid 1
@@ -2027,6 +2024,223 @@ describe("folded lines", function()
           virt_line below line 2                       |
           {5:+--  2 lines: line 3·························}|
           line 5                                       |
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      meths.buf_set_extmark(0, ns, 1, 0, { virt_lines = {{{"more virt_line below line 2", ""}}} })
+      feed('G<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          line 1                                       |
+          line 2                                       |
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          line 1                                       |
+          line 2                                       |
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      feed('<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          line 2                                       |
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          line 2                                       |
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      feed('<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          virt_line below line 2                       |
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      feed('<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          more virt_line below line 2                  |
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      feed('<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          {5:+--  2 lines: line 3·························}|
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+                                                       |
+        ]])
+      end
+
+      feed('<C-E>')
+      if multigrid then
+        screen:expect([[
+        ## grid 1
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [2:---------------------------------------------]|
+          [3:---------------------------------------------]|
+        ## grid 2
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+        ## grid 3
+                                                       |
+        ]])
+      else
+        screen:expect([[
+          ^line 5                                       |
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
+          {1:~                                            }|
           {1:~                                            }|
                                                        |
         ]])

--- a/test/functional/vimscript/screenpos_spec.lua
+++ b/test/functional/vimscript/screenpos_spec.lua
@@ -1,12 +1,12 @@
 local helpers = require('test.functional.helpers')(after_each)
 local clear, eq, meths = helpers.clear, helpers.eq, helpers.meths
 local command, funcs = helpers.command, helpers.funcs
+local feed = helpers.feed
 
 before_each(clear)
 
 describe('screenpos() function', function()
   it('works in floating window with border', function()
-    local bufnr = meths.create_buf(false, true)
     local opts = {
       relative='editor',
       height=8,
@@ -18,34 +18,56 @@ describe('screenpos() function', function()
       border='none',
       focusable=1
     }
-    local float = meths.open_win(bufnr, false, opts)
+    local float = meths.open_win(meths.create_buf(false, true), false, opts)
     command('redraw')
-    local pos = funcs.screenpos(bufnr, 1, 1)
-    eq(7, pos.row)
-    eq(9, pos.col)
+    eq({row = 7, col = 9, endcol = 9, curscol = 9}, funcs.screenpos(float, 1, 1))
 
     -- only left border
     opts.border = {'', '', '', '', '', '', '', '|'}
     meths.win_set_config(float, opts)
     command('redraw')
-    pos = funcs.screenpos(bufnr, 1, 1)
-    eq(7, pos.row)
-    eq(10, pos.col)
+    eq({row = 7, col = 10, endcol = 10, curscol = 10}, funcs.screenpos(float, 1, 1))
 
     -- only top border
     opts.border = {'', '_', '', '', '', '', '', ''}
     meths.win_set_config(float, opts)
     command('redraw')
-    pos = funcs.screenpos(bufnr, 1, 1)
-    eq(8, pos.row)
-    eq(9, pos.col)
+    eq({row = 8, col = 9, endcol = 9, curscol = 9}, funcs.screenpos(float, 1, 1))
 
     -- both left and top border
     opts.border = 'single'
     meths.win_set_config(float, opts)
     command('redraw')
-    pos = funcs.screenpos(bufnr, 1, 1)
-    eq(8, pos.row)
-    eq(10, pos.col)
+    eq({row = 8, col = 10, endcol = 10, curscol = 10}, funcs.screenpos(float, 1, 1))
+  end)
+
+  it('works for folded line with virt_lines attached to line above', function()
+    meths.buf_set_lines(0, 0, -1, true, {'aaa', 'bbb', 'ccc', 'ddd'})
+    local ns = meths.create_namespace('')
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_lines = {{{'abb'}}, {{'acc'}}, {{'add'}}} })
+    command('2,3fold')
+    eq({row = 5, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 2, 1))
+    eq({row = 5, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
+    eq({row = 6, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
+
+    feed('<C-E>')
+    eq({row = 4, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 2, 1))
+    eq({row = 4, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
+    eq({row = 5, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
+
+    feed('<C-E>')
+    eq({row = 3, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 2, 1))
+    eq({row = 3, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
+    eq({row = 4, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
+
+    feed('<C-E>')
+    eq({row = 2, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 2, 1))
+    eq({row = 2, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
+    eq({row = 3, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
+
+    feed('<C-E>')
+    eq({row = 1, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 2, 1))
+    eq({row = 1, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 3, 1))
+    eq({row = 2, col = 1, endcol = 1, curscol = 1}, funcs.screenpos(0, 4, 1))
   end)
 end)

--- a/test/old/testdir/test_cursor_func.vim
+++ b/test/old/testdir/test_cursor_func.vim
@@ -130,13 +130,14 @@ func Test_screenpos()
   1split
   normal G$
   redraw
+  " w_skipcol should be subtracted
   call assert_equal({'row': winrow + 0,
 	\ 'col': wincol + 20 - 1,
 	\ 'curscol': wincol + 20 - 1,
 	\ 'endcol': wincol + 20 - 1},
 	\ screenpos(win_getid(), line('.'), col('.')))
 
-  " w_skipcol should be subtracted
+  " w_leftcol should be subtracted
   setlocal nowrap
   normal 050zl$
   call assert_equal({'row': winrow + 0,
@@ -203,6 +204,19 @@ func Test_screenpos_diff()
   windo diffthis
   wincmd w
   call assert_equal(#{col: 3, row: 7, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 8, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! 3\<C-E>"
+  call assert_equal(#{col: 3, row: 4, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 5, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 3, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 4, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 2, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 3, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
+  exe "normal! \<C-E>"
+  call assert_equal(#{col: 3, row: 1, endcol: 3, curscol: 3}, screenpos(0, 4, 1))
+  call assert_equal(#{col: 3, row: 2, endcol: 3, curscol: 3}, screenpos(0, 5, 1))
 
   windo diffoff
   bwipe!

--- a/test/old/testdir/test_cursor_func.vim
+++ b/test/old/testdir/test_cursor_func.vim
@@ -125,7 +125,40 @@ func Test_screenpos()
 	\ 'curscol': wincol + 7,
 	\ 'endcol': wincol + 7}, winid->screenpos(line('$'), 8))
   call assert_equal({'row': 0, 'col': 0, 'curscol': 0, 'endcol': 0},
-        \ winid->screenpos(line('$'), 22))
+	\ winid->screenpos(line('$'), 22))
+
+  1split
+  normal G$
+  redraw
+  call assert_equal({'row': winrow + 0,
+	\ 'col': wincol + 20 - 1,
+	\ 'curscol': wincol + 20 - 1,
+	\ 'endcol': wincol + 20 - 1},
+	\ screenpos(win_getid(), line('.'), col('.')))
+
+  " w_skipcol should be subtracted
+  setlocal nowrap
+  normal 050zl$
+  call assert_equal({'row': winrow + 0,
+	\ 'col': wincol + 10 - 1,
+	\ 'curscol': wincol + 10 - 1,
+	\ 'endcol': wincol + 10 - 1},
+	\ screenpos(win_getid(), line('.'), col('.')))
+
+  " w_skipcol should only matter for the topline
+" FIXME: This fails because pline_m_win() does not take w_skipcol into
+" account.  If it does, then other tests fail.
+"  wincmd +
+"  setlocal wrap smoothscroll
+"  call setline(line('$') + 1, 'last line')
+"  exe "normal \<C-E>G$"
+"  redraw
+"  call assert_equal({'row': winrow + 1,
+"	\ 'col': wincol + 9 - 1,
+"	\ 'curscol': wincol + 9 - 1,
+"	\ 'endcol': wincol + 9 - 1},
+"	\ screenpos(win_getid(), line('.'), col('.')))
+  close
 
   close
   call assert_equal({}, screenpos(999, 1, 1))


### PR DESCRIPTION
#### vim-patch:9.0.1600: screenpos() does not take w_skipcol into account

Problem:    screenpos() does not take w_skipcol into account.
Solution:   Subtract w_skipcol from column. (closes vim/vim#12486)

https://github.com/vim/vim/commit/f0e68c0e2a3539f899e737e5b167622fe081fbbd


#### vim-patch:9.0.1607: screenpos() returns wrong row with diff filler lines

Problem:    screenpos() returns wrong row with diff filler lines.
Solution:   Only add filler lines when appropriate.  Also don't add the
            'smoothscroll' marker when w_skipcol is zero. (closes vim/vim#12485)

https://github.com/vim/vim/commit/55daae392157823dc5434e6be1344f4336bfe96f