### PR TITLE
vim-patch:9.0.1792: problem with gj/gk/gM and virtual text

### DIFF
--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -115,7 +115,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
     col = wcol;
 
     if ((addspaces || finetune) && !VIsual_active) {
-      curwin->w_curswant = linetabsize_str(line) + one_more;
+      curwin->w_curswant = (int)linetabsize(curwin, pos->lnum) + one_more;
       if (curwin->w_curswant > 0) {
         curwin->w_curswant--;
       }
@@ -129,7 +129,7 @@ static int coladvance2(pos_T *pos, bool addspaces, bool finetune, colnr_T wcol_a
         && curwin->w_width_inner != 0
         && wcol >= (colnr_T)width
         && width > 0) {
-      csize = linetabsize_str(line);
+      csize = (int)linetabsize(curwin, pos->lnum);
       if (csize > 0) {
         csize--;
       }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2471,7 +2471,7 @@ bool find_decl(char *ptr, size_t len, bool locally, bool thisblock, int flags_ar
 /// @return  true if able to move cursor, false otherwise.
 static bool nv_screengo(oparg_T *oap, int dir, long dist)
 {
-  int linelen = linetabsize_str(get_cursor_line_ptr());
+  int linelen = (int)linetabsize(curwin, curwin->w_cursor.lnum);
   bool retval = true;
   bool atend = false;
   int col_off1;                 // margin offset for first screen line
@@ -2535,7 +2535,7 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
           }
           cursor_up_inner(curwin, 1);
 
-          linelen = linetabsize_str(get_cursor_line_ptr());
+          linelen = (int)linetabsize(curwin, curwin->w_cursor.lnum);
           if (linelen > width1) {
             int w = (((linelen - width1 - 1) / width2) + 1) * width2;
             assert(curwin->w_curswant <= INT_MAX - w);
@@ -2568,7 +2568,7 @@ static bool nv_screengo(oparg_T *oap, int dir, long dist)
           if (curwin->w_curswant >= width1) {
             curwin->w_curswant -= width2;
           }
-          linelen = linetabsize_str(get_cursor_line_ptr());
+          linelen = (int)linetabsize(curwin, curwin->w_cursor.lnum);
         }
       }
     }
@@ -5492,7 +5492,7 @@ static void nv_g_cmd(cmdarg_T *cap)
   case 'M':
     oap->motion_type = kMTCharWise;
     oap->inclusive = false;
-    i = linetabsize_str(get_cursor_line_ptr());
+    i = (int)linetabsize(curwin, curwin->w_cursor.lnum);
     if (cap->count0 > 0 && cap->count0 <= 100) {
       coladvance((colnr_T)(i * cap->count0 / 100));
     } else {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -1811,6 +1811,98 @@ describe('decorations: inline virtual text', function()
     ]]}
   end)
 
+  it('Normal mode "gM" command works properly', function()
+    command([[call setline(1, '123456789')]])
+    meths.buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'bbb', 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 0, 7, { virt_text = { { 'bbb', 'Special' } }, virt_text_pos = 'inline' })
+    feed('gM')
+    screen:expect{grid=[[
+      12{10:bbb}34^567{10:bbb}89                                   |
+      {1:~                                                 }|
+                                                        |
+    ]]}
+  end)
+
+  local function test_normal_gj_gk()
+    screen:try_resize(60, 6)
+    command([[call setline(1, repeat([repeat('a', 55)], 2))]])
+    meths.buf_set_extmark(0, ns, 0, 40, { virt_text = { { ('b'):rep(10), 'Special' } }, virt_text_pos = 'inline' })
+    meths.buf_set_extmark(0, ns, 1, 40, { virt_text = { { ('b'):rep(10), 'Special' } }, virt_text_pos = 'inline' })
+    screen:expect{grid=[[
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gj')
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      ^aaaaa                                                       |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gj')
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gj')
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      ^aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gk')
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gk')
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      ^aaaaa                                                       |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+    feed('gk')
+    screen:expect{grid=[[
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
+      aaaaa                                                       |
+      {1:~                                                           }|
+                                                                  |
+    ]]}
+  end
+
+  describe('Normal mode "gj" "gk" commands work properly', function()
+    it('with virtualedit=', function()
+      test_normal_gj_gk()
+    end)
+
+    it('with virtualedit=all', function()
+      command('set virtualedit=all')
+      test_normal_gj_gk()
+    end)
+  end)
+
   it('cursor positions are correct with multiple inline virtual text', function()
     insert('12345678')
     meths.buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })


### PR DESCRIPTION
#### vim-patch:9.0.1792: problem with gj/gk/gM and virtual text

Problem:  Normal mode "gM", "gj", "gk" commands behave incorrectly with
          virtual text.
Solution: Use linetabsize() instead of linetabsize_str().

closes: vim/vim#12909

https://github.com/vim/vim/commit/d809c0a90387a23aed21ba37d0b65332fb5dafe7

Fix #24866