### PR TITLE
vim-patch:{c2bd205254c8,0401933a5be3}: typo fixes

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -398,7 +398,7 @@ bufload({buf})                                                       *bufload()*
 		refers to an existing file then the file is read.  Otherwise
 		the buffer will be empty.  If the buffer was already loaded
 		then there is no change.  If the buffer is not related to a
-		file the no file is read (e.g., when 'buftype' is "nofile").
+		file then no file is read (e.g., when 'buftype' is "nofile").
 		If there is an existing swap file for the file of the buffer,
 		there will be no dialog, the buffer will be loaded anyway.
 		The {buf} argument is used like with |bufexists()|.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -357,7 +357,7 @@ ways to change this:
    You must create a new filetype plugin in a directory early in
    'runtimepath'.  For Unix, for example you could use this file: >
 	vim ~/.config/nvim/ftplugin/fortran.vim
-<  You can set those settings and mappings that you would like to add.  Note
+<   You can set those settings and mappings that you would like to add.  Note
    that the global plugin will be loaded after this, it may overrule the
    settings that you do here.  If this is the case, you need to use one of the
    following two methods.
@@ -366,7 +366,7 @@ ways to change this:
    You must put the copy in a directory early in 'runtimepath'.  For Unix, for
    example, you could do this: >
 	cp $VIMRUNTIME/ftplugin/fortran.vim ~/.config/nvim/ftplugin/fortran.vim
-<  Then you can edit the copied file to your liking.  Since the b:did_ftplugin
+<   Then you can edit the copied file to your liking.  Since the b:did_ftplugin
    variable will be set, the global plugin will not be loaded.
    A disadvantage of this method is that when the distributed plugin gets
    improved, you will have to copy and modify it again.
@@ -375,7 +375,7 @@ ways to change this:
    You must create a new filetype plugin in a directory from the end of
    'runtimepath'.  For Unix, for example, you could use this file: >
 	vim ~/.config/nvim/after/ftplugin/fortran.vim
-<  In this file you can change just those settings that you want to change.
+<   In this file you can change just those settings that you want to change.
 
 ==============================================================================
 3.  Docs for the default filetype plugins.		*ftplugin-docs*

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -534,7 +534,7 @@ function vim.fn.buflisted(buf) end
 --- refers to an existing file then the file is read.  Otherwise
 --- the buffer will be empty.  If the buffer was already loaded
 --- then there is no change.  If the buffer is not related to a
---- file the no file is read (e.g., when 'buftype' is "nofile").
+--- file then no file is read (e.g., when 'buftype' is "nofile").
 --- If there is an existing swap file for the file of the buffer,
 --- there will be no dialog, the buffer will be loaded anyway.
 --- The {buf} argument is used like with |bufexists()|.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -747,7 +747,7 @@ M.funcs = {
       refers to an existing file then the file is read.  Otherwise
       the buffer will be empty.  If the buffer was already loaded
       then there is no change.  If the buffer is not related to a
-      file the no file is read (e.g., when 'buftype' is "nofile").
+      file then no file is read (e.g., when 'buftype' is "nofile").
       If there is an existing swap file for the file of the buffer,
       there will be no dialog, the buffer will be loaded anyway.
       The {buf} argument is used like with |bufexists()|.


### PR DESCRIPTION
Change "the" to "then" under ':help bufload()' (vim/vim#12662)

https://github.com/vim/vim/commit/c2bd205254c89ecf46e08965f53d7991315d9c98

Co-authored-by: Daniel Steinberg <dstein64@users.noreply.github.com>

Fix alignment in filetype.txt (https://github.com/vim/vim/pull/12618)

There are three spaces because the "<" is concealed.

https://github.com/vim/vim/commit/0401933a5be3b72e12427cdaf8b7ff2694690d02

Co-authored-by: zeertzjq <zeertzjq@outlook.com>

N/A commits:
vim-patch:64dea84bb05a (we have our own manpager at home)
vim-patch:958e15bb1c7d (we have our own editorconfig syntax file)
vim-patch:c41b3c9f95ac (we don't have defaults.vim)
