### PR TITLE
fix(ui.open): some URLs fail on Windows

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -136,7 +136,11 @@ function M.open(path)
   if vim.fn.has('mac') == 1 then
     cmd = { 'open', path }
   elseif vim.fn.has('win32') == 1 then
-    cmd = { 'explorer', path }
+    if vim.fn.executable('rundll32') == 1 then
+      cmd = { 'rundll32', 'url.dll,FileProtocolHandler', path }
+    else
+      return nil, 'vim.ui.open: rundll32 not found'
+    end
   elseif vim.fn.executable('wslview') == 1 then
     cmd = { 'wslview', path }
   elseif vim.fn.executable('xdg-open') == 1 then

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -6,6 +6,7 @@ local clear = helpers.clear
 local feed = helpers.feed
 local eval = helpers.eval
 local is_ci = helpers.is_ci
+local is_os = helpers.is_os
 local poke_eventloop = helpers.poke_eventloop
 
 describe('vim.ui', function()
@@ -134,8 +135,11 @@ describe('vim.ui', function()
 
   describe('open()', function()
     it('validation', function()
-      if is_ci('github') then
-        matches('vim.ui.open: command failed %(%d%): { "[^"]+", "non%-existent%-file" }',
+      if is_os('win') or not is_ci('github') then
+        exec_lua[[vim.system = function() return { wait=function() return { code=3} end } end]]
+      end
+      if not is_os('bsd') then
+        matches('vim.ui.open: command failed %(%d%): { "[^"]+", .*"non%-existent%-file" }',
           exec_lua[[local _, err = vim.ui.open('non-existent-file') ; return err]])
       end
 


### PR DESCRIPTION
Problem:
On Windows, `explorer.exe` fails to open some URLs, for example:

    :lua vim.ui.open('https://devdocs.io/#q=lua%20lua_call')

https://github.com/neovim/neovim/pull/23401#issuecomment-1641015704

Solution:
Use rundll32 instead.