### PR TITLE
vim-patch:9.0.1828: cursor wrong with virt text before double-width char

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -216,6 +216,7 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
   if (*s == NUL && !has_lcs_eol) {
     size = 0;  // NUL is not displayed
   }
+  bool is_doublewidth = size == 2 && MB_BYTE2LEN((uint8_t)(*s)) > 1;
 
   if (cts->cts_has_virt_text) {
     int tab_size = size;
@@ -247,8 +248,7 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
     }
   }
 
-  if (size == 2 && MB_BYTE2LEN((uint8_t)(*s)) > 1
-      && wp->w_p_wrap && in_win_border(wp, vcol)) {
+  if (is_doublewidth && wp->w_p_wrap && in_win_border(wp, vcol + size - 2)) {
     // Count the ">" in the last column.
     size++;
     mb_added = 1;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3244,6 +3244,19 @@ describe('decorations: inline virtual text', function()
                                                         |
     ]]}
   end)
+
+  it('before double-width char that wraps', function()
+    exec([[
+      call setline(1, repeat('a', 40) .. '口' .. '12345')
+      normal! $
+    ]])
+    meths.buf_set_extmark(0, ns, 0, 40, { virt_text = { { ('b'):rep(9) } }, virt_text_pos = 'inline' })
+    screen:expect{grid=[[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbb{1:>}|
+      口1234^5                                           |
+                                                        |
+    ]]}
+  end)
 end)
 
 describe('decorations: virtual lines', function()


### PR DESCRIPTION
#### vim-patch:9.0.1828: cursor wrong with virt text before double-width char

Problem:  Wrong cursor position with virtual text before double-width
          char at window edge.
Solution: Check for double-width char before adding virtual text size.

closes: vim/vim#12977

https://github.com/vim/vim/commit/ac2d8815ae7a93c54b07cba76475cfb3f26a3ac6