### PR TITLE
refactor: fix implicit conversion raises a warning during build in LP64 env

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5724,7 +5724,7 @@ static void ex_sleep(exarg_T *eap)
   case 'm':
     break;
   case NUL:
-    len *= 1000L; break;
+    len *= 1000; break;
   default:
     semsg(_(e_invarg2), eap->arg); return;
   }


### PR DESCRIPTION
An implicit conversion made at  `src/nvim/ex_docmd.c` raises a warning during build in LP64 environment.
This PR removes the "L" suffix of an integer literal assigned to `linenr_T len` which is 32-bit integer.