### PR TITLE
feat(treesitter): implement goto_node()

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -92,14 +92,8 @@ The following new APIs and features were added.
 
 • Added |vim.keycode()| for translating keycodes in a string.
 
-• Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
-  default).
-
 • |'smoothscroll'| option to scroll by screen line rather than by text line
   when |'wrap'| is set.
-
-• |Query:iter_matches()| now has the ability to set the maximum start depth
-  for matches.
 
 • Added inline virtual text support to |nvim_buf_set_extmark()|.
 
@@ -123,8 +117,14 @@ The following new APIs and features were added.
   • Implemented pull diagnostic textDocument/diagnostic: |vim.lsp.diagnostic.on_diagnostic()|
     https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic
 
-• Bundled treesitter parser and queries (highlight, folds) for Markdown,
-  Python, and Bash.
+• Treesitter
+  • Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
+    default).
+  • |Query:iter_matches()| now has the ability to set the maximum start depth
+    for matches.
+  • Bundled treesitter parser and queries (highlight, folds) for Markdown,
+    Python, and Bash.
+  • |vim.treesitter.goto_node()| moves the cursor to the given node.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -679,6 +679,27 @@ get_string_parser({str}, {lang}, {opts})
     Return: ~
         |LanguageTree| object to use for parsing
 
+goto_node({node}, {opts})                         *vim.treesitter.goto_node()*
+    Move the cursor to the given node.
+
+    Example:
+
+    >lua
+
+     local parser = vim.treesitter.get_parser()
+     local tree = parser:parse()[0]
+     local root = tree:root()
+     vim.treesitter.goto_node(root, { offset = { 0, 3 } })
+<
+
+    Parameters: ~
+      • {node}  |TSNode| Node to move cursor to.
+      • {opts}  (table|nil) Optional arguments:
+                • winid (number): Window ID to move cursor in. Defaults to 0
+                  (current window).
+                • offset (table): (row, col) offset from the node's start
+                  position.
+
 inspect_tree({opts})                           *vim.treesitter.inspect_tree()*
     Open a window that displays a textual representation of the nodes in the
     language tree.

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -504,4 +504,34 @@ function M.foldexpr(lnum)
   return require('vim.treesitter._fold').foldexpr(lnum)
 end
 
+--- Move the cursor to the given node.
+---
+--- Example:
+---
+--- <pre>lua
+--- local parser = vim.treesitter.get_parser()
+--- local tree = parser:parse()[0]
+--- local root = tree:root()
+--- vim.treesitter.goto_node(root, { offset = { 0, 3 } })
+--- </pre>
+---
+---@param node TSNode Node to move cursor to.
+---@param opts table|nil Optional arguments:
+---                      - winid (number): Window ID to move cursor in. Defaults to 0 (current
+---                                        window).
+---                      - offset (table): (row, col) offset from the node's start position.
+function M.goto_node(node, opts)
+  assert(node, 'Missing required argument: node')
+
+  opts = opts or {}
+  local winid = opts.winid or 0
+  local buf = api.nvim_win_get_buf(winid)
+  local metadata = opts.metadata or {}
+  local range = vim.treesitter.get_range(node, buf, metadata)
+  local row, col = unpack(range)
+  local offset = opts.offset or { 0, 0 }
+  assert(#offset == 2, 'offset must be a (row, col) tuple')
+  api.nvim_win_set_cursor(winid, { row + 1 + offset[1], col + offset[2] })
+end
+
 return M


### PR DESCRIPTION
vim.treesitter.goto_node() moves the cursor to the given node. Optional arguments include the window id in which to move the cursor (defaulting to the current window) and a (row, col) offset from the node's starting position.
