### PR TITLE
test: spellcheck :help (vimdoc) files

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -7,7 +7,7 @@
 Nvim API                                                           *API* *api*
 
 Nvim exposes a powerful API that can be used by plugins and external processes
-via |RPC|, |Lua| and VimL (|eval-api|).
+via |RPC|, |Lua| and Vimscript (|eval-api|).
 
 Applications can also embed libnvim to work with the C API directly.
 
@@ -587,7 +587,7 @@ nvim__get_runtime({pat}, {all}, {*opts})                 *nvim__get_runtime()*
     Parameters: ~
       • {pat}   pattern of files to search for
       • {all}   whether to return all matches or only the first
-      • {opts}  is_lua: only search lua subdirs
+      • {opts}  is_lua: only search Lua subdirs
 
     Return: ~
         list of absolute paths to the found files
@@ -1203,7 +1203,7 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
     Parameters: ~
       • {buffer}  the buffer to use (expected to be empty)
       • {opts}    Optional parameters.
-                  • on_input: lua callback for input sent, i e keypresses in
+                  • on_input: Lua callback for input sent, i e keypresses in
                     terminal mode. Note: keypresses are sent raw as they would
                     be to the pty master end. For instance, a carriage return
                     is sent as a "\r", not as a "\n". |textlock| applies. It
@@ -1556,22 +1556,22 @@ Vimscript Functions                                            *api-vimscript*
 
                                                    *nvim_call_dict_function()*
 nvim_call_dict_function({dict}, {fn}, {args})
-    Calls a VimL |Dictionary-function| with the given arguments.
+    Calls a Vimscript |Dictionary-function| with the given arguments.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Parameters: ~
-      • {dict}  Dictionary, or String evaluating to a VimL |self| dict
-      • {fn}    Name of the function defined on the VimL dict
+      • {dict}  Dictionary, or String evaluating to a Vimscript |self| dict
+      • {fn}    Name of the function defined on the Vimscript dict
       • {args}  Function arguments packed in an Array
 
     Return: ~
         Result of the function call
 
 nvim_call_function({fn}, {args})                        *nvim_call_function()*
-    Calls a VimL function with the given arguments.
+    Calls a Vimscript function with the given arguments.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Parameters: ~
       • {fn}    Function to call
@@ -1583,7 +1583,7 @@ nvim_call_function({fn}, {args})                        *nvim_call_function()*
 nvim_command({command})                                       *nvim_command()*
     Executes an Ex command.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Prefer using |nvim_cmd()| or |nvim_exec2()| over this. To evaluate
     multiple lines of Vim script or an Ex command directly, use
@@ -1595,13 +1595,13 @@ nvim_command({command})                                       *nvim_command()*
       • {command}  Ex command string
 
 nvim_eval({expr})                                                *nvim_eval()*
-    Evaluates a VimL |expression|. Dictionaries and Lists are recursively
+    Evaluates a Vimscript |expression|. Dictionaries and Lists are recursively
     expanded.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Parameters: ~
-      • {expr}  VimL expression string
+      • {expr}  Vimscript expression string
 
     Return: ~
         Evaluation result or expanded object
@@ -1613,7 +1613,7 @@ nvim_exec2({src}, {*opts})                                      *nvim_exec2()*
     Unlike |nvim_command()| this function supports heredocs, script-scope
     (s:), etc.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Parameters: ~
       • {src}   Vimscript code
@@ -1632,7 +1632,7 @@ nvim_exec2({src}, {*opts})                                      *nvim_exec2()*
 
                                                      *nvim_parse_expression()*
 nvim_parse_expression({expr}, {flags}, {highlight})
-    Parse a VimL expression.
+    Parse a Vimscript expression.
 
     Attributes: ~
         |api-fast|
@@ -1760,7 +1760,7 @@ nvim_cmd({*cmd}, {*opts})                                         *nvim_cmd()*
     example, instead of `vim.cmd.bdelete{ count = 2 }`, you may do
     `vim.cmd.bdelete(2)`.
 
-    On execution error: fails with VimL error, updates v:errmsg.
+    On execution error: fails with Vimscript error, updates v:errmsg.
 
     Parameters: ~
       • {cmd}   Command to execute. Must be a Dictionary that can contain the
@@ -2055,7 +2055,7 @@ nvim_buf_attach({buffer}, {send_buffer}, {opts})           *nvim_buf_attach()*
                          • deleted_codepoints (if `utf_sizes` is true)
                          • deleted_codeunits (if `utf_sizes` is true)
 
-                       • on_bytes: lua callback invoked on change. This
+                       • on_bytes: Lua callback invoked on change. This
                          callback receives more granular information about the
                          change compared to on_lines. Return `true` to detach. Args:
                          • the string "bytes"
@@ -2118,12 +2118,12 @@ nvim_buf_call({buffer}, {fun})                               *nvim_buf_call()*
 
     Parameters: ~
       • {buffer}  Buffer handle, or 0 for current buffer
-      • {fun}     Function to call inside the buffer (currently lua callable
+      • {fun}     Function to call inside the buffer (currently Lua callable
                   only)
 
     Return: ~
-        Return value of function. NB: will deepcopy lua values currently, use
-        upvalues to send lua references in and out.
+        Return value of function. NB: will deepcopy Lua values currently, use
+        upvalues to send Lua references in and out.
 
 nvim_buf_del_keymap({buffer}, {mode}, {lhs})           *nvim_buf_del_keymap()*
     Unmaps a buffer-local |mapping| for the given mode.
@@ -2720,7 +2720,7 @@ nvim_get_namespaces()                                  *nvim_get_namespaces()*
 nvim_set_decoration_provider({ns_id}, {*opts})
     Set or change decoration provider for a |namespace|
 
-    This is a very general purpose interface for having lua callbacks being
+    This is a very general purpose interface for having Lua callbacks being
     triggered during the redraw code.
 
     The expected usage is to set |extmarks| for the currently redrawn buffer.
@@ -2776,12 +2776,12 @@ nvim_win_call({window}, {fun})                               *nvim_win_call()*
 
     Parameters: ~
       • {window}  Window handle, or 0 for current window
-      • {fun}     Function to call inside the window (currently lua callable
+      • {fun}     Function to call inside the window (currently Lua callable
                   only)
 
     Return: ~
-        Return value of function. NB: will deepcopy lua values currently, use
-        upvalues to send lua references in and out.
+        Return value of function. NB: will deepcopy Lua values currently, use
+        upvalues to send Lua references in and out.
 
     See also: ~
       • |win_execute()|

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5703,7 +5703,7 @@ mode([expr])	Return a string that indicates the current mode.
 			DoFull()->mode()
 
 msgpackdump({list} [, {type}])				*msgpackdump()*
-		Convert a list of VimL objects to msgpack. Returned value is a
+		Convert a list of Vimscript objects to msgpack. Returned value is a
 		|readfile()|-style list. When {type} contains "B", a |Blob| is
 		returned instead. Example: >
 			call writefile(msgpackdump([{}]), 'fname.mpack', 'b')
@@ -5723,7 +5723,7 @@ msgpackdump({list} [, {type}])				*msgpackdump()*
 
 msgpackparse({data})					*msgpackparse()*
 		Convert a |readfile()|-style list or a |Blob| to a list of
-		VimL objects.
+		Vimscript objects.
 		Example: >
 			let fname = expand('~/.config/nvim/shada/main.shada')
 			let mpack = readfile(fname, 'b')

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -99,8 +99,8 @@ Examples:
    scripting is performed by an external host process implemented in ~2k lines
    of Python.
 
-The provider framework invokes VimL from C.  It is composed of two functions
-in eval.c:
+The provider framework invokes Vimscript from C.  It is composed of two
+functions in eval.c:
 
 - eval_call_provider(name, method, arguments, discard): calls
   provider#{name}#Call with the method and arguments. If discard is true, any
@@ -429,7 +429,7 @@ Examples of API-client package names:
 - GOOD: nvim-racket
 - GOOD: pynvim
 - BAD:  python-client
-- BAD:  neovim
+- BAD:  neovim_
 
 API client implementation guidelines ~
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -619,7 +619,7 @@ To use Nvim as a manpager: >
      export MANPAGER='nvim +Man!'
 
 Note that when running `man` from the shell and with that `MANPAGER` in your
-environment, `man` will pre-format the manpage using `groff`. Thus, Neovim
+environment, `man` will pre-format the manpage using `groff`. Thus, Nvim
 will inevitably display the manual page as it was passed to it from stdin. One
 of the caveats of this is that the width will _always_ be hard-wrapped and not
 soft wrapped as with `g:man_hardwrap=0`. You can set in your environment: >

--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -100,7 +100,7 @@ ADVANCED EDITING
 ------------------------------------------------------------------------------
 API (EXTENSIBILITY/SCRIPTING/PLUGINS)
 
-|api|			Nvim API via RPC, Lua and VimL
+|api|			Nvim API via RPC, Lua and Vimscript
 |ui|			Nvim UI protocol
 |lua-guide|		Nvim Lua guide
 |lua|			Lua API

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -108,7 +108,7 @@ to the next.
 ==============================================================================
 2. The VIM module					*perl-vim*
 
-Perl code gets all of its access to Neovim via the "VIM" module.
+Perl code gets all of its access to Nvim via the "VIM" module.
 
 Overview >
 	print "Hello"				# displays a message

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -575,8 +575,8 @@ Python 3						*python3*
 
 As Python 3 is the only supported version in Nvim, "python" is synonymous
 with "python3" in the current version. However, code that aims to support older
-versions of Neovim, as well as Vim, should prefer to use "python3"
-variants explicitly if Python 3 is required.
+versions of Nvim, as well as Vim, should prefer to use "python3" variants
+explicitly if Python 3 is required.
 
 							*:py3* *:python3*
 :[range]py3 {stmt}

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -83,7 +83,7 @@ For the most recent information about sponsoring look on the Vim web site:
 	https://www.vim.org/sponsor/
 
 
-Neovim development is funded separately from Vim:
+Nvim development is funded separately from Vim:
 
 	https://neovim.io/#sponsor
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -989,8 +989,8 @@ start_client({config})                                *vim.lsp.start_client()*
                     if `capabilities.offsetEncoding` was sent to it. You can
                     only modify the `client.offset_encoding` here before any
                     notifications are sent. Most language servers expect to be
-                    sent client specified settings after initialization.
-                    Neovim does not make this assumption. A
+                    sent client specified settings after initialization. Nvim
+                    does not make this assumption. A
                     `workspace/didChangeConfiguration` notification should be
                     sent to the server during on_init.
                   • on_exit Callback (code, signal, client_id) invoked on
@@ -1191,8 +1191,7 @@ format({options})                                       *vim.lsp.buf.format()*
                    fields:
                    • formatting_options (table|nil): Can be used to specify
                      FormattingOptions. Some unspecified options will be
-                     automatically derived from the current Neovim options.
-                     See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
+                     automatically derived from the current Nvim options. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
                    • timeout_ms (integer|nil, default 1000): Time in
                      milliseconds to block for formatting requests. No effect
                      if async=true

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -34,7 +34,7 @@ Nvim ever ships with Lua 5.4+, a Lua 5.1 compatibility shim will be provided
 so that old plugins continue to work transparently.
 
                                                                   *lua-luajit*
-Neovim is built with luajit on platforms which support it, which provides
+Nvim is built with luajit on platforms which support it, which provides
 extra functionality. Lua code in |init.lua| and plugins can assume its presence
 on installations on common platforms. For maximum compatibility with less
 common platforms, availability can be checked using the `jit` global variable: >lua
@@ -46,7 +46,7 @@ common platforms, availability can be checked using the `jit` global variable: >
 <
                                                                   *lua-bit*
 In particular, the luajit "bit" extension module is _always_ available.
-A fallback implementation is included when nvim is built with PUC lua 5.1,
+A fallback implementation is included when nvim is built with PUC Lua 5.1,
 and will be transparently used when `require("bit")` is invoked.
 
 ==============================================================================
@@ -549,7 +549,7 @@ Multithreading                                            *lua-loop-threading*
 
 Plugins can perform work in separate (os-level) threads using the threading
 APIs in luv, for instance `vim.uv.new_thread`. Note that every thread
-gets its own separate lua interpreter state, with no access to lua globals
+gets its own separate Lua interpreter state, with no access to Lua globals
 in the main thread. Neither can the state of the editor (buffers, windows,
 etc) be directly accessed from threads.
 
@@ -557,10 +557,10 @@ A subset of the `vim.*` API is available in threads. This includes:
 
 - `vim.uv` with a separate event loop per thread.
 - `vim.mpack` and `vim.json` (useful for serializing messages between threads)
-- `require` in threads can use lua packages from the global |package.path|
+- `require` in threads can use Lua packages from the global |package.path|
 - `print()` and `vim.inspect`
 - `vim.diff`
-- most utility functions in `vim.*` for working with pure lua values
+- most utility functions in `vim.*` for working with pure Lua values
   like `vim.split`, `vim.tbl_*`, `vim.list_*`, and so on.
 - `vim.is_thread()` returns true from a non-main thread.
 
@@ -624,7 +624,7 @@ vim.highlight.priorities                            *vim.highlight.priorities*
 ------------------------------------------------------------------------------
 VIM.REGEX                                                          *lua-regex*
 
-Vim regexes can be used directly from lua. Currently they only allow
+Vim regexes can be used directly from Lua. Currently they only allow
 matching within a single line.
 
 vim.regex({re})                                                  *vim.regex()*
@@ -933,8 +933,8 @@ vim.wait({time} [, {callback}, {interval}, {fast_only}])          *vim.wait()*
 
 vim.ui_attach({ns}, {options}, {callback})                *vim.ui_attach()*
     Attach to ui events, similar to |nvim_ui_attach()| but receive events
-    as lua callback. Can be used to implement screen elements like
-    popupmenu or message handling in lua.
+    as Lua callback. Can be used to implement screen elements like
+    popupmenu or message handling in Lua.
 
     {options} should be a dictionary-like table, where `ext_...` options should
     be set to true to receive events for the respective external element.
@@ -1262,7 +1262,7 @@ In any of the above examples, to replicate the behavior |:setlocal|, use
                                                                *vim.opt:get()*
 Option:get()
 
-    Returns a lua-representation of the option. Boolean, number and string
+    Returns a Lua-representation of the option. Boolean, number and string
     values will be returned in exactly the same fashion.
 
     For values that are comma-separated lists, an array will be returned with
@@ -1435,10 +1435,10 @@ keycode({str})                                                 *vim.keycode()*
       • |nvim_replace_termcodes()|
 
 lua_omnifunc({find_start}, {_})                           *vim.lua_omnifunc()*
-    Omnifunc for completing lua values from the runtime lua interpreter,
+    Omnifunc for completing Lua values from the runtime Lua interpreter,
     similar to the builtin completion for the `:lua` command.
 
-    Activate using `set omnifunc=v:lua.vim.lua_omnifunc` in a lua buffer.
+    Activate using `set omnifunc=v:lua.vim.lua_omnifunc` in a Lua buffer.
 
 notify({msg}, {level}, {opts})                                  *vim.notify()*
     Display a notification to the user.
@@ -2230,17 +2230,17 @@ Lua module: loader                                                *lua-loader*
 disable()                                               *vim.loader.disable()*
     Disables the experimental Lua module loader:
     • removes the loaders
-    • adds the default Neovim loader
+    • adds the default Nvim loader
 
 enable()                                                 *vim.loader.enable()*
     Enables the experimental Lua module loader:
     • overrides loadfile
-    • adds the lua loader using the byte-compilation cache
+    • adds the Lua loader using the byte-compilation cache
     • adds the libs loader
-    • removes the default Neovim loader
+    • removes the default Nvim loader
 
 find({modname}, {opts})                                    *vim.loader.find()*
-    Finds lua modules for the given module name.
+    Finds Lua modules for the given module name.
 
     Parameters: ~
       • {modname}  (string) Module name, or `"*"` to find the top-level

--- a/runtime/doc/message.txt
+++ b/runtime/doc/message.txt
@@ -327,7 +327,7 @@ You can switch the 'write' option on with ":set write".
 							*E25*  >
   Nvim does not have a built-in GUI
 
-Neovim does not have a built in GUI, so `:gvim` and `:gui` don't work.
+Nvim does not have a built in GUI, so `:gvim` and `:gui` don't work.
 
 							*E49*  >
   Invalid scroll size

--- a/runtime/doc/news-0.9.txt
+++ b/runtime/doc/news-0.9.txt
@@ -109,7 +109,7 @@ The following new APIs or features were added.
   (or the Vimscript equivalent) to their |config| file.
 
 • A new environment variable named NVIM_APPNAME enables configuring the
-  directories where Neovim should find its configuration and state files. See
+  directories where Nvim should find its configuration and state files. See
   `:help $NVIM_APPNAME` .
 
 • Added support for running Lua scripts from shell using |-l|. >
@@ -117,9 +117,9 @@ The following new APIs or features were added.
 <  Also works with stdin: >
       echo "print(42)" | nvim -l -
 
-• Added an omnifunc implementation for lua, |vim.lua_omnifunc()|
+• Added an omnifunc implementation for Lua, |vim.lua_omnifunc()|
 
-• Added a new experimental |lua-loader| that byte-compiles and caches lua files.
+• Added a new experimental |lua-loader| that byte-compiles and caches Lua files.
   To enable the new loader, add the following at the top of your |init.lua|: >lua
     vim.loader.enable()
 
@@ -223,7 +223,7 @@ The following changes to existing APIs or features add new behavior.
 • The `win_viewport` UI event now contains information about virtual lines,
   meaning that smooth scrolling can now be implemented more consistently.
 
-• The `:= {expr}` syntax can be used to evaluate a lua expression, as
+• The `:= {expr}` syntax can be used to evaluate a Lua expression, as
   a shorter form of `:lua ={expr}`. `:=` and `:[range]=` without argument
   are unchanged. However `:=#` and similar variants using |ex-flags|
   are no longer supported.

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -66,7 +66,7 @@ To disable Python 3 support: >vim
 PYTHON VIRTUALENVS ~
 						*python-virtualenv*
 If you plan to use per-project virtualenvs often, you should assign one
-virtualenv for Neovim and hard-code the interpreter path via
+virtualenv for Nvim and hard-code the interpreter path via
 |g:python3_host_prog| so that the "pynvim" package is not required
 for each virtualenv.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -241,8 +241,8 @@ argument.
 
 							*-ll*
 -ll {script} [args]
-		Execute a lua script, similarly to |-l|, but the editor is not
-		initialized. This gives a lua environment similar to a worker
+		Execute a Lua script, similarly to |-l|, but the editor is not
+		initialized. This gives a Lua environment similar to a worker
 		thread. See |lua-loop-threading|.
 
 		Unlike `-l` no prior arguments are allowed.
@@ -918,7 +918,7 @@ Shada ("shared data") file			*shada* *shada-file*
 If you exit Vim and later start it again, you would normally lose a lot of
 information.  The ShaDa file can be used to remember that information, which
 enables you to continue where you left off.  Its name is the abbreviation of
-SHAred DAta because it is used for sharing data between Neovim sessions.
+SHAred DAta because it is used for sharing data between Nvim sessions.
 
 This is introduced in section |21.3| of the user manual.
 
@@ -1010,16 +1010,16 @@ MERGING							*shada-merging*
 
 When writing ShaDa files with |:wshada| without bang or at regular exit
 information in the existing ShaDa file is merged with information from current
-Neovim instance.  For this purpose ShaDa files store timestamps associated
+Nvim instance.  For this purpose ShaDa files store timestamps associated
 with ShaDa entries.  Specifically the following is being done:
 
 1. History lines are merged, ordered by timestamp.  Maximum amount of items in
    ShaDa file is defined by 'shada' option (|shada-/|, |shada-:|, |shada-@|,
    etc: one suboption for each character that represents history name
    (|:history|)).
-2. Local marks and changes for files that were not opened by Neovim are copied
-   to new ShaDa file. Marks for files that were opened by Neovim are merged,
-   changes to files opened by Neovim are ignored. |shada-'|
+2. Local marks and changes for files that were not opened by Nvim are copied
+   to new ShaDa file. Marks for files that were opened by Nvim are merged,
+   changes to files opened by Nvim are ignored. |shada-'|
 3. Jump list is merged: jumps are ordered by timestamp, identical jumps
    (identical position AND timestamp) are squashed.
 4. Search patterns and substitute strings are not merged: search pattern or
@@ -1027,14 +1027,14 @@ with ShaDa entries.  Specifically the following is being done:
    to ShaDa file.
 5. For each register entity with greatest timestamp is the only saved.
    |shada-<|
-6. All saved variables are saved from current Neovim instance. Additionally
+6. All saved variables are saved from current Nvim instance. Additionally
    existing variable values are copied, meaning that the only way to remove
    variable from a ShaDa file is either removing it by hand or disabling
    writing variables completely. |shada-!|
 7. For each global mark entity with greatest timestamp is the only saved.
 8. Buffer list and header are the only entries which are not merged in any
    fashion: the only header and buffer list present are the ones from the
-   Neovim instance which was last writing the file. |shada-%|
+   Nvim instance which was last writing the file. |shada-%|
 
 COMPATIBILITY						*shada-compatibility*
 
@@ -1059,13 +1059,13 @@ ShaDa files are forward and backward compatible.  This means that
    history types. |history|
 6. Unknown keys found in register, local mark, global mark, change, jump and
    search pattern entries are saved internally and dumped when writing.
-   Entries created during Neovim session never have such additions.
+   Entries created during Nvim session never have such additions.
 7. Additional elements found in replacement string and history entries are
-   saved internally and dumped. Entries created during Neovim session never
+   saved internally and dumped. Entries created during Nvim session never
    have such additions.
 8. Additional elements found in variable entries are simply ignored when
    reading. When writing new variables they will be preserved during merging,
-   but that's all. Variable values dumped from current Neovim session never
+   but that's all. Variable values dumped from current Nvim session never
    have additional elements, even if variables themselves were obtained by
    reading ShaDa files.
 
@@ -1102,7 +1102,7 @@ start with an existing one to get the format right.  You need to understand
 MessagePack (or, more likely, find software that is able to use it) format to
 do this.  This can be useful in order to create a second file, say
 "~/.my.shada" which could contain certain settings that you always want when
-you first start Neovim.  For example, you can preload registers with
+you first start Nvim.  For example, you can preload registers with
 particular data, or put certain commands in the command line history.  A line
 in your |config| file like >
 	:rshada! ~/.my.shada
@@ -1112,12 +1112,12 @@ file name, using the ":autocmd" command (see |:autocmd|).  More information on
 ShaDa file format is contained in |shada-format| section.
 
 					  *E136* *E929* *shada-error-handling*
-Some errors make Neovim leave temporary file named `{basename}.tmp.X` (X is
+Some errors make Nvim leave temporary file named `{basename}.tmp.X` (X is
 any free letter from `a` to `z`) while normally it will create this file,
 write to it and then rename `{basename}.tmp.X` to `{basename}`. Such errors
 include:
 
-- Errors which make Neovim think that read file is not a ShaDa file at all:
+- Errors which make Nvim think that read file is not a ShaDa file at all:
   non-ShaDa files are not overwritten for safety reasons to avoid accidentally
   destroying an unrelated file.  This could happen e.g. when typing "nvim -i
   file" in place of "nvim -R file" (yes, somebody did that at least with Vim).
@@ -1125,26 +1125,26 @@ include:
 - If writing to the temporary file failed: e.g. because of the insufficient
   space left.
 - If renaming file failed: e.g. because of insufficient permissions.
-- If target ShaDa file has different from the Neovim instance's owners (user
+- If target ShaDa file has different from the Nvim instance's owners (user
   and group) and changing them failed.  Unix-specific, applies only when
-  Neovim was launched from root.
+  Nvim was launched from root.
 
 Do not forget to remove the temporary file or replace the target file with
 temporary one after getting one of the above errors or all attempts to create
 a ShaDa file may fail with |E929|.  If you got one of them when using
-|:wshada| (and not when exiting Neovim: i.e. when you have Neovim session
+|:wshada| (and not when exiting Nvim: i.e. when you have Nvim session
 running) you have additional options:
 
 - First thing which you should consider if you got any error, except failure
   to write to the temporary file: remove existing file and replace it with the
-  temporary file.  Do it even if you have running Neovim instance.
+  temporary file.  Do it even if you have running Nvim instance.
 - Fix the permissions and/or file ownership, free some space and attempt to
   write again.  Do not remove the existing file.
 - Use |:wshada| with bang.  Does not help in case of permission error.  If
   target file was actually the ShaDa file some information may be lost in this
   case.  To make the matters slightly better use |:rshada| prior to writing,
   but this still will loose buffer-local marks and change list entries for any
-  file which is not opened in the current Neovim instance.
+  file which is not opened in the current Nvim instance.
 - Remove the target file from shell and use |:wshada|.  Consequences are not
   different from using |:wshada| with bang, but "rm -f" works in some cases
   when you don't have write permissions.
@@ -1211,7 +1211,7 @@ exactly four MessagePack objects:
                        Key        Data ~
                        generator  Binary, software used to generate ShaDa
                                   file. Is equal to "nvim" when ShaDa file was
-                                  written by Neovim.
+                                  written by Nvim.
                        version    Binary, generator version.
                        encoding   Binary, effective 'encoding' value.
                        max_kbyte  Integer, effective |shada-s| limit value.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -459,7 +459,7 @@ Lua interface (|lua.txt|):
 - `:lua print("a\0b")` will print `a^@b`, like with `:echomsg "a\nb"` . In Vim
   that prints `a` and `b` on separate lines, exactly like
   `:lua print("a\nb")` .
-- `:lua error('TEST')` emits the error “E5105: Error while calling lua chunk:
+- `:lua error('TEST')` emits the error “E5105: Error while calling Lua chunk:
   [string "<VimL compiled string>"]:1: TEST”, whereas Vim emits only “TEST”.
 - Lua has direct access to Nvim |API| via `vim.api`.
 - Lua package.path and package.cpath are automatically updated according to

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -3,7 +3,7 @@
 -- Lua code lives in one of three places:
 --    1. runtime/lua/vim/ (the runtime): For "nice to have" features, e.g. the
 --       `inspect` and `lpeg` modules.
---    2. runtime/lua/vim/shared.lua: pure lua functions which always
+--    2. runtime/lua/vim/shared.lua: pure Lua functions which always
 --       are available. Used in the test runner, as well as worker threads
 --       and processes launched from Nvim.
 --    3. runtime/lua/vim/_editor.lua: Code which directly interacts with
@@ -839,10 +839,10 @@ do
   -- some bugs, so fake the two-step dance for now.
   local matches
 
-  --- Omnifunc for completing lua values from the runtime lua interpreter,
+  --- Omnifunc for completing Lua values from the runtime Lua interpreter,
   --- similar to the builtin completion for the `:lua` command.
   ---
-  --- Activate using `set omnifunc=v:lua.vim.lua_omnifunc` in a lua buffer.
+  --- Activate using `set omnifunc=v:lua.vim.lua_omnifunc` in a Lua buffer.
   function vim.lua_omnifunc(find_start, _)
     if find_start == 1 then
       local line = vim.api.nvim_get_current_line()

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -239,7 +239,7 @@ local to_vim_value = {
   end,
 }
 
---- Convert a lua value to a vimoption_T value
+--- Convert a Lua value to a vimoption_T value
 local function convert_value_to_vim(name, info, value)
   if value == nil then
     return vim.NIL
@@ -250,7 +250,7 @@ local function convert_value_to_vim(name, info, value)
   return to_vim_value[info.metatype](info, value)
 end
 
--- Map of OptionType to functions that take vimoption_T values and convert to lua values.
+-- Map of OptionType to functions that take vimoption_T values and convert to Lua values.
 -- Each function takes (info, vim_value) -> lua_value
 local to_lua_value = {
   boolean = passthrough,

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -161,7 +161,7 @@ function Loader.read(name)
   end
 end
 
---- The `package.loaders` loader for lua files using the cache.
+--- The `package.loaders` loader for Lua files using the cache.
 ---@param modname string module name
 ---@return string|function
 ---@private
@@ -211,7 +211,7 @@ end
 ---@private
 -- luacheck: ignore 312
 function Loader.loadfile(filename, mode, env)
-  -- ignore mode, since we byte-compile the lua source files
+  -- ignore mode, since we byte-compile the Lua source files
   mode = nil
   return Loader.load(normalize(filename), { mode = mode, env = env })
 end
@@ -268,7 +268,7 @@ function Loader.load(modpath, opts)
   return chunk, err
 end
 
---- Finds lua modules for the given module name.
+--- Finds Lua modules for the given module name.
 ---@param modname string Module name, or `"*"` to find the top-level modules instead
 ---@param opts? ModuleFindOpts (table|nil) Options for finding a module:
 ---    - rtp: (boolean) Search for modname in the runtime path (defaults to `true`)
@@ -289,7 +289,7 @@ function M.find(modname, opts)
   local idx = modname:find('.', 1, true)
 
   -- HACK: fix incorrect require statements. Really not a fan of keeping this,
-  -- but apparently the regular lua loader also allows this
+  -- but apparently the regular Lua loader also allows this
   if idx == 1 then
     modname = modname:gsub('^%.+', '')
     basename = modname:gsub('%.', '/')
@@ -386,9 +386,9 @@ end
 
 --- Enables the experimental Lua module loader:
 --- * overrides loadfile
---- * adds the lua loader using the byte-compilation cache
+--- * adds the Lua loader using the byte-compilation cache
 --- * adds the libs loader
---- * removes the default Neovim loader
+--- * removes the default Nvim loader
 function M.enable()
   if M.enabled then
     return
@@ -396,11 +396,11 @@ function M.enable()
   M.enabled = true
   vim.fn.mkdir(vim.fn.fnamemodify(M.path, ':p'), 'p')
   _G.loadfile = Loader.loadfile
-  -- add lua loader
+  -- add Lua loader
   table.insert(loaders, 2, Loader.loader)
   -- add libs loader
   table.insert(loaders, 3, Loader.loader_lib)
-  -- remove Neovim loader
+  -- remove Nvim loader
   for l, loader in ipairs(loaders) do
     if loader == vim._load_package then
       table.remove(loaders, l)
@@ -411,7 +411,7 @@ end
 
 --- Disables the experimental Lua module loader:
 --- * removes the loaders
---- * adds the default Neovim loader
+--- * adds the default Nvim loader
 function M.disable()
   if not M.enabled then
     return
@@ -426,8 +426,8 @@ function M.disable()
   table.insert(loaders, 2, vim._load_package)
 end
 
---- Return the top-level `/lua/*` modules for this path
----@param path string path to check for top-level lua modules
+--- Return the top-level \`/lua/*` modules for this path
+---@param path string path to check for top-level Lua modules
 ---@private
 function Loader.lsmod(path)
   if not Loader._indexed[path] then

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1076,7 +1076,7 @@ end
 ---       `initialize_result.offsetEncoding` if `capabilities.offsetEncoding` was
 ---       sent to it. You can only modify the `client.offset_encoding` here before
 ---       any notifications are sent. Most language servers expect to be sent client specified settings after
----       initialization. Neovim does not make this assumption. A
+---       initialization. Nvim does not make this assumption. A
 ---       `workspace/didChangeConfiguration` notification should be sent
 ---        to the server during on_init.
 ---

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -159,7 +159,7 @@ end
 --- @param options table|nil Optional table which holds the following optional fields:
 ---     - formatting_options (table|nil):
 ---         Can be used to specify FormattingOptions. Some unspecified options will be
----         automatically derived from the current Neovim options.
+---         automatically derived from the current Nvim options.
 ---         See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
 ---     - timeout_ms (integer|nil, default 1000):
 ---         Time in milliseconds to block for formatting requests. No effect if async=true

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -112,7 +112,7 @@ Integer nvim_buf_line_count(Buffer buffer, Error *err)
 ///               - byte count of previous contents
 ///               - deleted_codepoints (if `utf_sizes` is true)
 ///               - deleted_codeunits (if `utf_sizes` is true)
-///             - on_bytes: lua callback invoked on change.
+///             - on_bytes: Lua callback invoked on change.
 ///               This callback receives more granular information about the
 ///               change compared to on_lines.
 ///               Return `true` to detach.
@@ -1250,11 +1250,11 @@ ArrayOf(Integer, 2) nvim_buf_get_mark(Buffer buffer, String name, Error *err)
 /// buffer/window currently, like |termopen()|.
 ///
 /// @param buffer     Buffer handle, or 0 for current buffer
-/// @param fun        Function to call inside the buffer (currently lua callable
+/// @param fun        Function to call inside the buffer (currently Lua callable
 ///                   only)
 /// @param[out] err   Error details, if any
-/// @return           Return value of function. NB: will deepcopy lua values
-///                   currently, use upvalues to send lua references in and out.
+/// @return           Return value of function. NB: will deepcopy Lua values
+///                   currently, use upvalues to send Lua references in and out.
 Object nvim_buf_call(Buffer buffer, LuaRef fun, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_LUA_ONLY

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -306,7 +306,7 @@ end:
 /// make their usage simpler with |vim.cmd()|. For example, instead of
 /// `vim.cmd.bdelete{ count = 2 }`, you may do `vim.cmd.bdelete(2)`.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
 /// @see |nvim_exec2()|
 /// @see |nvim_command()|

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1048,7 +1048,7 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 
 /// Set or change decoration provider for a |namespace|
 ///
-/// This is a very general purpose interface for having lua callbacks
+/// This is a very general purpose interface for having Lua callbacks
 /// being triggered during the redraw code.
 ///
 /// The expected usage is to set |extmarks| for the currently

--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -256,7 +256,7 @@ Object vim_to_object(typval_T *obj)
   return ret;
 }
 
-/// Converts from type Object to a VimL value.
+/// Converts from type Object to a Vimscript value.
 ///
 /// @param obj  Object to convert from.
 /// @param tv   Conversion result is placed here. On failure member v_type is
@@ -283,7 +283,7 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
   case kObjectTypeTabpage:
   case kObjectTypeInteger:
     STATIC_ASSERT(sizeof(obj.data.integer) <= sizeof(varnumber_T),
-                  "Integer size must be <= VimL number size");
+                  "Integer size must be <= Vimscript number size");
     tv->v_type = VAR_NUMBER;
     tv->vval.v_number = (varnumber_T)obj.data.integer;
     break;

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -42,10 +42,10 @@ typedef enum {
 /// Mask for all internal calls
 #define INTERNAL_CALL_MASK (((uint64_t)1) << (sizeof(uint64_t) * 8 - 1))
 
-/// Internal call from VimL code
+/// Internal call from Vimscript code
 #define VIML_INTERNAL_CALL INTERNAL_CALL_MASK
 
-/// Internal call from lua code
+/// Internal call from Lua code
 #define LUA_INTERNAL_CALL (VIML_INTERNAL_CALL + 1)
 
 static inline bool is_internal_call(uint64_t channel_id)

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -40,10 +40,10 @@
 # include "api/private/ui_events_metadata.generated.h"
 #endif
 
-/// Start block that may cause VimL exceptions while evaluating another code
+/// Start block that may cause Vimscript exceptions while evaluating another code
 ///
-/// Used when caller is supposed to be operating when other VimL code is being
-/// processed and that “other VimL code” must not be affected.
+/// Used when caller is supposed to be operating when other Vimscript code is being
+/// processed and that “other Vimscript code” must not be affected.
 ///
 /// @param[out]  tstate  Location where try state should be saved.
 void try_enter(TryState *const tstate)
@@ -806,7 +806,7 @@ bool api_object_to_bool(Object obj, const char *what, bool nil_value, Error *err
   } else if (obj.type == kObjectTypeInteger) {
     return obj.data.integer;  // C semantics: non-zero int is true
   } else if (obj.type == kObjectTypeNil) {
-    return nil_value;  // caller decides what NIL (missing retval in lua) means
+    return nil_value;  // caller decides what NIL (missing retval in Lua) means
   } else {
     api_set_error(err, kErrorTypeValidation, "%s is not a boolean", what);
     return false;

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -135,8 +135,8 @@ EXTERN PMap(int) tabpage_handles INIT(= MAP_INIT);
 
 /// Structure used for saving state for :try
 ///
-/// Used when caller is supposed to be operating when other VimL code is being
-/// processed and that “other VimL code” must not be affected.
+/// Used when caller is supposed to be operating when other Vimscript code is being
+/// processed and that “other Vimscript code” must not be affected.
 typedef struct {
   except_T *current_exception;
   msglist_T *private_msg_list;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -544,7 +544,7 @@ String nvim__get_lib_dir(void)
 ///
 /// @param pat pattern of files to search for
 /// @param all whether to return all matches or only the first
-/// @param opts is_lua: only search lua subdirs
+/// @param opts is_lua: only search Lua subdirs
 /// @return list of absolute paths to the found files
 ArrayOf(String) nvim__get_runtime(Array pat, Boolean all, Dict(runtime) *opts, Error *err)
   FUNC_API_SINCE(8)
@@ -941,7 +941,7 @@ fail:
 ///
 /// @param buffer the buffer to use (expected to be empty)
 /// @param opts   Optional parameters.
-///          - on_input: lua callback for input sent, i e keypresses in terminal
+///          - on_input: Lua callback for input sent, i e keypresses in terminal
 ///            mode. Note: keypresses are sent raw as they would be to the pty
 ///            master end. For instance, a carriage return is sent
 ///            as a "\r", not as a "\n". |textlock| applies. It is possible
@@ -1009,7 +1009,7 @@ static void term_write(char *buf, size_t size, void *data)  // NOLINT(readabilit
 
 static void term_resize(uint16_t width, uint16_t height, void *data)
 {
-  // TODO(bfredl): lua callback
+  // TODO(bfredl): Lua callback
 }
 
 static void term_close(void *data)

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -38,7 +38,7 @@
 /// Unlike |nvim_command()| this function supports heredocs, script-scope (s:),
 /// etc.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
 /// @see |execute()|
 /// @see |nvim_command()|
@@ -126,7 +126,7 @@ theend:
 
 /// Executes an Ex command.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
 /// Prefer using |nvim_cmd()| or |nvim_exec2()| over this. To evaluate multiple lines of Vim script
 /// or an Ex command directly, use |nvim_exec2()|. To construct an Ex command using a structured
@@ -143,12 +143,12 @@ void nvim_command(String command, Error *err)
   try_end(err);
 }
 
-/// Evaluates a VimL |expression|.
+/// Evaluates a Vimscript |expression|.
 /// Dictionaries and Lists are recursively expanded.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
-/// @param expr     VimL expression string
+/// @param expr     Vimscript expression string
 /// @param[out] err Error details, if any
 /// @return         Evaluation result or expanded object
 Object nvim_eval(String expr, Error *err)
@@ -192,7 +192,7 @@ Object nvim_eval(String expr, Error *err)
   return rv;
 }
 
-/// Calls a VimL function.
+/// Calls a Vimscript function.
 ///
 /// @param fn Function name
 /// @param args Function arguments
@@ -258,9 +258,9 @@ free_vim_args:
   return rv;
 }
 
-/// Calls a VimL function with the given arguments.
+/// Calls a Vimscript function with the given arguments.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
 /// @param fn       Function to call
 /// @param args     Function arguments packed in an Array
@@ -272,12 +272,12 @@ Object nvim_call_function(String fn, Array args, Error *err)
   return _call_function(fn, args, NULL, err);
 }
 
-/// Calls a VimL |Dictionary-function| with the given arguments.
+/// Calls a Vimscript |Dictionary-function| with the given arguments.
 ///
-/// On execution error: fails with VimL error, updates v:errmsg.
+/// On execution error: fails with Vimscript error, updates v:errmsg.
 ///
-/// @param dict Dictionary, or String evaluating to a VimL |self| dict
-/// @param fn Name of the function defined on the VimL dict
+/// @param dict Dictionary, or String evaluating to a Vimscript |self| dict
+/// @param fn Name of the function defined on the Vimscript dict
 /// @param args Function arguments packed in an Array
 /// @param[out] err Error details, if any
 /// @return Result of the function call
@@ -363,7 +363,7 @@ typedef struct {
 typedef kvec_withinit_t(ExprASTConvStackItem, 16) ExprASTConvStack;
 /// @endcond
 
-/// Parse a VimL expression.
+/// Parse a Vimscript expression.
 ///
 /// @param[in]  expr  Expression to parse. Always treated as a single line.
 /// @param[in]  flags Flags:

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -412,11 +412,11 @@ void nvim_win_close(Window window, Boolean force, Error *err)
 /// @see |nvim_buf_call()|
 ///
 /// @param window     Window handle, or 0 for current window
-/// @param fun        Function to call inside the window (currently lua callable
+/// @param fun        Function to call inside the window (currently Lua callable
 ///                   only)
 /// @param[out] err   Error details, if any
-/// @return           Return value of function. NB: will deepcopy lua values
-///                   currently, use upvalues to send lua references in and out.
+/// @return           Return value of function. NB: will deepcopy Lua values
+///                   currently, use upvalues to send Lua references in and out.
 Object nvim_win_call(Window window, LuaRef fun, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_LUA_ONLY

--- a/test/functional/lua/help_spec.lua
+++ b/test/functional/lua/help_spec.lua
@@ -21,6 +21,7 @@ describe(':help docs', function()
     ok(rv.helpfiles > 100, '>100 :help files', rv.helpfiles)
     eq({}, rv.invalid_links, 'invalid tags in :help docs')
     eq({}, rv.invalid_urls, 'invalid URLs in :help docs')
+    eq({}, rv.invalid_spelling, 'invalid spelling in :help docs')
     -- Check that parse errors did not increase.
     ok(rv.err_count == 0, 'no parse errors', rv.err_count)
   end)


### PR DESCRIPTION
Enforce consistent terminology (defined in `gen_help_html.lua:spell_dict`) for common misspellings.

This does not spellcheck English in general (perhaps a future TODO, though it may be noisy).