### PR TITLE
fix(lsp): only send one workspace/didChangeWorkspaceFolders notification

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -494,7 +494,7 @@ function M.add_workspace_folder(workspace_folder)
       end
     end
     if not found then
-      vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
+      client.notify('workspace/didChangeWorkspaceFolders', params)
       if not client.workspace_folders then
         client.workspace_folders = {}
       end
@@ -517,16 +517,20 @@ function M.remove_workspace_folder(workspace_folder)
     {},
     { { uri = vim.uri_from_fname(workspace_folder), name = workspace_folder } }
   )
+  local sent = false
   for _, client in pairs(vim.lsp.get_clients({ bufnr = 0 })) do
     for idx, folder in pairs(client.workspace_folders or {}) do
       if folder.name == workspace_folder then
-        vim.lsp.buf_notify(0, 'workspace/didChangeWorkspaceFolders', params)
+        sent = true
+        client.notify('workspace/didChangeWorkspaceFolders', params)
         client.workspace_folders[idx] = nil
-        return
+        break
       end
     end
   end
-  print(workspace_folder, 'is not currently part of the workspace')
+  if not sent then
+    print(workspace_folder, 'is not currently part of the workspace')
+  end
 end
 
 --- Lists all symbols in the current workspace in the quickfix window.


### PR DESCRIPTION
Currently the functions in vim.lsp.buf loop over each client and send a
notification, but then the buf_notify function also loops over each
client. This results in N^2 notifications being sent.

I had 3 clients attached to a buffer, so my [language
server](https://github.com/elixir-tools/next-ls) was sent 3 identical
notifications for adding a workspace folder.

However, removing a workspace folder would return from the function
after finding the first matching folder while looping over the clients.
This results in a single notification being sent, but I believe only
removes the folder from the first client that it finds, leaving folders
in the other clients.

I don't think there are any tests for this workspace folders related code, but I'd be open to adding some if you are willing to provide some guidance if I have questions.

Thanks!
