### PR TITLE
refactor(lsp): use LspNotify for inlay_hint

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1572,9 +1572,9 @@ function lsp.start_client(config)
       changetracking.flush(client)
     end
 
-    local result = rpc.notify(method, params)
+    local client_active = rpc.notify(method, params)
 
-    if result then
+    if client_active then
       vim.schedule(function()
         nvim_exec_autocmds('LspNotify', {
           modeline = false,
@@ -1587,7 +1587,7 @@ function lsp.start_client(config)
       end)
     end
 
-    return result
+    return client_active
   end
 
   ---@private

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -6,27 +6,13 @@ local M = {}
 ---@class lsp._inlay_hint.bufstate
 ---@field version integer
 ---@field client_hint table<integer, table<integer, lsp.InlayHint[]>> client_id -> (lnum -> hints)
----@field enabled boolean Whether inlay hints are enabled for the buffer
----@field timer uv.uv_timer_t? Debounce timer associated with the buffer
 ---@field applied table<integer, integer> Last version of hints applied to this line
-
+---@field autocmd_id integer The autocmd id for the buffer
 ---@type table<integer, lsp._inlay_hint.bufstate>
 local bufstates = {}
 
 local namespace = api.nvim_create_namespace('vim_lsp_inlayhint')
 local augroup = api.nvim_create_augroup('vim_lsp_inlayhint', {})
-
---- Reset the request debounce timer of a buffer
-local function reset_timer(reset_bufnr)
-  local timer = bufstates[reset_bufnr].timer
-  if timer then
-    bufstates[reset_bufnr].timer = nil
-    if not timer:is_closing() then
-      timer:stop()
-      timer:close()
-    end
-  end
-end
 
 --- |lsp-handler| for the method `textDocument/inlayHint`
 --- Store hints for a specific buffer and client
@@ -97,7 +83,7 @@ function M.on_refresh(err, _, ctx, _)
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
         local bufstate = bufstates[bufnr]
-        if bufstate and bufstate.enabled then
+        if bufstate then
           util._refresh('textDocument/inlayHint', { bufnr = bufnr })
           break
         end
@@ -117,7 +103,6 @@ local function clear(bufnr)
   if not bufstates[bufnr] then
     return
   end
-  reset_timer(bufnr)
   local bufstate = bufstates[bufnr]
   local client_lens = (bufstate or {}).client_hint or {}
   local client_ids = vim.tbl_keys(client_lens)
@@ -130,9 +115,17 @@ local function clear(bufnr)
   api.nvim__buf_redraw_range(bufnr, 0, -1)
 end
 
-local function make_request(request_bufnr)
-  reset_timer(request_bufnr)
-  util._refresh('textDocument/inlayHint', { bufnr = request_bufnr })
+--- Disable inlay hints for a buffer
+---@param bufnr (integer) Buffer handle, or 0 for current
+local function disable(bufnr)
+  if bufnr == nil or bufnr == 0 then
+    bufnr = api.nvim_get_current_buf()
+  end
+  clear(bufnr)
+  if bufstates[bufnr] and bufstates[bufnr].autocmd_id then
+    api.nvim_del_autocmd(bufstates[bufnr].autocmd_id)
+  end
+  bufstates[bufnr] = nil
 end
 
 --- Enable inlay hints for a buffer
@@ -142,52 +135,41 @@ local function enable(bufnr)
     bufnr = api.nvim_get_current_buf()
   end
   local bufstate = bufstates[bufnr]
-  if not (bufstate and bufstate.enabled) then
-    bufstates[bufnr] = { enabled = true, timer = nil, applied = {} }
+  if not bufstate then
+    bufstates[bufnr] = { applied = {} }
+    bufstates[bufnr].autocmd_id = api.nvim_create_autocmd('LspNotify', {
+      buffer = bufnr,
+      callback = function(opts)
+        if opts.data.method ~= 'textDocument/didChange' then
+          return
+        end
+        if bufstates[bufnr] then
+          util._refresh('textDocument/inlayHint', { bufnr = bufnr })
+        end
+      end,
+      group = augroup,
+    })
     util._refresh('textDocument/inlayHint', { bufnr = bufnr })
     api.nvim_buf_attach(bufnr, true, {
-      on_lines = function(_, cb_bufnr)
-        if not bufstates[cb_bufnr].enabled then
-          return true
-        end
-        reset_timer(cb_bufnr)
-        bufstates[cb_bufnr].timer = vim.defer_fn(function()
-          make_request(cb_bufnr)
-        end, 200)
-      end,
       on_reload = function(_, cb_bufnr)
         clear(cb_bufnr)
-        if bufstates[cb_bufnr] and bufstates[cb_bufnr].enabled then
-          bufstates[cb_bufnr] = { enabled = true, applied = {} }
+        if bufstates[cb_bufnr] then
+          bufstates[cb_bufnr].applied = {}
+          util._refresh('textDocument/inlayHint', { bufnr = cb_bufnr })
         end
-        util._refresh('textDocument/inlayHint', { bufnr = cb_bufnr })
       end,
       on_detach = function(_, cb_bufnr)
-        clear(cb_bufnr)
-        bufstates[cb_bufnr] = nil
+        disable(cb_bufnr)
       end,
     })
     api.nvim_create_autocmd('LspDetach', {
       buffer = bufnr,
-      callback = function(opts)
-        clear(opts.buf)
+      callback = function()
+        disable(bufnr)
       end,
       once = true,
       group = augroup,
     })
-  end
-end
-
---- Disable inlay hints for a buffer
----@param bufnr (integer) Buffer handle, or 0 for current
-local function disable(bufnr)
-  if bufnr == nil or bufnr == 0 then
-    bufnr = api.nvim_get_current_buf()
-  end
-  if bufstates[bufnr] and bufstates[bufnr].enabled then
-    clear(bufnr)
-    bufstates[bufnr].enabled = nil
-    bufstates[bufnr].timer = nil
   end
 end
 
@@ -198,7 +180,7 @@ local function toggle(bufnr)
     bufnr = api.nvim_get_current_buf()
   end
   local bufstate = bufstates[bufnr]
-  if bufstate and bufstate.enabled then
+  if bufstate then
     disable(bufnr)
   else
     enable(bufnr)


### PR DESCRIPTION
In https://github.com/neovim/neovim/pull/24128 we introduced a new autocmd event, `LspNotify`, which is sent whenever the server is notified of various LSP events.

We can use this to trigger refreshes of inlay hints after the sever is sent the `textDocument/didChange` event.

`lsp.lua` is handling the timers and debouncing, so we can remove that from `inlay_hint.lua`.

I also removed the `enabled` flag. I *think* it's redundant with the presence of the table for the buffer in `bufstates` for the given buffer.