### PR TITLE
vim-patch:9.0.{1877,partial:1886}

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -119,7 +119,7 @@ CTRL-R {register}				*i_CTRL-R*
 			'/'	the last search pattern
 			':'	the last command-line
 			'.'	the last inserted text
-                                                       *i_CTRL-R_-*
+							*i_CTRL-R_-*
 			'-'	the last small (less than a line) delete
 				register. This is repeatable using |.| since
 				it remembers the register to put instead of

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -169,7 +169,7 @@ CTRL-W v						*CTRL-W_v*
 		it doesn't!
 
 CTRL-W n						*CTRL-W_n*
-CTRL-W CTRL_N						*CTRL-W_CTRL-N*
+CTRL-W CTRL-N						*CTRL-W_CTRL-N*
 :[N]new [++opt] [+cmd]					*:new*
 		Create a new window and start editing an empty file in it.
 		Make new window N high (default is to use half the existing

--- a/runtime/ftplugin/zig.vim
+++ b/runtime/ftplugin/zig.vim
@@ -39,7 +39,7 @@ endif
 
 let &l:define='\v(<fn>|<const>|<var>|^\s*\#\s*define)'
 
-" Safety check: don't execute zip from current directory
+" Safety check: don't execute zig from current directory
 if !exists('g:zig_std_dir') && exists('*json_decode') &&
     \  executable('zig') && get(g:, 'zig_exec', get(g:, 'plugin_exec', 0))
     \ && (fnamemodify(exepath("zig"), ":p:h") != s:tmp_cwd

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3888,6 +3888,10 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const long cmdpreview_
           nmatch = curbuf->b_ml.ml_line_count - sub_firstlnum + 1;
           current_match.end.lnum = sub_firstlnum + (linenr_T)nmatch;
           skip_match = true;
+          // safety check
+          if (nmatch < 0) {
+            goto skip;
+          }
         }
 
         // Save the line numbers for the preview buffer

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -919,7 +919,8 @@ char *replace_termcodes(const char *const from, const size_t from_len, char **co
     // Check for special <> keycodes, like "<C-S-LeftMouse>"
     if (do_special && ((flags & REPTERM_DO_LT) || ((end - src) >= 3
                                                    && strncmp(src, "<lt>", 4) != 0))) {
-      // Replace <SID> by K_SNR <script-nr> _.
+      // Change <SID>Func to K_SNR <script-nr> _Func.  This name is used
+      // for script-local user functions.
       // (room: 5 * 6 = 30 bytes; needed: 3 + <nr> + 1 <= 14)
       if (end - src >= 4 && STRNICMP(src, "<SID>", 5) == 0) {
         if (sid_arg < 0 || (sid_arg == 0 && current_sctx.sc_sid <= 0)) {

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1648,7 +1648,7 @@ bool utf_allow_break_before(int cc)
     0x2021,  // ‡ double dagger
     0x2026,  // … horizontal ellipsis
     0x2030,  // ‰ per mille sign
-    0x2031,  // ‱ per then thousand sign
+    0x2031,  // ‱ per the thousand sign
     0x203c,  // ‼ double exclamation mark
     0x2047,  // ⁇ double question mark
     0x2048,  // ⁈ question exclamation mark

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1884,6 +1884,10 @@ static void win_exchange(int Prenum)
     beep_flush();
     return;
   }
+  if (text_or_buf_locked()) {
+    beep_flush();
+    return;
+  }
 
   frame_T *frp;
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2002,8 +2002,8 @@ endfunc
 " Test for BufUnload autocommand that unloads all the other buffers
 func Test_bufunload_all()
   let g:test_is_flaky = 1
-  call writefile(['Test file Xxx1'], 'Xxx1', 'D')"
-  call writefile(['Test file Xxx2'], 'Xxx2', 'D')"
+  call writefile(['Test file Xxx1'], 'Xxx1', 'D')
+  call writefile(['Test file Xxx2'], 'Xxx2', 'D')
 
   let content =<< trim [CODE]
     func UnloadAllBufs()

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -1235,7 +1235,7 @@ func Test_edit_LEFT_RIGHT()
 endfunc
 
 func Test_edit_MOUSE()
-  " This is a simple test, since we not really using the mouse here
+  " This is a simple test, since we're not really using the mouse here
   CheckFeature mouse
   10new
   call setline(1, range(1, 100))
@@ -1817,7 +1817,7 @@ func Test_edit_charconvert()
   close!
   set charconvert&
 
-  " 'charconvert' function doesn't create a output file
+  " 'charconvert' function doesn't create an output file
   func Cconv1()
   endfunc
   set charconvert=Cconv1()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2630,7 +2630,7 @@ func Test_state()
   call term_sendkeys(buf, getstate)
   call WaitForAssert({-> assert_match('state: mSc; mode: n', term_getline(buf, 6))}, 1000)
 
-  " A operator is pending
+  " An operator is pending
   call term_sendkeys(buf, ":call RunTimer()\<CR>y")
   call TermWait(buf, 25)
   call term_sendkeys(buf, "y")

--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -346,7 +346,7 @@ func Test_dict_big()
   endtry
   call assert_equal('Vim(let):E716: "1500"', str)
 
-  " lookup each items
+  " lookup each item
   for i in range(1500)
     call assert_equal(3000 - i, d[i])
   endfor

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -347,7 +347,7 @@ func Test_normal06_formatprg()
   CheckNotMSWindows
 
   " uses sed to number non-empty lines
-  call writefile(['#!/bin/sh', 'sed ''/./=''|sed ''/./{', 'N', 's/\n/    /', '}'''], 'Xsed_format.sh')
+  call writefile(['#!/bin/sh', 'sed ''/./=''|sed ''/./{', 'N', 's/\n/    /', '}'''], 'Xsed_format.sh', 'D')
   call system('chmod +x ./Xsed_format.sh')
   let text = ['a', '', 'c', '', ' ', 'd', 'e']
   let expected = ['1    a', '', '3    c', '', '5     ', '6    d', '7    e']
@@ -378,11 +378,10 @@ func Test_normal06_formatprg()
   " clean up
   set formatprg=
   setlocal formatprg=
-  call delete('Xsed_format.sh')
 endfunc
 
 func Test_normal07_internalfmt()
-  " basic test for internal formmatter to textwidth of 12
+  " basic test for internal formatter to textwidth of 12
   let list=range(1,11)
   call map(list, 'v:val."    "')
   10new
@@ -2588,7 +2587,7 @@ func Test_normal33_g_cmd2()
   exe "norm! G0\<c-v>4k4ly"
   exe "norm! gvood"
   call assert_equal(['', 'abfgh', 'abfgh', 'abfgh', 'fgh', 'fgh', 'fgh', 'fgh', 'fgh'], getline(1,'$'))
-  " gv cannot be used  in operator pending mode
+  " gv cannot be used in operator pending mode
   call assert_beeps('normal! cgv')
   " gv should beep without a previously selected visual area
   new

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -1434,7 +1434,7 @@ func Test_substitute_expr_switch_win()
   let bufnr = bufnr('%')
   put ="abcdef"
   silent! s/\%')/\=R()
-  call assert_fails(':%s/./\=R()/g', 'E565')
+  call assert_fails(':%s/./\=R()/g', 'E565:')
   delfunc R
   exe bufnr .. "bw!"
 endfunc

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -1425,4 +1425,18 @@ func Test_z_substitute_expr_leak()
   delfunc SubExpr
 endfunc
 
+func Test_substitute_expr_switch_win()
+  func R()
+    wincmd x
+    return 'XXXX'
+  endfunc
+  new Xfoobar
+  let bufnr = bufnr('%')
+  put ="abcdef"
+  silent! s/\%')/\=R()
+  call assert_fails(':%s/./\=R()/g', 'E565')
+  delfunc R
+  exe bufnr .. "bw!"
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -3109,7 +3109,7 @@ endfunc
 "	    should be given.
 "
 "	    This test reuses the function MESSAGES() from the previous test.
-"	    This functions checks the messages in g:msgfile.
+"	    This function checks the messages in g:msgfile.
 "-------------------------------------------------------------------------------
 
 func Test_nested_while_error()
@@ -3236,7 +3236,7 @@ endfunc
 "	    error messages should be given.
 "
 "	    This test reuses the function MESSAGES() from the previous test.
-"	    This functions checks the messages in g:msgfile.
+"	    This function checks the messages in g:msgfile.
 "-------------------------------------------------------------------------------
 
 func Test_nested_cont_break_error()
@@ -3344,7 +3344,7 @@ endfunc
 "	    should be given.
 "
 "	    This test reuses the function MESSAGES() from the previous test.
-"	    This functions checks the messages in g:msgfile.
+"	    This function check the messages in g:msgfile.
 "-------------------------------------------------------------------------------
 
 func Test_nested_endtry_error()

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -236,7 +236,7 @@ func Test_ve_completion()
   set virtualedit=
 endfunc
 
-" Using "C" then then <CR> moves the last remaining character to the next
+" Using "C" then <CR> moves the last remaining character to the next
 " line.  (Mary Ellen Foster)
 func Test_ve_del_to_eol()
   new


### PR DESCRIPTION
#### vim-patch:9.0.1877: missing test for patch 9.0.1873

Problem:  missing test for patch 9.0.1873
Solution: add a test trying to exchange windows

Add a test, making sure that switching windows is not allowed when
textlock is active, e.g. when running `:s/<pat>/\=func()/`

https://github.com/vim/vim/commit/18d2709aa12ffa3f6ae1a13059990558c5f8e406

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:partial:9.0.1886: Various Typos

Problem:  Various Typos
Solution: Fix Typos

This is a collection of typo related commits.

closes: vim/vim#12753
closes: vim/vim#13016

https://github.com/vim/vim/commit/ee17b6f70d382ec6c5d8d27b56c4e84106ac8c55

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Adri Verhoef <a3@a3.xs4all.nl>
Co-authored-by: Viktor Szépe <viktor@szepe.net>
Co-authored-by: nuid64 <lvkuzvesov@proton.me>
Co-authored-by: Meng Xiangzhuo <aumo@foxmail.com>
Co-authored-by: Dominique Pellé <dominique.pelle@gmail.com>