### PR TITLE
fix(terminal): set $COLORTERM unconditionally in :terminal

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3943,12 +3943,13 @@ static dict_T *create_environment(const dictitem_T *job_env, const bool clear_en
         }
       }
 #ifndef MSWIN
-      // Set COLORTERM to "truecolor" if termguicolors is set and 256
-      // otherwise, but only if it was set in the parent terminal at all
-      dictitem_T *dv = tv_dict_find(env, S_LEN("COLORTERM"));
-      if (dv) {
-        tv_dict_item_remove(env, dv);
-        tv_dict_add_str(env, S_LEN("COLORTERM"), p_tgc ? "truecolor" : "256");
+      // Set COLORTERM to "truecolor" if termguicolors is set
+      if (p_tgc) {
+        dictitem_T *dv = tv_dict_find(env, S_LEN("COLORTERM"));
+        if (dv) {
+          tv_dict_item_remove(env, dv);
+        }
+        tv_dict_add_str(env, S_LEN("COLORTERM"), "truecolor");
       }
 #endif
     }


### PR DESCRIPTION
$COLORTERM is set in the terminal emulator based on the value of 'termguicolors' ("truecolor" if &tgc is set, 256 otherwise), but ONLY if $COLORTERM is also set in the parent terminal emulator.

This is an unnecessary restriction that can cause issues in some cases. For instance, $COLORTERM is stripped by default by OpenSSH, so is not present in an SSH session. The terminal emulator still supports 24 bit color, so the lack of $COLORTERM is not a reliable indicator. When an application runs in Nvim's :terminal it thus has no way to know whether or not true color is supported.

Instead, setting it unconditionally based on 'termguicolors' uses the user's own preferences to infer if 24-bit color is supported, rather than depending on the (unreliable) presence of $COLORTERM. If 'termguicolors' is set in a terminal that does not support true color then the colors in Nvim will already look bad. Enabling them for applications in the terminal emulator will not make it any worse.

If 'termguicolors' is not set then the value of $COLORTERM from the parent terminal (if any) is forwarded to Nvim's :terminal.

Fixes: https://github.com/neovim/neovim/issues/24717
