### PR TITLE
build(scripts): allow a git ref for lsp_types

### DIFF
--- a/scripts/lsp_types.lua
+++ b/scripts/lsp_types.lua
@@ -1,7 +1,9 @@
 --[[
 Generates lua-ls annotations for lsp
 USAGE:
-nvim -l scripts/lsp_types.lua gen --runtime/lua/vim/lsp/types/protocol.lua
+nvim -l scripts/lsp_types.lua gen  # this will overwrite runtime/lua/vim/lsp/types/protocol.lua
+nvim -l scripts/lsp_types.lua gen --build/new_lsp_types.lua
+nvim -l scripts/lsp_types.lua gen --out runtime/lua/vim/lsp/types/protocol.lua --ref 2023.0.0a2 # specify a git reference from microsoft/lsprotocol
 --]]
 
 local M = {}
@@ -22,13 +24,12 @@ function M.gen(opt)
   end
   vim.fn.system({
     'curl',
-    'https://raw.githubusercontent.com/microsoft/lsprotocol/2023.0.0a2/generator/lsp.json',
+    'https://raw.githubusercontent.com/microsoft/lsprotocol/' .. opt.ref .. '/generator/lsp.json',
     '-o',
     './lsp.json',
   })
   local protocol = vim.fn.json_decode(vim.fn.readfile('./lsp.json'))
   vim.fn.delete('./lsp.json')
-  local output_file = opt[1]
   protocol = protocol or {}
   local output = {
     '--[[',
@@ -184,17 +185,21 @@ function M.gen(opt)
     output[#output + 1] = line
   end
 
-  tofile(output_file, table.concat(output, '\n'))
+  tofile(opt.output_file, table.concat(output, '\n'))
 end
 
-local opt = {}
+local opt = {
+  output_file = 'runtime/lua/vim/lsp/types/protocol.lua',
+  ref = "main"
+}
 
-local index = 1
-for _, a in ipairs(arg) do
-  if vim.startswith(a, '--') then
-    local name = a:sub(3)
-    opt[index] = name
-    index = index + 1
+for i = 1, #_G.arg do
+  if _G.arg[i] == '--out' then
+    opt.output_file = _G.arg[i+1]
+  elseif _G.arg[i] == '--ref' then
+    opt.ref = _G.arg[i+1]
+  elseif vim.startswith(_G.arg[i], '--') then
+    opt.output_file = _G.arg[i]:sub(3)
   end
 end
 

--- a/scripts/lsp_types.lua
+++ b/scripts/lsp_types.lua
@@ -22,7 +22,7 @@ function M.gen(opt)
   end
   vim.fn.system({
     'curl',
-    'https://raw.githubusercontent.com/microsoft/lsprotocol/main/generator/lsp.json',
+    'https://raw.githubusercontent.com/microsoft/lsprotocol/2023.0.0a2/generator/lsp.json',
     '-o',
     './lsp.json',
   })

--- a/scripts/lsp_types.lua
+++ b/scripts/lsp_types.lua
@@ -190,7 +190,7 @@ end
 
 local opt = {
   output_file = 'runtime/lua/vim/lsp/types/protocol.lua',
-  ref = "main"
+  ref = 'main',
 }
 
 for i = 1, #_G.arg do

--- a/scripts/lsp_types.lua
+++ b/scripts/lsp_types.lua
@@ -17,7 +17,7 @@ local function tofile(fname, text)
 end
 
 function M.gen(opt)
-  if vim.loop.fs_stat('./lsp.json') then
+  if vim.uv.fs_stat('./lsp.json') then
     vim.fn.delete('./lsp.json')
   end
   vim.fn.system({


### PR DESCRIPTION
- build(scripts): vim.loop was renamed to vim.uv
- build(scripts): allow a git ref for lsp types

USAGE
```sh
# this will overwrite runtime/lua/vim/lsp/types/protocol.lua
nvim -l scripts/lsp_types.lua gen

# specify a custom output file
nvim -l scripts/lsp_types.lua gen --build/new_lsp_types.lua

# specify a git reference from https://github.com/microsoft/lsprotocol
nvim -l scripts/lsp_types.lua gen --out runtime/lua/vim/lsp/types/protocol.lua --ref 2023.0.0a2 
```

