### PR TITLE
build(nix): fix markdown parser

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -46,6 +46,15 @@
                   };
                 }))
             (mapAttrs (const final.fetchurl))
+            (self: self // {
+              markdown = final.stdenv.mkDerivation {
+                inherit (self.markdown) name;
+                src = self.markdown;
+                installPhase = ''
+                  mv tree-sitter-markdown $out
+                '';
+              };
+            })
           ];
         }).overrideAttrs (oa: rec {
           version = self.shortRev or "dirty";


### PR DESCRIPTION
#22481 added the markdown parser, which has its parser source under the `tree-sitter-markdown` directory, but the nix expression isn't able to figure that out, so I added a manual override to do so.

This is a bit of a hack, but I couldn't think of a better idea