### PR TITLE
vim-patch:9.0.1670: resetting local option to global value is inconsistent

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -794,10 +794,14 @@ static void do_set_num(int opt_idx, int opt_flags, char **argp, int nextchar, co
   if (nextchar == '&') {
     value = (long)(intptr_t)options[opt_idx].def_val;
   } else if (nextchar == '<') {
-    // For 'undolevels' NO_LOCAL_UNDOLEVEL means to
-    // use the global value.
     if ((long *)varp == &curbuf->b_p_ul && opt_flags == OPT_LOCAL) {
+      // for 'undolevels' NO_LOCAL_UNDOLEVEL means using the global value
       value = NO_LOCAL_UNDOLEVEL;
+    } else if (opt_flags == OPT_LOCAL
+               && ((long *)varp == &curwin->w_p_siso
+                   || (long *)varp == &curwin->w_p_so)) {
+      // for 'scrolloff'/'sidescrolloff' -1 means using the global value
+      value = -1;
     } else {
       value = *(long *)get_varp_scope(&(options[opt_idx]), OPT_GLOBAL);
     }

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -939,12 +939,16 @@ func Test_local_scrolloff()
   wincmd w
   call assert_equal(5, &so)
   wincmd w
+  call assert_equal(3, &so)
   setlocal so<
   call assert_equal(5, &so)
+  setglob so=8
+  call assert_equal(8, &so)
+  call assert_equal(-1, &l:so)
   setlocal so=0
   call assert_equal(0, &so)
   setlocal so=-1
-  call assert_equal(5, &so)
+  call assert_equal(8, &so)
 
   call assert_equal(7, &siso)
   setlocal siso=3
@@ -952,12 +956,16 @@ func Test_local_scrolloff()
   wincmd w
   call assert_equal(7, &siso)
   wincmd w
+  call assert_equal(3, &siso)
   setlocal siso<
   call assert_equal(7, &siso)
+  setglob siso=4
+  call assert_equal(4, &siso)
+  call assert_equal(-1, &l:siso)
   setlocal siso=0
   call assert_equal(0, &siso)
   setlocal siso=-1
-  call assert_equal(7, &siso)
+  call assert_equal(4, &siso)
 
   close
   set so&


### PR DESCRIPTION
#### vim-patch:9.0.1670: resetting local option to global value is inconsistent

Problem:    Resetting local option to global value is inconsistent.
Solution:   Handle "<" specifically for 'scrolloff' and 'sidescrolloff'.

https://github.com/vim/vim/commit/bf5f189e449d6517239b79804d7a422a46946838

Co-authored-by: Bram Moolenaar <Bram@vim.org>