### PR TITLE
revert: "ci: trigger tests when pushing"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,5 @@
 name: build
 on:
-  push:
-    paths:
-      - '**.cmake'
-      - '**/CMakeLists.txt'
-      - '**/CMakePresets.json'
-      - 'cmake.*/**'
-      - '.github/**'
   pull_request:
     branches:
       - 'master'
@@ -19,7 +12,7 @@ on:
       - '.github/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.repository_owner == 'neovim' && github.sha || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: test
 on:
   push:
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
   pull_request:
     branches:
       - 'master'
@@ -9,7 +12,7 @@ on:
       - 'contrib/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.repository_owner == 'neovim' && github.sha || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
This reverts commit e71c7898ca3cf3af1243227ff3cba526d48897e8.

Triggering jobs on users own fork turned out to be not that useful, and
only necessary in rare moments. It's easier to adjust the CI scripts if
the users wants CI results before creating a pull request. It also
reduces the complexity of the CI code.
