### PR TITLE
fix: always set arg0 to lua scripts

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1361,7 +1361,7 @@ static void command_line_scan(mparm_T *parmp)
           }
           parmp->luaf = argv[0];
           argc--;
-          if (argc > 0) {  // Lua args after "-l <file>".
+          if (argc >= 0) {  // Lua args after "-l <file>".
             parmp->lua_arg0 = parmp->argc - argc;
             argc = 0;
           }

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -144,6 +144,18 @@ describe('startup', function()
     end)
 
     it('sets _G.arg', function()
+      -- nvim -l foo.lua
+      assert_l_out([[
+          bufs:
+          nvim args: 3
+          lua args: {
+            [0] = "test/functional/fixtures/startup.lua"
+          }]],
+        {},
+        {}
+      )
+      eq(0, eval('v:shell_error'))
+
       -- nvim -l foo.lua [args]
       assert_l_out([[
           bufs:


### PR DESCRIPTION
Sets script's basename when no extra arguments are given

Fixes: #24110 