### PR TITLE
docs(term.txt): reorder paragraphs about TUI input

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -372,6 +372,7 @@ notation	meaning		    equivalent	decimal value(s)	~
 <C-…>		control-key			*control* *ctrl* *<C-*
 <M-…>		alt-key or meta-key		*META* *ALT* *<M-*
 <A-…>		same as <M-…>			*<A-*
+<T-…>		meta-key when it's not alt	*<T-*
 <D-…>		command-key or "super" key	*<D-*
 ----------------------------------------------------------------------- ~
 

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -1026,6 +1026,12 @@ CTRL-O			Go to [count] Older cursor position in jump list
 CTRL-I			Go to [count] newer cursor position in jump list
 			(not a motion command).
 
+			NOTE: In the GUI and in a terminal supporting
+			|tui-modifyOtherKeys| or |tui-csiu|, CTRL-I can be
+			mapped separately from <Tab>, on the condition that
+			both keys are mapped, otherwise the mapping applies to
+			both.
+
 							*:ju* *:jumps*
 :ju[mps]		Print the jump list (not a motion command).
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -104,6 +104,9 @@ The following new APIs and features were added.
 
 • |nvim_set_keymap()| and |nvim_del_keymap()| now support abbreviations.
 
+• Builtin TUI can now recognize "super" (|<D-|) and "meta" (|<T-|) modifiers in a
+  terminal emulator that supports |tui-csiu|.
+
 • Implemented LSP inlay hints: |vim.lsp.inlay_hint()|
   https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint
 

--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -108,10 +108,22 @@ and right scroll margins as well.  If Nvim detects that the terminal is Xterm,
 it will make use of this ability to speed up scrolling that is not the full
 width of the terminal.
 
-							*tui-input*
+								*tui-input*
+Historically, terminal emulators could not distinguish between certain control
+key modifiers and other keys. For example, <C-I> and <Tab> are represented in
+the same way, as are <Esc> and <C-[>, <CR> and <C-M>, and <NL> and <C-J>.
+
+Modern terminal emulators are able to distinguish between these pairs of keys
+by encoding control modifiers differently. There are two common but distinct
+ways of doing this, known as "modifyOtherKeys" and "CSI u". Nvim supports both
+encoding methods and at startup will tell the terminal emulator that it
+understands these key encodings. If your terminal emulator supports it then
+this will allow you to map the key pairs listed above separately. |<Tab>|
+
 Nvim uses libtermkey to convert terminal escape sequences to key codes.
 |terminfo| is used first, and CSI sequences not in |terminfo| (including
-extended keys a.k.a. modifyOtherKeys or "CSI u") can also be parsed.
+extended keys a.k.a. "modifyOtherKeys" or "CSI u") can also be parsed.
+
 For example, when running Nvim in tmux, this makes Nvim leave Insert mode and
 go to the window below: >
 	tmux send-keys 'Escape' [ 2 7 u 'C-W' j
@@ -124,41 +136,21 @@ For example, this sequence is recognized by Nvim as <C-kEnter>: >
 and can be used differently from <C-CR> in mappings.
 
 						*tui-modifyOtherKeys* *tui-csiu*
-Historically, terminal emulators could not distinguish between certain control
-key modifiers and other keys. For example, <C-I> and <Tab> are represented the
-same way, as are <Esc> and <C-[>, <CR> and <C-M>, and <NL> and <C-J>. This
-meant that Nvim also could not map these keys separately.
-
-Modern terminal emulators are able to distinguish between these pairs of keys
-by encoding control modifiers differently. There are two common but distinct
-ways of doing this, known as "modifyOtherKeys" and "CSI u". Nvim supports both
-encoding methods and at startup will tell the terminal emulator that it
-understands these key encodings. If your terminal emulator supports it then
-this will allow you to map the key pairs listed above separately.
-
-At startup Nvim will query your terminal to see if it supports the CSI u
+At startup Nvim will query your terminal to see if it supports the "CSI u"
 encoding by writing the sequence >
-
 	CSI ? u CSI c
-
 If your terminal emulator responds with >
-
 	CSI ? <flags> u
-
-this means your terminal supports the CSI u encoding and Nvim will tell your
+this means your terminal supports the "CSI u" encoding and Nvim will tell your
 terminal to enable it by writing the sequence >
-
 	CSI > 1 u
-
-If your terminal does not support CSI u then Nvim will instead enable the
+If your terminal does not support "CSI u" then Nvim will instead enable the
 "modifyOtherKeys" encoding by writing the sequence >
-
 	CSI > 4 ; 2 m
 
 When Nvim exits cleanly it will send the corresponding sequence to disable the
 special key encoding. If Nvim does not exit cleanly then your terminal
 emulator could be in a bad state. If this happens, simply run "reset".
-
 
 							*tui-colors*
 Nvim uses 256 colours by default, ignoring |terminfo| for most terminal types,


### PR DESCRIPTION
Make `|tui-modifyOtherKeys|` and `|tui-csiu|` tags appear at a better place.
Also adapt the `|<Tab>|` help update from https://github.com/vim/vim/commit/dad4473f02e1fec86d43a2fc094536a4b27d3b25
