### PR TITLE
vim-patch:9.0.{0380,0391,0415,0425,0428,0837}

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -73,7 +73,8 @@ append({lnum}, {text})                                                *append()*
 		{lnum} can be zero to insert a line before the first one.
 		{lnum} is used like with |getline()|.
 		Returns 1 for failure ({lnum} out of range or out of memory),
-		0 for success.  Example: >vim
+		0 for success.  When {text} is an empty list zero is returned,
+		no matter the value of {lnum}.  Example: >vim
 			let failed = append(line('$'), "# THE END")
 			let failed = append(0, ["Chapter 1", "the beginning"])
 <
@@ -96,7 +97,8 @@ appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 		If {buf} is not a valid buffer or {lnum} is not valid, an
 		error message is given. Example: >vim
 			let failed = appendbufline(13, 0, "# THE START")
-<
+<		However, when {text} is an empty list then no error is given
+		for an invalid {lnum}, since {lnum} isn't actually used.
 
 argc([{winid}])                                                         *argc()*
 		The result is the number of files in the argument list.  See
@@ -6213,9 +6215,10 @@ setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 
 		To insert lines use |appendbufline()|.
 
-		{text} can be a string to set one line, or a list of strings
-		to set multiple lines.  If the list extends below the last
-		line then those lines are added.
+		{text} can be a string to set one line, or a List of strings
+		to set multiple lines.  If the List extends below the last
+		line then those lines are added.  If the List is empty then
+		nothing is changed and zero is returned.
 
 		For the use of {buf}, see |bufname()| above.
 
@@ -6374,7 +6377,8 @@ setline({lnum}, {text})                                              *setline()*
 		When {lnum} is just below the last line the {text} will be
 		added below the last line.
 		{text} can be any type or a List of any type, each item is
-		converted to a String.
+		converted to a String.  When {text} is an empty List then
+		nothing is changed and FALSE is returned.
 
 		If this succeeds, FALSE is returned.  If this fails (most likely
 		because {lnum} is invalid) TRUE is returned.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -79,7 +79,8 @@ function vim.fn.api_info() end
 --- {lnum} can be zero to insert a line before the first one.
 --- {lnum} is used like with |getline()|.
 --- Returns 1 for failure ({lnum} out of range or out of memory),
---- 0 for success.  Example: >vim
+--- 0 for success.  When {text} is an empty list zero is returned,
+--- no matter the value of {lnum}.  Example: >vim
 ---   let failed = append(line('$'), "# THE END")
 ---   let failed = append(0, ["Chapter 1", "the beginning"])
 --- <
@@ -106,7 +107,8 @@ function vim.fn.append(lnum, text) end
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given. Example: >vim
 ---   let failed = appendbufline(13, 0, "# THE START")
---- <
+--- <However, when {text} is an empty list then no error is given
+--- for an invalid {lnum}, since {lnum} isn't actually used.
 ---
 --- @param buf any
 --- @param lnum integer
@@ -7398,9 +7400,10 @@ function vim.fn.serverstop(address) end
 ---
 --- To insert lines use |appendbufline()|.
 ---
---- {text} can be a string to set one line, or a list of strings
---- to set multiple lines.  If the list extends below the last
---- line then those lines are added.
+--- {text} can be a string to set one line, or a List of strings
+--- to set multiple lines.  If the List extends below the last
+--- line then those lines are added.  If the List is empty then
+--- nothing is changed and zero is returned.
 ---
 --- For the use of {buf}, see |bufname()| above.
 ---
@@ -7602,7 +7605,8 @@ function vim.fn.setfperm(fname, mode) end
 --- When {lnum} is just below the last line the {text} will be
 --- added below the last line.
 --- {text} can be any type or a List of any type, each item is
---- converted to a String.
+--- converted to a String.  When {text} is an empty List then
+--- nothing is changed and FALSE is returned.
 ---
 --- If this succeeds, FALSE is returned.  If this fails (most likely
 --- because {lnum} is invalid) TRUE is returned.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -141,7 +141,8 @@ M.funcs = {
       {lnum} can be zero to insert a line before the first one.
       {lnum} is used like with |getline()|.
       Returns 1 for failure ({lnum} out of range or out of memory),
-      0 for success.  Example: >vim
+      0 for success.  When {text} is an empty list zero is returned,
+      no matter the value of {lnum}.  Example: >vim
       	let failed = append(line('$'), "# THE END")
       	let failed = append(0, ["Chapter 1", "the beginning"])
       <
@@ -173,7 +174,8 @@ M.funcs = {
       If {buf} is not a valid buffer or {lnum} is not valid, an
       error message is given. Example: >vim
       	let failed = appendbufline(13, 0, "# THE START")
-      <
+      <However, when {text} is an empty list then no error is given
+      for an invalid {lnum}, since {lnum} isn't actually used.
 
     ]=],
     name = 'appendbufline',
@@ -8871,9 +8873,10 @@ M.funcs = {
 
       To insert lines use |appendbufline()|.
 
-      {text} can be a string to set one line, or a list of strings
-      to set multiple lines.  If the list extends below the last
-      line then those lines are added.
+      {text} can be a string to set one line, or a List of strings
+      to set multiple lines.  If the List extends below the last
+      line then those lines are added.  If the List is empty then
+      nothing is changed and zero is returned.
 
       For the use of {buf}, see |bufname()| above.
 
@@ -9117,7 +9120,8 @@ M.funcs = {
       When {lnum} is just below the last line the {text} will be
       added below the last line.
       {text} can be any type or a List of any type, each item is
-      converted to a String.
+      converted to a String.  When {text} is an empty List then
+      nothing is changed and FALSE is returned.
 
       If this succeeds, FALSE is returned.  If this fails (most likely
       because {lnum} is invalid) TRUE is returned.

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -160,10 +160,7 @@ static void set_buffer_lines(buf_T *buf, linenr_T lnum_arg, bool append, typval_
   if (lines->v_type == VAR_LIST) {
     l = lines->vval.v_list;
     if (l == NULL || tv_list_len(l) == 0) {
-      // set proper return code
-      if (lnum > curbuf->b_ml.ml_line_count) {
-        rettv->vval.v_number = 1;       // FAIL
-      }
+      // not appending anything always succeeds
       goto cleanup;
     }
     li = tv_list_first(l);

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -97,7 +97,7 @@ endfunc
 func Test_argadd_empty_curbuf()
   new
   let curbuf = bufnr('%')
-  call writefile(['test', 'Xargadd'], 'Xargadd')
+  call writefile(['test', 'Xargadd'], 'Xargadd', 'D')
   " must not re-use the current buffer.
   argadd Xargadd
   call assert_equal(curbuf, bufnr('%'))
@@ -516,9 +516,9 @@ endfunc
 " Test for autocommand that redefines the argument list, when doing ":all".
 func Test_arglist_autocmd()
   autocmd BufReadPost Xxx2 next Xxx2 Xxx1
-  call writefile(['test file Xxx1'], 'Xxx1')
-  call writefile(['test file Xxx2'], 'Xxx2')
-  call writefile(['test file Xxx3'], 'Xxx3')
+  call writefile(['test file Xxx1'], 'Xxx1', 'D')
+  call writefile(['test file Xxx2'], 'Xxx2', 'D')
+  call writefile(['test file Xxx3'], 'Xxx3', 'D')
 
   new
   " redefine arglist; go to Xxx1
@@ -534,18 +534,14 @@ func Test_arglist_autocmd()
 
   autocmd! BufReadPost Xxx2
   enew! | only
-  call delete('Xxx1')
-  call delete('Xxx2')
-  call delete('Xxx3')
   argdelete Xxx*
   bwipe! Xxx1 Xxx2 Xxx3
 endfunc
 
 func Test_arg_all_expand()
-  call writefile(['test file Xxx1'], 'Xx x')
+  call writefile(['test file Xxx1'], 'Xx x', 'D')
   next notexist Xx\ x runtest.vim
   call assert_equal('notexist Xx\ x runtest.vim', expand('##'))
-  call delete('Xx x')
 endfunc
 
 func Test_large_arg()

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -92,12 +92,12 @@ func Test_assert_equalfile()
   call remove(v:errors, 0)
 
   let goodtext = ["one", "two", "three"]
-  call writefile(goodtext, 'Xone')
+  call writefile(goodtext, 'Xone', 'D')
   call assert_equal(1, 'Xone'->assert_equalfile('xyzxyz'))
   call assert_match("E485: Can't read file xyzxyz", v:errors[0])
   call remove(v:errors, 0)
 
-  call writefile(goodtext, 'Xtwo')
+  call writefile(goodtext, 'Xtwo', 'D')
   call assert_equal(0, assert_equalfile('Xone', 'Xtwo'))
 
   call writefile([goodtext[0]], 'Xone')
@@ -127,9 +127,6 @@ func Test_assert_equalfile()
   call assert_equal(1, assert_equalfile('Xone', 'Xtwo', 'a message'))
   call assert_match("a message: difference at byte 234, line 1 after", v:errors[0])
   call remove(v:errors, 0)
-
-  call delete('Xone')
-  call delete('Xtwo')
 endfunc
 
 func Test_assert_notequal()

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -964,7 +964,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
     augroup END
 
     func WriteErrors()
-      call writefile([execute("messages")], "Xerrors")
+      call writefile([execute("messages")], "XerrorsBwipe")
     endfunc
     au VimLeave * call WriteErrors()
   [CODE]
@@ -972,11 +972,11 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   sleep 100m
-  let errors = join(readfile('Xerrors'))
+  let errors = join(readfile('XerrorsBwipe'))
   call assert_match('E814:', errors)
 
   set swapfile
-  for file in ['Session.vim', 'Xerrors']
+  for file in ['Session.vim', 'XerrorsBwipe']
     call delete(file)
   endfor
 endfunc
@@ -989,16 +989,16 @@ func Test_autocmd_blast_badd()
       edit foo1
       au BufNew,BufAdd,BufWinEnter,BufEnter,BufLeave,BufWinLeave,BufUnload,VimEnter foo* ball
       edit foo2
-      call writefile(['OK'], 'Xerrors')
+      call writefile(['OK'], 'XerrorsBlast')
       qall
   [CODE]
 
   call writefile(content, 'XblastBall', 'D')
   call system(GetVimCommand() .. ' --clean -S XblastBall')
   sleep 100m
-  call assert_match('OK', readfile('Xerrors')->join())
+  call assert_match('OK', readfile('XerrorsBlast')->join())
 
-  call delete('Xerrors')
+  call delete('XerrorsBlast')
 endfunc
 
 " SEGV occurs in older versions.
@@ -1025,7 +1025,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
     au SessionLoadPost * call DeleteInactiveBufs()
 
     func WriteErrors()
-      call writefile([execute("messages")], "Xerrors")
+      call writefile([execute("messages")], "XerrorsPost")
     endfunc
     au VimLeave * call WriteErrors()
   [CODE]
@@ -1033,13 +1033,13 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   sleep 100m
-  let errors = join(readfile('Xerrors'))
+  let errors = join(readfile('XerrorsPost'))
   " This probably only ever matches on unix.
   call assert_notmatch('Caught deadly signal SEGV', errors)
   call assert_match('SessionLoadPost DONE', errors)
 
   set swapfile
-  for file in ['Session.vim', 'Xerrors']
+  for file in ['Session.vim', 'XerrorsPost']
     call delete(file)
   endfor
 endfunc

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -971,6 +971,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
+  sleep 50m
   let errors = join(readfile('Xerrors'))
   call assert_match('E814:', errors)
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -24,12 +24,12 @@ endfunc
 " Test for the CursorHold autocmd
 func Test_CursorHold_autocmd()
   CheckRunVimInTerminal
-  call writefile(['one', 'two', 'three'], 'XoneTwoThree')
+  call writefile(['one', 'two', 'three'], 'XoneTwoThree', 'D')
   let before =<< trim END
     set updatetime=10
     au CursorHold * call writefile([line('.')], 'XCHoutput', 'a')
   END
-  call writefile(before, 'XCHinit')
+  call writefile(before, 'XCHinit', 'D')
   let buf = RunVimInTerminal('-S XCHinit XoneTwoThree', {})
   call term_sendkeys(buf, "G")
   call term_wait(buf, 50)
@@ -44,9 +44,7 @@ func Test_CursorHold_autocmd()
   call WaitForAssert({-> assert_equal(['1', '2', '3'], readfile('XCHoutput')[-3:-1])})
   call StopVimInTerminal(buf)
 
-  call delete('XCHinit')
   call delete('XCHoutput')
-  call delete('XoneTwoThree')
 endfunc
 
 if has('timers')
@@ -112,7 +110,7 @@ if has('timers')
     augroup set_tabstop
       au OptionSet tabstop call timer_start(1, {-> execute("echo 'Handler called'", "")})
     augroup END
-    call writefile(['vim: set ts=7 sw=5 :', 'something'], 'XoptionsetModeline')
+    call writefile(['vim: set ts=7 sw=5 :', 'something'], 'XoptionsetModeline', 'D')
     set modeline
     let v:errmsg = ''
     call assert_fails('split XoptionsetModeline', 'E12:')
@@ -124,7 +122,6 @@ if has('timers')
     augroup END
     bwipe!
     set ts&
-    call delete('XoptionsetModeline')
     call test_override('starting', 0)
   endfunc
 
@@ -234,8 +231,8 @@ endfunc
 
 func Test_autocmd_dummy_wipeout()
   " prepare files
-  call writefile([''], 'Xdummywipetest1.txt')
-  call writefile([''], 'Xdummywipetest2.txt')
+  call writefile([''], 'Xdummywipetest1.txt', 'D')
+  call writefile([''], 'Xdummywipetest2.txt', 'D')
   augroup test_bufunload_group
     autocmd!
     autocmd BufUnload * call add(s:li, "bufunload")
@@ -249,8 +246,6 @@ func Test_autocmd_dummy_wipeout()
   call assert_equal(["bufunload", "bufwipeout"], s:li)
 
   bwipeout
-  call delete('Xdummywipetest1.txt')
-  call delete('Xdummywipetest2.txt')
   au! test_bufunload_group
   augroup! test_bufunload_group
 endfunc
@@ -974,13 +969,13 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
     au VimLeave * call WriteErrors()
   [CODE]
 
-  call writefile(content, 'Xvimrc')
+  call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   let errors = join(readfile('Xerrors'))
-  call assert_match('E814', errors)
+  call assert_match('E814:', errors)
 
   set swapfile
-  for file in ['Session.vim', 'Xvimrc', 'Xerrors']
+  for file in ['Session.vim', 'Xerrors']
     call delete(file)
   endfor
 endfunc
@@ -997,11 +992,10 @@ func Test_autocmd_blast_badd()
       qall
   [CODE]
 
-  call writefile(content, 'XblastBall')
+  call writefile(content, 'XblastBall', 'D')
   call system(GetVimCommand() .. ' --clean -S XblastBall')
   call assert_match('OK', readfile('Xerrors')->join())
 
-  call delete('XblastBall')
   call delete('Xerrors')
 endfunc
 
@@ -1034,7 +1028,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
     au VimLeave * call WriteErrors()
   [CODE]
 
-  call writefile(content, 'Xvimrc')
+  call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
   let errors = join(readfile('Xerrors'))
   " This probably only ever matches on unix.
@@ -1042,7 +1036,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
   call assert_match('SessionLoadPost DONE', errors)
 
   set swapfile
-  for file in ['Session.vim', 'Xvimrc', 'Xerrors']
+  for file in ['Session.vim', 'Xerrors']
     call delete(file)
   endfor
 endfunc
@@ -1745,9 +1739,9 @@ endfunc
 func Test_Acmd_BufAll()
   enew!
   %bwipe!
-  call writefile(['Test file Xxx1'], 'Xxx1')
-  call writefile(['Test file Xxx2'], 'Xxx2')
-  call writefile(['Test file Xxx3'], 'Xxx3')
+  call writefile(['Test file Xxx1'], 'Xxx1', 'D')
+  call writefile(['Test file Xxx2'], 'Xxx2', 'D')
+  call writefile(['Test file Xxx3'], 'Xxx3', 'D')
 
   " Add three files to the buffer list
   split Xxx1
@@ -1769,9 +1763,6 @@ func Test_Acmd_BufAll()
 
   au! BufReadPost
   %bwipe!
-  call delete('Xxx1')
-  call delete('Xxx2')
-  call delete('Xxx3')
   enew! | only
 endfunc
 
@@ -1781,11 +1772,11 @@ func Test_Acmd_BufEnter()
   %bwipe!
   call writefile(['start of test file Xxx1',
 	      \ "\<Tab>this is a test",
-	      \ 'end of test file Xxx1'], 'Xxx1')
+	      \ 'end of test file Xxx1'], 'Xxx1', 'D')
   call writefile(['start of test file Xxx2',
 	      \ 'vim: set noai :',
 	      \ "\<Tab>this is a test",
-	      \ 'end of test file Xxx2'], 'Xxx2')
+	      \ 'end of test file Xxx2'], 'Xxx2', 'D')
 
   au BufEnter Xxx2 brew
   set ai modeline modelines=3
@@ -1807,8 +1798,6 @@ func Test_Acmd_BufEnter()
   call assert_equal(4, line('.'))
 
   %bwipe!
-  call delete('Xxx1')
-  call delete('Xxx2')
   set ai&vim modeline&vim modelines&vim
 endfunc
 
@@ -1835,8 +1824,8 @@ func Test_BufLeave_Wipe()
   let content = ['start of test file Xxx',
 	      \ 'this is a test',
 	      \ 'end of test file Xxx']
-  call writefile(content, 'Xxx1')
-  call writefile(content, 'Xxx2')
+  call writefile(content, 'Xxx1', 'D')
+  call writefile(content, 'Xxx2', 'D')
 
   au BufLeave Xxx2 bwipe
   edit Xxx1
@@ -1862,8 +1851,6 @@ func Test_BufLeave_Wipe()
   let g:bufinfo = getbufinfo()
   call assert_equal(1, len(g:bufinfo))
 
-  call delete('Xxx1')
-  call delete('Xxx2')
   call delete('test.out')
   %bwipe
   au! BufLeave
@@ -1990,32 +1977,30 @@ func Test_BufWritePre()
   au BufWritePre Xxx1 bunload
   au BufWritePre Xxx2 bwipe
 
-  call writefile(['start of Xxx1', 'test', 'end of Xxx1'], 'Xxx1')
-  call writefile(['start of Xxx2', 'test', 'end of Xxx2'], 'Xxx2')
+  call writefile(['start of Xxx1', 'test', 'end of Xxx1'], 'Xxx1', 'D')
+  call writefile(['start of Xxx2', 'test', 'end of Xxx2'], 'Xxx2', 'D')
 
   edit Xtest
   e! Xxx2
   bdel Xtest
   e Xxx1
   " write it, will unload it and give an error msg
-  call assert_fails('w', 'E203')
+  call assert_fails('w', 'E203:')
   call assert_equal('Xxx2', bufname('%'))
   edit Xtest
   e! Xxx2
   bwipe Xtest
   " write it, will delete the buffer and give an error msg
-  call assert_fails('w', 'E203')
+  call assert_fails('w', 'E203:')
   call assert_equal('Xxx1', bufname('%'))
   au! BufWritePre
-  call delete('Xxx1')
-  call delete('Xxx2')
 endfunc
 
 " Test for BufUnload autocommand that unloads all the other buffers
 func Test_bufunload_all()
   let g:test_is_flaky = 1
-  call writefile(['Test file Xxx1'], 'Xxx1')"
-  call writefile(['Test file Xxx2'], 'Xxx2')"
+  call writefile(['Test file Xxx1'], 'Xxx1', 'D')"
+  call writefile(['Test file Xxx2'], 'Xxx2', 'D')"
 
   let content =<< trim [CODE]
     func UnloadAllBufs()
@@ -2035,15 +2020,12 @@ func Test_bufunload_all()
     q
   [CODE]
 
-  call writefile(content, 'Xtest')
+  call writefile(content, 'Xbunloadtest', 'D')
 
   call delete('Xout')
-  call system(GetVimCommandClean() .. ' -N --headless -S Xtest')
+  call system(GetVimCommandClean() .. ' -N --headless -S Xbunloadtest')
   call assert_true(filereadable('Xout'))
 
-  call delete('Xxx1')
-  call delete('Xxx2')
-  call delete('Xtest')
   call delete('Xout')
 endfunc
 
@@ -2071,7 +2053,7 @@ endfunc
 
 " Test for "*Cmd" autocommands
 func Test_Cmd_Autocmds()
-  call writefile(['start of Xxx', "\tabc2", 'end of Xxx'], 'Xxx')
+  call writefile(['start of Xxx', "\tabc2", 'end of Xxx'], 'Xxx', 'D')
 
   enew!
   au BufReadCmd XtestA 0r Xxx|$del
@@ -2146,7 +2128,6 @@ func Test_Cmd_Autocmds()
   au! FileWriteCmd
   au! FileAppendCmd
   %bwipe!
-  call delete('Xxx')
   enew!
 endfunc
 
@@ -2171,7 +2152,7 @@ func Test_BufReadCmd()
   autocmd BufReadCmd *.test call s:ReadFile()
   autocmd BufWriteCmd *.test call s:WriteFile()
 
-  call writefile(['one', 'two', 'three'], 'Xcmd.test')
+  call writefile(['one', 'two', 'three'], 'Xcmd.test', 'D')
   edit Xcmd.test
   call assert_match('Xcmd.test" line 1 of 3', execute('file'))
   normal! Gofour
@@ -2179,7 +2160,6 @@ func Test_BufReadCmd()
   call assert_equal(['one', 'two', 'three', 'four'], readfile('Xcmd.test'))
 
   bwipe!
-  call delete('Xcmd.test')
   au! BufReadCmd
   au! BufWriteCmd
 endfunc
@@ -2543,7 +2523,7 @@ func Test_Changed_FirstTime()
   let g:test_is_flaky = 1
 
   " Prepare file for TextChanged event.
-  call writefile([''], 'Xchanged.txt')
+  call writefile([''], 'Xchanged.txt', 'D')
   let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile'], {'term_rows': 3})
   call assert_equal('running', term_getstatus(buf))
   " Wait for the ruler (in the status line) to be shown.
@@ -2555,7 +2535,6 @@ func Test_Changed_FirstTime()
   call assert_equal([''], readfile('Xchanged.txt'))
 
   " clean up
-  call delete('Xchanged.txt')
   bwipe!
 endfunc
 
@@ -2642,13 +2621,12 @@ func Test_autocmd_nested_switch_window()
       autocmd BufReadPost * autocmd SafeState * ++once foldclosed('.')
       autocmd WinEnter * matchadd('ErrorMsg', 'pat')
   END
-  call writefile(lines, 'Xautoscript')
+  call writefile(lines, 'Xautoscript', 'D')
   let buf = RunVimInTerminal('-S Xautoscript', {'rows': 10})
   call VerifyScreenDump(buf, 'Test_autocmd_nested_switch', {})
 
   call StopVimInTerminal(buf)
   call delete('Xautofile')
-  call delete('Xautoscript')
 endfunc
 
 func Test_autocmd_once()
@@ -2801,7 +2779,7 @@ func Test_ReadWrite_Autocmds()
     au FileAppendPost  *.out  !cat Xtest.c >> test.out
   augroup END
 
-  call writefile(['/*', ' * Here is a new .c file', ' */'], 'Xtest.c')
+  call writefile(['/*', ' * Here is a new .c file', ' */'], 'Xtest.c', 'D')
   new foo.c			" should load Xtest.c
   call assert_equal(['/*', ' * Here is a new .c file', ' */'], getline(2, 4))
   w! >> test.out		" append it to the output file
@@ -2925,7 +2903,6 @@ func Test_ReadWrite_Autocmds()
 
   au! FileChangedShell
   call delete('Xtestfile.gz')
-  call delete('Xtest.c')
   call delete('test.out')
 endfunc
 
@@ -2972,10 +2949,10 @@ func Test_autocmd_SafeState()
 	  call timer_start(10, {id -> execute('let g:again ..= "t"')})
 	endfunc
   END
-  call writefile(lines, 'XSafeState')
+  call writefile(lines, 'XSafeState', 'D')
   let buf = RunVimInTerminal('-S XSafeState', #{rows: 6})
 
-  " Sometimes we loop to handle a K_IGNORE, SafeState may be trigered once or
+  " Sometimes we loop to handle a K_IGNORE, SafeState may be triggered once or
   " more often.
   call term_sendkeys(buf, ":echo g:safe\<CR>")
   call WaitForAssert({-> assert_match('^\d ', term_getline(buf, 6))}, 1000)
@@ -2992,7 +2969,6 @@ func Test_autocmd_SafeState()
   call WaitForAssert({-> assert_match('xtx', term_getline(buf, 6))}, 1000)
 
   call StopVimInTerminal(buf)
-  call delete('XSafeState')
 endfunc
 
 func Test_autocmd_CmdWinEnter()
@@ -3244,11 +3220,11 @@ func Test_BufReadPre_delfile()
     au!
     autocmd BufReadPre XbufreadPre call delete('XbufreadPre')
   augroup END
-  call writefile([], 'XbufreadPre')
+  call writefile([], 'XbufreadPre', 'D')
   call assert_fails('new XbufreadPre', 'E200:')
   call assert_equal('XbufreadPre', @%)
   call assert_equal(1, &readonly)
-  call delete('XbufreadPre')
+
   augroup TestAuCmd
     au!
   augroup END
@@ -3261,11 +3237,11 @@ func Test_BufReadPre_changebuf()
     au!
     autocmd BufReadPre Xchangebuf edit Xsomeotherfile
   augroup END
-  call writefile([], 'Xchangebuf')
+  call writefile([], 'Xchangebuf', 'D')
   call assert_fails('new Xchangebuf', 'E201:')
   call assert_equal('Xsomeotherfile', @%)
   call assert_equal(1, &readonly)
-  call delete('Xchangebuf')
+
   augroup TestAuCmd
     au!
   augroup END

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -971,7 +971,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
-  sleep 50m
+  sleep 100m
   let errors = join(readfile('Xerrors'))
   call assert_match('E814:', errors)
 
@@ -995,6 +995,7 @@ func Test_autocmd_blast_badd()
 
   call writefile(content, 'XblastBall', 'D')
   call system(GetVimCommand() .. ' --clean -S XblastBall')
+  sleep 100m
   call assert_match('OK', readfile('Xerrors')->join())
 
   call delete('Xerrors')
@@ -1031,6 +1032,7 @@ func Test_autocmd_bufwipe_in_SessLoadPost2()
 
   call writefile(content, 'Xvimrc', 'D')
   call system(GetVimCommand('Xvimrc') .. ' --headless --noplugins -S Session.vim -c cq')
+  sleep 100m
   let errors = join(readfile('Xerrors'))
   " This probably only ever matches on unix.
   call assert_notmatch('Caught deadly signal SEGV', errors)

--- a/test/old/testdir/test_backup.vim
+++ b/test/old/testdir/test_backup.vim
@@ -79,11 +79,11 @@ endfunc
 func Test_non_existing_backupdir()
   throw 'Skipped: Nvim auto-creates backup directory'
   set backupdir=./non_existing_dir backupskip=
-  call writefile(['line1'], 'Xbackupdir')
+  call writefile(['line1'], 'Xbackupdir', 'D')
   new Xbackupdir
   call assert_fails('write', 'E510:')
+
   set backupdir&vim backupskip&vim
-  call delete('Xbackupdir')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -942,14 +942,13 @@ func Test_cursor_position_with_showbreak()
       repeat('x', &columns - leftcol - 1)->setline(1)
       'second line'->setline(2)
   END
-  call writefile(lines, 'XscriptShowbreak')
+  call writefile(lines, 'XscriptShowbreak', 'D')
   let buf = RunVimInTerminal('-S XscriptShowbreak', #{rows: 6})
 
   call term_sendkeys(buf, "AX")
   call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak', {})
 
   call StopVimInTerminal(buf)
-  call delete('XscriptShowbreak')
 endfunc
 
 func Test_no_spurious_match()

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -379,6 +379,7 @@ endfunc
 func Test_buffer_scheme()
   CheckMSWindows
 
+  set noswapfile
   set noshellslash
   %bwipe!
   let bufnames = [
@@ -401,6 +402,7 @@ func Test_buffer_scheme()
   endfor
 
   set shellslash&
+  set swapfile&
 endfunc
 
 " this was using a NULL pointer after failing to use the pattern

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -5,64 +5,60 @@ source check.vim
 " Test for the :bunload command with an offset
 func Test_bunload_with_offset()
   %bwipe!
-  call writefile(['B1'], 'b1')
-  call writefile(['B2'], 'b2')
-  call writefile(['B3'], 'b3')
-  call writefile(['B4'], 'b4')
+  call writefile(['B1'], 'Xb1', 'D')
+  call writefile(['B2'], 'Xb2', 'D')
+  call writefile(['B3'], 'Xb3', 'D')
+  call writefile(['B4'], 'Xb4', 'D')
 
   " Load four buffers. Unload the second and third buffers and then
   " execute .+3bunload to unload the last buffer.
-  edit b1
-  new b2
-  new b3
-  new b4
+  edit Xb1
+  new Xb2
+  new Xb3
+  new Xb4
 
-  bunload b2
-  bunload b3
-  exe bufwinnr('b1') . 'wincmd w'
+  bunload Xb2
+  bunload Xb3
+  exe bufwinnr('Xb1') . 'wincmd w'
   .+3bunload
-  call assert_equal(0, getbufinfo('b4')[0].loaded)
-  call assert_equal('b1',
+  call assert_equal(0, getbufinfo('Xb4')[0].loaded)
+  call assert_equal('Xb1',
         \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
 
   " Load four buffers. Unload the third and fourth buffers. Execute .+3bunload
   " and check whether the second buffer is unloaded.
   ball
-  bunload b3
-  bunload b4
-  exe bufwinnr('b1') . 'wincmd w'
+  bunload Xb3
+  bunload Xb4
+  exe bufwinnr('Xb1') . 'wincmd w'
   .+3bunload
-  call assert_equal(0, getbufinfo('b2')[0].loaded)
-  call assert_equal('b1',
+  call assert_equal(0, getbufinfo('Xb2')[0].loaded)
+  call assert_equal('Xb1',
         \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
 
   " Load four buffers. Unload the second and third buffers and from the last
   " buffer execute .-3bunload to unload the first buffer.
   ball
-  bunload b2
-  bunload b3
-  exe bufwinnr('b4') . 'wincmd w'
+  bunload Xb2
+  bunload Xb3
+  exe bufwinnr('Xb4') . 'wincmd w'
   .-3bunload
-  call assert_equal(0, getbufinfo('b1')[0].loaded)
-  call assert_equal('b4',
+  call assert_equal(0, getbufinfo('Xb1')[0].loaded)
+  call assert_equal('Xb4',
         \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
 
   " Load four buffers. Unload the first and second buffers. Execute .-3bunload
   " from the last buffer and check whether the third buffer is unloaded.
   ball
-  bunload b1
-  bunload b2
-  exe bufwinnr('b4') . 'wincmd w'
+  bunload Xb1
+  bunload Xb2
+  exe bufwinnr('Xb4') . 'wincmd w'
   .-3bunload
-  call assert_equal(0, getbufinfo('b3')[0].loaded)
-  call assert_equal('b4',
+  call assert_equal(0, getbufinfo('Xb3')[0].loaded)
+  call assert_equal('Xb4',
         \ fnamemodify(getbufinfo({'bufloaded' : 1})[0].name, ':t'))
 
   %bwipe!
-  call delete('b1')
-  call delete('b2')
-  call delete('b3')
-  call delete('b4')
 
   call assert_fails('1,4bunload', 'E16:')
   call assert_fails(',100bunload', 'E16:')
@@ -76,9 +72,9 @@ func Test_buflist_browse()
   %bwipe!
   call assert_fails('buffer 1000', 'E86:')
 
-  call writefile(['foo1', 'foo2', 'foo3', 'foo4'], 'Xbrowse1')
-  call writefile(['bar1', 'bar2', 'bar3', 'bar4'], 'Xbrowse2')
-  call writefile(['baz1', 'baz2', 'baz3', 'baz4'], 'Xbrowse3')
+  call writefile(['foo1', 'foo2', 'foo3', 'foo4'], 'Xbrowse1', 'D')
+  call writefile(['bar1', 'bar2', 'bar3', 'bar4'], 'Xbrowse2', 'D')
+  call writefile(['baz1', 'baz2', 'baz3', 'baz4'], 'Xbrowse3', 'D')
   edit Xbrowse1
   let b1 = bufnr()
   edit Xbrowse2
@@ -127,9 +123,6 @@ func Test_buflist_browse()
 
   call assert_fails('sandbox bnext', 'E48:')
 
-  call delete('Xbrowse1')
-  call delete('Xbrowse2')
-  call delete('Xbrowse3')
   %bwipe!
 endfunc
 
@@ -200,13 +193,13 @@ endfunc
 " Test for quitting the 'swapfile exists' dialog with the split buffer
 " command.
 func Test_buffer_sbuf_cleanup()
-  call writefile([], 'XsplitCleanup')
+  call writefile([], 'XsplitCleanup', 'D')
   " first open the file in a buffer
   new XsplitCleanup
   let bnr = bufnr()
   close
   " create the swap file
-  call writefile([], '.XsplitCleanup.swp')
+  call writefile([], '.XsplitCleanup.swp', 'D')
   " Remove the catch-all that runtest.vim adds
   au! SwapExists
   augroup BufTest
@@ -231,8 +224,6 @@ func Test_buffer_sbuf_cleanup()
   call assert_equal(0, getbufinfo('XsplitCleanup')[0].loaded)
   set shortmess&
 
-  call delete('XsplitCleanup')
-  call delete('.XsplitCleanup.swp')
   augroup BufTest
     au!
   augroup END
@@ -329,8 +320,8 @@ endfunc
 " Test for using CTRL-^ to edit the alternative file keeping the cursor
 " position with 'nostartofline'. Also test using the 'buf' command.
 func Test_buffer_edit_altfile()
-  call writefile(repeat(['one two'], 50), 'Xaltfile1')
-  call writefile(repeat(['five six'], 50), 'Xaltfile2')
+  call writefile(repeat(['one two'], 50), 'Xaltfile1', 'D')
+  call writefile(repeat(['five six'], 50), 'Xaltfile2', 'D')
   set nosol
   edit Xaltfile1
   call cursor(25, 5)
@@ -345,8 +336,6 @@ func Test_buffer_edit_altfile()
   buf Xaltfile2
   call assert_equal([0, 30, 4, 0], getpos('.'))
   set sol&
-  call delete('Xaltfile1')
-  call delete('Xaltfile2')
 endfunc
 
 " Test for running the :sball command with a maximum window count and a
@@ -499,7 +488,7 @@ func Test_buflist_alloc_failure()
   call assert_fails('%bw!', 'E342:')
 
   " test for :checktime loading the buffer
-  call writefile(['one'], 'XallocFail5')
+  call writefile(['one'], 'XallocFail5', 'D')
   if has('unix')
     edit XallocFail5
     " sleep for some time to make sure the timestamp is different
@@ -515,7 +504,6 @@ func Test_buflist_alloc_failure()
   " test for :vimgrep loading a dummy buffer
   call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)
   call assert_fails('vimgrep two XallocFail5', 'E342:')
-  call delete('XallocFail5')
 
   " test for quickfix command loading a buffer
   call test_alloc_fail(GetAllocId('newbuf_bvars'), 0, 0)

--- a/test/old/testdir/test_bufline.vim
+++ b/test/old/testdir/test_bufline.vim
@@ -88,6 +88,7 @@ func Test_setline_startup()
   endif
   call writefile(['call setline(1, "Hello")', 'silent w Xtest', 'q!'], 'Xscript', 'D')
   call system(cmd)
+  sleep 50m
   call assert_equal(['Hello'], readfile('Xtest'))
 
   call delete('Xtest')

--- a/test/old/testdir/test_bufline.vim
+++ b/test/old/testdir/test_bufline.vim
@@ -25,8 +25,8 @@ func Test_setbufline_getbufline()
 
   call assert_equal(1, setbufline(b, 5, 'x'))
   call assert_equal(1, setbufline(b, 5, ['x']))
-  call assert_equal(1, setbufline(b, 5, []))
-  call assert_equal(1, setbufline(b, 5, v:_null_list))
+  call assert_equal(0, setbufline(b, 5, []))
+  call assert_equal(0, setbufline(b, 5, v:_null_list))
 
   call assert_equal(1, 'x'->setbufline(bufnr('$') + 1, 1))
   call assert_equal(1, ['x']->setbufline(bufnr('$') + 1, 1))
@@ -91,6 +91,11 @@ func Test_setline_startup()
   sleep 50m
   call assert_equal(['Hello'], readfile('Xtest'))
 
+  call assert_equal(0, setline(1, []))
+  call assert_equal(0, setline(1, v:_null_list))
+  call assert_equal(0, setline(5, []))
+  call assert_equal(0, setline(6, v:_null_list))
+
   call delete('Xtest')
 endfunc
 
@@ -130,8 +135,8 @@ func Test_appendbufline()
 
   call assert_equal(1, appendbufline(b, 4, 'x'))
   call assert_equal(1, appendbufline(b, 4, ['x']))
-  call assert_equal(1, appendbufline(b, 4, []))
-  call assert_equal(1, appendbufline(b, 4, v:_null_list))
+  call assert_equal(0, appendbufline(b, 4, []))
+  call assert_equal(0, appendbufline(b, 4, v:_null_list))
 
   call assert_equal(1, appendbufline(1234, 1, 'x'))
   call assert_equal(1, appendbufline(1234, 1, ['x']))
@@ -140,8 +145,8 @@ func Test_appendbufline()
 
   call assert_equal(0, appendbufline(b, 1, []))
   call assert_equal(0, appendbufline(b, 1, v:_null_list))
-  call assert_equal(1, appendbufline(b, 3, []))
-  call assert_equal(1, appendbufline(b, 3, v:_null_list))
+  call assert_equal(0, appendbufline(b, 3, []))
+  call assert_equal(0, appendbufline(b, 3, v:_null_list))
 
   call assert_equal(['a', 'b', 'c'], getbufline(b, 1, '$'))
 

--- a/test/old/testdir/test_bufline.vim
+++ b/test/old/testdir/test_bufline.vim
@@ -86,11 +86,10 @@ func Test_setline_startup()
   if cmd == ''
     return
   endif
-  call writefile(['call setline(1, "Hello")', 'silent w Xtest', 'q!'], 'Xscript')
+  call writefile(['call setline(1, "Hello")', 'silent w Xtest', 'q!'], 'Xscript', 'D')
   call system(cmd)
   call assert_equal(['Hello'], readfile('Xtest'))
 
-  call delete('Xscript')
   call delete('Xtest')
 endfunc
 
@@ -215,12 +214,11 @@ func Test_appendbufline_redraw()
     call deletebufline(buf, 1, '$')
     call appendbufline(buf, '$', 'Hello Vim world...')
   END
-  call writefile(lines, 'XscriptMatchCommon')
+  call writefile(lines, 'XscriptMatchCommon', 'D')
   let buf = RunVimInTerminal('-S XscriptMatchCommon', #{rows: 10})
   call VerifyScreenDump(buf, 'Test_appendbufline_1', {})
 
   call StopVimInTerminal(buf)
-  call delete('XscriptMatchCommon')
 endfunc
 
 func Test_setbufline_select_mode()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -835,9 +835,13 @@ endfunc
 func Test_append()
   enew!
   split
-  call append(0, ["foo"])
-  call append(1, [])
-  call append(1, v:_null_list)
+  call assert_equal(0, append(1, []))
+  call assert_equal(0, append(1, v:_null_list))
+  call assert_equal(0, append(0, ["foo"]))
+  call assert_equal(0, append(1, []))
+  call assert_equal(0, append(1, v:_null_list))
+  call assert_equal(0, append(8, []))
+  call assert_equal(0, append(9, v:_null_list))
   call assert_equal(['foo', ''], getline(1, '$'))
   split
   only

--- a/test/old/testdir/test_profile.vim
+++ b/test/old/testdir/test_profile.vim
@@ -44,6 +44,7 @@ func Test_profile_func()
     \ . ' --cmd "qall!"')
   call assert_equal(0, v:shell_error)
 
+  sleep 50m
   let lines = readfile('Xprofile_func.log')
 
   " - Foo1() is called 3 times but should be reported as called twice

--- a/test/old/testdir/test_shell.vim
+++ b/test/old/testdir/test_shell.vim
@@ -5,6 +5,11 @@ source check.vim
 source shared.vim
 
 func Test_shell_options()
+  if has('win32')
+    " FIXME: This test is flaky on MS-Windows.
+    let g:test_is_flaky = 1
+  endif
+
   " The expected value of 'shellcmdflag', 'shellpipe', 'shellquote',
   " 'shellredir', 'shellxescape', 'shellxquote' for the supported shells.
   let shells = []

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -295,9 +295,9 @@ func Test_q_arg()
   call writefile(lines, 'Xbadfile.c')
 
   let after =<< trim [CODE]
-    call writefile([&errorfile, string(getpos("."))], "Xtestout")
+    call writefile([&errorfile, string(getpos("."))], "XtestoutQarg")
     copen
-    w >> Xtestout
+    w >> XtestoutQarg
     qall
   [CODE]
 
@@ -305,30 +305,30 @@ func Test_q_arg()
   call assert_equal('errors.err', &errorfile)
   call writefile(["Xbadfile.c:4:12: error: expected ';' before '}' token"], 'errors.err')
   if RunVim([], after, '-q')
-    let lines = readfile('Xtestout')
+    let lines = readfile('XtestoutQarg')
     call assert_equal(['errors.err',
 	\              '[0, 4, 12, 0]',
 	\              "Xbadfile.c|4 col 12| error: expected ';' before '}' token"],
 	\             lines)
   endif
-  call delete('Xtestout')
+  call delete('XtestoutQarg')
   call delete('errors.err')
 
-  " Test with explicit argument '-q Xerrors' (with space).
-  call writefile(["Xbadfile.c:4:12: error: expected ';' before '}' token"], 'Xerrors')
-  if RunVim([], after, '-q Xerrors')
-    let lines = readfile('Xtestout')
-    call assert_equal(['Xerrors',
+  " Test with explicit argument '-q XerrorsQarg' (with space).
+  call writefile(["Xbadfile.c:4:12: error: expected ';' before '}' token"], 'XerrorsQarg')
+  if RunVim([], after, '-q XerrorsQarg')
+    let lines = readfile('XtestoutQarg')
+    call assert_equal(['XerrorsQarg',
 	\              '[0, 4, 12, 0]',
 	\              "Xbadfile.c|4 col 12| error: expected ';' before '}' token"],
 	\             lines)
   endif
-  call delete('Xtestout')
+  call delete('XtestoutQarg')
 
-  " Test with explicit argument '-qXerrors' (without space).
-  if RunVim([], after, '-qXerrors')
-    let lines = readfile('Xtestout')
-    call assert_equal(['Xerrors',
+  " Test with explicit argument '-qXerrorsQarg' (without space).
+  if RunVim([], after, '-qXerrorsQarg')
+    let lines = readfile('XtestoutQarg')
+    call assert_equal(['XerrorsQarg',
 	\              '[0, 4, 12, 0]',
 	\              "Xbadfile.c|4 col 12| error: expected ';' before '}' token"],
 	\             lines)
@@ -339,8 +339,8 @@ func Test_q_arg()
   call assert_equal(3, v:shell_error)
 
   call delete('Xbadfile.c')
-  call delete('Xtestout')
-  call delete('Xerrors')
+  call delete('XtestoutQarg')
+  call delete('XerrorsQarg')
 endfunc
 
 " Test the -V[N]{filename} argument to set the 'verbose' option to N

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -399,6 +399,11 @@ endfunc
 
 func Test_undofile_earlier()
   throw 'Skipped: Nvim does not support test_settime()'
+  if has('win32')
+    " FIXME: This test is flaky on MS-Windows.
+    let g:test_is_flaky = 1
+  endif
+
   " Issue #1254
   " create undofile with timestamps older than Vim startup time.
   let t0 = localtime() - 43200


### PR DESCRIPTION
#### vim-patch:9.0.0380: deleting files in tests is a hassle

Problem:    Deleting files in tests is a hassle.
Solution:   Use the new 'D' flag of writefile().

https://github.com/vim/vim/commit/e1f3ab73bc7c4b3eee03b673c2983ed7eca6ea80

vim-patch:e1f3ab73bc7c

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0391: using separate delete() call instead of writefile() 'D' flag

Problem:    Using separate delete() call instead of writefile() 'D' flag.
Solution:   Use the writefile 'D' flag.

https://github.com/vim/vim/commit/3411265a3698c3d5ef56d9b0c3bb237a9f5fdba1

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0415: on MS-Windows some tests are flaky

Problem:    On MS-Windows some tests are flaky.
Solution:   Add sleeps, disable swapfile, mark test as flaky. (Ken Takata,
            closes vim/vim#11082)

https://github.com/vim/vim/commit/0500e87eba7b2a82392dbb5d573de19f8ff138e7

Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:9.0.0425: autocmd test is a bit flaky on MS-Windows

Problem:    Autocmd test is a bit flaky on MS-Windows.
Solution:   Add a bit more sleeping. (Ken Takata, closes vim/vim#11095)

https://github.com/vim/vim/commit/ae04a6049b3f0e30a671966ed2dda1979e0b5f20

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0428: autocmd test uses common file name

Problem:    Autocmd test uses common file name.
Solution:   Use unique name to reduce flakiness.

https://github.com/vim/vim/commit/be9fc5b60cbdf697c4f6d12345dd7fcdb5d6ca01

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0837: append() reports failure when not appending anything

Problem:    append() reports failure when not appending anything.
Solution:   Only report failure when appending something.

https://github.com/vim/vim/commit/cd9c8d400c1eb9cbb4ff6a33be02f91a30ab13b2

Co-authored-by: Bram Moolenaar <Bram@vim.org>