### PR TITLE
docs(diagnostic): diagnostic-structure in the return value of get()

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -53,6 +53,9 @@ indicated with (+):
     code: The diagnostic code
     user_data: Arbitrary data plugins or users can add
 
+In the return value of |vim.diagnostic.get()|, keys `bufnr`, `end_lnum`,
+`end_col`, and `severity` are guaranteed to be present.
+
 Diagnostics use the same indexing as the rest of the Nvim API (i.e. 0-based
 rows and columns). |api-indexing|
 
@@ -478,7 +481,7 @@ get({bufnr}, {opts})                                    *vim.diagnostic.get()*
                  • severity: See |diagnostic-severity|.
 
     Return: ~
-        Diagnostic [] table A list of diagnostic items |diagnostic-structure|.
+        Diagnostic [] table A list of diagnostic items |diagnostic-structure|. Keys `bufnr` , `end_lnum` , `end_col` , and `severity` are guaranteed to be present.
 
 get_namespace({namespace})                    *vim.diagnostic.get_namespace()*
     Get namespace metadata.

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -53,8 +53,6 @@ indicated with (+):
     code: The diagnostic code
     user_data: Arbitrary data plugins or users can add
 
-`end_col`, and `severity` are guaranteed to be present.
-
 Diagnostics use the same indexing as the rest of the Nvim API (i.e. 0-based
 rows and columns). |api-indexing|
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -53,7 +53,6 @@ indicated with (+):
     code: The diagnostic code
     user_data: Arbitrary data plugins or users can add
 
-In the return value of |vim.diagnostic.get()|, keys `bufnr`, `end_lnum`,
 `end_col`, and `severity` are guaranteed to be present.
 
 Diagnostics use the same indexing as the rest of the Nvim API (i.e. 0-based

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -767,7 +767,7 @@ end
 ---                        - namespace: (number) Limit diagnostics to the given namespace.
 ---                        - lnum: (number) Limit diagnostics to the given line number.
 ---                        - severity: See |diagnostic-severity|.
----@return Diagnostic[] table A list of diagnostic items |diagnostic-structure|.
+---@return Diagnostic[] table A list of diagnostic items |diagnostic-structure|. Keys `bufnr`, `end_lnum`, `end_col`, and `severity` are guaranteed to be present.
 function M.get(bufnr, opts)
   vim.validate({
     bufnr = { bufnr, 'n', true },


### PR DESCRIPTION
fix #24143 