### PR TITLE
fix(terminal): preserve $COLORTERM value from outer terminal

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3981,15 +3981,6 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
           tv_dict_item_remove(env, dv);
         }
       }
-#ifndef MSWIN
-      // Set COLORTERM to "truecolor" if termguicolors is set and 256
-      // otherwise, but only if it was set in the parent terminal at all
-      dictitem_T *dv = tv_dict_find(env, S_LEN("COLORTERM"));
-      if (dv) {
-        tv_dict_item_remove(env, dv);
-        tv_dict_add_str(env, S_LEN("COLORTERM"), p_tgc ? "truecolor" : "256");
-      }
-#endif
     }
   }
 


### PR DESCRIPTION
~~If the outer terminal claims to support truecolor through the $COLORTERM environment variable, then it should not be modified by Nvim just because 'termguicolors' is unset.~~

~~If an application running in :terminal writes a direct color sequence (i.e. `CSI 38 ; 2 ; <r> ; <g> ; <b> m`) that sequence is forwarded directly to the outer terminal emulator, where it is displayed in truecolor if the terminal supports it, regardless of the value of 'termguicolors'. The only affect that 'termguicolors' has on colors for applications in :terminal is how the 16 ANSI colors are displayed (when 'termguicolors' is set, the ANSI colors are set with g:terminal_color_x; otherwise, they are forwarded directly to the outer terminal).~~

^ This is all wrong. Ignore this.