### PR TITLE
fix(extmarks): make empty "conceal" respect &conceallevel = 1

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -332,7 +332,7 @@ next_mark:
 
   int attr = 0;
   size_t j = 0;
-  bool conceal = 0;
+  int conceal = 0;
   int conceal_char = 0;
   int conceal_attr = 0;
   TriState spell = kNone;
@@ -362,8 +362,9 @@ next_mark:
       attr = hl_combine_attr(attr, item.attr_id);
     }
     if (active && item.decor.conceal) {
-      conceal = true;
-      if (item.start_row == state->row && item.start_col == col && item.decor.conceal_char) {
+      conceal = 1;
+      if (item.start_row == state->row && item.start_col == col) {
+        conceal = 2;
         conceal_char = item.decor.conceal_char;
         state->col_until = MIN(state->col_until, item.start_col);
         conceal_attr = item.attr_id;

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -101,7 +101,7 @@ typedef struct {
   int current;
   int eol_col;
 
-  bool conceal;
+  int conceal;
   int conceal_char;
   int conceal_attr;
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2179,11 +2179,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
         if (has_decor && v > 0) {
           // extmarks take preceedence over syntax.c
           decor_attr = hl_combine_attr(decor_attr, extmark_attr);
-
           decor_conceal = decor_state.conceal;
-          if (decor_conceal && decor_state.conceal_char) {
-            decor_conceal = 2;  // really??
-          }
           can_spell = TRISTATE_TO_BOOL(decor_state.spell, can_spell);
         }
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1361,18 +1361,43 @@ describe('extmark decorations', function()
     assert_alive()
   end)
 
-  it('conceal #19007', function()
+  it('conceal with conceal char #19007', function()
     screen:try_resize(50, 5)
     insert('foo\n')
-    command('let &conceallevel=2')
     meths.buf_set_extmark(0, ns, 0, 0, {end_col=0, end_row=2, conceal='X'})
+    command('set conceallevel=2')
     screen:expect([[
-        {26:X}                                                 |
-        ^                                                  |
-        {1:~                                                 }|
-        {1:~                                                 }|
-                                                          |
-      ]])
+      {26:X}                                                 |
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+    command('set conceallevel=1')
+    screen:expect_unchanged()
+  end)
+
+  it('conceal without conceal char #24782', function()
+    screen:try_resize(50, 5)
+    insert('foobar\n')
+    meths.buf_set_extmark(0, ns, 0, 0, {end_col=3, conceal=''})
+    command('set listchars=conceal:?')
+    command('let &conceallevel=1')
+    screen:expect([[
+      {26:?}bar                                              |
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
+    command('let &conceallevel=2')
+    screen:expect([[
+      bar                                               |
+      ^                                                  |
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]])
   end)
 
   it('conceal works just before truncated double-width char #21486', function()

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -1655,8 +1655,7 @@ describe('ui/mouse/input', function()
       test_mouse_click_conceal()
     end)
 
-    -- FIXME: cannot make extmark conceal behave exactly like syntax conceal without cchar
-    pending('(extmarks)', function()
+    describe('(extmarks)', function()
       before_each(function()
         local ns = meths.create_namespace('conceal')
         meths.buf_set_extmark(0, ns, 0, 11, { end_col = 12, conceal = '' })


### PR DESCRIPTION
This treats extmark conceal more like matchadd() conceal.

Fix #24782
