### PR TITLE
vim-patch:9.0.1745: Missing test coverage for blockwise Visual highlight

### DIFF
--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2831,9 +2831,14 @@ bbbbbbb]])
 
   it('blockwise Visual highlight with double-width virtual text (replace)', function()
     screen:try_resize(60, 6)
-    insert('123456789\n123456789\n123456789')
+    insert('123456789\n123456789\n123456789\n123456789')
     meths.buf_set_extmark(0, ns, 1, 1, {
       virt_text = { { '-口-', 'Special' } },
+      virt_text_pos = 'inline',
+      hl_mode = 'replace',
+    })
+    meths.buf_set_extmark(0, ns, 2, 2, {
+      virt_text = { { '口', 'Special' } },
       virt_text_pos = 'inline',
       hl_mode = 'replace',
     })
@@ -2841,17 +2846,17 @@ bbbbbbb]])
     screen:expect{grid=[[
       ^123456789                                                   |
       1{10:-口-}23456789                                               |
+      12{10:口}3456789                                                 |
       123456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
                                                                   |
     ]]}
-    feed('<C-V>2jl')
+    feed('<C-V>3jl')
     screen:expect{grid=[[
       {7:12}3456789                                                   |
       {7:1}{10:-口-}23456789                                               |
+      {7:12}{10:口}3456789                                                 |
       {7:1}^23456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2859,8 +2864,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       {7:123}456789                                                   |
       {7:1}{10:-口-}23456789                                               |
+      {7:12}{10:口}3456789                                                 |
       {7:12}^3456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2868,8 +2873,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       {7:1234567}89                                                   |
       {7:1}{10:-口-}{7:23}456789                                               |
+      {7:12}{10:口}{7:345}6789                                                 |
       {7:123456}^789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2877,8 +2882,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       1{7:234567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
+      1{7:2}{10:口}{7:345}6789                                                 |
       1^2{7:34567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2886,8 +2891,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       12{7:34567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
+      12{10:口}{7:345}6789                                                 |
       12^3{7:4567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2895,8 +2900,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       123{7:4567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
+      12{10:口}{7:345}6789                                                 |
       123^4{7:567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2904,9 +2909,14 @@ bbbbbbb]])
 
   it('blockwise Visual highlight with double-width virtual text (combine)', function()
     screen:try_resize(60, 6)
-    insert('123456789\n123456789\n123456789')
+    insert('123456789\n123456789\n123456789\n123456789')
     meths.buf_set_extmark(0, ns, 1, 1, {
       virt_text = { { '-口-', 'Special' } },
+      virt_text_pos = 'inline',
+      hl_mode = 'combine',
+    })
+    meths.buf_set_extmark(0, ns, 2, 2, {
+      virt_text = { { '口', 'Special' } },
       virt_text_pos = 'inline',
       hl_mode = 'combine',
     })
@@ -2914,17 +2924,17 @@ bbbbbbb]])
     screen:expect{grid=[[
       ^123456789                                                   |
       1{10:-口-}23456789                                               |
+      12{10:口}3456789                                                 |
       123456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
                                                                   |
     ]]}
-    feed('<C-V>2jl')
+    feed('<C-V>3jl')
     screen:expect{grid=[[
       {7:12}3456789                                                   |
       {7:1}{20:-}{10:口-}23456789                                               |
+      {7:12}{10:口}3456789                                                 |
       {7:1}^23456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2932,8 +2942,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       {7:123}456789                                                   |
       {7:1}{20:-口}{10:-}23456789                                               |
+      {7:12}{20:口}3456789                                                 |
       {7:12}^3456789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2941,8 +2951,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       {7:1234567}89                                                   |
       {7:1}{20:-口-}{7:23}456789                                               |
+      {7:12}{20:口}{7:345}6789                                                 |
       {7:123456}^789                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2950,8 +2960,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       1{7:234567}89                                                   |
       1{20:-口-}{7:23}456789                                               |
+      1{7:2}{20:口}{7:345}6789                                                 |
       1^2{7:34567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2959,8 +2969,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       12{7:34567}89                                                   |
       1{10:-}{20:口-}{7:23}456789                                               |
+      12{20:口}{7:345}6789                                                 |
       12^3{7:4567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}
@@ -2968,8 +2978,8 @@ bbbbbbb]])
     screen:expect{grid=[[
       123{7:4567}89                                                   |
       1{10:-}{20:口-}{7:23}456789                                               |
+      12{20:口}{7:345}6789                                                 |
       123^4{7:567}89                                                   |
-      {1:~                                                           }|
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
     ]]}

--- a/test/old/testdir/test_conceal.vim
+++ b/test/old/testdir/test_conceal.vim
@@ -345,6 +345,10 @@ func Test_conceal_mouse_click()
   redraw
   call assert_equal(['conceal  click here '], ScreenLines(1, 20))
 
+  " click on the space between "this" and "click" puts cursor there
+  call Ntest_setmouse(1, 9)
+  call feedkeys("\<LeftMouse>", "tx")
+  call assert_equal([0, 1, 13, 0, 13], getcurpos())
   " click on 'h' of "here" puts cursor there
   call Ntest_setmouse(1, 16)
   call feedkeys("\<LeftMouse>", "tx")
@@ -371,7 +375,11 @@ func Test_conceal_mouse_click()
   call assert_equal([0, 1, 23, 0, 36], getcurpos())
 
   set virtualedit=all
-  redraw  " Nvim: redraw_for_cursorcolumn() redraws for conceal
+  redraw
+  " click on the space between "this" and "click" puts cursor there
+  call Ntest_setmouse(1, 9)
+  call feedkeys("\<LeftMouse>", "tx")
+  call assert_equal([0, 1, 13, 0, 13], getcurpos())
   " click on 'h' of "here" puts cursor there
   call Ntest_setmouse(1, 16)
   call feedkeys("\<LeftMouse>", "tx")

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -698,10 +698,9 @@ func Test_colorcolumn_sbr()
   let lines =<< trim END
 	call setline(1, 'The quick brown fox jumped over the lazy dogs')
   END
-  call writefile(lines, 'Xtest_colorcolumn_srb', 'D')
-  let buf = RunVimInTerminal('-S Xtest_colorcolumn_srb', {'rows': 10,'columns': 40})
+  call writefile(lines, 'Xtest_colorcolumn_sbr', 'D')
+  let buf = RunVimInTerminal('-S Xtest_colorcolumn_sbr', {'rows': 10,'columns': 40})
   call term_sendkeys(buf, ":set co=40 showbreak=+++>\\  cc=40,41,43\<CR>")
-  call TermWait(buf)
   call VerifyScreenDump(buf, 'Test_colorcolumn_3', {})
 
   " clean up


### PR DESCRIPTION
#### vim-patch:9.0.1745: Missing test coverage for blockwise Visual highlight

Problem:  Missing test coverage for blockwise Visual highlight with
          virtual that starts with a double-width char.
Solution: Add a new virtual text to the test. Some other small fixes.

closes: vim/vim#12835

https://github.com/vim/vim/commit/fc3058495d3ff58c8f2b9dd4452d0840f2d1fa42