### PR TITLE
docs: remove trailing spaces

### DIFF
--- a/runtime/doc/arabic.txt
+++ b/runtime/doc/arabic.txt
@@ -231,7 +231,7 @@ o  Enable Arabic settings [short-cut]
       - While in Left-to-right mode, enter ':set rl' in the command line
 	('rl' is the abbreviation for rightleft).
 
-      - Put the ':set rl' line in your vimrc file to start Vim in 
+      - Put the ':set rl' line in your vimrc file to start Vim in
         right-to-left mode permanently.
 
    +  Arabic right-to-left command-line Mode

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -293,7 +293,7 @@ BufReadPre			When starting to edit a new buffer, before
 				reading the file into the buffer.  Not used
 				if the file doesn't exist.
 							*BufUnload*
-BufUnload			Before unloading a buffer, when the text in 
+BufUnload			Before unloading a buffer, when the text in
 				the buffer is going to be freed.
 				After BufWritePost.
 				Before BufDelete.
@@ -590,7 +590,7 @@ FileChangedShell		When Vim notices that the modification time of
 				Triggered for each changed file, after:
 				- executing a shell command
 				- |:checktime|
-				- |FocusGained| 
+				- |FocusGained|
 
 				Not used when 'autoread' is set and the buffer
 				was not changed.  If a FileChangedShell

--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -82,7 +82,7 @@ only bytes can be written to Nvim's own stderr.
     thus the first and last items in the {data} list may be partial lines.
     Empty string completes the previous partial line. Examples (not including
     the final `['']` emitted at EOF):
-      - `foobar` may arrive as `['fo'], ['obar']` 
+      - `foobar` may arrive as `['fo'], ['obar']`
       - `foo\nbar` may arrive as
 	- `['foo','bar']`
 	- or `['foo',''], ['bar']`

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -981,7 +981,7 @@ These modifiers can be given, in this order:
 		precede any :r or :e.
 	:r	Root of the file name (the last extension removed).  When
 		there is only an extension (file name that starts with '.',
-		e.g., ".nvimrc"), it is not removed.  Can be repeated to 
+		e.g., ".nvimrc"), it is not removed.  Can be repeated to
 		remove several extensions (last one first).
 	:e	Extension of the file name.  Only makes sense when used alone.
 		When there is no extension the result is empty.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -725,7 +725,7 @@ file: |pi_spec.txt|.
 
 SHADA							*ft-shada*
 
-Allows editing binary |shada-file|s in a nice way.  Opened binary files are 
+Allows editing binary |shada-file|s in a nice way.  Opened binary files are
 displayed in the following format: >
 
     Type with timestamp YYYY-mm-ddTHH:MM:SS:
@@ -740,31 +740,31 @@ displayed in the following format: >
       # Unexpected type: type instead of map
       = {msgpack-value}
 
-Filetype plugin defines all |Cmd-event|s.  Defined |SourceCmd| event makes 
-"source file.shada" be equivalent to "|:rshada| file.shada".  |BufWriteCmd|, 
-|FileWriteCmd| and |FileAppendCmd| events are affected by the following 
+Filetype plugin defines all |Cmd-event|s.  Defined |SourceCmd| event makes
+"source file.shada" be equivalent to "|:rshada| file.shada".  |BufWriteCmd|,
+|FileWriteCmd| and |FileAppendCmd| events are affected by the following
 settings:
 
-*g:shada#keep_old_header*	Boolean, if set to false all header entries 
+*g:shada#keep_old_header*	Boolean, if set to false all header entries
 				are ignored when writing.  Defaults to 1.
-*g:shada#add_own_header*	Boolean, if set to true first written entry 
-				will always be header entry with two values in 
-				a map with attached data: |v:version| attached 
-				to "version" key and "shada.vim" attached to 
+*g:shada#add_own_header*	Boolean, if set to true first written entry
+				will always be header entry with two values in
+				a map with attached data: |v:version| attached
+				to "version" key and "shada.vim" attached to
 				"generator" key.  Defaults to 1.
 
 Format description:
 
-1. `#` starts a comment.  Lines starting with space characters and then `#` 
-   are ignored.  Plugin may only add comment lines to indicate some errors in 
-   ShaDa format.  Lines containing no non-whitespace characters are also 
+1. `#` starts a comment.  Lines starting with space characters and then `#`
+   are ignored.  Plugin may only add comment lines to indicate some errors in
+   ShaDa format.  Lines containing no non-whitespace characters are also
    ignored.
-2. Each entry starts with line that has format "{type} with timestamp 
-   {timestamp}:". {timestamp} is |strftime()|-formatted string representing 
+2. Each entry starts with line that has format "{type} with timestamp
+   {timestamp}:". {timestamp} is |strftime()|-formatted string representing
    actual Unix timestamp value. First strftime() argument is equal to
-   `%Y-%m-%dT%H:%M:%S`.  When writing this timestamp is parsed using 
-   |msgpack#strptime()|, with caching (it remembers which timestamp produced 
-   particular strftime() output and uses this value if you did not change 
+   `%Y-%m-%dT%H:%M:%S`.  When writing this timestamp is parsed using
+   |msgpack#strptime()|, with caching (it remembers which timestamp produced
+   particular strftime() output and uses this value if you did not change
    timestamp). {type} is one of
     1 - Header
     2 - Search pattern
@@ -779,28 +779,28 @@ Format description:
    11 - Change
     * - Unknown (0x{type-hex})
 
-   Each type may be represented using Unknown entry: "Jump with timestamp ..." 
+   Each type may be represented using Unknown entry: "Jump with timestamp ..."
    is the same as "Unknown (0x8) with timestamp ....".
 3. After header there is one of the following lines:
-   1. "  % Key__  Description__  Value": map header.  After mapping header 
-      follows a table which may contain comments and lines consisting of 
-      "  +", key, description and |{msgpack-value}|.  Key is separated by at 
-      least two spaces with description, description is separated by at least 
-      two spaces with the value.  Each key in the map must be at most as wide 
-      as "Key__" header: "Key" allows at most 3-byte keys, "Key__" allows at 
-      most 5-byte keys.  If keys actually occupy less bytes then the rest is 
-      filled with spaces.  Keys cannot be empty, end with spaces, contain two 
-      consequent spaces inside of them or contain multibyte characters (use 
-      "=" format if you need this).  Descriptions have the same restrictions 
-      on width and contents, except that empty descriptions are allowed.  
+   1. "  % Key__  Description__  Value": map header.  After mapping header
+      follows a table which may contain comments and lines consisting of
+      "  +", key, description and |{msgpack-value}|.  Key is separated by at
+      least two spaces with description, description is separated by at least
+      two spaces with the value.  Each key in the map must be at most as wide
+      as "Key__" header: "Key" allows at most 3-byte keys, "Key__" allows at
+      most 5-byte keys.  If keys actually occupy less bytes then the rest is
+      filled with spaces.  Keys cannot be empty, end with spaces, contain two
+      consequent spaces inside of them or contain multibyte characters (use
+      "=" format if you need this).  Descriptions have the same restrictions
+      on width and contents, except that empty descriptions are allowed.
       Description column may be omitted.
 
-      When writing description is ignored.  Keys with values |msgpack#equal| 
-      to default ones are ignored.  Order of keys is preserved.  All keys are 
+      When writing description is ignored.  Keys with values |msgpack#equal|
+      to default ones are ignored.  Order of keys is preserved.  All keys are
       treated as strings (not binary strings).
 
-      Note: specifically for buffer list entries it is allowed to have more 
-      then one map header.  Each map header starts a new map entry inside 
+      Note: specifically for buffer list entries it is allowed to have more
+      then one map header.  Each map header starts a new map entry inside
       buffer list because ShaDa buffer list entry is an array of maps.  I.e. >
 
         Buffer list with timestamp 1970-01-01T00:00:00:
@@ -828,7 +828,7 @@ Format description:
         Buffer list with timestamp 1970-01-01T00:00:00:
           = [{="f": "/foo"}, {="f": "/bar"}]
 <
-      Note 2: specifically for register entries special syntax for arrays was 
+      Note 2: specifically for register entries special syntax for arrays was
       designed: >
 
         Register with timestamp 1970-01-01T00:00:00:
@@ -843,10 +843,10 @@ Format description:
           % Key  Description  Value
           + rc   contents     ["line1", "line2"]
 <
-      Such syntax is automatically used if array representation appears to be 
+      Such syntax is automatically used if array representation appears to be
       too lengthy.
-   2. "  @  Description__  Value": array header.  Same as map, but key is 
-      omitted and description cannot be omitted.  Array entries start with 
+   2. "  @  Description__  Value": array header.  Same as map, but key is
+      omitted and description cannot be omitted.  Array entries start with
       "  -". Example: >
 
         History entry with timestamp 1970-01-01T00:00:00:
@@ -861,8 +861,8 @@ Format description:
           = [SEARCH, "foo", '/']
 <
       Note: special array syntax for register entries is not recognized here.
-   3. "  = {msgpack-value}": raw values.  |{msgpack-value}| in this case may 
-      have absolutely any type.  Special array syntax for register entries is 
+   3. "  = {msgpack-value}": raw values.  |{msgpack-value}| in this case may
+      have absolutely any type.  Special array syntax for register entries is
       not recognized here as well.
 
 

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -635,7 +635,7 @@ To see what version of Python is being used: >vim
 	:pyx print(sys.version)
 <
 					*:pyxfile* *python_x-special-comments*
-`:pyxfile` works the same as `:py3file`. 
+`:pyxfile` works the same as `:py3file`.
 
 							*:pyxdo*
 `:pyxdo` works the same as `:py3do`.

--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -386,9 +386,9 @@ window is used:
 >lua
     vim.bo[4].expandtab = true -- sets expandtab to true in buffer 4
     vim.wo.number = true       -- sets number to true in current window
-    vim.wo[0].number = true    -- same as above 
+    vim.wo[0].number = true    -- same as above
     vim.wo[0][0].number = true -- sets number to true in current buffer
-                               -- in current window only 
+                               -- in current window only
     print(vim.wo[0].number)    --> true
 <
 ------------------------------------------------------------------------------

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -892,7 +892,7 @@ was made yet in the current file.
 			for each opened file.
 			Only one position is remembered per buffer, not one
 			for each window.  As long as the buffer is visible in
-			a window the position won't be changed.  Mark is also 
+			a window the position won't be changed.  Mark is also
 			reset when |:wshada| is run.
 
 							*'^* *`^*
@@ -1149,7 +1149,7 @@ locations being removed:
    3  1260    8 src/nvim/mark.c
    2   685    0 src/nvim/option_defs.h
    1   462   36 src/nvim/option_defs.h  <-- location X
-> 
+>
 
 Then, when yet another location Z is jumped to, the new location Y appears
 directly after location X in the jumplist and location X remains in the same
@@ -1161,7 +1161,7 @@ prior to the original jump from X to Y:
    3   685    0 src/nvim/option_defs.h  <-- location X-1
    2   462   36 src/nvim/option_defs.h  <-- location X
    1   100    0 src/nvim/option_defs.h  <-- location Y
-> 
+>
 
 CHANGE LIST JUMPS			*changelist* *change-list-jumps* *E664*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2046,7 +2046,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	Possible items:
 	- The swap file will be created in the first directory where this is
-	  possible.  If it is not possible in any directory, but last 
+	  possible.  If it is not possible in any directory, but last
 	  directory listed in the option does not exist, it is created.
 	- Empty means that no swap file will be used (recovery is
 	  impossible!) and no |E303| error will be given.
@@ -4830,7 +4830,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Defaults are setup to search these locations:
 	1. Your home directory, for personal preferences.
 	   Given by `stdpath("config")`.  |$XDG_CONFIG_HOME|
-	2. Directories which must contain configuration files according to 
+	2. Directories which must contain configuration files according to
 	   |xdg| ($XDG_CONFIG_DIRS, defaults to /etc/xdg).  This also contains
 	   preferences from system administrator.
 	3. Data home directory, for plugins installed by user.
@@ -5070,8 +5070,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	%	When included, save and restore the buffer list.  If Vim is
 		started with a file name argument, the buffer list is not
 		restored.  If Vim is started without a file name argument, the
-		buffer list is restored from the shada file.  Quickfix 
-		('buftype'), unlisted ('buflisted'), unnamed and buffers on 
+		buffer list is restored from the shada file.  Quickfix
+		('buftype'), unlisted ('buflisted'), unnamed and buffers on
 		removable media (|shada-r|) are not saved.
 		When followed by a number, the number specifies the maximum
 		number of buffers that are stored.  Without a number all
@@ -5099,8 +5099,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	@	Maximum number of items in the input-line history to be
 		saved.  When not included, the value of 'history' is used.
 							*shada-c*
-	c	Dummy option, kept for compatibility reasons.  Has no actual 
-		effect: ShaDa always uses UTF-8 and 'encoding' value is fixed 
+	c	Dummy option, kept for compatibility reasons.  Has no actual
+		effect: ShaDa always uses UTF-8 and 'encoding' value is fixed
 		to UTF-8 as well.
 							*shada-f*
 	f	Whether file marks need to be stored.  If zero, file marks ('0
@@ -5125,13 +5125,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 		could use "ra:,rb:".  You can also use it for temp files,
 		e.g., for Unix: "r/tmp".  Case is ignored.
 							*shada-s*
-	s	Maximum size of an item contents in KiB.  If zero then nothing 
-		is saved.  Unlike Vim this applies to all items, except for 
-		the buffer list and header.  Full item size is off by three 
-		unsigned integers: with `s10` maximum item size may be 1 byte 
-		(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit 
-		integer) + 3 bytes (item size: up to 16-bit integer because 
-		2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item 
+	s	Maximum size of an item contents in KiB.  If zero then nothing
+		is saved.  Unlike Vim this applies to all items, except for
+		the buffer list and header.  Full item size is off by three
+		unsigned integers: with `s10` maximum item size may be 1 byte
+		(type: 7-bit integer) + 9 bytes (timestamp: up to 64-bit
+		integer) + 3 bytes (item size: up to 16-bit integer because
+		2^8 < 10240 < 2^16) + 10240 bytes (requested maximum item
 		contents size) = 10253 bytes.
 
 	Example: >
@@ -5141,7 +5141,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			edited.
 	<1000		Contents of registers (up to 1000 lines each) will be
 			remembered.
-	s100		Items with contents occupying more then 100 KiB are 
+	s100		Items with contents occupying more then 100 KiB are
 			skipped.
 	:0		Command-line history will not be saved.
 	n~/nvim/shada	The name of the file to use is "~/nvim/shada".
@@ -5180,30 +5180,30 @@ A jump table for the options with a short description can be found at |Q_op|.
 	If the name of the shell contains a space, you need to enclose it in
 	quotes.  Example with quotes: >
 		:set shell=\"c:\program\ files\unix\sh.exe\"\ -f
-<	Note the backslash before each quote (to avoid starting a comment) and 
-	each space (to avoid ending the option value), so better use |:let-&| 
+<	Note the backslash before each quote (to avoid starting a comment) and
+	each space (to avoid ending the option value), so better use |:let-&|
 	like this: >
 		:let &shell='"C:\Program Files\unix\sh.exe" -f'
-<	Also note that the "-f" is not inside the quotes, because it is not 
+<	Also note that the "-f" is not inside the quotes, because it is not
 	part of the command name.
 							*shell-unquoting*
 	Rules regarding quotes:
-	1. Option is split on space and tab characters that are not inside 
-	   quotes: "abc def" runs shell named "abc" with additional argument 
-	   "def", '"abc def"' runs shell named "abc def" with no additional 
-	   arguments (here and below: additional means “additional to 
+	1. Option is split on space and tab characters that are not inside
+	   quotes: "abc def" runs shell named "abc" with additional argument
+	   "def", '"abc def"' runs shell named "abc def" with no additional
+	   arguments (here and below: additional means “additional to
 	   'shellcmdflag'”).
-	2. Quotes in option may be present in any position and any number: 
-	   '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent 
+	2. Quotes in option may be present in any position and any number:
+	   '"abc"', '"a"bc', 'a"b"c', 'ab"c"' and '"a"b"c"' are all equivalent
 	   to just "abc".
-	3. Inside quotes backslash preceding backslash means one backslash.  
-	   Backslash preceding quote means one quote. Backslash preceding 
-	   anything else means backslash and next character literally: 
-	   '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally 
+	3. Inside quotes backslash preceding backslash means one backslash.
+	   Backslash preceding quote means one quote. Backslash preceding
+	   anything else means backslash and next character literally:
+	   '"a\\b"' is the same as "a\b", '"a\\"b"' runs shell named literally
 	   'a"b', '"a\b"' is the same as "a\b" again.
-	4. Outside of quotes backslash always means itself, it cannot be used 
+	4. Outside of quotes backslash always means itself, it cannot be used
 	   to escape quote: 'a\"b"' is the same as "a\b".
-	Note that such processing is done after |:set| did its own round of 
+	Note that such processing is done after |:set| did its own round of
 	unescaping, so to keep yourself sane use |:let-&| like shown above.
 							*shell-powershell*
 	To use PowerShell: >
@@ -5226,7 +5226,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	On Unix it can have more than one flag.  Each white space separated
 	part is passed as an argument to the shell command.
 	See |option-backslash| about including spaces and backslashes.
-	See |shell-unquoting| which talks about separating this option into 
+	See |shell-unquoting| which talks about separating this option into
 	multiple arguments.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
@@ -6032,36 +6032,36 @@ A jump table for the options with a short description can be found at |Q_op|.
 	( -   Start of item group.  Can be used for setting the width and
 	      alignment of a section.  Must be followed by %) somewhere.
 	) -   End of item group.  No width fields allowed.
-	T N   For 'tabline': start of tab page N label.  Use %T or %X to end 
-	      the label.  Clicking this label with left mouse button switches 
+	T N   For 'tabline': start of tab page N label.  Use %T or %X to end
+	      the label.  Clicking this label with left mouse button switches
 	      to the specified tab page.
-	X N   For 'tabline': start of close tab N label.  Use %X or %T to end 
-	      the label, e.g.: %3Xclose%X.  Use %999X for a "close current 
-	      tab" label.    Clicking this label with left mouse button closes 
+	X N   For 'tabline': start of close tab N label.  Use %X or %T to end
+	      the label, e.g.: %3Xclose%X.  Use %999X for a "close current
+	      tab" label.    Clicking this label with left mouse button closes
 	      specified tab page.
-	@ N   Start of execute function label. Use %X or %T to 
-	      end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this 
-	      label runs specified function: in the example when clicking once 
-	      using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l', 
-	      '    ')" expression will be run.  Function receives the 
+	@ N   Start of execute function label. Use %X or %T to
+	      end the label, e.g.: %10@SwitchBuffer@foo.c%X.  Clicking this
+	      label runs specified function: in the example when clicking once
+	      using left mouse button on "foo.c" "SwitchBuffer(10, 1, 'l',
+	      '    ')" expression will be run.  Function receives the
 	      following arguments in order:
 	      1. minwid field value or zero if no N was specified
 	      2. number of mouse clicks to detect multiple clicks
-	      3. mouse button used: "l", "r" or "m" for left, right or middle 
-	         button respectively; one should not rely on third argument 
-	         being only "l", "r" or "m": any other non-empty string value 
-	         that contains only ASCII lower case letters may be expected 
+	      3. mouse button used: "l", "r" or "m" for left, right or middle
+	         button respectively; one should not rely on third argument
+	         being only "l", "r" or "m": any other non-empty string value
+	         that contains only ASCII lower case letters may be expected
 	         for other mouse buttons
-	      4. modifiers pressed: string which contains "s" if shift 
-	         modifier was pressed, "c" for control, "a" for alt and "m" 
-	         for meta; currently if modifier is not pressed string 
-	         contains space instead, but one should not rely on presence 
-	         of spaces or specific order of modifiers: use |stridx()| to 
-	         test whether some modifier is present; string is guaranteed 
-	         to contain only ASCII letters and spaces, one letter per 
-	         modifier; "?" modifier may also be present, but its presence 
-	         is a bug that denotes that new mouse button recognition was 
-	         added without modifying code that reacts on mouse clicks on 
+	      4. modifiers pressed: string which contains "s" if shift
+	         modifier was pressed, "c" for control, "a" for alt and "m"
+	         for meta; currently if modifier is not pressed string
+	         contains space instead, but one should not rely on presence
+	         of spaces or specific order of modifiers: use |stridx()| to
+	         test whether some modifier is present; string is guaranteed
+	         to contain only ASCII letters and spaces, one letter per
+	         modifier; "?" modifier may also be present, but its presence
+	         is a bug that denotes that new mouse button recognition was
+	         added without modifying code that reacts on mouse clicks on
 	         this label.
 	      Use |getmousepos()|.winid in the specified function to get the
 	      corresponding window id of the clicked item.

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -224,7 +224,7 @@ argument.
 		All [args] are treated as {script} arguments and stored in the
 		Lua `_G.arg` global table, thus "-l" ends processing of Nvim
 		arguments. The {script} name is stored at `_G.arg[0]`.
-		
+
 		Sets 'verbose' to 1 (like "-V1"), so Lua `print()` writes to
 		output.
 		If {script} prints messages and doesn't cause Nvim to exit,

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3270,7 +3270,7 @@ This covers the shell named "tcsh".  It is a superset of csh.  See |csh.vim|
 for how the filetype is detected.
 
 Tcsh does not allow \" in strings unless the "backslash_quote" shell variable
-is set.  If you want VIM to assume that no backslash quote constructs exist 
+is set.  If you want VIM to assume that no backslash quote constructs exist
 add this line to your vimrc: >
 
 	:let tcsh_backslash_quote = 0
@@ -5067,7 +5067,7 @@ ctermbg={color-nr}				*ctermbg*
 	a number instead of a color name.
 
 	Note that for 16 color ansi style terminals (including xterms), the
-	numbers in the NR-8 column is used.  Here "*" means "add 8" so that 
+	numbers in the NR-8 column is used.  Here "*" means "add 8" so that
 	Blue is 12, DarkGray is 8 etc.
 
 	Note that for some color terminals these names may result in the wrong

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -907,7 +907,7 @@ The following fields are optional:
 If the function returns |v:null| instead of a List, a standard tag lookup will
 be performed instead.
 
-It is not allowed to change the tagstack from inside 'tagfunc'.  *E986* 
+It is not allowed to change the tagstack from inside 'tagfunc'.  *E986*
 It is not allowed to close a window or change window from inside 'tagfunc'.
 *E1299*
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -434,7 +434,7 @@ numerical highlight ids to the actual attributes.
 		+-------------------------+
 <
 	`cols` is always zero in this version of Nvim, and reserved for future
-	use. 
+	use.
 
 	Note when updating code from |ui-grid-old| events: ranges are
 	end-exclusive, which is consistent with API conventions, but different
@@ -652,7 +652,7 @@ tabs.
 
 ["win_extmark", grid, win, ns_id, mark_id, row, col] ~
 	Updates the position of an extmark which is currently visible in a
-	window. Only emitted if the mark has the `ui_watched` attribute. 
+	window. Only emitted if the mark has the `ui_watched` attribute.
 
 ==============================================================================
 Popupmenu Events						 *ui-popupmenu*

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -255,7 +255,7 @@ ignored if its owner differs from the owner of the edited file, except when
 the owner of the undo file is the current user.  Set 'verbose' to get a
 message about that when opening a file.
 
-Location of the undo files is controlled by the 'undodir' option, by default 
+Location of the undo files is controlled by the 'undodir' option, by default
 they are saved to the dedicated directory in the application data folder.
 
 You can also save and restore undo histories by using ":wundo" and ":rundo"

--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -82,7 +82,7 @@ After editing for a while you will have text in registers, marks in various
 files, a command line history filled with carefully crafted commands.  When
 you exit Vim all of this is lost.  But you can get it back!
 
-The ShaDa (abbreviation of SHAred DAta) file is designed to store status 
+The ShaDa (abbreviation of SHAred DAta) file is designed to store status
 information:
 
 	Command-line and Search pattern history
@@ -218,8 +218,8 @@ Obviously, the "w" stands for "write" and the "r" for "read".
    The ! character is used by ":wshada" to forcefully overwrite an existing
 file.  When it is omitted, and the file exists, the information is merged into
 the file.
-   The ! character used for ":rshada" means that all the information in ShaDa 
-file has priority over existing information, this may overwrite it.  Without 
+   The ! character used for ":rshada" means that all the information in ShaDa
+file has priority over existing information, this may overwrite it.  Without
 the ! only information that wasn't set is used.
    These commands can also be used to store info and use it again later.  You
 could make a directory full of ShaDa files, each containing info for a
@@ -277,8 +277,8 @@ example, use: >
 SESSION HERE, SESSION THERE
 
 The obvious way to use sessions is when working on different projects.
-Suppose you store your session files in the directory "~/.config/nvim".  You 
-are currently working on the "secret" project and have to switch to the 
+Suppose you store your session files in the directory "~/.config/nvim".  You
+are currently working on the "secret" project and have to switch to the
 "boring" project: >
 
 	:wall

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1782,7 +1782,7 @@ PITFALLS
 Even bigger problem arises in the following example: >
 
 	:map ,ab o#include
-	:unmap ,ab 
+	:unmap ,ab
 
 Here the unmap command will not work, because it tries to unmap ",ab ".  This
 does not exist as a mapped sequence.  An error will be issued, which is very
@@ -2244,7 +2244,7 @@ Example: >
 
 Write this single-line file as "ftdetect/foofoo.vim" in the first directory
 that appears in 'runtimepath'.  For Unix that would be
-"~/.config/nvim/ftdetect/foofoo.vim".  The convention is to use the name of 
+"~/.config/nvim/ftdetect/foofoo.vim".  The convention is to use the name of
 the filetype for the script name.
 
 You can make more complicated checks if you like, for example to inspect the
@@ -2315,7 +2315,7 @@ you can write the different setting in a script: >
 
 Now write this in the "after" directory, so that it gets sourced after the
 distributed "vim.vim" ftplugin |after-directory|.  For Unix this would be
-"~/.config/nvim/after/ftplugin/vim.vim".  Note that the default plugin will 
+"~/.config/nvim/after/ftplugin/vim.vim".  Note that the default plugin will
 have set "b:did_ftplugin", but it is ignored here.
 
 
@@ -2485,7 +2485,7 @@ a user to overrule or add to the default file.  The default files start with: >
 	:let current_compiler = "mine"
 
 When you write a compiler file and put it in your personal runtime directory
-(e.g., ~/.config/nvim/compiler for Unix), you set the "current_compiler" 
+(e.g., ~/.config/nvim/compiler for Unix), you set the "current_compiler"
 variable to make the default file skip the settings.
 							*:CompilerSet*
 The second mechanism is to use ":set" for ":compiler!" and ":setlocal" for

--- a/runtime/doc/usr_43.txt
+++ b/runtime/doc/usr_43.txt
@@ -27,7 +27,7 @@ want to set the 'softtabstop' option to 4 and define a mapping to insert a
 three-line comment.  You do this with only two steps:
 
 							*your-runtime-dir*
-1. Create your own runtime directory.  On Unix this usually is 
+1. Create your own runtime directory.  On Unix this usually is
    "~/.config/nvim".  In this directory create the "ftplugin" directory: >
 
 	mkdir -p ~/.config/nvim/ftplugin
@@ -125,7 +125,7 @@ What will happen now is that Vim searches for "filetype.vim" files in each
 directory in 'runtimepath'.  First ~/.config/nvim/filetype.vim is found.  The
 autocommand to catch `*.txt` files is defined there.  Then Vim finds the
 filetype.vim file in $VIMRUNTIME, which is halfway 'runtimepath'.  Finally
-~/.config/nvim/after/filetype.vim is found and the autocommand for detecting 
+~/.config/nvim/after/filetype.vim is found and the autocommand for detecting
 ruby files in /usr/share/scripts is added.
    When you now edit /usr/share/scripts/README.txt, the autocommands are
 checked in the order in which they were defined.  The `*.txt` pattern matches,

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -391,7 +391,7 @@ This section documents various low-level behavior changes.
 
 |mkdir()| behaviour changed:
 1. Assuming /tmp/foo does not exist and /tmp can be written to
-   mkdir('/tmp/foo/bar', 'p', 0700) will create both /tmp/foo and /tmp/foo/bar 
+   mkdir('/tmp/foo/bar', 'p', 0700) will create both /tmp/foo and /tmp/foo/bar
    with 0700 permissions. Vim mkdir will create /tmp/foo with 0755.
 2. If you try to create an existing directory with `'p'` (e.g. mkdir('/',
    'p')) mkdir() will silently exit. In Vim this was an error.
@@ -416,16 +416,16 @@ This section documents various low-level behavior changes.
    error out.
 5. Stringifyed infinite and NaN values now use |str2float()| and can be evaled
    back.
-6. (internal) Trying to print or stringify VAR_UNKNOWN in Vim results in 
+6. (internal) Trying to print or stringify VAR_UNKNOWN in Vim results in
    nothing, E908, in Nvim it is internal error.
 
 |json_decode()| behaviour changed:
 1. It may output |msgpack-special-dict|.
-2. |msgpack-special-dict| is emitted also in case of duplicate keys, while in 
+2. |msgpack-special-dict| is emitted also in case of duplicate keys, while in
    Vim it errors out.
 3. It accepts only valid JSON.  Trailing commas are not accepted.
 
-|json_encode()| behaviour slightly changed: now |msgpack-special-dict| values 
+|json_encode()| behaviour slightly changed: now |msgpack-special-dict| values
 are accepted, but |v:none| is not.
 
 Viminfo text files were replaced with binary (messagepack) |shada| files.
@@ -444,10 +444,10 @@ Additional differences:
   |shada-error-handling|
 - ShaDa file keeps search direction (|v:searchforward|), viminfo does not.
 
-|printf()| returns something meaningful when used with `%p` argument: in Vim 
-it used to return useless address of the string (strings are copied to the 
-newly allocated memory all over the place) and fail on types which cannot be 
-coerced to strings. See |id()| for more details, currently it uses 
+|printf()| returns something meaningful when used with `%p` argument: in Vim
+it used to return useless address of the string (strings are copied to the
+newly allocated memory all over the place) and fail on types which cannot be
+coerced to strings. See |id()| for more details, currently it uses
 `printf("%p", {expr})` internally.
 
 |c_CTRL-R| pasting a non-special register into |cmdline| omits the last <CR>.


### PR DESCRIPTION
Left out pi_msgpack.txt and spaces that are also present in upstream vim