### PR TITLE
feat(api): relax cmdwin restrictions for a few functions

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2915,7 +2915,7 @@ nvim_win_set_buf({window}, {buffer})                      *nvim_win_set_buf()*
     Sets the current buffer in a window, without side effects
 
     Attributes: ~
-        not allowed when |textlock| is active or in the |cmdwin|
+        not allowed when |textlock| is active
 
     Parameters: ~
       • {window}  Window handle, or 0 for current window
@@ -3036,7 +3036,7 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
 <
 
     Attributes: ~
-        not allowed when |textlock| is active or in the |cmdwin|
+        not allowed when |textlock| is active
 
     Parameters: ~
       • {buffer}  Buffer to display, or 0 for current buffer

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2897,7 +2897,7 @@ nvim_win_hide({window})                                      *nvim_win_hide()*
     or |nvim_win_close()|, which will close the buffer.
 
     Attributes: ~
-        not allowed when |textlock| is active or in the |cmdwin|
+        not allowed when |textlock| is active
 
     Parameters: ~
       • {window}  Window handle, or 0 for current window

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -967,7 +967,7 @@ Integer nvim_open_term(Buffer buffer, DictionaryOf(LuaRef) opts, Error *err)
   }
 
   if (cmdwin_type != 0 && buf == curbuf) {
-    api_set_error(err, kErrorTypeException, "%s", _(e_cmdwin));
+    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return 0;
   }
 

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -50,9 +50,18 @@ Buffer nvim_win_get_buf(Window window, Error *err)
 /// @param[out] err Error details, if any
 void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
   FUNC_API_SINCE(5)
-  FUNC_API_TEXTLOCK
+  FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
-  win_set_buf(window, buffer, false, err);
+  win_T *win = find_window_by_handle(window, err);
+  buf_T *buf = find_buffer_by_handle(buffer, err);
+  if (!win || !buf) {
+    return;
+  }
+  if (cmdwin_type != 0 && (win == curwin || buf == curbuf)) {
+    api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+    return;
+  }
+  win_set_buf(win, buf, false, err);
 }
 
 /// Gets the (1,0)-indexed, buffer-relative cursor position for a given window
@@ -396,7 +405,7 @@ void nvim_win_close(Window window, Boolean force, Error *err)
     if (win == curwin) {
       cmdwin_result = Ctrl_C;
     } else {
-      api_set_error(err, kErrorTypeException, "%s", _(e_cmdwin));
+      api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     }
     return;
   }

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -362,10 +362,10 @@ Boolean nvim_win_is_valid(Window window)
 /// @param[out] err Error details, if any
 void nvim_win_hide(Window window, Error *err)
   FUNC_API_SINCE(7)
-  FUNC_API_TEXTLOCK
+  FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
   win_T *win = find_window_by_handle(window, err);
-  if (!win) {
+  if (!win || !can_close_in_cmdwin(win, err)) {
     return;
   }
 
@@ -397,18 +397,8 @@ void nvim_win_close(Window window, Boolean force, Error *err)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
   win_T *win = find_window_by_handle(window, err);
-  if (!win) {
+  if (!win || !can_close_in_cmdwin(win, err)) {
     return;
-  }
-
-  if (cmdwin_type != 0) {
-    if (win == curwin) {
-      cmdwin_result = Ctrl_C;
-      return;
-    } else if (win == cmdwin_old_curwin) {
-      api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
-      return;
-    }
   }
 
   tabpage_T *tabpage = win_find_tabpage(win);

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -404,10 +404,11 @@ void nvim_win_close(Window window, Boolean force, Error *err)
   if (cmdwin_type != 0) {
     if (win == curwin) {
       cmdwin_result = Ctrl_C;
-    } else {
+      return;
+    } else if (win == cmdwin_old_curwin) {
       api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+      return;
     }
-    return;
   }
 
   tabpage_T *tabpage = win_find_tabpage(win);

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1137,7 +1137,7 @@ static void recording_mode(int attr)
 /// of 'ru_col'.
 void comp_col(void)
 {
-  int last_has_status = (p_ls > 1 || (p_ls == 1 && !ONE_WINDOW));
+  bool last_has_status = last_stl_height(false) > 0;
 
   sc_col = 0;
   ru_col = 0;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4398,6 +4398,7 @@ static int open_cmdwin(void)
   // Set "cmdwin_type" before any autocommands may mess things up.
   cmdwin_type = get_cmdline_type();
   cmdwin_level = ccline.level;
+  cmdwin_old_curwin = old_curwin;
 
   // Create empty command-line buffer.
   if (buf_open_scratch(0, _("[Command Line]")) == FAIL) {
@@ -4405,6 +4406,7 @@ static int open_cmdwin(void)
     win_close(curwin, true, false);
     ga_clear(&winsizes);
     cmdwin_type = 0;
+    cmdwin_old_curwin = NULL;
     return Ctrl_C;
   }
   // Command-line buffer has bufhidden=wipe, unlike a true "scratch" buffer.
@@ -4501,6 +4503,7 @@ static int open_cmdwin(void)
 
   cmdwin_type = 0;
   cmdwin_level = 0;
+  cmdwin_old_curwin = NULL;
 
   exmode_active = save_exmode;
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -831,6 +831,7 @@ EXTERN bool km_startsel INIT(= false);
 EXTERN int cmdwin_type INIT(= 0);    ///< type of cmdline window or 0
 EXTERN int cmdwin_result INIT(= 0);  ///< result of cmdline window or 0
 EXTERN int cmdwin_level INIT(= 0);   ///< cmdline recursion level
+EXTERN win_T *cmdwin_old_curwin INIT(= NULL);  ///< curwin before opening cmdline window or NULL
 
 EXTERN char no_lines_msg[] INIT(= N_("--No lines in buffer--"));
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2670,6 +2670,23 @@ static bool can_close_floating_windows(void)
   return true;
 }
 
+/// @return true if, considering the cmdwin, `win` is safe to close.
+/// If false and `win` is the cmdwin, it is closed; otherwise, `err` is set.
+bool can_close_in_cmdwin(win_T *win, Error *err)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (cmdwin_type != 0) {
+    if (win == curwin) {
+      cmdwin_result = Ctrl_C;
+      return false;
+    } else if (win == cmdwin_old_curwin) {
+      api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Close the possibly last window in a tab page.
 ///
 /// @param  win          window to close

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -698,15 +698,9 @@ static void cmd_with_count(char *cmd, char *bufp, size_t bufsize, int64_t Prenum
   }
 }
 
-void win_set_buf(Window window, Buffer buffer, bool noautocmd, Error *err)
+void win_set_buf(win_T *win, buf_T *buf, bool noautocmd, Error *err)
+  FUNC_ATTR_NONNULL_ALL
 {
-  win_T *win = find_window_by_handle(window, err);
-  buf_T *buf = find_buffer_by_handle(buffer, err);
-
-  if (!win || !buf) {
-    return;
-  }
-
   tabpage_T *tab = win_find_tabpage(win);
 
   // no redrawing and don't set the window title
@@ -720,7 +714,7 @@ void win_set_buf(Window window, Buffer buffer, bool noautocmd, Error *err)
     api_set_error(err,
                   kErrorTypeException,
                   "Failed to switch to window %d",
-                  window);
+                  win->handle);
   }
 
   try_start();
@@ -729,7 +723,7 @@ void win_set_buf(Window window, Buffer buffer, bool noautocmd, Error *err)
     api_set_error(err,
                   kErrorTypeException,
                   "Failed to set buffer %d",
-                  buffer);
+                  buf->handle);
   }
 
   // If window is not current, state logic will not validate its cursor.

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -615,6 +615,24 @@ describe('API/win', function()
       eq({oldwin}, meths.list_wins())
       eq({oldbuf}, meths.list_bufs())
     end)
+    it('in the cmdwin', function()
+      feed('q:')
+      -- Can close the cmdwin.
+      meths.win_hide(0)
+      eq('', funcs.getcmdwintype())
+
+      local old_win = meths.get_current_win()
+      local other_win = meths.open_win(0, false, {
+        relative='win', row=3, col=3, width=12, height=3
+      })
+      feed('q:')
+      -- Cannot close the previous window.
+      eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
+         pcall_err(meths.win_hide, old_win))
+      -- Can close other windows.
+      meths.win_hide(other_win)
+      eq(false, meths.win_is_valid(other_win))
+    end)
   end)
 
   describe('text_height', function()

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -540,15 +540,21 @@ describe('API/win', function()
       command('split')
       eq(2, #meths.list_wins())
       local oldwin = meths.get_current_win()
+      local otherwin = meths.open_win(0, false, {
+        relative='editor', row=10, col=10, width=10, height=10,
+      })
       -- Open cmdline-window.
       feed('q:')
-      eq(3, #meths.list_wins())
+      eq(4, #meths.list_wins())
       eq(':', funcs.getcmdwintype())
-      -- Vim: not allowed to close other windows from cmdline-window.
+      -- Not allowed to close previous window from cmdline-window.
       eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
-        pcall_err(meths.win_close, oldwin, true))
+         pcall_err(meths.win_close, oldwin, true))
+      -- Closing other windows is fine.
+      meths.win_close(otherwin, true)
+      eq(false, meths.win_is_valid(otherwin))
       -- Close cmdline-window.
-      meths.win_close(0,true)
+      meths.win_close(0, true)
       eq(2, #meths.list_wins())
       eq('', funcs.getcmdwintype())
     end)

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -984,13 +984,45 @@ it('tabline is not redrawn in Ex mode #24122', function()
 end)
 
 describe("cmdline height", function()
+  before_each(clear)
+
   it("does not crash resized screen #14263", function()
-    clear()
     local screen = Screen.new(25, 10)
     screen:attach()
     command('set cmdheight=9999')
     screen:try_resize(25, 5)
     assert_alive()
+  end)
+
+  it('unchanged when trying to restore window sizes', function()
+    command('set showtabline=0 cmdheight=2 laststatus=0')
+    feed('q:')  -- Closing cmdwin tries to restore sizes
+    command('set cmdheight=1 | quit')
+    eq(1, eval('&cmdheight'))
+
+    command('set showtabline=2 cmdheight=3')
+    feed('q:')
+    command('set showtabline=0 | quit')
+    eq(3, eval('&cmdheight'))
+
+    command('set cmdheight=1 laststatus=2')
+    feed('q:')
+    command('set laststatus=0 | quit')
+    eq(1, eval('&cmdheight'))
+
+    command('set laststatus=2')
+    feed('q:')
+    command('set laststatus=1 | quit')
+    eq(1, eval('&cmdheight'))
+
+    command('set laststatus=2 | belowright vsplit | wincmd _')
+    local restcmds = eval('winrestcmd()')
+    feed('q:')
+    command('set laststatus=1 | quit')
+    -- As we have 2 windows, &ls = 1 should still have a statusline on the last
+    -- window. As such, the number of available rows hasn't changed and the window
+    -- sizes should be restored.
+    eq(restcmds, eval('winrestcmd()'))
   end)
 end)
 

--- a/test/functional/vimscript/api_functions_spec.lua
+++ b/test/functional/vimscript/api_functions_spec.lua
@@ -73,9 +73,10 @@ describe('eval-API', function()
 
     -- Some functions checking textlock (usually those that may change the current window or buffer)
     -- also ought to not be usable in the cmdwin.
+    local old_win = meths.get_current_win()
     feed("q:")
     eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
-       pcall_err(meths.win_hide, 0))
+       pcall_err(meths.set_current_win, old_win))
 
     -- But others, like nvim_buf_set_lines(), which just changes text, is OK.
     curbufmeths.set_lines(0, -1, 1, {"wow!"})


### PR DESCRIPTION
Closes #24452.

Leaving this here to see what people think; see commit messages for details.

Personally, not too sold on the hacks-on-top-of-hacks approach here. :smiling_face_with_tear:
(I still have a mild preference for leaving the restrictions alone)

I have an open PR in Vim for the `win_size_restore()` bug, but I dunno when it'll be reviewed.