### PR TITLE
vim-patch:9.0.1767: '.-' no allowed in highlight group names

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -188,9 +188,8 @@ thing.  These are then linked to a highlight group that specifies the color.
 A syntax group name doesn't specify any color or attributes itself.
 
 The name for a highlight or syntax group must consist of ASCII letters,
-digits, underscores, periods, hyphens, and `@` characters.  As a regexp it is
-`[a-zA-Z0-9_.@-]*`. The maximum length of a group name is about 200 bytes.
-*E1249*
+digits, underscores, dots, hyphens, or `@`.  As a regexp: `[a-zA-Z0-9_.@-]*`.
+The maximum length of a group name is about 200 bytes.  *E1249*
 
 To be able to allow each user to pick their favorite set of colors, there must
 be preferred names for highlight groups that are common for many languages.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -494,7 +494,7 @@ Highlight groups:
   using |n| or |N|
   |hl-CursorLine| is low-priority unless foreground color is set
   |hl-VertSplit| superseded by |hl-WinSeparator|
-  Highlight groups names are allowed to contain the characters `.`, `@`, and `-`.
+  Highlight groups names are allowed to contain `@` characters.
   It is an error to define a highlight group with a name that doesn't match
   the regexp `[a-zA-Z0-9_.@-]*` (see |group-name|).
 

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1936,7 +1936,7 @@ int syn_check_group(const char *name, size_t len)
 /// @see syn_check_group
 static int syn_add_group(const char *name, size_t len)
 {
-  // Check that the name is ASCII letters, digits and underscore.
+  // Check that the name is valid (ASCII letters, digits, '_', '.', '@', '-').
   for (size_t i = 0; i < len; i++) {
     int c = (uint8_t)name[i];
     if (!vim_isprintc(c)) {


### PR DESCRIPTION
#### vim-patch:9.0.1767: '.-' no allowed in highlight group names

Problem:  '.-' no allowed in highlight group names
Solution: Allow dot and hyphen characters in highlight group names

Allow dots and hyphens in group names. There does not seem
to be any reason for these to be disallowed.

closes: vim/vim#12807

https://github.com/vim/vim/commit/d4376dc3ebea91abcb4d9ef9963ef5b968048b78

Co-authored-by: Gregory Anders <greg@gpanders.com>
Co-authored-by: Sean Dewar <seandewar@users.noreply.github.com>