### PR TITLE
fix(completion): don't escape backslash in runtime completion

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2659,6 +2659,9 @@ static int map_wildopts_to_ewflags(int options)
   if (options & WILD_ALLLINKS) {
     flags |= EW_ALLLINKS;
   }
+  if (options & WILD_KEEP_BSLASH) {
+    flags |= EW_KEEPBSLASH;
+  }
 
   return flags;
 }

--- a/src/nvim/cmdexpand.h
+++ b/src/nvim/cmdexpand.h
@@ -39,6 +39,7 @@ enum {
   WILD_NOERROR              = 0x800,  ///< sets EW_NOERROR
   WILD_BUFLASTUSED          = 0x1000,
   BUF_DIFF_FILTER           = 0x2000,
+  WILD_KEEP_BSLASH          = 0x4000,
 };
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -684,7 +684,7 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
 
   // convert the file pattern to a regexp pattern
   int starts_with_dot = *s == '.';
-  char *pat = file_pat_to_reg_pat(s, e, NULL, false);
+  char *pat = file_pat_to_reg_pat(s, e, NULL, flags & EW_KEEPBSLASH);
   if (pat == NULL) {
     xfree(buf);
     return 0;

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -27,6 +27,7 @@
 #define EW_EMPTYOK      0x8000   // no matches is not an error
 #define EW_NOTENV       0x10000  // do not expand environment variables
 #define EW_NOBREAK      0x20000  // do not invoke breakcheck
+#define EW_KEEPBSLASH   0x40000  // do not escape backslash
 
 /// Return value for the comparison of two files. Also @see path_full_compare.
 typedef enum file_comparison {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1249,7 +1249,7 @@ expand:
     if (*dirnames[i] == NUL && !expand_dirs) {
       // expand dir names in another round
       snprintf(tail, tail_buflen, "%s*", pat);
-      glob_flags = WILD_ADD_SLASH;
+      glob_flags |= WILD_ADD_SLASH;
       expand_dirs = true;
       goto expand;
     }


### PR DESCRIPTION
Fix #24292
