### PR TITLE
feat(lua)!: add vim.tbl_inv and deprecate vim.tbl_add_reverse_lookup

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2113,18 +2113,6 @@ vim.startswith({s}, {prefix})                               *vim.startswith()*
     Return: ~
         (boolean) `true` if `prefix` is a prefix of `s`
 
-vim.tbl_add_reverse_lookup({o})                 *vim.tbl_add_reverse_lookup()*
-    Add the reverse lookup values to an existing table. For example:
-    `tbl_add_reverse_lookup { A = 1 } == { [1] = 'A', A = 1 }`
-
-    Note that this modifies the input.
-
-    Parameters: ~
-      • {o}  (table) Table to add the reverse to
-
-    Return: ~
-        (table) o
-
 vim.tbl_contains({t}, {value}, {opts})                    *vim.tbl_contains()*
     Checks if a table contains a given value, specified either directly or via
     a predicate that is checked for each value.
@@ -2242,6 +2230,19 @@ vim.tbl_get({o}, {...})                                        *vim.tbl_get()*
 
     Return: ~
         any Nested value indexed by key (if it exists), else nil
+
+vim.tbl_inv({t})                                               *vim.tbl_inv()*
+    Return the inverse table with the keys and values swapped Examples: >lua
+
+       vim.tbl_inv({ a = 1, b = 2, c = 3 })
+       -- == { [1] = 'a', [2] = 'b', [3] = 'c'}
+<
+
+    Parameters: ~
+      • {t}  (table) Table to invert
+
+    Return: ~
+        (table) Inverted table
 
 vim.tbl_isarray({t})                                       *vim.tbl_isarray()*
     Tests if a Lua table can be treated as an array (a table indexed by

--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -1,11 +1,11 @@
 local M = {}
 
 --- Enumeration describing the types of events watchers will emit.
-M.FileChangeType = vim.tbl_add_reverse_lookup({
+M.FileChangeType = {
   Created = 1,
   Changed = 2,
   Deleted = 3,
-})
+}
 
 --- Joins filepath elements by static '/' separator
 ---

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2,6 +2,12 @@ local api, if_nil = vim.api, vim.F.if_nil
 
 local M = {}
 
+--- @alias DiagnosticSeverityName
+--- | 'ERROR'
+--- | 'WARN'
+--- | 'INFO'
+--- | 'HINT'
+
 ---@enum DiagnosticSeverity
 M.severity = {
   ERROR = 1,
@@ -10,7 +16,8 @@ M.severity = {
   HINT = 4,
 }
 
-vim.tbl_add_reverse_lookup(M.severity)
+--- @type table<integer,DiagnosticSeverityName>
+local severity_name = vim.tbl_inv(M.severity)
 
 -- Mappings from qflist/loclist error types to severities
 M.severity.E = M.severity.ERROR
@@ -195,9 +202,9 @@ local diagnostic_severities = {
 
 -- Make a map from DiagnosticSeverity -> Highlight Name
 local function make_highlight_map(base_name)
-  local result = {}
+  local result = {} --- @type table<DiagnosticSeverity,string>
   for k in pairs(diagnostic_severities) do
-    local name = M.severity[k]
+    local name = severity_name[k]
     name = name:sub(1, 1) .. name:sub(2):lower()
     result[k] = 'Diagnostic' .. base_name .. name
   end
@@ -220,9 +227,8 @@ local define_default_signs = (function()
 
     for severity, sign_hl_name in pairs(sign_highlight_map) do
       if vim.tbl_isempty(vim.fn.sign_getdefined(sign_hl_name)) then
-        local severity_name = M.severity[severity]
         vim.fn.sign_define(sign_hl_name, {
-          text = (severity_name or 'U'):sub(1, 1),
+          text = (severity_name[severity] or 'U'):sub(1, 1),
           texthl = sign_hl_name,
           linehl = '',
           numhl = '',

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -188,10 +188,11 @@ end
 lsp.client_errors = tbl_extend(
   'error',
   lsp_rpc.client_errors,
-  vim.tbl_add_reverse_lookup({
-    ON_INIT_CALLBACK_ERROR = table.maxn(lsp_rpc.client_errors) + 1,
-  })
+  { ON_INIT_CALLBACK_ERROR = table.maxn(lsp_rpc.client_errors) + 1 }
 )
+
+--- @nodoc
+lsp.client_errors_inv = vim.tbl_inv(lsp.client_errors)
 
 --- Normalizes {encoding} to valid LSP encoding names.
 ---
@@ -1057,7 +1058,7 @@ end
 ---       when the client operation throws an error. `code` is a number describing
 ---       the error. Other arguments may be passed depending on the error kind.  See
 ---       `vim.lsp.rpc.client_errors` for possible errors.
----       Use `vim.lsp.rpc.client_errors[code]` to get human-friendly name.
+---       Use `vim.lsp.rpc.client_errors_inv[code]` to get human-friendly name.
 ---
 --- - before_init: Callback with parameters (initialize_params, config)
 ---       invoked before the LSP "initialize" phase, where `params` contains the
@@ -1178,12 +1179,13 @@ function lsp.start_client(config)
   ---@param code (integer) Error code
   ---@param err (...) Other arguments may be passed depending on the error kind
   ---@see vim.lsp.rpc.client_errors for possible errors. Use
-  ---`vim.lsp.rpc.client_errors[code]` to get a human-friendly name.
+  ---`vim.lsp.rpc.client_errors_inv[code]` to get a human-friendly name.
   function dispatch.on_error(code, err)
+    local code_name = lsp.client_errors_inv[code]
     if log.error() then
-      log.error(log_prefix, 'on_error', { code = lsp.client_errors[code], err = err })
+      log.error(log_prefix, 'on_error', { code = code_name, err = err })
     end
-    err_message(log_prefix, ': Error ', lsp.client_errors[code], ': ', vim.inspect(err))
+    err_message(log_prefix, ': Error ', code_name, ': ', vim.inspect(err))
     if config.on_error then
       local status, usererr = pcall(config.on_error, code, err)
       if not status then

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -131,10 +131,6 @@ do
   end
 end
 
--- This is put here on purpose after the loop above so that it doesn't
--- interfere with iterating the levels
-vim.tbl_add_reverse_lookup(log.levels)
-
 --- Sets the current log level.
 ---@param level (string|integer) One of `vim.lsp.log.levels`
 function log.set_level(level)

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -1,7 +1,5 @@
 -- Protocol for the Microsoft Language Server Protocol (mslsp)
 
-local protocol = {}
-
 --[=[
 ---@private
 --- Useful for interfacing with:
@@ -20,8 +18,11 @@ function transform_schema_to_table()
 end
 --]=]
 
-local constants = {
-  --- @enum lsp.DiagnosticSeverity
+--- @diagnostic disable-next-line:deprecated
+local bitable = vim.tbl_add_reverse_lookup
+
+local protocol = {
+  --- @enum vim.lsp.DiagnosticSeverity
   DiagnosticSeverity = {
     -- Reports an error.
     Error = 1,
@@ -33,7 +34,7 @@ local constants = {
     Hint = 4,
   },
 
-  --- @enum lsp.DiagnosticTag
+  --- @enum vim.lsp.DiagnosticTag
   DiagnosticTag = {
     -- Unused or unnecessary code
     Unnecessary = 1,
@@ -41,7 +42,7 @@ local constants = {
     Deprecated = 2,
   },
 
-  ---@enum lsp.MessageType
+  ---@enum vim.lsp.MessageType
   MessageType = {
     -- An error message.
     Error = 1,
@@ -54,7 +55,7 @@ local constants = {
   },
 
   -- The file event type.
-  ---@enum lsp.FileChangeType
+  ---@enum vim.lsp.FileChangeType
   FileChangeType = {
     -- The file got created.
     Created = 1,
@@ -64,8 +65,10 @@ local constants = {
     Deleted = 3,
   },
 
-  -- The kind of a completion entry.
-  CompletionItemKind = {
+  --- The kind of a completion entry.
+  --- @class vim.lsp.CompletionItemKind
+  --- @field [lsp.CompletionItemKind] string
+  CompletionItemKind = bitable({
     Text = 1,
     Method = 2,
     Function = 3,
@@ -91,7 +94,7 @@ local constants = {
     Event = 23,
     Operator = 24,
     TypeParameter = 25,
-  },
+  }),
 
   -- How a completion was triggered
   CompletionTriggerKind = {
@@ -115,8 +118,10 @@ local constants = {
     Write = 3,
   },
 
-  -- A symbol kind.
-  SymbolKind = {
+  --- A symbol kind.
+  --- @class vim.lsp.SymbolKind
+  --- @field [lsp.SymbolKind] string
+  SymbolKind = bitable({
     File = 1,
     Module = 2,
     Namespace = 3,
@@ -143,10 +148,10 @@ local constants = {
     Event = 24,
     Operator = 25,
     TypeParameter = 26,
-  },
+  }),
 
   -- Represents reasons why a text document is saved.
-  ---@enum lsp.TextDocumentSaveReason
+  ---@enum vim.lsp.TextDocumentSaveReason
   TextDocumentSaveReason = {
     -- Manually triggered, e.g. by the user pressing save, by starting debugging,
     -- or by an API call.
@@ -218,8 +223,10 @@ local constants = {
     unknownProtocolVersion = 1,
   },
 
-  -- Defines how the host (editor) should sync document changes to the language server.
-  TextDocumentSyncKind = {
+  --- Defines how the host (editor) should sync document changes to the language server.
+  --- @class vim.lsp.TextDocumentSyncKind
+  --- @field [lsp.TextDocumentSyncKind] string
+  TextDocumentSyncKind = bitable({
     -- Documents should not be synced at all.
     None = 0,
     -- Documents are synced by always sending the full content
@@ -229,7 +236,7 @@ local constants = {
     -- After that only incremental updates to the document are
     -- send.
     Incremental = 2,
-  },
+  }),
 
   WatchKind = {
     -- Interested in create events.
@@ -240,9 +247,11 @@ local constants = {
     Delete = 4,
   },
 
-  -- Defines whether the insert text in a completion item should be interpreted as
-  -- plain text or a snippet.
-  InsertTextFormat = {
+  --- Defines whether the insert text in a completion item should be interpreted as
+  --- plain text or a snippet.
+  --- @class vim.lsp.InsertTextFormat
+  --- @field [lsp.InsertTextFormat] string
+  InsertTextFormat = bitable({
     -- The primary text to be inserted is treated as a plain string.
     PlainText = 1,
     -- The primary text to be inserted is treated as a snippet.
@@ -252,7 +261,7 @@ local constants = {
     -- the end of the snippet. Placeholders with equal identifiers are linked,
     -- that is typing in one will update others too.
     Snippet = 2,
-  },
+  }),
 
   -- A set of predefined code action kinds
   CodeActionKind = {
@@ -300,7 +309,7 @@ local constants = {
     SourceOrganizeImports = 'source.organizeImports',
   },
   -- The reason why code actions were requested.
-  ---@enum lsp.CodeActionTriggerKind
+  ---@enum vim.lsp.CodeActionTriggerKind
   CodeActionTriggerKind = {
     -- Code actions were explicitly requested by the user or by an extension.
     Invoked = 1,
@@ -311,12 +320,6 @@ local constants = {
     Automatic = 2,
   },
 }
-
-for k, v in pairs(constants) do
-  local tbl = vim.deepcopy(v)
-  vim.tbl_add_reverse_lookup(tbl)
-  protocol[k] = tbl
-end
 
 --[=[
 --Text document specific client capabilities.
@@ -717,7 +720,7 @@ function protocol.make_client_capabilities()
         codeActionLiteralSupport = {
           codeActionKind = {
             valueSet = (function()
-              local res = vim.tbl_values(constants.CodeActionKind)
+              local res = vim.tbl_values(protocol.CodeActionKind)
               table.sort(res)
               return res
             end)(),

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -125,7 +125,9 @@ M.client_errors = {
   SERVER_RESULT_CALLBACK_ERROR = 7,
 }
 
-M.client_errors = vim.tbl_add_reverse_lookup(M.client_errors)
+--- @nodoc
+--- @type table<integer,string>
+local client_errors_inv = vim.tbl_inv(M.client_errors)
 
 --- Constructs an error message from an LSP error object.
 ---
@@ -214,7 +216,7 @@ end
 ---@param err (any): Details about the error
 ---any)
 function default_dispatchers.on_error(code, err)
-  local _ = log.error() and log.error('client_error:', M.client_errors[code], err)
+  local _ = log.error() and log.error('client_error:', client_errors_inv[code], err)
 end
 
 ---@private

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -425,6 +425,7 @@ function vim.deep_equal(a, b)
   return false
 end
 
+--- @deprecated
 --- Add the reverse lookup values to an existing table.
 --- For example:
 --- ``tbl_add_reverse_lookup { A = 1 } == { [1] = 'A', A = 1 }``
@@ -448,6 +449,24 @@ function vim.tbl_add_reverse_lookup(o)
     o[v] = k
   end
   return o
+end
+
+--- Return the inverse table with the keys and values swapped
+--- Examples:
+--- <pre>lua
+---   vim.tbl_inv({ a = 1, b = 2, c = 3 })
+---   -- == { [1] = 'a', [2] = 'b', [3] = 'c'}
+--- </pre>
+--- @param t table Table to invert
+--- @return table # Inverted table
+function vim.tbl_inv(t)
+  local r = {}
+  --- @diagnostic disable-next-line:no-unknown
+  for k, v in pairs(t) do
+    --- @diagnostic disable-next-line:no-unknown
+    r[v] = k
+  end
+  return r
 end
 
 --- Index into a table (first argument) via string keys passed as subsequent arguments.

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -796,24 +796,6 @@ describe('lua stdlib', function()
     eq({2}, exec_lua [[ return vim.list_extend({}, {2;a=1}, -1, 2) ]])
   end)
 
-  it('vim.tbl_add_reverse_lookup', function()
-    eq(true, exec_lua [[
-    local a = { A = 1 }
-    vim.tbl_add_reverse_lookup(a)
-    return vim.deep_equal(a, { A = 1; [1] = 'A'; })
-    ]])
-    -- Throw an error for trying to do it twice (run into an existing key)
-    local code = [[
-    local res = {}
-    local a = { A = 1 }
-    vim.tbl_add_reverse_lookup(a)
-    assert(vim.deep_equal(a, { A = 1; [1] = 'A'; }))
-    vim.tbl_add_reverse_lookup(a)
-    ]]
-    matches('The reverse lookup found an existing value for "[1A]" while processing key "[1A]"$',
-      pcall_err(exec_lua, code))
-  end)
-
   it('vim.spairs', function()
     local res = ''
     local table = {


### PR DESCRIPTION
`vim.tbl_add_reverse_lookup` isn't type safe and is almost impossible for an LSP to analyze properly, since it is not a union type, and hence causes lots of diagnostics. It also just generally makes thing more confusing since it blurs both sides of the mapping.

Instead add `vim.tbl_inv` to keep the lookup separate.