### PR TITLE
vim-patch:9.0.{1753,1761}: g<End>

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -233,8 +233,8 @@ gM			Like "g0", but to halfway the text of the line.
 			Thus "10gM" is near the start of the text and "90gM"
 			is near the end of the text.
 
-							*g$* *g<End>*
-g$ or g<End>		When lines wrap ('wrap' on): To the last character of
+							*g$*
+g$			When lines wrap ('wrap' on): To the last character of
 			the screen line and [count - 1] screen lines downward
 			|inclusive|.  Differs from "$" when a line is wider
 			than the screen.
@@ -246,6 +246,9 @@ g$ or g<End>		When lines wrap ('wrap' on): To the last character of
 			instead of going to the end of the line.
 			When 'virtualedit' is enabled moves to the end of the
 			screen line.
+							*g<End>*
+g<End>			Like |g$| but to the last non-blank character
+			instead of the last character.
 
 							*bar*
 |			To screen column [count] in the current line.

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -246,7 +246,8 @@ g$			When lines wrap ('wrap' on): To the last character of
 			instead of going to the end of the line.
 			When 'virtualedit' is enabled moves to the end of the
 			screen line.
-							*g<End>*
+
+							*g<End>* *g<kEnd>*
 g<End>			Like |g$| but to the last non-blank character
 			instead of the last character.
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5323,7 +5323,7 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
   oparg_T *oap = cap->oap;
   int i;
   int col_off = curwin_col_off();
-  const bool flag = cap->nchar == K_END;
+  const bool flag = cap->nchar == K_END || cap->nchar == K_KEND;
 
   oap->motion_type = kMTCharWise;
   oap->inclusive = true;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5284,7 +5284,7 @@ static void nv_g_home_m_cmd(cmdarg_T *cap)
   if (flag) {
     do {
       i = gchar_cursor();
-    } while (ascii_iswhite(i) && oneright());
+    } while (ascii_iswhite(i) && oneright() == OK);
     curwin->w_valid &= ~VALID_WCOL;
   }
   curwin->w_set_curswant = true;
@@ -5323,6 +5323,7 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
   oparg_T *oap = cap->oap;
   int i;
   int col_off = curwin_col_off();
+  const bool flag = cap->nchar == K_END;
 
   oap->motion_type = kMTCharWise;
   oap->inclusive = true;
@@ -5372,6 +5373,12 @@ static void nv_g_dollar_cmd(cmdarg_T *cap)
 
     // Make sure we stick in this column.
     update_curswant_force();
+  }
+  if (flag) {
+    do {
+      i = gchar_cursor();
+    } while (ascii_iswhite(i) && oneleft() == OK);
+    curwin->w_valid &= ~VALID_WCOL;
   }
 }
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4118,20 +4118,24 @@ func Test_normal_click_on_double_width_char()
 endfunc
 
 func Test_normal33_g_cmd_nonblank()
-  " Test that g$ goes to the last non-blank char and g<end> to the last
+  " Test that g<End> goes to the last non-blank char and g$ to the last
   " visible column
   20vnew
   setlocal nowrap nonumber signcolumn=no
   call setline(1, ['fooo   fooo         fooo   fooo         fooo   fooo         fooo   fooo        '])
-  exe "normal 0g\<end>"
+  exe "normal 0g\<End>"
   call assert_equal(11, col('.'))
   normal 0g$
   call assert_equal(20, col('.'))
+  exe "normal 0g\<kEnd>"
+  call assert_equal(11, col('.'))
   setlocal wrap
-  exe "normal 0g\<end>"
+  exe "normal 0g\<End>"
   call assert_equal(11, col('.'))
   normal 0g$
   call assert_equal(20, col('.'))
+  exe "normal 0g\<kEnd>"
+  call assert_equal(11, col('.'))
   bw!
 endfunc
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4117,4 +4117,22 @@ func Test_normal_click_on_double_width_char()
   let &mouse = save_mouse
 endfunc
 
+func Test_normal33_g_cmd_nonblank()
+  " Test that g$ goes to the last non-blank char and g<end> to the last
+  " visible column
+  20vnew
+  setlocal nowrap nonumber signcolumn=no
+  call setline(1, ['fooo   fooo         fooo   fooo         fooo   fooo         fooo   fooo        '])
+  exe "normal 0g\<end>"
+  call assert_equal(11, col('.'))
+  normal 0g$
+  call assert_equal(20, col('.'))
+  setlocal wrap
+  exe "normal 0g\<end>"
+  call assert_equal(11, col('.'))
+  normal 0g$
+  call assert_equal(20, col('.'))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1753: can't move to last non-blank char

Problem: can't move to last non-blank char
Solution: Make g<end> behave like that

Make it possible to move to last non-blank char on a line

We can distinguish between g0 and g^ to move to the very first character
and the first non-blank char.

And while we can move to the last screen char, we cannot go to the last
non-blank screen char.

Since I think g$ is the more widely used and known movement command (and
g<end> is synonymous to it) change the behaviour of g<end> to move to
last non-screen char instead and don't have this be the same command as
the g$ command anymore.

If you want to keep the old behaviour, you can use:

```
nnoremap g<end> g$
```

Add a test to verify the behaviour.

closes: vim/vim#12593

https://github.com/vim/vim/commit/b5f6fe9ca2661d06bc0be839447ce1995450b9de

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1761: g<kEnd> behaves different from g<end>

Problem:  g<kEnd> behaves different from g<end>
Solution: Make g<kEnd> behave like g<End>

closes: vim/vim#12861

https://github.com/vim/vim/commit/654bdbbd329e7267051cc2eb496bc52b66053081