### PR TITLE
fix(api): more intuitive cursor updates in nvim_buf_set_text

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2438,6 +2438,8 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
     Prefer |nvim_buf_set_lines()| if you are only adding or deleting entire
     lines.
 
+    Prefer |nvim_put()| if you want to insert text at the cursor position.
+
     Attributes: ~
         not allowed when |textlock| is active
 
@@ -2451,6 +2453,7 @@ nvim_buf_set_text({buffer}, {start_row}, {start_col}, {end_row}, {end_col},
 
     See also: ~
       • |nvim_buf_set_lines()|
+      • |nvim_put()|
 
 nvim_buf_set_var({buffer}, {name}, {value})               *nvim_buf_set_var()*
     Sets a buffer-scoped (b:) variable

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -621,6 +621,7 @@ function vim.api.nvim_buf_set_option(buffer, name, value) end
 --- range, use `replacement = {}`.
 --- Prefer `nvim_buf_set_lines()` if you are only adding or deleting entire
 --- lines.
+--- Prefer `nvim_put()` if you want to insert text at the cursor position.
 ---
 --- @param buffer integer Buffer handle, or 0 for current buffer
 --- @param start_row integer First line index

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1787,7 +1787,7 @@ describe('LSP', function()
         eq({
           'First line of text';
         }, buf_lines(1))
-        eq({ 1, 6 }, funcs.nvim_win_get_cursor(0))
+        eq({ 1, 17 }, funcs.nvim_win_get_cursor(0))
       end)
 
       it('fix the cursor row', function()


### PR DESCRIPTION
Hello there! I'm trying to implement a bit more intuitive cursor position updates in `nvim_buf_set_text`. I looked through the issues and found one which mentions just one case https://github.com/neovim/neovim/issues/22526, which I as well find a bit counterintuitive, though it makes sense in INSERT mode as @bfredl clarified. I left a [comment](https://github.com/neovim/neovim/issues/22526#issuecomment-1693906375) there, suggesting that behavior could probably be different depending on the current mode/window.

I also described the problem I'm trying to solve within a plugin for code formatting. In short, moving cursors to proper positions after code formatting is a really nice feature, as well as adjusting extmark positions. Fortunately, `nvim_buf_set_text` already does all of that, though not in every case. And I think it would be great if `nvim_buf_set_text` would make of those kinds of adjustments. Based on the issue https://github.com/neovim/neovim/issues/10096 that seems to be one of the main reasons this api was introduced in the first place.

Right now I added a couple of test cases (there definitely should be more of them), in which `nvim_buf_set_text` could behave better IMO. And I only implemented a very basic change which roughly addresses first two of them (breaking the next two though :-)). So before I go further, I would like to know if these kinds of changes would be accepted at all, because they are kind of breaking. For example, right now lsp's `apply_text_edits` tests don't pass already with these changes. But I hope that may be in the end explicit cursor adjustments in `apply_text_edits` would not be needed at all, who knows... Otherwise, I'll just dig in and fix the lua code as well.

@bfredl could you please take a look at the test cases I added and tell me if I should continue fulfilling them and adding more as well?