### PR TITLE
vim-patch:9.0.1620: Nix files are not recognized from the hashbang line

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1459,6 +1459,7 @@ local patterns_hashbang = {
   ['gforth\\>'] = { 'forth', { vim_regex = true } },
   ['icon\\>'] = { 'icon', { vim_regex = true } },
   guile = 'scheme',
+  ['nix%-shell'] = 'nix',
 }
 
 ---@private
@@ -1491,7 +1492,7 @@ local function match_from_hashbang(contents, path, dispatch_extension)
   elseif matchregex(first_line, [[^#!\s*[^/\\ ]*\>\([^/\\]\|$\)]]) then
     name = vim.fn.substitute(first_line, [[^#!\s*\([^/\\ ]*\>\).*]], '\\1', '')
   else
-    name = vim.fn.substitute(first_line, [[^#!\s*\S*[/\\]\(\i\+\).*]], '\\1', '')
+    name = vim.fn.substitute(first_line, [[^#!\s*\S*[/\\]\(\f\+\).*]], '\\1', '')
   end
 
   -- tcl scripts may have #!/bin/sh in the first line and "exec wish" in the

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -772,6 +772,7 @@ let s:script_checks = {
       \ 'expect': [['#!/path/expect']],
       \ 'gnuplot': [['#!/path/gnuplot']],
       \ 'make': [['#!/path/make']],
+      \ 'nix': [['#!/path/nix-shell']],
       \ 'pike': [['#!/path/pike'],
       \          ['#!/path/pike0'],
       \          ['#!/path/pike9']],
@@ -818,6 +819,7 @@ let s:script_env_checks = {
       \ 'scheme': [['#!/usr/bin/env VAR=val --ignore-environment scheme']],
       \ 'python': [['#!/usr/bin/env VAR=val -S python -w -T']],
       \ 'wml': [['#!/usr/bin/env VAR=val --split-string wml']],
+      \ 'nix': [['#!/usr/bin/env nix-shell']],
       \ }
 
 func Run_script_detection(test_dict)


### PR DESCRIPTION
Problem:    Nix files are not recognized from the hashbang line.
Solution:   Add a hashbang check. (issue vim/vim#12507)

https://github.com/vim/vim/commit/19548c6a742d954ecd0b50b0680c37cc6ced7473

Co-authored-by: Bram Moolenaar <Bram@vim.org>
