### PR TITLE
vim-patch:8.0.0571: negative line number when using :z^ in an empty buffer

### DIFF
--- a/test/old/testdir/test_ex_z.vim
+++ b/test/old/testdir/test_ex_z.vim
@@ -98,11 +98,18 @@ func Test_z_bang()
   %bwipe!
 endfunc
 
-func Test_z_bug()
+func Test_z_overflow()
   " This used to access invalid memory as a result of an integer overflow
   " and freeze vim.
   normal ox
   normal Heat
   z777777776666666
   ')
+endfunc
+
+func Test_z_negative_lnum()
+  new
+  z^
+  call assert_equal(1, line('.'))
+  bwipe!
 endfunc


### PR DESCRIPTION
#### vim-patch:8.0.0571: negative line number when using :z^ in an empty buffer

Problem:    The cursor line number becomes negative when using :z^ in an empty
            buffer. (neovim vim/vim#6557)
Solution:   Correct the line number.  Also reset the column.

https://github.com/vim/vim/commit/a364cdb648ae009fa7aa05382f5659335683d349

Co-authored-by: Bram Moolenaar <Bram@vim.org>