### PR TITLE
vim-patch:9.0.{1710,1781}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -189,6 +189,8 @@ opt+=val" the expansion is done before the adding or removing.
 
 Handling of local options			*local-options*
 
+Note: The following also applies to |global-local| options.
+
 Some of the options only apply to a window or buffer.  Each window or buffer
 has its own copy of this option, thus each can have its own value.  This
 allows you to set 'list' in one window but not in another.  And set
@@ -237,6 +239,30 @@ You will get back the 'list' value as it was the last time you edited "one".
 The options local to a window are remembered for each buffer.  This also
 happens when the buffer is not loaded, but they are lost when the buffer is
 wiped out |:bwipe|.
+
+Special local window options			*special-local-window-option*
+
+The following local window options won't be copied over when new windows are
+created, thus they behave slightly differently:
+
+	Option		Reason	~
+	'previewwindow'	there can only be a single one
+	'scroll'	specific to existing window
+	'winfixheight'	specific to existing window
+	'winfixwidth'	specific to existing window
+
+Special local buffer options			*special-local-buffer-option*
+
+The following local buffer options won't be copied over when new buffers are
+created, thus they behave slightly differently:
+
+	Option		Reason	~
+	'filetype'	explicitly set by autocommands
+	'syntax'	explicitly set by autocommands
+	'bufhidden'	denote |special-buffers|
+	'buftype'	denote |special-buffers|
+	'readonly'	will be detected automatically
+	'modified'	will be detected automatically
 
 							*:setl* *:setlocal*
 :setl[ocal][!] ...	Like ":set" but set only the value local to the
@@ -310,7 +336,6 @@ used.  Thus it does the same as: >
 	:setlocal path=
 Note: In the future more global options can be made |global-local|.  Using
 ":setlocal" on a global option might work differently then.
-
 
 						*option-value-function*
 Some options ('completefunc', 'omnifunc', 'operatorfunc', 'quickfixtextfunc',
@@ -1070,7 +1095,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'bufhidden'* *'bh'*
 'bufhidden' 'bh'	string	(default "")
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	This option specifies what happens when a buffer is no longer
 	displayed in a window:
 	  <empty>	follow the global 'hidden' option
@@ -1102,7 +1127,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'buftype'* *'bt'* *E382*
 'buftype' 'bt'		string	(default "")
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	The value of this option specifies the type of a buffer:
 	  <empty>	normal buffer
 	  acwrite	buffer will always be written with |BufWriteCmd|s
@@ -2408,7 +2433,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'filetype'* *'ft'*
 'filetype' 'ft'		string	(default "")
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	When this option is set, the FileType autocommand event is triggered.
 	All autocommands that match with the value of this option will be
 	executed.  Thus the value of 'filetype' is used in place of the file
@@ -4084,7 +4109,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'modified'* *'mod'* *'nomodified'* *'nomod'*
 'modified' 'mod'	boolean	(default off)
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	When on, the buffer is considered to be modified.  This option is set
 	when:
 	1. A change was made to the text since it was last written.  Using the
@@ -4532,7 +4557,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 		*'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
 'previewwindow' 'pvw'	boolean	(default off)
-			local to window
+			local to window  |special-local-window-option|
 	Identifies the preview window.  Only one window can have this option
 	set.  It's normally not set directly, but by using one of the commands
 	|:ptag|, |:pedit|, etc.
@@ -4602,7 +4627,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'readonly'* *'ro'* *'noreadonly'* *'noro'*
 'readonly' 'ro'		boolean	(default off)
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	If on, writes fail unless you use a '!'.  Protects you from
 	accidentally overwriting a file.  Default on when Vim is started
 	in read-only mode ("vim -R") or when the executable is called "view".
@@ -4864,7 +4889,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'scroll'* *'scr'*
 'scroll' 'scr'		number	(default half the window height)
-			local to window
+			local to window  |special-local-window-option|
 	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 	set to half the number of lines in the window when the window size
 	changes.  This may happen when enabling the |status-line| or
@@ -6214,7 +6239,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'syntax'* *'syn'*
 'syntax' 'syn'		string	(default "")
-			local to buffer
+			local to buffer  |special-local-buffer-option|
 	When this option is set, the syntax with this name is loaded, unless
 	syntax highlighting has been switched off with ":syntax off".
 	Otherwise this option does not always reflect the current syntax (the
@@ -7081,7 +7106,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
 'winfixheight' 'wfh'	boolean	(default off)
-			local to window
+			local to window  |special-local-window-option|
 	Keep the window height when windows are opened or closed and
 	'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
 	|preview-window| and |quickfix-window|.
@@ -7089,7 +7114,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			*'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
 'winfixwidth' 'wfw'	boolean	(default off)
-			local to window
+			local to window  |special-local-window-option|
 	Keep the window width when windows are opened or closed and
 	'equalalways' is set.  Also for |CTRL-W_=|.
 	The width may be changed anyway when running out of room.

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -542,6 +542,36 @@ local function scope_to_doc(s)
   return 'global or '..m[s[2]]..' |global-local|'
 end
 
+-- @param o vim.option_meta
+-- @return string
+local function scope_more_doc(o)
+  if
+    vim.list_contains({
+      'previewwindow',
+      'scroll',
+      'winfixheight',
+      'winfixwidth',
+    }, o.full_name)
+  then
+    return '  |special-local-window-option|'
+  end
+
+  if
+    vim.list_contains({
+      'bufhidden',
+      'buftype',
+      'filetype',
+      'modified',
+      'readonly',
+      'syntax',
+    }, o.full_name)
+  then
+    return '  |special-local-buffer-option|'
+  end
+
+  return ''
+end
+
 --- @return table<string,vim.option_meta>
 local function get_option_meta()
   local opts = require('src/nvim/options').options
@@ -624,7 +654,7 @@ local function render_option_doc(_f, opt, write)
     write(string.format('%s\t%s', name_str, otype))
   end
 
-  write('\t\t\t'..scope_to_doc(opt.scope))
+  write('\t\t\t'..scope_to_doc(opt.scope)..scope_more_doc(opt))
   for _, l in ipairs(split(opt.desc)) do
     if l == '<' or l:match('^<%s') then
       write(l)

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -230,6 +230,10 @@ typedef struct {
 #define w_p_crb_save w_onebuf_opt.wo_crb_save
   char *wo_scl;
 #define w_p_scl w_onebuf_opt.wo_scl    // 'signcolumn'
+  long wo_siso;
+#define w_p_siso w_onebuf_opt.wo_siso  // 'sidescrolloff' local value
+  long wo_so;
+#define w_p_so w_onebuf_opt.wo_so      // 'scrolloff' local value
   char *wo_winhl;
 #define w_p_winhl w_onebuf_opt.wo_winhl    // 'winhighlight'
   char *wo_lcs;
@@ -1321,8 +1325,6 @@ struct window_S {
   uint32_t w_p_fdt_flags;           // flags for 'foldtext'
   int *w_p_cc_cols;                 // array of columns to highlight or NULL
   uint8_t w_p_culopt_flags;         // flags for cursorline highlighting
-  long w_p_siso;                    // 'sidescrolloff' local value
-  long w_p_so;                      // 'scrolloff' local value
 
   int w_briopt_min;                 // minimum width for breakindent
   int w_briopt_shift;               // additional shift for breakindent

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2161,8 +2161,129 @@ static const char *did_set_swapfile(optset_T *args)
 /// Process the updated 'paste' option value.
 static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
 {
-  // when 'paste' is set or reset also change other options
-  paste_option_changed();
+  static int old_p_paste = false;
+  static int save_sm = 0;
+  static int save_sta = 0;
+  static int save_ru = 0;
+  static int save_ri = 0;
+
+  if (p_paste) {
+    // Paste switched from off to on.
+    // Save the current values, so they can be restored later.
+    if (!old_p_paste) {
+      // save options for each buffer
+      FOR_ALL_BUFFERS(buf) {
+        buf->b_p_tw_nopaste = buf->b_p_tw;
+        buf->b_p_wm_nopaste = buf->b_p_wm;
+        buf->b_p_sts_nopaste = buf->b_p_sts;
+        buf->b_p_ai_nopaste = buf->b_p_ai;
+        buf->b_p_et_nopaste = buf->b_p_et;
+        if (buf->b_p_vsts_nopaste) {
+          xfree(buf->b_p_vsts_nopaste);
+        }
+        buf->b_p_vsts_nopaste = buf->b_p_vsts && buf->b_p_vsts != empty_option
+                                    ? xstrdup(buf->b_p_vsts)
+                                    : NULL;
+      }
+
+      // save global options
+      save_sm = p_sm;
+      save_sta = p_sta;
+      save_ru = p_ru;
+      save_ri = p_ri;
+      // save global values for local buffer options
+      p_ai_nopaste = p_ai;
+      p_et_nopaste = p_et;
+      p_sts_nopaste = p_sts;
+      p_tw_nopaste = p_tw;
+      p_wm_nopaste = p_wm;
+      if (p_vsts_nopaste) {
+        xfree(p_vsts_nopaste);
+      }
+      p_vsts_nopaste = p_vsts && p_vsts != empty_option ? xstrdup(p_vsts) : NULL;
+    }
+
+    // Always set the option values, also when 'paste' is set when it is
+    // already on.
+    // set options for each buffer
+    FOR_ALL_BUFFERS(buf) {
+      buf->b_p_tw = 0;              // textwidth is 0
+      buf->b_p_wm = 0;              // wrapmargin is 0
+      buf->b_p_sts = 0;             // softtabstop is 0
+      buf->b_p_ai = 0;              // no auto-indent
+      buf->b_p_et = 0;              // no expandtab
+      if (buf->b_p_vsts) {
+        free_string_option(buf->b_p_vsts);
+      }
+      buf->b_p_vsts = empty_option;
+      XFREE_CLEAR(buf->b_p_vsts_array);
+    }
+
+    // set global options
+    p_sm = 0;                       // no showmatch
+    p_sta = 0;                      // no smarttab
+    if (p_ru) {
+      status_redraw_all();          // redraw to remove the ruler
+    }
+    p_ru = 0;                       // no ruler
+    p_ri = 0;                       // no reverse insert
+    // set global values for local buffer options
+    p_tw = 0;
+    p_wm = 0;
+    p_sts = 0;
+    p_ai = 0;
+    p_et = 0;
+    if (p_vsts) {
+      free_string_option(p_vsts);
+    }
+    p_vsts = empty_option;
+  } else if (old_p_paste) {
+    // Paste switched from on to off: Restore saved values.
+
+    // restore options for each buffer
+    FOR_ALL_BUFFERS(buf) {
+      buf->b_p_tw = buf->b_p_tw_nopaste;
+      buf->b_p_wm = buf->b_p_wm_nopaste;
+      buf->b_p_sts = buf->b_p_sts_nopaste;
+      buf->b_p_ai = buf->b_p_ai_nopaste;
+      buf->b_p_et = buf->b_p_et_nopaste;
+      if (buf->b_p_vsts) {
+        free_string_option(buf->b_p_vsts);
+      }
+      buf->b_p_vsts = buf->b_p_vsts_nopaste ? xstrdup(buf->b_p_vsts_nopaste) : empty_option;
+      xfree(buf->b_p_vsts_array);
+      if (buf->b_p_vsts && buf->b_p_vsts != empty_option) {
+        (void)tabstop_set(buf->b_p_vsts, &buf->b_p_vsts_array);
+      } else {
+        buf->b_p_vsts_array = NULL;
+      }
+    }
+
+    // restore global options
+    p_sm = save_sm;
+    p_sta = save_sta;
+    if (p_ru != save_ru) {
+      status_redraw_all();          // redraw to draw the ruler
+    }
+    p_ru = save_ru;
+    p_ri = save_ri;
+    // set global values for local buffer options
+    p_ai = p_ai_nopaste;
+    p_et = p_et_nopaste;
+    p_sts = p_sts_nopaste;
+    p_tw = p_tw_nopaste;
+    p_wm = p_wm_nopaste;
+    if (p_vsts) {
+      free_string_option(p_vsts);
+    }
+    p_vsts = p_vsts_nopaste ? xstrdup(p_vsts_nopaste) : empty_option;
+  }
+
+  old_p_paste = p_paste;
+
+  // Remember where the dependent options were reset
+  didset_options_sctx((OPT_LOCAL | OPT_GLOBAL), p_paste_dep_opts);
+
   return NULL;
 }
 
@@ -5543,133 +5664,6 @@ bool shortmess(int x)
           && (vim_strchr(p_shm, x) != NULL
               || (vim_strchr(p_shm, 'a') != NULL
                   && vim_strchr(SHM_ALL_ABBREVIATIONS, x) != NULL)));
-}
-
-/// paste_option_changed() - Called after p_paste was set or reset.
-static void paste_option_changed(void)
-{
-  static int old_p_paste = false;
-  static int save_sm = 0;
-  static int save_sta = 0;
-  static int save_ru = 0;
-  static int save_ri = 0;
-
-  if (p_paste) {
-    // Paste switched from off to on.
-    // Save the current values, so they can be restored later.
-    if (!old_p_paste) {
-      // save options for each buffer
-      FOR_ALL_BUFFERS(buf) {
-        buf->b_p_tw_nopaste = buf->b_p_tw;
-        buf->b_p_wm_nopaste = buf->b_p_wm;
-        buf->b_p_sts_nopaste = buf->b_p_sts;
-        buf->b_p_ai_nopaste = buf->b_p_ai;
-        buf->b_p_et_nopaste = buf->b_p_et;
-        if (buf->b_p_vsts_nopaste) {
-          xfree(buf->b_p_vsts_nopaste);
-        }
-        buf->b_p_vsts_nopaste = buf->b_p_vsts && buf->b_p_vsts != empty_option
-                                    ? xstrdup(buf->b_p_vsts)
-                                    : NULL;
-      }
-
-      // save global options
-      save_sm = p_sm;
-      save_sta = p_sta;
-      save_ru = p_ru;
-      save_ri = p_ri;
-      // save global values for local buffer options
-      p_ai_nopaste = p_ai;
-      p_et_nopaste = p_et;
-      p_sts_nopaste = p_sts;
-      p_tw_nopaste = p_tw;
-      p_wm_nopaste = p_wm;
-      if (p_vsts_nopaste) {
-        xfree(p_vsts_nopaste);
-      }
-      p_vsts_nopaste = p_vsts && p_vsts != empty_option ? xstrdup(p_vsts) : NULL;
-    }
-
-    // Always set the option values, also when 'paste' is set when it is
-    // already on.
-    // set options for each buffer
-    FOR_ALL_BUFFERS(buf) {
-      buf->b_p_tw = 0;              // textwidth is 0
-      buf->b_p_wm = 0;              // wrapmargin is 0
-      buf->b_p_sts = 0;             // softtabstop is 0
-      buf->b_p_ai = 0;              // no auto-indent
-      buf->b_p_et = 0;              // no expandtab
-      if (buf->b_p_vsts) {
-        free_string_option(buf->b_p_vsts);
-      }
-      buf->b_p_vsts = empty_option;
-      XFREE_CLEAR(buf->b_p_vsts_array);
-    }
-
-    // set global options
-    p_sm = 0;                       // no showmatch
-    p_sta = 0;                      // no smarttab
-    if (p_ru) {
-      status_redraw_all();          // redraw to remove the ruler
-    }
-    p_ru = 0;                       // no ruler
-    p_ri = 0;                       // no reverse insert
-    // set global values for local buffer options
-    p_tw = 0;
-    p_wm = 0;
-    p_sts = 0;
-    p_ai = 0;
-    p_et = 0;
-    if (p_vsts) {
-      free_string_option(p_vsts);
-    }
-    p_vsts = empty_option;
-  } else if (old_p_paste) {
-    // Paste switched from on to off: Restore saved values.
-
-    // restore options for each buffer
-    FOR_ALL_BUFFERS(buf) {
-      buf->b_p_tw = buf->b_p_tw_nopaste;
-      buf->b_p_wm = buf->b_p_wm_nopaste;
-      buf->b_p_sts = buf->b_p_sts_nopaste;
-      buf->b_p_ai = buf->b_p_ai_nopaste;
-      buf->b_p_et = buf->b_p_et_nopaste;
-      if (buf->b_p_vsts) {
-        free_string_option(buf->b_p_vsts);
-      }
-      buf->b_p_vsts = buf->b_p_vsts_nopaste ? xstrdup(buf->b_p_vsts_nopaste) : empty_option;
-      xfree(buf->b_p_vsts_array);
-      if (buf->b_p_vsts && buf->b_p_vsts != empty_option) {
-        (void)tabstop_set(buf->b_p_vsts, &buf->b_p_vsts_array);
-      } else {
-        buf->b_p_vsts_array = NULL;
-      }
-    }
-
-    // restore global options
-    p_sm = save_sm;
-    p_sta = save_sta;
-    if (p_ru != save_ru) {
-      status_redraw_all();          // redraw to draw the ruler
-    }
-    p_ru = save_ru;
-    p_ri = save_ri;
-    // set global values for local buffer options
-    p_ai = p_ai_nopaste;
-    p_et = p_et_nopaste;
-    p_sts = p_sts_nopaste;
-    p_tw = p_tw_nopaste;
-    p_wm = p_wm_nopaste;
-    if (p_vsts) {
-      free_string_option(p_vsts);
-    }
-    p_vsts = p_vsts_nopaste ? xstrdup(p_vsts_nopaste) : empty_option;
-  }
-
-  old_p_paste = p_paste;
-
-  // Remember where the dependent options were reset
-  didset_options_sctx((OPT_LOCAL | OPT_GLOBAL), p_paste_dep_opts);
 }
 
 /// vimrc_found() - Called when a vimrc or "VIMINIT" has been found.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4702,6 +4702,8 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_sms = from->wo_sms;
   to->wo_crb = from->wo_crb;
   to->wo_crb_save = from->wo_crb_save;
+  to->wo_siso = from->wo_siso;
+  to->wo_so = from->wo_so;
   to->wo_spell = from->wo_spell;
   to->wo_cuc = from->wo_cuc;
   to->wo_cul = from->wo_cul;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5132,8 +5132,8 @@ static win_T *win_alloc(win_T *after, bool hidden)
   new_wp->w_ns_hl = -1;
 
   // use global option for global-local options
-  new_wp->w_p_so = -1;
-  new_wp->w_p_siso = -1;
+  new_wp->w_allbuf_opt.wo_so = new_wp->w_p_so = -1;
+  new_wp->w_allbuf_opt.wo_siso = new_wp->w_p_siso = -1;
 
   // We won't calculate w_fraction until resizing the window
   new_wp->w_fraction = 0;

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1548,7 +1548,7 @@ describe('lua stdlib', function()
     eq(100, funcs.luaeval "vim.wo.scrolloff")
     exec_lua [[
     vim.wo[0][0].scrolloff = 200
-    vim.cmd "split"
+    vim.cmd "enew"
     ]]
     eq(100, funcs.luaeval "vim.wo.scrolloff")
   end)

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1768,4 +1768,85 @@ func Test_set_option_window_global_local_all()
   bw!
 endfunc
 
+func Test_paste_depending_options()
+  " setting the paste option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set paste test
+    set autoindent
+    set expandtab
+    " disabled, because depends on compiled feature set
+    " set hkmap
+    " set revins
+    " set varsofttabstop=8,32,8
+    set ruler
+    set showmatch
+    set smarttab
+    set softtabstop=4
+    set textwidth=80
+    set wrapmargin=10
+
+    source Xvimrc_paste2
+
+    redir > Xoutput_paste
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_paste', 'D')
+  call writefile(['set paste'], 'Xvimrc_paste2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_paste')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_paste2 line 1$", result[5])
+
+  call delete('Xoutput_paste')
+endfunc
+
+func Test_binary_depending_options()
+  " setting the paste option, resets all dependent options
+  " and will be reported correctly using :verbose set <option>?
+  let lines =<< trim [CODE]
+    " set binary test
+    set expandtab
+
+    source Xvimrc_bin2
+
+    redir > Xoutput_bin
+    verbose set expandtab?
+    verbose setg expandtab?
+    verbose setl expandtab?
+    redir END
+
+    qall!
+  [CODE]
+
+  call writefile(lines, 'Xvimrc_bin', 'D')
+  call writefile(['set binary'], 'Xvimrc_bin2', 'D')
+  if !RunVim([], lines, '--clean')
+    return
+  endif
+
+  let result = readfile('Xoutput_bin')->filter('!empty(v:val)')
+  call assert_equal('noexpandtab', result[0])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[1])
+  call assert_equal('noexpandtab', result[2])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[3])
+  call assert_equal('noexpandtab', result[4])
+  call assert_match("^\tLast set from .*Xvimrc_bin2 line 1$", result[5])
+
+  call delete('Xoutput_bin')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1682,4 +1682,90 @@ func Test_string_option_revert_on_failure()
   bw!
 endfunc
 
+func Test_set_option_window_global_local()
+  new Xbuffer1
+  let [ _gso, _lso ] = [ &g:scrolloff, &l:scrolloff ]
+  setlocal scrolloff=2
+  setglobal scrolloff=3
+  setl modified
+  " A new buffer has its own window-local options
+  hide enew
+  call assert_equal(-1, &l:scrolloff)
+  call assert_equal(3, &g:scrolloff)
+  " A new window opened with its own buffer-local options
+  new
+  call assert_equal(-1, &l:scrolloff)
+  call assert_equal(3, &g:scrolloff)
+  " Re-open Xbuffer1 and it should use
+  " the previous set window-local options
+  b Xbuffer1
+  call assert_equal(2, &l:scrolloff)
+  call assert_equal(3, &g:scrolloff)
+  bw!
+  bw!
+  let &g:scrolloff =  _gso
+endfunc
+
+func GetGlobalLocalWindowOptions()
+  new
+  sil! r $VIMRUNTIME/doc/options.txt
+  " Filter for global or local to window
+  v/^'.*'.*\n.*global or local to window |global-local/d
+  " get option value and type
+  sil %s/^'\([^']*\)'.*'\s\+\(\w\+\)\s\+(default \%(\(".*"\|\d\+\|empty\)\).*/\1 \2 \3/g
+  " sil %s/empty/""/g
+  " split the result
+  " let result=getline(1,'$')->map({_, val -> split(val, ' ')})
+  let result = getline(1, '$')->map({_, val -> matchlist(val, '\([^ ]\+\) \+\([^ ]\+\) \+\(.*\)')[1:3]})
+  bw!
+  return result
+endfunc
+
+func Test_set_option_window_global_local_all()
+  new Xbuffer2
+
+  let optionlist = GetGlobalLocalWindowOptions()
+  for [opt, type, default] in optionlist
+    let _old = eval('&g:' .. opt)
+    if type == 'string'
+      if opt == 'fillchars'
+        exe 'setl ' .. opt .. '=vert:+'
+        exe 'setg ' .. opt .. '=vert:+,fold:+'
+      elseif opt == 'listchars'
+        exe 'setl ' .. opt .. '=tab:>>'
+        exe 'setg ' .. opt .. '=tab:++'
+      elseif opt == 'virtualedit'
+        exe 'setl ' .. opt .. '=all'
+        exe 'setg ' .. opt .. '=block'
+      else
+        exe 'setl ' .. opt .. '=Local'
+        exe 'setg ' .. opt .. '=Global'
+      endif
+    elseif type == 'number'
+      exe 'setl ' .. opt .. '=5'
+      exe 'setg ' .. opt .. '=10'
+    endif
+    setl modified
+    hide enew
+    if type == 'string'
+      call assert_equal('', eval('&l:' .. opt))
+      if opt == 'fillchars'
+        call assert_equal('vert:+,fold:+', eval('&g:' .. opt), 'option:' .. opt)
+      elseif opt == 'listchars'
+        call assert_equal('tab:++', eval('&g:' .. opt), 'option:' .. opt)
+      elseif opt == 'virtualedit'
+        call assert_equal('block', eval('&g:' .. opt), 'option:' .. opt)
+      else
+        call assert_equal('Global', eval('&g:' .. opt), 'option:' .. opt)
+      endif
+    elseif type == 'number'
+      call assert_equal(-1, eval('&l:' .. opt), 'option:' .. opt)
+      call assert_equal(10, eval('&g:' .. opt), 'option:' .. opt)
+    endif
+    bw!
+    exe 'let &g:' .. opt .. '=' .. default
+  endfor
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1710: scrolloff options work slightly different

Problem: sidescrolloff and scrolloff options work slightly
         different than other global-local options
Solution: Make it behave consistent for all global-local options

It was noticed, that sidescrolloff and scrolloff options behave
differently in comparison to other global-local window options like
'listchars'

So make those two behave like other global-local options. Also add some
extra documentation for a few special local-window options.

Add a few tests to make sure all global-local window options behave
similar

closes: vim/vim#12643

https://github.com/vim/vim/commit/4a8eb6e7a9df10f79bf95301ced012f0d6a13088

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1781: Problems when setting bin/paste option

Problem:  Problems when setting bin/paste option
Solution: When setting binary/paste, remember that this also affects
          depending options, so that :verbose set returns the right
          location.

Mention if depending options for 'binary' or 'paste' have been reset
indirectly. Add a test to verify it works.

Also noticed as small bug, that the global option value for expandtab
was not reset when paste option is set, so fix that while at it.

closes: vim/vim#12879

https://github.com/vim/vim/commit/757593c07a4f4ac43eb6c6e52fc299abc9bc08bc

Co-authored-by: Christian Brabandt <cb@256bit.org>