### PR TITLE
fix(iter): make pipeline termination conditions consistent

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3208,12 +3208,17 @@ receives as input the output values from the prior stage. The values used
 in the first stage of the pipeline depend on the type passed to this
 function:
 
-• List tables pass only the value of each element
-• Non-list (dict) tables pass both the key and value of each element
+• List tables (arrays) pass only the value of each element
+• Non-list tables (dictionaries) pass both the key and value of each
+  element
 • Function |iterator|s pass all of the values returned by their respective
   function
 • Tables with a metatable implementing |__call()| are treated as function
   iterators
+
+The iterator pipeline terminates when the original table or function
+iterator runs out of values (for function iterators, this means that the
+first value returned by the function is nil).
 
 Examples: >lua
 
@@ -3226,6 +3231,7 @@ Examples: >lua
    it:totable()
    -- { 9, 6, 3 }
 
+   -- ipairs() is a function iterator which returns both the index (i) and the value (v)
    vim.iter(ipairs({ 1, 2, 3, 4, 5 })):map(function(i, v)
      if i > 2 then return v end
    end):totable()

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -154,6 +154,9 @@ describe('vim.iter', function()
     eq({1, 2}, vim.iter(t):slice(1, 2):totable())
     eq({10}, vim.iter(t):slice(10, 10):totable())
     eq({8, 9, 10}, vim.iter(t):slice(8, 11):totable())
+
+    local it = vim.iter(vim.gsplit('a|b|c|d', '|'))
+    matches('slice%(%) requires a list%-like table', pcall_err(it.slice, it, 1, 3))
   end)
 
   it('nth()', function()
@@ -395,40 +398,5 @@ describe('vim.iter', function()
       { item_2 = 'test' },
       { item_3 = 'test' },
     }, output)
-  end)
-
-  it('handles nil values', function()
-    local t = {1, 2, 3, 4, 5}
-    do
-      local it = vim.iter(t):enumerate():map(function(i, v)
-        if i % 2 == 0 then
-          return nil, v*v
-        end
-        return v, nil
-      end)
-      eq({
-        { [1] = 1 },
-        { [2] = 4 },
-        { [1] = 3 },
-        { [2] = 16 },
-        { [1] = 5 },
-      }, it:totable())
-    end
-
-    do
-      local it = vim.iter(ipairs(t)):map(function(i, v)
-        if i % 2 == 0 then
-          return nil, v*v
-        end
-        return v, nil
-      end)
-      eq({
-        { [1] = 1 },
-        { [2] = 4 },
-        { [1] = 3 },
-        { [2] = 16 },
-        { [1] = 5 },
-      }, it:totable())
-    end
   end)
 end)


### PR DESCRIPTION
There is a design decision that must be made in vim.iter around how we determine when an iterator is complete.

When using the `for ... in ...` pattern in Lua (`:h for-in`), an iterator is complete when the _first_ value from the underlying function iterator returns nil. Excerpt from the 5.1 manual:

    A `for` statement like

           `for`  `var1, ..., varn`  `in`  `explist`  `do`  `block`  `end`

    is equivalent to the code:

           do
             local  f, s, var  =  explist
             while true do
                 local  var1, ..., varn  =  f(s, var)
                 var  =  var1
                 if  var  == nil then break end
                 block
             end
           end

However, in `vim.iter` we allow intermediate pipeline stages to return `nil` values without terminating the pipeline. Instead, the condition for being complete is that a pipeline stage returns _no_ values.

So this is perfectly valid:

```lua
vim.iter(t):map(function(v)
    return nil, v, v * 2
end)
```

This is of course a contrived example, but there may be instances where a pipeline stage may actually need to return `nil` as the first return value _without_ terminating the pipeline.

This works just fine, except for one wrinkle: `vim.iter` iterators support the `for ... in ...` syntax, so that one can use, for example:

```lua
local it = vim.iter(t):map(...):filter(...)
for a, b, c in it do
    ...
end
```

However, this causes an inconsistency: the language level constraints of `for ... in ...` will cause this loop to terminate as soon as the _first_ value (`a`) of the iterator pipeline is `nil`. If one were to instead use:

```lua
vim.iter(t):map(...):filter(...):each(function(a, b, c)
    ...
end)
```

then this will correctly drain the entire iterator, even if `a` is `nil`.

I really do not like this inconsistency, but am torn on how to address it. For maximum consistency, we should enforce the same constraint in iterator pipelines that exists in `for ... in ...`; namely, an iterator terminates as soon as the _first_ value returned from a prior stage is `nil`. However, this may inhibit some legitimate use-cases.

In either case, a decision should be made before the next release, as changing the behavior is a breaking change.

This PR modifies the behavior so that returning `nil` as the first return value in any pipeline stage is equivalent to only returning `nil` (i.e. if `nil` is the first return value, other return values are ignored). **This is a breaking change**, but since `vim.iter` is not yet in a release this is acceptable without any deprecation notice.

---

<details>
<summary>Concrete example</summary>

```lua
local t = { 1, 2, 3, 4, 5 }

do
  print('Using a for loop')
  local it = vim.iter(t):map(function(v) return nil, v, v * 2 end)
  for a, b, c in it do
    print(a, b, c)
  end
end

do
  print('Using :each()')
  local it = vim.iter(t):map(function(v) return nil, v, v * 2 end)
  it:each(function(a, b, c)
    print(a, b, c)
  end)
end
```

```
$ nvim -l test.lua
Using a for loop
Using :each()
nil 1 2
nil 2 4
nil 3 6
nil 4 8
nil 5 10
```
</details>