### PR TITLE
feat(lsp/buf): Optionally suppress no LSP notification.

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1249,6 +1249,19 @@ format({options})                                       *vim.lsp.buf.format()*
                  filter = function(client) return client.name ~= "tsserver" end
                }
 <
+                   • silent (boolean|nil) If true then notify will not be
+                     called if no LSP has a format option available. Will
+                     still notify on LSP error. Meant to be used alongside
+                     filter.               • >lua
+
+               -- Never request typescript-language-server for formatting
+               -- But don't notify if nothing else is available (eg. eslint is not
+               -- configured)
+               vim.lsp.buf.format {
+                 silent = true,
+                 filter = function(client) return client.name ~= "tsserver" end
+               }
+<
                    • async boolean|nil If true the method won't block.
                      Defaults to false. Editing the buffer while formatting
                      asynchronous can lead to unexpected changes.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -120,6 +120,8 @@ The following new APIs and features were added.
     indicator to see if a server supports a feature. Instead use
     `client.supports_method(<method>)`. It considers both the dynamic
     capabilities and static `server_capabilities`.
+  • Added `silent` option to `vim.lsp.buf.format` to suppress the no matching
+    language servers notification when `true`.
 
 • Treesitter
   • Bundled parsers and queries (highlight, folds) for Markdown, Python, and

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -177,6 +177,21 @@ end
 ---           }
 ---         </pre>
 ---
+---     - silent (boolean|nil)
+---         If true then notify will not be called if no LSP has a format option
+---         available. Will still notify on LSP error. Meant to be used alongside
+---         filter.
+---
+---         <pre>lua
+---           -- Never request typescript-language-server for formatting
+---           -- But don't notify if nothing else is available (eg. eslint is not
+---           -- configured)
+---           vim.lsp.buf.format {
+---             silent = true,
+---             filter = function(client) return client.name ~= "tsserver" end
+---           }
+---         </pre>
+---
 ---     - async boolean|nil
 ---         If true the method won't block. Defaults to false.
 ---         Editing the buffer while formatting asynchronous can lead to unexpected
@@ -197,6 +212,7 @@ function M.format(options)
   local bufnr = options.bufnr or api.nvim_get_current_buf()
   local mode = api.nvim_get_mode().mode
   local range = options.range
+  local silent = options.silent
   if not range and mode == 'v' or mode == 'V' then
     range = range_from_selection(bufnr, mode)
   end
@@ -212,7 +228,7 @@ function M.format(options)
     clients = vim.tbl_filter(options.filter, clients)
   end
 
-  if #clients == 0 then
+  if #clients == 0 and not silent then
     vim.notify('[LSP] Format request failed, no matching language servers.')
   end
 


### PR DESCRIPTION
This makes it possible to suppress the warning indicating that no LSP matching LSP servers were found. This can happen if you have a filter that would exclude one of the servers. For example you are excluding tsserver with the intention that you would use eslint instead. But if eslint is not installed or configured for that project then you would be able to silence the warning.

---

This was spawned literally just by wanting to not have this notify when I end up working on a project that maybe doesn't have something setup quite right and my save for typescript is

```lua
vim.api.nvim_create_autocmd({ "BufWritePre" }, {
  pattern = { "*.ts", "*.tsx" },
  callback = function ()
    vim.lsp.buf.format({
      -- Don't use tsserver _AND_ eslint for formatting. Preferrably just use eslint.
      -- Without this it would call format from both language servers.
      filter = function(client) return client.name ~= "tsserver" end
    })
  end
})
```

Maybe there is a better way to approach this? But it didn't seem unreasonable to just allow silencing of that one notify for a use case like `buf.format` either so I figured I would throw it out there; either it's not a huge deal or someone will be quick to point out a better way.