### PR TITLE
fix(lsp): remove buffer validate in buf_clear_references

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1078,11 +1078,8 @@ add_workspace_folder({workspace_folder})
     Add the folder at path to the workspace folders. If {path} is not
     provided, the user will be prompted for a path using |input()|.
 
-clear_references({bufnr})                     *vim.lsp.buf.clear_references()*
+clear_references()                            *vim.lsp.buf.clear_references()*
     Removes document highlights from current buffer.
-
-    Parameters: ~
-      • {bufnr}  integer|nil
 
 code_action({options})                             *vim.lsp.buf.code_action()*
     Selects a code action available at the current cursor position.
@@ -1567,7 +1564,7 @@ buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
     Removes document highlights from a buffer.
 
     Parameters: ~
-      • {bufnr}  (integer) Buffer id
+      • {bufnr}  (integer|nil) Buffer id
 
                                      *vim.lsp.util.buf_highlight_references()*
 buf_highlight_references({bufnr}, {references}, {offset_encoding})

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -581,9 +581,8 @@ function M.document_highlight()
 end
 
 --- Removes document highlights from current buffer.
---- @param bufnr integer|nil
-function M.clear_references(bufnr)
-  util.buf_clear_references(bufnr or 0)
+function M.clear_references()
+  util.buf_clear_references()
 end
 
 ---@private

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1769,9 +1769,9 @@ do --[[ References ]]
 
   --- Removes document highlights from a buffer.
   ---
-  ---@param bufnr integer Buffer id
+  ---@param bufnr integer|nil Buffer id
   function M.buf_clear_references(bufnr)
-    validate({ bufnr = { bufnr, { 'n', 'nil' }, true } })
+    validate({ bufnr = { bufnr, { 'n' }, true } })
     api.nvim_buf_clear_namespace(bufnr or 0, reference_ns, 0, -1)
   end
 


### PR DESCRIPTION
Problem: in prev lint pr added the `nil` validate. not correct.  because in `buf_clear_references` already use `true` to allow `nil` (my mistake)

Solution: remove `nil` validate and add `nil` in param annoation.

fix regression from #24046 