### PR TITLE
fix(gx): move to to _init_default_mappings

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1048,6 +1048,33 @@ function vim._init_default_mappings()
   -- Use : instead of <Cmd> so that ranges are supported. #19365
   map('n', '&', ':&&<CR>')
 
+  -- gx
+
+  -- TODO: use vim.region() when it lands... #13896 #16843
+  local function get_visual_selection()
+    local save_a = vim.fn.getreginfo('a')
+    vim.cmd([[norm! "ay]])
+    local selection = vim.fn.getreg('a', 1)
+    vim.fn.setreg('a', save_a)
+    return selection
+  end
+
+  local function do_open(uri)
+    local _, err = vim.ui.open(uri)
+    if err then
+      vim.notify(err, vim.log.levels.ERROR)
+    end
+  end
+
+  local gx_desc =
+    'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
+  vim.keymap.set({ 'n' }, 'gx', function()
+    do_open(vim.fn.expand('<cfile>'))
+  end, { desc = gx_desc })
+  vim.keymap.set({ 'x' }, 'gx', function()
+    do_open(get_visual_selection())
+  end, { desc = gx_desc })
+
   -- menus
 
   -- TODO VimScript, no l10n

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -18,31 +18,3 @@ vim.api.nvim_create_user_command('InspectTree', function(cmd)
     vim.treesitter.inspect_tree()
   end
 end, { desc = 'Inspect treesitter language tree for buffer', count = true })
-
--- TODO: use vim.region() when it lands... #13896 #16843
-local function get_visual_selection()
-  local save_a = vim.fn.getreginfo('a')
-  vim.cmd([[norm! "ay]])
-  local selection = vim.fn.getreg('a', 1)
-  vim.fn.setreg('a', save_a)
-  return selection
-end
-
-local gx_desc =
-  'Opens filepath or URI under cursor with the system handler (file explorer, web browser, …)'
-local function do_open(uri)
-  local _, err = vim.ui.open(uri)
-  if err then
-    vim.notify(err, vim.log.levels.ERROR)
-  end
-end
-if vim.fn.maparg('gx', 'n') == '' then
-  vim.keymap.set({ 'n' }, 'gx', function()
-    do_open(vim.fn.expand('<cfile>'))
-  end, { desc = gx_desc })
-end
-if vim.fn.maparg('gx', 'x') == '' then
-  vim.keymap.set({ 'x' }, 'gx', function()
-    do_open(get_visual_selection())
-  end, { desc = gx_desc })
-end


### PR DESCRIPTION
Problem:
Remapping gx did not work as expected. gx was still using netrw by default

Solution:
Move keymapping to `_init_default_mappings`. Remapping works as expected

https://github.com/neovim/neovim/pull/23401#issuecomment-1625533304