### PR TITLE
fix(docs): vimdoc syntax errors

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -50,8 +50,8 @@ TREESITTER_LUA_URL https://github.com/MunifTanjim/tree-sitter-lua/archive/v0.0.1
 TREESITTER_LUA_SHA256 659beef871a7fa1d9a02c23f5ebf55019aa3adce6d7f5441947781e128845256
 TREESITTER_VIM_URL https://github.com/neovim/tree-sitter-vim/archive/v0.3.0.tar.gz
 TREESITTER_VIM_SHA256 403acec3efb7cdb18ff3d68640fc823502a4ffcdfbb71cec3f98aa786c21cbe2
-TREESITTER_VIMDOC_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v2.0.0.tar.gz
-TREESITTER_VIMDOC_SHA256 1ff8f4afd3a9599dd4c3ce87c155660b078c1229704d1a254433e33794b8f274
+TREESITTER_VIMDOC_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v2.0.1.tar.gz
+TREESITTER_VIMDOC_SHA256 61e165df29778dc0c9277c2a7bc67447cc4e1bed36ca916a2f476dd25ce3260e
 TREESITTER_QUERY_URL https://github.com/nvim-treesitter/tree-sitter-query/archive/v0.1.0.tar.gz
 TREESITTER_QUERY_SHA256 e2b806f80e8bf1c4f4e5a96248393fe6622fc1fc6189d6896d269658f67f914c
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/91e4d940169a0c0b024560632ef53c4f119117ca.tar.gz

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5383,7 +5383,7 @@ matchfuzzy({list}, {str} [, {dict}])			*matchfuzzy()*
 <		results in `['two one', 'one two']` . >
 		   :echo ['one two', 'two one']->matchfuzzy('two one',
 						\ {'matchseq': 1})
-<		results in ['two one'].
+<		results in `['two one']`.
 
 matchfuzzypos({list}, {str} [, {dict}])			*matchfuzzypos()*
 		Same as |matchfuzzy()|, but returns the list of matched
@@ -5405,7 +5405,7 @@ matchfuzzypos({list}, {str} [, {dict}])			*matchfuzzypos()*
 <		results in [["lacy", "clay"], [[0, 1], [1, 2]], [153, 133]] >
 			:echo [{'text': 'hello', 'id' : 10}]
 				\ ->matchfuzzypos('ll', {'key' : 'text'})
-<		results in [[{"id": 10, "text": "hello"}], [[2, 3]], [127]]
+<		results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 
 matchlist({expr}, {pat} [, {start} [, {count}]])		*matchlist()*
 		Same as |match()|, but return a |List|.  The first item in the
@@ -9507,11 +9507,11 @@ winlayout([{tabnr}])					*winlayout()*
 		For a leaf window, it returns:
 			["leaf", {winid}]
 		For horizontally split windows, which form a column, it
-		returns:
+		returns: >
 			["col", [{nested list of windows}]]
-		For vertically split windows, which form a row, it returns:
+<		For vertically split windows, which form a row, it returns: >
 			["row", [{nested list of windows}]]
-
+<
 		Example: >
 			" Only one window in the tab page
 			:echo winlayout()

--- a/runtime/doc/indent.txt
+++ b/runtime/doc/indent.txt
@@ -574,7 +574,7 @@ The examples below assume a 'shiftwidth' of 4.
 	      them like every other preprocessor directive.
 
 
-The defaults, spelled out in full, are:
+The defaults, spelled out in full, are: >
 	cinoptions=>s,e0,n0,f0,{0,}0,^0,L-1,:s,=s,l0,b0,gs,hs,N0,E0,ps,ts,is,+s,
 			c3,C0,/0,(2s,us,U0,w0,W0,k0,m0,j0,J0,)20,*70,#0,P0
 
@@ -1060,19 +1060,19 @@ be configured by setting the following keys in the |Dictionary|
 b:sh_indent_defaults to a specific amount or to a |Funcref| that references a
 function that will return the amount desired:
 
-b:sh_indent_options['default']	Default amount of indent.
+b:sh_indent_options["default"]	Default amount of indent.
 
-b:sh_indent_options['continuation-line']
+b:sh_indent_options["continuation-line"]
 				Amount of indent to add to a continued line.
 
-b:sh_indent_options['case-labels']
+b:sh_indent_options["case-labels"]
 				Amount of indent to add for case labels.
 				(not actually implemented)
 
-b:sh_indent_options['case-statements']
+b:sh_indent_options["case-statements"]
 				Amount of indent to add for case statements.
 
-b:sh_indent_options['case-breaks']
+b:sh_indent_options["case-breaks"]
 				Amount of indent to add (or more likely
 				remove) for case breaks.
 

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -475,7 +475,7 @@ tag		command		   action in op-pending and Visual mode	~
 |v_a)|		a)		   same as ab
 |v_a<|		a<		   "a <>" from '<' to the matching '>'
 |v_a>|		a>		   same as a<
-|v_aB|		aB		   "a Block" from "[{" to "]}" (with brackets)
+|v_aB|		aB		   "a Block" from `[{` to `]}` (with brackets)
 |v_aW|		aW		   "a WORD" (with white space)
 |v_a[|		a[		   "a []" from '[' to the matching ']'
 |v_a]|		a]		   same as a[
@@ -493,7 +493,7 @@ tag		command		   action in op-pending and Visual mode	~
 |v_i)|		i)		   same as ib
 |v_i<|		i<		   "inner <>" from '<' to the matching '>'
 |v_i>|		i>		   same as i<
-|v_iB|		iB		   "inner Block" from "[{" and "]}"
+|v_iB|		iB		   "inner Block" from `[{` and `]}`
 |v_iW|		iW		   "inner WORD"
 |v_i[|		i[		   "inner []" from '[' to the matching ']'
 |v_i]|		i]		   same as i[

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -620,15 +620,15 @@ it			"inner tag block", select [count] tag blocks, from the
 
 a}							*v_a}* *a}* *a{*
 a{							*v_aB* *v_a{* *aB*
-aB			"a Block", select [count] Blocks, from "[count] [{" to
-			the matching '}', including the '{' and '}' (see
+aB			"a Block", select [count] Blocks, from `[count] [{` to
+			the matching "}", including the "{" and "}" (see
 			|[{|).
 			When used in Visual mode it is made charwise.
 
 i}							*v_i}* *i}* *i{*
 i{							*v_iB* *v_i{* *iB*
-iB			"inner Block", select [count] Blocks, from "[count] [{"
-			to the matching '}', excluding the '{' and '}' (see
+iB			"inner Block", select [count] Blocks, from `[count] [{`
+			to the matching "}", excluding the "{" and "}" (see
 			|[{|).
 			When used in Visual mode it is made charwise.
 
@@ -1279,9 +1279,9 @@ remembered.
 			|exclusive| motion.
 
 The above four commands can be used to go to the start or end of the current
-code block.  It is like doing "%" on the '(', ')', '{' or '}' at the other
+code block.  It is like doing "%" on the "(", ")", "{" or "}" at the other
 end of the code block, but you can do this from anywhere in the code block.
-Very useful for C programs.  Example: When standing on "case x:", "[{" will
+Very useful for C programs.  Example: When standing on "case x:", `[{` will
 bring you back to the switch statement.
 
 						*]m*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -901,7 +901,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	accidentally overwriting existing files with a backup file.  You might
 	prefer using ".bak", but make sure that you don't have files with
 	".bak" that you want to keep.
-	Only normal file name characters can be used; "/\*?[|<>" are illegal.
+	Only normal file name characters can be used; `/\*?[|<>` are illegal.
 
 	If you like to keep a lot of backups, you could use a BufWritePre
 	autocommand to change 'backupext' just before writing the file to
@@ -2445,7 +2445,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	one dot may appear.
 	This option is not copied to another buffer, independent of the 's' or
 	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
 						*'fillchars'* *'fcs'*
 'fillchars' 'fcs'	string	(default "")
@@ -2650,7 +2650,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 		item		commands ~
 		all		any
-		block		"(", "{", "[[", "[{", etc.
+		block		(, {, [[, [{, etc.
 		hor		horizontal movements: "l", "w", "fx", etc.
 		insert		any command in Insert mode
 		jump		far jumps: "G", "gg", etc.
@@ -3581,7 +3581,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Setting this option to a valid keymap name has the side effect of
 	setting 'iminsert' to one, so that the keymap becomes effective.
 	'imsearch' is also set to one, unless it was -1
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
 					*'keymodel'* *'km'*
 'keymodel' 'km'		string	(default "")
@@ -3666,7 +3666,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	matter what $LANG is set to: >
 		:set langmenu=nl_NL.ISO_8859-1
 <	When 'langmenu' is empty, |v:lang| is used.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 	If your $LANG is set to a non-English language but you do want to use
 	the English menus: >
 		:set langmenu=none
@@ -4477,7 +4477,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Using 'patchmode' for compressed files appends the extension at the
 	end (e.g., "file.gz.orig"), thus the resulting name isn't always
 	recognized as a compressed file.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
 				*'path'* *'pa'* *E343* *E345* *E347* *E854*
 'path' 'pa'		string	(default: ".,,")
@@ -6259,7 +6259,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Syntax autocommand event is triggered with the value as argument.
 	This option is not copied to another buffer, independent of the 's' or
 	'S' flag in 'cpoptions'.
-	Only normal file name characters can be used, "/\*?[|<>" are illegal.
+	Only normal file name characters can be used, `/\*?[|<>` are illegal.
 
 						*'tabline'* *'tal'*
 'tabline' 'tal'		string	(default empty)

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -489,8 +489,8 @@ In Insert or Command-line mode:
 |v_ip|	   N  ip	Select "inner paragraph"
 |v_ab|	   N  ab	Select "a block" (from "[(" to "])")
 |v_ib|	   N  ib	Select "inner block" (from "[(" to "])")
-|v_aB|	   N  aB	Select "a Block" (from "[{" to "]}")
-|v_iB|	   N  iB	Select "inner Block" (from "[{" to "]}")
+|v_aB|	   N  aB	Select "a Block" (from `[{` to `]}`)
+|v_iB|	   N  iB	Select "inner Block" (from `[{` to `]}`)
 |v_a>|	   N  a>	Select "a <> block"
 |v_i>|	   N  i>	Select "inner <> block"
 |v_at|	   N  at	Select "a tag block" (from <aaa> to </aaa>)

--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -59,8 +59,8 @@ is an overview with tags to jump to:
 
 |v_ab|			Select "a block" from "[(" to "])", including braces
 |v_ib|			Select "inner block" from "[(" to "])"
-|v_aB|			Select "a block" from "[{" to "]}", including brackets
-|v_iB|			Select "inner block" from "[{" to "]}"
+|v_aB|			Select "a block" from `[{` to `]}`, including brackets
+|v_iB|			Select "inner block" from `[{` to `]}`
 
 ==============================================================================
 Finding where identifiers are used			*ident-search*

--- a/runtime/doc/usr_29.txt
+++ b/runtime/doc/usr_29.txt
@@ -361,7 +361,7 @@ MOVING IN CODE BLOCKS
 In C code blocks are enclosed in {}.  These can get pretty long.  To move to
 the start of the outer block use the "[[" command.  Use "][" to find the end.
 This assumes that the "{" and "}" are in the first column.
-   The "[{" command moves to the start of the current block.  It skips over
+   The [{ command moves to the start of the current block.  It skips over
 pairs of {} at the same level.  "]}" jumps to the end.
    An overview:
 
@@ -410,7 +410,7 @@ That also works when they are many lines apart.
 
 MOVING IN BRACES
 
-The "[(" and "])" commands work similar to "[{" and "]}", except that they
+The [( and ]) commands work similar to [{ and ]}, except that they
 work on () pairs instead of {} pairs.
 >
 				  [(

--- a/runtime/doc/usr_40.txt
+++ b/runtime/doc/usr_40.txt
@@ -501,7 +501,7 @@ See |autocmd-events| for a complete list of events.
 PATTERNS
 
 The {file-pattern} argument can actually be a comma-separated list of file
-patterns.  For example: "*.c,*.h" matches files ending in ".c" and ".h".
+patterns.  For example: `*.c,*.h` matches files ending in ".c" and ".h".
    The usual file wildcards can be used.  Here is a summary of the most often
 used ones:
 


### PR DESCRIPTION


Prepare for https://github.com/neovim/tree-sitter-vimdoc/pull/108 which improves `{arg}` highlighting in many common cases:

    vim.foo({bar})
    vim.foo( {bar})
    nvim_foo({bar})
    nvim_foo({bar},{baz})
    nvim_foo({bar}, {baz})
    foo[{buf}]

The tradeoff is that things like `"[{"` are flagged as parse errors. Could avoid that if we drop support for `foo[{buf}]`, but that is rather common (see `builtin.txt`).