### PR TITLE
vim-patch:9.0.1708: getcompletion() failes for user-defined commands

### DIFF
--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -296,6 +296,9 @@ const char *set_context_in_user_cmdarg(const char *cmd FUNC_ATTR_UNUSED, const c
     return set_context_in_menu_cmd(xp, cmd, (char *)arg, forceit);
   }
   if (context == EXPAND_COMMANDS) {
+    if (xp->xp_context == EXPAND_NOTHING) {
+      xp->xp_context = context;
+    }
     return arg;
   }
   if (context == EXPAND_MAPPINGS) {

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3636,4 +3636,14 @@ func Test_rulerformat_position()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_usercmd_completion()
+  let g:complete=[]
+  command! -nargs=* -complete=command TestCompletion echo <q-args>
+  let g:complete = getcompletion('TestCompletion ', 'cmdline')
+  let a = getcompletion('', 'cmdline')
+
+  call assert_equal(a, g:complete)
+  delcom TestCompletion
+  unlet! g:complete
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1708: getcompletion() failes for user-defined commands

Problem: getcompletion() failes for user-defined commands
Solution: set context for completion function

closes: vim/vim#12681

https://github.com/vim/vim/commit/8ef1fbc0c3ca8dca32c352f3cf30e7a4b3096a94

Co-authored-by: Christian Brabandt <cb@256bit.org>