### PR TITLE
feat(treesitter): add injection language fallback

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -77,14 +77,8 @@ The following new APIs and features were added.
 
 • Added |vim.keycode()| for translating keycodes in a string.
 
-• Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
-  default).
-
 • |'smoothscroll'| option to scroll by screen line rather than by text line
   when |'wrap'| is set.
-
-• |Query:iter_matches()| now has the ability to set the maximum start depth
-  for matches.
 
 • Added inline virtual text support to |nvim_buf_set_extmark()|.
 
@@ -120,8 +114,16 @@ The following new APIs and features were added.
     `client.supports_method(<method>)`. It considers both the dynamic
     capabilities and static `server_capabilities`.
 
-• Bundled treesitter parser and queries (highlight, folds) for Markdown,
-  Python, and Bash.
+• Treesitter
+  • Bundled parsers and queries (highlight, folds) for Markdown, Python, and
+    Bash.
+  • Added |vim.treesitter.query.omnifunc()| for treesitter query files (set by
+    default).
+  • |Query:iter_matches()| now has the ability to set the maximum start depth
+    for matches.
+  • `@injection.language` is now case insensitive and allows specifying a
+    language via aliases (e.g., filetype) registered via
+    `vim.treesitter.language.register`.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -121,7 +121,7 @@ The following new APIs and features were added.
     default).
   • |Query:iter_matches()| now has the ability to set the maximum start depth
     for matches.
-  • `@injection.language` is now case insensitive and allows specifying a
+  • `@injection.language` now has smarter resolution and will now fallback to language aliases and/or attempt lower case variants of the text.
     language via aliases (e.g., filetype) registered via
     `vim.treesitter.language.register`.
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -311,19 +311,7 @@ The following directives are built in:
             {capture_id}
 
         Example: >query
-            (#inject-language! @_lang)
-<
-    `inject-language!`                    *treesitter-directive-inject-language!*
-        Set the injection language from the node text, interpreted first as a
-        language name, then (if a parser is not found) a filetype. Custom
-        aliases can be added via |vim.treesitter.language.register()|. This
-        will set a new `metadata[capture_id]['injection.language']`.
-
-        Parameters: ~
-            {capture_id}
-
-        Example: >query
-            (#inject-language! @_lang)
+            (#trim! @fold)
 <
 Further directives can be added via |vim.treesitter.query.add_directive()|.
 Use |vim.treesitter.query.list_directives()| to list all available directives.

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -541,33 +541,6 @@ local directive_handlers = {
       metadata.range = { start_row, start_col, end_row, end_col }
     end
   end,
-  -- Set injection language from node text, interpreted first as language and then as filetype
-  -- Example: (#inject-language! @_lang)
-  ['inject-language!'] = function(match, _, bufnr, pred, metadata)
-    local id = pred[2]
-    local node = match[id]
-    if not node then
-      return
-    end
-
-    -- TODO(clason): replace by refactored `ts.has_parser` API
-    local has_parser = function(lang)
-      return vim._ts_has_language(lang)
-        or #vim.api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
-    end
-
-    local alias = vim.treesitter.get_node_text(node, bufnr, { metadata = metadata[id] })
-    if not alias then
-      return
-    elseif has_parser(alias) then
-      metadata['injection.language'] = alias
-    else
-      local lang = vim.treesitter.language.get_lang(alias)
-      if lang and has_parser(lang) then
-        metadata['injection.language'] = lang
-      end
-    end
-  end,
 }
 
 --- Adds a new predicate to be used in queries

--- a/runtime/queries/markdown/injections.scm
+++ b/runtime/queries/markdown/injections.scm
@@ -1,8 +1,7 @@
 (fenced_code_block
   (info_string
-    (language) @_lang)
-  (code_fence_content) @injection.content
-  (#inject-language! @_lang))
+    (language) @injection.language)
+  (code_fence_content) @injection.content)
 
 ((html_block) @injection.content 
  (#set! injection.language "html")

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -783,7 +783,7 @@ int x = INT_MAX;
         return list
         ]]
 
-        eq({ 'gsub!', 'inject-language!', 'offset!', 'set!', 'trim!' }, res_list)
+        eq({ 'gsub!', 'offset!', 'set!', 'trim!' }, res_list)
       end)
     end)
   end)


### PR DESCRIPTION
Remove the `#inject-language!` directive in favor of including the fallback to filetype in the injection logic itself. Also try the language name as lower case as a fallback, removing the need for downstream `#downcase!` directive. 

@lewis6991 
