### PR TITLE
docs: fix vim.tbl_get type annotations

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2071,8 +2071,8 @@ tbl_get({o}, {...})                                            *vim.tbl_get()*
 
     Parameters: ~
       • {o}    (table) Table to index
-      • {...}  (string) Optional strings (0 or more, variadic) via which to
-               index the table
+      • {...}  any Optional keys (0 or more, variadic) via which to index the
+               table
 
     Return: ~
         any Nested value indexed by key (if it exists), else nil

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -456,7 +456,7 @@ end
 --- </pre>
 ---
 ---@param o table Table to index
----@param ... string Optional strings (0 or more, variadic) via which to index the table
+---@param ... any Optional keys (0 or more, variadic) via which to index the table
 ---
 ---@return any Nested value indexed by key (if it exists), else nil
 function vim.tbl_get(o, ...)


### PR DESCRIPTION
I want to fix a lua_ls warning for numeric keys. Table key can be anything (except nil) in lua. This function works fine with non-string keys.