### PR TITLE
feat(autocmd): add FoldChanged event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -664,6 +664,12 @@ FilterWritePre			Before writing a file for a filter command or
 				temporary file that is the output of the
 				filter command.
 				Not triggered when 'shelltemp' is off.
+							*FoldChanged*
+FoldChanged			When a fold in a window is either: updated,
+				changed, opened or closed.
+
+				Both <amatch> and <afile> are set to the
+				|window-ID|.
 							*FocusGained*
 FocusGained			Nvim got focus.
 							*FocusLost*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -116,6 +116,8 @@ The following new APIs and features were added.
 • |vim.wo| can now be double indexed for |:setlocal| behaviour. Currently only
   `0` for the buffer index is currently supported.
 
+• Added |FoldChanged| autocmd event.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -62,6 +62,7 @@ return {
     'FilterWritePre',         -- before writing to a filter
     'FocusGained',            -- got the focus
     'FocusLost',              -- lost the focus to another app
+    'FoldChanged',            -- Folds are updated, opened or closed
     'FuncUndefined',          -- if calling a function which doesn't exist
     'GUIEnter',               -- after starting the GUI
     'GUIFailed',              -- after starting the GUI failed

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -831,7 +831,7 @@ void f_winrestview(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   check_cursor();
   win_new_height(curwin, curwin->w_height);
   win_new_width(curwin, curwin->w_width);
-  changed_window_setting();
+  changed_window_setting_win(curwin);
 
   if (curwin->w_topline <= 0) {
     curwin->w_topline = 1;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4257,7 +4257,7 @@ skip:
 
   if (subflags.do_ask && hasAnyFolding(curwin)) {
     // Cursor position may require updating
-    changed_window_setting();
+    changed_window_setting_win(curwin);
   }
 
   vim_regfree(regmatch.regprog);

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -515,11 +515,6 @@ void check_cursor_moved(win_T *wp)
 // Call this function when some window settings have changed, which require
 // the cursor position, botline and topline to be recomputed and the window to
 // be redrawn.  E.g, when changing the 'wrap' option or folding.
-void changed_window_setting(void)
-{
-  changed_window_setting_win(curwin);
-}
-
 void changed_window_setting_win(win_T *wp)
 {
   wp->w_lines_valid = 0;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3007,7 +3007,7 @@ static void nv_zet(cmdarg_T *cap)
   case 'E':
     if (foldmethodIsManual(curwin)) {
       clearFolding(curwin);
-      changed_window_setting();
+      foldChanged(curwin);
     } else if (foldmethodIsMarker(curwin)) {
       deleteFold(curwin, 1, curbuf->b_ml.ml_line_count, true, false);
     } else {
@@ -3177,12 +3177,14 @@ static void nv_zet(cmdarg_T *cap)
       // Adjust 'foldenable' in diff-synced windows.
       FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (wp != curwin && foldmethodIsDiff(wp) && wp->w_p_scb) {
-          wp->w_p_fen = curwin->w_p_fen;
-          changed_window_setting_win(wp);
+          if (wp->w_p_fen != curwin->w_p_fen) {
+            wp->w_p_fen = curwin->w_p_fen;
+            foldChanged(wp);
+          }
         }
       }
     }
-    changed_window_setting();
+    foldChanged(curwin);
   }
 
   // Redraw when 'foldlevel' changed.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2404,7 +2404,7 @@ static const char *did_set_arabic(optset_T *args)
       // set rightleft mode
       if (!win->w_p_rl) {
         win->w_p_rl = true;
-        changed_window_setting();
+        changed_window_setting_win(win);
       }
 
       // Enable Arabic shaping (major part of what Arabic requires)
@@ -2435,7 +2435,7 @@ static const char *did_set_arabic(optset_T *args)
       // reset rightleft mode
       if (win->w_p_rl) {
         win->w_p_rl = false;
-        changed_window_setting();
+        changed_window_setting_win(win);
       }
 
       // 'arabicshape' isn't reset, it is a global option and
@@ -2635,6 +2635,17 @@ static const char *did_set_smoothscroll(optset_T *args FUNC_ATTR_UNUSED)
 
   win->w_skipcol = 0;
   changed_line_abv_curs_win(win);
+  return NULL;
+}
+
+/// Process the new 'foldenable' option value.
+static const char *did_set_foldenable(optset_T *args)
+{
+  win_T *win = (win_T *)args->os_win;
+  bool old_value = args->os_oldval.boolean;
+  if (win->w_p_fen != old_value) {
+    foldChanged(win);
+  }
   return NULL;
 }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -870,7 +870,8 @@ return {
       short_desc=N_("set to display all folds open"),
       type='bool', scope={'window'},
       redraw={'current_window'},
-      defaults={if_true=true}
+      defaults={if_true=true},
+      cb='did_set_foldenable'
     },
     {
       full_name='foldexpr', abbreviation='fde',

--- a/test/functional/autocmd/foldchanged_spec.lua
+++ b/test/functional/autocmd/foldchanged_spec.lua
@@ -1,0 +1,30 @@
+local helpers = require('test.functional.helpers')(after_each)
+
+local eq = helpers.eq
+local eval = helpers.eval
+local exec = helpers.exec
+local feed = helpers.feed
+
+before_each(helpers.clear)
+
+describe('FoldChanged', function()
+  it('works', function()
+    exec([[
+      set foldmethod=indent
+      set shiftwidth=1
+      call setline(1, ['111', ' 222', '  333'])
+
+      let g:foldchanged = 0
+      au FoldChanged * let g:foldchanged += 1
+      au FoldChanged * let g:amatch = str2nr(expand('<amatch>'))
+      au FoldChanged * let g:afile = str2nr(expand('<afile>'))
+    ]])
+    eq(0, eval('g:foldchanged'))
+
+    feed('zM')
+    eq(1, eval('g:foldchanged'))
+
+    feed('zR')
+    eq(2, eval('g:foldchanged'))
+  end)
+end)


### PR DESCRIPTION
## Problem:

Not possible for plugins to detect changes to the fold state.

## Solution:

Add a `FoldChanged` autocmd event.

---

- Complements #24236
- Partially resolves: #8538
- Allows me to remove this monstrosity: https://github.com/lewis6991/satellite.nvim/blob/a414ee7b55c51a9bb8491b76e6f1d4782bae8712/lua/satellite.lua#L102-L140