### PR TITLE
feat(events): add `MacroEnter` and `MacroLeave` events

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -836,6 +836,15 @@ LspProgress			See |LspProgress|
 LspRequest			See |LspRequest|
 LspTokenUpdate			See |LspTokenUpdate|
 
+							*MacroEnter*
+MacroEnter			When a macro starts replaying.
+				The pattern is the current file name, and
+				|reg_executing()| is the replayed register.
+							*MacroLeave*
+MacroLeave			When a macro stops replaying.
+				The pattern is the current file name, and
+				|reg_executing()| is the replayed register.
+
 							*MarkSet*
 MarkSet				After a |mark| is set by |m|, |:mark|, and
 				|nvim_buf_set_mark()|, or deleted by |:delmarks|

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -932,6 +932,15 @@ LspProgress			See |LspProgress|
 LspRequest			See |LspRequest|
 LspTokenUpdate			See |LspTokenUpdate|
 
+							*MacroEnter*
+MacroEnter			When a macro starts replaying.
+				The pattern is the current file name, and
+				|reg_executing()| is the replayed register.
+							*MacroLeave*
+MacroLeave			When a macro stops replaying.
+				The pattern is the current file name, and
+				|reg_executing()| is the replayed register.
+
 							*MarkSet*
 MarkSet				After a |mark| is set by |m|, |:mark|, and
 				|nvim_buf_set_mark()|, or deleted by |:delmarks|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -136,6 +136,7 @@ EDITOR
 
 EVENTS
 
+• New events for replaying macros: |MacroEnter| and |MacroLeave|.
 • |:delmarks| now triggers the |MarkSet| autocommand with line==col==0, same
   as |nvim_buf_del_mark()|
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -320,6 +320,7 @@ EDITOR
 
 EVENTS
 
+• New events for replaying macros: |MacroEnter| and |MacroLeave|.
 • |:delmarks| now triggers the |MarkSet| autocommand with line==col==0, same
   as |nvim_buf_del_mark()|
 • |ChanClose| is triggered after a channel is closed, before it is removed.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -128,6 +128,8 @@ q{0-9a-zA-Z"}		Record typed characters into register {0-9a-zA-Z"}
 			mapping.  This matters, for example, for undo, which
 			only syncs when commands were typed.
 
+			See also |RecordingEnter| and |RecordingLeave|.
+
 q			Stops recording.
 			Implementation note: The 'q' that stops recording is
 			not stored in the register, unless it was the result
@@ -144,6 +146,7 @@ q			Stops recording.
 			For "@=" you are prompted to enter an expression.  The
 			result of the expression is then executed.
 			See also |@:|.
+			See also |MacroEnter| and |MacroLeave|.
 
 							*@@* *E748*
 @@			Repeat the previous @{0-9a-z":*} [count] times.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -270,6 +270,8 @@ q{0-9a-zA-Z"}		Record typed characters into register {0-9a-zA-Z"}
 			mapping.  This matters, for example, for undo, which
 			only syncs when commands were typed.
 
+			See also |RecordingEnter| and |RecordingLeave|.
+
 q			Stops recording.
 			Implementation note: The 'q' that stops recording is
 			not stored in the register, unless it was the result
@@ -286,6 +288,7 @@ q			Stops recording.
 			For "@=" you are prompted to enter an expression.  The
 			result of the expression is then executed.
 			See also |@:|.
+			See also |MacroEnter| and |MacroLeave|.
 
 							*@@* *E748*
 @@			Repeat the previous @{0-9a-z":*} [count] times.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -336,6 +336,8 @@ Events (autocommands):
 - Fixed inconsistent behavior in execution of nested autocommands #23368
 - |BufModifiedSet|
 - |Progress|
+- |MacroEnter|
+- |MacroLeave|
 - |RecordingEnter|
 - |RecordingLeave|
 - |SearchWrapped|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -351,6 +351,8 @@ Events (autocommands):
 - |OptionSet| is triggered for 'modified' when writing a file, undoing changes,
   or using |:set| modified.
 - |Progress|
+- |MacroEnter|
+- |MacroLeave|
 - |RecordingEnter|
 - |RecordingLeave|
 - |SearchWrapped|

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -162,6 +162,8 @@ error('Cannot require a meta file')
 --- |'LspProgress'
 --- |'LspRequest'
 --- |'LspTokenUpdate'
+--- |'MacroEnter'
+--- |'MacroLeave'
 --- |'MarkSet'
 --- |'MenuPopup'
 --- |'ModeChanged'

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -163,6 +163,8 @@ error('Cannot require a meta file')
 --- |'LspProgress'
 --- |'LspRequest'
 --- |'LspTokenUpdate'
+--- |'MacroEnter'
+--- |'MacroLeave'
 --- |'MarkSet'
 --- |'MenuPopup'
 --- |'ModeChanged'

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -81,6 +81,8 @@ return {
     LspProgress = false, -- after a LSP progress update
     LspRequest = false, -- after an LSP request is started, canceled, or completed
     LspTokenUpdate = false, -- after a visible LSP token is updated
+    MacroEnter = true, -- when starting to replay a macro
+    MacroLeave = true, -- just before a macro stops replaying
     MarkSet = false, -- after a mark is set
     MenuPopup = false, -- just before popup menu is displayed
     ModeChanged = false, -- after changing the mode
@@ -165,6 +167,8 @@ return {
     LspProgress = true,
     LspRequest = true,
     LspTokenUpdate = true,
+    MacroEnter = true,
+    MacroLeave = true,
     PackChangedPre = true,
     PackChanged = true,
     Progress = true,

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -82,6 +82,8 @@ return {
     LspProgress = false, -- after a LSP progress update
     LspRequest = false, -- after an LSP request is started, canceled, or completed
     LspTokenUpdate = false, -- after a visible LSP token is updated
+    MacroEnter = true, -- when starting to replay a macro
+    MacroLeave = true, -- just before a macro stops replaying
     MarkSet = false, -- after a mark is set
     MenuPopup = false, -- just before popup menu is displayed
     ModeChanged = false, -- after changing the mode
@@ -169,6 +171,8 @@ return {
     LspProgress = true,
     LspRequest = true,
     LspTokenUpdate = true,
+    MacroEnter = true,
+    MacroLeave = true,
     PackChangedPre = true,
     PackChanged = true,
     Progress = true,

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -15,6 +15,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/vim.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
@@ -2550,6 +2551,7 @@ void check_end_reg_executing(bool advance)
 {
   if (reg_executing != 0 && (typebuf.tb_maplen == 0 || pending_end_reg_executing)) {
     if (advance) {
+      apply_autocmds(EVENT_MACROLEAVE, NULL, NULL, false, curbuf);
       reg_executing = 0;
       pending_end_reg_executing = false;
     } else {

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -55,6 +55,7 @@
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/vim.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/autocmd.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
@@ -2655,6 +2656,7 @@ void check_end_reg_executing(bool advance)
 {
   if (reg_executing != 0 && (typebuf.tb_maplen == 0 || pending_end_reg_executing)) {
     if (advance) {
+      apply_autocmds(EVENT_MACROLEAVE, NULL, NULL, false, curbuf);
       reg_executing = 0;
       pending_end_reg_executing = false;
     } else {

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -722,6 +722,7 @@ int do_execreg(int regname, int colon, int addcr, int silent)
       }
     }
     reg_executing = regname == 0 ? '"' : regname;  // disable the 'q' command
+    apply_autocmds(EVENT_MACROENTER, NULL, NULL, false, curbuf);
     pending_end_reg_executing = false;
   }
   return retval;

--- a/src/nvim/register.c
+++ b/src/nvim/register.c
@@ -747,6 +747,7 @@ int do_execreg(int regname, int colon, int addcr, int silent)
       }
     }
     reg_executing = regname == 0 ? '"' : regname;  // disable the 'q' command
+    apply_autocmds(EVENT_MACROENTER, NULL, NULL, false, curbuf);
     pending_end_reg_executing = false;
   }
   return retval;

--- a/test/functional/autocmd/macro_spec.lua
+++ b/test/functional/autocmd/macro_spec.lua
@@ -1,0 +1,38 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local eq = t.eq
+local eval = n.eval
+local source_vim = n.source
+local feed = n.feed
+
+describe('MacroEnter', function()
+  before_each(clear)
+  it('works', function()
+    source_vim([[
+      autocmd MacroEnter * let g:info = { 'register': reg_executing(), 'line': getline(1) }
+    ]])
+    feed('iab<Esc>')
+    feed('qqyiwPq')
+    feed('@q')
+
+    eq({ register = 'q', line = 'abab' }, eval('g:info'))
+    eq('abababab', eval('getline(1)'))
+  end)
+end)
+
+describe('MacroLeave', function()
+  before_each(clear)
+  it('works', function()
+    source_vim([[
+      autocmd MacroLeave * let g:info = { 'register': reg_executing(), 'line': getline(1) }
+    ]])
+    feed('iab<Esc>')
+    feed('qqyiwPq')
+    feed('@q')
+
+    eq({ register = 'q', line = 'abababab' }, eval('g:info'))
+    eq('abababab', eval('getline(1)'))
+  end)
+end)

--- a/test/functional/autocmd/macro_spec.lua
+++ b/test/functional/autocmd/macro_spec.lua
@@ -1,0 +1,39 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local describe, it, before_each = t.describe, t.it, t.before_each
+local clear = n.clear
+local eq = t.eq
+local eval = n.eval
+local source_vim = n.source
+local feed = n.feed
+
+describe('MacroEnter', function()
+  before_each(clear)
+  it('works', function()
+    source_vim([[
+      autocmd MacroEnter * let g:info = { 'register': reg_executing(), 'line': getline(1) }
+    ]])
+    feed('iab<Esc>')
+    feed('qqyiwPq')
+    feed('@q')
+
+    eq({ register = 'q', line = 'abab' }, eval('g:info'))
+    eq('abababab', eval('getline(1)'))
+  end)
+end)
+
+describe('MacroLeave', function()
+  before_each(clear)
+  it('works', function()
+    source_vim([[
+      autocmd MacroLeave * let g:info = { 'register': reg_executing(), 'line': getline(1) }
+    ]])
+    feed('iab<Esc>')
+    feed('qqyiwPq')
+    feed('@q')
+
+    eq({ register = 'q', line = 'abababab' }, eval('g:info'))
+    eq('abababab', eval('getline(1)'))
+  end)
+end)


### PR DESCRIPTION
Problem: There are no events for start and end of macro replaying,  although there are ones for recording.

Using `reg_executing()` to condition code on whether something is being executed inside a macro is not always possible. For example, if that code is executed inside a mapping which should not be executed inside a macro in the first place. Having that mapping deleted on new `MacroEnter` and restored on `MacroLeave` solves this issue.

------

Solution: Add `MacroEnter` and `MacroLeave`.