### PR TITLE
fix(editorconfig): do not set 'endofline'

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -112,7 +112,20 @@ end
 function M.properties.insert_final_newline(bufnr, val)
   assert(val == 'true' or val == 'false', 'insert_final_newline must be either "true" or "false"')
   vim.bo[bufnr].fixendofline = val == 'true'
-  vim.bo[bufnr].endofline = val == 'true'
+
+  -- 'endofline' can be read to detect if the file contains a final newline,
+  -- so only change 'endofline' right before writing the file
+  local endofline = val == 'true'
+  if vim.bo[bufnr].endofline ~= endofline then
+    vim.api.nvim_create_autocmd('BufWritePre', {
+      group = 'editorconfig',
+      buffer = bufnr,
+      once = true,
+      callback = function()
+        vim.bo[bufnr].endofline = endofline
+      end,
+    })
+  end
 end
 
 --- Modified version of |glob2regpat()| that does not match path separators on *.

--- a/test/functional/plugin/editorconfig_spec.lua
+++ b/test/functional/plugin/editorconfig_spec.lua
@@ -160,8 +160,8 @@ describe('editorconfig', function()
   end)
 
   it('sets newline options', function()
-    test_case('with_newline.txt', { fixendofline = true, endofline = true })
-    test_case('without_newline.txt', { fixendofline = false, endofline = false })
+    test_case('with_newline.txt', { fixendofline = true })
+    test_case('without_newline.txt', { fixendofline = false })
   end)
 
   it('respects trim_trailing_whitespace', function()


### PR DESCRIPTION
Problem:
  'endofline' can be used to detect if a file ends of `<EOL>`, however
  editorconfig can break this.

Solution:
  Do not set 'endofline' for insert_final_newline.

Fixes: #24869
