### PR TITLE
fix(lsp): fix attempt to call non existent function

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -245,9 +245,9 @@ local function toggle(bufnr)
   bufnr = resolve_bufnr(bufnr)
   local bufstate = bufstates[bufnr]
   if bufstate and bufstate.enabled then
-    M.disable(bufnr)
+    disable(bufnr)
   else
-    M.enable(bufnr)
+    enable(bufnr)
   end
 end
 


### PR DESCRIPTION
Commit 37079fc moved inlay_hint to vim.lsp() but in the process did missed converting a call to disable/enable which are now local.

Fixes the below error when trying to toggle inlay hints.

E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:248: attempt to call field 'disable' (a nil value) stack traceback:
        /usr/local/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:248: in function 'toggle'
        /usr/local/share/nvim/runtime/lua/vim/lsp/inlay_hint.lua:310: in function 'inlay_hint'
        [string ":lua"]:1: in main chunk