### PR TITLE
fix(runtime/tutor): don't try to close fold when there is none

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -29,7 +29,7 @@ function! tutor#MouseDoubleClick()
     if foldclosed(line('.')) > -1
         normal! zo
     else
-        if match(getline('.'), '^#\{1,} ') > -1
+        if match(getline('.'), '^#\{1,} ') > -1 && foldlevel(line('.')) > 0
             silent normal! zc
         else
             call tutor#FollowLink(0)


### PR DESCRIPTION
Problem:    when double clicking a line starting with a #, the code assumed
there was a fold there and tried to open it, resulting in an error if
there wasnt a fold.
solution:   check foldlevel before performing zo

Note: reproducible with 'nvim --clean' or ':set mouse=nvi' 
