### PR TITLE
docs(lua): adds links to related keymap functions to keymap.set

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2625,6 +2625,9 @@ set({mode}, {lhs}, {rhs}, {opts})                           *vim.keymap.set()*
 
     See also: ~
       • |nvim_set_keymap()|
+      • |maparg()|
+      • |mapcheck()|
+      • |mapset()|
 
 
 ==============================================================================

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -32,6 +32,9 @@ local keymap = {}
 ---                        - "remap": (boolean) Make the mapping recursive. Inverse of "noremap".
 ---                        Defaults to `false`.
 ---@see |nvim_set_keymap()|
+---@see |maparg()|
+---@see |mapcheck()|
+---@see |mapset()|
 function keymap.set(mode, lhs, rhs, opts)
   vim.validate({
     mode = { mode, { 's', 't' } },


### PR DESCRIPTION
Might help with discovery, given that there is no `keymap.get()`
