### PR TITLE
refactor: remove redundant loop

### DIFF
--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -112,17 +112,11 @@ int buf_init_chartab(buf_T *buf, int global)
     while (c < 256) {
       if (c >= 0xa0) {
         // UTF-8: bytes 0xa0 - 0xff are printable (latin1)
-        g_chartab[c++] = CT_PRINT_CHAR + 1;
+        // Also assume that every multi-byte char is a filename character.
+        g_chartab[c++] = (CT_PRINT_CHAR | CT_FNAME_CHAR) + 1;
       } else {
         // the rest is unprintable by default
         g_chartab[c++] = (dy_flags & DY_UHEX) ? 4 : 2;
-      }
-    }
-
-    // Assume that every multi-byte char is a filename character.
-    for (c = 1; c < 256; c++) {
-      if (c >= 0xa0) {
-        g_chartab[c] |= CT_FNAME_CHAR;
       }
     }
   }


### PR DESCRIPTION
I guess this loop is a leftover from vim's legacy DBCS encoding here [charset.c](https://github.com/vim/vim/blob/20f61d96f8f36e7c0994f49b43d0eb78f5274cca/src/charset.c#L112C2-L117)?  