### PR TITLE
feat(filetype): add norg support

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -727,6 +727,7 @@ local extension = {
   ora = 'ora',
   org = 'org',
   org_archive = 'org',
+  norg = 'norg',
   pxsl = 'papp',
   papp = 'papp',
   pxml = 'papp',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -460,6 +460,7 @@ func s:GetFilenameChecks() abort
     \ 'opl': ['file.OPL', 'file.OPl', 'file.OpL', 'file.Opl', 'file.oPL', 'file.oPl', 'file.opL', 'file.opl'],
     \ 'ora': ['file.ora'],
     \ 'org': ['file.org', 'file.org_archive'],
+    \ 'norg': ['file.norg'],
     \ 'pamconf': ['/etc/pam.conf', '/etc/pam.d/file', 'any/etc/pam.conf', 'any/etc/pam.d/file'],
     \ 'pamenv': ['/etc/security/pam_env.conf', '/home/user/.pam_environment', '.pam_environment', 'pam_env.conf'],
     \ 'papp': ['file.papp', 'file.pxml', 'file.pxsl'],


### PR DESCRIPTION
Hey, this PR aims to add [norg](https://github.com/nvim-neorg/norg-specs) filetype recognition in Neovim.

I'm not sure if this requires a patch on Vim as well, since neorg doesn't work in any way on Vim so I just followed the same thing that is done with orgmode files which is just adding recognition to its filetype and nothing more. However, if a Vim patch is needed, please let me know and I will too.

Cheers