### PR TITLE
build(deps): bump tree-sitter to HEAD - 0a1c4d846

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -60,5 +60,5 @@ TREESITTER_BASH_URL https://github.com/tree-sitter/tree-sitter-bash/archive/4936
 TREESITTER_BASH_SHA256 99ebe9f2886efecc1a5e9e1360d804a1b49ad89976a66bb5c3871539cca5fb7e
 TREESITTER_MARKDOWN_URL https://github.com/MDeiml/tree-sitter-markdown/archive/v0.1.6.tar.gz
 TREESITTER_MARKDOWN_SHA256 34cbeadfbe07454a5040163d04b3118ef0ac427a5cba39089de7384992729088
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/3f44b896852eb7daaa6df4fb778c9bb52c70c815.tar.gz
-TREESITTER_SHA256 16e4a43a305c128baf7e700e78001f9ab7544f3fd493545e1dc7628bbf9a3d35
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/0a1c4d8466efed6ef5971aa03a84ebb0836128b1.tar.gz
+TREESITTER_SHA256 22004e85c885b615e317746c342f438ccb77e21cd9f274c99ae367e797058fd7

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1441,7 +1441,7 @@ static int node_rawquery(lua_State *L)
 
 #ifdef NVIM_TS_HAS_SET_MAX_START_DEPTH
   // reset the start depth
-  ts_query_cursor_set_max_start_depth(cursor, 0);
+  ts_query_cursor_set_max_start_depth(cursor, UINT32_MAX);
 #endif
   ts_query_cursor_set_match_limit(cursor, 256);
   ts_query_cursor_exec(cursor, query, node);


### PR DESCRIPTION
adapt to breaking change in `ts_query_cursor_set_max_start_depth`
https://github.com/tree-sitter/tree-sitter/pull/2278
