### PR TITLE
fix(lsp): handle invalid buffer when resolving lenses

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -211,6 +211,11 @@ end
 ---@param client_id integer
 ---@param callback fun()
 local function resolve_lenses(lenses, bufnr, client_id, callback)
+  if not api.nvim_buf_is_valid(bufnr) then
+    active_refreshes[bufnr] = nil
+    return
+  end
+
   lenses = lenses or {}
   local num_lens = vim.tbl_count(lenses)
   if num_lens == 0 then


### PR DESCRIPTION
Problem:
While waiting for codelens response for a buffer, the buffer may have
been deleted. This results in invalid buffer error when resolving the
lenses.

Problem:
Ensure validity of the buffer before resolving.

