### PR TITLE
vim-patch:9.0.1626: Visual area not shown when using 'showbreak'

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -92,7 +92,7 @@ typedef struct {
   int fromcol;               ///< start of inverting
   int tocol;                 ///< end of inverting
 
-  long vcol_sbr;             ///< virtual column after showbreak
+  colnr_T vcol_sbr;          ///< virtual column after showbreak
   bool need_showbreak;       ///< overlong line, skipping first x chars
 
   int char_attr;             ///< attributes for next character
@@ -832,6 +832,12 @@ static void handle_showbreak_and_filler(win_T *wp, winlinevars_T *wlv)
       wlv->need_showbreak = false;
     }
     wlv->vcol_sbr = wlv->vcol + mb_charlen(sbr);
+
+    // Correct start of highlighted area for 'showbreak'.
+    if (wlv->fromcol >= wlv->vcol && wlv->fromcol < wlv->vcol_sbr) {
+      wlv->fromcol = wlv->vcol_sbr;
+    }
+
     // Correct end of highlighted area for 'showbreak',
     // required when 'linebreak' is also set.
     if (wlv->tocol == wlv->vcol) {

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -540,7 +540,7 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, int cle
     size_t skip = 0;
     if (wp->w_p_nu && wp->w_p_rnu) {
       // do not overwrite the line number, change "123 text" to
-      // "123>>>xt".
+      // "123<<<xt".
       while (skip < max_off_from && ascii_isdigit(*linebuf_char[off])) {
         off++;
         skip++;

--- a/test/functional/legacy/highlight_spec.lua
+++ b/test/functional/legacy/highlight_spec.lua
@@ -1,5 +1,3 @@
--- Tests for ":highlight".
-
 local Screen = require('test.functional.ui.screen')
 local helpers = require('test.functional.helpers')(after_each)
 local clear, feed = helpers.clear, helpers.feed
@@ -8,10 +6,11 @@ local eq = helpers.eq
 local poke_eventloop = helpers.poke_eventloop
 local exc_exec = helpers.exc_exec
 local feed_command = helpers.feed_command
+local exec = helpers.exec
+
+before_each(clear)
 
 describe(':highlight', function()
-  setup(clear)
-
   it('is working', function()
     local screen = Screen.new(35, 10)
     screen:attach()
@@ -92,5 +91,32 @@ describe(':highlight', function()
 
 
       Group3         xxx cleared]])
+  end)
+end)
+
+describe('Visual selection highlight', function()
+  -- oldtest: Test_visual_sbr()
+  it("when 'showbreak' is set", function()
+    local screen = Screen.new(60, 6)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.LightGrey},  -- Visual
+      [2] = {bold = true},  -- ModeMsg
+    })
+    screen:attach()
+    exec([[
+      set showbreak=>
+      call setline(1, 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.')
+      exe "normal! z1\<CR>"
+    ]])
+    feed('v$')
+    screen:expect([[
+      {0:>}{1:n, no sea takimata sanctus est Lorem ipsum dolor sit amet.}^ |
+                                                                  |
+                                                                  |
+                                                                  |
+                                                                  |
+      {2:-- VISUAL --}                                                |
+    ]])
   end)
 end)

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -698,7 +698,7 @@ func Test_colorcolumn_sbr()
   let lines =<< trim END
 	call setline(1, 'The quick brown fox jumped over the lazy dogs')
   END
-  call writefile(lines, 'Xtest_colorcolumn_srb')
+  call writefile(lines, 'Xtest_colorcolumn_srb', 'D')
   let buf = RunVimInTerminal('-S Xtest_colorcolumn_srb', {'rows': 10,'columns': 40})
   call term_sendkeys(buf, ":set co=40 showbreak=+++>\\  cc=40,41,43\<CR>")
   call TermWait(buf)
@@ -706,7 +706,26 @@ func Test_colorcolumn_sbr()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('Xtest_colorcolumn_srb')
+endfunc
+
+func Test_visual_sbr()
+  CheckScreendump
+
+  " check Visual highlight when 'showbreak' is set
+  let lines =<< trim END
+      set showbreak=>
+      call setline(1, 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.')
+      exe "normal! z1\<CR>"
+  END
+  call writefile(lines, 'Xtest_visual_sbr', 'D')
+  let buf = RunVimInTerminal('-S Xtest_visual_sbr', {'rows': 6,'columns': 60})
+
+  call term_sendkeys(buf, "v$")
+  call VerifyScreenDump(buf, 'Test_visual_sbr_1', {})
+
+  " clean up
+  call term_sendkeys(buf, "\<Esc>")
+  call StopVimInTerminal(buf)
 endfunc
 
 " This test must come before the Test_cursorline test, as it appears this


### PR DESCRIPTION
#### vim-patch:9.0.1626: Visual area not shown when using 'showbreak'

Problem:    Visual area not shown when using 'showbreak' and start of line is
            not visible. (Jaehwang Jung)
Solution:   Adjust "fromcol" for the space taken by 'showbreak'.

https://github.com/vim/vim/commit/f578ca2c8f36b61ac3301fe8b59a8473c964cdc2

Co-authored-by: Bram Moolenaar <Bram@vim.org>