### PR TITLE
feat(folds): add nofold fillchar

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2480,6 +2480,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  foldopen	'-'		mark the beginning of a fold
 	  foldclose	'+'		show a closed fold
 	  foldsep	'│' or '|'      open fold middle marker
+	  nofold	depth level	no fold marker
 	  diff		'-'		deleted lines of the 'diff' option
 	  msgsep	' '		message separator 'display'
 	  eob		'~'		empty lines at the end of a buffer

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2188,6 +2188,7 @@ vim.bo.ft = vim.bo.filetype
 ---   foldopen	'-'		mark the beginning of a fold
 ---   foldclose	'+'		show a closed fold
 ---   foldsep	'│' or '|'      open fold middle marker
+---   nofold	depth level	no fold marker
 ---   diff		'-'		deleted lines of the 'diff' option
 ---   msgsep	' '		message separator 'display'
 ---   eob		'~'		empty lines at the end of a buffer

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1074,6 +1074,7 @@ struct window_S {
     int foldopen;                    ///< when fold is open
     int foldclosed;                  ///< when fold is closed
     int foldsep;                     ///< continuous fold marker
+    int nofold;                      ///< when there's no fold
     int diff;
     int msgsep;
     int eob;

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -435,6 +435,8 @@ size_t fill_foldcolumn(char *p, win_T *wp, foldinfo_T foldinfo, linenr_T lnum)
       symbol = wp->w_p_fcs_chars.foldopen;
     } else if (first_level == 1) {
       symbol = wp->w_p_fcs_chars.foldsep;
+    } else if (wp->w_p_fcs_chars.nofold != NUL) {
+      symbol = wp->w_p_fcs_chars.nofold;
     } else if (first_level + i <= 9) {
       symbol = '0' + first_level + i;
     } else {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2805,6 +2805,7 @@ return {
           foldopen	'-'		mark the beginning of a fold
           foldclose	'+'		show a closed fold
           foldsep	'│' or '|'      open fold middle marker
+          nofold	depth level	no fold marker
           diff		'-'		deleted lines of the 'diff' option
           msgsep	' '		message separator 'display'
           eob		'~'		empty lines at the end of a buffer

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2371,6 +2371,7 @@ static const char *set_chars_option(win_T *wp, const char *value, const bool is_
     { &wp->w_p_fcs_chars.foldopen,   "foldopen",  '-' },
     { &wp->w_p_fcs_chars.foldclosed, "foldclose", '+' },
     { &wp->w_p_fcs_chars.foldsep,    "foldsep",   char2cells(0x2502) == 1 ? 0x2502 : '|' },  // │
+    { &wp->w_p_fcs_chars.nofold,    "nofold",   NUL },
     { &wp->w_p_fcs_chars.diff,       "diff",      '-' },
     { &wp->w_p_fcs_chars.msgsep,     "msgsep",    ' ' },
     { &wp->w_p_fcs_chars.eob,        "eob",       '~' },


### PR DESCRIPTION
Closes #21740.

This PR adds a new `fillchar` `nofold`, that when present will be used when constructing the fold column instead of displaying the fold level.