### PR TITLE
improved i3/sway syntax highlighting

### DIFF
--- a/runtime/syntax/i3config.vim
+++ b/runtime/syntax/i3config.vim
@@ -2,8 +2,9 @@
 " Language: i3 config file
 " Original Author: Mohamed Boughaba <mohamed dot bgb at gmail dot com>
 " Maintainer: Quentin Hibon (github user hiqua)
-" Version: 0.4
-" Last Change: 2022 Jun 05
+" Version: 0.4.22
+" Reference version (JosefLitos/i3config.vim): 4.22
+" Last Change: 2023-09-08
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -18,7 +19,7 @@ endif
 scriptencoding utf-8
 
 " Error
-syn match i3ConfigError /.*/
+syn match i3ConfigError /.\+/
 
 " Todo
 syn keyword i3ConfigTodo TODO FIXME XXX contained
@@ -27,238 +28,259 @@ syn keyword i3ConfigTodo TODO FIXME XXX contained
 " Comments are started with a # and can only be used at the beginning of a line
 syn match i3ConfigComment /^\s*#.*$/ contains=i3ConfigTodo
 
+syn match i3ConfigOperator /[,;:]/ contained
+
+syn keyword i3ConfigBoolean yes no enabled disabled on off true false contained
+
 " Font
 " A FreeType font description is composed by:
 " a font family, a style, a weight, a variant, a stretch and a size.
-syn match i3ConfigFontSeparator /,/ contained
-syn match i3ConfigFontSeparator /:/ contained
+syn match i3ConfigParen /[{}]/ contained
 syn keyword i3ConfigFontKeyword font contained
-syn match i3ConfigFontNamespace /\w\+:/ contained contains=i3ConfigFontSeparator
-syn match i3ConfigFontContent /-\?\w\+\(-\+\|\s\+\|,\)/ contained contains=i3ConfigFontNamespace,i3ConfigFontSeparator,i3ConfigFontKeyword
+syn match i3ConfigFontNamespace /\w\+:/ contained contains=i3ConfigOperator
+syn match i3ConfigFontContent /-\?\w\+\(-\+\|\s\+\|,\)/ contained contains=i3ConfigFontNamespace,i3ConfigFontKeyword,i3ConfigOperator
 syn match i3ConfigFontSize /\s\=\d\+\(px\)\?\s\?$/ contained
-syn match i3ConfigFont /^\s*font\s\+.*$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
-syn match i3ConfigFont /^\s*font\s\+.*\(\\\_.*\)\?$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
-syn match i3ConfigFont /^\s*font\s\+.*\(\\\_.*\)\?[^\\]\+$/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
-syn match i3ConfigFont /^\s*font\s\+\(\(.*\\\_.*\)\|\(.*[^\\]\+$\)\)/ contains=i3ConfigFontContent,i3ConfigFontSeparator,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^font\s\+.*$/ contains=i3ConfigFontContent,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^font\s\+.*\(\\\_.*\)\?$/ contains=i3ConfigFontContent,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^font\s\+.*\(\\\_.*\)\?[^\\]\+$/ contains=i3ConfigFontContent,i3ConfigFontSize,i3ConfigFontNamespace
+syn match i3ConfigFont /^font\s\+\(\(.*\\\_.*\)\|\(.*[^\\]\+$\)\)/ contains=i3ConfigFontContent,i3ConfigFontSize,i3ConfigFontNamespace
 
-" variables
-syn match i3ConfigString /\(['"]\)\(.\{-}\)\1/ contained
-syn match i3ConfigColor /#\w\{6}/ contained
-syn match i3ConfigVariableModifier /+/ contained
-syn match i3ConfigVariableAndModifier /+\w\+/ contained contains=i3ConfigVariableModifier
-syn match i3ConfigVariable /\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?/ contains=i3ConfigVariableModifier,i3ConfigVariableAndModifier
-syn keyword i3ConfigInitializeKeyword set contained
-syn match i3ConfigInitialize /^\s*set\s\+.*$/ contains=i3ConfigVariable,i3ConfigInitializeKeyword,i3ConfigColor,i3ConfigString
+" parameters
+syn region i3ConfigString start=/"/ skip=/\\"/ end=/"/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable keepend extend
+syn region i3ConfigString start=/'/ end=/'/ contained contains=i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigVariable keepend extend
+syn match i3ConfigColor /#\w\{3,8}/ contained
+syn match i3ConfigVariable /\$[A-Z0-9a-z-_]\+/
+syn keyword i3ConfigSetKeyword set contained
+syn match i3ConfigSet /^\s*set \$\w\+ .*$/ contains=i3ConfigVariable,i3ConfigSetKeyword,i3ConfigColor,i3ConfigString,i3ConfigNoStartupId,i3ConfigNumber,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper
 
 " Include
 syn keyword i3ConfigIncludeKeyword include contained
-syn match i3ConfigInclude /^\s*include\s\+.*$/ contains=i3ConfigIncludeKeyword,i3ConfigString,i3ConfigVariable
+syn match i3ConfigCommandSubstitutionRegion /`[^`]*`/ contained contains=i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper,i3ConfigShCommand
+syn match i3ConfigIncludePath /[~./a-zA-Z0-9`][^~]*$/ contained contains=i3ConfigCommandSubstitutionRegion
+syn match i3ConfigInclude /^include .[^~]*$/ contains=i3ConfigIncludeKeyword,i3ConfigString,i3ConfigVariable,i3ConfigIncludePath
 
 " Gaps
 syn keyword i3ConfigGapStyleKeyword inner outer horizontal vertical top right bottom left current all set plus minus toggle up down contained
-syn match i3ConfigGapStyle /^\s*\(gaps\)\s\+\(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,i3ConfigNumber,i3ConfigVariable
-syn keyword i3ConfigSmartGapKeyword on inverse_outer off contained
-syn match i3ConfigSmartGap /^\s*smart_gaps\s\+\(on\|inverse_outer\|off\)\s\?$/ contains=i3ConfigSmartGapKeyword
+syn match i3ConfigGapStyle /^gaps \(inner\|outer\|horizontal\|vertical\|left\|top\|right\|bottom\)\(\s\+\(current\|all\)\)\?\(\s\+\(set\|plus\|minus\|toggle\)\)\?\(\s\+\(-\?\d\+\|\$.*\)\)$/ contains=i3ConfigGapStyleKeyword,i3ConfigNumber,i3ConfigVariable
+syn keyword i3ConfigSmartGapKeyword on inverse_outer contained
+syn match i3ConfigSmartGap /^smart_gaps \(on\|inverse_outer\)$/ contains=i3ConfigSmartGapKeyword
 syn keyword i3ConfigSmartBorderKeyword on no_gaps contained
-syn match i3ConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\)\s\?$/ contains=i3ConfigSmartBorderKeyword
+syn match i3ConfigSmartBorder /^smart_borders \(on\|no_gaps\)$/ contains=i3ConfigSmartBorderKeyword
 
 " Keyboard bindings
-syn keyword i3ConfigAction toggle fullscreen restart key import kill shrink grow contained
-syn keyword i3ConfigAction focus move grow height width split layout resize restore reload mute unmute exit mode workspace container to contained
-syn match i3ConfigModifier /\w\++\w\+\(\(+\w\+\)\+\)\?/ contained contains=i3ConfigVariableModifier
-syn match i3ConfigNumber /\s\d\+/ contained
+syn keyword i3ConfigAction move exit restart reload layout append_layout workspace focus kill open fullscreen sticky split floating mark unmark resize rename scratchpad swap mode bar gaps border nop contained
+syn keyword i3ConfigOption enable disable toggle mode_toggle key shrink grow height width restore container to left right up down position absolute relative window splitv splith tabbed stacked default on off inner outer current all set plus minus top bottom horizontal vertical auto none normal pixel prev next back_and_forth child parent show contained
+syn match i3ConfigNumber /\([a-zA-Z0-9_$]\)\@<!\d\+\([a-zA-Z0-9_$]\)\@!/ contained
 syn match i3ConfigUnit /\sp\(pt\|x\)/ contained
 syn match i3ConfigUnitOr /\sor/ contained
-syn keyword i3ConfigBindKeyword bindsym bindcode exec gaps border contained
-syn match i3ConfigBindArgument /--\w\+\(\(-\w\+\)\+\)\?\s/ contained
-syn match i3ConfigBind /^\s*\(bindsym\|bindcode\)\s\+.*$/ contains=i3ConfigVariable,i3ConfigBindKeyword,i3ConfigVariableAndModifier,i3ConfigNumber,i3ConfigUnit,i3ConfigUnitOr,i3ConfigBindArgument,i3ConfigModifier,i3ConfigAction,i3ConfigString,i3ConfigGapStyleKeyword,i3ConfigBorderStyleKeyword
+syn keyword i3ConfigBindKeyword bindsym bindcode bindswitch bindgesture contained
+syn match i3ConfigBindArgument /--\(release\|border\|whole-window\|exclude-titlebar\|locked\|to-code\|no-repeat\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn match i3ConfigBindModifier /+/ contained
+syn keyword i3ConfigBindModkey Ctrl Shift Mod1 Mod4 Mod2 contained
+syn match i3ConfigBindCombo /[$a-zA-Z0-9_+]\+ / contained contains=i3ConfigBindModifier,i3ConfigVariable,i3ConfigBindModkey
+syn match i3ConfigBindComboLine /bind\(sym\|code\)\( --[a-z-]\+\)* [$a-zA-Z0-9_+]\+ / contained contains=i3ConfigBindKeyword,i3ConfigBindArgument,i3ConfigBindCombo
+syn match i3ConfigBind /^\s*bind\(sym\|code\|switch\|gesture\)\s\+.*[^{]$/ contains=i3ConfigBindComboLine,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,i3ConfigBoolean,i3ConfigExec
 
 " Floating
 syn keyword i3ConfigSizeSpecial x contained
-syn match i3ConfigNegativeSize /-/ contained
-syn match i3ConfigSize /-\?\d\+\s\?x\s\?-\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber,i3ConfigNegativeSize
-syn match i3ConfigFloatingModifier /^\s*floating_modifier\s\+\$\w\+\d\?/ contains=i3ConfigVariable
-syn match i3ConfigFloating /^\s*floating_\(maximum\|minimum\)_size\s\+-\?\d\+\s\?x\s\?-\?\d\+/ contains=i3ConfigSize
+syn match i3ConfigSize / -\?\d\+\s\?x\s\?-\?\d\+/ contained contains=i3ConfigSizeSpecial,i3ConfigNumber
+syn keyword i3ConfigFloatingModifier floating_modifier contained
+syn match i3ConfigFloating /^floating_modifier [$a-zA-Z0-9+]\+$/ contains=i3ConfigVariable,i3ConfigSize,i3ConfigFloatingModifier
+syn match i3ConfigFloating /^floating_\(maximum\|minimum\)_size\s\+-\?\d\+\s\?x\s\?-\?\d\+/ contains=i3ConfigSize
 
 " Orientation
 syn keyword i3ConfigOrientationKeyword vertical horizontal auto contained
-syn match i3ConfigOrientation /^\s*default_orientation\s\+\(vertical\|horizontal\|auto\)\s\?$/ contains=i3ConfigOrientationKeyword
+syn match i3ConfigOrientation /^default_orientation \(vertical\|horizontal\|auto\)$/ contains=i3ConfigOrientationKeyword
 
 " Layout
 syn keyword i3ConfigLayoutKeyword default stacking tabbed contained
-syn match i3ConfigLayout /^\s*workspace_layout\s\+\(default\|stacking\|tabbed\)\s\?$/ contains=i3ConfigLayoutKeyword
+syn match i3ConfigLayout /^workspace_layout \(default\|stacking\|tabbed\)$/ contains=i3ConfigLayoutKeyword
 
 " Border style
 syn keyword i3ConfigBorderStyleKeyword none normal pixel contained
-syn match i3ConfigBorderStyle /^\s*\(new_window\|new_float\|default_border\|default_floating_border\)\s\+\(none\|\(normal\|pixel\)\(\s\+\d\+\)\?\(\s\+\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?\)\?\)\s\?$/ contains=i3ConfigBorderStyleKeyword,i3ConfigNumber,i3ConfigVariable
+syn match i3ConfigBorderStyle /^\(new_window\|new_float\|default_border\|default_floating_border\)\s\+\(none\|\(normal\|pixel\)\(\s\+\d\+\)\?\(\s\+\$\w\+\(\(-\w\+\)\+\)\?\(\s\|+\)\?\)\?\)$/ contains=i3ConfigBorderStyleKeyword,i3ConfigNumber,i3ConfigVariable
 
 " Hide borders and edges
 syn keyword i3ConfigEdgeKeyword none vertical horizontal both smart smart_no_gaps contained
 syn match i3ConfigEdge /^\s*hide_edge_borders\s\+\(none\|vertical\|horizontal\|both\|smart\|smart_no_gaps\)\s\?$/ contains=i3ConfigEdgeKeyword
 
+
 " Arbitrary commands for specific windows (for_window)
 syn keyword i3ConfigCommandKeyword for_window contained
-syn region i3ConfigWindowStringSpecial start=+"+  skip=+\\"+  end=+"+ contained contains=i3ConfigString
-syn region i3ConfigWindowCommandSpecial start="\[" end="\]" contained contains=i3ConfigWindowStringSpacial,i3ConfigString
-syn match i3ConfigArbitraryCommand /^\s*for_window\s\+.*$/ contains=i3ConfigWindowCommandSpecial,i3ConfigCommandKeyword,i3ConfigBorderStyleKeyword,i3ConfigLayoutKeyword,i3ConfigOrientationKeyword,Size,i3ConfigNumber
+syn match i3ConfigConditionalText /\w\+\(-\w\+\)*/ contained
+syn match i3ConfigEqualsOperator /=/ contained
+syn region i3ConfigConditional start=/\[/ end=/\]/ contained contains=i3ConfigString,i3ConfigEqualsOperator,i3ConfigConditionalText
+syn match i3ConfigArbitraryCommand /^\s*for_window\s\+.*$/ contains=i3ConfigConditional,i3ConfigCommandKeyword,i3ConfigAction,i3ConfigOption,i3ConfigSize,i3ConfigNumber,i3ConfigString,i3ConfigOperator,i3ConfigBoolean,i3ConfigVariable
 
 " Disable focus open opening
 syn keyword i3ConfigNoFocusKeyword no_focus contained
-syn match i3ConfigDisableFocus /^\s*no_focus\s\+.*$/ contains=i3ConfigWindowCommandSpecial,i3ConfigNoFocusKeyword
+syn match i3ConfigDisableFocus /^\s*no_focus\s\+.*$/ contains=i3ConfigConditional,i3ConfigNoFocusKeyword
 
 " Move client to specific workspace automatically
 syn keyword i3ConfigAssignKeyword assign contained
 syn match i3ConfigAssignSpecial /→/ contained
-syn match i3ConfigAssign /^\s*assign\s\+.*$/ contains=i3ConfigAssignKeyword,i3ConfigWindowCommandSpecial,i3ConfigAssignSpecial
+syn match i3ConfigAssign /^assign\s\+.*$/ contains=i3ConfigAssignKeyword,i3ConfigAssignSpecial,i3ConfigConditional,i3ConfigVariable,i3ConfigString,i3ConfigNumber
 
 " X resources
 syn keyword i3ConfigResourceKeyword set_from_resource contained
-syn match i3ConfigResource /^\s*set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigWindowCommandSpecial,i3ConfigColor,i3ConfigVariable
+syn match i3ConfigResource /^\s*set_from_resource\s\+.*$/ contains=i3ConfigResourceKeyword,i3ConfigConditional,i3ConfigColor,i3ConfigVariable,i3ConfigString,i3ConfigNumber
 
-" Auto start applications
-syn keyword i3ConfigExecKeyword exec exec_always contained
-syn match i3ConfigNoStartupId /--no-startup-id/ contained " We are not using i3ConfigBindArgument as only no-startup-id is supported here
-syn match i3ConfigExec /^\s*exec\(_always\)\?\s\+.*$/ contains=i3ConfigExecKeyword,i3ConfigNoStartupId,i3ConfigString
+" Executing shell commands
+syn keyword i3ConfigExecKeyword exec contained
+syn keyword i3ConfigExecAlwaysKeyword exec_always contained
+syn match i3ConfigShCmdDelim /\$/ contained
+syn region i3ConfigShCommand start=/\$(/ end=/)/ contained contains=i3ConfigShCmdDelim,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigString,i3ConfigNumber,i3ConfigVariable keepend extend
+syn match  i3ConfigShDelim /[[\]{}();`]\+/ contained
+syn match  i3ConfigShOper /[<>&|+=~^*!.?]\+/ contained
+syn match i3ConfigShParam /\<-[a-zA-Z0-9_-]\+\>/ contained containedin=i3ConfigVar
+syn region i3ConfigExec start=/exec\(_always\)\?\( --no-startup-id\)\? [^{]/ skip=/\\$/ end=/\([,;]\|$\)/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigOperator keepend extend
 
 " Automatically putting workspaces on specific screens
 syn keyword i3ConfigWorkspaceKeyword workspace contained
 syn keyword i3ConfigOutput output contained
-syn match i3ConfigWorkspace /^\s*workspace\s\+.*$/ contains=i3ConfigWorkspaceKeyword,i3ConfigNumber,i3ConfigString,i3ConfigOutput
+syn match i3ConfigWorkspace /^\s*workspace\s\+.*$/ contains=i3ConfigWorkspaceKeyword,i3ConfigNumber,i3ConfigString,i3ConfigOutput,i3ConfigVariable,i3ConfigBoolean
 
 " Changing colors
 syn keyword i3ConfigClientColorKeyword client focused focused_inactive unfocused urgent placeholder background contained
 syn match i3ConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClientColorKeyword,i3ConfigColor,i3ConfigVariable
 
 syn keyword i3ConfigTitleAlignKeyword left center right contained
-syn match i3ConfigTitleAlign /^\s*title_align\s\+.*$/ contains=i3ConfigTitleAlignKeyword
+syn match i3ConfigTitleAlign /^title_align .*$/ contains=i3ConfigTitleAlignKeyword
 
 " Interprocess communication
 syn match i3ConfigInterprocessKeyword /ipc-socket/ contained
-syn match i3ConfigInterprocess /^\s*ipc-socket\s\+.*$/ contains=i3ConfigInterprocessKeyword
+syn match i3ConfigInterprocess /^ipc-socket .*$/ contains=i3ConfigInterprocessKeyword
 
 " Mouse warping
 syn keyword i3ConfigMouseWarpingKeyword mouse_warping contained
-syn keyword i3ConfigMouseWarpingType output none contained
-syn match i3ConfigMouseWarping /^\s*mouse_warping\s\+\(output\|none\)\s\?$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType
+syn keyword i3ConfigMouseWarpingType output container none contained
+syn match i3ConfigMouseWarping /^mouse_warping \(output\|container\|none\)$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType
 
 " Focus follows mouse
 syn keyword i3ConfigFocusFollowsMouseKeyword focus_follows_mouse contained
-syn keyword i3ConfigFocusFollowsMouseType yes no contained
-syn match i3ConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusFollowsMouseKeyword,i3ConfigFocusFollowsMouseType
-
-" Popups during fullscreen mode
-syn keyword i3ConfigPopupOnFullscreenKeyword popup_during_fullscreen contained
-syn keyword i3ConfigPopuponFullscreenType smart ignore leave_fullscreen contained
-syn match i3ConfigPopupOnFullscreen /^\s*popup_during_fullscreen\s\+\w\+\s\?$/ contains=i3ConfigPopupOnFullscreenKeyword,i3ConfigPopupOnFullscreenType
+syn keyword i3ConfigFocusFollowsMouseType always contained
+syn match i3ConfigFocusFollowsMouse /^focus_follows_mouse \(yes\|no\|always\)$/ contains=i3ConfigFocusFollowsMouseKeyword,i3ConfigBoolean,i3ConfigFocusFollowsMouseType
 
 " Focus wrapping
 syn keyword i3ConfigFocusWrappingKeyword force_focus_wrapping focus_wrapping contained
-syn keyword i3ConfigFocusWrappingType yes no contained
-syn match i3ConfigFocusWrapping /^\s*\(force_\)\?focus_wrapping\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigFocusWrappingKeyword
+syn keyword i3ConfigFocusWrappingType force workspace contained
+syn match i3ConfigFocusWrapping /^focus_wrapping \(yes\|no\|force\|workspace\)$/ contains=i3ConfigBoolean,i3ConfigFocusWrappingKeyword,i3ConfigFocusWrappingType
+
+" Popups during fullscreen mode
+syn keyword i3ConfigPopupOnFullscreenKeyword popup_during_fullscreen contained
+syn keyword i3ConfigPopupOnFullscreenType smart ignore leave_fullscreen contained
+syn match i3ConfigPopupOnFullscreen /^popup_during_fullscreen \w\+$/ contains=i3ConfigPopupOnFullscreenKeyword,i3ConfigPopupOnFullscreenType
 
 " Forcing Xinerama
 syn keyword i3ConfigForceXineramaKeyword force_xinerama contained
-syn match i3ConfigForceXinerama /^\s*force_xinerama\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigForceXineramaKeyword
+syn match i3ConfigForceXinerama /^force_xinerama \(yes\|no\)$/ contains=i3ConfigBoolean,i3ConfigForceXineramaKeyword
 
 " Automatic back-and-forth when switching to the current workspace
 syn keyword i3ConfigAutomaticSwitchKeyword workspace_auto_back_and_forth contained
-syn match i3ConfigAutomaticSwitch /^\s*workspace_auto_back_and_forth\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigAutomaticSwitchKeyword
+syn match i3ConfigAutomaticSwitch /^workspace_auto_back_and_forth \(yes\|no\)$/ contains=i3ConfigBoolean,i3ConfigAutomaticSwitchKeyword
 
 " Delay urgency hint
 syn keyword i3ConfigTimeUnit ms contained
 syn keyword i3ConfigDelayUrgencyKeyword force_display_urgency_hint contained
-syn match i3ConfigDelayUrgency /^\s*force_display_urgency_hint\s\+\d\+\s\+ms\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigDelayUrgencyKeyword,i3ConfigNumber,i3ConfigTimeUnit
+syn match i3ConfigDelayUrgency /^force_display_urgency_hint \d\+ ms$/ contains=i3ConfigBoolean,i3ConfigDelayUrgencyKeyword,i3ConfigNumber,i3ConfigTimeUnit
 
 " Focus on window activation
 syn keyword i3ConfigFocusOnActivationKeyword focus_on_window_activation contained
 syn keyword i3ConfigFocusOnActivationType smart urgent focus none contained
-syn match i3ConfigFocusOnActivation /^\s*focus_on_window_activation\s\+\(smart\|urgent\|focus\|none\)\s\?$/  contains=i3ConfigFocusOnActivationKeyword,i3ConfigFocusOnActivationType
+syn match i3ConfigFocusOnActivation /^focus_on_window_activation \(smart\|urgent\|focus\|none\)$/  contains=i3ConfigFocusOnActivationKeyword,i3ConfigFocusOnActivationType
 
-" Automatic back-and-forth when switching to the current workspace
-syn keyword i3ConfigDrawingMarksKeyword show_marks contained
-syn match i3ConfigDrawingMarks /^\s*show_marks\s\+\(yes\|no\)\s\?$/ contains=i3ConfigFocusWrappingType,i3ConfigDrawingMarksKeyword
+" Show window marks in their window title
+syn keyword i3ConfigShowMarksKeyword show_marks contained
+syn match i3ConfigShowMarks /^show_marks \(yes\|no\)$/ contains=i3ConfigBoolean,i3ConfigShowMarksKeyword
 
 " Group mode/bar
-syn keyword i3ConfigBlockKeyword mode bar colors i3bar_command status_command position exec mode hidden_state modifier id position output background statusline tray_output tray_padding separator separator_symbol workspace_min_width workspace_buttons strip_workspace_numbers binding_mode_indicator focused_workspace active_workspace inactive_workspace urgent_workspace binding_mode contained
-syn region i3ConfigBlock start=+^\s*[^#]*s\?{$+ end=+^\s*[^#]*}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
-
-" Line continuation
-syn region i3ConfigLineCont start=/^.*\\$/ end=/^.*$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable transparent keepend extend
+syn keyword i3ConfigBlockKeyword mode bar height colors i3bar_command status_command position hidden_state modifier id position tray_output tray_padding separator separator_symbol workspace_buttons strip_workspace_numbers binding_mode_indicator binding_mode exec exec_always contained
+syn region i3ConfigBlock start=/^\(mode \S\+\|bar\|\s\+colors\)\+\s\+{$/ end=/^\s*}$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigComment,i3ConfigFont,i3ConfigBoolean,i3ConfigNumber,i3ConfigOperator,i3ConfigModifier,i3ConfigParen,i3ConfigColor,i3ConfigVariable,i3ConfigBlock fold keepend extend
 
 " Define the highlighting.
+hi def link i3ConfigKeyword                         Keyword
+hi def link i3ConfigCommand                         Statement
 hi def link i3ConfigError                           Error
 hi def link i3ConfigTodo                            Todo
 hi def link i3ConfigComment                         Comment
-hi def link i3ConfigFontContent                     Type
-hi def link i3ConfigFocusOnActivationType           Type
-hi def link i3ConfigPopupOnFullscreenType           Type
-hi def link i3ConfigOrientationKeyword              Type
-hi def link i3ConfigMouseWarpingType                Type
-hi def link i3ConfigFocusFollowsMouseType           Type
-hi def link i3ConfigGapStyleKeyword                 Type
-hi def link i3ConfigTitleAlignKeyword               Type
-hi def link i3ConfigSmartGapKeyword                 Type
-hi def link i3ConfigSmartBorderKeyword              Type
-hi def link i3ConfigLayoutKeyword                   Type
-hi def link i3ConfigBorderStyleKeyword              Type
-hi def link i3ConfigEdgeKeyword                     Type
-hi def link i3ConfigAction                          Type
-hi def link i3ConfigCommand                         Type
-hi def link i3ConfigOutput                          Type
-hi def link i3ConfigWindowCommandSpecial            Type
-hi def link i3ConfigFocusWrappingType               Type
-hi def link i3ConfigUnitOr                          Type
-hi def link i3ConfigFontSize                        Constant
+hi def link i3ConfigOperator                        Operator
+hi def link i3ConfigParen                           Delimiter
+hi def link i3ConfigFontKeyword                     i3ConfigKeyword
+hi def link i3ConfigFontNamespace                   i3ConfigOption
+hi def link i3ConfigFontContent                     String
+hi def link i3ConfigFontSize                        Number
+hi def link i3ConfigString                          String
+hi def link i3ConfigNumber                          Number
+hi def link i3ConfigBoolean                         Boolean
 hi def link i3ConfigColor                           Constant
-hi def link i3ConfigNumber                          Constant
-hi def link i3ConfigUnit                            Constant
-hi def link i3ConfigVariableAndModifier             Constant
-hi def link i3ConfigTimeUnit                        Constant
-hi def link i3ConfigModifier                        Constant
-hi def link i3ConfigString                          Constant
-hi def link i3ConfigNegativeSize                    Constant
-hi def link i3ConfigInclude                         Constant
-hi def link i3ConfigFontSeparator                   Special
-hi def link i3ConfigVariableModifier                Special
-hi def link i3ConfigSizeSpecial                     Special
-hi def link i3ConfigWindowSpecial                   Special
-hi def link i3ConfigAssignSpecial                   Special
-hi def link i3ConfigFontNamespace                   PreProc
-hi def link i3ConfigBindArgument                    PreProc
-hi def link i3ConfigNoStartupId                     PreProc
-hi def link i3ConfigIncludeKeyword                  Identifier
-hi def link i3ConfigFontKeyword                     Identifier
-hi def link i3ConfigBindKeyword                     Identifier
-hi def link i3ConfigOrientation                     Identifier
-hi def link i3ConfigGapStyle                        Identifier
-hi def link i3ConfigTitleAlign                      Identifier
-hi def link i3ConfigSmartGap                        Identifier
-hi def link i3ConfigSmartBorder                     Identifier
-hi def link i3ConfigLayout                          Identifier
-hi def link i3ConfigBorderStyle                     Identifier
-hi def link i3ConfigEdge                            Identifier
-hi def link i3ConfigFloating                        Identifier
-hi def link i3ConfigFloatingModifier                Identifier
-hi def link i3ConfigCommandKeyword                  Identifier
-hi def link i3ConfigNoFocusKeyword                  Identifier
-hi def link i3ConfigInitializeKeyword               Identifier
-hi def link i3ConfigAssignKeyword                   Identifier
-hi def link i3ConfigResourceKeyword                 Identifier
-hi def link i3ConfigExecKeyword                     Identifier
-hi def link i3ConfigWorkspaceKeyword                Identifier
-hi def link i3ConfigClientColorKeyword              Identifier
-hi def link i3ConfigInterprocessKeyword             Identifier
-hi def link i3ConfigMouseWarpingKeyword             Identifier
-hi def link i3ConfigFocusFollowsMouseKeyword        Identifier
-hi def link i3ConfigPopupOnFullscreenKeyword        Identifier
-hi def link i3ConfigFocusWrappingKeyword            Identifier
-hi def link i3ConfigForceXineramaKeyword            Identifier
-hi def link i3ConfigAutomaticSwitchKeyword          Identifier
-hi def link i3ConfigDelayUrgencyKeyword             Identifier
-hi def link i3ConfigFocusOnActivationKeyword        Identifier
-hi def link i3ConfigDrawingMarksKeyword             Identifier
-hi def link i3ConfigBlockKeyword                    Identifier
-hi def link i3ConfigVariable                        Statement
-hi def link i3ConfigArbitraryCommand                Type
+hi def link i3ConfigVariable                        Variable
+hi def link i3ConfigSetKeyword                      i3ConfigKeyword
+hi def link i3ConfigIncludeKeyword                  i3ConfigKeyword
+hi def link i3ConfigCommandSubstitutionDelimiter    Delimiter
+hi def link i3ConfigIncludePath                     @parameter
+hi def link i3ConfigGapStyleKeyword                 i3ConfigOption
+hi def link i3ConfigGapStyle                        i3ConfigCommand
+hi def link i3ConfigSmartGapKeyword                 i3ConfigOption
+hi def link i3ConfigSmartGap                        i3ConfigKeyword
+hi def link i3ConfigSmartBorderKeyword              i3ConfigOption
+hi def link i3ConfigSmartBorder                     i3ConfigKeyword
+hi def link i3ConfigAction                          i3ConfigCommand
+hi def link i3ConfigOption                          Type
+hi def link i3ConfigUnit                            i3ConfigNumber
+hi def link i3ConfigUnitOr                          i3ConfigOperator
+hi def link i3ConfigBindKeyword                     i3ConfigKeyword
+hi def link i3ConfigBindModkey                      Special
+hi def link i3ConfigBindCombo                       SpecialChar
+hi def link i3ConfigBindModifier                    i3ConfigOperator
+hi def link i3ConfigBindArgument                    @parameter
+hi def link i3ConfigSizeSpecial                     i3ConfigOperator
+hi def link i3ConfigFloating                        i3ConfigKeyword
+hi def link i3ConfigFloatingModifier                Keyword
+hi def link i3ConfigOrientationKeyword              i3ConfigOption
+hi def link i3ConfigOrientation                     i3ConfigKeyword
+hi def link i3ConfigLayoutKeyword                   i3ConfigOption
+hi def link i3ConfigLayout                          i3ConfigKeyword
+hi def link i3ConfigBorderStyleKeyword              i3ConfigOption
+hi def link i3ConfigBorderStyle                     i3ConfigKeyword
+hi def link i3ConfigEdgeKeyword                     i3ConfigOption
+hi def link i3ConfigEdge                            i3ConfigKeyword
+hi def link i3ConfigCommandKeyword                  i3ConfigKeyword
+hi def link i3ConfigEqualsOperator                  i3ConfigOperator
+hi def link i3ConfigConditionalText                 @parameter
+hi def link i3ConfigConditional                     Delimiter
+hi def link i3ConfigNoFocusKeyword                  i3ConfigKeyword
+hi def link i3ConfigAssignKeyword                   i3ConfigKeyword
+hi def link i3ConfigAssignSpecial                   i3ConfigOption
+hi def link i3ConfigResourceKeyword                 i3ConfigKeyword
+hi def link i3ConfigExecKeyword                     i3ConfigCommand
+hi def link i3ConfigExecAlwaysKeyword               i3ConfigKeyword
+hi def link i3ConfigWorkspaceKeyword                i3ConfigCommand
+hi def link i3ConfigOutput                          i3ConfigOption
+hi def link i3ConfigClientColorKeyword              i3ConfigKeyword
+hi def link i3ConfigClientColor                     Operator
+hi def link i3ConfigTitleAlignKeyword               i3ConfigOption
+hi def link i3ConfigTitleAlign                      i3ConfigKeyword
+hi def link i3ConfigInterprocessKeyword             i3ConfigKeyword
+hi def link i3ConfigMouseWarpingKeyword             i3ConfigKeyword
+hi def link i3ConfigMouseWarpingType                i3ConfigOption
+hi def link i3ConfigFocusFollowsMouseKeyword        i3ConfigKeyword
+hi def link i3ConfigFocusFollowsMouseType           i3ConfigOption
+hi def link i3ConfigFocusWrappingKeyword            i3ConfigKeyword
+hi def link i3ConfigFocusWrappingType               i3ConfigOption
+hi def link i3ConfigPopupOnFullscreenKeyword        i3ConfigKeyword
+hi def link i3ConfigPopupOnFullscreenType           i3ConfigOption
+hi def link i3ConfigForceXineramaKeyword            i3ConfigKeyword
+hi def link i3ConfigAutomaticSwitchKeyword          i3ConfigKeyword
+hi def link i3ConfigTimeUnit                        i3ConfigNumber
+hi def link i3ConfigDelayUrgencyKeyword             i3ConfigKeyword
+hi def link i3ConfigFocusOnActivationKeyword        i3ConfigKeyword
+hi def link i3ConfigFocusOnActivationType           i3ConfigOption
+hi def link i3ConfigShowMarksKeyword                i3ConfigKeyword
+hi def link i3ConfigBlockKeyword                    i3ConfigKeyword
+hi def link i3ConfigShParam                         @parameter
+hi def link i3ConfigShDelim                         Delimiter
+hi def link i3ConfigShOper                          Operator
+hi def link i3ConfigShCmdDelim                      i3ConfigShDelim
+hi def link i3ConfigShCommand                       Normal
 
 let b:current_syntax = "i3config"

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -1,10 +1,10 @@
 " Vim syntax file
 " Language: sway window manager config
-" Original Author: James Eapen <james.eapen@vai.org>
+" Original Author: Josef Litos
 " Maintainer: James Eapen <james.eapen@vai.org>
-" Version: 0.2.1
-" Reference version (jamespeapen/swayconfig.vim): 0.12.1
-" Last Change: 2023 Mar 20
+" Version: 0.2.2
+" Reference version (JosefLitos/i3config.vim): 1.8.1
+" Last Change: 2023-09-08
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -19,98 +19,87 @@ endif
 
 runtime! syntax/i3config.vim
 
-scriptencoding utf-8
+" Add sway-specific options to i3config constructs
+syn match i3ConfigSet /^\s*set \$\w\+ .*$/ contains=i3ConfigVariable,i3ConfigSetKeyword,i3ConfigColor,i3ConfigString,i3ConfigNoStartupId,i3ConfigNumber,swayConfigOutputCommand,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShParam,i3ConfigShOper
 
-" Error
-"syn match swayConfigError /.*/
+syn match i3ConfigBind /^\s*bind\(sym\|code\|switch\|gesture\)\s\+.*[^{]$/ contains=i3ConfigBindComboLine,swayConfigBindswitchLine,swayConfigBindgestureLine,i3ConfigNumber,i3ConfigVariable,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec
+syn region i3ConfigBlock start=/^\(mode \S\+\|bar\|\s\+colors\)\+\s\+{$/ end=/^\s*}$/ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,swayConfigBindComboBlock,swayConfigBindswitchBlock,swayConfigBindgestureBlock,i3ConfigComment,i3ConfigFont,i3ConfigBoolean,i3ConfigNumber,i3ConfigOperator,i3ConfigModifier,i3ConfigParen,i3ConfigColor,i3ConfigVariable,i3ConfigBlock fold keepend extend
 
-" binding
-syn keyword swayConfigBindKeyword bindswitch bindgesture contained
-syn match swayConfigBind /^\s*\(bindswitch\)\s\+.*$/ contains=i3ConfigVariable,i3ConfigBindKeyword,swayConfigBindKeyword,i3ConfigVariableAndModifier,i3ConfigNumber,i3ConfigUnit,i3ConfigUnitOr,i3ConfigBindArgument,i3ConfigModifier,i3ConfigAction,i3ConfigString,i3ConfigGapStyleKeyword,i3ConfigBorderStyleKeyword
+" Sway options
+" sway bindswitch and bindgesture
+syn region swayConfigBindComboBlock start=/^\s*bind\(sym\|code\)\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,i3ConfigBindCombo,i3ConfigBindArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigModifier,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
+syn match swayConfigBindswitchArgument /--\(locked\|no-warn\|reload\)/ contained
+syn keyword swayConfigBindswitchType lid tablet contained
+syn keyword swayConfigBindswitchAction on off toggle contained
+syn match swayConfigBindswitch /\(lid\|tablet\):\(on\|off\|toggle\) / contained contains=swayConfigSwitchType,i3ConfigOperator,swayConfigBindswitchAction
+syn match swayConfigBindswitchLine /bindswitch\( --\(locked\|no-warn\|reload\)\)* \(lid\|tablet\):\(on\|off\|toggle\) / contained contains=i3ConfigBindKeyword,swayConfigBindswitchArgument,swayConfigBindswitchType,swayConfigBindswitchAction,i3ConfigOperator
+syn region swayConfigBindswitchBlock start=/^\s*bindswitch\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindswitch,swayConfigBindswitchArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigModifier,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
 
-" bindgestures
-syn keyword swayConfigBindGestureCommand swipe pinch hold contained
-syn keyword swayConfigBindGestureDirection up down left right next prev contained
-syn keyword swayConfigBindGesturePinchDirection inward outward clockwise counterclockwise contained
-syn match swayConfigBindGestureHold /^\s*\(bindgesture\)\s\+hold\(:[1-5]\)\?\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
-syn match swayConfigBindGestureSwipe /^\s*\(bindgesture\)\s\+swipe\(:[3-5]\)\?:\(up\|down\|left\|right\)\s\+.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
-syn match swayConfigBindGesturePinch /^\s*\(bindgesture\)\s\+pinch\(:[2-5]\)\?:\(up\|down\|left\|right\|inward\|outward\|clockwise\|counterclockwise\)\(+\(up\|down\|left\|right\|inward\|outward\|clockwise\|counterclockwise\)\)\?.*$/ contains=swayConfigBindKeyword,swayConfigBindGestureCommand,swayConfigBindGestureDirection,swayConfigBindGesturePinchDirection,i3ConfigWorkspaceKeyword,i3ConfigAction
+syn keyword swayConfigBindgestureType hold swipe pinch contained
+syn keyword swayConfigBindgestureDir up down left right inward outward clockwise counterclockwise contained
+syn match swayConfigBindgestureArgument /--\(exact\|input-device=[:0-9a-zA-Z_/-]\+\|no-warn\)/ contained
+syn match swayConfigBindgesture /\(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
+syn match swayConfigBindgestureLine /bindgesture\( --\(exact\|input-device=".*"\|no-warn\)\)* \(hold\(:[1-5]\)\?\|swipe\(:[3-5]\)\?\(:up\|:down\|:left\|:right\)\?\|pinch\(:[2-5]\)\?:\(+\?\(inward\|outward\|clockwise\|counterclockwise\|up\|down\|left\|right\)\)\+\) / contained contains=i3ConfigBindKeyword,swayConfigBindgestureArgument,i3ConfigNumber,swayConfigBindgestureType,i3ConfigOperator,swayConfigBindgestureDir,i3ConfigBindModifier
+syn region swayConfigBindgestureBlock start=/^\s*bindgesture\s\+.*{$/ end=/^\s*}$/ contains=i3ConfigBindKeyword,swayConfigBindgesture,swayConfigBindgestureArgument,i3ConfigNumber,i3ConfigVariable,i3ConfigModifier,i3ConfigAction,i3ConfigOption,i3ConfigGapStyleKeyword,i3ConfigOperator,i3ConfigString,i3ConfigUnit,i3ConfigUnitOr,i3ConfigConditional,swayConfigOutputCommand,i3ConfigBoolean,i3ConfigExec,i3ConfigComment,i3ConfigParen fold keepend extend
 
-" floating
-syn keyword swayConfigFloatingKeyword floating contained
-syn match swayConfigFloating /^\s*floating\s\+\(enable\|disable\|toggle\)\s*$/ contains=swayConfigFloatingKeyword
+syn region swayConfigExecBlock start=/exec\(_always\)\? {/ end=/^}$/ contains=i3ConfigExecKeyword,i3ConfigExecAlwaysKeyword,i3ConfigShCommand,i3ConfigShDelim,i3ConfigShOper,i3ConfigShParam,i3ConfigNumber,i3ConfigString,i3ConfigVariable,i3ConfigComment fold keepend extend
 
-syn clear i3ConfigFloatingModifier
-syn keyword swayConfigFloatingModifier floating_modifier contained
-syn match swayConfigFloatingMouseAction /^\s\?.*floating_modifier\s\S\+\s\?\(normal\|inverted\|none\)\?$/ contains=swayConfigFloatingModifier,i3ConfigVariable
+syn keyword swayConfigBlockKeyword input output seat contained
 
-" Gaps
-syn clear i3ConfigSmartBorderKeyword
-syn clear i3ConfigSmartBorder
-syn keyword swayConfigSmartBorderKeyword on no_gaps off contained
-syn match swayConfigSmartBorder /^\s*smart_borders\s\+\(on\|no_gaps\|off\)\s\?$/ contains=swayConfigSmartBorderKeyword
+" sway display outputs
+syn keyword swayConfigOutputOpts mode pos position adaptive_sync scale res resolution power max_render_time transform scale_filter subpixel bg background enable disable toggle contained
+syn keyword swayConfigOutputOptVals toggle normal flipped contained
+syn keyword swayConfigOutputBgOpts fill stretch fit center tile contained
+syn match swayConfigOutputBg / \(background\|bg\) .* \(fill\|fit\|center\|stretch\|tile\)/ contained contains=swayConfigOutputOpts,swayConfigOutputBgOpts,swayConfigBlockKeyword,i3ConfigString
+syn match swayConfigOutputFPS /@[0-9.]\+Hz/ contained
+syn match swayConfigOutputMode / [0-9]\+x[0-9]\+\(@[0-9.]\+Hz\)\?/ contained contains=swayConfigOutputFPS,i3ConfigNumber
+syn match swayConfigOutputCommand /output .*/ contains=swayConfigBlockKeyword,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigVariable,i3ConfigNumber,i3ConfigString,swayConfigOutputBg,i3ConfigBoolean
 
-" Changing colors
-syn keyword swayConfigClientColorKeyword focused_tab_title contained
-syn match swayConfigClientColor /^\s*client.\w\+\s\+.*$/ contains=i3ConfigClientColorKeyword,i3ConfigColor,i3ConfigVariable,i3ConfigClientColorKeyword,swayConfigClientColorKeyword
+" sway input devices
+syn keyword swayConfigInputOpts xkb_layout xkb_variant xkb_rules xkb_switch_layout xkb_numlock xkb_file xkb_capslock xkb_model repeat_delay repeat_rate map_to_output map_to_region map_from_region tool_mode accel_profile dwt dwtp drag_lock drag click_method middle_emulation tap events calibration_matrix natural_scroll left_handed pointer_accel scroll_button scroll_factor scroll_method tap_button_map contained
+syn keyword swayConfigInputOptVals absolute relative adaptive flat none button_areas clickfinger toggle two_finger edge on_button_down lrm lmr contained
+syn keyword swayConfigInputXkbOptsKeyword xkb_options contained
+syn match swayConfigInputXkbOptsVals /:[0-9a-z_-]\+/ contained contains=i3ConfigOperator
+syn match swayConfigInputXkbOptsOpts /[a-z]\+:[0-9a-z_-]\+/ contained contains=swayConfigInputXkbOptsVals
+syn match swayConfigInputXkbOpts /xkb_options \([a-z]\+:[0-9a-z_-]\+,\?\)\+/ contained contains=i3ConfigOperator,swayConfigInputXkbOptsKeyword,swayConfigInputXkbOptsOpts
+syn match swayConfigInputCommand /^input\s\+".*".*/ contains=swayConfigBlockKeyword,swayConfigInputXkbOptsOpts,i3ConfigNumber,i3ConfigString,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean
 
-" Input config
-syn keyword swayConfigInputKeyword input contained
-syn match swayConfigInput /^\s*input\s\+.*$/ contains=swayConfigInputKeyword
-
-" Seat config
-syn keyword swayConfigSeatKeyword seat contained
-syn match swayConfigSeat /^\s*seat\s\+.*$/ contains=swayConfigSeatKeyword
-
-" set display outputs
-syn match swayConfigOutput /^\s*output\s\+.*$/ contains=i3ConfigOutput
-
-" set display focus 
+" set display focus
 syn keyword swayConfigFocusKeyword focus contained
-syn keyword swayConfigFocusType output contained
-syn match swayConfigFocus /^\s*focus\soutput\s.*$/ contains=swayConfigFocusKeyword,swayConfigFocusType
+syn match swayConfigFocus /^focus output .*$/ contains=swayConfigFocusKeyword,swayConfigBlockKeyword
 
-" mouse warping
-syn keyword swayConfigMouseWarpingType container contained
-syn match swayConfigMouseWarping /^\s*mouse_warping\s\+\(output\|container\|none\)\s\?$/ contains=i3ConfigMouseWarpingKeyword,i3ConfigMouseWarpingType,swayConfigMouseWarpingType
+" enable/disable xwayland
+syn keyword swayConfigXOpt enable disable force contained
+syn match swayConfigXwayland /^xwayland \(enable\|disable\|force\)/ contains=swayConfigXOpt
 
-" focus follows mouse
-syn clear i3ConfigFocusFollowsMouseType
-syn clear i3ConfigFocusFollowsMouse
+" sway seat
+syn keyword swayConfigSeatOpts attach cursor fallback hide_cursor idle_inhibit idle_wake keyboard_grouping shortcuts_inhibitor pointer_constraint xcursor_theme contained
+syn keyword swayConfigSeatOptVals move set press release none smart activate deactivate toggle escape enable disable contained
+syn match swayConfigSeat /^seat .*/ contains=swayConfigBlockKeyword,i3ConfigString,i3ConfigNumber,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts
 
-syn keyword swayConfigFocusFollowsMouseType yes no always contained
-syn match swayConfigFocusFollowsMouse /^\s*focus_follows_mouse\s\+\(yes\|no\|always\)\s\?$/ contains=i3ConfigFocusFollowsMouseKeyword,swayConfigFocusFollowsMouseType
+syn region swayConfigBlock start=/^\(input\|output\|seat\).*\s{$/ end=/^}$/ contains=swayConfigInputXkbOptsOpts,swayConfigBlockKeyword,i3ConfigParen,i3ConfigVariable,i3ConfigString,i3ConfigNumber,swayConfigOutputKeyword,swayConfigOutputMode,swayConfigOutputOpts,i3ConfigColor,swayConfigOutputBg,swayConfigInputOpts,swayConfigInputOptVals,i3ConfigBoolean,swayConfigInputXkbOpts,i3ConfigOperator,i3ConfigBoolean,swayConfigSeatOptVals,swayConfigSeatOpts,i3ConfigComment fold keepend extend
 
-
-" xwayland 
-syn keyword swayConfigXwaylandKeyword xwayland contained
-syn match swayConfigXwaylandModifier /^\s*xwayland\s\+\(enable\|disable\|force\)\s\?$/ contains=swayConfigXwaylandKeyword
-
-" Group mode/bar
-syn clear i3ConfigBlock
-syn region swayConfigBlock start=+.*s\?{$+ end=+^}$+ contains=i3ConfigBlockKeyword,i3ConfigString,i3ConfigBind,i3ConfigInitializeKeyword,i3ConfigComment,i3ConfigFont,i3ConfigFocusWrappingType,i3ConfigColor,i3ConfigVariable,swayConfigInputKeyword,swayConfigSeatKeyword,i3ConfigOutput transparent keepend extend
-
-"hi def link swayConfigError                         Error
-hi def link i3ConfigFloating                        Error
-hi def link swayConfigFloating                      Type
-hi def link swayConfigFloatingMouseAction           Type
-hi def link swayConfigFocusKeyword                  Type
-hi def link swayConfigSmartBorderKeyword            Type
-hi def link swayConfigInputKeyword                  Type
-hi def link swayConfigSeatKeyword                   Type
-hi def link swayConfigMouseWarpingType              Type
-hi def link swayConfigFocusFollowsMouseType         Type
-hi def link swayConfigBindGestureCommand            Identifier
-hi def link swayConfigBindGestureDirection          Constant
-hi def link swayConfigBindGesturePinchDirection     Constant
-hi def link swayConfigBindKeyword                   Identifier
-hi def link swayConfigClientColorKeyword            Identifier
-hi def link swayConfigFloatingKeyword               Identifier
-hi def link swayConfigFloatingModifier              Identifier
-hi def link swayConfigFocusType                     Identifier
-hi def link swayConfigSmartBorder                   Identifier
-hi def link swayConfigXwaylandKeyword               Identifier
-hi def link swayConfigXwaylandModifier              Type
-hi def link swayConfigBindGesture                   PreProc
+" Define the highlighting.
+hi def link swayConfigFocusKeyword                  i3ConfigAction
+hi def link swayConfigOutputOpts                    i3ConfigOption
+hi def link swayConfigOutputBgOpts                  i3ConfigOption
+hi def link swayConfigOutputOptVals                 i3ConfigOption
+hi def link swayConfigOutputFPS                     Constant
+hi def link swayConfigInputOptVals                  i3ConfigOption
+hi def link swayConfigInputOpts                     i3ConfigKeyword
+hi def link swayConfigInputXkbOptsVals              i3ConfigString
+hi def link swayConfigInputXkbOptsOpts              i3ConfigOption
+hi def link swayConfigInputXkbOptsKeyword           i3ConfigKeyword
+hi def link swayConfigSeatOpts                      i3ConfigKeyword
+hi def link swayConfigSeatOptVals                   i3ConfigOption
+hi def link swayConfigBlockKeyword                  i3ConfigAction
+hi def link swayConfigXOpt                          i3ConfigOption
+hi def link swayConfigXwayland                      i3ConfigKeyword
+hi def link swayConfigBindswitchType                Type
+hi def link swayConfigBindswitchAction              Keyword
+hi def link swayConfigBindswitchArgument            i3ConfigBindArgument
+hi def link swayConfigBindgestureType               Type
+hi def link swayConfigBindgestureDir                Keyword
+hi def link swayConfigBindgestureArgument           i3ConfigBindArgument
 
 let b:current_syntax = "swayconfig"


### PR DESCRIPTION
a direct copyover from [my fork](https://github.com/JosefLitos/i3config.vim) of @mboughaba's `i3config.vim` 