### PR TITLE
vim-patch:8.2.4600: Vim9: not enough test coverage for executing :def function

### DIFF
--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -657,10 +657,14 @@ func Test_list_locked_var_unlet()
       call assert_equal(expected[depth][u][1], ps)
     endfor
   endfor
-  " Deleting a list range should fail if the range is locked
+
+  " Deleting a list range with locked items works, but changing the items
+  " fails.
   let l = [1, 2, 3, 4]
   lockvar l[1:2]
-  call assert_fails('unlet l[1:2]', 'E741:')
+  call assert_fails('let l[1:2] = [8, 9]', 'E741:')
+  unlet l[1:2]
+  call assert_equal([1, 4], l)
   unlet l
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.4600: Vim9: not enough test coverage for executing :def function

Problem:    Vim9: not enough test coverage for executing :def function.
Solution:   Add a few more tests.  Fix inconsistencies.

https://github.com/vim/vim/commit/6b8c7ba062ca4b50e8f983e0485be7afa4eef691

Cherry-pick a blank line in test_listdict.vim from patch 8.2.3842.

Co-authored-by: Bram Moolenaar <Bram@vim.org>