### PR TITLE
refactor(api): remove `BOOL` macro

### DIFF
--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -20,7 +20,6 @@
 #define BOOLEAN_OBJ(b) ((Object) { \
     .type = kObjectTypeBoolean, \
     .data.boolean = b })
-#define BOOL(b) BOOLEAN_OBJ(b)
 
 #define INTEGER_OBJ(i) ((Object) { \
     .type = kObjectTypeInteger, \

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -87,7 +87,7 @@ static void api_parse_enter(mpack_parser_t *parser, mpack_node_t *node)
     *result = NIL;
     break;
   case MPACK_TOKEN_BOOLEAN:
-    *result = BOOL(mpack_unpack_boolean(node->tok));
+    *result = BOOLEAN_OBJ(mpack_unpack_boolean(node->tok));
     break;
   case MPACK_TOKEN_SINT:
     *result = INTEGER_OBJ(mpack_unpack_sint(node->tok));

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6139,11 +6139,11 @@ static Dictionary vimoption2dict(vimoption_T *opt, int req_scope, buf_T *buf, wi
   PUT(dict, "scope", CSTR_TO_OBJ(scope));
 
   // welcome to the jungle
-  PUT(dict, "global_local", BOOL(opt->indir & PV_BOTH));
-  PUT(dict, "commalist", BOOL(opt->flags & P_COMMA));
-  PUT(dict, "flaglist", BOOL(opt->flags & P_FLAGLIST));
+  PUT(dict, "global_local", BOOLEAN_OBJ(opt->indir & PV_BOTH));
+  PUT(dict, "commalist", BOOLEAN_OBJ(opt->flags & P_COMMA));
+  PUT(dict, "flaglist", BOOLEAN_OBJ(opt->flags & P_FLAGLIST));
 
-  PUT(dict, "was_set", BOOL(opt->flags & P_WAS_SET));
+  PUT(dict, "was_set", BOOLEAN_OBJ(opt->flags & P_WAS_SET));
 
   LastSet last_set = { .channel_id = 0 };
   if (req_scope == OPT_GLOBAL) {
@@ -6177,13 +6177,13 @@ static Dictionary vimoption2dict(vimoption_T *opt, int req_scope, buf_T *buf, wi
     def = INTEGER_OBJ((Integer)(intptr_t)def_val);
   } else if (opt->flags & P_BOOL) {
     type = "boolean";
-    def = BOOL((intptr_t)def_val);
+    def = BOOLEAN_OBJ((intptr_t)def_val);
   } else {
     type = ""; def = NIL;
   }
   PUT(dict, "type", CSTR_TO_OBJ(type));
   PUT(dict, "default", def);
-  PUT(dict, "allows_duplicates", BOOL(!(opt->flags & P_NODUP)));
+  PUT(dict, "allows_duplicates", BOOLEAN_OBJ(!(opt->flags & P_NODUP)));
 
   return dict;
 }


### PR DESCRIPTION
Remove redundant `BOOL` macro that does the same thing as `BOOLEAN_OBJ`.