### PR TITLE
fix(rpc): fix race condition

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -207,8 +207,14 @@ Object rpc_send_call(uint64_t id, const char *method_name, Array args, ArenaMem 
   // Push the frame
   ChannelCallFrame frame = { request_id, false, false, NIL, NULL };
   kv_push(rpc->call_stack, &frame);
-  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, channel->events, -1, frame.returned);
+  LOOP_PROCESS_EVENTS_UNTIL(&main_loop, channel->events, -1, frame.returned || rpc->closed);
   (void)kv_pop(rpc->call_stack);
+
+  if (rpc->closed) {
+    api_set_error(err, kErrorTypeException, "Invalid channel: %" PRIu64, id);
+    channel_decref(channel);
+    return NIL;
+  }
 
   if (frame.errored) {
     if (frame.result.type == kObjectTypeString) {


### PR DESCRIPTION
I'm trying to figure a way to avoid freezing in ['cancels stale events on channel close' test](https://github.com/neovim/neovim/blob/f02bfb6a2a079fc223db9f941dc917aa06a45b09/test/functional/api/server_notifications_spec.lua#L92-L105). It's being ignored on CI because sourcehut builds were timing out at the time https://github.com/neovim/neovim/issues/14083. But I noticed that it also tends to time out on both of my machines, if before `make test` I run `make` with either `CMAKE_BUILD_TYPE=RelWithDebInfo` or `CMAKE_BUILD_TYPE=Release`. So it looks like a race condition is involved (because some code runs much faster with compiler optimizations?). I have no idea if that was the case on CI though.

I also took a look at another attempt to work around the problem using `sleep` https://github.com/neovim/neovim/pull/15251. And there I saw a comment with an assumption that the problem happens because the channel is not closed immediately, but instead the call to close it is just queued https://github.com/neovim/neovim/pull/15251#issuecomment-893362852. But at least in my case the problem seems to be a bit different.

I looked at what happens during that test using gdb and here's what I noticed. There are two messages which sometimes handled in a different order from what I assume is expected in the test. The relevant messages are by [`vim.rpcrequest`](https://github.com/neovim/neovim/blob/f02bfb6a2a079fc223db9f941dc917aa06a45b09/test/functional/api/server_notifications_spec.lua#L103) on line 103 and [`chanclose`](https://github.com/neovim/neovim/blob/f02bfb6a2a079fc223db9f941dc917aa06a45b09/test/functional/api/server_notifications_spec.lua#L97) on line 97.

Sometimes `vim.rpcrequest` is handled before `chanclose`. In which case `vim.rpcrequest` causes event handling loop in `rpc_send_call` to start, waiting for a response as it should. Then `chanclose` comes in and closes that channel. But at that point `rpc_send_call` doesn't care about it, because it only looks for channel before starting the loop. So it continues to wait for a response on an already closed channel and because of that, it loops forever.

In this PR I effectively made it care about channel being closed by one of those events it handles. Is it a proper way to fix this issue?