### PR TITLE
fix(loader): cache path ambiguity

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2428,8 +2428,27 @@ vim.loader.reset({path})                                  *vim.loader.reset()*
 ==============================================================================
 Lua module: vim.uri                                                  *vim.uri*
 
+vim.uri_decode({str})                                       *vim.uri_decode()*
+    URI-decodes a string containing percent escapes.
+
+    Parameters: ~
+      • {str}  (string) string to decode
+
+    Return: ~
+        (string) decoded string
+
+vim.uri_encode({str}, {rfc})                                *vim.uri_encode()*
+    URI-encodes a string using percent escapes.
+
+    Parameters: ~
+      • {str}  (string) string to encode
+      • {rfc}  "rfc2396" | "rfc2732" | "rfc3986" | nil
+
+    Return: ~
+        (string) encoded string
+
 vim.uri_from_bufnr({bufnr})                             *vim.uri_from_bufnr()*
-    Get a URI from a bufnr
+    Gets a URI from a bufnr.
 
     Parameters: ~
       • {bufnr}  (integer)
@@ -2438,7 +2457,7 @@ vim.uri_from_bufnr({bufnr})                             *vim.uri_from_bufnr()*
         (string) URI
 
 vim.uri_from_fname({path})                              *vim.uri_from_fname()*
-    Get a URI from a file path.
+    Gets a URI from a file path.
 
     Parameters: ~
       • {path}  (string) Path to file
@@ -2447,7 +2466,7 @@ vim.uri_from_fname({path})                              *vim.uri_from_fname()*
         (string) URI
 
 vim.uri_to_bufnr({uri})                                   *vim.uri_to_bufnr()*
-    Get the buffer for a uri. Creates a new unloaded buffer if no buffer for
+    Gets the buffer for a uri. Creates a new unloaded buffer if no buffer for
     the uri already exists.
 
     Parameters: ~
@@ -2457,7 +2476,7 @@ vim.uri_to_bufnr({uri})                                   *vim.uri_to_bufnr()*
         (integer) bufnr
 
 vim.uri_to_fname({uri})                                   *vim.uri_to_fname()*
-    Get a filename from a URI
+    Gets a filename from a URI.
 
     Parameters: ~
       • {uri}  (string)

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -1,4 +1,5 @@
 local uv = vim.uv
+local uri_encode = vim.uri_encode
 
 --- @type (fun(modename: string): fun()|string)[]
 local loaders = package.loaders
@@ -33,7 +34,7 @@ M.enabled = false
 ---@field _rtp_key string
 ---@field _hashes? table<string, CacheHash>
 local Loader = {
-  VERSION = 3,
+  VERSION = 4,
   ---@type table<string, table<string,ModuleInfo>>
   _indexed = {},
   ---@type table<string, string[]>
@@ -99,7 +100,7 @@ end
 ---@return string file_name
 ---@private
 function Loader.cache_file(name)
-  local ret = M.path .. '/' .. name:gsub('[/\\:]', '%%')
+  local ret = ('%s/%s'):format(M.path, uri_encode(name, 'rfc2396'))
   return ret:sub(-4) == '.lua' and (ret .. 'c') or (ret .. '.luac')
 end
 

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -33,4 +33,24 @@ describe('vim.loader', function()
       return _G.TEST
     ]], tmp))
   end)
+
+  it('handles % signs in modpath (#24491)', function()
+    exec_lua[[
+      vim.loader.enable()
+    ]]
+
+    local tmp1, tmp2 = (function (t)
+      assert(os.remove(t))
+      assert(helpers.mkdir(t))
+      assert(helpers.mkdir(t .. '/%'))
+      return t .. '/%/x', t .. '/%%x'
+    end)(helpers.tmpname())
+
+    helpers.write_file(tmp1, 'return 1', true)
+    helpers.write_file(tmp2, 'return 2', true)
+    vim.uv.fs_utime(tmp1, 0, 0)
+    vim.uv.fs_utime(tmp2, 0, 0)
+    eq(1, exec_lua('return loadfile(...)()', tmp1))
+    eq(2, exec_lua('return loadfile(...)()', tmp2))
+  end)
 end)


### PR DESCRIPTION
Problem: cache paths are derived by replacing each reserved/filesystem-
path-sensitive char with a `%` char in the original path. With this
method, two different files at two different paths (each containing `%`
chars) can erroneously resolve to the very same cache path in certain
edge-cases.

Solution: derive cache paths by url-encoding the original (path) instead
using `vim.uri_encode()` with `"rfc2396"`. Increment `Loader.VERSION` to
denote this change.