### PR TITLE
fix(terminal): don't send unknown special keys to terminal

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -766,7 +766,7 @@ void terminal_send_key(Terminal *term, int c)
 
   if (key) {
     vterm_keyboard_key(term->vt, key, mod);
-  } else {
+  } else if (!IS_SPECIAL(c)) {
     vterm_keyboard_unichar(term->vt, (uint32_t)c, mod);
   }
 }


### PR DESCRIPTION
Special keys are negative integers, so sending them to terminal leads to
strange behavior.
