### PR TITLE
vim-patch:9.0.1671: Termdebug: error with more than 99 breakpoints

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -493,6 +493,20 @@ If there is no g:termdebug_config you can use: >vim
 	let g:termdebug_popup = 0
 
 
+Change default signs ~
+							*termdebug_signs*
+Termdebug uses the last two characters of the breakpoint ID in the
+signcolumn to represent breakpoints. For example, breakpoint ID 133
+will be displayed as `33`.
+
+If you want to customize the breakpoint signs: >vim
+	let g:termdebug_config['sign'] = '>>'
+If there is no g:terminal_config yet you can use: >vim
+	let g:termdebug_config = {'sign': '>>'}
+
+After this, breakpoints will be displayed as `>>` in the signcolumn.
+
+
 Vim window width ~
 							*termdebug_wide*
 To change the width of the Vim window when debugging starts and use a vertical

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1543,8 +1543,18 @@ func s:CreateBreakpoint(id, subid, enabled)
     else
       let hiName = "debugBreakpoint"
     endif
+    let label = ''
+    if exists('g:termdebug_config')
+      let label = get(g:termdebug_config, 'sign', '')
+    endif
+    if label == ''
+      let label = substitute(nr, '\..*', '', '')
+      if strlen(label) > 2
+        let label = strpart(label, strlen(label) - 2)
+      endif
+    endif
     call sign_define('debugBreakpoint' .. nr,
-          \ #{text: substitute(nr, '\..*', '', ''),
+          \ #{text: strpart(label, 0, 2),
           \ texthl: hiName})
   endif
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1671: Termdebug: error with more than 99 breakpoints

Problem:    Termdebug: error with more than 99 breakpoints.
Solution:   Use a different sign for breakpoint 100 and over. (closes vim/vim#12589)

https://github.com/vim/vim/commit/e7d9ca2b3bf99b0b759be8952e02c77110a354c1

Co-authored-by: skywind3000 <skywind3000@163.com>