### PR TITLE
fix(treesitter): handle empty region when logging

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -447,6 +447,9 @@ end
 ---@private
 ---@param region Range6[]
 local function region_tostr(region)
+  if #region == 0 then
+    return '[]'
+  end
   local srow, scol = region[1][1], region[1][2]
   local erow, ecol = region[#region][4], region[#region][5]
   return string.format('[%d:%d-%d:%d]', srow, scol, erow, ecol)


### PR DESCRIPTION
Empty region can be created from here https://github.com/neovim/neovim/blob/929e4865d1f59cb356f3f2f8a10ad6095b435544/runtime/lua/vim/treesitter/languagetree.lua#L548.

I don't understand what that means, but changing `{ {} }` to `{}` seems to break everything. So fixing the logger to handle empty region.