### PR TITLE
ci: disable some jobs on forks

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'neovim'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
   publish:
     needs: [linux, macOS, windows]
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'neovim'
     env:
       GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -197,6 +198,7 @@ jobs:
   publish-winget:
     needs: publish
     runs-on: windows-latest
+    if: github.repository_owner == 'neovim'
     steps:
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         name: Publish stable


### PR DESCRIPTION
The coverage and release publishing jobs should only run on the main repo.