### PR TITLE
fix(docs): broken URL

### DIFF
--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -132,7 +132,7 @@ DOCUMENTATION						*dev-doc*
   optimize for the reader's time and energy: be "precise yet concise".
     - Prefer the active voice: "Foo does X", not "X is done by Foo".
     - "The words you choose are an essential part of the user experience."
-      https://developer.apple.com/design/human-interface-guidelines/foundations/writing/
+      https://developer.apple.com/design/human-interface-guidelines/writing
     - "...without being overly colloquial or frivolous."
       https://developers.google.com/style/tone
 - Write docstrings (as opposed to inline comments) with present tense ("Gets"),


### PR DESCRIPTION
Hello! Was reading through the documentation and noticed a dead link when opening up the guidelines for Apple.

This should be an easy fix

Before:
![image](https://github.com/neovim/neovim/assets/9924643/59464b05-056a-42f4-9f25-90af7c85e8b6)

After:
![image](https://github.com/neovim/neovim/assets/9924643/b6fb5144-a417-4a2c-8e1d-1adeb276e242)
