### PR TITLE
vim-patch:4868f637b84a,10f23e10a9f0,636d32b32730,20b33b56ad5d

### DIFF
--- a/runtime/keymap/russian-typograph.vim
+++ b/runtime/keymap/russian-typograph.vim
@@ -1,54 +1,140 @@
 " Vim Keymap file for Russian characters
-" layout English-US standard 104 key 'QWERTY', 'JCUKEN'
+" layout English-US 104 key 'QWERTY'
 "
-" Maintainer:	Restorer <restorers@users.sourceforge.net>
-" Last Changed: 20 Jan 2019
-" Description:  Раскладка сделана на основе раскладки «русская машинопись»
-" (KBDRU1.DLL), поставляемой в составе ОС MS Windows. Эта раскладка позволяет
-" печать практически все знаки препинания используя цифровой ряд и не требуя при
-" этом нажатия дополнительных клавиш, ну и также удобное расположение буквы «Ё».
-" Однако были внесены некоторые дополнения (улучшения?), в частности:
-" ‐ раздельные символы круглых скобок (), расположены на тех же позициях, что и
-" в US-International;
-" ‐ раздельные символы типографских кавычек «», расположены на клавишах «3» и
-" «4» соответственно;
-" ‐ на этих же клавишах находятся внутренние кавычки “лапки”, набираемые при
-" нажатой клавише «ALT»;
-" ‐ возможность набирать символы, отсутствующие в русской раскладке клавиатуры,
-" а именно @#$^&*{}[]"'`~<>, которые расположены на тех же местах, что и раньше.
-" Для этого не требуется переключаться в латинскую раскладку клавиатуры, а
-" оставаясь в русской, использовать для этого дополнительные клавиши «SHIFT» и
-" «ALT»;
-" ‐ и ещё несколько удобств, которые позволяют быстро и с минимальными усилиями
-" набирать текст.
+" Maintainer:	 Restorer <restorer@mail2k.ru>
+" Last Changed:	 25 Apr 2023
+" Version:	 3.3
+" Description:	 описание дано после изображений клавиатуры
 
-scriptencoding utf-8
+" Расположение символов для русского языка при подключенном файле с раскладкой
+" клавиатуры «русская типографская» (russian-typograph.vim). Версия 3.3
 
-" Переключение языка ввода со стандартного сочетания <CTRL+^> на указанные ниже
-" Для режимов вставки и замены
-""или SHIFT+SPACE
-"        inoremap <S-Space> <C-^>
-""или CTRL+SPACE"
-"        inoremap <C-Space> <C-^>
-" Для режима командной строки
-""или SHIFT+SPACE
-"        cnoremap <S-Space> <C-^>
-""или CTRL+SPACE"
-"        cnoremap <C-Space> <C-^>
-" Одной командой для режимов вставки, замены и командной строки
-"        noremap! <S-Space> <C-^>
-"        noremap! <C-Space> <C-^>
+
+"		  Ни одна из клавиш модификаторов не нажата
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  | % | ! | — | « | » | : | , | . | ? | ( | ) | ‐ | ; | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| | й | ц | у | к | е | н | г | ш | щ | з | х | ъ |  /  |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps | ф | ы | в | а | п | р | о | л | д | ж | э |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | Shift  | я | ч | с | м | и | т | ь | б | ю | ё |  Shift   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | Ctrl |  | Alt |                          | Alt  |  | Ctrl |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			    Нажата клавиша SHIFT
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  | = | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0 | - | + | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| | Й | Ц | У | К | Е | Н | Г | Ш | Щ | З | Х | Ъ |  §  |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps | Ф | Ы | В | А | П | Р | О | Л | Д | Ж | Э |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | SHIFT  | Я | Ч | С | М | И | Т | Ь | Б | Ю | Ё |   SHIFT  |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | Ctrl |  | Alt |                          | Alt  |  | Ctrl |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			     Нажата клавиша ALT
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  | ` | № | – | „ | “ |   |   | … |   |   |   | ‑ | ± | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| |   |   |   |   |   |   |   |   |   |   | [ | ] |  \  |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps |   |   |   |   |   | ₽ |   |   |   |   | ' |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | Shift  |   |   |   |   |   |   |   |   |   |   |  Shift   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | Ctrl |  | ALT |          NNBSP           | ALT  |  | Ctrl |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			 Нажаты клавиши SHIFT и ALT
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  | ~ |   | @ | # | $ |   | ^ | & | * |   |   | _ |   | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| |   |   |   |   |   |   |   |   |   |   | { | } |  |  |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps |   |   |   |   |   |   |   |   |   |   | " |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | SHIFT  |   |   |   |   |   |   |   | < | > |   |  SHIFT   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | Ctrl |  | ALT |                          | ALT  |  | Ctrl |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			 Нажаты клавиши SHIFT и CTRL
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  |   |   |   |   |   |   |   |   |   |   |   |   |   | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| |   |   |   |   |   |   |   |   |   |   |   |   |     |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps |   |   |   |   |   |   |   |   |   |   |   |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | SHIFT  |   |   |   |   |   |   |   |   |   |   |  SHIFT   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | CTRL |  | Alt |          NBSP            | Alt  |  | CTRL |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			 Нажаты клавиши ALT и CTRL
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  |   |   |   |   |   |   |   |   |   |   |   |   |   | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| |   |   | у́ |   | е́ |   |   |   |   |   |   |   |     |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps |   | ы́ |   | а́ |   |   | о́ |   |   |   | э́ |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | Shift  | я́ |   |   |   | и́ |   |   |   | ю́ |   |  Shift   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | CTRL |  | ALT |                          | ALT  |  | CTRL |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+"			 Нажаты клавиши SHIFT, ALT и CTRL
+
+"	  ,---,---,---,---,---,---,---,---,---,---,---,---,---,-------,
+"	  |   |   |   |   |   |   |   |   |   |   |   |   |   | <---  |
+"	  |---'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-----|
+"	  | ->| |   |   | У́ |   | Е́ |   |   |   |   |   |   |   |     |
+"	  |-----',--',--',--',--',--',--',--',--',--',--',--',--'-----|
+"	  | Caps |   | Ы́ |   | А́ |   |   | О́ |   |   |   | Э́ |  Enter |
+"	  |------'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'-,-'--------|
+"	  | SHIFT  | Я́ |   |   |   | И́ |   |   |   | Ю́ |   |  SHIFT   |
+"	  |------,-',--'--,'---'---'---'---'---'---'-,-'---',--,------|
+"	  | CTRL |  | ALT |                          | ALT  |  | CTRL |
+"	  '------'  '-----'--------------------------'------'  '------'
+
+
+" Раскладка сделана на основе раскладки «русская машинопись» (KBDRU1.DLL),
+" поставляемой в составе ОС MS Windows.
 "
-" Стандартное переключение по CTRL+^ после этих переназначений также сохраняется
+" Как видите, принцип достаточно простой, — при наборе русского текста все
+" буквы, знаки пунктуации и большинство специальных символов находятся под
+" пальцами и их набор не требует нажатия каких-то дополнительных клавиш.  При
+" наборе символов, которые отсутствуют в русской раскладке, но есть в раскладке
+" US-International, требуется нажать или клавишу <ALT>, если в английской
+" раскладке они набираются без модификаторов, или нажать <ALT>+<SHIFT>, если они
+" набираются с модификатором <SHIFT>.
+
+" scriptencoding utf-8
 
 let b:keymap_name ="RUS"
 
 loadkeymap
 
-"	    DIGITAL ROW
+"		DIGITAL ROW
 
-"	The Shift key is not pressed
-"
+"	None of the modifier keys are pressed
 <char-0x0060>	    <char-0x0025>	" PERCENT SIGN
 <char-0x0031>	    <char-0x0021>	" EXCLAMATION MARK
 <char-0x0032>	    <char-0x2014>	" EM DASH
@@ -63,8 +149,7 @@ loadkeymap
 <char-0x002d>	    <char-0x2010>	" HYPHEN
 <char-0x003d>	    <char-0x003b>	" SEMICOLON
 
-"	The Shift key is pressed
-
+"	The SHIFT key is pressed
 <char-0x007e>	    <char-0x003d>	" EQUALS SIGN
 <char-0x0021>	    <char-0x0031>	" DIGIT ONE
 <char-0x0040>	    <char-0x0032>	" DIGIT TWO
@@ -79,112 +164,188 @@ loadkeymap
 <char-0x005f>	    <char-0x002d>	" HYPHEN-MINUS
 <char-0x002b>	    <char-0x002b>	" PLUS SIGN
 
-"	    ALPHABETICAL 1st ROW
-
-<char-0x0071>	    <char-0x0439>	" CYRILLIC SMALL LETTER SHORT I
-<char-0x0051>	    <char-0x0419>	" CYRILLIC CAPITAL LETTER SHORT I
-<char-0x0077>	    <char-0x0446>	" CYRILLIC SMALL LETTER TSE
-<char-0x0057>	    <char-0x0426>	" CYRILLIC CAPITAL LETTER TSE
-<char-0x0065>	    <char-0x0443>	" CYRILLIC SMALL LETTER U
-<char-0x0045>	    <char-0x0423>	" CYRILLIC CAPITAL LETTER U
-<char-0x0072>	    <char-0x043a>	" CYRILLIC SMALL LETTER KA
-<char-0x0052>	    <char-0x041a>	" CYRILLIC CAPITAL LETTER KA
-<char-0x0074>	    <char-0x0435>	" CYRILLIC SMALL LETTER IE
-<char-0x0054>	    <char-0x0415>	" CYRILLIC CAPITAL LETTER IE
-<char-0x0079>	    <char-0x043d>	" CYRILLIC SMALL LETTER EN
-<char-0x0059>	    <char-0x041d>	" CYRILLIC CAPITAL LETTER EN
-<char-0x0075>	    <char-0x0433>	" CYRILLIC SMALL LETTER GHE
-<char-0x0055>	    <char-0x0413>	" CYRILLIC CAPITAL LETTER GHE
-<char-0x0069>	    <char-0x0448>	" CYRILLIC SMALL LETTER SHA
-<char-0x0049>	    <char-0x0428>	" CYRILLIC CAPITAL LETTER SHA
-<char-0x006f>	    <char-0x0449>	" CYRILLIC SMALL LETTER SHCHA
-<char-0x004f>	    <char-0x0429>	" CYRILLIC CAPITAL LETTER SHCHA
-<char-0x0070>	    <char-0x0437>	" CYRILLIC SMALL LETTER ZE
-<char-0x0050>	    <char-0x0417>	" CYRILLIC CAPITAL LETTER ZE
-<char-0x005b>	    <char-0x0445>	" CYRILLIC SMALL LETTER HA
-<char-0x007b>	    <char-0x0425>	" CYRILLIC CAPITAL LETTER HA
-<char-0x005d>	    <char-0x044a>	" CYRILLIC SMALL LETTER HARD SIGN
-<char-0x007d>	    <char-0x042a>	" CYRILLIC CAPITAL LETTER HARD SIGN
-
-"	    ALPHABETIC 2nd ROW
-
-<char-0x0061>	    <char-0x0444>	" CYRILLIC SMALL LETTER EF
-<char-0x0041>	    <char-0x0424>	" CYRILLIC CAPITAL LETTER EF
-<char-0x0073>	    <char-0x044b>	" CYRILLIC SMALL LETTER YERU
-<char-0x0053>	    <char-0x042b>	" CYRILLIC CAPITAL LETTER YERU
-<char-0x0064>	    <char-0x0432>	" CYRILLIC SMALL LETTER VE
-<char-0x0044>	    <char-0x0412>	" CYRILLIC CAPITAL LETTER VE
-<char-0x0066>	    <char-0x0430>	" CYRILLIC SMALL LETTER A
-<char-0x0046>	    <char-0x0410>	" CYRILLIC CAPITAL LETTER A
-<char-0x0067>	    <char-0x043f>	" CYRILLIC SMALL LETTER PE
-<char-0x0047>	    <char-0x041f>	" CYRILLIC CAPITAL LETTER PE
-<char-0x0068>	    <char-0x0440>	" CYRILLIC SMALL LETTER ER
-<char-0x0048>	    <char-0x0420>	" CYRILLIC CAPITAL LETTER ER
-<char-0x006a>	    <char-0x043e>	" CYRILLIC SMALL LETTER O
-<char-0x004a>	    <char-0x041e>	" CYRILLIC CAPITAL LETTER O
-<char-0x006b>	    <char-0x043b>	" CYRILLIC SMALL LETTER EL
-<char-0x004b>	    <char-0x041b>	" CYRILLIC CAPITAL LETTER EL
-<char-0x006c>	    <char-0x0434>	" CYRILLIC SMALL LETTER DE
-<char-0x004c>	    <char-0x0414>	" CYRILLIC CAPITAL LETTER DE
-<char-0x003b>	    <char-0x0436>	" CYRILLIC SMALL LETTER ZHE
-<char-0x003a>	    <char-0x0416>	" CYRILLIC CAPITAL LETTER ZHE
-<char-0x0027>	    <char-0x044d>	" CYRILLIC SMALL LETTER E
-<char-0x0022>	    <char-0x042d>	" CYRILLIC CAPITAL LETTER E
-
-"	    ALPHABETIC 3rd ROW
-
-<char-0x007a>	    <char-0x044f>	" CYRILLIC SMALL LETTER YA
-<char-0x005a>	    <char-0x042f>	" CYRILLIC CAPITAL LETTER YA
-<char-0x0078>	    <char-0x0447>	" CYRILLIC SMALL LETTER CHE
-<char-0x0058>	    <char-0x0427>	" CYRILLIC CAPITAL LETTER CHE
-<char-0x0063>	    <char-0x0441>	" CYRILLIC SMALL LETTER ES
-<char-0x0043>	    <char-0x0421>	" CYRILLIC CAPITAL LETTER ES
-<char-0x0076>	    <char-0x043c>	" CYRILLIC SMALL LETTER EM
-<char-0x0056>	    <char-0x041c>	" CYRILLIC CAPITAL LETTER EM
-<char-0x0062>	    <char-0x0438>	" CYRILLIC SMALL LETTER I
-<char-0x0042>	    <char-0x0418>	" CYRILLIC CAPITAL LETTER I
-<char-0x006e>	    <char-0x0442>	" CYRILLIC SMALL LETTER TE
-<char-0x004e>	    <char-0x0422>	" CYRILLIC CAPITAL LETTER TE
-<char-0x006d>	    <char-0x044c>	" CYRILLIC SMALL LETTER SOFT SIGN
-<char-0x004d>	    <char-0x042c>	" CYRILLIC CAPITAL LETTER SOFT SIGN
-<char-0x002c>	    <char-0x0431>	" CYRILLIC SMALL LETTER BE
-<char-0x003c>	    <char-0x0411>	" CYRILLIC CAPITAL LETTER BE
-<char-0x002e>	    <char-0x044e>	" CYRILLIC SMALL LETTER YU
-<char-0x003e>	    <char-0x042e>	" CYRILLIC CAPITAL LETTER YU
-<char-0x002f>	    <char-0x0451>	" CYRILLIC SMALL LETTER IO
-<char-0x003f>	    <char-0x0401>	" CYRILLIC CAPITAL LETTER IO
-
-"	    VK_OEM_5 key (scan code 2b)
-
-"	The Shift key is not pressed
-<char-0x005c>	    <char-0x002f>	" SOLIDUS
-"	The Shift key is pressed
-<char-0x007c>	    <char-0x005c>	" REVERSE SOLIDUS
-
-"	    Alt key pressed
-
+"	The ALT key pressed
 <A-char-0x0060>	    <char-0x0060>	" GRAVE ACCENT 
 <A-char-0x0031>	    <char-0x2116>       " NUMERO SIGN
-<A-char-0x0033>	    <char-0x201c>	" LEFT DOUBLE QUOTATION MARK
-<A-char-0x0034>	    <char-0x201d>	" RIGHT DOUBLE QUOTATION MARK
+<A-char-0x0032>	    <char-0x2013>	" EN DASH
+<A-char-0x0033>	    <char-0x201e>	" DOUBLE LOW-9 QUOTATION MARK
+<A-char-0x0034>	    <char-0x201c>	" LEFT DOUBLE QUOTATION MARK
+<A-char-0x0037>	    <char-0x2026>	" HORIZONTAL ELLIPSIS
+<A-char-0x002d>	    <char-0x2011>	" NON-BREAKING HYPHEN
+<A-char-0x003d>	    <char-0x00b1>	" PLUS-MINUS SIGN
+
+"	The SHIFT and ALT keys pressed
+<A-char-0x007e>	    <char-0x007e>	" TILDE
+<A-char-0x0040>	    <char-0x0040>	" COMMERCIAL AT
+<A-char-0x0023>	    <char-0x0023>	" NUMBER SIGN
+<A-char-0x0024>	    <char-0x0024>	" DOLLAR SIGN
+<A-char-0x005e>	    <char-0x005e>	" CIRCUMFLEX ACCENT
+<A-char-0x0026>	    <char-0x0026>	" AMPERSAND
+<A-char-0x002a>	    <char-0x002a>	" ASTERISK
+<A-char-0x005f>	    <char-0x005f>	" LOW LINE
+
+
+"		ALPHABETICAL 1st ROW
+
+"	None of the modifier keys are pressed
+<char-0x0071>	    <char-0x0439>	" CYRILLIC SMALL LETTER SHORT I
+<char-0x0077>	    <char-0x0446>	" CYRILLIC SMALL LETTER TSE
+<char-0x0065>	    <char-0x0443>	" CYRILLIC SMALL LETTER U
+<char-0x0072>	    <char-0x043a>	" CYRILLIC SMALL LETTER KA
+<char-0x0074>	    <char-0x0435>	" CYRILLIC SMALL LETTER IE
+<char-0x0079>	    <char-0x043d>	" CYRILLIC SMALL LETTER EN
+<char-0x0075>	    <char-0x0433>	" CYRILLIC SMALL LETTER GHE
+<char-0x0069>	    <char-0x0448>	" CYRILLIC SMALL LETTER SHA
+<char-0x006f>	    <char-0x0449>	" CYRILLIC SMALL LETTER SHCHA
+<char-0x0070>	    <char-0x0437>	" CYRILLIC SMALL LETTER ZE
+<char-0x005b>	    <char-0x0445>	" CYRILLIC SMALL LETTER HA
+<char-0x005d>	    <char-0x044a>	" CYRILLIC SMALL LETTER HARD SIGN
+
+"	The SHIFT key is pressed
+<char-0x0051>	    <char-0x0419>	" CYRILLIC CAPITAL LETTER SHORT I
+<char-0x0057>	    <char-0x0426>	" CYRILLIC CAPITAL LETTER TSE
+<char-0x0045>	    <char-0x0423>	" CYRILLIC CAPITAL LETTER U
+<char-0x0052>	    <char-0x041a>	" CYRILLIC CAPITAL LETTER KA
+<char-0x0054>	    <char-0x0415>	" CYRILLIC CAPITAL LETTER IE
+<char-0x0059>	    <char-0x041d>	" CYRILLIC CAPITAL LETTER EN
+<char-0x0055>	    <char-0x0413>	" CYRILLIC CAPITAL LETTER GHE
+<char-0x0049>	    <char-0x0428>	" CYRILLIC CAPITAL LETTER SHA
+<char-0x004f>	    <char-0x0429>	" CYRILLIC CAPITAL LETTER SHCHA
+<char-0x0050>	    <char-0x0417>	" CYRILLIC CAPITAL LETTER ZE
+<char-0x007b>	    <char-0x0425>	" CYRILLIC CAPITAL LETTER HA
+<char-0x007d>	    <char-0x042a>	" CYRILLIC CAPITAL LETTER HARD SIGN
+
+"	The ALT key pressed
 <A-char-0x005b>	    <char-0x005b>       " LEFT SQUARE BRACKET
 <A-char-0x005d>	    <char-0x005d>       " RIGHT SQUARE BRACKET
-<A-char-0x0027>	    <char-0x0027>       " APOSTROPHE
 
-"	    Alt and Shift keys pressed
-
-<A-char-0x007e>	    <char-0x007e>	" TILDE
-<A-char-0x0040>	    <char-0x0040>       " COMMERCIAL AT
-<A-char-0x0023>	    <char-0x0023>       " NUMBER SIGN
-<A-char-0x0024>	    <char-0x0024>       " DOLLAR SIGN
-<A-char-0x005e>	    <char-0x005e>       " CIRCUMFLEX ACCENT
-<A-char-0x0026>	    <char-0x0026>       " AMPERSAND
-<A-char-0x002a>	    <char-0x002a>       " ASTERISK
-<A-char-0x005f>	    <char-0x005f>       " LOW LINE
+"	The SHIFT and ALT keys pressed
 <A-char-0x007b>	    <char-0x007b>       " LEFT CURLY BRACKET
 <A-char-0x007d>	    <char-0x007d>       " RIGHT CURLY BRACKET
+
+"	The ALT and CTRL key pressed
+<A-C-char-0x0065>    <char-0x0443><char-0x0301>	" CYRILLIC SMALL LETTER U with COMBINING ACUTE ACCENT
+<A-C-char-0x0074>    <char-0x0435><char-0x0301>	" CYRILLIC SMALL LETTER IE with COMBINING ACUTE ACCENT
+
+"	The SHIFT and ALT and CTRL keys pressed
+<S-A-C-char-0x0045>    <char-0x0423><char-0x0301>   " CYRILLIC CAPITAL LETTER U with COMBINING ACUTE ACCENT
+<S-A-C-char-0x0054>    <char-0x0415><char-0x0301>   " CYRILLIC CAPITAL LETTER IE with COMBINING ACUTE ACCENT
+
+
+"		ALPHABETIC 2st ROW
+
+"	None of the modifier keys are pressed
+<char-0x0061>	    <char-0x0444>	" CYRILLIC SMALL LETTER EF
+<char-0x0073>	    <char-0x044b>	" CYRILLIC SMALL LETTER YERU
+<char-0x0064>	    <char-0x0432>	" CYRILLIC SMALL LETTER VE
+<char-0x0066>	    <char-0x0430>	" CYRILLIC SMALL LETTER A
+<char-0x0067>	    <char-0x043f>	" CYRILLIC SMALL LETTER PE
+<char-0x0068>	    <char-0x0440>	" CYRILLIC SMALL LETTER ER
+<char-0x006a>	    <char-0x043e>	" CYRILLIC SMALL LETTER O
+<char-0x006b>	    <char-0x043b>	" CYRILLIC SMALL LETTER EL
+<char-0x006c>	    <char-0x0434>	" CYRILLIC SMALL LETTER DE
+<char-0x003b>	    <char-0x0436>	" CYRILLIC SMALL LETTER ZHE
+<char-0x0027>	    <char-0x044d>	" CYRILLIC SMALL LETTER E
+
+"	The SHIFT key is pressed
+<char-0x0041>	    <char-0x0424>	" CYRILLIC CAPITAL LETTER EF
+<char-0x0053>	    <char-0x042b>	" CYRILLIC CAPITAL LETTER YERU
+<char-0x0044>	    <char-0x0412>	" CYRILLIC CAPITAL LETTER VE
+<char-0x0046>	    <char-0x0410>	" CYRILLIC CAPITAL LETTER A
+<char-0x0047>	    <char-0x041f>	" CYRILLIC CAPITAL LETTER PE
+<char-0x0048>	    <char-0x0420>	" CYRILLIC CAPITAL LETTER ER
+<char-0x004a>	    <char-0x041e>	" CYRILLIC CAPITAL LETTER O
+<char-0x004b>	    <char-0x041b>	" CYRILLIC CAPITAL LETTER EL
+<char-0x004c>	    <char-0x0414>	" CYRILLIC CAPITAL LETTER DE
+<char-0x003a>	    <char-0x0416>	" CYRILLIC CAPITAL LETTER ZHE
+<char-0x0022>	    <char-0x042d>	" CYRILLIC CAPITAL LETTER E
+
+"	The ALT key pressed
+<A-char-0x0027>	    <char-0x0027>       " APOSTROPHE
+<A-char-0x0068>	    <char-0x20bd>	" RUBLE SIGN
+
+"	The SHIFT and ALT keys pressed
 <A-char-0x0022>	    <char-0x0022>       " QUOTATION MARK
+
+"	The ALT and CTRL key pressed
+<A-C-char-0x0073>    <char-0x044b><char-0x0301>	" CYRILLIC SMALL LETTER YERU with COMBINING ACUTE ACCENT
+<A-C-char-0x0066>    <char-0x0430><char-0x0301>	" CYRILLIC SMALL LETTER A with COMBINING ACUTE ACCENT
+<A-C-char-0x006a>    <char-0x043e><char-0x0301>	" CYRILLIC SMALL LETTER O with COMBINING ACUTE ACCENT
+<A-C-char-0x0027>    <char-0x044d><char-0x0301>	" CYRILLIC SMALL LETTER E with COMBINING ACUTE ACCENT
+
+"	The SHIFT and ALT and CTRL keys pressed
+<S-A-C-char-0x0053>    <char-0x042b><char-0x0301>   " CYRILLIC CAPITAL LETTER YERU with COMBINING ACUTE ACCENT
+<S-A-C-char-0x0046>    <char-0x0410><char-0x0301>   " CYRILLIC CAPITAL LETTER A with COMBINING ACUTE ACCENT
+<S-A-C-char-0x004a>    <char-0x041e><char-0x0301>   " CYRILLIC CAPITAL LETTER O with COMBINING ACUTE ACCENT
+<S-A-C-char-0x0022>    <char-0x042d><char-0x0301>   " CYRILLIC CAPITAL LETTER E with COMBINING ACUTE ACCENT
+
+
+"		ALPHABETIC 3st ROW
+
+"	None of the modifier keys are pressed
+<char-0x007a>	    <char-0x044f>	" CYRILLIC SMALL LETTER YA
+<char-0x0078>	    <char-0x0447>	" CYRILLIC SMALL LETTER CHE
+<char-0x0063>	    <char-0x0441>	" CYRILLIC SMALL LETTER ES
+<char-0x0076>	    <char-0x043c>	" CYRILLIC SMALL LETTER EM
+<char-0x0062>	    <char-0x0438>	" CYRILLIC SMALL LETTER I
+<char-0x006e>	    <char-0x0442>	" CYRILLIC SMALL LETTER TE
+<char-0x006d>	    <char-0x044c>	" CYRILLIC SMALL LETTER SOFT SIGN
+<char-0x002c>	    <char-0x0431>	" CYRILLIC SMALL LETTER BE
+<char-0x002e>	    <char-0x044e>	" CYRILLIC SMALL LETTER YU
+<char-0x002f>	    <char-0x0451>	" CYRILLIC SMALL LETTER IO
+
+"	The SHIFT key is pressed
+<char-0x005a>	    <char-0x042f>	" CYRILLIC CAPITAL LETTER YA
+<char-0x0058>	    <char-0x0427>	" CYRILLIC CAPITAL LETTER CHE
+<char-0x0043>	    <char-0x0421>	" CYRILLIC CAPITAL LETTER ES
+<char-0x0056>	    <char-0x041c>	" CYRILLIC CAPITAL LETTER EM
+<char-0x0042>	    <char-0x0418>	" CYRILLIC CAPITAL LETTER I
+<char-0x004e>	    <char-0x0422>	" CYRILLIC CAPITAL LETTER TE
+<char-0x004d>	    <char-0x042c>	" CYRILLIC CAPITAL LETTER SOFT SIGN
+<char-0x003c>	    <char-0x0411>	" CYRILLIC CAPITAL LETTER BE
+<char-0x003e>	    <char-0x042e>	" CYRILLIC CAPITAL LETTER YU
+<char-0x003f>	    <char-0x0401>	" CYRILLIC CAPITAL LETTER IO
+
+"	The ALT key pressed
+
+
+"	The SHIFT and ALT keys pressed
 <A-char-0x003c>	    <char-0x003c>       " LESS-THAN SIGN
 <A-char-0x003e>	    <char-0x003e>       " GREATER-THAN SIGN
+
+"	The ALT and CTRL key pressed
+<A-C-char-0x007a>    <char-0x044f><char-0x0301>	" CYRILLIC SMALL LETTER YA with COMBINING ACUTE ACCENT
+<A-C-char-0x0062>    <char-0x0438><char-0x0301>	" CYRILLIC SMALL LETTER I with COMBINING ACUTE ACCENT
+<A-C-char-0x002e>    <char-0x044e><char-0x0301>	" CYRILLIC SMALL LETTER YU with COMBINING ACUTE ACCENT
+
+"	The SHIFT and ALT and CTRL keys pressed
+<S-A-C-char-0x005a>    <char-0x042f><char-0x0301>   " CYRILLIC CAPITAL LETTER YA with COMBINING ACUTE ACCENT
+<S-A-C-char-0x0042>    <char-0x0418><char-0x0301>   " CYRILLIC CAPITAL LETTER I with COMBINING ACUTE ACCENT
+<S-A-C-char-0x003e>    <char-0x042e><char-0x0301>   " CYRILLIC CAPITAL LETTER Y with COMBINING ACUTE ACCENT
+
+
+"		VK_OEM_5 key (scan code 2b)
+
+"	None of the modifier keys are pressed
+<char-0x005c>	    <char-0x002f>	" SOLIDUS
+
+"	The SHIFT key is pressed
+<char-0x007c>	    <char-0x00a7>	" SECTION SIGN
+
+"	The ALT key is pressed
+<A-char-0x005c>	    <char-0x005c>	" REVERSE SOLIDUS
+
+"	The SHIFT and ALT keys pressed
 <A-char-0x007c>	    <char-0x007c>       " VERTICAL LINE
+
+
+"		SPACE BAR key
+
+"	The ALT key pressed
+<A-char-0x0020>	    <char-0x202f>	" NARROW NO-BREAK SPACE
+
+"	The SHIFT and CTRL keys pressed
+<S-C-char-0x0020>   <char-0x00A0>	" NO-BREAK SPACE
+
+"	    \///\\
 

--- a/runtime/syntax/fortran.vim
+++ b/runtime/syntax/fortran.vim
@@ -1,6 +1,6 @@
 " Vim syntax file
 " Language:	Fortran 2008 (and older: Fortran 2003, 95, 90, and 77)
-" Version:	(v104) 2021 April 06
+" Version:	(v105) 2023 August 14
 " Maintainer:	Ajit J. Thakkar <ajit@unb.ca>; <http://www2.unb.ca/~ajit/>
 " Usage:	For instructions, do :help fortran-syntax from Vim
 " Credits:
@@ -11,7 +11,7 @@
 "  Walter Dieudonne, Alexander Wagner, Roman Bertle, Charles Rendleman,
 "  Andrew Griffiths, Joe Krahn, Hendrik Merx, Matt Thompson, Jan Hermann,
 "  Stefano Zaghi, Vishnu V. Krishnan, Judicael Grasset, Takuma Yoshida,
-"  Eisuke Kawashima, Andre Chalella, and Fritz Reese.
+"  Eisuke Kawashima, Andre Chalella, Fritz Reese, and Karl D. Hammond.
 
 if exists("b:current_syntax")
   finish
@@ -95,16 +95,14 @@ if exists("fortran_more_precise")
   syn match fortranConstructName "\(\<end\s*do\s\+\)\@11<=\a\w*"
   syn match fortranConstructName "\(\<end\s*if\s\+\)\@11<=\a\w*"
   syn match fortranConstructName "\(\<end\s*select\s\+\)\@15<=\a\w*"
+  syn match fortranConstructName "\(\<\%(exit\|cycle\)\s\+\)\@11<=\a\w*"
 endif
 
 syn match fortranUnitHeader	"\<end\>"
-syn match fortranType		"\<character\>"
-syn match fortranType		"\<complex\>"
-syn match fortranType		"\<integer\>"
-syn match fortranType		"\<real\>"
-syn match fortranType		"\<logical\>"
+syn match fortranType		"\<character\((\s*kind\s*=\w\+)\)\?\>"
+syn match fortranType		"\<complex\((\s*kind\s*=\w\+)\)\?\>"
 syn keyword fortranType		intrinsic
-syn match fortranType		"\<implicit\>"
+syn match fortranType		"\<implicit\>\s\+\(none\)\?"
 syn keyword fortranStructure	dimension
 syn keyword fortranStorageClass	parameter save
 syn match fortranUnitHeader	"\<subroutine\>"
@@ -131,7 +129,8 @@ syn match fortranTypeOb		"\<character\s*\*"
 
 syn match fortranBoolean	"\.\s*\(true\|false\)\s*\."
 
-syn keyword fortranReadWrite	backspace close endfile inquire open print read rewind write
+syn keyword fortranReadWrite	print
+syn match fortranReadWrite	'\<\(backspace\|close\|endfile\|inquire\|open\|read\|rewind\|write\)\ze\s*('
 
 "If tabs are allowed then the left margin checks do not work
 if exists("fortran_have_tabs")
@@ -140,7 +139,7 @@ else
   syn match fortranTab		"\t"
 endif
 
-syn keyword fortranIO		access blank direct exist file fmt form formatted iostat name named nextrec number opened rec recl sequential status unformatted unit
+syn match fortranIO		'\%(\((\|,\|, *&\n\)\s*\)\@<=\(access\|blank\|direct\|exist\|file\|fmt\|form\|formatted\|iostat\|name\|named\|nextrec\|number\|opened\|rec\|recl\|sequential\|status\|unformatted\|unit\)\ze\s*='
 
 syn keyword fortranIntrinsicR		alog alog10 amax0 amax1 amin0 amin1 amod cabs ccos cexp clog csin csqrt dabs dacos dasin datan datan2 dcos dcosh ddim dexp dint dlog dlog10 dmax1 dmin1 dmod dnint dsign dsin dsinh dsqrt dtan dtanh float iabs idim idint idnint ifix isign max0 max1 min0 min1 sngl
 
@@ -151,8 +150,9 @@ syn keyword fortranIntrinsic	abs acos aimag aint anint asin atan atan2 char cmpl
 syn match fortranIntrinsic	"\<len\s*[(,]"me=s+3
 syn match fortranIntrinsic	"\<real\s*("me=s+4
 syn match fortranIntrinsic	"\<logical\s*("me=s+7
-syn match fortranType           "\<implicit\s\+real\>"
-syn match fortranType           "\<implicit\s\+logical\>"
+syn match fortranType           "\<type\>\(\s\+is\>\)\?"
+syn match fortranType		"^\s*\(type\s\+\(is\)\? \)\?\s*\(real\|integer\|logical\|complex\|character\)\>"
+syn match fortranType           "^\s*\(implicit \)\?\s*\(real\|integer\|logical\|complex\|character\)\>"
 
 "Numbers of various sorts
 " Integers
@@ -206,9 +206,6 @@ syn region fortranStringR	start=+'+ end=+'+ contains=fortranContinueMark,fortran
 syn keyword fortranIntrinsicR	dim lge lgt lle llt mod
 syn keyword fortranKeywordDel	assign pause
 
-syn match fortranType           "\<type\>"
-syn keyword fortranType	        none
-
 syn keyword fortranStructure	private public intent optional
 syn keyword fortranStructure	pointer target allocatable
 syn keyword fortranStorageClass	in out
@@ -222,7 +219,8 @@ syn keyword fortranUnitHeader	result operator assignment
 syn match fortranUnitHeader	"\<interface\>"
 syn keyword fortranKeyword	allocate deallocate nullify cycle exit
 syn match fortranConditional	"\<select\>"
-syn keyword fortranConditional	case default where elsewhere
+syn match fortranConditional	"\<case\s\+default\>"
+syn keyword fortranConditional	where elsewhere
 
 syn match fortranOperator	"\(\(>\|<\)=\=\|==\|/=\|=\)"
 syn match fortranOperator	"=>"
@@ -231,8 +229,7 @@ syn region fortranString	start=+"+ end=+"+	contains=fortranLeftMargin,fortranCon
 syn keyword fortranIO		pad position action delim readwrite
 syn keyword fortranIO		eor advance nml
 
-syn keyword fortranIntrinsic	adjustl adjustr all allocated any associated bit_size btest ceiling count cshift date_and_time digits dot_product eoshift epsilon exponent floor fraction huge iand ibclr ibits ibset ieor ior ishft ishftc lbound len_trim matmul maxexponent maxloc maxval merge minexponent minloc minval modulo mvbits nearest pack precision present product radix random_number random_seed range repeat reshape rrspacing
-syn keyword fortranIntrinsic	scale scan selected_int_kind selected_real_kind set_exponent shape size spacing spread sum system_clock tiny transpose trim ubound unpack verify
+syn match fortranIntrinsic '\<\(adjustl\|adjustr\|all\|allocated\|any\|associated\|bit_size\|btest\|ceiling\|count\|cshift\|date_and_time\|digits\|dot_product\|eoshift\|epsilon\|exponent\|floor\|fraction\|huge\|iand\|ibclr\|ibits\|ibset\|ieor\|ior\|ishft\|ishftc\|lbound\|len_trim\|matmul\|maxexponent\|maxloc\|maxval\|merge\|minexponent\|minloc\|minval\|modulo\|mvbits\|nearest\|pack\|precision\|present\|product\|radix\|random_number\|random_seed\|range\|repeat\|reshape\|rrspacing\|scale\|scan\|selected_int_kind\|selected_real_kind\|set_exponent\|shape\|size\|spacing\|spread\|sum\|system_clock\|tiny\|transpose\|trim\|ubound\|unpack\|verify\)\>\ze\s*('
 syn match fortranIntrinsic		"\<not\>\(\s*\.\)\@!"me=s+3
 syn match fortranIntrinsic	"\<kind\>\s*[(,]"me=s+4
 
@@ -306,9 +303,9 @@ if b:fortran_dialect == "f08"
   syn match fortranType               "\<end\s*associate"
   syn match fortranType               "\<enum\s*,\s*bind\s*(\s*c\s*)"
   syn match fortranType               "\<end\s*enum"
-  syn match fortranConditional	"\<select\s*type"
-  syn match fortranConditional        "\<type\s*is\>"
+  syn match fortranConditional	      "\<select\s*type"
   syn match fortranConditional        "\<class\s*is\>"
+  syn match fortranConditional        "\<class\s*default\>"
   syn match fortranUnitHeader         "\<abstract\s*interface\>"
   syn match fortranOperator           "\([\|]\)"
 
@@ -525,11 +522,6 @@ else
   hi! def link fortranConditionalR	fortranConditional
 endif
 
-" CUDA
-hi def link fortranIntrinsicCUDA        fortranIntrinsic
-hi def link fortranTypeCUDA             fortranType
-hi def link fortranStringCUDA           fortranString
-
 hi def link fortranFormatSpec	Identifier
 hi def link fortranFloat	Float
 hi def link fortranPreCondit	PreCondit
@@ -543,8 +535,15 @@ hi def link fortranComment	Comment
 hi def link fortranSerialNumber	Todo
 hi def link fortranTab		Error
 
-" Uncomment the next line if you use extra intrinsics provided by vendors
-"hi def link fortranExtraIntrinsic	Function
+if exists("fortran_CUDA")
+  hi def link fortranIntrinsicCUDA        fortranIntrinsic
+  hi def link fortranTypeCUDA             fortranType
+  hi def link fortranStringCUDA           fortranString
+endif
+
+if exists("fortran_vendor_intrinsics")
+  hi def link fortranExtraIntrinsic	Function
+endif
 
 let b:current_syntax = "fortran"
 

--- a/runtime/syntax/freebasic.vim
+++ b/runtime/syntax/freebasic.vim
@@ -2,7 +2,7 @@
 " Language:		FreeBASIC
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Mark Manning <markem@sim1.us>
-" Last Change:		2022 Jun 26
+" Last Change:		2023 Aug 14
 "
 " Description:
 "
@@ -338,13 +338,13 @@ syn keyword	freebasicPredefined		__FB_64BIT__ __FB_ARGC__ __FB_ARG_COUNT__ __FB_
 syn keyword	freebasicPredefined		__FB_ARG_RIGHTOF__ __FB_ARGV__ __FB_ARM__ __FB_ASM__ __FB_BACKEND__
 syn keyword	freebasicPredefined		__FB_BIGENDIAN__ __FB_BUILD_DATE__ __FB_BUILD_DATE_ISO__ __FB_BUILD_SHA1__
 syn keyword	freebasicPredefined		__FB_CYGWIN__ __FB_DARWIN__ __FB_DEBUG__ __FB_DOS__ __FB_ERR__ __FB_EVAL__
-syn keyword	freebasicPredefined		__FB_FPMODE__ __FB_FPU__ __FB_FREEBSD__ __FB_GCC__ __FB_GUI__ __FB_JOIN__
+syn keyword	freebasicPredefined		__FB_FPMODE__ __FB_FPU__ __FB_FREEBSD__ __FB_GCC__ __FB_GUI__ __FB_IIF__ __FB_JOIN__
 syn keyword	freebasicPredefined		__FB_LANG__ __FB_LINUX__ __FB_MAIN__ __FB_MIN_VERSION__ __FB_MT__ __FB_NETBSD__
 syn keyword	freebasicPredefined		__FB_OPENBSD__ __FB_OPTIMIZE__ __FB_OPTION_BYVAL__ __FB_OPTION_DYNAMIC__
 syn keyword	freebasicPredefined		__FB_OPTION_ESCAPE__ __FB_OPTION_EXPLICIT__ __FB_OPTION_GOSUB__
 syn keyword	freebasicPredefined		__FB_OPTION_PRIVATE__ __FB_OUT_DLL__ __FB_OUT_EXE__ __FB_OUT_LIB__ __FB_OUT_OBJ__
-syn keyword	freebasicPredefined		__FB_PCOS__ __FB_PPC__ __FB_QUOTE__ __FB_SIGNATURE__ __FB_SSE__ __FB_UNIQUEID__
-syn keyword	freebasicPredefined		__FB_UNIQUEID_POP__ __FB_UNIQUEID_PUSH__ __FB_UNIX__ __FB_UNQUOTE__
+syn keyword	freebasicPredefined		__FB_PCOS__ __FB_PPC__ __FB_QUERY_SYMBOL__ __FB_QUOTE__ __FB_SIGNATURE__ __FB_SSE__
+syn keyword	freebasicPredefined		__FB_UNIQUEID__ __FB_UNIQUEID_POP__ __FB_UNIQUEID_PUSH__ __FB_UNIX__ __FB_UNQUOTE__
 syn keyword	freebasicPredefined		__FB_VECTORIZE__ __FB_VER_MAJOR__ __FB_VER_MINOR__ __FB_VER_PATCH__ __FB_VERSION__
 syn keyword	freebasicPredefined		__FB_WIN32__ __FB_X86__ __FB_XBOX__
 syn keyword	freebasicPredefined		__FILE__ __FILE_NQ__ __FUNCTION__ __FUNCTION_NQ__

--- a/runtime/syntax/muttrc.vim
+++ b/runtime/syntax/muttrc.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language:	Mutt setup files
 " Original:	Preben 'Peppe' Guldberg <peppe-vim@wielders.org>
-" Maintainer:	Kyle Wheeler <kyle-muttrc.vim@memoryhole.net>
-" Last Change:	21 May 2018
+" Maintainer:	Luna Celeste <luna@unixpoet.dev>
+" Last Change:	14 Aug 2023
 
-" This file covers mutt version 1.10.0
+" This file covers mutt version 2.2.10
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -103,88 +103,96 @@ syn match   muttrcKeyName	contained "<F[0-9]\+>"
 
 syn keyword muttrcVarBool	skipwhite contained 
 			\ allow_8bit allow_ansi arrow_cursor ascii_chars askbcc askcc attach_split
-			\ auto_tag autoedit beep beep_new bounce_delivered braille_friendly
-			\ browser_abbreviate_mailboxes change_folder_next check_mbox_size check_new
-			\ collapse_unread confirmappend confirmcreate crypt_autoencrypt crypt_autopgp
-			\ crypt_autosign crypt_autosmime crypt_confirmhook crypt_opportunistic_encrypt
-			\ crypt_replyencrypt crypt_replysign crypt_replysignencrypted crypt_timestamp
-			\ crypt_use_gpgme crypt_use_pka delete_untag digest_collapse duplicate_threads
-			\ edit_hdrs edit_headers encode_from envelope_from fast_reply fcc_clear
-			\ flag_safe followup_to force_name forw_decode forw_decrypt forw_quote
-			\ forward_decode forward_decrypt forward_quote hdrs header
-			\ header_color_partial help hidden_host hide_limited hide_missing
-			\ hide_thread_subject hide_top_limited hide_top_missing history_remove_dups
-			\ honor_disposition idn_decode idn_encode ignore_linear_white_space
-			\ ignore_list_reply_to imap_check_subscribed imap_list_subscribed imap_passive
-			\ imap_peek imap_servernoise implicit_autoview include_onlyfirst keep_flagged
+			\ auto_tag autoedit auto_subscribe background_edit background_confirm_quit beep beep_new
+			\ bounce_delivered braille_friendly browser_abbreviate_mailboxes browser_sticky_cursor
+			\ change_folder_next check_mbox_size check_new collapse_unread compose_confirm_detach_first
+			\ confirmappend confirmcreate copy_decode_weed count_alternatives crypt_autoencrypt crypt_autopgp
+			\ crypt_autosign crypt_autosmime crypt_confirmhook crypt_protected_headers_read
+			\ crypt_protected_headers_save crypt_protected_headers_write crypt_opportunistic_encrypt
+			\ crypt_opportunistic_encrypt_strong_keys crypt_replyencrypt crypt_replysign
+			\ crypt_replysignencrypted crypt_timestamp crypt_use_gpgme crypt_use_pka cursor_overlay
+			\ delete_untag digest_collapse duplicate_threads edit_hdrs edit_headers encode_from
+			\ envelope_from fast_reply fcc_before_send fcc_clear flag_safe followup_to force_name forw_decode
+			\ forw_decrypt forw_quote forward_decode forward_quote hdrs header
+			\ header_color_partial help hidden_host hide_limited hide_missing hide_thread_subject
+			\ hide_top_limited hide_top_missing history_remove_dups honor_disposition idn_decode idn_encode
+			\ ignore_linear_white_space ignore_list_reply_to imap_check_subscribed imap_condstore imap_deflate
+			\ imap_list_subscribed imap_passive imap_peek imap_qresync imap_servernoise
+			\ implicit_autoview include_encrypted include_onlyfirst keep_flagged local_date_header
 			\ mail_check_recent mail_check_stats mailcap_sanitize maildir_check_cur
 			\ maildir_header_cache_verify maildir_trash mark_old markers menu_move_off
 			\ menu_scroll message_cache_clean meta_key metoo mh_purge mime_forward_decode
-			\ mime_type_query_first narrow_tree pager_stop pgp_auto_decode
+			\ mime_type_query_first muttlisp_inline_eval narrow_tree pager_stop pgp_auto_decode
 			\ pgp_auto_traditional pgp_autoencrypt pgp_autoinline pgp_autosign
-			\ pgp_check_exit pgp_create_traditional pgp_ignore_subkeys pgp_long_ids
-			\ pgp_replyencrypt pgp_replyinline pgp_replysign pgp_replysignencrypted
-			\ pgp_retainable_sigs pgp_self_encrypt pgp_self_encrypt_as pgp_show_unusable
-			\ pgp_strict_enc pgp_use_gpg_agent pipe_decode pipe_split pop_auth_try_all
-			\ pop_last postpone_encrypt postpone_encrypt_as print_decode print_split
-			\ prompt_after read_only reflow_space_quotes reflow_text reflow_wrap
-			\ reply_self resolve resume_draft_files resume_edited_draft_files
-			\ reverse_alias reverse_name reverse_realname rfc2047_parameters save_address
-			\ save_empty save_name score sidebar_folder_indent sidebar_new_mail_only
-			\ sidebar_next_new_wrap sidebar_short_path sidebar_sort sidebar_visible
-			\ sig_dashes sig_on_top smart_wrap smime_ask_cert_label
-			\ smime_decrypt_use_default_key smime_is_default smime_self_encrypt
-			\ smime_self_encrypt_as sort_re ssl_force_tls ssl_use_sslv2 ssl_use_sslv3
-			\ ssl_use_tlsv1 ssl_usesystemcerts ssl_verify_dates ssl_verify_host
-			\ ssl_verify_partial_chains status_on_top strict_mime strict_threads suspend
-			\ text_flowed thorough_search thread_received tilde ts_enabled uncollapse_jump
-			\ use_8bitmime use_domain use_envelope_from use_from use_idn use_ipv6
-			\ uncollapse_new user_agent wait_key weed wrap_search write_bcc
+			\ pgp_check_exit pgp_check_gpg_decrypt_status_fd pgp_create_traditional
+			\ pgp_ignore_subkeys pgp_long_ids pgp_replyencrypt pgp_replyinline
+			\ pgp_replysign pgp_replysignencrypted pgp_retainable_sigs pgp_self_encrypt
+			\ pgp_self_encrypt_as pgp_show_unusable pgp_strict_enc pgp_use_gpg_agent
+			\ pipe_decode pipe_decode_weed pipe_split pop_auth_try_all pop_last postpone_encrypt
+			\ postpone_encrypt_as print_decode print_decode_weed print_split prompt_after read_only
+			\ reflow_space_quotes reflow_text reflow_wrap reply_self resolve
+			\ resume_draft_files resume_edited_draft_files reverse_alias reverse_name
+			\ reverse_realname rfc2047_parameters save_address save_empty save_name score
+			\ sidebar_folder_indent sidebar_new_mail_only sidebar_next_new_wrap
+			\ sidebar_relative_shortpath_indent sidebar_short_path sidebar_sort sidebar_use_mailbox_shortcuts
+			\ sidebar_visible sig_on_top sig_dashes size_show_bytes size_show_fraction size_show_mb
+			\ size_units_on_left smart_wrap smime_ask_cert_label smime_decrypt_use_default_key
+			\ smime_is_default smime_self_encrypt smime_self_encrypt_as sort_re
+			\ ssl_force_tls ssl_use_sslv2 ssl_use_sslv3 ssl_use_tlsv1 ssl_use_tlsv1_3 ssl_usesystemcerts
+			\ ssl_verify_dates ssl_verify_host ssl_verify_partial_chains status_on_top
+			\ strict_mime strict_threads suspend text_flowed thorough_search
+			\ thread_received tilde ts_enabled tunnel_is_secure uncollapse_jump use_8bitmime use_domain
+			\ use_envelope_from use_from use_idn use_ipv6 uncollapse_new user_agent
+			\ wait_key weed wrap_search write_bcc
 			\ nextgroup=muttrcSetBoolAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 syn keyword muttrcVarBool	skipwhite contained 
 			\ noallow_8bit noallow_ansi noarrow_cursor noascii_chars noaskbcc noaskcc
-			\ noattach_split noauto_tag noautoedit nobeep nobeep_new nobounce_delivered
-			\ nobraille_friendly nobrowser_abbreviate_mailboxes nochange_folder_next
-			\ nocheck_mbox_size nocheck_new nocollapse_unread noconfirmappend
-			\ noconfirmcreate nocrypt_autoencrypt nocrypt_autopgp nocrypt_autosign
-			\ nocrypt_autosmime nocrypt_confirmhook nocrypt_opportunistic_encrypt
-			\ nocrypt_replyencrypt nocrypt_replysign nocrypt_replysignencrypted
-			\ nocrypt_timestamp nocrypt_use_gpgme nocrypt_use_pka nodelete_untag
-			\ nodigest_collapse noduplicate_threads noedit_hdrs noedit_headers
-			\ noencode_from noenvelope_from nofast_reply nofcc_clear noflag_safe
+			\ noattach_split noauto_tag noautoedit noauto_subscribe nobackground_edit
+			\ nobackground_confirm_quit nobeep nobeep_new nobounce_delivered
+			\ nobraille_friendly nobrowser_abbreviate_mailboxes nobrowser_sticky_cursor nochange_folder_next
+			\ nocheck_mbox_size nocheck_new nocompose_confirm_detach_first nocollapse_unread noconfirmappend
+			\ noconfirmcreate nocopy_decode_weed nocount_alternatives nocrypt_autoencrypt nocrypt_autopgp
+			\ nocrypt_autosign nocrypt_autosmime nocrypt_confirmhook nocrypt_protected_headers_read
+			\ nocrypt_protected_headers_save nocrypt_protected_headers_write nocrypt_opportunistic_encrypt
+			\ nocrypt_opportunistic_encrypt_strong_keys nocrypt_replyencrypt nocrypt_replysign
+			\ nocrypt_replysignencrypted nocrypt_timestamp nocrypt_use_gpgme nocrypt_use_pka nocursor_overlay
+			\ nodelete_untag nodigest_collapse noduplicate_threads noedit_hdrs noedit_headers
+			\ noencode_from noenvelope_from nofast_reply nofcc_before_send nofcc_clear noflag_safe
 			\ nofollowup_to noforce_name noforw_decode noforw_decrypt noforw_quote
-			\ noforward_decode noforward_decrypt noforward_quote nohdrs noheader
+			\ noforward_decode noforward_quote nohdrs noheader
 			\ noheader_color_partial nohelp nohidden_host nohide_limited nohide_missing
 			\ nohide_thread_subject nohide_top_limited nohide_top_missing
 			\ nohistory_remove_dups nohonor_disposition noidn_decode noidn_encode
 			\ noignore_linear_white_space noignore_list_reply_to noimap_check_subscribed
-			\ noimap_list_subscribed noimap_passive noimap_peek noimap_servernoise
-			\ noimplicit_autoview noinclude_onlyfirst nokeep_flagged nomail_check_recent
-			\ nomail_check_stats nomailcap_sanitize nomaildir_check_cur
-			\ nomaildir_header_cache_verify nomaildir_trash nomark_old nomarkers
-			\ nomenu_move_off nomenu_scroll nomessage_cache_clean nometa_key nometoo
-			\ nomh_purge nomime_forward_decode nomime_type_query_first nonarrow_tree
-			\ nopager_stop nopgp_auto_decode nopgp_auto_traditional nopgp_autoencrypt
-			\ nopgp_autoinline nopgp_autosign nopgp_check_exit nopgp_create_traditional
+			\ noimap_condstore noimap_deflate noimap_list_subscribed noimap_passive noimap_peek
+			\ noimap_qresync noimap_servernoise noimplicit_autoview noinclude_encrypted noinclude_onlyfirst
+			\ nokeep_flagged nolocal_date_header nomail_check_recent nomail_check_stats nomailcap_sanitize
+			\ nomaildir_check_cur nomaildir_header_cache_verify nomaildir_trash nomark_old
+			\ nomarkers nomenu_move_off nomenu_scroll nomessage_cache_clean nometa_key
+			\ nometoo nomh_purge nomime_forward_decode nomime_type_query_first nomuttlisp_inline_eval
+			\ nonarrow_tree nopager_stop nopgp_auto_decode nopgp_auto_traditional nopgp_autoencrypt
+			\ nopgp_autoinline nopgp_autosign nopgp_check_exit
+			\ nopgp_check_gpg_decrypt_status_fd nopgp_create_traditional
 			\ nopgp_ignore_subkeys nopgp_long_ids nopgp_replyencrypt nopgp_replyinline
 			\ nopgp_replysign nopgp_replysignencrypted nopgp_retainable_sigs
 			\ nopgp_self_encrypt nopgp_self_encrypt_as nopgp_show_unusable
-			\ nopgp_strict_enc nopgp_use_gpg_agent nopipe_decode nopipe_split
+			\ nopgp_strict_enc nopgp_use_gpg_agent nopipe_decode nopipe_decode_weed nopipe_split
 			\ nopop_auth_try_all nopop_last nopostpone_encrypt nopostpone_encrypt_as
-			\ noprint_decode noprint_split noprompt_after noread_only
+			\ noprint_decode noprint_decode_weed noprint_split noprompt_after noread_only
 			\ noreflow_space_quotes noreflow_text noreflow_wrap noreply_self noresolve
 			\ noresume_draft_files noresume_edited_draft_files noreverse_alias
 			\ noreverse_name noreverse_realname norfc2047_parameters nosave_address
 			\ nosave_empty nosave_name noscore nosidebar_folder_indent
-			\ nosidebar_new_mail_only nosidebar_next_new_wrap nosidebar_short_path
-			\ nosidebar_sort nosidebar_visible nosig_dashes nosig_on_top nosmart_wrap
-			\ nosmime_ask_cert_label nosmime_decrypt_use_default_key nosmime_is_default
-			\ nosmime_self_encrypt nosmime_self_encrypt_as nosort_re nossl_force_tls
-			\ nossl_use_sslv2 nossl_use_sslv3 nossl_use_tlsv1 nossl_usesystemcerts
+			\ nosidebar_new_mail_only nosidebar_next_new_wrap nosidebar_relative_shortpath_indent
+			\ nosidebar_short_path nosidebar_sort nosidebar_visible nosidebar_use_mailbox_shortcuts
+			\ nosig_dashes nosig_on_top nosize_show_bytes nosize_show_fraction nosize_show_mb
+			\ nosize_units_on_left nosmart_wrap nosmime_ask_cert_label nosmime_decrypt_use_default_key
+			\ nosmime_is_default nosmime_self_encrypt nosmime_self_encrypt_as nosort_re nossl_force_tls
+			\ nossl_use_sslv2 nossl_use_sslv3 nossl_use_tlsv1 nossl_use_tlsv1_3 nossl_usesystemcerts
 			\ nossl_verify_dates nossl_verify_host nossl_verify_partial_chains
 			\ nostatus_on_top nostrict_mime nostrict_threads nosuspend notext_flowed
-			\ nothorough_search nothread_received notilde nots_enabled nouncollapse_jump
+			\ nothorough_search nothread_received notilde nots_enabled notunnel_is_secure nouncollapse_jump
 			\ nouse_8bitmime nouse_domain nouse_envelope_from nouse_from nouse_idn
 			\ nouse_ipv6 nouncollapse_new nouser_agent nowait_key noweed nowrap_search
 			\ nowrite_bcc
@@ -192,50 +200,53 @@ syn keyword muttrcVarBool	skipwhite contained
 
 syn keyword muttrcVarBool	skipwhite contained
 			\ invallow_8bit invallow_ansi invarrow_cursor invascii_chars invaskbcc
-			\ invaskcc invattach_split invauto_tag invautoedit invbeep invbeep_new
-			\ invbounce_delivered invbraille_friendly invbrowser_abbreviate_mailboxes
-			\ invchange_folder_next invcheck_mbox_size invcheck_new invcollapse_unread
-			\ invconfirmappend invconfirmcreate invcrypt_autoencrypt invcrypt_autopgp
-			\ invcrypt_autosign invcrypt_autosmime invcrypt_confirmhook
-			\ invcrypt_opportunistic_encrypt invcrypt_replyencrypt invcrypt_replysign
-			\ invcrypt_replysignencrypted invcrypt_timestamp invcrypt_use_gpgme
-			\ invcrypt_use_pka invdelete_untag invdigest_collapse invduplicate_threads
+			\ invaskcc invattach_split invauto_tag invautoedit invauto_subscribe nobackground_edit
+			\ nobackground_confirm_quit invbeep invbeep_new invbounce_delivered invbraille_friendly
+			\ invbrowser_abbreviate_mailboxes invbrowser_sticky_cursor invchange_folder_next
+			\ invcheck_mbox_size invcheck_new invcollapse_unread invcompose_confirm_detach_first
+			\ invconfirmappend invcopy_decode_weed invconfirmcreate invcount_alternatives invcrypt_autopgp
+			\ invcrypt_autoencrypt invcrypt_autosign invcrypt_autosmime invcrypt_confirmhook
+			\ invcrypt_protected_headers_read invcrypt_protected_headers_save invcrypt_protected_headers_write
+			\ invcrypt_opportunistic_encrypt invcrypt_opportunistic_encrypt_strong_keys invcrypt_replysign
+			\ invcrypt_replyencrypt invcrypt_replysignencrypted invcrypt_timestamp invcrypt_use_gpgme
+			\ invcrypt_use_pka invcursor_overlay invdelete_untag invdigest_collapse invduplicate_threads
 			\ invedit_hdrs invedit_headers invencode_from invenvelope_from invfast_reply
-			\ invfcc_clear invflag_safe invfollowup_to invforce_name invforw_decode
-			\ invforw_decrypt invforw_quote invforward_decode invforward_decrypt
+			\ invfcc_before_send invfcc_clear invflag_safe invfollowup_to invforce_name invforw_decode
+			\ invforw_decrypt invforw_quote invforward_decode
 			\ invforward_quote invhdrs invheader invheader_color_partial invhelp
 			\ invhidden_host invhide_limited invhide_missing invhide_thread_subject
 			\ invhide_top_limited invhide_top_missing invhistory_remove_dups
 			\ invhonor_disposition invidn_decode invidn_encode
 			\ invignore_linear_white_space invignore_list_reply_to
-			\ invimap_check_subscribed invimap_list_subscribed invimap_passive
-			\ invimap_peek invimap_servernoise invimplicit_autoview invinclude_onlyfirst
-			\ invkeep_flagged invmail_check_recent invmail_check_stats invmailcap_sanitize
-			\ invmaildir_check_cur invmaildir_header_cache_verify invmaildir_trash
-			\ invmark_old invmarkers invmenu_move_off invmenu_scroll
-			\ invmessage_cache_clean invmeta_key invmetoo invmh_purge
-			\ invmime_forward_decode invmime_type_query_first invnarrow_tree invpager_stop
-			\ invpgp_auto_decode invpgp_auto_traditional invpgp_autoencrypt
+			\ invimap_check_subscribed invimap_condstore invimap_deflate invimap_list_subscribed
+			\ invimap_passive invimap_peek invimap_qresync invimap_servernoise invimplicit_autoview
+			\ invinclude_encrypted invinclude_onlyfirst invkeep_flagged invlocal_date_header
+			\ invmail_check_recent invmail_check_stats invmailcap_sanitize invmaildir_check_cur
+			\ invmaildir_header_cache_verify invmaildir_trash invmark_old invmarkers invmenu_move_off
+			\ invmenu_scroll invmessage_cache_clean invmeta_key invmetoo invmh_purge
+			\ invmime_forward_decode invmime_type_query_first invmuttlisp_inline_eval invnarrow_tree
+			\ invpager_stop invpgp_auto_decode invpgp_auto_traditional invpgp_autoencrypt
 			\ invpgp_autoinline invpgp_autosign invpgp_check_exit
-			\ invpgp_create_traditional invpgp_ignore_subkeys invpgp_long_ids
-			\ invpgp_replyencrypt invpgp_replyinline invpgp_replysign
-			\ invpgp_replysignencrypted invpgp_retainable_sigs invpgp_self_encrypt
-			\ invpgp_self_encrypt_as invpgp_show_unusable invpgp_strict_enc
-			\ invpgp_use_gpg_agent invpipe_decode invpipe_split invpop_auth_try_all
-			\ invpop_last invpostpone_encrypt invpostpone_encrypt_as invprint_decode
-			\ invprint_split invprompt_after invread_only invreflow_space_quotes
-			\ invreflow_text invreflow_wrap invreply_self invresolve invresume_draft_files
-			\ invresume_edited_draft_files invreverse_alias invreverse_name
-			\ invreverse_realname invrfc2047_parameters invsave_address invsave_empty
-			\ invsave_name invscore invsidebar_folder_indent invsidebar_new_mail_only
-			\ invsidebar_next_new_wrap invsidebar_short_path invsidebar_sort
-			\ invsidebar_visible invsig_dashes invsig_on_top invsmart_wrap
-			\ invsmime_ask_cert_label invsmime_decrypt_use_default_key invsmime_is_default
-			\ invsmime_self_encrypt invsmime_self_encrypt_as invsort_re invssl_force_tls
-			\ invssl_use_sslv2 invssl_use_sslv3 invssl_use_tlsv1 invssl_usesystemcerts
+			\ invpgp_check_gpg_decrypt_status_fd invpgp_create_traditional
+			\ invpgp_ignore_subkeys invpgp_long_ids invpgp_replyencrypt invpgp_replyinline
+			\ invpgp_replysign invpgp_replysignencrypted invpgp_retainable_sigs
+			\ invpgp_self_encrypt invpgp_self_encrypt_as invpgp_show_unusable
+			\ invpgp_strict_enc invpgp_use_gpg_agent invpipe_decode invpipe_decode_weed invpipe_split
+			\ invpop_auth_try_all invpop_last invpostpone_encrypt invpostpone_encrypt_as
+			\ invprint_decode invprint_decode_weed invprint_split invprompt_after invread_only
+			\ invreflow_space_quotes invreflow_text invreflow_wrap invreply_self invresolve
+			\ invresume_draft_file sinvresume_edited_draft_files invreverse_alias
+			\ invreverse_name invreverse_realname invrfc2047_parameters invsave_address
+			\ invsave_empty invsave_name invscore invsidebar_folder_indent
+			\ invsidebar_new_mail_only invsidebar_next_new_wrap invsidebar_relative_shortpath_indent
+			\ invsidebar_short_path invsidebar_sort sidebar_use_mailbox_shortcuts invsidebar_visible
+			\ invsig_dashes invsig_on_top invsize_show_bytes invsize_show_fraction invsize_show_mb
+			\ invsize_units_on_left invsmart_wrap invsmime_ask_cert_label invsmime_decrypt_use_default_key
+			\ invsmime_is_default invsmime_self_encrypt invsmime_self_encrypt_as invsort_re invssl_force_tls
+			\ invssl_use_sslv2 invssl_use_sslv3 invssl_use_tlsv1 invssl_use_tlsv1_3 invssl_usesystemcerts
 			\ invssl_verify_dates invssl_verify_host invssl_verify_partial_chains
 			\ invstatus_on_top invstrict_mime invstrict_threads invsuspend invtext_flowed
-			\ invthorough_search invthread_received invtilde invts_enabled
+			\ invthorough_search invthread_received invtilde invts_enabled invtunnel_is_secure
 			\ invuncollapse_jump invuse_8bitmime invuse_domain invuse_envelope_from
 			\ invuse_from invuse_idn invuse_ipv6 invuncollapse_new invuser_agent
 			\ invwait_key invweed invwrap_search invwrite_bcc
@@ -243,32 +254,32 @@ syn keyword muttrcVarBool	skipwhite contained
 
 syn keyword muttrcVarQuad	skipwhite contained
 			\ abort_nosubject abort_unmodified abort_noattach bounce copy crypt_verify_sig
-			\ delete fcc_attach forward_edit honor_followup_to include mime_forward
-			\ mime_forward_rest mime_fwd move pgp_mime_auto pgp_verify_sig pop_delete
-			\ pop_reconnect postpone print quit recall reply_to ssl_starttls
+			\ delete fcc_attach forward_attachments forward_decrypt forward_edit honor_followup_to include
+			\ mime_forward mime_forward_rest mime_fwd move pgp_mime_auto pgp_verify_sig pop_delete
+			\ pop_reconnect postpone print quit recall reply_to send_multipart_alternative ssl_starttls
 			\ nextgroup=muttrcSetQuadAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 syn keyword muttrcVarQuad	skipwhite contained
 			\ noabort_nosubject noabort_unmodified noabort_noattach nobounce nocopy
-			\ nocrypt_verify_sig nodelete nofcc_attach noforward_edit nohonor_followup_to
-			\ noinclude nomime_forward nomime_forward_rest nomime_fwd nomove
+			\ nocrypt_verify_sig nodelete nofcc_attach noforward_attachments noforward_decrypt noforward_edit
+			\ nohonor_followup_to noinclude nomime_forward nomime_forward_rest nomime_fwd nomove
 			\ nopgp_mime_auto nopgp_verify_sig nopop_delete nopop_reconnect nopostpone
-			\ noprint noquit norecall noreply_to nossl_starttls
+			\ noprint noquit norecall noreply_to nosend_multipart_alternative nossl_starttls
 			\ nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 syn keyword muttrcVarQuad	skipwhite contained
 			\ invabort_nosubject invabort_unmodified invabort_noattach invbounce invcopy
-			\ invcrypt_verify_sig invdelete invfcc_attach invforward_edit
-			\ invhonor_followup_to invinclude invmime_forward invmime_forward_rest
+			\ invcrypt_verify_sig invdelete invfcc_attach invforward_attachments invforward_decrypt
+			\ invforward_edit invhonor_followup_to invinclude invmime_forward invmime_forward_rest
 			\ invmime_fwd invmove invpgp_mime_auto invpgp_verify_sig invpop_delete
 			\ invpop_reconnect invpostpone invprint invquit invrecall invreply_to
-			\ invssl_starttls
+			\ invsend_multipart_alternative invssl_starttls
 			\ nextgroup=muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 syn keyword muttrcVarNum	skipwhite contained
-			\ connect_timeout error_history history imap_keepalive imap_pipeline_depth
+			\ connect_timeout error_history history imap_fetch_chunk_size imap_keepalive imap_pipeline_depth
 			\ imap_poll_timeout mail_check mail_check_stats_interval menu_context net_inc
-			\ pager_context pager_index_lines pgp_timeout pop_checkinterval read_inc
+			\ pager_context pager_index_lines pager_skip_quoted_context pgp_timeout pop_checkinterval read_inc
 			\ save_history score_threshold_delete score_threshold_flag
 			\ score_threshold_read search_context sendmail_wait sidebar_width sleep_time
 			\ smime_timeout ssl_min_dh_prime_bits time_inc timeout wrap wrap_headers
@@ -365,10 +376,14 @@ syn keyword muttrcVarStr	contained skipwhite alias_format nextgroup=muttrcVarEqu
 syn match muttrcVarEqualsAliasFmt contained skipwhite "=" nextgroup=muttrcAliasFormatStr
 syn keyword muttrcVarStr	contained skipwhite attach_format nextgroup=muttrcVarEqualsAttachFmt
 syn match muttrcVarEqualsAttachFmt contained skipwhite "=" nextgroup=muttrcAttachFormatStr
+syn keyword muttrcVarStr	contained skipwhite background_format nextgroup=muttrcVarEqualsBackgroundFormatFmt
+syn match muttrcVarEqualsBackgroundFormatFmt contained skipwhite "=" nextgroup=muttrcBackgroundFormatStr
 syn keyword muttrcVarStr	contained skipwhite compose_format nextgroup=muttrcVarEqualsComposeFmt
 syn match muttrcVarEqualsComposeFmt contained skipwhite "=" nextgroup=muttrcComposeFormatStr
 syn keyword muttrcVarStr	contained skipwhite folder_format nextgroup=muttrcVarEqualsFolderFmt
 syn match muttrcVarEqualsFolderFmt contained skipwhite "=" nextgroup=muttrcFolderFormatStr
+syn keyword muttrcVarStr	contained skipwhite message_id_format nextgroup=muttrcVarEqualsMessageIdFmt
+syn match muttrcVarEqualsMessageIdFmt contained skipwhite "=" nextgroup=muttrcMessageIdFormatStr
 syn keyword muttrcVarStr	contained skipwhite mix_entry_format nextgroup=muttrcVarEqualsMixFmt
 syn match muttrcVarEqualsMixFmt contained skipwhite "=" nextgroup=muttrcMixFormatStr
 syn keyword muttrcVarStr	contained skipwhite pgp_entry_format nextgroup=muttrcVarEqualsPGPFmt
@@ -390,27 +405,29 @@ syn match muttrcVPrefix		contained /[?&]/ nextgroup=muttrcVarBool,muttrcVarQuad,
 
 syn match muttrcVarStr		contained skipwhite 'my_[a-zA-Z0-9_]\+' nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 syn keyword muttrcVarStr	contained skipwhite
-			\ abort_noattach_regexp alias_file assumed_charset attach_charset attach_sep
+			\ abort_noattach_regexp alias_file assumed_charset attach_charset attach_save_dir attach_sep
 			\ attribution_locale certificate_file charset config_charset content_type
-			\ default_hook display_filter dotlock_program dsn_notify dsn_return editor
-		        \ entropy_file envelope_from_address escape folder forw_format
+			\ crypt_protected_headers_subject default_hook display_filter dotlock_program dsn_notify
+		        \ dsn_return editor entropy_file envelope_from_address escape fcc_delimiter folder forw_format
 		        \ forward_attribution_intro forward_attribution_trailer forward_format from gecos_mask
 		        \ hdr_format header_cache header_cache_compress header_cache_pagesize history_file
 		        \ hostname imap_authenticators imap_delim_chars imap_headers imap_idle imap_login
-		        \ imap_pass imap_user indent_str indent_string ispell locale mailcap_path
-		        \ mark_macro_prefix mask mbox mbox_type message_cachedir mh_seq_flagged mh_seq_replied
-		        \ mh_seq_unseen mime_type_query_command mixmaster msg_format new_mail_command pager
-		        \ pgp_default_key pgp_decryption_okay pgp_good_sign pgp_mime_signature_description
+		        \ imap_oauth_refresh_command imap_pass imap_user indent_str indent_string ispell locale
+		        \ mailcap_pat hmark_macro_prefix mask mbox mbox_type message_cachedir mh_seq_flagged
+		        \ mh_seq_replied mh_seq_unseen mime_type_query_command mixmaster msg_format new_mail_command
+		        \ pager pgp_default_key pgp_decryption_okay pgp_good_sign pgp_mime_signature_description
 		        \ pgp_mime_signature_filename pgp_sign_as pgp_sort_keys pipe_sep pop_authenticators
-		        \ pop_host pop_pass pop_user post_indent_str post_indent_string postpone_encrypt_as
-		        \ postponed preconnect print_cmd print_command query_command quote_regexp realname
-		        \ record reply_regexp send_charset sendmail shell sidebar_delim sidebar_delim_chars
-		        \ sidebar_divider_char sidebar_format sidebar_indent_string sidebar_sort_method
-		        \ signature simple_search smileys smime_ca_location smime_certificates
+		        \ pop_host pop_oauth_refresh_command pop_pass pop_user post_indent_str post_indent_string
+		        \ postpone_encrypt_as postponed preconnect print_cmd print_command query_command
+		        \ quote_regexp realname record reply_regexp send_charset send_multipart_alternative_filter
+		        \ sendmail shell sidebar_delim
+		        \ sidebar_delim_chars sidebar_divider_char sidebar_format sidebar_indent_string
+		        \ sidebar_sort_method signature simple_search smileys smime_ca_location smime_certificates
 		        \ smime_default_key smime_encrypt_with smime_keys smime_sign_as smime_sign_digest_alg
-		        \ smtp_authenticators smtp_pass smtp_url sort sort_alias sort_aux sort_browser
-		        \ spam_separator spoolfile ssl_ca_certificates_file ssl_ciphers ssl_client_cert
-		        \ status_chars tmpdir to_chars trash ts_icon_format ts_status_format tunnel visual
+		        \ smtp_authenticators smtp_oauth_refresh_command smtp_pass smtp_url sort sort_alias
+		        \ sort_aux sort_browser sort_thread_groups spam_separator spoolfile ssl_ca_certificates_file
+		        \ ssl_ciphers ssl_client_cert ssl_verify_host_override status_chars tmpdir to_chars trash
+		        \ ts_icon_format ts_status_format tunnel visual
 			\ nextgroup=muttrcSetStrAssignment,muttrcVPrefix,muttrcVarBool,muttrcVarQuad,muttrcVarNum,muttrcVarStr
 
 " Present in 1.4.2.1 (pgp_create_traditional was a bool then)
@@ -422,11 +439,11 @@ syn keyword muttrcMenu		contained alias attach browser compose editor index page
 syn match muttrcMenuList "\S\+" contained contains=muttrcMenu
 syn match muttrcMenuCommas /,/ contained
 
-syn keyword muttrcHooks		contained skipwhite account-hook charset-hook iconv-hook message-hook folder-hook mbox-hook save-hook fcc-hook fcc-save-hook send-hook send2-hook reply-hook crypt-hook
+syn keyword muttrcHooks		contained skipwhite account-hook charset-hook iconv-hook index-format-hook message-hook folder-hook mbox-hook save-hook fcc-hook fcc-save-hook send-hook send2-hook reply-hook crypt-hook
 
 syn keyword muttrcCommand	skipwhite
-			\ alternative_order auto_view exec hdr_order iconv-hook ignore mailboxes
-			\ mailto_allow mime_lookup my_hdr pgp-hook push score sidebar_whitelist source
+			\ alternative_order auto_view cd exec hdr_order iconv-hook ignore index-format-hook mailboxes
+			\ mailto_allow mime_lookup my_hdr pgp-hook push run score sidebar_whitelist source
 			\ unalternative_order unalternative_order unauto_view ungroup unhdr_order
 			\ unignore unmailboxes unmailto_allow unmime_lookup unmono unmy_hdr unscore
 			\ unsidebar_whitelist
@@ -470,19 +487,24 @@ syn match muttrcFunction	contained "\<link-threads\>"
 syn match muttrcFunction	contained "\<\%(backward\|capitalize\|downcase\|forward\|kill\|upcase\)-word\>"
 syn match muttrcFunction	contained "\<\%(delete\|filter\|first\|last\|next\|pipe\|previous\|print\|save\|select\|tag\|undelete\)-entry\>"
 syn match muttrcFunction	contained "\<attach-\%(file\|key\)\>"
+syn match muttrcFunction	contained "\<background-compose-menu\>"
+syn match muttrcFunction	contained "\<browse-mailbox\>"
 syn match muttrcFunction	contained "\<change-\%(dir\|folder\|folder-readonly\)\>"
 syn match muttrcFunction	contained "\<check-\%(new\|traditional-pgp\)\>"
 syn match muttrcFunction	contained "\<current-\%(bottom\|middle\|top\)\>"
 syn match muttrcFunction	contained "\<decode-\%(copy\|save\)\>"
 syn match muttrcFunction	contained "\<delete-\%(char\|pattern\|subthread\)\>"
+syn match muttrcFunction	contained "\<descend-directory\>"
 syn match muttrcFunction	contained "\<display-\%(address\|toggle-weed\)\>"
 syn match muttrcFunction	contained "\<echo\>"
 syn match muttrcFunction	contained "\<edit\%(-\%(bcc\|cc\|description\|encoding\|fcc\|file\|from\|headers\|label\|mime\|reply-to\|subject\|to\|type\)\)\?\>"
 syn match muttrcFunction	contained "\<enter-\%(command\|mask\)\>"
 syn match muttrcFunction	contained "\<error-history\>"
+syn match muttrcFunction	contained "\<group-chat-reply\>"
 syn match muttrcFunction	contained "\<half-\%(up\|down\)\>"
 syn match muttrcFunction	contained "\<history-\%(up\|down\|search\)\>"
 syn match muttrcFunction	contained "\<kill-\%(eol\|eow\|line\)\>"
+syn match muttrcFunction	contained "\<move-\%(down\|up\)\>"
 syn match muttrcFunction	contained "\<next-\%(line\|new\%(-then-unread\)\?\|page\|subthread\|undeleted\|unread\|unread-mailbox\)\>"
 syn match muttrcFunction	contained "\<previous-\%(line\|new\%(-then-unread\)\?\|page\|subthread\|undeleted\|unread\)\>"
 syn match muttrcFunction	contained "\<search\%(-\%(next\|opposite\|reverse\|toggle\)\)\?\>"
@@ -490,15 +512,15 @@ syn match muttrcFunction	contained "\<show-\%(limit\|version\)\>"
 syn match muttrcFunction	contained "\<sort-\%(mailbox\|reverse\)\>"
 syn match muttrcFunction	contained "\<tag-\%(pattern\|\%(sub\)\?thread\|prefix\%(-cond\)\?\)\>"
 syn match muttrcFunction	contained "\<end-cond\>"
-syn match muttrcFunction	contained "\<sidebar-\%(next\|next-new\|open\|page-down\|page-up\|prev\|prev-new\|toggle-visible\)\>"
+syn match muttrcFunction	contained "\<sidebar-\%(first\|last\|next\|next-new\|open\|page-down\|page-up\|prev\|prev-new\|toggle-visible\)\>"
 syn match muttrcFunction	contained "\<toggle-\%(mailboxes\|new\|quoted\|subscribed\|unlink\|write\)\>"
 syn match muttrcFunction	contained "\<undelete-\%(pattern\|subthread\)\>"
 syn match muttrcFunction	contained "\<collapse-\%(parts\|thread\|all\)\>"
 syn match muttrcFunction	contained "\<rename-attachment\>"
 syn match muttrcFunction	contained "\<subjectrx\>"
 syn match muttrcFunction	contained "\<\%(un\)\?setenv\>"
-syn match muttrcFunction	contained "\<view-\%(attach\|attachments\|file\|mailcap\|name\|text\)\>"
-syn match muttrcFunction	contained "\<\%(backspace\|backward-char\|bol\|bottom\|bottom-page\|buffy-cycle\|clear-flag\|complete\%(-query\)\?\|copy-file\|create-alias\|detach-file\|eol\|exit\|extract-keys\|\%(imap-\)\?fetch-mail\|forget-passphrase\|forward-char\|group-reply\|help\|ispell\|jump\|limit\|list-reply\|mail\|mail-key\|mark-as-new\|middle-page\|new-mime\|noop\|pgp-menu\|query\|query-append\|quit\|quote-char\|read-subthread\|redraw-screen\|refresh\|rename-file\|reply\|select-new\|set-flag\|shell-escape\|skip-quoted\|sort\|subscribe\|sync-mailbox\|top\|top-page\|transpose-chars\|unsubscribe\|untag-pattern\|verify-key\|what-key\|write-fcc\)\>"
+syn match muttrcFunction	contained "\<view-\%(alt\|alt-text\|alt-mailcap\|alt-pager\|attach\|attachments\|file\|mailcap\|name\|pager\|text\)\>"
+syn match muttrcFunction	contained "\<\%(backspace\|backward-char\|bol\|bottom\|bottom-page\|buffy-cycle\|check-stats\|clear-flag\|complete\%(-query\)\?\|compose-to-sender\|copy-file\|create-alias\|detach-file\|eol\|exit\|extract-keys\|\%(imap-\)\?fetch-mail\|forget-passphrase\|forward-char\|group-reply\|help\|ispell\|jump\|limit\|list-action\|list-reply\|mail\|mail-key\|mark-as-new\|middle-page\|new-mime\|noop\|pgp-menu\|query\|query-append\|quit\|quote-char\|read-subthread\|redraw-screen\|refresh\|rename-file\|reply\|select-new\|set-flag\|shell-escape\|skip-headers\|skip-quoted\|sort\|subscribe\|sync-mailbox\|top\|top-page\|transpose-chars\|unsubscribe\|untag-pattern\|verify-key\|what-key\|write-fcc\)\>"
 syn keyword muttrcFunction	contained imap-logout-all
 if use_mutt_sidebar == 1
     syn match muttrcFunction    contained "\<sidebar-\%(prev\|next\|open\|scroll-up\|scroll-down\)"
@@ -518,6 +540,9 @@ syn match  muttrcRXHooks	/\<\%(account\|folder\)-hook\>/ skipwhite nextgroup=mut
 syn match muttrcPatHookNot	contained /!\s*/ skipwhite nextgroup=muttrcPattern
 syn match muttrcPatHooks	/\<\%(mbox\|crypt\)-hook\>/ skipwhite nextgroup=muttrcPatHookNot,muttrcPattern
 syn match muttrcPatHooks	/\<\%(message\|reply\|send\|send2\|save\|\|fcc\%(-save\)\?\)-hook\>/ skipwhite nextgroup=muttrcPatHookNot,muttrcOptPattern
+
+syn match muttrcIndexFormatHookName contained /\S\+/ skipwhite nextgroup=muttrcPattern,muttrcString
+syn match muttrcIndexFormatHook /index-format-hook/ skipwhite nextgroup=muttrcIndexFormatHookName,muttrcString
 
 syn match muttrcBindFunction	contained /\S\+\>/ skipwhite contains=muttrcFunction
 syn match muttrcBindFunctionNL	contained /\s*\\$/ skipwhite skipnl nextgroup=muttrcBindFunction,muttrcBindFunctionNL
@@ -751,6 +776,8 @@ hi def link muttrcShellString	muttrcEscape
 hi def link muttrcRXHooks		muttrcCommand
 hi def link muttrcRXHookNot	Type
 hi def link muttrcPatHooks		muttrcCommand
+hi def link muttrcIndexFormatHookName	muttrcCommand
+hi def link muttrcIndexFormatHook	 muttrcCommand
 hi def link muttrcPatHookNot	Type
 hi def link muttrcFormatConditionals2 Type
 hi def link muttrcIndexFormatStr	muttrcString
@@ -761,11 +788,13 @@ hi def link muttrcAliasFormatEscapes muttrcEscape
 hi def link muttrcAttachFormatStr	muttrcString
 hi def link muttrcAttachFormatEscapes muttrcEscape
 hi def link muttrcAttachFormatConditionals muttrcFormatConditionals2
+hi def link muttrcBackgroundFormatStr	muttrcString
 hi def link muttrcComposeFormatStr	muttrcString
 hi def link muttrcComposeFormatEscapes muttrcEscape
 hi def link muttrcFolderFormatStr	muttrcString
 hi def link muttrcFolderFormatEscapes muttrcEscape
 hi def link muttrcFolderFormatConditionals muttrcFormatConditionals2
+hi def link muttrcMessageIdFormatStr	muttrcString
 hi def link muttrcMixFormatStr	muttrcString
 hi def link muttrcMixFormatEscapes muttrcEscape
 hi def link muttrcMixFormatConditionals muttrcFormatConditionals2
@@ -787,10 +816,6 @@ hi def link muttrcTimeEscapes	muttrcEscape
 hi def link muttrcPGPTimeEscapes	muttrcEscape
 hi def link muttrcStrftimeEscapes	Type
 hi def link muttrcStrftimeFormatStr muttrcString
-hi def link muttrcFormatErrors Error
-
-hi def link muttrcBindFunctionNL	SpecialChar
-hi def link muttrcBindKeyNL	SpecialChar
 hi def link muttrcBindMenuListNL	SpecialChar
 hi def link muttrcMacroDescrNL	SpecialChar
 hi def link muttrcMacroBodyNL	SpecialChar


### PR DESCRIPTION
### vim-patch:20b33b56ad5d
    
    Update FreeBASIC syntax file (vim/vim#12781)
    
    https://github.com/vim/vim/commit/20b33b56ad5d92c1c11e0859dc9333166625e0ad
    
    Co-authored-by: dkearns <dougkearns@gmail.com>

### vim-patch:636d32b32730
    
    The keyboard layout "russian-typograph" has been updated to version 3.3 (vim/vim#12796)
    
    Co-authored-by: RestorerZ <restorer@mail2k.ru>
    
    https://github.com/vim/vim/commit/636d32b327309f453e5cdfe75bbe7ad14550093a
    
    Co-authored-by: Restorer <69863286+RestorerZ@users.noreply.github.com>
    Co-authored-by: RestorerZ <restorer@mail2k.ru>

### vim-patch:10f23e10a9f0
    
    Update syntax/muttrc.vim to latest mutt (vim/vim#12797)
    
    Nothing complicated, just lots of tedium keeping the lines wrapped at
    reasonable lengths.
    
    https://github.com/vim/vim/commit/10f23e10a9f0ea2a48f9e15f7ee53a20e5e09e91
    
    Co-authored-by: lunasophia <104850249+lunasophia@users.noreply.github.com>

### vim-patch:4868f637b84a
    
    Update syntax/fortran.vim (vim/vim#12798)
    
    Several small improvements including better discrimination of "real" used as a type and as an intrinsic
    
    https://github.com/vim/vim/commit/4868f637b84a18fd162db6eff6d716bf22595fd0
    
    Co-authored-by: Ajit-Thakkar <142174202+Ajit-Thakkar@users.noreply.github.com>
