### PR TITLE
vim-patch:9.0.{1664,1667}: divide by zero when scrolling with 'smoothscroll' set

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1954,17 +1954,19 @@ void scroll_cursor_bot(int min_scroll, int set_topbot)
       int top_plines = plines_win_nofill(curwin, curwin->w_topline, false);
       int skip_lines = 0;
       int width1 = curwin->w_width_inner - curwin_col_off();
-      int width2 = width1 + curwin_col_off2();
-      // similar formula is used in curs_columns()
-      if (curwin->w_skipcol > width1) {
-        skip_lines += (curwin->w_skipcol - width1) / width2 + 1;
-      } else if (curwin->w_skipcol > 0) {
-        skip_lines = 1;
-      }
+      if (width1 > 0) {
+        int width2 = width1 + curwin_col_off2();
+        // similar formula is used in curs_columns()
+        if (curwin->w_skipcol > width1) {
+          skip_lines += (curwin->w_skipcol - width1) / width2 + 1;
+        } else if (curwin->w_skipcol > 0) {
+          skip_lines = 1;
+        }
 
-      top_plines -= skip_lines;
-      if (top_plines > curwin->w_height_inner) {
-        scrolled += (top_plines - curwin->w_height_inner);
+        top_plines -= skip_lines;
+        if (top_plines > curwin->w_height_inner) {
+          scrolled += (top_plines - curwin->w_height_inner);
+        }
       }
     }
   }

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -939,6 +939,48 @@ describe('smoothscroll', function()
     ]])
   end)
 
+  -- oldtest: Test_smoothscroll_zero_width_scroll_cursor_bot()
+  it('does not divide by zero in zero-width window', function()
+    screen:try_resize(12, 19)
+    screen:set_default_attr_ids({
+      [1] = {foreground = Screen.colors.Brown};  -- LineNr
+      [2] = {bold = true, reverse = true};  -- StatusLine
+      [3] = {reverse = true};  -- StatusLineNC
+    })
+    exec([[
+      silent normal yy
+      silent normal 19p
+      winsize 0 19
+      vsplit
+      vertical resize 0
+      set foldcolumn=1
+      set number
+      set smoothscroll
+      silent normal 20G
+    ]])
+    screen:expect([[
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1: }│          |
+      {1:^ }│          |
+      {2:< }{3:<ame] [+] }|
+                  |
+    ]])
+  end)
+
   it("works with virt_lines above and below", function()
     screen:try_resize(55, 7)
     exec([=[

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -941,16 +941,17 @@ describe('smoothscroll', function()
 
   -- oldtest: Test_smoothscroll_zero_width_scroll_cursor_bot()
   it('does not divide by zero in zero-width window', function()
-    screen:try_resize(12, 19)
+    screen:try_resize(40, 19)
     screen:set_default_attr_ids({
       [1] = {foreground = Screen.colors.Brown};  -- LineNr
-      [2] = {bold = true, reverse = true};  -- StatusLine
-      [3] = {reverse = true};  -- StatusLineNC
+      [2] = {bold = true, foreground = Screen.colors.Blue};  -- NonText
+      [3] = {bold = true, reverse = true};  -- StatusLine
+      [4] = {reverse = true};  -- StatusLineNC
     })
     exec([[
       silent normal yy
       silent normal 19p
-      winsize 0 19
+      set cpoptions+=n
       vsplit
       vertical resize 0
       set foldcolumn=1
@@ -959,25 +960,25 @@ describe('smoothscroll', function()
       silent normal 20G
     ]])
     screen:expect([[
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1: }│          |
-      {1:^ }│          |
-      {2:< }{3:<ame] [+] }|
-                  |
+      {1: }│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:@}│                                      |
+      {2:^@}│                                      |
+      {3:< }{4:[No Name] [+]                         }|
+                                              |
     ]])
   end)
 

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -836,4 +836,28 @@ func Test_smoothscroll_multi_skipcol()
   call StopVimInTerminal(buf)
 endfunc
 
+" this was dividing by zero bug in scroll_cursor_bot
+func Test_smoothscroll_zero_width_scroll_cursor_bot()
+  CheckScreendump
+
+  let lines =<< trim END
+      silent normal yy
+      silent normal 19p
+      winsize 0 19
+      vsplit
+      vertical resize 0
+      set foldcolumn=1
+      set number
+      set smoothscroll
+      silent normal 20G
+  END
+  call writefile(lines, 'XSmoothScrollZeroBot', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollZeroBot', #{rows: 19, wait_for_ruler: 0})
+  call TermWait(buf, 1000)
+
+  call VerifyScreenDump(buf, 'Test_smoothscroll_zero_bot', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -843,7 +843,7 @@ func Test_smoothscroll_zero_width_scroll_cursor_bot()
   let lines =<< trim END
       silent normal yy
       silent normal 19p
-      winsize 0 19
+      set cpoptions+=n
       vsplit
       vertical resize 0
       set foldcolumn=1
@@ -852,9 +852,7 @@ func Test_smoothscroll_zero_width_scroll_cursor_bot()
       silent normal 20G
   END
   call writefile(lines, 'XSmoothScrollZeroBot', 'D')
-  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollZeroBot', #{rows: 19, wait_for_ruler: 0})
-  call TermWait(buf, 1000)
-
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollZeroBot', #{rows: 19})
   call VerifyScreenDump(buf, 'Test_smoothscroll_zero_bot', {})
 
   call StopVimInTerminal(buf)


### PR DESCRIPTION
#### vim-patch:9.0.1664: divide by zero when scrolling with 'smoothscroll' set

Problem:    Divide by zero when scrolling with 'smoothscroll' set.
Solution:   Avoid using a negative width. (closes vim/vim#12540)

https://github.com/vim/vim/commit/8154e642aa476e1a5d3de66c34e8289845b2b797

Co-authored-by: fullwaywang <fullwaywang@tencent.com>


#### vim-patch:9.0.1667: regression test doesn't fail when fix is reverted

Problem:    Regression test doesn't fail when fix is reverted.
Solution:   Add "n" to 'cpoptions' instead of using :winsize. (closes vim/vim#12587,
            issue vim/vim#12528)

https://github.com/vim/vim/commit/e42989374144a63d986b878618aeac328e35ac3b