### PR TITLE
fix(highlight): make winblend work on a transparent background

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -697,8 +697,8 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
 
     cattrs.rgb_ae_attr &= ~HL_BG_INDEXED;
   }
-  cattrs.rgb_bg_color = rgb_blend(ratio, battrs.rgb_bg_color,
-                                  fattrs.rgb_bg_color);
+  cattrs.rgb_bg_color = syn_attr2entry(back_attr).rgb_bg_color == -1 ? -1 :
+                        rgb_blend(ratio, battrs.rgb_bg_color, fattrs.rgb_bg_color);
 
   cattrs.hl_blend = -1;  // blend property was consumed
 


### PR DESCRIPTION
I do not know how we should handle cases like:

- `winblend=100`
- `fattrs.rgb_bg_color==-1`
- `battrs.rgb_bg_color==-1`

In that case we can bypass the `rgb_blend` call like in the current patch, which
causes the "black background" behaviour as described in the issue mentioned
below. This however introduces a different visual glitch: the characters from
the background window "shine through" because there isn't a background to block
it. We could fix this by hiding any characters which match
`battrs.rgb_bg_color==-1`, but what would be the best way to do that? Setting
`guifg=NONE` doesn't hide characters, but renders them as white. I'm not
familiar with Nvim's codebase, ~so I don't know how to clear characters from
rendering "on collision with blending window"~. Disabling `through` seems to do the job.
<br/>

Resolves: #18576
