### PR TITLE
fix(highlight): check has default and hl exist first in nvim_set_hl

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -160,6 +160,11 @@ void nvim_set_hl(Integer ns_id, String name, Dict(highlight) *val, Error *err)
   VALIDATE_S((hl_id != 0), "highlight name", name.data, {
     return;
   });
+
+  if (HAS_KEY(val, highlight, default) && val->default_ && hl_has_settings(hl_id - 1, true)) {
+    return;
+  }
+
   int link_id = -1;
 
   HlAttrs attrs = dict2hlattrs(val, true, &link_id, err);

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1441,7 +1441,7 @@ void restore_cterm_colors(void)
 /// @param check_link  if true also check for an existing link.
 ///
 /// @return true if highlight group "idx" has any settings.
-static int hl_has_settings(int idx, bool check_link)
+int hl_has_settings(int idx, bool check_link)
 {
   return hl_table[idx].sg_cleared == 0
          && (hl_table[idx].sg_attr != 0


### PR DESCRIPTION
Problem: when `default` is setting in `nvim_set_hl` and value is true and there already has this highlight group , this setting should be ignore.  no need run into `dict2hlattrs`.

Solution: check has default and has highlight group first