### PR TITLE
fix(lsp): change offset_encodings warning to notify_once

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2026,7 +2026,7 @@ function M._get_offset_encoding(bufnr)
     if not offset_encoding then
       offset_encoding = this_offset_encoding
     elseif offset_encoding ~= this_offset_encoding then
-      vim.notify(
+      vim.notify_once(
         'warning: multiple different client offset_encodings detected for buffer, this is not supported yet',
         vim.log.levels.WARN
       )


### PR DESCRIPTION
In the case you hit this warning in a buffer (like with C++ and clangd), this message potentially fires over and over again making it difficult to use the editor at all.