### PR TITLE
vim-patch:690963924956

### DIFF
--- a/runtime/syntax/dosini.vim
+++ b/runtime/syntax/dosini.vim
@@ -6,13 +6,17 @@
 " Current Maintainer:     Hong Xu <hong@topbug.net>
 " Homepage:               http://www.vim.org/scripts/script.php?script_id=3747
 " Repository:             https://github.com/xuhdev/syntax-dosini.vim
-" Last Change:            2023 Jun 27
+" Last Change:            2023 Aug 20
 
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
   finish
 endif
+
+" using of line-continuation requires cpo&vim
+let s:cpo_save = &cpo
+set cpo&vim
 
 " shut case off
 syn case ignore
@@ -38,5 +42,8 @@ hi def link dosiniValue    String
 
 
 let b:current_syntax = "dosini"
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
 
 " vim: sts=2 sw=2 et


### PR DESCRIPTION
runtime(dosini): save and restore cpo value in syntax script

Commit dd0ad2598898c2b4641c4acd5b70b6184fa698ed  introduced
line-continuation. However, to make sure this does not cause an error
when Vim is run in compatible mode, we need to set compatibility mode
temporarily and reset it back when finished reading the file.

This fixes: https://groups.google.com/g/vim_use/c/9zccgo_RIqM/m/xlUmhBktBgAJ

https://github.com/vim/vim/commit/690963924956d800b94bb86076aa9d25f04565ac

Co-authored-by: Christian Brabandt <cb@256bit.org>
