### PR TITLE
docs(lsp): remove references to protocol constants

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1154,7 +1154,7 @@ code_action({options})                             *vim.lsp.buf.code_action()*
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
-      • vim.lsp.protocol.constants.CodeActionTriggerKind
+      • vim.lsp.protocol.CodeActionTriggerKind
 
 completion({context})                               *vim.lsp.buf.completion()*
     Retrieves the completion items at the current cursor position. Can only be
@@ -1167,7 +1167,7 @@ completion({context})                               *vim.lsp.buf.completion()*
                    character, if applicable)
 
     See also: ~
-      • vim.lsp.protocol.constants.CompletionTriggerKind
+      • vim.lsp.protocol.CompletionTriggerKind
 
 declaration({options})                             *vim.lsp.buf.declaration()*
     Jumps to the declaration of the symbol under the cursor.

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -112,7 +112,7 @@ end
 --- about the context in which a completion was triggered (how it was triggered,
 --- and by which trigger character, if applicable)
 ---
----@see vim.lsp.protocol.constants.CompletionTriggerKind
+---@see vim.lsp.protocol.CompletionTriggerKind
 function M.completion(context)
   local params = util.make_position_params()
   params.context = context
@@ -728,7 +728,7 @@ end
 ---           using mark-like indexing. See |api-indexing|
 ---
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
----@see vim.lsp.protocol.constants.CodeActionTriggerKind
+---@see vim.lsp.protocol.CodeActionTriggerKind
 function M.code_action(options)
   validate({ options = { options, 't', true } })
   options = options or {}


### PR DESCRIPTION
These enums are part of the parent table, not nested inside `constants`.

I also noticed that I'm not getting editor completion when I try to access these values. I don't know if it's because of how they're [added to `protocol`](https://github.com/neovim/neovim/blob/ef44e597294e4d0d9128ef69b6aa7481a54e17cb/runtime/lua/vim/lsp/protocol.lua#L315-L319) or because there are duplicate type definitions (since these constant are also [autogenerated](https://github.com/neovim/neovim/blob/ef44e597294e4d0d9128ef69b6aa7481a54e17cb/runtime/lua/vim/lsp/types/protocol.lua)).

<img width="607" alt="image" src="https://github.com/neovim/neovim/assets/62502207/9717573a-92fa-4131-8867-07a8ba4c47b4">
