### PR TITLE
feat(lua): use callable table as iterator in vim.iter

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2999,8 +2999,8 @@ pipeline depend on the type passed to this function:
 • Non-list tables pass both the key and value of each element
 • Function iterators pass all of the values returned by their respective
   function
-• Tables with with a metatable implementing __call is treated as function
-  iterator
+• Tables with a metatable implementing __call are treated as function
+  iterators
 
 Examples: >lua
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2999,6 +2999,8 @@ pipeline depend on the type passed to this function:
 • Non-list tables pass both the key and value of each element
 • Function iterators pass all of the values returned by their respective
   function
+• Tables with with a metatable implementing __call is treated as function
+  iterator
 
 Examples: >lua
 
@@ -3031,6 +3033,12 @@ Examples: >lua
      return k == 'z'
    end)
    -- true
+
+   local rb = vim.ringbuf(3)
+   rb:push("a")
+   rb:push("b")
+   vim.iter(rb):totable()
+   -- { "a", "b" }
 
 <
 

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -889,6 +889,17 @@ end
 function Iter.new(src, ...)
   local it = {}
   if type(src) == 'table' then
+    local mt = getmetatable(src)
+    if mt and type(mt.__call) == 'function' then
+      ---@private
+      function it.next()
+        return src()
+      end
+
+      setmetatable(it, Iter)
+      return it
+    end
+
     local t = {}
 
     -- Check if source table can be treated like a list (indices are consecutive integers

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -14,8 +14,8 @@
 --- - Non-list tables pass both the key and value of each element
 --- - Function iterators pass all of the values returned by their respective
 ---   function
---- - Tables with with a metatable implementing __call is treated as function
----   iterator
+--- - Tables with a metatable implementing __call are treated as function
+---   iterators
 ---
 --- Examples:
 --- <pre>lua

--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -14,6 +14,8 @@
 --- - Non-list tables pass both the key and value of each element
 --- - Function iterators pass all of the values returned by their respective
 ---   function
+--- - Tables with with a metatable implementing __call is treated as function
+---   iterator
 ---
 --- Examples:
 --- <pre>lua
@@ -46,6 +48,12 @@
 ---     return k == 'z'
 ---   end)
 ---   -- true
+---
+---   local rb = vim.ringbuf(3)
+---   rb:push("a")
+---   rb:push("b")
+---   vim.iter(rb):totable()
+---   -- { "a", "b" }
 --- </pre>
 ---
 --- In addition to the |vim.iter()| function, the |vim.iter| module provides

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -4,6 +4,15 @@ local matches = helpers.matches
 local pcall_err = helpers.pcall_err
 
 describe('vim.iter', function()
+  it('new() on iterable class instance', function()
+    local rb = vim.ringbuf(3)
+    rb:push("a")
+    rb:push("b")
+
+    local it = vim.iter(rb)
+    eq({"a", "b"}, it:totable())
+  end)
+
   it('filter()', function()
     local function odd(v)
       return v % 2 ~= 0


### PR DESCRIPTION
A table passed to `vim.iter` can be a class instance with a `__call`
implementation for the iterator protocol.

See https://github.com/neovim/neovim/pull/22894#issuecomment-1582057128


Downside of this approach is that `__call` might _not_ be intended as iterator
and then this will likely result in errors. But if one really wants to get the
keys of a table it is still possible to use `vim.iter(pairs(mytable))`
