### PR TITLE
fix(treesitter): don't update fold if tree is unchanged

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -289,7 +289,9 @@ local function on_changedtree(bufnr, foldinfo, tree_changes)
       local srow, _, erow = Range.unpack4(change)
       get_folds_levels(bufnr, foldinfo, srow, erow)
     end
-    foldupdate(bufnr)
+    if #tree_changes > 0 then
+      foldupdate(bufnr)
+    end
   end)
 end
 


### PR DESCRIPTION
Problem:
Folds are opened when the visible range changes even if there are no modifications to the buffer, e.g, when using zM for the first time. If the parsed tree was invalid, on_win re-parses and gets empty tree changes, which triggers fold updates.

Solution:
Don't update folds in on_changedtree if there are no changes.