### PR TITLE
build(deps): bump tree-sitter to HEAD

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -60,5 +60,5 @@ TREESITTER_BASH_URL https://github.com/tree-sitter/tree-sitter-bash/archive/4936
 TREESITTER_BASH_SHA256 99ebe9f2886efecc1a5e9e1360d804a1b49ad89976a66bb5c3871539cca5fb7e
 TREESITTER_MARKDOWN_URL https://github.com/MDeiml/tree-sitter-markdown/archive/v0.1.6.tar.gz
 TREESITTER_MARKDOWN_SHA256 34cbeadfbe07454a5040163d04b3118ef0ac427a5cba39089de7384992729088
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/ab09ae20d640711174b8da8a654f6b3dec93da1a.tar.gz
-TREESITTER_SHA256 bd29423e971fdb366ddfa4379a4b280fbf07ca91c3d28bd25abaa226ae4f839b
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/a0d0b35c046681485fa19203cd121ce830968248.tar.gz
+TREESITTER_SHA256 02c0e9d0ba72978dafcd86e0eb0980e23fc378989b988d95861e0621da70ce65


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter/pull/2566 fixes segfaults with calling lexer->get_column at eof in certain weird cases, it would fix the crash experienced [here](https://github.com/nvim-treesitter/nvim-treesitter/pull/5315#issuecomment-1694213310) instead of having to have annoying scanner workarounds