### PR TITLE
fix(lsp): send empty list for added when removing workspace folder

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -514,7 +514,7 @@ function M.remove_workspace_folder(workspace_folder)
     return
   end
   local params = util.make_workspace_params(
-    { {} },
+    {},
     { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } }
   )
   for _, client in pairs(vim.lsp.get_clients({ bufnr = 0 })) do


### PR DESCRIPTION
When adding `workspace/didChangeWorkspaceFolders` support to my [language server](https://github.com/elixir-tools/next-ls), I noticed that when neovim removes a workspace, it was sending an empty table (which is serialized to an empty JSON array) for the value in the `added` field.

This does not follow the spec, and the `added` table should just be empty.

For reference, this is the error that led me to this discovery. You can the payload includes `"added" => [[]]`.

```
22:46:48.476 [error] LSP Exited.

Last message received: handle_notification %{"jsonrpc" => "2.0", "method" => "workspace/didChangeWorkspaceFolders", "params" => %{"event" => %{"added" => [[]], "removed" => [%{"name" => "/Users/mitchell/src/gen_lsp", "uri" => "file:///Users/mitchell/src/gen_lsp"}]}}}

** (MatchError) no match of right hand side value: {:error, %{"params" => %{"event" => %{"added" => [error: "expected a map"]}}}}
    (gen_lsp 0.4.0) lib/gen_lsp.ex:265: anonymous fn/4 in GenLSP.loop/3
    (gen_lsp 0.4.0) lib/gen_lsp.ex:292: GenLSP.attempt/3
    (stdlib 5.0.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```
