### PR TITLE
vim-patch:9.0.1734: :runtime completion fails for multiple args

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -1376,7 +1376,7 @@ char *skiptowhite(const char *p)
 /// @param p
 ///
 /// @return Pointer to the next whitespace character.
-char *skiptowhite_esc(char *p)
+char *skiptowhite_esc(const char *p)
   FUNC_ATTR_PURE
 {
   while (*p != ' ' && *p != '\t' && *p != NUL) {
@@ -1385,7 +1385,7 @@ char *skiptowhite_esc(char *p)
     }
     p++;
   }
-  return p;
+  return (char *)p;
 }
 
 /// Skip over text until '\n' or NUL.

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -265,6 +265,15 @@ void set_context_in_runtime_cmd(expand_T *xp, const char *arg)
   char *p = skiptowhite(arg);
   runtime_expand_flags
     = *p != NUL ? get_runtime_cmd_flags((char **)&arg, (size_t)(p - arg)) : 0;
+  // Skip to the last argument.
+  while (*(p = skiptowhite_esc(arg)) != NUL) {
+    if (runtime_expand_flags == 0) {
+      // When there are multiple arguments and [where] is not specified,
+      // use an unrelated non-zero flag to avoid expanding [where].
+      runtime_expand_flags = DIP_ALL;
+    }
+    arg = skipwhite(p);
+  }
   xp->xp_context = EXPAND_RUNTIME;
   xp->xp_pattern = (char *)arg;
 }

--- a/test/old/testdir/test_packadd.vim
+++ b/test/old/testdir/test_packadd.vim
@@ -388,9 +388,9 @@ func Test_runtime_completion()
   call writefile([], optdir . '/../Aunrelated')
   exe 'set rtp=' . &packpath . '/runtime'
 
-  func Check_runtime_completion(arg, arg1, res)
+  func Check_runtime_completion(arg, arg_prev, res)
     call feedkeys(':runtime ' .. a:arg .. "\<C-A>\<C-B>\"\<CR>", 'xt')
-    call assert_equal('"runtime ' .. a:arg1 .. join(a:res), @:)
+    call assert_equal('"runtime ' .. a:arg_prev .. join(a:res), @:)
     call assert_equal(a:res, getcompletion(a:arg, 'runtime'))
   endfunc
 
@@ -404,36 +404,67 @@ func Test_runtime_completion()
         \ ['PACK'])
   call Check_runtime_completion('A', '',
         \ ['Aextra/', 'Arunfoo.vim', 'ALL'])
+  call Check_runtime_completion('Other.vim ', 'Other.vim ',
+        \ ['Aextra/', 'Arunfoo.vim'])
   call Check_runtime_completion('Aextra/', '',
+        \ ['Aextra/Arunbar.vim', 'Aextra/Arunbaz/'])
+  call Check_runtime_completion('Other.vim Aextra/', 'Other.vim ',
         \ ['Aextra/Arunbar.vim', 'Aextra/Arunbaz/'])
 
   call Check_runtime_completion('START ', 'START ',
         \ ['Aextra/', 'Astartfoo.vim'])
+  call Check_runtime_completion('START Other.vim ', 'START Other.vim ',
+        \ ['Aextra/', 'Astartfoo.vim'])
   call Check_runtime_completion('START A', 'START ',
         \ ['Aextra/', 'Astartfoo.vim'])
+  call Check_runtime_completion('START Other.vim A', 'START Other.vim ',
+        \ ['Aextra/', 'Astartfoo.vim'])
   call Check_runtime_completion('START Aextra/', 'START ',
+        \ ['Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])
+  call Check_runtime_completion('START Other.vim Aextra/', 'START Other.vim ',
         \ ['Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])
 
   call Check_runtime_completion('OPT ', 'OPT ',
         \ ['Aextra/', 'Aoptfoo.vim'])
+  call Check_runtime_completion('OPT Other.vim ', 'OPT Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim'])
   call Check_runtime_completion('OPT A', 'OPT ',
         \ ['Aextra/', 'Aoptfoo.vim'])
+  call Check_runtime_completion('OPT Other.vim A', 'OPT Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim'])
   call Check_runtime_completion('OPT Aextra/', 'OPT ',
+        \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/'])
+  call Check_runtime_completion('OPT Other.vim Aextra/', 'OPT Other.vim ',
         \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/'])
 
   call Check_runtime_completion('PACK ', 'PACK ',
         \ ['Aextra/', 'Aoptfoo.vim', 'Astartfoo.vim'])
+  call Check_runtime_completion('PACK Other.vim ', 'PACK Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim', 'Astartfoo.vim'])
   call Check_runtime_completion('PACK A', 'PACK ',
         \ ['Aextra/', 'Aoptfoo.vim', 'Astartfoo.vim'])
+  call Check_runtime_completion('PACK Other.vim A', 'PACK Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim', 'Astartfoo.vim'])
   call Check_runtime_completion('PACK Aextra/', 'PACK ',
+        \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/',
+        \ 'Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])
+  call Check_runtime_completion('PACK Other.vim Aextra/', 'PACK Other.vim ',
         \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/',
         \ 'Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])
 
   call Check_runtime_completion('ALL ', 'ALL ',
         \ ['Aextra/', 'Aoptfoo.vim', 'Arunfoo.vim', 'Astartfoo.vim'])
+  call Check_runtime_completion('ALL Other.vim ', 'ALL Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim', 'Arunfoo.vim', 'Astartfoo.vim'])
   call Check_runtime_completion('ALL A', 'ALL ',
         \ ['Aextra/', 'Aoptfoo.vim', 'Arunfoo.vim', 'Astartfoo.vim'])
+  call Check_runtime_completion('ALL Other.vim A', 'ALL Other.vim ',
+        \ ['Aextra/', 'Aoptfoo.vim', 'Arunfoo.vim', 'Astartfoo.vim'])
   call Check_runtime_completion('ALL Aextra/', 'ALL ',
+        \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/',
+        \ 'Aextra/Arunbar.vim', 'Aextra/Arunbaz/',
+        \ 'Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])
+  call Check_runtime_completion('ALL Other.vim Aextra/', 'ALL Other.vim ',
         \ ['Aextra/Aoptbar.vim', 'Aextra/Aoptbaz/',
         \ 'Aextra/Arunbar.vim', 'Aextra/Arunbaz/',
         \ 'Aextra/Astartbar.vim', 'Aextra/Astartbaz/'])


### PR DESCRIPTION
#### vim-patch:9.0.1734: :runtime completion fails for multiple args

Problem: :runtime completion fails for multiple args
Solution: Make it work

closes: vim/vim#12616

https://github.com/vim/vim/commit/be5cdd1d634c2dfc7e415499fb18f4d246a8721c