### PR TITLE
vim-patch:9.0.1779: Need more state() tests

### DIFF
--- a/test/functional/vimscript/state_spec.lua
+++ b/test/functional/vimscript/state_spec.lua
@@ -10,6 +10,7 @@ local poke_eventloop = helpers.poke_eventloop
 before_each(clear)
 
 describe('state() function', function()
+  -- oldtest: Test_state()
   it('works', function()
     meths.ui_attach(80, 24, {})  -- Allow hit-enter-prompt
 
@@ -50,6 +51,20 @@ describe('state() function', function()
     meths.get_mode()  -- Process pending input and luv timer callback
     feed(';')
     eq({ 'mS', 'n' }, exec_lua('return _G.res'))
+
+    -- An operator is pending
+    feed([[:call RunTimer()<CR>y]])
+    poke_eventloop()  -- Process pending input
+    poke_eventloop()  -- Process time_event
+    feed('y')
+    eq({ 'oSc', 'n' }, exec_lua('return _G.res'))
+
+    -- A register was specified
+    feed([[:call RunTimer()<CR>"r]])
+    poke_eventloop()  -- Process pending input
+    poke_eventloop()  -- Process time_event
+    feed('yy')
+    eq({ 'oSc', 'n' }, exec_lua('return _G.res'))
 
     -- Insert mode completion
     feed([[:call RunTimer()<CR>Got<C-N>]])

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2630,6 +2630,20 @@ func Test_state()
   call term_sendkeys(buf, getstate)
   call WaitForAssert({-> assert_match('state: mSc; mode: n', term_getline(buf, 6))}, 1000)
 
+  " A operator is pending
+  call term_sendkeys(buf, ":call RunTimer()\<CR>y")
+  call TermWait(buf, 25)
+  call term_sendkeys(buf, "y")
+  call term_sendkeys(buf, getstate)
+  call WaitForAssert({-> assert_match('state: oSc; mode: n', term_getline(buf, 6))}, 1000)
+
+  " A register was specified
+  call term_sendkeys(buf, ":call RunTimer()\<CR>\"r")
+  call TermWait(buf, 25)
+  call term_sendkeys(buf, "yy")
+  call term_sendkeys(buf, getstate)
+  call WaitForAssert({-> assert_match('state: oSc; mode: n', term_getline(buf, 6))}, 1000)
+
   " Insert mode completion (bit slower on Mac)
   call term_sendkeys(buf, ":call RunTimer()\<CR>Got\<C-N>")
   call TermWait(buf, 25)


### PR DESCRIPTION
#### vim-patch:9.0.1779: Need more state() tests

Problem:  Need more state() tests
Solution: Add a few more tests for operater pending mode and register
          yank command

closes: vim/vim#12883

https://github.com/vim/vim/commit/8dabccd295271104ad5af0abc48e283d644cff59