### PR TITLE
fix(lsp): lint warnings, default offset_encoding

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1071,8 +1071,11 @@ add_workspace_folder({workspace_folder})
     Add the folder at path to the workspace folders. If {path} is not
     provided, the user will be prompted for a path using |input()|.
 
-clear_references()                            *vim.lsp.buf.clear_references()*
+clear_references({bufnr})                     *vim.lsp.buf.clear_references()*
     Removes document highlights from current buffer.
+
+    Parameters: ~
+      • {bufnr}  integer|nil
 
 code_action({options})                             *vim.lsp.buf.code_action()*
     Selects a code action available at the current cursor position.
@@ -1587,12 +1590,12 @@ character_offset({buf}, {row}, {col}, {offset_encoding})
       • {buf}              (integer) buffer number (0 for current)
       • {row}              0-indexed line
       • {col}              0-indexed byte offset in line
-      • {offset_encoding}  (string) utf-8|utf-16|utf-32|nil defaults to
+      • {offset_encoding}  (string) utf-8|utf-16|utf-32 defaults to
                            `offset_encoding` of first client of `buf`
 
     Return: ~
-        (integer, integer) `offset_encoding` index of the character in line
-        {row} column {col} in buffer {buf}
+        (integer) `offset_encoding` index of the character in line {row}
+        column {col} in buffer {buf}
 
                               *vim.lsp.util.convert_input_to_markdown_lines()*
 convert_input_to_markdown_lines({input}, {contents})
@@ -1607,7 +1610,7 @@ convert_input_to_markdown_lines({input}, {contents})
                     lines. Defaults to {}.
 
     Return: ~
-        {contents}, extended with lines of converted markdown.
+        (table) {contents} extended with lines of converted markdown.
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
@@ -1617,14 +1620,15 @@ convert_signature_help_to_markdown_lines({signature_help}, {ft}, {triggers})
     Converts `textDocument/SignatureHelp` response to markdown lines.
 
     Parameters: ~
-      • {signature_help}  Response of `textDocument/SignatureHelp`
-      • {ft}              optional filetype that will be use as the `lang` for
-                          the label markdown code block
-      • {triggers}        optional list of trigger characters from the lsp
+      • {signature_help}  (table) Response of `textDocument/SignatureHelp`
+      • {ft}              (string|nil) filetype that will be use as the `lang`
+                          for the label markdown code block
+      • {triggers}        (table|nil) list of trigger characters from the lsp
                           server. used to better determine parameter offsets
 
     Return: ~
-        (list) of lines of converted markdown.
+        (table|nil) table list of lines of converted markdown.
+        (table|nil) table of active hl
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
@@ -1660,7 +1664,7 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
+      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32
       • {reuse_win}        (boolean|nil) Jump to existing window if buffer is
                            already open.
 
@@ -1678,7 +1682,8 @@ locations_to_items({locations}, {offset_encoding})
     Parameters: ~
       • {locations}        (table) list of `Location`s or `LocationLink`s
       • {offset_encoding}  (string) offset_encoding for locations
-                           utf-8|utf-16|utf-32
+                           utf-8|utf-16|utf-32 default to first client of
+                           buffer
 
     Return: ~
         (table) list of items
@@ -1687,11 +1692,11 @@ lookup_section({settings}, {section})          *vim.lsp.util.lookup_section()*
     Helper function to return nested values in language server settings
 
     Parameters: ~
-      • {settings}  a table of language server settings
-      • {section}   a string indicating the field of the settings table
+      • {settings}  (table) language server settings
+      • {section}   string indicating the field of the settings table
 
     Return: ~
-        (table or string) The value of settings accessed via section
+        table|string The value of settings accessed via section
 
                                   *vim.lsp.util.make_floating_popup_options()*
 make_floating_popup_options({width}, {height}, {opts})
@@ -1701,7 +1706,7 @@ make_floating_popup_options({width}, {height}, {opts})
     Parameters: ~
       • {width}   (integer) window width (in character cells)
       • {height}  (integer) window height (in character cells)
-      • {opts}    (table, optional)
+      • {opts}    (table) optional
                   • offset_x (integer) offset to add to `col`
                   • offset_y (integer) offset to add to `row`
                   • border (string or table) override `border`
@@ -1742,8 +1747,8 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
                            `offset_encoding` of first client of `bufnr`
 
     Return: ~
-        { textDocument = { uri = `current_file_uri` }, range = { start =
-        `start_position`, end = `end_position` } }
+        (table) { textDocument = { uri = `current_file_uri` }, range = { start
+        = `start_position`, end = `end_position` } }
 
                                          *vim.lsp.util.make_position_params()*
 make_position_params({window}, {offset_encoding})
@@ -1758,7 +1763,7 @@ make_position_params({window}, {offset_encoding})
                            `window`
 
     Return: ~
-        `TextDocumentPositionParams` object
+        (table) `TextDocumentPositionParams` object
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
@@ -1778,8 +1783,8 @@ make_range_params({window}, {offset_encoding})
                            `window`
 
     Return: ~
-        { textDocument = { uri = `current_file_uri` }, range = { start =
-        `current_position`, end = `current_position` } }
+        (table) { textDocument = { uri = `current_file_uri` }, range = { start
+        = `current_position`, end = `current_position` } }
 
                                     *vim.lsp.util.make_text_document_params()*
 make_text_document_params({bufnr})
@@ -1789,7 +1794,7 @@ make_text_document_params({bufnr})
       • {bufnr}  (integer|nil) Buffer handle, defaults to current
 
     Return: ~
-        `TextDocumentIdentifier`
+        (table) `TextDocumentIdentifier`
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier
@@ -1799,8 +1804,8 @@ make_workspace_params({added}, {removed})
     Create the workspace params
 
     Parameters: ~
-      • {added}    
-      • {removed}
+      • {added}    (table)
+      • {removed}  (table)
 
                                         *vim.lsp.util.open_floating_preview()*
 open_floating_preview({contents}, {syntax}, {opts})
@@ -1832,8 +1837,8 @@ open_floating_preview({contents}, {syntax}, {opts})
                       window with the same {focus_id}
 
     Return: ~
-        bufnr,winnr buffer and window number of the newly created floating
-        preview window
+        (integer) bufnr of newly created float window
+        (integer) winid of newly created float window preview window
 
 parse_snippet({input})                          *vim.lsp.util.parse_snippet()*
     Parses snippets in a completion entry.
@@ -1853,10 +1858,11 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
       definition)
 
     Parameters: ~
-      • {location}  a single `Location` or `LocationLink`
+      • {location}  (table) a single `Location` or `LocationLink`
 
     Return: ~
-        (bufnr,winnr) buffer and window number of floating window or nil
+        (integer|nil) buffer id of float window
+        (integer|nil) window id of float window
 
 rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Rename old_fname to new_fname
@@ -1873,7 +1879,7 @@ set_lines({lines}, {A}, {B}, {new_lines})           *vim.lsp.util.set_lines()*
       • {lines}      (table) Original list of strings
       • {A}          (table) Start position; a 2-tuple of {line,col} numbers
       • {B}          (table) End position; a 2-tuple of {line,col} numbers
-      • {new_lines}  A list of strings to replace the original
+      • {new_lines}  (table) list of strings to replace the original
 
     Return: ~
         (table) The modified {lines} object
@@ -1884,7 +1890,7 @@ show_document({location}, {offset_encoding}, {opts})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  "utf-8" | "utf-16" | "utf-32"
+      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32
       • {opts}             (table|nil) options
                            • reuse_win (boolean) Jump to existing window if
                              buffer is already open.
@@ -1908,7 +1914,7 @@ stylize_markdown({bufnr}, {contents}, {opts})
 
     Parameters: ~
       • {contents}  (table) of lines to show in window
-      • {opts}      dictionary with optional fields
+      • {opts}      (table) with optional fields
                     • height of floating window
                     • width of floating window
                     • wrap_at character to wrap at for computing height
@@ -1919,13 +1925,13 @@ stylize_markdown({bufnr}, {contents}, {opts})
                     • separator insert separator after code block
 
     Return: ~
-        width,height size of float
+        (table) stripped content
 
 symbols_to_items({symbols}, {bufnr})         *vim.lsp.util.symbols_to_items()*
     Converts symbols to quickfix list items.
 
     Parameters: ~
-      • {symbols}  DocumentSymbol[] or SymbolInformation[]
+      • {symbols}  (table) DocumentSymbol[] or SymbolInformation[]
 
               *vim.lsp.util.text_document_completion_list_to_complete_items()*
 text_document_completion_list_to_complete_items({result}, {prefix})
@@ -1933,16 +1939,16 @@ text_document_completion_list_to_complete_items({result}, {prefix})
     vim-compatible |complete-items|.
 
     Parameters: ~
-      • {result}  The result of a `textDocument/completion` call, e.g. from
-                  |vim.lsp.buf.completion()|, which may be one of
+      • {result}  (table) The result of a `textDocument/completion` call, e.g.
+                  from |vim.lsp.buf.completion()|, which may be one of
                   `CompletionItem[]`, `CompletionList` or `null`
       • {prefix}  (string) the prefix to filter the completion items
 
     Return: ~
-        { matches = complete-items table, incomplete = bool }
+        (table) { matches = complete-items table, incomplete = bool }
 
     See also: ~
-      • |complete-items|
+      • complete-items
 
 trim_empty_lines({lines})                    *vim.lsp.util.trim_empty_lines()*
     Removes empty lines from the beginning and end.
@@ -1980,7 +1986,7 @@ get_level()                                          *vim.lsp.log.get_level()*
     Gets the current log level.
 
     Return: ~
-        (string) current log level
+        (integer) current log level
 
 set_format_func({handle})                      *vim.lsp.log.set_format_func()*
     Sets formatting function used to format logs
@@ -2117,6 +2123,6 @@ resolve_capabilities({server_capabilities})
                                server
 
     Return: ~
-        (table) Normalized table of capabilities
+        (table|nil) Normalized table of capabilities
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -581,9 +581,9 @@ function M.document_highlight()
 end
 
 --- Removes document highlights from current buffer.
----
-function M.clear_references()
-  util.buf_clear_references()
+--- @param bufnr integer|nil
+function M.clear_references(bufnr)
+  util.buf_clear_references(bufnr or 0)
 end
 
 ---@private

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -33,11 +33,9 @@ local function execute_lens(lens, bufnr, client_id)
 
   local client = vim.lsp.get_client_by_id(client_id)
   assert(client, 'Client is required to execute lens, client_id=' .. client_id)
-
   client._exec_cmd(lens.command, { bufnr = bufnr }, function(...)
-    local result = vim.lsp.handlers['workspace/executeCommand'](...)
+    vim.lsp.handlers['workspace/executeCommand'](...)
     M.refresh()
-    return result
   end)
 end
 

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -154,7 +154,7 @@ function log.set_level(level)
 end
 
 --- Gets the current log level.
----@return string current log level
+---@return integer current log level
 function log.get_level()
   return current_log_level
 end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -880,7 +880,7 @@ end
 
 --- Creates a normalized object describing LSP server capabilities.
 ---@param server_capabilities table Table of capabilities supported by the server
----@return table Normalized table of capabilities
+---@return table|nil Normalized table of capabilities
 function protocol.resolve_capabilities(server_capabilities)
   local TextDocumentSyncKind = protocol.TextDocumentSyncKind
   local textDocumentSync = server_capabilities.textDocumentSync
@@ -898,7 +898,8 @@ function protocol.resolve_capabilities(server_capabilities)
   elseif type(textDocumentSync) == 'number' then
     -- Backwards compatibility
     if not TextDocumentSyncKind[textDocumentSync] then
-      return nil, 'Invalid server TextDocumentSyncKind for textDocumentSync'
+      vim.notify('Invalid server TextDocumentSyncKind for textDocumentSync', vim.log.levels.ERROR)
+      return nil
     end
     server_capabilities.textDocumentSync = {
       openClose = true,
@@ -910,7 +911,11 @@ function protocol.resolve_capabilities(server_capabilities)
       },
     }
   elseif type(textDocumentSync) ~= 'table' then
-    return nil, string.format('Invalid type for textDocumentSync: %q', type(textDocumentSync))
+    vim.notify(
+      string.format('Invalid type for textDocumentSync: %q', type(textDocumentSync)),
+      vim.log.levels.ERROR
+    )
+    return nil
   end
   return server_capabilities
 end

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -36,7 +36,7 @@ end
 local function parse_headers(header)
   assert(type(header) == 'string', 'header must be a string')
   local headers = {}
-  for line in vim.gsplit(header, '\r\n', true) do
+  for line in vim.gsplit(header, '\r\n', { plain = true }) do
     if line == '' then
       break
     end


### PR DESCRIPTION
- fix lint / analysis warnings
- locations_to_items(): get default offset_encoding from active client
- character_offset(): get default offset_encoding from active client