### PR TITLE
vim-patch:9.0.1638: crypt tests hang and cause memory errors

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -990,7 +990,8 @@ retry:
           }
         } else {
           // Read bytes from the file.
-          size = read_eintr(fd, ptr, (size_t)size);
+          size_t read_size = (size_t)size;
+          size = read_eintr(fd, ptr, read_size);
         }
 
         if (size <= 0) {


### PR DESCRIPTION
#### vim-patch:9.0.1638: crypt tests hang and cause memory errors

Problem:    crypt tests hang and cause memory errors
Solution:   Move variable to start of function.

https://github.com/vim/vim/commit/438d0c5e58aa475179ade9a1b99013733c5b8f06

N/A patches for version.c:

vim-patch:9.0.1639: build failure without the crypt feature

Problem:    Build failure without the crypt feature.
Solution:   Adjust #ifdefs

https://github.com/vim/vim/commit/bc385a150f9d812bb3e54ff0d5db75d3c6c3bb43

vim-patch:9.0.1640: compiler warning for unused variables without crypt feature

Problem:    Compiler warning for unused variables without the crypt feature.
Solution:   Adjust #ifdefs

https://github.com/vim/vim/commit/7f29122c8ce2ca224d21abbaeb35e38bc354d95d

Co-authored-by: Bram Moolenaar <Bram@vim.org>