### PR TITLE
vim-patch:9.0.1772: Cursor may be adjusted in 'splitkeep'ed windows

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1194,6 +1194,7 @@ struct window_S {
   int w_hsep_height;                // Number of horizontal separator rows (0 or 1)
   int w_vsep_width;                 // Number of vertical separator columns (0 or 1).
   pos_save_T w_save_cursor;         // backup of cursor pos and topline
+  bool w_do_win_fix_cursor;         // if true cursor may be invalid
 
   int w_winrow_off;  ///< offset from winrow to the inner window area
   int w_wincol_off;  ///< offset from wincol to the inner window area

--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -43,6 +43,61 @@ describe('splitkeep', function()
     screen:attach()
   end)
 
+  -- oldtest: Test_splitkeep_cursor()
+  it('does not adjust cursor in window that did not change size', function()
+    screen:try_resize(75, 8)
+    -- FIXME: bottom window is different without the "vsplit | close"
+    exec([[
+      vsplit | close
+      set scrolloff=5
+      set splitkeep=screen
+      autocmd CursorMoved * wincmd p | wincmd p
+      call setline(1, range(1, 200))
+      func CursorEqualize()
+        call cursor(100, 1)
+        wincmd =
+      endfunc
+      wincmd s
+      call CursorEqualize()
+    ]])
+
+    screen:expect([[
+      99                                                                         |
+      ^100                                                                        |
+      101                                                                        |
+      [No Name] [+]                                                              |
+      5                                                                          |
+      6                                                                          |
+      [No Name] [+]                                                              |
+                                                                                 |
+    ]])
+
+    feed('j')
+    screen:expect([[
+      100                                                                        |
+      ^101                                                                        |
+      102                                                                        |
+      [No Name] [+]                                                              |
+      5                                                                          |
+      6                                                                          |
+      [No Name] [+]                                                              |
+                                                                                 |
+    ]])
+
+    command('set scrolloff=0')
+    feed('G')
+    screen:expect([[
+      198                                                                        |
+      199                                                                        |
+      ^200                                                                        |
+      [No Name] [+]                                                              |
+      5                                                                          |
+      6                                                                          |
+      [No Name] [+]                                                              |
+                                                                                 |
+    ]])
+  end)
+
   -- oldtest: Test_splitkeep_callback()
   it('does not scroll when split in callback', function()
     exec([[

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1805,6 +1805,33 @@ func Test_splitkeep_misc()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_cursor()
+  CheckScreendump
+  let lines =<< trim END
+    set splitkeep=screen
+    autocmd CursorMoved * wincmd p | wincmd p
+    call setline(1, range(1, 200))
+    func CursorEqualize()
+      call cursor(100, 1)
+      wincmd =
+    endfunc
+    wincmd s
+    call CursorEqualize()
+  END
+  call writefile(lines, 'XTestSplitkeepCallback', 'D')
+  let buf = RunVimInTerminal('-S XTestSplitkeepCallback', #{rows: 8})
+
+  call VerifyScreenDump(buf, 'Test_splitkeep_cursor_1', {})
+
+  call term_sendkeys(buf, "j")
+  call VerifyScreenDump(buf, 'Test_splitkeep_cursor_2', {})
+
+  call term_sendkeys(buf, ":set scrolloff=0\<CR>G")
+  call VerifyScreenDump(buf, 'Test_splitkeep_cursor_3', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_splitkeep_callback()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.0.1772: Cursor may be adjusted in 'splitkeep'ed windows

Problem:    Cursor is adjusted in window that did not change in size by
            'splitkeep'.
Solution:   Only check that cursor position is valid in a window that
            has changed in size.

closes: vim/vim#12509

https://github.com/vim/vim/commit/16af913eeefb288ce968fb87e09a597413861900

Co-authored-by: Luuk van Baal <luukvbaal@gmail.com>