### PR TITLE
fix(lsp): do not assume client capability exists in watchfiles check

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -974,8 +974,7 @@ start_client({config})                                *vim.lsp.start_client()*
                     passed to the language server on initialization. Hint: use
                     make_client_capabilities() and modify its result.
                     • Note: To send an empty dictionary use
-                      `{[vim.type_idx]=vim.types.dictionary}`, else it will be
-                      encoded as an array.
+                      |vim.empty_dict()|, else it will be encoded as an array.
 
                   • handlers: Map of language server method names to
                     |lsp-handler|

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -933,8 +933,7 @@ end
 ---       |vim.lsp.protocol.make_client_capabilities()|, passed to the language
 ---       server on initialization. Hint: use make_client_capabilities() and modify
 ---       its result.
----       - Note: To send an empty dictionary use
----         `{[vim.type_idx]=vim.types.dictionary}`, else it will be encoded as an
+---       - Note: To send an empty dictionary use |vim.empty_dict()|, else it will be encoded as an
 ---         array.
 ---
 --- - handlers: Map of language server method names to |lsp-handler|

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -193,12 +193,15 @@ local to_lsp_change_type = {
 function M.register(reg, ctx)
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  if
-    -- Ill-behaved servers may not honor the client capability and try to register
-    -- anyway, so ignore requests when the user has opted out of the feature.
-    not client.config.capabilities.workspace.didChangeWatchedFiles.dynamicRegistration
-    or not client.workspace_folders
-  then
+  -- Ill-behaved servers may not honor the client capability and try to register
+  -- anyway, so ignore requests when the user has opted out of the feature.
+  local has_capability = vim.tbl_get(
+    client.config.capabilities or {},
+    'workspace',
+    'didChangeWatchedFiles',
+    'dynamicRegistration'
+  )
+  if not has_capability or not client.workspace_folders then
     return
   end
   local watch_regs = {}

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -4217,58 +4217,79 @@ describe('LSP', function()
 
     it("ignores registrations by servers when the client doesn't advertise support", function()
       exec_lua(create_server_definition)
-      local result = exec_lua([[
-        local server = _create_server()
-        local client_id = vim.lsp.start({
-          name = 'watchfiles-test',
-          cmd = server.cmd,
-          root_dir = 'some_dir',
-          capabilities = {
-            workspace = {
-              didChangeWatchedFiles = {
-                dynamicRegistration = false,
-              },
-            },
-          },
-        })
-
-        local watching = false
+      exec_lua([[
+        server = _create_server()
         require('vim.lsp._watchfiles')._watchfunc = function(_, _, callback)
           -- Since the registration is ignored, this should not execute and `watching` should stay false
           watching = true
           return function() end
         end
+      ]])
 
-        vim.lsp.handlers['client/registerCapability'](nil, {
-          registrations = {
-            {
-              id = 'watchfiles-test-kind',
-              method = 'workspace/didChangeWatchedFiles',
-              registerOptions = {
-                watchers = {
-                  {
-                    globPattern = '**/*',
+      local function check_registered(capabilities)
+        return exec_lua([[
+          watching = false
+          local client_id = vim.lsp.start({
+            name = 'watchfiles-test',
+            cmd = server.cmd,
+            root_dir = 'some_dir',
+            capabilities = ...,
+          }, {
+            reuse_client = function() return false end,
+          })
+
+          vim.lsp.handlers['client/registerCapability'](nil, {
+            registrations = {
+              {
+                id = 'watchfiles-test-kind',
+                method = 'workspace/didChangeWatchedFiles',
+                registerOptions = {
+                  watchers = {
+                    {
+                      globPattern = '**/*',
+                    },
                   },
                 },
               },
             },
-          },
-        }, { client_id = client_id })
+          }, { client_id = client_id })
 
-        -- Ensure no errors occur when unregistering something that was never really registered.
-        vim.lsp.handlers['client/unregisterCapability'](nil, {
-          unregisterations = {
-            {
-              id = 'watchfiles-test-kind',
-              method = 'workspace/didChangeWatchedFiles',
+          -- Ensure no errors occur when unregistering something that was never really registered.
+          vim.lsp.handlers['client/unregisterCapability'](nil, {
+            unregisterations = {
+              {
+                id = 'watchfiles-test-kind',
+                method = 'workspace/didChangeWatchedFiles',
+              },
+            },
+          }, { client_id = client_id })
+
+          vim.lsp.stop_client(client_id, true)
+          return watching
+        ]], capabilities)
+      end
+
+      eq(false, check_registered(nil))  -- start{_client}() defaults to make_client_capabilities().
+      eq(false, check_registered(vim.empty_dict()))
+      eq(false, check_registered({
+          workspace = {
+            ignoreMe = true,
+          },
+        }))
+      eq(false, check_registered({
+          workspace = {
+            didChangeWatchedFiles = {
+              dynamicRegistration = false,
             },
           },
-        }, { client_id = client_id })
-
-        return watching
-      ]])
-
-      eq(false, result)
+        }))
+      eq(true, check_registered({
+          workspace = {
+            didChangeWatchedFiles = {
+              dynamicRegistration = true,
+            },
+          },
+        }))
     end)
   end)
 end)


### PR DESCRIPTION
Backports #24550.

Adjusts test to expect that didChangeWatchedFiles is *not* registered if client `capabilities` is nil (as not enabled by default for v0.9).