### PR TITLE
fix(treesitter): `vim.treesitter.stop` should treat `0` as the current buffer

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -462,7 +462,7 @@ end
 ---
 ---@param bufnr (integer|nil) Buffer to stop highlighting (default: current buffer)
 function M.stop(bufnr)
-  bufnr = bufnr or api.nvim_get_current_buf()
+  bufnr = bufnr and bufnr ~= 0 and bufnr or api.nvim_get_current_buf()
 
   if M.highlighter.active[bufnr] then
     M.highlighter.active[bufnr]:destroy()

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -462,7 +462,7 @@ end
 ---
 ---@param bufnr (integer|nil) Buffer to stop highlighting (default: current buffer)
 function M.stop(bufnr)
-  bufnr = bufnr and bufnr ~= 0 and bufnr or api.nvim_get_current_buf()
+  bufnr = (bufnr and bufnr ~= 0) and bufnr or api.nvim_get_current_buf()
 
   if M.highlighter.active[bufnr] then
     M.highlighter.active[bufnr]:destroy()


### PR DESCRIPTION
Currently `vim.treesitter.stop(0)` doesn't work which doesn't align with the rest of the Lua/Vim APIs. This adds a check to resolve the full current buffer if `0` is passed