### PR TITLE
fix(lsp): do not assume client capability exists in watchfiles check

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -988,8 +988,7 @@ start_client({config})                                *vim.lsp.start_client()*
                     passed to the language server on initialization. Hint: use
                     make_client_capabilities() and modify its result.
                     • Note: To send an empty dictionary use
-                      `{[vim.type_idx]=vim.types.dictionary}`, else it will be
-                      encoded as an array.
+                      |vim.empty_dict()|, else it will be encoded as an array.
 
                   • handlers: Map of language server method names to
                     |lsp-handler|

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1027,8 +1027,7 @@ end
 ---       \|vim.lsp.protocol.make_client_capabilities()|, passed to the language
 ---       server on initialization. Hint: use make_client_capabilities() and modify
 ---       its result.
----       - Note: To send an empty dictionary use
----         `{[vim.type_idx]=vim.types.dictionary}`, else it will be encoded as an
+---       - Note: To send an empty dictionary use |vim.empty_dict()|, else it will be encoded as an
 ---         array.
 ---
 --- - handlers: Map of language server method names to |lsp-handler|

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -121,12 +121,15 @@ M._poll_exclude_pattern = parse('**/.git/{objects,subtree-cache}/**')
 function M.register(reg, ctx)
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  if
-    -- Ill-behaved servers may not honor the client capability and try to register
-    -- anyway, so ignore requests when the user has opted out of the feature.
-    not client.config.capabilities.workspace.didChangeWatchedFiles.dynamicRegistration
-    or not client.workspace_folders
-  then
+  -- Ill-behaved servers may not honor the client capability and try to register
+  -- anyway, so ignore requests when the user has opted out of the feature.
+  local has_capability = vim.tbl_get(
+    client.config.capabilities or {},
+    'workspace',
+    'didChangeWatchedFiles',
+    'dynamicRegistration'
+  )
+  if not has_capability or not client.workspace_folders then
     return
   end
   local watch_regs = {} --- @type table<string,{pattern:userdata,kind:integer}>


### PR DESCRIPTION
PR https://github.com/neovim/neovim/pull/23689 assumes `client.config.capabilities.workspace.didChangeWatchedFiles`
exists when checking `dynamicRegistration`, but thats's true only if it was
passed to `vim.lsp.start{_client}`.

This caused https://github.com/neovim/neovim/issues/23806 (still an issue in v0.9.1; needs manual backport), but https://github.com/neovim/neovim/pull/23681
fixed it by defaulting `config.capabilities` to `make_client_capabilities` if
not passed to `vim.lsp.start{_client}`.

However, the bug resurfaces on HEAD if you provide a non-nil `capabilities` to
`vim.lsp.start{_client}` with missing fields (e.g: not made via
`make_client_capabilities`).

From what I see, the spec says such missing fields should be interpreted as an
absence of the capability (including those indicated by missing sub-fields):
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities

Also, suggest `vim.empty_dict` for an empty dict in
`:h vim.lsp.start_client()` (`{[vim.type_idx]=vim.types.dictionary}`
no longer works anyway, probably since the cjson switch).