### PR TITLE
vim-patch:9.0.1697: incsearch test not sufficient

### DIFF
--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -694,7 +694,16 @@ describe('search cmdline', function()
                           |
     ]]
     screen:expect(s)
-    feed('/xxx')
+    feed('/xx')
+    screen:expect([[
+                          |
+                          |
+                          |
+                          |
+      {inc:xx}x                 |
+      /xx^                 |
+    ]])
+    feed('x')
     screen:expect([[
                           |
                           |

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -2027,8 +2027,10 @@ func Test_incsearch_restore_view()
   let buf = RunVimInTerminal('-S Xincsearch_restore_view', {'rows': 6, 'cols': 20})
 
   call VerifyScreenDump(buf, 'Test_incsearch_restore_view_01', {})
-  call term_sendkeys(buf, '/xxx')
+  call term_sendkeys(buf, '/xx')
   call VerifyScreenDump(buf, 'Test_incsearch_restore_view_02', {})
+  call term_sendkeys(buf, 'x')
+  call VerifyScreenDump(buf, 'Test_incsearch_restore_view_03', {})
   call term_sendkeys(buf, "\<Esc>")
   call VerifyScreenDump(buf, 'Test_incsearch_restore_view_01', {})
 


### PR DESCRIPTION
#### vim-patch:9.0.1697: incsearch test not sufficient

Problem: incsearch test not sufficient (after 9.0.1691)
Solution: add an additional test

https://github.com/vim/vim/commit/73b8209266f0cd5c6d4df77b3700172d9c26df31

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>