### PR TITLE
refactor(types): replace `|nil` with `?` for LSP runtime

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -469,7 +469,7 @@ fromqflist({list})                               *vim.diagnostic.fromqflist()*
     Convert a list of quickfix items to a list of diagnostics.
 
     Parameters: ~
-      • {list}  table[] List of quickfix items from |getqflist()| or
+      • {list}  (table[]) List of quickfix items from |getqflist()| or
                 |getloclist()|.
 
     Return: ~
@@ -766,6 +766,6 @@ toqflist({diagnostics})                            *vim.diagnostic.toqflist()*
       • {diagnostics}  (table) List of diagnostics |diagnostic-structure|.
 
     Return: ~
-        table[] of quickfix list items |setqflist-what|
+        (table[]) of quickfix list items |setqflist-what|
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -669,7 +669,7 @@ buf_notify({bufnr}, {method}, {params})                 *vim.lsp.buf_notify()*
     Send a notification to a server
 
     Parameters: ~
-      • {bufnr}   (integer|nil) The number of the buffer
+      • {bufnr}   (integer?) The number of the buffer
       • {method}  (string) Name of the request method
       • {params}  (any) Arguments to send to the server
 
@@ -684,7 +684,7 @@ buf_request_all({bufnr}, {method}, {params}, {handler})
     Parameters: ~
       • {bufnr}    (integer) Buffer handle, or 0 for current.
       • {method}   (string) LSP method name
-      • {params}   (table|nil) Parameters to send to the server
+      • {params}   (table?) Parameters to send to the server
       • {handler}  (function) Handler called after all requests are completed.
                    Server results are passed as a `client_id:result` map.
 
@@ -702,13 +702,14 @@ buf_request_sync({bufnr}, {method}, {params}, {timeout_ms})
     Parameters: ~
       • {bufnr}       (integer) Buffer handle, or 0 for current.
       • {method}      (string) LSP method name
-      • {params}      (table|nil) Parameters to send to the server
-      • {timeout_ms}  (integer|nil) Maximum time in milliseconds to wait for a
+      • {params}      (table?) Parameters to send to the server
+      • {timeout_ms}  (integer?) Maximum time in milliseconds to wait for a
                       result. Defaults to 1000
 
     Return (multiple): ~
-        (table) result Map of client_id:request_result.
-        (string|nil) err On timeout, cancel, or error, `err` is a string
+        table<integer, {err: lsp.ResponseError, result: any}>? result Map of
+        client_id:request_result.
+        (string?) err On timeout, cancel, or error, `err` is a string
         describing the failure reason, and `result` is nil.
 
 client()                                                      *vim.lsp.client*
@@ -822,7 +823,7 @@ get_buffers_by_client_id({client_id})
       • {client_id}  (integer) client id
 
     Return: ~
-        integer[] buffers list of buffer ids
+        (integer[]) buffers list of buffer ids
 
 get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
     Gets a client by id, or nil if the id is invalid. The returned client may
@@ -838,7 +839,7 @@ get_clients({filter})                                  *vim.lsp.get_clients()*
     Get active clients.
 
     Parameters: ~
-      • {filter}  (table|nil) A table with key-value pairs used to filter the
+      • {filter}  (table?) A table with key-value pairs used to filter the
                   returned clients. The available keys are:
                   • id (number): Only return clients with the given id
                   • bufnr (number): Only return clients attached to this
@@ -861,7 +862,7 @@ inlay_hint({bufnr}, {enable})                           *vim.lsp.inlay_hint()*
 
     Parameters: ~
       • {bufnr}   (integer) Buffer handle, or 0 for current
-      • {enable}  (boolean|nil) true/false to enable/disable, nil to toggle
+      • {enable}  (boolean?) true/false to enable/disable, nil to toggle
 
 omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
     Implements 'omnifunc' compatible LSP completion.
@@ -946,7 +947,7 @@ start({config}, {opts})                                      *vim.lsp.start()*
                     re-using a client (0 for current).
 
     Return: ~
-        (integer|nil) client_id
+        (integer?) client_id
 
 start_client({config})                                *vim.lsp.start_client()*
     Starts and initializes a client with the given configuration.
@@ -1063,7 +1064,7 @@ start_client({config})                                *vim.lsp.start_client()*
                     initialization.
 
     Return: ~
-        (integer|nil) client_id. |vim.lsp.get_client_by_id()| Note: client may
+        (integer?) client_id. |vim.lsp.get_client_by_id()| Note: client may
         not be fully initialized. Use `on_init` to do any actions once the
         client has been initialized.
 
@@ -1088,7 +1089,7 @@ stop_client({client_id}, {force})                      *vim.lsp.stop_client()*
     Parameters: ~
       • {client_id}  integer|table id or |vim.lsp.client| object, or list
                      thereof
-      • {force}      (boolean|nil) shutdown forcefully
+      • {force}      (boolean?) shutdown forcefully
 
 tagfunc({pattern}, {flags})                                *vim.lsp.tagfunc()*
     Provides an interface between the built-in client and 'tagfunc'.
@@ -1103,7 +1104,7 @@ tagfunc({pattern}, {flags})                                *vim.lsp.tagfunc()*
       • {flags}    (string) See |tag-function|
 
     Return: ~
-        table[] tags A list of matching tags
+        (table[]) tags A list of matching tags
 
 with({handler}, {override_config})                            *vim.lsp.with()*
     Function to manage overriding defaults for LSP handlers.
@@ -1129,23 +1130,23 @@ code_action({options})                             *vim.lsp.buf.code_action()*
     Selects a code action available at the current cursor position.
 
     Parameters: ~
-      • {options}  (table|nil) Optional table which holds the following
-                   optional fields:
-                   • context: (table|nil) Corresponds to `CodeActionContext` of the LSP specification:
-                     • diagnostics (table|nil): LSP `Diagnostic[]`. Inferred
-                       from the current position if not provided.
-                     • only (table|nil): List of LSP `CodeActionKind`s used to
+      • {options}  (table?) Optional table which holds the following optional
+                   fields:
+                   • context?: (table) Corresponds to `CodeActionContext` of the LSP specification:
+                     • diagnostics? (table): LSP `Diagnostic[]`. Inferred from
+                       the current position if not provided.
+                     • only? (table): List of LSP `CodeActionKind`s used to
                        filter the code actions. Most language servers support
                        values like `refactor` or `quickfix`.
-                     • triggerKind (number|nil): The reason why code actions
-                       were requested.
+                     • triggerKind? (number): The reason why code actions were
+                       requested.
 
-                   • filter: (function|nil) Predicate taking an `CodeAction`
-                     and returning a boolean.
-                   • apply: (boolean|nil) When set to `true`, and there is
-                     just one remaining action (after filtering), the action
-                     is applied without user query.
-                   • range: (table|nil) Range for which code actions should be
+                   • filter?: (function) Predicate taking an `CodeAction` and
+                     returning a boolean.
+                   • apply?: (boolean) When set to `true`, and there is just
+                     one remaining action (after filtering), the action is
+                     applied without user query.
+                   • range?: (table) Range for which code actions should be
                      requested. If in visual mode this defaults to the active
                      selection. Table must contain `start` and `end` keys with
                      {row,col} tuples using mark-like indexing. See
@@ -1176,7 +1177,7 @@ declaration({options})                             *vim.lsp.buf.declaration()*
         |vim.lsp.buf.definition()| instead.
 
     Parameters: ~
-      • {options}  (table|nil) additional options
+      • {options}  (table?) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1186,7 +1187,7 @@ definition({options})                               *vim.lsp.buf.definition()*
     Jumps to the definition of the symbol under the cursor.
 
     Parameters: ~
-      • {options}  (table|nil) additional options
+      • {options}  (table?) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1210,7 +1211,7 @@ document_symbol({options})                     *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the quickfix window.
 
     Parameters: ~
-      • {options}  (table|nil) additional options
+      • {options}  (table?) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1228,18 +1229,17 @@ format({options})                                       *vim.lsp.buf.format()*
     server clients.
 
     Parameters: ~
-      • {options}  (table|nil) Optional table which holds the following
-                   optional fields:
-                   • formatting_options (table|nil): Can be used to specify
+      • {options}  (table?) Optional table which holds the following optional
+                   fields:
+                   • formatting_options? (table): Can be used to specify
                      FormattingOptions. Some unspecified options will be
                      automatically derived from the current Nvim options. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
-                   • timeout_ms (integer|nil, default 1000): Time in
-                     milliseconds to block for formatting requests. No effect
-                     if async=true
-                   • bufnr (number|nil): Restrict formatting to the clients
+                   • timeout_ms? (integer, default 1000): Time in milliseconds
+                     to block for formatting requests. No effect if async=true
+                   • bufnr? (number): Restrict formatting to the clients
                      attached to the given buffer, defaults to the current
                      buffer (0).
-                   • filter (function|nil): Predicate used to filter clients.
+                   • filter? (function): Predicate used to filter clients.
                      Receives a client as argument and must return a boolean.
                      Clients matching the predicate are included. Example: >lua
 
@@ -1248,14 +1248,14 @@ format({options})                                       *vim.lsp.buf.format()*
                            filter = function(client) return client.name ~= "tsserver" end
                          }
 <
-                   • async boolean|nil If true the method won't block.
-                     Defaults to false. Editing the buffer while formatting
+                   • async? (boolean) If true the method won't block. Defaults
+                     to false. Editing the buffer while formatting
                      asynchronous can lead to unexpected changes.
-                   • id (number|nil): Restrict formatting to the client with
-                     ID (client.id) matching this field.
-                   • name (string|nil): Restrict formatting to the client with
+                   • id? (number): Restrict formatting to the client with ID
+                     (client.id) matching this field.
+                   • name? (string): Restrict formatting to the client with
                      name (client.name) matching this field.
-                   • range (table|nil) Range to format. Table must contain
+                   • range? (table) Range to format. Table must contain
                      `start` and `end` keys with {row,col} tuples using (1,0)
                      indexing. Defaults to current selection in visual mode
                      Defaults to `nil` in other modes, formatting the full
@@ -1270,7 +1270,7 @@ implementation({options})                       *vim.lsp.buf.implementation()*
     quickfix window.
 
     Parameters: ~
-      • {options}  (table|nil) additional options
+      • {options}  (table?) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1292,8 +1292,8 @@ references({context}, {options})                    *vim.lsp.buf.references()*
     window.
 
     Parameters: ~
-      • {context}  (table|nil) Context for the request
-      • {options}  (table|nil) additional options
+      • {context}  (table?) Context for the request
+      • {options}  (table?) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1309,14 +1309,14 @@ rename({new_name}, {options})                           *vim.lsp.buf.rename()*
     Renames all references to the symbol under the cursor.
 
     Parameters: ~
-      • {new_name}  (string|nil) If not provided, the user will be prompted
-                    for a new name using |vim.ui.input()|.
-      • {options}   (table|nil) additional options
-                    • filter (function|nil): Predicate used to filter clients.
+      • {new_name}  (string?) If not provided, the user will be prompted for a
+                    new name using |vim.ui.input()|.
+      • {options}   (table?) additional options
+                    • filter? (function): Predicate used to filter clients.
                       Receives a client as argument and must return a boolean.
                       Clients matching the predicate are included.
-                    • name (string|nil): Restrict clients used for rename to
-                      ones where client.name matches this field.
+                    • name? (string): Restrict clients used for rename to ones
+                      where client.name matches this field.
 
 signature_help()                                *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
@@ -1326,7 +1326,7 @@ type_definition({options})                     *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.
 
     Parameters: ~
-      • {options}  (table|nil) additional options
+      • {options}  (table?) additional options
                    • reuse_win: (boolean) Jump to existing window if buffer is
                      already open.
                    • on_list: (function) handler for list results. See
@@ -1340,8 +1340,8 @@ workspace_symbol({query}, {options})          *vim.lsp.buf.workspace_symbol()*
     string means no filtering is done.
 
     Parameters: ~
-      • {query}    (string|nil) optional
-      • {options}  (table|nil) additional options
+      • {query}    (string?) optional
+      • {options}  (table?) additional options
                    • on_list: (function) handler for list results. See
                      |lsp-on-list-handler|
 
@@ -1423,8 +1423,8 @@ clear({client_id}, {bufnr})                         *vim.lsp.codelens.clear()*
     Clear the lenses
 
     Parameters: ~
-      • {client_id}  (integer|nil) filter by client_id. All clients if nil
-      • {bufnr}      (integer|nil) filter by buffer. All buffers if nil
+      • {client_id}  (integer?) filter by client_id. All clients if nil
+      • {bufnr}      (integer?) filter by buffer. All buffers if nil
 
 display({lenses}, {bufnr}, {client_id})           *vim.lsp.codelens.display()*
     Display the lenses using virtual text
@@ -1479,7 +1479,7 @@ force_refresh({bufnr})               *vim.lsp.semantic_tokens.force_refresh()*
     highlighting (|vim.lsp.semantic_tokens.start()| has been called for it)
 
     Parameters: ~
-      • {bufnr}  (integer|nil) filter by buffer. All buffers if nil, current
+      • {bufnr}  (integer?) filter by buffer. All buffers if nil, current
                  buffer if 0
 
                                         *vim.lsp.semantic_tokens.get_at_pos()*
@@ -1488,12 +1488,12 @@ get_at_pos({bufnr}, {row}, {col})
     arguments, returns the token under the cursor.
 
     Parameters: ~
-      • {bufnr}  (integer|nil) Buffer number (0 for current buffer, default)
-      • {row}    (integer|nil) Position row (default cursor position)
-      • {col}    (integer|nil) Position column (default cursor position)
+      • {bufnr}  (integer?) Buffer number (0 for current buffer, default)
+      • {row}    (integer?) Position row (default cursor position)
+      • {col}    (integer?) Position column (default cursor position)
 
     Return: ~
-        (table|nil) List of tokens at position. Each token has the following
+        (table?) List of tokens at position. Each token has the following
         fields:
         • line (integer) line number, 0-based
         • start_col (integer) start column, 0-based
@@ -1517,10 +1517,10 @@ highlight_token({token}, {bufnr}, {client_id}, {hl_group}, {opts})
       • {bufnr}      (integer) the buffer to highlight
       • {client_id}  (integer) The ID of the |vim.lsp.client|
       • {hl_group}   (string) Highlight group name
-      • {opts}       (table|nil) Optional parameters.
-                     • priority: (integer|nil) Priority for the applied
-                       extmark. Defaults to
-                       `vim.highlight.priorities.semantic_tokens + 3`
+      • {opts}       (table?) Optional parameters.
+                     • priority?: (integer) Priority for the applied extmark.
+                       Defaults to `vim.highlight.priorities.semantic_tokens +
+                       3`
 
 start({bufnr}, {client_id}, {opts})          *vim.lsp.semantic_tokens.start()*
     Start the semantic token highlighting engine for the given buffer with the
@@ -1641,7 +1641,7 @@ buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
     Removes document highlights from a buffer.
 
     Parameters: ~
-      • {bufnr}  (integer|nil) Buffer id
+      • {bufnr}  (integer?) Buffer id
 
                                      *vim.lsp.util.buf_highlight_references()*
 buf_highlight_references({bufnr}, {references}, {offset_encoding})
@@ -1680,8 +1680,8 @@ convert_input_to_markdown_lines({input}, {contents})
 
     Parameters: ~
       • {input}     (`MarkedString` | `MarkedString[]` | `MarkupContent`)
-      • {contents}  (table|nil) List of strings to extend with converted
-                    lines. Defaults to {}.
+      • {contents}  (table?) List of strings to extend with converted lines.
+                    Defaults to {}.
 
     Return: ~
         (table) {contents} extended with lines of converted markdown.
@@ -1695,14 +1695,14 @@ convert_signature_help_to_markdown_lines({signature_help}, {ft}, {triggers})
 
     Parameters: ~
       • {signature_help}  (table) Response of `textDocument/SignatureHelp`
-      • {ft}              (string|nil) filetype that will be use as the `lang`
+      • {ft}              (string?) filetype that will be use as the `lang`
                           for the label markdown code block
-      • {triggers}        (table|nil) list of trigger characters from the lsp
+      • {triggers}        (table?) list of trigger characters from the lsp
                           server. used to better determine parameter offsets
 
     Return (multiple): ~
-        (table|nil) table list of lines of converted markdown.
-        (table|nil) table of active hl
+        (table?) table list of lines of converted markdown.
+        (table?) table of active hl
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
@@ -1724,7 +1724,7 @@ get_effective_tabstop({bufnr})          *vim.lsp.util.get_effective_tabstop()*
     Returns indentation size.
 
     Parameters: ~
-      • {bufnr}  (integer|nil) Buffer handle, defaults to current
+      • {bufnr}  (integer?) Buffer handle, defaults to current
 
     Return: ~
         (integer) indentation size
@@ -1738,8 +1738,8 @@ jump_to_location({location}, {offset_encoding}, {reuse_win})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32
-      • {reuse_win}        (boolean|nil) Jump to existing window if buffer is
+      • {offset_encoding}  (string?) utf-8|utf-16|utf-32
+      • {reuse_win}        (boolean?) Jump to existing window if buffer is
                            already open.
 
     Return: ~
@@ -1807,7 +1807,7 @@ make_formatting_params({options})
     cursor position.
 
     Parameters: ~
-      • {options}  (table|nil) with valid `FormattingOptions` entries
+      • {options}  (table?) with valid `FormattingOptions` entries
 
     Return: ~
         `DocumentFormattingParams` object
@@ -1821,13 +1821,13 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
     similar to |vim.lsp.util.make_range_params()|.
 
     Parameters: ~
-      • {start_pos}        integer[]|nil {row,col} mark-indexed position.
+      • {start_pos}        (integer[]?) {row,col} mark-indexed position.
                            Defaults to the start of the last visual selection.
-      • {end_pos}          integer[]|nil {row,col} mark-indexed position.
+      • {end_pos}          (integer[]?) {row,col} mark-indexed position.
                            Defaults to the end of the last visual selection.
-      • {bufnr}            (integer|nil) buffer handle or 0 for current,
-                           defaults to current
-      • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
+      • {bufnr}            (integer?) buffer handle or 0 for current, defaults
+                           to current
+      • {offset_encoding}  ("utf-8"|"utf-16"|"utf-32"|nil) defaults to
                            `offset_encoding` of first client of `bufnr`
 
     Return: ~
@@ -1840,9 +1840,9 @@ make_position_params({window}, {offset_encoding})
     cursor position.
 
     Parameters: ~
-      • {window}           (integer|nil) window handle or 0 for current,
-                           defaults to current
-      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32|nil defaults to
+      • {window}           (integer?) window handle or 0 for current, defaults
+                           to current
+      • {offset_encoding}  (string?) utf-8|utf-16|utf-32|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
 
@@ -1860,8 +1860,8 @@ make_range_params({window}, {offset_encoding})
     `textDocument/rangeFormatting`.
 
     Parameters: ~
-      • {window}           (integer|nil) window handle or 0 for current,
-                           defaults to current
+      • {window}           (integer?) window handle or 0 for current, defaults
+                           to current
       • {offset_encoding}  "utf-8"|"utf-16"|"utf-32"|nil defaults to
                            `offset_encoding` of first client of buffer of
                            `window`
@@ -1875,7 +1875,7 @@ make_text_document_params({bufnr})
     Creates a `TextDocumentIdentifier` object for the current buffer.
 
     Parameters: ~
-      • {bufnr}  (integer|nil) Buffer handle, defaults to current
+      • {bufnr}  (integer?) Buffer handle, defaults to current
 
     Return: ~
         (table) `TextDocumentIdentifier`
@@ -1946,8 +1946,8 @@ preview_location({location}, {opts})         *vim.lsp.util.preview_location()*
       • {location}  (table) a single `Location` or `LocationLink`
 
     Return (multiple): ~
-        (integer|nil) buffer id of float window
-        (integer|nil) window id of float window
+        (integer?) buffer id of float window
+        (integer?) window id of float window
 
 rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Rename old_fname to new_fname
@@ -1975,8 +1975,8 @@ show_document({location}, {offset_encoding}, {opts})
 
     Parameters: ~
       • {location}         (table) (`Location`|`LocationLink`)
-      • {offset_encoding}  (string|nil) utf-8|utf-16|utf-32
-      • {opts}             (table|nil) options
+      • {offset_encoding}  (string?) utf-8|utf-16|utf-32
+      • {opts}             (table?) options
                            • reuse_win (boolean) Jump to existing window if
                              buffer is already open.
                            • focus (boolean) Whether to focus/jump to location
@@ -2124,7 +2124,7 @@ notify({method}, {params})                              *vim.lsp.rpc.notify()*
 
     Parameters: ~
       • {method}  (string) The invoked LSP method
-      • {params}  (table|nil) Parameters for the invoked LSP method
+      • {params}  (table?) Parameters for the invoked LSP method
 
     Return: ~
         (boolean) `true` if notification could be sent, `false` if not
@@ -2135,15 +2135,15 @@ request({method}, {params}, {callback}, {notify_reply_callback})
 
     Parameters: ~
       • {method}                 (string) The invoked LSP method
-      • {params}                 (table|nil) Parameters for the invoked LSP
+      • {params}                 (table?) Parameters for the invoked LSP
                                  method
-      • {callback}               fun(err: lsp.ResponseError | nil, result:
-                                 any) Callback to invoke
-      • {notify_reply_callback}  (function|nil) Callback to invoke as soon as
-                                 a request is no longer pending
+      • {callback}               (fun(err: lsp.ResponseError | nil, result:
+                                 any)) Callback to invoke
+      • {notify_reply_callback}  (function?) Callback to invoke as soon as a
+                                 request is no longer pending
 
     Return: ~
-        (boolean) success, integer|nil request_id true, message_id if request
+        (boolean) success, integer? request_id true, message_id if request
         could be sent, `false` if not
 
                                             *vim.lsp.rpc.rpc_response_error()*
@@ -2153,8 +2153,8 @@ rpc_response_error({code}, {message}, {data})
     Parameters: ~
       • {code}     (integer) RPC error code defined in
                    `vim.lsp.protocol.ErrorCodes`
-      • {message}  (string|nil) arbitrary message to send to server
-      • {data}     any|nil arbitrary data to send to server
+      • {message}  (string?) arbitrary message to send to server
+      • {data}     (any?) arbitrary data to send to server
 
                                                          *vim.lsp.rpc.start()*
 start({cmd}, {cmd_args}, {dispatchers}, {extra_spawn_params})
@@ -2167,21 +2167,21 @@ start({cmd}, {cmd_args}, {dispatchers}, {extra_spawn_params})
       • {cmd}                 (string) Command to start the LSP server.
       • {cmd_args}            (table) List of additional string arguments to
                               pass to {cmd}.
-      • {dispatchers}         (table|nil) Dispatchers for LSP message types.
+      • {dispatchers}         (table?) Dispatchers for LSP message types.
                               Valid dispatcher names are:
                               • `"notification"`
                               • `"server_request"`
                               • `"on_error"`
                               • `"on_exit"`
-      • {extra_spawn_params}  (table|nil) Additional context for the LSP
-                              server process. May contain:
+      • {extra_spawn_params}  (table?) Additional context for the LSP server
+                              process. May contain:
                               • {cwd} (string) Working directory for the LSP
                                 server process
                               • {env} (table) Additional environment variables
                                 for LSP server process
 
     Return: ~
-        (table|nil) Client RPC object, with these methods:
+        (table?) Client RPC object, with these methods:
         • `notify()` |vim.lsp.rpc.notify()|
         • `request()` |vim.lsp.rpc.request()|
         • `is_closing()` returns a boolean indicating if the RPC is closing.
@@ -2214,6 +2214,6 @@ resolve_capabilities({server_capabilities})
                                server
 
     Return: ~
-        (table|nil) Normalized table of capabilities
+        (table?) Normalized table of capabilities
 
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -671,8 +671,8 @@ vim.regex:match_line({bufnr}, {line_idx}, {start}, {end_})
     Parameters: ~
       • {bufnr}     (integer)
       • {line_idx}  (integer)
-      • {start}     (integer|nil)
-      • {end_}      (integer|nil)
+      • {start}     (integer?)
+      • {end_}      (integer?)
 
 vim.regex:match_str({str})                                 *regex:match_str()*
     Match the string against the regex. If the string should match the regex
@@ -789,7 +789,7 @@ vim.json.decode({str}, {opts})                             *vim.json.decode()*
 
     Parameters: ~
       • {str}   (string) Stringified JSON data.
-      • {opts}  table<string,any>|nil Options table with keys:
+      • {opts}  table<string,any>? Options table with keys:
                 • luanil: (table) Table with keys:
                   • object: (boolean) When true, converts `null` in JSON
                     objects to Lua `nil` instead of |vim.NIL|.
@@ -797,13 +797,13 @@ vim.json.decode({str}, {opts})                             *vim.json.decode()*
                     to Lua `nil` instead of |vim.NIL|.
 
     Return: ~
-        any
+        (any)
 
 vim.json.encode({obj})                                     *vim.json.encode()*
     Encodes (or "packs") Lua object {obj} as JSON in a Lua string.
 
     Parameters: ~
-      • {obj}  any
+      • {obj}  (any)
 
     Return: ~
         (string)
@@ -919,7 +919,7 @@ vim.iconv({str}, {from}, {to}, {opts})                           *vim.iconv()*
       • {str}   (string) Text to convert
       • {from}  (number) Encoding of {str}
       • {to}    (number) Target encoding
-      • {opts}  table<string,any>|nil
+      • {opts}  table<string,any>?
 
     Return: ~
         (string|nil) Converted string if conversion succeeds, `nil` otherwise.
@@ -940,8 +940,8 @@ vim.rpcnotify({channel}, {method}, {args}, {...})            *vim.rpcnotify()*
     Parameters: ~
       • {channel}  (integer)
       • {method}   (string)
-      • {args}     any[]|nil
-      • {...}      any|nil
+      • {args}     (any[]?)
+      • {...}      (any?)
 
 vim.rpcrequest({channel}, {method}, {args}, {...})          *vim.rpcrequest()*
     Sends a request to {channel} to invoke {method} via |RPC| and blocks until
@@ -953,8 +953,8 @@ vim.rpcrequest({channel}, {method}, {args}, {...})          *vim.rpcrequest()*
     Parameters: ~
       • {channel}  (integer)
       • {method}   (string)
-      • {args}     any[]|nil
-      • {...}      any|nil
+      • {args}     (any[]?)
+      • {...}      (any?)
 
 vim.schedule({callback})                                      *vim.schedule()*
     Schedules {callback} to be invoked soon by the main event-loop. Useful to
@@ -974,7 +974,7 @@ vim.str_byteindex({str}, {index}, {use_utf16})           *vim.str_byteindex()*
     Parameters: ~
       • {str}        (string)
       • {index}      (number)
-      • {use_utf16}  any|nil
+      • {use_utf16}  (any?)
 
 vim.str_utf_end({str}, {index})                            *vim.str_utf_end()*
     Gets the distance (in bytes) from the last byte of the codepoint
@@ -1044,7 +1044,7 @@ vim.str_utfindex({str}, {index})                          *vim.str_utfindex()*
 
     Parameters: ~
       • {str}    (string)
-      • {index}  (number|nil)
+      • {index}  (number?)
 
     Return (multiple): ~
         (integer) UTF-32 index
@@ -1140,11 +1140,11 @@ vim.wait({time}, {callback}, {interval}, {fast_only})             *vim.wait()*
 
     Parameters: ~
       • {time}       (integer) Number of milliseconds to wait
-      • {callback}   fun():|nil boolean Optional callback. Waits until
+      • {callback}   (fun():boolean)? Optional callback. Waits until
                      {callback} returns true
-      • {interval}   (integer|nil) (Approximate) number of milliseconds to
-                     wait between polls
-      • {fast_only}  (boolean|nil) If true, only |api-fast| events will be
+      • {interval}   (integer?) (Approximate) number of milliseconds to wait
+                     between polls
+      • {fast_only}  (boolean?) If true, only |api-fast| events will be
                      processed. If called from while in an |api-fast| event,
                      will automatically be set to `true`.
 
@@ -1638,7 +1638,7 @@ vim.on_key({fn}, {ns_id})                                       *vim.on_key()*
       • {fn}     fun(key: string) Function invoked on every key press.
                  |i_CTRL-V| Returning nil removes the callback associated with
                  namespace {ns_id}.
-      • {ns_id}  integer? Namespace ID. If nil or 0, generates and returns a
+      • {ns_id}  (integer?) Namespace ID. If nil or 0, generates and returns a
                  new |nvim_create_namespace()| id.
 
     Return: ~
@@ -1684,7 +1684,7 @@ vim.print({...})                                                 *vim.print()*
 <
 
     Return: ~
-        any given arguments.
+        (any) given arguments.
 
     See also: ~
       • |vim.inspect()|
@@ -1812,12 +1812,12 @@ vim.inspect_pos({bufnr}, {row}, {col}, {filter})           *vim.inspect_pos()*
     Can also be pretty-printed with `:Inspect!`.                   *:Inspect!*
 
     Parameters: ~
-      • {bufnr}   (integer|nil) defaults to the current buffer
-      • {row}     (integer|nil) row to inspect, 0-based. Defaults to the row
-                  of the current cursor
-      • {col}     (integer|nil) col to inspect, 0-based. Defaults to the col
-                  of the current cursor
-      • {filter}  (table|nil) a table with key-value pairs to filter the items
+      • {bufnr}   (integer?) defaults to the current buffer
+      • {row}     (integer?) row to inspect, 0-based. Defaults to the row of
+                  the current cursor
+      • {col}     (integer?) col to inspect, 0-based. Defaults to the col of
+                  the current cursor
+      • {filter}  (table?) a table with key-value pairs to filter the items
                   • syntax (boolean): include syntax based highlight groups
                     (defaults to true)
                   • treesitter (boolean): include treesitter based highlight
@@ -1829,6 +1829,7 @@ vim.inspect_pos({bufnr}, {row}, {col}, {filter})           *vim.inspect_pos()*
                     (defaults to true)
 
     Return: ~
+        {treesitter:table,syntax:table,extmarks:table,semantic_tokens:table,buffer:integer,col:integer,row:integer}
         (table) a table with the following key-value pairs. Items are in
         "traversal order":
         • treesitter: a list of treesitter captures
@@ -1845,12 +1846,12 @@ vim.show_pos({bufnr}, {row}, {col}, {filter})                 *vim.show_pos()*
     Can also be shown with `:Inspect`.                              *:Inspect*
 
     Parameters: ~
-      • {bufnr}   (integer|nil) defaults to the current buffer
-      • {row}     (integer|nil) row to inspect, 0-based. Defaults to the row
-                  of the current cursor
-      • {col}     (integer|nil) col to inspect, 0-based. Defaults to the col
-                  of the current cursor
-      • {filter}  (table|nil) see |vim.inspect_pos()|
+      • {bufnr}   (integer?) defaults to the current buffer
+      • {row}     (integer?) row to inspect, 0-based. Defaults to the row of
+                  the current cursor
+      • {col}     (integer?) col to inspect, 0-based. Defaults to the col of
+                  the current cursor
+      • {filter}  (table?) see |vim.inspect_pos()|
 
 
 
@@ -1861,8 +1862,8 @@ vim.deep_equal({a}, {b})                                    *vim.deep_equal()*
     Tables are compared recursively unless they both provide the `eq` metamethod. All other types are compared using the equality `==` operator.
 
     Parameters: ~
-      • {a}  any First value
-      • {b}  any Second value
+      • {a}  (any) First value
+      • {b}  (any) Second value
 
     Return: ~
         (boolean) `true` if values are equals, else `false`
@@ -1936,7 +1937,7 @@ vim.gsplit({s}, {sep}, {opts})                                  *vim.gsplit()*
                   of the sequence.
 
     Return: ~
-        (function) Iterator over the split components
+        fun():string|nil (function) Iterator over the split components
 
     See also: ~
       • |string.gmatch()|
@@ -1949,7 +1950,7 @@ vim.is_callable({f})                                       *vim.is_callable()*
     Returns true if object `f` can be called as a function.
 
     Parameters: ~
-      • {f}  any Any object
+      • {f}  (any) Any object
 
     Return: ~
         (boolean) `true` if `f` is callable, else `false`
@@ -1959,7 +1960,7 @@ vim.list_contains({t}, {value})                          *vim.list_contains()*
 
     Parameters: ~
       • {t}      (table) Table to check (must be list-like, not validated)
-      • {value}  any Value to compare
+      • {value}  (any) Value to compare
 
     Return: ~
         (boolean) `true` if `t` contains `value`
@@ -1994,7 +1995,7 @@ vim.list_slice({list}, {start}, {finish})                   *vim.list_slice()*
       • {finish}  (integer|nil) End range of slice
 
     Return: ~
-        (list) Copy of table sliced from start to finish (inclusive)
+        (any[]) (list) Copy of table sliced from start to finish (inclusive)
 
 vim.pesc({s})                                                     *vim.pesc()*
     Escapes magic chars in |lua-patterns|.
@@ -2037,7 +2038,7 @@ vim.ringbuf({size})                                            *vim.ringbuf()*
       • {size}  (integer)
 
     Return: ~
-        (table)
+        vim.Ringbuf ringbuf (table)
 
 vim.Ringbuf:clear()                                          *Ringbuf:clear()*
     Clear all items.
@@ -2046,19 +2047,19 @@ vim.Ringbuf:peek()                                            *Ringbuf:peek()*
     Returns the first unread item without removing it
 
     Return: ~
-        any?|nil
+        (any?)
 
 vim.Ringbuf:pop()                                              *Ringbuf:pop()*
     Removes and returns the first unread item
 
     Return: ~
-        any?|nil
+        (any?)
 
 vim.Ringbuf:push({item})                                      *Ringbuf:push()*
     Adds an item, overriding the oldest item if the buffer is full.
 
     Parameters: ~
-      • {item}  any
+      • {item}  (any)
 
 vim.spairs({t})                                                 *vim.spairs()*
     Enumerate a table sorted by its keys.
@@ -2090,7 +2091,7 @@ vim.split({s}, {sep}, {opts})                                    *vim.split()*
                 |vim.gsplit()|
 
     Return: ~
-        string[] List of split components
+        (string[]) List of split components
 
     See also: ~
       • |vim.gsplit()|
@@ -2131,7 +2132,7 @@ vim.tbl_contains({t}, {value}, {opts})                    *vim.tbl_contains()*
 
     Parameters: ~
       • {t}      (table) Table to check
-      • {value}  any Value to compare or predicate function reference
+      • {value}  (any) Value to compare or predicate function reference
       • {opts}   (table|nil) Keyword arguments |kwargs|:
                  • predicate: (boolean) `value` is a function reference to be
                    checked (default false)
@@ -2169,7 +2170,7 @@ vim.tbl_deep_extend({behavior}, {...})                 *vim.tbl_deep_extend()*
       • {...}       (table) Two or more tables
 
     Return: ~
-        (table) Merged table
+        table|table (table) Merged table
 
     See also: ~
       • |vim.tbl_extend()|
@@ -2199,7 +2200,7 @@ vim.tbl_filter({func}, {t})                                 *vim.tbl_filter()*
       • {t}     (table) Table
 
     Return: ~
-        (table) Table of filtered values
+        (any[]) (table) Table of filtered values
 
 vim.tbl_flatten({t})                                       *vim.tbl_flatten()*
     Creates a copy of a list-like table such that any nested tables are
@@ -2225,11 +2226,11 @@ vim.tbl_get({o}, {...})                                        *vim.tbl_get()*
 
     Parameters: ~
       • {o}    (table) Table to index
-      • {...}  any Optional keys (0 or more, variadic) via which to index the
-               table
+      • {...}  (any) Optional keys (0 or more, variadic) via which to index
+               the table
 
     Return: ~
-        any Nested value indexed by key (if it exists), else nil
+        (any) Nested value indexed by key (if it exists), else nil
 
 vim.tbl_isarray({t})                                       *vim.tbl_isarray()*
     Tests if a Lua table can be treated as an array (a table indexed by
@@ -2279,7 +2280,7 @@ vim.tbl_keys({t})                                             *vim.tbl_keys()*
       • {t}  (table) Table
 
     Return: ~
-        (list) List of keys
+        (table[]) (list) List of keys
 
     See also: ~
       • From https://github.com/premake/premake-core/blob/master/src/base/table.lua
@@ -2302,7 +2303,7 @@ vim.tbl_values({t})                                         *vim.tbl_values()*
       • {t}  (table) Table
 
     Return: ~
-        (list) List of values
+        (any[]) (list) List of values
 
 vim.trim({s})                                                     *vim.trim()*
     Trim whitespace (Lua pattern "%s") from both sides of a string.
@@ -2390,7 +2391,7 @@ vim.loader.find({modname}, {opts})                         *vim.loader.find()*
     Parameters: ~
       • {modname}  (string) Module name, or `"*"` to find the top-level
                    modules instead
-      • {opts}     (table|nil) Options for finding a module:
+      • {opts}     (table?) Options for finding a module:
                    • rtp: (boolean) Search for modname in the runtime path
                      (defaults to `true`)
                    • paths: (string[]) Extra paths to search for modname
@@ -2403,17 +2404,17 @@ vim.loader.find({modname}, {opts})                         *vim.loader.find()*
                      first one (defaults to `false`)
 
     Return: ~
-        (list) A list of results with the following properties:
+        ModuleInfo [] (list) A list of results with the following properties:
         • modpath: (string) the path to the module
         • modname: (string) the name of the module
-        • stat: (table|nil) the fs_stat of the module path. Won't be returned
-          for `modname="*"`
+        • stat: (table?) the fs_stat of the module path. Won't be returned for
+          `modname="*"`
 
 vim.loader.reset({path})                                  *vim.loader.reset()*
     Resets the cache for the path, or all the paths if path is nil.
 
     Parameters: ~
-      • {path}  string? path to reset
+      • {path}  (string?) path to reset
 
 
 ==============================================================================
@@ -3097,7 +3098,7 @@ vim.version.last({versions})                              *vim.version.last()*
       • {versions}  Version []
 
     Return: ~
-        Version ?|nil
+        Version ?
 
 vim.version.lt({v1}, {v2})                                  *vim.version.lt()*
     Returns `true` if `v1 < v2` . See |vim.version.cmp()| for usage.
@@ -3339,7 +3340,7 @@ Iter:find({f})                                                   *Iter:find()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:fold({init}, {f})                                           *Iter:fold()*
     Fold ("reduce") an iterator or table into a single value.
@@ -3357,11 +3358,11 @@ Iter:fold({init}, {f})                                           *Iter:fold()*
 <
 
     Parameters: ~
-      • {init}  any Initial value of the accumulator.
+      • {init}  (any) Initial value of the accumulator.
       • {f}     function(acc:any, ...):A Accumulation function.
 
     Return: ~
-        any
+        (any)
 
 Iter:last()                                                      *Iter:last()*
     Return the last item in the iterator.
@@ -3379,7 +3380,7 @@ Iter:last()                                                      *Iter:last()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:map({f})                                                     *Iter:map()*
     Add a map step to the iterator pipeline.
@@ -3419,7 +3420,7 @@ Iter:next()                                                      *Iter:next()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:nextback()                                              *Iter:nextback()*
     Return the next value from the end of the iterator.
@@ -3435,7 +3436,7 @@ Iter:nextback()                                              *Iter:nextback()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:nth({n})                                                     *Iter:nth()*
     Return the nth value in the iterator.
@@ -3454,7 +3455,7 @@ Iter:nth({n})                                                     *Iter:nth()*
       • {n}  (number) The index of the value to return.
 
     Return: ~
-        any
+        (any)
 
 Iter:nthback({n})                                             *Iter:nthback()*
     Return the nth value from the end of the iterator.
@@ -3475,7 +3476,7 @@ Iter:nthback({n})                                             *Iter:nthback()*
       • {n}  (number) The index of the value to return.
 
     Return: ~
-        any
+        (any)
 
 Iter:peek()                                                      *Iter:peek()*
     Peek at the next value in the iterator without consuming it.
@@ -3493,7 +3494,7 @@ Iter:peek()                                                      *Iter:peek()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:peekback()                                              *Iter:peekback()*
     Return the next value from the end of the iterator without consuming it.
@@ -3511,7 +3512,7 @@ Iter:peekback()                                              *Iter:peekback()*
 <
 
     Return: ~
-        any
+        (any)
 
 Iter:rev()                                                        *Iter:rev()*
     Reverse an iterator.
@@ -3545,7 +3546,7 @@ Iter:rfind({f})                                                 *Iter:rfind()*
 <
 
     Return: ~
-        any
+        (any)
 
     See also: ~
       • Iter.find

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -568,7 +568,7 @@ get_captures_at_cursor({winnr})
       • {winnr}  (integer|nil) Window handle or 0 for current window (default)
 
     Return: ~
-        string[] List of capture names
+        (string[]) List of capture names
 
                                         *vim.treesitter.get_captures_at_pos()*
 get_captures_at_pos({bufnr}, {row}, {col})
@@ -584,7 +584,7 @@ get_captures_at_pos({bufnr}, {row}, {col})
       • {col}    (integer) Position column
 
     Return: ~
-        table[] List of captures `{ capture = "name", metadata = { ... } }`
+        (table[]) List of captures `{ capture = "name", metadata = { ... } }`
 
 get_node({opts})                                   *vim.treesitter.get_node()*
     Returns the smallest named node at the given position
@@ -787,7 +787,7 @@ get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
       • {lang}  (string) Name of parser
 
     Return: ~
-        string[] filetypes
+        (string[]) filetypes
 
 get_lang({filetype})                      *vim.treesitter.language.get_lang()*
     Parameters: ~
@@ -862,8 +862,8 @@ edit({lang})                                     *vim.treesitter.query.edit()*
     persisted on disk.
 
     Parameters: ~
-      • {lang}  (string|nil) language to open the query editor for. If
-                omitted, inferred from the current buffer's filetype.
+      • {lang}  (string?) language to open the query editor for. If omitted,
+                inferred from the current buffer's filetype.
 
 get({lang}, {query_name})                         *vim.treesitter.query.get()*
     Returns the runtime query {query_name} for {lang}.
@@ -886,7 +886,7 @@ get_files({lang}, {query_name}, {is_included})
                        as `nil`
 
     Return: ~
-        string[] query_files List of files to load for given query and
+        (string[]) query_files List of files to load for given query and
         language
 
 lint({buf}, {opts})                              *vim.treesitter.query.lint()*
@@ -915,13 +915,13 @@ list_directives()                     *vim.treesitter.query.list_directives()*
     Lists the currently available directives to use in queries.
 
     Return: ~
-        string[] List of supported directives.
+        (string[]) List of supported directives.
 
 list_predicates()                     *vim.treesitter.query.list_predicates()*
     Lists the currently available predicates to use in queries.
 
     Return: ~
-        string[] List of supported predicates.
+        (string[]) List of supported predicates.
 
 omnifunc({findstart}, {base})                *vim.treesitter.query.omnifunc()*
     Omnifunc for completing node names and predicates in treesitter queries.
@@ -1190,9 +1190,8 @@ LanguageTree:register_cbs({cbs}, {recursive})
                      • `on_detach` : emitted when the buffer is detached, see
                        |nvim_buf_detach_event|. Takes one argument, the number
                        of the buffer.
-      • {recursive}  (boolean|nil) Apply callbacks recursively for all
-                     children. Any new children will also inherit the
-                     callbacks.
+      • {recursive}  (boolean?) Apply callbacks recursively for all children.
+                     Any new children will also inherit the callbacks.
 
 LanguageTree:source()                                  *LanguageTree:source()*
     Returns the source content of the language tree (bufnr or string).

--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -17,7 +17,7 @@ local defaults = {
 ---@param bufnr? integer defaults to the current buffer
 ---@param row? integer row to inspect, 0-based. Defaults to the row of the current cursor
 ---@param col? integer col to inspect, 0-based. Defaults to the col of the current cursor
----@param filter? InspectorFilter (table|nil) a table with key-value pairs to filter the items
+---@param filter? InspectorFilter (table) a table with key-value pairs to filter the items
 ---               - syntax (boolean): include syntax based highlight groups (defaults to true)
 ---               - treesitter (boolean): include treesitter based highlight groups (defaults to true)
 ---               - extmarks (boolean|"all"): include extmarks. When `all`, then extmarks without a `hl_group` will also be included (defaults to true)
@@ -139,7 +139,7 @@ end
 ---@param bufnr? integer defaults to the current buffer
 ---@param row? integer row to inspect, 0-based. Defaults to the row of the current cursor
 ---@param col? integer col to inspect, 0-based. Defaults to the col of the current cursor
----@param filter? InspectorFilter (table|nil) see |vim.inspect_pos()|
+---@param filter? InspectorFilter (table) see |vim.inspect_pos()|
 function vim.show_pos(bufnr, row, col, filter)
   local items = vim.inspect_pos(bufnr, row, col, filter)
 

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -232,7 +232,7 @@ function vim.schedule(callback) end
 --- ```
 ---
 --- @param time integer Number of milliseconds to wait
---- @param callback? fun(): boolean Optional callback. Waits until {callback} returns true
+--- @param callback? (fun():boolean) Optional callback. Waits until {callback} returns true
 --- @param interval? integer (Approximate) number of milliseconds to wait between polls
 --- @param fast_only? boolean If true, only |api-fast| events will be processed.
 ---                           If called from while in an |api-fast| event, will

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -235,7 +235,7 @@ end
 
 --- Loads the given module path using the cache
 ---@param modpath string
----@param opts? {mode?: "b"|"t"|"bt", env?:table} (table|nil) Options for loading the module:
+---@param opts? {mode?: "b"|"t"|"bt", env?:table} (table?) Options for loading the module:
 ---    - mode: (string) the mode to load the module with. "b"|"t"|"bt" (defaults to `nil`)
 ---    - env: (table) the environment to load the module in. (defaults to `nil`)
 ---@see |luaL_loadfile()|
@@ -272,7 +272,7 @@ end
 
 --- Finds Lua modules for the given module name.
 ---@param modname string Module name, or `"*"` to find the top-level modules instead
----@param opts? ModuleFindOpts (table|nil) Options for finding a module:
+---@param opts? ModuleFindOpts (table) Options for finding a module:
 ---    - rtp: (boolean) Search for modname in the runtime path (defaults to `true`)
 ---    - paths: (string[]) Extra paths to search for modname (defaults to `{}`)
 ---    - patterns: (string[]) List of patterns to use when searching for modules.
@@ -282,7 +282,7 @@ end
 ---@return ModuleInfo[] (list) A list of results with the following properties:
 ---    - modpath: (string) the path to the module
 ---    - modname: (string) the name of the module
----    - stat: (table|nil) the fs_stat of the module path. Won't be returned for `modname="*"`
+---    - stat: (table?) the fs_stat of the module path. Won't be returned for `modname="*"`
 function M.find(modname, opts)
   opts = opts or {}
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -78,7 +78,7 @@ end
 
 --- Returns the buffer number for the given {bufnr}.
 ---
----@param bufnr (integer|nil) Buffer number to resolve. Defaults to current buffer
+---@param bufnr? (integer) Buffer number to resolve. Defaults to current buffer
 ---@return integer bufnr
 local function resolve_bufnr(bufnr)
   validate({ bufnr = { bufnr, 'n', true } })
@@ -851,7 +851,7 @@ end
 ---             - bufnr (number)
 ---                     Buffer handle to attach to if starting or re-using a
 ---                     client (0 for current).
----@return integer|nil client_id
+---@return (integer?) client_id
 function lsp.start(config, opts)
   opts = opts or {}
   local reuse_client = opts.reuse_client
@@ -1100,7 +1100,7 @@ end
 ---       server will base its workspaceFolders, rootUri, and rootPath
 ---       on initialization.
 ---
----@return integer|nil client_id. |vim.lsp.get_client_by_id()| Note: client may not be
+---@return (integer?) client_id. |vim.lsp.get_client_by_id()| Note: client may not be
 --- fully initialized. Use `on_init` to do any actions once
 --- the client has been initialized.
 function lsp.start_client(config)
@@ -1128,7 +1128,7 @@ function lsp.start_client(config)
   --- Returns the default handler if the user hasn't set a custom one.
   ---
   ---@param method (string) LSP method name
-  ---@return lsp-handler|nil The handler for the given method, if defined, or the default from |vim.lsp.handlers|
+  ---@return (lsp-handler?) The handler for the given method, if defined, or the default from |vim.lsp.handlers|
   local function resolve_handler(method)
     return handlers[method] or default_handlers[method]
   end
@@ -1470,10 +1470,10 @@ function lsp.start_client(config)
   --- checks for capabilities and handler availability.
   ---
   ---@param method string LSP method name.
-  ---@param params table|nil LSP request params.
-  ---@param handler lsp-handler|nil Response |lsp-handler| for this method.
+  ---@param params? table LSP request params.
+  ---@param handler? lsp-handler Response |lsp-handler| for this method.
   ---@param bufnr integer Buffer handle (0 for current).
-  ---@return boolean status, integer|nil request_id {status} is a bool indicating
+  ---@return boolean status, integer? request_id {status} is a bool indicating
   ---whether the request was successful. If it is `false`, then it will
   ---always be `false` (the client has shutdown). If it was
   ---successful, then it will return {request_id} as the
@@ -1534,10 +1534,10 @@ function lsp.start_client(config)
   ---
   ---@param method (string) LSP method name.
   ---@param params (table) LSP request params.
-  ---@param timeout_ms (integer|nil) Maximum time in milliseconds to wait for
+  ---@param timeout_ms? (integer) Maximum time in milliseconds to wait for
   ---                               a result. Defaults to 1000
   ---@param bufnr (integer) Buffer handle (0 for current).
-  ---@return {err: lsp.ResponseError|nil, result:any}|nil, string|nil err # a dictionary, where
+  ---@return {err: lsp.ResponseError?, result:any}?, string? err # a dictionary, where
   --- `err` and `result` come from the |lsp-handler|.
   --- On timeout, cancel or error, returns `(nil, err)` where `err` is a
   --- string describing the failure reason. If the request was unsuccessful
@@ -1571,7 +1571,7 @@ function lsp.start_client(config)
   --- Sends a notification to an LSP server.
   ---
   ---@param method string LSP method name.
-  ---@param params table|nil LSP request params.
+  ---@param params? table LSP request params.
   ---@return boolean status true if the notification was successful.
   ---If it is false, then it will always be false
   ---(the client has shutdown).
@@ -1629,7 +1629,7 @@ function lsp.start_client(config)
   --- you request to stop a client which has previously been requested to
   --- shutdown, it will automatically escalate and force shutdown.
   ---
-  ---@param force boolean|nil
+  ---@param force? (boolean)
   function client.stop(force)
     if rpc.is_closing() then
       return
@@ -1998,7 +1998,7 @@ end
 --- already for this client, then force-shutdown is attempted.
 ---
 ---@param client_id integer|table id or |vim.lsp.client| object, or list thereof
----@param force boolean|nil shutdown forcefully
+---@param force? boolean shutdown forcefully
 function lsp.stop_client(client_id, force)
   local ids = type(client_id) == 'table' and client_id or { client_id }
   for _, id in ipairs(ids) do
@@ -2013,14 +2013,14 @@ function lsp.stop_client(client_id, force)
 end
 
 ---@class vim.lsp.get_clients.filter
----@field id integer|nil Match clients by id
----@field bufnr integer|nil match clients attached to the given buffer
----@field name string|nil match clients by name
----@field method string|nil match client by supported method name
+---@field id? integer Match clients by id
+---@field bufnr? integer match clients attached to the given buffer
+---@field name? string match clients by name
+---@field method? string match client by supported method name
 
 --- Get active clients.
 ---
----@param filter vim.lsp.get_clients.filter|nil (table|nil) A table with
+---@param filter? vim.lsp.get_clients.filter (table) A table with
 ---              key-value pairs used to filter the returned clients.
 ---              The available keys are:
 ---               - id (number): Only return clients with the given id
@@ -2119,8 +2119,8 @@ api.nvim_create_autocmd('VimLeavePre', {
 ---
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
----@param params table|nil Parameters to send to the server
----@param handler? lsp-handler See |lsp-handler|
+---@param params? (table) Parameters to send to the server
+---@param handler? (lsp-handler) See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
@@ -2174,7 +2174,7 @@ end
 ---
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
+---@param params? (table) Parameters to send to the server
 ---@param handler fun(results: table<integer, {error: lsp.ResponseError, result: any}>) (function)
 --- Handler called after all requests are completed. Server results are passed as
 --- a `client_id:result` map.
@@ -2215,12 +2215,12 @@ end
 ---
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
----@param timeout_ms (integer|nil) Maximum time in milliseconds to wait for a
+---@param params? (table) Parameters to send to the server
+---@param timeout_ms? (integer) Maximum time in milliseconds to wait for a
 ---                               result. Defaults to 1000
 ---
----@return table<integer, {err: lsp.ResponseError, result: any}>|nil (table) result Map of client_id:request_result.
----@return string|nil err On timeout, cancel, or error, `err` is a string describing the failure reason, and `result` is nil.
+---@return table<integer, {err: lsp.ResponseError, result: any}>? result Map of client_id:request_result.
+---@return string? err On timeout, cancel, or error, `err` is a string describing the failure reason, and `result` is nil.
 function lsp.buf_request_sync(bufnr, method, params, timeout_ms)
   local request_results
 
@@ -2241,7 +2241,7 @@ function lsp.buf_request_sync(bufnr, method, params, timeout_ms)
 end
 
 --- Send a notification to a server
----@param bufnr (integer|nil) The number of the buffer
+---@param bufnr? (integer) The number of the buffer
 ---@param method (string) Name of the request method
 ---@param params (any) Arguments to send to the server
 ---
@@ -2453,7 +2453,7 @@ end
 --- Gets a map of client_id:client pairs for the given buffer, where each value
 --- is a |vim.lsp.client| object.
 ---
----@param bufnr (integer|nil): Buffer handle, or 0 for current
+---@param bufnr? (integer): Buffer handle, or 0 for current
 ---@return table result is table of (client_id, client) pairs
 ---@deprecated Use |vim.lsp.get_clients()| instead.
 function lsp.buf_get_clients(bufnr)
@@ -2521,7 +2521,7 @@ end
 
 --- Enable/disable/toggle inlay hints for a buffer
 ---@param bufnr (integer) Buffer handle, or 0 for current
----@param enable (boolean|nil) true/false to enable/disable, nil to toggle
+---@param enable? (boolean) true/false to enable/disable, nil to toggle
 function lsp.inlay_hint(bufnr, enable)
   return require('vim.lsp.inlay_hint')(bufnr, enable)
 end

--- a/runtime/lua/vim/lsp/_dynamic.lua
+++ b/runtime/lua/vim/lsp/_dynamic.lua
@@ -56,7 +56,7 @@ end
 
 --- @param method string
 --- @param opts? {bufnr?: number}
---- @return lsp.Registration? (table|nil) the registration if found
+--- @return lsp.Registration? table? the registration if found
 --- @private
 function M:get(method, opts)
   opts = opts or {}

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -10,8 +10,8 @@ local M = {}
 --- buffer.
 ---
 ---@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
----@param handler (function|nil) See |lsp-handler|. Follows |lsp-handler-resolution|
+---@param params? (table) Parameters to send to the server
+---@param handler? (function) See |lsp-handler|. Follows |lsp-handler-resolution|
 --
 ---@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
 ---for all successful requests.
@@ -60,7 +60,7 @@ end
 --- Jumps to the declaration of the symbol under the cursor.
 ---@note Many servers do not implement this method. Generally, see |vim.lsp.buf.definition()| instead.
 ---
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.declaration(options)
@@ -70,7 +70,7 @@ end
 
 --- Jumps to the definition of the symbol under the cursor.
 ---
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.definition(options)
@@ -80,7 +80,7 @@ end
 
 --- Jumps to the definition of the type of the symbol under the cursor.
 ---
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - reuse_win: (boolean) Jump to existing window if buffer is already open.
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.type_definition(options)
@@ -91,7 +91,7 @@ end
 --- Lists all the implementations for the symbol under the cursor in the
 --- quickfix window.
 ---
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.implementation(options)
   local params = util.make_position_params()
@@ -155,18 +155,18 @@ end
 --- Formats a buffer using the attached (and optionally filtered) language
 --- server clients.
 ---
---- @param options table|nil Optional table which holds the following optional fields:
----     - formatting_options (table|nil):
+--- @param options? table Optional table which holds the following optional fields:
+---     - formatting_options? (table):
 ---         Can be used to specify FormattingOptions. Some unspecified options will be
 ---         automatically derived from the current Nvim options.
 ---         See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#formattingOptions
----     - timeout_ms (integer|nil, default 1000):
+---     - timeout_ms? (integer, default 1000):
 ---         Time in milliseconds to block for formatting requests. No effect if async=true
----     - bufnr (number|nil):
+---     - bufnr? (number):
 ---         Restrict formatting to the clients attached to the given buffer, defaults to the current
 ---         buffer (0).
 ---
----     - filter (function|nil):
+---     - filter? (function):
 ---         Predicate used to filter clients. Receives a client as argument and must return a
 ---         boolean. Clients matching the predicate are included. Example: <pre>lua
 ---                     -- Never request typescript-language-server for formatting
@@ -175,17 +175,17 @@ end
 ---                     }
 ---         </pre>
 ---
----     - async boolean|nil
+---     - async? (boolean)
 ---         If true the method won't block. Defaults to false.
 ---         Editing the buffer while formatting asynchronous can lead to unexpected
 ---         changes.
 ---
----     - id (number|nil):
+---     - id? (number):
 ---         Restrict formatting to the client with ID (client.id) matching this field.
----     - name (string|nil):
+---     - name? (string):
 ---         Restrict formatting to the client with name (client.name) matching this field.
 ---
----     - range (table|nil) Range to format.
+---     - range? (table) Range to format.
 ---         Table must contain `start` and `end` keys with {row,col} tuples using
 ---         (1,0) indexing.
 ---         Defaults to current selection in visual mode
@@ -253,13 +253,13 @@ end
 
 --- Renames all references to the symbol under the cursor.
 ---
----@param new_name string|nil If not provided, the user will be prompted for a new
+---@param new_name? (string) If not provided, the user will be prompted for a new
 ---                name using |vim.ui.input()|.
----@param options table|nil additional options
----     - filter (function|nil):
+---@param options? (table) additional options
+---     - filter? (function):
 ---         Predicate used to filter clients. Receives a client as argument and
 ---         must return a boolean. Clients matching the predicate are included.
----     - name (string|nil):
+---     - name? (string):
 ---         Restrict clients used for rename to ones where client.name matches
 ---         this field.
 function M.rename(new_name, options)
@@ -379,9 +379,9 @@ end
 
 --- Lists all the references to the symbol under the cursor in the quickfix window.
 ---
----@param context (table|nil) Context for the request
+---@param context? (table) Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.references(context, options)
   validate({ context = { context, 't', true } })
@@ -394,7 +394,7 @@ end
 
 --- Lists all symbols in the current buffer in the quickfix window.
 ---
----@param options table|nil additional options
+---@param options? (table) additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.document_symbol(options)
   local params = { textDocument = util.make_text_document_params() }
@@ -538,8 +538,8 @@ end
 --- call, the user is prompted to enter a string on the command line. An empty
 --- string means no filtering is done.
 ---
----@param query string|nil optional
----@param options table|nil additional options
+---@param query? (string) optional
+---@param options? (table) additional options
 ---     - on_list: (function) handler for list results. See |lsp-on-list-handler|
 function M.workspace_symbol(query, options)
   query = query or npcall(vim.fn.input, 'Query: ')
@@ -703,24 +703,24 @@ end
 --- Selects a code action available at the current
 --- cursor position.
 ---
----@param options table|nil Optional table which holds the following optional fields:
----  - context: (table|nil)
+---@param options? table Optional table which holds the following optional fields:
+---  - context?: (table)
 ---      Corresponds to `CodeActionContext` of the LSP specification:
----        - diagnostics (table|nil):
+---        - diagnostics? (table):
 ---                      LSP `Diagnostic[]`. Inferred from the current
 ---                      position if not provided.
----        - only (table|nil):
+---        - only? (table):
 ---               List of LSP `CodeActionKind`s used to filter the code actions.
 ---               Most language servers support values like `refactor`
 ---               or `quickfix`.
----        - triggerKind (number|nil): The reason why code actions were requested.
----  - filter: (function|nil)
+---        - triggerKind? (number): The reason why code actions were requested.
+---  - filter?: (function)
 ---           Predicate taking an `CodeAction` and returning a boolean.
----  - apply: (boolean|nil)
+---  - apply?: (boolean)
 ---           When set to `true`, and there is just one remaining action
 ---          (after filtering), the action is applied without user query.
 ---
----  - range: (table|nil)
+---  - range?: (table)
 ---           Range for which code actions should be requested.
 ---           If in visual mode this defaults to the active selection.
 ---           Table must contain `start` and `end` keys with {row,col} tuples

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -95,8 +95,8 @@ end
 
 --- Clear the lenses
 ---
----@param client_id integer|nil filter by client_id. All clients if nil
----@param bufnr integer|nil filter by buffer. All buffers if nil
+---@param client_id? (integer) filter by client_id. All clients if nil
+---@param bufnr? (integer) filter by buffer. All buffers if nil
 function M.clear(client_id, bufnr)
   local buffers = bufnr and { resolve_bufnr(bufnr) } or vim.tbl_keys(lens_cache_by_buf)
   for _, iter_bufnr in pairs(buffers) do

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -355,14 +355,14 @@ end
 --- Marked private as this is used internally by the LSP subsystem, but
 --- most users should instead prefer |vim.diagnostic.get()|.
 ---
----@param bufnr integer|nil The buffer number
----@param line_nr integer|nil The line number
----@param opts table|nil Configuration keys
+---@param bufnr? (integer) The buffer number
+---@param line_nr? (integer) The line number
+---@param opts? (table) Configuration keys
 ---         - severity: (DiagnosticSeverity, default nil)
 ---             - Only return diagnostics with this severity. Overrides severity_limit
 ---         - severity_limit: (DiagnosticSeverity, default nil)
 ---             - Limit severity of diagnostics found. E.g. "Warning" means { "Error", "Warning" } will be valid.
----@param client_id integer|nil the client id
+---@param client_id? (integer) the client id
 ---@return table Table with map of line number to list of diagnostics.
 ---              Structured: { [1] = {...}, [5] = {.... } }
 ---@private

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -883,7 +883,7 @@ end
 
 --- Creates a normalized object describing LSP server capabilities.
 ---@param server_capabilities table Table of capabilities supported by the server
----@return table|nil Normalized table of capabilities
+---@return table? Normalized table of capabilities
 function protocol.resolve_capabilities(server_capabilities)
   local TextDocumentSyncKind = protocol.TextDocumentSyncKind
   local textDocumentSync = server_capabilities.textDocumentSync

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -160,8 +160,8 @@ end
 --- Creates an RPC response object/table.
 ---
 ---@param code integer RPC error code defined in `vim.lsp.protocol.ErrorCodes`
----@param message string|nil arbitrary message to send to server
----@param data any|nil arbitrary data to send to server
+---@param message? string arbitrary message to send to server
+---@param data? any arbitrary data to send to server
 function M.rpc_response_error(code, message, data)
   -- TODO should this error or just pick a sane error (like InternalError)?
   local code_name = assert(protocol.ErrorCodes[code], 'Invalid RPC error code')
@@ -295,10 +295,10 @@ end
 --- Sends a request to the LSP server and runs {callback} upon response.
 ---
 ---@param method (string) The invoked LSP method
----@param params (table|nil) Parameters for the invoked LSP method
----@param callback fun(err: lsp.ResponseError|nil, result: any) Callback to invoke
----@param notify_reply_callback (function|nil) Callback to invoke as soon as a request is no longer pending
----@return boolean success, integer|nil request_id true, request_id if request could be sent, `false` if not
+---@param params? (table) Parameters for the invoked LSP method
+---@param callback (fun(err: lsp.ResponseError?, result: any)) Callback to invoke
+---@param notify_reply_callback? (function) Callback to invoke as soon as a request is no longer pending
+---@return boolean success, integer? request_id true, request_id if request could be sent, `false` if not
 function Client:request(method, params, callback, notify_reply_callback)
   validate({
     callback = { callback, 'f' },
@@ -512,17 +512,17 @@ local function public_client(client)
   --- Sends a request to the LSP server and runs {callback} upon response.
   ---
   ---@param method (string) The invoked LSP method
-  ---@param params (table|nil) Parameters for the invoked LSP method
-  ---@param callback fun(err: lsp.ResponseError | nil, result: any) Callback to invoke
-  ---@param notify_reply_callback (function|nil) Callback to invoke as soon as a request is no longer pending
-  ---@return boolean success, integer|nil request_id true, message_id if request could be sent, `false` if not
+  ---@param params? (table) Parameters for the invoked LSP method
+  ---@param callback (fun(err: lsp.ResponseError | nil, result: any)) Callback to invoke
+  ---@param notify_reply_callback? (function) Callback to invoke as soon as a request is no longer pending
+  ---@return boolean success, integer? request_id true, message_id if request could be sent, `false` if not
   function result.request(method, params, callback, notify_reply_callback)
     return client:request(method, params, callback, notify_reply_callback)
   end
 
   --- Sends a notification to the LSP server.
   ---@param method (string) The invoked LSP method
-  ---@param params (table|nil): Parameters for the invoked LSP method
+  ---@param params? (table) Parameters for the invoked LSP method
   ---@return boolean `true` if notification could be sent, `false` if not
   function result.notify(method, params)
     return client:notify(method, params)
@@ -614,17 +614,17 @@ end
 ---
 ---@param cmd (string) Command to start the LSP server.
 ---@param cmd_args (table) List of additional string arguments to pass to {cmd}.
----@param dispatchers table|nil Dispatchers for LSP message types. Valid
+---@param dispatchers? (table) Dispatchers for LSP message types. Valid
 ---dispatcher names are:
 --- - `"notification"`
 --- - `"server_request"`
 --- - `"on_error"`
 --- - `"on_exit"`
----@param extra_spawn_params table|nil Additional context for the LSP
+---@param extra_spawn_params? (table) Additional context for the LSP
 --- server process. May contain:
 --- - {cwd} (string) Working directory for the LSP server process
 --- - {env} (table) Additional environment variables for LSP server process
----@return table|nil Client RPC object, with these methods:
+---@return table? Client RPC object, with these methods:
 --- - `notify()` |vim.lsp.rpc.notify()|
 --- - `request()` |vim.lsp.rpc.request()|
 --- - `is_closing()` returns a boolean indicating if the RPC is closing.

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -639,11 +639,11 @@ end
 --- Return the semantic token(s) at the given position.
 --- If called without arguments, returns the token under the cursor.
 ---
----@param bufnr integer|nil Buffer number (0 for current buffer, default)
----@param row integer|nil Position row (default cursor position)
----@param col integer|nil Position column (default cursor position)
+---@param bufnr? (integer) Buffer number (0 for current buffer, default)
+---@param row? (integer) Position row (default cursor position)
+---@param col? (integer) Position column (default cursor position)
 ---
----@return table|nil (table|nil) List of tokens at position. Each token has
+---@return table? List of tokens at position. Each token has
 ---        the following fields:
 ---        - line (integer) line number, 0-based
 ---        - start_col (integer) start column, 0-based
@@ -692,7 +692,7 @@ end
 --- Only has an effect if the buffer is currently active for semantic token
 --- highlighting (|vim.lsp.semantic_tokens.start()| has been called for it)
 ---
----@param bufnr (integer|nil) filter by buffer. All buffers if nil, current
+---@param bufnr? (integer) filter by buffer. All buffers if nil, current
 ---       buffer if 0
 function M.force_refresh(bufnr)
   vim.validate({
@@ -722,8 +722,8 @@ end
 ---@param bufnr (integer) the buffer to highlight
 ---@param client_id (integer) The ID of the |vim.lsp.client|
 ---@param hl_group (string) Highlight group name
----@param opts (table|nil) Optional parameters.
----       - priority: (integer|nil) Priority for the applied extmark. Defaults
+---@param opts? (table) Optional parameters.
+---       - priority?: (integer) Priority for the applied extmark. Defaults
 ---         to `vim.highlight.priorities.semantic_tokens + 3`
 function M.highlight_token(token, bufnr, client_id, hl_group, opts)
   local highlighter = STHighlighter.active[bufnr]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -116,8 +116,8 @@ end
 --- Convert byte index to `encoding` index.
 --- Convenience wrapper around vim.str_utfindex
 ---@param line string line to be indexed
----@param index integer|nil byte index (utf-8), or `nil` for length
----@param encoding string|nil utf-8|utf-16|utf-32|nil defaults to utf-16
+---@param index? integer byte index (utf-8), or `nil` for length
+---@param encoding? string utf-8|utf-16|utf-32|nil defaults to utf-16
 ---@return integer `encoding` index of `index` in `line`
 function M._str_utfindex_enc(line, index, encoding)
   if not encoding then
@@ -321,7 +321,7 @@ end
 
 --- Position is a https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position
 --- Returns a zero-indexed column, since set_lines() does the conversion to
----@param offset_encoding string|nil utf-8|utf-16|utf-32
+---@param offset_encoding? (string) utf-8|utf-16|utf-32
 --- 1-indexed
 ---@return integer
 local function get_line_byte_from_position(bufnr, position, offset_encoding)
@@ -878,7 +878,7 @@ end
 --- `textDocument/signatureHelp`, and potentially others.
 ---
 ---@param input (`MarkedString` | `MarkedString[]` | `MarkupContent`)
----@param contents (table|nil) List of strings to extend with converted lines. Defaults to {}.
+---@param contents? (table) List of strings to extend with converted lines. Defaults to {}.
 ---@return table {contents} extended with lines of converted markdown.
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
 function M.convert_input_to_markdown_lines(input, contents)
@@ -928,10 +928,10 @@ end
 --- Converts `textDocument/SignatureHelp` response to markdown lines.
 ---
 ---@param signature_help table Response of `textDocument/SignatureHelp`
----@param ft string|nil filetype that will be use as the `lang` for the label markdown code block
----@param triggers table|nil list of trigger characters from the lsp server. used to better determine parameter offsets
----@return table|nil table list of lines of converted markdown.
----@return table|nil table of active hl
+---@param ft? string filetype that will be use as the `lang` for the label markdown code block
+---@param triggers? table list of trigger characters from the lsp server. used to better determine parameter offsets
+---@return table? table list of lines of converted markdown.
+---@return table? table of active hl
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_signatureHelp
 function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers)
   if not signature_help.signatures then
@@ -1128,8 +1128,8 @@ end
 --- Shows document and optionally jumps to the location.
 ---
 ---@param location table (`Location`|`LocationLink`)
----@param offset_encoding string|nil utf-8|utf-16|utf-32
----@param opts table|nil options
+---@param offset_encoding? string utf-8|utf-16|utf-32
+---@param opts? table options
 ---        - reuse_win (boolean) Jump to existing window if buffer is already open.
 ---        - focus (boolean) Whether to focus/jump to location if possible. Defaults to true.
 ---@return boolean `true` if succeeded
@@ -1185,8 +1185,8 @@ end
 --- Jumps to a location.
 ---
 ---@param location table (`Location`|`LocationLink`)
----@param offset_encoding string|nil utf-8|utf-16|utf-32
----@param reuse_win boolean|nil Jump to existing window if buffer is already open.
+---@param offset_encoding? string utf-8|utf-16|utf-32
+---@param reuse_win? boolean Jump to existing window if buffer is already open.
 ---@return boolean `true` if the jump succeeded
 function M.jump_to_location(location, offset_encoding, reuse_win)
   if offset_encoding == nil then
@@ -1206,8 +1206,8 @@ end
 ---   - for LocationLink, targetRange is shown (e.g., body of function definition)
 ---
 ---@param location table a single `Location` or `LocationLink`
----@return integer|nil buffer id of float window
----@return integer|nil window id of float window
+---@return integer? buffer id of float window
+---@return integer? window id of float window
 function M.preview_location(location, opts)
   -- location may be LocationLink or Location (more useful for the former)
   local uri = location.targetUri or location.uri
@@ -1487,7 +1487,7 @@ end
 --- Closes the preview window
 ---
 ---@param winnr integer window id of preview window
----@param bufnrs table|nil optional list of ignored buffers
+---@param bufnrs? table optional list of ignored buffers
 local function close_preview_window(winnr, bufnrs)
   vim.schedule(function()
     -- exit if we are in one of ignored buffers
@@ -1731,7 +1731,7 @@ do --[[ References ]]
 
   --- Removes document highlights from a buffer.
   ---
-  ---@param bufnr integer|nil Buffer id
+  ---@param bufnr? (integer) Buffer id
   function M.buf_clear_references(bufnr)
     validate({ bufnr = { bufnr, { 'n' }, true } })
     api.nvim_buf_clear_namespace(bufnr or 0, reference_ns, 0, -1)
@@ -1956,7 +1956,7 @@ function M.try_trim_markdown_code_blocks(lines)
   return 'markdown'
 end
 
----@param window integer|nil: window handle or 0 for current, defaults to current
+---@param window? integer window handle or 0 for current, defaults to current
 ---@param offset_encoding string utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 local function make_position_param(window, offset_encoding)
   window = window or 0
@@ -1976,8 +1976,8 @@ end
 
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
 ---
----@param window integer|nil: window handle or 0 for current, defaults to current
----@param offset_encoding string|nil utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
+---@param window? (integer) window handle or 0 for current, defaults to current
+---@param offset_encoding? (string) utf-8|utf-16|utf-32|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@return table `TextDocumentPositionParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
 function M.make_position_params(window, offset_encoding)
@@ -2029,7 +2029,7 @@ end
 --- `textDocument/codeAction`, `textDocument/colorPresentation`,
 --- `textDocument/rangeFormatting`.
 ---
----@param window integer|nil: window handle or 0 for current, defaults to current
+---@param window? integer window handle or 0 for current, defaults to current
 ---@param offset_encoding "utf-8"|"utf-16"|"utf-32"|nil defaults to `offset_encoding` of first client of buffer of `window`
 ---@return table { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`current_position`, end = `current_position` } }
@@ -2046,12 +2046,12 @@ end
 --- Using the given range in the current buffer, creates an object that
 --- is similar to |vim.lsp.util.make_range_params()|.
 ---
----@param start_pos integer[]|nil {row,col} mark-indexed position.
+---@param start_pos? (integer[]) {row,col} mark-indexed position.
 --- Defaults to the start of the last visual selection.
----@param end_pos integer[]|nil {row,col} mark-indexed position.
+---@param end_pos? (integer[]) {row,col} mark-indexed position.
 --- Defaults to the end of the last visual selection.
----@param bufnr integer|nil buffer handle or 0 for current, defaults to current
----@param offset_encoding "utf-8"|"utf-16"|"utf-32"|nil defaults to `offset_encoding` of first client of `bufnr`
+---@param bufnr? (integer) buffer handle or 0 for current, defaults to current
+---@param offset_encoding ("utf-8"|"utf-16"|"utf-32"|nil) defaults to `offset_encoding` of first client of `bufnr`
 ---@return table { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`start_position`, end = `end_position` } }
 function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
@@ -2091,7 +2091,7 @@ end
 
 --- Creates a `TextDocumentIdentifier` object for the current buffer.
 ---
----@param bufnr integer|nil: Buffer handle, defaults to current
+---@param bufnr? (integer) Buffer handle, defaults to current
 ---@return table `TextDocumentIdentifier`
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentIdentifier
 function M.make_text_document_params(bufnr)
@@ -2108,7 +2108,7 @@ end
 --- Returns indentation size.
 ---
 ---@see 'shiftwidth'
----@param bufnr (integer|nil): Buffer handle, defaults to current
+---@param bufnr? (integer) Buffer handle, defaults to current
 ---@return (integer) indentation size
 function M.get_effective_tabstop(bufnr)
   validate({ bufnr = { bufnr, 'n', true } })
@@ -2119,7 +2119,7 @@ end
 
 --- Creates a `DocumentFormattingParams` object for the current buffer and cursor position.
 ---
----@param options table|nil with valid `FormattingOptions` entries
+---@param options? (table) with valid `FormattingOptions` entries
 ---@return `DocumentFormattingParams` object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
 function M.make_formatting_params(options)


### PR DESCRIPTION
**Problem**:

As of 10 July 2023, [EmmyLuaCodeStyle](https://github.com/CppCXY/EmmyLuaCodeStyle/commit/668b88dd4c540537046456cb75fb6e7b7b7b0e43) and [lua-language-server](https://github.com/LuaLS/lua-language-server/commit/065cc4e3266ac683fd60af8929b0c79038cfc930) support the `?` symbol for nilable types (e.g. `string?`). `neovim` mostly uses `|nil` (e.g., `string|nil`), although the `?` symbol appears in a few places.

**Solution**:

When possible, instances of `|nil` are replaced with `?` in the LSP runtime. e.g., `string|nil` becomes `string?`. This can't be done in cases where the union is more than two different types. e.g. `string|int|nil`. This means we cannot use `sed` since that would lead to many false positives.

**Overall goal**:

Ideally we would replace `|nil` in all runtime modules, but that will be too large for one PR. If this PR is approved then I will make more PRs for each runtime. 

An alternative to this approach is to make PRs for each runtime to this branch. This will make it easier for reviewers and then we get the benefit of having only one commit to master. This is my first PR to `neovim`, so I don't know what is preferred by the devs here.