### PR TITLE
vim-patch:9.0.1679: Cleanup Tests from leftover files

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -353,6 +353,24 @@ func RunTheTest(test)
   endif
 endfunc
 
+function Delete_Xtest_Files()
+  for file in glob('X*', v:false, v:true)
+    if file ==? 'XfakeHOME'
+      " Clean up files created by setup.vim
+      call delete('XfakeHOME', 'rf')
+      continue
+    endif
+    " call add(v:errors, file .. " exists when it shouldn't, trying to delete it!")
+    call delete(file)
+    if !empty(glob(file, v:false, v:true))
+      " call add(v:errors, file .. " still exists after trying to delete it!")
+      if has('unix')
+        call system('rm -rf  ' .. file)
+      endif
+    endif
+  endfor
+endfunc
+
 func AfterTheTest(func_name)
   if len(v:errors) > 0
     if match(s:may_fail_list, '^' .. a:func_name) >= 0
@@ -381,12 +399,10 @@ endfunc
 " This function can be called by a test if it wants to abort testing.
 func FinishTesting()
   call AfterTheTest('')
+  call Delete_Xtest_Files()
 
   " Don't write viminfo on exit.
   set viminfo=
-
-  " Clean up files created by setup.vim
-  call delete('XfakeHOME', 'rf')
 
   if s:fail == 0 && s:fail_expected == 0
     " Success, create the .res file so that make knows it's done.

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -731,6 +731,7 @@ func Test_mksession_foldopt()
   close
   %bwipe
   set sessionoptions&
+  call delete('Xtest_mks.out')
 endfunc
 
 " Test for mksession with "help" but not "options" in 'sessionoptions'
@@ -857,14 +858,14 @@ func Test_mksession_shortmess_with_A()
   bwipe!
 
   " Recreate the swap file to pretend the file is being edited
-  call writefile(cont, fname)
+  call writefile(cont, fname, 'D')
   set shortmess+=A
   source Xtestsession
 
   set shortmess&
   set sessionoptions&
   call delete('Xtestsession')
-  call delete(fname)
+  call delete('Xtestfile')
 endfunc
 
 " Test for mksession with 'compatible' option


### PR DESCRIPTION
#### vim-patch:9.0.1679: Cleanup Tests from leftover files

Problem:    Tests may leave leftover files around
Solution:   Clean up tests and remove files

There were a few failures in 'linux (huge, gcc, testgui, true, true)'
e.g. here: https://github.com/vim/vim/actions/runs/5497376153/jobs/10018060156

,----
| Error detected while processing command line..script /home/runner/work/vim/vim/src/testdir/runtest.vim[585]..function RunTheTest[54]..Test_lvimgrep_crash[16]..TestTimeout[12]..VimLeavePre Autocommands for "*"..function EarlyExit[7]..FinishTesting:
| line   70:
| E445: Other window contains changes
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txt
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txt
| E937: Attempt to delete a buffer that is in use: Xtest_stable_xxd.txtmalloc(): unsorted double linked list corrupted
`----

Which is puzzling, because the Xtest_stable_xxd file should have been
long gone after test_crypt.vim is run (and definitely no longer be
staying around in test_quickfix.vim).

So try to clean up properly after a test script is run, just in case any
X<file> is still around. During testing, a found a few leftover files,
which I also fixed in the relevant test-file.

Unfortunately, the test workflow 'linux (huge, gcc, testgui, true,
true)' now seems to fail with 'E1230: Encryption: sodium_mlock()' in
test_crypt.vim. Hopefully this is only temporary.

https://github.com/vim/vim/commit/84bc00e9b52b1174888f2f696f8b628a83c49988

Co-authored-by: Christian Brabandt <cb@256bit.org>