### PR TITLE
vim-patch:9.0.1687: mapset() not properly handling script ID

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -431,7 +431,7 @@ String nvim_replace_termcodes(String str, Boolean from_part, Boolean do_lt, Bool
   }
 
   char *ptr = NULL;
-  replace_termcodes(str.data, str.size, &ptr, flags, NULL, CPO_TO_CPO_FLAGS);
+  replace_termcodes(str.data, str.size, &ptr, 0, flags, NULL, CPO_TO_CPO_FLAGS);
   return cstr_as_string(ptr);
 }
 

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -232,7 +232,7 @@ void ex_menu(exarg_T *eap)
       map_buf = NULL;  // Menu tips are plain text.
     } else {
       map_buf = NULL;
-      map_to = replace_termcodes(map_to, strlen(map_to), &map_buf,
+      map_to = replace_termcodes(map_to, strlen(map_to), &map_buf, 0,
                                  REPTERM_DO_LT, NULL, CPO_TO_CPO_FLAGS);
     }
     menuarg.modes = modes;

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -876,7 +876,7 @@ int uc_add_command(char *name, size_t name_len, const char *rep, uint32_t argt, 
   char *rep_buf = NULL;
   garray_T *gap;
 
-  replace_termcodes(rep, strlen(rep), &rep_buf, 0, NULL, CPO_TO_CPO_FLAGS);
+  replace_termcodes(rep, strlen(rep), &rep_buf, 0, 0, NULL, CPO_TO_CPO_FLAGS);
   if (rep_buf == NULL) {
     // Can't replace termcodes - try using the string as is
     rep_buf = xstrdup(rep);


### PR DESCRIPTION
#### vim-patch:9.0.1687: mapset() not properly handling script ID

Problem: mapset() not properly handling script ID
Solution: replace_termcodes() may accept a script ID

closes: vim/vim#12699

https://github.com/vim/vim/commit/7e0bae024d4c1673cff31763227ad52b936fa56f