### PR TITLE
vim-patch:9.0.{1722,1723}

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -147,6 +147,8 @@ PRAGMA_DIAG_POP
 
 static const char *e_listblobarg = N_("E899: Argument of %s must be a List or Blob");
 static const char *e_invalwindow = N_("E957: Invalid window number");
+static const char e_argument_of_str_must_be_list_string_or_dictionary[]
+  = N_("E706: Argument of %s must be a List, String or Dictionary");
 static const char e_invalid_submatch_number_nr[]
   = N_("E935: Invalid submatch number: %d");
 static const char *e_reduceempty = N_("E998: Reduce of an empty %s with no initial value");
@@ -997,8 +999,8 @@ static void f_count(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         n = count_dict(argvars[0].vval.v_dict, &argvars[1], ic);
       }
     }
-  } else {
-    semsg(_(e_listdictarg), "count()");
+  } else if (!error) {
+    semsg(_(e_argument_of_str_must_be_list_string_or_dictionary), "count()");
   }
   rettv->vval.v_number = n;
 }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -2953,7 +2953,7 @@ static void f_wait(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const int called_emsg_before = called_emsg;
 
   LOOP_PROCESS_EVENTS_UNTIL(&main_loop, main_loop.events, timeout,
-                            eval_expr_typval(&expr, &argv, 0, &exprval) != OK
+                            eval_expr_typval(&expr, false, &argv, 0, &exprval) != OK
                             || tv_get_number_chk(&exprval, &error)
                             || called_emsg > called_emsg_before || error || got_int);
 
@@ -3515,7 +3515,7 @@ static varnumber_T indexof_eval_expr(typval_T *expr)
   typval_T newtv;
   newtv.v_type = VAR_UNKNOWN;
 
-  if (eval_expr_typval(expr, argv, 2, &newtv) == FAIL) {
+  if (eval_expr_typval(expr, false, argv, 2, &newtv) == FAIL) {
     return false;
   }
 
@@ -5537,7 +5537,7 @@ static varnumber_T readdir_checkitem(void *context, const char *name)
   argv[0].vval.v_string = (char *)name;
 
   typval_T rettv;
-  if (eval_expr_typval(expr, argv, 1, &rettv) == FAIL) {
+  if (eval_expr_typval(expr, false, argv, 1, &rettv) == FAIL) {
     goto theend;
   }
 
@@ -6259,7 +6259,7 @@ static void reduce_list(typval_T *argvars, typval_T *expr, typval_T *rettv)
     argv[1] = *TV_LIST_ITEM_TV(li);
     rettv->v_type = VAR_UNKNOWN;
 
-    const int r = eval_expr_typval(expr, argv, 2, rettv);
+    const int r = eval_expr_typval(expr, true, argv, 2, rettv);
 
     tv_clear(&argv[0]);
     if (r == FAIL || called_emsg != called_emsg_start) {
@@ -6306,7 +6306,7 @@ static void reduce_string(typval_T *argvars, typval_T *expr, typval_T *rettv)
       .vval.v_string = xstrnsave(p, (size_t)len),
     };
 
-    const int r = eval_expr_typval(expr, argv, 2, rettv);
+    const int r = eval_expr_typval(expr, true, argv, 2, rettv);
 
     tv_clear(&argv[0]);
     tv_clear(&argv[1]);
@@ -6354,7 +6354,7 @@ static void reduce_blob(typval_T *argvars, typval_T *expr, typval_T *rettv)
       .vval.v_number = tv_blob_get(b, i),
     };
 
-    const int r = eval_expr_typval(expr, argv, 2, rettv);
+    const int r = eval_expr_typval(expr, true, argv, 2, rettv);
 
     if (r == FAIL || called_emsg != called_emsg_start) {
       return;

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -1627,7 +1627,8 @@ func Test_count()
   call assert_equal(2, count("fooooo", "oo"))
   call assert_equal(0, count("foo", ""))
 
-  call assert_fails('call count(0, 0)', 'E712:')
+  call assert_fails('call count(0, 0)', 'E706:')
+  call assert_fails('call count("", "", {})', ['E728:', 'E728:'])
 endfunc
 
 func Test_changenr()

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -944,6 +944,10 @@ func Test_reduce()
       call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
       call assert_equal('Å,s,t,r,ö,m', reduce('Åström', LSTART acc, val LMIDDLE acc .. ',' .. val LEND))
       call assert_equal(',a,b,c', reduce('abc', LSTART acc, val LMIDDLE acc .. ',' .. val LEND, v:_null_string))
+
+      call assert_equal(0x7d, reduce([0x30, 0x25, 0x08, 0x61], 'or'))
+      call assert_equal(0x7d, reduce(0z30250861, 'or'))
+      call assert_equal('β', reduce('ββββ', 'matchstr'))
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -958,7 +962,7 @@ func Test_reduce()
 
   call assert_fails("call reduce({}, { acc, val -> acc + val }, 1)", 'E1098:')
   call assert_fails("call reduce(0, { acc, val -> acc + val }, 1)", 'E1098:')
-  call assert_fails("call reduce([1, 2], 'Xdoes_not_exist')", 'E121:')
+  call assert_fails("call reduce([1, 2], 'Xdoes_not_exist')", 'E117:')
   call assert_fails("echo reduce(0z01, { acc, val -> 2 * acc + val }, '')", 'E1210:')
 
   " call assert_fails("vim9 reduce(0, (acc, val) => (acc .. val), '')", 'E1252:')


### PR DESCRIPTION
#### vim-patch:9.0.1722: wrong error messages when passing wrong types to count()

Problem: wrong error messages when passing wrong types to count()
Solution: fix it

This fixes two problems:
1. When passing wrong type to {ic} argument of count(), two error
   messages are given, the second of which is misleading.
2. When passing wrong type to {comp} argument of count(), the error
   message doesn't mention that {comp} may be a String.

closes: vim/vim#12825

https://github.com/vim/vim/commit/4f389e7c0fe7dfeccfa512a72fa36f9028d57159


#### vim-patch:9.0.1723: Fix regression in {func} argument of reduce()

Problem: Fix regression in {func} argument of reduce()
Solution: pass function name as string again

Before patch 9.0.0548, passing a string as {func} argument of reduce()
is treated as a function name, but after patch 9.0.0548 it is treated as
an expression instead, which is useless as reduce() doesn't set any v:
variables. This PR restores the behavior of {func} before that patch.

Also correct an emsg() call, as e_string_list_or_blob_required doesn't
contain format specifiers.

closes: vim/vim#12824

https://github.com/vim/vim/commit/ad0c442f1fcc6fe9c433777ee3e5b9e6addc6d69