### PR TITLE
refactor(lsp): add type annotation for lsp.Client.server_capabilities

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -397,8 +397,7 @@ do
   ---@return CTGroup
   local function get_group(client)
     local allow_inc_sync = if_nil(client.config.flags.allow_incremental_sync, true)
-    local change_capability =
-      vim.tbl_get(client.server_capabilities or {}, 'textDocumentSync', 'change')
+    local change_capability = vim.tbl_get(client.server_capabilities, 'textDocumentSync', 'change')
     local sync_kind = change_capability or protocol.TextDocumentSyncKind.None
     if not allow_inc_sync and change_capability == protocol.TextDocumentSyncKind.Incremental then
       sync_kind = protocol.TextDocumentSyncKind.Full
@@ -1312,6 +1311,9 @@ function lsp.start_client(config)
     --- - lsp.WorkDoneProgressEnd    (extended with title from Begin)
     progress = vim.ringbuf(50),
 
+    --- @type lsp.ServerCapabilities
+    server_capabilities = {},
+
     ---@deprecated use client.progress instead
     messages = { name = name, messages = {}, progress = {}, status = {} },
     dynamic_capabilities = require('vim.lsp._dynamic').new(client_id),
@@ -1401,7 +1403,7 @@ function lsp.start_client(config)
       if not required_capability then
         return true
       end
-      if vim.tbl_get(client.server_capabilities or {}, unpack(required_capability)) then
+      if vim.tbl_get(client.server_capabilities, unpack(required_capability)) then
         return true
       else
         if client.dynamic_capabilities:supports_registration(method) then


### PR DESCRIPTION
The class `lsp.Client` has a public member `server_capabilities`,
which is assumed to be non-nil once initialized, as documented in
`:help vim.lsp.client`. Due to the possibility that it may be nil
before initialization, `lsp.Client` was not having a proper lua type
annotations on the field `server_capabilities`.

Instead of having a nil `server_capabilities` until initialized in
the RPC response callback, we can have an initial value of empty table.

This **changes** the behavior of the `server_capabilities` field in a way
that it is no longer `nil` until initialization. Note that, as
already documented, `server_capabilities` should never be nil when
it is actually used by users, and even before asynchronous init is
complete (see #19735 for example).



<details>
   <summary>OLD (b7edd4e)</summary>


The class `lsp.Client` has a public member `server_capabilities`
as documented in `:help vim.lsp.Client`, which is assumed to be non-nil
once initialized. Due to the possibility it may be nil before
initialization, `lsp.Client` was not having a proper lua type
annotations on the field `server_capabilities`.

Note: Actually, server_capabilities can be nil until initialized,
which would be assigned in the RPC response callback. This commit did
not change any behaviors (see #19735 for instance). However,
uninitialized clients should not be used in user configs or plugins,
so it would be more convenient to mark the field as a non-nil type
rather than as optional (i.e., `@type lsp.ServerCapabilities?`) in the
public API.

</details>
