### PR TITLE
vim-patch:9.0.1774: no support for custom cmdline completion

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2354,7 +2354,9 @@ getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		color		color schemes
 		command		Ex command
 		compiler	compilers
-		diff_buffer     |:diffget| and |:diffput| completion
+		custom,{func}	custom completion, defined via {func}
+		customlist,{func} custom completion, defined via {func}
+		diff_buffer	|:diffget| and |:diffput| completion
 		dir		directory names
 		environment	environment variable names
 		event		autocommand events

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2871,7 +2871,9 @@ function vim.fn.getcmdwintype() end
 --- color    color schemes
 --- command    Ex command
 --- compiler  compilers
---- diff_buffer     |:diffget| and |:diffput| completion
+--- custom,{func}  custom completion, defined via {func}
+--- customlist,{func} custom completion, defined via {func}
+--- diff_buffer  |:diffget| and |:diffput| completion
 --- dir    directory names
 --- environment  environment variable names
 --- event    autocommand events

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3515,10 +3515,32 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   ExpandInit(&xpc);
   xpc.xp_pattern = (char *)pattern;
   xpc.xp_pattern_len = strlen(xpc.xp_pattern);
+  xpc.xp_line = (char *)pattern;
+
   xpc.xp_context = cmdcomplete_str_to_type(type);
   if (xpc.xp_context == EXPAND_NOTHING) {
     semsg(_(e_invarg2), type);
     return;
+  }
+
+  if (xpc.xp_context == EXPAND_USER_DEFINED) {
+    // Must be "custom,funcname" pattern
+    if (strncmp(type, "custom,", 7) != 0) {
+      semsg(_(e_invarg2), type);
+      return;
+    }
+
+    xpc.xp_arg = (char *)(type + 7);
+  }
+
+  if (xpc.xp_context == EXPAND_USER_LIST) {
+    // Must be "customlist,funcname" pattern
+    if (strncmp(type, "customlist,", 11) != 0) {
+      semsg(_(e_invarg2), type);
+      return;
+    }
+
+    xpc.xp_arg = (char *)(type + 11);
   }
 
   if (xpc.xp_context == EXPAND_MENUS) {

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3582,7 +3582,9 @@ M.funcs = {
       color		color schemes
       command		Ex command
       compiler	compilers
-      diff_buffer     |:diffget| and |:diffput| completion
+      custom,{func}	custom completion, defined via {func}
+      customlist,{func} custom completion, defined via {func}
+      diff_buffer	|:diffget| and |:diffput| completion
       dir		directory names
       environment	environment variable names
       event		autocommand events

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4165,11 +4165,19 @@ static char *get_cmdline_completion(void)
   }
 
   char *cmd_compl = get_user_cmd_complete(p->xpc, p->xpc->xp_context);
-  if (cmd_compl != NULL) {
-    return xstrdup(cmd_compl);
+  if (cmd_compl == NULL) {
+    return NULL;
   }
 
-  return NULL;
+  if (p->xpc->xp_context == EXPAND_USER_LIST
+      || p->xpc->xp_context == EXPAND_USER_DEFINED) {
+    size_t buflen = strlen(cmd_compl) + strlen(p->xpc->xp_arg) + 2;
+    char *buffer = xmalloc(buflen);
+    snprintf(buffer, buflen, "%s,%s", cmd_compl, p->xpc->xp_arg);
+    return buffer;
+  }
+
+  return xstrdup(cmd_compl);
 }
 
 /// "getcmdcompltype()" function

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -425,6 +425,13 @@ char *get_user_cmd_complete(expand_T *xp, int idx)
 
 int cmdcomplete_str_to_type(const char *complete_str)
 {
+  if (strncmp(complete_str, "custom,", 7) == 0) {
+    return EXPAND_USER_DEFINED;
+  }
+  if (strncmp(complete_str, "customlist,", 11) == 0) {
+    return EXPAND_USER_LIST;
+  }
+
   for (int i = 0; i < (int)(ARRAY_SIZE(command_complete)); i++) {
     char *cmd_compl = get_command_complete(i);
     if (cmd_compl == NULL) {

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3649,4 +3649,42 @@ func Test_getcompletion_usercmd()
   delcom TestCompletion
 endfunc
 
+func Test_custom_completion()
+  func CustomComplete1(lead, line, pos)
+    return "a\nb\nc"
+  endfunc
+  func CustomComplete2(lead, line, pos)
+    return ['a', 'b']->filter({ _, val -> val->stridx(a:lead) == 0 })
+  endfunc
+  func Check_custom_completion()
+    call assert_equal('custom,CustomComplete1', getcmdcompltype())
+    return ''
+  endfunc
+  func Check_customlist_completion()
+    call assert_equal('customlist,CustomComplete2', getcmdcompltype())
+    return ''
+  endfunc
+
+  command -nargs=1 -complete=custom,CustomComplete1 Test1 echo
+  command -nargs=1 -complete=customlist,CustomComplete2 Test2 echo
+
+  call feedkeys(":Test1 \<C-R>=Check_custom_completion()\<CR>\<Esc>", "xt")
+  call feedkeys(":Test2 \<C-R>=Check_customlist_completion()\<CR>\<Esc>", "xt")
+
+  call assert_fails("call getcompletion('', 'custom')", 'E475:')
+  call assert_fails("call getcompletion('', 'customlist')", 'E475:')
+
+  call assert_equal(getcompletion('', 'custom,CustomComplete1'), ['a', 'b', 'c'])
+  call assert_equal(getcompletion('', 'customlist,CustomComplete2'), ['a', 'b'])
+  call assert_equal(getcompletion('b', 'customlist,CustomComplete2'), ['b'])
+
+  delcom Test1
+  delcom Test2
+
+  delfunc CustomComplete1
+  delfunc CustomComplete2
+  delfunc Check_custom_completion
+  delfunc Check_customlist_completion
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1774: no support for custom cmdline completion

Problem:  no support for custom cmdline completion
Solution: Add new vimscript functions

Add the following two functions:
- getcmdcompltype() returns custom and customlist functions

- getcompletion() supports both custom and customlist

closes: vim/vim#12228

https://github.com/vim/vim/commit/92997dda789ad8061841128cbc99b15ec0374411

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>