### PR TITLE
fix(deps): make sure --force-config takes effect

### DIFF
--- a/cmake/BuildLuarocks.cmake
+++ b/cmake/BuildLuarocks.cmake
@@ -31,7 +31,7 @@ if(UNIX)
 
   set(LUAROCKS_CONFIGURE_COMMAND ${DEPS_BUILD_DIR}/src/luarocks/configure
       --prefix=${DEPS_INSTALL_DIR} --force-config ${LUAROCKS_OPTS})
-  set(LUAROCKS_INSTALL_COMMAND ${MAKE_PRG} -j1 bootstrap)
+  set(LUAROCKS_INSTALL_COMMAND ${MAKE_PRG} -j1 install)
 elseif(MSVC OR MINGW)
   if(MINGW)
     set(COMPILER_FLAG /MW)


### PR DESCRIPTION
Fixes #24881

I saw a couple of presentations about luarocks from 8-9 years ago linked from their docs
https://github.com/luarocks/luarocks/wiki/Documentation#presentations

I noticed that earlier it seemed that "make bootstrap" was sort of a recommended way to install luarocks, because that way it's being installed as a rock itself and it can be updated with "luarocks install luarocks" or something like that.

But first of all I didn't find "make bootstrap" being even mentioned in the docs anywhere anymore. And I doubt that it's useful in case of test dependencies. Plus looking at luarocks' GNUmakefile I noticed that --force-config only takes effect on "make install", but on "make bootstrap" it makes sure that it's value is in fact being ignored.