### PR TITLE
vim-patch:9.0.1621: FILETYPE_FILE is defined to the same value multiple times

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -29,8 +29,15 @@
 # define _PATHSEPSTR "/"
 #endif
 
+// FILETYPE_FILE        used for file type detection
+// FTPLUGIN_FILE        used for loading filetype plugin files
+// INDENT_FILE          used for loading indent files
+// FTOFF_FILE           used for file type detection
+// FTPLUGOF_FILE        used for loading settings files
+// INDOFF_FILE          used for loading indent files
+
 #ifndef FILETYPE_FILE
-# define FILETYPE_FILE "filetype.lua filetype.vim"
+# define FILETYPE_FILE  "filetype.lua filetype.vim"
 #endif
 
 #ifndef FTPLUGIN_FILE


### PR DESCRIPTION
#### vim-patch:9.0.1621: FILETYPE_FILE is defined to the same value multiple times

Problem:    FILETYPE_FILE is defined to the same value multiple times.  Same
            for a few similar macros.
Solution:   Define FILETYPE_FILE and others in feature.h only

https://github.com/vim/vim/commit/c81dfaa69ceec9f6b88caf1dcdf2f859d4fcae47

Co-authored-by: Bram Moolenaar <Bram@vim.org>