### PR TITLE
vim-patch:9.0.0579: using freed memory when 'tagfunc' wipes out buffer

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4572,7 +4572,8 @@ static int open_cmdwin(void)
       ccline.cmdlen = (int)strlen(ccline.cmdbuff);
       ccline.cmdbufflen = ccline.cmdlen + 1;
       ccline.cmdpos = curwin->w_cursor.col;
-      if (ccline.cmdpos > ccline.cmdlen) {
+      // If the cursor is on the last character, it probably should be after it.
+      if (ccline.cmdpos == ccline.cmdlen - 1 || ccline.cmdpos > ccline.cmdlen) {
         ccline.cmdpos = ccline.cmdlen;
       }
       if (cmdwin_result == K_IGNORE) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -622,6 +622,7 @@ int cursor_valid(void)
 // w_topline must be valid, you may need to call update_topline() first!
 void validate_cursor(void)
 {
+  check_cursor();
   check_cursor_moved(curwin);
   if ((curwin->w_valid & (VALID_WCOL|VALID_WROW)) != (VALID_WCOL|VALID_WROW)) {
     curs_columns(curwin, true);

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -316,7 +316,7 @@ local function test_cmdline(linegrid)
     screen:expect{grid=[[
                                |
       {2:[No Name]                }|
-      {1::}make^                    |
+      {1::}mak^e                    |
       {3:[Command Line]           }|
                                |
     ]]}
@@ -326,7 +326,7 @@ local function test_cmdline(linegrid)
     screen:expect{grid=[[
                                |
       {2:[No Name]                }|
-      {1::}make^                    |
+      {1::}mak^e                    |
       {3:[Command Line]           }|
                                |
     ]], cmdline={nil, {
@@ -339,7 +339,7 @@ local function test_cmdline(linegrid)
     screen:expect{grid=[[
                                |
       {2:[No Name]                }|
-      {1::}make^                    |
+      {1::}mak^e                    |
       {3:[Command Line]           }|
                                |
     ]], cmdline={nil, {
@@ -352,7 +352,7 @@ local function test_cmdline(linegrid)
     screen:expect{grid=[[
                                |
       {2:[No Name]                }|
-      {1::}make^                    |
+      {1::}mak^e                    |
       {3:[Command Line]           }|
                                |
     ]]}

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -3239,7 +3239,7 @@ describe('builtin popupmenu', function()
                                           |
           {3:[No Name]                       }|
           {1::}sign define                    |
-          {1::}sign define^                    |
+          {1::}sign defin^e                    |
           {1:~                               }|
           {1:~                               }|
           {1:~                               }|

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -52,7 +52,7 @@ describe('search highlighting', function()
       {1:~                                       }|
       /text^                                   |
     ]], win_viewport={
-      [2] = {win = {id = 1000}, topline = 0, botline = 3, curline = 0, curcol = 9, linecount = 2, sum_scroll_delta = 0};
+      [2] = {win = {id = 1000}, topline = 0, botline = 3, curline = 0, curcol = 8, linecount = 2, sum_scroll_delta = 0};
     }}
   end)
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -645,9 +645,8 @@ func Test_pum_with_preview_win()
 
   call writefile(lines, 'Xpreviewscript')
   let buf = RunVimInTerminal('-S Xpreviewscript', #{rows: 12})
-  call TermWait(buf, 50)
   call term_sendkeys(buf, "Gi\<C-X>\<C-O>")
-  call TermWait(buf, 100)
+  call TermWait(buf, 200)
   call term_sendkeys(buf, "\<C-N>")
   call VerifyScreenDump(buf, 'Test_pum_with_preview_win', {})
 
@@ -2236,5 +2235,22 @@ func Test_ins_complete_end_of_line()
 
   bwipe!
 endfunc
+
+func s:Tagfunc(t,f,o)
+  bwipe!
+  return []
+endfunc
+
+" This was using freed memory, since 'complete' was in a wiped out buffer.
+" Also using a window that was closed.
+func Test_tagfunc_wipes_out_buffer()
+  new
+  set complete=.,t,w,b,u,i
+  se tagfunc=s:Tagfunc
+  sil norm i
+
+  bwipe!
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.0579: using freed memory when 'tagfunc' wipes out buffer

Problem:    Using freed memory when 'tagfunc' wipes out buffer that holds
            'complete'.
Solution:   Make a copy of the option.  Make sure cursor position is valid.

https://github.com/vim/vim/commit/0ff01835a40f549c5c4a550502f62a2ac9ac447c

Cherry-pick a cmdwin change from patch 9.0.0500.

Co-authored-by: Bram Moolenaar <Bram@vim.org>