### PR TITLE
vim-patch:9.0.1672: tabline highlight wrong after truncated double width label

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -475,7 +475,7 @@ static bool can_unload_buffer(buf_T *buf)
 ///               Possible values:
 ///                 0            buffer becomes hidden
 ///                 DOBUF_UNLOAD buffer is unloaded
-///                 DOBUF_DELETE buffer is unloaded and removed from buffer list
+///                 DOBUF_DEL    buffer is unloaded and removed from buffer list
 ///                 DOBUF_WIPE   buffer is unloaded and really deleted
 ///               When doing all but the first one on the current buffer, the
 ///               caller should get a new buffer very soon!

--- a/test/old/testdir/test_tabline.vim
+++ b/test/old/testdir/test_tabline.vim
@@ -133,7 +133,7 @@ func Test_tabline_empty_group()
   tabnew
   redraw!
 
-  tabclose
+  bw!
   set tabline=
 endfunc
 
@@ -202,6 +202,30 @@ func Test_tabline_showcmd()
   call VerifyScreenDump(buf, 'Test_tabline_showcmd_5', {})
 
   call StopVimInTerminal(buf)
+endfunc
+
+func TruncTabLine()
+  return '%1T口口%2Ta' .. repeat('b', &columns - 4) .. '%999X%#TabLine#c'
+endfunc
+
+" Test 'tabline' with truncated double-width label at the start.
+func Test_tabline_truncated_double_width()
+  tabnew
+  redraw
+  call assert_match('X$', Screenline(1))
+  let attr_TabLineFill = screenattr(1, &columns - 1)
+  let attr_TabLine = screenattr(1, &columns)
+  call assert_notequal(attr_TabLine, attr_TabLineFill)
+
+  set tabline=%!TruncTabLine()
+  redraw
+  call assert_equal('<a' .. repeat('b', &columns - 4) .. 'c', Screenline(1))
+  call assert_equal(attr_TabLineFill, screenattr(1, &columns - 2))
+  call assert_equal(attr_TabLine, screenattr(1, &columns - 1))
+  call assert_equal(attr_TabLine, screenattr(1, &columns))
+
+  bw!
+  set tabline=
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1672: tabline highlight wrong after truncated double width label

Problem:    Tabline highlight wrong after truncated double width label.
Solution:   Fill up half a double width character later. (closes vim/vim#12614)

https://github.com/vim/vim/commit/d392a74c5a8af8271a33a20d37ae1a8ea422cb4b