### PR TITLE
vim-patch:9.0.1335: no test for bad use of spaces in help files

### DIFF
--- a/runtime/doc/digraph.txt
+++ b/runtime/doc/digraph.txt
@@ -203,7 +203,7 @@ The rouble sign was added in 2014 as 0x20bd.  Vim supports the digraphs =R and
   ^]	GS	0x1d	 29	GROUP SEPARATOR (IS3)
   ^^	RS	0x1e	 30	RECORD SEPARATOR (IS2)
   ^_	US	0x1f	 31	UNIT SEPARATOR (IS1)
-  	SP	0x20	 32	SPACE
+	SP	0x20	 32	SPACE
   #	Nb	0x23	 35	NUMBER SIGN
   $	DO	0x24	 36	DOLLAR SIGN
   @	At	0x40	 64	COMMERCIAL AT

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -207,8 +207,8 @@ release.
 
 • vim.lsp functions:
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
-  - |vim.lsp.get_active_clients()|	  	Use |vim.lsp.get_clients()| instead.
-  - |vim.lsp.for_each_buffer_client()|	  	Use |vim.lsp.get_clients()| instead.
+  - |vim.lsp.get_active_clients()|		Use |vim.lsp.get_clients()| instead.
+  - |vim.lsp.for_each_buffer_client()|		Use |vim.lsp.get_clients()| instead.
 
 • `vim.loop` has been renamed to `vim.uv`.
 

--- a/runtime/doc/pi_msgpack.txt
+++ b/runtime/doc/pi_msgpack.txt
@@ -3,13 +3,13 @@
 Author:  Nikolay Pavlov <kp-pav@yandex.ru>
 Copyright: (c) 2015 by Nikolay Pavlov
 
-The Apache license applies to the files in this package, including 
-runtime/autoload/msgpack.vim, runtime/doc/pi_msgpack.txt and 
-test/functional/plugin/msgpack_spec.lua.  Like anything else that's free, 
-msgpack.vim and its associated files are provided as is and comes with no 
-warranty of any kind, either expressed or implied.  No guarantees of 
-merchantability.  No guarantees of suitability for any purpose.  By using this 
-plugin, you agree that in no event will the copyright holder be liable for any 
+The Apache license applies to the files in this package, including
+runtime/autoload/msgpack.vim, runtime/doc/pi_msgpack.txt and
+test/functional/plugin/msgpack_spec.lua.  Like anything else that's free,
+msgpack.vim and its associated files are provided as is and comes with no
+warranty of any kind, either expressed or implied.  No guarantees of
+merchantability.  No guarantees of suitability for any purpose.  By using this
+plugin, you agree that in no event will the copyright holder be liable for any
 damages resulting from the use of this software. Use at your own risk!
 
 ==============================================================================
@@ -35,7 +35,7 @@ damages resulting from the use of this software. Use at your own risk!
 ==============================================================================
 2. Msgpack.vim introduction			*msgpack.vim-intro*
 
-This plugin contains utility functions to be used in conjunction with 
+This plugin contains utility functions to be used in conjunction with
 |msgpackdump()| and |msgpackparse()| functions.
 
 ==============================================================================
@@ -43,13 +43,13 @@ This plugin contains utility functions to be used in conjunction with
 
 FUNCTION ARGUMENTS				*msgpack.vim-arguments*
 
-Disambiguation of arguments described below.  Note: if e.g. function is listed 
-as accepting |{msgpack-integer}| (or anything else) it means that function 
+Disambiguation of arguments described below.  Note: if e.g. function is listed
+as accepting |{msgpack-integer}| (or anything else) it means that function
 does not check whether argument matches its description.
 
-*{msgpack-value}*	Either |msgpack-special-dict| or a regular value, but 
+*{msgpack-value}*	Either |msgpack-special-dict| or a regular value, but
 			not function reference.
-*{msgpack-integer}*	Any value for which |msgpack#type()| will return 
+*{msgpack-integer}*	Any value for which |msgpack#type()| will return
 			"integer".
 *{msgpack-special-int}*	|msgpack-special-dict| representing integer.
 
@@ -57,87 +57,87 @@ msgpack#is_int({msgpack-value})				*msgpack#is_int()*
 	Returns 1 if given {msgpack-value} is integer value, 0 otherwise.
 
 msgpack#is_uint({msgpack-value})			*msgpack#is_uint()*
-	Returns 1 if given {msgpack-value} is integer value greater or equal 
+	Returns 1 if given {msgpack-value} is integer value greater or equal
 	to zero, 0 otherwise.
 
 							*msgpack#strftime*
 msgpack#strftime({format}, {msgpack-integer})		*msgpack#strftime()*
-	Same as |strftime()|, but second argument may be 
+	Same as |strftime()|, but second argument may be
 	|msgpack-special-dict|.  Requires |Python| to really work with
 	|msgpack-special-dict|s.
 
 							*msgpack#strptime*
 msgpack#strptime({format}, {time})			*msgpack#strptime()*
-	Reverse of |msgpack#strftime()|: for any time and format 
-	|msgpack#equal|( |msgpack#strptime|(format, |msgpack#strftime|(format, 
+	Reverse of |msgpack#strftime()|: for any time and format
+	|msgpack#equal|( |msgpack#strptime|(format, |msgpack#strftime|(format,
 	time)), time) be true.  Requires ||Python|, without it only supports
 	non-|msgpack-special-dict| nonnegative times and format equal to
 	`%Y-%m-%dT%H:%M:%S`.
 
 msgpack#int_dict_to_str({msgpack-special-int})	*msgpack#int_dict_to_str()*
-	Function which converts |msgpack-special-dict| integer value to 
-	a hexadecimal value like 0x1234567890ABCDEF (always returns exactly 16 
+	Function which converts |msgpack-special-dict| integer value to
+	a hexadecimal value like 0x1234567890ABCDEF (always returns exactly 16
 	hexadecimal digits).
 
 msgpack#special_type({msgpack-value})		*msgpack#special_type()*
-	Returns zero if {msgpack-value} is not |msgpack-special-dict|.  If it 
-	is it returns name of the key in |v:msgpack_types| which represents 
+	Returns zero if {msgpack-value} is not |msgpack-special-dict|.  If it
+	is it returns name of the key in |v:msgpack_types| which represents
 	{msgpack-value} type.
 
 msgpack#type({msgpack-value})				*msgpack#type()*
-	Returns name of the key in |v:msgpack_types| that represents 
-	{msgpack-value} type.  Never returns zero: this function returns 
-	msgpack type which will be dumped by |msgpackdump()| should it receive 
+	Returns name of the key in |v:msgpack_types| that represents
+	{msgpack-value} type.  Never returns zero: this function returns
+	msgpack type which will be dumped by |msgpackdump()| should it receive
 	a list with single {msgpack-value} as input.
 
 msgpack#deepcopy({msgpack-value})			*msgpack#deepcopy()*
-	Like |deepcopy()|, but works correctly with |msgpack-special-dict| 
-	values.  Plain |deepcopy()| will destroy all types in 
-	|msgpack-special-dict| values because it will copy _TYPE key values, 
+	Like |deepcopy()|, but works correctly with |msgpack-special-dict|
+	values.  Plain |deepcopy()| will destroy all types in
+	|msgpack-special-dict| values because it will copy _TYPE key values,
 	while they should be preserved.
 
 msgpack#string({msgpack-value})				*msgpack#string()*
-	Like |string()|, but saves information about msgpack types.  Values 
-	dumped by msgpack#string may be read back by |msgpack#eval()|.  
+	Like |string()|, but saves information about msgpack types.  Values
+	dumped by msgpack#string may be read back by |msgpack#eval()|.
 	Returns is the following:
 
-	- Dictionaries are dumped as "{key1: value1, key2: value2}". Note: 
-	  msgpack allows any values in keys, so with some 
-	  |msgpack-special-dict| values |msgpack#string()| may produce even 
+	- Dictionaries are dumped as "{key1: value1, key2: value2}". Note:
+	  msgpack allows any values in keys, so with some
+	  |msgpack-special-dict| values |msgpack#string()| may produce even
 	  "{{1: 2}: 3, [4]: 5}".
 	- Lists are dumped as "[value1, value2]".
 	- Strings are dumped as
 	  1. `"abc"`: binary string.
 	  2. `="abc"`: string.
-	  3. `+(10)"ext"`: extension strings (10 may be replaced with any 
+	  3. `+(10)"ext"`: extension strings (10 may be replaced with any
 	     8-bit signed integer).
-	  Inside strings the following escape sequences may be present: "\0" 
-	  (represents NUL byte), "\n" (represents line feed) and "\"" 
+	  Inside strings the following escape sequences may be present: "\0"
+	  (represents NUL byte), "\n" (represents line feed) and "\""
 	  (represents double quote).
-	- Floating-point and integer values are dumped using |string()| or 
+	- Floating-point and integer values are dumped using |string()| or
 	  |msgpack#int_dict_to_str()|.
 	- Booleans are dumped as "TRUE" or "FALSE".
 	- Nil values are dumped as "NIL".
 
 msgpack#eval({string}, {dict})				*msgpack#eval()*
-	Transforms string created by |msgpack#string()| into a value suitable 
-	for |msgpackdump()|.  Second argument allows adding special values 
-	that start with head characters (|/\h|) and contain only word 
-	characters (|/\w|).  Built-in special values are "TRUE", "FALSE", 
-	"NIL", "nan" and "inf" and they cannot be overridden.  Map values are 
-	always evaluated to |msgpack-special-dict| values, as well as 
+	Transforms string created by |msgpack#string()| into a value suitable
+	for |msgpackdump()|.  Second argument allows adding special values
+	that start with head characters (|/\h|) and contain only word
+	characters (|/\w|).  Built-in special values are "TRUE", "FALSE",
+	"NIL", "nan" and "inf" and they cannot be overridden.  Map values are
+	always evaluated to |msgpack-special-dict| values, as well as
 	hexadecimal digits.  When evaluating maps order of keys is preserved.
 
-	Note that in addition to regular integer representations that may be 
-	obtained using |msgpack#string()| msgpack#eval() also supports C-style 
-	“character” integer constants like `'/'` (equivalent to 
+	Note that in addition to regular integer representations that may be
+	obtained using |msgpack#string()| msgpack#eval() also supports C-style
+	“character” integer constants like `'/'` (equivalent to
 	`char2nr('/')`: `47`). This also allows `'\0'` (number is decimal).
 
 							*msgpack#equal*
 msgpack#equal({msgpack-value}, {msgpack-value})		*msgpack#equal()*
-	Returns 1 if given values are equal, 0 otherwise.  When comparing 
-	msgpack map values order of keys is ignored.  Comparing 
-	|msgpack-special-dict| with equivalent non-special-dict value 
+	Returns 1 if given values are equal, 0 otherwise.  When comparing
+	msgpack map values order of keys is ignored.  Comparing
+	|msgpack-special-dict| with equivalent non-special-dict value
 	evaluates to 1.
 
 ==============================================================================

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -94,6 +94,9 @@ let s:test_script_fname = expand('%')
 au! SwapExists * call HandleSwapExists()
 func HandleSwapExists()
   if exists('g:ignoreSwapExists')
+    if type(g:ignoreSwapExists) == v:t_string
+      let v:swapchoice = g:ignoreSwapExists
+    endif
     return
   endif
   " Ignore finding a swap file for the test script (the user might be

--- a/test/old/testdir/test_codestyle.vim
+++ b/test/old/testdir/test_codestyle.vim
@@ -1,0 +1,63 @@
+" Test for checking the source code style.
+
+func s:ReportError(fname, lnum, msg)
+  if a:lnum > 0
+    call assert_report(a:fname .. ' line ' .. a:lnum .. ': ' .. a:msg)
+  endif
+endfunc
+
+func Test_help_files()
+  set nowrapscan
+
+  for fpath in glob('../../../runtime/doc/*.txt', 0, 1)
+    let g:ignoreSwapExists = 'e'
+    exe 'edit ' .. fpath
+
+    let fname = fnamemodify(fpath, ":t")
+
+    " todo.txt is for developers, it's not need a strictly check
+    " version*.txt is a history and large size, so it's not checked
+    if fname == 'todo.txt' || fname =~ 'version.*\.txt'
+      continue
+    endif
+
+    " Check for mixed tabs and spaces
+    call cursor(1, 1)
+    while 1
+      let lnum = search('[^/] \t')
+      if fname == 'visual.txt' && getline(lnum) =~ "STRING  \tjkl"
+            \ || fname == 'usr_27.txt' && getline(lnum) =~ "\[^\? \t\]"
+        continue
+      endif
+      call s:ReportError(fpath, lnum, 'space before tab')
+      if lnum == 0
+        break
+      endif
+    endwhile
+
+    " Check for unnecessary whitespace at the end of a line
+    call cursor(1, 1)
+    while 1
+      let lnum = search('[^/~\\]\s$')
+      " skip line that are known to have trailing white space
+      if fname == 'map.txt' && getline(lnum) =~ "unmap @@ $"
+            \ || fname == 'usr_12.txt' && getline(lnum) =~ "^\t/ \t$"
+            \ || fname == 'usr_41.txt' && getline(lnum) =~ "map <F4> o#include  $"
+            \ || fname == 'change.txt' && getline(lnum) =~ "foobar bla $"
+        continue
+      endif
+      call s:ReportError('testdir' .. fpath, lnum, 'trailing white space')
+      if lnum == 0
+        break
+      endif
+    endwhile
+
+
+  endfor
+
+  set wrapscan&vim
+  bwipe!
+endfunc
+
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1335: no test for bad use of spaces in help files

Problem:    No test for bad use of spaces in help files.
Solution:   Add checks for use of spaces in help files.  Ignore intentional
            spaces. (Hirohito Higashi, closes vim/vim#11952)

https://github.com/vim/vim/commit/d950984489e50b12d87c85f0cce1d672c880aa23

Cherry-pick changes from patch 9.0.1604.

Co-authored-by: h-east <h.east.727@gmail.com>
Co-authored-by: Bram Moolenaar <Bram@vim.org>