### PR TITLE
fix(lsp): buffer may have become invalid when callback is called

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1511,11 +1511,13 @@ function lsp.start_client(config)
     end, function(request_id)
       local request = client.requests[request_id]
       request.type = 'complete'
-      nvim_exec_autocmds('LspRequest', {
-        buffer = bufnr,
-        modeline = false,
-        data = { client_id = client_id, request_id = request_id, request = request },
-      })
+      if api.nvim_buf_is_valid(bufnr) then
+        nvim_exec_autocmds('LspRequest', {
+          buffer = bufnr,
+          modeline = false,
+          data = { client_id = client_id, request_id = request_id, request = request },
+        })
+      end
       client.requests[request_id] = nil
     end)
 


### PR DESCRIPTION
A buffer may have become invalid when callback is called. For example, I ran into this case when I opened a rust file, which requested inlayHint (via rust-tools.nvim), and I :bwipeout-ed the buffer. 

Ideally, I think every scheduled callback that refers to buffers/windows/etc should be guarded against such cases. 