### PR TITLE
fix(keycodes): recognize <t_xx> as a key

### DIFF
--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -825,6 +825,10 @@ int find_special_key_in_table(int c)
 int get_special_key_code(const char *name)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
+  if (name[0] == 't' && name[1] == '_' && name[2] != NUL && name[3] != NUL) {
+    return TERMCAP2KEY((uint8_t)name[2], (uint8_t)name[3]);
+  }
+
   for (int i = 0; key_names_table[i].name != NULL; i++) {
     const char *const table_name = key_names_table[i].name;
     int j;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1957,6 +1957,12 @@ describe('API', function()
       -- value.
       eq('', meths.replace_termcodes('', true, true, true))
     end)
+
+    -- Not exactly the case, as nvim_replace_termcodes() escapes K_SPECIAL in Unicode
+    it('translates the result of keytrans() on string with 0x80 byte back', function()
+      local s = 'ff\128\253\097tt'
+      eq(s, meths.replace_termcodes(funcs.keytrans(s), true, true, true))
+    end)
   end)
 
   describe('nvim_feedkeys', function()


### PR DESCRIPTION
Problem:    The result of keytrans() sometimes can't be translated back.
Solution:   Recognize <t_xx> as a key.
