### PR TITLE
vim-patch:9.0.{1846,1847}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3136,7 +3136,7 @@ int cmd_exists(const char *const name)
 /// "fullcommand" function
 void f_fullcommand(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  char *name = argvars[0].vval.v_string;
+  char *name = (char *)tv_get_string(&argvars[0]);
 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4770,7 +4770,7 @@ int do_addsub(int op_type, pos_T *pos, int length, linenr_T Prenum1)
         }
       }
 
-      while (bits > 0) {
+      while (bits > 0 && i < NUMBUFLEN - 1) {
         buf2[i++] = ((n >> --bits) & 0x1) ? '1' : '0';
       }
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3273,4 +3273,9 @@ func Test_string_reverse()
   let &encoding = save_enc
 endfunc
 
+func Test_fullcommand()
+  " this used to crash vim
+  call assert_equal('', fullcommand(10))
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1846: [security] crash in fullcommand

Problem:  crash in fullcommand
Solution: Check for typeval correctly

https://github.com/vim/vim/commit/4c6fe2e2ea62469642ed1d80b16d39e616b25cf5

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1847: [security] potential oob write in do_addsub()

Problem:  potential oob write in do_addsub()
Solution: don't overflow buf2, check size in for loop()

https://github.com/vim/vim/commit/889f6af37164775192e33b233a90e86fd3df0f57

Co-authored-by: Christian Brabandt <cb@256bit.org>