### PR TITLE
vim-patch:9.0.1884: Wrong order of arguments for error messages

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -44,8 +44,8 @@ static const char e_positional_arg_num_type_inconsistent_str_str[]
   = N_("E1404: Positional argument %d type used inconsistently: %s/%s");
 static const char e_invalid_format_specifier_str[]
   = N_("E1405: Invalid format specifier: %s");
-static const char e_aptypes_is_null_str_nr[]
-  = "E1408: Internal error: ap_types or ap_types[idx] is NULL: %s: %d";
+static const char e_aptypes_is_null_nr_str[]
+  = "E1408: Internal error: ap_types or ap_types[idx] is NULL: %d: %s";
 
 static const char typename_unknown[] = N_("unknown");
 static const char typename_int[] = N_("int");
@@ -1250,7 +1250,7 @@ static void skip_to_arg(const char **ap_types, va_list ap_start, va_list *ap, in
 
   for (*arg_cur = arg_min; *arg_cur < *arg_idx - 1; (*arg_cur)++) {
     if (ap_types == NULL || ap_types[*arg_cur] == NULL) {
-      siemsg(e_aptypes_is_null_str_nr, fmt, *arg_cur);
+      siemsg(e_aptypes_is_null_nr_str, fmt, *arg_cur);
       return;
     }
 


### PR DESCRIPTION
#### vim-patch:9.0.1884: Wrong order of arguments for error messages

Problem:  Wrong order of arguments for error messages
Solution: Reverse order or arguments for e_aptypes_is_null_nr_str

closes: vim/vim#13051

https://github.com/vim/vim/commit/1bd2cb11694690a77e4141bce2e34d9dfb882f1c

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>