### PR TITLE
feat(options)!: remove compatible behaviours for vim 5.0 and earlier

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -51,6 +51,16 @@ The following changes may require adaptations in user config or plugins.
   • `vim.json.null` is redundant with `vim.NIL`.
   • `vim.json.array_mt` (and related) is redundant with `vim.empty_dict()`.
 
+• Removed some Vim 5.0<= option compatibilities:
+  • |'backspace'| no longer supports number values. Instead:
+    • for `backspace=0` set `backspace=` (empty)
+    • for `backspace=1` set `backspace=indent,eol`
+    • for `backspace=2` set `backspace=indent,eol,start` (default behavior in Nvim)
+    • for `backspace=3` set `backspace=indent,eol,nostop`
+  • paths in |'backupdir'|, |'path'| and |'cdpath'| can no longer be separated with
+    spaces (but paths themselves may contain spaces now).
+  • |'directory'| will no longer remove a `>` at the start of the option.
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -762,13 +762,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When the value is empty, Vi compatible backspacing is used, none of
 	the ways mentioned for the items above are possible.
 
-	For backwards compatibility with version 5.4 and earlier:
-	value	effect	~
-	  0	same as ":set backspace=" (Vi compatible)
-	  1	same as ":set backspace=indent,eol"
-	  2	same as ":set backspace=indent,eol,start"
-	  3	same as ":set backspace=indent,eol,nostop"
-
 				*'backup'* *'bk'* *'nobackup'* *'nobk'*
 'backup' 'bk'		boolean	(default off)
 			global
@@ -880,8 +873,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	- Careful with '\' characters, type one before a space, type two to
 	  get one in the option (see |option-backslash|), for example: >
 	    :set bdir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
-<	- For backwards compatibility with Vim version 3.0 a '>' at the start
-	  of the option is removed.
+<
 	See also 'backup' and 'writebackup' options.
 	If you want to hide your backup files on Unix, consider this value: >
 		:set backupdir=./.backup,~/.backup,.,/tmp
@@ -2083,9 +2075,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	- Careful with '\' characters, type one before a space, type two to
 	  get one in the option (see |option-backslash|), for example: >
 	    :set dir=c:\\tmp,\ dir\\,with\\,commas,\\\ dir\ with\ spaces
-<	- For backwards compatibility with Vim version 3.0 a '>' at the start
-	  of the option is removed.
-
+<
 	Editing the same file twice will result in a warning.  Using "/tmp" on
 	is discouraged: if the system crashes you lose the swap file. And
 	others on the computer may be able to see the files.
@@ -4490,10 +4480,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	option may be relative or absolute.
 	- Use commas to separate directory names: >
 		:set path=.,/usr/local/include,/usr/include
-<	- Spaces can also be used to separate directory names (for backwards
-	  compatibility with version 3.0).  To have a space in a directory
-	  name, precede it with an extra backslash, and escape the space: >
-		:set path=.,/dir/with\\\ space
 <	- To include a comma in a directory name precede it with an extra
 	  backslash: >
 		:set path=.,/dir/with\\,comma

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -623,10 +623,17 @@ Highlight groups:
 Options:
   *'aleph'* *'al'*
   antialias
+  'backspace' no longer supports number values. Instead:
+    - for `backspace=0` set `backspace=` (empty)
+    - for `backspace=1` set `backspace=indent,eol`
+    - for `backspace=2` set `backspace=indent,eol,start` (default behavior in Nvim)
+    - for `backspace=3` set `backspace=indent,eol,nostop`
   *'balloondelay'* *'bdlay'*
   *'ballooneval'* *'beval'* *'noballooneval'* *'nobeval'*
   *'balloonexpr'* *'bexpr'*
+  'backupdir': paths can no longer be separated with spaces.
   bioskey (MS-DOS)
+  'cdpath': paths can no longer be separated with spaces.
   conskey (MS-DOS)
   *'cp'* *'nocompatible'* *'nocp'* *'compatible'* (Nvim is always "nocompatible".)
   'cpoptions' (gjkHw<*- and all POSIX flags were removed)
@@ -691,6 +698,7 @@ Options:
     Use |g8| or |ga|.  See |mbyte-combining|.
   *'maxmem'* Nvim delegates memory-management to the OS.
   *'maxmemtot'* Nvim delegates memory-management to the OS.
+  |'path'|: paths can no longer be separated with spaces.
   printoptions
   *'printdevice'*
   *'printencoding'*

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1469,7 +1469,7 @@ char *find_file_in_path_option(char *ptr, size_t len, int options, int first, ch
 
         // copy next path
         buf[0] = 0;
-        copy_option_part(&dir, buf, MAXPATHL, " ,");
+        copy_option_part(&dir, buf, MAXPATHL, ",");
 
         // get the stopdir string
         r_ptr = vim_findfile_stopdir(buf);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1664,7 +1664,7 @@ const char *did_set_foldcolumn(optset_T *args)
 const char *did_set_backspace(optset_T *args FUNC_ATTR_UNUSED)
 {
   if (ascii_isdigit(*p_bs)) {
-    if (*p_bs > '3' || p_bs[1] != NUL) {
+    if (*p_bs != '2') {
       return e_invarg;
     }
   } else if (check_opt_strings(p_bs, p_bs_values, true) != OK) {

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -847,7 +847,7 @@ static void expand_path_option(char *curdir, garray_T *gap)
   char *buf = xmalloc(MAXPATHL);
 
   while (*path_option != NUL) {
-    copy_option_part(&path_option, buf, MAXPATHL, " ,");
+    copy_option_part(&path_option, buf, MAXPATHL, ",");
 
     if (buf[0] == '.' && (buf[1] == NUL || vim_ispathsep(buf[1]))) {
       // Relative to current buffer:

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -46,6 +46,7 @@ describe('fileio', function()
     os.remove('Xtest-overwrite-forced')
     rmdir('Xtest_startup_swapdir')
     rmdir('Xtest_backupdir')
+    rmdir('Xtest_backupdir with spaces')
   end)
 
   it('fsync() codepaths #8304', function()
@@ -127,6 +128,28 @@ describe('fileio', function()
     local backup_file_name = string.gsub(currentdir()..'/Xtest_startup_file1',
       is_os('win') and '[:/\\]' or '/', '%%') .. '~'
     local foo_contents = trim(read_file('Xtest_backupdir/'..backup_file_name))
+    local foobar_contents = trim(read_file('Xtest_startup_file1'))
+
+    eq('foobar', foobar_contents);
+    eq('foo', foo_contents);
+  end)
+
+  it('backup with full path with spaces', function()
+    skip(is_ci('cirrus'))
+    clear()
+    mkdir('Xtest_backup with spaces')
+    command('set backup')
+    command('set backupdir=Xtest_backupdir\\ with\\ spaces//')
+    command('write Xtest_startup_file1')
+    feed('ifoo<esc>')
+    command('write')
+    feed('Abar<esc>')
+    command('write')
+
+    -- Backup filename = fullpath, separators replaced with "%".
+    local backup_file_name = string.gsub(currentdir()..'/Xtest_startup_file1',
+      is_os('win') and '[:/\\]' or '/', '%%') .. '~'
+    local foo_contents = trim(read_file('Xtest_backupdir with spaces/'..backup_file_name))
     local foobar_contents = trim(read_file('Xtest_startup_file1'))
 
     eq('foobar', foobar_contents);

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -542,13 +542,6 @@ describe('au OptionSet', function()
       expected_combination({'cursorcolumn', 0, 0, 0, 1, 'global', 'set'})
     end)
 
-    it('with option value converted internally', function()
-      command('noa set backspace=1')
-      command('set backspace=2')
-      expected_combination(({
-        'backspace', 'indent,eol', 'indent,eol', 'indent,eol', '2', 'global', 'set'
-      }))
-    end)
   end)
 
   describe('with specific option', function()

--- a/test/old/testdir/test_backspace_opt.vim
+++ b/test/old/testdir/test_backspace_opt.vim
@@ -36,15 +36,15 @@ func Test_backspace_option()
   " NOTE: Vim doesn't check following error...
   "call assert_fails('set backspace-=ghi', 'E474:')
 
-  " Check backwards compatibility with version 5.4 and earlier
-  set backspace=0
-  call assert_equal('0', &backspace)
-  set backspace=1
-  call assert_equal('1', &backspace)
-  set backspace=2
-  call assert_equal('2', &backspace)
-  set backspace=3
-  call assert_equal('3', &backspace)
+  " " Check backwards compatibility with version 5.4 and earlier
+  " set backspace=0
+  " call assert_equal('0', &backspace)
+  " set backspace=1
+  " call assert_equal('1', &backspace)
+  " set backspace=2
+  " call assert_equal('2', &backspace)
+  " set backspace=3
+  " call assert_equal('3', &backspace)
   call assert_fails('set backspace=4', 'E474:')
   call assert_fails('set backspace=10', 'E474:')
 

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -22,20 +22,20 @@ func Test_whichwrap()
   set whichwrap=h,h,h
   call assert_equal('h', &whichwrap)
 
-  " For compatibility with Vim 3.0 and before, number values are also
-  " supported for 'whichwrap'
-  set whichwrap=1
-  call assert_equal('b', &whichwrap)
-  set whichwrap=2
-  call assert_equal('s', &whichwrap)
-  set whichwrap=4
-  call assert_equal('h,l', &whichwrap)
-  set whichwrap=8
-  call assert_equal('<,>', &whichwrap)
-  set whichwrap=16
-  call assert_equal('[,]', &whichwrap)
-  set whichwrap=31
-  call assert_equal('b,s,h,l,<,>,[,]', &whichwrap)
+  " " For compatibility with Vim 3.0 and before, number values are also
+  " " supported for 'whichwrap'
+  " set whichwrap=1
+  " call assert_equal('b', &whichwrap)
+  " set whichwrap=2
+  " call assert_equal('s', &whichwrap)
+  " set whichwrap=4
+  " call assert_equal('h,l', &whichwrap)
+  " set whichwrap=8
+  " call assert_equal('<,>', &whichwrap)
+  " set whichwrap=16
+  " call assert_equal('[,]', &whichwrap)
+  " set whichwrap=31
+  " call assert_equal('b,s,h,l,<,>,[,]', &whichwrap)
 
   set whichwrap&
 endfunc


### PR DESCRIPTION
## Problem

Options code is messy

## Solution

Remove some very old compatibility mappings.

Related: #15484