### PR TITLE
fix(extmarks): fix visual highlight continuing after "combine" virtual text

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2011,12 +2011,15 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
         if (wlv.saved_n_extra <= 0) {
           if (search_attr == 0) {
             search_attr = saved_search_attr;
+            saved_search_attr = 0;
           }
           if (area_attr == 0 && *ptr != NUL) {
             area_attr = saved_area_attr;
+            saved_area_attr = 0;
           }
           if (decor_attr == 0) {
             decor_attr = saved_decor_attr;
+            saved_decor_attr = 0;
           }
 
           if (wlv.extra_for_extmark) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1596,6 +1596,7 @@ describe('decorations: inline virtual text', function()
       [18] = {background = Screen.colors.LightGrey, foreground = Screen.colors.Red};
       [19] = {background = Screen.colors.Yellow, foreground = Screen.colors.SlateBlue};
       [20] = {background = Screen.colors.LightGrey, foreground = Screen.colors.SlateBlue};
+      [21] = {reverse = true, foreground = Screen.colors.SlateBlue}
     }
 
     ns = meths.create_namespace 'test'
@@ -2068,6 +2069,27 @@ bbbbbbb]])
       {1:~                                                 }|
       /foo^                                              |
       ]]}
+    feed('<enter>')
+
+    feed('dddd')
+    insert('foo foo bar foo')
+    meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
+    meths.buf_set_extmark(0, ns, 0, 11, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
+    feed('/bar')
+
+    screen:expect { grid = [[
+      foo foo {13:b}{10:AAA}{21:BBB}{13:ar}{19:EEE} foo                          |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      /bar^                                              |
+      ]]}
   end)
 
   it('visual select highlight is correct', function()
@@ -2095,6 +2117,20 @@ bbbbbbb]])
     feed('2hj')
     screen:expect { grid = [[
       foo fo{7:o }{10:AAA}{20:BBB}{7:f}oo foo                             |
+      foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo foo                             |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {8:-- VISUAL BLOCK --}                                |
+      ]]}
+
+    meths.buf_set_extmark(0, ns, 0, 10, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
+    screen:expect { grid = [[
+      foo fo{7:o }{10:AAA}{20:BBB}{7:f}o{10:EEE}o foo                          |
       foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo foo                             |
       {1:~                                                 }|
       {1:~                                                 }|

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2037,15 +2037,15 @@ bbbbbbb]])
   end)
 
   it('search highlight is correct', function()
-    insert('foo foo foo foo\nfoo foo foo foo')
+    insert('foo foo foo bar\nfoo foo foo bar')
     feed('gg0')
     meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
     meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     screen:expect { grid = [[
-      ^foo foo f{10:AAABBB}oo foo                             |
-      foo foo f{10:CCCDDD}oo foo                             |
+      ^foo foo f{10:AAABBB}oo bar                             |
+      foo foo f{10:CCCDDD}oo bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2058,8 +2058,8 @@ bbbbbbb]])
 
     feed('/foo')
     screen:expect { grid = [[
-      {12:foo} {13:foo} {12:f}{10:AAA}{19:BBB}{12:oo} {12:foo}                             |
-      {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} {12:foo}                             |
+      {12:foo} {13:foo} {12:f}{10:AAA}{19:BBB}{12:oo} bar                             |
+      {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2069,17 +2069,12 @@ bbbbbbb]])
       {1:~                                                 }|
       /foo^                                              |
       ]]}
-    feed('<enter>')
 
-    feed('dddd')
-    insert('foo foo bar foo')
-    meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
-    meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
-    meths.buf_set_extmark(0, ns, 0, 11, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
-    feed('/bar')
-
-    screen:expect { grid = [[
-      foo foo {13:b}{10:AAA}{21:BBB}{13:ar}{19:EEE} foo                          |
+    meths.buf_set_extmark(0, ns, 0, 13, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
+    feed('<C-G>')
+    screen:expect{ grid = [[
+      {12:foo} {12:foo} {13:f}{10:AAA}{21:BBB}{13:oo} b{10:EEE}ar                          |
+      {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2087,13 +2082,12 @@ bbbbbbb]])
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      /bar^                                              |
+      /foo^                                              |
       ]]}
   end)
 
   it('visual select highlight is correct', function()
-    insert('foo foo foo foo\nfoo foo foo foo')
+    insert('foo foo foo bar\nfoo foo foo bar')
     feed('gg0')
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
@@ -2101,8 +2095,8 @@ bbbbbbb]])
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     feed('8l')
     screen:expect { grid = [[
-      foo foo {10:AAABBB}^foo foo                             |
-      foo foo {10:CCCDDD}foo foo                             |
+      foo foo {10:AAABBB}^foo bar                             |
+      foo foo {10:CCCDDD}foo bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2116,8 +2110,8 @@ bbbbbbb]])
     feed('<C-V>')
     feed('2hj')
     screen:expect { grid = [[
-      foo fo{7:o }{10:AAA}{20:BBB}{7:f}oo foo                             |
-      foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo foo                             |
+      foo fo{7:o }{10:AAA}{20:BBB}{7:f}oo bar                             |
+      foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2130,8 +2124,8 @@ bbbbbbb]])
 
     meths.buf_set_extmark(0, ns, 0, 10, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     screen:expect { grid = [[
-      foo fo{7:o }{10:AAA}{20:BBB}{7:f}o{10:EEE}o foo                          |
-      foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo foo                             |
+      foo fo{7:o }{10:AAA}{20:BBB}{7:f}o{10:EEE}o bar                          |
+      foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2144,7 +2138,7 @@ bbbbbbb]])
   end)
 
   it('inside highlight range of another extmark', function()
-    insert('foo foo foo foo\nfoo foo foo foo')
+    insert('foo foo foo bar\nfoo foo foo bar')
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
@@ -2152,8 +2146,8 @@ bbbbbbb]])
     meths.buf_set_extmark(0, ns, 0, 4, { end_col = 11, hl_group = 'Search' })
     meths.buf_set_extmark(0, ns, 1, 4, { end_col = 11, hl_group = 'Search' })
     screen:expect{grid=[[
-      foo {12:foo }{10:AAA}{19:BBB}{12:foo} foo                             |
-      foo {12:foo }{19:CCC}{10:DDD}{12:foo} fo^o                             |
+      foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
+      foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|
@@ -2166,15 +2160,15 @@ bbbbbbb]])
   end)
 
   it('inside highlight range of syntax', function()
-    insert('foo foo foo foo\nfoo foo foo foo')
+    insert('foo foo foo bar\nfoo foo foo bar')
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
-    command([[syntax match Search 'foo \zsfoo foo\ze foo']])
+    command([[syntax match Search 'foo \zsfoo foo\ze bar']])
     screen:expect{grid=[[
-      foo {12:foo }{10:AAA}{19:BBB}{12:foo} foo                             |
-      foo {12:foo }{19:CCC}{10:DDD}{12:foo} fo^o                             |
+      foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
+      foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
       {1:~                                                 }|
       {1:~                                                 }|
       {1:~                                                 }|


### PR DESCRIPTION
This only happens if a "replace" virtual text is visually selected and is before the "combine" virtual text. Should other saved attributes (such as `saved_decor_attr` and `saved_search_attr`) also be reset after they are restored? Just to be safe?