### PR TITLE
fix(terminal): call validate_cursor to update the viewport

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -532,6 +532,7 @@ static int terminal_check(VimState *state)
   }
 
   terminal_check_cursor();
+  validate_cursor();
 
   if (must_redraw) {
     update_screen();


### PR DESCRIPTION
# Problem

When the `CurSearch` highlight group is set, and a search is active and you are listening to the remote UI `win_viewport` events,  then the typing is very unresponsive, since `win_viewport` is not sent as soon as the character is typed. On the other hand if you refresh the screen on `flush`, the screen will scroll with a delay, since `win_viewport` comes too late. I estimate this delay be up to one second, but it varies. 

Note this is most likely the same problem as #23590. But I have not been able to reproduce it anywhere else in the terminal mode with multigrid and Neovide.

# Solution

`validate_cursor` is called before drawing the screen, just like other modes do.

NOTE: No tests have been added, since only the intermediate state is wrong, and as far as  I know there's no way to properly test using the screen based tests.
