### PR TITLE
vim-patch:9.0.1785: wrong cursor position with 'showbreak' and lcs-eol

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -879,7 +879,7 @@ void curs_columns(win_T *wp, int may_scroll)
       // column
       char *const sbr = get_showbreak_value(wp);
       if (*sbr && *get_cursor_pos_ptr() == NUL
-          && wp->w_wcol == vim_strsize(sbr)) {
+          && wp->w_wcol == (wp->w_width_inner - width2) + vim_strsize(sbr)) {
         wp->w_wcol = 0;
       }
     }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2886,6 +2886,15 @@ bbbbbbb]])
       {1:~                             }|
                                     |
     ]]}
+    feed('zbx')
+    screen:expect{grid=[[
+        1 ^12312312312312312312312312|
+            {1:+}31231231231231231231231|
+            {1:+}23123123123123123123   |
+      {1:~                             }|
+      {1:~                             }|
+                                    |
+    ]]}
   end
 
   describe('with showbreak, smoothscroll', function()

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -937,7 +937,9 @@ func Test_cursor_position_with_showbreak()
   let lines =<< trim END
       vim9script
       &signcolumn = 'yes'
-      &showbreak = '+ '
+      &showbreak = '++'
+      &breakindent = true
+      &breakindentopt = 'shift:2'
       var leftcol: number = win_getid()->getwininfo()->get(0, {})->get('textoff')
       repeat('x', &columns - leftcol - 1)->setline(1)
       'second line'->setline(2)
@@ -946,7 +948,13 @@ func Test_cursor_position_with_showbreak()
   let buf = RunVimInTerminal('-S XscriptShowbreak', #{rows: 6})
 
   call term_sendkeys(buf, "AX")
-  call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak', {})
+  call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak_1', {})
+  " No line wraps, so changing 'showbreak' should lead to the same screen.
+  call term_sendkeys(buf, "\<C-\>\<C-O>:setlocal showbreak=+\<CR>")
+  call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak_1', {})
+  " The first line now wraps because of "eol" in 'listchars'.
+  call term_sendkeys(buf, "\<C-\>\<C-O>:setlocal list\<CR>")
+  call VerifyScreenDump(buf, 'Test_cursor_position_with_showbreak_2', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.0.1785: wrong cursor position with 'showbreak' and lcs-eol

Problem:  wrong cursor position with 'showbreak' and lcs-eol
Solution: Add size of 'showbreak' before when 'listchars' "eol" is used.
          Also fix wrong cursor position with wrapping virtual text on
          empty line and 'showbreak'.

closes: vim/vim#12891

https://github.com/vim/vim/commit/1193951bebcff50d88403ce17dec5d3be14f131d