### PR TITLE
fix: tostring(vim.version()) fails if build is NIL

### DIFF
--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -125,7 +125,7 @@ function Version:__tostring()
   if self.prerelease then
     ret = ret .. '-' .. self.prerelease
   end
-  if self.build then
+  if self.build and self.build ~= vim.NIL then
     ret = ret .. '+' .. self.build
   end
   return ret


### PR DESCRIPTION
Fix for https://github.com/neovim/neovim/pull/23925
I was building neovim from the pre-releases in the github releases pages, and `vim.version()` started throwing:

```
E5108: Error executing lua E5114: Error while converting print argument #1: /usr/share/nvim/runtime/lua/vim/version.lua:129: attempt to concatenate field 'build' (a userdata value)
stack traceback:
        [C]: in function 'print'
        [string ":lua"]:1: in main chunk
```

The reason is that `Version.build` was set to `vim.NIL` in #23925. We need to account for this value