### PR TITLE
vim-patch:9.0.1810: camel-case spelling has issues with digits

### DIFF
--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -131,6 +131,26 @@ foobar/?
   set spell&
 endfunc
 
+func Test_spell_camelcase()
+  set spell spelloptions=camel
+  let words = [
+      \ 'UPPER',
+      \ 'lower',
+      \ 'mixedCase',
+      \ 'HTML',
+      \ 'XMLHttpRequest',
+      \ 'foo123bar',
+      \ '12345678',
+      \ 'HELLO123world',
+      \]
+
+  for word in words
+    call assert_equal(['', ''],  spellbadword(word))
+  endfor
+
+  set spell& spelloptions&
+endfunc
+
 func Test_spell_file_missing()
   let s:spell_file_missing = 0
   augroup TestSpellFileMissing


### PR DESCRIPTION
#### vim-patch:9.0.1810: camel-case spelling has issues with digits

Problem:  camel-case spelling has issues with digits
Solution: Improve the camCase spell checking by taking digits
          and caps into account

Rewrite the conditions to check for word boundaries by taking into
account the presence of digits and all-caps sequences such as acronyms.

closes: vim/vim#12933

https://github.com/vim/vim/commit/d08745040bb82c5e9a81b6c8a414e50951642492

Co-authored-by: LemonBoy <thatlemon@gmail.com>