### PR TITLE
vim-patch:9.0.1663: Termdebug on MS-Windows: some file names are not recognized

### DIFF
--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -640,7 +640,7 @@ func s:GdbOutCallback(job_id, msgs, event)
   for msg in a:msgs
     if msg =~ '^\^error,msg='
       if exists('s:evalexpr')
-            \ && s:DecodeMessage(msg[11:])
+            \ && s:DecodeMessage(msg[11:], v:false)
             \    =~ 'A syntax error in expression, near\|No symbol .* in current context'
         " Silently drop evaluation errors.
         call remove(a:msgs, index)
@@ -648,7 +648,7 @@ func s:GdbOutCallback(job_id, msgs, event)
         continue
       endif
     elseif msg[0] == '~'
-      call add(lines, s:DecodeMessage(msg[1:]))
+      call add(lines, s:DecodeMessage(msg[1:], v:false))
       call remove(a:msgs, index)
       continue
     endif
@@ -670,21 +670,20 @@ func s:GdbOutCallback(job_id, msgs, event)
   call s:CommOutput(a:job_id, a:msgs, a:event)
 endfunc
 
-" Decode a message from gdb.  quotedText starts with a ", return the text up
+" Decode a message from gdb.  "quotedText" starts with a ", return the text up
 " to the next ", unescaping characters:
-" - remove line breaks
-" - change \\t to \t
+" - remove line breaks (unless "literal" is v:true)
+" - change \\t to \t (unless "literal" is v:true)
 " - change \0xhh to \xhh (disabled for now)
 " - change \ooo to octal
 " - change \\ to \
-func s:DecodeMessage(quotedText)
+func s:DecodeMessage(quotedText, literal)
   if a:quotedText[0] != '"'
     echoerr 'DecodeMessage(): missing quote in ' . a:quotedText
     return
   endif
-  return a:quotedText
-        \ ->substitute('^"\|".*\|\\n', '', 'g')
-        \ ->substitute('\\t', "\t", 'g')
+  let msg = a:quotedText
+        \ ->substitute('^"\|".*', '', 'g')
         " multi-byte characters arrive in octal form
         " NULL-values must be kept encoded as those break the string otherwise
         \ ->substitute('\\000', s:NullRepl, 'g')
@@ -696,6 +695,13 @@ func s:DecodeMessage(quotedText)
         " \ ->substitute('\\0x00', s:NullRepl, 'g')
         \ ->substitute('\\\\', '\', 'g')
         \ ->substitute(s:NullRepl, '\\000', 'g')
+  if !a:literal
+          return msg
+        \ ->substitute('\\t', "\t", 'g')
+        \ ->substitute('\\n', '', 'g')
+  else
+          return msg
+  endif
 endfunc
 const s:NullRepl = 'XXXNULLXXX'
 
@@ -704,7 +710,7 @@ func s:GetFullname(msg)
   if a:msg !~ 'fullname'
     return ''
   endif
-  let name = s:DecodeMessage(substitute(a:msg, '.*fullname=', '', ''))
+  let name = s:DecodeMessage(substitute(a:msg, '.*fullname=', '', ''), v:true)
   if has('win32') && name =~ ':\\\\'
     " sometimes the name arrives double-escaped
     let name = substitute(name, '\\\\', '\\', 'g')
@@ -717,11 +723,11 @@ func s:GetAsmAddr(msg)
   if a:msg !~ 'addr='
     return ''
   endif
-  let addr = s:DecodeMessage(substitute(a:msg, '.*addr=', '', ''))
+  let addr = s:DecodeMessage(substitute(a:msg, '.*addr=', '', ''), v:false)
   return addr
 endfunc
 
-function s:EndTermDebug(job_id, exit_code, event)
+func s:EndTermDebug(job_id, exit_code, event)
   let s:running = v:false
   if s:starting
     return


### PR DESCRIPTION
#### vim-patch:9.0.1663: Termdebug on MS-Windows: some file names are not recognized

Problem:    Termdebug on MS-Windows: some file names are not recognized.
Solution:   Do not always change \t and \n. (Christian Brabandt,
            closes vim/vim#12565)

https://github.com/vim/vim/commit/c9a4a8ab28da2b11856a3f08ccba2e91f46b85c3

Co-authored-by: Christian Brabandt <cb@256bit.org>