### PR TITLE
fix(api): redundant error when using `nvim_cmd`

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1690,7 +1690,7 @@ int execute_cmd(exarg_T *eap, CmdParseInfo *cmdinfo, bool preview)
       && !(eap->cmdidx == CMD_file && *eap->arg == NUL)
       && !IS_USER_CMDIDX(eap->cmdidx)
       && curbuf_locked()) {
-    ERROR(_(e_cannot_edit_other_buf));
+    goto end;
   }
 
   correct_range(eap);


### PR DESCRIPTION
`nvim_cmd` shows multiple errors when attempting to edit another buffer through a command when `curbuf->b_ro_locked` is set. This PR fixes that by removing a redundant error in `execute_cmd`.