### PR TITLE
fix(lsp): return a success bool after buf client attach

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -678,6 +678,10 @@ buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*
       • {bufnr}      (integer) Buffer handle, or 0 for current
       • {client_id}  (integer) Client id
 
+    Return: ~
+        (boolean) success `true` if client was attached successfully; `false`
+        otherwise
+
 buf_detach_client({bufnr}, {client_id})          *vim.lsp.buf_detach_client()*
     Detaches client from the specified buffer. Note: While the server is
     notified that the text document (buffer) was closed, it is still able to

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1759,6 +1759,7 @@ end
 ---
 ---@param bufnr (integer) Buffer handle, or 0 for current
 ---@param client_id (integer) Client id
+---@return boolean success `true` if client was attached successfully; `false` otherwise
 function lsp.buf_attach_client(bufnr, client_id)
   validate({
     bufnr = { bufnr, 'n', true },
@@ -1847,7 +1848,7 @@ function lsp.buf_attach_client(bufnr, client_id)
   end
 
   if buffer_client_ids[client_id] then
-    return
+    return true
   end
   -- This is our first time attaching this client to this buffer.
   buffer_client_ids[client_id] = true

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1070,7 +1070,7 @@ describe('LSP', function()
           eq(full_kind, client.server_capabilities().textDocumentSync.change)
           eq(true, client.server_capabilities().textDocumentSync.openClose)
           exec_lua [[
-            assert(not lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID), "Shouldn't attach twice")
+            assert(lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID), "Already attached, returns true")
           ]]
         end;
         on_exit = function(code, signal)


### PR DESCRIPTION
Fixes #24066. I think a success bool should be enough information but let me know if the result of calling attach could be more nuanced. [There's a test](https://github.com/null-char/neovim/blob/a47267712549265acb469d2615285e62348b9b4b/test/functional/plugin/lsp_spec.lua#L1073) that checks if a client is attached twice but this obviously can't be checked if we return `true` as long as the client is attached to the buffer. At the same time I'm not sure it makes sense to return `false` in that case.