### PR TITLE
vim-patch:a5988f5,442d174,817db40

### DIFF
--- a/runtime/syntax/bindzone.vim
+++ b/runtime/syntax/bindzone.vim
@@ -33,7 +33,7 @@ syn match       zoneDomain      contained  /[^[:space:]!"#$%&'()*+,\/:;<=>?@[\]\
 syn match       zoneSpecial     contained /^[@*.]\s/
 syn match       zoneTTL         contained /\s\@<=\d[0-9WwDdHhMmSs]*\(\s\|$\)\@=/ nextgroup=zoneClass,zoneRRType skipwhite
 syn keyword     zoneClass       contained IN CHAOS CH HS HESIOD nextgroup=zoneRRType,zoneTTL skipwhite
-syn keyword     zoneRRType      contained A AAAA CERT CNAME DNAME DNSKEY DS HINFO LOC MX NAPTR NS NSEC NSEC3 NSEC3PARAM PTR RP RRSIG SSHFP SOA SPF SRV TLSA TXT nextgroup=zoneRData skipwhite
+syn keyword     zoneRRType      contained A AAAA CAA CERT CNAME DNAME DNSKEY DS HINFO LOC MX NAPTR NS NSEC NSEC3 NSEC3PARAM OPENPGPKEY PTR RP RRSIG SMIMEA SOA SPF SRV SSHFP TLSA TXT nextgroup=zoneRData skipwhite
 syn match       zoneRData       contained /[^;]*/ contains=zoneDomain,zoneIPAddr,zoneIP6Addr,zoneText,zoneNumber,zoneParen,zoneUnknown
 
 syn match       zoneIPAddr      contained /\<[0-9]\{1,3}\(\.[0-9]\{1,3}\)\{,3}\>/

--- a/runtime/syntax/haskell.vim
+++ b/runtime/syntax/haskell.vim
@@ -108,6 +108,8 @@ syn match   hsLineComment      "---*\([^-!#$%&\*\+./<=>\?@\\^|~].*\)\?$" contain
 syn region  hsBlockComment     start="{-"  end="-}" contains=hsBlockComment,@Spell
 syn region  hsPragma	       start="{-#" end="#-}"
 
+syn keyword hsTodo	        contained FIXME TODO XXX NOTE
+
 " C Preprocessor directives. Shamelessly ripped from c.vim and trimmed
 " First, see whether to flag directive-like lines or not
 if (!exists("hs_allow_hash_operator"))

--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -52,11 +52,11 @@ syn match   javaScriptNumber           "\<\d\+\(_\d\+\)*\.\(\d\+\(_\d\+\)*\([eE]
 syn region  javaScriptRegexpString     start=+[,(=+]\s*/[^/*]+ms=e-1,me=e-1 skip=+\\\\\|\\/+ end=+/[gimuys]\{0,2\}\s*$+ end=+/[gimuys]\{0,2\}\s*[+;.,)\]}]+me=e-1 end=+/[gimuys]\{0,2\}\s\+\/+me=e-1 contains=@htmlPreproc,javaScriptComment oneline
 
 syn keyword javaScriptConditional	if else switch
-syn keyword javaScriptRepeat		while for do in
+syn keyword javaScriptRepeat		while for do in of
 syn keyword javaScriptBranch		break continue
 syn keyword javaScriptOperator		new delete instanceof typeof
 syn keyword javaScriptType		Array Boolean Date Function Number Object String RegExp
-syn keyword javaScriptStatement		return with await
+syn keyword javaScriptStatement		return with await yield
 syn keyword javaScriptBoolean		true false
 syn keyword javaScriptNull		null undefined
 syn keyword javaScriptIdentifier	arguments this var let


### PR DESCRIPTION
###    vim-patch:442d174
    
    bindzone runtime: add new DNS record types (vim/vim#7351)
    
    Recognize some newer DNS record types - CAA (RFC8659, certificate authority authorization), OPENPGPKEY (RFC7929), SMIMEA (RFC8162). Sort SSHFP alphabetically while there.
    
    https://github.com/vim/vim/commit/442d1746f4c650e2e41246fd5679f635a4a30232
    
    Co-authored-by: Stuart Henderson <sthen@users.noreply.github.com>


###    vim-patch:817db40
    
    Add TODO, FIXME to Haskell syntax file (vim/vim#8055)
    
    Adding TODO, XXX, FIXME to Haskell syntax file vim/vim#8054
    
    https://github.com/vim/vim/commit/817db406bb12b9fd5df25d4cda392b515d44ee05
    
    Co-authored-by: Bruno-366 <81762173+Bruno-366@users.noreply.github.com>


###    vim-patch:a5988f5
    
    Keywords 'of' and 'yield' for Javascript. (vim/vim#7873)
    
    * Keyword 'of' in for...of statement.
    
    * Keyword 'yield' for generator function.
    
    https://github.com/vim/vim/commit/a5988f582e482150023862052d41e5215253a3de
    
    Co-authored-by: Yuri Klimov <yuri@klimov.net>
