### PR TITLE
feat(version): unverbose ":version", ":verbose version"

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -66,6 +66,8 @@ set(ENV{SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_NAME})  # used by test/helpers.lua.
 set(ENV{DEPS_INSTALL_DIR} ${DEPS_INSTALL_DIR})  # used by test/busted_runner.lua
 
 execute_process(
+  # Note: because of "-ll" (low-level interpreter mode), some modules like
+  # _editor.lua are not loaded.
   COMMAND ${NVIM_PRG} -ll ${WORKING_DIR}/test/busted_runner.lua -v -o test.busted.outputHandlers.${BUSTED_OUTPUT_TYPE}
     --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2700,33 +2700,39 @@ void list_version(void)
   msg(longVersion);
   msg(version_buildtype);
   list_lua_version();
-#ifndef NDEBUG
-  msg(version_cflags);
-#endif
 
-  version_msg("\n\n");
+  if (p_verbose > 0) {
+#ifndef NDEBUG
+    msg(version_cflags);
+#endif
+    version_msg("\n\n");
 
 #ifdef SYS_VIMRC_FILE
-  version_msg(_("   system vimrc file: \""));
-  version_msg(SYS_VIMRC_FILE);
-  version_msg("\"\n");
-#endif  // ifdef SYS_VIMRC_FILE
+    version_msg(_("   system vimrc file: \""));
+    version_msg(SYS_VIMRC_FILE);
+    version_msg("\"\n");
+#endif
+
 #ifdef HAVE_PATHDEF
+    if (*default_vim_dir != NUL) {
+      version_msg(_("  fall-back for $VIM: \""));
+      version_msg(default_vim_dir);
+      version_msg("\"\n");
+    }
 
-  if (*default_vim_dir != NUL) {
-    version_msg(_("  fall-back for $VIM: \""));
-    version_msg(default_vim_dir);
-    version_msg("\"\n");
+    if (*default_vimruntime_dir != NUL) {
+      version_msg(_(" f-b for $VIMRUNTIME: \""));
+      version_msg(default_vimruntime_dir);
+      version_msg("\"\n");
+    }
+#endif
   }
 
-  if (*default_vimruntime_dir != NUL) {
-    version_msg(_(" f-b for $VIMRUNTIME: \""));
-    version_msg(default_vimruntime_dir);
-    version_msg("\"\n");
-  }
-#endif  // ifdef HAVE_PATHDEF
-
-  version_msg("\nRun :checkhealth for more info");
+  version_msg(p_verbose > 0
+              ? "\nRun :checkhealth for more info"
+              : (starting
+                 ? "\nRun \"nvim -V1 -v\" for more info"
+                 : "\nRun \":verbose version\" for more info"));
 }
 
 /// Show the intro message when not editing a file.


### PR DESCRIPTION
Problem:
`nvim -v` and `:version` prints "system vimrc", "fallback", and compilation info which is usually unnecessary, though sometimes helpful.

Solution:
Omit compilation info unless 'verbose' is set.

Example:

```
$ ./build/bin/nvim -v
NVIM v0.10.0-dev-594+g132f00cc5bc4
Build type: Debug
LuaJIT 2.1.0-beta3
Run "nvim -V1 -v" or ":checkhealth" for more info
```