### PR TITLE
vim-patch:9.0.1731: blockwise Visual highlight not working with virtual text

### DIFF
--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2146,7 +2146,7 @@ bbbbbbb]])
       ]]}
   end)
 
-  it('visual select highlight is correct', function()
+  it('Visual select highlight is correct', function()
     insert('foo foo foo bar\nfoo foo foo bar')
     feed('gg0')
     meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'AAA', 'Special' } }, virt_text_pos = 'inline' })
@@ -2802,6 +2802,152 @@ bbbbbbb]])
       {1:~                                                 }|
                                                         |
       ]]}
+  end)
+
+  it('blockwise Visual highlight with double-width virtual text (replace)', function()
+    screen:try_resize(60, 6)
+    insert('123456789\n123456789\n123456789')
+    meths.buf_set_extmark(0, ns, 1, 1, {
+      virt_text = { { '-口-', 'Special' } },
+      virt_text_pos = 'inline',
+      hl_mode = 'replace',
+    })
+    feed('gg0')
+    screen:expect{grid=[[
+      ^123456789                                                   |
+      1{10:-口-}23456789                                               |
+      123456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('<C-V>2jl')
+    screen:expect{grid=[[
+      {7:12}3456789                                                   |
+      {7:1}{10:-口-}23456789                                               |
+      {7:1}^23456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      {7:123}456789                                                   |
+      {7:1}{10:-口-}23456789                                               |
+      {7:12}^3456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('4l')
+    screen:expect{grid=[[
+      {7:1234567}89                                                   |
+      {7:1}{10:-口-}{7:23}456789                                               |
+      {7:123456}^789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('Ol')
+    screen:expect{grid=[[
+      1{7:234567}89                                                   |
+      1{10:-口-}{7:23}456789                                               |
+      1^2{7:34567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      12{7:34567}89                                                   |
+      1{10:-口-}{7:23}456789                                               |
+      12^3{7:4567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      123{7:4567}89                                                   |
+      1{10:-口-}{7:23}456789                                               |
+      123^4{7:567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+  end)
+
+  it('blockwise Visual highlight with double-width virtual text (combine)', function()
+    screen:try_resize(60, 6)
+    insert('123456789\n123456789\n123456789')
+    meths.buf_set_extmark(0, ns, 1, 1, {
+      virt_text = { { '-口-', 'Special' } },
+      virt_text_pos = 'inline',
+      hl_mode = 'combine',
+    })
+    feed('gg0')
+    screen:expect{grid=[[
+      ^123456789                                                   |
+      1{10:-口-}23456789                                               |
+      123456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('<C-V>2jl')
+    screen:expect{grid=[[
+      {7:12}3456789                                                   |
+      {7:1}{20:-}{10:口-}23456789                                               |
+      {7:1}^23456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      {7:123}456789                                                   |
+      {7:1}{20:-口}{10:-}23456789                                               |
+      {7:12}^3456789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('4l')
+    screen:expect{grid=[[
+      {7:1234567}89                                                   |
+      {7:1}{20:-口-}{7:23}456789                                               |
+      {7:123456}^789                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('Ol')
+    screen:expect{grid=[[
+      1{7:234567}89                                                   |
+      1{20:-口-}{7:23}456789                                               |
+      1^2{7:34567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      12{7:34567}89                                                   |
+      1{10:-}{20:口-}{7:23}456789                                               |
+      12^3{7:4567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+    feed('l')
+    screen:expect{grid=[[
+      123{7:4567}89                                                   |
+      1{10:-}{20:口-}{7:23}456789                                               |
+      123^4{7:567}89                                                   |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {8:-- VISUAL BLOCK --}                                          |
+    ]]}
   end)
 end)
 


### PR DESCRIPTION
#### vim-patch:9.0.1731: blockwise Visual highlight not working with virtual text

Problem: blockwise Visual highlight not working with virtual text
Solution: Reset the correct variable at the end of virtual selection and
          Check for double-width char inside virtual text.

closes: vim/vim#12606

https://github.com/vim/vim/commit/6e940d9a1d4ff122aad1b0821c784a60b507d45c

Need to remove area_active and use wlv.fromcol and wlv.tocol directly.