### PR TITLE
vim-patch:9.0.1866: undo is synced after character find

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -831,7 +831,7 @@ static void normal_get_additional_char(NormalState *s)
       // because if it's put back with vungetc() it's too late to apply
       // mapping.
       no_mapping--;
-      while (lang && (s->c = vpeekc()) > 0
+      while ((s->c = vpeekc()) > 0
              && (s->c >= 0x100 || MB_BYTE2LEN(vpeekc()) > 1)) {
         s->c = plain_vgetc();
         if (!utf_iscomposing(s->c)) {
@@ -848,7 +848,9 @@ static void normal_get_additional_char(NormalState *s)
       // but when replaying a recording the next key is already in the
       // typeahead buffer, so record a <Nop> before that to prevent the
       // vpeekc() above from applying wrong mappings when replaying.
+      no_u_sync++;
       gotchars_nop();
+      no_u_sync--;
     }
   }
   no_mapping--;

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -870,5 +870,15 @@ func Test_undo_after_write()
   call delete('Xtestfile.txt')
 endfunc
 
+func Test_undo_range_normal()
+  new
+  call setline(1, ['asa', 'bsb'])
+  let &l:undolevels = &l:undolevels
+  %normal dfs
+  call assert_equal(['a', 'b'], getline(1, '$'))
+  undo
+  call assert_equal(['asa', 'bsb'], getline(1, '$'))
+  bwipe!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1866: undo is synced after character find

Problem:  Undo is synced after character find.
Solution: Set no_u_sync when calling gotchars_nop().

closes: vim/vim#13024

https://github.com/vim/vim/commit/dccc29c228f8336ef7dd069a447886639af4458e