### PR TITLE
vim-patch:3170342af304

### DIFF
--- a/runtime/ftplugin/ruby.vim
+++ b/runtime/ftplugin/ruby.vim
@@ -77,7 +77,7 @@ function! s:query_path(root) abort
   let cwd = fnameescape(getcwd())
   try
     exe cd fnameescape(a:root)
-    if fnamemodify(exepath('ruby'), ':p:h') ==# getcwd()
+    if fnamemodify(exepath('ruby'), ':p:h') ==# cwd
       let path = []
     else
       let path = split(system(path_check),',')


### PR DESCRIPTION
runtime(php): Update the php indent script to the 1.75 (from 1.70) (vim/vim#13025)

Changes:

1.75:
- Fix 2072/PHP-Indenting-for-VImvim/vim#87: The indent optimization was causing wrong indentation of lines
  preceded by a line ending with '}' when preceded by non white characters.
- Fix long standing non-reported regex escaping issue in cleaning end of line
  comments function. This should help fixing some other unreported issues when
  parts of codes are commented out at ends of lines...

1.74:
- Fix 2072/PHP-Indenting-for-VImvim/vim#86: Add support for `match` expression.

1.73:
- Fix 2072/PHP-Indenting-for-VImvim/vim#77 where multi line strings and true/false keywords at beginning of a
  line would cause indentation failures.

1.72:
- Fix vim/vimvim/vim#5722 where it was reported that the option PHP_BracesAtCodeLevel
  had not been working for the last 6 years.

1.71:
- Fix 2072/PHP-Indenting-for-VImvim/vim#75 where the indent script would hang on some multi-line quoted strings.

https://github.com/vim/vim/commit/3170342af3049852afb2fbca85df37baf5fec82f

Co-authored-by: John Wellesz <john.wellesz@gmail.com>
