### PR TITLE
refactor: adjust headers according to the style guide

### DIFF
--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -10,7 +10,7 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"
 #include "nvim/func_attr.h"
-#include "nvim/grid_defs.h"  // for StlClickRecord
+#include "nvim/grid_defs.h"
 #include "nvim/macros.h"
 #include "nvim/memline.h"
 #include "nvim/memline_defs.h"

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -18,6 +18,7 @@ typedef struct {
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/eval/typval_defs.h"
+#include "nvim/extmark_defs.h"
 #include "nvim/garray.h"
 #include "nvim/grid_defs.h"
 #include "nvim/hashtab.h"
@@ -25,9 +26,6 @@ typedef struct {
 #include "nvim/map.h"
 #include "nvim/mark_defs.h"
 #include "nvim/marktree.h"
-// for float window title
-#include "nvim/extmark_defs.h"
-// for click definitions
 #include "nvim/option_defs.h"
 #include "nvim/pos.h"
 #include "nvim/statusline_defs.h"

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -14,6 +14,19 @@
 #include <sys/stat.h>
 #include <uv.h>
 
+#ifdef MSWIN
+# include <shlobj.h>
+#endif
+
+#if defined(HAVE_ACL)
+# ifdef HAVE_SYS_ACL_H
+#  include <sys/acl.h>
+# endif
+# ifdef HAVE_SYS_ACCESS_H
+#  include <sys/access.h>
+# endif
+#endif
+
 #include "auto/config.h"
 #include "nvim/ascii.h"
 #include "nvim/gettext.h"
@@ -731,15 +744,6 @@ int os_setperm(const char *const name, int perm)
   return (r == kLibuvSuccess ? OK : FAIL);
 }
 
-#if defined(HAVE_ACL)
-# ifdef HAVE_SYS_ACL_H
-#  include <sys/acl.h>
-# endif
-# ifdef HAVE_SYS_ACCESS_H
-#  include <sys/access.h>
-# endif
-#endif
-
 // Return a pointer to the ACL of file "fname" in allocated memory.
 // Return NULL if the ACL is not available for whatever reason.
 vim_acl_T os_get_acl(const char *fname)
@@ -1225,8 +1229,6 @@ char *os_realpath(const char *name, char *buf)
 }
 
 #ifdef MSWIN
-# include <shlobj.h>
-
 /// When "fname" is the name of a shortcut (*.lnk) resolve the file it points
 /// to and return that name in allocated memory.
 /// Otherwise NULL is returned.

--- a/src/nvim/os/os_defs.h
+++ b/src/nvim/os/os_defs.h
@@ -7,6 +7,12 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+// Note: Some systems need both string.h and strings.h (Savage).
+#include <string.h>
+#ifdef HAVE_STRINGS_H
+# include <strings.h>
+#endif
+
 #ifdef MSWIN
 # include "nvim/os/win_defs.h"
 #else
@@ -35,12 +41,6 @@
 
 // Command-processing buffer. Use large buffers for all platforms.
 #define CMDBUFFSIZE 1024
-
-// Note: Some systems need both string.h and strings.h (Savage).
-#include <string.h>
-#ifdef HAVE_STRINGS_H
-# include <strings.h>
-#endif
 
 /// Converts libuv error (negative int) to error description string.
 #define os_strerror uv_strerror

--- a/src/nvim/os/process.c
+++ b/src/nvim/os/process.c
@@ -13,14 +13,8 @@
 #include <stdio.h>
 #include <uv.h>
 
-#include "nvim/log.h"
-#include "nvim/memory.h"
-#include "nvim/os/process.h"
-
 #ifdef MSWIN
 # include <tlhelp32.h>
-
-# include "nvim/api/private/helpers.h"
 #endif
 
 #if defined(__FreeBSD__)  // XXX: OpenBSD ?
@@ -36,6 +30,14 @@
 #if defined(__APPLE__) || defined(BSD)
 # include <pwd.h>
 # include <sys/sysctl.h>
+#endif
+
+#include "nvim/log.h"
+#include "nvim/memory.h"
+#include "nvim/os/process.h"
+
+#ifdef MSWIN
+# include "nvim/api/private/helpers.h"
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/os/pty_process_unix.c
+++ b/src/nvim/os/pty_process_unix.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>
+#include <uv.h>
 
 // forkpty is not in POSIX, so headers are platform-specific
 #if defined(__FreeBSD__) || defined(__DragonFly__)
@@ -30,8 +31,6 @@
 #ifdef __APPLE__
 # include <crt_externs.h>
 #endif
-
-#include <uv.h>
 
 #include "auto/config.h"
 #include "klib/klist.h"

--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -7,7 +7,7 @@
 
 #include "nvim/ascii.h"
 #include "nvim/eval/typval.h"
-#include "nvim/mbyte.h"  // for utf8_to_utf16, utf16_to_utf8
+#include "nvim/mbyte.h"
 #include "nvim/memory.h"
 #include "nvim/os/os.h"
 #include "nvim/os/pty_conpty_win.h"

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #ifndef MSWIN
-# include <signal.h>  // for sigset_t
+# include <signal.h>
 #endif
 
 #include "nvim/autocmd.h"

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -1,7 +1,7 @@
 #ifndef NVIM_UNDO_DEFS_H
 #define NVIM_UNDO_DEFS_H
 
-#include <time.h>  // for time_t
+#include <time.h>
 
 #include "nvim/extmark_defs.h"
 #include "nvim/mark_defs.h"


### PR DESCRIPTION
System headers should be included first to prevent naming conflicts.
