### PR TITLE
feature: add match for branches and HEAD in Git syntax

### DIFF
--- a/runtime/syntax/git.vim
+++ b/runtime/syntax/git.vim
@@ -81,6 +81,8 @@ syn match  gitHashAbbrev /\<\x\{4,\}\>/             contained nextgroup=gitHashA
 syn match  gitHashAbbrev /\<\x\{4,39\}\.\.\./he=e-3 contained nextgroup=gitHashAbbrev skipwhite contains=@NoSpell
 syn match  gitHashStage /\<\x\{4,\}\>/              contained nextgroup=gitStage skipwhite contains=@NoSpell
 syn match  gitStage     /\<\d\t\@=/                 contained contains=@NoSpell
+syn match gitHEAD /HEAD ->/
+syn match gitBranch /(.*)/ contains=gitHEAD contains=gitHashAbbrev
 
 
 syn match  gitNotesHeader /^Notes:\ze\n    /
@@ -107,5 +109,7 @@ hi def link gitStage             gitType
 hi def link gitType              Type
 hi def link gitDiffAdded         diffAdded
 hi def link gitDiffRemoved       diffRemoved
+hi def link gitBranch            String
+hi def link gitHEAD              Special
 
 let b:current_syntax = "git"

--- a/runtime/syntax/git.vim
+++ b/runtime/syntax/git.vim
@@ -82,7 +82,7 @@ syn match  gitHashAbbrev /\<\x\{4,39\}\.\.\./he=e-3 contained nextgroup=gitHashA
 syn match  gitHashStage /\<\x\{4,\}\>/              contained nextgroup=gitStage skipwhite contains=@NoSpell
 syn match  gitStage     /\<\d\t\@=/                 contained contains=@NoSpell
 syn match gitHEAD /HEAD ->/
-syn match gitBranch /(.*)/ contains=gitHEAD contains=gitHashAbbrev
+syn match gitBranch / (.\{-}) / contains=gitHEAD contains=gitHashAbbrev
 
 
 syn match  gitNotesHeader /^Notes:\ze\n    /


### PR DESCRIPTION
related to 
- https://github.com/tpope/vim-fugitive/issues/2150

## description
when i run commands like `git log --graph --oneline --decorate` or [my `git tr` aliases](https://github.com/goatfiles/dotfiles/blob/4a111d9/.config/git/config#L67-L73) with `vim-fugitive` the colors do not look right... (see issue linked above for screenshots to see the *missing* colors).

by tinkering the source of *neovim*, i found where this appears to happen the [Git syntax file](https://github.com/neovim/neovim/blob/c07dceba3/runtime/syntax/git.vim) :smirk: 

in this PR, i add two *rules* to the syntax file of Git
- `gitHEAD` which matches `HEAD ->` to highlight the *HEAD* of a worktree
- `gitBranch` which matches non-greedily anything in between parentheses, namely the branches in a `git log --oneline --decorate`

### missing items
- proper distinctions between remote and local branches
- highlighting graph edges

it's not as "*perfect*" as `git log` in the terminal, but i hope you will like this :blush: 
please feel very free to ask for changes if i'm missing anything, i'd be happy to tweak this PR :yum: 

## the results
let's take an example of the worktree i saw for this PR, i.e. the PR branch just on top of `master`

> **Note**
> the following points do not have anything to do with the current PR :relieved: 
> - the cursor changes the color of the line it's on, e.g. the second line in the first image
> - the 80th and 81th columns are hightlighted in my config
> - the red characters are just trailing whitespaces i hightlight for convenience

### before the PR
![neovim-pr-before](https://github.com/neovim/neovim/assets/44101798/fca06d92-43b2-4efa-a374-7bb7cbf20778)

### after the PR
![neovim-pr-after](https://github.com/neovim/neovim/assets/44101798/78627709-b966-4080-ac8c-de3748bd5591)

### another example with tags and the `--short` option triggered
![alacritty](https://github.com/neovim/neovim/assets/44101798/6331f999-7fd8-4b07-a849-ad551f23d0fa)