### PR TITLE
vim-patch:9.0.1645: zserio files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1174,6 +1174,7 @@ local extension = {
   zir = 'zir',
   zu = 'zimbu',
   zut = 'zimbutempl',
+  zs = 'zserio',
   zsh = 'zsh',
   vala = 'vala',
   web = function(path, bufnr)

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -697,6 +697,7 @@ let s:filename_checks = {
     \ 'zimbu': ['file.zu'],
     \ 'zimbutempl': ['file.zut'],
     \ 'zir': ['file.zir'],
+    \ 'zserio': ['file.zs'],
     \ 'zsh': ['.zprofile', '/etc/zprofile', '.zfbfmarks', 'file.zsh', '.zcompdump', '.zlogin', '.zlogout', '.zshenv', '.zshrc', '.zcompdump-file', '.zlog', '.zlog-file', '.zsh', '.zsh-file', 'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file'],
     \
     \ 'help': [$VIMRUNTIME . '/doc/help.txt'],


### PR DESCRIPTION
Problem:    zserio files are not recognized.
Solution:   Add a pattern for zserio files. (Dominique Pellé,
            closes vim/vim#12544)

https://github.com/vim/vim/commit/2b994da57a0ac6ec0ec09fe3783f48ecd2bce610

Co-authored-by: =?UTF-8?q?Dominique=20Pell=C3=A9?= <dominique.pelle@gmail.com>
