### PR TITLE
build(Makefile): remove a phony target uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,4 +173,4 @@ $(DEPS_BUILD_DIR)/%: phony_force
 	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
 endif
 
-.PHONY: test clean distclean nvim libnvim cmake deps install appimage checkprefix benchmark uninstall $(FORMAT) $(LINT) $(TEST)
+.PHONY: test clean distclean nvim libnvim cmake deps install appimage checkprefix benchmark $(FORMAT) $(LINT) $(TEST)


### PR DESCRIPTION
#22966  removed `uninstall` target from Makefile, but forgot to remove it from phony targets. 
This PR removes the `uninstall` phony target.