### PR TITLE
vim-patch:9.0.1718: dict-completion does not respect region

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3260,11 +3260,9 @@ void spell_dump_compl(char *pat, int ic, Direction *dir, int dumpflags_arg)
     }
   }
 
-  if (do_region && region_names != NULL) {
-    if (pat == NULL) {
-      vim_snprintf(IObuff, IOSIZE, "/regions=%s", region_names);
-      ml_append(lnum++, IObuff, (colnr_T)0, false);
-    }
+  if (do_region && region_names != NULL && pat == NULL) {
+    vim_snprintf(IObuff, IOSIZE, "/regions=%s", region_names);
+    ml_append(lnum++, IObuff, (colnr_T)0, false);
   } else {
     do_region = false;
   }

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -274,8 +274,7 @@ func Test_compl_with_CTRL_X_CTRL_K_using_spell()
   call assert_equal(['theater'], getline(1, '$'))
   set spelllang=en_gb
   call feedkeys("Stheat\<c-x>\<c-k>\<esc>", 'tnx')
-  " FIXME: commented out, expected theatre bug got theater. See issue #7025.
-  " call assert_equal(['theatre'], getline(1, '$'))
+  call assert_equal(['theatre'], getline(1, '$'))
 
   bwipe!
   set spell& spelllang& dictionary& ignorecase&


### PR DESCRIPTION
#### vim-patch:9.0.1718: dict-completion does not respect region

Problem: dict-completion does not respect region
Solution: respect selected region in dict completion

Set do_region to zero as we don't want a complete dump of the matching
words, we want the code to filter them according to the user's selected
region.

closes: vim/vim#12792

https://github.com/vim/vim/commit/e98fb643ec5f84f9088c8b1434a0bd6ff988dc2d

Co-authored-by: LemonBoy <thatlemon@gmail.com>