### PR TITLE
fix(filetype): make sure buffer is valid before call nvim_buf_call

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -8,6 +8,9 @@ vim.api.nvim_create_augroup('filetypedetect', { clear = false })
 vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
   group = 'filetypedetect',
   callback = function(args)
+    if not vim.api.nvim_buf_is_valid(args.buf) then
+      return
+    end
     local ft, on_detect = vim.filetype.match({ filename = args.match, buf = args.buf })
     if not ft then
       -- Generic configuration file used as fallback


### PR DESCRIPTION
In some cases, there may be following error:

<img width="1191" alt="image" src="https://github.com/neovim/neovim/assets/2898670/2d3277cf-e6b2-4a20-bc12-70714ab52580">
