### PR TITLE
Add special HEEX comments to match_words

### DIFF
--- a/runtime/ftplugin/heex.vim
+++ b/runtime/ftplugin/heex.vim
@@ -18,7 +18,7 @@ let b:undo_ftplugin = 'set sw< sts< et< com< cms<'
 " HTML: thanks to Johannes Zellner and Benji Fisher.
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 1
-  let b:match_words = '<!--:-->,' ..
+  let b:match_words = '<%\{-}!--:--%\{-}>,' ..
 	\	      '<:>,' ..
 	\	      '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,' ..
 	\	      '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,' ..


### PR DESCRIPTION
Just adding [the special HEEX comments](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html#module-comments) to the HEEX match_words. 

CC: @clason & @cvincent 