### PR TITLE
vim-patch:9.0.1637: compiler warning for uninitialized variable

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3618,7 +3618,7 @@ bool match_file_list(char *list, char *sfname, char *ffname)
   // try all patterns in 'wildignore'
   char *p = list;
   while (*p) {
-    char buf[100];
+    char buf[MAXPATHL];
     copy_option_part(&p, buf, ARRAY_SIZE(buf), ",");
     char allow_dirs;
     char *regpat = file_pat_to_reg_pat(buf, NULL, &allow_dirs, false);


### PR DESCRIPTION
#### vim-patch:9.0.1637: compiler warning for uninitialized variable

Problem:    Compiler warning for uninitialized variable.
Solution:   Move the variable to an inner block and initialize it. (Christian
            Brabandt, closes vim/vim#12549)

https://github.com/vim/vim/commit/54f50cbf6a470316a262e4389d62424e6f06b81c

The "eof" variable is not present in Nvim because it is only used by
FEAT_CRYPT.

Co-authored-by: Christian Brabandt <cb@256bit.org>