### PR TITLE
fix: undo cmdpreview changes in reverse order

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2357,7 +2357,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
       set_put(ptr_t, &saved_bufs, buf);
 
       u_clearall(buf);
-      buf->b_p_ul = LONG_MAX;  // Make sure we can undo all changes
+      buf->b_p_ul = INT_MAX;  // Make sure we can undo all changes
     }
 
     CpWinInfo cp_wininfo;
@@ -2396,7 +2396,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
 static void cmdpreview_restore_state(CpInfo *cpinfo)
   FUNC_ATTR_NONNULL_ALL
 {
-  for (size_t i = 0; i < cpinfo->buf_info.size; i++) {
+  for (size_t i = cpinfo->buf_info.size; i-- > 0;) {
     CpBufInfo cp_bufinfo = cpinfo->buf_info.items[i];
     buf_T *buf = cp_bufinfo.buf;
 
@@ -2436,7 +2436,7 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
     extmark_clear(buf, (uint32_t)cmdpreview_ns, 0, 0, MAXLNUM, MAXCOL);
   }
 
-  for (size_t i = 0; i < cpinfo->win_info.size; i++) {
+  for (size_t i = cpinfo->win_info.size; i-- > 0;) {
     CpWinInfo cp_wininfo = cpinfo->win_info.items[i];
     win_T *win = cp_wininfo.win;
 


### PR DESCRIPTION
Neovim's cmdpreview feature saves the state of windows and their associated buffers before previewing, and restores this state after the preview completes.

In order to ensure the ability to undo buffer changes caused by the preview operation, the code sets the buffer's 'undolevels' option to a large value (originally `LONG_MAX`), expecting this value to be restored after the preview operation completes.

Before the preview operation, state is preserved by looping across all windows; loosely:

```
for each window:
    get state for the window and associated buffer
    append state to a list
    adjust current windows and buffer setttings for preview
```

Restoring was originally done by looping across the list of saved state in order; loosely:

```
for each saved state in the list:
    restore the state for the window and associated buffer
```

Restoring in the same order as saving causes a loss of state when a buffer is shown in two or more windows.  For example, with a single buffer (Buffer1) showing in two windows (Window1 and Window2), the state-saving process is:

```
save original state for Window1 and Buffer1
change state of Window1 and Buffer1
save original state for Window2 and *changed* state of Buffer1
change state of Window2 and (for the second time) Buffer1
```

Restoring is then:

```
restore original state for Window1 and Buffer1
restore original state for Window2 and *changed* state of Buffer1
```

Given the above scenario, a cmdpreview operation changes the buffer's 'undolevels' value to `LONG_MAX`.

This can be demonstrated as follows:

1. Launch Neovim, setting the status line to show the buffer-local value of 'undolevels' and splitting the single buffer to show in two windows:

   ``` nvim --clean '+set statusline=%!&l:undolevels | wincmd v' ```

2. Start a substitute command that performs a preview.  It's not necessary to complete the command; notice that the status line updates as soon as a regular expression is provided:

   ```vim :s/.*/ ```

Though Neovim options are stored as `long` variables, a check has been added to the option-setting logic to prevent value outside the range of `int`:

```c
// Many number options assume their value is in the signed int range.
if (value < INT_MIN || value > INT_MAX) {
  return e_invarg;
}
```

As a result, the value `LONG_MAX` is invalid on systems where `long` has a bigger range than `int`.  This can cause errors for plugins that want to insert an undo break by setting 'undolevels' to its current value (a method recommend in `:help undo-break`).  In the above scenario on such a system, after 'undolevels' has acquired the value `LONG_MAX` the following causes the error `E474: Invalid argument`:

```vim
:let &l:undolevels = &l:undolevels
```

The fix involves restoring the windows in reverse order (as if by unstacking the changes).  To avoid use of an invalid option value even temporarily, the buffer's 'undolevels' value during a preview operation is now set to `INT_MAX`.