### PR TITLE
vim-patch:9.0.1852: i_CTRL-O does not reset Select Mode

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3579,6 +3579,7 @@ static void ins_insert(int replaceState)
 // Pressed CTRL-O in Insert mode.
 static void ins_ctrl_o(void)
 {
+  restart_VIsual_select = 0;
   if (State & VREPLACE_FLAG) {
     restart_edit = 'V';
   } else if (State & REPLACE_FLAG) {

--- a/test/old/testdir/test_selectmode.vim
+++ b/test/old/testdir/test_selectmode.vim
@@ -312,4 +312,15 @@ func Test_selectmode_register()
   bw!
 endfunc
 
+func Test_ins_ctrl_o_in_insert_mode_resets_selectmode()
+  new
+  " ctrl-o in insert mode resets restart_VIsual_select
+  call setline(1, 'abcdef')
+  call cursor(1, 1)
+  exe "norm! \<c-v>\<c-g>\<c-o>c\<c-o>\<c-v>\<right>\<right>IABC"
+  call assert_equal('ABCbcdef', getline(1))
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1852: i_CTRL-O does not reset Select Mode

Problem:  i_CTRL-O does not reset Select Mode
Solution: Reset select mode on CTRL-O in insert mode

closes: vim/vim#13001

https://github.com/vim/vim/commit/d69aecf141ff05a645d02f39f1cbf6381ed7d0c0

Co-authored-by: pierreganty <pierreganty@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>