### PR TITLE
feat(lsp): opt-in to dynamicRegistration for inlay hints

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -642,7 +642,7 @@ function protocol.make_client_capabilities()
     },
     textDocument = {
       inlayHint = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
         resolveSupport = {
           properties = {},
         },

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -2,6 +2,7 @@ local helpers = require('test.functional.helpers')(after_each)
 local lsp_helpers = require('test.functional.plugin.lsp.helpers')
 local Screen = require('test.functional.ui.screen')
 
+local eq = helpers.eq
 local dedent = helpers.dedent
 local exec_lua = helpers.exec_lua
 local insert = helpers.insert
@@ -65,11 +66,17 @@ describe('inlay hints', function()
     it(
       'inlay hints are applied when vim.lsp.buf.inlay_hint(true) is called',
       function()
-        exec_lua([[
-        bufnr = vim.api.nvim_get_current_buf()
-        vim.api.nvim_win_set_buf(0, bufnr)
-        client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
-      ]])
+        local res = exec_lua([[
+          bufnr = vim.api.nvim_get_current_buf()
+          vim.api.nvim_win_set_buf(0, bufnr)
+          client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+          local client = vim.lsp.get_client_by_id(client_id)
+          return {
+            supports_method = client.supports_method("textDocument/inlayHint")
+          }
+        ]])
+        eq(res, { supports_method = true })
+
 
         insert(text)
         exec_lua([[vim.lsp.buf.inlay_hint(bufnr, true)]])


### PR DESCRIPTION
Since https://github.com/neovim/neovim/pull/23681 there is dynamic
registration support. We should use that for new features unless there
is a good reason to turn it off.
