### PR TITLE
vim-patch:9.0.1661: BUCK files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1372,6 +1372,7 @@ local filename = {
   ['named.root'] = 'bindzone',
   WORKSPACE = 'bzl',
   ['WORKSPACE.bzlmod'] = 'bzl',
+  BUCK = 'bzl',
   BUILD = 'bzl',
   ['cabal.project'] = 'cabalproject',
   ['cabal.config'] = 'cabalconfig',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -705,7 +705,7 @@ let s:filename_checks = {
 
 let s:filename_case_checks = {
     \ 'modula2': ['file.DEF'],
-    \ 'bzl': ['file.BUILD', 'BUILD'],
+    \ 'bzl': ['file.BUILD', 'BUILD', 'BUCK'],
     \ }
 
 func CheckItems(checks)


### PR DESCRIPTION
Problem:    BUCK files are not recognized.
Solution:   Recognize BUCK files as "bzl". (Son Luong Ngoc, closes vim/vim#12564)

https://github.com/vim/vim/commit/b46e0f3263acd99c61df06ee3c4d1f6e0b471bc3

Co-authored-by: Son Luong Ngoc <sluongng@gmail.com>
