### PR TITLE
vim-patch:9.0.1807: runtime: crystal scripts not recognised

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1636,6 +1636,7 @@ local patterns_hashbang = {
   ['icon\\>'] = { 'icon', { vim_regex = true } },
   guile = 'scheme',
   ['nix%-shell'] = 'nix',
+  ['crystal\\>'] = { 'crystal', { vim_regex = true } },
 }
 
 ---@private

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -854,6 +854,7 @@ let s:script_checks = {
       \ 'fish': [['#!/path/fish']],
       \ 'forth': [['#!/path/gforth']],
       \ 'icon': [['#!/path/icon']],
+      \ 'crystal': [['#!/path/crystal']],
       \ }
 
 " Various forms of "env" optional arguments.


### PR DESCRIPTION
#### vim-patch:9.0.1807: runtime: crystal scripts not recognised

Problem:  runtime: crystal scripts not recognised
Solution: Filetype detect Crystal scripts by shebang line

closes: vim/vim#12935

https://github.com/vim/vim/commit/9b73902dbe6f7940326bcd8dbc89d010d85d69c5

Co-authored-by: Doug Kearns <dougkearns@gmail.com>