### PR TITLE
fix(lsp): allow whitespace info string in markdown

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1347,7 +1347,7 @@ function M.stylize_markdown(bufnr, contents, opts)
   -- table of fence types to {ft, begin, end}
   -- when ft is nil, we get the ft from the regex match
   local matchers = {
-    block = { nil, '```+([a-zA-Z0-9_]*)', '```+' },
+    block = { nil, '```+%s*([a-zA-Z0-9_]*)', '```+' },
     pre = { nil, '<pre>([a-z0-9]*)', '</pre>' },
     code = { '', '<code>', '</code>' },
     text = { 'text', '<text>', '</text>' },

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -34,6 +34,19 @@ describe('vim.lsp.util', function()
       eq(expected, stylize_markdown(lines, opts))
     end)
 
+    it('code fences with whitespace surrounded info string', function()
+      local lines = {
+        "```   lua   ",
+        "local hello = 'world'",
+        "```",
+      }
+      local expected = {
+        "local hello = 'world'",
+      }
+      local opts = {}
+      eq(expected, stylize_markdown(lines, opts))
+    end)
+
     it('adds separator after code block', function()
       local lines = {
         "```lua",


### PR DESCRIPTION
Hi 👋, I discovered an issue displaying markdown provided from an LSP server.

In this particular case, I am using bash language server. Bash language server is returning markdown content that starts with a code fence and info string of `man`. This is not properly rendered in Neovim because of whitespace between the code fence and `man`.

See https://github.com/bash-lsp/bash-language-server/blob/0ee73c53cebdc18311d4a4ad9367185ea4d98a03/server/src/server.ts#L821C15-L821C15
```typescript
function getMarkdownContent(documentation: string, language?: string): LSP.MarkupContent {
  return {
    value: language
      ? // eslint-disable-next-line prefer-template
        ['``` ' + language, documentation, '```'].join('\n')
      : documentation,
    kind: LSP.MarkupKind.Markdown,
  }
}
```


For example,
```
    ``` man
    NAME
       git - the stupid content tracker
    ```
```

If I remove the white space, then it is properly formatted. 
```    
    ```man instead of ``` man
```

Per CommonMark Spec https://spec.commonmark.org/0.30/#info-string it allows for whitespace before and after the `info string` which is typically used to identify the language in code blocks.
> The line with the opening code fence may optionally contain some text following the code fence; this is trimmed of leading and trailing spaces or tabs and called the [info string](https://spec.commonmark.org/0.30/#info-string). If the [info string](https://spec.commonmark.org/0.30/#info-string) comes after a backtick fence, it may not contain any backtick characters. (The reason for this restriction is that otherwise some inline code would be incorrectly interpreted as the beginning of a fenced code block.)

I have tested this locally against bash language server.

### before
![before-fix](https://github.com/neovim/neovim/assets/10135646/60270e08-a99c-486d-bcca-5c29710cf656)


### after

![after-fix](https://github.com/neovim/neovim/assets/10135646/ade219bb-f537-47cb-a838-67e76db78df7)

Please let me know if you have an questions or suggestions. Also, I love Neovim 🙂!