### PR TITLE
vim-patch:9.0.1678: blade files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1809,6 +1809,7 @@ local pattern = {
   ['.*/build/conf/.*%.conf'] = 'bitbake',
   ['.*/meta/conf/.*%.conf'] = 'bitbake',
   ['.*/meta%-.*/conf/.*%.conf'] = 'bitbake',
+  ['.*%.blade%.php'] = 'blade',
   ['bzr_log%..*'] = 'bzr',
   ['.*enlightenment/.*%.cfg'] = 'c',
   ['${HOME}/cabal%.config'] = 'cabalconfig',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -112,6 +112,7 @@ func s:GetFilenameChecks() abort
     \ 'bicep': ['file.bicep'],
     \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
     \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
+    \ 'blade': ['file.blade.php'],
     \ 'blank': ['file.bl'],
     \ 'blueprint': ['file.blp'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],


### PR DESCRIPTION
Problem:    Blade files are not recognized.
Solution:   Add a pattern for Blade files. (closes vim/vim#12650)

https://github.com/vim/vim/commit/ad34abee258322826146d597ac5b5fd2111c2b79