### PR TITLE
test: unignore test which froze sourcehut

### DIFF
--- a/test/functional/api/server_notifications_spec.lua
+++ b/test/functional/api/server_notifications_spec.lua
@@ -6,9 +6,7 @@ local eq, clear, eval, command, nvim, next_msg =
 local meths = helpers.meths
 local exec_lua = helpers.exec_lua
 local retry = helpers.retry
-local is_ci = helpers.is_ci
 local assert_alive = helpers.assert_alive
-local skip = helpers.skip
 
 local testlog = 'Xtest-server-notify-log'
 
@@ -90,7 +88,6 @@ describe('notify', function()
   end)
 
   it('cancels stale events on channel close', function()
-    skip(is_ci(), 'hangs on CI #14083 #15251')
     local catchan = eval("jobstart(['cat'], {'rpc': v:true})")
     local catpath = eval('exepath("cat")')
     eq({id=catchan, argv={catpath}, stream='job', mode='rpc', client = {}}, exec_lua ([[


### PR DESCRIPTION
https://github.com/neovim/neovim/pull/24983 follow-up.

I tried to uncomment this test on my personal fork, before the fix above to see if it would freeze GitHub Actions as well. And it did https://github.com/faergeek/neovim/actions/runs/6130884120. 3 test jobs froze on that test.

Then I rebased on top of the commit fixing race condition https://github.com/faergeek/neovim/actions/runs/6131091352 and none of the jobs froze on that test. One job failed for a different reason, but at least it has gone past that test. windows job timed out on another test before this one for some reason. I did not rerun any jobs so it's easier to see.

I suggest to have this PR open for some time, during which I'll periodically rebase it on master to trigger workflows to run and see if anything freezes on that test. Does that make sense?