### PR TITLE
vim-patch:a13eb2b14791

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1049,6 +1049,7 @@ local extension = {
   wat = 'wat',
   wdl = 'wdl',
   wm = 'webmacro',
+  wgsl = 'wgsl',
   wbt = 'winbatch',
   wit = 'wit',
   wml = 'wml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -697,6 +697,7 @@ func s:GetFilenameChecks() abort
     \ 'webmacro': ['file.wm'],
     \ 'wget': ['.wgetrc', 'wgetrc'],
     \ 'wget2': ['.wget2rc', 'wget2rc'],
+    \ 'wgsl': ['file.wgsl'],
     \ 'winbatch': ['file.wbt'],
     \ 'wit': ['file.wit'],
     \ 'wml': ['file.wml'],


### PR DESCRIPTION
Add WebGPU Shading Language (WGSL) filetype (vim/vim#12723)

The current W3C Working Draft for the WebGPU Shading Language (WGSL) specifies
'text/wgsl' media type for WGSL modules with the '.wgsl' file extension:
https://www.w3.org/TR/WGSL/#text-wgsl-media-type

It has also been registered at the Internet Assigned Numbers Authority (IANA):
https://www.iana.org/assignments/media-types/text/wgsl

Neovim's nvim-lspconfig already associates wgsl language servers
with 'filetype wgsl':
https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#wgsl_analyzer

However currenly setting 'filetype wgsl' for *.wgsl files by defalut in Neovim
is blocked by adding this filetype to the vim project first:
https://github.com/neovim/neovim/pull/23331

This commit adds this missing wgsl filetype.

https://github.com/vim/vim/commit/a13eb2b147915e7e92a6de6c19ce448c7def4057

Co-authored-by: Gergő Sályi <87373293+gergo-salyi@users.noreply.github.com>
