### PR TITLE
fix(api, lua): make blank lines in a message work properly

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1687,6 +1687,7 @@ static void write_msg(String message, bool to_err, bool writeln)
   if (c == NL) { \
     kv_push(line_buf, NUL); \
     msg(line_buf.items); \
+    msg_didout = true; \
     kv_drop(line_buf, kv_size(line_buf)); \
     kv_resize(line_buf, LINE_BUFFER_MIN_SIZE); \
   } else { \

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -954,6 +954,7 @@ static void nlua_print_event(void **argv)
       break;
     }
     msg(str + start);
+    msg_didout = true;  // Make blank lines work properly
   }
   if (len && str[len - 1] == NUL) {  // Last was newline
     msg("");

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -577,7 +577,6 @@ describe('API', function()
     local start_dir
 
     before_each(function()
-      clear()
       funcs.mkdir("Xtestdir")
       start_dir = funcs.getcwd()
     end)
@@ -1990,6 +1989,39 @@ describe('API', function()
       ]])
       eq('\naaa\n' .. ('a'):rep(5002) .. '\naaa', meths.get_var('out'))
     end)
+
+    it('blank line in message works', function()
+      local screen = Screen.new(40, 8)
+      screen:attach()
+      screen:set_default_attr_ids({
+        [0] = {bold = true, foreground = Screen.colors.Blue},
+        [1] = {bold = true, foreground = Screen.colors.SeaGreen},
+        [2] = {bold = true, reverse = true},
+      })
+      feed([[:call nvim_out_write("\na\n")<CR>]])
+      screen:expect{grid=[[
+                                                |
+        {0:~                                       }|
+        {0:~                                       }|
+        {0:~                                       }|
+        {2:                                        }|
+                                                |
+        a                                       |
+        {1:Press ENTER or type command to continue}^ |
+      ]]}
+      feed('<CR>')
+      feed([[:call nvim_out_write("b\n\nc\n")<CR>]])
+      screen:expect{grid=[[
+                                                |
+        {0:~                                       }|
+        {0:~                                       }|
+        {2:                                        }|
+        b                                       |
+                                                |
+        c                                       |
+        {1:Press ENTER or type command to continue}^ |
+      ]]}
+    end)
   end)
 
   describe('nvim_err_write', function()
@@ -3029,11 +3061,10 @@ describe('API', function()
     local screen
 
     before_each(function()
-      clear()
       screen = Screen.new(40, 8)
       screen:attach()
       screen:set_default_attr_ids({
-        [0] = {bold=true, foreground=Screen.colors.Blue},
+        [0] = {bold = true, foreground = Screen.colors.Blue},
         [1] = {bold = true, foreground = Screen.colors.SeaGreen},
         [2] = {bold = true, reverse = true},
         [3] = {foreground = Screen.colors.Brown, bold = true}, -- Statement
@@ -3103,7 +3134,6 @@ describe('API', function()
     local screen
 
     before_each(function()
-      clear()
       screen = Screen.new(100, 35)
       screen:attach()
       screen:set_default_attr_ids({

--- a/test/functional/lua/overrides_spec.lua
+++ b/test/functional/lua/overrides_spec.lua
@@ -15,8 +15,6 @@ local exec_lua = helpers.exec_lua
 local pcall_err = helpers.pcall_err
 local is_os = helpers.is_os
 
-local screen
-
 local fname = 'Xtest-functional-lua-overrides-luafile'
 
 before_each(clear)
@@ -138,9 +136,44 @@ describe('print', function()
     ]], (is_os('win') and "timeout 1") or "sleep 0.1")
     eq('very slow\nvery fast', exec_capture('lua test()'))
   end)
+
+  it('blank line in message works', function()
+    local screen = Screen.new(40, 8)
+    screen:attach()
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground=Screen.colors.Blue},
+      [1] = {bold = true, foreground = Screen.colors.SeaGreen},
+      [2] = {bold = true, reverse = true},
+    })
+    feed([[:lua print('\na')<CR>]])
+    screen:expect{grid=[[
+                                              |
+      {0:~                                       }|
+      {0:~                                       }|
+      {0:~                                       }|
+      {2:                                        }|
+                                              |
+      a                                       |
+      {1:Press ENTER or type command to continue}^ |
+    ]]}
+    feed('<CR>')
+    feed([[:lua print('b\n\nc')<CR>]])
+    screen:expect{grid=[[
+                                              |
+      {0:~                                       }|
+      {0:~                                       }|
+      {2:                                        }|
+      b                                       |
+                                              |
+      c                                       |
+      {1:Press ENTER or type command to continue}^ |
+    ]]}
+  end)
 end)
 
 describe('debug.debug', function()
+  local screen
+
   before_each(function()
     screen = Screen.new()
     screen:attach()


### PR DESCRIPTION
Fix #24242

`nvim_echo` already handles this properly.