### PR TITLE
feat(lua): vim.get()

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -567,6 +567,27 @@ describe('lua stdlib', function()
     eq(1, exec_lua("return select('#', vim.tbl_get({ nested = {} }, 'nested', 'missing_key'))"))
   end)
 
+  it('vim.get get', function()
+    eq(true, exec_lua('return vim.get({ test = { nested_test = true }}).test.nested_test()'))
+    eq(NIL, exec_lua('return vim.get({ unindexable = true }).unindexable.missing_key()'))
+    eq(NIL, exec_lua('return vim.get({ unindexable = 1 }).unindexable.missing_key()'))
+    eq(NIL, exec_lua('return vim.get({ unindexable = coroutine.create(function () end) }).unindexable.missing_key()'))
+    eq(NIL, exec_lua('return vim.get({ unindexable = function () end }).unindexable.missing_key()'))
+    eq(NIL, exec_lua('return vim.get({}).missing_key()'))
+    eq('vim/shared.lua:0: calling vim.get() on its shim, did you forget to call() the leaf?',
+      pcall_err(exec_lua, 'vim.get((vim.get({})))'))
+    eq(1, exec_lua("return select('#', (vim.get({})()))"))
+    eq(1, exec_lua("return select('#', vim.get({ nested = {} }).nested.missing_key)"))
+  end)
+
+  it('vim.get set', function()
+    eq({ k1 = { k2 = 'assigned-value' }}, exec_lua([[
+      local t = { k1 = { k2 = true }}
+      vim.get(t).k1.k2 = 'assigned-value'
+      return t
+    ]]))
+  end)
+
   it('vim.tbl_extend', function()
     ok(exec_lua([[
       local a = {x = 1}


### PR DESCRIPTION
(WIP, but not "draft" to invite feedback.)

# Problem:
`vim.tbl_get()` is somewhat awkward to use:

```lua
    local t = { a = { b = { c = 'foo' } }}
    local nested_item = vim.tbl_get(t, 'a', 'b', 'c')
```

# Solution:
Introduce `vim.get()`:

```lua
    local t = { a = { b = { c = 'foo' } }}
    local nested_item = vim.get(t).a.b.c()

    -- Assignment also works:
    vim.get(t).a.b.c = 'bar'
```

# Discussion

- pro:
  - More natural syntax than `tbl_get()`.
  - Supports "set", not only "get".
- con:
  - somewhat "magic".
  - caller may forget to call `a.b.….z()` the expression, which will break the next caller that uses `vim.get()`. But plugins can break all kinds of things; and `vim.get()` with `verbose=1` could store the caller stack to make troubleshooting easy.

Note:
- clojure analog is `get-in`: https://stackoverflow.com/q/15639060/152142