### PR TITLE
vim-patch:9.0.{0359,0548,1416}

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -154,8 +154,6 @@ static const char e_string_list_or_blob_required[]
   = N_("E1098: String, List or Blob required");
 static const char e_missing_function_argument[]
   = N_("E1132: Missing function argument");
-static const char e_string_expected_for_argument_nr[]
-  = N_("E1253: String expected for argument %d");
 
 /// Dummy va_list for passing to vim_snprintf
 ///
@@ -1187,18 +1185,16 @@ static void f_debugbreak(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "deepcopy()" function
 static void f_deepcopy(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  int noref = 0;
+  if (tv_check_for_opt_bool_arg(argvars, 1) == FAIL) {
+    return;
+  }
 
+  varnumber_T noref = 0;
   if (argvars[1].v_type != VAR_UNKNOWN) {
-    noref = (int)tv_get_bool_chk(&argvars[1], NULL);
+    noref = tv_get_bool_chk(&argvars[1], NULL);
   }
-  if (noref < 0 || noref > 1) {
-    semsg(_(e_using_number_as_bool_nr), noref);
-  } else {
-    var_item_copy(NULL, &argvars[0], rettv, true, (noref == 0
-                                                   ? get_copyID()
-                                                   : 0));
-  }
+
+  var_item_copy(NULL, &argvars[0], rettv, true, (noref == 0 ? get_copyID() : 0));
 }
 
 /// "delete()" function
@@ -6236,8 +6232,7 @@ static void reduce_string(typval_T *argvars, const char *func_name, funcexe_T *f
       .vval.v_string = xstrnsave(p, (size_t)len),
     };
     p += len;
-  } else if (argvars[2].v_type != VAR_STRING) {
-    semsg(_(e_string_expected_for_argument_nr), 3);
+  } else if (tv_check_for_string_arg(argvars, 2) == FAIL) {
     return;
   } else {
     tv_copy(&argvars[2], rettv);
@@ -6281,8 +6276,7 @@ static void reduce_blob(typval_T *argvars, const char *func_name, funcexe_T *fun
       .vval.v_number = tv_blob_get(b, 0),
     };
     i = 1;
-  } else if (argvars[2].v_type != VAR_NUMBER) {
-    emsg(_(e_number_exp));
+  } else if (tv_check_for_number_arg(argvars, 2) == FAIL) {
     return;
   } else {
     initial = argvars[2];

--- a/test/old/testdir/test_filter_map.vim
+++ b/test/old/testdir/test_filter_map.vim
@@ -109,6 +109,21 @@ func Test_map_and_modify()
   let d = #{a: 1, b: 2, c: 3}
   call assert_fails('call map(d, "remove(d, v:key)[0]")', 'E741:')
   call assert_fails('echo map(d, {k,v -> remove(d, k)})', 'E741:')
+
+  let b = 0z1234
+  call assert_fails('call filter(b, "remove(b, 0)")', 'E741:')
+endfunc
+
+func Test_filter_and_modify()
+  let l = [0]
+  " cannot change the list halfway a map()
+  call assert_fails('call filter(l, "remove(l, 0)")', 'E741:')
+
+  let d = #{a: 0, b: 0, c: 0}
+  call assert_fails('call filter(d, "remove(d, v:key)")', 'E741:')
+
+  let b = 0z1234
+  call assert_fails('call filter(b, "remove(b, 0)")', 'E741:')
 endfunc
 
 func Test_mapnew_dict()

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -526,7 +526,7 @@ func Test_dict_deepcopy()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails("call deepcopy([1, 2], 2)", 'E1023:')
+  call assert_fails("call deepcopy([1, 2], 2)", 'E1212:')
 endfunc
 
 " Locked variables
@@ -952,25 +952,26 @@ func Test_reduce()
 
   call assert_fails("call reduce([], { acc, val -> acc + val })", 'E998: Reduce of an empty List with no initial value')
   call assert_fails("call reduce(0z, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
+  call assert_fails("call reduce(v:_null_blob, { acc, val -> acc + val })", 'E998: Reduce of an empty Blob with no initial value')
   call assert_fails("call reduce('', { acc, val -> acc + val })", 'E998: Reduce of an empty String with no initial value')
   call assert_fails("call reduce(v:_null_string, { acc, val -> acc + val })", 'E998: Reduce of an empty String with no initial value')
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E1098:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E1098:')
   call assert_fails("call reduce([1, 2], 'Xdoes_not_exist')", 'E117:')
-  call assert_fails("echo reduce(0z01, { acc, val -> 2 * acc + val }, '')", 'E39:')
+  call assert_fails("echo reduce(0z01, { acc, val -> 2 * acc + val }, '')", 'E1210:')
 
   " call assert_fails("vim9 reduce(0, (acc, val) => (acc .. val), '')", 'E1252:')
   " call assert_fails("vim9 reduce({}, (acc, val) => (acc .. val), '')", 'E1252:')
   " call assert_fails("vim9 reduce(0.1, (acc, val) => (acc .. val), '')", 'E1252:')
   " call assert_fails("vim9 reduce(function('tr'), (acc, val) => (acc .. val), '')", 'E1252:')
-  call assert_fails("call reduce('', { acc, val -> acc + val }, 1)", 'E1253:')
-  call assert_fails("call reduce('', { acc, val -> acc + val }, {})", 'E1253:')
-  call assert_fails("call reduce('', { acc, val -> acc + val }, 0.1)", 'E1253:')
-  call assert_fails("call reduce('', { acc, val -> acc + val }, function('tr'))", 'E1253:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, 1)", 'E1174:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, {})", 'E1174:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, 0.1)", 'E1174:')
+  call assert_fails("call reduce('', { acc, val -> acc + val }, function('tr'))", 'E1174:')
   call assert_fails("call reduce('abc', { a, v -> a10}, '')", 'E121:')
-  call assert_fails("call reduce(0z01, { a, v -> a10}, 1)", 'E121:')
-  call assert_fails("call reduce([1], { a, v -> a10}, '')", 'E121:')
+  call assert_fails("call reduce(0z0102, { a, v -> a10}, 1)", 'E121:')
+  call assert_fails("call reduce([1, 2], { a, v -> a10}, '')", 'E121:')
 
   let g:lut = [1, 2, 3, 4]
   func EvilRemove()

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -958,7 +958,7 @@ func Test_reduce()
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E1098:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E1098:')
-  call assert_fails("call reduce([1, 2], 'Xdoes_not_exist')", 'E117:')
+  call assert_fails("call reduce([1, 2], 'Xdoes_not_exist')", 'E121:')
   call assert_fails("echo reduce(0z01, { acc, val -> 2 * acc + val }, '')", 'E1210:')
 
   " call assert_fails("vim9 reduce(0, (acc, val) => (acc .. val), '')", 'E1252:')


### PR DESCRIPTION
#### vim-patch:9.0.0359: error message for wrong argument type is not specific

Problem:    Error message for wrong argument type is not specific.
Solution:   Include more information in the error. (Yegappan Lakshmanan,
            closes vim/vim#11037)

https://github.com/vim/vim/commit/8deb2b30c77035bb682ccf80b781455ac1d6038b

Cherry-pick test_listdict.vim changes from patch 8.2.4809.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.0548: reduce() with a compiled lambda could be faster

Problem:    reduce() with a compiled lambda could be faster.
Solution:   Call eval_expr_typval() instead of call_func() directly.

https://github.com/vim/vim/commit/f1c60d4bf10794265b828afd9c5f7eddacada10b

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1416: crash when collection is modified when using filter()

Problem:    Crash when collection is modified when using filter().
Solution:   Lock the list/dict/blob. (Ernie Rael, closes vim/vim#12183)

https://github.com/vim/vim/commit/e6d40dcdc7227594935d2db01eca29f0e575dcee

Co-authored-by: Ernie Rael <errael@raelity.com>