### PR TITLE
fix(lsp): disable `signcolumn` in floating window made by `vim.lsp.util.open_floating_preview()`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1719,6 +1719,8 @@ function M.open_floating_preview(contents, syntax, opts)
   end
   -- disable folding
   vim.wo[floating_winnr].foldenable = false
+  -- disable sign column
+  vim.wo[floating_winnr].signcolumn = 'no'
   -- soft wrapping
   vim.wo[floating_winnr].wrap = opts.wrap
 


### PR DESCRIPTION
Problem: when `signcolumn` is set to be visible, opening floating window of hover/signatureHelp/diagnostic will have the header divider line wraps at wrong position.
Solution: disable `signcolumn` in `vim.lsp.util.open_floating_preview()`

Fix: #24444 

May be a follow up for #14649, which disable folding (`foldenable`) and make `wrap` configurable