### PR TITLE
vim-patch:9.0.{1515,1540,1738}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5666,11 +5666,13 @@ resolve({filename})                                             *resolve()* *E65
 		path name) and also keeps a trailing path separator.
 
 reverse({object})                                                    *reverse()*
-		Reverse the order of items in {object} in-place.
-		{object} can be a |List| or a |Blob|.
-		Returns {object}.
-		Returns zero if {object} is not a List or a Blob.
-		If you want an object to remain unmodified make a copy first: >vim
+		Reverse the order of items in {object}.  {object} can be a
+		|List|, a |Blob| or a |String|.  For a List and a Blob the
+		items are reversed in-place and {object} is returned.
+		For a String a new String is returned.
+		Returns zero if {object} is not a List, Blob or a String.
+		If you want a List or Blob to remain unmodified make a copy
+		first: >vim
 			let revlist = reverse(copy(mylist))
 <
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -626,6 +626,7 @@ String manipulation:					*string-functions*
 	strdisplaywidth()	size of string when displayed, deals with tabs
 	setcellwidths()		set character cell width overrides
 	getcellwidths()		get character cell width overrides
+	reverse()		reverse the order of characters in a string
 	substitute()		substitute a pattern match with a string
 	submatch()		get a specific match in ":s" and substitute()
 	strpart()		get part of a string using byte index
@@ -664,7 +665,7 @@ List manipulation:					*list-functions*
 	reduce()		reduce a List to a value
 	slice()			take a slice of a List
 	sort()			sort a List
-	reverse()		reverse the order of a List or Blob
+	reverse()		reverse the order of items in a List
 	uniq()			remove copies of repeated adjacent items
 	split()			split a String into a List
 	join()			join List items into a String
@@ -731,6 +732,7 @@ Floating point computation:				*float-functions*
 Blob manipulation:					*blob-functions*
 	blob2list()		get a list of numbers from a blob
 	list2blob()		get a blob from a list of numbers
+	reverse()		reverse the order of numbers in a blob
 
 Other computation:					*bitwise-function*
 	and()			bitwise AND

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6762,11 +6762,13 @@ vim.fn['repeat'] = function(expr, count) end
 --- @return any
 function vim.fn.resolve(filename) end
 
---- Reverse the order of items in {object} in-place.
---- {object} can be a |List| or a |Blob|.
---- Returns {object}.
---- Returns zero if {object} is not a List or a Blob.
---- If you want an object to remain unmodified make a copy first: >vim
+--- Reverse the order of items in {object}.  {object} can be a
+--- |List|, a |Blob| or a |String|.  For a List and a Blob the
+--- items are reversed in-place and {object} is returned.
+--- For a String a new String is returned.
+--- Returns zero if {object} is not a List, Blob or a String.
+--- If you want a List or Blob to remain unmodified make a copy
+--- first: >vim
 ---   let revlist = reverse(copy(mylist))
 --- <
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8151,11 +8151,13 @@ M.funcs = {
     args = 1,
     base = 1,
     desc = [=[
-      Reverse the order of items in {object} in-place.
-      {object} can be a |List| or a |Blob|.
-      Returns {object}.
-      Returns zero if {object} is not a List or a Blob.
-      If you want an object to remain unmodified make a copy first: >vim
+      Reverse the order of items in {object}.  {object} can be a
+      |List|, a |Blob| or a |String|.  For a List and a Blob the
+      items are reversed in-place and {object} is returned.
+      For a String a new String is returned.
+      Returns zero if {object} is not a List, Blob or a String.
+      If you want a List or Blob to remain unmodified make a copy
+      first: >vim
       	let revlist = reverse(copy(mylist))
       <
     ]=],

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6209,6 +6209,13 @@ static void f_reverse(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       tv_blob_set(b, len - i - 1, tmp);
     }
     tv_blob_set_ret(rettv, b);
+  } else if (argvars[0].v_type == VAR_STRING) {
+    rettv->v_type = VAR_STRING;
+    if (argvars[0].vval.v_string != NULL) {
+      rettv->vval.v_string = reverse_text(argvars[0].vval.v_string);
+    } else {
+      rettv->vval.v_string = NULL;
+    }
   } else if (argvars[0].v_type != VAR_LIST) {
     semsg(_(e_listblobarg), "reverse()");
   } else {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6199,6 +6199,10 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "reverse({list})" function
 static void f_reverse(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  if (tv_check_for_string_or_list_or_blob_arg(argvars, 0) == FAIL) {
+    return;
+  }
+
   if (argvars[0].v_type == VAR_BLOB) {
     blob_T *const b = argvars[0].vval.v_blob;
     const int len = tv_blob_len(b);
@@ -6216,9 +6220,7 @@ static void f_reverse(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     } else {
       rettv->vval.v_string = NULL;
     }
-  } else if (argvars[0].v_type != VAR_LIST) {
-    semsg(_(e_listblobarg), "reverse()");
-  } else {
+  } else if (argvars[0].v_type == VAR_LIST) {
     list_T *const l = argvars[0].vval.v_list;
     if (!value_check_lock(tv_list_locked(l), N_("reverse() argument"),
                           TV_TRANSLATE)) {

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -81,6 +81,8 @@ static const char e_blob_required_for_argument_nr[]
   = N_("E1238: Blob required for argument %d");
 static const char e_invalid_value_for_blob_nr[]
   = N_("E1239: Invalid value for blob: %d");
+static const char e_string_list_or_blob_required_for_argument_nr[]
+  = N_("E1252: String, List or Blob required for argument %d");
 static const char e_string_or_function_required_for_argument_nr[]
   = N_("E1256: String or function required for argument %d");
 static const char e_non_null_dict_required_for_argument_nr[]
@@ -4350,7 +4352,20 @@ int tv_check_for_string_or_list_arg(const typval_T *const args, const int idx)
   return OK;
 }
 
-/// Check for an optional string or list argument at 'idx'
+/// Give an error and return FAIL unless "args[idx]" is a string, a list or a blob.
+int tv_check_for_string_or_list_or_blob_arg(const typval_T *const args, const int idx)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
+{
+  if (args[idx].v_type != VAR_STRING
+      && args[idx].v_type != VAR_LIST
+      && args[idx].v_type != VAR_BLOB) {
+    semsg(_(e_string_list_or_blob_required_for_argument_nr), idx + 1);
+    return FAIL;
+  }
+  return OK;
+}
+
+/// Check for an optional string or list argument at "idx"
 int tv_check_for_opt_string_or_list_arg(const typval_T *const args, const int idx)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -2168,20 +2168,17 @@ int kv_do_printf(StringBuilder *str, const char *fmt, ...)
 ///
 /// @return  the allocated string.
 char *reverse_text(char *s)
-  FUNC_ATTR_NONNULL_RET
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
-  // Reverse the pattern.
   size_t len = strlen(s);
   char *rev = xmalloc(len + 1);
-  size_t rev_i = len;
-  for (size_t s_i = 0; s_i < len; s_i++) {
+  for (size_t s_i = 0, rev_i = len; s_i < len; s_i++) {
     const int mb_len = utfc_ptr2len(s + s_i);
     rev_i -= (size_t)mb_len;
     memmove(rev + rev_i, s + s_i, (size_t)mb_len);
     s_i += (size_t)mb_len - 1;
   }
   rev[len] = NUL;
-
   return rev;
 }
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3148,4 +3148,21 @@ func Test_delfunc_while_listing()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for the reverse() function with a string
+func Test_string_reverse()
+  call assert_equal('', reverse(v:_null_string))
+  for [s1, s2] in [['', ''], ['a', 'a'], ['ab', 'ba'], ['abc', 'cba'],
+        \ ['abcd', 'dcba'], ['«-«-»-»', '»-»-«-«'],
+        \ ['🇦', '🇦'], ['🇦🇧', '🇧🇦'], ['🇦🇧🇨', '🇨🇧🇦'],
+        \ ['🇦«🇧-🇨»🇩', '🇩»🇨-🇧«🇦']]
+    call assert_equal(s2, reverse(s1))
+  endfor
+
+  " test in latin1 encoding
+  let save_enc = &encoding
+  " set encoding=latin1
+  call assert_equal('dcba', reverse('abcd'))
+  let &encoding = save_enc
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3150,13 +3150,16 @@ endfunc
 
 " Test for the reverse() function with a string
 func Test_string_reverse()
-  call assert_equal('', reverse(v:_null_string))
-  for [s1, s2] in [['', ''], ['a', 'a'], ['ab', 'ba'], ['abc', 'cba'],
-        \ ['abcd', 'dcba'], ['«-«-»-»', '»-»-«-«'],
-        \ ['🇦', '🇦'], ['🇦🇧', '🇧🇦'], ['🇦🇧🇨', '🇨🇧🇦'],
-        \ ['🇦«🇧-🇨»🇩', '🇩»🇨-🇧«🇦']]
-    call assert_equal(s2, reverse(s1))
-  endfor
+  let lines =<< trim END
+    call assert_equal('', reverse(v:_null_string))
+    for [s1, s2] in [['', ''], ['a', 'a'], ['ab', 'ba'], ['abc', 'cba'],
+                   \ ['abcd', 'dcba'], ['«-«-»-»', '»-»-«-«'],
+                   \ ['🇦', '🇦'], ['🇦🇧', '🇧🇦'], ['🇦🇧🇨', '🇨🇧🇦'],
+                   \ ['🇦«🇧-🇨»🇩', '🇩»🇨-🇧«🇦']]
+      call assert_equal(s2, reverse(s1))
+    endfor
+  END
+  call CheckLegacyAndVim9Success(lines)
 
   " test in latin1 encoding
   let save_enc = &encoding

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -894,7 +894,7 @@ func Test_reverse_sort_uniq()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails('call reverse("")', 'E899:')
+  call assert_fails('call reverse({})', 'E899:')
   call assert_fails('call uniq([1, 2], {x, y -> []})', 'E745:')
   call assert_fails("call sort([1, 2], function('min'), 1)", "E1206:")
   call assert_fails("call sort([1, 2], function('invalid_func'))", "E700:")

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -894,7 +894,7 @@ func Test_reverse_sort_uniq()
   END
   call CheckLegacyAndVim9Success(lines)
 
-  call assert_fails('call reverse({})', 'E899:')
+  call assert_fails('call reverse({})', 'E1252:')
   call assert_fails('call uniq([1, 2], {x, y -> []})', 'E745:')
   call assert_fails("call sort([1, 2], function('min'), 1)", "E1206:")
   call assert_fails("call sort([1, 2], function('invalid_func'))", "E700:")

--- a/test/old/testdir/test_method.vim
+++ b/test/old/testdir/test_method.vim
@@ -63,7 +63,7 @@ func Test_dict_method()
   call assert_equal(2, d->remove("two"))
   let d.two = 2
   call assert_fails('let x = d->repeat(2)', 'E731:')
-  call assert_fails('let x = d->reverse()', 'E899:')
+  call assert_fails('let x = d->reverse()', 'E1252:')
   call assert_fails('let x = d->sort()', 'E686:')
   call assert_equal("{'one': 1, 'two': 2, 'three': 3}", d->string())
   call assert_equal(v:t_dict, d->type())


### PR DESCRIPTION
#### vim-patch:9.0.1515: reverse() does not work for a String

Problem:    reverse() does not work for a String.
Solution:   Implement reverse() for a String. (Yegappan Lakshmanan,
            closes vim/vim#12179)

https://github.com/vim/vim/commit/03ff1c2dde7f15eca5c9baa6dafbda9b49bedc3b

vim-patch:9.0.1738: Duplicate code to reverse a string

Problem:  Duplicate code to reverse a string
Solution: Move reverse_text() to strings.c and remove string_reverse().

closes: vim/vim#12847

https://github.com/vim/vim/commit/4dd266cb66d901cf5324f09405cfea3f004bd29f

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.0.1540: reverse() on string doesn't work in compiled function

Problem:    reverse() on string doesn't work in compiled function.
Solution:   Accept string in argument type check. (Yegappan Lakshmanan,
            closes vim/vim#12377)

https://github.com/vim/vim/commit/f9dc278946d52235a0025fd347bd9ff571258470

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>