### PR TITLE
vim-patch:8.2.4611: typos in tests; one lua line not covered by test

### DIFF
--- a/test/old/testdir/test_cursorline.vim
+++ b/test/old/testdir/test_cursorline.vim
@@ -162,7 +162,7 @@ func Test_cursorline_screenline()
   call term_sendkeys(buf, "gj")
   call VerifyScreenDump(buf, 'Test_'. filename. '_12', {})
   if exists("+foldcolumn") && exists("+signcolumn") && exists("+breakindent")
-    " test with set foldcolumn signcoloumn and breakindent
+    " test with set foldcolumn signcolumn and breakindent
     call term_sendkeys(buf, "gg0")
     call term_sendkeys(buf, ":set breakindent foldcolumn=2 signcolumn=yes\<cr>")
     call VerifyScreenDump(buf, 'Test_'. filename. '_13', {})

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -51,7 +51,7 @@ func Test_digraphs()
   call Put_Dig("'e")
   call Put_Dig("b'") " not defined
   call assert_equal(["á", "é", "'"], getline(line('.')-2,line('.')))
-  " Cicumflex
+  " Circumflex
   call Put_Dig("a>")
   call Put_Dig(">e")
   call Put_Dig("b>") " not defined

--- a/test/old/testdir/test_menu.vim
+++ b/test/old/testdir/test_menu.vim
@@ -162,7 +162,7 @@ endfunc
 
 " Test for menu item completion in command line
 func Test_menu_expand()
-  " Create the menu itmes for test
+  " Create the menu items for test
   menu Dummy.Nothing lll
   for i in range(1, 4)
     let m = 'menu Xmenu.A' .. i .. '.A' .. i

--- a/test/old/testdir/test_signals.vim
+++ b/test/old/testdir/test_signals.vim
@@ -100,8 +100,8 @@ func Test_signal_INT()
   call term_sendkeys(buf, ":while 1 | endwhile\n")
   call WaitForAssert({-> assert_equal(':while 1 | endwhile', term_getline(buf, 6))})
   exe 'silent !kill -s INT ' .. pid_vim
-  call term_sendkeys(buf, ":call setline(1, 'INTERUPTED')\n")
-  call WaitForAssert({-> assert_equal('INTERUPTED', term_getline(buf, 1))})
+  call term_sendkeys(buf, ":call setline(1, 'INTERRUPTED')\n")
+  call WaitForAssert({-> assert_equal('INTERRUPTED', term_getline(buf, 1))})
 
   call StopVimInTerminal(buf)
 endfunc

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -491,7 +491,7 @@ func Test_spellsuggest_option_expr()
   bwipe!
 endfunc
 
-" Test for 'spellsuggest' expr errrors
+" Test for 'spellsuggest' expr errors
 func Test_spellsuggest_expr_errors()
   " 'spellsuggest'
   func MySuggest()

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -269,7 +269,7 @@ func Test_statusline()
   call assert_match('^vimLineComment\s*$', s:get_statusline())
   syntax off
 
-  "%{%expr%}: evaluates enxpressions present in result of expr
+  "%{%expr%}: evaluates expressions present in result of expr
   func! Inner_eval()
     return '%n some other text'
   endfunc

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -3641,7 +3641,7 @@ endfunc
 "	    exceptions.
 "-------------------------------------------------------------------------------
 
-func Test_execption_info_for_error()
+func Test_exception_info_for_error()
   CheckEnglish
 
   let test =<< trim [CODE]


### PR DESCRIPTION
#### vim-patch:8.2.4611: typos in tests; one lua line not covered by test

Problem:    Typos in tests; one lua line not covered by test.
Solution:   Fix typos. Add test case. (Dominique Pellé, closes vim/vim#9994)

https://github.com/vim/vim/commit/81b573d7e55bd48988f298ce8e652d902e9bdeba

Cherry-pick test_menu.vim change from patch 9.0.1453.

N/A patch:
vim-patch:8.2.3045: minor typos

Co-authored-by: Dominique Pelle <dominique.pelle@gmail.com>