### PR TITLE
fix(runtime): make `:Sman/:{Get,Run}Help` work in Nvim

### DIFF
--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -16,14 +16,17 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -17,14 +17,17 @@ setlocal comments=:# commentstring=#\ %s include=^\\s*include
 setlocal formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -19,14 +19,17 @@ setlocal formatoptions-=t formatoptions+=croql
 let &l:include = '^\s*source\>'
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -39,15 +39,18 @@ elseif executable('powershell.exe') | let s:pwsh_cmd = 'powershell.exe'
 endif
 
 if exists('s:pwsh_cmd')
-  if !has('gui_running') && executable('less') &&
-        \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
-    " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
-    command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
-  elseif has('terminal')
-    command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
-  else
-    command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')
-  endif
+  " Nvim's :! is not interactive.
+  " if !has('gui_running') && executable('less') &&
+  "       \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
+  "   " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
+  "   command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
+  " elseif has('terminal')
+    " Nvim's :terminal doesn't split or enter terminal mode by default.
+    " command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
+    command! -buffer -nargs=1 GetHelp split | startinsert | silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
+  " else
+  "   command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')
+  " endif
 endif
 setlocal keywordprg=:GetHelp
 

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -31,14 +31,17 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -43,13 +43,15 @@ endif
 
 if (exists('b:is_bash') && (b:is_bash == 1)) ||
       \ (exists('b:is_sh') && (b:is_sh == 1))
-  if !has('gui_running') && executable('less')
-    command! -buffer -nargs=1 Help silent exe '!bash -c "{ help "<args>" 2>/dev/null || man "<args>"; } | LESS= less"' | redraw!
-  elseif has('terminal')
-    command! -buffer -nargs=1 Help silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
-  else
-    command! -buffer -nargs=1 Help echo system('bash -c "help <args>" 2>/dev/null || man "<args>"')
-  endif
+  " if !has('gui_running') && executable('less')
+  "   command! -buffer -nargs=1 Help silent exe '!bash -c "{ help "<args>" 2>/dev/null || man "<args>"; } | LESS= less"' | redraw!
+  " elseif has('terminal')
+      " Nvim's :terminal doesn't split or enter terminal mode by default.
+      " command! -buffer -nargs=1 Help silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
+      command! -buffer -nargs=1 Help split | startinsert | silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
+  " else
+  "   command! -buffer -nargs=1 Help echo system('bash -c "help <args>" 2>/dev/null || man "<args>"')
+  " endif
   setlocal keywordprg=:Help
   let b:undo_ftplugin .= '| setlocal keywordprg<'
 endif

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -15,14 +15,17 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -16,14 +16,17 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -8,11 +8,14 @@ if !exists('b:did_ftplugin')
 endif
 
 if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 Sman silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman silent exe 'term ' . KeywordLookup_systemd(<q-args>)
-  endif
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
+  " elseif has('terminal')
+    " Nvim's :terminal doesn't split or enter terminal mode by default.
+    " command -buffer -nargs=1 Sman silent exe 'term ' . KeywordLookup_systemd(<q-args>)
+    command -buffer -nargs=1 Sman split | startinsert | silent exe 'term ' . KeywordLookup_systemd(<q-args>)
+  " endif
   if exists(':Sman') == 2
     if !exists('*KeywordLookup_systemd')
       function KeywordLookup_systemd(keyword) abort

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -16,14 +16,17 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  " Nvim's :! is not interactive.
+  " if !has('gui_running')
+  "   command -buffer -nargs=1 Sman
+  "         \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
+  "         \ redraw!
+  " elseif has('terminal')
     command -buffer -nargs=1 Sman
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 Sman
+          "\ Nvim's :terminal doesn't split or enter terminal mode by default.
+          \ split | startinsert |
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
-  endif
+  " endif
   if exists(':Sman') == 2
     setlocal iskeyword+=-
     setlocal keywordprg=:Sman

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -19,13 +19,16 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
-  if !has('gui_running') && executable('less')
-    command! -buffer -nargs=1 RunHelp silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
-  elseif has('terminal')
-    command! -buffer -nargs=1 RunHelp silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
-  else
-    command! -buffer -nargs=1 RunHelp echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
-  endif
+  " Nvim's :! is not interactive.
+  " if !has('gui_running') && executable('less')
+  "   command! -buffer -nargs=1 RunHelp silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
+  " elseif has('terminal')
+    " Nvim's :terminal doesn't split or enter terminal mode by default.
+    " command! -buffer -nargs=1 RunHelp silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
+    command! -buffer -nargs=1 RunHelp split | startinsert | silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
+  " else
+  "   command! -buffer -nargs=1 RunHelp echo system('zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+  " endif
   if !exists('current_compiler')
     compiler zsh
   endif


### PR DESCRIPTION
Problem: https://github.com/neovim/neovim/commit/e2c10dea19a329f7913eb1d6110f10ec4bc525f9 may use `less` interactively via :! in :Sman and :Help, which doesn't work in Nvim. This made me also notice there's :{Get,Run}Help in other files...

Solution: Use :terminal. :split by default (like Vim) so it works well with K, and :startinsert so that spawned pagers can be interacted with immediately.

Maybe :Man is better (when possible), but this is simpler and diverges less (also the "--pattern"s used in `less` would need to be adjusted to Vim syntax).

yay or nay?