### PR TITLE
vim-patch:9.0.0423: "for" and "while" not recognized after :vim9cmd and :legacy

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2411,7 +2411,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
 
     char *p = skip_range(eap->cmd, NULL);
     switch (*p) {
-    // When adding an entry, also modify cmd_exists().
+    // When adding an entry, also modify cmdmods[]
     case 'a':
       if (!checkforcmd(&eap->cmd, "aboveleft", 3)) {
         break;
@@ -3051,6 +3051,7 @@ static struct cmdmod {
   { "confirm", 4, false },
   { "filter", 4, false },
   { "hide", 3, false },
+  { "horizontal", 3, false },
   { "keepalt", 5, false },
   { "keepjumps", 5, false },
   { "keepmarks", 3, false },

--- a/test/old/testdir/test_eval_stuff.vim
+++ b/test/old/testdir/test_eval_stuff.vim
@@ -146,6 +146,15 @@ func Test_for_over_null_string()
   let &enc = save_enc
 endfunc
 
+func Test_for_with_modifier()
+  " this checks has_loop_cmd() works with a modifier
+  let result = []
+  horizontal for i in range(3)
+    call extend(result, [i])
+  endfor
+  call assert_equal([0, 1, 2], result)
+endfunc
+
 func Test_for_invalid_line_count()
   let lines =<< trim END
       111111111111111111111111 for line in ['one']


### PR DESCRIPTION
Problem:    "for" and "while" not recognized after :vim9cmd and :legacy.
            (Emanuele Torre)
Solution:   Recognize all the command modifiers. (closes vim/vim#11087)
            Add a test to check the list of modifiers.

https://github.com/vim/vim/commit/9132426334a8c7e159db93ec1b08ed61ac600aae

Co-authored-by: Bram Moolenaar <Bram@vim.org>

---

Omitted `legacy` and `vim9cmd` from the `cmdmods` array. Omitted the `test_cmdmods.vim` file as it's written in Vim9script. Changed the modifier in
`test_eval_stuff.vim` to use `:horizontal` instead of `:vim9cmd` (not sure what the best way to mark this is).
