### PR TITLE
feat(runtime): highlight hl groups in syntax.txt

### DIFF
--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -1,0 +1,3 @@
+if vim.endswith(vim.fs.normalize(vim.api.nvim_buf_get_name(0)), '/doc/syntax.txt') then
+  require('vim.vimhelp').highlight_groups()
+end

--- a/runtime/lua/vim/vimhelp.lua
+++ b/runtime/lua/vim/vimhelp.lua
@@ -1,0 +1,31 @@
+-- Extra functionality for displaying Vim help.
+
+local M = {}
+
+-- Called when editing the doc/syntax.txt file
+function M.highlight_groups()
+  local save_cursor = vim.fn.getcurpos()
+
+  local start_lnum = vim.fn.search([[\*highlight-groups\*]], 'c')
+  if start_lnum == 0 then
+    return
+  end
+  local end_lnum = vim.fn.search('^======')
+  if end_lnum == 0 then
+    return
+  end
+
+  local ns = vim.api.nvim_create_namespace('vimhelp')
+  vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
+
+  for lnum = start_lnum, end_lnum do
+    local word = vim.api.nvim_buf_get_lines(0, lnum - 1, lnum, true)[1]:match('^(%w+)\t')
+    if vim.fn.hlexists(word) ~= 0 then
+      vim.api.nvim_buf_set_extmark(0, ns, lnum - 1, 0, { end_col = #word, hl_group = word })
+    end
+  end
+
+  vim.fn.setpos('.', save_cursor)
+end
+
+return M


### PR DESCRIPTION
- Add runtime/lua/vim/vimhelp.lua, which is a translation of Vim's
  runtime/import/dist/vimhelp.vim.
- Unlike Vim, run the highlighting from an ftplugin file instead of a
  syntax file, so that it is run even if using treesitter.

Close #25036
