### PR TITLE
refactor(memline): distinguish mutating uses of ml_get_buf()

### DIFF
--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -546,7 +546,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   char *str_at_end = NULL;
 
   // Another call to ml_get_buf() may free the line, so make a copy.
-  str_at_start = xstrdup(ml_get_buf(buf, (linenr_T)start_row, false));
+  str_at_start = xstrdup(ml_get_buf(buf, (linenr_T)start_row));
   size_t len_at_start = strlen(str_at_start);
   start_col = start_col < 0 ? (int64_t)len_at_start + start_col + 1 : start_col;
   VALIDATE_RANGE((start_col >= 0 && (size_t)start_col <= len_at_start), "start_col", {
@@ -554,7 +554,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
   });
 
   // Another call to ml_get_buf() may free the line, so make a copy.
-  str_at_end = xstrdup(ml_get_buf(buf, (linenr_T)end_row, false));
+  str_at_end = xstrdup(ml_get_buf(buf, (linenr_T)end_row));
   size_t len_at_end = strlen(str_at_end);
   end_col = end_col < 0 ? (int64_t)len_at_end + end_col + 1 : end_col;
   VALIDATE_RANGE((end_col >= 0 && (size_t)end_col <= len_at_end), "end_col", {
@@ -584,7 +584,7 @@ void nvim_buf_set_text(uint64_t channel_id, Buffer buffer, Integer start_row, In
     for (int64_t i = 1; i < end_row - start_row; i++) {
       int64_t lnum = start_row + i;
 
-      const char *bufline = ml_get_buf(buf, (linenr_T)lnum, false);
+      const char *bufline = ml_get_buf(buf, (linenr_T)lnum);
       old_byte += (bcount_t)(strlen(bufline)) + 1;
     }
     old_byte += (bcount_t)end_col + 1;
@@ -1415,7 +1415,7 @@ bool buf_collect_lines(buf_T *buf, size_t n, linenr_T start, int start_idx, bool
       return false;
     }
 
-    char *bufstr = ml_get_buf(buf, lnum, false);
+    char *bufstr = ml_get_buf(buf, lnum);
     push_linestr(lstate, l, bufstr, strlen(bufstr), start_idx + (int)i, replace_nl);
   }
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -783,7 +783,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     });
     line = buf->b_ml.ml_line_count;
   } else if (line < buf->b_ml.ml_line_count) {
-    len = opts->ephemeral ? MAXCOL : strlen(ml_get_buf(buf, (linenr_T)line + 1, false));
+    len = opts->ephemeral ? MAXCOL : strlen(ml_get_buf(buf, (linenr_T)line + 1));
   }
 
   if (col == -1) {
@@ -801,7 +801,7 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
 
   if (col2 >= 0) {
     if (line2 >= 0 && line2 < buf->b_ml.ml_line_count) {
-      len = opts->ephemeral ? MAXCOL : strlen(ml_get_buf(buf, (linenr_T)line2 + 1, false));
+      len = opts->ephemeral ? MAXCOL : strlen(ml_get_buf(buf, (linenr_T)line2 + 1));
     } else if (line2 == buf->b_ml.ml_line_count) {
       // We are trying to add an extmark past final newline
       len = 0;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -517,7 +517,7 @@ String buf_get_text(buf_T *buf, int64_t lnum, int64_t start_col, int64_t end_col
     return rv;
   }
 
-  char *bufstr = ml_get_buf(buf, (linenr_T)lnum, false);
+  char *bufstr = ml_get_buf(buf, (linenr_T)lnum);
   size_t line_length = strlen(bufstr);
 
   start_col = start_col < 0 ? (int64_t)line_length + start_col + 1 : start_col;

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -4250,7 +4250,7 @@ bool buf_contents_changed(buf_T *buf)
     if (buf->b_ml.ml_line_count == curbuf->b_ml.ml_line_count) {
       differ = false;
       for (linenr_T lnum = 1; lnum <= curbuf->b_ml.ml_line_count; lnum++) {
-        if (strcmp(ml_get_buf(buf, lnum, false), ml_get(lnum)) != 0) {
+        if (strcmp(ml_get_buf(buf, lnum), ml_get(lnum)) != 0) {
           differ = true;
           break;
         }

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -138,7 +138,7 @@ static inline void buf_inc_changedtick(buf_T *const buf)
 static inline bool buf_is_empty(buf_T *buf)
 {
   return buf->b_ml.ml_line_count == 1
-         && *ml_get_buf(buf, (linenr_T)1, false) == '\0';
+         && *ml_get_buf(buf, (linenr_T)1) == '\0';
 }
 
 #endif  // NVIM_BUFFER_H

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1524,7 +1524,7 @@ restore_backup:
     for (lnum = start; lnum <= end; lnum++) {
       // The next while loop is done once for each character written.
       // Keep it fast!
-      char *ptr = ml_get_buf(buf, lnum, false) - 1;
+      char *ptr = ml_get_buf(buf, lnum) - 1;
       if (write_undo_file) {
         sha256_update(&sha_ctx, (uint8_t *)ptr + 1, (uint32_t)(strlen(ptr + 1) + 1));
       }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -609,7 +609,7 @@ bool file_ff_differs(buf_T *buf, bool ignore_empty)
   if (ignore_empty
       && (buf->b_flags & BF_NEW)
       && buf->b_ml.ml_line_count == 1
-      && *ml_get_buf(buf, (linenr_T)1, false) == NUL) {
+      && *ml_get_buf(buf, (linenr_T)1) == NUL) {
     return false;
   }
   if (buf->b_start_ffc != *buf->b_p_ff) {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -971,7 +971,7 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
   int ts = (int)wp->w_buffer->b_p_ts;
 
   colnr_T vcol = 0;
-  char *line = ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);  // start of the line
+  char *line = ptr = ml_get_buf(wp->w_buffer, pos->lnum);  // start of the line
 
   if (pos->col == MAXCOL) {
     // continue until the NUL
@@ -1141,7 +1141,7 @@ void getvvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *e
     colnr_T endadd = 0;
 
     // Cannot put the cursor on part of a wide character.
-    char *ptr = ml_get_buf(wp->w_buffer, pos->lnum, false);
+    char *ptr = ml_get_buf(wp->w_buffer, pos->lnum);
 
     if (pos->col < (colnr_T)strlen(ptr)) {
       int c = utf_ptr2char(ptr + pos->col);

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -108,7 +108,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
                  || (VIsual_active && *p_sel != 'o')
                  || ((get_ve_flags() & VE_ONEMORE) && wcol < MAXCOL);
 
-  char *line = ml_get_buf(curbuf, pos->lnum, false);
+  char *line = ml_get_buf(curbuf, pos->lnum);
 
   if (wcol >= MAXCOL) {
     idx = (int)strlen(line) - 1 + one_more;
@@ -315,7 +315,7 @@ void check_pos(buf_T *buf, pos_T *pos)
   }
 
   if (pos->col > 0) {
-    char *line = ml_get_buf(buf, pos->lnum, false);
+    char *line = ml_get_buf(buf, pos->lnum);
     colnr_T len = (colnr_T)strlen(line);
     if (pos->col > len) {
       pos->col = len;
@@ -353,7 +353,7 @@ void check_cursor_col_win(win_T *win)
   colnr_T oldcoladd = win->w_cursor.col + win->w_cursor.coladd;
   unsigned cur_ve_flags = get_ve_flags();
 
-  colnr_T len = (colnr_T)strlen(ml_get_buf(win->w_buffer, win->w_cursor.lnum, false));
+  colnr_T len = (colnr_T)strlen(ml_get_buf(win->w_buffer, win->w_cursor.lnum));
   if (len == 0) {
     win->w_cursor.col = 0;
   } else if (win->w_cursor.col >= len) {
@@ -501,18 +501,17 @@ int gchar_cursor(void)
 /// It is directly written into the block.
 void pchar_cursor(char c)
 {
-  *(ml_get_buf(curbuf, curwin->w_cursor.lnum, true)
-    + curwin->w_cursor.col) = c;
+  *(ml_get_buf_mut(curbuf, curwin->w_cursor.lnum) + curwin->w_cursor.col) = c;
 }
 
 /// @return  pointer to cursor line.
 char *get_cursor_line_ptr(void)
 {
-  return ml_get_buf(curbuf, curwin->w_cursor.lnum, false);
+  return ml_get_buf(curbuf, curwin->w_cursor.lnum);
 }
 
 /// @return  pointer to cursor position.
 char *get_cursor_pos_ptr(void)
 {
-  return ml_get_buf(curbuf, curwin->w_cursor.lnum, false) + curwin->w_cursor.col;
+  return ml_get_buf(curbuf, curwin->w_cursor.lnum) + curwin->w_cursor.col;
 }

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -596,9 +596,7 @@ static void diff_check_unchanged(tabpage_T *tp, diff_T *dp)
       if (dir == BACKWARD) {
         off_org = dp->df_count[i_org] - 1;
       }
-      char *line_org = xstrdup(ml_get_buf(tp->tp_diffbuf[i_org],
-                                          dp->df_lnum[i_org] + off_org,
-                                          false));
+      char *line_org = xstrdup(ml_get_buf(tp->tp_diffbuf[i_org], dp->df_lnum[i_org] + off_org));
 
       int i_new;
       for (i_new = i_org + 1; i_new < DB_COUNT; i_new++) {
@@ -616,8 +614,7 @@ static void diff_check_unchanged(tabpage_T *tp, diff_T *dp)
         }
 
         if (diff_cmp(line_org, ml_get_buf(tp->tp_diffbuf[i_new],
-                                          dp->df_lnum[i_new] + off_new,
-                                          false)) != 0) {
+                                          dp->df_lnum[i_new] + off_new)) != 0) {
           break;
         }
       }
@@ -756,7 +753,7 @@ static int diff_write_buffer(buf_T *buf, mmfile_t *m, linenr_T start, linenr_T e
 
   // xdiff requires one big block of memory with all the text.
   for (linenr_T lnum = start; lnum <= end; lnum++) {
-    len += strlen(ml_get_buf(buf, lnum, false)) + 1;
+    len += strlen(ml_get_buf(buf, lnum)) + 1;
   }
   char *ptr = try_malloc(len);
   if (ptr == NULL) {
@@ -777,7 +774,7 @@ static int diff_write_buffer(buf_T *buf, mmfile_t *m, linenr_T start, linenr_T e
 
   len = 0;
   for (linenr_T lnum = start; lnum <= end; lnum++) {
-    char *s = ml_get_buf(buf, lnum, false);
+    char *s = ml_get_buf(buf, lnum);
     if (diff_flags & DIFF_ICASE) {
       while (*s != NUL) {
         char cbuf[MB_MAXBYTES + 1];
@@ -2244,11 +2241,9 @@ static bool diff_equal_entry(diff_T *dp, int idx1, int idx2)
   }
 
   for (int i = 0; i < dp->df_count[idx1]; i++) {
-    char *line = xstrdup(ml_get_buf(curtab->tp_diffbuf[idx1],
-                                    dp->df_lnum[idx1] + i, false));
+    char *line = xstrdup(ml_get_buf(curtab->tp_diffbuf[idx1], dp->df_lnum[idx1] + i));
 
-    int cmp = diff_cmp(line, ml_get_buf(curtab->tp_diffbuf[idx2],
-                                        dp->df_lnum[idx2] + i, false));
+    int cmp = diff_cmp(line, ml_get_buf(curtab->tp_diffbuf[idx2], dp->df_lnum[idx2] + i));
     xfree(line);
 
     if (cmp != 0) {
@@ -2617,7 +2612,7 @@ bool diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   // Make a copy of the line, the next ml_get() will invalidate it.
-  char *line_org = xstrdup(ml_get_buf(wp->w_buffer, lnum, false));
+  char *line_org = xstrdup(ml_get_buf(wp->w_buffer, lnum));
 
   int idx = diff_buf_idx(wp->w_buffer);
   if (idx == DB_COUNT) {
@@ -2661,7 +2656,7 @@ bool diff_find_change(win_T *wp, linenr_T lnum, int *startp, int *endp)
         continue;
       }
       added = false;
-      char *line_new = ml_get_buf(curtab->tp_diffbuf[i], dp->df_lnum[i] + off, false);
+      char *line_new = ml_get_buf(curtab->tp_diffbuf[i], dp->df_lnum[i] + off);
 
       // Search for start of difference
       si_org = si_new = 0;
@@ -3097,7 +3092,7 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
         if (nr > curtab->tp_diffbuf[idx_from]->b_ml.ml_line_count) {
           break;
         }
-        char *p = xstrdup(ml_get_buf(curtab->tp_diffbuf[idx_from], nr, false));
+        char *p = xstrdup(ml_get_buf(curtab->tp_diffbuf[idx_from], nr));
         ml_append(lnum + i - 1, p, 0, false);
         xfree(p);
         added++;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -770,7 +770,7 @@ static void handle_breakindent(win_T *wp, winlinevars_T *wlv)
       wlv->p_extra = NULL;
       wlv->c_extra = ' ';
       wlv->c_final = NUL;
-      wlv->n_extra = get_breakindent_win(wp, ml_get_buf(wp->w_buffer, wlv->lnum, false));
+      wlv->n_extra = get_breakindent_win(wp, ml_get_buf(wp->w_buffer, wlv->lnum));
       if (wlv->row == wlv->startrow) {
         wlv->n_extra -= win_col_off2(wp);
         if (wlv->n_extra < 0) {
@@ -1431,11 +1431,11 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
     // Trick: skip a few chars for C/shell/Vim comments
     nextline[SPWORDLEN] = NUL;
     if (lnum < wp->w_buffer->b_ml.ml_line_count) {
-      line = ml_get_buf(wp->w_buffer, lnum + 1, false);
+      line = ml_get_buf(wp->w_buffer, lnum + 1);
       spell_cat_line(nextline + SPWORDLEN, line, SPWORDLEN);
     }
     assert(!end_fill);
-    line = ml_get_buf(wp->w_buffer, lnum, false);
+    line = ml_get_buf(wp->w_buffer, lnum);
 
     // If current line is empty, check first word in next line for capital.
     ptr = skipwhite(line);
@@ -1470,7 +1470,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
     }
   }
 
-  line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum, false);
+  line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum);
   ptr = line;
 
   colnr_T trailcol = MAXCOL;  // start of trailing spaces
@@ -1567,7 +1567,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
       len = spell_move_to(wp, FORWARD, true, true, &spell_hlf);
 
       // spell_move_to() may call ml_get() and make "line" invalid
-      line = ml_get_buf(wp->w_buffer, lnum, false);
+      line = ml_get_buf(wp->w_buffer, lnum);
       ptr = line + linecol;
 
       if (len == 0 || (int)wp->w_cursor.col > ptr - line) {
@@ -1712,7 +1712,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
             get_statuscol_str(wp, lnum, wlv.row - startrow - wlv.filler_lines, &statuscol);
             if (!end_fill) {
               // Get the line again as evaluating 'statuscolumn' may free it.
-              line = ml_get_buf(wp->w_buffer, lnum, false);
+              line = ml_get_buf(wp->w_buffer, lnum);
               ptr = line + v;
             }
             if (wp->w_redr_statuscol) {
@@ -1912,7 +1912,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
       wlv.p_extra[wlv.n_extra] = NUL;
 
       // Get the line again as evaluating 'foldtext' may free it.
-      line = ml_get_buf(wp->w_buffer, lnum, false);
+      line = ml_get_buf(wp->w_buffer, lnum);
       ptr = line + v;
     }
 
@@ -2166,7 +2166,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
           // Need to get the line again, a multi-line regexp may
           // have made it invalid.
-          line = ml_get_buf(wp->w_buffer, lnum, false);
+          line = ml_get_buf(wp->w_buffer, lnum);
           ptr = line + v;
 
           // no concealing past the end of the line, it interferes

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -823,7 +823,7 @@ void show_cursor_info_later(bool force)
 {
   int state = get_real_state();
   int empty_line = (State & MODE_INSERT) == 0
-                   && *ml_get_buf(curwin->w_buffer, curwin->w_cursor.lnum, false) == NUL;
+                   && *ml_get_buf(curwin->w_buffer, curwin->w_cursor.lnum) == NUL;
 
   // Only draw when something changed.
   validate_virtcol_win(curwin);
@@ -1875,7 +1875,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
                  pos.lnum += cursor_above ? 1 : -1) {
               colnr_T t;
 
-              pos.col = (colnr_T)strlen(ml_get_buf(wp->w_buffer, pos.lnum, false));
+              pos.col = (colnr_T)strlen(ml_get_buf(wp->w_buffer, pos.lnum));
               getvvcol(wp, &pos, NULL, NULL, &t);
               if (toc < t) {
                 toc = t;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3775,7 +3775,7 @@ static bool ins_bs(int c, int mode, int *inserted_space_p)
         // again when auto-formatting.
         if (has_format_option(FO_AUTO)
             && has_format_option(FO_WHITE_PAR)) {
-          char *ptr = ml_get_buf(curbuf, curwin->w_cursor.lnum, true);
+          char *ptr = ml_get_buf_mut(curbuf, curwin->w_cursor.lnum);
           int len;
 
           len = (int)strlen(ptr);

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6423,7 +6423,7 @@ char *save_tv_as_string(typval_T *tv, ptrdiff_t *const len, bool endnl, bool crl
     buf_T *buf = buflist_findnr((int)tv->vval.v_number);
     if (buf) {
       for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
-        for (char *p = ml_get_buf(buf, lnum, false); *p != NUL; p++) {
+        for (char *p = ml_get_buf(buf, lnum); *p != NUL; p++) {
           *len += 1;
         }
         *len += 1;
@@ -6441,7 +6441,7 @@ char *save_tv_as_string(typval_T *tv, ptrdiff_t *const len, bool endnl, bool crl
     char *ret = xmalloc((size_t)(*len) + 1);
     char *end = ret;
     for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
-      for (char *p = ml_get_buf(buf, lnum, false); *p != NUL; p++) {
+      for (char *p = ml_get_buf(buf, lnum); *p != NUL; p++) {
         *end++ = (*p == '\n') ? NUL : *p;
       }
       *end++ = '\n';
@@ -6493,7 +6493,7 @@ int buf_byteidx_to_charidx(buf_T *buf, linenr_T lnum, int byteidx)
     lnum = buf->b_ml.ml_line_count;
   }
 
-  char *str = ml_get_buf(buf, lnum, false);
+  char *str = ml_get_buf(buf, lnum);
 
   if (*str == NUL) {
     return 0;
@@ -6531,7 +6531,7 @@ int buf_charidx_to_byteidx(buf_T *buf, linenr_T lnum, int charidx)
     lnum = buf->b_ml.ml_line_count;
   }
 
-  char *str = ml_get_buf(buf, lnum, false);
+  char *str = ml_get_buf(buf, lnum);
 
   // Convert the character offset to a byte offset
   char *t = str;

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -604,12 +604,12 @@ static void get_buffer_lines(buf_T *buf, linenr_T start, linenr_T end, int retli
     }
     tv_list_alloc_ret(rettv, end - start + 1);
     while (start <= end) {
-      tv_list_append_string(rettv->vval.v_list, ml_get_buf(buf, start++, false), -1);
+      tv_list_append_string(rettv->vval.v_list, ml_get_buf(buf, start++), -1);
     }
   } else {
     rettv->v_type = VAR_STRING;
     rettv->vval.v_string = ((start >= 1 && start <= buf->b_ml.ml_line_count)
-                            ? xstrdup(ml_get_buf(buf, start, false)) : NULL);
+                            ? xstrdup(ml_get_buf(buf, start)) : NULL);
   }
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4644,7 +4644,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
         if (next_linenr == orig_buf->b_ml.ml_line_count + 1) {
           line = "";
         } else {
-          line = ml_get_buf(orig_buf, next_linenr, false);
+          line = ml_get_buf(orig_buf, next_linenr);
           line_size = strlen(line) + (size_t)col_width + 1;
 
           // Reallocate if line not long enough

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -2842,7 +2842,7 @@ static int move_lines(buf_T *frombuf, buf_T *tobuf)
   // Copy the lines in "frombuf" to "tobuf".
   curbuf = tobuf;
   for (linenr_T lnum = 1; lnum <= frombuf->b_ml.ml_line_count; lnum++) {
-    char *p = xstrdup(ml_get_buf(frombuf, lnum, false));
+    char *p = xstrdup(ml_get_buf(frombuf, lnum));
     if (ml_append(lnum - 1, p, 0, false) == FAIL) {
       xfree(p);
       retval = FAIL;

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1601,7 +1601,7 @@ static void foldAddMarker(buf_T *buf, pos_T pos, const char *marker, size_t mark
   linenr_T lnum = pos.lnum;
 
   // Allocate a new line: old-line + 'cms'-start + marker + 'cms'-end
-  char *line = ml_get_buf(buf, lnum, false);
+  char *line = ml_get_buf(buf, lnum);
   size_t line_len = strlen(line);
   size_t added = 0;
 
@@ -1661,7 +1661,7 @@ static void foldDelMarker(buf_T *buf, linenr_T lnum, char *marker, size_t marker
   }
 
   char *cms = buf->b_p_cms;
-  char *line = ml_get_buf(buf, lnum, false);
+  char *line = ml_get_buf(buf, lnum);
   for (char *p = line; *p != NUL; p++) {
     if (strncmp(p, marker, markerlen) != 0) {
       continue;
@@ -2874,7 +2874,7 @@ static void foldlevelIndent(fline_T *flp)
   linenr_T lnum = flp->lnum + flp->off;
 
   buf_T *buf = flp->wp->w_buffer;
-  char *s = skipwhite(ml_get_buf(buf, lnum, false));
+  char *s = skipwhite(ml_get_buf(buf, lnum));
 
   // empty line or lines starting with a character in 'foldignore': level
   // depends on surrounding lines
@@ -3036,7 +3036,7 @@ static void foldlevelMarker(fline_T *flp)
   flp->start = 0;
   flp->lvl_next = flp->lvl;
 
-  char *s = ml_get_buf(flp->wp->w_buffer, flp->lnum + flp->off, false);
+  char *s = ml_get_buf(flp->wp->w_buffer, flp->lnum + flp->off);
   while (*s) {
     if (*s == cstart
         && strncmp(s + 1, startmarker, foldstartmarkerlen - 1) == 0) {

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -660,13 +660,13 @@ void fix_help_buffer(void)
   if (!syntax_present(curwin)) {
     bool in_example = false;
     for (lnum = 1; lnum <= curbuf->b_ml.ml_line_count; lnum++) {
-      line = ml_get_buf(curbuf, lnum, false);
+      line = ml_get_buf(curbuf, lnum);
       const size_t len = strlen(line);
       if (in_example && len > 0 && !ascii_iswhite(line[0])) {
         // End of example: non-white or '<' in first column.
         if (line[0] == '<') {
           // blank-out a '<' in the first column
-          line = ml_get_buf(curbuf, lnum, true);
+          line = ml_get_buf_mut(curbuf, lnum);
           line[0] = ' ';
         }
         in_example = false;
@@ -674,12 +674,12 @@ void fix_help_buffer(void)
       if (!in_example && len > 0) {
         if (line[len - 1] == '>' && (len == 1 || line[len - 2] == ' ')) {
           // blank-out a '>' in the last column (start of example)
-          line = ml_get_buf(curbuf, lnum, true);
+          line = ml_get_buf_mut(curbuf, lnum);
           line[len - 1] = ' ';
           in_example = true;
         } else if (line[len - 1] == '~') {
           // blank-out a '~' at the end of line (header marker)
-          line = ml_get_buf(curbuf, lnum, true);
+          line = ml_get_buf_mut(curbuf, lnum);
           line[len - 1] = ' ';
         }
       }
@@ -696,7 +696,7 @@ void fix_help_buffer(void)
           && TOLOWER_ASC(fname[7]) == 'x'
           && fname[8] == NUL)) {
     for (lnum = 1; lnum < curbuf->b_ml.ml_line_count; lnum++) {
-      line = ml_get_buf(curbuf, lnum, false);
+      line = ml_get_buf(curbuf, lnum);
       if (strstr(line, "*local-additions*") == NULL) {
         continue;
       }

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -378,10 +378,7 @@ int get_indent_lnum(linenr_T lnum)
 // "buf".
 int get_indent_buf(buf_T *buf, linenr_T lnum)
 {
-  return get_indent_str_vtab(ml_get_buf(buf, lnum, false),
-                             buf->b_p_ts,
-                             buf->b_p_vts_array,
-                             false);
+  return get_indent_str_vtab(ml_get_buf(buf, lnum), buf->b_p_ts, buf->b_p_vts_array, false);
 }
 
 /// Count the size (in window cells) of the indent in line "ptr", with

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3045,14 +3045,14 @@ static char *ins_compl_get_next_word_or_line(buf_T *ins_buf, pos_T *cur_match_po
                                              bool *cont_s_ipos)
 {
   *match_len = 0;
-  char *ptr = ml_get_buf(ins_buf, cur_match_pos->lnum, false) + cur_match_pos->col;
+  char *ptr = ml_get_buf(ins_buf, cur_match_pos->lnum) + cur_match_pos->col;
   int len;
   if (ctrl_x_mode_line_or_eval()) {
     if (compl_status_adding()) {
       if (cur_match_pos->lnum >= ins_buf->b_ml.ml_line_count) {
         return NULL;
       }
-      ptr = ml_get_buf(ins_buf, cur_match_pos->lnum + 1, false);
+      ptr = ml_get_buf(ins_buf, cur_match_pos->lnum + 1);
       if (!p_paste) {
         ptr = skipwhite(ptr);
       }
@@ -3080,7 +3080,7 @@ static char *ins_compl_get_next_word_or_line(buf_T *ins_buf, pos_T *cur_match_po
         // normal command "J" was used. IOSIZE is always greater than
         // compl_length, so the next strncpy always works -- Acevedo
         strncpy(IObuff, ptr, (size_t)len);  // NOLINT(runtime/printf)
-        ptr = ml_get_buf(ins_buf, cur_match_pos->lnum + 1, false);
+        ptr = ml_get_buf(ins_buf, cur_match_pos->lnum + 1);
         tmp_ptr = ptr = skipwhite(ptr);
         // Find start of next word.
         tmp_ptr = find_word_start(tmp_ptr);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1707,7 +1707,7 @@ void ex_luado(exarg_T *const eap)
       break;
     }
     lua_pushvalue(lstate, -1);
-    const char *const old_line = ml_get_buf(curbuf, l, false);
+    const char *const old_line = ml_get_buf(curbuf, l);
     // Get length of old_line here as calling Lua code may free it.
     const size_t old_line_len = strlen(old_line);
     lua_pushstring(lstate, old_line);

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -105,7 +105,7 @@ static int regex_match_line(lua_State *lstate)
     return luaL_error(lstate, "invalid row");
   }
 
-  char *line = ml_get_buf(buf, rownr + 1, false);
+  char *line = ml_get_buf(buf, rownr + 1);
   size_t len = strlen(line);
 
   if (start < 0 || (size_t)start > len) {

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -365,7 +365,7 @@ static const char *input_cb(void *payload, uint32_t byte_index, TSPoint position
     *bytes_read = 0;
     return "";
   }
-  char *line = ml_get_buf(bp, (linenr_T)position.row + 1, false);
+  char *line = ml_get_buf(bp, (linenr_T)position.row + 1);
   size_t len = strlen(line);
   if (position.column > len) {
     *bytes_read = 0;

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1706,7 +1706,7 @@ void mark_mb_adjustpos(buf_T *buf, pos_T *lp)
   FUNC_ATTR_NONNULL_ALL
 {
   if (lp->col > 0 || lp->coladd > 1) {
-    const char *const p = ml_get_buf(buf, lp->lnum, false);
+    const char *const p = ml_get_buf(buf, lp->lnum);
     if (*p == NUL || (int)strlen(p) < lp->col) {
       lp->col = 0;
     } else {

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -463,7 +463,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
       char *ml;
 
       matchcol = shl->rm.startpos[0].col;
-      ml = ml_get_buf(shl->buf, lnum, false) + matchcol;
+      ml = ml_get_buf(shl->buf, lnum) + matchcol;
       if (*ml == NUL) {
         matchcol++;
         shl->lnum = 0;
@@ -630,7 +630,7 @@ bool prepare_search_hl_line(win_T *wp, linenr_T lnum, colnr_T mincol, char **lin
 
     // Need to get the line again, a multi-line regexp may have made it
     // invalid.
-    *line = ml_get_buf(wp->w_buffer, lnum, false);
+    *line = ml_get_buf(wp->w_buffer, lnum);
 
     if (shl->lnum != 0 && shl->lnum <= lnum) {
       if (shl->lnum == lnum) {
@@ -740,7 +740,7 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
 
         // Need to get the line again, a multi-line regexp
         // may have made it invalid.
-        *line = ml_get_buf(wp->w_buffer, lnum, false);
+        *line = ml_get_buf(wp->w_buffer, lnum);
 
         if (shl->lnum == lnum) {
           shl->startcol = shl->rm.startpos[0].col;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1970,7 +1970,7 @@ void mb_check_adjust_col(void *win_)
 
   // Column 0 is always valid.
   if (oldcol != 0) {
-    char *p = ml_get_buf(win->w_buffer, win->w_cursor.lnum, false);
+    char *p = ml_get_buf(win->w_buffer, win->w_cursor.lnum);
     colnr_T len = (colnr_T)strlen(p);
 
     // Empty line or invalid column?

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -208,7 +208,7 @@ void mf_close_file(buf_T *buf, bool getlines)
   if (getlines) {
     // get all blocks in memory by accessing all lines (clumsy!)
     for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
-      (void)ml_get_buf(buf, lnum, false);
+      (void)ml_get_buf(buf, lnum);
     }
   }
 

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1803,20 +1803,40 @@ theend:
 //  line2 = ml_get(2);  // line1 is now invalid!
 // Make a copy of the line if necessary.
 
-/// @return  a pointer to a (read-only copy of a) line.
+/// @return  a pointer to a (read-only copy of a) line in curbuf.
 ///
 /// On failure an error message is given and IObuff is returned (to avoid
 /// having to check for error everywhere).
 char *ml_get(linenr_T lnum)
 {
-  return ml_get_buf(curbuf, lnum, false);
+  return ml_get_buf_impl(curbuf, lnum, false);
+}
+
+/// @return  a pointer to a (read-only copy of a) line.
+///
+/// This is the same as ml_get(), but taking in the buffer
+/// as an argument.
+char *ml_get_buf(buf_T *buf, linenr_T lnum)
+{
+  return ml_get_buf_impl(buf, lnum, false);
+}
+
+/// Like `ml_get_buf`, but allow the line to be mutated in place.
+///
+/// This is very limited. Generally ml_replace_buf()
+/// should be used to modify a line.
+///
+/// @return a pointer to a line in the buffer
+char *ml_get_buf_mut(buf_T *buf, linenr_T lnum)
+{
+  return ml_get_buf_impl(buf, lnum, true);
 }
 
 /// @return  pointer to position "pos".
 char *ml_get_pos(const pos_T *pos)
   FUNC_ATTR_NONNULL_ALL
 {
-  return ml_get_buf(curbuf, pos->lnum, false) + pos->col;
+  return ml_get_buf(curbuf, pos->lnum) + pos->col;
 }
 
 /// @return  codepoint at pos. pos must be either valid or have col set to MAXCOL!
@@ -1833,7 +1853,7 @@ int gchar_pos(pos_T *pos)
 /// @param will_change  true mark the buffer dirty (chars in the line will be changed)
 ///
 /// @return  a pointer to a line in a specific buffer
-char *ml_get_buf(buf_T *buf, linenr_T lnum, bool will_change)
+static char *ml_get_buf_impl(buf_T *buf, linenr_T lnum, bool will_change)
   FUNC_ATTR_NONNULL_ALL
 {
   static int recursive = 0;
@@ -2447,7 +2467,7 @@ int ml_replace_buf(buf_T *buf, linenr_T lnum, char *line, bool copy)
   }
 
   if (kv_size(buf->update_callbacks)) {
-    ml_add_deleted_len_buf(buf, ml_get_buf(buf, lnum, false), -1);
+    ml_add_deleted_len_buf(buf, ml_get_buf(buf, lnum), -1);
   }
 
   if (buf->b_ml.ml_flags & (ML_LINE_DIRTY | ML_ALLOCATED)) {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1750,7 +1750,7 @@ colnr_T vcol2col(win_T *const wp, const linenr_T lnum, const colnr_T vcol)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   // try to advance to the specified column
-  char *line = ml_get_buf(wp->w_buffer, lnum, false);
+  char *line = ml_get_buf(wp->w_buffer, lnum);
   chartabsize_T cts;
   init_chartabsize_arg(&cts, wp, lnum, 0, line, line);
   while (cts.cts_vcol < vcol && *cts.cts_ptr != NUL) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1164,7 +1164,7 @@ void f_screenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 static int virtcol2col(win_T *wp, linenr_T lnum, int vcol)
 {
   int offset = vcol2col(wp, lnum, vcol);
-  char *line = ml_get_buf(wp->w_buffer, lnum, false);
+  char *line = ml_get_buf(wp->w_buffer, lnum);
   char *p = line + offset;
 
   // For a multibyte character, need to return the column number of the first byte.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1638,7 +1638,7 @@ size_t find_ident_at_pos(win_T *wp, linenr_T lnum, colnr_T startcol, char **text
 
   // if i == 0: try to find an identifier
   // if i == 1: try to find any non-white text
-  char *ptr = ml_get_buf(wp->w_buffer, lnum, false);
+  char *ptr = ml_get_buf(wp->w_buffer, lnum);
   for (i = (find_type & FIND_IDENT) ? 0 : 1; i < 2; i++) {
     // 1. skip to start of identifier/text
     col = startcol;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1373,7 +1373,7 @@ bool get_spec_reg(int regname, char **argp, bool *allocated, bool errmsg)
       return false;
     }
 
-    *argp = ml_get_buf(curwin->w_buffer, curwin->w_cursor.lnum, false);
+    *argp = ml_get_buf(curwin->w_buffer, curwin->w_cursor.lnum);
     return true;
 
   case '_':                     // black hole: always empty
@@ -1783,7 +1783,7 @@ static void mb_adjust_opend(oparg_T *oap)
 static inline void pbyte(pos_T lp, int c)
 {
   assert(c <= UCHAR_MAX);
-  *(ml_get_buf(curbuf, lp.lnum, true) + lp.col) = (char)c;
+  *(ml_get_buf_mut(curbuf, lp.lnum) + lp.col) = (char)c;
   if (!curbuf_splice_pending) {
     extmark_splice_cols(curbuf, (int)lp.lnum - 1, lp.col, 1, 1, kExtmarkUndo);
   }
@@ -6915,14 +6915,14 @@ bcount_t get_region_bytecount(buf_T *buf, linenr_T start_lnum, linenr_T end_lnum
   if (start_lnum == end_lnum) {
     return end_col - start_col;
   }
-  const char *first = ml_get_buf(buf, start_lnum, false);
+  const char *first = ml_get_buf(buf, start_lnum);
   bcount_t deleted_bytes = (bcount_t)strlen(first) - start_col + 1;
 
   for (linenr_T i = 1; i <= end_lnum - start_lnum - 1; i++) {
     if (start_lnum + i > max_lnum) {
       return deleted_bytes;
     }
-    deleted_bytes += (bcount_t)strlen(ml_get_buf(buf, start_lnum + i, false)) + 1;
+    deleted_bytes += (bcount_t)strlen(ml_get_buf(buf, start_lnum + i)) + 1;
   }
   if (end_lnum > max_lnum) {
     return deleted_bytes;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -98,7 +98,7 @@ int plines_win_nofill(win_T *wp, linenr_T lnum, bool limit_winheight)
 /// Does not care about folding, 'wrap' or filler lines.
 int plines_win_nofold(win_T *wp, linenr_T lnum)
 {
-  char *s = ml_get_buf(wp->w_buffer, lnum, false);
+  char *s = ml_get_buf(wp->w_buffer, lnum);
   chartabsize_T cts;
   init_chartabsize_arg(&cts, wp, lnum, 0, s, s);
   if (*s == NUL && !cts.cts_has_virt_text) {
@@ -143,7 +143,7 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
     return lines + 1;
   }
 
-  char *line = ml_get_buf(wp->w_buffer, lnum, false);
+  char *line = ml_get_buf(wp->w_buffer, lnum);
 
   colnr_T col = 0;
   chartabsize_T cts;
@@ -292,7 +292,7 @@ unsigned win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T len)
 /// screen, taking into account the size of a tab and inline virtual text.
 unsigned linetabsize(win_T *wp, linenr_T lnum)
 {
-  return win_linetabsize(wp, lnum, ml_get_buf(wp->w_buffer, lnum, false), (colnr_T)MAXCOL);
+  return win_linetabsize(wp, lnum, ml_get_buf(wp->w_buffer, lnum), (colnr_T)MAXCOL);
 }
 
 void win_linetabsize_cts(chartabsize_T *cts, colnr_T len)

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -761,7 +761,7 @@ static int qf_get_next_buf_line(qfstate_T *state)
   if (state->buflnum > state->lnumlast) {
     return QF_END_OF_INPUT;
   }
-  char *p_buf = ml_get_buf(state->buf, state->buflnum, false);
+  char *p_buf = ml_get_buf(state->buf, state->buflnum);
   state->buflnum += 1;
 
   size_t len = strlen(p_buf);
@@ -5245,7 +5245,7 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
                          fname,
                          NULL,
                          duplicate_name ? 0 : buf->b_fnum,
-                         ml_get_buf(buf, regmatch->startpos[0].lnum + lnum, false),
+                         ml_get_buf(buf, regmatch->startpos[0].lnum + lnum),
                          regmatch->startpos[0].lnum + lnum,
                          regmatch->endpos[0].lnum + lnum,
                          regmatch->startpos[0].col + 1,
@@ -5268,12 +5268,12 @@ static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *sp
           break;
         }
         col = regmatch->endpos[0].col + (col == regmatch->endpos[0].col);
-        if (col > (colnr_T)strlen(ml_get_buf(buf, lnum, false))) {
+        if (col > (colnr_T)strlen(ml_get_buf(buf, lnum))) {
           break;
         }
       }
     } else {
-      char *const str = ml_get_buf(buf, lnum, false);
+      char *const str = ml_get_buf(buf, lnum);
       int score;
       uint32_t matches[MAX_FUZZY_MATCHES];
       const size_t sz = sizeof(matches) / sizeof(matches[0]);

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1049,7 +1049,7 @@ static char *reg_getline(linenr_T lnum)
     // Must have matched the "\n" in the last line.
     return "";
   }
-  return ml_get_buf(rex.reg_buf, rex.reg_firstlnum + lnum, false);
+  return ml_get_buf(rex.reg_buf, rex.reg_firstlnum + lnum);
 }
 
 static uint8_t *reg_startzp[NSUBEXP];  // Workspace to mark beginning

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -596,7 +596,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
                && pos->lnum <= buf->b_ml.ml_line_count
                && pos->col < MAXCOL - 2) {
       // Watch out for the "col" being MAXCOL - 2, used in a closed fold.
-      ptr = ml_get_buf(buf, pos->lnum, false);
+      ptr = ml_get_buf(buf, pos->lnum);
       if ((int)strlen(ptr) <= pos->col) {
         start_char_len = 1;
       } else {
@@ -667,7 +667,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
           if (lnum + matchpos.lnum > buf->b_ml.ml_line_count) {
             ptr = "";
           } else {
-            ptr = ml_get_buf(buf, lnum + matchpos.lnum, false);
+            ptr = ml_get_buf(buf, lnum + matchpos.lnum);
           }
 
           // Forward search in the first line: match should be after
@@ -739,7 +739,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
               }
               // Need to get the line pointer again, a multi-line search may
               // have made it invalid.
-              ptr = ml_get_buf(buf, lnum, false);
+              ptr = ml_get_buf(buf, lnum);
             }
             if (!match_ok) {
               continue;
@@ -821,7 +821,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
               }
               // Need to get the line pointer again, a
               // multi-line search may have made it invalid.
-              ptr = ml_get_buf(buf, lnum + matchpos.lnum, false);
+              ptr = ml_get_buf(buf, lnum + matchpos.lnum);
             }
 
             // If there is only a match after the cursor, skip
@@ -844,12 +844,12 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
             if (endpos.col == 0) {
               if (pos->lnum > 1) {              // just in case
                 pos->lnum--;
-                pos->col = (colnr_T)strlen(ml_get_buf(buf, pos->lnum, false));
+                pos->col = (colnr_T)strlen(ml_get_buf(buf, pos->lnum));
               }
             } else {
               pos->col--;
               if (pos->lnum <= buf->b_ml.ml_line_count) {
-                ptr = ml_get_buf(buf, pos->lnum, false);
+                ptr = ml_get_buf(buf, pos->lnum);
                 pos->col -= utf_head_off(ptr, ptr + pos->col);
               }
             }
@@ -962,7 +962,7 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
   // A pattern like "\n\zs" may go past the last line.
   if (pos->lnum > buf->b_ml.ml_line_count) {
     pos->lnum = buf->b_ml.ml_line_count;
-    pos->col = (int)strlen(ml_get_buf(buf, pos->lnum, false));
+    pos->col = (int)strlen(ml_get_buf(buf, pos->lnum));
     if (pos->col > 0) {
       pos->col--;
     }
@@ -1467,7 +1467,7 @@ int search_for_exact_line(buf_T *buf, pos_T *pos, Direction dir, char *pat)
     if (start == 0) {
       start = pos->lnum;
     }
-    char *ptr = ml_get_buf(buf, pos->lnum, false);
+    char *ptr = ml_get_buf(buf, pos->lnum);
     char *p = skipwhite(ptr);
     pos->col = (colnr_T)(p - ptr);
 

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -1289,7 +1289,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
   decor_spell_nav_start(wp);
 
   while (!got_int) {
-    char *line = ml_get_buf(wp->w_buffer, lnum, false);
+    char *line = ml_get_buf(wp->w_buffer, lnum);
 
     len = strlen(line);
     if (buflen < len + MAXWLEN + 2) {
@@ -1316,7 +1316,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
 
       // Need to get the line again, may have looked at the previous
       // one.
-      line = ml_get_buf(wp->w_buffer, lnum, false);
+      line = ml_get_buf(wp->w_buffer, lnum);
     }
 
     // Copy the line into "buf" and append the start of the next line if
@@ -1326,7 +1326,7 @@ size_t spell_move_to(win_T *wp, int dir, bool allwords, bool curline, hlf_T *att
     STRCPY(buf, line);
     if (lnum < wp->w_buffer->b_ml.ml_line_count) {
       spell_cat_line(buf + strlen(buf),
-                     ml_get_buf(wp->w_buffer, lnum + 1, false),
+                     ml_get_buf(wp->w_buffer, lnum + 1),
                      MAXWLEN);
     }
     char *p = buf + skip;
@@ -2550,7 +2550,7 @@ bool check_need_cap(win_T *wp, linenr_T lnum, colnr_T col)
   }
 
   bool need_cap = false;
-  char *line = col ? ml_get_buf(wp->w_buffer, lnum, false) : NULL;
+  char *line = col ? ml_get_buf(wp->w_buffer, lnum) : NULL;
   char *line_copy = NULL;
   colnr_T endcol = 0;
   if (col == 0 || getwhitecols(line) >= col) {
@@ -2559,7 +2559,7 @@ bool check_need_cap(win_T *wp, linenr_T lnum, colnr_T col)
     if (lnum == 1) {
       need_cap = true;
     } else {
-      line = ml_get_buf(wp->w_buffer, lnum - 1, false);
+      line = ml_get_buf(wp->w_buffer, lnum - 1);
       if (*skipwhite(line) == NUL) {
         need_cap = true;
       } else {

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5220,7 +5220,7 @@ static void sug_write(spellinfo_T *spin, char *fname)
 
   for (linenr_T lnum = 1; lnum <= wcount; lnum++) {
     // <sugline>: <sugnr> ... NUL
-    char *line = ml_get_buf(spin->si_spellbuf, lnum, false);
+    char *line = ml_get_buf(spin->si_spellbuf, lnum);
     size_t len = strlen(line) + 1;
     if (fwrite(line, len, 1, fd) == 0) {
       emsg(_(e_write));

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -2816,7 +2816,7 @@ static void add_sound_suggest(suginfo_T *su, char *goodword, int score, langp_T 
   }
 
   // Go over the list of good words that produce this soundfold word
-  char *nrline = ml_get_buf(slang->sl_sugbuf, (linenr_T)sfwordnr + 1, false);
+  char *nrline = ml_get_buf(slang->sl_sugbuf, (linenr_T)sfwordnr + 1);
   int orgnr = 0;
   while (*nrline != NUL) {
     // The wordnr was stored in a minimal nr of bytes as an offset to the

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -512,7 +512,7 @@ void win_redr_ruler(win_T *wp)
 
   // Check if not in Insert mode and the line is empty (will show "0-1").
   int empty_line = (State & MODE_INSERT) == 0
-                   && *ml_get_buf(wp->w_buffer, wp->w_cursor.lnum, false) == NUL;
+                   && *ml_get_buf(wp->w_buffer, wp->w_cursor.lnum) == NUL;
 
   int width;
   int row;
@@ -1012,7 +1012,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
   }
 
   // Get line & check if empty (cursorpos will show "0-1").
-  const char *line_ptr = ml_get_buf(wp->w_buffer, lnum, false);
+  const char *line_ptr = ml_get_buf(wp->w_buffer, lnum);
   bool empty_line = (*line_ptr == NUL);
 
   // Get the byte value now, in case we need it below. This is more

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -2475,7 +2475,7 @@ static void find_endpos(int idx, lpos_T *startpos, lpos_T *m_endpos, lpos_T *hl_
           break;
         }
 
-        line = ml_get_buf(syn_buf, startpos->lnum, false);
+        line = ml_get_buf(syn_buf, startpos->lnum);
         int line_len = (int)strlen(line);
 
         // take care of an empty match or negative offset
@@ -2611,7 +2611,7 @@ static void syn_add_end_off(lpos_T *result, regmmatch_T *regmatch, synpat_T *spp
   if (result->lnum > syn_buf->b_ml.ml_line_count) {
     col = 0;
   } else if (off != 0) {
-    base = ml_get_buf(syn_buf, result->lnum, false);
+    base = ml_get_buf(syn_buf, result->lnum);
     p = base + col;
     if (off > 0) {
       while (off-- > 0 && *p != NUL) {
@@ -2653,10 +2653,10 @@ static void syn_add_start_off(lpos_T *result, regmmatch_T *regmatch, synpat_T *s
   if (result->lnum > syn_buf->b_ml.ml_line_count) {
     // a "\n" at the end of the pattern may take us below the last line
     result->lnum = syn_buf->b_ml.ml_line_count;
-    col = (int)strlen(ml_get_buf(syn_buf, result->lnum, false));
+    col = (int)strlen(ml_get_buf(syn_buf, result->lnum));
   }
   if (off != 0) {
-    base = ml_get_buf(syn_buf, result->lnum, false);
+    base = ml_get_buf(syn_buf, result->lnum);
     p = base + col;
     if (off > 0) {
       while (off-- && *p != NUL) {
@@ -2675,7 +2675,7 @@ static void syn_add_start_off(lpos_T *result, regmmatch_T *regmatch, synpat_T *s
 /// Get current line in syntax buffer.
 static char *syn_getcurline(void)
 {
-  return ml_get_buf(syn_buf, current_lnum, false);
+  return ml_get_buf(syn_buf, current_lnum);
 }
 
 // Call vim_regexec() to find a match with "rmp" in "syn_buf".

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -645,7 +645,7 @@ void u_compute_hash(buf_T *buf, uint8_t *hash)
   context_sha256_T ctx;
   sha256_start(&ctx);
   for (linenr_T lnum = 1; lnum <= buf->b_ml.ml_line_count; lnum++) {
-    char *p = ml_get_buf(buf, lnum, false);
+    char *p = ml_get_buf(buf, lnum);
     sha256_update(&ctx, (uint8_t *)p, strlen(p) + 1);
   }
   sha256_finish(&ctx, hash);
@@ -2779,7 +2779,7 @@ void u_find_first_changed(void)
   linenr_T lnum;
   for (lnum = 1; lnum < curbuf->b_ml.ml_line_count
        && lnum <= uep->ue_size; lnum++) {
-    if (strcmp(ml_get_buf(curbuf, lnum, false), uep->ue_array[lnum - 1]) != 0) {
+    if (strcmp(ml_get_buf(curbuf, lnum), uep->ue_array[lnum - 1]) != 0) {
       clearpos(&(uhp->uh_cursor));
       uhp->uh_cursor.lnum = lnum;
       return;
@@ -3073,7 +3073,7 @@ static char *u_save_line(linenr_T lnum)
 /// @param buf buffer to copy from
 static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
 {
-  return xstrdup(ml_get_buf(buf, lnum, false));
+  return xstrdup(ml_get_buf(buf, lnum));
 }
 
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to


### PR DESCRIPTION
`ml_get_buf()` takes a third parameters to indicate whether the caller wants to mutate the memline data in place. However the _vast_ majority of the call sites is using this function just to specify a buffer but without any mutation. This makes it harder to grep for the places which actually perform mutation.

Solution: Remove the bool param from `ml_get_buf()`. it now works like `ml_get()` except for a non-current buffer. Add a new `ml_get_buf_mut()` function for the mutating use-case, which can be grepped along with the other `ml_replace` etc functions which can modify the memline.