### PR TITLE
Revert "[Backport release-0.9] fix(ui): propagate line flags on grid_line events"

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -78,14 +78,14 @@ Example of a typical "redraw" batch in a single RPC notification: >
       [
 	['grid_resize', [2, 77, 36]],
 	['grid_line',
-	  [2, 0, 0, [[' ' , 0, 77]], false],
-	  [2, 1, 0, [['~', 7], [' ', 7, 76]], false],
-	  [2, 9, 0, [['~', 7], [' ', 7, 76]], false],
+	  [2, 0, 0, [[' ' , 0, 77]]],
+	  [2, 1, 0, [['~', 7], [' ', 7, 76]]],
+	  [2, 9, 0, [['~', 7], [' ', 7, 76]]], 
 	  ...
-	  [2, 35, 0, [['~', 7], [' ', 7, 76]], false],
-	  [1, 36, 0, [['[', 9], ['N'], ['o'], [' '], ['N'], ['a'], ['m'], ['e'], [']']], false],
-	  [1, 36, 9, [[' ', 9, 50]], false],
-	  [1, 36, 59, [['0', 9], [','], ['0'], ['-' ], ['1'], [' ', 9, 10], ['A'], ['l', 9, 2]], false]
+	  [2, 35, 0, [['~', 7], [' ', 7, 76]]],
+	  [1, 36, 0, [['[', 9], ['N'], ['o'], [' '], ['N'], ['a'], ['m'], ['e'], [']']]],
+	  [1, 36, 9, [[' ', 9, 50]]],
+	  [1, 36, 59, [['0', 9], [','], ['0'], ['-' ], ['1'], [' ', 9, 10], ['A'], ['l', 9, 2]]]
 	],
 	['msg_showmode', [[]]],
 	['win_pos', [2, 1000, 0, 0, 77, 36]],
@@ -360,7 +360,7 @@ numerical highlight ids to the actual attributes.
 	use the |hl-Pmenu| family of builtin highlights.
 
 							    *ui-event-grid_line*
-["grid_line", grid, row, col_start, cells, wrap] ~
+["grid_line", grid, row, col_start, cells] ~
 	Redraw a continuous part of a `row` on a `grid`, starting at the column
 	`col_start`. `cells` is an array of arrays each with 1 to 3 items:
 	`[text(, hl_id, repeat)]` . `text` is the UTF-8 text that should be put in
@@ -378,12 +378,6 @@ numerical highlight ids to the actual attributes.
 	rest should remain unchanged. A whitespace char, repeated
 	enough to cover the remaining line, will be sent when the rest of the
 	line should be cleared.
-
-	`wrap` is a boolean indicating that this line wraps to the next row.
-	When redrawing a line which wraps to the next row, Nvim will emit a
-	`grid_line` event covering the last column of the line with `wrap` set
-	to true, followed immediately by a `grid_line` event starting at the
-	first column of the next row.
 
 ["grid_clear", grid] ~
 	Clear a `grid`.

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -82,7 +82,7 @@ void grid_clear(Integer grid)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL;
 void grid_cursor_goto(Integer grid, Integer row, Integer col)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
-void grid_line(Integer grid, Integer row, Integer col_start, Array data, Boolean wrap)
+void grid_line(Integer grid, Integer row, Integer col_start, Array data)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_ONLY FUNC_API_CLIENT_IMPL;
 void grid_scroll(Integer grid, Integer top, Integer bot, Integer left, Integer right, Integer rows,
                  Integer cols)

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -117,7 +117,6 @@ typedef struct {
   int coloff;
   int cur_attr;
   int clear_width;
-  bool wrap;
 } GridLineEvent;
 
 #endif  // NVIM_GRID_DEFS_H

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -440,7 +440,7 @@ redo:
   case 14:
     NEXT_TYPE(tok, MPACK_TOKEN_ARRAY);
     int eventarrsize = (int)tok.length;
-    if (eventarrsize != 5) {
+    if (eventarrsize != 4) {
       p->state = -1;
       return false;
     }
@@ -508,16 +508,11 @@ redo:
     }
 
     g->icell++;
-    if (g->icell == g->ncells) {
-      NEXT_TYPE(tok, MPACK_TOKEN_BOOLEAN);
-      g->wrap = mpack_unpack_boolean(tok);
-      p->read_ptr = data;
-      p->read_size = size;
-      return true;
-    }
-
     p->read_ptr = data;
     p->read_size = size;
+    if (g->icell == g->ncells) {
+      return true;
+    }
     goto redo;
 
   case 12:

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -210,7 +210,9 @@ void ui_client_event_raw_line(GridLineEvent *g)
   int grid = g->args[0], row = g->args[1], startcol = g->args[2];
   Integer endcol = startcol + g->coloff;
   Integer clearcol = endcol + g->clear_width;
-  LineFlags lineflags = g->wrap ? kLineFlagWrap : 0;
+
+  // TODO(hlpr98): Accommodate other LineFlags when included in grid_line
+  LineFlags lineflags = 0;
 
   tui_raw_line(tui, grid, row, startcol, endcol, clearcol, g->cur_attr, lineflags,
                (const schar_T *)grid_line_buf_char, grid_line_buf_attr);


### PR DESCRIPTION
Reverts neovim/neovim#24243