### PR TITLE
lua: Add missing fields to treesitter/_meta.lua

### DIFF
--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -25,6 +25,8 @@
 ---@field prev_named_sibling fun(self: TSNode): TSNode?
 ---@field named_children fun(self: TSNode): TSNode[]
 ---@field has_changes fun(self: TSNode): boolean
+---@field has_error fun(self: TSNode): boolean
+---@field sexpr fun(self: TSNode): string
 ---@field equal fun(self: TSNode, other: TSNode): boolean
 ---@field iter_children fun(self: TSNode): fun(): TSNode, string
 local TSNode = {}


### PR DESCRIPTION
According to `:h TSNode` docs, there's also `TSNode:sexpr()` and `TSNode:has_error()` that is part of `TSNode` class, but this wasn't documented in `treesitter/_meta.lua`.

Adding missing fields in so the types is similar to `:h TSNode`