### PR TITLE
feat(man): respect 'wrapmargin' when wrapping man pages

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -134,6 +134,8 @@ The following changes to existing APIs or features add new behavior.
 • |:checkhealth| buffer now implements |folding|. The initial folding status is
   defined by the 'foldenable' option.
 
+• |:Man| now respects 'wrapmargin'
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -436,7 +436,7 @@ local function get_page(path, silent)
   elseif vim.env.MANWIDTH then
     manwidth = vim.env.MANWIDTH
   else
-    manwidth = api.nvim_win_get_width(0)
+    manwidth = api.nvim_win_get_width(0) - vim.o.wrapmargin
   end
 
   local cmd = localfile_arg and { 'man', '-l', path } or { 'man', path }


### PR DESCRIPTION
This is particularly useful when setting `'wrapmargin'` with "scrollbar" plugins like [satellite.nvim](https://github.com/lewis6991/satellite.nvim).

With `set wrapmargin=2`:

**Before**:
![image](https://github.com/neovim/neovim/assets/8965202/42a4e82e-1e41-44fc-ac2c-0f75106da196)


**After**:
![image](https://github.com/neovim/neovim/assets/8965202/a779c38d-d3ad-4c79-93fc-be6ad27ac026)

Note that in the **Before** picture, `'wrapmargin'` is not respected, so the text is wrapped exactly at the window length and is partially occluded by the scrollbar.

In the **After** picture, `'wrapmargin'` is respected and leaves space for the scrollbar.