### PR TITLE
vim-patch:9.0.1813: linebreak incorrect drawn with breakindent

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2291,14 +2291,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           wlv.n_extra = win_lbr_chartabsize(&cts, NULL) - 1;
           clear_chartabsize_arg(&cts);
 
-          // We have just drawn the showbreak value, no need to add
-          // space for it again.
-          if (wlv.vcol == wlv.vcol_sbr) {
-            wlv.n_extra -= mb_charlen(get_showbreak_value(wp));
-            if (wlv.n_extra < 0) {
-              wlv.n_extra = 0;
-            }
-          }
           if (on_last_col && c != TAB) {
             // Do not continue search/match highlighting over the
             // line break, but for TABs the highlighting should

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -311,6 +311,9 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
     int col_off_prev = win_col_off(wp);
     int width2 = wp->w_width_inner - col_off_prev + win_col_off2(wp);
     colnr_T wcol = vcol + col_off_prev;
+    colnr_T max_head_vcol = cts->cts_max_head_vcol;
+    int added = 0;
+
     // cells taken by 'showbreak'/'breakindent' before current char
     int head_prev = 0;
     if (wcol >= wp->w_width_inner) {
@@ -326,23 +329,17 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
         head_prev += get_breakindent_win(wp, line);
       }
       if (wcol < head_prev) {
-        wcol = head_prev;
-      }
-      wcol += col_off_prev;
-    }
-
-    if ((vcol > 0 && wcol == col_off_prev + head_prev)
-        || wcol + size > wp->w_width_inner) {
-      int added = 0;
-      colnr_T max_head_vcol = cts->cts_max_head_vcol;
-
-      if (vcol > 0 && wcol == col_off_prev + head_prev) {
+        head_prev -= wcol;
+        wcol += head_prev;
         added += head_prev;
         if (max_head_vcol <= 0 || vcol < max_head_vcol) {
           head += head_prev;
         }
       }
+      wcol += col_off_prev;
+    }
 
+    if (wcol + size > wp->w_width) {
       // cells taken by 'showbreak'/'breakindent' halfway current char
       int head_mid = 0;
       if (*sbr != NUL) {
@@ -379,9 +376,9 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
           }
         }
       }
-
-      size += added;
     }
+
+    size += added;
   }
 
   if (headp != NULL) {

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -420,12 +420,19 @@ func Test_display_linebreak_breakat()
   new
   vert resize 25
   let _breakat = &breakat
-  setl signcolumn=yes linebreak breakat=) showbreak=+\ 
+  setl signcolumn=yes linebreak breakat=) showbreak=++
   call setline(1, repeat('x', winwidth(0) - 2) .. ')abc')
   let lines = ScreenLines([1, 2], 25)
   let expected = [
           \ '  xxxxxxxxxxxxxxxxxxxxxxx',
-          \ '  + )abc                 '
+          \ '  ++)abc                 ',
+          \ ]
+  call assert_equal(expected, lines)
+  setl breakindent breakindentopt=shift:2
+  let lines = ScreenLines([1, 2], 25)
+  let expected = [
+          \ '  xxxxxxxxxxxxxxxxxxxxxxx',
+          \ '    ++)abc               ',
           \ ]
   call assert_equal(expected, lines)
   %bw!


### PR DESCRIPTION
#### vim-patch:9.0.1813: linebreak incorrect drawn with breakindent

Problem: 'linebreak' is incorrectly drawn after 'breakindent'.
Solution: Don't include 'breakindent' size when already after it.

closes: vim/vim#12940

https://github.com/vim/vim/commit/1d3e0e8f3110a7807431eae056914ccea57b057b