### PR TITLE
feat(api): add `delete` option for `nvim_buf_delete()`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2162,7 +2162,9 @@ nvim_buf_delete({buffer}, {opts})                          *nvim_buf_delete()*
       • {buffer}  Buffer handle, or 0 for current buffer
       • {opts}    Optional parameters. Keys:
                   • force: Force deletion and ignore unsaved changes.
-                  • unload: Unloaded only, do not delete. See |:bunload|
+                  • unload: Unload only, do not delete. See |:bunload|
+                  • delete: Delete buffer only, do not wipe it out. See
+                    |:bdelete|
 
 nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
     Deactivates buffer-update events on the channel.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -91,6 +91,9 @@ The following new APIs or features were added.
 
 • Added |lsp-handler| for inlay hints: `textDocument/inlayHint` and
   `workspace/inlayHint/refresh`
+
+• |nvim_buf_delete()| now supports a `delete` option to simulate the behavior
+  of |:bdelete|
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -776,12 +776,26 @@ describe('api/buf', function()
     end)
 
     it('allows for just unloading', function()
-      nvim('command', 'new')
+      -- A named buffer is required since Nvim automatically deletes unnamed buffers, even when
+      -- asked to unload.
+      nvim('command', 'new | e foo.txt')
       local b = nvim('get_current_buf')
       ok(buffer('is_valid', b))
       nvim('buf_delete', b, { unload = true })
       ok(not buffer('is_loaded', b))
       ok(buffer('is_valid', b))
+      ok(nvim('get_option_value', 'buflisted', { buf = b }))
+    end)
+
+    it('allows deletion without wipeout', function()
+      -- Named buffer is required for the same reason as above.
+      nvim('command', 'new | e foo.txt')
+      local b = nvim('get_current_buf')
+      ok(buffer('is_valid', b))
+      nvim('buf_delete', b, { delete = true })
+      ok(not buffer('is_loaded', b))
+      ok(buffer('is_valid', b))
+      ok(not nvim('get_option_value', 'buflisted', { buf = b }))
     end)
   end)
 


### PR DESCRIPTION
Previously it was impossible to replicate the behavior of `:bdelete` with `nvim_buf_delete()`. The closest you could get would be to use `nvim_buf_delete()` with `unload = true` and then manually set `buflisted = false` for the buffer. But even then it would not be a perfect replication because `:bdelete` deletes some information for the buffer which unloading the buffer does not do. This PR adds a `delete` option which replicates the behavior of `:bdelete`.