### PR TITLE
vim-patch:9.0.1616: quickfix text field is truncated

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2848,6 +2848,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
   // Add the message, skipping leading whitespace and newlines.
   ga_concat(gap, IObuff);
   qf_fmt_text(gap, skipwhite(qf_ptr->qf_text));
+  ga_append(gap, NUL);
 
   // Output the message.  Overwrite to avoid scrolling when the 'O'
   // flag is present in 'shortmess'; But when not jumping, print the
@@ -3123,9 +3124,7 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
     msg_puts_attr(":", qfSepAttr);
   }
   garray_T *gap = qfga_get();
-  if (qfp->qf_lnum == 0) {
-    ga_append(gap, NUL);
-  } else {
+  if (qfp->qf_lnum != 0) {
     qf_range_text(gap, qfp);
   }
   ga_concat(gap, qf_types(qfp->qf_type, qfp->qf_nr));
@@ -3135,6 +3134,7 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   if (qfp->qf_pattern != NULL) {
     gap = qfga_get();
     qf_fmt_text(gap, qfp->qf_pattern);
+    ga_append(gap, NUL);
     msg_puts(gap->ga_data);
     msg_puts_attr(":", qfSepAttr);
   }
@@ -3145,6 +3145,7 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   // with ^^^^.
   gap = qfga_get();
   qf_fmt_text(gap, (fname != NULL || qfp->qf_lnum != 0) ? skipwhite(qfp->qf_text) : qfp->qf_text);
+  ga_append(gap, NUL);
   msg_prt_line(gap->ga_data, false);
 }
 
@@ -3229,7 +3230,6 @@ static void qf_fmt_text(garray_T *gap, const char *restrict text)
   FUNC_ATTR_NONNULL_ALL
 {
   const char *p = text;
-
   while (*p != NUL) {
     if (*p == '\n') {
       ga_append(gap, ' ');
@@ -3242,8 +3242,6 @@ static void qf_fmt_text(garray_T *gap, const char *restrict text)
       ga_append(gap, (uint8_t)(*p++));
     }
   }
-
-  ga_append(gap, NUL);
 }
 
 /// Add the range information from the lnum, col, end_lnum, and end_col values
@@ -3268,7 +3266,6 @@ static void qf_range_text(garray_T *gap, const qfline_T *qfp)
       len += strlen(buf + len);
     }
   }
-  buf[len] = NUL;
 
   ga_concat_len(gap, buf, len);
 }
@@ -3983,7 +3980,6 @@ static int qf_buf_add_line(qf_list_T *qfl, buf_T *buf, linenr_T lnum, const qfli
   // for this entry, then use it.
   if (qftf_str != NULL && *qftf_str != NUL) {
     ga_concat(gap, qftf_str);
-    ga_append(gap, NUL);
   } else {
     buf_T *errbuf;
     if (qfp->qf_module != NULL) {
@@ -4026,6 +4022,7 @@ static int qf_buf_add_line(qf_list_T *qfl, buf_T *buf, linenr_T lnum, const qfli
     qf_fmt_text(gap, gap->ga_len > 3 ? skipwhite(qfp->qf_text) : qfp->qf_text);
   }
 
+  ga_append(gap, NUL);
   if (ml_append_buf(buf, lnum, gap->ga_data, gap->ga_len, false) == FAIL) {
     return FAIL;
   }

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -167,19 +167,21 @@ func XlistTests(cchar)
 	      \ {'lnum':20,'col':10,'type':'e','text':'Error','nr':22},
 	      \ {'lnum':30,'col':15,'type':'i','text':'Info','nr':33},
 	      \ {'lnum':40,'col':20,'type':'x', 'text':'Other','nr':44},
-	      \ {'lnum':50,'col':25,'type':"\<C-A>",'text':'one','nr':55}])
+	      \ {'lnum':50,'col':25,'type':"\<C-A>",'text':'one','nr':55},
+	      \ {'lnum':0,'type':'e','text':'Check type field is output even when lnum==0. ("error" was not output by v9.0.0736.)','nr':66}])
   let l = split(execute('Xlist', ""), "\n")
   call assert_equal([' 1:10 col 5 warning  11: Warning',
 	      \ ' 2:20 col 10 error  22: Error',
 	      \ ' 3:30 col 15 info  33: Info',
 	      \ ' 4:40 col 20 x  44: Other',
-	      \ ' 5:50 col 25  55: one'], l)
+	      \ ' 5:50 col 25  55: one',
+              \ ' 6 error  66: Check type field is output even when lnum==0. ("error" was not output by v9.0.0736.)'], l)
 
   " Test for module names, one needs to explicitly set `'valid':v:true` so
   call g:Xsetlist([
-        \ {'lnum':10,'col':5,'type':'W','module':'Data.Text','text':'ModuleWarning','nr':11,'valid':v:true},
-        \ {'lnum':20,'col':10,'type':'W','module':'Data.Text','filename':'Data/Text.hs','text':'ModuleWarning','nr':22,'valid':v:true},
-        \ {'lnum':30,'col':15,'type':'W','filename':'Data/Text.hs','text':'FileWarning','nr':33,'valid':v:true}])
+	\ {'lnum':10,'col':5,'type':'W','module':'Data.Text','text':'ModuleWarning','nr':11,'valid':v:true},
+	\ {'lnum':20,'col':10,'type':'W','module':'Data.Text','filename':'Data/Text.hs','text':'ModuleWarning','nr':22,'valid':v:true},
+	\ {'lnum':30,'col':15,'type':'W','filename':'Data/Text.hs','text':'FileWarning','nr':33,'valid':v:true}])
   let l = split(execute('Xlist', ""), "\n")
   call assert_equal([' 1 Data.Text:10 col 5 warning  11: ModuleWarning',
 	\ ' 2 Data.Text:20 col 10 warning  22: ModuleWarning',
@@ -6302,6 +6304,13 @@ func Test_setqflist_stopinsert()
   delfunc StopInsert
   call setqflist([], 'f')
   bwipe!
+endfunc
+
+func Test_quickfix_buffer_contents()
+  call setqflist([{'filename':'filename', 'pattern':'pattern', 'text':'text'}])
+  copen
+  call assert_equal(['filename|pattern| text'], getline(1, '$'))  " The assert failed with Vim v9.0.0736; '| text' did not appear after the pattern.
+  call setqflist([], 'f')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1616: quickfix text field is truncated

Problem:    Quickfix text field is truncated.
Solution:   Fix output of text field after pattern field in quickfix buffer.
            (Shane Harper, closes vim/vim#12498)

https://github.com/vim/vim/commit/5bf042810b19a627eda2f170624a0cfd7b4f6ed6

Co-authored-by: Shane Harper <shane@shaneharper.net>