### PR TITLE
vim-patch:9.0.1632: not all cabal config files are recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1809,6 +1809,8 @@ local pattern = {
   ['bzr_log%..*'] = 'bzr',
   ['.*enlightenment/.*%.cfg'] = 'c',
   ['${HOME}/cabal%.config'] = 'cabalconfig',
+  ['${HOME}/%.config/cabal/config'] = 'cabalconfig',
+  ['${XDG_CONFIG_HOME}/cabal/config'] = 'cabalconfig',
   ['cabal%.project%..*'] = starsetf('cabalproject'),
   ['.*/%.calendar/.*'] = starsetf('calendar'),
   ['.*/share/calendar/.*/calendar%..*'] = starsetf('calendar'),
@@ -2490,7 +2492,7 @@ local function match_pattern(name, path, tail, pat)
         return_early = true
         return nil
       end
-      return vim.env[env]
+      return vim.pesc(vim.env[env])
     end)
     if return_early then
       return false


### PR DESCRIPTION
#### vim-patch:9.0.1632: not all cabal config files are recognized

Problem:    Not all cabal config files are recognized.
Solution:   Add a couple of patterns. (Marcin Szamotulski, closes vim/vim#12463)

https://github.com/vim/vim/commit/166cd7b801ebe4aa042a9bbd6007d1951800aaa9

Co-authored-by: Marcin Szamotulski <coot@coot.me>