### PR TITLE
fix(builtin): fix incorrect optional fields for fn.sign_define

### DIFF
--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -62,10 +62,10 @@
 --- @field winrow integer
 
 --- @class vim.fn.sign_define.dict
---- @field icon string
+--- @field text string
+--- @field icon? string
 --- @field linehl? string
 --- @field numhl? string
---- @field text? string
 --- @field texthl? string
 --- @field culhl? string
 


### PR DESCRIPTION
The field `icon` is not a mandatory field. This seems to be a mistake; `vim.fn.sign_define.dict` should be consistent with `vim.fn.sign_getdefined.ret.item`
