### PR TITLE
vim-patch:9.0.1742: wrong curswant when clicking on second cell of double-width char

### DIFF
--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -634,7 +634,7 @@ void grid_put_linebuf(ScreenGrid *grid, int row, int coloff, int endcol, int cle
 
     grid->vcols[off_to] = linebuf_vcol[off_from];
     if (char_cells == 2) {
-      grid->vcols[off_to + 1] = linebuf_vcol[off_from];
+      grid->vcols[off_to + 1] = linebuf_vcol[off_from + 1];
     }
 
     off_to += (size_t)char_cells;

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4092,4 +4092,29 @@ func Test_normal_click_on_ctrl_char()
   let &mouse = save_mouse
 endfunc
 
+" Test clicking on a double-width character in Normal mode
+func Test_normal_click_on_double_width_char()
+  let save_mouse = &mouse
+  set mouse=a
+  new
+
+  call setline(1, "口口")
+  redraw
+  call Ntest_setmouse(1, 1)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 1, 0, 1], getcurpos())
+  call Ntest_setmouse(1, 2)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 1, 0, 2], getcurpos())
+  call Ntest_setmouse(1, 3)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 4, 0, 3], getcurpos())
+  call Ntest_setmouse(1, 4)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 1, 4, 0, 4], getcurpos())
+
+  bwipe!
+  let &mouse = save_mouse
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1742: wrong curswant when clicking on second cell of double-width char

Problem:  Wrong curswant when clicking and the second cell of a
          double-width char.
Solution: Don't copy virtcol of the first char to the second one.

closes: vim/vim#12842

https://github.com/vim/vim/commit/9994160bfe74501886bbbf5631aec8ea2ae05991