### PR TITLE
fix(treesitter): clear callbacks when destroying language tree

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -439,6 +439,15 @@ end
 --- `remove_child` must be called on the parent to remove it.
 function LanguageTree:destroy()
   -- Cleanup here
+
+  -- Clear all callbacks
+  self._callbacks = {}
+  self._callbacks_rec = {}
+  for _, cbname in pairs(TSCallbackNames) do
+    self._callbacks[cbname] = {}
+    self._callbacks_rec[cbname] = {}
+  end
+
   for _, child in pairs(self._children) do
     child:destroy()
   end

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1046,4 +1046,38 @@ int x = INT_MAX;
     eq(rb, r)
 
   end)
+
+  it('clears all callbacks when destroying a parser', function()
+    insert([[
+      print "Hello, world!"
+    ]])
+    exec_lua([[
+      parser = vim.treesitter.get_parser(0, "lua")
+      parser:register_cbs ({
+        on_bytes = function() end,
+        on_changedtree = function() end,
+        on_child_added = function() end,
+        on_child_removed = function() end,
+      })
+      parser:register_cbs ({
+        on_bytes = function() end,
+        on_changedtree = function() end,
+        on_child_added = function() end,
+        on_child_removed = function() end,
+      }, true)
+      parser:destroy()
+    ]])
+
+    eq(0, exec_lua("return #parser._callbacks.bytes"))
+    eq(0, exec_lua("return #parser._callbacks.changedtree"))
+    eq(0, exec_lua("return #parser._callbacks.child_added"))
+    eq(0, exec_lua("return #parser._callbacks.child_removed"))
+    eq(0, exec_lua("return #parser._callbacks.detach"))
+
+    eq(0, exec_lua("return #parser._callbacks_rec.bytes"))
+    eq(0, exec_lua("return #parser._callbacks_rec.changedtree"))
+    eq(0, exec_lua("return #parser._callbacks_rec.child_added"))
+    eq(0, exec_lua("return #parser._callbacks_rec.child_removed"))
+    eq(0, exec_lua("return #parser._callbacks_rec.detach"))
+  end)
 end)


### PR DESCRIPTION
Recursively removes all registered callbacks from a LanguageTree and its children.  Without this cleanup it is possible for callbacks to accumulate; for example if there is an autocommand to register a callback when attaching to a buffer and the user executes `:edit` the callback will be registered again.  With this change the user can `destroy` the parser when it is detached from the buffer to release the references to the callback functions.
