### PR TITLE
fix(inccommand): don't set an invalid 'undolevels' value

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2357,7 +2357,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
       set_put(ptr_t, &saved_bufs, buf);
 
       u_clearall(buf);
-      buf->b_p_ul = LONG_MAX;  // Make sure we can undo all changes
+      buf->b_p_ul = INT_MAX;  // Make sure we can undo all changes
     }
 
     CpWinInfo cp_wininfo;


### PR DESCRIPTION
Problem:    Cannot break undo by setting 'undolevels' to itself in
            'inccommand' preview callback.
Solution:   Don't set an invalid 'undolevels' value.

Close #24574
