### PR TITLE
fix(netrwSymLink): made new variable with sym link syntax killed

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5230,9 +5230,10 @@ fun! s:NetrwBrowseUpDir(islocal)
    elseif curfile == '../'
      keepj call search('^\M'.curfile,"wb")
    else
-"    call Decho("search(^\\M".s:treedepthstring.curfile.") backwards"))
+    let fileWithoutLinkSyntax = substitute(curfile, '@. --> .*$', '', '')
+"    call Decho("search(^\\M".s:treedepthstring.fileWithoutLinkSyntax.") backwards"))
     while 1
-     keepj call search('^\M'.s:treedepthstring.curfile,"wb")
+     keepj call search('^\M'.s:treedepthstring.fileWithoutLinkSyntax,"wb")
      let treepath= s:NetrwTreePath(w:netrw_treetop)
 "     call Decho("..current treepath<".treepath.">",'~'.expand("<slnum>"))
      if treepath == curpath


### PR DESCRIPTION
Fixes: #21542

What I think is happening is that in the `fun! s:NetrwBrowseUpDir(islocal)` function, `if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST where s:TREELIST == 3` it grabs the name of the file that the cursor is currently on and searches for it’s line number and moves the cursor there in the up directory. The issue is that there’s no file with the `@. —> ` syntax when the directory goes back one.

My solution is to just include a substitute to kill all chars after the symbolic link syntax: `let curfile = substitute(curfile, '@. --> .*$', '', '')` (see below).

In the actual PR I made a new variable `fileWithoutLinkSyntax` to keep behavior local.

There's also something to consider, I doubt this be a big deal as it's current behavior before my fix, but if there were to be a file that has the same name as the linked file in the opened file tree one dir up - the cursor will be placed there instead.

See below a log from Decho and the file tree that's being searched.

![symlink](https://github.com/neovim/neovim/assets/53851087/e969d777-2ef4-4373-a911-bb76b5057129)

![updir](https://github.com/neovim/neovim/assets/53851087/1ad1bd1e-8bbf-47f7-a067-c038bc548f9b)
