### PR TITLE
fix(lsp): don't use hl_mode = combine for inlay hints

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -289,7 +289,6 @@ api.nvim_set_decoration_provider(namespace, {
               virt_text_pos = 'inline',
               ephemeral = false,
               virt_text = vt,
-              hl_mode = 'combine',
             })
           end
         end


### PR DESCRIPTION
I used `combine` earlier to ensure it worked with cursorline, not knowing that cursorline combined anyway. I don't believe this is needed

Fixes #24152