### PR TITLE
fix(lsp): extra "." when completing with tsserver

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2262,7 +2262,7 @@ end
 local function adjust_start_col(lnum, line, items, encoding)
   local min_start_char = nil
   for _, item in pairs(items) do
-    if item.filterText == nil and item.textEdit and item.textEdit.range.start.line == lnum - 1 then
+    if item.textEdit and item.textEdit.range.start.line == lnum - 1 then
       if min_start_char and min_start_char ~= item.textEdit.range.start.character then
         return nil
       end


### PR DESCRIPTION
## Problem

With tsserver LSP, triggering omni completion after "." and selecting an item, inserts an extra "."

## Solution

Apply adjust_start_col() regardless of `filterText`.
adjust_start_col() is explained here:
https://github.com/neovim/neovim/blob/0ea8dfeb3dc347579753169d9e3588f6306ab703/runtime/lua/vim/lsp.lua#L2334-L2351


Fix #22803