### PR TITLE
chore: ignore test log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ tags
 /contrib/result-*
 
 CMakeUserPresets.json
+Xtest-server-notify-log


### PR DESCRIPTION
It doesn't seem like this log file should be tracked.