### PR TITLE
fix(lsp): only disable inlay hints / diagnostics if no other clients are connected

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2118,7 +2118,7 @@ api.nvim_create_autocmd('VimLeavePre', {
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
 ---@param params table|nil Parameters to send to the server
----@param handler lsp-handler See |lsp-handler|
+---@param handler lsp-handler|nil See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2118,7 +2118,7 @@ api.nvim_create_autocmd('VimLeavePre', {
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
 ---@param params table|nil Parameters to send to the server
----@param handler lsp-handler|nil See |lsp-handler|
+---@param handler? lsp-handler See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -408,6 +408,15 @@ local function disable(bufnr)
   clear(bufnr)
 end
 
+--- Refresh diagnostics, only if we have attached clients that support it
+---@param bufnr (integer) buffer number
+---@param opts? table Additional options to pass to util_refresh
+---@private
+local function _refresh(bufnr, opts)
+  opts['bufnr'] = bufnr
+  util._refresh(ms.textDocument_diagnostic, opts)
+end
+
 --- Enable pull diagnostics for a buffer
 ---@param bufnr (integer) Buffer handle, or 0 for current
 ---@private
@@ -429,7 +438,7 @@ function M._enable(bufnr)
           return
         end
         if bufstates[bufnr] and bufstates[bufnr].enabled then
-          util._refresh(ms.textDocument_diagnostic, { bufnr = bufnr, only_visible = true })
+          _refresh(bufnr, { only_visible = true })
         end
       end,
       group = augroup,
@@ -438,7 +447,7 @@ function M._enable(bufnr)
     api.nvim_buf_attach(bufnr, false, {
       on_reload = function()
         if bufstates[bufnr] and bufstates[bufnr].enabled then
-          util._refresh(ms.textDocument_diagnostic, { bufnr = bufnr })
+          _refresh(bufnr)
         end
       end,
       on_detach = function()
@@ -448,8 +457,16 @@ function M._enable(bufnr)
 
     api.nvim_create_autocmd('LspDetach', {
       buffer = bufnr,
-      callback = function()
-        disable(bufnr)
+      callback = function(args)
+        local clients = vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_diagnostic })
+
+        if
+          not vim.iter(clients):any(function(c)
+            return c.id ~= args.data.client_id
+          end)
+        then
+          disable(bufnr)
+        end
       end,
       group = augroup,
     })

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -410,9 +410,10 @@ end
 
 --- Refresh diagnostics, only if we have attached clients that support it
 ---@param bufnr (integer) buffer number
----@param opts? table Additional options to pass to util_refresh
+---@param opts? table Additional options to pass to util._refresh
 ---@private
 local function _refresh(bufnr, opts)
+  opts = opts or {}
   opts['bufnr'] = bufnr
   util._refresh(ms.textDocument_diagnostic, opts)
 end
@@ -438,7 +439,7 @@ function M._enable(bufnr)
           return
         end
         if bufstates[bufnr] and bufstates[bufnr].enabled then
-          _refresh(bufnr, { only_visible = true })
+          _refresh(bufnr, { only_visible = true, client_id = opts.data.client_id })
         end
       end,
       group = augroup,

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -131,6 +131,13 @@ local function disable(bufnr)
   end
 end
 
+--- Refresh inlay hints, only if we have attached clients that support it
+---@param bufnr (integer) Buffer handle, or 0 for current
+---@private
+local function _refresh(bufnr)
+  util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+end
+
 --- Enable inlay hints for a buffer
 ---@param bufnr (integer) Buffer handle, or 0 for current
 local function enable(bufnr)
@@ -150,18 +157,18 @@ local function enable(bufnr)
           return
         end
         if bufstates[bufnr] and bufstates[bufnr].enabled then
-          util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+          _refresh(bufnr)
         end
       end,
       group = augroup,
     })
-    util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+    _refresh(bufnr)
     api.nvim_buf_attach(bufnr, false, {
       on_reload = function(_, cb_bufnr)
         clear(cb_bufnr)
         if bufstates[cb_bufnr] and bufstates[cb_bufnr].enabled then
           bufstates[cb_bufnr].applied = {}
-          util._refresh(ms.textDocument_inlayHint, { bufnr = cb_bufnr })
+          _refresh(cb_bufnr)
         end
       end,
       on_detach = function(_, cb_bufnr)
@@ -170,14 +177,22 @@ local function enable(bufnr)
     })
     api.nvim_create_autocmd('LspDetach', {
       buffer = bufnr,
-      callback = function()
-        disable(bufnr)
+      callback = function(args)
+        local clients = vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_inlayHint })
+
+        if
+          not vim.iter(clients):any(function(c)
+            return c.id ~= args.data.client_id
+          end)
+        then
+          disable(bufnr)
+        end
       end,
       group = augroup,
     })
   else
     bufstate.enabled = true
-    util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+    _refresh(bufnr)
   end
 end
 

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -133,9 +133,12 @@ end
 
 --- Refresh inlay hints, only if we have attached clients that support it
 ---@param bufnr (integer) Buffer handle, or 0 for current
+---@param opts? table Additional options to pass to util._refresh
 ---@private
-local function _refresh(bufnr)
-  util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+local function _refresh(bufnr, opts)
+  opts = opts or {}
+  opts['bufnr'] = bufnr
+  util._refresh(ms.textDocument_inlayHint, opts)
 end
 
 --- Enable inlay hints for a buffer
@@ -157,7 +160,7 @@ local function enable(bufnr)
           return
         end
         if bufstates[bufnr] and bufstates[bufnr].enabled then
-          _refresh(bufnr)
+          _refresh(bufnr, { client_id = opts.data.client_id })
         end
       end,
       group = augroup,

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2122,6 +2122,7 @@ end
 function M.make_workspace_params(added, removed)
   return { event = { added = added, removed = removed } }
 end
+
 --- Returns indentation size.
 ---
 ---@see 'shiftwidth'
@@ -2193,15 +2194,23 @@ end
 --- Request updated LSP information for a buffer.
 ---
 ---@param method string LSP method to call
----@param opts (nil|table) Optional arguments
+---@param opts? table Optional arguments
 ---  - bufnr (integer, default: 0): Buffer to refresh
 ---  - only_visible (boolean, default: false): Whether to only refresh for the visible regions of the buffer
+---  - force (boolean, default: false): Whether to force a refresh even if no clients support the method
 function M._refresh(method, opts)
   opts = opts or {}
   local bufnr = opts.bufnr
   if bufnr == nil or bufnr == 0 then
     bufnr = api.nvim_get_current_buf()
   end
+
+  if
+    not (opts.force or false) and #vim.lsp.get_clients({ bufnr = bufnr, method = method }) == 0
+  then
+    return
+  end
+
   local only_visible = opts.only_visible or false
   for _, window in ipairs(api.nvim_list_wins()) do
     if api.nvim_win_get_buf(window) == bufnr then

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2193,11 +2193,13 @@ end
 ---@private
 --- Request updated LSP information for a buffer.
 ---
+---@class lsp.util.RefreshOptions
+---@field bufnr integer? Buffer to refresh (default: 0)
+---@field only_visible? boolean Whether to only refresh for the visible regions of the buffer (default: false)
+---@field client_id? integer Client ID to refresh (default: all clients)
+--
 ---@param method string LSP method to call
----@param opts? table Optional arguments
----  - bufnr (integer, default: 0): Buffer to refresh
----  - only_visible (boolean, default: false): Whether to only refresh for the visible regions of the buffer
----  - force (boolean, default: false): Whether to force a refresh even if no clients support the method
+---@param opts? lsp.util.RefreshOptions Options table
 function M._refresh(method, opts)
   opts = opts or {}
   local bufnr = opts.bufnr
@@ -2205,28 +2207,32 @@ function M._refresh(method, opts)
     bufnr = api.nvim_get_current_buf()
   end
 
-  if
-    not (opts.force or false) and #vim.lsp.get_clients({ bufnr = bufnr, method = method }) == 0
-  then
+  local clients = vim.lsp.get_clients({ bufnr = bufnr, method = method, id = opts.client_id })
+
+  if #clients == 0 then
     return
   end
 
   local only_visible = opts.only_visible or false
-  for _, window in ipairs(api.nvim_list_wins()) do
-    if api.nvim_win_get_buf(window) == bufnr then
-      local first = vim.fn.line('w0', window)
-      local last = vim.fn.line('w$', window)
-      local params = {
-        textDocument = M.make_text_document_params(bufnr),
-        range = {
-          start = { line = first - 1, character = 0 },
-          ['end'] = { line = last, character = 0 },
-        },
-      }
-      vim.lsp.buf_request(bufnr, method, params)
+
+  if only_visible then
+    for _, window in ipairs(api.nvim_list_wins()) do
+      if api.nvim_win_get_buf(window) == bufnr then
+        local first = vim.fn.line('w0', window)
+        local last = vim.fn.line('w$', window)
+        local params = {
+          textDocument = M.make_text_document_params(bufnr),
+          range = {
+            start = { line = first - 1, character = 0 },
+            ['end'] = { line = last, character = 0 },
+          },
+        }
+        for _, client in ipairs(clients) do
+          client.request(method, params, nil, bufnr)
+        end
+      end
     end
-  end
-  if not only_visible then
+  else
     local params = {
       textDocument = M.make_text_document_params(bufnr),
       range = {
@@ -2234,7 +2240,9 @@ function M._refresh(method, opts)
         ['end'] = { line = api.nvim_buf_line_count(bufnr), character = 0 },
       },
     }
-    vim.lsp.buf_request(bufnr, method, params)
+    for _, client in ipairs(clients) do
+      client.request(method, params, nil, bufnr)
+    end
   end
 end
 


### PR DESCRIPTION
In https://github.com/neovim/neovim/pull/24469#issuecomment-1651992691, @stasjok observed that in the current implementation, if one LSP client disconnects from a buffer, then inlay_hints and diagnostics will be disabled.

In this PR I've tried to fix that by examining the other LSP clients attached to the current buffer in the `LspDetach` handler. NB the handler is called *before* the client detaches, so we expect the number of attached clients to be 1 if this is the last client in the process of disconnecting.

I also used a similar method in each feature's refresh logic to prevent making calls if no attached clients support the method. This can happen if e.g. you enable inlay hints on a buffer that doesn't have any clients connected that support it.