### PR TITLE
vim-patch:9.0.1612: "skipcol" not reset when using multi-byte characters

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1825,10 +1825,13 @@ void scroll_cursor_top(int min_scroll, int always)
       }
     }
     check_topfill(curwin, false);
-    // TODO(vim): if the line doesn't fit may optimize w_skipcol
-    if (curwin->w_topline == curwin->w_cursor.lnum
-        && curwin->w_skipcol >= curwin->w_cursor.col) {
-      reset_skipcol(curwin);
+    if (curwin->w_topline == curwin->w_cursor.lnum) {
+      validate_virtcol();
+      if (curwin->w_skipcol >= curwin->w_virtcol) {
+        // TODO(vim): if the line doesn't fit may optimize w_skipcol instead
+        // of making it zero
+        reset_skipcol(curwin);
+      }
     }
     if (curwin->w_topline != old_topline
         || curwin->w_skipcol != old_skipcol

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -174,6 +174,24 @@ describe('smoothscroll', function()
     screen:expect(s8)
   end)
 
+  -- oldtest: Test_smoothscroll_multibyte()
+  it('works with multibyte characters', function()
+    screen:try_resize(40, 6)
+    exec([[
+      set scrolloff=0 smoothscroll
+      call setline(1, [repeat('ϛ', 45), repeat('2', 36)])
+      exe "normal G35l\<C-E>k"
+    ]])
+    screen:expect([[
+      ϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛϛ^ϛϛϛϛϛ|
+      ϛϛϛϛϛ                                   |
+      222222222222222222222222222222222222    |
+      ~                                       |
+      ~                                       |
+                                              |
+    ]])
+  end)
+
   -- oldtest: Test_smoothscroll_number()
   it("works 'number' and 'cpo'+=n", function()
     exec([[

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -124,6 +124,21 @@ func Test_smoothscroll_CtrlE_CtrlY()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_multibyte()
+  CheckScreendump
+
+  let lines =<< trim END
+      set scrolloff=0 smoothscroll
+      call setline(1, [repeat('ϛ', 45), repeat('2', 36)])
+      exe "normal G35l\<C-E>k"
+  END
+  call writefile(lines, 'XSmoothMultibyte', 'D')
+  let buf = RunVimInTerminal('-S XSmoothMultibyte', #{rows: 6, cols: 40})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_multi_1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_smoothscroll_number()
   CheckScreendump
 


### PR DESCRIPTION
#### vim-patch:9.0.1612: "skipcol" not reset when using multi-byte characters

Problem:    "skipcol" not reset when using multi-byte characters.
Solution:   Compare with w_virtcol instead of w_cursor.col.

https://github.com/vim/vim/commit/15d4747ffd197ffa5b5a41a852a1fe93b6cc35fd

Co-authored-by: Bram Moolenaar <Bram@vim.org>