### PR TITLE
feat(diagnostic): provide more control over virtual text display

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -382,7 +382,10 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                      • virtual_text: (default true) Use virtual text for
                        diagnostics. If multiple diagnostics are set for a
                        namespace, one prefix per diagnostic + the last
-                       diagnostic message are shown. Options:
+                       diagnostic message are shown. In addition to the
+                       options listed below, the "virt_text" options of
+                       |nvim_buf_set_extmark| may also be used here (e.g.
+                       "virt_text_pos" and "hl_mode"). Options:
                        • severity: Only show virtual text for diagnostics
                          matching the given severity |diagnostic-severity|
                        • source: (boolean or string) Include the diagnostic

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -384,7 +384,7 @@ config({opts}, {namespace})                          *vim.diagnostic.config()*
                        namespace, one prefix per diagnostic + the last
                        diagnostic message are shown. In addition to the
                        options listed below, the "virt_text" options of
-                       |nvim_buf_set_extmark| may also be used here (e.g.
+                       |nvim_buf_set_extmark()| may also be used here (e.g.
                        "virt_text_pos" and "hl_mode"). Options:
                        • severity: Only show virtual text for diagnostics
                          matching the given severity |diagnostic-severity|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -194,6 +194,11 @@ The following changes to existing APIs or features add new behavior.
   automatically if the job exited without error, eliminating the (often
   unwanted) "[Process exited 0]" message.
 
+• |vim.diagnostic.config()| now accepts virtual text relevant options to
+  |nvim_buf_set_extmark()| (e.g. "virt_text_pos" and "hl_mode") in its
+  "virtual_text" table, which gives users more control over how diagnostic
+  virtual text is displayed.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -566,7 +566,9 @@ end
 ---                    severity |diagnostic-severity|
 ---       - virtual_text: (default true) Use virtual text for diagnostics. If multiple diagnostics
 ---                       are set for a namespace, one prefix per diagnostic + the last diagnostic
----                       message are shown.
+---                       message are shown. In addition to the options listed below, the
+---                       "virt_text" options of |nvim_buf_set_extmark| may also be used here (e.g.
+---                       "virt_text_pos" and "hl_mode").
 ---                       Options:
 ---                       * severity: Only show virtual text for diagnostics matching the given
 ---                       severity |diagnostic-severity|
@@ -1008,8 +1010,11 @@ M.handlers.virtual_text = {
 
       if virt_texts then
         api.nvim_buf_set_extmark(bufnr, virt_text_ns, line, 0, {
-          hl_mode = 'combine',
+          hl_mode = opts.virtual_text.hl_mode or 'combine',
           virt_text = virt_texts,
+          virt_text_pos = opts.virtual_text.virt_text_pos,
+          virt_text_hide = opts.virtual_text.virt_text_hide,
+          virt_text_win_col = opts.virtual_text.virt_text_win_col,
         })
       end
     end

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -567,8 +567,8 @@ end
 ---       - virtual_text: (default true) Use virtual text for diagnostics. If multiple diagnostics
 ---                       are set for a namespace, one prefix per diagnostic + the last diagnostic
 ---                       message are shown. In addition to the options listed below, the
----                       "virt_text" options of |nvim_buf_set_extmark| may also be used here (e.g.
----                       "virt_text_pos" and "hl_mode").
+---                       "virt_text" options of |nvim_buf_set_extmark()| may also be used here
+---                       (e.g. "virt_text_pos" and "hl_mode").
 ---                       Options:
 ---                       * severity: Only show virtual text for diagnostics matching the given
 ---                       severity |diagnostic-severity|


### PR DESCRIPTION
Allow users to pass virtual text options to nvim_buf_set_extmark through
the "virtual_text" table in vim.diagnostic.config().

Fixes: https://github.com/neovim/neovim/issues/16545
