### PR TITLE
defaults: smoothscroll

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -90,6 +90,7 @@ The following changes to existing APIs or features add new behavior.
 
 • Defaults:
   • 'shortmess' includes the "C" flag.
+  • 'smoothscroll' is enabled.
   • Automatic linting of treesitter query files (see |ft-query-plugin|).
     Can be disabled via: >lua
       vim.g.query_lint_on = {}

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5659,7 +5659,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	number of spaces is minimized by using <Tab>s.
 
 			*'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
-'smoothscroll' 'sms'	boolean  (default off)
+'smoothscroll' 'sms'	boolean  (default on)
 			local to window
 	Scrolling works with screen lines.  When 'wrap' is set and the first
 	line in the window wraps part of it may not be visible, as if it is

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -61,6 +61,7 @@ Defaults					            *nvim-defaults*
 - 'showcmd' is enabled
 - 'sidescroll' defaults to 1
 - 'smarttab' is enabled
+- 'smoothscroll' is enabled
 - 'startofline' is disabled
 - 'switchbuf' defaults to "uselast"
 - 'tabpagemax' defaults to 50

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2017,7 +2017,7 @@ return {
       type='bool', scope={'window'},
       pv_name='p_sms',
       redraw={'current_window'},
-      defaults={if_true=0},
+      defaults={if_true=true},
       cb='did_set_smoothscroll'
     },
     {


### PR DESCRIPTION
Problem:
'wrap' is enabled by default but 'smoothscroll' is not. smoothscroll is a low-risk option that makes 'wrap' behave slightly more intuitively, there is little reason not to enable it. (Corrections welcome :)

Solution:
Enable 'smoothscroll' by default.