### PR TITLE
ci: add runner image version to cache key

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -10,6 +10,10 @@ runs:
       run: echo "CACHE_KEY=$CACHE_KEY-${{ join(matrix.*, '-') }}" >> $GITHUB_ENV
       shell: bash
 
+    - id: image
+      run: echo "version=$ImageVersion" >> $GITHUB_OUTPUT
+      shell: bash
+
     # Avoid using '**/CMakeLists.txt' (or any pattern starting with '**/') even
     # if it makes the expression below simpler. hashFiles() has a timer that
     # will fail the job if it times out, which can happen if there are too many
@@ -17,6 +21,6 @@ runs:
     - uses: actions/cache@v3
       with:
         path: .deps
-        key: ${{ env.CACHE_KEY }}-${{ hashFiles('cmake**',
+        key: ${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ hashFiles('cmake**',
           '.github/workflows/test.yml', 'CMakeLists.txt',
           'runtime/CMakeLists.txt', 'src/nvim/**/CMakeLists.txt') }}


### PR DESCRIPTION
This will ensure the cache isn't used when an image upgrade changes the
compiler version, causing the build to fail.
