### PR TITLE
vim-patch:9.0.1694: wrong mapping applied when replaying a char search

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1147,6 +1147,13 @@ static void gotchars(const uint8_t *chars, size_t len)
   maptick++;
 }
 
+/// Record a <Nop> key.
+void gotchars_nop(void)
+{
+  uint8_t nop_buf[3] = { K_SPECIAL, KS_EXTRA, KE_NOP };
+  gotchars(nop_buf, 3);
+}
+
 /// Undo the last gotchars() for "len" bytes.  To be used when putting a typed
 /// character back into the typeahead buffer, thus gotchars() will be called
 /// again.
@@ -2745,14 +2752,9 @@ static int vgetorpeek(bool advance)
   }
 
   if (timedout && c == ESC) {
-    uint8_t nop_buf[3];
-
     // When recording there will be no timeout.  Add a <Nop> after the ESC
     // to avoid that it forms a key code with following characters.
-    nop_buf[0] = K_SPECIAL;
-    nop_buf[1] = KS_EXTRA;
-    nop_buf[2] = KE_NOP;
-    gotchars(nop_buf, 3);
+    gotchars_nop();
   }
 
   vgetc_busy--;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -807,25 +807,32 @@ static void normal_get_additional_char(NormalState *s)
       }
     }
 
-    // When getting a text character and the next character is a
-    // multi-byte character, it could be a composing character.
-    // However, don't wait for it to arrive. Also, do enable mapping,
-    // because if it's put back with vungetc() it's too late to apply
-    // mapping.
-    no_mapping--;
-    while (lang && (s->c = vpeekc()) > 0
-           && (s->c >= 0x100 || MB_BYTE2LEN(vpeekc()) > 1)) {
-      s->c = plain_vgetc();
-      if (!utf_iscomposing(s->c)) {
-        vungetc(s->c);                   // it wasn't, put it back
-        break;
-      } else if (s->ca.ncharC1 == 0) {
-        s->ca.ncharC1 = s->c;
-      } else {
-        s->ca.ncharC2 = s->c;
+    if (lang) {
+      // When getting a text character and the next character is a
+      // multi-byte character, it could be a composing character.
+      // However, don't wait for it to arrive. Also, do enable mapping,
+      // because if it's put back with vungetc() it's too late to apply
+      // mapping.
+      no_mapping--;
+      while (lang && (s->c = vpeekc()) > 0
+             && (s->c >= 0x100 || MB_BYTE2LEN(vpeekc()) > 1)) {
+        s->c = plain_vgetc();
+        if (!utf_iscomposing(s->c)) {
+          vungetc(s->c);                   // it wasn't, put it back
+          break;
+        } else if (s->ca.ncharC1 == 0) {
+          s->ca.ncharC1 = s->c;
+        } else {
+          s->ca.ncharC2 = s->c;
+        }
       }
+      no_mapping++;
+      // Vim may be in a different mode when the user types the next key,
+      // but when replaying a recording the next key is already in the
+      // typeahead buffer, so record a <Nop> before that to prevent the
+      // vpeekc() above from applying wrong mappings when replaying.
+      gotchars_nop();
     }
-    no_mapping++;
   }
   no_mapping--;
   allow_keys--;


### PR DESCRIPTION
#### vim-patch:9.0.1694: wrong mapping applied when replaying a char search

Problem: wrong mapping applied when replaying a char search
Solution: Store a NOP after the ESC

closes: vim/vim#12708

https://github.com/vim/vim/commit/bacc83009bc38c9ba0247aaa22b76d1993d57993

Fix #12551