### PR TITLE
vim-patch:9.0.1691: wrong viewport restored for incsearch and smoothscroll

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -82,6 +82,7 @@ static unsigned last_prompt_id = 0;
 typedef struct {
   colnr_T vs_curswant;
   colnr_T vs_leftcol;
+  colnr_T vs_skipcol;
   linenr_T vs_topline;
   int vs_topfill;
   linenr_T vs_botline;
@@ -208,6 +209,7 @@ static void save_viewstate(win_T *wp, viewstate_T *vs)
 {
   vs->vs_curswant = wp->w_curswant;
   vs->vs_leftcol = wp->w_leftcol;
+  vs->vs_skipcol = wp->w_skipcol;
   vs->vs_topline = wp->w_topline;
   vs->vs_topfill = wp->w_topfill;
   vs->vs_botline = wp->w_botline;
@@ -219,6 +221,7 @@ static void restore_viewstate(win_T *wp, viewstate_T *vs)
 {
   wp->w_curswant = vs->vs_curswant;
   wp->w_leftcol = vs->vs_leftcol;
+  wp->w_skipcol = vs->vs_skipcol;
   wp->w_topline = vs->vs_topline;
   wp->w_topfill = vs->vs_topfill;
   wp->w_botline = vs->vs_botline;

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -642,7 +642,7 @@ describe('search cmdline', function()
   end)
 
   -- oldtest: Test_incsearch_substitute_dump2()
-  it('detects empty pattern properly vim-patch:8.2.2295', function()
+  it('incsearch detects empty pattern properly vim-patch:8.2.2295', function()
     screen:try_resize(70, 6)
     exec([[
       set incsearch hlsearch scrolloff=0
@@ -674,6 +674,37 @@ describe('search cmdline', function()
       abc|def                                                               |
       :1,5s/\v|^                                                             |
     ]])
+  end)
+
+  -- oldtest: Test_incsearch_restore_view()
+  it('incsearch restores viewport', function()
+    screen:try_resize(20, 6)
+    exec([[
+      set incsearch nohlsearch
+      setlocal scrolloff=0 smoothscroll
+      call setline(1, [join(range(25), ' '), '', '', '', '', 'xxx'])
+      call feedkeys("2\<C-E>", 't')
+    ]])
+    local s = [[
+      {tilde:<<<} 18 19 20 21 22 2|
+      ^3 24                |
+                          |
+                          |
+                          |
+                          |
+    ]]
+    screen:expect(s)
+    feed('/xxx')
+    screen:expect([[
+                          |
+                          |
+                          |
+                          |
+      {inc:xxx}                 |
+      /xxx^                |
+    ]])
+    feed('<Esc>')
+    screen:expect(s)
   end)
 end)
 

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1996,7 +1996,7 @@ func Test_incsearch_substitute_dump2()
 	\ 'endfor',
 	\ 'call setline(5, "abc|def")',
 	\ '3',
-	\ ], 'Xis_subst_script2')
+	\ ], 'Xis_subst_script2', 'D')
   let buf = RunVimInTerminal('-S Xis_subst_script2', {'rows': 9, 'cols': 70})
 
   call term_sendkeys(buf, ':%s/\vabc|')
@@ -2011,7 +2011,28 @@ func Test_incsearch_substitute_dump2()
 
 
   call StopVimInTerminal(buf)
-  call delete('Xis_subst_script2')
+endfunc
+
+func Test_incsearch_restore_view()
+  CheckOption incsearch
+  CheckScreendump
+
+  let lines =<< trim [CODE]
+    set incsearch nohlsearch
+    setlocal scrolloff=0 smoothscroll
+    call setline(1, [join(range(25), ' '), '', '', '', '', 'xxx'])
+    call feedkeys("2\<C-E>", 't')
+  [CODE]
+  call writefile(lines, 'Xincsearch_restore_view', 'D')
+  let buf = RunVimInTerminal('-S Xincsearch_restore_view', {'rows': 6, 'cols': 20})
+
+  call VerifyScreenDump(buf, 'Test_incsearch_restore_view_01', {})
+  call term_sendkeys(buf, '/xxx')
+  call VerifyScreenDump(buf, 'Test_incsearch_restore_view_02', {})
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_incsearch_restore_view_01', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_pattern_is_uppercase_smartcase()


### PR DESCRIPTION
#### vim-patch:9.0.1691: wrong viewport restored for incsearch and smoothscroll

Problem: wrong viewport restored for incsearch and smoothscroll
Solution: Save and restore skipcol as well

closes: vim/vim#12713

https://github.com/vim/vim/commit/7b7b4cb6f274e7bace127107b0d2752133c4020b