### PR TITLE
vim-patch:535b9e12d02f

### DIFF
--- a/runtime/syntax/shared/typescriptcommon.vim
+++ b/runtime/syntax/shared/typescriptcommon.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     TypeScript and TypeScriptReact
 " Maintainer:   Herrington Darkholme
-" Last Change:	2023 Aug 13
+" Last Change:	2023 Aug 24
 " Based On:     Herrington Darkholme's yats.vim
 " Changes:      See https://github.com/HerringtonDarkholme/yats.vim
 " Credits:      See yats.vim on github
@@ -149,7 +149,7 @@ syntax match typescriptNumber /\<0[bB][01][01_]*\>/        nextgroup=@typescript
 syntax match typescriptNumber /\<0[oO][0-7][0-7_]*\>/       nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<0[xX][0-9a-fA-F][0-9a-fA-F_]*\>/ nextgroup=@typescriptSymbols skipwhite skipempty
 syntax match typescriptNumber /\<\%(\d[0-9_]*\%(\.\d[0-9_]*\)\=\|\.\d[0-9_]*\)\%([eE][+-]\=\d[0-9_]*\)\=\>/
-  \ nextgroup=typescriptSymbols skipwhite skipempty
+  \ nextgroup=@typescriptSymbols skipwhite skipempty
 
 syntax region  typescriptObjectLiteral         matchgroup=typescriptBraces
   \ start=/{/ end=/}/


### PR DESCRIPTION
runtime(typescript): Fix highlighting symbols after number literal (vim/vim#12911)

fixes vim/vim#12831

https://github.com/vim/vim/commit/535b9e12d02f5fef969fb680d579c586bd5f40db

Co-authored-by: Herrington Darkholme <2883231+HerringtonDarkholme@users.noreply.github.com>
