### PR TITLE
feat(ui): forward :intro message properly to external UI:s

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -654,6 +654,8 @@ tabs.
 	Updates the position of an extmark which is currently visible in a
 	window. Only emitted if the mark has the `ui_watched` attribute.
 
+|ui-event-msg_intro| is used for the intro message.
+
 ==============================================================================
 Popupmenu Events						 *ui-popupmenu*
 
@@ -828,6 +830,11 @@ events, which the UI must handle.
 
 ["msg_history_clear"] ~
 	Clear the |:messages| history.
+
+							*ui-event-msg_intro*
+["msg_intro", lines] ~
+	The |:intro| message. Used both on |ui-startup| and when the Ex command was used.
+	The Ex command additionally causes a press-enter prompt, just like in the TUI.
 
 ==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -167,4 +167,8 @@ void msg_history_show(Array entries)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void msg_history_clear(void)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
+
+void msg_intro(Array lines)
+  FUNC_API_SINCE(12) FUNC_API_REMOTE_ONLY;
+
 #endif  // NVIM_API_UI_EVENTS_IN_H

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1112,6 +1112,10 @@ function Screen:_handle_msg_history_clear()
   self.msg_history = {}
 end
 
+function Screen:_handle_msg_intro(lines)
+  self.msg_intro = lines
+end
+
 function Screen:_clear_block(grid, top, bot, left, right)
   for i = top, bot do
     self:_clear_row_section(grid, i, left, right)


### PR DESCRIPTION
The intro message doesn't work very well with multigrid UI:s The message is plainly drawn on the `default_grid` which is kinda ok in TUI but doesn't provide any useful context for external UI:s.

Introduce a new `msg_intro` event with is used when `ext_multigrid` and/or `ext_messages` is set.

Fixes #24705