### PR TITLE
refactor: remove some unnecessary char <-> int casts

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7006,21 +7006,21 @@ static char *make_expanded_name(const char *in_start, char *expr_start, char *ex
 
 /// @return  true if character "c" can be used in a variable or function name.
 ///          Does not include '{' or '}' for magic braces.
-bool eval_isnamec(int c)
+bool eval_isnamec(char c) FUNC_ATTR_CONST
 {
   return ASCII_ISALNUM(c) || c == '_' || c == ':' || c == AUTOLOAD_CHAR;
 }
 
 /// @return  true if character "c" can be used as the first character in a
 ///          variable or function name (excluding '{' and '}').
-bool eval_isnamec1(int c)
+bool eval_isnamec1(char c) FUNC_ATTR_CONST
 {
   return ASCII_ISALPHA(c) || c == '_';
 }
 
 /// @return  true if character "c" can be used as the first character of a
 ///          dictionary key.
-bool eval_isdictc(int c)
+bool eval_isdictc(char c) FUNC_ATTR_CONST
 {
   return ASCII_ISALNUM(c) || c == '_';
 }

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -1682,7 +1682,7 @@ bool valid_varname(const char *varname)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   for (const char *p = varname; *p != NUL; p++) {
-    if (!eval_isnamec1((int)(uint8_t)(*p))
+    if (!eval_isnamec1(*p)
         && (p == varname || !ascii_isdigit(*p))
         && *p != AUTOLOAD_CHAR) {
       semsg(_(e_illvar), varname);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4381,7 +4381,7 @@ static void ex_blast(exarg_T *eap)
   }
 }
 
-int ends_excmd(int c) FUNC_ATTR_CONST
+bool ends_excmd(char c) FUNC_ATTR_CONST
 {
   return c == NUL || c == '|' || c == '"' || c == '\n';
 }

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1080,7 +1080,7 @@ void ex_mkrc(exarg_T *eap)
 }
 
 /// @return  the name of the view file for the current buffer.
-static char *get_view_file(int c)
+static char *get_view_file(char c)
 {
   if (curbuf->b_ffname == NULL) {
     emsg(_(e_noname));
@@ -1119,8 +1119,7 @@ static char *get_view_file(int c)
     }
   }
   *s++ = '=';
-  assert(c >= CHAR_MIN && c <= CHAR_MAX);
-  *s++ = (char)c;
+  *s++ = c;
   xstrlcpy(s, ".vim", 5);
 
   xfree(sname);

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -896,7 +896,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   FUNC_ATTR_NONNULL_ALL
 {
   // If no argument, list current highlighting.
-  if (!init && ends_excmd((uint8_t)(*line))) {
+  if (!init && ends_excmd(*line)) {
     for (int i = 1; i <= highlight_ga.ga_len && !got_int; i++) {
       // TODO(brammool): only call when the group has attributes set
       highlight_list_one(i);
@@ -929,7 +929,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   }
 
   // ":highlight {group-name}": list highlighting for one group.
-  if (!doclear && !dolink && ends_excmd((uint8_t)(*linep))) {
+  if (!doclear && !dolink && ends_excmd(*linep)) {
     int id = syn_name2id_len(line, (size_t)(name_end - line));
     if (id == 0) {
       semsg(_(e_highlight_group_name_not_found_str), line);
@@ -953,8 +953,8 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     to_start = skipwhite(from_end);
     to_end   = skiptowhite(to_start);
 
-    if (ends_excmd((uint8_t)(*from_start))
-        || ends_excmd((uint8_t)(*to_start))) {
+    if (ends_excmd(*from_start)
+        || ends_excmd(*to_start)) {
       semsg(_("E412: Not enough arguments: \":highlight link %s\""),
             from_start);
       return;
@@ -1014,7 +1014,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   if (doclear) {
     // ":highlight clear [group]" command.
     line = linep;
-    if (ends_excmd((uint8_t)(*line))) {
+    if (ends_excmd(*line)) {
       do_unlet(S_LEN("g:colors_name"), true);
       restore_cterm_colors();
 
@@ -1063,7 +1063,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
   if (!doclear) {
     const char *arg_start;
 
-    while (!ends_excmd((uint8_t)(*linep))) {
+    while (!ends_excmd(*linep)) {
       const char *key_start = linep;
       if (*linep == '=') {
         semsg(_(e_unexpected_equal_sign_str), key_start);


### PR DESCRIPTION
These functions are passed a `char` in a string, so make them accept a
`char` instead of an `int` to avoid worrying about casting to `uint8_t`.
If in future they have to be passed a multibyte char (which is very
unlikely to happen) then this may need reconsideration.
