### PR TITLE
fix(fs): make `normalize()` work with '/' path

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -348,9 +348,7 @@ function M.normalize(path, opts)
     path = path:gsub('%$([%w_]+)', vim.uv.os_getenv)
   end
 
-  path = path:gsub('\\', '/'):gsub('/+', '/')
-
-  return path:sub(-1) == '/' and path:sub(1, -2) or path
+  return (path:gsub('\\', '/'):gsub('/+', '/'):gsub('(.)/$', '%1'))
 end
 
 return M

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -281,6 +281,12 @@ describe('vim.fs', function()
     it('works with backward slashes', function()
       eq('C:/Users/jdoe', exec_lua [[ return vim.fs.normalize('C:\\Users\\jdoe') ]])
     end)
+    it('removes trailing /', function()
+      eq('/home/user', exec_lua [[ return vim.fs.normalize('/home/user/') ]])
+    end)
+    it('works with /', function()
+      eq('/', exec_lua [[ return vim.fs.normalize('/') ]])
+    end)
     it('works with ~', function()
       eq( exec_lua([[
       local home = ...


### PR DESCRIPTION
Problem: Current implementation of "remove trailing /" doesn't account for the case of literal '/' as path.
Solution: Remove trailing / only if it preceded by something else.