### PR TITLE
vim-patch:e978b4534a5e

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -233,8 +233,8 @@ II) It is allowed to distribute a modified (or extended) version of Vim,
 	  maintainer will do with your changes and under what license they
 	  will be distributed is negotiable.  If there has been no negotiation
 	  then this license, or a later version, also applies to your changes.
-	  The current maintainer is Bram Moolenaar <Bram@vim.org>.  If this
-	  changes it will be announced in appropriate places (most likely
+	  The current maintainers are listed here: https://github.com/orgs/vim/people.
+	  If this changes it will be announced in appropriate places (most likely
 	  vim.sf.net, www.vim.org and/or comp.editors).  When it is completely
 	  impossible to contact the maintainer, the obligation to send him
 	  your changes ceases.  Once the maintainer has confirmed that he has

--- a/runtime/autoload/ccomplete.lua
+++ b/runtime/autoload/ccomplete.lua
@@ -24,10 +24,11 @@ local SearchMembers = nil
 -- vim9script
 
 -- # Vim completion script
--- # Language:     C
--- # Maintainer:   Bram Moolenaar <Bram@vim.org>
+-- # Language:	C
+-- # Maintainer:	The Vim Project <https://github.com/vim/vim>
+-- # Last Change:	2023 Aug 10
 -- #		Rewritten in Vim9 script by github user lacygoill
--- # Last Change:  2022 Jan 31
+-- # Former Maintainer:   Bram Moolenaar <Bram@vim.org>
 
 prepended = ''
 grepCache = vim.empty_dict()

--- a/runtime/autoload/gzip.vim
+++ b/runtime/autoload/gzip.vim
@@ -1,6 +1,7 @@
 " Vim autoload file for editing compressed files.
-" Maintainer: Bram Moolenaar <Bram@vim.org>
-" Last Change: 2016 Sep 28
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer: Bram Moolenaar <Bram@vim.org>
 
 " These functions are used by the gzip plugin.
 

--- a/runtime/autoload/paste.vim
+++ b/runtime/autoload/paste.vim
@@ -1,6 +1,7 @@
 " Vim support file to help with paste mappings and menus
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2019 Jan 27
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Define the string to use for items that are present both in Edit, Popup and
 " Toolbar menu.  Also used in mswin.vim and macmap.vim.

--- a/runtime/colors/default.vim
+++ b/runtime/colors/default.vim
@@ -1,6 +1,7 @@
 " Vim color file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2001 Jul 23
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is the default color scheme.  It doesn't define the Normal
 " highlighting, it uses whatever the colors used to be.

--- a/runtime/compiler/README.txt
+++ b/runtime/compiler/README.txt
@@ -8,4 +8,4 @@ If you want to write your own compiler plugin, have a look at the other files
 for how to do it, the format is simple.
 
 If you think a compiler plugin you have written is useful for others, please
-send it to Bram@vim.org.
+send it to the vim-dev mailing list: <vim-dev@vim.org>

--- a/runtime/compiler/msvc.vim
+++ b/runtime/compiler/msvc.vim
@@ -1,7 +1,8 @@
 " Vim compiler file
 " Compiler:	Microsoft Visual C
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2014 Sep 20
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("current_compiler")
   finish

--- a/runtime/delmenu.vim
+++ b/runtime/delmenu.vim
@@ -1,8 +1,9 @@
 " This Vim script deletes all the menus, so that they can be redefined.
 " Warning: This also deletes all menus defined by the user!
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2019 Dec 10
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 aunmenu *
 tlunmenu *

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -88,9 +88,9 @@ Nvim development is funded separately from Vim:
 	https://neovim.io/#sponsor
 
 ==============================================================================
-Credits				*credits*
+Credits							*credits*
 
-Most of Vim was written by Bram Moolenaar <Bram@vim.org>.
+Most of Vim was written by Bram Moolenaar <Bram@vim.org> |Bram-Moolenaar|
 
 Parts of the documentation come from several Vi manuals, written by:
 	W.N. Joy
@@ -194,7 +194,7 @@ Elvis	Another Vi clone, made by Steve Kirkendall.  Very compact but isn't
 Vim	Nvim is based on Vim.  https://www.vim.org/
 
 ==============================================================================
-Bram Moolenaar                                    *Bram* *brammool*
+Bram Moolenaar			*Bram* *Moolenaar* *Bram-Moolenaar* *brammool*
 
 Nvim is a fork of the Vim ("Vi IMproved") text editor, which was originally
 developed by Bram Moolenaar.  Searching his name within the source code of
@@ -202,6 +202,9 @@ Nvim will reveal just how much of his work still remains in Nvim.
 On August 3, 2023, he passed away at the age of 62.  If Vim or Nvim have been
 of use to you in your life, please read |Uganda| and consider honoring his
 memory however you may see fit.
+
+Obituary Articles: https://github.com/vim/vim/discussions/12742
+Say Farewell: https://github.com/vim/vim/discussions/12737
 
 ==============================================================================
 Notation						*notation*

--- a/runtime/doc/uganda.txt
+++ b/runtime/doc/uganda.txt
@@ -46,8 +46,8 @@ II) It is allowed to distribute a modified (or extended) version of Vim,
 	  maintainer will do with your changes and under what license they
 	  will be distributed is negotiable.  If there has been no negotiation
 	  then this license, or a later version, also applies to your changes.
-	  The current maintainer is Bram Moolenaar <Bram@vim.org>.  If this
-	  changes it will be announced in appropriate places (most likely
+	  The current maintainers are listed here: https://github.com/orgs/vim/people.
+	  If this changes it will be announced in appropriate places (most likely
 	  vim.sf.net, www.vim.org and/or comp.editors).  When it is completely
 	  impossible to contact the maintainer, the obligation to send him
 	  your changes ceases.  Once the maintainer has confirmed that he has

--- a/runtime/ftoff.vim
+++ b/runtime/ftoff.vim
@@ -1,7 +1,8 @@
 " Vim support file to switch off detection of file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2001 Jun 11
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("did_load_filetypes")
   unlet did_load_filetypes

--- a/runtime/ftplugin.vim
+++ b/runtime/ftplugin.vim
@@ -1,7 +1,8 @@
 " Vim support file to switch on loading plugins for file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2006 Apr 30
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("did_load_ftplugin")
   finish

--- a/runtime/ftplugin/aap.vim
+++ b/runtime/ftplugin/aap.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Aap recipe
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Nov 14
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/btm.vim
+++ b/runtime/ftplugin/btm.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	BTM
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2004 Jul 06
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	C
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Apr 08
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	C++
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Jul 26
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/diff.vim
+++ b/runtime/ftplugin/diff.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Diff
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Nov 14
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/mail.vim
+++ b/runtime/ftplugin/mail.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Mail
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Oct 23
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/make.vim
+++ b/runtime/ftplugin/make.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Make
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Oct 16
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/objc.vim
+++ b/runtime/ftplugin/objc.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Objective C
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2003 Jan 15
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin
 " Language:	Vim
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2023 Feb 07
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugin/zimbu.vim
+++ b/runtime/ftplugin/zimbu.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:	Zimbu
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Sep 07
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")

--- a/runtime/ftplugof.vim
+++ b/runtime/ftplugof.vim
@@ -1,7 +1,8 @@
 " Vim support file to switch off loading plugins for file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2011 Oct 20
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("did_load_ftplugin")
   unlet did_load_ftplugin

--- a/runtime/indent.vim
+++ b/runtime/indent.vim
@@ -1,7 +1,8 @@
 " Vim support file to switch on loading indent files for file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2008 Feb 22
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("did_indent_on")
   finish

--- a/runtime/indent/README.txt
+++ b/runtime/indent/README.txt
@@ -6,9 +6,9 @@ at ":help indent-expression".  Looking at the existing files should give you
 inspiration.
 
 If you make a new indent file which would be useful for others, please send it
-to Bram@vim.org.  Include instructions for detecting the file type for this
-language, by file name extension or by checking a few lines in the file.
-And please stick to the rules below.
+to the vim-dev mailing list <vim-dev@vim.org>.  Include instructions for
+detecting the file type for this language, by file name extension or by
+checking a few lines in the file. And please stick to the rules below.
 
 If you have remarks about an existing file, send them to the maintainer of
 that file.  Only when you get no response send a message to Bram@vim.org.

--- a/runtime/indent/aap.vim
+++ b/runtime/indent/aap.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	Aap recipe
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Jun 24
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/c.vim
+++ b/runtime/indent/c.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	C
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Mar 27
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/cpp.vim
+++ b/runtime/indent/cpp.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	C++
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2008 Nov 29
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/cuda.vim
+++ b/runtime/indent/cuda.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	CUDA
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2008 Nov 29
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/python.vim
+++ b/runtime/indent/python.vim
@@ -1,8 +1,9 @@
 " Vim indent file
-" Language:		Python
-" Maintainer:		Bram Moolenaar <Bram@vim.org>
+" Language:	Python
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 " Original Author:	David Bustos <bustos@caltech.edu>
-" Last Change:		2021 Sep 26
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/vim.vim
+++ b/runtime/indent/vim.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	Vim script
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Jun 24
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/xhtml.vim
+++ b/runtime/indent/xhtml.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	XHTML
-" Maintainer:	Bram Moolenaar <Bram@vim.org> (for now)
-" Last Change:	2005 Jun 24
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indent/zimbu.vim
+++ b/runtime/indent/zimbu.vim
@@ -1,7 +1,8 @@
 " Vim indent file
 " Language:	Zimbu
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 Sep 26
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")

--- a/runtime/indoff.vim
+++ b/runtime/indoff.vim
@@ -1,7 +1,8 @@
 " Vim support file to switch off loading indent files for file types
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2001 Jun 11
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 if exists("did_indent_on")
   unlet did_indent_on

--- a/runtime/macros/less.vim
+++ b/runtime/macros/less.vim
@@ -1,6 +1,7 @@
 " Vim script to work like "less"
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2020 Dec 17
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Avoid loading this file twice, allow the user to define his own script.
 if exists("loaded_less")

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -1,6 +1,7 @@
 " Script to define the syntax menu in synmenu.vim
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2019 Dec 07
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This is used by "make menu" in the src directory.
 edit <sfile>:p:h/synmenu.vim

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1,8 +1,9 @@
 " Vim support file to define the default menus
 " You can also use this as a start for your own set of menus.
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2023 May 03
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Note that ":an" (short for ":anoremenu") is often used to make a menu work
 " in all modes and avoid side effects from mappings defined by the user.

--- a/runtime/mswin.vim
+++ b/runtime/mswin.vim
@@ -1,7 +1,8 @@
 " Set options and add mapping such that Vim behaves a lot like MS-Windows
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2018 Dec 07
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Bail out if this isn't wanted.
 if exists("g:skip_loading_mswin") && g:skip_loading_mswin

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,8 @@
 " These commands create the option window.
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Dec 16
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
 let buf = bufnr('option-window')

--- a/runtime/plugin/gzip.vim
+++ b/runtime/plugin/gzip.vim
@@ -1,6 +1,7 @@
 " Vim plugin for editing compressed files.
-" Maintainer: Bram Moolenaar <Bram@vim.org>
-" Last Change: 2016 Oct 30
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
 " - this plugin was already loaded

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,7 @@
 " Vim plugin for showing matching parens
-" Maintainer:  Bram Moolenaar <Bram@vim.org>
-" Last Change: 2022 Dec 01
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
 " - this plugin was already loaded (or disabled)

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -1,8 +1,9 @@
 " Vim support file to define the syntax selection menu
 " This file is normally sourced from menu.vim.
 "
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Oct 04
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Define the SetSyn function, used for the Syntax menu entries.
 " Set 'filetype' and also 'syntax' if it is manually selected.

--- a/runtime/syntax/README.txt
+++ b/runtime/syntax/README.txt
@@ -28,9 +28,10 @@ whitespace.vim  View Tabs and Spaces.
 If you want to write a syntax file, read the docs at ":help usr_44.txt".
 
 If you make a new syntax file which would be useful for others, please send it
-to Bram@vim.org.  Include instructions for detecting the file type for this
-language, by file name extension or by checking a few lines in the file.
-And please write the file in a portable way, see ":help 44.12".
+to the vim-dev mailing list <vim-dev@vim.org>.  Include instructions for
+detecting the file type for this language, by file name extension or by
+checking a few lines in the file. And please write the file in a portable way,
+see ":help 44.12".
 
 If you have remarks about an existing file, send them to the maintainer of
 that file.  Only when you get no response send a message to Bram@vim.org.

--- a/runtime/syntax/aap.vim
+++ b/runtime/syntax/aap.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	A-A-P recipe
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2004 Jun 13
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	C
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2023 Mar 08
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/colortest.vim
+++ b/runtime/syntax/colortest.vim
@@ -1,7 +1,8 @@
 " Vim script for testing colors
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
 " Contributors:	Rafael Garcia-Suarez, Charles Campbell
-" Last Change:	2008 Jun 04
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " edit this file, then do ":source %", and check if the colors match
 

--- a/runtime/syntax/conf.vim
+++ b/runtime/syntax/conf.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	generic configure file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2021 May 01
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/ctrlh.vim
+++ b/runtime/syntax/ctrlh.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	CTRL-H (e.g., ASCII manpages)
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Jun 20
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Existing syntax is kept, this file can be used as an addition
 

--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -1,8 +1,9 @@
 " Vim syntax file
 " Language:	Diff (context or unified)
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-"               Translations by Jakson Alves de Aquino.
-" Last Change:	2020 Dec 30
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+"		Translations by Jakson Alves de Aquino.
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Vim help file
-" Maintainer:	Bram Moolenaar (Bram@vim.org)
-" Last Change:	2022 Nov 13
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/manual.vim
+++ b/runtime/syntax/manual.vim
@@ -1,6 +1,7 @@
 " Vim syntax support file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2016 Feb 01
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This file is used for ":syntax manual".
 " It installs the Syntax autocommands, but no the FileType autocommands.

--- a/runtime/syntax/model.vim
+++ b/runtime/syntax/model.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Model
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Jun 20
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " very basic things only (based on the vgrindefs file).
 " If you use this language, please improve it, and send me the patches!

--- a/runtime/syntax/nosyntax.vim
+++ b/runtime/syntax/nosyntax.vim
@@ -1,6 +1,7 @@
 " Vim syntax support file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2006 Apr 16
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This file is used for ":syntax off".
 " It removes the autocommands and stops highlighting for all buffers.

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Quickfix window
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last change:	2001 Jan 15
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/synload.vim
+++ b/runtime/syntax/synload.vim
@@ -1,6 +1,7 @@
 " Vim syntax support file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Apr 12
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This file sets up for syntax highlighting.
 " It is loaded from "syntax.vim" and "manual.vim".

--- a/runtime/syntax/syntax.vim
+++ b/runtime/syntax/syntax.vim
@@ -1,6 +1,7 @@
 " Vim syntax support file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2022 Apr 12
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " This file is used for ":syntax on".
 " It installs the autocommands and starts highlighting for all buffers.

--- a/runtime/syntax/template.vim
+++ b/runtime/syntax/template.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Generic template
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2019 May 06
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/runtime/syntax/vgrindefs.vim
+++ b/runtime/syntax/vgrindefs.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Vgrindefs
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2005 Jun 20
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " The Vgrindefs file is used to specify a language for vgrind
 

--- a/runtime/syntax/viminfo.vim
+++ b/runtime/syntax/viminfo.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:	Vim .viminfo file
-" Maintainer:	Bram Moolenaar <Bram@vim.org>
-" Last Change:	2016 Jun 05
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2023 Aug 10
+" Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -3787,7 +3787,7 @@ msgstr "linje %4ld:"
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Ugyldigt registernavn: '%s'"
 
-msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
+msgid "Messages maintainer: The Vim Project"
 msgstr "Oversætter: scootergrisen"
 
 msgid "Interrupt: "

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -3657,7 +3657,7 @@ msgstr "linio %4ld:"
 msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nevalida nomo de reĝistro: '%s'"
 
-msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
+msgid "Messages maintainer: The Vim Project"
 msgstr "Flegado de mesaĝoj: Dominique PELLÉ <dominique.pelle@gmail.com>"
 
 msgid "Interrupt: "

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -3375,7 +3375,7 @@ msgid "E354: Invalid register name: '%s'"
 msgstr "E354: Nom de registre invalide : '%s'"
 
 # DB - todo : mettre à jour ?
-msgid "Messages maintainer: Bram Moolenaar <Bram@vim.org>"
+msgid "Messages maintainer: The Vim Project"
 msgstr "Maintenance des messages : Dominique Pellé <dominique.pelle@gmail.com>"
 
 msgid "Interrupt: "


### PR DESCRIPTION
Farewell to Bram and dedicate upcoming Vim 9.1 to him (vim/vim#12749)

https://github.com/vim/vim/commit/e978b4534a5e10471108259118c0ef791106fd92

Also update the header for the following files that were converted to Vim9 script upstream:

- autoload/ccomplete.lua (vim9jitted)
- ftplugin.vim
- ftplugof.vim
- indent.vim
- indent/vim.vim
- makemenu.vim

This also updates the "Last Change" dates, even if some changes (due to rewrites to Vim9 script) were not ported.

There's still a few other places where Bram is still mentioned as a maintainer in the files we and Vim have:

- ftplugin/bash.vim
- indent/bash.vim
- indent/html.vim
- indent/mail.vim
- macros/accents.vim
- macros/editexisting.vim
- syntax/bash.vim
- syntax/shared/typescriptcommon.vim
- syntax/tar.vim
- syntax/typescript.vim
- syntax/typescriptreact.vim
- syntax/zimbu.vim

Maybe future patches will address that.

Also exclude changes to .po files that didn't apply automatically (the `:messages` maintainer string isn't used in Nvim anyway).