### PR TITLE
vim-patch:9.0.1693: Ctrl-Q not handled like Ctrl-V in replace mode

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4506,7 +4506,7 @@ static void nv_replace(cmdarg_T *cap)
   }
 
   // get another character
-  if (cap->nchar == Ctrl_V) {
+  if (cap->nchar == Ctrl_V || cap->nchar == Ctrl_Q) {
     had_ctrl_v = Ctrl_V;
     cap->nchar = get_literal(false);
     // Don't redo a multibyte character with CTRL-V.
@@ -4733,7 +4733,8 @@ static void nv_vreplace(cmdarg_T *cap)
   if (!MODIFIABLE(curbuf)) {
     emsg(_(e_modifiable));
   } else {
-    if (cap->extra_char == Ctrl_V) {          // get another character
+    if (cap->extra_char == Ctrl_V || cap->extra_char == Ctrl_Q) {
+      // get another character
       cap->extra_char = get_literal(false);
     }
     if (cap->extra_char < ' ') {

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4011,4 +4011,42 @@ func Test_normal_j_below_botline()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for r (replace) command with CTRL_V and CTRL_Q
+func Test_normal_r_ctrl_v_cmd()
+  new
+  call append(0, 'This is a simple test: abcd')
+  exe "norm! 1gg$r\<C-V>\<C-V>"
+  call assert_equal(['This is a simple test: abc', ''], getline(1,'$'))
+  exe "norm! 1gg$hr\<C-Q>\<C-Q>"
+  call assert_equal(['This is a simple test: ab', ''], getline(1,'$'))
+  exe "norm! 1gg$2hr\<C-V>x7e"
+  call assert_equal(['This is a simple test: a~', ''], getline(1,'$'))
+  exe "norm! 1gg$3hr\<C-Q>x7e"
+  call assert_equal(['This is a simple test: ~~', ''], getline(1,'$'))
+
+  if &encoding == 'utf-8'
+    exe "norm! 1gg$4hr\<C-V>u20ac"
+    call assert_equal(['This is a simple test:€~~', ''], getline(1,'$'))
+    exe "norm! 1gg$5hr\<C-Q>u20ac"
+    call assert_equal(['This is a simple test€€~~', ''], getline(1,'$'))
+    exe "norm! 1gg0R\<C-V>xff WAS  \<esc>"
+    call assert_equal(['ÿ WAS   a simple test€€~~', ''], getline(1,'$'))
+    exe "norm! 1gg0elR\<C-Q>xffNOT\<esc>"
+    call assert_equal(['ÿ WASÿNOT simple test€€~~', ''], getline(1,'$'))
+  endif
+
+  call setline(1, 'This is a simple test: abcd')
+  exe "norm! 1gg$gr\<C-V>\<C-V>"
+  call assert_equal(['This is a simple test: abc', ''], getline(1,'$'))
+  exe "norm! 1gg$hgr\<C-Q>\<C-Q>"
+  call assert_equal(['This is a simple test: ab ', ''], getline(1,'$'))
+  exe "norm! 1gg$2hgr\<C-V>x7e"
+  call assert_equal(['This is a simple test: a~ ', ''], getline(1,'$'))
+  exe "norm! 1gg$3hgr\<C-Q>x7e"
+  call assert_equal(['This is a simple test: ~~ ', ''], getline(1,'$'))
+
+  " clean up
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1693: Ctrl-Q not handled like Ctrl-V in replace mode

Problem: Ctrl-Q not handled like Ctrl-V in replace mode
Solution: Handle Ctrl-Q like Ctrl-V

closes: vim/vim#12686

https://github.com/vim/vim/commit/2d63e4b3ccc0bb34db21a3c1d024cb114f8c4071

Co-authored-by: Christian Brabandt <cb@256bit.org>