### PR TITLE
docs(options): fix typos in 'guicursor'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2901,10 +2901,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
 				In Normal et al. modes, use a block cursor
 				with the default colors defined by the host
-				terminal.  In Insert-likes modes, use
+				terminal.  In Insert-like modes, use
 				a vertical bar cursor with colors from
-				"Cursor" highlight group.  In Replace-likes
-				modes, use a underline cursor with
+				"Cursor" highlight group.  In Replace-like
+				modes, use an underline cursor with
 				default colors.
 	   i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
 				In Insert and Command-line Insert mode, use a

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2697,10 +2697,10 @@ vim.go.gp = vim.go.grepprg
 ---    n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
 --- 			In Normal et al. modes, use a block cursor
 --- 			with the default colors defined by the host
---- 			terminal.  In Insert-likes modes, use
+--- 			terminal.  In Insert-like modes, use
 --- 			a vertical bar cursor with colors from
---- 			"Cursor" highlight group.  In Replace-likes
---- 			modes, use a underline cursor with
+--- 			"Cursor" highlight group.  In Replace-like
+--- 			modes, use an underline cursor with
 --- 			default colors.
 ---    i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
 --- 			In Insert and Command-line Insert mode, use a

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3441,10 +3441,10 @@ return {
            n-v-c-sm:block,i-ci-ve:ver25-Cursor,r-cr-o:hor20
         			In Normal et al. modes, use a block cursor
         			with the default colors defined by the host
-        			terminal.  In Insert-likes modes, use
+        			terminal.  In Insert-like modes, use
         			a vertical bar cursor with colors from
-        			"Cursor" highlight group.  In Replace-likes
-        			modes, use a underline cursor with
+        			"Cursor" highlight group.  In Replace-like
+        			modes, use an underline cursor with
         			default colors.
            i-ci:ver30-iCursor-blinkwait300-blinkon200-blinkoff150
         			In Insert and Command-line Insert mode, use a


### PR DESCRIPTION
This PR serves to amend the `options.txt` help file. In particular, it fixes several typos in the passage concerning the `'guicursor'` option.