### PR TITLE
vim-patch:9.0.{1634,1635}: message is cleared when removing mode message

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1562,7 +1562,7 @@ int msg_outtrans_len_attr(const char *msgstr, int len, int attr)
 
   // When drawing over the command line no need to clear it later or remove
   // the mode message.
-  if (msg_row == cmdline_row && msg_col == 0) {
+  if (msg_row >= cmdline_row && msg_col == 0) {
     clear_cmdline = false;
     mode_displayed = false;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1560,6 +1560,13 @@ int msg_outtrans_len_attr(const char *msgstr, int len, int attr)
     attr &= ~MSG_HIST;
   }
 
+  // When drawing over the command line no need to clear it later or remove
+  // the mode message.
+  if (msg_row == cmdline_row && msg_col == 0) {
+    clear_cmdline = false;
+    mode_displayed = false;
+  }
+
   // If the string starts with a composing character first draw a space on
   // which the composing char can be drawn.
   if (utf_iscomposing(utf_ptr2char(msgstr))) {

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -54,6 +54,7 @@ describe('messages', function()
     screen = Screen.new(60, 10)
     screen:set_default_attr_ids({
       [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+      [1] = {background = Screen.colors.Red, foreground = Screen.colors.White},  -- ErrorMsg
     })
     screen:attach()
     exec([[
@@ -64,13 +65,13 @@ describe('messages', function()
       endfunction
       set showmode
       set cmdheight=1
-      call setline(1, ['one', 'two', 'three'])
+      call setline(1, ['one', 'NoSuchFile', 'three'])
     ]])
 
     feed('gx')
     screen:expect([[
       ^one                                                         |
-      two                                                         |
+      NoSuchFile                                                  |
       three                                                       |
       {0:~                                                           }|
       {0:~                                                           }|
@@ -85,7 +86,7 @@ describe('messages', function()
     feed('vEgx')
     screen:expect([[
       ^one                                                         |
-      two                                                         |
+      NoSuchFile                                                  |
       three                                                       |
       {0:~                                                           }|
       {0:~                                                           }|
@@ -94,6 +95,22 @@ describe('messages', function()
       {0:~                                                           }|
       {0:~                                                           }|
       from DebugSilent visual                                     |
+    ]])
+
+    -- removing the mode message used to also clear the error message
+    command('set cmdheight=2')
+    feed('2GvEgf')
+    screen:expect([[
+      one                                                         |
+      NoSuchFil^e                                                  |
+      three                                                       |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      from DebugSilent visual                                     |
+      {1:E447: Can't find file "NoSuchFile" in path}                  |
     ]])
   end)
 

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -49,6 +49,54 @@ describe('messages', function()
     ]])
   end)
 
+  -- oldtest: Test_message_not_cleared_after_mode()
+  it('clearing mode does not remove message', function()
+    screen = Screen.new(60, 10)
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    })
+    screen:attach()
+    exec([[
+      nmap <silent> gx :call DebugSilent('normal')<CR>
+      vmap <silent> gx :call DebugSilent('visual')<CR>
+      function DebugSilent(arg)
+          echomsg "from DebugSilent" a:arg
+      endfunction
+      set showmode
+      set cmdheight=1
+      call setline(1, ['one', 'two', 'three'])
+    ]])
+
+    feed('gx')
+    screen:expect([[
+      ^one                                                         |
+      two                                                         |
+      three                                                       |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      from DebugSilent normal                                     |
+    ]])
+
+    -- removing the mode message used to also clear the intended message
+    feed('vEgx')
+    screen:expect([[
+      ^one                                                         |
+      two                                                         |
+      three                                                       |
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      {0:~                                                           }|
+      from DebugSilent visual                                     |
+    ]])
+  end)
+
   describe('more prompt', function()
     before_each(function()
       command('set more')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2475,7 +2475,7 @@ describe("TUI as a client", function()
 
     -- grid smaller than containing terminal window is cleared properly
     feed_data(":call setline(1,['a'->repeat(&columns)]->repeat(&lines))\n")
-    feed_data("0:set lines=2\n")
+    feed_data("0:set lines=3\n")
     screen_server:expect{grid=[[
       {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {5:[No Name] [+]                                     }|

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -341,6 +341,34 @@ func Test_message_more_scrollback()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_message_not_cleared_after_mode()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      nmap <silent> gx :call DebugSilent('normal')<CR>
+      vmap <silent> gx :call DebugSilent('visual')<CR>
+      function DebugSilent(arg)
+          echomsg "from DebugSilent" a:arg
+      endfunction
+      set showmode
+      set cmdheight=1
+      call setline(1, ['one', 'two', 'three'])
+  END
+  call writefile(lines, 'XmessageMode', 'D')
+  let buf = RunVimInTerminal('-S XmessageMode', {'rows': 10})
+
+  call term_sendkeys(buf, 'gx')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_message_not_cleared_after_mode_1', {})
+
+  " removing the mode message used to also clear the intended message
+  call term_sendkeys(buf, 'vEgx')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_message_not_cleared_after_mode_2', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test verbose message before echo command
 func Test_echo_verbose_system()
   CheckRunVimInTerminal

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -352,7 +352,8 @@ func Test_message_not_cleared_after_mode()
       endfunction
       set showmode
       set cmdheight=1
-      call setline(1, ['one', 'two', 'three'])
+      call test_settime(1)
+      call setline(1, ['one', 'NoSuchFile', 'three'])
   END
   call writefile(lines, 'XmessageMode', 'D')
   let buf = RunVimInTerminal('-S XmessageMode', {'rows': 10})
@@ -365,6 +366,12 @@ func Test_message_not_cleared_after_mode()
   call term_sendkeys(buf, 'vEgx')
   call TermWait(buf)
   call VerifyScreenDump(buf, 'Test_message_not_cleared_after_mode_2', {})
+
+  " removing the mode message used to also clear the error message
+  call term_sendkeys(buf, ":set cmdheight=2\<CR>")
+  call term_sendkeys(buf, '2GvEgf')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_message_not_cleared_after_mode_3', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1634: message is cleared when removing mode message

Problem:    Message is cleared when removing mode message (Gary Johnson).
Solution:   Do not clear the command line after displaying a message.

https://github.com/vim/vim/commit/800cdbb7caeb5dd4379c6cb071bb12391f20bcf3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1635: error message is cleared when removing mode message

Problem:    Error message is cleared when removing mode message.
Solution:   Also reset flags when the message is further down.

https://github.com/vim/vim/commit/da51ad51bf4fbd66619786d0e6a83fb3ca09930b

Co-authored-by: Bram Moolenaar <Bram@vim.org>