### PR TITLE
ci: introduce CI_LINT option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           cmake --build .deps
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
-        run: cmake -B build -G Ninja
+        run: cmake -B build -G Ninja -D CI_LINT=ON
 
       - if: "!cancelled()"
         name: Determine if run should be aborted

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,11 +229,14 @@ endif()
 #
 # Lint
 #
-find_program(SHELLCHECK_PRG shellcheck)
-find_program(STYLUA_PRG stylua)
+option(CI_LINT "Abort if lint programs not found" OFF)
+if(CI_LINT)
+  set(LINT_REQUIRED "REQUIRED")
+endif()
+find_program(SHELLCHECK_PRG shellcheck ${LINT_REQUIRED})
+find_program(STYLUA_PRG stylua ${LINT_REQUIRED})
 
 add_glob_target(
-  REQUIRED
   TARGET lintlua-luacheck
   COMMAND ${DEPS_BIN_DIR}/luacheck
   FLAGS -q

--- a/cmake/Util.cmake
+++ b/cmake/Util.cmake
@@ -4,7 +4,6 @@
 # depends on the value of TOUCH_STRATEGY.
 #
 # Options:
-# REQUIRED            - Abort if COMMAND doesn't exist.
 #
 # Single value arguments:
 # TARGET         - Name of the target
@@ -53,7 +52,7 @@
 #             files.
 function(add_glob_target)
   cmake_parse_arguments(ARG
-    "REQUIRED"
+    ""
     "TARGET;COMMAND;GLOB_PAT;TOUCH_STRATEGY"
     "FLAGS;FILES;GLOB_DIRS;EXCLUDE"
     ${ARGN}
@@ -61,14 +60,8 @@ function(add_glob_target)
 
   if(NOT ARG_COMMAND)
     add_custom_target(${ARG_TARGET})
-    if(ARG_REQUIRED)
-      add_custom_command(TARGET ${ARG_TARGET}
-        COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET}: ${ARG_COMMAND} not found"
-        COMMAND false)
-    else()
-      add_custom_command(TARGET ${ARG_TARGET}
-        COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET} SKIP: ${ARG_COMMAND} not found")
-    endif()
+    add_custom_command(TARGET ${ARG_TARGET}
+      COMMAND ${CMAKE_COMMAND} -E echo "${ARG_TARGET} SKIP: ${ARG_COMMAND} not found")
     return()
   endif()
 


### PR DESCRIPTION
This will abort if lint programs are not found, and is meant primarily
for the lint job in CI. Supersedes the REQUIRED argument in
add_glob_target as it's a superior replacement by being a built-in
solution.
