### PR TITLE
vim-patch:9.0.{partial:0669,1874}

### DIFF
--- a/test/old/testdir/test_recover.vim
+++ b/test/old/testdir/test_recover.vim
@@ -166,6 +166,7 @@ endfunc
 func Test_recover_empty_swap_file()
   CheckUnix
   call writefile([], '.Xfile1.swp', 'D')
+  set dir=.
   let msg = execute('recover Xfile1')
   call assert_match('Unable to read block 0 from .Xfile1.swp', msg)
   call assert_equal('Xfile1', @%)
@@ -178,6 +179,7 @@ func Test_recover_empty_swap_file()
 
   " :recover from an empty buffer
   call assert_fails('recover', 'E305:')
+  set dir&vim
 endfunc
 
 " Test for :recover using a corrupted swap file

--- a/test/old/testdir/test_recover.vim
+++ b/test/old/testdir/test_recover.vim
@@ -144,9 +144,9 @@ func Test_recover_multiple_swap_files()
   call setline(1, ['a', 'b', 'c'])
   preserve
   let b = readblob(swapname(''))
-  call writefile(b, '.Xfile1.swm')
-  call writefile(b, '.Xfile1.swn')
-  call writefile(b, '.Xfile1.swo')
+  call writefile(b, '.Xfile1.swm', 'D')
+  call writefile(b, '.Xfile1.swn', 'D')
+  call writefile(b, '.Xfile1.swo', 'D')
   %bw!
   call feedkeys(":recover Xfile1\<CR>3\<CR>q", 'xt')
   call assert_equal(['a', 'b', 'c'], getline(1, '$'))
@@ -160,16 +160,12 @@ func Test_recover_multiple_swap_files()
   call assert_equal('Xfile1', @%)
   call assert_equal([''], getline(1, '$'))
   bw!
-
-  call delete('.Xfile1.swm')
-  call delete('.Xfile1.swn')
-  call delete('.Xfile1.swo')
 endfunc
 
 " Test for :recover using an empty swap file
 func Test_recover_empty_swap_file()
   CheckUnix
-  call writefile([], '.Xfile1.swp')
+  call writefile([], '.Xfile1.swp', 'D')
   let msg = execute('recover Xfile1')
   call assert_match('Unable to read block 0 from .Xfile1.swp', msg)
   call assert_equal('Xfile1', @%)
@@ -182,7 +178,6 @@ func Test_recover_empty_swap_file()
 
   " :recover from an empty buffer
   call assert_fails('recover', 'E305:')
-  call delete('.Xfile1.swp')
 endfunc
 
 " Test for :recover using a corrupted swap file
@@ -389,16 +384,15 @@ func Test_recover_encrypted_swap_file()
 endfunc
 
 " Test for :recover using a unreadable swap file
-func Test_recover_unreadble_swap_file()
+func Test_recover_unreadable_swap_file()
   CheckUnix
   CheckNotRoot
   new Xfile1
   let b = readblob('.Xfile1.swp')
-  call writefile(b, '.Xfile1.swm')
+  call writefile(b, '.Xfile1.swm', 'D')
   bw!
   call setfperm('.Xfile1.swm', '-w-------')
   call assert_fails('recover Xfile1', 'E306:')
-  call delete('.Xfile1.swm')
 endfunc
 
 " Test for using :recover when the original file and the swap file have the
@@ -410,20 +404,19 @@ func Test_recover_unmodified_file()
   preserve
   let b = readblob('.Xfile1.swp')
   %bw!
-  call writefile(b, '.Xfile1.swz')
+  call writefile(b, '.Xfile1.swz', 'D')
   let msg = execute('recover Xfile1')
   call assert_equal(['aaa', 'bbb', 'ccc'], getline(1, '$'))
   call assert_false(&modified)
   call assert_match('Buffer contents equals file contents', msg)
   bw!
   call delete('Xfile1')
-  call delete('.Xfile1.swz')
 endfunc
 
 " Test for recovering a file when editing a symbolically linked file
 func Test_recover_symbolic_link()
   CheckUnix
-  call writefile(['aaa', 'bbb', 'ccc'], 'Xfile1')
+  call writefile(['aaa', 'bbb', 'ccc'], 'Xfile1', 'D')
   silent !ln -s Xfile1 Xfile2
   edit Xfile2
   call assert_equal('.Xfile1.swp', fnamemodify(swapname(''), ':t'))
@@ -438,7 +431,6 @@ func Test_recover_symbolic_link()
   update
   %bw!
   call assert_equal(['aaa', 'bbb', 'ccc'], readfile('Xfile1'))
-  call delete('Xfile1')
   call delete('Xfile2')
   call delete('.Xfile1.swp')
 endfunc
@@ -447,7 +439,7 @@ endfunc
 " line. This used to result in an internal error (E315) which is fixed
 " by 8.2.2966.
 func Test_recover_invalid_cursor_pos()
-  call writefile([], 'Xfile1')
+  call writefile([], 'Xfile1', 'D')
   edit Xfile1
   preserve
   let b = readblob('.Xfile1.swp')
@@ -457,7 +449,7 @@ func Test_recover_invalid_cursor_pos()
     au BufReadPost Xfile1 normal! 3G
   augroup END
   call writefile(range(1, 3), 'Xfile1')
-  call writefile(b, '.Xfile1.swp')
+  call writefile(b, '.Xfile1.swp', 'D')
   try
     recover Xfile1
   catch /E308:/
@@ -469,8 +461,6 @@ func Test_recover_invalid_cursor_pos()
     au!
   augroup END
   augroup! Test
-  call delete('Xfile1')
-  call delete('.Xfile1.swp')
 endfunc
 
 " Test for recovering a buffer without a name
@@ -481,10 +471,9 @@ func Test_noname_buffer()
   let sn = swapname('')
   let b = readblob(sn)
   bw!
-  call writefile(b, sn)
+  call writefile(b, sn, 'D')
   exe "recover " .. sn
   call assert_equal(['one', 'two'], getline(1, '$'))
-  call delete(sn)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:partial:9.0.0669: too many delete() calls in tests

Problem:    Too many delete() calls in tests.
Solution:   Use deferred delete where possible.

https://github.com/vim/vim/commit/db77cb3c08784e6038dd029271b2080c1b2d9acb

Include test_recover.vim changes only.
Cherry-pick test_recover.vim change from patch 8.2.3637.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1874: CI may fail in test_recover_empty_swap

Problem:  CI may fail in test_recover_empty_swap
Solution: Set directory option

Fix failing Test_recover_empty_swap test

:recover by default not only looks in the current directory, but also in
~/tmp for files to recover. If it finds some files to recover, it will
interactively prompt for a file to recover. However, prompting doesn't
work when running the test suite (and even if it would, there is no one
that can answer the prompt).

So it doesn't really make sense during testing, to inspect different
directories for swap files and prompt and wait (which will lead to a
timeout and therefore a failing test).

So set the 'directory' option temporarily to the current directory only
and reset it back once the test finishes.

closes: vim/vim#13038

https://github.com/vim/vim/commit/1c7397f3f1e168541f88bb1bbd93a9f0b1235852

Co-authored-by: Christian Brabandt <cb@256bit.org>