### PR TITLE
vim-patch:9.0.1747: screenpos() may cause unnecessary redraw

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2112,7 +2112,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
               new_rows++;
             } else if (l == wp->w_topline) {
               int n = plines_win_nofill(wp, l, false) + wp->w_topfill;
-              n = adjust_plines_for_skipcol(wp, n);
+              n -= adjust_plines_for_skipcol(wp);
               if (n > wp->w_height_inner) {
                 n = wp->w_height_inner;
               }


### PR DESCRIPTION
#### vim-patch:9.0.1747: screenpos() may cause unnecessary redraw

Problem:  screenpos() may cause unnecessary redraw.
Solution: Don't unnecessarily reset VALID_WROW flag.

VALID_WROW flag is only used by two functions: validate_cursor() and
cursor_valid(), and cursor_valid() is only used once in ex_sleep().
When adjust_plines_for_skipcol() was first added in patch 9.0.0640, it
was called in two functions: comp_botline() and curs_rows().
- comp_botline() is called in two places:
  - onepage(), which resets VALID_WROW flag immediately afterwards.
  - validate_botline_win(), where resetting a VALID_ flag is strange.
- curs_rows() is called in two places:
  - curs_columns(), which sets VALID_WROW flag afterwards.
  - validate_cline_row(), which is only used by GUI mouse focus.

Therefore resetting VALID_WROW there doesn't seem to do anything useful.
Also, a w_skipcol check (which resets VALID_WROW flag) was added to
check_cursor_moved() in patch 9.0.0734, which seems to make more sense
than resetting that flag in the middle of a computation.

While at it make adjust_plines_for_skipcol() and textpos2screenpos() a
bit less confusing:
- Make adjust_plines_for_skipcol() return "off" instead of "n - off".
- Use 0-based "row" in textpos2screenpos() until W_WINROW is added.

closes: vim/vim#12832

https://github.com/vim/vim/commit/6235a109c48ff2559eca3b16578c429ffb61eadc