### PR TITLE
feat(defaults): treat "•" as a list item prefix

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -151,6 +151,7 @@ The following changes to existing APIs or features add new behavior.
   option, which allows for rendering e.g., diagnostic severities differently.
 
 • Defaults:
+  • 'comments' includes "fb:•".
   • 'shortmess' includes the "C" flag.
   • Automatic linting of treesitter query files (see |ft-query-plugin|).
     Can be disabled via: >lua

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1374,7 +1374,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	Minimum value is 12, maximum value is 10000.
 
 					*'comments'* *'com'* *E524* *E525*
-'comments' 'com'	string	(default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-")
+'comments' 'com'	string	(default "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•")
 			local to buffer
 	A comma-separated list of strings that can start a comment line.  See
 	|format-comments|.  See |option-backslash| about using backslashes to

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -37,6 +37,7 @@ Defaults					            *nvim-defaults*
 - 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/state/nvim/backup// (|xdg|), auto-created
 - 'belloff' defaults to "all"
+- 'comments' includes "fb:•"
 - 'commentstring' defaults to ""
 - 'compatible' is always disabled
 - 'complete' excludes "i"

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -956,7 +956,7 @@ vim.go.co = vim.go.columns
 --- insert a space.
 ---
 --- @type string
-vim.o.comments = "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-"
+vim.o.comments = "s1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•"
 vim.o.com = vim.o.comments
 vim.bo.comments = vim.o.comments
 vim.bo.com = vim.bo.comments

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1287,7 +1287,7 @@ return {
       abbreviation = 'com',
       alloced = true,
       cb = 'did_set_comments',
-      defaults = { if_true = 's1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-' },
+      defaults = { if_true = 's1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•' },
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of strings that can start a comment line.  See


### PR DESCRIPTION
Problem:
Nvim docs use "•" as a list item prefix but `gw{motion}` doesn't format such lists by default.

Solution:
Change the 'comments' option to include "fb:•" by default.