### PR TITLE
fix(remote): restore previous --remote-expr output formatting

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -940,14 +940,13 @@ function vim._cs_remote(rcid, server_addr, connect_error, args)
     if rcid == 0 then
       return { errmsg = connection_failure_errmsg('Send failed.') }
     end
-    vim.fn.rpcrequest(rcid, 'nvim_input', args[2])
+    vim.rpcrequest(rcid, 'nvim_input', args[2])
     return { should_exit = true, tabbed = false }
   elseif subcmd == 'expr' then
     if rcid == 0 then
       return { errmsg = connection_failure_errmsg('Send expression failed.') }
     end
-    local expr = 'string(' .. args[2] .. ')'
-    local res = vim.fn.rpcrequest(rcid, 'nvim_eval', expr)
+    local res = tostring(vim.rpcrequest(rcid, 'nvim_eval', args[2]))
     return { result = res, should_exit = true, tabbed = false }
   elseif subcmd ~= '' then
     return { errmsg = 'Unknown option argument: ' .. args[1] }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -967,7 +967,6 @@ static void remote_request(mparm_T *params, int remote_args, char *server_addr, 
         os_exit(2);
       }
       os_msg(rvobj.data.dictionary.items[i].value.data.string.data);
-      os_msg("\n");
     } else if (strequal(rvobj.data.dictionary.items[i].key.data, "tabbed")) {
       if (rvobj.data.dictionary.items[i].value.type != kObjectTypeBoolean) {
         os_errmsg("vim._cs_remote returned an unexpected type for 'tabbed'\n");

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -8,7 +8,6 @@ local exec_lua = helpers.exec_lua
 local expect = helpers.expect
 local funcs = helpers.funcs
 local insert = helpers.insert
-local is_os = helpers.is_os
 local nvim_prog = helpers.nvim_prog
 local new_argv = helpers.new_argv
 local neq = helpers.neq
@@ -105,10 +104,12 @@ describe('Remote', function()
     end)
 
     it('evaluate expressions', function()
-      local linesep = is_os('win') and '\r\n' or '\n'
-      eq({ "function('get')" .. linesep, '' }, run_remote('--remote-expr', 'function("get")'))
-      eq({ '0' .. linesep, '' }, run_remote('--remote-expr', 'setline(1, "Yo")'))
+      eq({ '0', '' }, run_remote('--remote-expr', 'setline(1, "Yo")'))
+      eq({ 'Yo', '' }, run_remote('--remote-expr', 'getline(1)'))
       expect('Yo')
+      eq({ '1.25', '' }, run_remote('--remote-expr', '1.25'))
+      eq({ 'no', '' }, run_remote('--remote-expr', '0z6E6F'))
+      eq({ '\t', '' }, run_remote('--remote-expr', '"\t"'))
     end)
   end)
 


### PR DESCRIPTION
- Use tostring() as that's what print() uses internally.
- Do not append trailing new line.
