### PR TITLE
fix(events): change the triggering of VimSuspend and VimResume

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4874,12 +4874,8 @@ static void ex_stop(exarg_T *eap)
   if (!eap->forceit) {
     autowrite_all();
   }
-  apply_autocmds(EVENT_VIMSUSPEND, NULL, NULL, false, NULL);
-
   ui_call_suspend();
   ui_flush();
-
-  apply_autocmds(EVENT_VIMRESUME, NULL, NULL, false, NULL);
 }
 
 /// ":exit", ":xit" and ":wq": Write file and quit the current window.

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -4,7 +4,6 @@ local spawn, set_session, clear = helpers.spawn, helpers.set_session, helpers.cl
 local feed, command = helpers.feed, helpers.command
 local insert = helpers.insert
 local eq = helpers.eq
-local eval = helpers.eval
 local funcs, meths = helpers.funcs, helpers.meths
 
 describe('screen', function()
@@ -70,25 +69,17 @@ local function screen_tests(linegrid)
         eq(true, screen.suspended)
       end
 
-      command('let g:ev = []')
-      command('autocmd VimResume  * :call add(g:ev, "r")')
-      command('autocmd VimSuspend * :call add(g:ev, "s")')
-
       eq(false, screen.suspended)
       command('suspend')
-      eq({ 's', 'r' }, eval('g:ev'))
-
       screen:expect(check)
-      screen.suspended = false
 
+      screen.suspended = false
       feed('<c-z>')
-      eq({ 's', 'r', 's', 'r' }, eval('g:ev'))
-
       screen:expect(check)
-      screen.suspended = false
 
+      screen.suspended = false
       command('suspend')
-      eq({ 's', 'r', 's', 'r', 's', 'r' }, eval('g:ev'))
+      screen:expect(check)
     end)
   end)
 


### PR DESCRIPTION
Fix #22041

This is a complete change of the triggering of VimSuspend and VimResume.

These two events are now decoupled from the :suspend command. Instead,
VimSuspend is triggered when all UIs have detached, and VimResume is
triggered when a UI attaches later.
