### PR TITLE
Add netrw_use_notify as an alternative notification method

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -77,6 +77,14 @@ fun! netrw#ErrorMsg(level,msg,errnum)
    return
   endif
 
+  if g:netrw_use_notify == 1
+    " nvim has levels 0 for trace and 1 for debug. Info, Warning and Error are
+    " thus shifted by 2
+    let level= a:level + 2
+    call nvim_notify(a:msg, level, {})
+    return
+  endif
+
   if a:level == 1
    let level= "**warning** (netrw) "
   elseif a:level == 2
@@ -215,6 +223,9 @@ if (v:version > 802 || (v:version == 802 && has("patch486"))) && has("balloon_ev
   call s:NetrwInit("g:netrw_use_errorwindow",2)
 else
   call s:NetrwInit("g:netrw_use_errorwindow",1)
+endif
+if !exists("g:netrw_use_notify")
+  let g:netrw_use_notify= 0
 endif
 
 if !exists("g:netrw_dav_cmd")

--- a/runtime/autoload/netrwSettings.vim
+++ b/runtime/autoload/netrwSettings.vim
@@ -95,6 +95,7 @@ fun! netrwSettings#NetrwSettings()
   put =''
   put ='+ Netrw Messages'
   put ='let g:netrw_use_errorwindow    = '.g:netrw_use_errorwindow
+  put ='let g:netrw_use_notify         = '.g:netrw_use_notify
 
   put = ''
   put ='+ Netrw Browser Control'

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -437,6 +437,11 @@ settings are described below, in |netrw-browser-options|, and in
   *g:netrw_silent*	=0 : transfers done normally
 			=1 : transfers done silently
 
+ *g:netrw_use_notify*     =1 use nvim_notify instead of a separate
+			   errorwindow. This is useful when plugins override
+			   the vim.notify function with custom notification
+			   handling
+
  *g:netrw_use_errorwindow* =2: messages from netrw will use a popup window
 			     Move the mouse and pause to remove the popup window.
 			     (default value if popup windows are available)


### PR DESCRIPTION
The default notfication mechanism for netrw opens a new window, and takes focus which can be very annoying. This change allows using the neovim notification system provided by neovim (through `vim.notify` in lua and `nvim_notify` in viml).
This introduces a new variable to set for netrw called `g:netrw_use_notify` which essentially makes netrw error and warnings work like the rest of nvim, and also allows plugins to override the default notifications.

Comments are greatly appreciated