### PR TITLE
feat(lsp): improve control over placement of floating windows

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1580,7 +1580,8 @@ hover({_}, {result}, {ctx}, {config})               *vim.lsp.handlers.hover()*
       • {config}  (table) Configuration table.
                   • border: (default=nil)
                     • Add borders to the floating window
-                    • See |nvim_open_win()|
+                    • See |vim.lsp.util.open_floating_preview()| for more
+                      options.
 
                                            *vim.lsp.handlers.signature_help()*
 signature_help({_}, {result}, {ctx}, {config})
@@ -1599,7 +1600,8 @@ signature_help({_}, {result}, {ctx}, {config})
       • {config}  (table) Configuration table.
                   • border: (default=nil)
                     • Add borders to the floating window
-                    • See |nvim_open_win()|
+                    • See |vim.lsp.util.open_floating_preview()| for more
+                      options
 
 
 ==============================================================================
@@ -1788,6 +1790,13 @@ make_floating_popup_options({width}, {height}, {opts})
                   • focusable (string or table) override `focusable`
                   • zindex (string or table) override `zindex`, defaults to 50
                   • relative ("mouse"|"cursor") defaults to "cursor"
+                  • anchor_bias ("auto"|"above"|"below") defaults to "auto"
+                    • "auto": place window based on which side of the cursor
+                      has more lines
+                    • "above": place the window above the cursor unless there
+                      are not enough lines to display the full window height.
+                    • "below": place the window below the cursor unless there
+                      are not enough lines to display the full window height.
 
     Return: ~
         (table) Options
@@ -1889,8 +1898,9 @@ open_floating_preview({contents}, {syntax}, {opts})
     Parameters: ~
       • {contents}  (table) of lines to show in window
       • {syntax}    (string) of syntax to set for opened buffer
-      • {opts}      (table) with optional fields (additional keys are passed
-                    on to |nvim_open_win()|)
+      • {opts}      (table) with optional fields (additional keys are filtered
+                    with |vim.lsp.util.make_floating_popup_options()| before
+                    they are passed on to |nvim_open_win()|)
                     • height: (integer) height of floating window
                     • width: (integer) width of floating window
                     • wrap: (boolean, default true) wrap long lines

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -120,6 +120,8 @@ The following new APIs and features were added.
     indicator to see if a server supports a feature. Instead use
     `client.supports_method(<method>)`. It considers both the dynamic
     capabilities and static `server_capabilities`.
+  • Added a new `anchor_bias` option to |lsp-handlers| to aid in positioning of
+    floating windows.
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -355,7 +355,7 @@ end
 ---@param config table Configuration table.
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
----         - See |nvim_open_win()|
+---         - See |vim.lsp.util.open_floating_preview()| for more options.
 function M.hover(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method
@@ -442,7 +442,7 @@ M[ms.textDocument_implementation] = location_handler
 ---@param config table Configuration table.
 ---     - border:     (default=nil)
 ---         - Add borders to the floating window
----         - See |nvim_open_win()|
+---         - See |vim.lsp.util.open_floating_preview()| for more options
 function M.signature_help(_, result, ctx, config)
   config = config or {}
   config.focus_id = ctx.method


### PR DESCRIPTION
Currently, floating windows spawned by `vim.lsp.buf.hover()` and `vim.lsp.buf.signature_help()` will always render to the side of the cursor that has more lines. This can result in overlapping with other floating windows such as nvim-cmp:

![image](https://github.com/neovim/neovim/assets/5047809/315676c2-6b6b-48a4-91e3-d76be4faee56)

This PR adds an `anchor_bias` option to lsp floating windows that gives a preference to either position the window above or below the cursor to avoid overlapping with other windows/menus. With some config in a handler, overlapping is prevented unless the cursor is very close to the top or bottom of the screen:

```lua
vim.lsp.handlers['textDocument/signatureHelp'] = vim.lsp.with(
    vim.lsp.handlers.signature_help, {
        max_height = 15,
        anchor_bias = 'above'
    }
)
```
![image](https://github.com/neovim/neovim/assets/5047809/baccd591-3fa3-45d7-82d2-642d90baa744)

When the cursor is close enough to an edge of the screen that the full window height would not fit on screen, the floating window is positioned away from the edge regardless of `anchor_bias`:

![image](https://github.com/neovim/neovim/assets/5047809/eacdbaa9-c31e-4101-8af1-d6178f8f669d)