### PR TITLE
feat(lsp): soft deprecate vim.lsp.for_each_buffer_client

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -139,6 +139,7 @@ LSP FUNCTIONS
 						or |vim.lsp.buf.format()| instead.
 - *vim.lsp.util.get_progress_messages()*	Use |vim.lsp.status()| or access
 						`progress` of |vim.lsp.client|
+- *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_active_clients()|
 
 TREESITTER FUNCTIONS
 - *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -751,21 +751,6 @@ client_is_stopped({client_id})                   *vim.lsp.client_is_stopped()*
     Return: ~
         (boolean) stopped true if client is stopped, false otherwise.
 
-                                            *vim.lsp.for_each_buffer_client()*
-for_each_buffer_client({bufnr}, {fn})
-    Invokes a function for each LSP client attached to a buffer.
-
-    Parameters: ~
-      • {bufnr}  (integer) Buffer number
-      • {fn}     (function) Function to run on each client attached to buffer
-                 {bufnr}. The function takes the client, client ID, and buffer
-                 number as arguments. Example: >lua
-
-                   vim.lsp.for_each_buffer_client(0, function(client, client_id, bufnr)
-                     print(vim.inspect(client))
-                   end)
-<
-
 formatexpr({opts})                                      *vim.lsp.formatexpr()*
     Provides an interface between the built-in client and a `formatexpr`
     function.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -167,6 +167,7 @@ release.
 
 • vim.lsp functions:
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
+  - |vim.lsp.for_each_buffer_client()|	  	Use |vim.lsp.get_active_clients()| instead.
 
 • `vim.loop` has been renamed to `vim.uv`.
 


### PR DESCRIPTION
There is no need for two ways to access all clients of a buffer.

This doesn't add a `vim.deprecate` call yet, as the function is probably
used a lot, but removes it from the documentation and annotates it with
`@deprecated`
