### PR TITLE
vim-patch:d8f981138aa0

### DIFF
--- a/runtime/ftplugin/nix.vim
+++ b/runtime/ftplugin/nix.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin
+" Language:    nix
+" Maintainer:  Keith Smiley <keithbsmiley@gmail.com>
+" Last Change: 2023 Jul 22
+
+" Only do this when not done yet for this buffer
+if exists("b:did_ftplugin")
+  finish
+endif
+
+" Don't load another plugin for this buffer
+let b:did_ftplugin = 1
+
+let b:undo_ftplugin = "setl commentstring< comments<"
+
+setlocal comments=:#
+setlocal commentstring=#\ %s


### PR DESCRIPTION
Add commentstring for nix file format (vim/vim#12696)

https://github.com/vim/vim/commit/d8f981138aa04c15ff87b306e9003df8d4b09d17

Co-authored-by: Keith Smiley <keithbsmiley@gmail.com>
