### PR TITLE
Add Unison language file detection

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1146,6 +1146,7 @@ local extension = {
   mpd = 'xml',
   rss = 'xml',
   fsproj = 'xml',
+  u = 'unison',
   ui = 'xml',
   vbproj = 'xml',
   xlf = 'xml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -663,6 +663,7 @@ func s:GetFilenameChecks() abort
     \ 'udevperm': ['/etc/udev/permissions.d/file.permissions', 'any/etc/udev/permissions.d/file.permissions'],
     \ 'udevrules': ['/etc/udev/rules.d/file.rules', '/usr/lib/udev/rules.d/file.rules', '/lib/udev/rules.d/file.rules'],
     \ 'uil': ['file.uit', 'file.uil'],
+    \ 'unison': ['file.u', 'scratch.u'],
     \ 'updatedb': ['/etc/updatedb.conf', 'any/etc/updatedb.conf'],
     \ 'upstart': ['/usr/share/upstart/file.conf', '/usr/share/upstart/file.override', '/etc/init/file.conf', '/etc/init/file.override', '/.init/file.conf', '/.init/file.override', '/.config/upstart/file.conf', '/.config/upstart/file.override', 'any/.config/upstart/file.conf', 'any/.config/upstart/file.override', 'any/.init/file.conf', 'any/.init/file.override', 'any/etc/init/file.conf', 'any/etc/init/file.override', 'any/usr/share/upstart/file.conf', 'any/usr/share/upstart/file.override'],
     \ 'upstreamdat': ['upstream.dat', 'UPSTREAM.DAT', 'upstream.file.dat', 'UPSTREAM.FILE.DAT', 'file.upstream.dat', 'FILE.UPSTREAM.DAT'],


### PR DESCRIPTION
[Unison](https://www.unison-lang.org/) is new pure FP language.

I see that all language detections are added through patches from the mainstream vim repository. I can ask the author for permission to [copy that over](https://github.com/unisonweb/unison/tree/trunk/editor-support/vim), but if it's not a necessary step it would be great to have it in Neovim at least.