### PR TITLE
docs: drop "Can also be used as a method"

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1,7 +1,7 @@
 *builtin.txt*	Nvim
 
 
-		  VIM REFERENCE MANUAL	  by Bram Moolenaar
+		  NVIM REFERENCE MANUAL
 
 
 Builtin functions		*vimscript-functions* *builtin-functions*
@@ -25,10 +25,6 @@ abs({expr})                                                              *abs()*
 			echo abs(-4)
 <			4
 
-		Can also be used as a |method|: >vim
-			Compute()->abs()
-<
-
 acos({expr})                                                            *acos()*
 		Return the arc cosine of {expr} measured in radians, as a
 		|Float| in the range of [0, pi].
@@ -42,10 +38,6 @@ acos({expr})                                                            *acos()*
 			echo acos(-0.5)
 <			2.094395
 
-		Can also be used as a |method|: >vim
-			Compute()->acos()
-<
-
 add({object}, {expr})                                                    *add()*
 		Append the item {expr} to |List| or |Blob| {object}.  Returns
 		the resulting |List| or |Blob|.  Examples: >vim
@@ -57,18 +49,12 @@ add({object}, {expr})                                                    *add()*
 		Use |insert()| to add an item at another position.
 		Returns 1 if {object} is not a |List| or a |Blob|.
 
-		Can also be used as a |method|: >vim
-			mylist->add(val1)->add(val2)
-<
-
 and({expr}, {expr})                                                      *and()*
 		Bitwise AND on the two arguments.  The arguments are converted
 		to a number.  A List, Dict or Float argument causes an error.
 		Also see `or()` and `xor()`.
 		Example: >vim
 			let flag = and(bits, 0x80)
-<		Can also be used as a |method|: >vim
-			let flag = bits->and(0x80)
 <
 
 api_info()                                                          *api_info()*
@@ -90,9 +76,6 @@ append({lnum}, {text})                                                *append()*
 		0 for success.  Example: >vim
 			let failed = append(line('$'), "# THE END")
 			let failed = append(0, ["Chapter 1", "the beginning"])
-
-<		Can also be used as a |method| after a List: >vim
-			mylist->append(lnum)
 <
 
 appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
@@ -113,9 +96,6 @@ appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 		If {buf} is not a valid buffer or {lnum} is not valid, an
 		error message is given. Example: >vim
 			let failed = appendbufline(13, 0, "# THE START")
-<
-		Can also be used as a |method| after a List: >vim
-			mylist->appendbufline(buf, lnum)
 <
 
 argc([{winid}])                                                         *argc()*
@@ -176,19 +156,11 @@ asin({expr})                                                            *asin()*
 			echo asin(-0.5)
 <			-0.523599
 
-		Can also be used as a |method|: >vim
-			Compute()->asin()
-<
-
 assert_beeps({cmd})                                             *assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does
 		NOT produce a beep or visual bell.
 		Also see |assert_fails()|, |assert_nobeep()| and
 		|assert-return|.
-
-		Can also be used as a |method|: >vim
-			GetCmd()->assert_beeps()
-<
 
 assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
 		When {expected} and {actual} are not equal an error message is
@@ -206,20 +178,12 @@ assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
 <		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Expected 'foo' but got 'bar' ~
 
-		Can also be used as a |method|: >vim
-			mylist->assert_equal([1, 2, 3])
-<
-
 assert_equalfile({fname-one}, {fname-two})                  *assert_equalfile()*
 		When the files {fname-one} and {fname-two} do not contain
 		exactly the same text an error message is added to |v:errors|.
 		Also see |assert-return|.
 		When {fname-one} or {fname-two} does not exist the error will
 		mention that.
-
-		Can also be used as a |method|: >vim
-			GetLog()->assert_equalfile('expected.log')
-<
 
 assert_exception({error} [, {msg}])                         *assert_exception()*
 		When v:exception does not contain the string {error} an error
@@ -270,10 +234,6 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		Note that beeping is not considered an error, and some failing
 		commands only beep.  Use |assert_beeps()| for those.
 
-		Can also be used as a |method|: >vim
-			GetCmd()->assert_fails('E99:')
-<
-
 assert_false({actual} [, {msg}])                                *assert_false()*
 		When {actual} is not false an error message is added to
 		|v:errors|, like with |assert_equal()|.
@@ -283,10 +243,6 @@ assert_false({actual} [, {msg}])                                *assert_false()*
 
 		A value is false when it is zero. When {actual} is not a
 		number the assert fails.
-
-		Can also be used as a |method|: >vim
-			GetResult()->assert_false()
-<
 
 assert_inrange({lower}, {upper}, {actual} [, {msg}])          *assert_inrange()*
 		This asserts number and |Float| values.  When {actual}  is lower
@@ -315,44 +271,24 @@ assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
 <		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
-		Can also be used as a |method|: >vim
-			getFile()->assert_match('foo.*')
-<
-
 assert_nobeep({cmd})                                           *assert_nobeep()*
 		Run {cmd} and add an error message to |v:errors| if it
 		produces a beep or visual bell.
 		Also see |assert_beeps()|.
-
-		Can also be used as a |method|: >vim
-			GetCmd()->assert_nobeep()
-<
 
 assert_notequal({expected}, {actual} [, {msg}])              *assert_notequal()*
 		The opposite of `assert_equal()`: add an error message to
 		|v:errors| when {expected} and {actual} are equal.
 		Also see |assert-return|.
 
-		Can also be used as a |method|: >vim
-			mylist->assert_notequal([1, 2, 3])
-<
-
 assert_notmatch({pattern}, {actual} [, {msg}])               *assert_notmatch()*
 		The opposite of `assert_match()`: add an error message to
 		|v:errors| when {pattern} matches {actual}.
 		Also see |assert-return|.
 
-		Can also be used as a |method|: >vim
-			getFile()->assert_notmatch('bar.*')
-<
-
 assert_report({msg})                                           *assert_report()*
 		Report a test failure directly, using String {msg}.
 		Always returns one.
-
-		Can also be used as a |method|: >vim
-			GetMessage()->assert_report()
-<
 
 assert_true({actual} [, {msg}])                                  *assert_true()*
 		When {actual} is not true an error message is added to
@@ -361,10 +297,6 @@ assert_true({actual} [, {msg}])                                  *assert_true()*
 		A value is |TRUE| when it is a non-zero number or |v:true|.
 		When {actual} is not a number or |v:true| the assert fails.
 		When {msg} is given it precedes the default message.
-
-		Can also be used as a |method|: >vim
-			GetResult()->assert_true()
-<
 
 atan({expr})                                                            *atan()*
 		Return the principal value of the arc tangent of {expr}, in
@@ -376,10 +308,6 @@ atan({expr})                                                            *atan()*
 <			1.560797 >vim
 			echo atan(-4.01)
 <			-1.326405
-
-		Can also be used as a |method|: >vim
-			Compute()->atan()
-<
 
 atan2({expr1}, {expr2})                                                *atan2()*
 		Return the arc tangent of {expr1} / {expr2}, measured in
@@ -393,10 +321,6 @@ atan2({expr1}, {expr2})                                                *atan2()*
 			echo atan2(1, -1)
 <			2.356194
 
-		Can also be used as a |method|: >vim
-			Compute()->atan2(1)
-<
-
 blob2list({blob})                                                  *blob2list()*
 		Return a List containing the number value of each byte in Blob
 		{blob}.  Examples: >vim
@@ -404,10 +328,6 @@ blob2list({blob})                                                  *blob2list()*
 			blob2list(0z)		" returns []
 <		Returns an empty List on error.  |list2blob()| does the
 		opposite.
-
-		Can also be used as a |method|: >vim
-			GetBlob()->blob2list()
-<
 
 browse({save}, {title}, {initdir}, {default})                         *browse()*
 		Put up a file requester.  This only works when "has("browse")"
@@ -445,9 +365,6 @@ bufadd({name})                                                        *bufadd()*
 			call bufload(bufnr)
 			call setbufline(bufnr, 1, ['some', 'text'])
 <		Returns 0 on error.
-		Can also be used as a |method|: >vim
-			let bufnr = 'somename'->bufadd()
-<
 
 bufexists({buf})                                                   *bufexists()*
 		The result is a Number, which is |TRUE| if a buffer called
@@ -471,18 +388,10 @@ bufexists({buf})                                                   *bufexists()*
 		Use "bufexists(0)" to test for the existence of an alternate
 		file name.
 
-		Can also be used as a |method|: >vim
-			let exists = 'somename'->bufexists()
-<
-
 buflisted({buf})                                                   *buflisted()*
 		The result is a Number, which is |TRUE| if a buffer called
 		{buf} exists and is listed (has the 'buflisted' option set).
 		The {buf} argument is used like with |bufexists()|.
-
-		Can also be used as a |method|: >vim
-			let listed = 'somename'->buflisted()
-<
 
 bufload({buf})                                                       *bufload()*
 		Ensure the buffer {buf} is loaded.  When the buffer name
@@ -494,18 +403,10 @@ bufload({buf})                                                       *bufload()*
 		there will be no dialog, the buffer will be loaded anyway.
 		The {buf} argument is used like with |bufexists()|.
 
-		Can also be used as a |method|: >vim
-			eval 'somename'->bufload()
-<
-
 bufloaded({buf})                                                   *bufloaded()*
 		The result is a Number, which is |TRUE| if a buffer called
 		{buf} exists and is loaded (shown in a window or hidden).
 		The {buf} argument is used like with |bufexists()|.
-
-		Can also be used as a |method|: >vim
-			let loaded = 'somename'->bufloaded()
-<
 
 bufname([{buf}])                                                     *bufname()*
 		The result is the name of a buffer.  Mostly as it is displayed
@@ -528,11 +429,6 @@ bufname([{buf}])                                                     *bufname()*
 		with a listed buffer, that one is returned.  Next unlisted
 		buffers are searched for.
 		If the {buf} is a String, but you want to use it as a buffer
-		number, force it to be a Number by adding zero to it: >vim
-			echo bufname("3" + 0)
-<		Can also be used as a |method|: >vim
-			echo bufnr->bufname()
-
 <		If the buffer doesn't exist, or doesn't have a name, an empty
 		string is returned. >vim
 			echo bufname("#")		" alternate buffer name
@@ -555,10 +451,6 @@ bufnr([{buf} [, {create}]])                                            *bufnr()*
 		number necessarily exist, because ":bwipeout" may have removed
 		them.  Use bufexists() to test for the existence of a buffer.
 
-		Can also be used as a |method|: >vim
-			echo bufref->bufnr()
-<
-
 bufwinid({buf})                                                     *bufwinid()*
 		The result is a Number, which is the |window-ID| of the first
 		window associated with buffer {buf}.  For the use of {buf},
@@ -569,10 +461,6 @@ bufwinid({buf})                                                     *bufwinid()*
 <
 		Only deals with the current tab page.  See |win_findbuf()| for
 		finding more.
-
-		Can also be used as a |method|: >vim
-			FindBuffer()->bufwinid()
-<
 
 bufwinnr({buf})                                                     *bufwinnr()*
 		Like |bufwinid()| but return the window number instead of the
@@ -585,10 +473,6 @@ bufwinnr({buf})                                                     *bufwinnr()*
 <		The number can be used with |CTRL-W_w| and ":wincmd w"
 		|:wincmd|.
 
-		Can also be used as a |method|: >vim
-			FindBuffer()->bufwinnr()
-<
-
 byte2line({byte})                                                  *byte2line()*
 		Return the line number that contains the character at byte
 		count {byte} in the current buffer.  This includes the
@@ -598,10 +482,6 @@ byte2line({byte})                                                  *byte2line()*
 		Also see |line2byte()|, |go| and |:goto|.
 
 		Returns -1 if the {byte} value is invalid.
-
-		Can also be used as a |method|: >vim
-			GetOffset()->byte2line()
-<
 
 byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
 		Return byte index of the {nr}th character in the String
@@ -638,9 +518,6 @@ byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
 			echo byteidx('a😊😊', 2, 1)	" returns 1
 			echo byteidx('a😊😊', 3, 1)	" returns 5
 <
-		Can also be used as a |method|: >vim
-			GetName()->byteidx(idx)
-<
 
 byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
 		Like byteidx(), except that a composing character is counted
@@ -653,10 +530,6 @@ byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
 		character is 3 bytes), the second echo results in 1 ('e' is
 		one byte).
 
-		Can also be used as a |method|: >vim
-			GetName()->byteidxcomp(idx)
-<
-
 call({func}, {arglist} [, {dict}])                                 *call()* *E699*
 		Call function {func} with the items in |List| {arglist} as
 		arguments.
@@ -665,10 +538,6 @@ call({func}, {arglist} [, {dict}])                                 *call()* *E69
 		Returns the return value of the called function.
 		{dict} is for functions with the "dict" attribute.  It will be
 		used to set the local variable "self". |Dictionary-function|
-
-		Can also be used as a |method|: >vim
-			GetFunc()->call([arg, arg], dict)
-<
 
 ceil({expr})                                                            *ceil()*
 		Return the smallest integral value greater than or equal to
@@ -683,10 +552,6 @@ ceil({expr})                                                            *ceil()*
 <			4.0
 
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
-
-		Can also be used as a |method|: >vim
-			Compute()->ceil()
-<
 
 chanclose({id} [, {stream}])                                       *chanclose()*
 		Close a channel or a specific stream associated with it.
@@ -740,10 +605,6 @@ char2nr({string} [, {utf8}])                                         *char2nr()*
 
 		Returns 0 if {string} is not a |String|.
 
-		Can also be used as a |method|: >vim
-			GetChar()->char2nr()
-<
-
 charclass({string})                                                *charclass()*
 		Return the character class of the first character in {string}.
 		The character class is one of:
@@ -763,10 +624,6 @@ charcol({expr} [, {winid}])                                          *charcol()*
 		With the cursor on '세' in line 5 with text "여보세요": >vim
 			echo charcol('.')		" returns 3
 			echo col('.')		" returns 7
-
-<		Can also be used as a |method|: >vim
-			GetPos()->col()
-<
 
 charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
 		Return the character index of the byte at {idx} in {string}.
@@ -801,9 +658,6 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
 			echo charidx('áb́ć', 16)		" returns -1
 			echo charidx('a😊😊', 4, 0, 1)	" returns 2
 <
-		Can also be used as a |method|: >vim
-			GetName()->charidx(idx)
-<
 
 chdir({dir})                                                           *chdir()*
 		Change the current working directory to {dir}.  The scope of
@@ -827,10 +681,6 @@ chdir({dir})                                                           *chdir()*
 			   call chdir(save_dir)
 			endif
 
-<		Can also be used as a |method|: >vim
-			GetDir()->chdir()
-<
-
 cindent({lnum})                                                      *cindent()*
 		Get the amount of indent for line {lnum} according the C
 		indenting rules, as with 'cindent'.
@@ -839,19 +689,11 @@ cindent({lnum})                                                      *cindent()*
 		When {lnum} is invalid -1 is returned.
 		See |C-indenting|.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->cindent()
-<
-
 clearmatches([{win}])                                           *clearmatches()*
 		Clears all matches previously defined for the current window
 		by |matchadd()| and the |:match| commands.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
-
-		Can also be used as a |method|: >vim
-			GetWin()->clearmatches()
-<
 
 col({expr} [, {winid}])                                                  *col()*
 		The result is a Number, which is the byte index of the column
@@ -891,10 +733,6 @@ col({expr} [, {winid}])                                                  *col()*
 		moved, this can be used to obtain the column in Insert mode: >vim
 			imap <F2> <Cmd>echo col(".").."\n"<CR>
 
-<		Can also be used as a |method|: >vim
-			GetPos()->col()
-<
-
 complete({startcol}, {matches})                                *complete()* *E785*
 		Set the matches for Insert mode completion.
 		Can only be used in Insert mode.  You need to use a mapping
@@ -925,11 +763,6 @@ complete({startcol}, {matches})                                *complete()* *E78
 <		This isn't very useful, but it shows how it works.  Note that
 		an empty string is returned to avoid a zero being inserted.
 
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetMatches()->complete(col('.'))
-<
-
 complete_add({expr})                                            *complete_add()*
 		Add {expr} to the list of matches.  Only to be used by the
 		function specified with the 'completefunc' option.
@@ -938,10 +771,6 @@ complete_add({expr})                                            *complete_add()*
 		the list.
 		See |complete-functions| for an explanation of {expr}.  It is
 		the same as one item in the list that 'omnifunc' would return.
-
-		Can also be used as a |method|: >vim
-			GetMoreMatches()->complete_add()
-<
 
 complete_check()                                              *complete_check()*
 		Check for a key typed while looking for completion matches.
@@ -1009,10 +838,6 @@ complete_info([{what}])                                        *complete_info()*
 			" Get only 'mode' and 'pum_visible'
 			call complete_info(['mode', 'pum_visible'])
 
-<		Can also be used as a |method|: >vim
-			GetItems()->complete_info()
-<
-
 confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
 		confirm() offers the user a dialog, from which a choice can be
 		made.  It returns the number of the choice.  For the first
@@ -1065,10 +890,6 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
 		don't fit, a vertical layout is used anyway.  For some systems
 		the horizontal layout is always used.
 
-		Can also be used as a |method|in: >vim
-			BuildMessage()->confirm("&Yes\n&No")
-<
-
 copy({expr})                                                            *copy()*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
 		different from using {expr} directly.
@@ -1078,9 +899,6 @@ copy({expr})                                                            *copy()*
 		changing an item changes the contents of both |Lists|.
 		A |Dictionary| is copied in a similar way as a |List|.
 		Also see |deepcopy()|.
-		Can also be used as a |method|: >vim
-			mylist->copy()
-<
 
 cos({expr})                                                              *cos()*
 		Return the cosine of {expr}, measured in radians, as a |Float|.
@@ -1092,10 +910,6 @@ cos({expr})                                                              *cos()*
 			echo cos(-4.01)
 <			-0.646043
 
-		Can also be used as a |method|: >vim
-			Compute()->cos()
-<
-
 cosh({expr})                                                            *cosh()*
 		Return the hyperbolic cosine of {expr} as a |Float| in the range
 		[1, inf].
@@ -1106,10 +920,6 @@ cosh({expr})                                                            *cosh()*
 <			1.127626 >vim
 			echo cosh(-0.5)
 <			-1.127626
-
-		Can also be used as a |method|: >vim
-			Compute()->cosh()
-<
 
 count({comp}, {expr} [, {ic} [, {start}]])                             *count()*
 		Return the number of times an item with value {expr} appears
@@ -1123,10 +933,6 @@ count({comp}, {expr} [, {ic} [, {start}]])                             *count()*
 		When {comp} is a string then the number of not overlapping
 		occurrences of {expr} is returned. Zero is returned when
 		{expr} is an empty string.
-
-		Can also be used as a |method|: >vim
-			mylist->count(val)
-<
 
 ctxget([{index}])                                                     *ctxget()*
 		Returns a |Dictionary| representing the |context| at {index}
@@ -1186,10 +992,6 @@ cursor({list})                                                        *cursor()*
 		position within a <Tab> or after the last character.
 		Returns 0 when the position could be set, -1 otherwise.
 
-		Can also be used as a |method|: >vim
-			GetCursorPos()->cursor()
-<
-
 debugbreak({pid})                                                 *debugbreak()*
 		Specifically used to interrupt a program being debugged.  It
 		will cause process {pid} to get a SIGTRAP.  Behavior for other
@@ -1198,10 +1000,6 @@ debugbreak({pid})                                                 *debugbreak()*
 
 		Returns |TRUE| if successfully interrupted the program.
 		Otherwise returns |FALSE|.
-
-		Can also be used as a |method|: >vim
-			GetPid()->debugbreak()
-<
 
 deepcopy({expr} [, {noref}])                                   *deepcopy()* *E698*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
@@ -1223,10 +1021,6 @@ deepcopy({expr} [, {noref}])                                   *deepcopy()* *E69
 		{noref} set to 1 will fail.
 		Also see |copy()|.
 
-		Can also be used as a |method|: >vim
-			GetObject()->deepcopy()
-<
-
 delete({fname} [, {flags}])                                           *delete()*
 		Without {flags} or with {flags} empty: Deletes the file by the
 		name {fname}.
@@ -1246,10 +1040,6 @@ delete({fname} [, {flags}])                                           *delete()*
 		operation was successful and -1/true when the deletion failed
 		or partly failed.
 
-		Can also be used as a |method|: >vim
-			GetName()->delete()
-<
-
 deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
 		Delete lines {first} to {last} (inclusive) from buffer {buf}.
 		If {last} is omitted then delete line {first} only.
@@ -1263,10 +1053,6 @@ deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
 		{first} and {last} are used like with |getline()|. Note that
 		when using |line()| this refers to the current buffer. Use "$"
 		to refer to the last line in buffer {buf}.
-
-		Can also be used as a |method|: >vim
-			GetBuffer()->deletebufline(1)
-<
 
 dictwatcheradd({dict}, {pattern}, {callback})                 *dictwatcheradd()*
 		Adds a watcher to a dictionary. A dictionary watcher is
@@ -1334,10 +1120,6 @@ diff_filler({lnum})                                              *diff_filler()*
 		line, "'m" mark m, etc.
 		Returns 0 if the current window is not in diff mode.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->diff_filler()
-<
-
 diff_hlID({lnum}, {col})                                           *diff_hlID()*
 		Returns the highlight ID for diff mode at line {lnum} column
 		{col} (byte index).  When the current line does not have a
@@ -1348,10 +1130,6 @@ diff_hlID({lnum}, {col})                                           *diff_hlID()*
 		line.
 		The highlight ID can be used with |synIDattr()| to obtain
 		syntax information about the highlighting.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->diff_hlID(col)
-<
 
 digraph_get({chars})                                       *digraph_get()* *E1214*
 		Return the digraph of {chars}.  This should be a string with
@@ -1369,9 +1147,6 @@ digraph_get({chars})                                       *digraph_get()* *E121
 		call digraph_set('aa', 'あ')
 		echo digraph_get('aa')		" Returns 'あ'
 <
-		Can also be used as a |method|: >vim
-			GetChars()->digraph_get()
-<
 
 digraph_getlist([{listall}])                                 *digraph_getlist()*
 		Return a list of digraphs.  If the {listall} argument is given
@@ -1386,9 +1161,6 @@ digraph_getlist([{listall}])                                 *digraph_getlist()*
 
 		" Get all the digraphs, including default digraphs
 		echo digraph_getlist(1)
-<
-		Can also be used as a |method|: >vim
-			GetNumber()->digraph_getlist()
 <
 
 digraph_set({chars}, {digraph})                                  *digraph_set()*
@@ -1440,10 +1212,6 @@ empty({expr})                                                          *empty()*
 		- |v:false| and |v:null| are empty, |v:true| is not.
 		- A |Blob| is empty when its length is zero.
 
-		Can also be used as a |method|: >vim
-			mylist->empty()
-<
-
 environ()                                                            *environ()*
 		Return all of environment variables as dictionary. You can
 		check if an environment variable exists like this: >vim
@@ -1461,20 +1229,12 @@ escape({string}, {chars})                                             *escape()*
 			c:\\program\ files\\vim
 <		Also see |shellescape()| and |fnameescape()|.
 
-		Can also be used as a |method|: >vim
-			GetText()->escape(' \')
-<
-
 eval({string})                                                          *eval()*
 		Evaluate {string} and return the result.  Especially useful to
 		turn the result of |string()| back into the original value.
 		This works for Numbers, Floats, Strings, Blobs and composites
 		of them.  Also works for |Funcref|s that refer to existing
 		functions.
-
-		Can also be used as a |method|: >vim
-			argv->join()->eval()
-<
 
 eventhandler()                                                  *eventhandler()*
 		Returns 1 when inside an event handler.  That is that Vim got
@@ -1505,10 +1265,6 @@ executable({expr})                                                *executable()*
 			-1	not implemented on this system
 		|exepath()| can be used to get the full path of an executable.
 
-		Can also be used as a |method|: >vim
-			GetCommand()->executable()
-<
-
 execute({command} [, {silent}])                                      *execute()*
 		Execute {command} and capture its output.
 		If {command} is a |String|, returns {command} output.
@@ -1537,19 +1293,11 @@ execute({command} [, {silent}])                                      *execute()*
 		To execute a command in another window than the current one
 		use `win_execute()`.
 
-		Can also be used as a |method|: >vim
-			GetCommand()->execute()
-<
-
 exepath({expr})                                                      *exepath()*
 		Returns the full path of {expr} if it is an executable and
 		given as a (partial or full) path or is found in $PATH.
 		Returns empty string otherwise.
 		If {expr} starts with "./" the |current-directory| is used.
-
-		Can also be used as a |method|: >vim
-			GetCommand()->exepath()
-<
 
 exists({expr})                                                        *exists()*
 		The result is a Number, which is |TRUE| if {expr} is
@@ -1639,10 +1387,6 @@ exists({expr})                                                        *exists()*
 <		This doesn't check for existence of the "bufcount" variable,
 		but gets the value of "bufcount", and checks if that exists.
 
-		Can also be used as a |method|: >vim
-			Varname()->exists()
-<
-
 exp({expr})                                                              *exp()*
 		Return the exponential of {expr} as a |Float| in the range
 		[0, inf].
@@ -1653,10 +1397,6 @@ exp({expr})                                                              *exp()*
 <			7.389056 >vim
 			echo exp(-1)
 <			0.367879
-
-		Can also be used as a |method|: >vim
-			Compute()->exp()
-<
 
 expand({string} [, {nosuf} [, {list}]])                               *expand()*
 		Expand wildcards and the following special keywords in
@@ -1749,10 +1489,6 @@ expand({string} [, {nosuf} [, {list}]])                               *expand()*
 		See |glob()| for finding existing files.  See |system()| for
 		getting the raw output of an external command.
 
-		Can also be used as a |method|: >vim
-			Getpattern()->expand()
-<
-
 expandcmd({string} [, {options}])                                  *expandcmd()*
 		Expand special items in String {string} like what is done for
 		an Ex command such as `:edit`.  This expands special keywords,
@@ -1775,9 +1511,6 @@ expandcmd({string} [, {options}])                                  *expandcmd()*
 			make /path/runtime/doc/builtin.o
 <		 >vim
 			echo expandcmd('make %<.o', {'errmsg': v:true})
-<
-		Can also be used as a |method|: >vim
-			GetCommand()->expandcmd()
 <
 
 extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
@@ -1815,10 +1548,6 @@ extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
 		When {expr1} is locked and {expr2} is not empty the operation
 		fails.
 		Returns {expr1}.  Returns 0 on error.
-
-		Can also be used as a |method|: >vim
-			mylist->extend(otherlist)
-<
 
 extendnew({expr1}, {expr2} [, {expr3}])                            *extendnew()*
 		Like |extend()| but instead of adding items to {expr1} a new
@@ -1870,10 +1599,6 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
 
 		Return value is always 0.
 
-		Can also be used as a |method|: >vim
-			GetInput()->feedkeys()
-<
-
 filereadable({file})                                            *filereadable()*
 		The result is a Number, which is |TRUE| when a file with the
 		name {file} exists, and can be read.  If {file} doesn't exist,
@@ -1891,19 +1616,11 @@ filereadable({file})                                            *filereadable()*
 			1
 <
 
-		Can also be used as a |method|: >vim
-			GetName()->filereadable()
-<
-
 filewritable({file})                                            *filewritable()*
 		The result is a Number, which is 1 when a file with the
 		name {file} exists, and can be written.  If {file} doesn't
 		exist, or is not writable, the result is 0.  If {file} is a
 		directory, and we can write to it, the result is 2.
-
-		Can also be used as a |method|: >vim
-			GetName()->filewritable()
-<
 
 filter({expr1}, {expr2})                                              *filter()*
 		{expr1} must be a |List|, |Blob|, or a |Dictionary|.
@@ -1955,10 +1672,6 @@ filter({expr1}, {expr2})                                              *filter()*
 		{expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
 
-		Can also be used as a |method|: >vim
-			mylist->filter(expr2)
-<
-
 finddir({name} [, {path} [, {count}]])                               *finddir()*
 		Find directory {name} in {path}.  Supports both downwards and
 		upwards recursive directory searches.  See |file-searching|
@@ -1977,10 +1690,6 @@ finddir({name} [, {path} [, {count}]])                               *finddir()*
 
 		This is quite similar to the ex-command `:find`.
 
-		Can also be used as a |method|: >vim
-			GetName()->finddir()
-<
-
 findfile({name} [, {path} [, {count}]])                             *findfile()*
 		Just like |finddir()|, but find a file instead of a directory.
 		Uses 'suffixesadd'.
@@ -1988,10 +1697,6 @@ findfile({name} [, {path} [, {count}]])                             *findfile()*
 			echo findfile("tags.vim", ".;")
 <		Searches from the directory of the current file upwards until
 		it finds the file "tags.vim".
-
-		Can also be used as a |method|: >vim
-			GetName()->findfile()
-<
 
 flatten({list} [, {maxdepth}])                                       *flatten()*
 		Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
@@ -2011,10 +1716,6 @@ flatten({list} [, {maxdepth}])                                       *flatten()*
 <			[1, 2, 3, 4, 5] >vim
 			echo flatten([1, [2, [3, 4]], 5], 1)
 <			[1, 2, [3, 4], 5]
-
-		Can also be used as a |method|: >vim
-			mylist->flatten()
-<
 
 flattennew({list} [, {maxdepth}])                                 *flattennew()*
 		Like |flatten()| but first make a copy of {list}.
@@ -2041,10 +1742,6 @@ float2nr({expr})                                                    *float2nr()*
 			echo float2nr(1.0e-100)
 <			0
 
-		Can also be used as a |method|: >vim
-			Compute()->float2nr()
-<
-
 floor({expr})                                                          *floor()*
 		Return the largest integral value less than or equal to
 		{expr} as a |Float| (round down).
@@ -2057,10 +1754,6 @@ floor({expr})                                                          *floor()*
 <			-6.0  >vim
 			echo floor(4.0)
 <			4.0
-
-		Can also be used as a |method|: >vim
-			Compute()->floor()
-<
 
 fmod({expr1}, {expr2})                                                  *fmod()*
 		Return the remainder of {expr1} / {expr2}, even if the
@@ -2078,10 +1771,6 @@ fmod({expr1}, {expr2})                                                  *fmod()*
 			echo fmod(-12.33, 1.22)
 <			-0.13
 
-		Can also be used as a |method|: >vim
-			Compute()->fmod(1.22)
-<
-
 fnameescape({string})                                            *fnameescape()*
 		Escape {string} for use as file name command argument.  All
 		characters that have a special meaning, such as `'%'` and `'|'`
@@ -2097,9 +1786,6 @@ fnameescape({string})                                            *fnameescape()*
 			exe "edit " .. fnameescape(fname)
 <		results in executing: >vim
 			edit \+some\ str\%nge\|name
-<
-		Can also be used as a |method|: >vim
-			GetName()->fnameescape()
 <
 
 fnamemodify({fname}, {mods})                                     *fnamemodify()*
@@ -2119,10 +1805,6 @@ fnamemodify({fname}, {mods})                                     *fnamemodify()*
 		Note: Environment variables don't work in {fname}, use
 		|expand()| first then.
 
-		Can also be used as a |method|: >vim
-			GetName()->fnamemodify(':p:h')
-<
-
 foldclosed({lnum})                                                *foldclosed()*
 		The result is a Number.  If the line {lnum} is in a closed
 		fold, the result is the number of the first line in that fold.
@@ -2130,20 +1812,12 @@ foldclosed({lnum})                                                *foldclosed()*
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->foldclosed()
-<
-
 foldclosedend({lnum})                                          *foldclosedend()*
 		The result is a Number.  If the line {lnum} is in a closed
 		fold, the result is the number of the last line in that fold.
 		If the line {lnum} is not in a closed fold, -1 is returned.
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->foldclosedend()
-<
 
 foldlevel({lnum})                                                  *foldlevel()*
 		The result is a Number, which is the foldlevel of line {lnum}
@@ -2156,10 +1830,6 @@ foldlevel({lnum})                                                  *foldlevel()*
 		previous line is usually available.
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->foldlevel()
-<
 
 foldtext()                                                          *foldtext()*
 		Returns a String, to be displayed for a closed fold.  This is
@@ -2187,10 +1857,6 @@ foldtextresult({lnum})                                        *foldtextresult()*
 		line, "'m" mark m, etc.
 		Useful when exporting folded text, e.g., to HTML.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->foldtextresult()
-<
-
 fullcommand({name})                                              *fullcommand()*
 		Get the full command name from a short abbreviated command
 		name; see |20.2| for details on command abbreviations.
@@ -2203,10 +1869,6 @@ fullcommand({name})                                              *fullcommand()*
 		For example `fullcommand('s')`, `fullcommand('sub')`,
 		`fullcommand(':%substitute')` all return "substitute".
 
-		Can also be used as a |method|: >vim
-			GetName()->fullcommand()
-<
-
 funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
 		Just like |function()|, but the returned Funcref will lookup
 		the function by reference, not by name.  This matters when the
@@ -2218,10 +1880,6 @@ funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
 		when only intending to use the function name, use |function()|
 		instead). {name} cannot be a builtin function.
 		Returns 0 on error.
-
-		Can also be used as a |method|: >vim
-			GetFuncname()->funcref([arg])
-<
 
 function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* *E923*
 		Return a |Funcref| variable that refers to function {name}.
@@ -2305,10 +1963,6 @@ function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* 
 <
 		Returns 0 on error.
 
-		Can also be used as a |method|: >vim
-			GetFuncname()->function([arg])
-<
-
 garbagecollect([{atexit}])                                    *garbagecollect()*
 		Cleanup unused |Lists| and |Dictionaries| that have circular
 		references.
@@ -2333,9 +1987,6 @@ get({list}, {idx} [, {default}])                                         *get()*
 		Get item {idx} from |List| {list}.  When this item is not
 		available return {default}.  Return zero when {default} is
 		omitted.
-		Can also be used as a |method|: >vim
-			mylist->get(idx)
-<
 
 get({blob}, {idx} [, {default}])
 		Get byte {idx} from |Blob| {blob}.  When this byte is not
@@ -2425,9 +2076,6 @@ getbufinfo([{dict}])                                              *getbufinfo()*
 		To get buffer-local options use: >vim
 			getbufvar({bufnr}, '&option_name')
 <
-		Can also be used as a |method|: >vim
-			GetBufnr()->getbufinfo()
-<
 
 getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
 		Return a |List| with the lines starting from {lnum} to {end}
@@ -2454,10 +2102,6 @@ getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
 		Example: >vim
 			let lines = getbufline(bufnr("myfile"), 1, "$")
 
-<		Can also be used as a |method|: >vim
-			GetBufnr()->getbufline(lnum)
-<
-
 getbufoneline({buf}, {lnum})                                   *getbufoneline()*
 		Just like `getbufline()` but only get one line and return it
 		as a string.
@@ -2483,10 +2127,6 @@ getbufvar({buf}, {varname} [, {def}])                              *getbufvar()*
 			let bufmodified = getbufvar(1, "&mod")
 			echo "todo myvar = " .. getbufvar("todo", "myvar")
 
-<		Can also be used as a |method|: >vim
-			GetBufnr()->getbufvar(varname)
-<
-
 getcellwidths()                                                *getcellwidths()*
 		Returns a |List| of cell widths of character ranges overridden
 		by |setcellwidths()|.  The format is equal to the argument of
@@ -2508,10 +2148,6 @@ getchangelist([{buf}])                                         *getchangelist()*
 		If buffer {buf} is the current buffer, then the current
 		position refers to the position in the list. For other
 		buffers, it is set to the length of the list.
-
-		Can also be used as a |method|: >vim
-			GetBufnr()->getchangelist()
-<
 
 getchar([expr])                                                      *getchar()*
 		Get a single character from the user or input stream.
@@ -2606,9 +2242,6 @@ getcharpos({expr})                                                *getcharpos()*
 		With the cursor on '세' in line 5 with text "여보세요": >vim
 			getcharpos('.')		returns [0, 5, 3, 0]
 			getpos('.')		returns [0, 5, 7, 0]
-<
-		Can also be used as a |method|: >vim
-			GetMark()->getcharpos()
 <
 
 getcharsearch()                                                *getcharsearch()*
@@ -2768,10 +2401,6 @@ getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		If there are no matches, an empty list is returned.  An
 		invalid value for {type} produces an error.
 
-		Can also be used as a |method|: >vim
-			GetPattern()->getcompletion('color')
-<
-
 getcurpos([{winid}])                                               *getcurpos()*
 		Get the position of the cursor.  This is like getpos('.'), but
 		includes an extra "curswant" item in the list:
@@ -2797,10 +2426,6 @@ getcurpos([{winid}])                                               *getcurpos()*
 <		Note that this only works within the window.  See
 		|winrestview()| for restoring more state.
 
-		Can also be used as a |method|: >vim
-			GetWinid()->getcurpos()
-<
-
 getcursorcharpos([{winid}])                                 *getcursorcharpos()*
 		Same as |getcurpos()| but the column number in the returned
 		List is a character index instead of a byte index.
@@ -2809,9 +2434,6 @@ getcursorcharpos([{winid}])                                 *getcursorcharpos()*
 		With the cursor on '보' in line 3 with text "여보세요": >vim
 			getcursorcharpos()	" returns [0, 3, 2, 0, 3]
 			getcurpos()		" returns [0, 3, 4, 0, 3]
-<
-		Can also be used as a |method|: >vim
-			GetWinid()->getcursorcharpos()
 <
 
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
@@ -2830,10 +2452,6 @@ getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		directory is returned.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
-		Can also be used as a |method|: >vim
-			GetWinnr()->getcwd()
-<
-
 getenv({name})                                                        *getenv()*
 		Return the value of environment variable {name}.  The {name}
 		argument is a string, without a leading '$'.  Example: >vim
@@ -2842,10 +2460,6 @@ getenv({name})                                                        *getenv()*
 <		When the variable does not exist |v:null| is returned.  That
 		is different from a variable set to an empty string.
 		See also |expr-env|.
-
-		Can also be used as a |method|: >vim
-			GetVarname()->getenv()
-<
 
 getfontname([{name}])                                            *getfontname()*
 		Without an argument returns the name of the normal font being
@@ -2874,9 +2488,6 @@ getfperm({fname})                                                   *getfperm()*
 <		This will hopefully (from a security point of view) display
 		the string "rw-r--r--" or even "rw-------".
 
-		Can also be used as a |method|: >vim
-			GetFilename()->getfperm()
-<
 		For setting permissions use |setfperm()|.
 
 getfsize({fname})                                                   *getfsize()*
@@ -2887,20 +2498,12 @@ getfsize({fname})                                                   *getfsize()*
 		If the size of {fname} is too big to fit in a Number then -2
 		is returned.
 
-		Can also be used as a |method|: >vim
-			GetFilename()->getfsize()
-<
-
 getftime({fname})                                                   *getftime()*
 		The result is a Number, which is the last modification time of
 		the given file {fname}.  The value is measured as seconds
 		since 1st Jan 1970, and may be passed to strftime().  See also
 		|localtime()| and |strftime()|.
 		If the file {fname} can't be found -1 is returned.
-
-		Can also be used as a |method|: >vim
-			GetFilename()->getftime()
-<
 
 getftype({fname})                                                   *getftype()*
 		The result is a String, which is a description of the kind of
@@ -2922,10 +2525,6 @@ getftype({fname})                                                   *getftype()*
 		systems that support it.  On some systems only "dir" and
 		"file" are returned.
 
-		Can also be used as a |method|: >vim
-			GetFilename()->getftype()
-<
-
 getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 		Returns the |jumplist| for the specified window.
 
@@ -2945,10 +2544,6 @@ getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 			coladd		column offset for 'virtualedit'
 			filename	filename if available
 			lnum		line number
-
-		Can also be used as a |method|: >vim
-			GetWinnr()->getjumplist()
-<
 
 getline({lnum} [, {end}])                                            *getline()*
 		Without {end} the result is a String, which is line {lnum}
@@ -2971,9 +2566,6 @@ getline({lnum} [, {end}])                                            *getline()*
 			let start = line('.')
 			let end = search("^$") - 1
 			let lines = getline(start, end)
-
-<		Can also be used as a |method|: >vim
-			ComputeLnum()->getline()
 
 <		To get lines from another buffer see |getbufline()| and
 		|getbufoneline()|
@@ -3028,10 +2620,6 @@ getmarklist([{buf}])                                             *getmarklist()*
 
 		Refer to |getpos()| for getting information about a specific
 		mark.
-
-		Can also be used as a |method|: >vim
-			GetBufnr()->getmarklist()
-<
 
 getmatches([{win}])                                               *getmatches()*
 		Returns a |List| with all matches previously defined for the
@@ -3126,10 +2714,6 @@ getpos({expr})                                                        *getpos()*
 			" ...
 			call setpos("'a", save_a_mark)
 <		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
-
-		Can also be used as a |method|: >vim
-			GetMark()->getpos()
-<
 
 getqflist([{what}])                                                *getqflist()*
 		Returns a |List| with all the current quickfix errors.  Each
@@ -3255,10 +2839,6 @@ getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
 
 		If {regname} is not specified, |v:register| is used.
 
-		Can also be used as a |method|: >vim
-			GetRegname()->getreg()
-<
-
 getreginfo([{regname}])                                           *getreginfo()*
 		Returns detailed information about register {regname} as a
 		Dictionary with the following entries:
@@ -3283,10 +2863,6 @@ getreginfo([{regname}])                                           *getreginfo()*
 		If {regname} is not specified, |v:register| is used.
 		The returned Dictionary can be passed to |setreg()|.
 
-		Can also be used as a |method|: >vim
-			GetRegname()->getreginfo()
-<
-
 getregtype([{regname}])                                           *getregtype()*
 		The result is a String, which is type of register {regname}.
 		The value will be one of:
@@ -3297,10 +2873,6 @@ getregtype([{regname}])                                           *getregtype()*
 		<CTRL-V> is one character with value 0x16.
 		The {regname} argument is a string.  If {regname} is not
 		specified, |v:register| is used.
-
-		Can also be used as a |method|: >vim
-			GetRegname()->getregtype()
-<
 
 getscriptinfo([{opts}])                                        *getscriptinfo()*
 		Returns a |List| with information about all the sourced Vim
@@ -3352,10 +2924,6 @@ gettabinfo([{tabnr}])                                             *gettabinfo()*
 					tabpage-local variables
 			windows		List of |window-ID|s in the tab page.
 
-		Can also be used as a |method|: >vim
-			GetTabnr()->gettabinfo()
-<
-
 gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
 		Get the value of a tab-local variable {varname} in tab page
 		{tabnr}. |t:var|
@@ -3365,10 +2933,6 @@ gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
 		Note that the name without "t:" must be used.
 		When the tab or variable doesn't exist {def} or an empty
 		string is returned, there is no error message.
-
-		Can also be used as a |method|: >vim
-			GetTabnr()->gettabvar(varname)
-<
 
 gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
 		Get the value of window-local variable {varname} in window
@@ -3395,9 +2959,6 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
 <
 		To obtain all window-local variables use: >vim
 			gettabwinvar({tabnr}, {winnr}, '&')
-<
-		Can also be used as a |method|: >vim
-			GetTabnr()->gettabwinvar(winnr, varname)
 <
 
 gettagstack([{winnr}])                                           *gettagstack()*
@@ -3427,10 +2988,6 @@ gettagstack([{winnr}])                                           *gettagstack()*
 			tagname		name of the tag
 
 		See |tagstack| for more information about the tag stack.
-
-		Can also be used as a |method|: >vim
-			GetWinnr()->gettagstack()
-<
 
 gettext({text})                                                      *gettext()*
 		Translate String {text} if possible.
@@ -3477,10 +3034,6 @@ getwininfo([{winid}])                                             *getwininfo()*
 			winrow		topmost screen line of the window;
 					"row" from |win_screenpos()|
 
-		Can also be used as a |method|: >vim
-			GetWinnr()->getwininfo()
-<
-
 getwinpos([{timeout}])                                             *getwinpos()*
 		The result is a |List| with two numbers, the result of
 		|getwinposx()| and |getwinposy()| combined:
@@ -3501,9 +3054,6 @@ getwinpos([{timeout}])                                             *getwinpos()*
 			  " Do some work here
 			endwhile
 <
-		Can also be used as a |method|: >vim
-			GetTimeout()->getwinpos()
-<
 
 getwinposx()                                                      *getwinposx()*
 		The result is a Number, which is the X coordinate in pixels of
@@ -3522,10 +3072,6 @@ getwinvar({winnr}, {varname} [, {def}])                            *getwinvar()*
 		Examples: >vim
 			let list_is_on = getwinvar(2, '&list')
 			echo "myvar = " .. getwinvar(1, 'myvar')
-
-<		Can also be used as a |method|: >vim
-			GetWinnr()->getwinvar(varname)
-<
 
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
 		Expand the file wildcards in {expr}.  See |wildcards| for the
@@ -3563,10 +3109,6 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
 		See |expand()| for expanding special Vim variables.  See
 		|system()| for getting the raw output of an external command.
 
-		Can also be used as a |method|: >vim
-			GetExpr()->glob()
-<
-
 glob2regpat({string})                                            *glob2regpat()*
 		Convert a file pattern, as used by glob(), into a search
 		pattern.  The result can be used to match with a string that
@@ -3582,10 +3124,6 @@ glob2regpat({string})                                            *glob2regpat()*
 		empty string.
 		Note that the result depends on the system.  On MS-Windows
 		a backslash usually means a path separator.
-
-		Can also be used as a |method|: >vim
-			GetExpr()->glob2regpat()
-<
 
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 		Perform glob() for String {expr} on all directories in {path}
@@ -3621,11 +3159,6 @@ globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 			echo globpath(&rtp, "**/README.txt")
 <		Upwards search and limiting the depth of "**" is not
 		supported, thus using 'path' will not always work properly.
-
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetExpr()->globpath(&rtp)
-<
 
 has({feature})                                                           *has()*
 		Returns 1 if {feature} is supported, 0 otherwise.  The
@@ -3700,10 +3233,6 @@ has_key({dict}, {key})                                               *has_key()*
 		has an entry with key {key}.  FALSE otherwise. The {key}
 		argument is a string.
 
-		Can also be used as a |method|: >vim
-			mydict->has_key(key)
-<
-
 haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
 		The result is a Number, which is 1 when the window has set a
 		local path via |:lcd| or when {winnr} is -1 and the tabpage
@@ -3720,10 +3249,6 @@ haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
 		{winnr} can be the window number or the |window-ID|.
 		If {winnr} is -1 it is ignored, only the tab is resolved.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
-
-		Can also be used as a |method|: >vim
-			GetWinnr()->haslocaldir()
-<
 
 hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
 		The result is a Number, which is TRUE if there is a mapping
@@ -3756,10 +3281,6 @@ hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
 <		This installs the mapping to "\ABCdoit" only if there isn't
 		already a mapping to "\ABCdoit".
 
-		Can also be used as a |method|: >vim
-			GetRHS()->hasmapto()
-<
-
 histadd({history}, {item})                                           *histadd()*
 		Add the String {item} to the history {history} which can be
 		one of:					*hist-names*
@@ -3780,11 +3301,6 @@ histadd({history}, {item})                                           *histadd()*
 			call histadd("input", strftime("%Y %b %d"))
 			let date=input("Enter date: ")
 <		This function is not available in the |sandbox|.
-
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetHistory()->histadd('search')
-<
 
 histdel({history} [, {item}])                                        *histdel()*
 		Clear {history}, i.e. delete all its entries.  See |hist-names|
@@ -3818,9 +3334,6 @@ histdel({history} [, {item}])                                        *histdel()*
 			call histdel("search", -1)
 			let @/ = histget("search", -1)
 <
-		Can also be used as a |method|: >vim
-			GetHistory()->histdel()
-<
 
 histget({history} [, {index}])                                       *histget()*
 		The result is a String, the entry with Number {index} from
@@ -3837,9 +3350,6 @@ histget({history} [, {index}])                                       *histget()*
 		the {num}th entry from the output of |:history|. >vim
 			command -nargs=1 H execute histget("cmd", 0+<args>)
 <
-		Can also be used as a |method|: >vim
-			GetHistory()->histget()
-<
 
 histnr({history})                                                     *histnr()*
 		The result is the Number of the current entry in {history}.
@@ -3848,10 +3358,6 @@ histnr({history})                                                     *histnr()*
 
 		Example: >vim
 			let inp_index = histnr("expr")
-
-<		Can also be used as a |method|: >vim
-			GetHistory()->histnr()
-<
 
 hlID({name})                                                            *hlID()*
 		The result is a Number, which is the ID of the highlight group
@@ -3862,9 +3368,6 @@ hlID({name})                                                            *hlID()*
 		"Comment" group: >vim
 			echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 <
-		Can also be used as a |method|: >vim
-			GetName()->hlID()
-<
 
 hlexists({name})                                                    *hlexists()*
 		The result is a Number, which is TRUE if a highlight group
@@ -3872,10 +3375,6 @@ hlexists({name})                                                    *hlexists()*
 		defined in some way.  Not necessarily when highlighting has
 		been defined for it, it may also have been used for a syntax
 		item.
-
-		Can also be used as a |method|: >vim
-			GetName()->hlexists()
-<
 
 hostname()                                                          *hostname()*
 		The result is a String, which is the name of the machine on
@@ -3893,10 +3392,6 @@ iconv({string}, {from}, {to})                                          *iconv()*
 		Note that Vim uses UTF-8 for all Unicode encodings, conversion
 		from/to UCS-2 is automatically changed to use UTF-8.  You
 		cannot use UCS-2 in a string anyway, because of the NUL bytes.
-
-		Can also be used as a |method|: >vim
-			GetText()->iconv('latin1', 'utf-8')
-<
 
 id({expr})                                                                *id()*
 		Returns a |String| which is a unique identifier of the
@@ -3920,10 +3415,6 @@ indent({lnum})                                                        *indent()*
 		of 'tabstop' is relevant.  {lnum} is used just like in
 		|getline()|.
 		When {lnum} is invalid -1 is returned.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->indent()
-<
 
 index({object}, {expr} [, {start} [, {ic}]])                           *index()*
 		Find {expr} in {object} and return its index.  See
@@ -3951,10 +3442,6 @@ index({object}, {expr} [, {start} [, {ic}]])                           *index()*
 			if index(numbers, 123) >= 0
 			  " ...
 			endif
-
-<		Can also be used as a |method|: >vim
-			GetObject()->index(what)
-<
 
 indexof({object}, {expr} [, {opts}])                                 *indexof()*
 		Returns the index of an item in {object} where {expr} is
@@ -3993,10 +3480,6 @@ indexof({object}, {expr} [, {opts}])                                 *indexof()*
 			echo indexof(l, "v:val.n == 20")
 			echo indexof(l, {i, v -> v.n == 30})
 			echo indexof(l, "v:val.n == 20", #{startidx: 1})
-
-<		Can also be used as a |method|: >vim
-			mylist->indexof(expr)
-<
 
 input({prompt} [, {text} [, {completion}]])                            *input()*
 
@@ -4110,10 +3593,6 @@ input({opts})
 			  call inputrestore()
 			endfunction
 
-<		Can also be used as a |method|: >vim
-			GetPrompt()->input()
-<
-
 inputlist({textlist})                                              *inputlist()*
 		{textlist} must be a |List| of strings.  This |List| is
 		displayed, one string per line.  The user will be prompted to
@@ -4130,10 +3609,6 @@ inputlist({textlist})                                              *inputlist()*
 		Example: >vim
 			let color = inputlist(['Select color:', '1. red',
 				\ '2. green', '3. blue'])
-
-<		Can also be used as a |method|: >vim
-			GetChoices()->inputlist()
-<
 
 inputrestore()                                                  *inputrestore()*
 		Restore typeahead that was saved with a previous |inputsave()|.
@@ -4160,10 +3635,6 @@ inputsecret({prompt} [, {text}])                                 *inputsecret()*
 		typed on the command-line in response to the issued prompt.
 		NOTE: Command-line completion is not supported.
 
-		Can also be used as a |method|: >vim
-			GetPrompt()->inputsecret()
-<
-
 insert({object}, {item} [, {idx}])                                    *insert()*
 		When {object} is a |List| or a |Blob| insert {item} at the start
 		of it.
@@ -4181,10 +3652,6 @@ insert({object}, {item} [, {idx}])                                    *insert()*
 		Note that when {item} is a |List| it is inserted as a single
 		item.  Use |extend()| to concatenate |Lists|.
 
-		Can also be used as a |method|: >vim
-			mylist->insert(item)
-<
-
 interrupt()                                                        *interrupt()*
 		Interrupt script execution.  It works more or less like the
 		user typing CTRL-C, most commands won't execute and control
@@ -4201,21 +3668,12 @@ interrupt()                                                        *interrupt()*
 
 invert({expr})                                                        *invert()*
 		Bitwise invert.  The argument is converted to a number.  A
-		List, Dict or Float argument causes an error.  Example: >vim
-			let bits = invert(bits)
-<		Can also be used as a |method|: >vim
-			let bits = bits->invert()
-<
 
 isdirectory({directory})                                         *isdirectory()*
 		The result is a Number, which is |TRUE| when a directory
 		with the name {directory} exists.  If {directory} doesn't
 		exist, or isn't a directory, the result is |FALSE|.  {directory}
 		is any expression, which is used as a String.
-
-		Can also be used as a |method|: >vim
-			GetName()->isdirectory()
-<
 
 isinf({expr})                                                          *isinf()*
 		Return 1 if {expr} is a positive infinity, or -1 a negative
@@ -4224,10 +3682,6 @@ isinf({expr})                                                          *isinf()*
 <			1 >vim
 			echo isinf(-1.0 / 0.0)
 <			-1
-
-		Can also be used as a |method|: >vim
-			Compute()->isinf()
-<
 
 islocked({expr})                                               *islocked()* *E786*
 		The result is a Number, which is |TRUE| when {expr} is the
@@ -4243,18 +3697,10 @@ islocked({expr})                                               *islocked()* *E78
 <		When {expr} is a variable that does not exist you get an error
 		message.  Use |exists()| to check for existence.
 
-		Can also be used as a |method|: >vim
-			GetName()->islocked()
-<
-
 isnan({expr})                                                          *isnan()*
 		Return |TRUE| if {expr} is a float with value NaN. >vim
 			echo isnan(0.0 / 0.0)
 <			1
-
-		Can also be used as a |method|: >vim
-			Compute()->isnan()
-<
 
 items({dict})                                                          *items()*
 		Return a |List| with all the key-value pairs of {dict}.  Each
@@ -4265,10 +3711,6 @@ items({dict})                                                          *items()*
 			for [key, value] in items(mydict)
 			   echo key .. ': ' .. value
 			endfor
-
-<		Can also be used as a |method|: >vim
-			mydict->items()
-<
 
 jobpid({job})                                                         *jobpid()*
 		Return the PID (process id) of |job-id| {job}.
@@ -4406,10 +3848,6 @@ join({list} [, {sep}])                                                  *join()*
 		converted into a string like with |string()|.
 		The opposite function is |split()|.
 
-		Can also be used as a |method|: >vim
-			mylist->join()
-<
-
 json_decode({expr})                                              *json_decode()*
 		Convert {expr} from JSON object.  Accepts |readfile()|-style
 		list as the input, as well as regular string.  May output any
@@ -4426,10 +3864,6 @@ json_decode({expr})                                              *json_decode()*
 		recommended and the only one required to be supported.
 		Non-UTF-8 characters are an error.
 
-		Can also be used as a |method|: >vim
-			ReadObject()->json_decode()
-<
-
 json_encode({expr})                                              *json_encode()*
 		Convert {expr} into a JSON string.  Accepts
 		|msgpack-special-dict| as the input.  Will not convert
@@ -4442,17 +3876,9 @@ json_encode({expr})                                              *json_encode()*
 		or special escapes like "\t", other are dumped as-is.
 		|Blob|s are converted to arrays of the individual bytes.
 
-		Can also be used as a |method|: >vim
-			GetObject()->json_encode()
-<
-
 keys({dict})                                                            *keys()*
 		Return a |List| with all the keys of {dict}.  The |List| is in
 		arbitrary order.  Also see |items()| and |values()|.
-
-		Can also be used as a |method|: >vim
-			mydict->keys()
-<
 
 keytrans({string})                                                  *keytrans()*
 		Turn the internal byte representation of keys into a form that
@@ -4460,10 +3886,6 @@ keytrans({string})                                                  *keytrans()*
 			let xx = "\<C-Home>"
 			echo keytrans(xx)
 <			<C-Home>
-
-		Can also be used as a |method|: >vim
-			"\<C-Home>"->keytrans()
-<
 
 len({expr})                                                         *len()* *E701*
 		When {expr} is a String or a Number the length in bytes is
@@ -4474,10 +3896,6 @@ len({expr})                                                         *len()* *E70
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
 		Otherwise an error is given and returns zero.
-
-		Can also be used as a |method|: >vim
-			mylist->len()
-<
 
 libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E368*
 		Call function {funcname} in the run-time library {libname}
@@ -4521,11 +3939,6 @@ libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E
 		Examples: >vim
 			echo libcall("libc.so", "getenv", "HOME")
 
-<		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetValue()->libcall("libc.so", "getenv")
-<
-
 libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
 		Just like |libcall()|, but used for a function that returns an
 		int instead of a string.
@@ -4533,10 +3946,6 @@ libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
 			echo libcallnr("/usr/lib/libc.so", "getpid", "")
 			call libcallnr("libc.so", "printf", "Hello World!\n")
 			call libcallnr("libc.so", "sleep", 10)
-<
-		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetValue()->libcallnr("libc.so", "printf")
 <
 
 line({expr} [, {winid}])                                                *line()*
@@ -4571,10 +3980,6 @@ line({expr} [, {winid}])                                                *line()*
 		To jump to the last known position when opening a file see
 		|last-position-jump|.
 
-		Can also be used as a |method|: >vim
-			GetValue()->line()
-<
-
 line2byte({lnum})                                                  *line2byte()*
 		Return the byte count from the start of the buffer for line
 		{lnum}.  This includes the end-of-line character, depending on
@@ -4588,20 +3993,12 @@ line2byte({lnum})                                                  *line2byte()*
 		|getline()|.  When {lnum} is invalid -1 is returned.
 		Also see |byte2line()|, |go| and |:goto|.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->line2byte()
-<
-
 lispindent({lnum})                                                *lispindent()*
 		Get the amount of indent for line {lnum} according the lisp
 		indenting rules, as with 'lisp'.
 		The indent is counted in spaces, the value of 'tabstop' is
 		relevant.  {lnum} is used just like in |getline()|.
 		When {lnum} is invalid, -1 is returned.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->lispindent()
-<
 
 list2blob({list})                                                  *list2blob()*
 		Return a Blob concatenating all the number values in {list}.
@@ -4612,10 +4009,6 @@ list2blob({list})                                                  *list2blob()*
 		negative or more than 255 error *E1239* is given.
 
 		|blob2list()| does the opposite.
-
-		Can also be used as a |method|: >vim
-			GetList()->list2blob()
-<
 
 list2str({list} [, {utf8}])                                         *list2str()*
 		Convert each number in {list} to a character string can
@@ -4633,10 +4026,6 @@ list2str({list} [, {utf8}])                                         *list2str()*
 <
 		Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			GetList()->list2str()
-<
-
 localtime()                                                        *localtime()*
 		Return the current time, measured as seconds since 1st Jan
 		1970.  See also |strftime()|, |strptime()| and |getftime()|.
@@ -4652,10 +4041,6 @@ log({expr})                                                              *log()*
 			echo log(exp(5))
 <			5.0
 
-		Can also be used as a |method|: >vim
-			Compute()->log()
-<
-
 log10({expr})                                                          *log10()*
 		Return the logarithm of Float {expr} to base 10 as a |Float|.
 		{expr} must evaluate to a |Float| or a |Number|.
@@ -4666,17 +4051,9 @@ log10({expr})                                                          *log10()*
 			echo log10(0.01)
 <			-2.0
 
-		Can also be used as a |method|: >vim
-			Compute()->log10()
-<
-
 luaeval({expr} [, {expr}])                                           *luaeval()*
 		Evaluate Lua expression {expr} and return its result converted
 		to Vim data structures. See |lua-eval| for more details.
-
-		Can also be used as a |method|: >vim
-			GetExpr()->luaeval()
-<
 
 map({expr1}, {expr2})                                                    *map()*
 		{expr1} must be a |List|, |Blob| or |Dictionary|.
@@ -4724,10 +4101,6 @@ map({expr1}, {expr2})                                                    *map()*
 		{expr2} no further items in {expr1} are processed.  When
 		{expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
-
-		Can also be used as a |method|: >vim
-			mylist->map(expr2)
-<
 
 maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		When {dict} is omitted or zero: Return the rhs of mapping
@@ -4793,10 +4166,6 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		mapped, and have it do the original mapping too.  Sketch: >vim
 			exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
-<		Can also be used as a |method|: >vim
-			GetKey()->maparg('n')
-<
-
 mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
 		Check if there is a mapping that matches with {name} in mode
 		{mode}.  See |maparg()| for {mode} and special names in
@@ -4829,10 +4198,6 @@ mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
 			endif
 <		This avoids adding the "_vv" mapping when there already is a
 		mapping for "_v" or for "_vvv".
-
-		Can also be used as a |method|: >vim
-			GetKey()->mapcheck('n')
-<
 
 mapset({mode}, {abbr}, {dict})                                        *mapset()*
 		Restore a mapping from a dictionary returned by |maparg()|.
@@ -4911,11 +4276,6 @@ match({expr}, {pat} [, {start} [, {count}]])                           *match()*
 		zero matches at the start instead of a number of matches
 		further down in the text.
 
-		Can also be used as a |method|: >vim
-			GetText()->match('word')
-			GetList()->match('word')
-<
-
                                                 *matchadd()* *E798* *E799* *E801* *E957*
 matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		Defines a pattern to be highlighted in the current window (a
@@ -4975,10 +4335,6 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		available from |getmatches()|.  All matches can be deleted in
 		one operation by |clearmatches()|.
 
-		Can also be used as a |method|: >vim
-			GetGroup()->matchadd('TODO')
-<
-
 matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 		Same as |matchadd()|, but requires a list of positions {pos}
 		instead of a pattern. This command is faster than |matchadd()|
@@ -5016,10 +4372,6 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 <		Matches added by |matchaddpos()| are returned by
 		|getmatches()|.
 
-		Can also be used as a |method|: >vim
-			GetGroup()->matchaddpos([23, 11])
-<
-
 matcharg({nr})                                                      *matcharg()*
 		Selects the {nr} match item, as set with a |:match|,
 		|:2match| or |:3match| command.
@@ -5032,10 +4384,6 @@ matcharg({nr})                                                      *matcharg()*
 		Highlighting matches using the |:match| commands are limited
 		to three matches. |matchadd()| does not have this limitation.
 
-		Can also be used as a |method|: >vim
-			GetMatch()->matcharg()
-<
-
 matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E803*
 		Deletes a match with ID {id} previously defined by |matchadd()|
 		or one of the |:match| commands.  Returns 0 if successful,
@@ -5043,10 +4391,6 @@ matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E
 		be deleted in one operation by |clearmatches()|.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
-
-		Can also be used as a |method|: >vim
-			GetMatch()->matchdelete()
-<
 
 matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
 		Same as |match()|, but return the index of first character
@@ -5066,10 +4410,6 @@ matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
 			echo matchend("testing", "ing", 5)
 <		result is "-1".
 		When {expr} is a |List| the result is equal to |match()|.
-
-		Can also be used as a |method|: >vim
-			GetText()->matchend('word')
-<
 
 matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
@@ -5168,10 +4508,6 @@ matchlist({expr}, {pat} [, {start} [, {count}]])                   *matchlist()*
 
 		You can pass in a List, but that is not very useful.
 
-		Can also be used as a |method|: >vim
-			GetText()->matchlist('word')
-<
-
 matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
 		Same as |match()|, but return the matched string.  Example: >vim
 			echo matchstr("testing", "ing")
@@ -5184,10 +4520,6 @@ matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
 <		result is "".
 		When {expr} is a |List| then the matching item is returned.
 		The type isn't changed, it's not necessarily a String.
-
-		Can also be used as a |method|: >vim
-			GetText()->matchstr('word')
-<
 
 matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
 		Same as |matchstr()|, but return the matched string, the start
@@ -5207,10 +4539,6 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
 <		result is ["x", 1, 2, 3].
 		The type isn't changed, it's not necessarily a String.
 
-		Can also be used as a |method|: >vim
-			GetText()->matchstrpos('word')
-<
-
 max({expr})                                                              *max()*
 		Return the maximum value of all items in {expr}. Example: >vim
 			echo max([apples, pears, oranges])
@@ -5220,10 +4548,6 @@ max({expr})                                                              *max()*
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
 		                an error.  An empty |List| or |Dictionary| results in zero.
-
-		Can also be used as a |method|: >vim
-			mylist->max()
-<
 
 menu_get({path} [, {modes}])                                        *menu_get()*
 		Returns a |List| of |Dictionaries| describing |menus| (defined
@@ -5341,9 +4665,6 @@ menu_info({name} [, {mode}])                                       *menu_info()*
 			  call ShowMenu(topmenu, '')
 			endfor
 <
-		Can also be used as a |method|: >vim
-			GetMenuName()->menu_info('v')
-<
 
 min({expr})                                                              *min()*
 		Return the minimum value of all items in {expr}. Example: >vim
@@ -5354,10 +4675,6 @@ min({expr})                                                              *min()*
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
 		an error.  An empty |List| or |Dictionary| results in zero.
-
-		Can also be used as a |method|: >vim
-			mylist->min()
-<
 
 mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
 		Create directory {name}.
@@ -5401,10 +4718,6 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		The function result is a Number, which is TRUE if the call was
 		successful or FALSE if the directory creation failed or partly
 		failed.
-
-		Can also be used as a |method|: >vim
-			GetName()->mkdir()
-<
 
 mode([expr])                                                            *mode()*
 		Return a string that indicates the current mode.
@@ -5456,10 +4769,6 @@ mode([expr])                                                            *mode()*
 		be added. It's better not to compare the whole string but only
 		the leading character(s).
 		Also see |visualmode()|.
-
-		Can also be used as a |method|: >vim
-			DoFull()->mode()
-<
 
 msgpackdump({list} [, {type}])                                   *msgpackdump()*
 		Convert a list of Vimscript objects to msgpack. Returned value is a
@@ -5563,10 +4872,6 @@ nextnonblank({lnum})                                            *nextnonblank()*
 		{lnum} is used like with |getline()|.
 		See also |prevnonblank()|.
 
-		Can also be used as a |method|: >vim
-			GetLnum()->nextnonblank()
-<
-
 nr2char({expr} [, {utf8}])                                           *nr2char()*
 		Return a string with a single character, which has the number
 		value {expr}.  Examples: >vim
@@ -5581,10 +4886,6 @@ nr2char({expr} [, {utf8}])                                           *nr2char()*
 		nr2char(10), because NULs are represented with newline
 		characters.  nr2char(0) is a real NUL and terminates the
 		string, thus results in an empty string.
-
-		Can also be used as a |method|: >vim
-			GetNumber()->nr2char()
-<
 
 nvim_...({...})                                      *nvim_...()* *E5555* *eval-api*
 		Call nvim |api| functions. The type checking of arguments will
@@ -5603,8 +4904,6 @@ or({expr}, {expr})                                                        *or()*
 		Also see `and()` and `xor()`.
 		Example: >vim
 			let bits = or(bits, 0x80)
-<		Can also be used as a |method|: >vim
-			let bits = bits->or(0x80)
 
 <		Rationale: The reason this is a function and not using the "|"
 		character like many languages, is that Vi has always used "|"
@@ -5625,10 +4924,6 @@ pathshorten({path} [, {len}])                                    *pathshorten()*
 		It doesn't matter if the path exists or not.
 		Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			GetDirectories()->pathshorten()
-<
-
 perleval({expr})                                                    *perleval()*
 		Evaluate |perl| expression {expr} and return its result
 		converted to Vim data structures.
@@ -5644,10 +4939,6 @@ perleval({expr})                                                    *perleval()*
 			echo perleval('[1 .. 4]')
 <			[1, 2, 3, 4]
 
-		Can also be used as a |method|: >vim
-			GetExpr()->perleval()
-<
-
 pow({x}, {y})                                                            *pow()*
 		Return the power of {x} to the exponent {y} as a |Float|.
 		{x} and {y} must evaluate to a |Float| or a |Number|.
@@ -5660,10 +4951,6 @@ pow({x}, {y})                                                            *pow()*
 			echo pow(32, 0.20)
 <			2.0
 
-		Can also be used as a |method|: >vim
-			Compute()->pow(3)
-<
-
 prevnonblank({lnum})                                            *prevnonblank()*
 		Return the line number of the first line at or above {lnum}
 		that is not blank.  Example: >vim
@@ -5672,10 +4959,6 @@ prevnonblank({lnum})                                            *prevnonblank()*
 		above it, zero is returned.
 		{lnum} is used like with |getline()|.
 		Also see |nextnonblank()|.
-
-		Can also be used as a |method|: >vim
-			GetLnum()->prevnonblank()
-<
 
 printf({fmt}, {expr1} ...)                                            *printf()*
 		Return a String with {fmt}, where "%" items are replaced by
@@ -5884,10 +5167,6 @@ prompt_getprompt({buf})                                     *prompt_getprompt()*
 		If the buffer doesn't exist or isn't a prompt buffer, an empty
 		string is returned.
 
-		Can also be used as a |method|: >vim
-			GetBuffer()->prompt_getprompt()
-<
-
 prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
 		Set prompt callback for buffer {buf} to {expr}.  When {expr}
 		is an empty string the callback is removed.  This has only
@@ -5920,10 +5199,6 @@ prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
 		   endfunc
 		   call prompt_setcallback(bufnr(), function('s:TextEntered'))
 
-<		Can also be used as a |method|: >vim
-			GetBuffer()->prompt_setcallback(callback)
-<
-
 prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
 		Set a callback for buffer {buf} to {expr}.  When {expr} is an
 		empty string the callback is removed.  This has only effect if
@@ -5933,19 +5208,12 @@ prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
 		mode.  Without setting a callback Vim will exit Insert mode,
 		as in any buffer.
 
-		Can also be used as a |method|: >vim
-			GetBuffer()->prompt_setinterrupt(callback)
-<
-
 prompt_setprompt({buf}, {text})                             *prompt_setprompt()*
 		Set prompt for buffer {buf} to {text}.  You most likely want
 		{text} to end in a space.
 		The result is only visible if {buf} has 'buftype' set to
 		"prompt".  Example: >vim
 			call prompt_setprompt(bufnr(''), 'command: ')
-<
-		Can also be used as a |method|: >vim
-			GetBuffer()->prompt_setprompt('command: ')
 <
 
 pum_getpos()                                                      *pum_getpos()*
@@ -5977,10 +5245,6 @@ py3eval({expr})                                                      *py3eval()*
 		Dictionaries are represented as Vim |Dictionary| type with
 		keys converted to strings.
 
-		Can also be used as a |method|: >vim
-			GetExpr()->py3eval()
-<
-
 pyeval({expr})                                              *pyeval()* *E858* *E859*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
@@ -5990,19 +5254,11 @@ pyeval({expr})                                              *pyeval()* *E858* *E
 		Dictionaries are represented as Vim |Dictionary| type,
 		non-string keys result in error.
 
-		Can also be used as a |method|: >vim
-			GetExpr()->pyeval()
-<
-
 pyxeval({expr})                                                      *pyxeval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
 		Uses Python 2 or 3, see |python_x| and 'pyxversion'.
 		See also: |pyeval()|, |py3eval()|
-
-		Can also be used as a |method|: >vim
-			GetExpr()->pyxeval()
-<
 
 rand([{expr}])                                                          *rand()*
 		Return a pseudo-random Number generated with an xoshiro128**
@@ -6018,9 +5274,6 @@ rand([{expr}])                                                          *rand()*
 			let seed = srand()
 			echo rand(seed)
 			echo rand(seed) % 16  " random number 0 - 15
-<
-		Can also be used as a |method|: >vim
-			seed->rand()
 <
 
 range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E727*
@@ -6040,9 +5293,6 @@ range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E
 			echo range(2, -2, -1)	" [2, 1, 0, -1, -2]
 			echo range(0)		" []
 			echo range(2, 0)		" error!
-<
-		Can also be used as a |method|: >vim
-			GetExpr()->range()
 <
 
 readblob({fname} [, {offset} [, {size}]])                           *readblob()*
@@ -6099,10 +5349,6 @@ readdir({directory} [, {expr}])                                      *readdir()*
 <
 		Returns an empty List on error.
 
-		Can also be used as a |method|: >vim
-			GetDirName()->readdir()
-<
-
 readfile({fname} [, {type} [, {max}]])                              *readfile()*
 		Read file {fname} and return a |List|, each line of the file
 		as an item.  Lines are broken at NL characters.  Macintosh
@@ -6136,10 +5382,6 @@ readfile({fname} [, {type} [, {max}]])                              *readfile()*
 		the result is an empty list.
 		Also see |writefile()|.
 
-		Can also be used as a |method|: >vim
-			GetFileName()->readfile()
-<
-
 reduce({object}, {func} [, {initial}])                           *reduce()* *E998*
 		{func} is called for every item in {object}, which can be a
 		|List| or a |Blob|.  {func} is called with two arguments: the
@@ -6155,9 +5397,6 @@ reduce({object}, {func} [, {initial}])                           *reduce()* *E99
 			echo reduce([1, 3, 5], { acc, val -> acc + val })
 			echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
 			echo reduce(0z1122, { acc, val -> 2 * acc + val })
-<
-		Can also be used as a |method|: >vim
-			echo mylist->reduce({ acc, val -> acc + val }, 0)
 <
 
 reg_executing()                                                *reg_executing()*
@@ -6194,9 +5433,6 @@ reltime({start}, {end})                                              *reltime()*
 		The {start} and {end} arguments must be values returned by
 		reltime().  Returns zero on error.
 
-		Can also be used as a |method|: >vim
-			GetStart()->reltime()
-<
 		Note: |localtime()| returns the current (non-relative) time.
 
 reltimefloat({time})                                            *reltimefloat()*
@@ -6209,10 +5445,6 @@ reltimefloat({time})                                            *reltimefloat()*
 		See the note of reltimestr() about overhead.
 		Also see |profiling|.
 		If there is an error an empty string is returned
-
-		Can also be used as a |method|: >vim
-			reltime(start)->reltimefloat()
-<
 
 reltimestr({time})                                                *reltimestr()*
 		Return a String that represents the time value of {time}.
@@ -6227,10 +5459,6 @@ reltimestr({time})                                                *reltimestr()*
 			echo split(reltimestr(reltime(start)))[0]
 <		Also see |profiling|.
 		If there is an error an empty string is returned
-
-		Can also be used as a |method|: >vim
-			echo reltime(start)->reltimestr()
-<
 
 remove({list}, {idx})
 remove({list}, {idx}, {end})                                          *remove()*
@@ -6247,10 +5475,6 @@ remove({list}, {idx}, {end})                                          *remove()*
 			call remove(mylist, 0, 9)
 <
 		Use |delete()| to remove a file.
-
-		Can also be used as a |method|: >vim
-			mylist->remove(idx)
-<
 
 remove({blob}, {idx})
 remove({blob}, {idx}, {end})
@@ -6281,10 +5505,6 @@ rename({from}, {to})                                                  *rename()*
 		NOTE: If {to} exists it is overwritten without warning.
 		This function is not available in the |sandbox|.
 
-		Can also be used as a |method|: >vim
-			GetOldName()->rename(newname)
-<
-
 repeat({expr}, {count})                                               *repeat()*
 		Repeat {expr} {count} times and return the concatenated
 		result.  Example: >vim
@@ -6294,10 +5514,6 @@ repeat({expr}, {count})                                               *repeat()*
 		concatenated {count} times.  Example: >vim
 			let longlist = repeat(['a', 'b'], 3)
 <		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
-
-		Can also be used as a |method|: >vim
-			mylist->repeat(count)
-<
 
 resolve({filename})                                             *resolve()* *E655*
 		On MS-Windows, when {filename} is a shortcut (a .lnk file),
@@ -6312,20 +5528,11 @@ resolve({filename})                                             *resolve()* *E65
 		current directory (provided the result is still a relative
 		path name) and also keeps a trailing path separator.
 
-		Can also be used as a |method|: >vim
-			GetName()->resolve()
-<
-
 reverse({object})                                                    *reverse()*
 		Reverse the order of items in {object} in-place.
 		{object} can be a |List| or a |Blob|.
 		Returns {object}.
 		Returns zero if {object} is not a List or a Blob.
-		If you want an object to remain unmodified make a copy first: >vim
-			let revlist = reverse(copy(mylist))
-<		Can also be used as a |method|: >vim
-			mylist->reverse()
-<
 
 round({expr})                                                          *round()*
 		Round off {expr} to the nearest integral value and return it
@@ -6340,10 +5547,6 @@ round({expr})                                                          *round()*
 <			5.0 >vim
 			echo round(-4.5)
 <			-5.0
-
-		Can also be used as a |method|: >vim
-			Compute()->round()
-<
 
 rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
 		Sends {event} to {channel} via |RPC| and returns immediately.
@@ -6376,19 +5579,11 @@ rubyeval({expr})                                                    *rubyeval()*
 		Other objects are represented as strings resulted from their
 		"Object#to_s" method.
 
-		Can also be used as a |method|: >vim
-			GetRubyExpr()->rubyeval()
-<
-
 screenattr({row}, {col})                                          *screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the
 		attribute at other positions.
 		Returns -1 when row or col is out of range.
-
-		Can also be used as a |method|: >vim
-			GetRow()->screenattr(col)
-<
 
 screenchar({row}, {col})                                          *screenchar()*
 		The result is a Number, which is the character at position
@@ -6400,20 +5595,12 @@ screenchar({row}, {col})                                          *screenchar()*
 		This is mainly to be used for testing.
 		Returns -1 when row or col is out of range.
 
-		Can also be used as a |method|: >vim
-			GetRow()->screenchar(col)
-<
-
 screenchars({row}, {col})                                        *screenchars()*
 		The result is a List of Numbers.  The first number is the same
 		as what |screenchar()| returns.  Further numbers are
 		composing characters on top of the base character.
 		This is mainly to be used for testing.
 		Returns an empty List when row or col is out of range.
-
-		Can also be used as a |method|: >vim
-			GetRow()->screenchars(col)
-<
 
 screencol()                                                        *screencol()*
 		The result is a Number, which is the current screen column of
@@ -6454,10 +5641,6 @@ screenpos({winid}, {lnum}, {col})                                  *screenpos()*
 		first character is returned, {col} is not used.
 		Returns an empty Dict if {winid} is invalid.
 
-		Can also be used as a |method|: >vim
-			GetWinid()->screenpos(lnum, col)
-<
-
 screenrow()                                                        *screenrow()*
 		The result is a Number, which is the current screen row of the
 		cursor.  The top line has number one.
@@ -6473,10 +5656,6 @@ screenstring({row}, {col})                                      *screenstring()*
 		characters.
 		This is mainly to be used for testing.
 		Returns an empty String when row or col is out of range.
-
-		Can also be used as a |method|: >vim
-			GetRow()->screenstring(col)
-<
 
 search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		Search for regexp pattern {pattern}.  The search starts at the
@@ -6578,10 +5757,6 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		finds the "endif" and returns 3.  The same thing happens
 		without the 'e' flag if the cursor is on the "f" of "if".
 		The 'n' flag tells the function not to move the cursor.
-
-		Can also be used as a |method|: >vim
-			GetPattern()->search()
-<
 
 searchcount([{options}])                                         *searchcount()*
 		Get or update the last search count, like what is displayed
@@ -6704,10 +5879,6 @@ searchcount([{options}])                                         *searchcount()*
 						value. see |cursor()|, |getpos()|
 						(default: cursor's position)
 
-		Can also be used as a |method|: >vim
-			GetSearchOpts()->searchcount()
-<
-
 searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
 		Search for the declaration of {name}.
 
@@ -6725,9 +5896,6 @@ searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
 			if searchdecl('myvar') == 0
 			   echo getline('.')
 			endif
-<
-		Can also be used as a |method|: >vim
-			GetName()->searchdecl()
 <
 
                                                                   *searchpair()*
@@ -6844,10 +6012,6 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 <		In this example "submatch" is 2 when a lowercase letter is
 		found |/\l|, 3 when an uppercase letter is found |/\u|.
 
-		Can also be used as a |method|: >vim
-			GetPattern()->searchpos()
-<
-
 serverlist()                                                      *serverlist()*
 		Returns a list of server addresses, or empty if all servers
 		were stopped. |serverstart()| |serverstop()|
@@ -6919,11 +6083,6 @@ setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 		If {buf} is not a valid buffer or {lnum} is not valid, an
 		error message is given.
 
-		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetText()->setbufline(buf, lnum)
-<
-
 setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 		Set option or local variable {varname} in buffer {buf} to
 		{val}.
@@ -6937,11 +6096,6 @@ setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 			call setbufvar(1, "&mod", 1)
 			call setbufvar("todo", "myvar", "foobar")
 <		This function is not available in the |sandbox|.
-
-		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetValue()->setbufvar(buf, varname)
-<
 
 setcellwidths({list})                                          *setcellwidths()*
 		Specify overrides for cell widths of character ranges.  This
@@ -6988,10 +6142,6 @@ setcharpos({expr}, {list})                                        *setcharpos()*
 			call setpos('.', [0, 8, 4, 0])
 <		positions the cursor on the second character '보'.
 
-		Can also be used as a |method|: >vim
-			GetPosition()->setcharpos('.')
-<
-
 setcharsearch({dict})                                          *setcharsearch()*
 		Set the current character search information to {dict},
 		which contains one or more of the following entries:
@@ -7012,20 +6162,12 @@ setcharsearch({dict})                                          *setcharsearch()*
 			call setcharsearch(prevsearch)
 <		Also see |getcharsearch()|.
 
-		Can also be used as a |method|: >vim
-			SavedSearch()->setcharsearch()
-<
-
 setcmdline({str} [, {pos}])                                       *setcmdline()*
 		Set the command line to {str} and set the cursor position to
 		{pos}.
 		If {pos} is omitted, the cursor is positioned after the text.
 		Returns 0 when successful, 1 when not editing the command
 		line.
-
-		Can also be used as a |method|: >vim
-			GetText()->setcmdline()
-<
 
 setcmdpos({pos})                                                   *setcmdpos()*
 		Set the cursor position in the command line to byte position
@@ -7042,10 +6184,6 @@ setcmdpos({pos})                                                   *setcmdpos()*
 		Returns 0 when successful, 1 when not editing the command
 		line.
 
-		Can also be used as a |method|: >vim
-			GetPos()->setcmdpos()
-<
-
 setcursorcharpos({lnum}, {col} [, {off}])
 setcursorcharpos({list})                                    *setcursorcharpos()*
 		Same as |cursor()| but uses the specified column number as the
@@ -7058,21 +6196,12 @@ setcursorcharpos({list})                                    *setcursorcharpos()*
 			call cursor(4, 3)
 <		positions the cursor on the first character '여'.
 
-		Can also be used as a |method|: >vim
-			GetCursorPos()->setcursorcharpos()
-<
-
 setenv({name}, {val})                                                 *setenv()*
 		Set environment variable {name} to {val}.  Example: >vim
 			call setenv('HOME', '/home/myhome')
 
 <		When {val} is |v:null| the environment variable is deleted.
 		See also |expr-env|.
-
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetPath()->setenv('PATH')
-<
 
 setfperm({fname}, {mode})                                     *setfperm()* *chmod*
 		Set the file permissions for {fname} to {mode}.
@@ -7089,9 +6218,6 @@ setfperm({fname}, {mode})                                     *setfperm()* *chmo
 
 		Returns non-zero for success, zero for failure.
 
-		Can also be used as a |method|: >vim
-			GetFilename()->setfperm(mode)
-<
 		To read permissions see |getfperm()|.
 
 setline({lnum}, {text})                                              *setline()*
@@ -7121,11 +6247,6 @@ setline({lnum}, {text})                                              *setline()*
 
 <		Note: The '[ and '] marks are not set.
 
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetText()->setline(lnum)
-<
-
 setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 		Create or replace or add to the location list for window {nr}.
 		{nr} can be the window number or the |window-ID|.
@@ -7142,11 +6263,6 @@ setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 		only the items listed in {what} are set. Refer to |setqflist()|
 		for the list of supported keys in {what}.
 
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetLoclist()->setloclist(winnr)
-<
-
 setmatches({list} [, {win}])                                      *setmatches()*
 		Restores a list of matches saved by |getmatches()| for the
 		current window.  Returns 0 if successful, otherwise -1.  All
@@ -7154,10 +6270,6 @@ setmatches({list} [, {win}])                                      *setmatches()*
 		example for |getmatches()|.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
-
-		Can also be used as a |method|: >vim
-			GetMatches()->setmatches()
-<
 
 setpos({expr}, {list})                                                *setpos()*
 		Set the position for String {expr}.  Possible values:
@@ -7207,10 +6319,6 @@ setpos({expr}, {list})                                                *setpos()*
 		|k| motions will jump to previous columns!  Use |cursor()| to
 		also set the preferred column.  Also see the "curswant" key in
 		|winrestview()|.
-
-		Can also be used as a |method|: >vim
-			GetPosition()->setpos('.')
-<
 
 setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		Create or replace or add to the quickfix list.
@@ -7323,11 +6431,6 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		independent of the 'errorformat' setting.  Use a command like
 		`:cc 1` to jump to the first position.
 
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetErrorlist()->setqflist()
-<
-
 setreg({regname}, {value} [, {options}])                              *setreg()*
 		Set the register {regname} to {value}.
 		If {regname} is "" or "@", the unnamed register '"' is used.
@@ -7384,11 +6487,6 @@ setreg({regname}, {value} [, {options}])                              *setreg()*
 		nothing: >vim
 			call setreg('a', '', 'al')
 
-<		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetText()->setreg('a')
-<
-
 settabvar({tabnr}, {varname}, {val})                               *settabvar()*
 		Set tab-local variable {varname} to {val} in tab page {tabnr}.
 		|t:var|
@@ -7396,11 +6494,6 @@ settabvar({tabnr}, {varname}, {val})                               *settabvar()*
 		Note that the variable name without "t:" must be used.
 		Tabs are numbered starting with one.
 		This function is not available in the |sandbox|.
-
-		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetValue()->settabvar(tab, name)
-<
 
 settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
 		Set option or local variable {varname} in window {winnr} to
@@ -7417,11 +6510,6 @@ settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
 			call settabwinvar(1, 1, "&list", 0)
 			call settabwinvar(3, 2, "myvar", "foobar")
 <		This function is not available in the |sandbox|.
-
-		Can also be used as a |method|, the base is passed as the
-		fourth argument: >vim
-			GetValue()->settabwinvar(tab, winnr, name)
-<
 
 settagstack({nr}, {dict} [, {action}])                           *settagstack()*
 		Modify the tag stack of the window {nr} using {dict}.
@@ -7456,10 +6544,6 @@ settagstack({nr}, {dict} [, {action}])                           *settagstack()*
 			call settagstack(1003, stack)
 			unlet stack
 <
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetStack()->settagstack(winnr)
-<
 
 setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
 		Like |settabwinvar()| for the current tab page.
@@ -7467,18 +6551,9 @@ setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
 			call setwinvar(1, "&list", 0)
 			call setwinvar(2, "myvar", "foobar")
 
-<		Can also be used as a |method|, the base is passed as the
-		third argument: >vim
-			GetValue()->setwinvar(winnr, name)
-<
-
 sha256({string})                                                      *sha256()*
 		Returns a String with 64 hex characters, which is the SHA256
 		checksum of {string}.
-
-		Can also be used as a |method|: >vim
-			GetText()->sha256()
-<
 
 shellescape({string} [, {special}])                              *shellescape()*
 		Escape {string} for use as a shell command argument.
@@ -7511,10 +6586,6 @@ shellescape({string} [, {special}])                              *shellescape()*
 		    call system("chmod +w -- " .. shellescape(expand("%")))
 <		See also |::S|.
 
-		Can also be used as a |method|: >vim
-			GetCommand()->shellescape()
-<
-
 shiftwidth([{col}])                                               *shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
 		'shiftwidth' value unless it is zero, in which case it is the
@@ -7535,10 +6606,6 @@ shiftwidth([{col}])                                               *shiftwidth()*
 		for which to return the 'shiftwidth' value. This matters for the
 		'vartabstop' feature. If no {col} argument is given, column 1
 		will be assumed.
-
-		Can also be used as a |method|: >vim
-			GetColumn()->shiftwidth()
-<
 
 sign_define({name} [, {dict}])
 sign_define({list})                                              *sign_define()*
@@ -7586,9 +6653,6 @@ sign_define({list})                                              *sign_define()*
 				\  'text' : '!!'}
 				\ ])
 <
-		Can also be used as a |method|: >vim
-			GetSignList()->sign_define()
-<
 
 sign_getdefined([{name}])                                    *sign_getdefined()*
 		Get a list of defined signs and their attributes.
@@ -7624,9 +6688,6 @@ sign_getdefined([{name}])                                    *sign_getdefined()*
 
 			" Get the attribute of the sign named mySign
 			echo sign_getdefined("mySign")
-<
-		Can also be used as a |method|: >vim
-			GetSignList()->sign_getdefined()
 <
 
 sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
@@ -7689,9 +6750,6 @@ sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
 			" Get a List of all the placed signs
 			echo sign_getplaced()
 <
-		Can also be used as a |method|: >vim
-			GetBufname()->sign_getplaced()
-<
 
 sign_jump({id}, {group}, {buf})                                    *sign_jump()*
 		Open the buffer {buf} or jump to the window that contains
@@ -7707,9 +6765,6 @@ sign_jump({id}, {group}, {buf})                                    *sign_jump()*
 		Example: >vim
 			" Jump to sign 10 in the current buffer
 			call sign_jump(10, '', '')
-<
-		Can also be used as a |method|: >vim
-			GetSignid()->sign_jump()
 <
 
 sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
@@ -7759,9 +6814,6 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 			" at line 40 in buffer json.c with priority 90
 			call sign_place(10, 'g3', 'sign4', 'json.c',
 					\ {'lnum' : 40, 'priority' : 90})
-<
-		Can also be used as a |method|: >vim
-			GetSignid()->sign_place(group, name, expr)
 <
 
 sign_placelist({list})                                        *sign_placelist()*
@@ -7822,9 +6874,6 @@ sign_placelist({list})                                        *sign_placelist()*
 				\  'lnum' : 50}
 				\ ])
 <
-		Can also be used as a |method|: >vim
-			GetSignlist()->sign_placelist()
-<
 
 sign_undefine([{name}])
 sign_undefine({list})                                          *sign_undefine()*
@@ -7848,9 +6897,6 @@ sign_undefine({list})                                          *sign_undefine()*
 
 			" Delete all the signs
 			call sign_undefine()
-<
-		Can also be used as a |method|: >vim
-			GetSignlist()->sign_undefine()
 <
 
 sign_unplace({group} [, {dict}])                                *sign_unplace()*
@@ -7895,10 +6941,6 @@ sign_unplace({group} [, {dict}])                                *sign_unplace()*
 			" Remove all the placed signs from all the buffers
 			call sign_unplace('*')
 
-<		Can also be used as a |method|: >vim
-			GetSigngroup()->sign_unplace()
-<
-
 sign_unplacelist({list})                                    *sign_unplacelist()*
 		Remove previously placed signs from one or more buffers.  This
 		is similar to the |sign_unplace()| function.
@@ -7927,9 +6969,6 @@ sign_unplacelist({list})                                    *sign_unplacelist()*
 				\ {'id' : 20, 'buffer' : 'b.vim'},
 				\ ])
 <
-		Can also be used as a |method|: >vim
-			GetSignlist()->sign_unplacelist()
-<
 
 simplify({filename})                                                *simplify()*
 		Simplify the file name as much as possible without changing
@@ -7948,10 +6987,6 @@ simplify({filename})                                                *simplify()*
 		directory.  In order to resolve all the involved symbolic
 		links before simplifying the path name, use |resolve()|.
 
-		Can also be used as a |method|: >vim
-			GetName()->simplify()
-<
-
 sin({expr})                                                              *sin()*
 		Return the sine of {expr}, measured in radians, as a |Float|.
 		{expr} must evaluate to a |Float| or a |Number|.
@@ -7961,10 +6996,6 @@ sin({expr})                                                              *sin()*
 <			-0.506366 >vim
 			echo sin(-4.01)
 <			0.763301
-
-		Can also be used as a |method|: >vim
-			Compute()->sin()
-<
 
 sinh({expr})                                                            *sinh()*
 		Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -7977,10 +7008,6 @@ sinh({expr})                                                            *sinh()*
 			echo sinh(-0.9)
 <			-1.026517
 
-		Can also be used as a |method|: >vim
-			Compute()->sinh()
-<
-
 slice({expr}, {start} [, {end}])                                       *slice()*
 		Similar to using a |slice| "expr[start : end]", but "end" is
 		used exclusive.  And for a string the indexes are used as
@@ -7989,10 +7016,6 @@ slice({expr}, {start} [, {end}])                                       *slice()*
 		When {end} is omitted the slice continues to the last item.
 		When {end} is -1 the last item is omitted.
 		Returns an empty value if {start} or {end} are invalid.
-
-		Can also be used as a |method|: >vim
-			GetList()->slice(offset)
-<
 
 sockconnect({mode}, {address} [, {opts}])                        *sockconnect()*
 		Connect a socket to an address. If {mode} is "pipe" then
@@ -8076,10 +7099,6 @@ sort({list} [, {func} [, {dict}]])                                 *sort()* *E70
 		on numbers, text strings will sort next to each other, in the
 		same order as they were originally.
 
-		Can also be used as a |method|: >vim
-			mylist->sort()
-
-<		Also see |uniq()|.
 
 		Example: >vim
 			func MyCompare(i1, i2)
@@ -8102,10 +7121,6 @@ soundfold({word})                                                  *soundfold()*
 		possible the {word} is returned unmodified.
 		This can be used for making spelling suggestions.  Note that
 		the method can be quite slow.
-
-		Can also be used as a |method|: >vim
-			GetWord()->soundfold()
-<
 
 spellbadword([{sentence}])                                      *spellbadword()*
 		Without argument: The result is the badly spelled word under
@@ -8131,10 +7146,6 @@ spellbadword([{sentence}])                                      *spellbadword()*
 		The spelling information for the current window and the value
 		of 'spelllang' are used.
 
-		Can also be used as a |method|: >vim
-			GetText()->spellbadword()
-<
-
 spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
 		Return a |List| with spelling suggestions to replace {word}.
 		When {max} is given up to this number of suggestions are
@@ -8155,10 +7166,6 @@ spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
 
 		The spelling information for the current window is used.  The
 		values of 'spelllang' and 'spellsuggest' are used.
-
-		Can also be used as a |method|: >vim
-			GetWord()->spellsuggest()
-<
 
 split({string} [, {pattern} [, {keepempty}]])                          *split()*
 		Make a |List| out of {string}.  When {pattern} is omitted or
@@ -8185,10 +7192,6 @@ split({string} [, {pattern} [, {keepempty}]])                          *split()*
 			let items = split(line, ':', 1)
 <		The opposite function is |join()|.
 
-		Can also be used as a |method|: >vim
-			GetString()->split()
-<
-
 sqrt({expr})                                                            *sqrt()*
 		Return the non-negative square root of Float {expr} as a
 		|Float|.
@@ -8201,10 +7204,6 @@ sqrt({expr})                                                            *sqrt()*
 			echo sqrt(-4.01)
 <			str2float("nan")
 		NaN may be different, it depends on system libraries.
-
-		Can also be used as a |method|: >vim
-			Compute()->sqrt()
-<
 
 srand([{expr}])                                                        *srand()*
 		Initialize seed used by |rand()|:
@@ -8219,9 +7218,6 @@ srand([{expr}])                                                        *srand()*
 			let seed = srand()
 			let seed = srand(userinput)
 			echo rand(seed)
-<
-		Can also be used as a |method|: >vim
-			userinput->srand()
 <
 
 stdioopen({opts})                                                  *stdioopen()*
@@ -8286,10 +7282,6 @@ str2float({string} [, {quoted}])                                   *str2float()*
 <
 		Returns 0.0 if the conversion fails.
 
-		Can also be used as a |method|: >vim
-			let f = text->substitute(',', '', 'g')->str2float()
-<
-
 str2list({string} [, {utf8}])                                       *str2list()*
 		Return a list containing the number values which represent
 		each character in String {string}.  Examples: >vim
@@ -8301,10 +7293,6 @@ str2list({string} [, {utf8}])                                       *str2list()*
 		and exists only for backwards-compatibility.
 		With UTF-8 composing characters are handled properly: >vim
 			echo str2list("á")		" returns [97, 769]
-
-<		Can also be used as a |method|: >vim
-			GetString()->str2list()
-<
 
 str2nr({string} [, {base}])                                           *str2nr()*
 		Convert string {string} to a number.
@@ -8325,10 +7313,6 @@ str2nr({string} [, {base}])                                           *str2nr()*
 
 		Returns 0 if {string} is empty or on error.
 
-		Can also be used as a |method|: >vim
-			GetText()->str2nr()
-<
-
 strcharlen({string})                                              *strcharlen()*
 		The result is a Number, which is the number of characters
 		in String {string}.  Composing characters are ignored.
@@ -8338,10 +7322,6 @@ strcharlen({string})                                              *strcharlen()*
 		Returns 0 if {string} is empty or on error.
 
 		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
-
-		Can also be used as a |method|: >vim
-			GetText()->strcharlen()
-<
 
 strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 		Like |strpart()| but using character index and length instead
@@ -8357,10 +7337,6 @@ strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 <		results in 'a'.
 
 		Returns an empty string on error.
-
-		Can also be used as a |method|: >vim
-			GetText()->strcharpart(5)
-<
 
 strchars({string} [, {skipcc}])                                     *strchars()*
 		The result is a Number, which is the number of characters
@@ -8390,9 +7366,6 @@ strchars({string} [, {skipcc}])                                     *strchars()*
 		      endfunction
 		    endif
 <
-		Can also be used as a |method|: >vim
-			GetText()->strchars()
-<
 
 strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
 		The result is a Number, which is the number of display cells
@@ -8407,10 +7380,6 @@ strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
 		Ambiguous, this function's return value depends on 'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strwidth()| and |strchars()|.
-
-		Can also be used as a |method|: >vim
-			GetText()->strdisplaywidth()
-<
 
 strftime({format} [, {time}])                                       *strftime()*
 		The result is a String, which is a formatted date and time, as
@@ -8429,10 +7398,6 @@ strftime({format} [, {time}])                                       *strftime()*
 		  echo strftime("%c", getftime("file.c"))
 						   " Show mod time of file.c.
 
-<		Can also be used as a |method|: >vim
-			GetFormat()->strftime()
-<
-
 strgetchar({str}, {index})                                        *strgetchar()*
 		Get a Number corresponding to the character at {index} in
 		{str}.  This uses a zero-based character index, not a byte
@@ -8441,10 +7406,6 @@ strgetchar({str}, {index})                                        *strgetchar()*
 		String.
 		Returns -1 if {index} is invalid.
 		Also see |strcharpart()| and |strchars()|.
-
-		Can also be used as a |method|: >vim
-			GetText()->strgetchar(5)
-<
 
 stridx({haystack}, {needle} [, {start}])                              *stridx()*
 		The result is a Number, which gives the byte index in
@@ -8464,10 +7425,6 @@ stridx({haystack}, {needle} [, {start}])                              *stridx()*
 <						*strstr()* *strchr()*
 		stridx() works similar to the C function strstr().  When used
 		with a single character it works similar to strchr().
-
-		Can also be used as a |method|: >vim
-			GetHaystack()->stridx(needle)
-<
 
 string({expr})                                                        *string()*
 		Return {expr} converted to a String.  If {expr} is a Number,
@@ -8493,10 +7450,6 @@ string({expr})                                                        *string()*
 		method, use |msgpackdump()| or |json_encode()| if you need to
 		share data with other application.
 
-		Can also be used as a |method|: >vim
-			mylist->string()
-<
-
 strlen({string})                                                      *strlen()*
 		The result is a Number, which is the length of the String
 		{string} in bytes.
@@ -8505,10 +7458,6 @@ strlen({string})                                                      *strlen()*
 		If you want to count the number of multibyte characters use
 		|strchars()|.
 		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
-
-		Can also be used as a |method|: >vim
-			GetString()->strlen()
-<
 
 strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
 		The result is a String, which is part of {src}, starting from
@@ -8535,10 +7484,6 @@ strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
 <
 		Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			GetText()->strpart(5)
-<
-
 strptime({format}, {timestring})                                    *strptime()*
 		The result is a Number, which is a unix timestamp representing
 		the date and time in {timestring}, which is expected to match
@@ -8563,10 +7508,6 @@ strptime({format}, {timestring})                                    *strptime()*
 		  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
 <		  Sun Apr 27 12:53:55 1997
 
-		Can also be used as a |method|: >vim
-			GetFormat()->strptime(timestring)
-<
-
 strridx({haystack}, {needle} [, {start}])                            *strridx()*
 		The result is a Number, which gives the byte index in
 		{haystack} of the last occurrence of the String {needle}.
@@ -8585,10 +7526,6 @@ strridx({haystack}, {needle} [, {start}])                            *strridx()*
 		When used with a single character it works similar to the C
 		function strrchr().
 
-		Can also be used as a |method|: >vim
-			GetHaystack()->strridx(needle)
-<
-
 strtrans({string})                                                  *strtrans()*
 		The result is a String, which is {string} with all unprintable
 		characters translated into printable characters |'isprint'|.
@@ -8598,10 +7535,6 @@ strtrans({string})                                                  *strtrans()*
 		starting a new line.
 
 		Returns an empty string on error.
-
-		Can also be used as a |method|: >vim
-			GetString()->strtrans()
-<
 
 strutf16len({string} [, {countcc}])                              *strutf16len()*
 		The result is a Number, which is the number of UTF-16 code
@@ -8622,10 +7555,6 @@ strutf16len({string} [, {countcc}])                              *strutf16len()*
 		    echo strutf16len('ą́')		" returns 1
 		    echo strutf16len('ą́', v:true)	" returns 3
 
-		Can also be used as a |method|: >vim
-			GetText()->strutf16len()
-<
-
 strwidth({string})                                                  *strwidth()*
 		The result is a Number, which is the number of display cells
 		String {string} occupies.  A Tab character is counted as one
@@ -8634,10 +7563,6 @@ strwidth({string})                                                  *strwidth()*
 		Ambiguous, this function's return value depends on 'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
-
-		Can also be used as a |method|: >vim
-			GetString()->strwidth()
-<
 
 submatch({nr} [, {list}])                                      *submatch()* *E935*
 		Only for an expression in a |:substitute| command or
@@ -8666,10 +7591,6 @@ submatch({nr} [, {list}])                                      *submatch()* *E93
 			echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 <		This finds the first number in the line and adds one to it.
 		A line break is included as a newline character.
-
-		Can also be used as a |method|: >vim
-			GetNr()->submatch()
-<
 
 substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
 		The result is a String, which is a copy of {string}, in which
@@ -8714,10 +7635,6 @@ substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
 
 <		Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			GetString()->substitute(pat, sub, flags)
-<
-
 swapfilelist()                                                  *swapfilelist()*
 		Returns a list of swap file names, like what "vim -r" shows.
 		See the |-r| command argument.  The 'directory' option is used
@@ -8747,20 +7664,12 @@ swapinfo({fname})                                                   *swapinfo()*
 			Not a swap file: does not contain correct block ID
 			Magic number mismatch: Info in first block is invalid
 
-		Can also be used as a |method|: >vim
-			GetFilename()->swapinfo()
-<
-
 swapname({buf})                                                     *swapname()*
 		The result is the swap file path of the buffer {buf}.
 		For the use of {buf}, see |bufname()| above.
 		If buffer {buf} is the current buffer, the result is equal to
 		|:swapname| (unless there is no swap file).
 		If buffer {buf} has no swap file, returns an empty string.
-
-		Can also be used as a |method|: >vim
-			GetBufname()->swapname()
-<
 
 synID({lnum}, {col}, {trans})                                          *synID()*
 		The result is a Number, which is the syntax ID at the position
@@ -8841,10 +7750,6 @@ synIDtrans({synID})                                               *synIDtrans()*
 		":highlight link" are followed.
 
 		Returns zero on error.
-
-		Can also be used as a |method|: >vim
-			echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
-<
 
 synconcealed({lnum}, {col})                                     *synconcealed()*
 		The result is a |List| with currently three items:
@@ -8940,10 +7845,6 @@ system({cmd} [, {input}])                                        *system()* *E67
 <		Unlike ":!cmd" there is no automatic check for changed files.
 		Use |:checktime| to force a check.
 
-		Can also be used as a |method|: >vim
-			echo GetCmd()->system()
-<
-
 systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 		Same as |system()|, but returns a |List| with lines (parts of
 		output separated by NL) with NULs transformed into NLs. Output
@@ -8958,10 +7859,6 @@ systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 <
 		Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			echo GetCmd()->systemlist()
-<
-
 tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 		The result is a |List|, where each item is the number of the
 		buffer associated with each window in the current tab page.
@@ -8974,10 +7871,6 @@ tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 			   call extend(buflist, tabpagebuflist(i + 1))
 			endfor
 <		Note that a buffer may appear in more than one window.
-
-		Can also be used as a |method|: >vim
-			GetTabpage()->tabpagebuflist()
-<
 
 tabpagenr([{arg}])                                                 *tabpagenr()*
 		The result is a Number, which is the number of the current
@@ -9005,10 +7898,6 @@ tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
 		    tabpagewinnr(1)	    " current window of tab page 1
 		    tabpagewinnr(4, '$')    " number of windows in tab page 4
 <		When {tabarg} is invalid zero is returned.
-
-		Can also be used as a |method|: >vim
-			GetTabpage()->tabpagewinnr()
-<
 
 tagfiles()                                                          *tagfiles()*
 		Returns a |List| with the file names used to search for tags
@@ -9057,9 +7946,6 @@ taglist({expr} [, {filename}])                                       *taglist()*
 		located by Vim. Refer to |tags-file-format| for the format of
 		the tags file generated by the different ctags tools.
 
-		Can also be used as a |method|: >vim
-			GetTagpattern()->taglist()
-
 tan({expr})                                                              *tan()*
 		Return the tangent of {expr}, measured in radians, as a |Float|
 		in the range [-inf, inf].
@@ -9071,10 +7957,6 @@ tan({expr})                                                              *tan()*
 			echo tan(-4.01)
 <			-1.181502
 
-		Can also be used as a |method|: >vim
-			Compute()->tan()
-<
-
 tanh({expr})                                                            *tanh()*
 		Return the hyperbolic tangent of {expr} as a |Float| in the
 		range [-1, 1].
@@ -9085,10 +7967,6 @@ tanh({expr})                                                            *tanh()*
 <			0.462117 >vim
 			echo tanh(-1)
 <			-0.761594
-
-		Can also be used as a |method|: >vim
-			Compute()->tanh()
-<
 
 tempname()                                                          *tempname()*
 		Generates a (non-existent) filename located in the Nvim root
@@ -9128,10 +8006,6 @@ timer_info([{id}])                                                *timer_info()*
 				    -1 means forever
 		    "callback"	    the callback
 
-		Can also be used as a |method|: >vim
-			GetTimer()->timer_info()
-<
-
 timer_pause({timer}, {paused})                                   *timer_pause()*
 		Pause or unpause a timer.  A paused timer does not invoke its
 		callback when its time expires.  Unpausing a timer may cause
@@ -9144,10 +8018,6 @@ timer_pause({timer}, {paused})                                   *timer_pause()*
 		If {paused} evaluates to a non-zero Number or a non-empty
 		String, then the timer is paused, otherwise it is unpaused.
 		See |non-zero-arg|.
-
-		Can also be used as a |method|: >vim
-			GetTimer()->timer_pause(1)
-<
 
 timer_start({time}, {callback} [, {options}])              *timer_start()* *timer*
 		Create a timer and return the timer ID.
@@ -9179,19 +8049,10 @@ timer_start({time}, {callback} [, {options}])              *timer_start()* *time
 				\ {'repeat': 3})
 <		This invokes MyHandler() three times at 500 msec intervals.
 
-		Can also be used as a |method|: >vim
-			GetMsec()->timer_start(callback)
-
-<		Not available in the |sandbox|.
-
 timer_stop({timer})                                               *timer_stop()*
 		Stop a timer.  The timer callback will no longer be invoked.
 		{timer} is an ID returned by timer_start(), thus it must be a
 		Number.  If {timer} does not exist there is no error.
-
-		Can also be used as a |method|: >vim
-			GetTimer()->timer_stop()
-<
 
 timer_stopall()                                                *timer_stopall()*
 		Stop all timers.  The timer callbacks will no longer be
@@ -9203,18 +8064,10 @@ tolower({expr})                                                      *tolower()*
 		characters turned into lowercase (just like applying |gu| to
 		the string).  Returns an empty string on error.
 
-		Can also be used as a |method|: >vim
-			GetText()->tolower()
-<
-
 toupper({expr})                                                      *toupper()*
 		The result is a copy of the String given, with all lowercase
 		characters turned into uppercase (just like applying |gU| to
 		the string).  Returns an empty string on error.
-
-		Can also be used as a |method|: >vim
-			GetText()->toupper()
-<
 
 tr({src}, {fromstr}, {tostr})                                             *tr()*
 		The result is a copy of the {src} string with all characters
@@ -9231,10 +8084,6 @@ tr({src}, {fromstr}, {tostr})                                             *tr()*
 <		returns "Hello THere" >vim
 			echo tr("<blob>", "<>", "{}")
 <		returns "{blob}"
-
-		Can also be used as a |method|: >vim
-			GetText()->tr(from, to)
-<
 
 trim({text} [, {mask} [, {dir}]])                                       *trim()*
 		Return {text} as a String where any character in {mask} is
@@ -9261,10 +8110,6 @@ trim({text} [, {mask} [, {dir}]])                                       *trim()*
 			echo trim("  vim  ", " ", 2)
 <		returns "  vim"
 
-		Can also be used as a |method|: >vim
-			GetText()->trim()
-<
-
 trunc({expr})                                                          *trunc()*
 		Return the largest integral value with magnitude less than or
 		equal to {expr} as a |Float| (truncate towards zero).
@@ -9277,10 +8122,6 @@ trunc({expr})                                                          *trunc()*
 <			-5.0  >vim
 			echo trunc(4.0)
 <			4.0
-
-		Can also be used as a |method|: >vim
-			Compute()->trunc()
-<
 
 type({expr})                                                            *type()*
 		The result is a Number representing the type of {expr}.
@@ -9309,10 +8150,6 @@ type({expr})                                                            *type()*
 <		To check if the v:t_ variables exist use this: >vim
 			if exists('v:t_number') | endif
 
-<		Can also be used as a |method|: >vim
-			mylist->type()
-<
-
 undofile({name})                                                    *undofile()*
 		Return the name of the undo file that would be used for a file
 		with name {name} when writing.  This uses the 'undodir'
@@ -9323,10 +8160,6 @@ undofile({name})                                                    *undofile()*
 		If {name} is empty undofile() returns an empty string, since a
 		buffer without a file name will not write an undo file.
 		Useful in combination with |:wundo| and |:rundo|.
-
-		Can also be used as a |method|: >vim
-			GetFilename()->undofile()
-<
 
 undotree()                                                          *undotree()*
 		Return the current state of the undo tree in a dictionary with
@@ -9381,10 +8214,6 @@ uniq({list} [, {func} [, {dict}]])                                 *uniq()* *E88
 
 		Returns zero if {list} is not a |List|.
 
-		Can also be used as a |method|: >vim
-			mylist->uniq()
-<
-
 utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
 		Same as |charidx()| but returns the UTF-16 code unit index of
 		the byte at {idx} in {string} (after converting it to UTF-16).
@@ -9412,18 +8241,11 @@ utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
 			echo utf16idx('aą́c', 6, 1)	" returns 4
 			echo utf16idx('a😊😊', 9)	" returns -1
 <
-		Can also be used as a |method|: >vim
-			GetName()->utf16idx(idx)
-<
 
 values({dict})                                                        *values()*
 		Return a |List| with all the values of {dict}.  The |List| is
 		in arbitrary order.  Also see |items()| and |keys()|.
 		Returns zero if {dict} is not a |Dict|.
-
-		Can also be used as a |method|: >vim
-			mydict->values()
-<
 
 virtcol({expr} [, {list}])                                           *virtcol()*
 		The result is a Number, which is the screen column of the file
@@ -9477,10 +8299,6 @@ virtcol({expr} [, {list}])                                           *virtcol()*
 		all lines: >vim
 		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 
-<		Can also be used as a |method|: >vim
-			GetPos()->virtcol()
-<
-
 virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
 		The result is a Number, which is the byte index of the
 		character in window {winid} at buffer line {lnum} and virtual
@@ -9497,10 +8315,6 @@ virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
 		line {lnum} or virtual column {col} is invalid.
 
 		See also |screenpos()|, |virtcol()| and |col()|.
-
-		Can also be used as a |method|: >vim
-			GetWinid()->virtcol2col(lnum, col)
-<
 
 visualmode([{expr}])                                              *visualmode()*
 		The result is a String, which describes the last Visual mode
@@ -9561,18 +8375,9 @@ win_execute({id}, {command} [, {silent}])                        *win_execute()*
 		When window {id} does not exist then no error is given and
 		an empty string is returned.
 
-		Can also be used as a |method|, the base is passed as the
-		second argument: >vim
-			GetCommand()->win_execute(winid)
-<
-
 win_findbuf({bufnr})                                             *win_findbuf()*
 		Returns a |List| with |window-ID|s for windows that contain
 		buffer {bufnr}.  When there is none the list is empty.
-
-		Can also be used as a |method|: >vim
-			GetBufnr()->win_findbuf()
-<
 
 win_getid([{win} [, {tab}]])                                       *win_getid()*
 		Get the |window-ID| for the specified window.
@@ -9582,10 +8387,6 @@ win_getid([{win} [, {tab}]])                                       *win_getid()*
 		Without {tab} use the current tab, otherwise the tab with
 		number {tab}.  The first tab has number one.
 		Return zero if the window cannot be found.
-
-		Can also be used as a |method|: >vim
-			GetWinnr()->win_getid()
-<
 
 win_gettype([{nr}])                                              *win_gettype()*
 		Return the type of the window:
@@ -9605,35 +8406,19 @@ win_gettype([{nr}])                                              *win_gettype()*
 
 		Also see the 'buftype' option.
 
-		Can also be used as a |method|: >vim
-			GetWinid()->win_gettype()
-<
-
 win_gotoid({expr})                                                *win_gotoid()*
 		Go to window with ID {expr}.  This may also change the current
 		tabpage.
 		Return TRUE if successful, FALSE if the window cannot be found.
-
-		Can also be used as a |method|: >vim
-			GetWinid()->win_gotoid()
-<
 
 win_id2tabwin({expr})                                          *win_id2tabwin()*
 		Return a list with the tab number and window number of window
 		with ID {expr}: [tabnr, winnr].
 		Return [0, 0] if the window cannot be found.
 
-		Can also be used as a |method|: >vim
-			GetWinid()->win_id2tabwin()
-<
-
 win_id2win({expr})                                                *win_id2win()*
 		Return the window number of window with ID {expr}.
 		Return 0 if the window cannot be found in the current tabpage.
-
-		Can also be used as a |method|: >vim
-			GetWinid()->win_id2win()
-<
 
 win_move_separator({nr}, {offset})                        *win_move_separator()*
 		Move window {nr}'s vertical separator (i.e., the right border)
@@ -9650,10 +8435,6 @@ win_move_separator({nr}, {offset})                        *win_move_separator()*
 		window, since it has no separator on the right.
 		Only works for the current tab page. *E1308*
 
-		Can also be used as a |method|: >vim
-			GetWinnr()->win_move_separator(offset)
-<
-
 win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		Move window {nr}'s status line (i.e., the bottom border) by
 		{offset} rows, as if being dragged by the mouse. {nr} can be a
@@ -9666,10 +8447,6 @@ win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		be found and FALSE otherwise.
 		Only works for the current tab page.
 
-		Can also be used as a |method|: >vim
-			GetWinnr()->win_move_statusline(offset)
-<
-
 win_screenpos({nr})                                            *win_screenpos()*
 		Return the screen position of window {nr} as a list with two
 		numbers: [row, col].  The first window always has position
@@ -9678,10 +8455,6 @@ win_screenpos({nr})                                            *win_screenpos()*
 		for the current window.
 		Returns [0, 0] if the window cannot be found in the current
 		tabpage.
-
-		Can also be used as a |method|: >vim
-			GetWinid()->win_screenpos()
-<
 
 win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 		Move the window {nr} to a new split of the window {target}.
@@ -9703,10 +8476,6 @@ win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 				present, the values of 'splitbelow' and
 				'splitright' are used.
 
-		Can also be used as a |method|: >vim
-			GetWinid()->win_splitmove(target)
-<
-
 winbufnr({nr})                                                      *winbufnr()*
 		The result is a Number, which is the number of the buffer
 		associated with window {nr}.  {nr} can be the window number or
@@ -9716,9 +8485,6 @@ winbufnr({nr})                                                      *winbufnr()*
 		When window {nr} doesn't exist, -1 is returned.
 		Example: >vim
 		  echo "The file in the current window is " .. bufname(winbufnr(0))
-<
-		Can also be used as a |method|: >vim
-			FindWindow()->winbufnr()->bufname()
 <
 
 wincol()                                                              *wincol()*
@@ -9741,10 +8507,6 @@ winheight({nr})                                                    *winheight()*
 		This excludes any window toolbar line.
 		Examples: >vim
 		  echo "The current window has " .. winheight(0) .. " lines."
-
-<		Can also be used as a |method|: >vim
-			GetWinid()->winheight()
-<
 
 winlayout([{tabnr}])                                               *winlayout()*
 		The result is a nested List containing the layout of windows
@@ -9781,9 +8543,6 @@ winlayout([{tabnr}])                                               *winlayout()*
 <		 >
 			['col', [['leaf', 1002], ['row', [['leaf', 1003],
 					    ['leaf', 1001]]], ['leaf', 1000]]]
-<
-		Can also be used as a |method|: >vim
-			GetTabnr()->winlayout()
 <
 
 winline()                                                            *winline()*
@@ -9822,10 +8581,6 @@ winnr([{arg}])                                                         *winnr()*
 			let prev_window = winnr('#')
 			let wnum = winnr('3k')
 
-<		Can also be used as a |method|: >vim
-			GetWinval()->winnr()
-<
-
 winrestcmd()                                                      *winrestcmd()*
 		Returns a sequence of |:resize| commands that should restore
 		the current window sizes.  Only works properly when no windows
@@ -9852,10 +8607,6 @@ winrestview({dict})                                              *winrestview()*
 
 		If you have changed the values the result is unpredictable.
 		If the window size changed the result won't be the same.
-
-		Can also be used as a |method|: >vim
-			GetView()->winrestview()
-<
 
 winsaveview()                                                    *winsaveview()*
 		Returns a |Dictionary| that contains information to restore
@@ -9897,10 +8648,6 @@ winwidth({nr})                                                      *winwidth()*
 		  endif
 <		For getting the terminal or screen size, see the 'columns'
 		option.
-
-		Can also be used as a |method|: >vim
-			GetWinid()->winwidth()
-<
 
 wordcount()                                                        *wordcount()*
 		The result is a dictionary of byte/chars/word statistics for
@@ -9969,19 +8716,12 @@ writefile({object}, {fname} [, {flags}])                           *writefile()*
 			let fl = readfile("foo", "b")
 			call writefile(fl, "foocopy", "b")
 
-<		Can also be used as a |method|: >vim
-			GetText()->writefile("thefile")
-<
-
 xor({expr}, {expr})                                                      *xor()*
 		Bitwise XOR on the two arguments.  The arguments are converted
 		to a number.  A List, Dict or Float argument causes an error.
 		Also see `and()` and `or()`.
 		Example: >vim
 			let bits = xor(bits, 0x80)
-<
-		Can also be used as a |method|: >vim
-			let bits = bits->xor(0x80)
 <
 
 ==============================================================================

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -15,10 +15,6 @@ error('Cannot require a meta file')
 ---   echo abs(-4)
 --- <  4
 ---
---- Can also be used as a |method|: >vim
----   Compute()->abs()
---- <
----
 --- @param expr any
 --- @return number
 function vim.fn.abs(expr) end
@@ -35,10 +31,6 @@ function vim.fn.abs(expr) end
 ---   echo acos(-0.5)
 --- <  2.094395
 ---
---- Can also be used as a |method|: >vim
----   Compute()->acos()
---- <
----
 --- @param expr any
 --- @return number
 function vim.fn.acos(expr) end
@@ -53,10 +45,6 @@ function vim.fn.acos(expr) end
 --- Use |insert()| to add an item at another position.
 --- Returns 1 if {object} is not a |List| or a |Blob|.
 ---
---- Can also be used as a |method|: >vim
----   mylist->add(val1)->add(val2)
---- <
----
 --- @param object any
 --- @param expr any
 --- @return any
@@ -67,8 +55,6 @@ function vim.fn.add(object, expr) end
 --- Also see `or()` and `xor()`.
 --- Example: >vim
 ---   let flag = and(bits, 0x80)
---- <Can also be used as a |method|: >vim
----   let flag = bits->and(0x80)
 --- <
 ---
 --- @param expr any
@@ -96,9 +82,6 @@ function vim.fn.api_info() end
 --- 0 for success.  Example: >vim
 ---   let failed = append(line('$'), "# THE END")
 ---   let failed = append(0, ["Chapter 1", "the beginning"])
----
---- <Can also be used as a |method| after a List: >vim
----   mylist->append(lnum)
 --- <
 ---
 --- @param lnum integer
@@ -123,9 +106,6 @@ function vim.fn.append(lnum, text) end
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given. Example: >vim
 ---   let failed = appendbufline(13, 0, "# THE START")
---- <
---- Can also be used as a |method| after a List: >vim
----   mylist->appendbufline(buf, lnum)
 --- <
 ---
 --- @param buf any
@@ -204,10 +184,6 @@ function vim.fn.argv(nr, winid) end
 ---   echo asin(-0.5)
 --- <  -0.523599
 ---
---- Can also be used as a |method|: >vim
----   Compute()->asin()
---- <
----
 --- @param expr any
 --- @return number
 function vim.fn.asin(expr) end
@@ -216,10 +192,6 @@ function vim.fn.asin(expr) end
 --- NOT produce a beep or visual bell.
 --- Also see |assert_fails()|, |assert_nobeep()| and
 --- |assert-return|.
----
---- Can also be used as a |method|: >vim
----   GetCmd()->assert_beeps()
---- <
 ---
 --- @param cmd any
 --- @return 0|1
@@ -240,10 +212,6 @@ function vim.fn.assert_beeps(cmd) end
 --- <Will result in a string to be added to |v:errors|:
 ---   test.vim line 12: Expected 'foo' but got 'bar' ~
 ---
---- Can also be used as a |method|: >vim
----   mylist->assert_equal([1, 2, 3])
---- <
----
 --- @param expected any
 --- @param actual any
 --- @param msg? any
@@ -255,10 +223,6 @@ function vim.fn.assert_equal(expected, actual, msg) end
 --- Also see |assert-return|.
 --- When {fname-one} or {fname-two} does not exist the error will
 --- mention that.
----
---- Can also be used as a |method|: >vim
----   GetLog()->assert_equalfile('expected.log')
---- <
 ---
 --- @return 0|1
 function vim.fn.assert_equalfile() end
@@ -314,10 +278,6 @@ function vim.fn.assert_exception(error, msg) end
 --- Note that beeping is not considered an error, and some failing
 --- commands only beep.  Use |assert_beeps()| for those.
 ---
---- Can also be used as a |method|: >vim
----   GetCmd()->assert_fails('E99:')
---- <
----
 --- @param cmd any
 --- @param error? any
 --- @param msg? any
@@ -334,10 +294,6 @@ function vim.fn.assert_fails(cmd, error, msg, lnum, context) end
 ---
 --- A value is false when it is zero. When {actual} is not a
 --- number the assert fails.
----
---- Can also be used as a |method|: >vim
----   GetResult()->assert_false()
---- <
 ---
 --- @param actual any
 --- @param msg? any
@@ -376,10 +332,6 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- <Will result in a string to be added to |v:errors|:
 ---   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 ---
---- Can also be used as a |method|: >vim
----   getFile()->assert_match('foo.*')
---- <
----
 --- @param pattern any
 --- @param actual any
 --- @param msg? any
@@ -390,10 +342,6 @@ function vim.fn.assert_match(pattern, actual, msg) end
 --- produces a beep or visual bell.
 --- Also see |assert_beeps()|.
 ---
---- Can also be used as a |method|: >vim
----   GetCmd()->assert_nobeep()
---- <
----
 --- @param cmd any
 --- @return 0|1
 function vim.fn.assert_nobeep(cmd) end
@@ -401,10 +349,6 @@ function vim.fn.assert_nobeep(cmd) end
 --- The opposite of `assert_equal()`: add an error message to
 --- |v:errors| when {expected} and {actual} are equal.
 --- Also see |assert-return|.
----
---- Can also be used as a |method|: >vim
----   mylist->assert_notequal([1, 2, 3])
---- <
 ---
 --- @param expected any
 --- @param actual any
@@ -416,10 +360,6 @@ function vim.fn.assert_notequal(expected, actual, msg) end
 --- |v:errors| when {pattern} matches {actual}.
 --- Also see |assert-return|.
 ---
---- Can also be used as a |method|: >vim
----   getFile()->assert_notmatch('bar.*')
---- <
----
 --- @param pattern any
 --- @param actual any
 --- @param msg? any
@@ -428,10 +368,6 @@ function vim.fn.assert_notmatch(pattern, actual, msg) end
 
 --- Report a test failure directly, using String {msg}.
 --- Always returns one.
----
---- Can also be used as a |method|: >vim
----   GetMessage()->assert_report()
---- <
 ---
 --- @param msg any
 --- @return 0|1
@@ -443,10 +379,6 @@ function vim.fn.assert_report(msg) end
 --- A value is |TRUE| when it is a non-zero number or |v:true|.
 --- When {actual} is not a number or |v:true| the assert fails.
 --- When {msg} is given it precedes the default message.
----
---- Can also be used as a |method|: >vim
----   GetResult()->assert_true()
---- <
 ---
 --- @param actual any
 --- @param msg? any
@@ -463,10 +395,6 @@ function vim.fn.assert_true(actual, msg) end
 ---   echo atan(-4.01)
 --- <  -1.326405
 ---
---- Can also be used as a |method|: >vim
----   Compute()->atan()
---- <
----
 --- @param expr any
 --- @return number
 function vim.fn.atan(expr) end
@@ -482,10 +410,6 @@ function vim.fn.atan(expr) end
 ---   echo atan2(1, -1)
 --- <  2.356194
 ---
---- Can also be used as a |method|: >vim
----   Compute()->atan2(1)
---- <
----
 --- @param expr1 any
 --- @param expr2 any
 --- @return number
@@ -497,10 +421,6 @@ function vim.fn.atan2(expr1, expr2) end
 ---   blob2list(0z)    " returns []
 --- <Returns an empty List on error.  |list2blob()| does the
 --- opposite.
----
---- Can also be used as a |method|: >vim
----   GetBlob()->blob2list()
---- <
 ---
 --- @param blob any
 --- @return any[]
@@ -551,9 +471,6 @@ function vim.fn.browsedir(title, initdir) end
 ---   call bufload(bufnr)
 ---   call setbufline(bufnr, 1, ['some', 'text'])
 --- <Returns 0 on error.
---- Can also be used as a |method|: >vim
----   let bufnr = 'somename'->bufadd()
---- <
 ---
 --- @param name string
 --- @return integer
@@ -579,10 +496,6 @@ function vim.fn.bufadd(name) end
 --- for MS-Windows 8.3 names in the form "c:\DOCUME~1"
 --- Use "bufexists(0)" to test for the existence of an alternate
 --- file name.
----
---- Can also be used as a |method|: >vim
----   let exists = 'somename'->bufexists()
---- <
 ---
 --- @param buf any
 --- @return 0|1
@@ -613,10 +526,6 @@ function vim.fn.buffer_number(...) end
 --- {buf} exists and is listed (has the 'buflisted' option set).
 --- The {buf} argument is used like with |bufexists()|.
 ---
---- Can also be used as a |method|: >vim
----   let listed = 'somename'->buflisted()
---- <
----
 --- @param buf any
 --- @return 0|1
 function vim.fn.buflisted(buf) end
@@ -630,20 +539,12 @@ function vim.fn.buflisted(buf) end
 --- there will be no dialog, the buffer will be loaded anyway.
 --- The {buf} argument is used like with |bufexists()|.
 ---
---- Can also be used as a |method|: >vim
----   eval 'somename'->bufload()
---- <
----
 --- @param buf any
 function vim.fn.bufload(buf) end
 
 --- The result is a Number, which is |TRUE| if a buffer called
 --- {buf} exists and is loaded (shown in a window or hidden).
 --- The {buf} argument is used like with |bufexists()|.
----
---- Can also be used as a |method|: >vim
----   let loaded = 'somename'->bufloaded()
---- <
 ---
 --- @param buf any
 --- @return 0|1
@@ -669,11 +570,6 @@ function vim.fn.bufloaded(buf) end
 --- with a listed buffer, that one is returned.  Next unlisted
 --- buffers are searched for.
 --- If the {buf} is a String, but you want to use it as a buffer
---- number, force it to be a Number by adding zero to it: >vim
----   echo bufname("3" + 0)
---- <Can also be used as a |method|: >vim
----   echo bufnr->bufname()
----
 --- <If the buffer doesn't exist, or doesn't have a name, an empty
 --- string is returned. >vim
 ---   echo bufname("#")    " alternate buffer name
@@ -699,10 +595,6 @@ function vim.fn.bufname(buf) end
 --- number necessarily exist, because ":bwipeout" may have removed
 --- them.  Use bufexists() to test for the existence of a buffer.
 ---
---- Can also be used as a |method|: >vim
----   echo bufref->bufnr()
---- <
----
 --- @param buf? any
 --- @param create? any
 --- @return integer
@@ -718,10 +610,6 @@ function vim.fn.bufnr(buf, create) end
 --- Only deals with the current tab page.  See |win_findbuf()| for
 --- finding more.
 ---
---- Can also be used as a |method|: >vim
----   FindBuffer()->bufwinid()
---- <
----
 --- @param buf any
 --- @return integer
 function vim.fn.bufwinid(buf) end
@@ -736,10 +624,6 @@ function vim.fn.bufwinid(buf) end
 --- <The number can be used with |CTRL-W_w| and ":wincmd w"
 --- |:wincmd|.
 ---
---- Can also be used as a |method|: >vim
----   FindBuffer()->bufwinnr()
---- <
----
 --- @param buf any
 --- @return integer
 function vim.fn.bufwinnr(buf) end
@@ -752,10 +636,6 @@ function vim.fn.bufwinnr(buf) end
 --- Also see |line2byte()|, |go| and |:goto|.
 ---
 --- Returns -1 if the {byte} value is invalid.
----
---- Can also be used as a |method|: >vim
----   GetOffset()->byte2line()
---- <
 ---
 --- @param byte any
 --- @return integer
@@ -795,9 +675,6 @@ function vim.fn.byte2line(byte) end
 ---   echo byteidx('a😊😊', 2, 1)  " returns 1
 ---   echo byteidx('a😊😊', 3, 1)  " returns 5
 --- <
---- Can also be used as a |method|: >vim
----   GetName()->byteidx(idx)
---- <
 ---
 --- @param expr any
 --- @param nr integer
@@ -815,10 +692,6 @@ function vim.fn.byteidx(expr, nr, utf16) end
 --- character is 3 bytes), the second echo results in 1 ('e' is
 --- one byte).
 ---
---- Can also be used as a |method|: >vim
----   GetName()->byteidxcomp(idx)
---- <
----
 --- @param expr any
 --- @param nr integer
 --- @param utf16? any
@@ -832,10 +705,6 @@ function vim.fn.byteidxcomp(expr, nr, utf16) end
 --- Returns the return value of the called function.
 --- {dict} is for functions with the "dict" attribute.  It will be
 --- used to set the local variable "self". |Dictionary-function|
----
---- Can also be used as a |method|: >vim
----   GetFunc()->call([arg, arg], dict)
---- <
 ---
 --- @param func any
 --- @param arglist any
@@ -855,10 +724,6 @@ function vim.fn.call(func, arglist, dict) end
 --- <  4.0
 ---
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
----
---- Can also be used as a |method|: >vim
----   Compute()->ceil()
---- <
 ---
 --- @param expr any
 --- @return number
@@ -925,10 +790,6 @@ function vim.fn.chansend(id, data) end
 ---
 --- Returns 0 if {string} is not a |String|.
 ---
---- Can also be used as a |method|: >vim
----   GetChar()->char2nr()
---- <
----
 --- @param string string
 --- @param utf8? any
 --- @return 0|1
@@ -955,10 +816,6 @@ function vim.fn.charclass(string) end
 --- With the cursor on '세' in line 5 with text "여보세요": >vim
 ---   echo charcol('.')    " returns 3
 ---   echo col('.')    " returns 7
----
---- <Can also be used as a |method|: >vim
----   GetPos()->col()
---- <
 ---
 --- @param expr any
 --- @param winid? integer
@@ -997,9 +854,6 @@ function vim.fn.charcol(expr, winid) end
 ---   echo charidx('áb́ć', 16)    " returns -1
 ---   echo charidx('a😊😊', 4, 0, 1)  " returns 2
 --- <
---- Can also be used as a |method|: >vim
----   GetName()->charidx(idx)
---- <
 ---
 --- @param string string
 --- @param idx integer
@@ -1029,10 +883,6 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 ---      call chdir(save_dir)
 ---   endif
 ---
---- <Can also be used as a |method|: >vim
----   GetDir()->chdir()
---- <
----
 --- @param dir string
 --- @return string
 function vim.fn.chdir(dir) end
@@ -1044,10 +894,6 @@ function vim.fn.chdir(dir) end
 --- When {lnum} is invalid -1 is returned.
 --- See |C-indenting|.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->cindent()
---- <
----
 --- @param lnum integer
 --- @return integer
 function vim.fn.cindent(lnum) end
@@ -1056,10 +902,6 @@ function vim.fn.cindent(lnum) end
 --- by |matchadd()| and the |:match| commands.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
----
---- Can also be used as a |method|: >vim
----   GetWin()->clearmatches()
---- <
 ---
 --- @param win? any
 function vim.fn.clearmatches(win) end
@@ -1101,10 +943,6 @@ function vim.fn.clearmatches(win) end
 --- moved, this can be used to obtain the column in Insert mode: >vim
 ---   imap <F2> <Cmd>echo col(".").."\n"<CR>
 ---
---- <Can also be used as a |method|: >vim
----   GetPos()->col()
---- <
----
 --- @param expr any
 --- @param winid? integer
 --- @return integer
@@ -1139,11 +977,6 @@ function vim.fn.col(expr, winid) end
 --- <This isn't very useful, but it shows how it works.  Note that
 --- an empty string is returned to avoid a zero being inserted.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetMatches()->complete(col('.'))
---- <
----
 --- @param startcol any
 --- @param matches any
 function vim.fn.complete(startcol, matches) end
@@ -1155,10 +988,6 @@ function vim.fn.complete(startcol, matches) end
 --- the list.
 --- See |complete-functions| for an explanation of {expr}.  It is
 --- the same as one item in the list that 'omnifunc' would return.
----
---- Can also be used as a |method|: >vim
----   GetMoreMatches()->complete_add()
---- <
 ---
 --- @param expr any
 --- @return 0|1|2
@@ -1231,10 +1060,6 @@ function vim.fn.complete_check() end
 ---   " Get only 'mode' and 'pum_visible'
 ---   call complete_info(['mode', 'pum_visible'])
 ---
---- <Can also be used as a |method|: >vim
----   GetItems()->complete_info()
---- <
----
 --- @param what? any
 --- @return table
 function vim.fn.complete_info(what) end
@@ -1290,10 +1115,6 @@ function vim.fn.complete_info(what) end
 --- don't fit, a vertical layout is used anyway.  For some systems
 --- the horizontal layout is always used.
 ---
---- Can also be used as a |method|in: >vim
----   BuildMessage()->confirm("&Yes\n&No")
---- <
----
 --- @param msg any
 --- @param choices? any
 --- @param default? any
@@ -1309,9 +1130,6 @@ function vim.fn.confirm(msg, choices, default, type) end
 --- changing an item changes the contents of both |Lists|.
 --- A |Dictionary| is copied in a similar way as a |List|.
 --- Also see |deepcopy()|.
---- Can also be used as a |method|: >vim
----   mylist->copy()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -1326,10 +1144,6 @@ function vim.fn.copy(expr) end
 ---   echo cos(-4.01)
 --- <  -0.646043
 ---
---- Can also be used as a |method|: >vim
----   Compute()->cos()
---- <
----
 --- @param expr any
 --- @return number
 function vim.fn.cos(expr) end
@@ -1343,10 +1157,6 @@ function vim.fn.cos(expr) end
 --- <  1.127626 >vim
 ---   echo cosh(-0.5)
 --- <  -1.127626
----
---- Can also be used as a |method|: >vim
----   Compute()->cosh()
---- <
 ---
 --- @param expr any
 --- @return number
@@ -1363,10 +1173,6 @@ function vim.fn.cosh(expr) end
 --- When {comp} is a string then the number of not overlapping
 --- occurrences of {expr} is returned. Zero is returned when
 --- {expr} is an empty string.
----
---- Can also be used as a |method|: >vim
----   mylist->count(val)
---- <
 ---
 --- @param comp any
 --- @param expr any
@@ -1451,10 +1257,6 @@ function vim.fn.cursor(lnum, col, off) end
 --- position within a <Tab> or after the last character.
 --- Returns 0 when the position could be set, -1 otherwise.
 ---
---- Can also be used as a |method|: >vim
----   GetCursorPos()->cursor()
---- <
----
 --- @param list any
 --- @return any
 function vim.fn.cursor(list) end
@@ -1466,10 +1268,6 @@ function vim.fn.cursor(list) end
 ---
 --- Returns |TRUE| if successfully interrupted the program.
 --- Otherwise returns |FALSE|.
----
---- Can also be used as a |method|: >vim
----   GetPid()->debugbreak()
---- <
 ---
 --- @param pid any
 --- @return any
@@ -1494,10 +1292,6 @@ function vim.fn.debugbreak(pid) end
 --- {noref} set to 1 will fail.
 --- Also see |copy()|.
 ---
---- Can also be used as a |method|: >vim
----   GetObject()->deepcopy()
---- <
----
 --- @param expr any
 --- @param noref? any
 --- @return any
@@ -1521,10 +1315,6 @@ function vim.fn.deepcopy(expr, noref) end
 --- operation was successful and -1/true when the deletion failed
 --- or partly failed.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->delete()
---- <
----
 --- @param fname integer
 --- @param flags? string
 --- @return integer
@@ -1542,10 +1332,6 @@ function vim.fn.delete(fname, flags) end
 --- {first} and {last} are used like with |getline()|. Note that
 --- when using |line()| this refers to the current buffer. Use "$"
 --- to refer to the last line in buffer {buf}.
----
---- Can also be used as a |method|: >vim
----   GetBuffer()->deletebufline(1)
---- <
 ---
 --- @param buf any
 --- @param first any
@@ -1630,10 +1416,6 @@ function vim.fn.did_filetype() end
 --- line, "'m" mark m, etc.
 --- Returns 0 if the current window is not in diff mode.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->diff_filler()
---- <
----
 --- @param lnum integer
 --- @return any
 function vim.fn.diff_filler(lnum) end
@@ -1647,10 +1429,6 @@ function vim.fn.diff_filler(lnum) end
 --- line.
 --- The highlight ID can be used with |synIDattr()| to obtain
 --- syntax information about the highlighting.
----
---- Can also be used as a |method|: >vim
----   GetLnum()->diff_hlID(col)
---- <
 ---
 --- @param lnum integer
 --- @param col integer
@@ -1672,9 +1450,6 @@ function vim.fn.diff_hlID(lnum, col) end
 --- call digraph_set('aa', 'あ')
 --- echo digraph_get('aa')    " Returns 'あ'
 --- <
---- Can also be used as a |method|: >vim
----   GetChars()->digraph_get()
---- <
 ---
 --- @param chars any
 --- @return any
@@ -1692,9 +1467,6 @@ function vim.fn.digraph_get(chars) end
 ---
 --- " Get all the digraphs, including default digraphs
 --- echo digraph_getlist(1)
---- <
---- Can also be used as a |method|: >vim
----   GetNumber()->digraph_getlist()
 --- <
 ---
 --- @param listall? any
@@ -1756,10 +1528,6 @@ function vim.fn.digraph_setlist(digraphlist) end
 --- - |v:false| and |v:null| are empty, |v:true| is not.
 --- - A |Blob| is empty when its length is zero.
 ---
---- Can also be used as a |method|: >vim
----   mylist->empty()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.empty(expr) end
@@ -1782,10 +1550,6 @@ function vim.fn.environ() end
 ---   c:\\program\ files\\vim
 --- <Also see |shellescape()| and |fnameescape()|.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->escape(' \')
---- <
----
 --- @param string string
 --- @param chars any
 --- @return any
@@ -1796,10 +1560,6 @@ function vim.fn.escape(string, chars) end
 --- This works for Numbers, Floats, Strings, Blobs and composites
 --- of them.  Also works for |Funcref|s that refer to existing
 --- functions.
----
---- Can also be used as a |method|: >vim
----   argv->join()->eval()
---- <
 ---
 --- @param string string
 --- @return any
@@ -1835,10 +1595,6 @@ function vim.fn.eventhandler() end
 ---   -1  not implemented on this system
 --- |exepath()| can be used to get the full path of an executable.
 ---
---- Can also be used as a |method|: >vim
----   GetCommand()->executable()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.executable(expr) end
@@ -1870,10 +1626,6 @@ function vim.fn.executable(expr) end
 --- To execute a command in another window than the current one
 --- use `win_execute()`.
 ---
---- Can also be used as a |method|: >vim
----   GetCommand()->execute()
---- <
----
 --- @param command any
 --- @param silent? boolean
 --- @return any
@@ -1883,10 +1635,6 @@ function vim.fn.execute(command, silent) end
 --- given as a (partial or full) path or is found in $PATH.
 --- Returns empty string otherwise.
 --- If {expr} starts with "./" the |current-directory| is used.
----
---- Can also be used as a |method|: >vim
----   GetCommand()->exepath()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -1979,10 +1727,6 @@ function vim.fn.exepath(expr) end
 --- <This doesn't check for existence of the "bufcount" variable,
 --- but gets the value of "bufcount", and checks if that exists.
 ---
---- Can also be used as a |method|: >vim
----   Varname()->exists()
---- <
----
 --- @param expr any
 --- @return 0|1
 function vim.fn.exists(expr) end
@@ -1996,10 +1740,6 @@ function vim.fn.exists(expr) end
 --- <  7.389056 >vim
 ---   echo exp(-1)
 --- <  0.367879
----
---- Can also be used as a |method|: >vim
----   Compute()->exp()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -2095,10 +1835,6 @@ function vim.fn.exp(expr) end
 --- See |glob()| for finding existing files.  See |system()| for
 --- getting the raw output of an external command.
 ---
---- Can also be used as a |method|: >vim
----   Getpattern()->expand()
---- <
----
 --- @param string string
 --- @param nosuf? boolean
 --- @param list? any
@@ -2126,9 +1862,6 @@ function vim.fn.expand(string, nosuf, list) end
 ---   make /path/runtime/doc/builtin.o
 --- < >vim
 ---   echo expandcmd('make %<.o', {'errmsg': v:true})
---- <
---- Can also be used as a |method|: >vim
----   GetCommand()->expandcmd()
 --- <
 ---
 --- @param string string
@@ -2170,10 +1903,6 @@ function vim.fn.expandcmd(string, options) end
 --- When {expr1} is locked and {expr2} is not empty the operation
 --- fails.
 --- Returns {expr1}.  Returns 0 on error.
----
---- Can also be used as a |method|: >vim
----   mylist->extend(otherlist)
---- <
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -2235,10 +1964,6 @@ function vim.fn.extendnew(expr1, expr2, expr3) end
 ---
 --- Return value is always 0.
 ---
---- Can also be used as a |method|: >vim
----   GetInput()->feedkeys()
---- <
----
 --- @param string string
 --- @param mode? string
 --- @return any
@@ -2267,10 +1992,6 @@ function vim.fn.file_readable(file) end
 ---   1
 --- <
 ---
---- Can also be used as a |method|: >vim
----   GetName()->filereadable()
---- <
----
 --- @param file string
 --- @return 0|1
 function vim.fn.filereadable(file) end
@@ -2279,10 +2000,6 @@ function vim.fn.filereadable(file) end
 --- name {file} exists, and can be written.  If {file} doesn't
 --- exist, or is not writable, the result is 0.  If {file} is a
 --- directory, and we can write to it, the result is 2.
----
---- Can also be used as a |method|: >vim
----   GetName()->filewritable()
---- <
 ---
 --- @param file string
 --- @return 0|1
@@ -2337,10 +2054,6 @@ function vim.fn.filewritable(file) end
 --- {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
 ---
---- Can also be used as a |method|: >vim
----   mylist->filter(expr2)
---- <
----
 --- @param expr1 any
 --- @param expr2 any
 --- @return any
@@ -2363,10 +2076,6 @@ function vim.fn.filter(expr1, expr2) end
 ---
 --- This is quite similar to the ex-command `:find`.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->finddir()
---- <
----
 --- @param name string
 --- @param path? string
 --- @param count? any
@@ -2379,10 +2088,6 @@ function vim.fn.finddir(name, path, count) end
 ---   echo findfile("tags.vim", ".;")
 --- <Searches from the directory of the current file upwards until
 --- it finds the file "tags.vim".
----
---- Can also be used as a |method|: >vim
----   GetName()->findfile()
---- <
 ---
 --- @param name string
 --- @param path? string
@@ -2407,10 +2112,6 @@ function vim.fn.findfile(name, path, count) end
 --- <  [1, 2, 3, 4, 5] >vim
 ---   echo flatten([1, [2, [3, 4]], 5], 1)
 --- <  [1, 2, [3, 4], 5]
----
---- Can also be used as a |method|: >vim
----   mylist->flatten()
---- <
 ---
 --- @param list any
 --- @param maxdepth? any
@@ -2445,10 +2146,6 @@ function vim.fn.flattennew(list, maxdepth) end
 ---   echo float2nr(1.0e-100)
 --- <  0
 ---
---- Can also be used as a |method|: >vim
----   Compute()->float2nr()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.float2nr(expr) end
@@ -2464,10 +2161,6 @@ function vim.fn.float2nr(expr) end
 --- <  -6.0  >vim
 ---   echo floor(4.0)
 --- <  4.0
----
---- Can also be used as a |method|: >vim
----   Compute()->floor()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -2488,10 +2181,6 @@ function vim.fn.floor(expr) end
 ---   echo fmod(-12.33, 1.22)
 --- <  -0.13
 ---
---- Can also be used as a |method|: >vim
----   Compute()->fmod(1.22)
---- <
----
 --- @param expr1 any
 --- @param expr2 any
 --- @return any
@@ -2511,9 +2200,6 @@ function vim.fn.fmod(expr1, expr2) end
 ---   exe "edit " .. fnameescape(fname)
 --- <results in executing: >vim
 ---   edit \+some\ str\%nge\|name
---- <
---- Can also be used as a |method|: >vim
----   GetName()->fnameescape()
 --- <
 ---
 --- @param string string
@@ -2536,10 +2222,6 @@ function vim.fn.fnameescape(string) end
 --- Note: Environment variables don't work in {fname}, use
 --- |expand()| first then.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->fnamemodify(':p:h')
---- <
----
 --- @param fname integer
 --- @param mods string
 --- @return string
@@ -2551,10 +2233,6 @@ function vim.fn.fnamemodify(fname, mods) end
 --- {lnum} is used like with |getline()|.  Thus "." is the current
 --- line, "'m" mark m, etc.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->foldclosed()
---- <
----
 --- @param lnum integer
 --- @return integer
 function vim.fn.foldclosed(lnum) end
@@ -2564,10 +2242,6 @@ function vim.fn.foldclosed(lnum) end
 --- If the line {lnum} is not in a closed fold, -1 is returned.
 --- {lnum} is used like with |getline()|.  Thus "." is the current
 --- line, "'m" mark m, etc.
----
---- Can also be used as a |method|: >vim
----   GetLnum()->foldclosedend()
---- <
 ---
 --- @param lnum integer
 --- @return integer
@@ -2583,10 +2257,6 @@ function vim.fn.foldclosedend(lnum) end
 --- previous line is usually available.
 --- {lnum} is used like with |getline()|.  Thus "." is the current
 --- line, "'m" mark m, etc.
----
---- Can also be used as a |method|: >vim
----   GetLnum()->foldlevel()
---- <
 ---
 --- @param lnum integer
 --- @return integer
@@ -2619,10 +2289,6 @@ function vim.fn.foldtext() end
 --- line, "'m" mark m, etc.
 --- Useful when exporting folded text, e.g., to HTML.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->foldtextresult()
---- <
----
 --- @param lnum integer
 --- @return string
 function vim.fn.foldtextresult(lnum) end
@@ -2638,10 +2304,6 @@ function vim.fn.foldtextresult(lnum) end
 --- For example `fullcommand('s')`, `fullcommand('sub')`,
 --- `fullcommand(':%substitute')` all return "substitute".
 ---
---- Can also be used as a |method|: >vim
----   GetName()->fullcommand()
---- <
----
 --- @param name string
 --- @return string
 function vim.fn.fullcommand(name) end
@@ -2656,10 +2318,6 @@ function vim.fn.fullcommand(name) end
 --- when only intending to use the function name, use |function()|
 --- instead). {name} cannot be a builtin function.
 --- Returns 0 on error.
----
---- Can also be used as a |method|: >vim
----   GetFuncname()->funcref([arg])
---- <
 ---
 --- @param name string
 --- @param arglist? any
@@ -2748,10 +2406,6 @@ function vim.fn.funcref(name, arglist, dict) end
 --- <
 --- Returns 0 on error.
 ---
---- Can also be used as a |method|: >vim
----   GetFuncname()->function([arg])
---- <
----
 --- @param name string
 --- @param arglist? any
 --- @param dict? any
@@ -2784,9 +2438,6 @@ function vim.fn.garbagecollect(atexit) end
 --- Get item {idx} from |List| {list}.  When this item is not
 --- available return {default}.  Return zero when {default} is
 --- omitted.
---- Can also be used as a |method|: >vim
----   mylist->get(idx)
---- <
 ---
 --- @param list any[]
 --- @param idx integer
@@ -2898,9 +2549,6 @@ function vim.fn.getbufinfo(buf) end
 --- To get buffer-local options use: >vim
 ---   getbufvar({bufnr}, '&option_name')
 --- <
---- Can also be used as a |method|: >vim
----   GetBufnr()->getbufinfo()
---- <
 ---
 --- @param dict? table<string,any>
 --- @return any
@@ -2929,10 +2577,6 @@ function vim.fn.getbufinfo(dict) end
 ---
 --- Example: >vim
 ---   let lines = getbufline(bufnr("myfile"), 1, "$")
----
---- <Can also be used as a |method|: >vim
----   GetBufnr()->getbufline(lnum)
---- <
 ---
 --- @param buf any
 --- @param lnum integer
@@ -2968,10 +2612,6 @@ function vim.fn.getbufoneline(buf, lnum) end
 ---   let bufmodified = getbufvar(1, "&mod")
 ---   echo "todo myvar = " .. getbufvar("todo", "myvar")
 ---
---- <Can also be used as a |method|: >vim
----   GetBufnr()->getbufvar(varname)
---- <
----
 --- @param buf any
 --- @param varname string
 --- @param def? any
@@ -3000,10 +2640,6 @@ function vim.fn.getcellwidths() end
 --- If buffer {buf} is the current buffer, then the current
 --- position refers to the position in the list. For other
 --- buffers, it is set to the length of the list.
----
---- Can also be used as a |method|: >vim
----   GetBufnr()->getchangelist()
---- <
 ---
 --- @param buf? integer|string
 --- @return table[]
@@ -3105,9 +2741,6 @@ function vim.fn.getcharmod() end
 --- With the cursor on '세' in line 5 with text "여보세요": >vim
 ---   getcharpos('.')    returns [0, 5, 3, 0]
 ---   getpos('.')    returns [0, 5, 7, 0]
---- <
---- Can also be used as a |method|: >vim
----   GetMark()->getcharpos()
 --- <
 ---
 --- @param expr any
@@ -3286,10 +2919,6 @@ function vim.fn.getcmdwintype() end
 --- If there are no matches, an empty list is returned.  An
 --- invalid value for {type} produces an error.
 ---
---- Can also be used as a |method|: >vim
----   GetPattern()->getcompletion('color')
---- <
----
 --- @param pat any
 --- @param type any
 --- @param filtered? any
@@ -3320,10 +2949,6 @@ function vim.fn.getcompletion(pat, type, filtered) end
 --- <Note that this only works within the window.  See
 --- |winrestview()| for restoring more state.
 ---
---- Can also be used as a |method|: >vim
----   GetWinid()->getcurpos()
---- <
----
 --- @param winid? integer
 --- @return any
 function vim.fn.getcurpos(winid) end
@@ -3335,9 +2960,6 @@ function vim.fn.getcurpos(winid) end
 --- With the cursor on '보' in line 3 with text "여보세요": >vim
 ---   getcursorcharpos()  " returns [0, 3, 2, 0, 3]
 ---   getcurpos()    " returns [0, 3, 4, 0, 3]
---- <
---- Can also be used as a |method|: >vim
----   GetWinid()->getcursorcharpos()
 --- <
 ---
 --- @param winid? integer
@@ -3359,10 +2981,6 @@ function vim.fn.getcursorcharpos(winid) end
 --- directory is returned.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 ---
---- Can also be used as a |method|: >vim
----   GetWinnr()->getcwd()
---- <
----
 --- @param winnr? integer
 --- @param tabnr? integer
 --- @return string
@@ -3375,10 +2993,6 @@ function vim.fn.getcwd(winnr, tabnr) end
 --- <When the variable does not exist |v:null| is returned.  That
 --- is different from a variable set to an empty string.
 --- See also |expr-env|.
----
---- Can also be used as a |method|: >vim
----   GetVarname()->getenv()
---- <
 ---
 --- @param name string
 --- @return string
@@ -3413,9 +3027,6 @@ function vim.fn.getfontname(name) end
 --- <This will hopefully (from a security point of view) display
 --- the string "rw-r--r--" or even "rw-------".
 ---
---- Can also be used as a |method|: >vim
----   GetFilename()->getfperm()
---- <
 --- For setting permissions use |setfperm()|.
 ---
 --- @param fname integer
@@ -3429,10 +3040,6 @@ function vim.fn.getfperm(fname) end
 --- If the size of {fname} is too big to fit in a Number then -2
 --- is returned.
 ---
---- Can also be used as a |method|: >vim
----   GetFilename()->getfsize()
---- <
----
 --- @param fname integer
 --- @return integer
 function vim.fn.getfsize(fname) end
@@ -3442,10 +3049,6 @@ function vim.fn.getfsize(fname) end
 --- since 1st Jan 1970, and may be passed to strftime().  See also
 --- |localtime()| and |strftime()|.
 --- If the file {fname} can't be found -1 is returned.
----
---- Can also be used as a |method|: >vim
----   GetFilename()->getftime()
---- <
 ---
 --- @param fname integer
 --- @return integer
@@ -3470,10 +3073,6 @@ function vim.fn.getftime(fname) end
 --- systems that support it.  On some systems only "dir" and
 --- "file" are returned.
 ---
---- Can also be used as a |method|: >vim
----   GetFilename()->getftype()
---- <
----
 --- @param fname integer
 --- @return 'file'|'dir'|'link'|'bdev'|'cdev'|'socket'|'fifo'|'other'
 function vim.fn.getftype(fname) end
@@ -3496,10 +3095,6 @@ function vim.fn.getftype(fname) end
 ---   coladd    column offset for 'virtualedit'
 ---   filename  filename if available
 ---   lnum    line number
----
---- Can also be used as a |method|: >vim
----   GetWinnr()->getjumplist()
---- <
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -3526,9 +3121,6 @@ function vim.fn.getjumplist(winnr, tabnr) end
 ---   let start = line('.')
 ---   let end = search("^$") - 1
 ---   let lines = getline(start, end)
----
---- <Can also be used as a |method|: >vim
----   ComputeLnum()->getline()
 ---
 --- <To get lines from another buffer see |getbufline()| and
 --- |getbufoneline()|
@@ -3591,10 +3183,6 @@ function vim.fn.getloclist(nr, what) end
 ---
 --- Refer to |getpos()| for getting information about a specific
 --- mark.
----
---- Can also be used as a |method|: >vim
----   GetBufnr()->getmarklist()
---- <
 ---
 --- @param buf? any
 --- @return any
@@ -3699,10 +3287,6 @@ function vim.fn.getpid() end
 ---   " ...
 ---   call setpos("'a", save_a_mark)
 --- <Also see |getcharpos()|, |getcurpos()| and |setpos()|.
----
---- Can also be used as a |method|: >vim
----   GetMark()->getpos()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -3834,10 +3418,6 @@ function vim.fn.getqflist(what) end
 ---
 --- If {regname} is not specified, |v:register| is used.
 ---
---- Can also be used as a |method|: >vim
----   GetRegname()->getreg()
---- <
----
 --- @param regname? string
 --- @param list? any
 --- @return string|string[]
@@ -3866,10 +3446,6 @@ function vim.fn.getreg(regname, list) end
 --- If {regname} is not specified, |v:register| is used.
 --- The returned Dictionary can be passed to |setreg()|.
 ---
---- Can also be used as a |method|: >vim
----   GetRegname()->getreginfo()
---- <
----
 --- @param regname? string
 --- @return table
 function vim.fn.getreginfo(regname) end
@@ -3883,10 +3459,6 @@ function vim.fn.getreginfo(regname) end
 --- <CTRL-V> is one character with value 0x16.
 --- The {regname} argument is a string.  If {regname} is not
 --- specified, |v:register| is used.
----
---- Can also be used as a |method|: >vim
----   GetRegname()->getregtype()
---- <
 ---
 --- @param regname? string
 --- @return string
@@ -3944,10 +3516,6 @@ function vim.fn.getscriptinfo(opts) end
 ---       tabpage-local variables
 ---   windows    List of |window-ID|s in the tab page.
 ---
---- Can also be used as a |method|: >vim
----   GetTabnr()->gettabinfo()
---- <
----
 --- @param tabnr? integer
 --- @return any
 function vim.fn.gettabinfo(tabnr) end
@@ -3960,10 +3528,6 @@ function vim.fn.gettabinfo(tabnr) end
 --- Note that the name without "t:" must be used.
 --- When the tab or variable doesn't exist {def} or an empty
 --- string is returned, there is no error message.
----
---- Can also be used as a |method|: >vim
----   GetTabnr()->gettabvar(varname)
---- <
 ---
 --- @param tabnr integer
 --- @param varname string
@@ -3995,9 +3559,6 @@ function vim.fn.gettabvar(tabnr, varname, def) end
 --- <
 --- To obtain all window-local variables use: >vim
 ---   gettabwinvar({tabnr}, {winnr}, '&')
---- <
---- Can also be used as a |method|: >vim
----   GetTabnr()->gettabwinvar(winnr, varname)
 --- <
 ---
 --- @param tabnr integer
@@ -4033,10 +3594,6 @@ function vim.fn.gettabwinvar(tabnr, winnr, varname, def) end
 ---   tagname    name of the tag
 ---
 --- See |tagstack| for more information about the tag stack.
----
---- Can also be used as a |method|: >vim
----   GetWinnr()->gettagstack()
---- <
 ---
 --- @param winnr? integer
 --- @return any
@@ -4089,10 +3646,6 @@ function vim.fn.gettext(text) end
 ---   winrow    topmost screen line of the window;
 ---       "row" from |win_screenpos()|
 ---
---- Can also be used as a |method|: >vim
----   GetWinnr()->getwininfo()
---- <
----
 --- @param winid? integer
 --- @return any
 function vim.fn.getwininfo(winid) end
@@ -4115,9 +3668,6 @@ function vim.fn.getwininfo(winid) end
 ---     endif
 ---     " Do some work here
 ---   endwhile
---- <
---- Can also be used as a |method|: >vim
----   GetTimeout()->getwinpos()
 --- <
 ---
 --- @param timeout? integer
@@ -4144,10 +3694,6 @@ function vim.fn.getwinposy() end
 --- Examples: >vim
 ---   let list_is_on = getwinvar(2, '&list')
 ---   echo "myvar = " .. getwinvar(1, 'myvar')
----
---- <Can also be used as a |method|: >vim
----   GetWinnr()->getwinvar(varname)
---- <
 ---
 --- @param winnr integer
 --- @param varname string
@@ -4190,10 +3736,6 @@ function vim.fn.getwinvar(winnr, varname, def) end
 --- See |expand()| for expanding special Vim variables.  See
 --- |system()| for getting the raw output of an external command.
 ---
---- Can also be used as a |method|: >vim
----   GetExpr()->glob()
---- <
----
 --- @param expr any
 --- @param nosuf? boolean
 --- @param list? any
@@ -4215,10 +3757,6 @@ function vim.fn.glob(expr, nosuf, list, alllinks) end
 --- empty string.
 --- Note that the result depends on the system.  On MS-Windows
 --- a backslash usually means a path separator.
----
---- Can also be used as a |method|: >vim
----   GetExpr()->glob2regpat()
---- <
 ---
 --- @param string string
 --- @return any
@@ -4257,11 +3795,6 @@ function vim.fn.glob2regpat(string) end
 ---   echo globpath(&rtp, "**/README.txt")
 --- <Upwards search and limiting the depth of "**" is not
 --- supported, thus using 'path' will not always work properly.
----
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetExpr()->globpath(&rtp)
---- <
 ---
 --- @param path string
 --- @param expr any
@@ -4346,10 +3879,6 @@ function vim.fn.has(feature) end
 --- has an entry with key {key}.  FALSE otherwise. The {key}
 --- argument is a string.
 ---
---- Can also be used as a |method|: >vim
----   mydict->has_key(key)
---- <
----
 --- @param dict any
 --- @param key any
 --- @return 0|1
@@ -4370,10 +3899,6 @@ function vim.fn.has_key(dict, key) end
 --- {winnr} can be the window number or the |window-ID|.
 --- If {winnr} is -1 it is ignored, only the tab is resolved.
 --- Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
----
---- Can also be used as a |method|: >vim
----   GetWinnr()->haslocaldir()
---- <
 ---
 --- @param winnr? integer
 --- @param tabnr? integer
@@ -4409,10 +3934,6 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 ---   endif
 --- <This installs the mapping to "\ABCdoit" only if there isn't
 --- already a mapping to "\ABCdoit".
----
---- Can also be used as a |method|: >vim
----   GetRHS()->hasmapto()
---- <
 ---
 --- @param what any
 --- @param mode? string
@@ -4454,11 +3975,6 @@ function vim.fn.highlight_exists(name) end
 ---   let date=input("Enter date: ")
 --- <This function is not available in the |sandbox|.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetHistory()->histadd('search')
---- <
----
 --- @param history any
 --- @param item any
 --- @return 0|1
@@ -4495,9 +4011,6 @@ function vim.fn.histadd(history, item) end
 ---   call histdel("search", -1)
 ---   let \@/ = histget("search", -1)
 --- <
---- Can also be used as a |method|: >vim
----   GetHistory()->histdel()
---- <
 ---
 --- @param history any
 --- @param item? any
@@ -4518,9 +4031,6 @@ function vim.fn.histdel(history, item) end
 --- the {num}th entry from the output of |:history|. >vim
 ---   command -nargs=1 H execute histget("cmd", 0+<args>)
 --- <
---- Can also be used as a |method|: >vim
----   GetHistory()->histget()
---- <
 ---
 --- @param history any
 --- @param index? any
@@ -4534,10 +4044,6 @@ function vim.fn.histget(history, index) end
 --- Example: >vim
 ---   let inp_index = histnr("expr")
 ---
---- <Can also be used as a |method|: >vim
----   GetHistory()->histnr()
---- <
----
 --- @param history any
 --- @return integer
 function vim.fn.histnr(history) end
@@ -4550,9 +4056,6 @@ function vim.fn.histnr(history) end
 --- "Comment" group: >vim
 ---   echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 --- <
---- Can also be used as a |method|: >vim
----   GetName()->hlID()
---- <
 ---
 --- @param name string
 --- @return integer
@@ -4563,10 +4066,6 @@ function vim.fn.hlID(name) end
 --- defined in some way.  Not necessarily when highlighting has
 --- been defined for it, it may also have been used for a syntax
 --- item.
----
---- Can also be used as a |method|: >vim
----   GetName()->hlexists()
---- <
 ---
 --- @param name string
 --- @return 0|1
@@ -4589,10 +4088,6 @@ function vim.fn.hostname() end
 --- Note that Vim uses UTF-8 for all Unicode encodings, conversion
 --- from/to UCS-2 is automatically changed to use UTF-8.  You
 --- cannot use UCS-2 in a string anyway, because of the NUL bytes.
----
---- Can also be used as a |method|: >vim
----   GetText()->iconv('latin1', 'utf-8')
---- <
 ---
 --- @param string string
 --- @param from any
@@ -4625,10 +4120,6 @@ function vim.fn.id(expr) end
 --- |getline()|.
 --- When {lnum} is invalid -1 is returned.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->indent()
---- <
----
 --- @param lnum integer
 --- @return integer
 function vim.fn.indent(lnum) end
@@ -4658,10 +4149,6 @@ function vim.fn.indent(lnum) end
 ---   if index(numbers, 123) >= 0
 ---     " ...
 ---   endif
----
---- <Can also be used as a |method|: >vim
----   GetObject()->index(what)
---- <
 ---
 --- @param object any
 --- @param expr any
@@ -4706,10 +4193,6 @@ function vim.fn.index(object, expr, start, ic) end
 ---   echo indexof(l, "v:val.n == 20")
 ---   echo indexof(l, {i, v -> v.n == 30})
 ---   echo indexof(l, "v:val.n == 20", #{startidx: 1})
----
---- <Can also be used as a |method|: >vim
----   mylist->indexof(expr)
---- <
 ---
 --- @param object any
 --- @param expr any
@@ -4833,10 +4316,6 @@ function vim.fn.input(prompt, text, completion) end
 ---     call inputrestore()
 ---   endfunction
 ---
---- <Can also be used as a |method|: >vim
----   GetPrompt()->input()
---- <
----
 --- @param opts table
 --- @return any
 function vim.fn.input(opts) end
@@ -4863,10 +4342,6 @@ function vim.fn.inputdialog(...) end
 --- Example: >vim
 ---   let color = inputlist(['Select color:', '1. red',
 ---     \ '2. green', '3. blue'])
----
---- <Can also be used as a |method|: >vim
----   GetChoices()->inputlist()
---- <
 ---
 --- @param textlist any
 --- @return any
@@ -4900,10 +4375,6 @@ function vim.fn.inputsave() end
 --- typed on the command-line in response to the issued prompt.
 --- NOTE: Command-line completion is not supported.
 ---
---- Can also be used as a |method|: >vim
----   GetPrompt()->inputsecret()
---- <
----
 --- @param prompt any
 --- @param text? any
 --- @return any
@@ -4924,10 +4395,6 @@ function vim.fn.inputsecret(prompt, text) end
 --- <The last example can be done simpler with |add()|.
 --- Note that when {item} is a |List| it is inserted as a single
 --- item.  Use |extend()| to concatenate |Lists|.
----
---- Can also be used as a |method|: >vim
----   mylist->insert(item)
---- <
 ---
 --- @param object any
 --- @param item any
@@ -4952,11 +4419,6 @@ function vim.fn.insert(object, item, idx) end
 function vim.fn.interrupt() end
 
 --- Bitwise invert.  The argument is converted to a number.  A
---- List, Dict or Float argument causes an error.  Example: >vim
----   let bits = invert(bits)
---- <Can also be used as a |method|: >vim
----   let bits = bits->invert()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -4966,10 +4428,6 @@ function vim.fn.invert(expr) end
 --- with the name {directory} exists.  If {directory} doesn't
 --- exist, or isn't a directory, the result is |FALSE|.  {directory}
 --- is any expression, which is used as a String.
----
---- Can also be used as a |method|: >vim
----   GetName()->isdirectory()
---- <
 ---
 --- @param directory any
 --- @return 0|1
@@ -4981,10 +4439,6 @@ function vim.fn.isdirectory(directory) end
 --- <  1 >vim
 ---   echo isinf(-1.0 / 0.0)
 --- <  -1
----
---- Can also be used as a |method|: >vim
----   Compute()->isinf()
---- <
 ---
 --- @param expr any
 --- @return 1|0|-1
@@ -5003,10 +4457,6 @@ function vim.fn.isinf(expr) end
 --- <When {expr} is a variable that does not exist you get an error
 --- message.  Use |exists()| to check for existence.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->islocked()
---- <
----
 --- @param expr any
 --- @return 0|1
 function vim.fn.islocked(expr) end
@@ -5014,10 +4464,6 @@ function vim.fn.islocked(expr) end
 --- Return |TRUE| if {expr} is a float with value NaN. >vim
 ---   echo isnan(0.0 / 0.0)
 --- <  1
----
---- Can also be used as a |method|: >vim
----   Compute()->isnan()
---- <
 ---
 --- @param expr any
 --- @return 0|1
@@ -5031,10 +4477,6 @@ function vim.fn.isnan(expr) end
 ---   for [key, value] in items(mydict)
 ---      echo key .. ': ' .. value
 ---   endfor
----
---- <Can also be used as a |method|: >vim
----   mydict->items()
---- <
 ---
 --- @param dict any
 --- @return any
@@ -5208,10 +4650,6 @@ function vim.fn.jobwait(jobs, timeout) end
 --- converted into a string like with |string()|.
 --- The opposite function is |split()|.
 ---
---- Can also be used as a |method|: >vim
----   mylist->join()
---- <
----
 --- @param list any
 --- @param sep? any
 --- @return any
@@ -5232,10 +4670,6 @@ function vim.fn.join(list, sep) end
 --- recommended and the only one required to be supported.
 --- Non-UTF-8 characters are an error.
 ---
---- Can also be used as a |method|: >vim
----   ReadObject()->json_decode()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.json_decode(expr) end
@@ -5251,20 +4685,12 @@ function vim.fn.json_decode(expr) end
 --- or special escapes like "\t", other are dumped as-is.
 --- |Blob|s are converted to arrays of the individual bytes.
 ---
---- Can also be used as a |method|: >vim
----   GetObject()->json_encode()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.json_encode(expr) end
 
 --- Return a |List| with all the keys of {dict}.  The |List| is in
 --- arbitrary order.  Also see |items()| and |values()|.
----
---- Can also be used as a |method|: >vim
----   mydict->keys()
---- <
 ---
 --- @param dict any
 --- @return any
@@ -5275,10 +4701,6 @@ function vim.fn.keys(dict) end
 ---   let xx = "\<C-Home>"
 ---   echo keytrans(xx)
 --- <  <C-Home>
----
---- Can also be used as a |method|: >vim
----   "\<C-Home>"->keytrans()
---- <
 ---
 --- @param string string
 --- @return any
@@ -5298,10 +4720,6 @@ function vim.fn.last_buffer_nr() end
 --- When {expr} is a |Dictionary| the number of entries in the
 --- |Dictionary| is returned.
 --- Otherwise an error is given and returns zero.
----
---- Can also be used as a |method|: >vim
----   mylist->len()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -5348,11 +4766,6 @@ function vim.fn.len(expr) end
 --- Examples: >vim
 ---   echo libcall("libc.so", "getenv", "HOME")
 ---
---- <Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetValue()->libcall("libc.so", "getenv")
---- <
----
 --- @param libname string
 --- @param funcname string
 --- @param argument any
@@ -5365,10 +4778,6 @@ function vim.fn.libcall(libname, funcname, argument) end
 ---   echo libcallnr("/usr/lib/libc.so", "getpid", "")
 ---   call libcallnr("libc.so", "printf", "Hello World!\n")
 ---   call libcallnr("libc.so", "sleep", 10)
---- <
---- Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetValue()->libcallnr("libc.so", "printf")
 --- <
 ---
 --- @param libname string
@@ -5408,10 +4817,6 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 --- To jump to the last known position when opening a file see
 --- |last-position-jump|.
 ---
---- Can also be used as a |method|: >vim
----   GetValue()->line()
---- <
----
 --- @param expr any
 --- @param winid? integer
 --- @return integer
@@ -5429,10 +4834,6 @@ function vim.fn.line(expr, winid) end
 --- |getline()|.  When {lnum} is invalid -1 is returned.
 --- Also see |byte2line()|, |go| and |:goto|.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->line2byte()
---- <
----
 --- @param lnum integer
 --- @return integer
 function vim.fn.line2byte(lnum) end
@@ -5442,10 +4843,6 @@ function vim.fn.line2byte(lnum) end
 --- The indent is counted in spaces, the value of 'tabstop' is
 --- relevant.  {lnum} is used just like in |getline()|.
 --- When {lnum} is invalid, -1 is returned.
----
---- Can also be used as a |method|: >vim
----   GetLnum()->lispindent()
---- <
 ---
 --- @param lnum integer
 --- @return any
@@ -5459,10 +4856,6 @@ function vim.fn.lispindent(lnum) end
 --- negative or more than 255 error *E1239* is given.
 ---
 --- |blob2list()| does the opposite.
----
---- Can also be used as a |method|: >vim
----   GetList()->list2blob()
---- <
 ---
 --- @param list any
 --- @return any
@@ -5482,10 +4875,6 @@ function vim.fn.list2blob(list) end
 ---   echo list2str([97, 769])  " returns "á"
 --- <
 --- Returns an empty string on error.
----
---- Can also be used as a |method|: >vim
----   GetList()->list2str()
---- <
 ---
 --- @param list any
 --- @param utf8? any
@@ -5508,10 +4897,6 @@ function vim.fn.localtime() end
 ---   echo log(exp(5))
 --- <  5.0
 ---
---- Can also be used as a |method|: >vim
----   Compute()->log()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.log(expr) end
@@ -5524,10 +4909,6 @@ function vim.fn.log(expr) end
 --- <  3.0 >vim
 ---   echo log10(0.01)
 --- <  -2.0
----
---- Can also be used as a |method|: >vim
----   Compute()->log10()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -5578,10 +4959,6 @@ function vim.fn.log10(expr) end
 --- {expr2} no further items in {expr1} are processed.  When
 --- {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
----
---- Can also be used as a |method|: >vim
----   mylist->map(expr2)
---- <
 ---
 --- @param expr1 any
 --- @param expr2 any
@@ -5651,10 +5028,6 @@ function vim.fn.map(expr1, expr2) end
 --- mapped, and have it do the original mapping too.  Sketch: >vim
 ---   exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 ---
---- <Can also be used as a |method|: >vim
----   GetKey()->maparg('n')
---- <
----
 --- @param name string
 --- @param mode? string
 --- @param abbr? boolean
@@ -5693,10 +5066,6 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 ---   endif
 --- <This avoids adding the "_vv" mapping when there already is a
 --- mapping for "_v" or for "_vvv".
----
---- Can also be used as a |method|: >vim
----   GetKey()->mapcheck('n')
---- <
 ---
 --- @param name string
 --- @param mode? string
@@ -5785,11 +5154,6 @@ function vim.fn.mapset(mode, abbr, dict) end
 --- zero matches at the start instead of a number of matches
 --- further down in the text.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->match('word')
----   GetList()->match('word')
---- <
----
 --- @param expr any
 --- @param pat any
 --- @param start? any
@@ -5854,10 +5218,6 @@ function vim.fn.match(expr, pat, start, count) end
 --- available from |getmatches()|.  All matches can be deleted in
 --- one operation by |clearmatches()|.
 ---
---- Can also be used as a |method|: >vim
----   GetGroup()->matchadd('TODO')
---- <
----
 --- @param group any
 --- @param pattern any
 --- @param priority? any
@@ -5902,10 +5262,6 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- <Matches added by |matchaddpos()| are returned by
 --- |getmatches()|.
 ---
---- Can also be used as a |method|: >vim
----   GetGroup()->matchaddpos([23, 11])
---- <
----
 --- @param group any
 --- @param pos any
 --- @param priority? any
@@ -5925,10 +5281,6 @@ function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 --- Highlighting matches using the |:match| commands are limited
 --- to three matches. |matchadd()| does not have this limitation.
 ---
---- Can also be used as a |method|: >vim
----   GetMatch()->matcharg()
---- <
----
 --- @param nr integer
 --- @return any
 function vim.fn.matcharg(nr) end
@@ -5939,10 +5291,6 @@ function vim.fn.matcharg(nr) end
 --- be deleted in one operation by |clearmatches()|.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
----
---- Can also be used as a |method|: >vim
----   GetMatch()->matchdelete()
---- <
 ---
 --- @param id any
 --- @param win? any
@@ -5966,10 +5314,6 @@ function vim.fn.matchdelete(id, win) end
 ---   echo matchend("testing", "ing", 5)
 --- <result is "-1".
 --- When {expr} is a |List| the result is equal to |match()|.
----
---- Can also be used as a |method|: >vim
----   GetText()->matchend('word')
---- <
 ---
 --- @param expr any
 --- @param pat any
@@ -6084,10 +5428,6 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 ---
 --- You can pass in a List, but that is not very useful.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->matchlist('word')
---- <
----
 --- @param expr any
 --- @param pat any
 --- @param start? any
@@ -6106,10 +5446,6 @@ function vim.fn.matchlist(expr, pat, start, count) end
 --- <result is "".
 --- When {expr} is a |List| then the matching item is returned.
 --- The type isn't changed, it's not necessarily a String.
----
---- Can also be used as a |method|: >vim
----   GetText()->matchstr('word')
---- <
 ---
 --- @param expr any
 --- @param pat any
@@ -6135,10 +5471,6 @@ function vim.fn.matchstr(expr, pat, start, count) end
 --- <result is ["x", 1, 2, 3].
 --- The type isn't changed, it's not necessarily a String.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->matchstrpos('word')
---- <
----
 --- @param expr any
 --- @param pat any
 --- @param start? any
@@ -6154,10 +5486,6 @@ function vim.fn.matchstrpos(expr, pat, start, count) end
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
 ---                 an error.  An empty |List| or |Dictionary| results in zero.
----
---- Can also be used as a |method|: >vim
----   mylist->max()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -6282,9 +5610,6 @@ function vim.fn.menu_get(path, modes) end
 ---     call ShowMenu(topmenu, '')
 ---   endfor
 --- <
---- Can also be used as a |method|: >vim
----   GetMenuName()->menu_info('v')
---- <
 ---
 --- @param name string
 --- @param mode? string
@@ -6299,10 +5624,6 @@ function vim.fn.menu_info(name, mode) end
 --- If {expr} is neither a List nor a Dictionary, or one of the
 --- items in {expr} cannot be used as a Number this results in
 --- an error.  An empty |List| or |Dictionary| results in zero.
----
---- Can also be used as a |method|: >vim
----   mylist->min()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -6349,10 +5670,6 @@ function vim.fn.min(expr) end
 --- The function result is a Number, which is TRUE if the call was
 --- successful or FALSE if the directory creation failed or partly
 --- failed.
----
---- Can also be used as a |method|: >vim
----   GetName()->mkdir()
---- <
 ---
 --- @param name string
 --- @param flags? string
@@ -6409,10 +5726,6 @@ function vim.fn.mkdir(name, flags, prot) end
 --- be added. It's better not to compare the whole string but only
 --- the leading character(s).
 --- Also see |visualmode()|.
----
---- Can also be used as a |method|: >vim
----   DoFull()->mode()
---- <
 ---
 --- @return any
 function vim.fn.mode() end
@@ -6525,10 +5838,6 @@ function vim.fn.msgpackparse(data) end
 --- {lnum} is used like with |getline()|.
 --- See also |prevnonblank()|.
 ---
---- Can also be used as a |method|: >vim
----   GetLnum()->nextnonblank()
---- <
----
 --- @param lnum integer
 --- @return any
 function vim.fn.nextnonblank(lnum) end
@@ -6547,10 +5856,6 @@ function vim.fn.nextnonblank(lnum) end
 --- characters.  nr2char(0) is a real NUL and terminates the
 --- string, thus results in an empty string.
 ---
---- Can also be used as a |method|: >vim
----   GetNumber()->nr2char()
---- <
----
 --- @param expr any
 --- @param utf8? any
 --- @return any
@@ -6561,8 +5866,6 @@ function vim.fn.nr2char(expr, utf8) end
 --- Also see `and()` and `xor()`.
 --- Example: >vim
 ---   let bits = or(bits, 0x80)
---- <Can also be used as a |method|: >vim
----   let bits = bits->or(0x80)
 ---
 --- <Rationale: The reason this is a function and not using the "|"
 --- character like many languages, is that Vi has always used "|"
@@ -6587,10 +5890,6 @@ vim.fn['or'] = function(expr, expr1) end
 --- It doesn't matter if the path exists or not.
 --- Returns an empty string on error.
 ---
---- Can also be used as a |method|: >vim
----   GetDirectories()->pathshorten()
---- <
----
 --- @param path string
 --- @param len? any
 --- @return any
@@ -6610,10 +5909,6 @@ function vim.fn.pathshorten(path, len) end
 ---   echo perleval('[1 .. 4]')
 --- <  [1, 2, 3, 4]
 ---
---- Can also be used as a |method|: >vim
----   GetExpr()->perleval()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.perleval(expr) end
@@ -6629,10 +5924,6 @@ function vim.fn.perleval(expr) end
 ---   echo pow(32, 0.20)
 --- <  2.0
 ---
---- Can also be used as a |method|: >vim
----   Compute()->pow(3)
---- <
----
 --- @param x any
 --- @param y any
 --- @return any
@@ -6645,10 +5936,6 @@ function vim.fn.pow(x, y) end
 --- above it, zero is returned.
 --- {lnum} is used like with |getline()|.
 --- Also see |nextnonblank()|.
----
---- Can also be used as a |method|: >vim
----   GetLnum()->prevnonblank()
---- <
 ---
 --- @param lnum integer
 --- @return any
@@ -6864,10 +6151,6 @@ function vim.fn.printf(fmt, expr1) end
 --- If the buffer doesn't exist or isn't a prompt buffer, an empty
 --- string is returned.
 ---
---- Can also be used as a |method|: >vim
----   GetBuffer()->prompt_getprompt()
---- <
----
 --- @param buf any
 --- @return any
 function vim.fn.prompt_getprompt(buf) end
@@ -6903,10 +6186,6 @@ function vim.fn.prompt_getprompt(buf) end
 ---    endfunc
 ---    call prompt_setcallback(bufnr(), function('s:TextEntered'))
 ---
---- <Can also be used as a |method|: >vim
----   GetBuffer()->prompt_setcallback(callback)
---- <
----
 --- @param buf any
 --- @param expr any
 --- @return any
@@ -6920,10 +6199,6 @@ function vim.fn.prompt_setcallback(buf, expr) end
 --- mode.  Without setting a callback Vim will exit Insert mode,
 --- as in any buffer.
 ---
---- Can also be used as a |method|: >vim
----   GetBuffer()->prompt_setinterrupt(callback)
---- <
----
 --- @param buf any
 --- @param expr any
 --- @return any
@@ -6934,9 +6209,6 @@ function vim.fn.prompt_setinterrupt(buf, expr) end
 --- The result is only visible if {buf} has 'buftype' set to
 --- "prompt".  Example: >vim
 ---   call prompt_setprompt(bufnr(''), 'command: ')
---- <
---- Can also be used as a |method|: >vim
----   GetBuffer()->prompt_setprompt('command: ')
 --- <
 ---
 --- @param buf any
@@ -6976,10 +6248,6 @@ function vim.fn.pumvisible() end
 --- Dictionaries are represented as Vim |Dictionary| type with
 --- keys converted to strings.
 ---
---- Can also be used as a |method|: >vim
----   GetExpr()->py3eval()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.py3eval(expr) end
@@ -6992,10 +6260,6 @@ function vim.fn.py3eval(expr) end
 --- Dictionaries are represented as Vim |Dictionary| type,
 --- non-string keys result in error.
 ---
---- Can also be used as a |method|: >vim
----   GetExpr()->pyeval()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.pyeval(expr) end
@@ -7004,10 +6268,6 @@ function vim.fn.pyeval(expr) end
 --- converted to Vim data structures.
 --- Uses Python 2 or 3, see |python_x| and 'pyxversion'.
 --- See also: |pyeval()|, |py3eval()|
----
---- Can also be used as a |method|: >vim
----   GetExpr()->pyxeval()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -7026,9 +6286,6 @@ function vim.fn.pyxeval(expr) end
 ---   let seed = srand()
 ---   echo rand(seed)
 ---   echo rand(seed) % 16  " random number 0 - 15
---- <
---- Can also be used as a |method|: >vim
----   seed->rand()
 --- <
 ---
 --- @param expr? any
@@ -7051,9 +6308,6 @@ function vim.fn.rand(expr) end
 ---   echo range(2, -2, -1)  " [2, 1, 0, -1, -2]
 ---   echo range(0)    " []
 ---   echo range(2, 0)    " error!
---- <
---- Can also be used as a |method|: >vim
----   GetExpr()->range()
 --- <
 ---
 --- @param expr any
@@ -7120,10 +6374,6 @@ function vim.fn.readblob(fname, offset, size) end
 --- <
 --- Returns an empty List on error.
 ---
---- Can also be used as a |method|: >vim
----   GetDirName()->readdir()
---- <
----
 --- @param directory any
 --- @param expr? any
 --- @return any
@@ -7161,10 +6411,6 @@ function vim.fn.readdir(directory, expr) end
 --- the result is an empty list.
 --- Also see |writefile()|.
 ---
---- Can also be used as a |method|: >vim
----   GetFileName()->readfile()
---- <
----
 --- @param fname integer
 --- @param type? any
 --- @param max? any
@@ -7185,9 +6431,6 @@ function vim.fn.readfile(fname, type, max) end
 ---   echo reduce([1, 3, 5], { acc, val -> acc + val })
 ---   echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
 ---   echo reduce(0z1122, { acc, val -> 2 * acc + val })
---- <
---- Can also be used as a |method|: >vim
----   echo mylist->reduce({ acc, val -> acc + val }, 0)
 --- <
 ---
 --- @param object any
@@ -7240,9 +6483,6 @@ function vim.fn.reltime(start) end
 --- The {start} and {end} arguments must be values returned by
 --- reltime().  Returns zero on error.
 ---
---- Can also be used as a |method|: >vim
----   GetStart()->reltime()
---- <
 --- Note: |localtime()| returns the current (non-relative) time.
 ---
 --- @param start? any
@@ -7260,10 +6500,6 @@ function vim.fn.reltime(start, end_) end
 --- Also see |profiling|.
 --- If there is an error an empty string is returned
 ---
---- Can also be used as a |method|: >vim
----   reltime(start)->reltimefloat()
---- <
----
 --- @param time any
 --- @return any
 function vim.fn.reltimefloat(time) end
@@ -7280,10 +6516,6 @@ function vim.fn.reltimefloat(time) end
 ---   echo split(reltimestr(reltime(start)))[0]
 --- <Also see |profiling|.
 --- If there is an error an empty string is returned
----
---- Can also be used as a |method|: >vim
----   echo reltime(start)->reltimestr()
---- <
 ---
 --- @param time any
 --- @return any
@@ -7307,10 +6539,6 @@ function vim.fn.remove(list, idx) end
 ---   call remove(mylist, 0, 9)
 --- <
 --- Use |delete()| to remove a file.
----
---- Can also be used as a |method|: >vim
----   mylist->remove(idx)
---- <
 ---
 --- @param list any
 --- @param idx integer
@@ -7359,10 +6587,6 @@ function vim.fn.remove(dict, key) end
 --- NOTE: If {to} exists it is overwritten without warning.
 --- This function is not available in the |sandbox|.
 ---
---- Can also be used as a |method|: >vim
----   GetOldName()->rename(newname)
---- <
----
 --- @param from any
 --- @param to any
 --- @return any
@@ -7376,10 +6600,6 @@ function vim.fn.rename(from, to) end
 --- concatenated {count} times.  Example: >vim
 ---   let longlist = repeat(['a', 'b'], 3)
 --- <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
----
---- Can also be used as a |method|: >vim
----   mylist->repeat(count)
---- <
 ---
 --- @param expr any
 --- @param count any
@@ -7398,10 +6618,6 @@ vim.fn['repeat'] = function(expr, count) end
 --- current directory (provided the result is still a relative
 --- path name) and also keeps a trailing path separator.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->resolve()
---- <
----
 --- @param filename any
 --- @return any
 function vim.fn.resolve(filename) end
@@ -7410,11 +6626,6 @@ function vim.fn.resolve(filename) end
 --- {object} can be a |List| or a |Blob|.
 --- Returns {object}.
 --- Returns zero if {object} is not a List or a Blob.
---- If you want an object to remain unmodified make a copy first: >vim
----   let revlist = reverse(copy(mylist))
---- <Can also be used as a |method|: >vim
----   mylist->reverse()
---- <
 ---
 --- @param object any
 --- @return any
@@ -7432,10 +6643,6 @@ function vim.fn.reverse(object) end
 --- <  5.0 >vim
 ---   echo round(-4.5)
 --- <  -5.0
----
---- Can also be used as a |method|: >vim
----   Compute()->round()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -7495,10 +6702,6 @@ function vim.fn.rpcstop(...) end
 --- Other objects are represented as strings resulted from their
 --- "Object#to_s" method.
 ---
---- Can also be used as a |method|: >vim
----   GetRubyExpr()->rubyeval()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.rubyeval(expr) end
@@ -7507,10 +6710,6 @@ function vim.fn.rubyeval(expr) end
 --- arbitrary number that can only be used to compare to the
 --- attribute at other positions.
 --- Returns -1 when row or col is out of range.
----
---- Can also be used as a |method|: >vim
----   GetRow()->screenattr(col)
---- <
 ---
 --- @param row any
 --- @param col integer
@@ -7526,10 +6725,6 @@ function vim.fn.screenattr(row, col) end
 --- This is mainly to be used for testing.
 --- Returns -1 when row or col is out of range.
 ---
---- Can also be used as a |method|: >vim
----   GetRow()->screenchar(col)
---- <
----
 --- @param row any
 --- @param col integer
 --- @return any
@@ -7540,10 +6735,6 @@ function vim.fn.screenchar(row, col) end
 --- composing characters on top of the base character.
 --- This is mainly to be used for testing.
 --- Returns an empty List when row or col is out of range.
----
---- Can also be used as a |method|: >vim
----   GetRow()->screenchars(col)
---- <
 ---
 --- @param row any
 --- @param col integer
@@ -7590,10 +6781,6 @@ function vim.fn.screencol() end
 --- first character is returned, {col} is not used.
 --- Returns an empty Dict if {winid} is invalid.
 ---
---- Can also be used as a |method|: >vim
----   GetWinid()->screenpos(lnum, col)
---- <
----
 --- @param winid integer
 --- @param lnum integer
 --- @param col integer
@@ -7616,10 +6803,6 @@ function vim.fn.screenrow() end
 --- characters.
 --- This is mainly to be used for testing.
 --- Returns an empty String when row or col is out of range.
----
---- Can also be used as a |method|: >vim
----   GetRow()->screenstring(col)
---- <
 ---
 --- @param row any
 --- @param col integer
@@ -7725,10 +6908,6 @@ function vim.fn.screenstring(row, col) end
 --- finds the "endif" and returns 3.  The same thing happens
 --- without the 'e' flag if the cursor is on the "f" of "if".
 --- The 'n' flag tells the function not to move the cursor.
----
---- Can also be used as a |method|: >vim
----   GetPattern()->search()
---- <
 ---
 --- @param pattern any
 --- @param flags? string
@@ -7858,10 +7037,6 @@ function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 ---         value. see |cursor()|, |getpos()|
 ---         (default: cursor's position)
 ---
---- Can also be used as a |method|: >vim
----   GetSearchOpts()->searchcount()
---- <
----
 --- @param options? table
 --- @return any
 function vim.fn.searchcount(options) end
@@ -7882,9 +7057,6 @@ function vim.fn.searchcount(options) end
 ---   if searchdecl('myvar') == 0
 ---      echo getline('.')
 ---   endif
---- <
---- Can also be used as a |method|: >vim
----   GetName()->searchdecl()
 --- <
 ---
 --- @param name string
@@ -8007,10 +7179,6 @@ function vim.fn.searchpairpos() end
 --- <In this example "submatch" is 2 when a lowercase letter is
 --- found |/\l|, 3 when an uppercase letter is found |/\u|.
 ---
---- Can also be used as a |method|: >vim
----   GetPattern()->searchpos()
---- <
----
 --- @param pattern any
 --- @param flags? string
 --- @param stopline? any
@@ -8097,11 +7265,6 @@ function vim.fn.serverstop(address) end
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given.
 ---
---- Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetText()->setbufline(buf, lnum)
---- <
----
 --- @param buf any
 --- @param lnum integer
 --- @param text any
@@ -8120,11 +7283,6 @@ function vim.fn.setbufline(buf, lnum, text) end
 ---   call setbufvar(1, "&mod", 1)
 ---   call setbufvar("todo", "myvar", "foobar")
 --- <This function is not available in the |sandbox|.
----
---- Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetValue()->setbufvar(buf, varname)
---- <
 ---
 --- @param buf any
 --- @param varname string
@@ -8179,10 +7337,6 @@ function vim.fn.setcellwidths(list) end
 ---   call setpos('.', [0, 8, 4, 0])
 --- <positions the cursor on the second character '보'.
 ---
---- Can also be used as a |method|: >vim
----   GetPosition()->setcharpos('.')
---- <
----
 --- @param expr any
 --- @param list any
 --- @return any
@@ -8207,10 +7361,6 @@ function vim.fn.setcharpos(expr, list) end
 ---   call setcharsearch(prevsearch)
 --- <Also see |getcharsearch()|.
 ---
---- Can also be used as a |method|: >vim
----   SavedSearch()->setcharsearch()
---- <
----
 --- @param dict any
 --- @return any
 function vim.fn.setcharsearch(dict) end
@@ -8220,10 +7370,6 @@ function vim.fn.setcharsearch(dict) end
 --- If {pos} is omitted, the cursor is positioned after the text.
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
----
---- Can also be used as a |method|: >vim
----   GetText()->setcmdline()
---- <
 ---
 --- @param str any
 --- @param pos? any
@@ -8243,10 +7389,6 @@ function vim.fn.setcmdline(str, pos) end
 --- line.  A number smaller than one has undefined results.
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
----
---- Can also be used as a |method|: >vim
----   GetPos()->setcmdpos()
---- <
 ---
 --- @param pos any
 --- @return any
@@ -8268,10 +7410,6 @@ function vim.fn.setcursorcharpos(lnum, col, off) end
 ---   call cursor(4, 3)
 --- <positions the cursor on the first character '여'.
 ---
---- Can also be used as a |method|: >vim
----   GetCursorPos()->setcursorcharpos()
---- <
----
 --- @param list any
 --- @return any
 function vim.fn.setcursorcharpos(list) end
@@ -8281,11 +7419,6 @@ function vim.fn.setcursorcharpos(list) end
 ---
 --- <When {val} is |v:null| the environment variable is deleted.
 --- See also |expr-env|.
----
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetPath()->setenv('PATH')
---- <
 ---
 --- @param name string
 --- @param val any
@@ -8306,9 +7439,6 @@ function vim.fn.setenv(name, val) end
 ---
 --- Returns non-zero for success, zero for failure.
 ---
---- Can also be used as a |method|: >vim
----   GetFilename()->setfperm(mode)
---- <
 --- To read permissions see |getfperm()|.
 ---
 --- @param fname integer
@@ -8342,11 +7472,6 @@ function vim.fn.setfperm(fname, mode) end
 ---
 --- <Note: The '[ and '] marks are not set.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetText()->setline(lnum)
---- <
----
 --- @param lnum integer
 --- @param text any
 --- @return any
@@ -8367,11 +7492,6 @@ function vim.fn.setline(lnum, text) end
 --- only the items listed in {what} are set. Refer to |setqflist()|
 --- for the list of supported keys in {what}.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetLoclist()->setloclist(winnr)
---- <
----
 --- @param nr integer
 --- @param list any
 --- @param action? any
@@ -8385,10 +7505,6 @@ function vim.fn.setloclist(nr, list, action, what) end
 --- example for |getmatches()|.
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
----
---- Can also be used as a |method|: >vim
----   GetMatches()->setmatches()
---- <
 ---
 --- @param list any
 --- @param win? any
@@ -8442,10 +7558,6 @@ function vim.fn.setmatches(list, win) end
 --- |k| motions will jump to previous columns!  Use |cursor()| to
 --- also set the preferred column.  Also see the "curswant" key in
 --- |winrestview()|.
----
---- Can also be used as a |method|: >vim
----   GetPosition()->setpos('.')
---- <
 ---
 --- @param expr any
 --- @param list any
@@ -8562,11 +7674,6 @@ function vim.fn.setpos(expr, list) end
 --- independent of the 'errorformat' setting.  Use a command like
 --- `:cc 1` to jump to the first position.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetErrorlist()->setqflist()
---- <
----
 --- @param list any
 --- @param action? any
 --- @param what? any
@@ -8628,11 +7735,6 @@ function vim.fn.setqflist(list, action, what) end
 --- nothing: >vim
 ---   call setreg('a', '', 'al')
 ---
---- <Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetText()->setreg('a')
---- <
----
 --- @param regname string
 --- @param value any
 --- @param options? table
@@ -8645,11 +7747,6 @@ function vim.fn.setreg(regname, value, options) end
 --- Note that the variable name without "t:" must be used.
 --- Tabs are numbered starting with one.
 --- This function is not available in the |sandbox|.
----
---- Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetValue()->settabvar(tab, name)
---- <
 ---
 --- @param tabnr integer
 --- @param varname string
@@ -8671,11 +7768,6 @@ function vim.fn.settabvar(tabnr, varname, val) end
 ---   call settabwinvar(1, 1, "&list", 0)
 ---   call settabwinvar(3, 2, "myvar", "foobar")
 --- <This function is not available in the |sandbox|.
----
---- Can also be used as a |method|, the base is passed as the
---- fourth argument: >vim
----   GetValue()->settabwinvar(tab, winnr, name)
---- <
 ---
 --- @param tabnr integer
 --- @param winnr integer
@@ -8716,10 +7808,6 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 ---   call settagstack(1003, stack)
 ---   unlet stack
 --- <
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetStack()->settagstack(winnr)
---- <
 ---
 --- @param nr integer
 --- @param dict any
@@ -8732,11 +7820,6 @@ function vim.fn.settagstack(nr, dict, action) end
 ---   call setwinvar(1, "&list", 0)
 ---   call setwinvar(2, "myvar", "foobar")
 ---
---- <Can also be used as a |method|, the base is passed as the
---- third argument: >vim
----   GetValue()->setwinvar(winnr, name)
---- <
----
 --- @param nr integer
 --- @param varname string
 --- @param val any
@@ -8745,10 +7828,6 @@ function vim.fn.setwinvar(nr, varname, val) end
 
 --- Returns a String with 64 hex characters, which is the SHA256
 --- checksum of {string}.
----
---- Can also be used as a |method|: >vim
----   GetText()->sha256()
---- <
 ---
 --- @param string string
 --- @return any
@@ -8784,10 +7863,6 @@ function vim.fn.sha256(string) end
 ---     call system("chmod +w -- " .. shellescape(expand("%")))
 --- <See also |::S|.
 ---
---- Can also be used as a |method|: >vim
----   GetCommand()->shellescape()
---- <
----
 --- @param string string
 --- @param special? any
 --- @return any
@@ -8812,10 +7887,6 @@ function vim.fn.shellescape(string, special) end
 --- for which to return the 'shiftwidth' value. This matters for the
 --- 'vartabstop' feature. If no {col} argument is given, column 1
 --- will be assumed.
----
---- Can also be used as a |method|: >vim
----   GetColumn()->shiftwidth()
---- <
 ---
 --- @param col? integer
 --- @return any
@@ -8870,9 +7941,6 @@ function vim.fn.sign_define(name, dict) end
 ---     \  'text' : '!!'}
 ---     \ ])
 --- <
---- Can also be used as a |method|: >vim
----   GetSignList()->sign_define()
---- <
 ---
 --- @param list any
 --- @return any
@@ -8911,9 +7979,6 @@ function vim.fn.sign_define(list) end
 ---
 ---   " Get the attribute of the sign named mySign
 ---   echo sign_getdefined("mySign")
---- <
---- Can also be used as a |method|: >vim
----   GetSignList()->sign_getdefined()
 --- <
 ---
 --- @param name? string
@@ -8979,9 +8044,6 @@ function vim.fn.sign_getdefined(name) end
 ---   " Get a List of all the placed signs
 ---   echo sign_getplaced()
 --- <
---- Can also be used as a |method|: >vim
----   GetBufname()->sign_getplaced()
---- <
 ---
 --- @param buf? any
 --- @param dict? any
@@ -9001,9 +8063,6 @@ function vim.fn.sign_getplaced(buf, dict) end
 --- Example: >vim
 ---   " Jump to sign 10 in the current buffer
 ---   call sign_jump(10, '', '')
---- <
---- Can also be used as a |method|: >vim
----   GetSignid()->sign_jump()
 --- <
 ---
 --- @param id any
@@ -9058,9 +8117,6 @@ function vim.fn.sign_jump(id, group, buf) end
 ---   " at line 40 in buffer json.c with priority 90
 ---   call sign_place(10, 'g3', 'sign4', 'json.c',
 ---       \ {'lnum' : 40, 'priority' : 90})
---- <
---- Can also be used as a |method|: >vim
----   GetSignid()->sign_place(group, name, expr)
 --- <
 ---
 --- @param id any
@@ -9128,9 +8184,6 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 ---     \  'lnum' : 50}
 ---     \ ])
 --- <
---- Can also be used as a |method|: >vim
----   GetSignlist()->sign_placelist()
---- <
 ---
 --- @param list any
 --- @return any
@@ -9160,9 +8213,6 @@ function vim.fn.sign_undefine(name) end
 ---
 ---   " Delete all the signs
 ---   call sign_undefine()
---- <
---- Can also be used as a |method|: >vim
----   GetSignlist()->sign_undefine()
 --- <
 ---
 --- @param list? any
@@ -9210,10 +8260,6 @@ function vim.fn.sign_undefine(list) end
 ---   " Remove all the placed signs from all the buffers
 ---   call sign_unplace('*')
 ---
---- <Can also be used as a |method|: >vim
----   GetSigngroup()->sign_unplace()
---- <
----
 --- @param group any
 --- @param dict? any
 --- @return any
@@ -9246,9 +8292,6 @@ function vim.fn.sign_unplace(group, dict) end
 ---     \ {'id' : 20, 'buffer' : 'b.vim'},
 ---     \ ])
 --- <
---- Can also be used as a |method|: >vim
----   GetSignlist()->sign_unplacelist()
---- <
 ---
 --- @param list any
 --- @return any
@@ -9270,10 +8313,6 @@ function vim.fn.sign_unplacelist(list) end
 --- directory.  In order to resolve all the involved symbolic
 --- links before simplifying the path name, use |resolve()|.
 ---
---- Can also be used as a |method|: >vim
----   GetName()->simplify()
---- <
----
 --- @param filename any
 --- @return any
 function vim.fn.simplify(filename) end
@@ -9286,10 +8325,6 @@ function vim.fn.simplify(filename) end
 --- <  -0.506366 >vim
 ---   echo sin(-4.01)
 --- <  0.763301
----
---- Can also be used as a |method|: >vim
----   Compute()->sin()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -9305,10 +8340,6 @@ function vim.fn.sin(expr) end
 ---   echo sinh(-0.9)
 --- <  -1.026517
 ---
---- Can also be used as a |method|: >vim
----   Compute()->sinh()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.sinh(expr) end
@@ -9320,10 +8351,6 @@ function vim.fn.sinh(expr) end
 --- When {end} is omitted the slice continues to the last item.
 --- When {end} is -1 the last item is omitted.
 --- Returns an empty value if {start} or {end} are invalid.
----
---- Can also be used as a |method|: >vim
----   GetList()->slice(offset)
---- <
 ---
 --- @param expr any
 --- @param start any
@@ -9417,10 +8444,6 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- on numbers, text strings will sort next to each other, in the
 --- same order as they were originally.
 ---
---- Can also be used as a |method|: >vim
----   mylist->sort()
----
---- <Also see |uniq()|.
 ---
 --- Example: >vim
 ---   func MyCompare(i1, i2)
@@ -9449,10 +8472,6 @@ function vim.fn.sort(list, func, dict) end
 --- This can be used for making spelling suggestions.  Note that
 --- the method can be quite slow.
 ---
---- Can also be used as a |method|: >vim
----   GetWord()->soundfold()
---- <
----
 --- @param word any
 --- @return any
 function vim.fn.soundfold(word) end
@@ -9480,10 +8499,6 @@ function vim.fn.soundfold(word) end
 --- The spelling information for the current window and the value
 --- of 'spelllang' are used.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->spellbadword()
---- <
----
 --- @param sentence? any
 --- @return any
 function vim.fn.spellbadword(sentence) end
@@ -9507,10 +8522,6 @@ function vim.fn.spellbadword(sentence) end
 ---
 --- The spelling information for the current window is used.  The
 --- values of 'spelllang' and 'spellsuggest' are used.
----
---- Can also be used as a |method|: >vim
----   GetWord()->spellsuggest()
---- <
 ---
 --- @param word any
 --- @param max? any
@@ -9542,10 +8553,6 @@ function vim.fn.spellsuggest(word, max, capital) end
 ---   let items = split(line, ':', 1)
 --- <The opposite function is |join()|.
 ---
---- Can also be used as a |method|: >vim
----   GetString()->split()
---- <
----
 --- @param string string
 --- @param pattern? any
 --- @param keepempty? any
@@ -9564,10 +8571,6 @@ function vim.fn.split(string, pattern, keepempty) end
 --- <  str2float("nan")
 --- NaN may be different, it depends on system libraries.
 ---
---- Can also be used as a |method|: >vim
----   Compute()->sqrt()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.sqrt(expr) end
@@ -9584,9 +8587,6 @@ function vim.fn.sqrt(expr) end
 ---   let seed = srand()
 ---   let seed = srand(userinput)
 ---   echo rand(seed)
---- <
---- Can also be used as a |method|: >vim
----   userinput->srand()
 --- <
 ---
 --- @param expr? any
@@ -9660,10 +8660,6 @@ function vim.fn.stdpath(what) end
 --- <
 --- Returns 0.0 if the conversion fails.
 ---
---- Can also be used as a |method|: >vim
----   let f = text->substitute(',', '', 'g')->str2float()
---- <
----
 --- @param string string
 --- @param quoted? any
 --- @return any
@@ -9679,10 +8675,6 @@ function vim.fn.str2float(string, quoted) end
 --- and exists only for backwards-compatibility.
 --- With UTF-8 composing characters are handled properly: >vim
 ---   echo str2list("á")    " returns [97, 769]
----
---- <Can also be used as a |method|: >vim
----   GetString()->str2list()
---- <
 ---
 --- @param string string
 --- @param utf8? any
@@ -9707,10 +8699,6 @@ function vim.fn.str2list(string, utf8) end
 ---
 --- Returns 0 if {string} is empty or on error.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->str2nr()
---- <
----
 --- @param string string
 --- @param base? any
 --- @return any
@@ -9724,10 +8712,6 @@ function vim.fn.str2nr(string, base) end
 --- Returns 0 if {string} is empty or on error.
 ---
 --- Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
----
---- Can also be used as a |method|: >vim
----   GetText()->strcharlen()
---- <
 ---
 --- @param string string
 --- @return any
@@ -9746,10 +8730,6 @@ function vim.fn.strcharlen(string) end
 --- <results in 'a'.
 ---
 --- Returns an empty string on error.
----
---- Can also be used as a |method|: >vim
----   GetText()->strcharpart(5)
---- <
 ---
 --- @param src any
 --- @param start any
@@ -9785,9 +8765,6 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 ---       endfunction
 ---     endif
 --- <
---- Can also be used as a |method|: >vim
----   GetText()->strchars()
---- <
 ---
 --- @param string string
 --- @param skipcc? any
@@ -9806,10 +8783,6 @@ function vim.fn.strchars(string, skipcc) end
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
 --- Also see |strlen()|, |strwidth()| and |strchars()|.
----
---- Can also be used as a |method|: >vim
----   GetText()->strdisplaywidth()
---- <
 ---
 --- @param string string
 --- @param col? integer
@@ -9832,10 +8805,6 @@ function vim.fn.strdisplaywidth(string, col) end
 ---   echo strftime("%c", getftime("file.c"))
 ---            " Show mod time of file.c.
 ---
---- <Can also be used as a |method|: >vim
----   GetFormat()->strftime()
---- <
----
 --- @param format any
 --- @param time? any
 --- @return any
@@ -9848,10 +8817,6 @@ function vim.fn.strftime(format, time) end
 --- String.
 --- Returns -1 if {index} is invalid.
 --- Also see |strcharpart()| and |strchars()|.
----
---- Can also be used as a |method|: >vim
----   GetText()->strgetchar(5)
---- <
 ---
 --- @param str any
 --- @param index any
@@ -9875,10 +8840,6 @@ function vim.fn.strgetchar(str, index) end
 --- <        *strstr()* *strchr()*
 --- stridx() works similar to the C function strstr().  When used
 --- with a single character it works similar to strchr().
----
---- Can also be used as a |method|: >vim
----   GetHaystack()->stridx(needle)
---- <
 ---
 --- @param haystack any
 --- @param needle any
@@ -9909,10 +8870,6 @@ function vim.fn.stridx(haystack, needle, start) end
 --- method, use |msgpackdump()| or |json_encode()| if you need to
 --- share data with other application.
 ---
---- Can also be used as a |method|: >vim
----   mylist->string()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.string(expr) end
@@ -9924,10 +8881,6 @@ function vim.fn.string(expr) end
 --- If you want to count the number of multibyte characters use
 --- |strchars()|.
 --- Also see |len()|, |strdisplaywidth()| and |strwidth()|.
----
---- Can also be used as a |method|: >vim
----   GetString()->strlen()
---- <
 ---
 --- @param string string
 --- @return any
@@ -9956,10 +8909,6 @@ function vim.fn.strlen(string) end
 ---   strpart(getline("."), col(".") - 1, 1, v:true)
 --- <
 --- Returns an empty string on error.
----
---- Can also be used as a |method|: >vim
----   GetText()->strpart(5)
---- <
 ---
 --- @param src any
 --- @param start any
@@ -9991,10 +8940,6 @@ function vim.fn.strpart(src, start, len, chars) end
 ---   echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
 --- <  Sun Apr 27 12:53:55 1997
 ---
---- Can also be used as a |method|: >vim
----   GetFormat()->strptime(timestring)
---- <
----
 --- @param format any
 --- @param timestring any
 --- @return any
@@ -10017,10 +8962,6 @@ function vim.fn.strptime(format, timestring) end
 --- When used with a single character it works similar to the C
 --- function strrchr().
 ---
---- Can also be used as a |method|: >vim
----   GetHaystack()->strridx(needle)
---- <
----
 --- @param haystack any
 --- @param needle any
 --- @param start? any
@@ -10035,10 +8976,6 @@ function vim.fn.strridx(haystack, needle, start) end
 --- starting a new line.
 ---
 --- Returns an empty string on error.
----
---- Can also be used as a |method|: >vim
----   GetString()->strtrans()
---- <
 ---
 --- @param string string
 --- @return any
@@ -10062,10 +8999,6 @@ function vim.fn.strtrans(string) end
 ---     echo strutf16len('ą́')    " returns 1
 ---     echo strutf16len('ą́', v:true)  " returns 3
 ---
---- Can also be used as a |method|: >vim
----   GetText()->strutf16len()
---- <
----
 --- @param string string
 --- @param countcc? any
 --- @return any
@@ -10078,10 +9011,6 @@ function vim.fn.strutf16len(string, countcc) end
 --- Ambiguous, this function's return value depends on 'ambiwidth'.
 --- Returns zero on error.
 --- Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
----
---- Can also be used as a |method|: >vim
----   GetString()->strwidth()
---- <
 ---
 --- @param string string
 --- @return any
@@ -10113,10 +9042,6 @@ function vim.fn.strwidth(string) end
 ---   echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 --- <This finds the first number in the line and adds one to it.
 --- A line break is included as a newline character.
----
---- Can also be used as a |method|: >vim
----   GetNr()->submatch()
---- <
 ---
 --- @param nr integer
 --- @param list? any
@@ -10165,10 +9090,6 @@ function vim.fn.submatch(nr, list) end
 ---
 --- <Returns an empty string on error.
 ---
---- Can also be used as a |method|: >vim
----   GetString()->substitute(pat, sub, flags)
---- <
----
 --- @param string string
 --- @param pat any
 --- @param sub any
@@ -10206,10 +9127,6 @@ function vim.fn.swapfilelist() end
 ---   Not a swap file: does not contain correct block ID
 ---   Magic number mismatch: Info in first block is invalid
 ---
---- Can also be used as a |method|: >vim
----   GetFilename()->swapinfo()
---- <
----
 --- @param fname integer
 --- @return any
 function vim.fn.swapinfo(fname) end
@@ -10219,10 +9136,6 @@ function vim.fn.swapinfo(fname) end
 --- If buffer {buf} is the current buffer, the result is equal to
 --- |:swapname| (unless there is no swap file).
 --- If buffer {buf} has no swap file, returns an empty string.
----
---- Can also be used as a |method|: >vim
----   GetBufname()->swapname()
---- <
 ---
 --- @param buf any
 --- @return any
@@ -10316,10 +9229,6 @@ function vim.fn.synIDattr(synID, what, mode) end
 --- ":highlight link" are followed.
 ---
 --- Returns zero on error.
----
---- Can also be used as a |method|: >vim
----   echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
---- <
 ---
 --- @param synID any
 --- @return any
@@ -10426,10 +9335,6 @@ function vim.fn.synstack(lnum, col) end
 --- <Unlike ":!cmd" there is no automatic check for changed files.
 --- Use |:checktime| to force a check.
 ---
---- Can also be used as a |method|: >vim
----   echo GetCmd()->system()
---- <
----
 --- @param cmd any
 --- @param input? any
 --- @return any
@@ -10448,10 +9353,6 @@ function vim.fn.system(cmd, input) end
 --- <
 --- Returns an empty string on error.
 ---
---- Can also be used as a |method|: >vim
----   echo GetCmd()->systemlist()
---- <
----
 --- @param cmd any
 --- @param input? any
 --- @param keepempty? any
@@ -10469,10 +9370,6 @@ function vim.fn.systemlist(cmd, input, keepempty) end
 ---      call extend(buflist, tabpagebuflist(i + 1))
 ---   endfor
 --- <Note that a buffer may appear in more than one window.
----
---- Can also be used as a |method|: >vim
----   GetTabpage()->tabpagebuflist()
---- <
 ---
 --- @param arg? any
 --- @return any
@@ -10506,10 +9403,6 @@ function vim.fn.tabpagenr(arg) end
 ---     tabpagewinnr(1)      " current window of tab page 1
 ---     tabpagewinnr(4, '$')    " number of windows in tab page 4
 --- <When {tabarg} is invalid zero is returned.
----
---- Can also be used as a |method|: >vim
----   GetTabpage()->tabpagewinnr()
---- <
 ---
 --- @param tabarg any
 --- @param arg? any
@@ -10564,9 +9457,6 @@ function vim.fn.tagfiles() end
 --- located by Vim. Refer to |tags-file-format| for the format of
 --- the tags file generated by the different ctags tools.
 ---
---- Can also be used as a |method|: >vim
----   GetTagpattern()->taglist()
----
 --- @param expr any
 --- @param filename? any
 --- @return any
@@ -10582,10 +9472,6 @@ function vim.fn.taglist(expr, filename) end
 ---   echo tan(-4.01)
 --- <  -1.181502
 ---
---- Can also be used as a |method|: >vim
----   Compute()->tan()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.tan(expr) end
@@ -10599,10 +9485,6 @@ function vim.fn.tan(expr) end
 --- <  0.462117 >vim
 ---   echo tanh(-1)
 --- <  -0.761594
----
---- Can also be used as a |method|: >vim
----   Compute()->tanh()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -10651,10 +9533,6 @@ function vim.fn.termopen(cmd, opts) end
 ---         -1 means forever
 ---     "callback"      the callback
 ---
---- Can also be used as a |method|: >vim
----   GetTimer()->timer_info()
---- <
----
 --- @param id? any
 --- @return any
 function vim.fn.timer_info(id) end
@@ -10670,10 +9548,6 @@ function vim.fn.timer_info(id) end
 --- If {paused} evaluates to a non-zero Number or a non-empty
 --- String, then the timer is paused, otherwise it is unpaused.
 --- See |non-zero-arg|.
----
---- Can also be used as a |method|: >vim
----   GetTimer()->timer_pause(1)
---- <
 ---
 --- @param timer any
 --- @param paused any
@@ -10709,11 +9583,6 @@ function vim.fn.timer_pause(timer, paused) end
 ---     \ {'repeat': 3})
 --- <This invokes MyHandler() three times at 500 msec intervals.
 ---
---- Can also be used as a |method|: >vim
----   GetMsec()->timer_start(callback)
----
---- <Not available in the |sandbox|.
----
 --- @param time any
 --- @param callback any
 --- @param options? table
@@ -10723,10 +9592,6 @@ function vim.fn.timer_start(time, callback, options) end
 --- Stop a timer.  The timer callback will no longer be invoked.
 --- {timer} is an ID returned by timer_start(), thus it must be a
 --- Number.  If {timer} does not exist there is no error.
----
---- Can also be used as a |method|: >vim
----   GetTimer()->timer_stop()
---- <
 ---
 --- @param timer any
 --- @return any
@@ -10743,10 +9608,6 @@ function vim.fn.timer_stopall() end
 --- characters turned into lowercase (just like applying |gu| to
 --- the string).  Returns an empty string on error.
 ---
---- Can also be used as a |method|: >vim
----   GetText()->tolower()
---- <
----
 --- @param expr any
 --- @return string
 function vim.fn.tolower(expr) end
@@ -10754,10 +9615,6 @@ function vim.fn.tolower(expr) end
 --- The result is a copy of the String given, with all lowercase
 --- characters turned into uppercase (just like applying |gU| to
 --- the string).  Returns an empty string on error.
----
---- Can also be used as a |method|: >vim
----   GetText()->toupper()
---- <
 ---
 --- @param expr any
 --- @return string
@@ -10777,10 +9634,6 @@ function vim.fn.toupper(expr) end
 --- <returns "Hello THere" >vim
 ---   echo tr("<blob>", "<>", "{}")
 --- <returns "{blob}"
----
---- Can also be used as a |method|: >vim
----   GetText()->tr(from, to)
---- <
 ---
 --- @param src any
 --- @param fromstr any
@@ -10812,10 +9665,6 @@ function vim.fn.tr(src, fromstr, tostr) end
 ---   echo trim("  vim  ", " ", 2)
 --- <returns "  vim"
 ---
---- Can also be used as a |method|: >vim
----   GetText()->trim()
---- <
----
 --- @param text any
 --- @param mask? any
 --- @param dir? string
@@ -10833,10 +9682,6 @@ function vim.fn.trim(text, mask, dir) end
 --- <  -5.0  >vim
 ---   echo trunc(4.0)
 --- <  4.0
----
---- Can also be used as a |method|: >vim
----   Compute()->trunc()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -10868,10 +9713,6 @@ function vim.fn.trunc(expr) end
 --- <To check if the v:t_ variables exist use this: >vim
 ---   if exists('v:t_number') | endif
 ---
---- <Can also be used as a |method|: >vim
----   mylist->type()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.type(expr) end
@@ -10885,10 +9726,6 @@ function vim.fn.type(expr) end
 --- If {name} is empty undofile() returns an empty string, since a
 --- buffer without a file name will not write an undo file.
 --- Useful in combination with |:wundo| and |:rundo|.
----
---- Can also be used as a |method|: >vim
----   GetFilename()->undofile()
---- <
 ---
 --- @param name string
 --- @return string
@@ -10948,10 +9785,6 @@ function vim.fn.undotree() end
 ---
 --- Returns zero if {list} is not a |List|.
 ---
---- Can also be used as a |method|: >vim
----   mylist->uniq()
---- <
----
 --- @param list any
 --- @param func? any
 --- @param dict? any
@@ -10984,9 +9817,6 @@ function vim.fn.uniq(list, func, dict) end
 ---   echo utf16idx('aą́c', 6, 1)  " returns 4
 ---   echo utf16idx('a😊😊', 9)  " returns -1
 --- <
---- Can also be used as a |method|: >vim
----   GetName()->utf16idx(idx)
---- <
 ---
 --- @param string string
 --- @param idx integer
@@ -10998,10 +9828,6 @@ function vim.fn.utf16idx(string, idx, countcc, charidx) end
 --- Return a |List| with all the values of {dict}.  The |List| is
 --- in arbitrary order.  Also see |items()| and |keys()|.
 --- Returns zero if {dict} is not a |Dict|.
----
---- Can also be used as a |method|: >vim
----   mydict->values()
---- <
 ---
 --- @param dict any
 --- @return any
@@ -11058,10 +9884,6 @@ function vim.fn.values(dict) end
 --- all lines: >vim
 ---     echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 ---
---- <Can also be used as a |method|: >vim
----   GetPos()->virtcol()
---- <
----
 --- @param expr any
 --- @param list? any
 --- @return any
@@ -11082,10 +9904,6 @@ function vim.fn.virtcol(expr, list) end
 --- line {lnum} or virtual column {col} is invalid.
 ---
 --- See also |screenpos()|, |virtcol()| and |col()|.
----
---- Can also be used as a |method|: >vim
----   GetWinid()->virtcol2col(lnum, col)
---- <
 ---
 --- @param winid integer
 --- @param lnum integer
@@ -11161,11 +9979,6 @@ function vim.fn.wildmenumode() end
 --- When window {id} does not exist then no error is given and
 --- an empty string is returned.
 ---
---- Can also be used as a |method|, the base is passed as the
---- second argument: >vim
----   GetCommand()->win_execute(winid)
---- <
----
 --- @param id any
 --- @param command any
 --- @param silent? boolean
@@ -11174,10 +9987,6 @@ function vim.fn.win_execute(id, command, silent) end
 
 --- Returns a |List| with |window-ID|s for windows that contain
 --- buffer {bufnr}.  When there is none the list is empty.
----
---- Can also be used as a |method|: >vim
----   GetBufnr()->win_findbuf()
---- <
 ---
 --- @param bufnr any
 --- @return integer[]
@@ -11190,10 +9999,6 @@ function vim.fn.win_findbuf(bufnr) end
 --- Without {tab} use the current tab, otherwise the tab with
 --- number {tab}.  The first tab has number one.
 --- Return zero if the window cannot be found.
----
---- Can also be used as a |method|: >vim
----   GetWinnr()->win_getid()
---- <
 ---
 --- @param win? any
 --- @param tab? any
@@ -11217,10 +10022,6 @@ function vim.fn.win_getid(win, tab) end
 ---
 --- Also see the 'buftype' option.
 ---
---- Can also be used as a |method|: >vim
----   GetWinid()->win_gettype()
---- <
----
 --- @param nr? integer
 --- @return 'autocmd'|'command'|''|'loclist'|'popup'|'preview'|'quickfix'|'unknown'
 function vim.fn.win_gettype(nr) end
@@ -11228,10 +10029,6 @@ function vim.fn.win_gettype(nr) end
 --- Go to window with ID {expr}.  This may also change the current
 --- tabpage.
 --- Return TRUE if successful, FALSE if the window cannot be found.
----
---- Can also be used as a |method|: >vim
----   GetWinid()->win_gotoid()
---- <
 ---
 --- @param expr any
 --- @return 0|1
@@ -11241,20 +10038,12 @@ function vim.fn.win_gotoid(expr) end
 --- with ID {expr}: [tabnr, winnr].
 --- Return [0, 0] if the window cannot be found.
 ---
---- Can also be used as a |method|: >vim
----   GetWinid()->win_id2tabwin()
---- <
----
 --- @param expr any
 --- @return any
 function vim.fn.win_id2tabwin(expr) end
 
 --- Return the window number of window with ID {expr}.
 --- Return 0 if the window cannot be found in the current tabpage.
----
---- Can also be used as a |method|: >vim
----   GetWinid()->win_id2win()
---- <
 ---
 --- @param expr any
 --- @return any
@@ -11274,10 +10063,6 @@ function vim.fn.win_id2win(expr) end
 --- window, since it has no separator on the right.
 --- Only works for the current tab page. *E1308*
 ---
---- Can also be used as a |method|: >vim
----   GetWinnr()->win_move_separator(offset)
---- <
----
 --- @param nr integer
 --- @param offset any
 --- @return any
@@ -11294,10 +10079,6 @@ function vim.fn.win_move_separator(nr, offset) end
 --- be found and FALSE otherwise.
 --- Only works for the current tab page.
 ---
---- Can also be used as a |method|: >vim
----   GetWinnr()->win_move_statusline(offset)
---- <
----
 --- @param nr integer
 --- @param offset any
 --- @return any
@@ -11310,10 +10091,6 @@ function vim.fn.win_move_statusline(nr, offset) end
 --- for the current window.
 --- Returns [0, 0] if the window cannot be found in the current
 --- tabpage.
----
---- Can also be used as a |method|: >vim
----   GetWinid()->win_screenpos()
---- <
 ---
 --- @param nr integer
 --- @return any
@@ -11338,10 +10115,6 @@ function vim.fn.win_screenpos(nr) end
 ---     present, the values of 'splitbelow' and
 ---     'splitright' are used.
 ---
---- Can also be used as a |method|: >vim
----   GetWinid()->win_splitmove(target)
---- <
----
 --- @param nr integer
 --- @param target any
 --- @param options? table
@@ -11356,9 +10129,6 @@ function vim.fn.win_splitmove(nr, target, options) end
 --- When window {nr} doesn't exist, -1 is returned.
 --- Example: >vim
 ---   echo "The file in the current window is " .. bufname(winbufnr(0))
---- <
---- Can also be used as a |method|: >vim
----   FindWindow()->winbufnr()->bufname()
 --- <
 ---
 --- @param nr integer
@@ -11388,10 +10158,6 @@ function vim.fn.windowsversion() end
 --- This excludes any window toolbar line.
 --- Examples: >vim
 ---   echo "The current window has " .. winheight(0) .. " lines."
----
---- <Can also be used as a |method|: >vim
----   GetWinid()->winheight()
---- <
 ---
 --- @param nr integer
 --- @return integer
@@ -11431,9 +10197,6 @@ function vim.fn.winheight(nr) end
 --- < >
 ---   ['col', [['leaf', 1002], ['row', [['leaf', 1003],
 ---           ['leaf', 1001]]], ['leaf', 1000]]]
---- <
---- Can also be used as a |method|: >vim
----   GetTabnr()->winlayout()
 --- <
 ---
 --- @param tabnr? integer
@@ -11477,10 +10240,6 @@ function vim.fn.winline() end
 ---   let prev_window = winnr('#')
 ---   let wnum = winnr('3k')
 ---
---- <Can also be used as a |method|: >vim
----   GetWinval()->winnr()
---- <
----
 --- @param arg? any
 --- @return any
 function vim.fn.winnr(arg) end
@@ -11512,10 +10271,6 @@ function vim.fn.winrestcmd() end
 ---
 --- If you have changed the values the result is unpredictable.
 --- If the window size changed the result won't be the same.
----
---- Can also be used as a |method|: >vim
----   GetView()->winrestview()
---- <
 ---
 --- @param dict any
 --- @return any
@@ -11562,10 +10317,6 @@ function vim.fn.winsaveview() end
 ---   endif
 --- <For getting the terminal or screen size, see the 'columns'
 --- option.
----
---- Can also be used as a |method|: >vim
----   GetWinid()->winwidth()
---- <
 ---
 --- @param nr integer
 --- @return any
@@ -11639,10 +10390,6 @@ function vim.fn.wordcount() end
 ---   let fl = readfile("foo", "b")
 ---   call writefile(fl, "foocopy", "b")
 ---
---- <Can also be used as a |method|: >vim
----   GetText()->writefile("thefile")
---- <
----
 --- @param object any
 --- @param fname integer
 --- @param flags? string
@@ -11654,9 +10401,6 @@ function vim.fn.writefile(object, fname, flags) end
 --- Also see `and()` and `or()`.
 --- Example: >vim
 ---   let bits = xor(bits, 0x80)
---- <
---- Can also be used as a |method|: >vim
----   let bits = bits->xor(0x80)
 --- <
 ---
 --- @param expr any

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -451,7 +451,7 @@ local CONFIG = {
       '*builtin.txt*	Nvim',
       '',
       '',
-      '\t\t  VIM REFERENCE MANUAL\t  by Bram Moolenaar',
+      '\t\t  NVIM REFERENCE MANUAL',
       '',
       '',
       'Builtin functions\t\t*vimscript-functions* *builtin-functions*',

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -50,9 +50,6 @@ M.funcs = {
       	echo abs(-4)
       <	4
 
-      Can also be used as a |method|: >vim
-      	Compute()->abs()
-      <
     ]=],
     name = 'abs',
     params = { { 'expr', 'any' } },
@@ -75,9 +72,6 @@ M.funcs = {
       	echo acos(-0.5)
       <	2.094395
 
-      Can also be used as a |method|: >vim
-      	Compute()->acos()
-      <
     ]=],
     float_func = 'acos',
     name = 'acos',
@@ -99,9 +93,6 @@ M.funcs = {
       Use |insert()| to add an item at another position.
       Returns 1 if {object} is not a |List| or a |Blob|.
 
-      Can also be used as a |method|: >vim
-      	mylist->add(val1)->add(val2)
-      <
     ]=],
     name = 'add',
     params = { { 'object', 'any' }, { 'expr', 'any' } },
@@ -117,8 +108,6 @@ M.funcs = {
       Also see `or()` and `xor()`.
       Example: >vim
       	let flag = and(bits, 0x80)
-      <Can also be used as a |method|: >vim
-      	let flag = bits->and(0x80)
       <
     ]=],
     name = 'and',
@@ -155,10 +144,8 @@ M.funcs = {
       0 for success.  Example: >vim
       	let failed = append(line('$'), "# THE END")
       	let failed = append(0, ["Chapter 1", "the beginning"])
-
-      <Can also be used as a |method| after a List: >vim
-      	mylist->append(lnum)
       <
+
     ]=],
     name = 'append',
     params = { { 'lnum', 'integer' }, { 'text', 'any' } },
@@ -187,9 +174,7 @@ M.funcs = {
       error message is given. Example: >vim
       	let failed = appendbufline(13, 0, "# THE START")
       <
-      Can also be used as a |method| after a List: >vim
-      	mylist->appendbufline(buf, lnum)
-      <
+
     ]=],
     name = 'appendbufline',
     params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'text', 'string' } },
@@ -284,9 +269,6 @@ M.funcs = {
       	echo asin(-0.5)
       <	-0.523599
 
-      Can also be used as a |method|: >vim
-      	Compute()->asin()
-      <
     ]=],
     float_func = 'asin',
     name = 'asin',
@@ -303,9 +285,6 @@ M.funcs = {
       Also see |assert_fails()|, |assert_nobeep()| and
       |assert-return|.
 
-      Can also be used as a |method|: >vim
-      	GetCmd()->assert_beeps()
-      <
     ]=],
     name = 'assert_beeps',
     params = { { 'cmd', 'any' } },
@@ -331,9 +310,6 @@ M.funcs = {
       <Will result in a string to be added to |v:errors|:
       	test.vim line 12: Expected 'foo' but got 'bar' ~
 
-      Can also be used as a |method|: >vim
-      	mylist->assert_equal([1, 2, 3])
-      <
     ]=],
     name = 'assert_equal',
     params = { { 'expected', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
@@ -350,9 +326,6 @@ M.funcs = {
       When {fname-one} or {fname-two} does not exist the error will
       mention that.
 
-      Can also be used as a |method|: >vim
-      	GetLog()->assert_equalfile('expected.log')
-      <
     ]=],
     name = 'assert_equalfile',
     params = {},
@@ -417,9 +390,6 @@ M.funcs = {
       Note that beeping is not considered an error, and some failing
       commands only beep.  Use |assert_beeps()| for those.
 
-      Can also be used as a |method|: >vim
-      	GetCmd()->assert_fails('E99:')
-      <
     ]=],
     name = 'assert_fails',
     params = {
@@ -445,9 +415,6 @@ M.funcs = {
       A value is false when it is zero. When {actual} is not a
       number the assert fails.
 
-      Can also be used as a |method|: >vim
-      	GetResult()->assert_false()
-      <
     ]=],
     name = 'assert_false',
     params = { { 'actual', 'any' }, { 'msg', 'any' } },
@@ -492,9 +459,6 @@ M.funcs = {
       <Will result in a string to be added to |v:errors|:
       	test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
-      Can also be used as a |method|: >vim
-      	getFile()->assert_match('foo.*')
-      <
     ]=],
     name = 'assert_match',
     params = { { 'pattern', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
@@ -509,9 +473,6 @@ M.funcs = {
       produces a beep or visual bell.
       Also see |assert_beeps()|.
 
-      Can also be used as a |method|: >vim
-      	GetCmd()->assert_nobeep()
-      <
     ]=],
     name = 'assert_nobeep',
     params = { { 'cmd', 'any' } },
@@ -526,9 +487,6 @@ M.funcs = {
       |v:errors| when {expected} and {actual} are equal.
       Also see |assert-return|.
 
-      Can also be used as a |method|: >vim
-      	mylist->assert_notequal([1, 2, 3])
-      <
     ]=],
     name = 'assert_notequal',
     params = { { 'expected', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
@@ -543,9 +501,6 @@ M.funcs = {
       |v:errors| when {pattern} matches {actual}.
       Also see |assert-return|.
 
-      Can also be used as a |method|: >vim
-      	getFile()->assert_notmatch('bar.*')
-      <
     ]=],
     name = 'assert_notmatch',
     params = { { 'pattern', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
@@ -559,9 +514,6 @@ M.funcs = {
       Report a test failure directly, using String {msg}.
       Always returns one.
 
-      Can also be used as a |method|: >vim
-      	GetMessage()->assert_report()
-      <
     ]=],
     name = 'assert_report',
     params = { { 'msg', 'any' } },
@@ -579,9 +531,6 @@ M.funcs = {
       When {actual} is not a number or |v:true| the assert fails.
       When {msg} is given it precedes the default message.
 
-      Can also be used as a |method|: >vim
-      	GetResult()->assert_true()
-      <
     ]=],
     name = 'assert_true',
     params = { { 'actual', 'any' }, { 'msg', 'any' } },
@@ -602,9 +551,6 @@ M.funcs = {
       	echo atan(-4.01)
       <	-1.326405
 
-      Can also be used as a |method|: >vim
-      	Compute()->atan()
-      <
     ]=],
     float_func = 'atan',
     name = 'atan',
@@ -627,9 +573,6 @@ M.funcs = {
       	echo atan2(1, -1)
       <	2.356194
 
-      Can also be used as a |method|: >vim
-      	Compute()->atan2(1)
-      <
     ]=],
     name = 'atan2',
     params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
@@ -647,9 +590,6 @@ M.funcs = {
       <Returns an empty List on error.  |list2blob()| does the
       opposite.
 
-      Can also be used as a |method|: >vim
-      	GetBlob()->blob2list()
-      <
     ]=],
     name = 'blob2list',
     params = { { 'blob', 'any' } },
@@ -709,9 +649,6 @@ M.funcs = {
       	call bufload(bufnr)
       	call setbufline(bufnr, 1, ['some', 'text'])
       <Returns 0 on error.
-      Can also be used as a |method|: >vim
-      	let bufnr = 'somename'->bufadd()
-      <
     ]=],
     name = 'bufadd',
     params = { { 'name', 'string' } },
@@ -743,9 +680,6 @@ M.funcs = {
       Use "bufexists(0)" to test for the existence of an alternate
       file name.
 
-      Can also be used as a |method|: >vim
-      	let exists = 'somename'->bufexists()
-      <
     ]=],
     name = 'bufexists',
     params = { { 'buf', 'any' } },
@@ -799,9 +733,6 @@ M.funcs = {
       {buf} exists and is listed (has the 'buflisted' option set).
       The {buf} argument is used like with |bufexists()|.
 
-      Can also be used as a |method|: >vim
-      	let listed = 'somename'->buflisted()
-      <
     ]=],
     name = 'buflisted',
     params = { { 'buf', 'any' } },
@@ -821,9 +752,6 @@ M.funcs = {
       there will be no dialog, the buffer will be loaded anyway.
       The {buf} argument is used like with |bufexists()|.
 
-      Can also be used as a |method|: >vim
-      	eval 'somename'->bufload()
-      <
     ]=],
     name = 'bufload',
     params = { { 'buf', 'any' } },
@@ -838,9 +766,6 @@ M.funcs = {
       {buf} exists and is loaded (shown in a window or hidden).
       The {buf} argument is used like with |bufexists()|.
 
-      Can also be used as a |method|: >vim
-      	let loaded = 'somename'->bufloaded()
-      <
     ]=],
     name = 'bufloaded',
     params = { { 'buf', 'any' } },
@@ -871,11 +796,6 @@ M.funcs = {
       with a listed buffer, that one is returned.  Next unlisted
       buffers are searched for.
       If the {buf} is a String, but you want to use it as a buffer
-      number, force it to be a Number by adding zero to it: >vim
-      	echo bufname("3" + 0)
-      <Can also be used as a |method|: >vim
-      	echo bufnr->bufname()
-
       <If the buffer doesn't exist, or doesn't have a name, an empty
       string is returned. >vim
       	echo bufname("#")		" alternate buffer name
@@ -906,9 +826,6 @@ M.funcs = {
       number necessarily exist, because ":bwipeout" may have removed
       them.  Use bufexists() to test for the existence of a buffer.
 
-      Can also be used as a |method|: >vim
-      	echo bufref->bufnr()
-      <
     ]=],
     name = 'bufnr',
     params = { { 'buf', 'any' }, { 'create', 'any' } },
@@ -929,9 +846,6 @@ M.funcs = {
       Only deals with the current tab page.  See |win_findbuf()| for
       finding more.
 
-      Can also be used as a |method|: >vim
-      	FindBuffer()->bufwinid()
-      <
     ]=],
     name = 'bufwinid',
     params = { { 'buf', 'any' } },
@@ -952,9 +866,6 @@ M.funcs = {
       <The number can be used with |CTRL-W_w| and ":wincmd w"
       |:wincmd|.
 
-      Can also be used as a |method|: >vim
-      	FindBuffer()->bufwinnr()
-      <
     ]=],
     name = 'bufwinnr',
     params = { { 'buf', 'any' } },
@@ -974,9 +885,6 @@ M.funcs = {
 
       Returns -1 if the {byte} value is invalid.
 
-      Can also be used as a |method|: >vim
-      	GetOffset()->byte2line()
-      <
     ]=],
     name = 'byte2line',
     params = { { 'byte', 'any' } },
@@ -1021,9 +929,6 @@ M.funcs = {
       	echo byteidx('a😊😊', 2, 1)	" returns 1
       	echo byteidx('a😊😊', 3, 1)	" returns 5
       <
-      Can also be used as a |method|: >vim
-      	GetName()->byteidx(idx)
-      <
     ]=],
     fast = true,
     name = 'byteidx',
@@ -1045,9 +950,6 @@ M.funcs = {
       character is 3 bytes), the second echo results in 1 ('e' is
       one byte).
 
-      Can also be used as a |method|: >vim
-      	GetName()->byteidxcomp(idx)
-      <
     ]=],
     fast = true,
     name = 'byteidxcomp',
@@ -1067,9 +969,6 @@ M.funcs = {
       {dict} is for functions with the "dict" attribute.  It will be
       used to set the local variable "self". |Dictionary-function|
 
-      Can also be used as a |method|: >vim
-      	GetFunc()->call([arg, arg], dict)
-      <
     ]=],
     name = 'call',
     params = { { 'func', 'any' }, { 'arglist', 'any' }, { 'dict', 'any' } },
@@ -1094,9 +993,6 @@ M.funcs = {
 
       Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
-      Can also be used as a |method|: >vim
-      	Compute()->ceil()
-      <
     ]=],
     float_func = 'ceil',
     name = 'ceil',
@@ -1179,9 +1075,6 @@ M.funcs = {
 
       Returns 0 if {string} is not a |String|.
 
-      Can also be used as a |method|: >vim
-      	GetChar()->char2nr()
-      <
     ]=],
     fast = true,
     name = 'char2nr',
@@ -1220,9 +1113,6 @@ M.funcs = {
       	echo charcol('.')		" returns 3
       	echo col('.')		" returns 7
 
-      <Can also be used as a |method|: >vim
-      	GetPos()->col()
-      <
     ]=],
     name = 'charcol',
     params = { { 'expr', 'any' }, { 'winid', 'integer' } },
@@ -1265,9 +1155,6 @@ M.funcs = {
       	echo charidx('áb́ć', 16)		" returns -1
       	echo charidx('a😊😊', 4, 0, 1)	" returns 2
       <
-      Can also be used as a |method|: >vim
-      	GetName()->charidx(idx)
-      <
     ]=],
     name = 'charidx',
     params = {
@@ -1304,9 +1191,6 @@ M.funcs = {
       	   call chdir(save_dir)
       	endif
 
-      <Can also be used as a |method|: >vim
-      	GetDir()->chdir()
-      <
     ]=],
     name = 'chdir',
     params = { { 'dir', 'string' } },
@@ -1324,9 +1208,6 @@ M.funcs = {
       When {lnum} is invalid -1 is returned.
       See |C-indenting|.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->cindent()
-      <
     ]=],
     name = 'cindent',
     params = { { 'lnum', 'integer' } },
@@ -1342,9 +1223,6 @@ M.funcs = {
       If {win} is specified, use the window with this number or
       window ID instead of the current window.
 
-      Can also be used as a |method|: >vim
-      	GetWin()->clearmatches()
-      <
     ]=],
     name = 'clearmatches',
     params = { { 'win', 'any' } },
@@ -1392,9 +1270,6 @@ M.funcs = {
       moved, this can be used to obtain the column in Insert mode: >vim
       	imap <F2> <Cmd>echo col(".").."\n"<CR>
 
-      <Can also be used as a |method|: >vim
-      	GetPos()->col()
-      <
     ]=],
     name = 'col',
     params = { { 'expr', 'any' }, { 'winid', 'integer' } },
@@ -1434,10 +1309,6 @@ M.funcs = {
       <This isn't very useful, but it shows how it works.  Note that
       an empty string is returned to avoid a zero being inserted.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetMatches()->complete(col('.'))
-      <
     ]=],
     name = 'complete',
     params = { { 'startcol', 'any' }, { 'matches', 'any' } },
@@ -1457,9 +1328,6 @@ M.funcs = {
       See |complete-functions| for an explanation of {expr}.  It is
       the same as one item in the list that 'omnifunc' would return.
 
-      Can also be used as a |method|: >vim
-      	GetMoreMatches()->complete_add()
-      <
     ]=],
     name = 'complete_add',
     params = { { 'expr', 'any' } },
@@ -1541,9 +1409,6 @@ M.funcs = {
       	" Get only 'mode' and 'pum_visible'
       	call complete_info(['mode', 'pum_visible'])
 
-      <Can also be used as a |method|: >vim
-      	GetItems()->complete_info()
-      <
     ]=],
     name = 'complete_info',
     params = { { 'what', 'any' } },
@@ -1605,9 +1470,6 @@ M.funcs = {
       don't fit, a vertical layout is used anyway.  For some systems
       the horizontal layout is always used.
 
-      Can also be used as a |method|in: >vim
-      	BuildMessage()->confirm("&Yes\n&No")
-      <
     ]=],
     name = 'confirm',
     params = { { 'msg', 'any' }, { 'choices', 'any' }, { 'default', 'any' }, { 'type', 'any' } },
@@ -1626,9 +1488,6 @@ M.funcs = {
       changing an item changes the contents of both |Lists|.
       A |Dictionary| is copied in a similar way as a |List|.
       Also see |deepcopy()|.
-      Can also be used as a |method|: >vim
-      	mylist->copy()
-      <
     ]=],
     name = 'copy',
     params = { { 'expr', 'any' } },
@@ -1648,9 +1507,6 @@ M.funcs = {
       	echo cos(-4.01)
       <	-0.646043
 
-      Can also be used as a |method|: >vim
-      	Compute()->cos()
-      <
     ]=],
     float_func = 'cos',
     name = 'cos',
@@ -1672,9 +1528,6 @@ M.funcs = {
       	echo cosh(-0.5)
       <	-1.127626
 
-      Can also be used as a |method|: >vim
-      	Compute()->cosh()
-      <
     ]=],
     float_func = 'cosh',
     name = 'cosh',
@@ -1698,9 +1551,6 @@ M.funcs = {
       occurrences of {expr} is returned. Zero is returned when
       {expr} is an empty string.
 
-      Can also be used as a |method|: >vim
-      	mylist->count(val)
-      <
     ]=],
     name = 'count',
     params = { { 'comp', 'any' }, { 'expr', 'any' }, { 'ic', 'any' }, { 'start', 'any' } },
@@ -1803,9 +1653,6 @@ M.funcs = {
       position within a <Tab> or after the last character.
       Returns 0 when the position could be set, -1 otherwise.
 
-      Can also be used as a |method|: >vim
-      	GetCursorPos()->cursor()
-      <
     ]=],
     name = 'cursor',
     params = { { 'list', 'any' } },
@@ -1823,9 +1670,6 @@ M.funcs = {
       Returns |TRUE| if successfully interrupted the program.
       Otherwise returns |FALSE|.
 
-      Can also be used as a |method|: >vim
-      	GetPid()->debugbreak()
-      <
     ]=],
     name = 'debugbreak',
     params = { { 'pid', 'any' } },
@@ -1855,9 +1699,6 @@ M.funcs = {
       {noref} set to 1 will fail.
       Also see |copy()|.
 
-      Can also be used as a |method|: >vim
-      	GetObject()->deepcopy()
-      <
     ]=],
     name = 'deepcopy',
     params = { { 'expr', 'any' }, { 'noref', 'any' } },
@@ -1885,9 +1726,6 @@ M.funcs = {
       operation was successful and -1/true when the deletion failed
       or partly failed.
 
-      Can also be used as a |method|: >vim
-      	GetName()->delete()
-      <
     ]=],
     name = 'delete',
     params = { { 'fname', 'integer' }, { 'flags', 'string' } },
@@ -1911,9 +1749,6 @@ M.funcs = {
       when using |line()| this refers to the current buffer. Use "$"
       to refer to the last line in buffer {buf}.
 
-      Can also be used as a |method|: >vim
-      	GetBuffer()->deletebufline(1)
-      <
     ]=],
     name = 'deletebufline',
     params = { { 'buf', 'any' }, { 'first', 'any' }, { 'last', 'any' } },
@@ -2006,9 +1841,6 @@ M.funcs = {
       line, "'m" mark m, etc.
       Returns 0 if the current window is not in diff mode.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->diff_filler()
-      <
     ]=],
     name = 'diff_filler',
     params = { { 'lnum', 'integer' } },
@@ -2028,9 +1860,6 @@ M.funcs = {
       The highlight ID can be used with |synIDattr()| to obtain
       syntax information about the highlighting.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->diff_hlID(col)
-      <
     ]=],
     name = 'diff_hlID',
     params = { { 'lnum', 'integer' }, { 'col', 'integer' } },
@@ -2056,9 +1885,6 @@ M.funcs = {
       call digraph_set('aa', 'あ')
       echo digraph_get('aa')		" Returns 'あ'
       <
-      Can also be used as a |method|: >vim
-      	GetChars()->digraph_get()
-      <
     ]=],
     name = 'digraph_get',
     params = { { 'chars', 'any' } },
@@ -2080,9 +1906,6 @@ M.funcs = {
 
       " Get all the digraphs, including default digraphs
       echo digraph_getlist(1)
-      <
-      Can also be used as a |method|: >vim
-      	GetNumber()->digraph_getlist()
       <
     ]=],
     name = 'digraph_getlist',
@@ -2155,9 +1978,6 @@ M.funcs = {
       - |v:false| and |v:null| are empty, |v:true| is not.
       - A |Blob| is empty when its length is zero.
 
-      Can also be used as a |method|: >vim
-      	mylist->empty()
-      <
     ]=],
     name = 'empty',
     params = { { 'expr', 'any' } },
@@ -2189,9 +2009,6 @@ M.funcs = {
       	c:\\program\ files\\vim
       <Also see |shellescape()| and |fnameescape()|.
 
-      Can also be used as a |method|: >vim
-      	GetText()->escape(' \')
-      <
     ]=],
     fast = true,
     name = 'escape',
@@ -2208,9 +2025,6 @@ M.funcs = {
       of them.  Also works for |Funcref|s that refer to existing
       functions.
 
-      Can also be used as a |method|: >vim
-      	argv->join()->eval()
-      <
     ]=],
     name = 'eval',
     params = { { 'string', 'string' } },
@@ -2253,9 +2067,6 @@ M.funcs = {
       	-1	not implemented on this system
       |exepath()| can be used to get the full path of an executable.
 
-      Can also be used as a |method|: >vim
-      	GetCommand()->executable()
-      <
     ]=],
     fast = true,
     name = 'executable',
@@ -2293,9 +2104,6 @@ M.funcs = {
       To execute a command in another window than the current one
       use `win_execute()`.
 
-      Can also be used as a |method|: >vim
-      	GetCommand()->execute()
-      <
     ]=],
     name = 'execute',
     params = { { 'command', 'any' }, { 'silent', 'boolean' } },
@@ -2310,9 +2118,6 @@ M.funcs = {
       Returns empty string otherwise.
       If {expr} starts with "./" the |current-directory| is used.
 
-      Can also be used as a |method|: >vim
-      	GetCommand()->exepath()
-      <
     ]=],
     name = 'exepath',
     params = { { 'expr', 'any' } },
@@ -2409,9 +2214,6 @@ M.funcs = {
       <This doesn't check for existence of the "bufcount" variable,
       but gets the value of "bufcount", and checks if that exists.
 
-      Can also be used as a |method|: >vim
-      	Varname()->exists()
-      <
     ]=],
     name = 'exists',
     params = { { 'expr', 'any' } },
@@ -2432,9 +2234,6 @@ M.funcs = {
       	echo exp(-1)
       <	0.367879
 
-      Can also be used as a |method|: >vim
-      	Compute()->exp()
-      <
     ]=],
     float_func = 'exp',
     name = 'exp',
@@ -2535,9 +2334,6 @@ M.funcs = {
       See |glob()| for finding existing files.  See |system()| for
       getting the raw output of an external command.
 
-      Can also be used as a |method|: >vim
-      	Getpattern()->expand()
-      <
     ]=],
     name = 'expand',
     params = { { 'string', 'string' }, { 'nosuf', 'boolean' }, { 'list', 'any' } },
@@ -2569,9 +2365,6 @@ M.funcs = {
       	make /path/runtime/doc/builtin.o
       < >vim
       	echo expandcmd('make %<.o', {'errmsg': v:true})
-      <
-      Can also be used as a |method|: >vim
-      	GetCommand()->expandcmd()
       <
     ]=],
     name = 'expandcmd',
@@ -2617,9 +2410,6 @@ M.funcs = {
       fails.
       Returns {expr1}.  Returns 0 on error.
 
-      Can also be used as a |method|: >vim
-      	mylist->extend(otherlist)
-      <
     ]=],
     name = 'extend',
     params = { { 'expr1', 'any' }, { 'expr2', 'any' }, { 'expr3', 'any' } },
@@ -2685,9 +2475,6 @@ M.funcs = {
 
       Return value is always 0.
 
-      Can also be used as a |method|: >vim
-      	GetInput()->feedkeys()
-      <
     ]=],
     name = 'feedkeys',
     params = { { 'string', 'string' }, { 'mode', 'string' } },
@@ -2725,9 +2512,6 @@ M.funcs = {
       	1
       <
 
-      Can also be used as a |method|: >vim
-      	GetName()->filereadable()
-      <
     ]=],
     fast = true,
     name = 'filereadable',
@@ -2744,9 +2528,6 @@ M.funcs = {
       exist, or is not writable, the result is 0.  If {file} is a
       directory, and we can write to it, the result is 2.
 
-      Can also be used as a |method|: >vim
-      	GetName()->filewritable()
-      <
     ]=],
     fast = true,
     name = 'filewritable',
@@ -2807,9 +2588,6 @@ M.funcs = {
       {expr2} is a Funcref errors inside a function are ignored,
       unless it was defined with the "abort" flag.
 
-      Can also be used as a |method|: >vim
-      	mylist->filter(expr2)
-      <
     ]=],
     name = 'filter',
     params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
@@ -2836,9 +2614,6 @@ M.funcs = {
 
       This is quite similar to the ex-command `:find`.
 
-      Can also be used as a |method|: >vim
-      	GetName()->finddir()
-      <
     ]=],
     name = 'finddir',
     params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'any' } },
@@ -2855,9 +2630,6 @@ M.funcs = {
       <Searches from the directory of the current file upwards until
       it finds the file "tags.vim".
 
-      Can also be used as a |method|: >vim
-      	GetName()->findfile()
-      <
     ]=],
     name = 'findfile',
     params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'any' } },
@@ -2885,9 +2657,6 @@ M.funcs = {
       	echo flatten([1, [2, [3, 4]], 5], 1)
       <	[1, 2, [3, 4], 5]
 
-      Can also be used as a |method|: >vim
-      	mylist->flatten()
-      <
     ]=],
     name = 'flatten',
     params = { { 'list', 'any' }, { 'maxdepth', 'any' } },
@@ -2930,9 +2699,6 @@ M.funcs = {
       	echo float2nr(1.0e-100)
       <	0
 
-      Can also be used as a |method|: >vim
-      	Compute()->float2nr()
-      <
     ]=],
     name = 'float2nr',
     params = { { 'expr', 'any' } },
@@ -2954,9 +2720,6 @@ M.funcs = {
       	echo floor(4.0)
       <	4.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->floor()
-      <
     ]=],
     float_func = 'floor',
     name = 'floor',
@@ -2982,9 +2745,6 @@ M.funcs = {
       	echo fmod(-12.33, 1.22)
       <	-0.13
 
-      Can also be used as a |method|: >vim
-      	Compute()->fmod(1.22)
-      <
     ]=],
     name = 'fmod',
     params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
@@ -3008,9 +2768,6 @@ M.funcs = {
       	exe "edit " .. fnameescape(fname)
       <results in executing: >vim
       	edit \+some\ str\%nge\|name
-      <
-      Can also be used as a |method|: >vim
-      	GetName()->fnameescape()
       <
     ]=],
     fast = true,
@@ -3039,9 +2796,6 @@ M.funcs = {
       Note: Environment variables don't work in {fname}, use
       |expand()| first then.
 
-      Can also be used as a |method|: >vim
-      	GetName()->fnamemodify(':p:h')
-      <
     ]=],
     fast = true,
     name = 'fnamemodify',
@@ -3059,9 +2813,6 @@ M.funcs = {
       {lnum} is used like with |getline()|.  Thus "." is the current
       line, "'m" mark m, etc.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->foldclosed()
-      <
     ]=],
     name = 'foldclosed',
     params = { { 'lnum', 'integer' } },
@@ -3078,9 +2829,6 @@ M.funcs = {
       {lnum} is used like with |getline()|.  Thus "." is the current
       line, "'m" mark m, etc.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->foldclosedend()
-      <
     ]=],
     name = 'foldclosedend',
     params = { { 'lnum', 'integer' } },
@@ -3102,9 +2850,6 @@ M.funcs = {
       {lnum} is used like with |getline()|.  Thus "." is the current
       line, "'m" mark m, etc.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->foldlevel()
-      <
     ]=],
     name = 'foldlevel',
     params = { { 'lnum', 'integer' } },
@@ -3146,9 +2891,6 @@ M.funcs = {
       line, "'m" mark m, etc.
       Useful when exporting folded text, e.g., to HTML.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->foldtextresult()
-      <
     ]=],
     name = 'foldtextresult',
     params = { { 'lnum', 'integer' } },
@@ -3173,9 +2915,6 @@ M.funcs = {
       For example `fullcommand('s')`, `fullcommand('sub')`,
       `fullcommand(':%substitute')` all return "substitute".
 
-      Can also be used as a |method|: >vim
-      	GetName()->fullcommand()
-      <
     ]=],
     name = 'fullcommand',
     params = { { 'name', 'string' } },
@@ -3197,9 +2936,6 @@ M.funcs = {
       instead). {name} cannot be a builtin function.
       Returns 0 on error.
 
-      Can also be used as a |method|: >vim
-      	GetFuncname()->funcref([arg])
-      <
     ]=],
     name = 'funcref',
     params = { { 'name', 'string' }, { 'arglist', 'any' }, { 'dict', 'any' } },
@@ -3290,9 +3026,6 @@ M.funcs = {
       <
       Returns 0 on error.
 
-      Can also be used as a |method|: >vim
-      	GetFuncname()->function([arg])
-      <
     ]=],
     name = 'function',
     params = { { 'name', 'string' }, { 'arglist', 'any' }, { 'dict', 'any' } },
@@ -3332,9 +3065,6 @@ M.funcs = {
       Get item {idx} from |List| {list}.  When this item is not
       available return {default}.  Return zero when {default} is
       omitted.
-      Can also be used as a |method|: >vim
-      	mylist->get(idx)
-      <
     ]=],
     name = 'get',
     params = { { 'list', 'any[]' }, { 'idx', 'integer' }, { 'default', 'any' } },
@@ -3459,9 +3189,6 @@ M.funcs = {
       To get buffer-local options use: >vim
       	getbufvar({bufnr}, '&option_name')
       <
-      Can also be used as a |method|: >vim
-      	GetBufnr()->getbufinfo()
-      <
     ]=],
     name = 'getbufinfo',
     params = { { 'dict', 'table<string,any>' } },
@@ -3495,9 +3222,6 @@ M.funcs = {
       Example: >vim
       	let lines = getbufline(bufnr("myfile"), 1, "$")
 
-      <Can also be used as a |method|: >vim
-      	GetBufnr()->getbufline(lnum)
-      <
     ]=],
     name = 'getbufline',
     params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'end', 'integer' } },
@@ -3538,9 +3262,6 @@ M.funcs = {
       	let bufmodified = getbufvar(1, "&mod")
       	echo "todo myvar = " .. getbufvar("todo", "myvar")
 
-      <Can also be used as a |method|: >vim
-      	GetBufnr()->getbufvar(varname)
-      <
     ]=],
     name = 'getbufvar',
     params = { { 'buf', 'any' }, { 'varname', 'string' }, { 'def', 'any' } },
@@ -3576,9 +3297,6 @@ M.funcs = {
       position refers to the position in the list. For other
       buffers, it is set to the length of the list.
 
-      Can also be used as a |method|: >vim
-      	GetBufnr()->getchangelist()
-      <
     ]=],
     name = 'getchangelist',
     params = { { 'buf', 'integer|string' } },
@@ -3694,9 +3412,6 @@ M.funcs = {
       With the cursor on '세' in line 5 with text "여보세요": >vim
       	getcharpos('.')		returns [0, 5, 3, 0]
       	getpos('.')		returns [0, 5, 7, 0]
-      <
-      Can also be used as a |method|: >vim
-      	GetMark()->getcharpos()
       <
     ]=],
     name = 'getcharpos',
@@ -3912,9 +3627,6 @@ M.funcs = {
       If there are no matches, an empty list is returned.  An
       invalid value for {type} produces an error.
 
-      Can also be used as a |method|: >vim
-      	GetPattern()->getcompletion('color')
-      <
     ]=],
     name = 'getcompletion',
     params = { { 'pat', 'any' }, { 'type', 'any' }, { 'filtered', 'any' } },
@@ -3949,9 +3661,6 @@ M.funcs = {
       <Note that this only works within the window.  See
       |winrestview()| for restoring more state.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->getcurpos()
-      <
     ]=],
     name = 'getcurpos',
     params = { { 'winid', 'integer' } },
@@ -3968,9 +3677,6 @@ M.funcs = {
       With the cursor on '보' in line 3 with text "여보세요": >vim
       	getcursorcharpos()	" returns [0, 3, 2, 0, 3]
       	getcurpos()		" returns [0, 3, 4, 0, 3]
-      <
-      Can also be used as a |method|: >vim
-      	GetWinid()->getcursorcharpos()
       <
     ]=],
     name = 'getcursorcharpos',
@@ -3996,9 +3702,6 @@ M.funcs = {
       directory is returned.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->getcwd()
-      <
     ]=],
     name = 'getcwd',
     params = { { 'winnr', 'integer' }, { 'tabnr', 'integer' } },
@@ -4017,9 +3720,6 @@ M.funcs = {
       is different from a variable set to an empty string.
       See also |expr-env|.
 
-      Can also be used as a |method|: >vim
-      	GetVarname()->getenv()
-      <
     ]=],
     name = 'getenv',
     params = { { 'name', 'string' } },
@@ -4063,9 +3763,6 @@ M.funcs = {
       <This will hopefully (from a security point of view) display
       the string "rw-r--r--" or even "rw-------".
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->getfperm()
-      <
       For setting permissions use |setfperm()|.
     ]=],
     fast = true,
@@ -4085,9 +3782,6 @@ M.funcs = {
       If the size of {fname} is too big to fit in a Number then -2
       is returned.
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->getfsize()
-      <
     ]=],
     fast = true,
     name = 'getfsize',
@@ -4105,9 +3799,6 @@ M.funcs = {
       |localtime()| and |strftime()|.
       If the file {fname} can't be found -1 is returned.
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->getftime()
-      <
     ]=],
     fast = true,
     name = 'getftime',
@@ -4138,9 +3829,6 @@ M.funcs = {
       systems that support it.  On some systems only "dir" and
       "file" are returned.
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->getftype()
-      <
     ]=],
     fast = true,
     name = 'getftype',
@@ -4171,9 +3859,6 @@ M.funcs = {
       	filename	filename if available
       	lnum		line number
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->getjumplist()
-      <
     ]=],
     name = 'getjumplist',
     params = { { 'winnr', 'integer' }, { 'tabnr', 'integer' } },
@@ -4203,9 +3888,6 @@ M.funcs = {
       	let start = line('.')
       	let end = search("^$") - 1
       	let lines = getline(start, end)
-
-      <Can also be used as a |method|: >vim
-      	ComputeLnum()->getline()
 
       <To get lines from another buffer see |getbufline()| and
       |getbufoneline()|
@@ -4275,9 +3957,6 @@ M.funcs = {
       Refer to |getpos()| for getting information about a specific
       mark.
 
-      Can also be used as a |method|: >vim
-      	GetBufnr()->getmarklist()
-      <
     ]=],
     name = 'getmarklist',
     params = { { 'buf', 'any' } },
@@ -4398,9 +4077,6 @@ M.funcs = {
       	call setpos("'a", save_a_mark)
       <Also see |getcharpos()|, |getcurpos()| and |setpos()|.
 
-      Can also be used as a |method|: >vim
-      	GetMark()->getpos()
-      <
     ]=],
     name = 'getpos',
     params = { { 'expr', 'any' } },
@@ -4539,9 +4215,6 @@ M.funcs = {
 
       If {regname} is not specified, |v:register| is used.
 
-      Can also be used as a |method|: >vim
-      	GetRegname()->getreg()
-      <
     ]=],
     name = 'getreg',
     params = { { 'regname', 'string' }, { 'list', 'any' } },
@@ -4575,9 +4248,6 @@ M.funcs = {
       If {regname} is not specified, |v:register| is used.
       The returned Dictionary can be passed to |setreg()|.
 
-      Can also be used as a |method|: >vim
-      	GetRegname()->getreginfo()
-      <
     ]=],
     name = 'getreginfo',
     params = { { 'regname', 'string' } },
@@ -4598,9 +4268,6 @@ M.funcs = {
       The {regname} argument is a string.  If {regname} is not
       specified, |v:register| is used.
 
-      Can also be used as a |method|: >vim
-      	GetRegname()->getregtype()
-      <
     ]=],
     name = 'getregtype',
     params = { { 'regname', 'string' } },
@@ -4666,9 +4333,6 @@ M.funcs = {
       			tabpage-local variables
       	windows		List of |window-ID|s in the tab page.
 
-      Can also be used as a |method|: >vim
-      	GetTabnr()->gettabinfo()
-      <
     ]=],
     name = 'gettabinfo',
     params = { { 'tabnr', 'integer' } },
@@ -4687,9 +4351,6 @@ M.funcs = {
       When the tab or variable doesn't exist {def} or an empty
       string is returned, there is no error message.
 
-      Can also be used as a |method|: >vim
-      	GetTabnr()->gettabvar(varname)
-      <
     ]=],
     name = 'gettabvar',
     params = { { 'tabnr', 'integer' }, { 'varname', 'string' }, { 'def', 'any' } },
@@ -4723,9 +4384,6 @@ M.funcs = {
       <
       To obtain all window-local variables use: >vim
       	gettabwinvar({tabnr}, {winnr}, '&')
-      <
-      Can also be used as a |method|: >vim
-      	GetTabnr()->gettabwinvar(winnr, varname)
       <
     ]=],
     name = 'gettabwinvar',
@@ -4768,9 +4426,6 @@ M.funcs = {
 
       See |tagstack| for more information about the tag stack.
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->gettagstack()
-      <
     ]=],
     name = 'gettagstack',
     params = { { 'winnr', 'integer' } },
@@ -4831,9 +4486,6 @@ M.funcs = {
       	winrow		topmost screen line of the window;
       			"row" from |win_screenpos()|
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->getwininfo()
-      <
     ]=],
     name = 'getwininfo',
     params = { { 'winid', 'integer' } },
@@ -4861,9 +4513,6 @@ M.funcs = {
       	  endif
       	  " Do some work here
       	endwhile
-      <
-      Can also be used as a |method|: >vim
-      	GetTimeout()->getwinpos()
       <
     ]=],
     name = 'getwinpos',
@@ -4903,9 +4552,6 @@ M.funcs = {
       	let list_is_on = getwinvar(2, '&list')
       	echo "myvar = " .. getwinvar(1, 'myvar')
 
-      <Can also be used as a |method|: >vim
-      	GetWinnr()->getwinvar(varname)
-      <
     ]=],
     name = 'getwinvar',
     params = { { 'winnr', 'integer' }, { 'varname', 'string' }, { 'def', 'any' } },
@@ -4950,9 +4596,6 @@ M.funcs = {
       See |expand()| for expanding special Vim variables.  See
       |system()| for getting the raw output of an external command.
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->glob()
-      <
     ]=],
     name = 'glob',
     params = { { 'expr', 'any' }, { 'nosuf', 'boolean' }, { 'list', 'any' }, { 'alllinks', 'any' } },
@@ -4977,9 +4620,6 @@ M.funcs = {
       Note that the result depends on the system.  On MS-Windows
       a backslash usually means a path separator.
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->glob2regpat()
-      <
     ]=],
     name = 'glob2regpat',
     params = { { 'string', 'string' } },
@@ -5023,10 +4663,6 @@ M.funcs = {
       <Upwards search and limiting the depth of "**" is not
       supported, thus using 'path' will not always work properly.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetExpr()->globpath(&rtp)
-      <
     ]=],
     name = 'globpath',
     params = {
@@ -5121,9 +4757,6 @@ M.funcs = {
       has an entry with key {key}.  FALSE otherwise. The {key}
       argument is a string.
 
-      Can also be used as a |method|: >vim
-      	mydict->has_key(key)
-      <
     ]=],
     name = 'has_key',
     params = { { 'dict', 'any' }, { 'key', 'any' } },
@@ -5150,9 +4783,6 @@ M.funcs = {
       If {winnr} is -1 it is ignored, only the tab is resolved.
       Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->haslocaldir()
-      <
     ]=],
     name = 'haslocaldir',
     params = { { 'winnr', 'integer' }, { 'tabnr', 'integer' } },
@@ -5193,9 +4823,6 @@ M.funcs = {
       <This installs the mapping to "\ABCdoit" only if there isn't
       already a mapping to "\ABCdoit".
 
-      Can also be used as a |method|: >vim
-      	GetRHS()->hasmapto()
-      <
     ]=],
     name = 'hasmapto',
     params = { { 'what', 'any' }, { 'mode', 'string' }, { 'abbr', 'any' } },
@@ -5248,10 +4875,6 @@ M.funcs = {
       	let date=input("Enter date: ")
       <This function is not available in the |sandbox|.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetHistory()->histadd('search')
-      <
     ]=],
     name = 'histadd',
     params = { { 'history', 'any' }, { 'item', 'any' } },
@@ -5293,9 +4916,6 @@ M.funcs = {
       	call histdel("search", -1)
       	let @/ = histget("search", -1)
       <
-      Can also be used as a |method|: >vim
-      	GetHistory()->histdel()
-      <
     ]=],
     name = 'histdel',
     params = { { 'history', 'any' }, { 'item', 'any' } },
@@ -5320,9 +4940,6 @@ M.funcs = {
       the {num}th entry from the output of |:history|. >vim
       	command -nargs=1 H execute histget("cmd", 0+<args>)
       <
-      Can also be used as a |method|: >vim
-      	GetHistory()->histget()
-      <
     ]=],
     name = 'histget',
     params = { { 'history', 'any' }, { 'index', 'any' } },
@@ -5340,9 +4957,6 @@ M.funcs = {
       Example: >vim
       	let inp_index = histnr("expr")
 
-      <Can also be used as a |method|: >vim
-      	GetHistory()->histnr()
-      <
     ]=],
     name = 'histnr',
     params = { { 'history', 'any' } },
@@ -5361,9 +4975,6 @@ M.funcs = {
       "Comment" group: >vim
       	echo synIDattr(synIDtrans(hlID("Comment")), "bg")
       <
-      Can also be used as a |method|: >vim
-      	GetName()->hlID()
-      <
     ]=],
     name = 'hlID',
     params = { { 'name', 'string' } },
@@ -5380,9 +4991,6 @@ M.funcs = {
       been defined for it, it may also have been used for a syntax
       item.
 
-      Can also be used as a |method|: >vim
-      	GetName()->hlexists()
-      <
     ]=],
     name = 'hlexists',
     params = { { 'name', 'string' } },
@@ -5416,9 +5024,6 @@ M.funcs = {
       from/to UCS-2 is automatically changed to use UTF-8.  You
       cannot use UCS-2 in a string anyway, because of the NUL bytes.
 
-      Can also be used as a |method|: >vim
-      	GetText()->iconv('latin1', 'utf-8')
-      <
     ]=],
     fast = true,
     name = 'iconv',
@@ -5457,9 +5062,6 @@ M.funcs = {
       |getline()|.
       When {lnum} is invalid -1 is returned.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->indent()
-      <
     ]=],
     name = 'indent',
     params = { { 'lnum', 'integer' } },
@@ -5496,9 +5098,6 @@ M.funcs = {
       	  " ...
       	endif
 
-      <Can also be used as a |method|: >vim
-      	GetObject()->index(what)
-      <
     ]=],
     name = 'index',
     params = { { 'object', 'any' }, { 'expr', 'any' }, { 'start', 'any' }, { 'ic', 'any' } },
@@ -5545,9 +5144,6 @@ M.funcs = {
       	echo indexof(l, {i, v -> v.n == 30})
       	echo indexof(l, "v:val.n == 20", #{startidx: 1})
 
-      <Can also be used as a |method|: >vim
-      	mylist->indexof(expr)
-      <
     ]=],
     name = 'indexof',
     params = { { 'object', 'any' }, { 'expr', 'any' }, { 'opts', 'table' } },
@@ -5674,9 +5270,6 @@ M.funcs = {
       	  call inputrestore()
       	endfunction
 
-      <Can also be used as a |method|: >vim
-      	GetPrompt()->input()
-      <
     ]=],
     name = 'input',
     params = { { 'opts', 'table' } },
@@ -5712,9 +5305,6 @@ M.funcs = {
       	let color = inputlist(['Select color:', '1. red',
       		\ '2. green', '3. blue'])
 
-      <Can also be used as a |method|: >vim
-      	GetChoices()->inputlist()
-      <
     ]=],
     name = 'inputlist',
     params = { { 'textlist', 'any' } },
@@ -5758,9 +5348,6 @@ M.funcs = {
       typed on the command-line in response to the issued prompt.
       NOTE: Command-line completion is not supported.
 
-      Can also be used as a |method|: >vim
-      	GetPrompt()->inputsecret()
-      <
     ]=],
     name = 'inputsecret',
     params = { { 'prompt', 'any' }, { 'text', 'any' } },
@@ -5786,9 +5373,6 @@ M.funcs = {
       Note that when {item} is a |List| it is inserted as a single
       item.  Use |extend()| to concatenate |Lists|.
 
-      Can also be used as a |method|: >vim
-      	mylist->insert(item)
-      <
     ]=],
     name = 'insert',
     params = { { 'object', 'any' }, { 'item', 'any' }, { 'idx', 'integer' } },
@@ -5819,11 +5403,6 @@ M.funcs = {
     base = 1,
     desc = [=[
       Bitwise invert.  The argument is converted to a number.  A
-      List, Dict or Float argument causes an error.  Example: >vim
-      	let bits = invert(bits)
-      <Can also be used as a |method|: >vim
-      	let bits = bits->invert()
-      <
     ]=],
     name = 'invert',
     params = { { 'expr', 'any' } },
@@ -5838,9 +5417,6 @@ M.funcs = {
       exist, or isn't a directory, the result is |FALSE|.  {directory}
       is any expression, which is used as a String.
 
-      Can also be used as a |method|: >vim
-      	GetName()->isdirectory()
-      <
     ]=],
     fast = true,
     name = 'isdirectory',
@@ -5859,9 +5435,6 @@ M.funcs = {
       	echo isinf(-1.0 / 0.0)
       <	-1
 
-      Can also be used as a |method|: >vim
-      	Compute()->isinf()
-      <
     ]=],
     name = 'isinf',
     params = { { 'expr', 'any' } },
@@ -5885,9 +5458,6 @@ M.funcs = {
       <When {expr} is a variable that does not exist you get an error
       message.  Use |exists()| to check for existence.
 
-      Can also be used as a |method|: >vim
-      	GetName()->islocked()
-      <
     ]=],
     name = 'islocked',
     params = { { 'expr', 'any' } },
@@ -5903,9 +5473,6 @@ M.funcs = {
       	echo isnan(0.0 / 0.0)
       <	1
 
-      Can also be used as a |method|: >vim
-      	Compute()->isnan()
-      <
     ]=],
     name = 'isnan',
     params = { { 'expr', 'any' } },
@@ -5925,9 +5492,6 @@ M.funcs = {
       	   echo key .. ': ' .. value
       	endfor
 
-      <Can also be used as a |method|: >vim
-      	mydict->items()
-      <
     ]=],
     name = 'items',
     params = { { 'dict', 'any' } },
@@ -6123,9 +5687,6 @@ M.funcs = {
       converted into a string like with |string()|.
       The opposite function is |split()|.
 
-      Can also be used as a |method|: >vim
-      	mylist->join()
-      <
     ]=],
     name = 'join',
     params = { { 'list', 'any' }, { 'sep', 'any' } },
@@ -6150,9 +5711,6 @@ M.funcs = {
       recommended and the only one required to be supported.
       Non-UTF-8 characters are an error.
 
-      Can also be used as a |method|: >vim
-      	ReadObject()->json_decode()
-      <
     ]=],
     name = 'json_decode',
     params = { { 'expr', 'any' } },
@@ -6173,9 +5731,6 @@ M.funcs = {
       or special escapes like "\t", other are dumped as-is.
       |Blob|s are converted to arrays of the individual bytes.
 
-      Can also be used as a |method|: >vim
-      	GetObject()->json_encode()
-      <
     ]=],
     name = 'json_encode',
     params = { { 'expr', 'any' } },
@@ -6188,9 +5743,6 @@ M.funcs = {
       Return a |List| with all the keys of {dict}.  The |List| is in
       arbitrary order.  Also see |items()| and |values()|.
 
-      Can also be used as a |method|: >vim
-      	mydict->keys()
-      <
     ]=],
     name = 'keys',
     params = { { 'dict', 'any' } },
@@ -6206,9 +5758,6 @@ M.funcs = {
       	echo keytrans(xx)
       <	<C-Home>
 
-      Can also be used as a |method|: >vim
-      	"\<C-Home>"->keytrans()
-      <
     ]=],
     name = 'keytrans',
     params = { { 'string', 'string' } },
@@ -6235,9 +5784,6 @@ M.funcs = {
       |Dictionary| is returned.
       Otherwise an error is given and returns zero.
 
-      Can also be used as a |method|: >vim
-      	mylist->len()
-      <
     ]=],
     name = 'len',
     params = { { 'expr', 'any' } },
@@ -6289,10 +5835,6 @@ M.funcs = {
       Examples: >vim
       	echo libcall("libc.so", "getenv", "HOME")
 
-      <Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetValue()->libcall("libc.so", "getenv")
-      <
     ]=],
     name = 'libcall',
     params = { { 'libname', 'string' }, { 'funcname', 'string' }, { 'argument', 'any' } },
@@ -6309,10 +5851,6 @@ M.funcs = {
       	echo libcallnr("/usr/lib/libc.so", "getpid", "")
       	call libcallnr("libc.so", "printf", "Hello World!\n")
       	call libcallnr("libc.so", "sleep", 10)
-      <
-      Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetValue()->libcallnr("libc.so", "printf")
       <
     ]=],
     name = 'libcallnr',
@@ -6354,9 +5892,6 @@ M.funcs = {
       To jump to the last known position when opening a file see
       |last-position-jump|.
 
-      Can also be used as a |method|: >vim
-      	GetValue()->line()
-      <
     ]=],
     name = 'line',
     params = { { 'expr', 'any' }, { 'winid', 'integer' } },
@@ -6379,9 +5914,6 @@ M.funcs = {
       |getline()|.  When {lnum} is invalid -1 is returned.
       Also see |byte2line()|, |go| and |:goto|.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->line2byte()
-      <
     ]=],
     name = 'line2byte',
     params = { { 'lnum', 'integer' } },
@@ -6398,9 +5930,6 @@ M.funcs = {
       relevant.  {lnum} is used just like in |getline()|.
       When {lnum} is invalid, -1 is returned.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->lispindent()
-      <
     ]=],
     name = 'lispindent',
     params = { { 'lnum', 'integer' } },
@@ -6419,9 +5948,6 @@ M.funcs = {
 
       |blob2list()| does the opposite.
 
-      Can also be used as a |method|: >vim
-      	GetList()->list2blob()
-      <
     ]=],
     name = 'list2blob',
     params = { { 'list', 'any' } },
@@ -6446,9 +5972,6 @@ M.funcs = {
       <
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetList()->list2str()
-      <
     ]=],
     name = 'list2str',
     params = { { 'list', 'any' }, { 'utf8', 'any' } },
@@ -6477,9 +6000,6 @@ M.funcs = {
       	echo log(exp(5))
       <	5.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->log()
-      <
     ]=],
     float_func = 'log',
     name = 'log',
@@ -6499,9 +6019,6 @@ M.funcs = {
       	echo log10(0.01)
       <	-2.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->log10()
-      <
     ]=],
     float_func = 'log10',
     name = 'log10',
@@ -6515,9 +6032,6 @@ M.funcs = {
       Evaluate Lua expression {expr} and return its result converted
       to Vim data structures. See |lua-eval| for more details.
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->luaeval()
-      <
     ]=],
     lua = false,
     name = 'luaeval',
@@ -6574,9 +6088,6 @@ M.funcs = {
       {expr2} is a Funcref errors inside a function are ignored,
       unless it was defined with the "abort" flag.
 
-      Can also be used as a |method|: >vim
-      	mylist->map(expr2)
-      <
     ]=],
     name = 'map',
     params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
@@ -6649,9 +6160,6 @@ M.funcs = {
       mapped, and have it do the original mapping too.  Sketch: >vim
       	exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
 
-      <Can also be used as a |method|: >vim
-      	GetKey()->maparg('n')
-      <
     ]=],
     name = 'maparg',
     params = { { 'name', 'string' }, { 'mode', 'string' }, { 'abbr', 'boolean' }, { 'dict', 'boolean' } },
@@ -6694,9 +6202,6 @@ M.funcs = {
       <This avoids adding the "_vv" mapping when there already is a
       mapping for "_v" or for "_vvv".
 
-      Can also be used as a |method|: >vim
-      	GetKey()->mapcheck('n')
-      <
     ]=],
     name = 'mapcheck',
     params = { { 'name', 'string' }, { 'mode', 'string' }, { 'abbr', 'any' } },
@@ -6789,10 +6294,6 @@ M.funcs = {
       zero matches at the start instead of a number of matches
       further down in the text.
 
-      Can also be used as a |method|: >vim
-      	GetText()->match('word')
-      	GetList()->match('word')
-      <
     ]=],
     name = 'match',
     params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
@@ -6859,9 +6360,6 @@ M.funcs = {
       available from |getmatches()|.  All matches can be deleted in
       one operation by |clearmatches()|.
 
-      Can also be used as a |method|: >vim
-      	GetGroup()->matchadd('TODO')
-      <
     ]=],
     name = 'matchadd',
     params = {
@@ -6914,9 +6412,6 @@ M.funcs = {
       <Matches added by |matchaddpos()| are returned by
       |getmatches()|.
 
-      Can also be used as a |method|: >vim
-      	GetGroup()->matchaddpos([23, 11])
-      <
     ]=],
     name = 'matchaddpos',
     params = {
@@ -6943,9 +6438,6 @@ M.funcs = {
       Highlighting matches using the |:match| commands are limited
       to three matches. |matchadd()| does not have this limitation.
 
-      Can also be used as a |method|: >vim
-      	GetMatch()->matcharg()
-      <
     ]=],
     name = 'matcharg',
     params = { { 'nr', 'integer' } },
@@ -6962,9 +6454,6 @@ M.funcs = {
       If {win} is specified, use the window with this number or
       window ID instead of the current window.
 
-      Can also be used as a |method|: >vim
-      	GetMatch()->matchdelete()
-      <
     ]=],
     name = 'matchdelete',
     params = { { 'id', 'any' }, { 'win', 'any' } },
@@ -6993,9 +6482,6 @@ M.funcs = {
       <result is "-1".
       When {expr} is a |List| the result is equal to |match()|.
 
-      Can also be used as a |method|: >vim
-      	GetText()->matchend('word')
-      <
     ]=],
     name = 'matchend',
     params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
@@ -7115,9 +6601,6 @@ M.funcs = {
 
       You can pass in a List, but that is not very useful.
 
-      Can also be used as a |method|: >vim
-      	GetText()->matchlist('word')
-      <
     ]=],
     name = 'matchlist',
     params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
@@ -7139,9 +6622,6 @@ M.funcs = {
       When {expr} is a |List| then the matching item is returned.
       The type isn't changed, it's not necessarily a String.
 
-      Can also be used as a |method|: >vim
-      	GetText()->matchstr('word')
-      <
     ]=],
     name = 'matchstr',
     params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
@@ -7168,9 +6648,6 @@ M.funcs = {
       <result is ["x", 1, 2, 3].
       The type isn't changed, it's not necessarily a String.
 
-      Can also be used as a |method|: >vim
-      	GetText()->matchstrpos('word')
-      <
     ]=],
     name = 'matchstrpos',
     params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
@@ -7189,9 +6666,6 @@ M.funcs = {
       items in {expr} cannot be used as a Number this results in
                       an error.  An empty |List| or |Dictionary| results in zero.
 
-      Can also be used as a |method|: >vim
-      	mylist->max()
-      <
     ]=],
     name = 'max',
     params = { { 'expr', 'any' } },
@@ -7322,9 +6796,6 @@ M.funcs = {
       	  call ShowMenu(topmenu, '')
       	endfor
       <
-      Can also be used as a |method|: >vim
-      	GetMenuName()->menu_info('v')
-      <
     ]=],
     name = 'menu_info',
     params = { { 'name', 'string' }, { 'mode', 'string' } },
@@ -7343,9 +6814,6 @@ M.funcs = {
       items in {expr} cannot be used as a Number this results in
       an error.  An empty |List| or |Dictionary| results in zero.
 
-      Can also be used as a |method|: >vim
-      	mylist->min()
-      <
     ]=],
     name = 'min',
     params = { { 'expr', 'any' } },
@@ -7397,9 +6865,6 @@ M.funcs = {
       successful or FALSE if the directory creation failed or partly
       failed.
 
-      Can also be used as a |method|: >vim
-      	GetName()->mkdir()
-      <
     ]=],
     name = 'mkdir',
     params = { { 'name', 'string' }, { 'flags', 'string' }, { 'prot', 'any' } },
@@ -7460,9 +6925,6 @@ M.funcs = {
       the leading character(s).
       Also see |visualmode()|.
 
-      Can also be used as a |method|: >vim
-      	DoFull()->mode()
-      <
     ]=],
     name = 'mode',
     params = {},
@@ -7585,9 +7047,6 @@ M.funcs = {
       {lnum} is used like with |getline()|.
       See also |prevnonblank()|.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->nextnonblank()
-      <
     ]=],
     name = 'nextnonblank',
     params = { { 'lnum', 'integer' } },
@@ -7611,9 +7070,6 @@ M.funcs = {
       characters.  nr2char(0) is a real NUL and terminates the
       string, thus results in an empty string.
 
-      Can also be used as a |method|: >vim
-      	GetNumber()->nr2char()
-      <
     ]=],
     name = 'nr2char',
     params = { { 'expr', 'any' }, { 'utf8', 'any' } },
@@ -7648,8 +7104,6 @@ M.funcs = {
       Also see `and()` and `xor()`.
       Example: >vim
       	let bits = or(bits, 0x80)
-      <Can also be used as a |method|: >vim
-      	let bits = bits->or(0x80)
 
       <Rationale: The reason this is a function and not using the "|"
       character like many languages, is that Vi has always used "|"
@@ -7677,9 +7131,6 @@ M.funcs = {
       It doesn't matter if the path exists or not.
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetDirectories()->pathshorten()
-      <
     ]=],
     name = 'pathshorten',
     params = { { 'path', 'string' }, { 'len', 'any' } },
@@ -7703,9 +7154,6 @@ M.funcs = {
       	echo perleval('[1 .. 4]')
       <	[1, 2, 3, 4]
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->perleval()
-      <
     ]=],
     name = 'perleval',
     params = { { 'expr', 'any' } },
@@ -7726,9 +7174,6 @@ M.funcs = {
       	echo pow(32, 0.20)
       <	2.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->pow(3)
-      <
     ]=],
     name = 'pow',
     params = { { 'x', 'any' }, { 'y', 'any' } },
@@ -7746,9 +7191,6 @@ M.funcs = {
       {lnum} is used like with |getline()|.
       Also see |nextnonblank()|.
 
-      Can also be used as a |method|: >vim
-      	GetLnum()->prevnonblank()
-      <
     ]=],
     name = 'prevnonblank',
     params = { { 'lnum', 'integer' } },
@@ -7971,9 +7413,6 @@ M.funcs = {
       If the buffer doesn't exist or isn't a prompt buffer, an empty
       string is returned.
 
-      Can also be used as a |method|: >vim
-      	GetBuffer()->prompt_getprompt()
-      <
     ]=],
     name = 'prompt_getprompt',
     params = { { 'buf', 'any' } },
@@ -8014,9 +7453,6 @@ M.funcs = {
          endfunc
          call prompt_setcallback(bufnr(), function('s:TextEntered'))
 
-      <Can also be used as a |method|: >vim
-      	GetBuffer()->prompt_setcallback(callback)
-      <
     ]=],
     name = 'prompt_setcallback',
     params = { { 'buf', 'any' }, { 'expr', 'any' } },
@@ -8034,9 +7470,6 @@ M.funcs = {
       mode.  Without setting a callback Vim will exit Insert mode,
       as in any buffer.
 
-      Can also be used as a |method|: >vim
-      	GetBuffer()->prompt_setinterrupt(callback)
-      <
     ]=],
     name = 'prompt_setinterrupt',
     params = { { 'buf', 'any' }, { 'expr', 'any' } },
@@ -8051,9 +7484,6 @@ M.funcs = {
       The result is only visible if {buf} has 'buftype' set to
       "prompt".  Example: >vim
       	call prompt_setprompt(bufnr(''), 'command: ')
-      <
-      Can also be used as a |method|: >vim
-      	GetBuffer()->prompt_setprompt('command: ')
       <
     ]=],
     name = 'prompt_setprompt',
@@ -8102,9 +7532,6 @@ M.funcs = {
       Dictionaries are represented as Vim |Dictionary| type with
       keys converted to strings.
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->py3eval()
-      <
     ]=],
     name = 'py3eval',
     params = { { 'expr', 'any' } },
@@ -8122,9 +7549,6 @@ M.funcs = {
       Dictionaries are represented as Vim |Dictionary| type,
       non-string keys result in error.
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->pyeval()
-      <
     ]=],
     func = 'f_py3eval',
     name = 'pyeval',
@@ -8141,9 +7565,6 @@ M.funcs = {
       Uses Python 2 or 3, see |python_x| and 'pyxversion'.
       See also: |pyeval()|, |py3eval()|
 
-      Can also be used as a |method|: >vim
-      	GetExpr()->pyxeval()
-      <
     ]=],
     func = 'f_py3eval',
     name = 'pyxeval',
@@ -8167,9 +7588,6 @@ M.funcs = {
       	let seed = srand()
       	echo rand(seed)
       	echo rand(seed) % 16  " random number 0 - 15
-      <
-      Can also be used as a |method|: >vim
-      	seed->rand()
       <
     ]=],
     name = 'rand',
@@ -8196,9 +7614,6 @@ M.funcs = {
       	echo range(2, -2, -1)	" [2, 1, 0, -1, -2]
       	echo range(0)		" []
       	echo range(2, 0)		" error!
-      <
-      Can also be used as a |method|: >vim
-      	GetExpr()->range()
       <
     ]=],
     name = 'range',
@@ -8270,9 +7685,6 @@ M.funcs = {
       <
       Returns an empty List on error.
 
-      Can also be used as a |method|: >vim
-      	GetDirName()->readdir()
-      <
     ]=],
     name = 'readdir',
     params = { { 'directory', 'any' }, { 'expr', 'any' } },
@@ -8314,9 +7726,6 @@ M.funcs = {
       the result is an empty list.
       Also see |writefile()|.
 
-      Can also be used as a |method|: >vim
-      	GetFileName()->readfile()
-      <
     ]=],
     name = 'readfile',
     params = { { 'fname', 'integer' }, { 'type', 'any' }, { 'max', 'any' } },
@@ -8341,9 +7750,6 @@ M.funcs = {
       	echo reduce([1, 3, 5], { acc, val -> acc + val })
       	echo reduce(['x', 'y'], { acc, val -> acc .. val }, 'a')
       	echo reduce(0z1122, { acc, val -> 2 * acc + val })
-      <
-      Can also be used as a |method|: >vim
-      	echo mylist->reduce({ acc, val -> acc + val }, 0)
       <
     ]=],
     name = 'reduce',
@@ -8416,9 +7822,6 @@ M.funcs = {
       The {start} and {end} arguments must be values returned by
       reltime().  Returns zero on error.
 
-      Can also be used as a |method|: >vim
-      	GetStart()->reltime()
-      <
       Note: |localtime()| returns the current (non-relative) time.
     ]=],
     fast = true,
@@ -8440,9 +7843,6 @@ M.funcs = {
       Also see |profiling|.
       If there is an error an empty string is returned
 
-      Can also be used as a |method|: >vim
-      	reltime(start)->reltimefloat()
-      <
     ]=],
     fast = true,
     name = 'reltimefloat',
@@ -8466,9 +7866,6 @@ M.funcs = {
       <Also see |profiling|.
       If there is an error an empty string is returned
 
-      Can also be used as a |method|: >vim
-      	echo reltime(start)->reltimestr()
-      <
     ]=],
     fast = true,
     name = 'reltimestr',
@@ -8500,9 +7897,6 @@ M.funcs = {
       <
       Use |delete()| to remove a file.
 
-      Can also be used as a |method|: >vim
-      	mylist->remove(idx)
-      <
     ]=],
     name = 'remove',
     params = { { 'list', 'any' }, { 'idx', 'integer' }, { 'end', 'any' } },
@@ -8560,9 +7954,6 @@ M.funcs = {
       NOTE: If {to} exists it is overwritten without warning.
       This function is not available in the |sandbox|.
 
-      Can also be used as a |method|: >vim
-      	GetOldName()->rename(newname)
-      <
     ]=],
     name = 'rename',
     params = { { 'from', 'any' }, { 'to', 'any' } },
@@ -8581,9 +7972,6 @@ M.funcs = {
       	let longlist = repeat(['a', 'b'], 3)
       <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 
-      Can also be used as a |method|: >vim
-      	mylist->repeat(count)
-      <
     ]=],
     fast = true,
     name = 'repeat',
@@ -8607,9 +7995,6 @@ M.funcs = {
       current directory (provided the result is still a relative
       path name) and also keeps a trailing path separator.
 
-      Can also be used as a |method|: >vim
-      	GetName()->resolve()
-      <
     ]=],
     fast = true,
     name = 'resolve',
@@ -8624,11 +8009,6 @@ M.funcs = {
       {object} can be a |List| or a |Blob|.
       Returns {object}.
       Returns zero if {object} is not a List or a Blob.
-      If you want an object to remain unmodified make a copy first: >vim
-      	let revlist = reverse(copy(mylist))
-      <Can also be used as a |method|: >vim
-      	mylist->reverse()
-      <
     ]=],
     name = 'reverse',
     params = { { 'object', 'any' } },
@@ -8651,9 +8031,6 @@ M.funcs = {
       	echo round(-4.5)
       <	-5.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->round()
-      <
     ]=],
     float_func = 'round',
     name = 'round',
@@ -8724,9 +8101,6 @@ M.funcs = {
       Other objects are represented as strings resulted from their
       "Object#to_s" method.
 
-      Can also be used as a |method|: >vim
-      	GetRubyExpr()->rubyeval()
-      <
     ]=],
     name = 'rubyeval',
     params = { { 'expr', 'any' } },
@@ -8741,9 +8115,6 @@ M.funcs = {
       attribute at other positions.
       Returns -1 when row or col is out of range.
 
-      Can also be used as a |method|: >vim
-      	GetRow()->screenattr(col)
-      <
     ]=],
     name = 'screenattr',
     params = { { 'row', 'any' }, { 'col', 'integer' } },
@@ -8762,9 +8133,6 @@ M.funcs = {
       This is mainly to be used for testing.
       Returns -1 when row or col is out of range.
 
-      Can also be used as a |method|: >vim
-      	GetRow()->screenchar(col)
-      <
     ]=],
     name = 'screenchar',
     params = { { 'row', 'any' }, { 'col', 'integer' } },
@@ -8780,9 +8148,6 @@ M.funcs = {
       This is mainly to be used for testing.
       Returns an empty List when row or col is out of range.
 
-      Can also be used as a |method|: >vim
-      	GetRow()->screenchars(col)
-      <
     ]=],
     name = 'screenchars',
     params = { { 'row', 'any' }, { 'col', 'integer' } },
@@ -8835,9 +8200,6 @@ M.funcs = {
       first character is returned, {col} is not used.
       Returns an empty Dict if {winid} is invalid.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->screenpos(lnum, col)
-      <
     ]=],
     name = 'screenpos',
     params = { { 'winid', 'integer' }, { 'lnum', 'integer' }, { 'col', 'integer' } },
@@ -8867,9 +8229,6 @@ M.funcs = {
       This is mainly to be used for testing.
       Returns an empty String when row or col is out of range.
 
-      Can also be used as a |method|: >vim
-      	GetRow()->screenstring(col)
-      <
     ]=],
     name = 'screenstring',
     params = { { 'row', 'any' }, { 'col', 'integer' } },
@@ -8979,9 +8338,6 @@ M.funcs = {
       without the 'e' flag if the cursor is on the "f" of "if".
       The 'n' flag tells the function not to move the cursor.
 
-      Can also be used as a |method|: >vim
-      	GetPattern()->search()
-      <
     ]=],
     name = 'search',
     params = {
@@ -9117,9 +8473,6 @@ M.funcs = {
       				value. see |cursor()|, |getpos()|
       				(default: cursor's position)
 
-      Can also be used as a |method|: >vim
-      	GetSearchOpts()->searchcount()
-      <
     ]=],
     name = 'searchcount',
     params = { { 'options', 'table' } },
@@ -9145,9 +8498,6 @@ M.funcs = {
       	if searchdecl('myvar') == 0
       	   echo getline('.')
       	endif
-      <
-      Can also be used as a |method|: >vim
-      	GetName()->searchdecl()
       <
     ]=],
     name = 'searchdecl',
@@ -9280,9 +8630,6 @@ M.funcs = {
       <In this example "submatch" is 2 when a lowercase letter is
       found |/\l|, 3 when an uppercase letter is found |/\u|.
 
-      Can also be used as a |method|: >vim
-      	GetPattern()->searchpos()
-      <
     ]=],
     name = 'searchpos',
     params = {
@@ -9385,10 +8732,6 @@ M.funcs = {
       If {buf} is not a valid buffer or {lnum} is not valid, an
       error message is given.
 
-      Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetText()->setbufline(buf, lnum)
-      <
     ]=],
     name = 'setbufline',
     params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'text', 'any' } },
@@ -9411,10 +8754,6 @@ M.funcs = {
       	call setbufvar("todo", "myvar", "foobar")
       <This function is not available in the |sandbox|.
 
-      Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetValue()->setbufvar(buf, varname)
-      <
     ]=],
     name = 'setbufvar',
     params = { { 'buf', 'any' }, { 'varname', 'string' }, { 'val', 'any' } },
@@ -9475,9 +8814,6 @@ M.funcs = {
       	call setpos('.', [0, 8, 4, 0])
       <positions the cursor on the second character '보'.
 
-      Can also be used as a |method|: >vim
-      	GetPosition()->setcharpos('.')
-      <
     ]=],
     name = 'setcharpos',
     params = { { 'expr', 'any' }, { 'list', 'any' } },
@@ -9506,9 +8842,6 @@ M.funcs = {
       	call setcharsearch(prevsearch)
       <Also see |getcharsearch()|.
 
-      Can also be used as a |method|: >vim
-      	SavedSearch()->setcharsearch()
-      <
     ]=],
     name = 'setcharsearch',
     params = { { 'dict', 'any' } },
@@ -9524,9 +8857,6 @@ M.funcs = {
       Returns 0 when successful, 1 when not editing the command
       line.
 
-      Can also be used as a |method|: >vim
-      	GetText()->setcmdline()
-      <
     ]=],
     name = 'setcmdline',
     params = { { 'str', 'any' }, { 'pos', 'any' } },
@@ -9550,9 +8880,6 @@ M.funcs = {
       Returns 0 when successful, 1 when not editing the command
       line.
 
-      Can also be used as a |method|: >vim
-      	GetPos()->setcmdpos()
-      <
     ]=],
     name = 'setcmdpos',
     params = { { 'pos', 'any' } },
@@ -9579,9 +8906,6 @@ M.funcs = {
       	call cursor(4, 3)
       <positions the cursor on the first character '여'.
 
-      Can also be used as a |method|: >vim
-      	GetCursorPos()->setcursorcharpos()
-      <
     ]=],
     name = 'setcursorcharpos',
     params = { { 'list', 'any' } },
@@ -9597,10 +8921,6 @@ M.funcs = {
       <When {val} is |v:null| the environment variable is deleted.
       See also |expr-env|.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetPath()->setenv('PATH')
-      <
     ]=],
     name = 'setenv',
     params = { { 'name', 'string' }, { 'val', 'any' } },
@@ -9625,9 +8945,6 @@ M.funcs = {
 
       Returns non-zero for success, zero for failure.
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->setfperm(mode)
-      <
       To read permissions see |getfperm()|.
     ]=],
     name = 'setfperm',
@@ -9664,10 +8981,6 @@ M.funcs = {
 
       <Note: The '[ and '] marks are not set.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetText()->setline(lnum)
-      <
     ]=],
     name = 'setline',
     params = { { 'lnum', 'integer' }, { 'text', 'any' } },
@@ -9692,10 +9005,6 @@ M.funcs = {
       only the items listed in {what} are set. Refer to |setqflist()|
       for the list of supported keys in {what}.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetLoclist()->setloclist(winnr)
-      <
     ]=],
     name = 'setloclist',
     params = { { 'nr', 'integer' }, { 'list', 'any' }, { 'action', 'any' }, { 'what', 'any' } },
@@ -9712,9 +9021,6 @@ M.funcs = {
       If {win} is specified, use the window with this number or
       window ID instead of the current window.
 
-      Can also be used as a |method|: >vim
-      	GetMatches()->setmatches()
-      <
     ]=],
     name = 'setmatches',
     params = { { 'list', 'any' }, { 'win', 'any' } },
@@ -9772,9 +9078,6 @@ M.funcs = {
       also set the preferred column.  Also see the "curswant" key in
       |winrestview()|.
 
-      Can also be used as a |method|: >vim
-      	GetPosition()->setpos('.')
-      <
     ]=],
     name = 'setpos',
     params = { { 'expr', 'any' }, { 'list', 'any' } },
@@ -9894,10 +9197,6 @@ M.funcs = {
       independent of the 'errorformat' setting.  Use a command like
       `:cc 1` to jump to the first position.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetErrorlist()->setqflist()
-      <
     ]=],
     name = 'setqflist',
     params = { { 'list', 'any' }, { 'action', 'any' }, { 'what', 'any' } },
@@ -9962,10 +9261,6 @@ M.funcs = {
       nothing: >vim
       	call setreg('a', '', 'al')
 
-      <Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetText()->setreg('a')
-      <
     ]=],
     name = 'setreg',
     params = { { 'regname', 'string' }, { 'value', 'any' }, { 'options', 'table' } },
@@ -9982,10 +9277,6 @@ M.funcs = {
       Tabs are numbered starting with one.
       This function is not available in the |sandbox|.
 
-      Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetValue()->settabvar(tab, name)
-      <
     ]=],
     name = 'settabvar',
     params = { { 'tabnr', 'integer' }, { 'varname', 'string' }, { 'val', 'any' } },
@@ -10010,10 +9301,6 @@ M.funcs = {
       	call settabwinvar(3, 2, "myvar", "foobar")
       <This function is not available in the |sandbox|.
 
-      Can also be used as a |method|, the base is passed as the
-      fourth argument: >vim
-      	GetValue()->settabwinvar(tab, winnr, name)
-      <
     ]=],
     name = 'settabwinvar',
     params = {
@@ -10060,10 +9347,6 @@ M.funcs = {
       	call settagstack(1003, stack)
       	unlet stack
       <
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetStack()->settagstack(winnr)
-      <
     ]=],
     name = 'settagstack',
     params = { { 'nr', 'integer' }, { 'dict', 'any' }, { 'action', 'any' } },
@@ -10078,10 +9361,6 @@ M.funcs = {
       	call setwinvar(1, "&list", 0)
       	call setwinvar(2, "myvar", "foobar")
 
-      <Can also be used as a |method|, the base is passed as the
-      third argument: >vim
-      	GetValue()->setwinvar(winnr, name)
-      <
     ]=],
     name = 'setwinvar',
     params = { { 'nr', 'integer' }, { 'varname', 'string' }, { 'val', 'any' } },
@@ -10094,9 +9373,6 @@ M.funcs = {
       Returns a String with 64 hex characters, which is the SHA256
       checksum of {string}.
 
-      Can also be used as a |method|: >vim
-      	GetText()->sha256()
-      <
     ]=],
     name = 'sha256',
     params = { { 'string', 'string' } },
@@ -10136,9 +9412,6 @@ M.funcs = {
           call system("chmod +w -- " .. shellescape(expand("%")))
       <See also |::S|.
 
-      Can also be used as a |method|: >vim
-      	GetCommand()->shellescape()
-      <
     ]=],
     name = 'shellescape',
     params = { { 'string', 'string' }, { 'special', 'any' } },
@@ -10168,9 +9441,6 @@ M.funcs = {
       'vartabstop' feature. If no {col} argument is given, column 1
       will be assumed.
 
-      Can also be used as a |method|: >vim
-      	GetColumn()->shiftwidth()
-      <
     ]=],
     name = 'shiftwidth',
     params = { { 'col', 'integer' } },
@@ -10231,9 +9501,6 @@ M.funcs = {
       		\  'text' : '!!'}
       		\ ])
       <
-      Can also be used as a |method|: >vim
-      	GetSignList()->sign_define()
-      <
     ]=],
     name = 'sign_define',
     params = { { 'list', 'any' } },
@@ -10276,9 +9543,6 @@ M.funcs = {
 
       	" Get the attribute of the sign named mySign
       	echo sign_getdefined("mySign")
-      <
-      Can also be used as a |method|: >vim
-      	GetSignList()->sign_getdefined()
       <
     ]=],
     name = 'sign_getdefined',
@@ -10348,9 +9612,6 @@ M.funcs = {
       	" Get a List of all the placed signs
       	echo sign_getplaced()
       <
-      Can also be used as a |method|: >vim
-      	GetBufname()->sign_getplaced()
-      <
     ]=],
     name = 'sign_getplaced',
     params = { { 'buf', 'any' }, { 'dict', 'any' } },
@@ -10373,9 +9634,6 @@ M.funcs = {
       Example: >vim
       	" Jump to sign 10 in the current buffer
       	call sign_jump(10, '', '')
-      <
-      Can also be used as a |method|: >vim
-      	GetSignid()->sign_jump()
       <
     ]=],
     name = 'sign_jump',
@@ -10432,9 +9690,6 @@ M.funcs = {
       	" at line 40 in buffer json.c with priority 90
       	call sign_place(10, 'g3', 'sign4', 'json.c',
       			\ {'lnum' : 40, 'priority' : 90})
-      <
-      Can also be used as a |method|: >vim
-      	GetSignid()->sign_place(group, name, expr)
       <
     ]=],
     name = 'sign_place',
@@ -10508,9 +9763,6 @@ M.funcs = {
       		\  'lnum' : 50}
       		\ ])
       <
-      Can also be used as a |method|: >vim
-      	GetSignlist()->sign_placelist()
-      <
     ]=],
     name = 'sign_placelist',
     params = { { 'list', 'any' } },
@@ -10547,9 +9799,6 @@ M.funcs = {
 
       	" Delete all the signs
       	call sign_undefine()
-      <
-      Can also be used as a |method|: >vim
-      	GetSignlist()->sign_undefine()
       <
     ]=],
     name = 'sign_undefine',
@@ -10601,9 +9850,6 @@ M.funcs = {
       	" Remove all the placed signs from all the buffers
       	call sign_unplace('*')
 
-      <Can also be used as a |method|: >vim
-      	GetSigngroup()->sign_unplace()
-      <
     ]=],
     name = 'sign_unplace',
     params = { { 'group', 'any' }, { 'dict', 'any' } },
@@ -10640,9 +9886,6 @@ M.funcs = {
       		\ {'id' : 20, 'buffer' : 'b.vim'},
       		\ ])
       <
-      Can also be used as a |method|: >vim
-      	GetSignlist()->sign_unplacelist()
-      <
     ]=],
     name = 'sign_unplacelist',
     params = { { 'list', 'any' } },
@@ -10668,9 +9911,6 @@ M.funcs = {
       directory.  In order to resolve all the involved symbolic
       links before simplifying the path name, use |resolve()|.
 
-      Can also be used as a |method|: >vim
-      	GetName()->simplify()
-      <
     ]=],
     name = 'simplify',
     params = { { 'filename', 'any' } },
@@ -10689,9 +9929,6 @@ M.funcs = {
       	echo sin(-4.01)
       <	0.763301
 
-      Can also be used as a |method|: >vim
-      	Compute()->sin()
-      <
     ]=],
     float_func = 'sin',
     name = 'sin',
@@ -10712,9 +9949,6 @@ M.funcs = {
       	echo sinh(-0.9)
       <	-1.026517
 
-      Can also be used as a |method|: >vim
-      	Compute()->sinh()
-      <
     ]=],
     float_func = 'sinh',
     name = 'sinh',
@@ -10733,9 +9967,6 @@ M.funcs = {
       When {end} is -1 the last item is omitted.
       Returns an empty value if {start} or {end} are invalid.
 
-      Can also be used as a |method|: >vim
-      	GetList()->slice(offset)
-      <
     ]=],
     name = 'slice',
     params = { { 'expr', 'any' }, { 'start', 'any' }, { 'end', 'any' } },
@@ -10833,10 +10064,6 @@ M.funcs = {
       on numbers, text strings will sort next to each other, in the
       same order as they were originally.
 
-      Can also be used as a |method|: >vim
-      	mylist->sort()
-
-      <Also see |uniq()|.
 
       Example: >vim
       	func MyCompare(i1, i2)
@@ -10867,9 +10094,6 @@ M.funcs = {
       This can be used for making spelling suggestions.  Note that
       the method can be quite slow.
 
-      Can also be used as a |method|: >vim
-      	GetWord()->soundfold()
-      <
     ]=],
     name = 'soundfold',
     params = { { 'word', 'any' } },
@@ -10902,9 +10126,6 @@ M.funcs = {
       The spelling information for the current window and the value
       of 'spelllang' are used.
 
-      Can also be used as a |method|: >vim
-      	GetText()->spellbadword()
-      <
     ]=],
     name = 'spellbadword',
     params = { { 'sentence', 'any' } },
@@ -10934,9 +10155,6 @@ M.funcs = {
       The spelling information for the current window is used.  The
       values of 'spelllang' and 'spellsuggest' are used.
 
-      Can also be used as a |method|: >vim
-      	GetWord()->spellsuggest()
-      <
     ]=],
     name = 'spellsuggest',
     params = { { 'word', 'any' }, { 'max', 'any' }, { 'capital', 'any' } },
@@ -10970,9 +10188,6 @@ M.funcs = {
       	let items = split(line, ':', 1)
       <The opposite function is |join()|.
 
-      Can also be used as a |method|: >vim
-      	GetString()->split()
-      <
     ]=],
     name = 'split',
     params = { { 'string', 'string' }, { 'pattern', 'any' }, { 'keepempty', 'any' } },
@@ -10994,9 +10209,6 @@ M.funcs = {
       <	str2float("nan")
       NaN may be different, it depends on system libraries.
 
-      Can also be used as a |method|: >vim
-      	Compute()->sqrt()
-      <
     ]=],
     float_func = 'sqrt',
     name = 'sqrt',
@@ -11019,9 +10231,6 @@ M.funcs = {
       	let seed = srand()
       	let seed = srand(userinput)
       	echo rand(seed)
-      <
-      Can also be used as a |method|: >vim
-      	userinput->srand()
       <
     ]=],
     name = 'srand',
@@ -11107,9 +10316,6 @@ M.funcs = {
       <
       Returns 0.0 if the conversion fails.
 
-      Can also be used as a |method|: >vim
-      	let f = text->substitute(',', '', 'g')->str2float()
-      <
     ]=],
     name = 'str2float',
     params = { { 'string', 'string' }, { 'quoted', 'any' } },
@@ -11130,9 +10336,6 @@ M.funcs = {
       With UTF-8 composing characters are handled properly: >vim
       	echo str2list("á")		" returns [97, 769]
 
-      <Can also be used as a |method|: >vim
-      	GetString()->str2list()
-      <
     ]=],
     name = 'str2list',
     params = { { 'string', 'string' }, { 'utf8', 'any' } },
@@ -11160,9 +10363,6 @@ M.funcs = {
 
       Returns 0 if {string} is empty or on error.
 
-      Can also be used as a |method|: >vim
-      	GetText()->str2nr()
-      <
     ]=],
     name = 'str2nr',
     params = { { 'string', 'string' }, { 'base', 'any' } },
@@ -11181,9 +10381,6 @@ M.funcs = {
 
       Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
 
-      Can also be used as a |method|: >vim
-      	GetText()->strcharlen()
-      <
     ]=],
     name = 'strcharlen',
     params = { { 'string', 'string' } },
@@ -11207,9 +10404,6 @@ M.funcs = {
 
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetText()->strcharpart(5)
-      <
     ]=],
     fast = true,
     name = 'strcharpart',
@@ -11247,9 +10441,6 @@ M.funcs = {
             endfunction
           endif
       <
-      Can also be used as a |method|: >vim
-      	GetText()->strchars()
-      <
     ]=],
     name = 'strchars',
     params = { { 'string', 'string' }, { 'skipcc', 'any' } },
@@ -11272,9 +10463,6 @@ M.funcs = {
       Returns zero on error.
       Also see |strlen()|, |strwidth()| and |strchars()|.
 
-      Can also be used as a |method|: >vim
-      	GetText()->strdisplaywidth()
-      <
     ]=],
     name = 'strdisplaywidth',
     params = { { 'string', 'string' }, { 'col', 'integer' } },
@@ -11300,9 +10488,6 @@ M.funcs = {
         echo strftime("%c", getftime("file.c"))
       				   " Show mod time of file.c.
 
-      <Can also be used as a |method|: >vim
-      	GetFormat()->strftime()
-      <
     ]=],
     name = 'strftime',
     params = { { 'format', 'any' }, { 'time', 'any' } },
@@ -11320,9 +10505,6 @@ M.funcs = {
       Returns -1 if {index} is invalid.
       Also see |strcharpart()| and |strchars()|.
 
-      Can also be used as a |method|: >vim
-      	GetText()->strgetchar(5)
-      <
     ]=],
     name = 'strgetchar',
     params = { { 'str', 'any' }, { 'index', 'any' } },
@@ -11350,9 +10532,6 @@ M.funcs = {
       stridx() works similar to the C function strstr().  When used
       with a single character it works similar to strchr().
 
-      Can also be used as a |method|: >vim
-      	GetHaystack()->stridx(needle)
-      <
     ]=],
     fast = true,
     name = 'stridx',
@@ -11386,9 +10565,6 @@ M.funcs = {
       method, use |msgpackdump()| or |json_encode()| if you need to
       share data with other application.
 
-      Can also be used as a |method|: >vim
-      	mylist->string()
-      <
     ]=],
     name = 'string',
     params = { { 'expr', 'any' } },
@@ -11406,9 +10582,6 @@ M.funcs = {
       |strchars()|.
       Also see |len()|, |strdisplaywidth()| and |strwidth()|.
 
-      Can also be used as a |method|: >vim
-      	GetString()->strlen()
-      <
     ]=],
     name = 'strlen',
     params = { { 'string', 'string' } },
@@ -11442,9 +10615,6 @@ M.funcs = {
       <
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetText()->strpart(5)
-      <
     ]=],
     fast = true,
     name = 'strpart',
@@ -11478,9 +10648,6 @@ M.funcs = {
         echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
       <  Sun Apr 27 12:53:55 1997
 
-      Can also be used as a |method|: >vim
-      	GetFormat()->strptime(timestring)
-      <
     ]=],
     name = 'strptime',
     params = { { 'format', 'any' }, { 'timestring', 'any' } },
@@ -11507,9 +10674,6 @@ M.funcs = {
       When used with a single character it works similar to the C
       function strrchr().
 
-      Can also be used as a |method|: >vim
-      	GetHaystack()->strridx(needle)
-      <
     ]=],
     name = 'strridx',
     params = { { 'haystack', 'any' }, { 'needle', 'any' }, { 'start', 'any' } },
@@ -11528,9 +10692,6 @@ M.funcs = {
 
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetString()->strtrans()
-      <
     ]=],
     fast = true,
     name = 'strtrans',
@@ -11559,9 +10720,6 @@ M.funcs = {
           echo strutf16len('ą́')		" returns 1
           echo strutf16len('ą́', v:true)	" returns 3
 
-      Can also be used as a |method|: >vim
-      	GetText()->strutf16len()
-      <
     ]=],
     name = 'strutf16len',
     params = { { 'string', 'string' }, { 'countcc', 'any' } },
@@ -11579,9 +10737,6 @@ M.funcs = {
       Returns zero on error.
       Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
 
-      Can also be used as a |method|: >vim
-      	GetString()->strwidth()
-      <
     ]=],
     fast = true,
     name = 'strwidth',
@@ -11620,9 +10775,6 @@ M.funcs = {
       <This finds the first number in the line and adds one to it.
       A line break is included as a newline character.
 
-      Can also be used as a |method|: >vim
-      	GetNr()->submatch()
-      <
     ]=],
     name = 'submatch',
     params = { { 'nr', 'integer' }, { 'list', 'any' } },
@@ -11674,9 +10826,6 @@ M.funcs = {
 
       <Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetString()->substitute(pat, sub, flags)
-      <
     ]=],
     name = 'substitute',
     params = { { 'string', 'string' }, { 'pat', 'any' }, { 'sub', 'any' }, { 'flags', 'string' } },
@@ -11719,9 +10868,6 @@ M.funcs = {
       	Not a swap file: does not contain correct block ID
       	Magic number mismatch: Info in first block is invalid
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->swapinfo()
-      <
     ]=],
     name = 'swapinfo',
     params = { { 'fname', 'integer' } },
@@ -11737,9 +10883,6 @@ M.funcs = {
       |:swapname| (unless there is no swap file).
       If buffer {buf} has no swap file, returns an empty string.
 
-      Can also be used as a |method|: >vim
-      	GetBufname()->swapname()
-      <
     ]=],
     name = 'swapname',
     params = { { 'buf', 'any' } },
@@ -11841,9 +10984,6 @@ M.funcs = {
 
       Returns zero on error.
 
-      Can also be used as a |method|: >vim
-      	echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
-      <
     ]=],
     name = 'synIDtrans',
     params = { { 'synID', 'any' } },
@@ -11959,9 +11099,6 @@ M.funcs = {
       <Unlike ":!cmd" there is no automatic check for changed files.
       Use |:checktime| to force a check.
 
-      Can also be used as a |method|: >vim
-      	echo GetCmd()->system()
-      <
     ]=],
     name = 'system',
     params = { { 'cmd', 'any' }, { 'input', 'any' } },
@@ -11984,9 +11121,6 @@ M.funcs = {
       <
       Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	echo GetCmd()->systemlist()
-      <
     ]=],
     name = 'systemlist',
     params = { { 'cmd', 'any' }, { 'input', 'any' }, { 'keepempty', 'any' } },
@@ -12008,9 +11142,6 @@ M.funcs = {
       	endfor
       <Note that a buffer may appear in more than one window.
 
-      Can also be used as a |method|: >vim
-      	GetTabpage()->tabpagebuflist()
-      <
     ]=],
     name = 'tabpagebuflist',
     params = { { 'arg', 'any' } },
@@ -12052,9 +11183,6 @@ M.funcs = {
           tabpagewinnr(4, '$')    " number of windows in tab page 4
       <When {tabarg} is invalid zero is returned.
 
-      Can also be used as a |method|: >vim
-      	GetTabpage()->tabpagewinnr()
-      <
     ]=],
     name = 'tabpagewinnr',
     params = { { 'tabarg', 'any' }, { 'arg', 'any' } },
@@ -12115,8 +11243,6 @@ M.funcs = {
       located by Vim. Refer to |tags-file-format| for the format of
       the tags file generated by the different ctags tools.
 
-      Can also be used as a |method|: >vim
-      	GetTagpattern()->taglist()
     ]=],
     name = 'taglist',
     params = { { 'expr', 'any' }, { 'filename', 'any' } },
@@ -12136,9 +11262,6 @@ M.funcs = {
       	echo tan(-4.01)
       <	-1.181502
 
-      Can also be used as a |method|: >vim
-      	Compute()->tan()
-      <
     ]=],
     float_func = 'tan',
     name = 'tan',
@@ -12159,9 +11282,6 @@ M.funcs = {
       	echo tanh(-1)
       <	-0.761594
 
-      Can also be used as a |method|: >vim
-      	Compute()->tanh()
-      <
     ]=],
     float_func = 'tanh',
     name = 'tanh',
@@ -12228,9 +11348,6 @@ M.funcs = {
       		    -1 means forever
           "callback"	    the callback
 
-      Can also be used as a |method|: >vim
-      	GetTimer()->timer_info()
-      <
     ]=],
     name = 'timer_info',
     params = { { 'id', 'any' } },
@@ -12252,9 +11369,6 @@ M.funcs = {
       String, then the timer is paused, otherwise it is unpaused.
       See |non-zero-arg|.
 
-      Can also be used as a |method|: >vim
-      	GetTimer()->timer_pause(1)
-      <
     ]=],
     name = 'timer_pause',
     params = { { 'timer', 'any' }, { 'paused', 'any' } },
@@ -12294,10 +11408,6 @@ M.funcs = {
       		\ {'repeat': 3})
       <This invokes MyHandler() three times at 500 msec intervals.
 
-      Can also be used as a |method|: >vim
-      	GetMsec()->timer_start(callback)
-
-      <Not available in the |sandbox|.
     ]=],
     name = 'timer_start',
     params = { { 'time', 'any' }, { 'callback', 'any' }, { 'options', 'table' } },
@@ -12311,9 +11421,6 @@ M.funcs = {
       {timer} is an ID returned by timer_start(), thus it must be a
       Number.  If {timer} does not exist there is no error.
 
-      Can also be used as a |method|: >vim
-      	GetTimer()->timer_stop()
-      <
     ]=],
     name = 'timer_stop',
     params = { { 'timer', 'any' } },
@@ -12338,9 +11445,6 @@ M.funcs = {
       characters turned into lowercase (just like applying |gu| to
       the string).  Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetText()->tolower()
-      <
     ]=],
     fast = true,
     name = 'tolower',
@@ -12356,9 +11460,6 @@ M.funcs = {
       characters turned into uppercase (just like applying |gU| to
       the string).  Returns an empty string on error.
 
-      Can also be used as a |method|: >vim
-      	GetText()->toupper()
-      <
     ]=],
     fast = true,
     name = 'toupper',
@@ -12385,9 +11486,6 @@ M.funcs = {
       	echo tr("<blob>", "<>", "{}")
       <returns "{blob}"
 
-      Can also be used as a |method|: >vim
-      	GetText()->tr(from, to)
-      <
     ]=],
     name = 'tr',
     params = { { 'src', 'any' }, { 'fromstr', 'any' }, { 'tostr', 'any' } },
@@ -12421,9 +11519,6 @@ M.funcs = {
       	echo trim("  vim  ", " ", 2)
       <returns "  vim"
 
-      Can also be used as a |method|: >vim
-      	GetText()->trim()
-      <
     ]=],
     name = 'trim',
     params = { { 'text', 'any' }, { 'mask', 'any' }, { 'dir', 'string' } },
@@ -12446,9 +11541,6 @@ M.funcs = {
       	echo trunc(4.0)
       <	4.0
 
-      Can also be used as a |method|: >vim
-      	Compute()->trunc()
-      <
     ]=],
     float_func = 'trunc',
     name = 'trunc',
@@ -12485,9 +11577,6 @@ M.funcs = {
       <To check if the v:t_ variables exist use this: >vim
       	if exists('v:t_number') | endif
 
-      <Can also be used as a |method|: >vim
-      	mylist->type()
-      <
     ]=],
     fast = true,
     name = 'type',
@@ -12508,9 +11597,6 @@ M.funcs = {
       buffer without a file name will not write an undo file.
       Useful in combination with |:wundo| and |:rundo|.
 
-      Can also be used as a |method|: >vim
-      	GetFilename()->undofile()
-      <
     ]=],
     name = 'undofile',
     params = { { 'name', 'string' } },
@@ -12579,9 +11665,6 @@ M.funcs = {
 
       Returns zero if {list} is not a |List|.
 
-      Can also be used as a |method|: >vim
-      	mylist->uniq()
-      <
     ]=],
     name = 'uniq',
     params = { { 'list', 'any' }, { 'func', 'any' }, { 'dict', 'any' } },
@@ -12618,9 +11701,6 @@ M.funcs = {
       	echo utf16idx('aą́c', 6, 1)	" returns 4
       	echo utf16idx('a😊😊', 9)	" returns -1
       <
-      Can also be used as a |method|: >vim
-      	GetName()->utf16idx(idx)
-      <
     ]=],
     name = 'utf16idx',
     params = {
@@ -12640,9 +11720,6 @@ M.funcs = {
       in arbitrary order.  Also see |items()| and |keys()|.
       Returns zero if {dict} is not a |Dict|.
 
-      Can also be used as a |method|: >vim
-      	mydict->values()
-      <
     ]=],
     name = 'values',
     params = { { 'dict', 'any' } },
@@ -12703,9 +11780,6 @@ M.funcs = {
       all lines: >vim
           echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 
-      <Can also be used as a |method|: >vim
-      	GetPos()->virtcol()
-      <
     ]=],
     name = 'virtcol',
     params = { { 'expr', 'any' }, { 'list', 'any' } },
@@ -12731,9 +11805,6 @@ M.funcs = {
 
       See also |screenpos()|, |virtcol()| and |col()|.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->virtcol2col(lnum, col)
-      <
     ]=],
     name = 'virtcol2col',
     params = { { 'winid', 'integer' }, { 'lnum', 'integer' }, { 'col', 'integer' } },
@@ -12818,10 +11889,6 @@ M.funcs = {
       When window {id} does not exist then no error is given and
       an empty string is returned.
 
-      Can also be used as a |method|, the base is passed as the
-      second argument: >vim
-      	GetCommand()->win_execute(winid)
-      <
     ]=],
     name = 'win_execute',
     params = { { 'id', 'any' }, { 'command', 'any' }, { 'silent', 'boolean' } },
@@ -12834,9 +11901,6 @@ M.funcs = {
       Returns a |List| with |window-ID|s for windows that contain
       buffer {bufnr}.  When there is none the list is empty.
 
-      Can also be used as a |method|: >vim
-      	GetBufnr()->win_findbuf()
-      <
     ]=],
     name = 'win_findbuf',
     params = { { 'bufnr', 'any' } },
@@ -12855,9 +11919,6 @@ M.funcs = {
       number {tab}.  The first tab has number one.
       Return zero if the window cannot be found.
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->win_getid()
-      <
     ]=],
     name = 'win_getid',
     params = { { 'win', 'any' }, { 'tab', 'any' } },
@@ -12885,9 +11946,6 @@ M.funcs = {
 
       Also see the 'buftype' option.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_gettype()
-      <
     ]=],
     name = 'win_gettype',
     params = { { 'nr', 'integer' } },
@@ -12902,9 +11960,6 @@ M.funcs = {
       tabpage.
       Return TRUE if successful, FALSE if the window cannot be found.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_gotoid()
-      <
     ]=],
     name = 'win_gotoid',
     params = { { 'expr', 'any' } },
@@ -12919,9 +11974,6 @@ M.funcs = {
       with ID {expr}: [tabnr, winnr].
       Return [0, 0] if the window cannot be found.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_id2tabwin()
-      <
     ]=],
     name = 'win_id2tabwin',
     params = { { 'expr', 'any' } },
@@ -12934,9 +11986,6 @@ M.funcs = {
       Return the window number of window with ID {expr}.
       Return 0 if the window cannot be found in the current tabpage.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_id2win()
-      <
     ]=],
     name = 'win_id2win',
     params = { { 'expr', 'any' } },
@@ -12960,9 +12009,6 @@ M.funcs = {
       window, since it has no separator on the right.
       Only works for the current tab page. *E1308*
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->win_move_separator(offset)
-      <
     ]=],
     name = 'win_move_separator',
     params = { { 'nr', 'integer' }, { 'offset', 'any' } },
@@ -12983,9 +12029,6 @@ M.funcs = {
       be found and FALSE otherwise.
       Only works for the current tab page.
 
-      Can also be used as a |method|: >vim
-      	GetWinnr()->win_move_statusline(offset)
-      <
     ]=],
     name = 'win_move_statusline',
     params = { { 'nr', 'integer' }, { 'offset', 'any' } },
@@ -13003,9 +12046,6 @@ M.funcs = {
       Returns [0, 0] if the window cannot be found in the current
       tabpage.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_screenpos()
-      <
     ]=],
     name = 'win_screenpos',
     params = { { 'nr', 'integer' } },
@@ -13034,9 +12074,6 @@ M.funcs = {
       		present, the values of 'splitbelow' and
       		'splitright' are used.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->win_splitmove(target)
-      <
     ]=],
     name = 'win_splitmove',
     params = { { 'nr', 'integer' }, { 'target', 'any' }, { 'options', 'table' } },
@@ -13054,9 +12091,6 @@ M.funcs = {
       When window {nr} doesn't exist, -1 is returned.
       Example: >vim
         echo "The file in the current window is " .. bufname(winbufnr(0))
-      <
-      Can also be used as a |method|: >vim
-      	FindWindow()->winbufnr()->bufname()
       <
     ]=],
     name = 'winbufnr',
@@ -13101,9 +12135,6 @@ M.funcs = {
       Examples: >vim
         echo "The current window has " .. winheight(0) .. " lines."
 
-      <Can also be used as a |method|: >vim
-      	GetWinid()->winheight()
-      <
     ]=],
     name = 'winheight',
     params = { { 'nr', 'integer' } },
@@ -13148,9 +12179,6 @@ M.funcs = {
       < >
       	['col', [['leaf', 1002], ['row', [['leaf', 1003],
       			    ['leaf', 1001]]], ['leaf', 1000]]]
-      <
-      Can also be used as a |method|: >vim
-      	GetTabnr()->winlayout()
       <
     ]=],
     name = 'winlayout',
@@ -13202,9 +12230,6 @@ M.funcs = {
       	let prev_window = winnr('#')
       	let wnum = winnr('3k')
 
-      <Can also be used as a |method|: >vim
-      	GetWinval()->winnr()
-      <
     ]=],
     name = 'winnr',
     params = { { 'arg', 'any' } },
@@ -13245,9 +12270,6 @@ M.funcs = {
       If you have changed the values the result is unpredictable.
       If the window size changed the result won't be the same.
 
-      Can also be used as a |method|: >vim
-      	GetView()->winrestview()
-      <
     ]=],
     name = 'winrestview',
     params = { { 'dict', 'any' } },
@@ -13302,9 +12324,6 @@ M.funcs = {
       <For getting the terminal or screen size, see the 'columns'
       option.
 
-      Can also be used as a |method|: >vim
-      	GetWinid()->winwidth()
-      <
     ]=],
     name = 'winwidth',
     params = { { 'nr', 'integer' } },
@@ -13385,9 +12404,6 @@ M.funcs = {
       	let fl = readfile("foo", "b")
       	call writefile(fl, "foocopy", "b")
 
-      <Can also be used as a |method|: >vim
-      	GetText()->writefile("thefile")
-      <
     ]=],
     name = 'writefile',
     params = { { 'object', 'any' }, { 'fname', 'integer' }, { 'flags', 'string' } },
@@ -13402,9 +12418,6 @@ M.funcs = {
       Also see `and()` and `or()`.
       Example: >vim
       	let bits = xor(bits, 0x80)
-      <
-      Can also be used as a |method|: >vim
-      	let bits = bits->xor(0x80)
       <
     ]=],
     name = 'xor',


### PR DESCRIPTION
Now that we "own" builtin.txt, we can remove the repetitive mention of Vimscript's UFCS syntax. It's noisy to mention this for each function, and it's also not a Vimscript feature that should be encouraged.