### PR TITLE
fix(lsp): announce publishDiagnostics.dataSupport

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -828,6 +828,7 @@ function protocol.make_client_capabilities()
             return res
           end)(),
         },
+        dataSupport = true,
       },
       callHierarchy = {
         dynamicRegistration = false,


### PR DESCRIPTION
Neovim already passed `data` element from published diagnostic to code action, but failed to announce it in client capabilities.

Here is the test that shows that `data` element is returned by `vim.lsp.diagnostic.get_line_diagnostics()`:

https://github.com/neovim/neovim/blob/f56c1848091bb64c63b5bc25ec74bcbd2f52bdde/test/functional/plugin/lsp/diagnostic_spec.lua#L103-L115

and then `get_line_diagnostics()` is used to construct the context for code action request:

https://github.com/neovim/neovim/blob/f56c1848091bb64c63b5bc25ec74bcbd2f52bdde/runtime/lua/vim/lsp/buf.lua#L742