### PR TITLE
fix(codelens): actually use handler["textDocument/codeLens"]

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -267,7 +267,7 @@ function M.refresh()
     return
   end
   active_refreshes[bufnr] = true
-  vim.lsp.buf_request(0, 'textDocument/codeLens', params, M.on_codelens)
+  vim.lsp.buf_request(0, 'textDocument/codeLens', params)
 end
 
 return M


### PR DESCRIPTION
This tiny change will actually force neovim to resolve the codelens handler instead of only using the built-in one. This way one may overwrite the `handler["textDocument/codeLens"]` similar to all other handlers and it should work.