### PR TITLE
fix(lsp): wrong iterator in registerCapability handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -112,7 +112,7 @@ M[ms.client_registerCapability] = function(_, result, ctx)
   local client = vim.lsp.get_client_by_id(client_id)
 
   client.dynamic_capabilities:register(result.registrations)
-  for bufnr, _ in ipairs(client.attached_buffers) do
+  for bufnr, _ in pairs(client.attached_buffers) do
     vim.lsp._set_defaults(client, bufnr)
   end
 


### PR DESCRIPTION
`client.attached_buffers` uses a structure like this:
```lua
{
    [<buffer>] = true,
    ...
}
```
Therefore we have to use `pairs` instead of `ipairs` to get a valid buffer number here