### PR TITLE
fix(tui): check for out of bound access after snprintf

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -297,10 +297,10 @@ static void forward_simple_utf8(TermInput *input, TermKeyKey *key)
     } else {
       buf[len++] = *ptr;
     }
+    assert(len < sizeof(buf));
     ptr++;
   }
 
-  assert(len < sizeof(buf));
   tinput_enqueue(input, buf, len);
 }
 


### PR DESCRIPTION
Counterintuitively, snprintf returns the number of characters it _should have written_ if it had not encoutered the length bound, thus leading to a potential buffer overflow.

This was discovered by CodeQL.
