### PR TITLE
vim-patch:cd4e4e169ab3

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,6 @@ freebsd_task:
     image_family: freebsd-13-1
   timeout_in: 30m
   install_script:
-    - pkg update -f
     - pkg install -y cmake gmake ninja unzip wget gettext python git
   build_deps_script:
     - gmake deps


### PR DESCRIPTION
#### vim-patch:cd4e4e169ab3

.cirrus.yml: skip pkg update for FreeBSD 13.1 (vim/vim#12767)

https://github.com/vim/vim/commit/cd4e4e169ab3ff0b9315e5bc16d5ba490ee251ff

Co-authored-by: Philip H <47042125+pheiduck@users.noreply.github.com>