### PR TITLE
fix(lsp): check if inlay hints are enabled for a buffer before disabling

### DIFF
--- a/runtime/lua/vim/lsp/_inlay_hint.lua
+++ b/runtime/lua/vim/lsp/_inlay_hint.lua
@@ -207,9 +207,11 @@ end
 ---@private
 function M.disable(bufnr)
   bufnr = resolve_bufnr(bufnr)
-  clear(bufnr)
-  bufstates[bufnr].enabled = nil
-  bufstates[bufnr].timer = nil
+  if bufstates[bufnr] and bufstates[bufnr].enabled then
+    clear(bufnr)
+    bufstates[bufnr].enabled = nil
+    bufstates[bufnr].timer = nil
+  end
 end
 
 --- Toggle inlay hints for a buffer


### PR DESCRIPTION
disabling before enabling throws an error otherwise, because bufstate[bufnr] doesn't exist