### PR TITLE
refactor(lsp): use protocol.Methods instead of strings

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1612,7 +1612,7 @@ function lsp.start_client(config)
         data = { client_id = client_id, request_id = id, request = request },
       })
     end
-    return rpc.notify('$/cancelRequest', { id = id })
+    return rpc.notify(ms.dollar_cancelRequest, { id = id })
   end
 
   -- Track this so that we can escalate automatically if we've already tried a
@@ -1636,9 +1636,9 @@ function lsp.start_client(config)
       return
     end
     -- Sending a signal after a process has exited is acceptable.
-    rpc.request('shutdown', nil, function(err, _)
+    rpc.request(ms.shutdown, nil, function(err, _)
       if err == nil then
-        rpc.notify('exit')
+        rpc.notify(ms.exit)
       else
         -- If there was an error in the shutdown request, then term to be safe.
         rpc.terminate()

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -446,14 +446,14 @@ end
 --- |quickfix| window. If the symbol can resolve to multiple
 --- items, the user can pick one in the |inputlist()|.
 function M.incoming_calls()
-  call_hierarchy('callHierarchy/incomingCalls')
+  call_hierarchy(ms.callHierarchy_incomingCalls)
 end
 
 --- Lists all the items that are called by the symbol under the
 --- cursor in the |quickfix| window. If the symbol can resolve to
 --- multiple items, the user can pick one in the |inputlist()|.
 function M.outgoing_calls()
-  call_hierarchy('callHierarchy/outgoingCalls')
+  call_hierarchy(ms.callHierarchy_outgoingCalls)
 end
 
 --- List workspace folders.
@@ -659,10 +659,10 @@ local function on_code_action_results(results, ctx, options)
     local reg = client.dynamic_capabilities:get(ms.textDocument_codeAction, { bufnr = ctx.bufnr })
 
     local supports_resolve = vim.tbl_get(reg or {}, 'registerOptions', 'resolveProvider')
-      or client.supports_method('codeAction/resolve')
+      or client.supports_method(ms.codeAction_resolve)
 
     if not action.edit and client and supports_resolve then
-      client.request('codeAction/resolve', action, function(err, resolved_action)
+      client.request(ms.codeAction_resolve, action, function(err, resolved_action)
         if err then
           vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)
           return


### PR DESCRIPTION
follow up #24537 