### PR TITLE
fix(tests): set $SHELL = sh in tests

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -64,6 +64,13 @@ endif()
 
 set(ENV{SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_NAME})  # used by test/helpers.lua.
 
+if(NOT WIN32)
+  # Some tests may fail on fish shell #24941 #6172
+  # And in general $SHELL value can be pretty arbitrary and cause issues
+  # during a test run. Setting it to sh aims to avoid those kinds of issues.
+  set(ENV{SHELL} sh)
+endif()
+
 execute_process(
   # Note: because of "-ll" (low-level interpreter mode), some modules like
   # _editor.lua are not loaded.

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -65,9 +65,7 @@ endif()
 set(ENV{SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_NAME})  # used by test/helpers.lua.
 
 if(NOT WIN32)
-  # Some tests may fail on fish shell #24941 #6172
-  # And in general $SHELL value can be pretty arbitrary and cause issues
-  # during a test run. Setting it to sh aims to avoid those kinds of issues.
+  # Tests assume POSIX "sh" and may fail if SHELL=fish. #24941 #6172
   set(ENV{SHELL} sh)
 endif()
 

--- a/test/functional/vimscript/system_spec.lua
+++ b/test/functional/vimscript/system_spec.lua
@@ -335,12 +335,12 @@ describe('system()', function()
       if is_os('win') then
         eq("echoed\n", eval('system("echo echoed")'))
       else
-        eq("echoed", eval('system("echo -n echoed")'))
+        eq("echoed", eval('system("printf echoed")'))
       end
     end)
     it('to backgrounded command does not crash', function()
       -- This is indeterminate, just exercise the codepath. May get E5677.
-      feed_command('call system(has("win32") ? "start /b /wait cmd /c echo echoed" : "echo -n echoed &")')
+      feed_command('call system(has("win32") ? "start /b /wait cmd /c echo echoed" : "printf echoed &")')
       local v_errnum = string.match(eval("v:errmsg"), "^E%d*:")
       if v_errnum then
         eq("E5677:", v_errnum)


### PR DESCRIPTION
Trying to run `make test` under fish shell results in a failure with the following output:

```
FAILED   test/functional/terminal/tui_spec.lua @ 1017: TUI paste: terminal mode
test/functional/terminal/tui_spec.lua:1024: Row 1 did not match.
Expected:
  |*tty ready                                         |
  |*{1: }                                                 |
  |*                                                  |
  |                                                  |
  |{5:^^^^^^^                                           }|
  |{3:-- TERMINAL --}                                    |
  |{3:-- TERMINAL --}                                    |
Actual:
  |*process does not own the terminal                 |
  |*                                                  |
  |*[Process exited 2]{1: }                               |
  |                                                  |
  |{5:^^^^^^^                                           }|
  |{3:-- TERMINAL --}                                    |
  |{3:-- TERMINAL --}                                    |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.

stack traceback:
	test/functional/ui/screen.lua:622: in function '_wait'
	test/functional/ui/screen.lua:352: in function 'expect'
	test/functional/terminal/tui_spec.lua:1024: in function <test/functional/terminal/tui_spec.lua:1017>

FAILED   test/functional/terminal/tui_spec.lua @ 1551: TUI forwards :term palette colors with termguicolors
test/functional/terminal/tui_spec.lua:1567: Row 1 did not match.
Expected:
  |*{1:t}ty ready                                         |
  |                                                  |
  |*                                                  |
  |                                                  |
  |{2:^^^^^^^                                           }|
  |                                                  |
  |{3:-- TERMINAL --}                                    |
Actual:
  |*{1:p}rocess does not own the terminal                 |
  |                                                  |
  |*[Process exited 2]                                |
  |                                                  |
  |{2:^^^^^^^                                           }|
  |                                                  |
  |{3:-- TERMINAL --}                                    |

To print the expect() call that would assert the current screen state, use
screen:snapshot_util(). In case of non-deterministic failures, use
screen:redraw_debug() to show all intermediate screen states.

stack traceback:
	test/functional/ui/screen.lua:622: in function '_wait'
	test/functional/ui/screen.lua:352: in function 'expect'
	test/functional/terminal/tui_spec.lua:1567: in function <test/functional/terminal/tui_spec.lua:1551>
```

Which may be kind of related to https://github.com/neovim/neovim/issues/2354

I suppose that fish does not make the process it starts a session leader, based on this [comment](https://github.com/neovim/neovim/issues/2354#issuecomment-92386195). I checked it by running `:terminal ./build/bin/tty-test` from neovim with `shell=/bin/fish` (inherited from `$SHELL`) and it indeed complains about "process does not own the terminal". With `shell=sh` it doesn't complain. And unsetting `$SHELL` seems to make `neovim` to fall back to `shell=sh`.

I have also found another issue about test failures under fish, though the reason seem to be quite different https://github.com/neovim/neovim/issues/6172, but there is an associated PR https://github.com/neovim/neovim/pull/6176, in which in most recent review comments @justinmk suggests unsetting `$SHELL` in a `clear()` helper, instead of doing `set shell=sh` (which broke tests on windows at the time as I understand), which I did here. Though I'm not sure if exactly this is what was meant in that comment. Should it be done through `env` in `spawn_argv` or in `new_argv` instead?

I'm also not sure if two of the test runs fail because of this change or this tests just might be flaky. Failures occur in different tests in each of them.