### PR TITLE
fix: Fix a failed CI for a Linux release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     outputs:
       version: ${{ steps.build.outputs.version }}
     container:
-      image: ubuntu:18.04
+      image: ubuntu:20.04
       options: --privileged # Privileged mode is needed to load fuse module.
     steps:
       - name: Prepare container


### PR DESCRIPTION
Linux release CI is now failing from this commit (https://github.com/neovim/neovim/commit/cf7d37ad13c74461e6a05a72123ba44676e6106c, https://github.com/neovim/neovim/actions/runs/6080409980).
This is because actions/checkout has stopped supporting Ubuntu 18.04. https://github.com/actions/checkout/issues/1442

The official GitHub runner has also deprecated 18.04 (https://github.com/actions/runner-images/issues/6002) and we should upgrade the version so that it is not used within Neovim as well.
