### PR TITLE
vim-patch:6a500661a9cb,81b8bf5b4a33

### DIFF
--- a/runtime/doc/tips.txt
+++ b/runtime/doc/tips.txt
@@ -346,14 +346,26 @@ comma-separated list of extension(s) you find yourself wanting to edit: >
 
 	" vim -b : edit binary using xxd-format!
 	augroup Binary
-	  au!
-	  au BufReadPre  *.bin let &bin=1
-	  au BufReadPost *.bin if &bin | %!xxd
-	  au BufReadPost *.bin set ft=xxd | endif
-	  au BufWritePre *.bin if &bin | %!xxd -r
-	  au BufWritePre *.bin endif
-	  au BufWritePost *.bin if &bin | %!xxd
-	  au BufWritePost *.bin set nomod | endif
+	  autocmd!
+	  autocmd BufReadPre  *.bin set binary
+	  autocmd BufReadPost *.bin
+	    \ if &binary
+	    \ |   execute "silent %!xxd -c 32"
+	    \ |   set filetype=xxd
+	    \ |   redraw
+	    \ | endif
+	  autocmd BufWritePre *.bin
+	    \ if &binary
+	    \ |   let s:view = winsaveview()
+	    \ |   execute "silent %!xxd -r -c 32"
+	    \ | endif
+	  autocmd BufWritePost *.bin
+	    \ if &binary
+	    \ |   execute "silent %!xxd -c 32"
+	    \ |   set nomodified
+	    \ |   call winrestview(s:view)
+	    \ |   redraw
+	    \ | endif
 	augroup END
 
 ==============================================================================

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -118,15 +118,27 @@ This switches on three very clever mechanisms:
 
 
 				*restore-cursor* *last-position-jump*  >
-    autocmd BufRead * autocmd FileType <buffer> ++once
-      \ if &ft !~# 'commit\|rebase' && line("'\"") > 1 && line("'\"") <= line("$") | exe 'normal! g`"' | endif
+    augroup RestoreCursor
+      autocmd!
+      autocmd BufRead * autocmd FileType <buffer> ++once
+        \ let s:line = line("'\"")
+        \ | if s:line >= 1 && s:line <= line("$") && &filetype !~# 'commit'
+        \      && index(['xxd', 'gitrebase'], &filetype) == -1
+        \ |   execute "normal! g`\""
+        \ | endif
+    augroup END
 
 Another autocommand.  This time it is used after reading any file.  The
 complicated stuff after it checks if the '" mark is defined, and jumps to it
-if so.  The backslash at the start of a line is used to continue the command
-from the previous line.  That avoids a line getting very long.
-See |line-continuation|.  This only works in a Vim script file, not when
-typing commands at the command-line.
+if so.  It doesn't do that for a commit or rebase message, which are likely
+a different one than last time, and when using xxd(1) to filter and edit
+binary files, which transforms input files back and forth, causing them to
+have dual nature, so to speak.  See also |using-xxd|.
+
+The backslash at the start of a line is used to continue the command from the
+previous line.  That avoids a line getting very long.  See |line-continuation|.
+This only works in a Vim script file, not when typing commands at the
+command line.
 
 >
 	command DiffOrig vert new | set bt=nofile | r ++edit # | 0d_ | diffthis


### PR DESCRIPTION
#### vim-patch:6a500661a9cb

Improve the vimscript code in ":h hex-editing"

Save and restore the view position before and after saving the buffer,
respectively, to keep the current view of the xxd(1)'s hex dump
unchanged after doing ":w", which previously caused the window to
scroll back to the very beginning of the buffer.  I believe it's
needless to say how annoying and counterproductive that was.

Get rid of the "Press ENTER or type command to continue" message, which
was previously displayed after opening larger binary files.  The use
of "silent" and "redraw" commands is tailored specifically to avoid
screen flickering, e.g. when doing ":w", which is caused by the buffer
being filtered by an external command.

Increase the number of octets per line, produced by xxd(1), from the
default value of 16 to 32.  This puts bigger chunks of the hex dump
on the screen and makes the whole thing much more usable.

While there, reformat the code to make it more readable, and use the
long form of the commands and variables to make the code slightly more
consistent and more understandable to newcomers.

https://github.com/vim/vim/commit/6a500661a9cb7b57093cf1095aa67e9c4aabc709

Co-authored-by: Dragan Simic' via vim_dev <vim_dev@googlegroups.com>


#### vim-patch:81b8bf5b4a33

Update the vimscript code for restoring cursor position

Using xxd(1) to filter and edit binary files causes the input files
to have dual nature, so to speak, which effectively makes restoring
the cursor position broken.  Fix that by ignoring the "xxd" file type
in the code that restores the cursor position.

Interactive rebasing in git causes files to be edited in vim, which,
similarly to commit messages, are rarely the same as the last one
edited.  Thus, also add "gitrebase" to the list of file types for
which the cursor position isn't restored.

While there, refactor the code a bit to possibly save a few CPU cycles
and to keep the line lengths in check, and use the long form of the
commands and variables, to make the code slightly more consistent and
more understandable to newcomers.

Update the relevant comments in the code and the associated parts of
the documentation, to keep them in sync with the updated code.

Remove some redundant trailing whitespace as well, as spotted.

https://github.com/vim/vim/commit/81b8bf5b4a33552c610dc2ea743ac2698a16aef7

Co-authored-by: Dragan Simic' via vim_dev <vim_dev@googlegroups.com>