### PR TITLE
fix(filetype): call on_detect before setting buffer filetype

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2600,7 +2600,8 @@ vim.filetype.add({filetypes})                             *vim.filetype.add()*
     matched pattern, if any) and should return a string that will be used as
     the buffer's filetype. Optionally, the function can return a second
     function value which, when called, modifies the state of the buffer. This
-    can be used to, for example, set filetype-specific buffer variables.
+    can be used to, for example, set filetype-specific buffer variables. This
+    function will be called by Nvim before setting the buffer's filetype.
 
     Filename patterns can specify an optional priority to resolve cases when a
     file path matches multiple patterns. Higher priorities are matched first.

--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -18,12 +18,15 @@ vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
         end)
       end
     else
-      vim.api.nvim_buf_call(args.buf, function()
-        vim.api.nvim_cmd({ cmd = 'setf', args = { ft } }, {})
-      end)
+      -- on_detect is called before setting the filetype so that it can set any buffer local
+      -- variables that may be used the filetype's ftplugin
       if on_detect then
         on_detect(args.buf)
       end
+
+      vim.api.nvim_buf_call(args.buf, function()
+        vim.api.nvim_cmd({ cmd = 'setf', args = { ft } }, {})
+      end)
     end
   end,
 })

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2061,7 +2061,8 @@ end
 --- pattern, if any) and should return a string that will be used as the
 --- buffer's filetype. Optionally, the function can return a second function
 --- value which, when called, modifies the state of the buffer. This can be used
---- to, for example, set filetype-specific buffer variables.
+--- to, for example, set filetype-specific buffer variables. This function will
+--- be called by Nvim before setting the buffer's filetype.
 ---
 --- Filename patterns can specify an optional priority to resolve cases when a
 --- file path matches multiple patterns. Higher priorities are matched first.

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2377,11 +2377,16 @@ function M.match(args)
     -- If the function tries to use the filename that is nil then it will fail,
     -- but this enables checks which do not need a filename to still work.
     local ok
-    ok, ft = pcall(require('vim.filetype.detect').match_contents, contents, name, function(ext)
-      return dispatch(extension[ext], name, bufnr)
-    end)
-    if ok and ft then
-      return ft
+    ok, ft, on_detect = pcall(
+      require('vim.filetype.detect').match_contents,
+      contents,
+      name,
+      function(ext)
+        return dispatch(extension[ext], name, bufnr)
+      end
+    )
+    if ok then
+      return ft, on_detect
     end
   end
 end


### PR DESCRIPTION
The on_detect functions returned by filetype.lua set buffer local
variables which are often used by filetype plugins. For example, the
on_detect function for shell buffers sets variables such as b:is_bash or
b:is_sh, which are used by the sh ftplugin.

When called after setting the buffer's filetype, these variables cannot
be used by the ftplugin (because they are not yet defined). Instead,
call on_detect before setting the buffer filetype so that any buffer
variables set by on_detect can be used in the ftplugin.
