### PR TITLE
fix(inccommand): block errors when parsing command line again

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -261,6 +261,7 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
     return false;
   }
 
+  emsg_off++;
   exarg_T ea = {
     .line1 = 1,
     .line2 = 1,
@@ -368,6 +369,7 @@ static bool do_incsearch_highlighting(int firstc, int *search_delim, incsearch_s
   curwin->w_cursor = save_cursor;
   retval = true;
 theend:
+  emsg_off--;
   return retval;
 }
 
@@ -2427,9 +2429,12 @@ static bool cmdpreview_may_show(CommandLineState *s)
   int cmdpreview_type = 0;
   char *cmdline = xstrdup(ccline.cmdbuff);
   const char *errormsg = NULL;
+  emsg_off++;  // Block errors when parsing the command line, and don't update v:errmsg
   if (!parse_cmdline(cmdline, &ea, &cmdinfo, &errormsg)) {
+    emsg_off--;
     goto end;
   }
+  emsg_off--;
 
   // Check if command is previewable, if not, don't attempt to show preview
   if (!(ea.argt & EX_PREVIEW)) {

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -3086,8 +3086,7 @@ end)
 it('long :%s/ with inccommand does not collapse cmdline', function()
   clear()
   local screen = Screen.new(10,5)
-  common_setup(screen)
-  command('set inccommand=nosplit')
+  common_setup(screen, 'nosplit')
   feed(':%s/AAAAAAA', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A',
     'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A')
   screen:expect([[
@@ -3096,6 +3095,21 @@ it('long :%s/ with inccommand does not collapse cmdline', function()
     :%s/AAAAAAAA|
     AAAAAAAAAAAA|
     AAAAAAA^     |
+  ]])
+end)
+
+it("with 'inccommand' typing invalid `={expr}` does not show error", function()
+  clear()
+  local screen = Screen.new(30, 6)
+  common_setup(screen, 'nosplit')
+  feed(':edit `=`')
+  screen:expect([[
+                                  |
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    {15:~                             }|
+    :edit `=`^                     |
   ]])
 end)
 


### PR DESCRIPTION
Revert the change to ex_getln.c from a741c7fd0465c949a0016fcbee5f4526b65f8c02
Ref #24373 #24220
