### PR TITLE
feat(lsp)!: add vim.lsp.status, client.progress and promote LspProgressUpdate

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -117,19 +117,21 @@ internally and are no longer exposed as part of the API. Instead, use
 - *vim.lsp.diagnostic.set_virtual_text()*
 
 LSP FUNCTIONS
-- *vim.lsp.buf.range_code_action()*	Use |vim.lsp.buf.code_action()| with
-					the `range` parameter.
-- *vim.lsp.util.diagnostics_to_items()*	Use |vim.diagnostic.toqflist()| instead.
-- *vim.lsp.util.set_qflist()*		Use |setqflist()| instead.
-- *vim.lsp.util.set_loclist()*		Use |setloclist()| instead.
-- *vim.lsp.buf_get_clients()*		Use |vim.lsp.get_active_clients()| with
-					{buffer = bufnr} instead.
-- *vim.lsp.buf.formatting()*		Use |vim.lsp.buf.format()| with
-					{async = true} instead.
-- *vim.lsp.buf.formatting_sync()*	Use |vim.lsp.buf.format()| with
-					{async = false} instead.
-- *vim.lsp.buf.range_formatting()*	Use |vim.lsp.formatexpr()|
-					or |vim.lsp.buf.format()| instead.
+- *vim.lsp.buf.range_code_action()*		Use |vim.lsp.buf.code_action()| with
+						the `range` parameter.
+- *vim.lsp.util.diagnostics_to_items()*		Use |vim.diagnostic.toqflist()| instead.
+- *vim.lsp.util.set_qflist()*			Use |setqflist()| instead.
+- *vim.lsp.util.set_loclist()*			Use |setloclist()| instead.
+- *vim.lsp.buf_get_clients()*			Use |vim.lsp.get_active_clients()| with
+						{buffer = bufnr} instead.
+- *vim.lsp.buf.formatting()*			Use |vim.lsp.buf.format()| with
+						{async = true} instead.
+- *vim.lsp.buf.formatting_sync()*		Use |vim.lsp.buf.format()| with
+						{async = false} instead.
+- *vim.lsp.buf.range_formatting()*		Use |vim.lsp.formatexpr()|
+						or |vim.lsp.buf.format()| instead.
+- *vim.lsp.util.get_progress_messages()*	Use |vim.lsp.status()| or access
+						`progress` of |vim.lsp.client|
 
 TREESITTER FUNCTIONS
 - *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -659,14 +659,20 @@ callbacks. Example: >lua
     })
 <
 
-Also the following |User| |autocommand| is provided:
+LspProgress                                                       *LspProgress*
+    Upon receipt of a progress notification from the server. Notifications can
+    be polled from a `progress` ring buffer of a |vim.lsp.client| or use
+    |vim.lsp.status()| to get an aggregate message
 
-LspProgressUpdate                                          *LspProgressUpdate*
-    Upon receipt of a progress notification from the server. See
-    |vim.lsp.util.get_progress_messages()|.
+    If the server sends a "work done progress", the `pattern` is set to `kind`
+    (one of `begin`, `report` or `end`).
+
+    When used from Lua, the event contains a `data` table with `client_id` and
+    `result` properties. `result` will contain the request params sent by the
+    server.
 
 Example: >vim
-    autocmd User LspProgressUpdate redrawstatus
+    autocmd LspProgress * redrawstatus
 <
 
 ==============================================================================
@@ -806,6 +812,8 @@ client()                                                      *vim.lsp.client*
         |vim.lsp.start_client()|.
       • {server_capabilities} (table): Response from the server sent on
         `initialize` describing the server's capabilities.
+      • {progress} A ring buffer (|vim.ringbuf()|) containing progress
+        messages sent by the server.
 
 client_is_stopped({client_id})                   *vim.lsp.client_is_stopped()*
     Checks whether a client is stopped.
@@ -1091,6 +1099,13 @@ start_client({config})                                *vim.lsp.start_client()*
         (integer|nil) client_id. |vim.lsp.get_client_by_id()| Note: client may
         not be fully initialized. Use `on_init` to do any actions once the
         client has been initialized.
+
+status()                                                    *vim.lsp.status()*
+    Consumes the latest progress messages from all clients and formats them as
+    string. Empty if there are no clients or if no new messages
+
+    Return: ~
+        (string)
 
 stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
     Stops a client(s).

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1102,7 +1102,7 @@ start_client({config})                                *vim.lsp.start_client()*
 
 status()                                                    *vim.lsp.status()*
     Consumes the latest progress messages from all clients and formats them as
-    string. Empty if there are no clients or if no new messages
+    a string. Empty if there are no clients or if no new messages
 
     Return: ~
         (string)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -33,8 +33,8 @@ The following changes may require adaptations in user config or plugins.
 • When switching windows, |CursorMoved| autocommands trigger when Nvim is back
   in the main loop rather than immediately. This is more compatible with Vim.
 
-• |LspRequest| autocmd was promoted from a |User| autocmd to a first class
-  citizen.
+• |LspRequest| and LspProgressUpdate (renamed to |LspProgress|) autocmds were
+  promoted from a |User| autocmd to first class citizen.
 
 • Renamed `vim.treesitter.playground` to `vim.treesitter.dev`.
 
@@ -42,6 +42,8 @@ The following changes may require adaptations in user config or plugins.
 ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
+
+• Added |vim.lsp.status()| to consume the last progress messages as string.
 
 • Neovim's LSP client now always saves and restores named buffer marks when
   applying text edits.
@@ -141,6 +143,9 @@ release.
   - |nvim_set_option()|		Use |nvim_set_option_value()| instead.
   - |nvim_win_get_option()|	Use |nvim_get_option_value()| instead.
   - |nvim_win_set_option()|	Use |nvim_set_option_value()| instead.
+
+• vim.lsp functions:
+  - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
 
 • `vim.loop` has been renamed to `vim.uv`.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -43,7 +43,7 @@ ADDED FEATURES                                                     *news-added*
 
 The following new APIs or features were added.
 
-• Added |vim.lsp.status()| to consume the last progress messages as string.
+• Added |vim.lsp.status()| to consume the last progress messages as a string.
 
 • Neovim's LSP client now always saves and restores named buffer marks when
   applying text edits.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -894,7 +894,7 @@ function lsp.start(config, opts)
   return client_id
 end
 
---- Consumes the latest progress messages from all clients and formats them as string.
+--- Consumes the latest progress messages from all clients and formats them as a string.
 --- Empty if there are no clients or if no new messages
 ---
 ---@return string

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1327,7 +1327,7 @@ function lsp.start_client(config)
     dynamic_capabilities = require('vim.lsp._dynamic').new(client_id),
   }
 
-  ---@type table<string|integer, table[]>
+  ---@type table<string|integer, string> title of unfinished progress sequences by token
   client.progress.pending = {}
 
   --- @type lsp.ClientCapabilities

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -807,6 +807,9 @@ end
 ---
 ---  - {server_capabilities} (table): Response from the server sent on
 ---    `initialize` describing the server's capabilities.
+---
+---  - {progress} A ring buffer (|vim.ringbuf()|) containing progress messages
+---    sent by the server.
 function lsp.client()
   error()
 end
@@ -889,6 +892,50 @@ function lsp.start(config, opts)
   end
   lsp.buf_attach_client(bufnr, client_id)
   return client_id
+end
+
+--- Consumes the latest progress messages from all clients and formats them as string.
+--- Empty if there are no clients or if no new messages
+---
+---@return string
+function lsp.status()
+  local percentage = nil
+  local groups = {}
+  for _, client in ipairs(vim.lsp.get_active_clients()) do
+    for progress in client.progress do
+      local value = progress.value
+      if type(value) == 'table' and value.kind then
+        local group = groups[progress.token]
+        if not group then
+          group = {}
+          groups[progress.token] = group
+        end
+        group.title = value.title or group.title
+        group.message = value.message or group.message
+        if value.percentage then
+          percentage = math.max(percentage or 0, value.percentage)
+        end
+      end
+      -- else: Doesn't look like work done progress and can be in any format
+      -- Just ignore it as there is no sensible way to display it
+    end
+  end
+  local messages = {}
+  for _, group in pairs(groups) do
+    if group.title then
+      table.insert(
+        messages,
+        group.message and (group.title .. ': ' .. group.message) or group.title
+      )
+    elseif group.message then
+      table.insert(messages, group.message)
+    end
+  end
+  local message = table.concat(messages, ', ')
+  if percentage then
+    return string.format('%03d: %s', percentage, message)
+  end
+  return message
 end
 
 ---@private
@@ -1266,10 +1313,23 @@ function lsp.start_client(config)
 
     --- @type table<integer,{ type: string, bufnr: integer, method: string}>
     requests = {},
-    -- for $/progress report
+
+    --- Contains $/progress report messages.
+    --- They have the format {token: integer|string, value: any}
+    --- For "work done progress", value will be one of:
+    --- - lsp.WorkDoneProgressBegin,
+    --- - lsp.WorkDoneProgressReport (extended with title from Begin)
+    --- - lsp.WorkDoneProgressEnd    (extended with title from Begin)
+    progress = vim.ringbuf(50),
+
+    ---@deprecated use client.progress instead
     messages = { name = name, messages = {}, progress = {}, status = {} },
     dynamic_capabilities = require('vim.lsp._dynamic').new(client_id),
   }
+
+  ---@type table<string|integer, table[]>
+  client.progress.pending = {}
+
   --- @type lsp.ClientCapabilities
   client.config.capabilities = config.capabilities or protocol.make_client_capabilities()
 

--- a/runtime/lua/vim/lsp/types.lua
+++ b/runtime/lua/vim/lsp/types.lua
@@ -1,6 +1,12 @@
 ---@meta
 
----@alias lsp-handler fun(err: lsp.ResponseError|nil, result: any, context: table, config: table|nil)
+---@alias lsp-handler fun(err: lsp.ResponseError|nil, result: any, context: lsp.HandlerContext, config: table|nil)
+
+---@class lsp.HandlerContext
+---@field method string
+---@field client_id integer
+---@field bufnr integer
+---@field params any
 
 ---@class lsp.ResponseError
 ---@field code integer

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -74,6 +74,7 @@ return {
     'LspDetach',              -- after an LSP client detaches from a buffer
     'LspRequest',             -- after an LSP request is started, canceled, or completed
     'LspTokenUpdate',         -- after a visible LSP token is updated
+    'LspProgress',            -- after a LSP progress update
     'MenuPopup',              -- just before popup menu is displayed
     'ModeChanged',            -- after changing the mode
     'OptionSet',              -- after setting any option
@@ -154,6 +155,7 @@ return {
     LspAttach=true,
     LspDetach=true,
     LspRequest=true,
+    LspProgress=true,
     LspTokenUpdate=true,
     RecordingEnter=true,
     RecordingLeave=true,


### PR DESCRIPTION
`client.messages` could grow unbounded because the default handler only
added new messages, never removing them.

A user either had to consume the messages by calling
`vim.lsp.util.get_progress_messages` or by manually removing them from
`client.messages.progress`. If they didn't do that, using LSP
effectively leaked memory.

To fix this, this deprecates the `messages` property and instead adds a
`progress` ring buffer that only keeps at most 50 messages. In addition
it deprecates `vim.lsp.util.get_progress_messages` in favour of a new
`vim.lsp.status()` and also promotes the `LspProgressUpdate` user
autocmd to a regular autocmd to allow users to pattern match on the
progress kind.

Also closes https://github.com/neovim/neovim/pull/20327
