### PR TITLE
fix(lsp): remove unknown LSP protocol property

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -844,7 +844,6 @@ function protocol.make_client_capabilities()
             return res
           end)(),
         },
-        hierarchicalWorkspaceSymbolSupport = true,
       },
       configuration = true,
       workspaceFolders = true,


### PR DESCRIPTION
[WorkspaceSymbolClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#workspace_symbol) has not field named `hierarchicalWorkspaceSymbolSupport`.
This is likely a copy-paste error because [DocumentSymbolClientCapabilities](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#documentSymbolClientCapabilities) contains a similar field named `hierarchicalDocumentSymbolSupport`.

https://github.com/neovim/neovim/blob/9176b5e10a6b32ff65c8ba3f532e3bd55c168ec6/runtime/lua/vim/lsp/protocol.lua#L796-L810
https://github.com/neovim/neovim/blob/9176b5e10a6b32ff65c8ba3f532e3bd55c168ec6/runtime/lua/vim/lsp/protocol.lua#L834-L848