### PR TITLE
vim-patch:9.0.1698: Test_map_restore_sid fails in GUI

### DIFF
--- a/test/old/testdir/test_maparg.vim
+++ b/test/old/testdir/test_maparg.vim
@@ -339,7 +339,7 @@ func Test_map_restore_sid()
   new
   source Xmapscript
   inoremap <buffer> <C-B> <Cmd>call RestoreMap()<CR>
-  call feedkeys("i\<CR>\<C-B>\<CR>", 'xt')
+  call feedkeys("i\<CR>\<*C-B>\<CR>", 'xt')
   call assert_equal(['', '42', '42'], getline(1, '$'))
 
   bwipe!


### PR DESCRIPTION
#### vim-patch:9.0.1698: Test_map_restore_sid fails in GUI

Problem: Test_map_restore_sid fails in GUI
Solution: Feed an unsimplified Ctrl-B

closes: vim/vim#12770

https://github.com/vim/vim/commit/7fe108990423535fa7cb804deae49d64831e25a9