### PR TITLE
fix(extmarks): wrong display when changing text with virt_lines

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -319,7 +319,12 @@ static void changed_common(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnum
           if (wp->w_lines[i].wl_lnum >= lnum) {
             // Do not change wl_lnum at index zero, it is used to
             // compare with w_topline.  Invalidate it instead.
-            if (wp->w_lines[i].wl_lnum < lnume || i == 0) {
+            // If the buffer has virt_lines, invalidate the line
+            // after the changed lines as the virt_lines for a
+            // changed line may become invalid.
+            if (i == 0 || wp->w_lines[i].wl_lnum < lnume
+                || (wp->w_lines[i].wl_lnum == lnume
+                    && wp->w_buffer->b_virt_line_blocks > 0)) {
               // line included in change
               wp->w_lines[i].wl_valid = false;
             } else if (xtra != 0) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3784,6 +3784,63 @@ if (h->n_buckets < new_n_buckets) { // expand
     ]]}
   end)
 
+  it('works when using dd or yyp #23915 #23916', function()
+    insert([[
+      line1
+      line2
+      line3
+      line4
+      line5]])
+    meths.buf_set_extmark(0, ns, 0, 0, {virt_lines={{{"foo"}}, {{"bar"}}, {{"baz"}}}})
+    screen:expect{grid=[[
+      line1                                             |
+      foo                                               |
+      bar                                               |
+      baz                                               |
+      line2                                             |
+      line3                                             |
+      line4                                             |
+      line^5                                             |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]]}
+
+    feed('gg')
+    feed('dd')
+    screen:expect{grid=[[
+      ^line2                                             |
+      foo                                               |
+      bar                                               |
+      baz                                               |
+      line3                                             |
+      line4                                             |
+      line5                                             |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]]}
+
+    feed('yyp')
+    screen:expect{grid=[[
+      line2                                             |
+      foo                                               |
+      bar                                               |
+      baz                                               |
+      ^line2                                             |
+      line3                                             |
+      line4                                             |
+      line5                                             |
+      {1:~                                                 }|
+      {1:~                                                 }|
+      {1:~                                                 }|
+                                                        |
+    ]]}
+  end)
+
 end)
 
 describe('decorations: signs', function()


### PR DESCRIPTION
Fixes #23916
Fixes #23915

I think this is mainly because "below" virtual lines are only drawn when the line below is being drawn. This leads to invalid virtual lines when deleting that particular line as the line below is not invalidated or redrawn.

I don't know if we should just invalidate the following line every single time though. Perhaps it should only be limited to when there are virtual lines in the buffer, would it be worth adding that?