### PR TITLE
feat(lsp): move inlay_hint() to vim.lsp

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -810,6 +810,13 @@ get_log_path()                                        *vim.lsp.get_log_path()*
     Return: ~
         (string) path to log file
 
+inlay_hint({bufnr}, {enable})                           *vim.lsp.inlay_hint()*
+    Enable/disable/toggle inlay hints for a buffer
+
+    Parameters: ~
+      • {bufnr}   (integer) Buffer handle, or 0 for current
+      • {enable}  (boolean|nil) true/false to enable/disable, nil to toggle
+
 omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
     Implements 'omnifunc' compatible LSP completion.
 
@@ -1226,13 +1233,6 @@ incoming_calls()                                *vim.lsp.buf.incoming_calls()*
     Lists all the call sites of the symbol under the cursor in the |quickfix|
     window. If the symbol can resolve to multiple items, the user can pick one
     in the |inputlist()|.
-
-inlay_hint({bufnr}, {enable})                       *vim.lsp.buf.inlay_hint()*
-    Enable/disable/toggle inlay hints for a buffer
-
-    Parameters: ~
-      • {bufnr}   (integer) Buffer handle, or 0 for current
-      • {enable}  (boolean|nil) true/false to enable/disable, nil to toggle
 
 list_workspace_folders()                *vim.lsp.buf.list_workspace_folders()*
     List workspace folders.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -98,7 +98,7 @@ The following new APIs and features were added.
 
 • |nvim_set_keymap()| and |nvim_del_keymap()| now support abbreviations.
 
-• Implemented LSP inlay hints: |vim.lsp.buf.inlay_hint()|
+• Implemented LSP inlay hints: |vim.lsp.inlay_hint()|
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
 
 ==============================================================================

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2474,6 +2474,13 @@ function lsp.with(handler, override_config)
   end
 end
 
+--- Enable/disable/toggle inlay hints for a buffer
+---@param bufnr (integer) Buffer handle, or 0 for current
+---@param enable (boolean|nil) true/false to enable/disable, nil to toggle
+function lsp.inlay_hint(bufnr, enable)
+  return require('vim.lsp.inlay_hint')(bufnr, enable)
+end
+
 --- Helper function to use when implementing a handler.
 --- This will check that all of the keys in the user configuration
 --- are valid keys and make sense to include for this handler.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -796,19 +796,4 @@ function M.execute_command(command_params)
   request('workspace/executeCommand', command_params)
 end
 
---- Enable/disable/toggle inlay hints for a buffer
----@param bufnr (integer) Buffer handle, or 0 for current
----@param enable (boolean|nil) true/false to enable/disable, nil to toggle
-function M.inlay_hint(bufnr, enable)
-  vim.validate({ enable = { enable, { 'boolean', 'nil' } }, bufnr = { bufnr, 'number' } })
-  local inlay_hint = require('vim.lsp._inlay_hint')
-  if enable then
-    inlay_hint.enable(bufnr)
-  elseif enable == false then
-    inlay_hint.disable(bufnr)
-  else
-    inlay_hint.toggle(bufnr)
-  end
-end
-
 return M

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -220,7 +220,7 @@ M['textDocument/codeLens'] = function(...)
 end
 
 M['textDocument/inlayHint'] = function(...)
-  return require('vim.lsp._inlay_hint').on_inlayhint(...)
+  return require('vim.lsp.inlay_hint').on_inlayhint(...)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
@@ -617,22 +617,8 @@ M['window/showDocument'] = function(_, result, ctx, _)
 end
 
 ---@see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_inlayHint_refresh
-M['workspace/inlayHint/refresh'] = function(err, _, ctx)
-  local inlay_hint = require('vim.lsp._inlay_hint')
-  if err then
-    return vim.NIL
-  end
-
-  for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
-    for _, winid in ipairs(api.nvim_list_wins()) do
-      if api.nvim_win_get_buf(winid) == bufnr then
-        inlay_hint.refresh({ bufnr = bufnr })
-        break
-      end
-    end
-  end
-
-  return vim.NIL
+M['workspace/inlayHint/refresh'] = function(err, result, ctx, config)
+  return require('vim.lsp.inlay_hint').on_refresh(err, result, ctx, config)
 end
 
 -- Add boilerplate error validation and logging for all of these.

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -64,7 +64,7 @@ describe('inlay hints', function()
     end)
 
     it(
-      'inlay hints are applied when vim.lsp.buf.inlay_hint(true) is called',
+      'inlay hints are applied when vim.lsp.inlay_hint(true) is called',
       function()
         local res = exec_lua([[
           bufnr = vim.api.nvim_get_current_buf()
@@ -79,7 +79,7 @@ describe('inlay hints', function()
 
 
         insert(text)
-        exec_lua([[vim.lsp.buf.inlay_hint(bufnr, true)]])
+        exec_lua([[vim.lsp.inlay_hint(bufnr, true)]])
         screen:expect({
           grid = [[
   auto add(int a, int b)-> int { return a + b; }    |
@@ -96,7 +96,7 @@ describe('inlay hints', function()
       end)
 
     it(
-      'inlay hints are cleared when vim.lsp.buf.inlay_hint(false) is called',
+      'inlay hints are cleared when vim.lsp.inlay_hint(false) is called',
       function()
         exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
@@ -105,7 +105,7 @@ describe('inlay hints', function()
       ]])
 
         insert(text)
-        exec_lua([[vim.lsp.buf.inlay_hint(bufnr, true)]])
+        exec_lua([[vim.lsp.inlay_hint(bufnr, true)]])
         screen:expect({
           grid = [[
   auto add(int a, int b)-> int { return a + b; }    |
@@ -119,7 +119,7 @@ describe('inlay hints', function()
                                                     |
 ]]
         })
-        exec_lua([[vim.lsp.buf.inlay_hint(bufnr, false)]])
+        exec_lua([[vim.lsp.inlay_hint(bufnr, false)]])
         screen:expect({
           grid = [[
   auto add(int a, int b) { return a + b; }          |


### PR DESCRIPTION
Allows to keep more functions hidden and gives a path forward for
further inlay_hint related functions - like applying textEdits.

See https://github.com/neovim/neovim/pull/23984#pullrequestreview-1486624668
