### PR TITLE
feat(highlight): Allow hyphens (-) in highlight group names

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -188,8 +188,8 @@ thing.  These are then linked to a highlight group that specifies the color.
 A syntax group name doesn't specify any color or attributes itself.
 
 The name for a highlight or syntax group must consist of ASCII letters,
-digits, underscores, periods and `@` characters.  As a regexp it is
-`[a-zA-Z0-9_.@]*`. The maximum length of a group name is about 200 bytes.
+digits, underscores, periods, hyphens, and `@` characters.  As a regexp it is
+`[a-zA-Z0-9_.@-]*`. The maximum length of a group name is about 200 bytes.
 *E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -494,9 +494,9 @@ Highlight groups:
   using |n| or |N|
   |hl-CursorLine| is low-priority unless foreground color is set
   |hl-VertSplit| superseded by |hl-WinSeparator|
-  Highlight groups names are allowed to contain the characters `.` and `@`.
+  Highlight groups names are allowed to contain the characters `.`, `@`, and `-`.
   It is an error to define a highlight group with a name that doesn't match
-  the regexp `[a-zA-Z0-9_.@]*` (see |group-name|).
+  the regexp `[a-zA-Z0-9_.@-]*` (see |group-name|).
 
 Macro/|recording| behavior
   Replay of a macro recorded during :lmap produces the same actions as when it

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1942,7 +1942,7 @@ static int syn_add_group(const char *name, size_t len)
     if (!vim_isprintc(c)) {
       emsg(_("E669: Unprintable character in group name"));
       return 0;
-    } else if (!ASCII_ISALNUM(c) && c != '_' && c != '.' && c != '@') {
+    } else if (!ASCII_ISALNUM(c) && c != '_' && c != '.' && c != '@' && c != '-') {
       // '.' and '@' are allowed characters for use with treesitter capture names.
       msg_source(HL_ATTR(HLF_W));
       emsg(_(e_highlight_group_name_invalid_char));

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -106,6 +106,7 @@ describe('semantic token highlighting', function()
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
+        vim.bo[bufnr].filetype = 'some-filetype'
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
 


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/23184
