### PR TITLE
vim-patch:10e8ff9b2607

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -774,6 +774,9 @@ OptionSet			After setting an option (except during
 				the option. Similarly |v:option_oldglobal| is
 				only set when |:set| or |:setglobal| was used.
 
+				This does not set |<abuf>|, you could use
+				|bufnr()|.
+
 				Note that when setting a |global-local| string
 				option with |:set|, then |v:option_old| is the
 				old global value. However, for all other kinds

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1233,7 +1233,7 @@ clearmatches([{win}])					*clearmatches()*
 		Can also be used as a |method|: >
 			GetWin()->clearmatches()
 <
-col({expr} [, {winid})					*col()*
+col({expr} [, {winid}])					*col()*
 		The result is a Number, which is the byte index of the column
 		position given with {expr}.  The accepted positions are:
 		    .	    the cursor position
@@ -1296,7 +1296,7 @@ complete({startcol}, {matches})			*complete()* *E785*
 		Example: >
 	inoremap <F5> <C-R>=ListMonths()<CR>
 
-	func! ListMonths()
+	func ListMonths()
 	  call complete(col('.'), ['January', 'February', 'March',
 		\ 'April', 'May', 'June', 'July', 'August', 'September',
 		\ 'October', 'November', 'December'])
@@ -1540,7 +1540,7 @@ cursor({list})
 		This is like the return value of |getpos()| or |getcurpos()|,
 		but without the first item.
 
-		To position the cursor using the character count, use
+		To position the cursor using {col} as the character count, use
 		|setcursorcharpos()|.
 
 		Does not change the jumplist.
@@ -5626,7 +5626,7 @@ mkdir({name} [, {flags} [, {prot}]])
 <		and "subdir" already exists then "subdir/tmp" will be
 		scheduled for deletion, like with: >
 			defer delete('subdir/tmp', 'rf')
-
+<
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 		the user, readable for others).  Use 0o700 to make it

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -902,9 +902,10 @@ Note: these are typed literally, they are not special keys!
 		   write.  *E495*
 							*:<abuf>* *<abuf>*
 	<abuf>     When executing autocommands, is replaced with the currently
-		   effective buffer number (for ":r file" and ":so file" it is
-		   the current buffer, the file being read/sourced is not in a
-		   buffer).  *E496*
+		   effective buffer number.  It is not set for all events,
+		   also see |bufnr()|.  For ":r file" and ":so file" it is the
+		   current buffer, the file being read/sourced is not in a
+		   buffer.  *E496*
 							*:<amatch>* *<amatch>*
 	<amatch>   When executing autocommands, is replaced with the match for
 		   which this autocommand was executed.  *E497*

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2799,7 +2799,7 @@ text...
 				let mylist = [1, 2, 3]
 				lockvar 0 mylist
 				let mylist[0] = 77	" OK
-				call add(mylist, 4]	" OK
+				call add(mylist, 4)	" OK
 				let mylist = [7, 8, 9]  " Error!
 <								*E743*
 			For unlimited depth use [!] and omit [depth].

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -349,7 +349,7 @@ Note:
 - The command is not echo'ed, no need for <silent>.
 - The {rhs} is not subject to abbreviations nor to other mappings, even if the
   mapping is recursive.
-- In Visual mode  you can use `line('v')` and `col('v')` to get one end of the
+- In Visual mode you can use `line('v')` and `col('v')` to get one end of the
   Visual area, the cursor is at the other end.
 
 							*E1255* *E1136*

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -392,8 +392,8 @@ If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_map_K = 0
 <
 						*termdebug_disasm_window*
-If you want the Asm window shown by default, set the flag to 1.
-the "disasm_window_height" entry can be used to set the window height: >vim
+If you want the Asm window shown by default, set the "disasm_window" flag to
+1.  The "disasm_window_height" entry can be used to set the window height: >vim
 	let g:termdebug_config['disasm_window'] = 1
 	let g:termdebug_config['disasm_window_height'] = 15
 If there is no g:termdebug_config you can use: >vim

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1361,7 +1361,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The screen column can be an absolute number, or a number preceded with
 	'+' or '-', which is added to or subtracted from 'textwidth'. >
 
-		:set cc=+1  " highlight column after 'textwidth'
+		:set cc=+1	  " highlight column after 'textwidth'
 		:set cc=+1,+2,+3  " highlight three columns after 'textwidth'
 		:hi ColorColumn ctermbg=lightgrey guibg=lightgrey
 <
@@ -5386,7 +5386,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to buffer
 	Number of spaces to use for each step of (auto)indent.  Used for
 	|'cindent'|, |>>|, |<<|, etc.
-	When zero the 'ts' value will be used.  Use the |shiftwidth()|
+	When zero the 'tabstop' value will be used.  Use the |shiftwidth()|
 	function to get the effective shiftwidth value.
 
 						*'shortmess'* *'shm'*
@@ -5662,6 +5662,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	line in the window wraps part of it may not be visible, as if it is
 	above the window. "<<<" is displayed at the start of the first line,
 	highlighted with |hl-NonText|.
+	You may also want to add "lastline" to the 'display' option to show as
+	much of the last line as possible.
 	NOTE: only partly implemented, currently works with CTRL-E, CTRL-Y
 	and scrolling with the mouse.
 
@@ -6313,13 +6315,25 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   (or 3 or whatever you prefer) and use 'noexpandtab'.  Then Vim
 	   will use a mix of tabs and spaces, but typing <Tab> and <BS> will
 	   behave like a tab appears every 4 (or 3) characters.
-	2. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
+	   This is the recommended way, the file will look the same with other
+	   tools and when listing it in a terminal.
+	2. Set 'softtabstop' and 'shiftwidth' to whatever you prefer and use
+	   'expandtab'.  This way you will always insert spaces.  The
+	   formatting will never be messed up when 'tabstop' is changed (leave
+	   it at 8 just in case).  The file will be a bit larger.
+	   You do need to check if no Tabs exist in the file.  You can get rid
+	   of them by first setting 'expandtab' and using `%retab!`, making
+	   sure the value of 'tabstop' is set correctly.
+	3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use
 	   'expandtab'.  This way you will always insert spaces.  The
 	   formatting will never be messed up when 'tabstop' is changed.
-	3. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
+	   You do need to check if no Tabs exist in the file, just like in the
+	   item just above.
+	4. Set 'tabstop' and 'shiftwidth' to whatever you prefer and use a
 	   |modeline| to set these values when editing the file again.  Only
-	   works when using Vim to edit the file.
-	4. Always set 'tabstop' and 'shiftwidth' to the same value, and
+	   works when using Vim to edit the file, other tools assume a tabstop
+	   is worth 8 spaces.
+	5. Always set 'tabstop' and 'shiftwidth' to the same value, and
 	   'noexpandtab'.  This should then work (for initial indents only)
 	   for any tabstop setting that people use.  It might be nice to have
 	   tabs after the first non-blank inserted as spaces if you do this

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -260,8 +260,8 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			'runtimepath'.
 
 			If the filetype detection was already enabled (this
-			is usually done with a "syntax enable" or "filetype
-			on" command in your |init.vim|, or automatically during
+			is usually done with a `syntax enable` or `filetype on`
+			command in your |vimrc|, or automatically during
 			|initialization|), and the package was found in
 			"pack/*/opt/{name}", this command will also look
 			for "{name}/ftdetect/*.vim" files.

--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -111,7 +111,7 @@ zuG			Undo |zW| and |zG|, remove the word from the internal
 			list, like with |zW|.
 
 							*:spellra* *:spellrare*
-:[count]spellr[are] {word}
+:[count]spellra[re] {word}
 			Add {word} as a rare word to 'spellfile', similar to
 			|zw|.  Without count the first name is used, with
 			a count of two the second entry, etc.
@@ -124,7 +124,7 @@ zuG			Undo |zW| and |zG|, remove the word from the internal
 		nnoremap z/  :exe ':spellrare! ' .. expand('<cWORD>')<CR>
 <			|:spellundo|, |zuw|, or |zuW| can be used to undo this.
 
-:spellr[rare]! {word}	Add {word} as a rare word to the internal word
+:spellra[re]! {word}	Add {word} as a rare word to the internal word
 			list, similar to |zW|.
 
 :[count]spellu[ndo] {word}				*:spellu* *:spellundo*

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -426,9 +426,11 @@ accordingly, proceeding as follows:
 
 2. Process the arguments
 	The options and file names from the command that start Vim are
-	inspected.  Buffers are created for all files (but not loaded yet).
+	inspected.
 	The |-V| argument can be used to display or log what happens next,
 	useful for debugging the initializations.
+	The |--cmd| arguments are executed.
+	Buffers are created for all files (but not loaded yet).
 
 3. Start a server (unless |--listen| was given) and set |v:servername|.
 

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -44,6 +44,13 @@ functions.
 			unless "!" is given.
 			{name} may be a |Dictionary| |Funcref| entry: >
 				:function dict.init
+<			Note that {name} is not an expression, you cannot use
+			a variable that is a function reference.  You can use
+			this dirty trick to list the function referred to with
+			variable "Funcref": >
+				let g:MyFuncref = Funcref
+				func g:MyFuncref
+				unlet g:MyFuncref
 
 :fu[nction] /{pattern}	List functions with a name matching {pattern}.
 			Example that lists all functions ending with "File": >
@@ -72,8 +79,7 @@ See |:verbose-cmd| for more information.
 			name has a colon in the name, e.g. for "foo:bar()".
 			Before that patch no error was given).
 
-			{name} can also be a |Dictionary| entry that is a
-			|Funcref|: >
+			{name} may be a |Dictionary| |Funcref| entry: >
 				:function dict.init(arg)
 <			"dict" must be an existing dictionary.  The entry
 			"init" is added if it didn't exist yet.  Otherwise [!]

--- a/runtime/ftplugin/corn.vim
+++ b/runtime/ftplugin/corn.vim
@@ -1,0 +1,18 @@
+" Vim filetype plugin
+" Language:         Corn
+" Original Author:  Jake Stanger (mail@jstanger.dev) 
+" License:          MIT
+" Last Change:      2023 May 28
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal formatoptions-=t
+
+" Set comment (formatting) related options.
+setlocal commentstring=//\ %s comments=:// 
+
+" Let Vim know how to disable the plug-in.
+let b:undo_ftplugin = 'setlocal commentstring< comments< formatoptions<'

--- a/runtime/ftplugin/fennel.vim
+++ b/runtime/ftplugin/fennel.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:     Fennel
 " Maintainer:   Gregory Anders <greg[NOSPAM]@gpanders.com>
-" Last Update:  2022 Apr 20
+" Last Update:  2023 Jun 9
 
 if exists('b:did_ftplugin')
   finish
@@ -13,6 +13,6 @@ setlocal comments=:;;,:;
 setlocal formatoptions-=t
 setlocal suffixesadd=.fnl
 setlocal lisp
-setlocal lispwords=accumulate,collect,do,doto,each,eval-compiler,fn,for,icollect,lambda,let,macro,macros,match,match-try,when,while,with-open
+setlocal lispwords=accumulate,case,case-try,collect,do,doto,each,eval-compiler,faccumulate,fcollect,fn,for,icollect,lambda,let,macro,macros,match,match-try,when,while,with-open
 
 let b:undo_ftplugin = 'setlocal commentstring< comments< formatoptions< suffixesadd< lisp< lispwords<'

--- a/runtime/ftplugin/urlshortcut.vim
+++ b/runtime/ftplugin/urlshortcut.vim
@@ -1,0 +1,20 @@
+" Vim filetype plugin file
+" Language:             MS Windows URL shortcut file
+" Maintainer:           ObserverOfTime <chronobserver@disroot.org>
+" Latest Revision:      2023-06-04
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+let b:undo_ftplugin = "setl com< cms< fo<"
+
+setlocal comments=:; commentstring=;\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/runtime/syntax/meson.vim
+++ b/runtime/syntax/meson.vim
@@ -3,7 +3,7 @@
 " License:	VIM License
 " Maintainer:	Nirbheek Chauhan <nirbheek.chauhan@gmail.com>
 "		Liam Beguin <liambeguin@gmail.com>
-" Last Change:	2021 Aug 16
+" Last Change:	2023 May 27
 " Credits:	Zvezdan Petkovic <zpetkovic@acm.org>
 "		Neil Schemenauer <nas@meson.ca>
 "		Dmitry Vasiliev
@@ -68,6 +68,7 @@ syn keyword mesonBuiltin
   \ add_global_link_arguments
   \ add_languages
   \ add_project_arguments
+  \ add_project_dependencies
   \ add_project_link_arguments
   \ add_test_setup
   \ alias_target
@@ -99,6 +100,7 @@ syn keyword mesonBuiltin
   \ install_headers
   \ install_man
   \ install_subdir
+  \ install_symlink
   \ install_emptydir
   \ is_disabler
   \ is_variable
@@ -115,6 +117,7 @@ syn keyword mesonBuiltin
   \ shared_library
   \ shared_module
   \ static_library
+  \ structured_sources
   \ subdir
   \ subdir_done
   \ subproject
@@ -125,6 +128,7 @@ syn keyword mesonBuiltin
   \ vcs_tag
   \ warning
   \ range
+  \ debug
 
 if exists("meson_space_error_highlight")
   " trailing whitespace
@@ -146,7 +150,7 @@ hi def link mesonEscape		Special
 hi def link mesonNumber		Number
 hi def link mesonBuiltin	Function
 hi def link mesonBoolean	Boolean
-if exists("meson_space_error_higlight")
+if exists("meson_space_error_highlight")
   hi def link mesonSpaceError	Error
 endif
 

--- a/runtime/syntax/structurizr.vim
+++ b/runtime/syntax/structurizr.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:      Structurizr DSL
 " Maintainer:    Bastian Venthur <venthur@debian.org>
-" Last Change:   2022-02-15
+" Last Change:   2022-05-22
 " Remark:        For a language reference, see
 "                https://github.com/structurizr/dsl
 
@@ -26,6 +26,7 @@ syn keyword skeyword configuration
 syn keyword skeyword container
 syn keyword skeyword containerinstance
 syn keyword skeyword custom
+syn keyword skeyword default
 syn keyword skeyword deployment
 syn keyword skeyword deploymentenvironment
 syn keyword skeyword deploymentgroup
@@ -40,6 +41,7 @@ syn keyword skeyword group
 syn keyword skeyword healthcheck
 syn keyword skeyword include
 syn keyword skeyword infrastructurenode
+syn keyword skeyword instances
 syn keyword skeyword model
 syn keyword skeyword person
 syn keyword skeyword perspectives
@@ -54,6 +56,7 @@ syn keyword skeyword tags
 syn keyword skeyword technology
 syn keyword skeyword terminology
 syn keyword skeyword theme
+syn keyword skeyword themes
 syn keyword skeyword title
 syn keyword skeyword url
 syn keyword skeyword users

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -2,9 +2,9 @@
 " Language: sway window manager config
 " Original Author: James Eapen <james.eapen@vai.org>
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 0.1.6
-" Reference version (jamespeapen/swayconfig.vim): 0.11.6
-" Last Change: 2022 Aug 08
+" Version: 0.2.1
+" Reference version (jamespeapen/swayconfig.vim): 0.12.1
+" Last Change: 2023 Mar 20
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -58,6 +58,10 @@ syn match swayConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClient
 syn keyword swayConfigInputKeyword input contained
 syn match swayConfigInput /^\s*input\s\+.*$/ contains=swayConfigInputKeyword
 
+" Seat config
+syn keyword swayConfigSeatKeyword seat contained
+syn match swayConfigSeat /^\s*seat\s\+.*$/ contains=swayConfigSeatKeyword
+
 " set display outputs
 syn match swayConfigOutput /^\s*output\s\+.*$/ contains=i3ConfigOutput
 
@@ -65,6 +69,10 @@ syn match swayConfigOutput /^\s*output\s\+.*$/ contains=i3ConfigOutput
 syn keyword swayConfigFocusKeyword focus contained
 syn keyword swayConfigFocusType output contained
 syn match swayConfigFocus /^\s*focus\soutput\s.*$/ contains=swayConfigFocusKeyword,swayConfigFocusType
+
+" mouse warping
+syn keyword swayConfigMouseWarpingType container contained
+syn match swayConfigMouseWarping /^\s*mouse_warping\s\+\(output\|container\|none\)\s\?$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType,swayConfigMouseWarpingType
 
 " focus follows mouse
 syn clear i3ConfigFocusFollowsMouseType
@@ -80,7 +88,7 @@ syn match swayConfigXwaylandModifier /^\s*xwayland\s\+\(enable\|disable\|force\)
 
 " Group mode/bar
 syn clear i3ConfigBlock
-syn region swayConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigInitializeKeyword,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable,swayConfigInputKeyword,i3ConfigOutput transparent keepend extend
+syn region swayConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigInitializeKeyword,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable,swayConfigInputKeyword,swayConfigSeatKeyword,i3ConfigOutput transparent keepend extend
 
 "hi def link swayConfigError                         Error
 hi def link i3ConfigFloating                        Error
@@ -89,6 +97,8 @@ hi def link swayConfigFloatingMouseAction           Type
 hi def link swayConfigFocusKeyword                  Type
 hi def link swayConfigSmartBorderKeyword            Type
 hi def link swayConfigInputKeyword                  Type
+hi def link swayConfigSeatKeyword                   Type
+hi def link swayConfigMouseWarpingType              Type
 hi def link swayConfigFocusFollowsMouseType         Type
 hi def link swayConfigBindGestureCommand            Identifier
 hi def link swayConfigBindGestureDirection          Constant

--- a/runtime/syntax/urlshortcut.vim
+++ b/runtime/syntax/urlshortcut.vim
@@ -1,0 +1,14 @@
+" Vim syntax file
+" Language:      MS Windows URL shortcut file
+" Maintainer:    ObserverOfTime <chronobserver@disroot.org>
+" LastChange:    2023-06-04
+
+" Quit when a syntax file was already loaded.
+if exists("b:current_syntax")
+   finish
+endif
+
+" Just use the dosini syntax for now
+runtime! syntax/dosini.vim
+
+let b:current_syntax = "urlshortcut"

--- a/runtime/syntax/xpm.vim
+++ b/runtime/syntax/xpm.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	X Pixmap
 " Maintainer:	Ronald Schild <rs@scutum.de>
-" Last Change:	2023 May 11
+" Last Change:	2023 May 24
 " Version:	5.4n.2
 "               Jemma Nelson added termguicolors support
 "               Dominique Pellé fixed spelling support
@@ -42,7 +42,7 @@ function s:CreateSyntax() abort
 	    let values = split(s[1 : -2])
 
 	    " Values string invalid, bail out
-	    if len(values) != 4
+	    if len(values) != 4 && len(values) != 6 && len(values) != 7
 	       return
 	    endif
 
@@ -100,8 +100,8 @@ function s:CreateSyntax() abort
 	    endif
 
 	    " escape meta characters in patterns
-	    let s = escape(s, '/\*^$.~[] ')
-	    let chars = escape(chars, '/\*^$.~[] ')
+	    let s = escape(s, '/\*^$.~[]')
+	    let chars = escape(chars, '/\*^$.~[]')
 
 	    " now create syntax items
 	    " highlight the color string as normal string (no pixel string)


### PR DESCRIPTION
Hopefully you don't mind me yoinking this one :P

Update runtime files

https://github.com/vim/vim/commit/10e8ff9b26078994cae57c2422b145d37aaf714e

Also:
- fix a missing `<` in builtin.txt.
- edit `:function` `{name}` wording to match the change made for the docs above
  by Justin in https://github.com/neovim/neovim/pull/10619.