### PR TITLE
vim-patch:8.2.3833,9.0.1665

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1784,11 +1784,13 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     }
 
     const int save_did_emsg = did_emsg;
+    const bool save_ex_pressedreturn = get_pressedreturn();
 
     // Execute the autocmd. The `getnextac` callback handles iteration.
     do_cmdline(NULL, getnextac, &patcmd, DOCMD_NOWAIT | DOCMD_VERBOSE | DOCMD_REPEAT);
 
     did_emsg += save_did_emsg;
+    set_pressedreturn(save_ex_pressedreturn);
 
     if (nesting == 1) {
       // restore cursor and topline, unless they were changed

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1783,8 +1783,12 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
       check_lnums_nested(true);
     }
 
+    const int save_did_emsg = did_emsg;
+
     // Execute the autocmd. The `getnextac` callback handles iteration.
-    do_cmdline(NULL, getnextac, (void *)&patcmd, DOCMD_NOWAIT | DOCMD_VERBOSE | DOCMD_REPEAT);
+    do_cmdline(NULL, getnextac, &patcmd, DOCMD_NOWAIT | DOCMD_VERBOSE | DOCMD_REPEAT);
+
+    did_emsg += save_did_emsg;
 
     if (nesting == 1) {
       // restore cursor and topline, unless they were changed

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -244,6 +244,12 @@ func Test_ex_mode_errors()
 
   au! CmdLineEnter
   delfunc ExEnterFunc
+
+  au CmdlineEnter * :
+  call feedkeys("gQecho 1\r", 'xt')
+
+  au! CmdlineEnter
+
   quit
 endfunc
 


### PR DESCRIPTION
#### vim-patch:8.2.3833: error from term_start() not caught by try/catch

Problem:    Error from term_start() not caught by try/catch.
Solution:   save and restore did_emsg when applying autocommands. (Ozaki
            Kiichi, closes vim/vim#9361)

https://github.com/vim/vim/commit/c3f91c0648f4b04a6a9ceb4ccec45ea767a63796

Co-authored-by: ichizok <gclient.gaap@gmail.com>


#### vim-patch:9.0.1665: empty CmdlineEnter autocommand causes errors in Ex mode

Problem:    Empty CmdlineEnter autocommand causes errors in Ex mode.
Solution:   Save and restore ex_pressedreturn. (Christian Brabandt,
            closes # 12581)

https://github.com/vim/vim/commit/590aae35575cbd74d80c41d87fc647f2812aad70

Co-authored-by: Christian Brabandt <cb@256bit.org>