### PR TITLE
fix(scan-build): fix dead increment clang warning

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1320,7 +1320,6 @@ bool scrolldown(long line_count, int byfold)
     }
     if (col > width2 && width2 > 0) {
       row += (int)col / width2;
-      col = col % width2;
     }
     if (row >= curwin->w_height_inner) {
       curwin->w_curswant = curwin->w_virtcol - (row - curwin->w_height_inner + 1) * width2;
@@ -1525,7 +1524,6 @@ void adjust_skipcol(void)
   }
   if (col > width2) {
     row += (int)col / width2;
-    col = col % width2;
   }
   if (row >= curwin->w_height_inner) {
     if (curwin->w_skipcol == 0) {


### PR DESCRIPTION
This may be a dangerous commit, however all the tests pass on my side. I did not notice anything while running `gdb` and getting rid of those two lines does not seems suspicious on the(my?) eyes.

To conclude, I would rather say this is an easy modification to fix two clang warnings underlined by the scan-build analyzer.

I am sorry for the annoyance if any (especially if this pull request is dumb) !