### PR TITLE
feat(lua): vim.uri

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -301,6 +301,12 @@ LSP FUNCTIONS
 
 LUA
 • vim.register_keystroke_callback()	Use |vim.on_key()| instead.
+- *vim.pretty_print()*			Use |vim.print()| instead.
+- *vim.loop*				Use |vim.uv| instead.
+- *vim.uri_from_fname()*		Use |vim.uri.from_fname()| instead.
+- *vim.uri_from_bufnr()*		Use |vim.uri.from_bufnr()| instead.
+- *vim.uri_to_fname()*			Use |vim.uri.to_fname()| instead.
+- *vim.uri_to_bufn()*			Use |vim.uri.to_bufnr()| instead.
 
 NORMAL COMMANDS
 • *]f* *[f*		Same as "gf".

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -172,11 +172,6 @@ BUILD
   the user's terminfo database won't be loaded and only internal definitions
   for the most common terminals are used: >
 
-  make distclean && make CMAKE_EXTRA_FLAGS="-DENABLE_UNIBILIUM=0" DEPS_CMAKE_FLAGS"-DUSE_BUNDLED_UNIBILIUM=0"
-<
-• On Windows, `tee.exe` is installed with `nvim.exe` by default so that
-  commands like :make, :grep work out of the box.
-
 DEFAULTS
 
 • 'diffopt' default value now includes "indent-heuristic" and "inline:char".
@@ -310,6 +305,7 @@ LSP
 
 LUA
 
+• |vim.uri| |vim.uri.encode()| |vim.uri.decode()|.
 • |vim.net.request()| can fetch files via HTTP GET requests.
 • |vim.wait()| returns the callback results.
 • Lua type annotations for `vim.uv`.

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -30,10 +30,6 @@ end
 -- for legacy reasons (uri) or for performance (_inspector).
 -- most new things should go into a submodule namespace ( vim.foobar.do_thing() )
 vim._extra = {
-  uri_from_fname = true,
-  uri_from_bufnr = true,
-  uri_to_fname = true,
-  uri_to_bufnr = true,
   show_pos = true,
   inspect_pos = true,
 }
@@ -1310,5 +1306,15 @@ vim.loop = vim.uv
 
 -- Deprecated. Remove at Nvim 2.0
 vim.highlight = vim._defer_deprecated_module('vim.highlight', 'vim.hl')
+
+local uri = require('vim.uri')
+--- @deprecated
+vim.uri_from_fname = uri.from_fname
+--- @deprecated
+vim.uri_from_bufnr = uri.from_bufnr
+--- @deprecated
+vim.uri_to_fname = uri.to_fname
+--- @deprecated
+vim.uri_to_bufnr = uri.to_bufnr
 
 return vim

--- a/runtime/lua/vim/_init_packages.lua
+++ b/runtime/lua/vim/_init_packages.lua
@@ -73,14 +73,6 @@ setmetatable(vim, {
     elseif key == 'inspect_pos' or key == 'show_pos' then
       require('vim._inspector')
       return t[key]
-    elseif vim.startswith(key, 'uri_') then
-      --- @type any?
-      local val = require('vim.uri')[key]
-      if val ~= nil then
-        -- Expose all `vim.uri` functions on the `vim` module.
-        t[key] = val
-        return t[key]
-      end
     end
   end,
 })

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -1,6 +1,6 @@
 local fs = vim.fs -- "vim.fs" is a dependency, so must be loaded early.
 local uv = vim.uv
-local uri_encode = vim.uri_encode --- @type function
+local uri_encode = vim.uri.encode --- @type function
 
 --- @type (fun(modename: string): fun()|string)[]
 local loaders = package.loaders

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -1,4 +1,8 @@
--- TODO: This is implemented only for files currently.
+-- TODO:
+-- * This is implemented only for files currently.
+-- * Introduce `Uri` structure which unambiguously represents any file or URL.
+--   See vscode.Uri: https://github.com/microsoft/vscode-uri
+--
 -- https://tools.ietf.org/html/rfc3986
 -- https://tools.ietf.org/html/rfc2732
 -- https://tools.ietf.org/html/rfc2396
@@ -10,63 +14,60 @@ local tohex = require('bit').tohex
 local URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):.*'
 local WINDOWS_URI_SCHEME_PATTERN = '^([a-zA-Z]+[a-zA-Z0-9.+-]*):[a-zA-Z]:.*'
 local PATTERNS = {
-  -- RFC 2396
-  -- https://tools.ietf.org/html/rfc2396#section-2.2
+  -- RFC 2396 https://tools.ietf.org/html/rfc2396#section-2.2
   rfc2396 = "^A-Za-z0-9%-_.!~*'()",
-  -- RFC 2732
-  -- https://tools.ietf.org/html/rfc2732
+  -- RFC 2732 https://tools.ietf.org/html/rfc2732
   rfc2732 = "^A-Za-z0-9%-_.!~*'()%[%]",
-  -- RFC 3986
-  -- https://tools.ietf.org/html/rfc3986#section-2.2
+  -- RFC 3986 https://tools.ietf.org/html/rfc3986#section-2.2
   rfc3986 = "^A-Za-z0-9%-._~!$&'()*+,;=:@/",
 }
 
----Converts hex to char
----@param hex string
----@return string
+--- Converts hex to char
+--- @param hex string
+--- @return string
 local function hex_to_char(hex)
   return schar(tonumber(hex, 16))
 end
 
----@param char string
----@return string
+--- @param char string
+--- @return string
 local function percent_encode_char(char)
   return '%' .. tohex(sbyte(char), 2)
 end
 
----@param uri string
----@return boolean
+--- @param uri string
+--- @return boolean
 local function is_windows_file_uri(uri)
   return uri:match('^file:/+[a-zA-Z]:') ~= nil
 end
 
----URI-encodes a string using percent escapes.
----@param str string string to encode
----@param rfc "rfc2396" | "rfc2732" | "rfc3986" | nil
----@return string encoded string
-function M.uri_encode(str, rfc)
+--- URI-encodes a string.
+--- @param str string string to encode
+--- @param rfc "rfc2396" | "rfc2732" | "rfc3986" | nil
+--- @return string encoded string
+function M.encode(str, rfc)
   local pattern = PATTERNS[rfc] or PATTERNS.rfc3986
   return (str:gsub('([' .. pattern .. '])', percent_encode_char)) -- clamped to 1 retval with ()
 end
 
----URI-decodes a string containing percent escapes.
----@param str string string to decode
----@return string decoded string
-function M.uri_decode(str)
+--- Decodes a URI-encoded string.
+--- @param str string string to decode
+--- @return string decoded string
+function M.decode(str)
   return (str:gsub('%%([a-fA-F0-9][a-fA-F0-9])', hex_to_char)) -- clamped to 1 retval with ()
 end
 
----Gets a URI from a file path.
----@param path string Path to file
----@return string URI
-function M.uri_from_fname(path)
+--- Gets a URI from a file path.
+--- @param path string Path to file
+--- @return string URI
+function M.from_fname(path)
   local volume_path, fname = path:match('^([a-zA-Z]:)(.*)') ---@type string?, string?
   local is_windows = volume_path ~= nil
   if is_windows then
     assert(fname)
-    path = volume_path .. M.uri_encode(fname:gsub('\\', '/'))
+    path = volume_path .. M.encode(fname:gsub('\\', '/'))
   else
-    path = M.uri_encode(path)
+    path = M.encode(path)
   end
   local uri_parts = { 'file://' }
   if is_windows then
@@ -76,10 +77,10 @@ function M.uri_from_fname(path)
   return table.concat(uri_parts)
 end
 
----Gets a URI from a bufnr.
----@param bufnr integer
----@return string URI
-function M.uri_from_bufnr(bufnr)
+--- Gets a URI from a bufnr.
+--- @param bufnr integer
+--- @return string URI
+function M.from_bufnr(bufnr)
   local fname = vim.api.nvim_buf_get_name(bufnr)
   local volume_path = fname:match('^([a-zA-Z]:).*')
   local is_windows = volume_path ~= nil
@@ -93,14 +94,14 @@ function M.uri_from_bufnr(bufnr)
   if scheme then
     return fname
   else
-    return M.uri_from_fname(fname)
+    return M.from_fname(fname)
   end
 end
 
----Gets a filename from a URI.
----@param uri string
----@return string filename or unchanged URI for non-file URIs
-function M.uri_to_fname(uri)
+--- Gets a filename from a URI.
+--- @param uri string
+--- @return string filename or unchanged URI for non-file URIs
+function M.to_fname(uri)
   local scheme = assert(uri:match(URI_SCHEME_PATTERN), 'URI must contain a scheme: ' .. uri)
   if scheme ~= 'file' then
     return uri
@@ -109,8 +110,8 @@ function M.uri_to_fname(uri)
   if fragment_index ~= nil then
     uri = uri:sub(1, fragment_index - 1)
   end
-  uri = M.uri_decode(uri)
-  --TODO improve this.
+  uri = M.decode(uri)
+  -- TODO improve this.
   if is_windows_file_uri(uri) then
     uri = uri:gsub('^file:/+', ''):gsub('/', '\\') --- @type string
   else
@@ -119,12 +120,12 @@ function M.uri_to_fname(uri)
   return uri
 end
 
----Gets the buffer for a uri.
----Creates a new unloaded buffer if no buffer for the uri already exists.
----@param uri string
----@return integer bufnr
-function M.uri_to_bufnr(uri)
-  return vim.fn.bufadd(M.uri_to_fname(uri))
+--- Gets the buffer for a URI, or creates a new unloaded buffer if no buffer exists.
+---
+--- @param uri string
+--- @return integer bufnr
+function M.to_bufnr(uri)
+  return vim.fn.bufadd(M.to_fname(uri))
 end
 
 return M


### PR DESCRIPTION
( followup to https://github.com/neovim/neovim/pull/24491 )

- Introduce `vim.uri` module.
- Deprecate old top-level `vim.uri_x` functions

TODO:

- test coverage for encode/decode
- deprecate() ?
- migrate all internal usages of the old deprecated functions
- introduce `Uri` container object which unambiguously represents a path, reference https://github.com/microsoft/vscode-uri