### PR TITLE
vim-patch:9.0.1820: Rexx files may not be recognised

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -194,12 +194,17 @@ function M.cls(_, bufnr)
     return vim.g.filetype_cls
   end
   local line1 = getline(bufnr, 1)
-  if line1:find('^[%%\\]') then
-    return 'tex'
-  elseif line1:find('^#') and line1:lower():find('rexx') then
+  if matchregex(line1, [[^#!.*\<\%(rexx\|regina\)\>]]) then
     return 'rexx'
   elseif line1 == 'VERSION 1.0 CLASS' then
     return 'vb'
+  end
+
+  local nonblank1 = nextnonblank(bufnr, 1)
+  if nonblank1 and nonblank1:find('^[%%\\]') then
+    return 'tex'
+  elseif nonblank1 and findany(nonblank1, { '^%s*/%*', '^%s*::%w' }) then
+    return 'rexx'
   end
   return 'st'
 end
@@ -1648,6 +1653,7 @@ local patterns_hashbang = {
   guile = 'scheme',
   ['nix%-shell'] = 'nix',
   ['crystal\\>'] = { 'crystal', { vim_regex = true } },
+  ['^\\%(rexx\\|regina\\)\\>'] = { 'rexx', { vim_regex = true } },
 }
 
 ---@private

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -856,6 +856,8 @@ let s:script_checks = {
       \ 'forth': [['#!/path/gforth']],
       \ 'icon': [['#!/path/icon']],
       \ 'crystal': [['#!/path/crystal']],
+      \ 'rexx': [['#!/path/rexx'],
+      \          ['#!/path/regina']],
       \ }
 
 " Various forms of "env" optional arguments.
@@ -1953,7 +1955,22 @@ func Test_cls_file()
 
   " Rexx
 
-  call writefile(['# rexx'], 'Xfile.cls')
+  call writefile(['#!/usr/bin/rexx'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['#!/usr/bin/regina'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['/* Comment */'], 'Xfile.cls')
+  split Xfile.cls
+  call assert_equal('rexx', &filetype)
+  bwipe!
+
+  call writefile(['::class Foo subclass Bar public'], 'Xfile.cls')
   split Xfile.cls
   call assert_equal('rexx', &filetype)
   bwipe!


### PR DESCRIPTION
#### vim-patch:9.0.1820: Rexx files may not be recognised

Problem:  Rexx files may not be recognised
Solution: Add shebang detection and improve disambiguation of *.cls
	  files

closes: vim/vim#12951

https://github.com/vim/vim/commit/e06afb7860805537ccd69966bc03169852c9b378

Co-authored-by: Doug Kearns <dougkearns@gmail.com>