### PR TITLE
vim-patch:8967f6c4b9e2

### DIFF
--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -14,3 +14,14 @@ setlocal comments=:<%!--
 setlocal commentstring=<%!--\ %s\ --%>
 
 let b:undo_ftplugin = 'set sw< sts< et< com< cms<'
+
+" HTML: thanks to Johannes Zellner and Benji Fisher.
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_ignorecase = 1
+  let b:match_words = '<!--:-->,' ..
+	\	      '<:>,' ..
+	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
+	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..
+	\	      '<\@<=\([^/!][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+  let b:undo_ftplugin ..= " | unlet! b:match_ignorecase b:match_words"
+endif


### PR DESCRIPTION
feat(heex): borrow matchit support from html (vim/vim#12717)

* feat(heex): borrow matchit support from html

Makes % support behave the same in heex as in html. For example, quickly moving the cursor between opening and closing tags.

* Remove unnecessary line; define b:undo_ftplugin first

* Remove b:html_set_match_words

https://github.com/vim/vim/commit/8967f6c4b9e2071dea9a63dbbbb93f6b9119ae99

Co-authored-by: Chris Vincent <chris.vincent@hey.com>
