### PR TITLE
vim-patch:9.0.1763: crash when passing invalid buffer to undotree()

### DIFF
--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -3171,10 +3171,13 @@ void f_undofile(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "undotree(expr)" function
 void f_undotree(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  typval_T *const tv = &argvars[0];
-  buf_T *const buf = tv->v_type == VAR_UNKNOWN ? curbuf : tv_get_buf_from_arg(tv);
-
   tv_dict_alloc_ret(rettv);
+
+  typval_T *const tv = &argvars[0];
+  buf_T *const buf = tv->v_type == VAR_UNKNOWN ? curbuf : get_buf_arg(tv);
+  if (buf == NULL) {
+    return;
+  }
 
   dict_T *dict = rettv->vval.v_dict;
 

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -134,6 +134,18 @@ func Test_undotree_bufnr()
   call assert_notequal(d1, d)
   call assert_equal(d2, d)
 
+  " error cases
+  call assert_fails('call undotree(-1)', 'E158:')
+  call assert_fails('call undotree("nosuchbuf")', 'E158:')
+
+  " after creating a buffer nosuchbuf, undotree('nosuchbuf') should
+  " not error out
+  new nosuchbuf
+  let d = {'seq_last': 0, 'entries': [], 'time_cur': 0, 'save_last': 0, 'synced': 1, 'save_cur': 0, 'seq_cur': 0}
+  call assert_equal(d, undotree("nosuchbuf"))
+  " clean up
+  bw nosuchbuf
+
   " Drop created windows
   set ul&
   new


### PR DESCRIPTION
#### vim-patch:9.0.1763: crash when passing invalid buffer to undotree()

Problem:  crash when passing invalid buffer to undotree()
Solution: Use get_buf_arg() instead of tv_get_buf_from_arg().

closes: vim/vim#12862

https://github.com/vim/vim/commit/ab9f2ecfd4ecaf74eeed0e5ec41355589af3ec8f