### PR TITLE
fix(lsp): add spacing for inlay hints separately

### DIFF
--- a/runtime/lua/vim/lsp/_inlay_hint.lua
+++ b/runtime/lua/vim/lsp/_inlay_hint.lua
@@ -252,18 +252,18 @@ api.nvim_set_decoration_provider(namespace, {
               text = text .. part.value
             end
           end
+          local vt = {}
           if hint.paddingLeft then
-            text = ' ' .. text
+            vt[#vt + 1] = { ' ' }
           end
+          vt[#vt + 1] = { text, 'LspInlayHint' }
           if hint.paddingRight then
-            text = text .. ' '
+            vt[#vt + 1] = { ' ' }
           end
           api.nvim_buf_set_extmark(bufnr, namespace, lnum, hint.position.character, {
             virt_text_pos = 'inline',
             ephemeral = false,
-            virt_text = {
-              { text, 'LspInlayHint' },
-            },
+            virt_text = vt,
             hl_mode = 'combine',
           })
         end


### PR DESCRIPTION
With the addition of lsp inlay hints in the last days, I noticed that the spacing around the hint itself also has the same highlight as the hint e.g. 

<img width="613" alt="image" src="https://github.com/neovim/neovim/assets/22454918/31a04a8f-c155-4cbf-acc9-b703d1b5327a">

Looking at the language server spec for inlay hints it specifically mentions ([link](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#inlayHint))

> 	/**
> 	 * Render padding before the hint.
> 	 *
> 	 * Note: Padding should use the editor's background color, not the
> 	 * background color of the hint itself. That means padding can be used
> 	 * to visually align/separate an inlay hint.
> 	 */
> 	paddingLeft?: boolean;
> 
> 	/**
> 	 * Render padding after the hint.
> 	 *
> 	 * Note: Padding should use the editor's background color, not the
> 	 * background color of the hint itself. That means padding can be used
> 	 * to visually align/separate an inlay hint.
> 	 */
> 	paddingRight?: boolean;

i.e. the padding should not be coloured. I believe this is happening because the space is added to the text itself rather than as separate parts of the virtual text

https://github.com/neovim/neovim/blob/96b94f8d77774e3dabdec48bba2b56246a3ccba8/runtime/lua/vim/lsp/_inlay_hint.lua#L253-L258


Before:

<img width="841" alt="image" src="https://github.com/neovim/neovim/assets/22454918/160d2c05-16eb-484e-b58f-586a8a73a0aa">

After:

<img width="760" alt="image" src="https://github.com/neovim/neovim/assets/22454918/71f960a7-063b-4160-8bd7-504d27df4fca">

