### PR TITLE
Add BUCK file to bzl filetype

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1371,6 +1371,7 @@ local filename = {
   ['named.root'] = 'bindzone',
   WORKSPACE = 'bzl',
   ['WORKSPACE.bzlmod'] = 'bzl',
+  BUCK = 'bzl',
   BUILD = 'bzl',
   ['cabal.project'] = 'cabalproject',
   ['cabal.config'] = 'cabalconfig',


### PR DESCRIPTION
BUCK is the BUILD equivalent of Bazel for Buck2 build system.
