### PR TITLE
vim-patch:8.2.{2533,3191,3202,partial:3335}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1604,13 +1604,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
 
       lp->ll_dict = NULL;
       lp->ll_list = lp->ll_tv->vval.v_list;
-      lp->ll_li = tv_list_find(lp->ll_list, (int)lp->ll_n1);
-      if (lp->ll_li == NULL) {
-        if (lp->ll_n1 < 0) {
-          lp->ll_n1 = 0;
-          lp->ll_li = tv_list_find(lp->ll_list, (int)lp->ll_n1);
-        }
-      }
+      lp->ll_li = tv_list_find_index(lp->ll_list, &lp->ll_n1);
       if (lp->ll_li == NULL) {
         tv_clear(&var2);
         if (!quiet) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -3019,11 +3019,12 @@ static void tv_dict_list(typval_T *const tv, typval_T *const rettv, const DictLi
     emsg(_(e_dictreq));
     return;
   }
-  if (tv->vval.v_dict == NULL) {
-    return;
-  }
 
   tv_list_alloc_ret(rettv, tv_dict_len(tv->vval.v_dict));
+  if (tv->vval.v_dict == NULL) {
+    // NULL dict behaves like an empty dict
+    return;
+  }
 
   TV_DICT_ITER(tv->vval.v_dict, di, {
     typval_T tv_item = { .v_lock = VAR_UNLOCKED };

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -1507,6 +1507,21 @@ const char *tv_list_find_str(list_T *const l, const int n)
   return tv_get_string(TV_LIST_ITEM_TV(li));
 }
 
+/// Like tv_list_find() but when a negative index is used that is not found use
+/// zero and set "idx" to zero.  Used for first index of a range.
+listitem_T *tv_list_find_index(list_T *const l, long *const idx)
+  FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  listitem_T *li = tv_list_find(l, (int)(*idx));
+  if (li == NULL) {
+    if (*idx < 0) {
+      *idx = 0;
+      li = tv_list_find(l, (int)(*idx));
+    }
+  }
+  return li;
+}
+
 /// Locate item in a list and return its index
 ///
 /// @param[in]  l  List to search.

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -810,24 +810,27 @@ endfunc
 
 " Tests for reverse(), sort(), uniq()
 func Test_reverse_sort_uniq()
-  let l = ['-0', 'A11', 2, 2, 'xaaa', 4, 'foo', 'foo6', 'foo', [0, 1, 2], 'x8', [0, 1, 2], 1.5]
-  call assert_equal(['-0', 'A11', 2, 'xaaa', 4, 'foo', 'foo6', 'foo', [0, 1, 2], 'x8', [0, 1, 2], 1.5], uniq(copy(l)))
-  call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(l))
-  call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(reverse(l)))
-  if has('float')
-    call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(l))
-    call assert_equal([[0, 1, 2], [0, 1, 2], 4, 2, 2, 1.5, 'xaaa', 'x8', 'foo6', 'foo', 'foo', 'A11', '-0'], reverse(sort(l)))
-    call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(reverse(sort(l))))
-    call assert_equal(['-0', 'A11', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 4, [0, 1, 2]], uniq(sort(l)))
+  let lines =<< trim END
+      VAR l = ['-0', 'A11', 2, 2, 'xaaa', 4, 'foo', 'foo6', 'foo', [0, 1, 2], 'x8', [0, 1, 2], 1.5]
+      call assert_equal(['-0', 'A11', 2, 'xaaa', 4, 'foo', 'foo6', 'foo', [0, 1, 2], 'x8', [0, 1, 2], 1.5], uniq(copy(l)))
+      call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(l))
+      call assert_equal([1.5, [0, 1, 2], 'x8', [0, 1, 2], 'foo', 'foo6', 'foo', 4, 'xaaa', 2, 2, 'A11', '-0'], reverse(reverse(l)))
+      if has('float')
+        call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(l))
+        call assert_equal([[0, 1, 2], [0, 1, 2], 4, 2, 2, 1.5, 'xaaa', 'x8', 'foo6', 'foo', 'foo', 'A11', '-0'], reverse(sort(l)))
+        call assert_equal(['-0', 'A11', 'foo', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 2, 4, [0, 1, 2], [0, 1, 2]], sort(reverse(sort(l))))
+        call assert_equal(['-0', 'A11', 'foo', 'foo6', 'x8', 'xaaa', 1.5, 2, 4, [0, 1, 2]], uniq(sort(l)))
 
-    let l = [7, 9, 'one', 18, 12, 22, 'two', 10.0e-16, -1, 'three', 0xff, 0.22, 'four']
-    call assert_equal([-1, 'one', 'two', 'three', 'four', 1.0e-15, 0.22, 7, 9, 12, 18, 22, 255], sort(copy(l), 'n'))
+        LET l = [7, 9, 'one', 18, 12, 22, 'two', 10.0e-16, -1, 'three', 0xff, 0.22, 'four']
+        call assert_equal([-1, 'one', 'two', 'three', 'four', 1.0e-15, 0.22, 7, 9, 12, 18, 22, 255], sort(copy(l), 'n'))
 
-    let l = [7, 9, 18, 12, 22, 10.0e-16, -1, 0xff, 0, -0, 0.22, 'bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', {}, []]
-    call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 1))
-    call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 'i'))
-    call assert_equal(['BAR', 'Bar', 'FOO', 'FOOBAR', 'Foo', 'bar', 'foo', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l)))
-  endif
+        LET l = [7, 9, 18, 12, 22, 10.0e-16, -1, 0xff, 0, -0, 0.22, 'bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', {}, []]
+        call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 1))
+        call assert_equal(['bar', 'BAR', 'Bar', 'Foo', 'FOO', 'foo', 'FOOBAR', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l), 'i'))
+        call assert_equal(['BAR', 'Bar', 'FOO', 'FOOBAR', 'Foo', 'bar', 'foo', -1, 0, 0, 0.22, 1.0e-15, 12, 18, 22, 255, 7, 9, [], {}], sort(copy(l)))
+      endif
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   call assert_fails('call reverse("")', 'E899:')
   call assert_fails('call uniq([1, 2], {x, y -> []})', 'E745:')
@@ -838,28 +841,34 @@ endfunc
 
 " reduce a list or a blob
 func Test_reduce()
-  call assert_equal(1, reduce([], { acc, val -> acc + val }, 1))
-  call assert_equal(10, reduce([1, 3, 5], { acc, val -> acc + val }, 1))
-  call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([2, 3, 4], { acc, val -> 2 * acc + val }, 1))
-  call assert_equal('a x y z', ['x', 'y', 'z']->reduce({ acc, val -> acc .. ' ' .. val}, 'a'))
-  call assert_equal(#{ x: 1, y: 1, z: 1 }, ['x', 'y', 'z']->reduce({ acc, val -> extend(acc, { val: 1 }) }, {}))
-  call assert_equal([0, 1, 2, 3], reduce([1, 2, 3], function('add'), [0]))
+  let lines =<< trim END
+      call assert_equal(1, reduce([], LSTART acc, val LMIDDLE acc + val LEND, 1))
+      call assert_equal(10, reduce([1, 3, 5], LSTART acc, val LMIDDLE acc + val LEND, 1))
+      call assert_equal(2 * (2 * ((2 * 1) + 2) + 3) + 4, reduce([2, 3, 4], LSTART acc, val LMIDDLE 2 * acc + val LEND, 1))
+      call assert_equal('a x y z', ['x', 'y', 'z']->reduce(LSTART acc, val LMIDDLE acc .. ' ' .. val LEND, 'a'))
+      call assert_equal([0, 1, 2, 3], reduce([1, 2, 3], function('add'), [0]))
 
-  let l = ['x', 'y', 'z']
-  call assert_equal(42, reduce(l, function('get'), #{ x: #{ y: #{ z: 42 } } }))
-  call assert_equal(['x', 'y', 'z'], l)
+      VAR l = ['x', 'y', 'z']
+      call assert_equal(42, reduce(l, function('get'), {'x': {'y': {'z': 42 } } }))
+      call assert_equal(['x', 'y', 'z'], l)
 
-  call assert_equal(1, reduce([1], { acc, val -> acc + val }))
-  call assert_equal('x y z', reduce(['x', 'y', 'z'], { acc, val -> acc .. ' ' .. val }))
-  call assert_equal(120, range(1, 5)->reduce({ acc, val -> acc * val }))
+      call assert_equal(1, reduce([1], LSTART acc, val LMIDDLE acc + val LEND))
+      call assert_equal('x y z', reduce(['x', 'y', 'z'], LSTART acc, val LMIDDLE acc .. ' ' .. val LEND))
+      call assert_equal(120, range(1, 5)->reduce(LSTART acc, val LMIDDLE acc * val LEND))
+
+      call assert_equal(1, reduce(0z, LSTART acc, val LMIDDLE acc + val LEND, 1))
+      call assert_equal(1 + 0xaf + 0xbf + 0xcf, reduce(0zAFBFCF, LSTART acc, val LMIDDLE acc + val LEND, 1))
+      call assert_equal(2 * (2 * 1 + 0xaf) + 0xbf, 0zAFBF->reduce(LSTART acc, val LMIDDLE 2 * acc + val LEND, 1))
+
+      call assert_equal(0xff, reduce(0zff, LSTART acc, val LMIDDLE acc + val LEND))
+      call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, LSTART acc, val LMIDDLE 2 * acc + val LEND))
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  call assert_equal({'x': 1, 'y': 1, 'z': 1 }, ['x', 'y', 'z']->reduce({ acc, val -> extend(acc, { val: 1 }) }, {}))
+  " vim9 assert_equal({'x': 1, 'y': 1, 'z': 1 }, ['x', 'y', 'z']->reduce((acc, val) => extend(acc, {[val]: 1 }), {}))
+
   call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
-
-  call assert_equal(1, reduce(0z, { acc, val -> acc + val }, 1))
-  call assert_equal(1 + 0xaf + 0xbf + 0xcf, reduce(0zAFBFCF, { acc, val -> acc + val }, 1))
-  call assert_equal(2 * (2 * 1 + 0xaf) + 0xbf, 0zAFBF->reduce({ acc, val -> 2 * acc + val }, 1))
-
-  call assert_equal(0xff, reduce(0zff, { acc, val -> acc + val }))
-  call assert_equal(2 * (2 * 0xaf + 0xbf) + 0xcf, reduce(0zAFBFCF, { acc, val -> 2 * acc + val }))
   call assert_fails("call reduce(0z, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E897:')
@@ -889,29 +898,36 @@ endfunc
 
 " splitting a string to a List using split()
 func Test_str_split()
-  call assert_equal(['aa', 'bb'], split('  aa  bb '))
-  call assert_equal(['aa', 'bb'], split('  aa  bb  ', '\W\+', 0))
-  call assert_equal(['', 'aa', 'bb', ''], split('  aa  bb  ', '\W\+', 1))
-  call assert_equal(['', '', 'aa', '', 'bb', '', ''], split('  aa  bb  ', '\W', 1))
-  call assert_equal(['aa', '', 'bb'], split(':aa::bb:', ':', 0))
-  call assert_equal(['', 'aa', '', 'bb', ''], split(':aa::bb:', ':', 1))
-  call assert_equal(['aa', '', 'bb', 'cc', ''], split('aa,,bb, cc,', ',\s*', 1))
-  call assert_equal(['a', 'b', 'c'], split('abc', '\zs'))
-  call assert_equal(['', 'a', '', 'b', '', 'c', ''], split('abc', '\zs', 1))
+  let lines =<< trim END
+      call assert_equal(['aa', 'bb'], split('  aa  bb '))
+      call assert_equal(['aa', 'bb'], split('  aa  bb  ', '\W\+', 0))
+      call assert_equal(['', 'aa', 'bb', ''], split('  aa  bb  ', '\W\+', 1))
+      call assert_equal(['', '', 'aa', '', 'bb', '', ''], split('  aa  bb  ', '\W', 1))
+      call assert_equal(['aa', '', 'bb'], split(':aa::bb:', ':', 0))
+      call assert_equal(['', 'aa', '', 'bb', ''], split(':aa::bb:', ':', 1))
+      call assert_equal(['aa', '', 'bb', 'cc', ''], split('aa,,bb, cc,', ',\s*', 1))
+      call assert_equal(['a', 'b', 'c'], split('abc', '\zs'))
+      call assert_equal(['', 'a', '', 'b', '', 'c', ''], split('abc', '\zs', 1))
+      call assert_equal(['abc'], split('abc', '\\%('))
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   call assert_fails("call split('abc', [])", 'E730:')
   call assert_fails("call split('abc', 'b', [])", 'E745:')
-  call assert_equal(['abc'], split('abc', '\\%('))
 endfunc
 
 " compare recursively linked list and dict
 func Test_listdict_compare()
-  let l = [1, 2, 3, 4]
-  let d = {'1': 1, '2': l, '3': 3}
-  let l[1] = d
-  call assert_true(l == l)
-  call assert_true(d == d)
-  call assert_false(l != deepcopy(l))
-  call assert_false(d != deepcopy(d))
+  let lines =<< trim END
+      VAR l = [1, 2, 3, '4']
+      VAR d = {'1': 1, '2': l, '3': 3}
+      LET l[1] = d
+      call assert_true(l == l)
+      call assert_true(d == d)
+      call assert_false(l != deepcopy(l))
+      call assert_false(d != deepcopy(d))
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   " comparison errors
   call assert_fails('echo [1, 2] =~ {}', 'E691:')
@@ -922,14 +938,17 @@ endfunc
 
   " compare complex recursively linked list and dict
 func Test_listdict_compare_complex()
-  let l = []
-  call add(l, l)
-  let dict4 = {"l": l}
-  call add(dict4.l, dict4)
-  let lcopy = deepcopy(l)
-  let dict4copy = deepcopy(dict4)
-  call assert_true(l == lcopy)
-  call assert_true(dict4 == dict4copy)
+  let lines =<< trim END
+      VAR l = []
+      call add(l, l)
+      VAR dict4 = {"l": l}
+      call add(dict4.l, dict4)
+      VAR lcopy = deepcopy(l)
+      VAR dict4copy = deepcopy(dict4)
+      call assert_true(l == lcopy)
+      call assert_true(dict4 == dict4copy)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " Test for extending lists and dictionaries
@@ -937,33 +956,36 @@ func Test_listdict_extend()
   " Test extend() with lists
 
   " Pass the same List to extend()
-  let l = [1, 2, 3]
-  call assert_equal([1, 2, 3, 1, 2, 3], extend(l, l))
-  call assert_equal([1, 2, 3, 1, 2, 3], l)
+  let lines =<< trim END
+      VAR l = [1, 2, 3]
+      call assert_equal([1, 2, 3, 1, 2, 3], extend(l, l))
+      call assert_equal([1, 2, 3, 1, 2, 3], l)
 
-  let l = [1, 2, 3]
-  call assert_equal([1, 2, 3, 4, 5, 6], extend(l, [4, 5, 6]))
-  call assert_equal([1, 2, 3, 4, 5, 6], l)
+      LET l = [1, 2, 3]
+      call assert_equal([1, 2, 3, 4, 5, 6], extend(l, [4, 5, 6]))
+      call assert_equal([1, 2, 3, 4, 5, 6], l)
 
-  let l = [1, 2, 3]
-  call extend(l, [4, 5, 6], 0)
-  call assert_equal([4, 5, 6, 1, 2, 3], l)
+      LET l = [1, 2, 3]
+      call extend(l, [4, 5, 6], 0)
+      call assert_equal([4, 5, 6, 1, 2, 3], l)
 
-  let l = [1, 2, 3]
-  call extend(l, [4, 5, 6], 1)
-  call assert_equal([1, 4, 5, 6, 2, 3], l)
+      LET l = [1, 2, 3]
+      call extend(l, [4, 5, 6], 1)
+      call assert_equal([1, 4, 5, 6, 2, 3], l)
 
-  let l = [1, 2, 3]
-  call extend(l, [4, 5, 6], 3)
-  call assert_equal([1, 2, 3, 4, 5, 6], l)
+      LET l = [1, 2, 3]
+      call extend(l, [4, 5, 6], 3)
+      call assert_equal([1, 2, 3, 4, 5, 6], l)
 
-  let l = [1, 2, 3]
-  call extend(l, [4, 5, 6], -1)
-  call assert_equal([1, 2, 4, 5, 6, 3], l)
+      LET l = [1, 2, 3]
+      call extend(l, [4, 5, 6], -1)
+      call assert_equal([1, 2, 4, 5, 6, 3], l)
 
-  let l = [1, 2, 3]
-  call extend(l, [4, 5, 6], -3)
-  call assert_equal([4, 5, 6, 1, 2,  3], l)
+      LET l = [1, 2, 3]
+      call extend(l, [4, 5, 6], -3)
+      call assert_equal([4, 5, 6, 1, 2,  3], l)
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   let l = [1, 2, 3]
   call assert_fails("call extend(l, [4, 5, 6], 4)", 'E684:')
@@ -975,21 +997,24 @@ func Test_listdict_extend()
   " Test extend() with dictionaries.
 
   " Pass the same Dict to extend()
-  let d = { 'a': {'b': 'B'}}
-  call extend(d, d)
-  call assert_equal({'a': {'b': 'B'}}, d)
+  let lines =<< trim END
+      VAR d = {'a': {'b': 'B'}, 'x': 9}
+      call extend(d, d)
+      call assert_equal({'a': {'b': 'B'}, 'x': 9}, d)
 
-  let d = {'a': 'A', 'b': 'B'}
-  call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, extend(d, {'b': 0, 'c':'C'}))
-  call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, d)
+      LET d = {'a': 'A', 'b': 9}
+      call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, extend(d, {'b': 0, 'c': 'C'}))
+      call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, d)
 
-  let d = {'a': 'A', 'b': 'B'}
-  call extend(d, {'a': 'A', 'b': 0, 'c': 'C'}, "force")
-  call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, d)
+      LET d = {'a': 'A', 'b': 9}
+      call extend(d, {'a': 'A', 'b': 0, 'c': 'C'}, "force")
+      call assert_equal({'a': 'A', 'b': 0, 'c': 'C'}, d)
 
-  let d = {'a': 'A', 'b': 'B'}
-  call extend(d, {'b': 0, 'c':'C'}, "keep")
-  call assert_equal({'a': 'A', 'b': 'B', 'c': 'C'}, d)
+      LET d = {'a': 'A', 'b': 9}
+      call extend(d, {'b': 0, 'c': 'C'}, "keep")
+      call assert_equal({'a': 'A', 'b': 9, 'c': 'C'}, d)
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   let d = {'a': 'A', 'b': 'B'}
   call assert_fails("call extend(d, {'b': 0, 'c':'C'}, 'error')", 'E737:')
@@ -1006,18 +1031,21 @@ func Test_listdict_extend()
   call assert_fails("call extend(g:, {'-!' : 10})", 'E461:')
 
   " Extend a list with itself.
-  let l = [1, 5, 7]
-  call extend(l, l, 0)
-  call assert_equal([1, 5, 7, 1, 5, 7], l)
-  let l = [1, 5, 7]
-  call extend(l, l, 1)
-  call assert_equal([1, 1, 5, 7, 5, 7], l)
-  let l = [1, 5, 7]
-  call extend(l, l, 2)
-  call assert_equal([1, 5, 1, 5, 7, 7], l)
-  let l = [1, 5, 7]
-  call extend(l, l, 3)
-  call assert_equal([1, 5, 7, 1, 5, 7], l)
+  let lines =<< trim END
+      VAR l = [1, 5, 7]
+      call extend(l, l, 0)
+      call assert_equal([1, 5, 7, 1, 5, 7], l)
+      LET l = [1, 5, 7]
+      call extend(l, l, 1)
+      call assert_equal([1, 1, 5, 7, 5, 7], l)
+      LET l = [1, 5, 7]
+      call extend(l, l, 2)
+      call assert_equal([1, 5, 1, 5, 7, 7], l)
+      LET l = [1, 5, 7]
+      call extend(l, l, 3)
+      call assert_equal([1, 5, 7, 1, 5, 7], l)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 func Test_listdict_extendnew()
@@ -1216,9 +1244,9 @@ func Test_null_dict()
   call assert_equal({}, d)
   call assert_equal(0, len(d))
   call assert_equal(1, empty(d))
-  call assert_equal(0, items(d))
-  call assert_equal(0, keys(d))
-  call assert_equal(0, values(d))
+  call assert_equal([], items(d))
+  call assert_equal([], keys(d))
+  call assert_equal([], values(d))
   call assert_false(has_key(d, 'k'))
   call assert_equal('{}', string(d))
   call assert_fails('let x = d[10]')

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -60,68 +60,89 @@ endfunc
 
 " List identity
 func Test_list_identity()
-  let l = [1, 'as''d', [1, 2, function("strlen")], {'a': 1},]
-  let ll = l
-  let lx = copy(l)
-  call assert_true(l == ll)
-  call assert_false(l isnot ll)
-  call assert_true(l is ll)
-  call assert_true(l == lx)
-  call assert_false(l is lx)
-  call assert_true(l isnot lx)
+  let lines =<< trim END
+      VAR l = [1, 'as''d', [1, 2, function("strlen")], {'a': 1},]
+      VAR ll = l
+      VAR lx = copy(l)
+      call assert_true(l == ll)
+      call assert_false(l isnot ll)
+      call assert_true(l is ll)
+      call assert_true(l == lx)
+      call assert_false(l is lx)
+      call assert_true(l isnot lx)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " removing items with :unlet
 func Test_list_unlet()
-  let l = [1, 'as''d', [1, 2, function("strlen")], {'a': 1},]
-  unlet l[2]
-  call assert_equal([1, 'as''d', {'a': 1}], l)
-  let l = range(8)
-  unlet l[:3]
-  unlet l[1:]
-  call assert_equal([4], l)
+  let lines =<< trim END
+      VAR l = [1, 'as''d', [1, 2, function("strlen")], {'a': 1},]
+      unlet l[2]
+      call assert_equal([1, 'as''d', {'a': 1}], l)
+      LET l = range(8)
+      unlet l[: 3]
+      unlet l[1 :]
+      call assert_equal([4], l)
 
-  " removing items out of range: silently skip items that don't exist
-  let l = [0, 1, 2, 3]
-  call assert_fails('unlet l[2:1]', 'E684')
+      #" removing items out of range: silently skip items that don't exist
+      LET l = [0, 1, 2, 3]
+      unlet l[2 : 2]
+      call assert_equal([0, 1, 3], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[2 : 3]
+      call assert_equal([0, 1], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[2 : 4]
+      call assert_equal([0, 1], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[2 : 5]
+      call assert_equal([0, 1], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[-2 : 2]
+      call assert_equal([0, 1, 3], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[-3 : 2]
+      call assert_equal([0, 3], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[-4 : 2]
+      call assert_equal([3], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[-5 : 2]
+      call assert_equal([3], l)
+      LET l = [0, 1, 2, 3]
+      unlet l[-6 : 2]
+      call assert_equal([3], l)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let l = [0, 1, 2, 3]
   unlet l[2:2]
   call assert_equal([0, 1, 3], l)
   let l = [0, 1, 2, 3]
   unlet l[2:3]
   call assert_equal([0, 1], l)
+
   let l = [0, 1, 2, 3]
-  unlet l[2:4]
-  call assert_equal([0, 1], l)
+  call assert_fails('unlet l[2:1]', 'E684:')
   let l = [0, 1, 2, 3]
-  unlet l[2:5]
-  call assert_equal([0, 1], l)
-  let l = [0, 1, 2, 3]
-  call assert_fails('unlet l[-1:2]', 'E684')
-  let l = [0, 1, 2, 3]
-  unlet l[-2:2]
-  call assert_equal([0, 1, 3], l)
-  let l = [0, 1, 2, 3]
-  unlet l[-3:2]
-  call assert_equal([0, 3], l)
-  let l = [0, 1, 2, 3]
-  unlet l[-4:2]
-  call assert_equal([3], l)
-  let l = [0, 1, 2, 3]
-  unlet l[-5:2]
-  call assert_equal([3], l)
-  let l = [0, 1, 2, 3]
-  unlet l[-6:2]
-  call assert_equal([3], l)
+  call assert_fails('unlet l[-1:2]', 'E684:')
 endfunc
 
 " assignment to a list
 func Test_list_assign()
+  let lines =<< trim END
+      VAR l = [0, 1, 2, 3]
+      VAR va = 0
+      VAR vb = 0
+      LET [va, vb] = l[2 : 3]
+      call assert_equal([2, 3], [va, vb])
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let l = [0, 1, 2, 3]
-  let [va, vb] = l[2:3]
-  call assert_equal([2, 3], [va, vb])
-  call assert_fails('let [va, vb] = l', 'E687')
-  call assert_fails('let [va, vb] = l[1:1]', 'E688')
+  call assert_fails('let [va, vb] = l', 'E687:')
+  call assert_fails('let [va, vb] = l[1:1]', 'E688:')
 endfunc
 
 " test for range assign
@@ -135,31 +156,34 @@ endfunc
 
 " Test removing items in list
 func Test_list_func_remove()
-  " Test removing 1 element
-  let l = [1, 2, 3, 4]
-  call assert_equal(1, remove(l, 0))
-  call assert_equal([2, 3, 4], l)
+  let lines =<< trim END
+      #" Test removing 1 element
+      VAR l = [1, 2, 3, 4]
+      call assert_equal(1, remove(l, 0))
+      call assert_equal([2, 3, 4], l)
 
-  let l = [1, 2, 3, 4]
-  call assert_equal(2, remove(l, 1))
-  call assert_equal([1, 3, 4], l)
+      LET l = [1, 2, 3, 4]
+      call assert_equal(2, remove(l, 1))
+      call assert_equal([1, 3, 4], l)
 
-  let l = [1, 2, 3, 4]
-  call assert_equal(4, remove(l, -1))
-  call assert_equal([1, 2, 3], l)
+      LET l = [1, 2, 3, 4]
+      call assert_equal(4, remove(l, -1))
+      call assert_equal([1, 2, 3], l)
 
-  " Test removing range of element(s)
-  let l = [1, 2, 3, 4]
-  call assert_equal([3], remove(l, 2, 2))
-  call assert_equal([1, 2, 4], l)
+      #" Test removing range of element(s)
+      LET l = [1, 2, 3, 4]
+      call assert_equal([3], remove(l, 2, 2))
+      call assert_equal([1, 2, 4], l)
 
-  let l = [1, 2, 3, 4]
-  call assert_equal([2, 3], remove(l, 1, 2))
-  call assert_equal([1, 4], l)
+      LET l = [1, 2, 3, 4]
+      call assert_equal([2, 3], remove(l, 1, 2))
+      call assert_equal([1, 4], l)
 
-  let l = [1, 2, 3, 4]
-  call assert_equal([2, 3], remove(l, -3, -2))
-  call assert_equal([1, 4], l)
+      LET l = [1, 2, 3, 4]
+      call assert_equal([2, 3], remove(l, -3, -2))
+      call assert_equal([1, 4], l)
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   " Test invalid cases
   let l = [1, 2, 3, 4]
@@ -172,15 +196,20 @@ endfunc
 
 " List add() function
 func Test_list_add()
-  let l = []
-  call add(l, 1)
-  call add(l, [2, 3])
-  call add(l, [])
-  call add(l, v:_null_list)
-  call add(l, {'k' : 3})
-  call add(l, {})
-  call add(l, v:_null_dict)
-  call assert_equal([1, [2, 3], [], [], {'k' : 3}, {}, {}], l)
+  let lines =<< trim END
+      VAR l = []
+      call add(l, 1)
+      call add(l, [2, 3])
+      call add(l, [])
+      call add(l, v:_null_list)
+      call add(l, {'k': 3})
+      call add(l, {})
+      call add(l, v:_null_dict)
+      call assert_equal([1, [2, 3], [], [], {'k': 3}, {}, {}], l)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  " weird legacy behavior
   " call assert_equal(1, add(v:_null_list, 4))
 endfunc
 
@@ -188,11 +217,21 @@ endfunc
 
 func Test_dict()
   " Creating Dictionary directly with different types
+  let lines =<< trim END
+      VAR d = {'1': 'asd', 'b': [1, 2, function('strlen')], '-1': {'a': 1}, }
+      call assert_equal("{'1': 'asd', 'b': [1, 2, function('strlen')], '-1': {'a': 1}}", string(d))
+      call assert_equal('asd', d.1)
+      call assert_equal(['-1', '1', 'b'], sort(keys(d)))
+      call assert_equal(['asd', [1, 2, function('strlen')], {'a': 1}], values(d))
+      call extend(d, {3: 33, 1: 99})
+      call extend(d, {'b': 'bbb', 'c': 'ccc'}, "keep")
+      call assert_equal({'c': 'ccc', '1': 99, 'b': [1, 2, function('strlen')], '3': 33, '-1': {'a': 1}}, d)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
   let d = {001: 'asd', 'b': [1, 2, function('strlen')], -1: {'a': 1},}
   call assert_equal("{'1': 'asd', 'b': [1, 2, function('strlen')], '-1': {'a': 1}}", string(d))
-  call assert_equal('asd', d.1)
-  call assert_equal(['-1', '1', 'b'], sort(keys(d)))
-  call assert_equal(['asd', [1, 2, function('strlen')], {'a': 1}], values(d))
+
   let v = []
   for [key, val] in items(d)
     call extend(v, [key, val])
@@ -200,12 +239,8 @@ func Test_dict()
   endfor
   call assert_equal(['1','asd','b',[1, 2, function('strlen')],'-1',{'a': 1}], v)
 
-  call extend(d, {3:33, 1:99})
-  call extend(d, {'b':'bbb', 'c':'ccc'}, "keep")
-  call assert_fails("call extend(d, {3:333,4:444}, 'error')", 'E737')
-  call assert_equal({'c': 'ccc', '1': 99, 'b': [1, 2, function('strlen')], '3': 33, '-1': {'a': 1}}, d)
-  call filter(d, 'v:key =~ ''[ac391]''')
-  call assert_equal({'c': 'ccc', '1': 99, '3': 33, '-1': {'a': 1}}, d)
+  call extend(d, {3: 33, 1: 99})
+  call assert_fails("call extend(d, {3:333,4:444}, 'error')", 'E737:')
 
   " duplicate key
   call assert_fails("let d = {'k' : 10, 'k' : 20}", 'E721:')

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -123,10 +123,17 @@ func Test_list_unlet()
   unlet l[2:3]
   call assert_equal([0, 1], l)
 
-  let l = [0, 1, 2, 3]
-  call assert_fails('unlet l[2:1]', 'E684:')
-  let l = [0, 1, 2, 3]
-  call assert_fails('unlet l[-1:2]', 'E684:')
+  let lines =<< trim END
+      VAR l = [0, 1, 2, 3]
+      unlet l[2 : 1]
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E684:')
+
+  let lines =<< trim END
+      VAR l = [0, 1, 2, 3]
+      unlet l[-1 : 2]
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E684:')
 endfunc
 
 " assignment to a list
@@ -140,9 +147,33 @@ func Test_list_assign()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  let l = [0, 1, 2, 3]
-  call assert_fails('let [va, vb] = l', 'E687:')
-  call assert_fails('let [va, vb] = l[1:1]', 'E688:')
+  let lines =<< trim END
+      let l = [0, 1, 2, 3]
+      let [va, vb] = l
+  END
+  call CheckScriptFailure(lines, 'E687:')
+  let lines =<< trim END
+      var l = [0, 1, 2, 3]
+      var va = 0
+      var vb = 0
+      [va, vb] = l
+  END
+  call CheckScriptFailure(['vim9script'] + lines, 'E687:')
+  call CheckDefExecFailure(lines, 'E1093: Expected 2 items but got 4')
+
+  let lines =<< trim END
+      let l = [0, 1, 2, 3]
+      let [va, vb] = l[1:1]
+  END
+  call CheckScriptFailure(lines, 'E688:')
+  let lines =<< trim END
+      var l = [0, 1, 2, 3]
+      var va = 0
+      var vb = 0
+      [va, vb] = l[1 : 1]
+  END
+  call CheckScriptFailure(['vim9script'] + lines, 'E688:')
+  call CheckDefExecFailure(lines, 'E1093: Expected 2 items but got 1')
 endfunc
 
 " test for range assign
@@ -265,23 +296,29 @@ endfunc
 
 " Dictionary identity
 func Test_dict_identity()
-  let d = {001: 'asd', 'b': [1, 2, function('strlen')], -1: {'a': 1},}
-  let dd = d
-  let dx = copy(d)
-  call assert_true(d == dd)
-  call assert_false(d isnot dd)
-  call assert_true(d is dd)
-  call assert_true(d == dx)
-  call assert_false(d is dx)
-  call assert_true(d isnot dx)
+  let lines =<< trim END
+      VAR d = {'1': 'asd', 'b': [1, 2, function('strlen')], -1: {'a': 1}, }
+      VAR dd = d
+      VAR dx = copy(d)
+      call assert_true(d == dd)
+      call assert_false(d isnot dd)
+      call assert_true(d is dd)
+      call assert_true(d == dx)
+      call assert_false(d is dx)
+      call assert_true(d isnot dx)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " removing items with :unlet
 func Test_dict_unlet()
-  let d = {'b':'bbb', '1': 99, '3': 33, '-1': {'a': 1}}
-  unlet d.b
-  unlet d[-1]
-  call assert_equal({'1': 99, '3': 33}, d)
+  let lines =<< trim END
+      VAR d = {'b': 'bbb', '1': 99, '3': 33, '-1': {'a': 1}}
+      unlet d.b
+      unlet d[-1]
+      call assert_equal({'1': 99, '3': 33}, d)
+  END
+  call CheckLegacyAndVim9Success(lines)
 endfunc
 
 " manipulating a big Dictionary (hashtable.c has a border of 1000 entries)
@@ -349,8 +386,30 @@ func Test_dict_assign()
   let d._ = 2
   call assert_equal({'1': 1, '_': 2}, d)
 
-  let n = 0
-  call assert_fails('let n.key = 3', 'E1203: Dot can only be used on a dictionary: n.key = 3')
+  let lines =<< trim END
+      VAR d = {}
+      LET d.a = 1
+      LET d._ = 2
+      call assert_equal({'a': 1, '_': 2}, d)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+    let n = 0
+    let n.key = 3
+  END
+  call CheckScriptFailure(lines, 'E1203: Dot can only be used on a dictionary: n.key = 3')
+  let lines =<< trim END
+    vim9script
+    var n = 0
+    n.key = 3
+  END
+  call CheckScriptFailure(lines, 'E1203: Dot can only be used on a dictionary: n.key = 3')
+  let lines =<< trim END
+    var n = 0
+    n.key = 3
+  END
+  call CheckDefFailure(lines, 'E1141:')
 endfunc
 
 " Function in script-local List or Dict
@@ -367,13 +426,41 @@ endfunc
 
 " Test removing items in a dictionary
 func Test_dict_func_remove()
-  let d = {1:'a', 2:'b', 3:'c'}
-  call assert_equal('b', remove(d, 2))
-  call assert_equal({1:'a', 3:'c'}, d)
+  let lines =<< trim END
+      VAR d = {1: 'a', 2: 'b', 3: 'c'}
+      call assert_equal('b', remove(d, 2))
+      call assert_equal({1: 'a', 3: 'c'}, d)
+  END
+  call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails("call remove(d, 1, 2)", 'E118:')
-  call assert_fails("call remove(d, 'a')", 'E716:')
-  call assert_fails("call remove(d, [])", 'E730:')
+  let lines =<< trim END
+      VAR d = {1: 'a', 3: 'c'}
+      call remove(d, 1, 2)
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E118:')
+
+  let lines =<< trim END
+      VAR d = {1: 'a', 3: 'c'}
+      call remove(d, 'a')
+  END
+  call CheckLegacyAndVim9Failure(lines, 'E716:')
+
+  let lines =<< trim END
+      let d = {1: 'a', 3: 'c'}
+      call remove(d, [])
+  END
+  call CheckScriptFailure(lines, 'E730:')
+  let lines =<< trim END
+      vim9script
+      var d = {1: 'a', 3: 'c'}
+      call remove(d, [])
+  END
+  call CheckScriptFailure(lines, 'E1174: String required for argument 2')
+  let lines =<< trim END
+      var d = {1: 'a', 3: 'c'}
+      call remove(d, [])
+  END
+  call CheckDefExecFailure(lines, 'E1013: Argument 2: type mismatch, expected string but got list<unknown>')
 endfunc
 
 " Nasty: remove func from Dict that's being called (works)
@@ -389,7 +476,7 @@ endfunc
 func Test_dict_literal_keys()
   call assert_equal({'one': 1, 'two2': 2, '3three': 3, '44': 4}, #{one: 1, two2: 2, 3three: 3, 44: 4},)
 
-  " why *{} cannot be used
+  " why *{} cannot be used for a literal dictionary
   let blue = 'blue'
   call assert_equal('6', trim(execute('echo 2 *{blue: 3}.blue')))
 endfunc
@@ -581,15 +668,13 @@ endfunc
 
 " No :unlet after lock on dict:
 func Test_dict_lock_unlet()
-  unlet! d
   let d = {'a': 99, 'b': 100}
   lockvar 1 d
-  call assert_fails('unlet d.a', 'E741')
+  call assert_fails('unlet d.a', 'E741:')
 endfunc
 
 " unlet after lock on dict item
 func Test_dict_item_lock_unlet()
-  unlet! d
   let d = {'a': 99, 'b': 100}
   lockvar d.a
   unlet d.a
@@ -598,7 +683,6 @@ endfunc
 
 " filter() after lock on dict item
 func Test_dict_lock_filter()
-  unlet! d
   let d = {'a': 99, 'b': 100}
   lockvar d.a
   call filter(d, 'v:key != "a"')
@@ -607,7 +691,6 @@ endfunc
 
 " map() after lock on dict
 func Test_dict_lock_map()
-  unlet! d
   let d = {'a': 99, 'b': 100}
   lockvar 1 d
   call map(d, 'v:val + 200')
@@ -616,16 +699,14 @@ endfunc
 
 " No extend() after lock on dict item
 func Test_dict_lock_extend()
-  unlet! d
   let d = {'a': 99, 'b': 100}
   lockvar d.a
-  call assert_fails("call extend(d, {'a' : 123})", 'E741')
+  call assert_fails("call extend(d, {'a' : 123})", 'E741:')
   call assert_equal({'a': 99, 'b': 100}, d)
 endfunc
 
 " Cannot use += with a locked dict
 func Test_dict_lock_operator()
-  unlet! d
   let d = {}
   lockvar d
   call assert_fails("let d += {'k' : 10}", 'E741:')
@@ -634,7 +715,7 @@ endfunc
 
 " No remove() of write-protected scope-level variable
 func Tfunc1(this_is_a_long_parameter_name)
-  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E742')
+  call assert_fails("call remove(a:, 'this_is_a_long_parameter_name')", 'E742:')
 endfunc
 func Test_dict_scope_var_remove()
   call Tfunc1('testval')
@@ -642,10 +723,10 @@ endfunc
 
 " No extend() of write-protected scope-level variable
 func Test_dict_scope_var_extend()
-  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
+  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742:')
 endfunc
 func Tfunc2(this_is_a_long_parameter_name)
-  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742')
+  call assert_fails("call extend(a:, {'this_is_a_long_parameter_name': 1234})", 'E742:')
 endfunc
 func Test_dict_scope_var_extend_overwrite()
   call Tfunc2('testval')
@@ -725,9 +806,6 @@ endfunc
 
 func Test_func_arg_list()
   call s:arg_list_test(1, 2, [3, 4], {5: 6})
-endfunc
-
-func Test_dict_item_locked()
 endfunc
 
 " Tests for reverse(), sort(), uniq()

--- a/test/old/testdir/vim9.vim
+++ b/test/old/testdir/vim9.vim
@@ -2,6 +2,10 @@
 " Use a different file name for each run.
 let s:sequence = 1
 
+func CheckDefFailure(lines, error, lnum = -3)
+  return
+endfunc
+
 func CheckDefExecFailure(lines, error, lnum = -3)
   return
 endfunc


### PR DESCRIPTION
#### vim-patch:8.2.2533: Vim9: cannot use a range with :unlet

Problem:    Vim9: cannot use a range with :unlet.
Solution:   Implement ISN_UNLETRANGE.

https://github.com/vim/vim/commit/5b5ae29bd3d7b832b6f15320430f7f191e0abd1f

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3191: Vim9: not enough code is tested

Problem:    Vim9: not enough code is tested.
Solution:   Use CheckLegacyAndVim9Success() in more places.  Fix uncovered
            problems.

https://github.com/vim/vim/commit/63cb6567f0153c35dc75cbc09039ff5d0a7b60e3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3202: Vim9: tests are only executed for legacy script

Problem:    Vim9: tests are only executed for legacy script.
Solution:   Run more tests also for Vim9 script.  Fix uncovered problems.

https://github.com/vim/vim/commit/5dd839ce20466eea52e59ecf86456f1ab370d2bd

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:partial:8.2.3335: Vim9: not enough tests run with Vim9

Problem:    Vim9: not enough tests run with Vim9.
Solution:   Run a few more tests in Vim9 script and :def function.  Fix that
            items(), keys() and values9) return zero for a NULL dict.
            Make join() return an empty string for a NULL list.  Make sort()
            return an empty list for a NULL list.

https://github.com/vim/vim/commit/ef98257593a0abf1300d0f70358dc45a70a62580

Skip f_reverse() change for consistency with other functions.
Skip Test_null_list() and Test_null_dict() because of missing patches.

Co-authored-by: Bram Moolenaar <Bram@vim.org>