### PR TITLE
feat(version): add build field to vim.version()

### DIFF
--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -14,7 +14,7 @@ if(RES)
   return()
 endif()
 
-# Extract build info: "145-g0f9113907" => "g0f9113907"
+# Extract build info: "v0.9.0-145-g0f9113907" => "g0f9113907"
 string(REGEX REPLACE ".*\\-" "" NVIM_VERSION_BUILD "${GIT_TAG}")
 
 # `git describe` annotates the most recent tagged release; for pre-release

--- a/cmake/GenerateVersion.cmake
+++ b/cmake/GenerateVersion.cmake
@@ -14,6 +14,9 @@ if(RES)
   return()
 endif()
 
+# Extract build info: "145-g0f9113907" => "g0f9113907"
+string(REGEX REPLACE ".*\\-" "" NVIM_VERSION_BUILD "${GIT_TAG}")
+
 # `git describe` annotates the most recent tagged release; for pre-release
 # builds we append that to the dev version.
 if(NVIM_VERSION_PRERELEASE)
@@ -24,7 +27,7 @@ if(NVIM_VERSION_PRERELEASE)
   set(NVIM_VERSION "${NVIM_VERSION}-${NVIM_VERSION_GIT}")
 endif()
 
-set(NVIM_VERSION_STRING "#define NVIM_VERSION_MEDIUM \"${NVIM_VERSION}\"\n")
+set(NVIM_VERSION_STRING "#define NVIM_VERSION_MEDIUM \"${NVIM_VERSION}\"\n#define NVIM_VERSION_BUILD \"${NVIM_VERSION_BUILD}\"\n")
 
 string(SHA1 CURRENT_VERSION_HASH "${NVIM_VERSION_STRING}")
 if(EXISTS ${OUTPUT})

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -43,7 +43,6 @@
   "." STR(NVIM_VERSION_MINOR) "." STR(NVIM_VERSION_PATCH) \
   NVIM_VERSION_PRERELEASE
 #endif
-
 #define NVIM_VERSION_LONG "NVIM " NVIM_VERSION_MEDIUM  // NOLINT(bugprone-suspicious-missing-comma)
 
 char *Version = VIM_VERSION_SHORT;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -43,6 +43,7 @@
   "." STR(NVIM_VERSION_MINOR) "." STR(NVIM_VERSION_PATCH) \
   NVIM_VERSION_PRERELEASE
 #endif
+
 #define NVIM_VERSION_LONG "NVIM " NVIM_VERSION_MEDIUM  // NOLINT(bugprone-suspicious-missing-comma)
 
 char *Version = VIM_VERSION_SHORT;
@@ -2560,6 +2561,11 @@ Dictionary version_dict(void)
   PUT(d, "major", INTEGER_OBJ(NVIM_VERSION_MAJOR));
   PUT(d, "minor", INTEGER_OBJ(NVIM_VERSION_MINOR));
   PUT(d, "patch", INTEGER_OBJ(NVIM_VERSION_PATCH));
+#ifndef NVIM_VERSION_BUILD
+  PUT(d, "build", NIL);
+#else
+  PUT(d, "build", CSTR_AS_OBJ(NVIM_VERSION_BUILD));
+#endif
   PUT(d, "prerelease", BOOLEAN_OBJ(NVIM_VERSION_PRERELEASE[0] != '\0'));
   PUT(d, "api_level", INTEGER_OBJ(NVIM_API_LEVEL));
   PUT(d, "api_compatible", INTEGER_OBJ(NVIM_API_LEVEL_COMPAT));

--- a/test/functional/api/version_spec.lua
+++ b/test/functional/api/version_spec.lua
@@ -34,6 +34,7 @@ describe("api_info()['version']", function()
     local minor   = version['minor']
     local patch   = version['patch']
     local prerelease = version['prerelease']
+    local build   = version['build']
     eq("number", type(major))
     eq("number", type(minor))
     eq("number", type(patch))
@@ -42,6 +43,7 @@ describe("api_info()['version']", function()
     eq(0, funcs.has("nvim-"..major.."."..minor.."."..(patch + 1)))
     eq(0, funcs.has("nvim-"..major.."."..(minor + 1).."."..patch))
     eq(0, funcs.has("nvim-"..(major + 1).."."..minor.."."..patch))
+    assert(build == nil or type(build) == 'string')
   end)
 end)
 


### PR DESCRIPTION
This exposes the git hash of the build to the `vim.version` lua table:

https://github.com/neovim/neovim/assets/58627896/4bbc277c-c6f9-4c73-9b83-a7d2e6ec7684

Closes #23863