### PR TITLE
fix(completion): don't add backslashes to runtime pattern

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -338,7 +338,7 @@ int do_in_path(char *path, char *name, int flags, DoInRuntimepathCB callback, vo
           }
 
           int ew_flags = ((flags & DIP_DIR) ? EW_DIR : EW_FILE)
-                         | (flags & DIP_DIRFILE) ? (EW_DIR|EW_FILE) : 0;
+                         | ((flags & DIP_DIRFILE) ? (EW_DIR|EW_FILE) : 0);
 
           // Expand wildcards, invoke the callback for each match.
           if (gen_expand_wildcards(1, &buf, &num_files, &files, ew_flags) == OK) {
@@ -1222,9 +1222,9 @@ static void ExpandRTDir_int(char *pat, size_t pat_len, int flags, bool keep_ext,
     bool expand_dirs = false;
 
     if (*dirnames[i] == NUL) {  // empty dir used for :runtime
-      snprintf(tail, tail_buflen, "%s*.\\(vim\\|lua\\)", pat);
+      snprintf(tail, tail_buflen, "%s*.{vim,lua}", pat);
     } else {
-      snprintf(tail, tail_buflen, "%s/%s*.\\(vim\\|lua\\)", dirnames[i], pat);
+      snprintf(tail, tail_buflen, "%s/%s*.{vim,lua}", dirnames[i], pat);
     }
 
 expand:

--- a/test/functional/lua/runtime_spec.lua
+++ b/test/functional/lua/runtime_spec.lua
@@ -18,7 +18,10 @@ describe('runtime:', function()
     io.open(init, 'w'):close()  --  touch init file
     clear{args = {'-u', init}}
     exec('set rtp+=' .. plug_dir)
-    exec('set completeslash=slash')
+    exec([[
+      set completeslash=slash
+      set isfname+=(,)
+    ]])
   end)
 
   teardown(function()


### PR DESCRIPTION
Problem:    Bashslashes added as regexp in runtime completion may be
            treated as path separator with some 'isfname' value.
Solution:   Make curly braces work for runtime completion and use it.

Fix #24292
