### PR TITLE
ci: remove container solution for the linux runner

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
 
-SUDO="sudo"
-
 while (($# > 0)); do
   case $1 in
   --test) # install test dependencies
     TEST=1
-    shift
-    ;;
-  --container) # don't use sudo
-    SUDO=""
     shift
     ;;
   esac
@@ -17,10 +11,10 @@ done
 
 os=$(uname -s)
 if [[ $os == Linux ]]; then
-  $SUDO apt-get update
-  $SUDO apt-get install -y build-essential cmake curl gettext ninja-build unzip
+  sudo apt-get update
+  sudo apt-get install -y build-essential cmake curl gettext ninja-build unzip
   if [[ -n $TEST ]]; then
-    $SUDO apt-get install -y locales-all cpanminus
+    sudo apt-get install -y locales-all cpanminus
   fi
 elif [[ $os == Darwin ]]; then
   brew update --quiet

--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -27,6 +27,10 @@ ${NVIM_VERSION}
 
 ### Linux (x64)
 
+Minimum glibc version to run these releases is 3.31. People requring releases
+that work on older glibc versions can find them at
+https://github.com/neovim/neovim-releases.
+
 #### AppImage
 1. Download **nvim.appimage**
 2. Run `chmod u+x nvim.appimage && ./nvim.appimage`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,25 +21,11 @@ jobs:
       CC: gcc-10
     outputs:
       version: ${{ steps.build.outputs.version }}
-    container:
-      image: ubuntu:18.04
-      options: --privileged # Privileged mode is needed to load fuse module.
     steps:
-      - name: Prepare container
-        run: |
-          apt-get update
-          apt-get install -y software-properties-common
-          add-apt-repository -y ppa:ubuntu-toolchain-r/test # For gcc-10.
-          add-apt-repository -y ppa:git-core/ppa # For git>=2.18.
-          apt-get update
-          apt-get install -y git gcc-10
-          apt-get install -y fuse libfuse2 # For linuxdeploy.
-          # Workaround for https://github.com/actions/checkout/issues/766.
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: ./.github/scripts/install_deps.sh --container
+      - run: ./.github/scripts/install_deps.sh
       - if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != 'nightly')
         run: |
           echo 'NVIM_BUILD_TYPE=Release' >> $GITHUB_ENV


### PR DESCRIPTION
This will fix the failing release job.

Ubuntu 18.04 is incompatible with checkout action version 4, which
requires glibc 2.28+. This will bump the minimum glibc version required
to use the release versions to 2.31. People requring the older releases
can find them at https://github.com/neovim/neovim-releases.