### PR TITLE
docs(builtin): fix some missing lines

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -429,6 +429,8 @@ bufname([{buf}])                                                     *bufname()*
 		with a listed buffer, that one is returned.  Next unlisted
 		buffers are searched for.
 		If the {buf} is a String, but you want to use it as a buffer
+		number, force it to be a Number by adding zero to it: >vim
+			echo bufname("3" + 0)
 <		If the buffer doesn't exist, or doesn't have a name, an empty
 		string is returned. >vim
 			echo bufname("#")	" alternate buffer name
@@ -3676,6 +3678,9 @@ interrupt()                                                        *interrupt()*
 
 invert({expr})                                                        *invert()*
 		Bitwise invert.  The argument is converted to a number.  A
+		List, Dict or Float argument causes an error.  Example: >vim
+			let bits = invert(bits)
+<
 
 isdirectory({directory})                                         *isdirectory()*
 		The result is a Number, which is |TRUE| when a directory
@@ -5665,6 +5670,9 @@ reverse({object})                                                    *reverse()*
 		{object} can be a |List| or a |Blob|.
 		Returns {object}.
 		Returns zero if {object} is not a List or a Blob.
+		If you want an object to remain unmodified make a copy first: >vim
+			let revlist = reverse(copy(mylist))
+<
 
 round({expr})                                                          *round()*
 		Round off {expr} to the nearest integral value and return it

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -570,6 +570,8 @@ function vim.fn.bufloaded(buf) end
 --- with a listed buffer, that one is returned.  Next unlisted
 --- buffers are searched for.
 --- If the {buf} is a String, but you want to use it as a buffer
+--- number, force it to be a Number by adding zero to it: >vim
+---   echo bufname("3" + 0)
 --- <If the buffer doesn't exist, or doesn't have a name, an empty
 --- string is returned. >vim
 ---   echo bufname("#")  " alternate buffer name
@@ -4426,6 +4428,9 @@ function vim.fn.insert(object, item, idx) end
 function vim.fn.interrupt() end
 
 --- Bitwise invert.  The argument is converted to a number.  A
+--- List, Dict or Float argument causes an error.  Example: >vim
+---   let bits = invert(bits)
+--- <
 ---
 --- @param expr any
 --- @return any
@@ -6761,6 +6766,9 @@ function vim.fn.resolve(filename) end
 --- {object} can be a |List| or a |Blob|.
 --- Returns {object}.
 --- Returns zero if {object} is not a List or a Blob.
+--- If you want an object to remain unmodified make a copy first: >vim
+---   let revlist = reverse(copy(mylist))
+--- <
 ---
 --- @param object any
 --- @return any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -796,6 +796,8 @@ M.funcs = {
       with a listed buffer, that one is returned.  Next unlisted
       buffers are searched for.
       If the {buf} is a String, but you want to use it as a buffer
+      number, force it to be a Number by adding zero to it: >vim
+      	echo bufname("3" + 0)
       <If the buffer doesn't exist, or doesn't have a name, an empty
       string is returned. >vim
       	echo bufname("#")	" alternate buffer name
@@ -5413,6 +5415,9 @@ M.funcs = {
     base = 1,
     desc = [=[
       Bitwise invert.  The argument is converted to a number.  A
+      List, Dict or Float argument causes an error.  Example: >vim
+      	let bits = invert(bits)
+      <
     ]=],
     name = 'invert',
     params = { { 'expr', 'any' } },
@@ -8150,6 +8155,9 @@ M.funcs = {
       {object} can be a |List| or a |Blob|.
       Returns {object}.
       Returns zero if {object} is not a List or a Blob.
+      If you want an object to remain unmodified make a copy first: >vim
+      	let revlist = reverse(copy(mylist))
+      <
     ]=],
     name = 'reverse',
     params = { { 'object', 'any' } },


### PR DESCRIPTION
Some things got chopped off in the PR that removed method syntax examples. These were all that I found.