### PR TITLE
feat(lsp): add vim.lsp.server to create in-process server

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2522,6 +2522,76 @@ function lsp._with_extend(name, options, user_config)
   return resulting_config
 end
 
+
+---@class lsp.server.opts
+---@field handlers? table<string, fun(method: string, params: any): any>
+---@field on_request? fun(method: string, params)
+---@field on_notify? fun(method: string, params)
+---@field capabilities? table
+
+
+--- Create a in-process LSP server that can be used as `cmd` with |vim.lsp.start|
+--- Example:
+--- <pre>lua
+--- vim.lsp.start({
+---   name = "my-in-process-server",
+---   cmd = vim.lsp.server({
+---   handlers = {
+---
+---   }
+---   })
+--- })
+---
+--- @param opts nil|lsp.server.opts
+function lsp.server(opts)
+  opts = opts or {}
+  local capabilities = opts.capabilities or {}
+  local on_request = opts.on_request or function(_, _) end
+  local on_notify = opts.on_notify or function(_, _) end
+  local handlers = opts.handlers or {}
+
+  return function(dispatchers)
+    local closing = false
+    local srv = {}
+    local request_id = 0
+
+    function srv.request(method, params, callback)
+      pcall(on_request, method, params)
+      local handler = handlers[method]
+      if handler then
+        local response, err = handler(method, params)
+        callback(err, response)
+      elseif method == 'initialize' then
+        callback(nil, {
+          capabilities = capabilities
+        })
+      elseif method == 'shutdown' then
+        callback(nil, nil)
+      end
+      request_id = request_id + 1
+      return true, request_id
+    end
+
+    function srv.notify(method, params)
+      pcall(on_notify, method, params)
+      if method == 'exit' then
+        dispatchers.on_exit(0, 15)
+      end
+    end
+
+    function srv.is_closing()
+      return closing
+    end
+
+    function srv.terminate()
+      closing = true
+    end
+
+    return srv
+  end
+end
+
+
 --- Registry for client side commands.
 --- This is an extension point for plugins to handle custom commands which are
 --- not part of the core language server protocol specification.

--- a/test/functional/plugin/lsp/helpers.lua
+++ b/test/functional/plugin/lsp/helpers.lua
@@ -20,57 +20,26 @@ end
 
 M.create_server_definition = [[
   function _create_server(opts)
-    opts = opts or {}
-    local server = {}
-    server.messages = {}
-
-    function server.cmd(dispatchers)
-      local closing = false
-      local handlers = opts.handlers or {}
-      local srv = {}
-
-      function srv.request(method, params, callback)
-        table.insert(server.messages, {
+    local messages = {}
+    opts = vim.tbl_extend("error", opts or {}, {
+      on_request = function(method, params)
+        table.insert(messages, {
           method = method,
           params = params,
         })
-        local handler = handlers[method]
-        if handler then
-          local response, err = handler(method, params)
-          callback(err, response)
-        elseif method == 'initialize' then
-          callback(nil, {
-            capabilities = opts.capabilities or {}
-          })
-        elseif method == 'shutdown' then
-          callback(nil, nil)
-        end
-        local request_id = #server.messages
-        return true, request_id
-      end
-
-      function srv.notify(method, params)
-        table.insert(server.messages, {
+      end,
+      on_notify = function(method, params)
+        table.insert(messages, {
           method = method,
           params = params
         })
-        if method == 'exit' then
-          dispatchers.on_exit(0, 15)
-        end
       end
-
-      function srv.is_closing()
-        return closing
-      end
-
-      function srv.terminate()
-        closing = true
-      end
-
-      return srv
-    end
-
-    return server
+    })
+    local server = vim.lsp.server(opts)
+    return {
+      messages = messages,
+      cmd = server,
+    }
   end
 ]]
 


### PR DESCRIPTION
Early WIP/draft:

There are occasionally requests for dedicated APIs for code actions or codelens, (also formatter, but there's `formatexpr`, `formatprg` and `!cmd` and afaik so far no explanation of why they are not sufficient). Concrete request for codelens: https://github.com/neovim/neovim/issues/20181

Or potential use-cases for code-action:

- https://github.com/lervag/vimtex/blob/01733c0969cf8922e932bcc30b768966c69ffaf0/doc/vimtex.txt#L5953
- https://github.com/lewis6991/gitsigns.nvim#null-ls

For `vim.diagnostic`, a dedicated module made a lot of sense as linters have existed long before LSP and there are lots of standalone tools.


For the others (codelens, code actions, hover, inline-hints, etc.) the value proposition is more questionable. What would a dedicated API improve over just using LSP?

One problem with "just use LSP" is that you either need a separate process, or some boilerplate.
This PR would address the boilerplate problem.

E.g. a implementation for hover could look like this:


```lua
local api = vim.api
local server = vim.lsp.server({
  capabilities = {
    hoverProvider = true
  },
  handlers = {
    ---@param params lsp.HoverParams
    ["textDocument/hover"] = function(_, params)
      local bufnr = vim.uri_to_bufnr(params.textDocument.uri)
      local lnum = params.position.line
      local col = params.position.character
      -- use bufnr/lnum/col to provide actual text
      return {
        contents = {
          kind = "plaintext",
          value = "just some dummy text",
        }
      }
    end,
  }
})
vim.lsp.start({ name = "dummy-ls", cmd = server })
```

Advantages:

- We don't need to figure out a provider pull/push model for plugins to register code-actions, hover, etc.
- We don't need a ton of new APIs, documentations and tests
- Also provides answers for progress notification and cancellation (although with open construction sites, e.g. https://github.com/neovim/neovim/issues/22852)
- We already use something like that in the tests.  Even if we decide to add dedicated APIs later, this might be low cost due do that
- We can maybe convince Lewis to improve multi-client support, which we want anyway, instead of working on https://github.com/lewis6991/hover.nvim
- Would also be useful for plugins implementing off-spec LSP extensions or similar functions for testing.  (E.g lsp-compl has something like this in its tests)


Disadvantages:

- LSP allows to make requests for buffers that are not visible and not "current": That means in the handlers you cannot make good use of functions like `vim.fn.expand("<cexpr>")`, but you'd currently have to create a dummy window, and open the buffer in that windows
- Slightly more verbose than dedicated APIs might be
-  Limited to LSP functionality


---

TBD:

- [x] Decide if we want this
- [ ] Finetune API
    - is the `method` param required for each handler, it's kinda redundant.
    - How about push from server to client?
- [ ] Finish example in the docs (including how to `vim.lsp.start` such a server)
