### PR TITLE
fix(lua): add missing vim.treesitter to meta file

### DIFF
--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -15,6 +15,7 @@ vim.loader = require('vim.loader')
 vim.lsp = require('vim.lsp')
 vim.re = require('vim.re')
 vim.secure = require('vim.secure')
+vim.treesitter = require('vim.treesitter')
 vim.ui = require('vim.ui')
 vim.version = require('vim.version')
 


### PR DESCRIPTION
vim.treesitter was missing from this file, so no autocompletion was provided by LSP

`vim.treesitter.{highlighter,query,language}` can be resolved by the LSP itself, so no need to added them.