### PR TITLE
vim-patch:8.2.{3333,3334}

### DIFF
--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -480,6 +480,19 @@ func Test_dict_func_remove_in_use()
   endfunc
   let expected = 'a:' . string(get(d, 'func'))
   call assert_equal(expected, d.func(string(remove(d, 'func'))))
+
+  " similar, in a way it also works in Vim9
+  let lines =<< trim END
+      VAR d = {1: 1, 2: 'x'}
+      func GetArg(a)
+        return "a:" .. a:a
+      endfunc
+      LET d.func = function('GetArg')
+      VAR expected = 'a:' .. string(get(d, 'func'))
+      call assert_equal(expected, d.func(string(remove(d, 'func'))))
+  END
+  call CheckTransLegacySuccess(lines)
+  call CheckTransVim9Success(lines)
 endfunc
 
 func Test_dict_literal_keys()


### PR DESCRIPTION
#### vim-patch:8.2.3333: Vim9: not enough tests run with Vim9

Problem:    Vim9: not enough tests run with Vim9.
Solution:   Run a few more tests in Vim9 script and :def function.

https://github.com/vim/vim/commit/3e9c0b9608736e7d888f3141443f8754143364d7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3334: Vim9: not enough tests run with Vim9

Problem:    Vim9: not enough tests run with Vim9.
Solution:   Run a few more tests in Vim9 script and :def function. Fix
            islocked().  Fix error for locking local variable.

https://github.com/vim/vim/commit/bd77aa92744d79f3ba69aee713739ec17da474f6

Omit GLV_NO_DECL: Vim9 script only.

Co-authored-by: Bram Moolenaar <Bram@vim.org>