### PR TITLE
vim-patch:9.0.1714: getcompletion() "cmdline" fails after :autocmd

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3479,7 +3479,6 @@ void wildmenu_cleanup(CmdlineInfo *cclp)
 /// "getcompletion()" function
 void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  char *pat;
   expand_T xpc;
   bool filtered = false;
   int options = WILD_SILENT | WILD_USE_NL | WILD_ADD_SLASH
@@ -3510,9 +3509,10 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *pattern = tv_get_string(&argvars[0]);
 
   if (strcmp(type, "cmdline") == 0) {
-    set_one_cmd_context(&xpc, pattern);
+    const int cmdline_len = (int)strlen(pattern);
+    set_cmd_context(&xpc, (char *)pattern, cmdline_len, cmdline_len, false);
     xpc.xp_pattern_len = strlen(xpc.xp_pattern);
-    xpc.xp_col = (int)strlen(pattern);
+    xpc.xp_col = cmdline_len;
     goto theend;
   }
 
@@ -3539,6 +3539,8 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
 theend:
+  ;
+  char *pat;
   if (cmdline_fuzzy_completion_supported(&xpc)) {
     // when fuzzy matching, don't modify the search string
     pat = xstrdup(xpc.xp_pattern);

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -296,9 +296,6 @@ const char *set_context_in_user_cmdarg(const char *cmd FUNC_ATTR_UNUSED, const c
     return set_context_in_menu_cmd(xp, cmd, (char *)arg, forceit);
   }
   if (context == EXPAND_COMMANDS) {
-    if (xp->xp_context == EXPAND_NOTHING) {
-      xp->xp_context = context;
-    }
     return arg;
   }
   if (context == EXPAND_MAPPINGS) {

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -601,6 +601,8 @@ func Test_getcompletion()
   call assert_true(index(l, 'taglist(') >= 0)
   let l = getcompletion('call paint', 'cmdline')
   call assert_equal([], l)
+  let l = getcompletion('autocmd BufEnter * map <bu', 'cmdline')
+  call assert_equal(['<buffer>'], l)
 
   func T(a, c, p)
     let g:cmdline_compl_params = [a:a, a:c, a:p]
@@ -3636,14 +3638,15 @@ func Test_rulerformat_position()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_usercmd_completion()
-  let g:complete=[]
+func Test_getcompletion_usercmd()
   command! -nargs=* -complete=command TestCompletion echo <q-args>
-  let g:complete = getcompletion('TestCompletion ', 'cmdline')
-  let a = getcompletion('', 'cmdline')
 
-  call assert_equal(a, g:complete)
+  call assert_equal(getcompletion('', 'cmdline'),
+        \ getcompletion('TestCompletion ', 'cmdline'))
+  call assert_equal(['<buffer>'],
+        \ getcompletion('TestCompletion map <bu', 'cmdline'))
+
   delcom TestCompletion
-  unlet! g:complete
 endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1714: getcompletion() "cmdline" fails after :autocmd

Problem:  getcompletion() "cmdline" fails after :autocmd
Solution: Use set_cmd_context() instead of set_one_cmd_context().

closes: vim/vim#12804

https://github.com/vim/vim/commit/e4c79d36150431ffb97cb8952ec482af2e57f228