### PR TITLE
vim-patch:b69b9d5e1753

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1090,6 +1090,7 @@ local extension = {
   yxx = 'yacc',
   yml = 'yaml',
   yaml = 'yaml',
+  eyaml = 'yaml',
   yang = 'yang',
   yuck = 'yuck',
   z8a = 'z8a',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -717,7 +717,7 @@ func s:GetFilenameChecks() abort
     \ 'xsd': ['file.xsd'],
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
-    \ 'yaml': ['file.yaml', 'file.yml', '.clangd', '.clang-format', '.clang-tidy'],
+    \ 'yaml': ['file.yaml', 'file.yml', 'file.eyaml', '.clangd', '.clang-format', '.clang-tidy'],
     \ 'yang': ['file.yang'],
     \ 'yuck': ['file.yuck'],
     \ 'z8a': ['file.z8a'],


### PR DESCRIPTION
Add filetype detection for eyaml files (vim/vim#12659)

https://github.com/voxpupuli/hiera-eyaml/ uses and produces the eyaml
format, which is simply yaml with some encrypted values.

It's convenient to edit the file without decrypting when not touching
encrypted values (or when you don't have access to the decryption key),
which is why vim should treat those files as yaml files.

https://github.com/vim/vim/commit/b69b9d5e175351c9a25507139954f6211f37fdd9

Co-authored-by: Max Gautier <mg@max.gautier.name>
