### PR TITLE
docs(builtin): fix some missing lines

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3411,6 +3411,7 @@ id({expr})                                                                *id()*
 		reuse identifiers of the garbage-collected ones.
 
 indent({lnum})                                                        *indent()*
+		The result is a Number, which is indent of line {lnum} in the
 		current buffer.  The indent is counted in spaces, the value
 		of 'tabstop' is relevant.  {lnum} is used just like in
 		|getline()|.
@@ -3888,6 +3889,7 @@ keytrans({string})                                                  *keytrans()*
 <			<C-Home>
 
 len({expr})                                                         *len()* *E701*
+		The result is a Number, which is the length of the argument.
 		When {expr} is a String or a Number the length in bytes is
 		used, as with |strlen()|.
 		When {expr} is a |List| the number of items in the |List| is

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4115,6 +4115,7 @@ function vim.fn.iconv(string, from, to) end
 --- @return any
 function vim.fn.id(expr) end
 
+--- The result is a Number, which is indent of line {lnum} in the
 --- current buffer.  The indent is counted in spaces, the value
 --- of 'tabstop' is relevant.  {lnum} is used just like in
 --- |getline()|.
@@ -4712,6 +4713,7 @@ function vim.fn.keytrans(string) end
 --- @return any
 function vim.fn.last_buffer_nr() end
 
+--- The result is a Number, which is the length of the argument.
 --- When {expr} is a String or a Number the length in bytes is
 --- used, as with |strlen()|.
 --- When {expr} is a |List| the number of items in the |List| is

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5057,6 +5057,7 @@ M.funcs = {
     args = 1,
     base = 1,
     desc = [=[
+      The result is a Number, which is indent of line {lnum} in the
       current buffer.  The indent is counted in spaces, the value
       of 'tabstop' is relevant.  {lnum} is used just like in
       |getline()|.
@@ -5775,6 +5776,7 @@ M.funcs = {
     args = 1,
     base = 1,
     desc = [=[
+      The result is a Number, which is the length of the argument.
       When {expr} is a String or a Number the length in bytes is
       used, as with |strlen()|.
       When {expr} is a |List| the number of items in the |List| is


### PR DESCRIPTION
These two functions seem to have previously had their docs start on the same line as the signature, which I guess contributed to the lines being lost (though I checked all other such functions from before and these were the only two).