### PR TITLE
vim-patch:8.2.{3852,3853}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -89,20 +89,25 @@
 
 static const char *e_missbrac = N_("E111: Missing ']'");
 static const char *e_list_end = N_("E697: Missing end of List ']': %s");
-static const char *e_cannot_slice_dictionary
+static const char e_cannot_slice_dictionary[]
   = N_("E719: Cannot slice a Dictionary");
 static const char e_cannot_index_special_variable[]
   = N_("E909: Cannot index a special variable");
 static const char *e_nowhitespace
   = N_("E274: No white space allowed before parenthesis");
 static const char *e_write2 = N_("E80: Error while writing: %s");
+static const char e_cannot_index_a_funcref[]
+  = N_("E695: Cannot index a Funcref");
 static const char e_variable_nested_too_deep_for_making_copy[]
   = N_("E698: Variable nested too deep for making a copy");
-static const char *e_string_list_or_blob_required = N_("E1098: String, List or Blob required");
-static const char e_expression_too_recursive_str[] = N_("E1169: Expression too recursive: %s");
+static const char e_string_list_or_blob_required[]
+  = N_("E1098: String, List or Blob required");
+static const char e_expression_too_recursive_str[]
+  = N_("E1169: Expression too recursive: %s");
 static const char e_dot_can_only_be_used_on_dictionary_str[]
   = N_("E1203: Dot can only be used on a dictionary: %s");
-static const char e_empty_function_name[] = N_("E1192: Empty function name");
+static const char e_empty_function_name[]
+  = N_("E1192: Empty function name");
 
 static char * const namespace_char = "abglstvw";
 
@@ -3567,7 +3572,7 @@ static int check_can_index(typval_T *rettv, bool evaluate, bool verbose)
   case VAR_FUNC:
   case VAR_PARTIAL:
     if (verbose) {
-      emsg(_("E695: Cannot index a Funcref"));
+      emsg(_(e_cannot_index_a_funcref));
     }
     return FAIL;
   case VAR_FLOAT:

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1181,30 +1181,27 @@ func Test_listdict_index()
   call CheckLegacyAndVim9Failure(['echo function("min")[0]'], 'E695:')
   call CheckLegacyAndVim9Failure(['echo v:true[0]'], 'E909:')
   call CheckLegacyAndVim9Failure(['echo v:null[0]'], 'E909:')
-
-  let d = {'k' : 10}
-  call assert_fails('echo d.', 'E15:')
-  call CheckDefAndScriptFailure2(['var d = {k: 10}', 'echo d.'], 'E1127', 'E15:')
-
+  call CheckLegacyAndVim9Failure(['VAR d = {"k": 10}', 'echo d.'], ['E15:', 'E1127:', 'E15:'])
   call CheckLegacyAndVim9Failure(['VAR d = {"k": 10}', 'echo d[1 : 2]'], 'E719:')
 
   call assert_fails("let v = [4, 6][{-> 1}]", 'E729:')
-  call CheckDefAndScriptFailure2(['var v = [4, 6][() => 1]'], 'E1012', 'E703:')
+  call CheckDefAndScriptFailure(['var v = [4, 6][() => 1]'], ['E1012', 'E703:'])
 
-  call assert_fails("let v = range(5)[2:[]]", 'E730:')
+  call CheckLegacyAndVim9Failure(['VAR v = range(5)[2 : []]'], ['E730:', 'E1012:', 'E730:'])
+
   call assert_fails("let v = range(5)[2:{-> 2}(]", ['E15:', 'E116:'])
-  call assert_fails("let v = range(5)[2:3", 'E111:')
-  call assert_fails("let l = insert([1,2,3], 4, 10)", 'E684:')
-  call assert_fails("let l = insert([1,2,3], 4, -10)", 'E684:')
-  call assert_fails("let l = insert([1,2,3], 4, [])", 'E745:')
-  let l = [1, 2, 3]
-  call assert_fails("let l[i] = 3", 'E121:')
-  call assert_fails("let l[1.1] = 4", 'E805:')
-  call assert_fails("let l[:i] = [4, 5]", 'E121:')
-  call assert_fails("let l[:3.2] = [4, 5]", 'E805:')
-  " Nvim doesn't have test_unknown()
-  " let t = test_unknown()
-  " call assert_fails("echo t[0]", 'E685:')
+  call CheckDefAndScriptFailure(['var v = range(5)[2 : () => 2(]'], 'E15:')
+
+  call CheckLegacyAndVim9Failure(['VAR v = range(5)[2 : 3'], ['E111:', 'E1097:', 'E111:'])
+  call CheckLegacyAndVim9Failure(['VAR l = insert([1, 2, 3], 4, 10)'], 'E684:')
+  call CheckLegacyAndVim9Failure(['VAR l = insert([1, 2, 3], 4, -10)'], 'E684:')
+  call CheckLegacyAndVim9Failure(['VAR l = insert([1, 2, 3], 4, [])'], ['E745:', 'E1013:', 'E1210:'])
+
+  call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[i] = 3'], ['E121:', 'E1001:', 'E121:'])
+  call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[1.1] = 4'], ['E805:', 'E1012:', 'E805:'])
+  call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[: i] = [4, 5]'], ['E121:', 'E1001:', 'E121:'])
+  call CheckLegacyAndVim9Failure(['VAR l = [1, 2, 3]', 'LET l[: 3.2] = [4, 5]'], ['E805:', 'E1012:', 'E805:'])
+  " call CheckLegacyAndVim9Failure(['VAR t = test_unknown()', 'echo t[0]'], 'E685:')
 endfunc
 
 " Test for a null list

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1178,12 +1178,19 @@ endfunc
 
 " List and dict indexing tests
 func Test_listdict_index()
-  call assert_fails('echo function("min")[0]', 'E695:')
-  call assert_fails('echo v:true[0]', 'E909:')
+  call CheckLegacyAndVim9Failure(['echo function("min")[0]'], 'E695:')
+  call CheckLegacyAndVim9Failure(['echo v:true[0]'], 'E909:')
+  call CheckLegacyAndVim9Failure(['echo v:null[0]'], 'E909:')
+
   let d = {'k' : 10}
   call assert_fails('echo d.', 'E15:')
-  call assert_fails('echo d[1:2]', 'E719:')
+  call CheckDefAndScriptFailure2(['var d = {k: 10}', 'echo d.'], 'E1127', 'E15:')
+
+  call CheckLegacyAndVim9Failure(['VAR d = {"k": 10}', 'echo d[1 : 2]'], 'E719:')
+
   call assert_fails("let v = [4, 6][{-> 1}]", 'E729:')
+  call CheckDefAndScriptFailure2(['var v = [4, 6][() => 1]'], 'E1012', 'E703:')
+
   call assert_fails("let v = range(5)[2:[]]", 'E730:')
   call assert_fails("let v = range(5)[2:{-> 2}(]", ['E15:', 'E116:'])
   call assert_fails("let v = range(5)[2:3", 'E111:')


### PR DESCRIPTION
#### vim-patch:8.2.3852: Vim9: not enough tests

Problem:    Vim9: not enough tests.
Solution:   Also run existing tests for Vim9 script.  Make errors more
            consistent.

https://github.com/vim/vim/commit/f47c5a8e2d8eda7c2c8a9cccf9568eb56c03a0cf

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3853: Vim9: not enough tests

Problem:    Vim9: not enough tests.
Solution:   Run more existing tests for Vim9 script.

https://github.com/vim/vim/commit/700e6b166298ecfb53fe4bf593085b29ca78d556

Cherry-pick test_listdict.vim change from patch 8.2.3854.

Co-authored-by: Bram Moolenaar <Bram@vim.org>