### PR TITLE
vim-patch:9.0.1688: cannot store custom data in quickfix list

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2734,6 +2734,9 @@ getqflist([{what}])                                                *getqflist()*
 			text	description of the error
 			type	type of the error, 'E', '1', etc.
 			valid	|TRUE|: recognized error message
+			user_data
+				custom data associated with the item, can be
+				any type.
 
 		When there is no error list or it's empty, an empty list is
 		returned. Quickfix list entries with a non-existing buffer
@@ -6353,6 +6356,9 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		    text	description of the error
 		    type	single-character error type, 'E', 'W', etc.
 		    valid	recognized error message
+		    user_data
+				custom data associated with the item, can be
+				any type.
 
 		The "col", "vcol", "nr", "type" and "text" entries are
 		optional.  Either "lnum" or "pattern" entry can be used to

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3309,6 +3309,9 @@ function vim.fn.getpos(expr) end
 ---   text  description of the error
 ---   type  type of the error, 'E', '1', etc.
 ---   valid  |TRUE|: recognized error message
+---   user_data
+---     custom data associated with the item, can be
+---     any type.
 ---
 --- When there is no error list or it's empty, an empty list is
 --- returned. Quickfix list entries with a non-existing buffer
@@ -7595,6 +7598,9 @@ function vim.fn.setpos(expr, list) end
 ---     text  description of the error
 ---     type  single-character error type, 'E', 'W', etc.
 ---     valid  recognized error message
+---     user_data
+---     custom data associated with the item, can be
+---     any type.
 ---
 --- The "col", "vcol", "nr", "type" and "text" entries are
 --- optional.  Either "lnum" or "pattern" entry can be used to

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4105,6 +4105,9 @@ M.funcs = {
       	text	description of the error
       	type	type of the error, 'E', '1', etc.
       	valid	|TRUE|: recognized error message
+      	user_data
+      		custom data associated with the item, can be
+      		any type.
 
       When there is no error list or it's empty, an empty list is
       returned. Quickfix list entries with a non-existing buffer
@@ -9121,6 +9124,9 @@ M.funcs = {
           text	description of the error
           type	single-character error type, 'E', 'W', etc.
           valid	recognized error message
+          user_data
+      		custom data associated with the item, can be
+      		any type.
 
       The "col", "vcol", "nr", "type" and "text" entries are
       optional.  Either "lnum" or "pattern" entry can be used to

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -1649,13 +1649,23 @@ func SetXlistTests(cchar, bnum)
   call s:setup_commands(a:cchar)
 
   call g:Xsetlist([{'bufnr': a:bnum, 'lnum': 1},
-	      \  {'bufnr': a:bnum, 'lnum': 2, 'end_lnum': 3, 'col': 4, 'end_col': 5}])
+        \  {'bufnr': a:bnum, 'lnum': 2, 'end_lnum': 3, 'col': 4, 'end_col': 5, 'user_data': {'6': [7, 8]}}])
   let l = g:Xgetlist()
   call assert_equal(2, len(l))
   call assert_equal(2, l[1].lnum)
   call assert_equal(3, l[1].end_lnum)
   call assert_equal(4, l[1].col)
   call assert_equal(5, l[1].end_col)
+  call assert_equal({'6': [7, 8]}, l[1].user_data)
+
+  " Test that user_data is garbage collected
+  call g:Xsetlist([{'user_data': ['high', 5]},
+        \  {'user_data': {'this': [7, 'eight'], 'is': ['a', 'dictionary']}}])
+  call test_garbagecollect_now()
+  let l = g:Xgetlist()
+  call assert_equal(2, len(l))
+  call assert_equal(['high', 5], l[0].user_data)
+  call assert_equal({'this': [7, 'eight'], 'is': ['a', 'dictionary']}, l[1].user_data)
 
   Xnext
   call g:Xsetlist([{'bufnr': a:bnum, 'lnum': 3}], 'a')


### PR DESCRIPTION
#### vim-patch:9.0.1688: cannot store custom data in quickfix list

Problem: cannot store custom data in quickfix list
Solution: add `user_data` field for the quickfix list

closes: vim/vim#11818

https://github.com/vim/vim/commit/ca6ac99077d2e6d020a34267aa5e0fbc4d23dc38

Co-authored-by: Tom Praschan <13141438+tom-anders@users.noreply.github.com>