### PR TITLE
vim-patch:9.0.1735: Rename completion specific findex var

### DIFF
--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -244,6 +244,7 @@ struct expand {
 #endif
   int xp_numfiles;              // number of files found by file name completion
   int xp_col;                   // cursor position in line
+  int xp_selected;              // selected index in completion
   char **xp_files;              // list of files
   char *xp_line;                // text being completed
 #define EXPAND_BUF_LEN 256


### PR DESCRIPTION
#### vim-patch:9.0.1735: Rename completion specific findex var

Problem: Rename completion specific findex var
Solution: Move "findex" static variable to xp_selected in expand_T

closes: vim/vim#12548

https://github.com/vim/vim/commit/e9ef347c137aca6c2592beb19da45a8aece65e11