### PR TITLE
feat(api): allow buf_set_text to modify line like `virtualedit=all`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2475,6 +2475,9 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     Indexing is zero-based. Row indices are end-inclusive, and column indices
     are end-exclusive.
 
+    If `start_col` or `end_col` exceed line length the remaining space is
+    padded using spaces.
+
     To insert text at a given `(row, column)` location, use `start_row =
     end_row = row` and `start_col = end_col = col`. To delete the text in a
     range, use `replacement = {}`.

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2475,8 +2475,8 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     Indexing is zero-based. Row indices are end-inclusive, and column indices
     are end-exclusive.
 
-    If `start_col` or `end_col` exceed line length the remaining space is
-    padded using spaces.
+    If `start_col` exceeds line length the leading space is padded using
+    spaces and `end_col` is silently ignored.
 
     To insert text at a given `(row, column)` location, use `start_row =
     end_row = row` and `start_col = end_col = col`. To delete the text in a

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -480,8 +480,8 @@ end:
 /// Indexing is zero-based. Row indices are end-inclusive, and column indices
 /// are end-exclusive.
 ///
-/// If `start_col` or `end_col` exceed line length the remaining space is padded
-/// using spaces.
+/// If `start_col` exceeds line length the leading space is padded using spaces
+/// and `end_col` is silently ignored.
 ///
 /// To insert text at a given `(row, column)` location, use `start_row = end_row
 /// = row` and `start_col = end_col = col`. To delete the text in a range, use

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -555,8 +555,8 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
 
   end_col = end_col < 0 ? (int64_t)len_at_end + end_col + 1 : end_col;
 
-  bool ve_start_col= (size_t)start_col > len_at_start;
-  bool ve_end_col= (size_t)end_col > len_at_end;
+  bool ve_start_col = (size_t)start_col > len_at_start;
+  bool ve_end_col = (size_t)end_col > len_at_end;
   // CHECK: possible wraparound bug?
   end_col = ve_end_col ? (int64_t)len_at_end : end_col;
 
@@ -565,7 +565,8 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   });
 
   // Silently ignore larger than line end_col
-  VALIDATE(( (start_row <= end_row ) && !(end_row == start_row && ( !ve_end_col && start_col > end_col ))),
+  VALIDATE(((start_row <= end_row)
+            && !(end_row == start_row && (!ve_end_col && start_col > end_col))),
            "%s", "'start' is higher than 'end'", {
     goto early_end;
   });

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -480,6 +480,9 @@ end:
 /// Indexing is zero-based. Row indices are end-inclusive, and column indices
 /// are end-exclusive.
 ///
+/// If `start_col` or `end_col` exceed line length the remaining space is padded
+/// using spaces.
+///
 /// To insert text at a given `(row, column)` location, use `start_row = end_row
 /// = row` and `start_col = end_col = col`. To delete the text in a range, use
 /// `replacement = {}`.
@@ -542,15 +545,20 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   str_at_start = xstrdup(ml_get_buf(buf, (linenr_T)start_row));
   size_t len_at_start = strlen(str_at_start);
   start_col = start_col < 0 ? (int64_t)len_at_start + start_col + 1 : start_col;
-  VALIDATE_RANGE((start_col >= 0 && (size_t)start_col <= len_at_start), "start_col", {
+  VALIDATE_RANGE((start_col >= 0), "start_col", {
     goto early_end;
   });
 
   // Another call to ml_get_buf() may free the line, so make a copy.
   str_at_end = xstrdup(ml_get_buf(buf, (linenr_T)end_row));
   size_t len_at_end = strlen(str_at_end);
+
   end_col = end_col < 0 ? (int64_t)len_at_end + end_col + 1 : end_col;
-  VALIDATE_RANGE((end_col >= 0 && (size_t)end_col <= len_at_end), "end_col", {
+
+  bool ve_start_col= (size_t)start_col > len_at_start;
+  bool ve_end_col= (size_t)end_col > len_at_end;
+
+  VALIDATE_RANGE((end_col >= 0), "end_col", {
     goto early_end;
   });
 
@@ -587,17 +595,40 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   String last_item = replacement.items[replacement.size - 1].data.string;
 
   size_t firstlen = (size_t)start_col + first_item.size;
-  size_t last_part_len = len_at_end - (size_t)end_col;
+  size_t last_part_len = 0;
+
+  if (ve_end_col) {
+    if (start_row == end_row) {
+      last_part_len = (size_t)end_col > firstlen ? (size_t)end_col - firstlen :0;
+    } else {
+      last_part_len = (size_t)end_col;
+    }
+  } else {
+    last_part_len = len_at_end - (size_t)end_col;
+  }
+
   if (replacement.size == 1) {
     firstlen += last_part_len;
   }
   char *first = xmallocz(firstlen);
   char *last = NULL;
-  memcpy(first, str_at_start, (size_t)start_col);
+
+  if (ve_start_col) {
+    size_t pad = (size_t)start_col - len_at_start;
+
+    memcpy(first, str_at_start, len_at_start);
+    memset(first + len_at_start, ' ', pad);
+  } else {
+    memcpy(first, str_at_start, (size_t)start_col);
+  }
   memcpy(first + start_col, first_item.data, first_item.size);
   memchrsub(first + start_col, NUL, NL, first_item.size);
   if (replacement.size == 1) {
-    memcpy(first + start_col + first_item.size, str_at_end + end_col, last_part_len);
+    if (ve_end_col) {
+      memset(first + start_col + first_item.size, ' ', last_part_len);
+    } else {
+      memcpy(first + start_col + first_item.size, str_at_end + end_col, last_part_len);
+    }
   } else {
     last = xmallocz(last_item.size + last_part_len);
     memcpy(last, last_item.data, last_item.size);

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -779,8 +779,8 @@ describe('api/buf', function()
       eq({'more  baz      '}, get_lines(2, 3, true))
 
       -- can use negative column numbers
-      set_text(0, -5, 0, -1, { '!' })
-      eq({ 'goodbye!' }, get_lines(0, 1, true))
+      set_text(2, -7, 2, -1, {'!'})
+      eq({'more  baz!'}, get_lines(2, 3, true))
     end)
 
     it('works with undo', function()
@@ -1685,8 +1685,6 @@ describe('api/buf', function()
       eq("Invalid 'start_row': out of range", pcall_err(set_text, -3, 0, 0, 0, {}))
       eq("Invalid 'end_row': out of range", pcall_err(set_text, 0, 0, 2, 0, {}))
       eq("Invalid 'end_row': out of range", pcall_err(set_text, 0, 0, -3, 0, {}))
-      eq("Invalid 'start_col': out of range", pcall_err(set_text, 1, 5, 1, 5, {}))
-      eq("Invalid 'end_col': out of range", pcall_err(set_text, 1, 0, 1, 5, {}))
     end)
 
     it('errors when start is greater than end', function()

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -775,11 +775,12 @@ describe('api/buf', function()
       set_text(0, 20, 0, 21, {'foo'})
       eq({'goodbye bar         foo', 'text and', 'more'}, get_lines(0, 3, true))
 
+      -- silently ignores end column
       set_text(2, 6, 2, 15, {'baz'})
-      eq({'more  baz      '}, get_lines(2, 3, true))
+      eq({'more  baz'}, get_lines(2, 3, true))
 
       -- can use negative column numbers
-      set_text(2, -7, 2, -1, {'!'})
+      set_text(2, -1, 2, -1, {'!'})
       eq({'more  baz!'}, get_lines(2, 3, true))
     end)
 

--- a/test/functional/api/buffer_spec.lua
+++ b/test/functional/api/buffer_spec.lua
@@ -771,6 +771,13 @@ describe('api/buf', function()
       set_text(1, 4, -1, 4, { ' and', 'more' })
       eq({ 'goodbye bar', 'text and', 'more' }, get_lines(0, 3, true))
 
+      -- can append after line end
+      set_text(0, 20, 0, 21, {'foo'})
+      eq({'goodbye bar         foo', 'text and', 'more'}, get_lines(0, 3, true))
+
+      set_text(2, 6, 2, 15, {'baz'})
+      eq({'more  baz      '}, get_lines(2, 3, true))
+
       -- can use negative column numbers
       set_text(0, -5, 0, -1, { '!' })
       eq({ 'goodbye!' }, get_lines(0, 1, true))


### PR DESCRIPTION
This PR enables the `buf_set_text` function in Neovim to modify lines even
when the Start or End columns are outside of the current line limits just like Virtual Edit.

## Why ?
I was writing a plugin and expected `buf_set_text` api call to allow me edit the buf text freely, but realised
that wasn't the case (#23658)
I looked at plugins and all of them used a compare and pad approach...

Many plugins that wish to add text to a buffer pragmatically for any reason
they first need to run some checks on the lines length and then pad it with spaces
usually , for every single edit they do .

Something similar to this:
```lua
function U.write_to_buffer(pos, brush)
    local buff_num, s_row, s_col, e_row, e_col = unpack(pos)

    local s_row_norm, e_row_norm = s_row - 1, e_row - 1
    local s_col_norm, e_col_norm = s_col - 1, e_col - 1
    local line = vim.fn.getline(e_row)
    local line_len = line:len()

    if s_col > line_len then
        local offset = s_col - line_len - 1
        vim.api.nvim_buf_set_lines(buff_num, s_row_norm, e_row_norm + 1, true, { line .. (" "):rep(offset) .. brush })
        return
    end
    if e_col > line_len then
        local offset = e_col - s_col
        vim.api.nvim_buf_set_lines(buff_num, s_row_norm, e_row_norm + 1, true, { line .. (" "):rep(offset) .. brush })
        return
    end

    vim.api.nvim_buf_set_text(0, s_row_norm, s_col_norm, e_row_norm, e_col_norm, { brush })
end
```

## How does this PR solve this ?

It checks and does all this boiler plate inside of neovim , as it is expected ,
and you just give to the API call what you want , nothing else to think about!

> Larger `end_column` gets silenty ignored as comments received about how it was confusing that it padded with spaces.

ex. ($ is EOL)

```lua
-- hello$
vim.api.nvim_buf_set_text(X,X,10,X,20,{'world'})
-- hello     world$
--           ^10       ^20
```

```lua
-- hello$
vim.api.nvim_buf_set_text(X,X,-1,X,8,{' world'})
--or
vim.api.nvim_buf_set_text(X,X,-1,X,-1,{' world'})
--or
vim.api.nvim_buf_set_text(X,X,6,X,7,{'world'})
--
-- hello world$
```

```lua
-- hello$
vim.api.nvim_buf_set_text(X,X,-1,X,20,{' world'})
-- hello world$
--     ^-1             ^20
```
```lua
-- hello$
vim.api.nvim_buf_set_text(X,X,10,X,11,{'world'})
-- hello    world$
--          ^10
```

By merging this commit, users will gain `enhanced` editing flexibility and a
more consistent user experience.

Testing has been performed,
and documentation has been updated.


https://github.com/neovim/neovim/assets/61395246/c5e04f11-ca3b-4f67-9773-086580bf87ef
