### PR TITLE
vim-patch:9.0.1730: passing multiple patterns to runtime not working

### DIFF
--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -1188,7 +1188,7 @@ void ex_helptags(exarg_T *eap)
   }
 
   if (strcmp(eap->arg, "ALL") == 0) {
-    do_in_path(p_rtp, "doc", DIP_ALL + DIP_DIR, helptags_cb, &add_help_tags);
+    do_in_path(p_rtp, "", "doc", DIP_ALL + DIP_DIR, helptags_cb, &add_help_tags);
   } else {
     ExpandInit(&xpc);
     xpc.xp_context = EXPAND_DIRECTORIES;

--- a/test/old/testdir/test_packadd.vim
+++ b/test/old/testdir/test_packadd.vim
@@ -338,11 +338,35 @@ func Test_runtime()
   runtime extra/bar.vim
   call assert_equal('run', g:sequence)
   let g:sequence = ''
+  runtime NoSuchFile extra/bar.vim
+  call assert_equal('run', g:sequence)
+
+  let g:sequence = ''
   runtime START extra/bar.vim
   call assert_equal('start', g:sequence)
   let g:sequence = ''
+  runtime START NoSuchFile extra/bar.vim extra/foo.vim
+  call assert_equal('start', g:sequence)
+  let g:sequence = ''
+  runtime START NoSuchFile extra/foo.vim extra/bar.vim
+  call assert_equal('foostart', g:sequence)
+  let g:sequence = ''
+  runtime! START NoSuchFile extra/bar.vim extra/foo.vim
+  call assert_equal('startfoostart', g:sequence)
+
+  let g:sequence = ''
   runtime OPT extra/bar.vim
   call assert_equal('opt', g:sequence)
+  let g:sequence = ''
+  runtime OPT NoSuchFile extra/bar.vim extra/xxx.vim
+  call assert_equal('opt', g:sequence)
+  let g:sequence = ''
+  runtime OPT NoSuchFile extra/xxx.vim extra/bar.vim
+  call assert_equal('xxxopt', g:sequence)
+  let g:sequence = ''
+  runtime! OPT NoSuchFile extra/bar.vim extra/xxx.vim
+  call assert_equal('optxxxopt', g:sequence)
+
   let g:sequence = ''
   runtime PACK extra/bar.vim
   call assert_equal('start', g:sequence)
@@ -352,6 +376,12 @@ func Test_runtime()
   let g:sequence = ''
   runtime PACK extra/xxx.vim
   call assert_equal('xxxopt', g:sequence)
+  let g:sequence = ''
+  runtime PACK extra/xxx.vim extra/foo.vim extra/bar.vim
+  call assert_equal('foostart', g:sequence)
+  let g:sequence = ''
+  runtime! PACK extra/bar.vim extra/xxx.vim extra/foo.vim
+  call assert_equal('startfoostartoptxxxopt', g:sequence)
 
   let g:sequence = ''
   runtime ALL extra/bar.vim
@@ -365,6 +395,12 @@ func Test_runtime()
   let g:sequence = ''
   runtime! ALL extra/bar.vim
   call assert_equal('runstartopt', g:sequence)
+  let g:sequence = ''
+  runtime ALL extra/xxx.vim extra/foo.vim extra/bar.vim
+  call assert_equal('run', g:sequence)
+  let g:sequence = ''
+  runtime! ALL extra/bar.vim extra/xxx.vim extra/foo.vim
+  call assert_equal('runstartfoostartoptxxxopt', g:sequence)
 endfunc
 
 func Test_runtime_completion()


### PR DESCRIPTION
#### vim-patch:9.0.1730: passing multiple patterns to runtime not working

Problem: passing multiple patterns to runtime not working
Solution: prepend prefix to each argument separately

closes: vim/vim#12617

https://github.com/vim/vim/commit/008c91537b55835aa91cd8fbe1a139256581da31