### PR TITLE
fix(cmdline): don't redraw 'tabline' in Ex mode

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -791,7 +791,7 @@ static uint8_t *command_line_enter(int firstc, long count, int indent, bool clea
 
   // Redraw the statusline in case it uses the current mode using the mode()
   // function.
-  if (!cmd_silent) {
+  if (!cmd_silent && !exmode_active) {
     bool found_one = false;
 
     FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -944,6 +944,45 @@ describe('statusline is redrawn on entering cmdline', function()
   end)
 end)
 
+it('tabline is not redrawn in Ex mode #24122', function()
+  clear()
+  local screen = Screen.new(60, 5)
+  screen:set_default_attr_ids({
+    [0] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+    [1] = {bold = true, reverse = true},  -- MsgSeparator
+    [2] = {reverse = true},  -- TabLineFill
+  })
+  screen:attach()
+
+  exec([[
+    set showtabline=2
+    set tabline=%!MyTabLine()
+
+    function! MyTabLine()
+
+      return "foo"
+    endfunction
+  ]])
+
+  feed('gQ')
+  screen:expect{grid=[[
+    {2:foo                                                         }|
+                                                                |
+    {1:                                                            }|
+    Entering Ex mode.  Type "visual" to go to Normal mode.      |
+    :^                                                           |
+  ]]}
+
+  feed('echo 1<CR>')
+  screen:expect{grid=[[
+    {1:                                                            }|
+    Entering Ex mode.  Type "visual" to go to Normal mode.      |
+    :echo 1                                                     |
+    1                                                           |
+    :^                                                           |
+  ]]}
+end)
+
 describe("cmdline height", function()
   it("does not crash resized screen #14263", function()
     clear()


### PR DESCRIPTION
Fix #24122

Redrawing of 'statusline' and 'winbar' are actually already inhibited by
RedawingDisabled in Ex mode.

In Vim there is a check for `msg_scrolled == 0` (which is false in Ex
mode) since Vim doesn't have msgsep. Add a `!exmode_active` check here
in Nvim instead.
