### PR TITLE
vim-patch:9.0.1798: The 'syntax' option has no completion.

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5394,6 +5394,11 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
 
   xp->xp_pattern = p + 1;
 
+  if (options[opt_idx].var == &p_syn) {
+    xp->xp_context = EXPAND_OWNSYNTAX;
+    return;
+  }
+
   if (flags & P_EXPAND) {
     p = options[opt_idx].var;
     if (p == (char *)&p_bdir

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -378,6 +378,12 @@ func Test_set_completion()
   call assert_equal('"set filetype=sshdconfig', @:)
   call feedkeys(":set filetype=a\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"set filetype=' .. getcompletion('a*', 'filetype')->join(), @:)
+
+  " Expand values for 'syntax'
+  call feedkeys(":set syntax=sshdconfi\<Tab>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set syntax=sshdconfig', @:)
+  call feedkeys(":set syntax=a\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal('"set syntax=' .. getcompletion('a*', 'syntax')->join(), @:)
 endfunc
 
 func Test_set_option_errors()


### PR DESCRIPTION
#### vim-patch:9.0.1798: The 'syntax' option has no completion.

Problem:  The 'syntax' option has no completion.
Solution: Add syntax option completion.

closes: vim/vim#12900

https://github.com/vim/vim/commit/6dfdff3f273dcea29099d81e3eceb871ae089998

N/A patches:
vim-patch:9.0.1795: Indentation issues

Co-authored-by: Doug Kearns <dougkearns@gmail.com>