### PR TITLE
fix: use snprintf instead of sprintf

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2702,7 +2702,7 @@ void ex_function(exarg_T *eap)
     // Give the function a sequential number.  Can only be used with a
     // Funcref!
     xfree(name);
-    sprintf(numbuf, "%d", ++func_nr);  // NOLINT(runtime/printf)
+    snprintf(numbuf, sizeof(numbuf), "%d", ++func_nr);
     name = xstrdup(numbuf);
   }
 

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1522,21 +1522,17 @@ int mb_stricmp(const char *s1, const char *s2)
 // 'encoding' has been set to.
 void show_utf8(void)
 {
-  int len;
-  int rlen = 0;
-  char *line;
-  int clen;
-
   // Get the byte length of the char under the cursor, including composing
   // characters.
-  line = get_cursor_pos_ptr();
-  len = utfc_ptr2len(line);
+  char *line = get_cursor_pos_ptr();
+  int len = utfc_ptr2len(line);
   if (len == 0) {
     msg("NUL");
     return;
   }
 
-  clen = 0;
+  size_t rlen = 0;
+  int clen = 0;
   for (int i = 0; i < len; i++) {
     if (clen == 0) {
       // start of (composing) character, get its length
@@ -1546,10 +1542,11 @@ void show_utf8(void)
       }
       clen = utf_ptr2len(line + i);
     }
-    sprintf(IObuff + rlen, "%02x ",  // NOLINT(runtime/printf)
-            (line[i] == NL) ? NUL : (uint8_t)line[i]);          // NUL is stored as NL
+    assert(IOSIZE > rlen);
+    snprintf(IObuff + rlen, IOSIZE - rlen, "%02x ",
+             (line[i] == NL) ? NUL : (uint8_t)line[i]);  // NUL is stored as NL
     clen--;
-    rlen += (int)strlen(IObuff + rlen);
+    rlen += strlen(IObuff + rlen);
     if (rlen > IOSIZE - 20) {
       break;
     }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2350,13 +2350,13 @@ bool find_decl(char *ptr, size_t len, bool locally, bool thisblock, int flags_ar
   bool incll;
   int searchflags = flags_arg;
 
-  pat = xmalloc(len + 7);
+  size_t patlen = len + 7;
+  pat = xmalloc(patlen);
 
   // Put "\V" before the pattern to avoid that the special meaning of "."
   // and "~" causes trouble.
-  assert(len <= INT_MAX);
-  sprintf(pat, vim_iswordp(ptr) ? "\\V\\<%.*s\\>" : "\\V%.*s",  // NOLINT(runtime/printf)
-          (int)len, ptr);
+  assert(patlen <= INT_MAX);
+  snprintf(pat, patlen, vim_iswordp(ptr) ? "\\V\\<%.*s\\>" : "\\V%.*s", (int)len, ptr);
   old_pos = curwin->w_cursor;
   save_p_ws = p_ws;
   save_p_scs = p_scs;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -2472,11 +2472,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
             char buf[MAXLINELEN];
 
             aff_entry->ae_cond = getroom_save(spin, items[4]);
-            if (*items[0] == 'P') {
-              sprintf(buf, "^%s", items[4]);  // NOLINT(runtime/printf)
-            } else {
-              sprintf(buf, "%s$", items[4]);  // NOLINT(runtime/printf)
-            }
+            snprintf(buf, sizeof(buf), *items[0] == 'P' ? "^%s" : "%s$", items[4]);
             aff_entry->ae_prog = vim_regcomp(buf, RE_MAGIC + RE_STRING + RE_STRICT);
             if (aff_entry->ae_prog == NULL) {
               smsg(_("Broken condition in %s line %d: %s"),
@@ -2520,7 +2516,7 @@ static afffile_T *spell_read_aff(spellinfo_T *spin, char *fname)
                     onecap_copy(items[4], buf, true);
                     aff_entry->ae_cond = getroom_save(spin, buf);
                     if (aff_entry->ae_cond != NULL) {
-                      sprintf(buf, "^%s", aff_entry->ae_cond);  // NOLINT(runtime/printf)
+                      snprintf(buf, MAXLINELEN, "^%s", aff_entry->ae_cond);
                       vim_regfree(aff_entry->ae_prog);
                       aff_entry->ae_prog = vim_regcomp(buf, RE_MAGIC + RE_STRING);
                     }


### PR DESCRIPTION
Clang 14 now reports sprintf as deprecated.
