### PR TITLE
vim-patch:9.0.1711: dead code in charset.c

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -268,11 +268,6 @@ int linetabsize_col(int startcol, char *s)
   while (*cts.cts_ptr != NUL) {
     cts.cts_vcol += lbr_chartabsize_adv(&cts);
   }
-  if (cts.cts_has_virt_text && cts.cts_ptr == cts.cts_line) {
-    // check for virtual text in an empty line
-    (void)lbr_chartabsize_adv(&cts);
-    cts.cts_vcol += cts.cts_cur_text_width_left + cts.cts_cur_text_width_right;
-  }
   clear_chartabsize_arg(&cts);
   return cts.cts_vcol;
 }


### PR DESCRIPTION
#### vim-patch:9.0.1711: dead code in charset.c

Problem: dead code in charset.c
Solution: remove it

linetabsize_col() calls init_chartabsize_arg() with 0 as "lnum", so
cts.cts_has_prop_with_text is always FALSE.

closes: #PR

https://github.com/vim/vim/commit/d3515a1e88cf25c1d5eae8faa965b587a124e687

N/A patches for version.c:
vim-patch:9.0.1702: Undo test is flaky