### PR TITLE
vim-patch:9.0.1803: runtime(filetype): Add norg language detection

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -695,6 +695,7 @@ local extension = {
   nimble = 'nim',
   ninja = 'ninja',
   nix = 'nix',
+  norg = 'norg',
   nqc = 'nqc',
   roff = 'nroff',
   tmac = 'nroff',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -442,6 +442,7 @@ func s:GetFilenameChecks() abort
     \ 'nim': ['file.nim', 'file.nims', 'file.nimble'],
     \ 'ninja': ['file.ninja'],
     \ 'nix': ['file.nix'],
+    \ 'norg': ['file.norg'],
     \ 'nqc': ['file.nqc'],
     \ 'nroff': ['file.tr', 'file.nr', 'file.roff', 'file.tmac', 'file.mom', 'tmac.file'],
     \ 'nsis': ['file.nsi', 'file.nsh'],


### PR DESCRIPTION
#### vim-patch:9.0.1803: runtime(filetype): Add norg language detection

runtime(filetype): Add norg markup language detection

closes: vim/vim#12913

https://github.com/vim/vim/commit/03e44a1d70e914504e6151fe88ad1e574cbf0a59

Co-authored-by: NTBBloodbath <bloodbathalchemist@protonmail.com>