### PR TITLE
fix(lsp): error in reset_timer on second detach

### DIFF
--- a/runtime/lua/vim/lsp/_inlay_hint.lua
+++ b/runtime/lua/vim/lsp/_inlay_hint.lua
@@ -187,7 +187,9 @@ function M.enable(bufnr)
       end,
       on_reload = function(_, cb_bufnr)
         clear(cb_bufnr)
-        bufstates[cb_bufnr] = nil
+        if bufstates[cb_bufnr] and bufstates[cb_bufnr].enabled then
+          bufstates[cb_bufnr] = { enabled = true }
+        end
         M.refresh({ bufnr = cb_bufnr })
       end,
       on_detach = function(_, cb_bufnr)

--- a/runtime/lua/vim/lsp/_inlay_hint.lua
+++ b/runtime/lua/vim/lsp/_inlay_hint.lua
@@ -144,6 +144,9 @@ end
 ---@private
 local function clear(bufnr)
   bufnr = resolve_bufnr(bufnr)
+  if not bufstates[bufnr] then
+    return
+  end
   reset_timer(bufnr)
   local bufstate = bufstates[bufnr]
   local client_lens = (bufstate or {}).client_hint or {}


### PR DESCRIPTION
On running `zig fmt` manually, the on_lines callback and the server both detach (for some reason), and both of them call `clear()`. This fixes it, otherwise the second one to detach has an error in `reset_timer` since the bufstate doesn't exist