### PR TITLE
feat(lua): vim.version() returns Version object

### DIFF
--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -226,13 +226,11 @@ function Range:has(version)
   if type(version) == 'string' then
     ---@diagnostic disable-next-line: cast-local-type
     version = M.parse(version)
-  else
+  elseif getmetatable(version) ~= Version then
     -- Need metatable to compare versions.
     version = setmetatable(vim.deepcopy(version), Version)
   end
   if version then
-    -- Workaround: vim.version() reports "prerelease" as a boolean.
-    version.prerelease = version.prerelease or nil
     if version.prerelease ~= self.from.prerelease then
       return false
     end
@@ -423,8 +421,12 @@ function M.parse(version, opts)
 end
 
 setmetatable(M, {
+  --- Returns the current Nvim version.
   __call = function()
-    return vim.fn.api_info().version
+    local version = vim.fn.api_info().version
+    -- Workaround: vim.fn.api_info().version reports "prerelease" as a boolean.
+    version.prerelease = version.prerelease or nil
+    return setmetatable(version, Version)
   end,
 })
 

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -425,7 +425,7 @@ setmetatable(M, {
   __call = function()
     local version = vim.fn.api_info().version
     -- Workaround: vim.fn.api_info().version reports "prerelease" as a boolean.
-    version.prerelease = version.prerelease or nil
+    version.prerelease = version.prerelease and 'dev' or nil
     return setmetatable(version, Version)
   end,
 })

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -17,6 +17,18 @@ describe('version', function()
     eq({ major = 42, minor = 3, patch = 99 }, exec_lua("return vim.version.parse('v42.3.99')"))
   end)
 
+  it('version() returns Nvim version', function()
+    local expected = exec_lua('return vim.fn.api_info().version')
+    local actual = exec_lua('return vim.version()')
+    eq(expected.major, actual.major)
+    eq(expected.minor, actual.minor)
+    eq(expected.patch, actual.patch)
+    eq(expected.prerelease and 'dev' or nil, actual.prerelease)
+
+    -- tostring() #23863
+    matches([[%d+%.%d+%.%d+]], exec_lua('return tostring(vim.version())'))
+  end)
+
   describe('_version()', function()
     local tests = {
       ['v1.2.3'] = { major = 1, minor = 2, patch = 3 },


### PR DESCRIPTION
- vim.version() returns a Version object. Makes it printable and removes the need of workarounds when passing it to other vim.version methods.

- ~~vim.version.range() converts a table to a Version object only when necessary.~~

-~~ vim.version.is() To easily check a version range against current version, or target version. Eg.:~~

      vim.version.is('>0.9.0')          --> true
      vim.version.is('>0.9.0', '0.8.0') --> false

- ~~cache the result of vim.fn.api_info().version~~