### PR TITLE
vim-patch:9.0.{1603,1610}: display wrong if scrolling multiple lines with 'smoothscroll'

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1344,7 +1344,6 @@ bool scrollup(long line_count, int byfold)
     int width1 = curwin->w_width_inner - curwin_col_off();
     int width2 = width1 + curwin_col_off2();
     unsigned size = 0;
-    linenr_T prev_topline = curwin->w_topline;
     const colnr_T prev_skipcol = curwin->w_skipcol;
 
     if (do_sms) {
@@ -1397,9 +1396,9 @@ bool scrollup(long line_count, int byfold)
       }
     }
 
-    if (curwin->w_topline == prev_topline
-        || curwin->w_skipcol != prev_skipcol) {
-      // need to redraw because wl_size of the topline may now be invalid
+    if (prev_skipcol > 0 || curwin->w_skipcol > 0) {
+      // need to redraw more, because wl_size of the (new) topline may
+      // now be invalid
       redraw_later(curwin, UPD_NOT_VALID);
     }
   } else {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1345,6 +1345,7 @@ bool scrollup(long line_count, int byfold)
     int width2 = width1 + curwin_col_off2();
     unsigned size = 0;
     linenr_T prev_topline = curwin->w_topline;
+    const colnr_T prev_skipcol = curwin->w_skipcol;
 
     if (do_sms) {
       size = linetabsize(curwin, curwin->w_topline);
@@ -1396,8 +1397,9 @@ bool scrollup(long line_count, int byfold)
       }
     }
 
-    if (curwin->w_topline == prev_topline) {
-      // need to redraw even though w_topline didn't change
+    if (curwin->w_topline == prev_topline
+        || curwin->w_skipcol != prev_skipcol) {
+      // need to redraw because wl_size of the topline may now be invalid
       redraw_later(curwin, UPD_NOT_VALID);
     }
   } else {

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -874,10 +874,11 @@ describe('smoothscroll', function()
     })
     exec([[
       setlocal cursorline scrolloff=0 smoothscroll
-      call setline(1, repeat([''], 9))
+      call setline(1, repeat([''], 8))
       call setline(3, repeat('a', 50))
-      call setline(8, 'bbb')
-      call setline(9, 'ccc')
+      call setline(4, repeat('a', 50))
+      call setline(7, 'bbb')
+      call setline(8, 'ccc')
       redraw
     ]])
     screen:expect([[
@@ -885,8 +886,8 @@ describe('smoothscroll', function()
                                               |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaaaaaaaa                              |
-                                              |
-                                              |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaa                              |
                                               |
                                               |
       bbb                                     |
@@ -895,12 +896,25 @@ describe('smoothscroll', function()
     feed('3<C-E>')
     screen:expect([[
       {0:<<<}{1:aaaaaa^a                              }|
-                                              |
-                                              |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaa                              |
                                               |
                                               |
       bbb                                     |
       ccc                                     |
+      {0:~                                       }|
+      {0:~                                       }|
+                                              |
+    ]])
+    feed('2<C-E>')
+    screen:expect([[
+      {0:<<<}{1:aaaaaa^a                              }|
+                                              |
+                                              |
+      bbb                                     |
+      ccc                                     |
+      {0:~                                       }|
+      {0:~                                       }|
       {0:~                                       }|
       {0:~                                       }|
                                               |

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -865,6 +865,48 @@ describe('smoothscroll', function()
     ]])
   end)
 
+  -- oldtest: Test_smoothscroll_multi_skipcol()
+  it('scrolling mulitple lines and stopping at non-zero skipcol', function()
+    screen:try_resize(40, 10)
+    screen:set_default_attr_ids({
+      [0] = {foreground = Screen.colors.Blue, bold = true},
+      [1] = {background = Screen.colors.Grey90},
+    })
+    exec([[
+      setlocal cursorline scrolloff=0 smoothscroll
+      call setline(1, repeat([''], 9))
+      call setline(3, repeat('a', 50))
+      call setline(8, 'bbb')
+      call setline(9, 'ccc')
+      redraw
+    ]])
+    screen:expect([[
+      {1:^                                        }|
+                                              |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaa                              |
+                                              |
+                                              |
+                                              |
+                                              |
+      bbb                                     |
+                                              |
+    ]])
+    feed('3<C-E>')
+    screen:expect([[
+      {0:<<<}{1:aaaaaa^a                              }|
+                                              |
+                                              |
+                                              |
+                                              |
+      bbb                                     |
+      ccc                                     |
+      {0:~                                       }|
+      {0:~                                       }|
+                                              |
+    ]])
+  end)
+
   it("works with virt_lines above and below", function()
     screen:try_resize(55, 7)
     exec([=[

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -780,7 +780,7 @@ func Test_smoothscroll_incsearch()
       call setline(14, 'bbbb')
   END
   call writefile(lines, 'XSmoothIncsearch', 'D')
-  let buf = RunVimInTerminal('-S XSmoothIncsearch', #{rows: 8, cols:40})
+  let buf = RunVimInTerminal('-S XSmoothIncsearch', #{rows: 8, cols: 40})
 
   call term_sendkeys(buf, "/b")
   call VerifyScreenDump(buf, 'Test_smooth_incsearch_1', {})
@@ -791,6 +791,28 @@ func Test_smoothscroll_incsearch()
   call term_sendkeys(buf, "b")
   call VerifyScreenDump(buf, 'Test_smooth_incsearch_4', {})
   call term_sendkeys(buf, "\<CR>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
+" Test scrolling multiple lines and stopping at non-zero skipcol.
+func Test_smoothscroll_multi_skipcol()
+  CheckScreendump
+
+  let lines =<< trim END
+      setlocal cursorline scrolloff=0 smoothscroll
+      call setline(1, repeat([''], 9))
+      call setline(3, repeat('a', 50))
+      call setline(8, 'bbb')
+      call setline(9, 'ccc')
+      redraw
+  END
+  call writefile(lines, 'XSmoothMultiSkipcol', 'D')
+  let buf = RunVimInTerminal('-S XSmoothMultiSkipcol', #{rows: 10, cols: 40})
+  call VerifyScreenDump(buf, 'Test_smooth_multi_skipcol_1', {})
+
+  call term_sendkeys(buf, "3\<C-E>")
+  call VerifyScreenDump(buf, 'Test_smooth_multi_skipcol_2', {})
 
   call StopVimInTerminal(buf)
 endfunc

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -801,10 +801,11 @@ func Test_smoothscroll_multi_skipcol()
 
   let lines =<< trim END
       setlocal cursorline scrolloff=0 smoothscroll
-      call setline(1, repeat([''], 9))
+      call setline(1, repeat([''], 8))
       call setline(3, repeat('a', 50))
-      call setline(8, 'bbb')
-      call setline(9, 'ccc')
+      call setline(4, repeat('a', 50))
+      call setline(7, 'bbb')
+      call setline(8, 'ccc')
       redraw
   END
   call writefile(lines, 'XSmoothMultiSkipcol', 'D')
@@ -813,6 +814,9 @@ func Test_smoothscroll_multi_skipcol()
 
   call term_sendkeys(buf, "3\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_multi_skipcol_2', {})
+
+  call term_sendkeys(buf, "2\<C-E>")
+  call VerifyScreenDump(buf, 'Test_smooth_multi_skipcol_3', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
Fix #23822

#### vim-patch:9.0.1603: display wrong if scrolling multiple lines with 'smoothscroll'

Problem:    Display wrong when scrolling multiple lines with 'smoothscroll'
            set.
Solution:   Redraw when w_skipcol changed. (closes vim/vim#12477)

https://github.com/vim/vim/commit/3c802277604a6b21110e41bedfe4c937ba7c2b7d


#### vim-patch:9.0.1610: display is wrong when 'smoothscroll' is set

Problem:    Display is wrong when 'smoothscroll' is set and scrolling multiple
            lines.
Solution:   Redraw with UPD_NOT_VALID when "skipcol" is or was set.
            (closes vim/vim#12490)

https://github.com/vim/vim/commit/d9a92dc70b20c76cef9ca186676583c92c14311c