### PR TITLE
vim-patch:9.0.1863: wrong format specifiers in e_aptypes_is_null_str_nr

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1250,7 +1250,7 @@ static void skip_to_arg(const char **ap_types, va_list ap_start, va_list *ap, in
 
   for (*arg_cur = arg_min; *arg_cur < *arg_idx - 1; (*arg_cur)++) {
     if (ap_types == NULL || ap_types[*arg_cur] == NULL) {
-      semsg(e_aptypes_is_null_str_nr, fmt, *arg_cur);
+      siemsg(e_aptypes_is_null_str_nr, fmt, *arg_cur);
       return;
     }
 


### PR DESCRIPTION
#### vim-patch:9.0.1863: wrong format specifiers in e_aptypes_is_null_str_nr

Problem:  wrong format specifiers in e_aptypes_is_null_str_nr
Solution: Fix the wrong format specifier

closes: vim/vim#13020

https://github.com/vim/vim/commit/7db89bdc23e53c7bc43af6f1c7281bc69a6a3098