### PR TITLE
feat(lsp): add callback argument to lsp.buf.format

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1261,6 +1261,9 @@ format({options})                                       *vim.lsp.buf.format()*
                      indexing. Defaults to current selection in visual mode
                      Defaults to `nil` in other modes, formatting the full
                      buffer
+                   • callback (function|nil) When called with async=true, call
+                     callback after the buffer is edited. It has no effect if
+                     async=false
 
 hover()                                                  *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1261,7 +1261,7 @@ format({options})                                       *vim.lsp.buf.format()*
                      indexing. Defaults to current selection in visual mode
                      Defaults to `nil` in other modes, formatting the full
                      buffer
-                   • callback (function|nil) When called with async=true,
+                   • callback (function|nil): When called with async=true,
                      call callback after the buffer is edited. It has no
                      effect if async=false
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1261,9 +1261,9 @@ format({options})                                       *vim.lsp.buf.format()*
                      indexing. Defaults to current selection in visual mode
                      Defaults to `nil` in other modes, formatting the full
                      buffer
-                   • callback (function|nil) When called with async=true, call
-                     callback after the buffer is edited. It has no effect if
-                     async=false
+                   • callback (function|nil) When called with async=true,
+                     call callback after the buffer is edited. It has no
+                     effect if async=false
 
 hover()                                                  *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -192,6 +192,10 @@ end
 ---         (1,0) indexing.
 ---         Defaults to current selection in visual mode
 ---         Defaults to `nil` in other modes, formatting the full buffer
+---
+---     - callback (function|nil):
+---         When called with async=true, call callback after the buffer is edited.
+---         It has no effect if async=false
 function M.format(options)
   options = options or {}
   local bufnr = options.bufnr or api.nvim_get_current_buf()
@@ -229,6 +233,9 @@ function M.format(options)
     local do_format
     do_format = function(idx, client)
       if not client then
+        if options.callback ~= nil then
+          options.callback()
+        end
         return
       end
       local params = set_range(client, util.make_formatting_params(options.formatting_options))

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3655,6 +3655,45 @@ describe('LSP', function()
         end,
       }
     end)
+    it('calls callback when calling async', function()
+      local expected_handlers = {
+        {NIL, {}, {method="shutdown", client_id=1}};
+        {NIL, {}, {method="start", client_id=1}};
+      }
+      local client
+      test_rpc_server {
+        test_name = "basic_formatting",
+        on_init = function(c)
+          client = c
+        end,
+        on_handler = function(_, _, ctx)
+          table.remove(expected_handlers)
+          if ctx.method == "start" then
+            local result = exec_lua([[
+              local bufnr = vim.api.nvim_get_current_buf()
+              vim.lsp.buf_attach_client(bufnr, TEST_RPC_CLIENT_ID)
+
+              local notify_msg
+              local notify = vim.notify
+              vim.notify = function(msg, log_level)
+                notify_msg = msg
+              end
+
+              local callback_called = false
+              local callback = function() callback_called = true end
+              vim.lsp.buf.format({ bufnr = bufnr, async = true, callback = callback })
+              vim.wait(1000, function() return callback_called end)
+
+              vim.notify = notify
+              return {callback_called = callback_called}
+            ]])
+            eq({callback_called=true}, result)
+          elseif ctx.method == "shutdown" then
+            client.stop()
+          end
+        end,
+      }
+    end)
     it('format formats range in visual mode', function()
       exec_lua(create_server_definition)
       local result = exec_lua([[


### PR DESCRIPTION
I thought this would be useful to implement a `FormatWrite` kind of command using `lsp.buf.format`, as follows:

```
vim.api.nvim_create_autocmd("BufWritePost", {
	group = vim.api.nvim_create_augroup("FormatAutogroup", {}),
	callback = function()
                vim.lsp.buf.format { async = true, callback = function() vim.cmd.update() end }
	end,
})
```

I am not very familiar with the design of neovim APIs, so I am not sure if this is something that makes sense, but since it was easy to implement, I thought I'd drop a PR and see if there's interest.