### PR TITLE
vim-patch:9.0.1783: Display issues with virt text smoothscroll and showbreak

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -991,6 +991,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
   chartabsize_T cts;
   bool on_NUL = false;
   init_chartabsize_arg(&cts, wp, pos->lnum, 0, line, line);
+  cts.cts_max_head_vcol = -1;
 
   // This function is used very often, do some speed optimizations.
   // When 'list', 'linebreak', 'showbreak' and 'breakindent' are not set

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -232,7 +232,8 @@ static void insert_enter(InsertState *s)
   may_trigger_modechanged();
   stop_insert_mode = false;
 
-  // need to position cursor again when on a TAB
+  // need to position cursor again when on a TAB and
+  // when on a char with inline virtual text
   if (gchar_cursor() == TAB || curbuf->b_virt_text_inline > 0) {
     curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL);
   }
@@ -3471,7 +3472,8 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
 
   State = MODE_NORMAL;
   may_trigger_modechanged();
-  // need to position cursor again when on a TAB
+  // need to position cursor again when on a TAB and
+  // when on a char with inline virtual text
   if (gchar_cursor() == TAB || curbuf->b_virt_text_inline > 0) {
     curwin->w_valid &= ~(VALID_WROW|VALID_WCOL|VALID_VIRTCOL);
   }

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -494,7 +494,10 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
   // string at start of line.
   // Do not use 'showbreak' at the NUL after the text.
   int head = mb_added;
-  char *const sbr = c == NUL ? empty_option : get_showbreak_value(wp);
+  char *const sbr
+  // XXX: there should be a better check deeper below
+    = ((c == NUL && cts->cts_cur_text_width_left + cts->cts_cur_text_width_right == 0)
+       ? empty_option : get_showbreak_value(wp));
   if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap) {
     int col_off_prev = win_col_off(wp);
     int width2 = wp->w_width_inner - col_off_prev + win_col_off2(wp);

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -369,16 +369,19 @@ int lbr_chartabsize_adv(chartabsize_T *cts)
   return retval;
 }
 
+/// Get the number of characters taken up on the screen indicated by "cts".
+/// "cts->cts_cur_text_width_left" and "cts->cts_cur_text_width_right" are set
+/// to the extra size for inline virtual text.
 /// This function is used very often, keep it fast!!!!
 ///
-/// If "headp" not NULL, set *headp to the size of what we for 'showbreak'
-/// string at start of line.  Warning: *headp is only set if it's a non-zero
-/// value, init to 0 before calling.
+/// If "headp" not NULL, set "*headp" to the size of 'showbreak'/'breakindent'
+/// included in the return value.
+/// When "cts->cts_max_head_vcol" is positive, only count in "*headp" the size
+/// of 'showbreak'/'breakindent' before "cts->cts_max_head_vcol".
+/// When "cts->cts_max_head_vcol" is negative, only count in "*headp" the size
+/// of 'showbreak'/'breakindent' before where cursor should be placed.
 ///
-/// @param cts
-/// @param headp
-///
-/// @return The number of characters taken up on the screen.
+/// Warning: "*headp" may not be set if it's 0, init to 0 before calling.
 int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
 {
   win_T *wp = cts->cts_win;
@@ -388,7 +391,6 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
 
   colnr_T col_adj = 0;  // vcol + screen size of tab
   int mb_added = 0;
-  int numberextra;
 
   cts->cts_cur_text_width_left = 0;
   cts->cts_cur_text_width_right = 0;
@@ -449,7 +451,7 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
       && (wp->w_width_inner != 0)) {
     // Count all characters from first non-blank after a blank up to next
     // non-blank after a blank.
-    numberextra = win_col_off(wp);
+    int numberextra = win_col_off(wp);
     colnr_T col2 = vcol;
     colnr_T colmax = (colnr_T)(wp->w_width_inner - numberextra - col_adj);
 
@@ -490,72 +492,92 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
 
   // May have to add something for 'breakindent' and/or 'showbreak'
   // string at start of line.
-  // Set *headp to the size of what we add.
   // Do not use 'showbreak' at the NUL after the text.
-  int added = 0;
+  int head = mb_added;
   char *const sbr = c == NUL ? empty_option : get_showbreak_value(wp);
-  if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap && vcol != 0) {
-    colnr_T sbrlen = 0;
-    int numberwidth = win_col_off(wp);
-
-    numberextra = numberwidth;
-    vcol += numberextra + mb_added;
-
-    if (vcol >= (colnr_T)wp->w_width_inner) {
-      vcol -= wp->w_width_inner;
-      numberextra = wp->w_width_inner - (numberextra - win_col_off2(wp));
-      if (vcol >= numberextra && numberextra > 0) {
-        vcol %= numberextra;
+  if ((*sbr != NUL || wp->w_p_bri) && wp->w_p_wrap) {
+    int col_off_prev = win_col_off(wp);
+    int width2 = wp->w_width_inner - col_off_prev + win_col_off2(wp);
+    colnr_T wcol = vcol + col_off_prev;
+    // cells taken by 'showbreak'/'breakindent' before current char
+    int head_prev = 0;
+    if (wcol >= wp->w_width_inner) {
+      wcol -= wp->w_width_inner;
+      col_off_prev = wp->w_width_inner - width2;
+      if (wcol >= width2 && width2 > 0) {
+        wcol %= width2;
       }
       if (*sbr != NUL) {
-        sbrlen = (colnr_T)mb_charlen(sbr);
-        if (vcol >= sbrlen) {
-          vcol -= sbrlen;
-        }
+        head_prev += vim_strsize(sbr);
       }
-      if (vcol >= numberextra && numberextra > 0) {
-        vcol %= numberextra;
-      } else if (vcol > 0 && numberextra > 0) {
-        vcol += numberwidth - win_col_off2(wp);
+      if (wp->w_p_bri) {
+        head_prev += get_breakindent_win(wp, line);
       }
-
-      numberwidth -= win_col_off2(wp);
+      if (wcol < head_prev) {
+        wcol = head_prev;
+      }
+      wcol += col_off_prev;
     }
 
-    if (vcol == 0 || (vcol + size + sbrlen > (colnr_T)wp->w_width_inner)) {
+    if ((vcol > 0 && wcol == col_off_prev + head_prev)
+        || wcol + size > wp->w_width_inner) {
+      int added = 0;
+      colnr_T max_head_vcol = cts->cts_max_head_vcol;
+
+      if (vcol > 0 && wcol == col_off_prev + head_prev) {
+        added += head_prev;
+        if (max_head_vcol <= 0 || vcol < max_head_vcol) {
+          head += head_prev;
+        }
+      }
+
+      // cells taken by 'showbreak'/'breakindent' halfway current char
+      int head_mid = 0;
       if (*sbr != NUL) {
-        if (size + sbrlen + numberwidth > (colnr_T)wp->w_width_inner) {
+        head_mid += vim_strsize(sbr);
+      }
+      if (wp->w_p_bri) {
+        head_mid += get_breakindent_win(wp, line);
+      }
+      if (head_mid > 0) {
+        if (wcol + size > wp->w_width_inner) {
           // Calculate effective window width.
-          int width = (colnr_T)wp->w_width_inner - sbrlen - numberwidth;
-          int prev_width = vcol ? ((colnr_T)wp->w_width_inner - (sbrlen + vcol))
-                               : 0;
+          int prev_rem = wp->w_width_inner - wcol;
+          int width = width2 - head_mid;
 
           if (width <= 0) {
             width = 1;
           }
-          added += ((size - prev_width) / width) * vim_strsize(sbr);
-          if ((size - prev_width) % width) {
-            // Wrapped, add another length of 'sbr'.
-            added += vim_strsize(sbr);
+          // divide "size - prev_width" by "width", rounding up
+          int cnt = (size - prev_rem + width - 1) / width;
+          added += cnt * head_mid;
+
+          if (max_head_vcol == 0 || vcol + size + added < max_head_vcol) {
+            head += cnt * head_mid;
+          } else if (max_head_vcol > vcol + head_prev + prev_rem) {
+            head += (max_head_vcol - (vcol + head_prev + prev_rem)
+                     + width2 - 1) / width2 * head_mid;
+          } else if (max_head_vcol < 0) {
+            int off = 0;
+            if (c != NUL || !(State & MODE_NORMAL)) {
+              off += cts->cts_cur_text_width_left;
+            }
+            if (c != NUL && (State & MODE_NORMAL)) {
+              off += cts->cts_cur_text_width_right;
+            }
+            if (off >= prev_rem) {
+              head += (1 + (off - prev_rem) / width) * head_mid;
+            }
           }
-        } else {
-          added += vim_strsize(sbr);
         }
       }
 
-      if (wp->w_p_bri) {
-        added += get_breakindent_win(wp, line);
-      }
-
       size += added;
-      if (vcol != 0) {
-        added = 0;
-      }
     }
   }
 
   if (headp != NULL) {
-    *headp = added + mb_added;
+    *headp = head;
   }
   return size;
 }

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -19,6 +19,7 @@ typedef struct {
   MarkTreeIter cts_iter[1];
 
   int cts_vcol;                  ///< virtual column at current position
+  int cts_max_head_vcol;         ///< see win_lbr_chartabsize()
 } chartabsize_T;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2021,7 +2021,7 @@ bbbbbbb]])
     ]]}
   end)
 
-  it('cursor position is correct with virtual text attached to hard tabs', function()
+  it('cursor position is correct with virtual text attached to hard TABs', function()
     command('set noexpandtab')
     feed('i')
     feed('<TAB>')
@@ -2692,7 +2692,7 @@ bbbbbbb]])
       ]]}
   end)
 
-  it('correctly draws when overflowing virtual text is followed by tab with no wrap', function()
+  it('correctly draws when overflowing virtual text is followed by TAB with no wrap', function()
     command('set nowrap')
     feed('i<TAB>test<ESC>')
     meths.buf_set_extmark(
@@ -2982,6 +2982,328 @@ bbbbbbb]])
       123^4{7:567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
+    ]]}
+  end)
+
+  local function test_virt_inline_showbreak_smoothscroll()
+    screen:try_resize(30, 6)
+    exec([[
+      highlight! link LineNr Normal
+      call setline(1, repeat('a', 28))
+      setlocal number showbreak=+ breakindent breakindentopt=shift:2
+      setlocal scrolloff=0 smoothscroll
+      normal! $
+    ]])
+    meths.buf_set_extmark(0, ns, 0, 27, { virt_text = { { ('123'):rep(23) } }, virt_text_pos = 'inline' })
+    feed(':<CR>')  -- Have a screen line that doesn't start with spaces
+    screen:expect{grid=[[
+        1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
+            {1:+}a1231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}12312312312312312312312|
+            {1:+}3^a                     |
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}a1231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}12312312312312312312312|
+            {1:+}3^a                     |
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}23123123123123123123123|
+            {1:+}12312312312312312312312|
+            {1:+}3^a                     |
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}12312312312312312312312|
+            {1:+}3^a                     |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}3^a                     |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('zbi')
+    screen:expect{grid=[[
+        1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
+            {1:+}a^1231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}12312312312312312312312|
+            {1:+}3a                     |
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<BS>')
+    screen:expect{grid=[[
+        1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
+            {1:+}^12312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}a                      |
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<Esc>l')
+    feed(':<CR>')  -- Have a screen line that doesn't start with spaces
+    screen:expect{grid=[[
+        1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
+            {1:+}12312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}12312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('023x$')
+    screen:expect{grid=[[
+        1 aaa12312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}23123123123123123123123|
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}^a                      |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      :                             |
+    ]]}
+    feed('zbi')
+    screen:expect{grid=[[
+        1 aaa^12312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123123|
+            {1:+}a                      |
+      {1:~                             }|
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<C-U>')
+    screen:expect{grid=[[
+        1 ^12312312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123a  |
+      {1:~                             }|
+      {1:~                             }|
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<Esc>')
+    screen:expect{grid=[[
+        1 12312312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123^a  |
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123^a  |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+            {1:+}23123123123123123123^a  |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+  end
+
+  describe('with showbreak, smoothscroll', function()
+    it('and cpoptions-=n', function()
+      test_virt_inline_showbreak_smoothscroll()
+    end)
+
+    it('and cpoptions+=n', function()
+      command('set cpoptions+=n')
+      -- because of 'breakindent' the screen states are the same
+      test_virt_inline_showbreak_smoothscroll()
+    end)
+  end)
+
+  it('before TABs with smoothscroll', function()
+    screen:try_resize(30, 6)
+    exec([[
+      call setline(1, repeat("\t", 4) .. 'a')
+      setlocal list listchars=tab:<-> scrolloff=0 smoothscroll
+      normal! $
+    ]])
+    meths.buf_set_extmark(0, ns, 0, 3, { virt_text = { { ('12'):rep(32) } }, virt_text_pos = 'inline' })
+    screen:expect{grid=[[
+      {1:<------><------><------>}121212|
+      121212121212121212121212121212|
+      1212121212121212121212121212{1:<-}|
+      {1:----->}^a                       |
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<}212121212121212121212121212|
+      1212121212121212121212121212{1:<-}|
+      {1:----->}^a                       |
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<}2121212121212121212121212{1:<-}|
+      {1:----->}^a                       |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<-->}^a                       |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('zbh')
+    screen:expect{grid=[[
+      {1:<------><------><------>}121212|
+      121212121212121212121212121212|
+      1212121212121212121212121212{1:^<-}|
+      {1:----->}a                       |
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('i')
+    screen:expect{grid=[[
+      {1:<------><------><------>}^121212|
+      121212121212121212121212121212|
+      1212121212121212121212121212{1:<-}|
+      {1:----->}a                       |
+      {1:~                             }|
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<C-O>:setlocal nolist<CR>')
+    screen:expect{grid=[[
+                              ^121212|
+      121212121212121212121212121212|
+      1212121212121212121212121212  |
+            a                       |
+      {1:~                             }|
+      {8:-- INSERT --}                  |
+    ]]}
+    feed('<Esc>l')
+    screen:expect{grid=[[
+                              121212|
+      121212121212121212121212121212|
+      1212121212121212121212121212  |
+           ^ a                       |
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<}212121212121212121212121212|
+      1212121212121212121212121212  |
+           ^ a                       |
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<}2121212121212121212121212  |
+           ^ a                       |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
+    feed('<C-E>')
+    screen:expect{grid=[[
+      {1:<<<}  ^ a                       |
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+      {1:~                             }|
+                                    |
     ]]}
   end)
 end)
@@ -3643,7 +3965,7 @@ if (h->n_buckets < new_n_buckets) { // expand
   end)
 
 
-  it('works with hard tabs', function()
+  it('works with hard TABs', function()
     insert(example_text2)
     feed 'gg'
     meths.buf_set_extmark(0, ns, 1, 0, {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1658,7 +1658,7 @@ describe('decorations: inline virtual text', function()
   local screen, ns
   before_each( function()
     clear()
-    screen = Screen.new(50, 10)
+    screen = Screen.new(50, 3)
     screen:attach()
     screen:set_default_attr_ids {
       [1] = {bold=true, foreground=Screen.colors.Blue};
@@ -1689,6 +1689,7 @@ describe('decorations: inline virtual text', function()
 
 
   it('works', function()
+    screen:try_resize(50, 10)
     insert(example_text)
     feed 'gg'
     screen:expect{grid=[[
@@ -1748,6 +1749,7 @@ describe('decorations: inline virtual text', function()
   end)
 
   it('works with empty chunk', function()
+    screen:try_resize(50, 10)
     insert(example_text)
     feed 'gg'
     screen:expect{grid=[[
@@ -1796,142 +1798,86 @@ describe('decorations: inline virtual text', function()
 
   it('cursor positions are correct with multiple inline virtual text', function()
     insert('12345678')
-    meths.buf_set_extmark(0, ns, 0, 4,
-        { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
-    meths.buf_set_extmark(0, ns, 0, 4,
-        { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
     feed '^'
     feed '4l'
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       1234{10: virtual text  virtual text }^5678              |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('adjusts cursor location correctly when inserting around inline virtual text', function()
     insert('12345678')
     feed '$'
-    meths.buf_set_extmark(0, ns, 0, 4,
-            { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
 
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       1234{10: virtual text }567^8                            |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('has correct highlighting with multi-byte characters', function()
     insert('12345678')
-    meths.buf_set_extmark(0, ns, 0, 4,
-            { virt_text = { { 'múlti-byté chñröcters 修补', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { 'múlti-byté chñröcters 修补', 'Special' } }, virt_text_pos = 'inline' })
 
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       1234{10:múlti-byté chñröcters 修补}567^8                |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('has correct cursor position when inserting around virtual text', function()
     insert('12345678')
-    meths.buf_set_extmark(0, ns, 0, 4,
-            { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed '^'
     feed '3l'
     feed 'a'
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       1234{10:^virtual text}5678                              |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- INSERT --}                                      |
-      ]]}
+    ]]}
     feed '<ESC>'
     screen:expect{grid=[[
       123^4{10:virtual text}5678                              |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {1:~                                                 }|
                                                         |
     ]]}
     feed '^'
     feed '4l'
     feed 'i'
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       1234{10:^virtual text}5678                              |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- INSERT --}                                      |
-      ]]}
+    ]]}
   end)
 
   it('has correct cursor position with virtual text on an empty line', function()
-    meths.buf_set_extmark(0, ns, 0, 0,
-            { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
-    screen:expect { grid = [[
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    screen:expect{grid=[[
       {10:^virtual text}                                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('text is drawn correctly with a wrapping virtual text', function()
+    screen:try_resize(50, 8)
     feed('o<esc>')
     insert([[aaaaaaa
 
 bbbbbbb]])
-    meths.buf_set_extmark(0, ns, 0, 0,
-            { virt_text = { { string.rep('X', 51), 'Special' } }, virt_text_pos = 'inline' })
-    meths.buf_set_extmark(0, ns, 2, 0,
-            { virt_text = { { string.rep('X', 50), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('X', 51), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 2, 0, { virt_text = { { string.rep('X', 50), 'Special' } }, virt_text_pos = 'inline' })
     feed('gg0')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:X}                                                 |
       aaaaaaa                                           |
@@ -1939,13 +1885,11 @@ bbbbbbb]])
       bbbbbbb                                           |
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
       ]]}
 
     feed('j')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:X}                                                 |
       ^aaaaaaa                                           |
@@ -1953,13 +1897,11 @@ bbbbbbb]])
       bbbbbbb                                           |
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('j')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:X}                                                 |
       aaaaaaa                                           |
@@ -1967,13 +1909,11 @@ bbbbbbb]])
       bbbbbbb                                           |
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('j')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:X}                                                 |
       aaaaaaa                                           |
@@ -1981,13 +1921,11 @@ bbbbbbb]])
       ^bbbbbbb                                           |
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('ggic')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       c{10:^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:XX}                                                |
       aaaaaaa                                           |
@@ -1995,10 +1933,8 @@ bbbbbbb]])
       bbbbbbb                                           |
       {1:~                                                 }|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- INSERT --}                                      |
-      ]]}
+    ]]}
   end)
 
   it('regexp \\%V does not count trailing virtual text', function()
@@ -2028,97 +1964,53 @@ bbbbbbb]])
     feed('<TAB>')
     feed('test')
     feed('<ESC>')
-    meths.buf_set_extmark(0, ns, 0, 1,
-            { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 1, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('0')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
              ^ {10:virtual text}    test                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('l')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
               {10:virtual text}   ^ test                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('l')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
               {10:virtual text}    ^test                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('l')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
               {10:virtual text}    t^est                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('l')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
               {10:virtual text}    te^st                      |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('cursor position is correct with virtual text on an empty line', function()
     command('set linebreak')
     insert('one twoword')
     feed('0')
-    meths.buf_set_extmark(0, ns, 0, 3,
-            { virt_text = { { ': virtual text', 'Special' } }, virt_text_pos = 'inline' })
-    screen:expect { grid = [[
+    meths.buf_set_extmark(0, ns, 0, 3, { virt_text = { { ': virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    screen:expect{grid=[[
       ^one{10:: virtual text} twoword                         |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('search highlight is correct', function()
@@ -2128,47 +2020,26 @@ bbbbbbb]])
     meths.buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       ^foo foo f{10:AAABBB}oo bar                             |
       foo foo f{10:CCCDDD}oo bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('/foo')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {12:foo} {13:foo} {12:f}{10:AAA}{19:BBB}{12:oo} bar                             |
       {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       /foo^                                              |
-      ]]}
+    ]]}
 
     meths.buf_set_extmark(0, ns, 0, 13, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     feed('<C-G>')
-    screen:expect{ grid = [[
+    screen:expect{grid=[[
       {12:foo} {12:foo} {13:f}{10:AAA}{21:BBB}{13:oo} b{10:EEE}ar                          |
       {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       /foo^                                              |
-      ]]}
+    ]]}
   end)
 
   it('Visual select highlight is correct', function()
@@ -2179,47 +2050,26 @@ bbbbbbb]])
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     meths.buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     feed('8l')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       foo foo {10:AAABBB}^foo bar                             |
       foo foo {10:CCCDDD}foo bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
 
     feed('<C-V>')
     feed('2hj')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       foo fo{7:o }{10:AAA}{20:BBB}{7:f}oo bar                             |
       foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- VISUAL BLOCK --}                                |
-      ]]}
+    ]]}
 
     meths.buf_set_extmark(0, ns, 0, 10, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       foo fo{7:o }{10:AAA}{20:BBB}{7:f}o{10:EEE}o bar                          |
       foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- VISUAL BLOCK --}                                |
-      ]]}
+    ]]}
   end)
 
   it('inside highlight range of another extmark', function()
@@ -2233,13 +2083,6 @@ bbbbbbb]])
     screen:expect{grid=[[
       foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
       foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
     ]]}
   end)
@@ -2254,22 +2097,13 @@ bbbbbbb]])
     screen:expect{grid=[[
       foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
       foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
     ]]}
   end)
 
   it('cursor position is correct when inserting around a virtual text with left gravity', function()
-    screen:try_resize(50, 3)
     insert('foo foo foo foo')
-    meths.buf_set_extmark(0, ns, 0, 8,
-      { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline', right_gravity = false })
+    meths.buf_set_extmark(0, ns, 0, 8, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline', right_gravity = false })
     feed('0')
     feed('8l')
     screen:expect{grid=[[
@@ -2329,161 +2163,131 @@ bbbbbbb]])
   end)
 
   it('cursor position is correct when inserting around virtual texts with both left and right gravity', function()
-    screen:try_resize(50, 3)
+    screen:try_resize(30, 4)
+    command('setlocal showbreak=+ breakindent breakindentopt=shift:2')
     insert('foo foo foo foo')
-    meths.buf_set_extmark(0, ns, 0, 8, { virt_text = {{ '>>', 'Special' }}, virt_text_pos = 'inline', right_gravity = false })
-    meths.buf_set_extmark(0, ns, 0, 8, { virt_text = {{ '<<', 'Special' }}, virt_text_pos = 'inline', right_gravity = true })
+    meths.buf_set_extmark(0, ns, 0, 8, { virt_text = {{ ('>'):rep(32), 'Special' }}, virt_text_pos = 'inline', right_gravity = false })
+    meths.buf_set_extmark(0, ns, 0, 8, { virt_text = {{ ('<'):rep(32), 'Special' }}, virt_text_pos = 'inline', right_gravity = true })
+
     feed('08l')
     screen:expect{grid=[[
-      foo foo {10:>><<}^foo foo                               |
-      {1:~                                                 }|
-                                                        |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>><<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<}^foo foo     |
+                                    |
     ]]}
-
     feed('i')
     screen:expect{grid=[[
-      foo foo {10:>>^<<}foo foo                               |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>>^<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<}foo foo     |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed('a')
     screen:expect{grid=[[
-      foo foo {10:>>}a{10:^<<}foo foo                              |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>>}a{10:^<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<<}foo foo    |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed([[<C-\><C-O>]])
     screen:expect{grid=[[
-      foo foo {10:>>}a{10:<<}^foo foo                              |
-      {1:~                                                 }|
-      {8:-- (insert) --}                                    |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>>}a{10:<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<<}^foo foo    |
+      {8:-- (insert) --}                |
     ]]}
-
     feed('D')
     screen:expect{grid=[[
-      foo foo {10:>>}a{10:^<<}                                     |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>>}a{10:^<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<<}           |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed('<BS>')
     screen:expect{grid=[[
-      foo foo {10:>>^<<}                                      |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      foo foo {10:>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>>>>>>>>>^<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<<<<<<<<}            |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed('<C-U>')
     screen:expect{grid=[[
-      {10:>>^<<}                                              |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>^<<<<<<<<<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<}                    |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed('a')
     screen:expect{grid=[[
-      {10:>>}a{10:^<<}                                             |
-      {1:~                                                 }|
-      {8:-- INSERT --}                                      |
+      {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>}a{10:^<<<<<<<<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<}                   |
+      {8:-- INSERT --}                  |
     ]]}
-
     feed('<Esc>')
     screen:expect{grid=[[
-      {10:>>}^a{10:<<}                                             |
-      {1:~                                                 }|
-                                                        |
+      {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>>}^a{10:<<<<<<<<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<<}                   |
+                                    |
     ]]}
-
     feed('x')
     screen:expect{grid=[[
-      {10:^>><<}                                              |
-      {1:~                                                 }|
-                                                        |
+      {10:^>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
+        {1:+}{10:>><<<<<<<<<<<<<<<<<<<<<<<<<}|
+        {1:+}{10:<<<<<<<}                    |
+                                    |
     ]]}
   end)
 
   it('draws correctly with no wrap multiple virtual text, where one is hidden', function()
     insert('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz')
     command("set nowrap")
-    meths.buf_set_extmark(0, ns, 0, 50,
-      { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
-    meths.buf_set_extmark(0, ns, 0, 2,
-      { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 50, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       opqrstuvwxyzabcdefghijklmnopqrstuvwx{10:virtual text}y^z|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('draws correctly with no wrap and a long virtual text', function()
     insert('abcdefghi')
     command("set nowrap")
-    meths.buf_set_extmark(0, ns, 0, 2,
-      { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 2, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}cdefgh^i|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('tabs are the correct length with no wrap following virtual text', function()
     command('set nowrap')
     feed('itest<TAB>a<ESC>')
-    meths.buf_set_extmark(0, ns, 0, 0,
-      { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('gg$')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:aaaaaaaaaaaaaaaaaaaaaaaaa}test     ^a               |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
-  it('highlighting does not extend when no wrap is enabled with a long virtual text', function()
+  it('highlighting does not extend with no wrap and a long virtual text', function()
     insert('abcdef')
     command("set nowrap")
-    meths.buf_set_extmark(0, ns, 0, 3,
-      { virt_text = { { string.rep('X', 50), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 3, { virt_text = { { string.rep('X', 50), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}de^f|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('hidden virtual text does not interfere with Visual highlight', function()
@@ -2494,25 +2298,11 @@ bbbbbbb]])
     screen:expect{grid=[[
       {10:X}{7:abcde}^f                                           |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
     ]]}
     feed('zl')
     screen:expect{grid=[[
       {7:abcde}^f                                            |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
     ]]}
@@ -2520,105 +2310,64 @@ bbbbbbb]])
     screen:expect{grid=[[
       {7:bcde}^f                                             |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
     ]]}
   end)
 
   it('highlighting is correct when virtual text wraps with number', function()
+    screen:try_resize(50, 5)
     insert([[
     test
     test]])
     command('set number')
-    meths.buf_set_extmark(0, ns, 0, 1,
-      { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 1, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('gg0')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {2:  1 }^t{10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {2:    }{10:XXXXXXXXXX}est                                 |
       {2:  2 }test                                          |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('highlighting is correct when virtual text is proceeded with a match', function()
     insert([[test]])
-    meths.buf_set_extmark(0, ns, 0, 2,
-      { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('gg0')
     command('match ErrorMsg /e/')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       ^t{4:e}{10:virtual text}st                                  |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
     command('match ErrorMsg /s/')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       ^te{10:virtual text}{4:s}t                                  |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('smoothscroll works correctly when virtual text wraps', function()
     insert('foobar')
-    meths.buf_set_extmark(0, ns, 0, 3,
-      { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 3, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     command('setlocal smoothscroll')
     screen:expect{grid=[[
       foo{10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:XXXXXXXX}ba^r                                       |
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
     ]]}
     feed('<C-E>')
     screen:expect{grid=[[
       {1:<<<}{10:XXXXX}ba^r                                       |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
     ]]}
   end)
 
   it('in diff mode is highlighted correct', function()
+    screen:try_resize(50, 10)
     insert([[
     9000
     0009
@@ -2642,7 +2391,7 @@ bbbbbbb]])
     insert('aaabbb')
     command("set diff")
     feed('gg0')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {9:^000                      }│{5:9}{14:test}{9:000                }|
       {9:000                      }│{9:000}{5:9}{9:                    }|
       {9:000                      }│{9:000}{5:9}{9:                    }|
@@ -2653,10 +2402,10 @@ bbbbbbb]])
       {1:~                        }│{1:~                       }|
       {15:[No Name] [+]             }{13:[No Name] [+]           }|
                                                         |
-      ]]}
+    ]]}
     command('wincmd w | set nowrap')
     feed('zl')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {9:000                      }│{14:test}{9:000                 }|
       {9:000                      }│{9:00}{5:9}{9:                     }|
       {9:000                      }│{9:00}{5:9}{9:                     }|
@@ -2667,56 +2416,32 @@ bbbbbbb]])
       {1:~                        }│{1:~                       }|
       {13:[No Name] [+]             }{15:[No Name] [+]           }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('correctly draws when there are multiple overlapping virtual texts on the same line with nowrap', function()
     command('set nowrap')
     insert('a')
-    meths.buf_set_extmark(0, ns, 0, 0,
-      { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
-    meths.buf_set_extmark(0, ns, 0, 0,
-      { virt_text = { { string.rep('b', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('b', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       {10:bbbbbbbbbbbbbbbbbbbbbbbbb}^a                        |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('correctly draws when overflowing virtual text is followed by TAB with no wrap', function()
     command('set nowrap')
     feed('i<TAB>test<ESC>')
-    meths.buf_set_extmark(
-      0,
-      ns,
-      0,
-      0,
-      { virt_text = { { string.rep('a', 60), 'Special' } }, virt_text_pos = 'inline' }
-    )
+    meths.buf_set_extmark( 0, ns, 0, 0, { virt_text = { { string.rep('a', 60), 'Special' } }, virt_text_pos = 'inline' })
     feed('0')
-    screen:expect({
-      grid = [[
+    screen:expect({grid=[[
       {10:aaaaaaaaaaaaaaaaaaaaaa}   ^ test                    |
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]],
-    })
+    ]]})
   end)
 
   it('does not crash at column 0 when folded in a wide window', function()
@@ -2811,37 +2536,21 @@ bbbbbbb]])
     command('set nowrap')
     command('set list')
     command('set listchars+=extends:c')
-    meths.buf_set_extmark(0, ns, 0, 0,
-      { virt_text = { { 'test', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'test', 'Special' } }, virt_text_pos = 'inline' })
     insert(string.rep('a', 50))
     feed('gg0')
-    screen:expect { grid = [[
+    screen:expect{grid=[[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:c}|
       {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
-      {1:~                                                 }|
                                                         |
-      ]]}
+    ]]}
   end)
 
   it('blockwise Visual highlight with double-width virtual text (replace)', function()
     screen:try_resize(60, 6)
     insert('123456789\n123456789\n123456789\n123456789')
-    meths.buf_set_extmark(0, ns, 1, 1, {
-      virt_text = { { '-口-', 'Special' } },
-      virt_text_pos = 'inline',
-      hl_mode = 'replace',
-    })
-    meths.buf_set_extmark(0, ns, 2, 2, {
-      virt_text = { { '口', 'Special' } },
-      virt_text_pos = 'inline',
-      hl_mode = 'replace',
-    })
+    meths.buf_set_extmark(0, ns, 1, 1, { virt_text = { { '-口-', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
+    meths.buf_set_extmark(0, ns, 2, 2, { virt_text = { { '口', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     feed('gg0')
     screen:expect{grid=[[
       ^123456789                                                   |
@@ -2910,16 +2619,8 @@ bbbbbbb]])
   it('blockwise Visual highlight with double-width virtual text (combine)', function()
     screen:try_resize(60, 6)
     insert('123456789\n123456789\n123456789\n123456789')
-    meths.buf_set_extmark(0, ns, 1, 1, {
-      virt_text = { { '-口-', 'Special' } },
-      virt_text_pos = 'inline',
-      hl_mode = 'combine',
-    })
-    meths.buf_set_extmark(0, ns, 2, 2, {
-      virt_text = { { '口', 'Special' } },
-      virt_text_pos = 'inline',
-      hl_mode = 'combine',
-    })
+    meths.buf_set_extmark(0, ns, 1, 1, { virt_text = { { '-口-', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
+    meths.buf_set_extmark(0, ns, 2, 2, { virt_text = { { '口', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     feed('gg0')
     screen:expect{grid=[[
       ^123456789                                                   |

--- a/test/old/testdir/test_listlbr_utf8.vim
+++ b/test/old/testdir/test_listlbr_utf8.vim
@@ -249,7 +249,6 @@ endfunc
 
 func Test_chinese_char_on_wrap_column()
   call s:test_windows("setl nolbr wrap sbr=")
-  syntax off
   call setline(1, [
 \ 'aaaaaaaaaaaaaaaaaaa中'.
 \ 'aaaaaaaaaaaaaaaaa中'.
@@ -278,5 +277,85 @@ func Test_chinese_char_on_wrap_column()
 \ '中hello             ']
   let lines = s:screen_lines([1, 10], winwidth(0))
   call s:compare_lines(expect, lines)
+  call assert_equal(len(expect), winline())
+  call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
   call s:close_windows()
-endfu
+endfunc
+
+func Test_chinese_char_on_wrap_column_sbr()
+  call s:test_windows("setl nolbr wrap sbr=!!!")
+  call setline(1, [
+\ 'aaaaaaaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'aaaaaaaaaaaaaa中'.
+\ 'hello'])
+  call cursor(1,1)
+  norm! $
+  redraw!
+  let expect=[
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中aaaaaaaaaaaaaa>',
+\ '!!!中hello          ']
+  let lines = s:screen_lines([1, 10], winwidth(0))
+  call s:compare_lines(expect, lines)
+  call assert_equal(len(expect), winline())
+  call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
+  call s:close_windows()
+endfunc
+
+func Test_unprintable_char_on_wrap_column()
+  call s:test_windows("setl nolbr wrap sbr=")
+  call setline(1, 'aaa' .. repeat("\uFEFF", 50) .. 'bbb')
+  call cursor(1,1)
+  norm! $
+  redraw!
+  let expect=[
+\ '<<<<feff><feff><feff',
+\ '><feff><feff><feff><',
+\ 'feff><feff><feff><fe',
+\ 'ff><feff><feff><feff',
+\ '><feff><feff><feff><',
+\ 'feff><feff><feff><fe',
+\ 'ff><feff><feff><feff',
+\ '><feff><feff><feff><',
+\ 'feff><feff><feff><fe',
+\ 'ff>bbb              ']
+  let lines = s:screen_lines([1, 10], winwidth(0))
+  call s:compare_lines(expect, lines)
+  call assert_equal(len(expect), winline())
+  call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
+  setl sbr=!!
+  redraw!
+  let expect=[
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff><feff',
+\ '!!><feff><feff>bbb  ']
+  let lines = s:screen_lines([1, 10], winwidth(0))
+  call s:compare_lines(expect, lines)
+  call assert_equal(len(expect), winline())
+  call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
+  call s:close_windows()
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1783: Display issues with virt text smoothscroll and showbreak

Problem:  Wrong display with wrapping virtual text or unprintable chars,
          'showbreak' and 'smoothscroll'.
Solution: Don't skip cells taken by 'showbreak' in screen lines before
          "w_skipcol". Combined "n_skip" and "skip_cells".

closes: vim/vim#12597

https://github.com/vim/vim/commit/b557f4898208105b674df605403cac1b1292707b