### PR TITLE
vim-patch:9.0.1726: incorrect heights in win_size_restore()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7198,7 +7198,7 @@ int global_stl_height(void)
 /// @param morewin  pretend there are two or more windows if true.
 int last_stl_height(bool morewin)
 {
-  return (p_ls > 1 || (p_ls == 1 && (!one_nonfloat() || morewin))) ? STATUS_HEIGHT : 0;
+  return (p_ls > 1 || (p_ls == 1 && (morewin || !one_nonfloat()))) ? STATUS_HEIGHT : 0;
 }
 
 /// Return the minimal number of rows that is needed on the screen to display

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -994,35 +994,13 @@ describe("cmdline height", function()
     assert_alive()
   end)
 
-  it('unchanged when trying to restore window sizes', function()
-    command('set showtabline=0 cmdheight=2 laststatus=0')
-    feed('q:')  -- Closing cmdwin tries to restore sizes
-    command('set cmdheight=1 | quit')
+  it('unchanged when restoring window sizes with global statusline', function()
+    command('set cmdheight=2 laststatus=2')
+    feed('q:')
+    command('set cmdheight=1 laststatus=3 | quit')
+    -- Available lines changed, so closing cmdwin should skip restoring window sizes, leaving the
+    -- cmdheight unchanged.
     eq(1, eval('&cmdheight'))
-
-    command('set showtabline=2 cmdheight=3')
-    feed('q:')
-    command('set showtabline=0 | quit')
-    eq(3, eval('&cmdheight'))
-
-    command('set cmdheight=1 laststatus=2')
-    feed('q:')
-    command('set laststatus=0 | quit')
-    eq(1, eval('&cmdheight'))
-
-    command('set laststatus=2')
-    feed('q:')
-    command('set laststatus=1 | quit')
-    eq(1, eval('&cmdheight'))
-
-    command('set laststatus=2 | belowright vsplit | wincmd _')
-    local restcmds = eval('winrestcmd()')
-    feed('q:')
-    command('set laststatus=1 | quit')
-    -- As we have 2 windows, &ls = 1 should still have a statusline on the last
-    -- window. As such, the number of available rows hasn't changed and the window
-    -- sizes should be restored.
-    eq(restcmds, eval('winrestcmd()'))
   end)
 end)
 

--- a/test/old/testdir/test_cmdwin.vim
+++ b/test/old/testdir/test_cmdwin.vim
@@ -63,5 +63,34 @@ func Test_cmdwin_split_often()
   let &columns = columns
 endfunc
 
+func Test_cmdwin_restore_heights()
+  set showtabline=0 cmdheight=2 laststatus=0
+  call feedkeys("q::set cmdheight=1\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set showtabline=2 cmdheight=3
+  call feedkeys("q::set showtabline=0\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 3, winheight(0))
+
+  set cmdheight=1 laststatus=2
+  call feedkeys("q::set laststatus=0\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set laststatus=2
+  call feedkeys("q::set laststatus=1\<CR>:q\<CR>", 'ntx')
+  call assert_equal(&lines - 1, winheight(0))
+
+  set laststatus=2
+  belowright vsplit
+  wincmd _
+  let restcmds = winrestcmd()
+  call feedkeys("q::set laststatus=1\<CR>:q\<CR>", 'ntx')
+  " As we have 2 windows, &ls = 1 should still have a statusline on the last
+  " window. As such, the number of available rows hasn't changed and the window
+  " sizes should be restored.
+  call assert_equal(restcmds, winrestcmd())
+
+  set cmdheight& showtabline& laststatus&
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem: incorrect heights in win_size_restore()
Solution: avoid restoring incorrect heights in win_size_restore()

https://github.com/vim/vim/commit/876f5fb570d8401aa4c58af4a5da91f10520aa9d

I already merged this prior, so just replace the new test with the old one, but add a test case for the global statusline.