### PR TITLE
perf(extmarks): don't handle inline virt_text if there is none

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1831,7 +1831,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
                                          && wlv.vcol == wp->w_virtcol));
         extmark_attr = decor_redraw_col(wp, (colnr_T)v, wlv.off, selected, &decor_state);
 
-        if (!has_fold) {
+        if (!has_fold && wp->w_buffer->b_virt_text_inline > 0) {
           handle_inline_virtual_text(wp, &wlv, v);
           if (wlv.n_extra > 0 && wlv.virt_inline_hl_mode <= kHlModeReplace) {
             // restore search_attr and area_attr when n_extra is down to zero

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -329,7 +329,7 @@ void init_chartabsize_arg(chartabsize_T *cts, win_T *wp, linenr_T lnum, colnr_T 
   cts->cts_has_virt_text = false;
   cts->cts_row = lnum - 1;
 
-  if (cts->cts_row >= 0) {
+  if (cts->cts_row >= 0 && wp->w_buffer->b_virt_text_inline > 0) {
     marktree_itr_get(wp->w_buffer->b_marktree, cts->cts_row, 0, cts->cts_iter);
     mtkey_t mark = marktree_itr_current(cts->cts_iter);
     if (mark.pos.row == cts->cts_row) {


### PR DESCRIPTION
Extreme testcase:
```lua
vim.fn.setline(1, 'foobar')
local ns = vim.api.nvim_create_namespace('')
for _ = 1, 100000 do
  vim.api.nvim_buf_set_extmark(0, ns, 0, 3, {})
end
local start_time = vim.loop.hrtime()
vim.fn.virtcol('$')
local stop_time = vim.loop.hrtime()
print(stop_time - start_time)
```
Before #20130: 31696
On master branch: 26191344
After this PR: 37692
