### PR TITLE
feat(defaults): set g:netrw_use_errorwindow = 0

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -211,10 +211,8 @@ let g:netrw_localmovecmdopt    = ""
 
 " ---------------------------------------------------------------------
 " Default values for netrw's global protocol variables {{{2
-if (v:version > 802 || (v:version == 802 && has("patch486"))) && has("balloon_eval") && !exists("s:initbeval") && !exists("g:netrw_nobeval") && has("syntax") && exists("g:syntax_on") && has("mouse")
-  call s:NetrwInit("g:netrw_use_errorwindow",2)
-else
-  call s:NetrwInit("g:netrw_use_errorwindow",1)
+if !exists("g:netrw_use_errorwindow")
+  let g:netrw_use_errorwindow = 0
 endif
 
 if !exists("g:netrw_dav_cmd")

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -439,12 +439,10 @@ settings are described below, in |netrw-browser-options|, and in
 
  *g:netrw_use_errorwindow* =2: messages from netrw will use a popup window
 			     Move the mouse and pause to remove the popup window.
-			     (default value if popup windows are available)
 			 =1 : messages from netrw will use a separate one
 			      line window.  This window provides reliable
 			      delivery of messages.
-			     (default value if popup windows are not available)
-			 =0 : messages from netrw will use echoerr ;
+			 =0 : (default) messages from netrw will use echoerr ;
 			      messages don't always seem to show up this
 			      way, but one doesn't have to quit the window.
 


### PR DESCRIPTION
The default notfication mechanism for netrw opens a new window, and takes focus which can be very annoying. This change allows using the neovim notification system provided by neovim (through vim.notify in lua and nvim_notify in viml).
This introduces a new variable to set for netrw called g:netrw_use_notify which essentially makes netrw error and warnings work like the rest of nvim, and also allows plugins to override the default notifications.

Comments are greatly appreciated