### PR TITLE
fix(api): disallow win_set_buf from changing cmdwin's old curbuf

### DIFF
--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -58,7 +58,7 @@ void nvim_win_set_buf(Window window, Buffer buffer, Error *err)
   if (!win || !buf) {
     return;
   }
-  if (cmdwin_type != 0 && (win == curwin || buf == curbuf)) {
+  if (cmdwin_type != 0 && (win == curwin || win == cmdwin_old_curwin || buf == curbuf)) {
     api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
     return;
   }

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -44,14 +44,17 @@ describe('API/win', function()
       eq('Invalid window id: 23', pcall_err(window, 'set_buf', 23, nvim('get_current_buf')))
     end)
 
-    it('disallowed in cmdwin if win=curwin or buf=curbuf', function()
+    it('disallowed in cmdwin if win={old_}curwin or buf=curbuf', function()
       local new_buf = meths.create_buf(true, true)
+      local old_win = meths.get_current_win()
       local new_win = meths.open_win(new_buf, false, {
         relative='editor', row=10, col=10, width=50, height=10,
       })
       feed('q:')
       eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
          pcall_err(meths.win_set_buf, 0, new_buf))
+      eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
+         pcall_err(meths.win_set_buf, old_win, new_buf))
       eq('E11: Invalid in command-line window; <CR> executes, CTRL-C quits',
          pcall_err(meths.win_set_buf, new_win, 0))
 


### PR DESCRIPTION
A command typed in the cmdwin and executed with `<CR>` is expected to be executed in the context of the old curwin/buf, so it shouldn't be changed.