### PR TITLE
vim-patch:9.0.1614: strlen() called too often for :spellrepall

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2606,7 +2606,7 @@ void ex_spellrepall(exarg_T *eap)
   }
   const size_t repl_from_len = strlen(repl_from);
   const size_t repl_to_len = strlen(repl_to);
-  int addlen = (int)(repl_to_len - repl_from_len);
+  const int addlen = (int)(repl_to_len - repl_from_len);
 
   const size_t frompatlen = repl_from_len + 7;
   char *frompat = xmalloc(frompatlen);

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -281,7 +281,7 @@ func Test_compl_with_CTRL_X_CTRL_K_using_spell()
   set spell& spelllang& dictionary& ignorecase&
 endfunc
 
-func Test_spellreall()
+func Test_spellrepall()
   new
   set spell
   call assert_fails('spellrepall', 'E752:')


### PR DESCRIPTION
#### vim-patch:9.0.1614: strlen() called too often for :spellrepall

Problem:    strlen() called too often for :spellrepall.
Solution:   Store the result in a variable. (closes vim/vim#12497)

https://github.com/vim/vim/commit/59f7038536a370d771758dc34036cc1424be7421