### PR TITLE
refactor(api): use typed keysets

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -134,6 +134,8 @@ The following new APIs and features were added.
   • `vim.fn.*`
   • `vim.api.*`
 
+• Improved messages for type errors in `vim.api.*` calls (including `opts` params)
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -4,112 +4,112 @@
 error('Cannot require a meta file')
 
 --- @class vim.api.keyset.clear_autocmds
---- @field buffer any
+--- @field buffer integer
 --- @field event any
 --- @field group any
 --- @field pattern any
 
 --- @class vim.api.keyset.cmd
---- @field cmd any
---- @field range any
---- @field count any
---- @field reg any
---- @field bang any
---- @field args any
---- @field magic any
---- @field mods any
+--- @field cmd string
+--- @field range any[]
+--- @field count integer
+--- @field reg string
+--- @field bang boolean
+--- @field args any[]
+--- @field magic table<string,any>
+--- @field mods table<string,any>
 --- @field nargs any
 --- @field addr any
 --- @field nextcmd any
 
 --- @class vim.api.keyset.cmd_magic
---- @field file any
---- @field bar any
+--- @field file boolean
+--- @field bar boolean
 
 --- @class vim.api.keyset.cmd_mods
---- @field silent any
---- @field emsg_silent any
---- @field unsilent any
---- @field filter any
---- @field sandbox any
---- @field noautocmd any
---- @field browse any
---- @field confirm any
---- @field hide any
---- @field horizontal any
---- @field keepalt any
---- @field keepjumps any
---- @field keepmarks any
---- @field keeppatterns any
---- @field lockmarks any
---- @field noswapfile any
---- @field tab any
---- @field verbose any
---- @field vertical any
---- @field split any
+--- @field silent boolean
+--- @field emsg_silent boolean
+--- @field unsilent boolean
+--- @field filter table<string,any>
+--- @field sandbox boolean
+--- @field noautocmd boolean
+--- @field browse boolean
+--- @field confirm boolean
+--- @field hide boolean
+--- @field horizontal boolean
+--- @field keepalt boolean
+--- @field keepjumps boolean
+--- @field keepmarks boolean
+--- @field keeppatterns boolean
+--- @field lockmarks boolean
+--- @field noswapfile boolean
+--- @field tab integer
+--- @field verbose integer
+--- @field vertical boolean
+--- @field split string
 
 --- @class vim.api.keyset.cmd_mods_filter
---- @field pattern any
---- @field force any
+--- @field pattern string
+--- @field force boolean
 
 --- @class vim.api.keyset.cmd_opts
---- @field output any
+--- @field output boolean
 
 --- @class vim.api.keyset.context
---- @field types any
+--- @field types any[]
 
 --- @class vim.api.keyset.create_augroup
 --- @field clear any
 
 --- @class vim.api.keyset.create_autocmd
---- @field buffer any
+--- @field buffer integer
 --- @field callback any
---- @field command any
---- @field desc any
+--- @field command string
+--- @field desc string
 --- @field group any
---- @field nested any
---- @field once any
+--- @field nested boolean
+--- @field once boolean
 --- @field pattern any
 
 --- @class vim.api.keyset.echo_opts
---- @field verbose any
+--- @field verbose boolean
 
 --- @class vim.api.keyset.eval_statusline
---- @field winid any
---- @field maxwidth any
---- @field fillchar any
---- @field highlights any
---- @field use_winbar any
---- @field use_tabline any
---- @field use_statuscol_lnum any
+--- @field winid integer
+--- @field maxwidth integer
+--- @field fillchar string
+--- @field highlights boolean
+--- @field use_winbar boolean
+--- @field use_tabline boolean
+--- @field use_statuscol_lnum integer
 
 --- @class vim.api.keyset.exec_autocmds
---- @field buffer any
+--- @field buffer integer
 --- @field group any
---- @field modeline any
+--- @field modeline boolean
 --- @field pattern any
 --- @field data any
 
 --- @class vim.api.keyset.exec_opts
---- @field output any
+--- @field output boolean
 
 --- @class vim.api.keyset.float_config
---- @field row any
---- @field col any
---- @field width any
---- @field height any
---- @field anchor any
---- @field relative any
---- @field win any
---- @field bufpos any
---- @field external any
---- @field focusable any
---- @field zindex any
+--- @field row number
+--- @field col number
+--- @field width integer
+--- @field height integer
+--- @field anchor string
+--- @field relative string
+--- @field win integer
+--- @field bufpos any[]
+--- @field external boolean
+--- @field focusable boolean
+--- @field zindex integer
 --- @field border any
 --- @field title any
---- @field title_pos any
---- @field style any
---- @field noautocmd any
+--- @field title_pos string
+--- @field style string
+--- @field noautocmd boolean
 
 --- @class vim.api.keyset.get_autocmds
 --- @field event any
@@ -118,27 +118,27 @@ error('Cannot require a meta file')
 --- @field buffer any
 
 --- @class vim.api.keyset.get_commands
---- @field builtin any
+--- @field builtin boolean
 
 --- @class vim.api.keyset.get_highlight
---- @field id any
---- @field name any
---- @field link any
+--- @field id integer
+--- @field name string
+--- @field link boolean
 
 --- @class vim.api.keyset.highlight
---- @field bold any
---- @field standout any
---- @field strikethrough any
---- @field underline any
---- @field undercurl any
---- @field underdouble any
---- @field underdotted any
---- @field underdashed any
---- @field italic any
---- @field reverse any
---- @field altfont any
---- @field nocombine any
---- @field default_ any
+--- @field bold boolean
+--- @field standout boolean
+--- @field strikethrough boolean
+--- @field underline boolean
+--- @field undercurl boolean
+--- @field underdouble boolean
+--- @field underdotted boolean
+--- @field underdashed boolean
+--- @field italic boolean
+--- @field reverse boolean
+--- @field altfont boolean
+--- @field nocombine boolean
+--- @field default boolean
 --- @field cterm any
 --- @field foreground any
 --- @field fg any
@@ -150,100 +150,100 @@ error('Cannot require a meta file')
 --- @field sp any
 --- @field link any
 --- @field global_link any
---- @field fallback any
---- @field blend any
---- @field fg_indexed any
---- @field bg_indexed any
+--- @field fallback boolean
+--- @field blend integer
+--- @field fg_indexed boolean
+--- @field bg_indexed boolean
 
 --- @class vim.api.keyset.highlight_cterm
---- @field bold any
---- @field standout any
---- @field strikethrough any
---- @field underline any
---- @field undercurl any
---- @field underdouble any
---- @field underdotted any
---- @field underdashed any
---- @field italic any
---- @field reverse any
---- @field altfont any
---- @field nocombine any
+--- @field bold boolean
+--- @field standout boolean
+--- @field strikethrough boolean
+--- @field underline boolean
+--- @field undercurl boolean
+--- @field underdouble boolean
+--- @field underdotted boolean
+--- @field underdashed boolean
+--- @field italic boolean
+--- @field reverse boolean
+--- @field altfont boolean
+--- @field nocombine boolean
 
 --- @class vim.api.keyset.keymap
---- @field noremap any
---- @field nowait any
---- @field silent any
---- @field script any
---- @field expr any
---- @field unique any
---- @field callback any
---- @field desc any
---- @field replace_keycodes any
+--- @field noremap boolean
+--- @field nowait boolean
+--- @field silent boolean
+--- @field script boolean
+--- @field expr boolean
+--- @field unique boolean
+--- @field callback function
+--- @field desc string
+--- @field replace_keycodes boolean
 
 --- @class vim.api.keyset.option
---- @field scope any
---- @field win any
---- @field buf any
---- @field filetype any
+--- @field scope string
+--- @field win integer
+--- @field buf integer
+--- @field filetype string
 
 --- @class vim.api.keyset.runtime
---- @field is_lua any
---- @field do_source any
+--- @field is_lua boolean
+--- @field do_source boolean
 
 --- @class vim.api.keyset.set_decoration_provider
---- @field on_start any
---- @field on_buf any
---- @field on_win any
---- @field on_line any
---- @field on_end any
---- @field _on_hl_def any
---- @field _on_spell_nav any
+--- @field on_start function
+--- @field on_buf function
+--- @field on_win function
+--- @field on_line function
+--- @field on_end function
+--- @field _on_hl_def function
+--- @field _on_spell_nav function
 
 --- @class vim.api.keyset.set_extmark
---- @field id any
---- @field end_line any
---- @field end_row any
---- @field end_col any
+--- @field id integer
+--- @field end_line integer
+--- @field end_row integer
+--- @field end_col integer
 --- @field hl_group any
---- @field virt_text any
---- @field virt_text_pos any
---- @field virt_text_win_col any
---- @field virt_text_hide any
---- @field hl_eol any
---- @field hl_mode any
---- @field ephemeral any
---- @field priority any
---- @field right_gravity any
---- @field end_right_gravity any
---- @field virt_lines any
---- @field virt_lines_above any
---- @field virt_lines_leftcol any
---- @field strict any
---- @field sign_text any
+--- @field virt_text any[]
+--- @field virt_text_pos string
+--- @field virt_text_win_col integer
+--- @field virt_text_hide boolean
+--- @field hl_eol boolean
+--- @field hl_mode string
+--- @field ephemeral boolean
+--- @field priority integer
+--- @field right_gravity boolean
+--- @field end_right_gravity boolean
+--- @field virt_lines any[]
+--- @field virt_lines_above boolean
+--- @field virt_lines_leftcol boolean
+--- @field strict boolean
+--- @field sign_text string
 --- @field sign_hl_group any
 --- @field number_hl_group any
 --- @field line_hl_group any
 --- @field cursorline_hl_group any
---- @field conceal any
---- @field spell any
---- @field ui_watched any
+--- @field conceal string
+--- @field spell boolean
+--- @field ui_watched boolean
 
 --- @class vim.api.keyset.user_command
 --- @field addr any
---- @field bang any
---- @field bar any
+--- @field bang boolean
+--- @field bar boolean
 --- @field complete any
 --- @field count any
 --- @field desc any
---- @field force any
---- @field keepscript any
+--- @field force boolean
+--- @field keepscript boolean
 --- @field nargs any
 --- @field preview any
 --- @field range any
---- @field register_ any
+--- @field register boolean
 
 --- @class vim.api.keyset.win_text_height
---- @field start_row any
---- @field end_row any
---- @field start_vcol any
---- @field end_vcol any
+--- @field start_row integer
+--- @field end_row integer
+--- @field start_vcol integer
+--- @field end_vcol integer

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -260,19 +260,18 @@ local function get_api_keysets()
 
   local ret = {} --- @type table<string, vim.EvalFn>
 
-  --- @type {[1]: string, [2]: {[1]: string, [2]: string}[] }[]
+  --- @type {name: string, keys: string[], types: table<string,string>}[]
   local keysets = metadata.keysets
 
-  for _, keyset in ipairs(keysets) do
-    local kname = keyset[1]
-    local kdef = keyset[2]
-    for _, field in ipairs(kdef) do
-      field[2] = api_type(field[2])
+  for _, k in ipairs(keysets) do
+    local params = {}
+    for _, key in ipairs(k.keys) do
+      table.insert(params, {key, api_type(k.types[key] or 'any')})
     end
-    ret[kname] = {
+    ret[k.name] = {
       signature = 'NA',
-      name = kname,
-      params = kdef,
+      name = k.name,
+      params = params,
     }
   end
 

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -35,8 +35,7 @@ String nvim_exec(uint64_t channel_id, String src, Boolean output, Error *err)
   FUNC_API_SINCE(7)
   FUNC_API_DEPRECATED_SINCE(11)
 {
-  Dict(exec_opts) opts = { 0 };
-  opts.output = BOOLEAN_OBJ(output);
+  Dict(exec_opts) opts = { .output = output };
   return exec_impl(channel_id, src, &opts, err);
 }
 
@@ -46,8 +45,7 @@ String nvim_command_output(uint64_t channel_id, String command, Error *err)
   FUNC_API_SINCE(1)
   FUNC_API_DEPRECATED_SINCE(7)
 {
-  Dict(exec_opts) opts = { 0 };
-  opts.output = BOOLEAN_OBJ(true);
+  Dict(exec_opts) opts = { .output = true };
   return exec_impl(channel_id, command, &opts, err);
 }
 

--- a/src/nvim/api/keysets.h
+++ b/src/nvim/api/keysets.h
@@ -4,135 +4,144 @@
 #include "nvim/api/private/defs.h"
 
 typedef struct {
-  Object types;
+  OptionalKeys is_set__context_;
+  Array types;
 } Dict(context);
 
 typedef struct {
-  Object on_start;
-  Object on_buf;
-  Object on_win;
-  Object on_line;
-  Object on_end;
-  Object _on_hl_def;
-  Object _on_spell_nav;
+  OptionalKeys is_set__set_decoration_provider_;
+  LuaRef on_start;
+  LuaRef on_buf;
+  LuaRef on_win;
+  LuaRef on_line;
+  LuaRef on_end;
+  LuaRef _on_hl_def;
+  LuaRef _on_spell_nav;
 } Dict(set_decoration_provider);
 
 typedef struct {
-  Object id;
-  Object end_line;
-  Object end_row;
-  Object end_col;
+  OptionalKeys is_set__set_extmark_;
+  Integer id;
+  Integer end_line;
+  Integer end_row;
+  Integer end_col;
   Object hl_group;
-  Object virt_text;
-  Object virt_text_pos;
-  Object virt_text_win_col;
-  Object virt_text_hide;
-  Object hl_eol;
-  Object hl_mode;
-  Object ephemeral;
-  Object priority;
-  Object right_gravity;
-  Object end_right_gravity;
-  Object virt_lines;
-  Object virt_lines_above;
-  Object virt_lines_leftcol;
-  Object strict;
-  Object sign_text;
+  Array virt_text;
+  String virt_text_pos;
+  Integer virt_text_win_col;
+  Boolean virt_text_hide;
+  Boolean hl_eol;
+  String hl_mode;
+  Boolean ephemeral;
+  Integer priority;
+  Boolean right_gravity;
+  Boolean end_right_gravity;
+  Array virt_lines;
+  Boolean virt_lines_above;
+  Boolean virt_lines_leftcol;
+  Boolean strict;
+  String sign_text;
   Object sign_hl_group;
   Object number_hl_group;
   Object line_hl_group;
   Object cursorline_hl_group;
-  Object conceal;
-  Object spell;
-  Object ui_watched;
+  String conceal;
+  Boolean spell;
+  Boolean ui_watched;
 } Dict(set_extmark);
 
 typedef struct {
-  Object noremap;
-  Object nowait;
-  Object silent;
-  Object script;
-  Object expr;
-  Object unique;
-  Object callback;
-  Object desc;
-  Object replace_keycodes;
+  OptionalKeys is_set__keymap_;
+  Boolean noremap;
+  Boolean nowait;
+  Boolean silent;
+  Boolean script;
+  Boolean expr;
+  Boolean unique;
+  LuaRef callback;
+  String desc;
+  Boolean replace_keycodes;
 } Dict(keymap);
 
 typedef struct {
-  Object builtin;
+  Boolean builtin;
 } Dict(get_commands);
 
 typedef struct {
+  OptionalKeys is_set__user_command_;
   Object addr;
-  Object bang;
-  Object bar;
+  Boolean bang;
+  Boolean bar;
   Object complete;
   Object count;
   Object desc;
-  Object force;
-  Object keepscript;
+  Boolean force;
+  Boolean keepscript;
   Object nargs;
   Object preview;
   Object range;
-  Object register_;
+  Boolean register_;
 } Dict(user_command);
 
 typedef struct {
-  Object row;
-  Object col;
-  Object width;
-  Object height;
-  Object anchor;
-  Object relative;
-  Object win;
-  Object bufpos;
-  Object external;
-  Object focusable;
-  Object zindex;
+  OptionalKeys is_set__float_config_;
+  Float row;
+  Float col;
+  Integer width;
+  Integer height;
+  String anchor;
+  String relative;
+  Window win;
+  Array bufpos;
+  Boolean external;
+  Boolean focusable;
+  Integer zindex;
   Object border;
   Object title;
-  Object title_pos;
-  Object style;
-  Object noautocmd;
+  String title_pos;
+  String style;
+  Boolean noautocmd;
 } Dict(float_config);
 
 typedef struct {
-  Object is_lua;
-  Object do_source;
+  Boolean is_lua;
+  Boolean do_source;
 } Dict(runtime);
 
 typedef struct {
-  Object winid;
-  Object maxwidth;
-  Object fillchar;
-  Object highlights;
-  Object use_winbar;
-  Object use_tabline;
-  Object use_statuscol_lnum;
+  OptionalKeys is_set__eval_statusline_;
+  Window winid;
+  Integer maxwidth;
+  String fillchar;
+  Boolean highlights;
+  Boolean use_winbar;
+  Boolean use_tabline;
+  Integer use_statuscol_lnum;
 } Dict(eval_statusline);
 
 typedef struct {
-  Object scope;
-  Object win;
-  Object buf;
-  Object filetype;
+  OptionalKeys is_set__option_;
+  String scope;
+  Window win;
+  Buffer buf;
+  String filetype;
 } Dict(option);
 
 typedef struct {
-  Object bold;
-  Object standout;
-  Object strikethrough;
-  Object underline;
-  Object undercurl;
-  Object underdouble;
-  Object underdotted;
-  Object underdashed;
-  Object italic;
-  Object reverse;
-  Object altfont;
-  Object nocombine;
-  Object default_;
+  OptionalKeys is_set__highlight_;
+  Boolean bold;
+  Boolean standout;
+  Boolean strikethrough;
+  Boolean underline;
+  Boolean undercurl;
+  Boolean underdouble;
+  Boolean underdotted;
+  Boolean underdashed;
+  Boolean italic;
+  Boolean reverse;
+  Boolean altfont;
+  Boolean nocombine;
+  Boolean default_;
   Object cterm;
   Object foreground;
   Object fg;
@@ -144,67 +153,73 @@ typedef struct {
   Object sp;
   Object link;
   Object global_link;
-  Object fallback;
-  Object blend;
-  Object fg_indexed;
-  Object bg_indexed;
+  Boolean fallback;
+  Integer blend;
+  Boolean fg_indexed;
+  Boolean bg_indexed;
 } Dict(highlight);
 
 typedef struct {
-  Object bold;
-  Object standout;
-  Object strikethrough;
-  Object underline;
-  Object undercurl;
-  Object underdouble;
-  Object underdotted;
-  Object underdashed;
-  Object italic;
-  Object reverse;
-  Object altfont;
-  Object nocombine;
+  Boolean bold;
+  Boolean standout;
+  Boolean strikethrough;
+  Boolean underline;
+  Boolean undercurl;
+  Boolean underdouble;
+  Boolean underdotted;
+  Boolean underdashed;
+  Boolean italic;
+  Boolean reverse;
+  Boolean altfont;
+  Boolean nocombine;
 } Dict(highlight_cterm);
 
 typedef struct {
-  Object id;
-  Object name;
-  Object link;
+  OptionalKeys is_set__get_highlight_;
+  Integer id;
+  String name;
+  Boolean link;
 } Dict(get_highlight);
 
 typedef struct {
-  Object start_row;
-  Object end_row;
-  Object start_vcol;
-  Object end_vcol;
+  OptionalKeys is_set__win_text_height_;
+  Integer start_row;
+  Integer end_row;
+  Integer start_vcol;
+  Integer end_vcol;
 } Dict(win_text_height);
 
 typedef struct {
-  Object buffer;
+  OptionalKeys is_set__clear_autocmds_;
+  Buffer buffer;
   Object event;
   Object group;
   Object pattern;
 } Dict(clear_autocmds);
 
 typedef struct {
-  Object buffer;
+  OptionalKeys is_set__create_autocmd_;
+  Buffer buffer;
   Object callback;
-  Object command;
-  Object desc;
+  String command;
+  String desc;
   Object group;
-  Object nested;
-  Object once;
+  Boolean nested;
+  Boolean once;
   Object pattern;
 } Dict(create_autocmd);
 
 typedef struct {
-  Object buffer;
+  OptionalKeys is_set__exec_autocmds_;
+  Buffer buffer;
   Object group;
-  Object modeline;
+  Boolean modeline;
   Object pattern;
   Object data;
 } Dict(exec_autocmds);
 
 typedef struct {
+  OptionalKeys is_set__get_autocmds_;
   Object event;
   Object group;
   Object pattern;
@@ -216,62 +231,66 @@ typedef struct {
 } Dict(create_augroup);
 
 typedef struct {
-  Object cmd;
-  Object range;
-  Object count;
-  Object reg;
-  Object bang;
-  Object args;
-  Object magic;
-  Object mods;
+  OptionalKeys is_set__cmd_;
+  String cmd;
+  Array range;
+  Integer count;
+  String reg;
+  Boolean bang;
+  Array args;
+  Dictionary magic;
+  Dictionary mods;
   Object nargs;
   Object addr;
   Object nextcmd;
 } Dict(cmd);
 
 typedef struct {
-  Object file;
-  Object bar;
+  OptionalKeys is_set__cmd_magic_;
+  Boolean file;
+  Boolean bar;
 } Dict(cmd_magic);
 
 typedef struct {
-  Object silent;
-  Object emsg_silent;
-  Object unsilent;
-  Object filter;
-  Object sandbox;
-  Object noautocmd;
-  Object browse;
-  Object confirm;
-  Object hide;
-  Object horizontal;
-  Object keepalt;
-  Object keepjumps;
-  Object keepmarks;
-  Object keeppatterns;
-  Object lockmarks;
-  Object noswapfile;
-  Object tab;
-  Object verbose;
-  Object vertical;
-  Object split;
+  OptionalKeys is_set__cmd_mods_;
+  Boolean silent;
+  Boolean emsg_silent;
+  Boolean unsilent;
+  Dictionary filter;
+  Boolean sandbox;
+  Boolean noautocmd;
+  Boolean browse;
+  Boolean confirm;
+  Boolean hide;
+  Boolean horizontal;
+  Boolean keepalt;
+  Boolean keepjumps;
+  Boolean keepmarks;
+  Boolean keeppatterns;
+  Boolean lockmarks;
+  Boolean noswapfile;
+  Integer tab;
+  Integer verbose;
+  Boolean vertical;
+  String split;
 } Dict(cmd_mods);
 
 typedef struct {
-  Object pattern;
-  Object force;
+  OptionalKeys is_set__cmd_mods_filter_;
+  String pattern;
+  Boolean force;
 } Dict(cmd_mods_filter);
 
 typedef struct {
-  Object output;
+  Boolean output;
 } Dict(cmd_opts);
 
 typedef struct {
-  Object verbose;
+  Boolean verbose;
 } Dict(echo_opts);
 
 typedef struct {
-  Object output;
+  Boolean output;
 } Dict(exec_opts);
 
 #endif  // NVIM_API_KEYSETS_H

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -124,10 +124,20 @@ struct key_value_pair {
   Object value;
 };
 
-typedef Object *(*field_hash)(void *retval, const char *str, size_t len);
+typedef uint64_t OptionalKeys;
+
+// this is the prefix of all keysets with optional keys
+typedef struct {
+  OptionalKeys is_set_;
+} OptKeySet;
+
 typedef struct {
   char *str;
   size_t ptr_off;
+  ObjectType type;  // kObjectTypeNil == untyped
+  int opt_index;
 } KeySetLink;
+
+typedef KeySetLink *(*FieldHashfn)(const char *str, size_t len);
 
 #endif  // NVIM_API_PRIVATE_DEFS_H

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -63,8 +63,9 @@
 #define NIL ((Object)OBJECT_INIT)
 #define NULL_STRING ((String)STRING_INIT)
 
-// currently treat key=vim.NIL as if the key was missing
-#define HAS_KEY(o) ((o).type != kObjectTypeNil)
+#define HAS_KEY(d, typ, key) (((d)->is_set__##typ##_ & (1 << KEYSET_OPTIDX_##typ##__##key)) != 0)
+
+#define GET_BOOL_OR_TRUE(d, typ, key) (HAS_KEY(d, typ, key) ? (d)->key : true)
 
 #define PUT(dict, k, v) \
   kv_push(dict, ((KeyValuePair) { .key = cstr_to_string(k), .value = v }))

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 
 #include "nvim/api/private/defs.h"
+#include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/private/validate.h"
 #include "nvim/api/window.h"
@@ -513,18 +514,12 @@ Dictionary nvim_win_text_height(Window window, Dict(win_text_height) *opts, Aren
 
   bool oob = false;
 
-  if (HAS_KEY(opts->start_row)) {
-    VALIDATE_T("start_row", kObjectTypeInteger, opts->start_row.type, {
-      return rv;
-    });
-    start_lnum = (linenr_T)normalize_index(buf, opts->start_row.data.integer, false, &oob);
+  if (HAS_KEY(opts, win_text_height, start_row)) {
+    start_lnum = (linenr_T)normalize_index(buf, opts->start_row, false, &oob);
   }
 
-  if (HAS_KEY(opts->end_row)) {
-    VALIDATE_T("end_row", kObjectTypeInteger, opts->end_row.type, {
-      return rv;
-    });
-    end_lnum = (linenr_T)normalize_index(buf, opts->end_row.data.integer, false, &oob);
+  if (HAS_KEY(opts, win_text_height, end_row)) {
+    end_lnum = (linenr_T)normalize_index(buf, opts->end_row, false, &oob);
   }
 
   VALIDATE(!oob, "%s", "Line index out of bounds", {
@@ -534,27 +529,23 @@ Dictionary nvim_win_text_height(Window window, Dict(win_text_height) *opts, Aren
     return rv;
   });
 
-  if (HAS_KEY(opts->start_vcol)) {
-    VALIDATE(HAS_KEY(opts->start_row), "%s", "'start_vcol' specified without 'start_row'", {
+  if (HAS_KEY(opts, win_text_height, start_vcol)) {
+    VALIDATE(HAS_KEY(opts, win_text_height, start_row),
+             "%s", "'start_vcol' specified without 'start_row'", {
       return rv;
     });
-    VALIDATE_T("start_vcol", kObjectTypeInteger, opts->start_vcol.type, {
-      return rv;
-    });
-    start_vcol = opts->start_vcol.data.integer;
+    start_vcol = opts->start_vcol;
     VALIDATE_RANGE((start_vcol >= 0 && start_vcol <= MAXCOL), "start_vcol", {
       return rv;
     });
   }
 
-  if (HAS_KEY(opts->end_vcol)) {
-    VALIDATE(HAS_KEY(opts->end_row), "%s", "'end_vcol' specified without 'end_row'", {
+  if (HAS_KEY(opts, win_text_height, end_vcol)) {
+    VALIDATE(HAS_KEY(opts, win_text_height, end_row),
+             "%s", "'end_vcol' specified without 'end_row'", {
       return rv;
     });
-    VALIDATE_T("end_vcol", kObjectTypeInteger, opts->end_vcol.type, {
-      return rv;
-    });
-    end_vcol = opts->end_vcol.data.integer;
+    end_vcol = opts->end_vcol;
     VALIDATE_RANGE((end_vcol >= 0 && end_vcol <= MAXCOL), "end_vcol", {
       return rv;
     });
@@ -568,7 +559,7 @@ Dictionary nvim_win_text_height(Window window, Dict(win_text_height) *opts, Aren
 
   int64_t fill = 0;
   int64_t all = win_text_height(win, start_lnum, start_vcol, end_lnum, end_vcol, &fill);
-  if (!HAS_KEY(opts->end_row)) {
+  if (!HAS_KEY(opts, win_text_height, end_row)) {
     const int64_t end_fill = win_get_fill(win, line_count + 1);
     fill += end_fill;
     all += end_fill;

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -271,8 +271,7 @@ static inline void ctx_save_funcs(Context *ctx, bool scriptonly)
       size_t cmd_len = sizeof("func! ") + strlen(name);
       char *cmd = xmalloc(cmd_len);
       snprintf(cmd, cmd_len, "func! %s", name);
-      Dict(exec_opts) opts = { 0 };
-      opts.output = BOOLEAN_OBJ(true);
+      Dict(exec_opts) opts = { .output = true };
       String func_body = exec_impl(VIML_INTERNAL_CALL, cstr_as_string(cmd),
                                    &opts, &err);
       xfree(cmd);

--- a/src/nvim/generators/gen_api_dispatch.lua
+++ b/src/nvim/generators/gen_api_dispatch.lua
@@ -630,7 +630,7 @@ local function process_function(fn)
     local seterr = ''
     if string.match(param_type, '^KeyDict_') then
       write_shifted_output(output, string.format([[
-      %s %s = { 0 }; nlua_pop_keydict(lstate, &%s, %s_get_field, %s&err);]], param_type, cparam, cparam, param_type, extra))
+      %s %s = { 0 }; nlua_pop_keydict(lstate, &%s, %s_get_field, &err_param, &err);]], param_type, cparam, cparam, param_type))
       cparam = '&'..cparam
       errshift = 1 -- free incomplete dict on error
     else

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -871,7 +871,8 @@ static inline LuaTableProps nlua_check_type(lua_State *const lstate, Error *cons
 {
   if (lua_type(lstate, -1) != LUA_TTABLE) {
     if (err) {
-      api_set_error(err, kErrorTypeValidation, "Expected lua table");
+      api_set_error(err, kErrorTypeValidation, "Expected lua %s",
+                    (type == kObjectTypeFloat) ? "number" : "table");
     }
     return (LuaTableProps) { .type = kObjectTypeNil };
   }
@@ -884,7 +885,7 @@ static inline LuaTableProps nlua_check_type(lua_State *const lstate, Error *cons
 
   if (table_props.type != type) {
     if (err) {
-      api_set_error(err, kErrorTypeValidation, "Unexpected type");
+      api_set_error(err, kErrorTypeValidation, "Expected %s-like lua table", api_typename(type));
     }
   }
 
@@ -1224,26 +1225,19 @@ LuaRef nlua_pop_LuaRef(lua_State *const lstate, Error *err)
   return rv;
 }
 
-#define GENERATE_INDEX_FUNCTION(type) \
-  type nlua_pop_##type(lua_State *lstate, Error *err) \
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT \
-  { \
-    type ret; \
-    if (lua_type(lstate, -1) != LUA_TNUMBER) { \
-      api_set_error(err, kErrorTypeValidation, "Expected Lua number"); \
-      ret = (type) - 1; \
-    } else { \
-      ret = (type)lua_tonumber(lstate, -1); \
-    } \
-    lua_pop(lstate, 1); \
-    return ret; \
+handle_T nlua_pop_handle(lua_State *lstate, Error *err)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  handle_T ret;
+  if (lua_type(lstate, -1) != LUA_TNUMBER) {
+    api_set_error(err, kErrorTypeValidation, "Expected Lua number");
+    ret = (handle_T) - 1;
+  } else {
+    ret = (handle_T)lua_tonumber(lstate, -1);
   }
-
-GENERATE_INDEX_FUNCTION(Buffer)
-GENERATE_INDEX_FUNCTION(Window)
-GENERATE_INDEX_FUNCTION(Tabpage)
-
-#undef GENERATE_INDEX_FUNCTION
+  lua_pop(lstate, 1);
+  return ret;
+}
 
 /// Record some auxiliary values in vim module
 ///
@@ -1292,7 +1286,8 @@ void nlua_init_types(lua_State *const lstate)
   lua_rawset(lstate, -3);
 }
 
-void nlua_pop_keydict(lua_State *L, void *retval, field_hash hashy, Error *err)
+// lua specific variant of api_dict_to_keydict
+void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, Error *err)
 {
   if (!lua_istable(L, -1)) {
     api_set_error(err, kErrorTypeValidation, "Expected lua table");
@@ -1305,14 +1300,44 @@ void nlua_pop_keydict(lua_State *L, void *retval, field_hash hashy, Error *err)
     // [dict, key, value]
     size_t len;
     const char *s = lua_tolstring(L, -2, &len);
-    Object *field = hashy(retval, s, len);
+    KeySetLink *field = hashy(s, len);
     if (!field) {
       api_set_error(err, kErrorTypeValidation, "invalid key: %.*s", (int)len, s);
       lua_pop(L, 3);  // []
       return;
     }
 
-    *field = nlua_pop_Object(L, true, err);
+    if (field->opt_index >= 0) {
+      OptKeySet *ks = (OptKeySet *)retval;
+      ks->is_set_ |= (1ULL << field->opt_index);
+    }
+    char *mem = ((char *)retval + field->ptr_off);
+
+    if (field->type == kObjectTypeNil) {
+      *(Object *)mem = nlua_pop_Object(L, true, err);
+    } else if (field->type == kObjectTypeInteger) {
+      *(Integer *)mem = nlua_pop_Integer(L, err);
+    } else if (field->type == kObjectTypeBoolean) {
+      *(Boolean *)mem = nlua_pop_Boolean(L, err);
+    } else if (field->type == kObjectTypeString) {
+      *(String *)mem = nlua_pop_String(L, err);
+    } else if (field->type == kObjectTypeFloat) {
+      *(Float *)mem = nlua_pop_Float(L, err);
+    } else if (field->type == kObjectTypeBuffer || field->type == kObjectTypeWindow
+               || field->type == kObjectTypeTabpage) {
+      *(handle_T *)mem = nlua_pop_handle(L, err);
+    } else if (field->type == kObjectTypeArray) {
+      *(Array *)mem = nlua_pop_Array(L, err);
+    } else if (field->type == kObjectTypeDictionary) {
+      *(Dictionary *)mem = nlua_pop_Dictionary(L, false, err);
+    } else if (field->type == kObjectTypeLuaRef) {
+      *(LuaRef *)mem = nlua_pop_LuaRef(L, err);
+    } else {
+      abort();
+    }
+    if (ERROR_SET(err)) {
+      break;
+    }
   }
   // [dict]
   lua_pop(L, 1);

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -813,7 +813,7 @@ String nlua_pop_String(lua_State *lstate, Error *err)
 {
   if (lua_type(lstate, -1) != LUA_TSTRING) {
     lua_pop(lstate, 1);
-    api_set_error(err, kErrorTypeValidation, "Expected lua string");
+    api_set_error(err, kErrorTypeValidation, "Expected Lua string");
     return (String) { .size = 0, .data = NULL };
   }
   String ret;
@@ -834,7 +834,7 @@ Integer nlua_pop_Integer(lua_State *lstate, Error *err)
 {
   if (lua_type(lstate, -1) != LUA_TNUMBER) {
     lua_pop(lstate, 1);
-    api_set_error(err, kErrorTypeValidation, "Expected lua number");
+    api_set_error(err, kErrorTypeValidation, "Expected Lua number");
     return 0;
   }
   const lua_Number n = lua_tonumber(lstate, -1);
@@ -871,7 +871,7 @@ static inline LuaTableProps nlua_check_type(lua_State *const lstate, Error *cons
 {
   if (lua_type(lstate, -1) != LUA_TTABLE) {
     if (err) {
-      api_set_error(err, kErrorTypeValidation, "Expected lua %s",
+      api_set_error(err, kErrorTypeValidation, "Expected Lua %s",
                     (type == kObjectTypeFloat) ? "number" : "table");
     }
     return (LuaTableProps) { .type = kObjectTypeNil };
@@ -885,7 +885,7 @@ static inline LuaTableProps nlua_check_type(lua_State *const lstate, Error *cons
 
   if (table_props.type != type) {
     if (err) {
-      api_set_error(err, kErrorTypeValidation, "Expected %s-like lua table", api_typename(type));
+      api_set_error(err, kErrorTypeValidation, "Expected %s-like Lua table", api_typename(type));
     }
   }
 
@@ -1169,7 +1169,7 @@ Object nlua_pop_Object(lua_State *const lstate, bool ref, Error *const err)
         break;
       case kObjectTypeNil:
         api_set_error(err, kErrorTypeValidation,
-                      "Cannot convert given lua table");
+                      "Cannot convert given Lua table");
         break;
       default:
         abort();
@@ -1287,10 +1287,10 @@ void nlua_init_types(lua_State *const lstate)
 }
 
 // lua specific variant of api_dict_to_keydict
-void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, Error *err)
+void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, char **err_opt, Error *err)
 {
   if (!lua_istable(L, -1)) {
-    api_set_error(err, kErrorTypeValidation, "Expected lua table");
+    api_set_error(err, kErrorTypeValidation, "Expected Lua table");
     lua_pop(L, -1);
     return;
   }
@@ -1336,6 +1336,7 @@ void nlua_pop_keydict(lua_State *L, void *retval, FieldHashfn hashy, Error *err)
       abort();
     }
     if (ERROR_SET(err)) {
+      *err_opt = field->str;
       break;
     }
   }

--- a/src/nvim/lua/converter.h
+++ b/src/nvim/lua/converter.h
@@ -9,6 +9,10 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/func_attr.h"
 
+#define nlua_pop_Buffer nlua_pop_handle
+#define nlua_pop_Window nlua_pop_handle
+#define nlua_pop_Tabpage nlua_pop_handle
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "lua/converter.h.generated.h"
 #endif

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -737,7 +737,7 @@ describe('autocmd api', function()
       eq("Invalid 'group': 0", pcall_err(meths.exec_autocmds, 'FileType', {
         group = 0,
       }))
-      eq("Invalid 'buffer': expected Integer, got Array", pcall_err(meths.exec_autocmds, 'FileType', {
+      eq("Invalid 'buffer': expected Buffer, got Array", pcall_err(meths.exec_autocmds, 'FileType', {
         buffer = {},
       }))
       eq("Invalid 'event' item: expected String, got Array", pcall_err(meths.exec_autocmds,

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -109,7 +109,7 @@ describe('API/extmarks', function()
     eq("Invalid 'virt_text_pos': 'foo'", pcall_err(set_extmark, ns, marks[2], 0, 0, { virt_text_pos = 'foo' }))
     eq("Invalid 'hl_mode': expected String, got Integer", pcall_err(set_extmark, ns, marks[2], 0, 0, { hl_mode = 0 }))
     eq("Invalid 'hl_mode': 'foo'", pcall_err(set_extmark, ns, marks[2], 0, 0, { hl_mode = 'foo' }))
-    eq("Invalid 'id': expected positive Integer", pcall_err(set_extmark, ns, {}, 0, 0, { end_col = 1, end_row = 1 }))
+    eq("Invalid 'id': expected Integer, got Array", pcall_err(set_extmark, ns, {}, 0, 0, { end_col = 1, end_row = 1 }))
     eq("Invalid mark position: expected 2 Integer items", pcall_err(get_extmarks, ns, {}, {-1, -1}))
     eq("Invalid mark position: expected mark id Integer or 2-item Array", pcall_err(get_extmarks, ns, true, {-1, -1}))
     -- No memory leak with virt_text, virt_lines, sign_text

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -434,10 +434,8 @@ describe('API: get highlight', function()
   before_each(clear)
 
   it('validation', function()
-    eq(
-      'Invalid highlight name: expected String, got Integer',
-      pcall_err(meths.get_hl, 0, { name = 177 })
-    )
+    eq("Invalid 'name': expected String, got Integer",
+       pcall_err(meths.get_hl, 0, { name = 177 }))
     eq('Highlight id out of bounds', pcall_err(meths.get_hl, 0, { name = 'Test set hl' }))
   end)
 
@@ -534,7 +532,7 @@ describe('API: get highlight', function()
     eq('Highlight id out of bounds', pcall_err(meths.get_hl, 0, { id = 0 }))
 
     eq(
-      'Invalid highlight id: expected Integer, got String',
+      "Invalid 'id': expected Integer, got String",
       pcall_err(meths.get_hl, 0, { id = 'Test_set_hl' })
     )
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -4112,12 +4112,10 @@ describe('API', function()
     it('validation', function()
       eq("Invalid 'cmd': expected non-empty String",
         pcall_err(meths.cmd, { cmd = ""}, {}))
-      eq("Invalid 'cmd': expected non-empty String",
+      eq("Invalid 'cmd': expected String, got Array",
         pcall_err(meths.cmd, { cmd = {}}, {}))
       eq("Invalid 'args': expected Array, got Boolean",
         pcall_err(meths.cmd, { cmd = "set", args = true }, {}))
-      eq("Invalid 'magic': expected Dict, got Array",
-        pcall_err(meths.cmd, { cmd = "set", args = {}, magic = {} }, {}))
       eq("Invalid command arg: expected non-whitespace",
         pcall_err(meths.cmd, { cmd = "set", args = {'  '}, }, {}))
       eq("Invalid command arg: expected valid type, got Array",
@@ -4138,7 +4136,7 @@ describe('API', function()
 
       eq("Command cannot accept count: set",
         pcall_err(meths.cmd, { cmd = "set", args = {}, count = 1 }, {}))
-      eq("Invalid 'count': expected non-negative Integer",
+      eq("Invalid 'count': expected Integer, got Boolean",
         pcall_err(meths.cmd, { cmd = "print", args = {}, count = true }, {}))
       eq("Invalid 'count': expected non-negative Integer",
         pcall_err(meths.cmd, { cmd = "print", args = {}, count = -1 }, {}))
@@ -4158,9 +4156,10 @@ describe('API', function()
       -- Lua call allows empty {} for dict item.
       eq('', exec_lua([[return vim.cmd{ cmd = "set", args = {}, magic = {} }]]))
       eq('', exec_lua([[return vim.cmd{ cmd = "set", args = {}, mods = {} }]]))
+      eq('', meths.cmd({ cmd = "set", args = {}, magic = {} }, {}))
 
       -- Lua call does not allow non-empty list-like {} for dict item.
-      eq("Invalid 'magic': expected Dict, got Array",
+      eq("Invalid 'magic': Expected Dict-like Lua table",
         pcall_err(exec_lua, [[return vim.cmd{ cmd = "set", args = {}, magic = { 'a' } }]]))
       eq("Invalid key: 'bogus'",
         pcall_err(exec_lua, [[return vim.cmd{ cmd = "set", args = {}, magic = { bogus = true } }]]))

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -173,7 +173,7 @@ describe('luaeval(vim.api.…)', function()
 
   it('errors out correctly when working with API', function()
     -- Conversion errors
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Cannot convert given lua table',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'obj': Cannot convert given Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id({1, foo=42})")]])))
     -- Errors in number of arguments
     eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 1 argument',
@@ -183,32 +183,32 @@ describe('luaeval(vim.api.…)', function()
     eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected 2 arguments',
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2, 3)")]])))
     -- Error in argument types
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua string',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'name': Expected Lua string]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_set_var(1, 2)")]])))
 
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua number',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'start': Expected Lua number]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_buf_get_lines(0, 'test', 1, false)")]])))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Number is not integral',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'start': Number is not integral]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_buf_get_lines(0, 1.5, 1, false)")]])))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected Lua number',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'window': Expected Lua number]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_win_is_valid(nil)")]])))
 
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'flt': Expected Lua number]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_float('test')")]])))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'flt': Expected Float-like Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_float({[vim.type_idx]=vim.types.dictionary})")]])))
 
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'arr': Expected Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_array(1)")]])))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'arr': Expected Array-like Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_array({[vim.type_idx]=vim.types.dictionary})")]])))
 
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'dct': Expected Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_dictionary(1)")]])))
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Unexpected type',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Invalid 'dct': Expected Dict-like Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim__id_dictionary({[vim.type_idx]=vim.types.array})")]])))
 
-    eq('Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected lua table',
+    eq([[Vim(call):E5108: Error executing lua [string "luaeval()"]:1: Expected Lua table]],
        remove_trace(exc_exec([[call luaeval("vim.api.nvim_set_keymap('', '', '', '')")]])))
 
     -- TODO: check for errors with Tabpage argument

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1511,7 +1511,7 @@ describe('lua stdlib', function()
     eq(true, funcs.luaeval "vim.bo[BUF].modifiable")
     matches("Unknown option 'nosuchopt'$",
        pcall_err(exec_lua, 'return vim.bo.nosuchopt'))
-    matches("Expected lua string$",
+    matches("Expected Lua string$",
        pcall_err(exec_lua, 'return vim.bo[0][0].autoread'))
     matches("Invalid buffer id: %-1$",
        pcall_err(exec_lua, 'return vim.bo[-1].filetype'))


### PR DESCRIPTION
Initially this is just for geting rid of boilerplate, but eventually the types could get exposed as metadata