### PR TITLE
feat(lsp): use treesitter for markdown floating windows

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -141,6 +141,7 @@ LSP FUNCTIONS
 						`progress` of |vim.lsp.client|
 - *vim.lsp.get_active_clients()*		Use |vim.lsp.get_clients()|
 - *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()|
+- *vim.lsp.util.trim_empty_lines()*		Use |vim.split()| with `trimempty` instead.
 
 TREESITTER FUNCTIONS
 - *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2036,15 +2036,6 @@ text_document_completion_list_to_complete_items({result}, {prefix})
     See also: ~
       • complete-items
 
-trim_empty_lines({lines})                    *vim.lsp.util.trim_empty_lines()*
-    Removes empty lines from the beginning and end.
-
-    Parameters: ~
-      • {lines}  (table) list of lines to trim
-
-    Return: ~
-        (table) trimmed list of lines
-
                                 *vim.lsp.util.try_trim_markdown_code_blocks()*
 try_trim_markdown_code_blocks({lines})
     Accepts markdown lines and tries to reduce them to a filetype if they

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1681,20 +1681,24 @@ convert_input_to_markdown_lines({input}, {contents})
     window for `textDocument/hover`, for parsing the result of
     `textDocument/signatureHelp`, and potentially others.
 
+    Note that if the input is of type `MarkupContent` and its kind is
+    `plaintext`, then the corresponding value is returned without further
+    modifications.
+
     Parameters: ~
       • {input}     (`MarkedString` | `MarkedString[]` | `MarkupContent`)
       • {contents}  (table|nil) List of strings to extend with converted
                     lines. Defaults to {}.
 
     Return: ~
-        (table) {contents} extended with lines of converted markdown.
+        string[] extended with lines of converted markdown.
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
 
                      *vim.lsp.util.convert_signature_help_to_markdown_lines()*
 convert_signature_help_to_markdown_lines({signature_help}, {ft}, {triggers})
-    Converts `textDocument/SignatureHelp` response to markdown lines.
+    Converts `textDocument/signatureHelp` response to markdown lines.
 
     Parameters: ~
       • {signature_help}  (table) Response of `textDocument/SignatureHelp`
@@ -1911,10 +1915,6 @@ open_floating_preview({contents}, {syntax}, {opts})
                       height when wrap is enabled
                     • max_width: (integer) maximal width of floating window
                     • max_height: (integer) maximal height of floating window
-                    • pad_top: (integer) number of lines to pad contents at
-                      top
-                    • pad_bottom: (integer) number of lines to pad contents at
-                      bottom
                     • focus_id: (string) if a popup with this id is opened,
                       then focus it
                     • close_events: (table) list of events that closes the
@@ -2008,8 +2008,6 @@ stylize_markdown({bufnr}, {contents}, {opts})
                     • wrap_at character to wrap at for computing height
                     • max_width maximal width of floating window
                     • max_height maximal height of floating window
-                    • pad_top number of lines to pad contents at top
-                    • pad_bottom number of lines to pad contents at bottom
                     • separator insert separator after code block
 
     Return: ~

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -270,6 +270,7 @@ release.
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
   - |vim.lsp.get_active_clients()|		Use |vim.lsp.get_clients()| instead.
   - |vim.lsp.for_each_buffer_client()|		Use |vim.lsp.get_clients()| instead.
+  - |vim.lsp.util.trim_empty_lines()|		Use |vim.split()| with `trimempty` instead.
 
 • `vim.loop` has been renamed to `vim.uv`.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -230,6 +230,11 @@ The following changes to existing APIs or features add new behavior.
   In addition, |nvim_buf_get_extmarks()| has gained an "overlap" option to
   return such ranges even if they started before the specified position.
 
+• LSP hover and signature help now use Treesitter for highlighting of Markdown
+  content.
+  Note that syntax highlighting of code examples requires a matching parser
+  and may be affected by custom queries.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -373,11 +373,10 @@ function M.hover(_, result, ctx, config)
   local contents ---@type string[]
   if type(result.contents) == 'table' and result.contents.kind == 'plaintext' then
     format = 'plaintext'
-    contents = { result.contents.value or '' }
+    contents = vim.split(result.contents.value or '', '\n', { trimempty = true })
   else
     contents = util.convert_input_to_markdown_lines(result.contents)
   end
-  contents = util.trim_empty_lines(contents)
   if vim.tbl_isempty(contents) then
     if config.silent ~= true then
       vim.notify('No information available')
@@ -470,7 +469,6 @@ function M.signature_help(_, result, ctx, config)
     vim.tbl_get(client.server_capabilities, 'signatureHelpProvider', 'triggerCharacters')
   local ft = vim.bo[ctx.bufnr].filetype
   local lines, hl = util.convert_signature_help_to_markdown_lines(result, ft, triggers)
-  lines = util.trim_empty_lines(lines)
   if vim.tbl_isempty(lines) then
     if config.silent ~= true then
       print('No signature help available')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -369,15 +369,22 @@ function M.hover(_, result, ctx, config)
     end
     return
   end
-  local markdown_lines = util.convert_input_to_markdown_lines(result.contents)
-  markdown_lines = util.trim_empty_lines(markdown_lines)
-  if vim.tbl_isempty(markdown_lines) then
+  local format = 'markdown'
+  local contents ---@type string[]
+  if type(result.contents) == 'table' and result.contents.kind == 'plaintext' then
+    format = 'plaintext'
+    contents = { result.contents.value or '' }
+  else
+    contents = util.convert_input_to_markdown_lines(result.contents)
+  end
+  contents = util.trim_empty_lines(contents)
+  if vim.tbl_isempty(contents) then
     if config.silent ~= true then
       vim.notify('No information available')
     end
     return
   end
-  return util.open_floating_preview(markdown_lines, 'markdown', config)
+  return util.open_floating_preview(contents, format, config)
 end
 
 --see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -877,9 +877,12 @@ end
 --- window for `textDocument/hover`, for parsing the result of
 --- `textDocument/signatureHelp`, and potentially others.
 ---
+--- Note that if the input is of type `MarkupContent` and its kind is `plaintext`,
+--- then the corresponding value is returned without further modifications.
+---
 ---@param input (`MarkedString` | `MarkedString[]` | `MarkupContent`)
 ---@param contents (table|nil) List of strings to extend with converted lines. Defaults to {}.
----@return table {contents} extended with lines of converted markdown.
+---@return string[] extended with lines of converted markdown.
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_hover
 function M.convert_input_to_markdown_lines(input, contents)
   contents = contents or {}
@@ -887,27 +890,13 @@ function M.convert_input_to_markdown_lines(input, contents)
   if type(input) == 'string' then
     list_extend(contents, split_lines(input))
   else
-    assert(type(input) == 'table', 'Expected a table for Hover.contents')
+    assert(type(input) == 'table', 'Expected a table for LSP input')
     -- MarkupContent
     if input.kind then
-      -- The kind can be either plaintext or markdown.
-      -- If it's plaintext, then wrap it in a <text></text> block
-
-      -- Some servers send input.value as empty, so let's ignore this :(
       local value = input.value or ''
-
-      if input.kind == 'plaintext' then
-        -- wrap this in a <text></text> block so that stylize_markdown
-        -- can properly process it as plaintext
-        value = string.format('<text>\n%s\n</text>', value)
-      end
-
-      -- assert(type(value) == 'string')
       list_extend(contents, split_lines(value))
       -- MarkupString variation 2
     elseif input.language then
-      -- Some servers send input.value as empty, so let's ignore this :(
-      -- assert(type(input.value) == 'string')
       table.insert(contents, '```' .. input.language)
       list_extend(contents, split_lines(input.value or ''))
       table.insert(contents, '```')
@@ -925,7 +914,7 @@ function M.convert_input_to_markdown_lines(input, contents)
   return contents
 end
 
---- Converts `textDocument/SignatureHelp` response to markdown lines.
+--- Converts `textDocument/signatureHelp` response to markdown lines.
 ---
 ---@param signature_help table Response of `textDocument/SignatureHelp`
 ---@param ft string|nil filetype that will be use as the `lang` for the label markdown code block
@@ -955,7 +944,7 @@ function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers
   end
   local label = signature.label
   if ft then
-    -- wrap inside a code block so stylize_markdown can render it properly
+    -- wrap inside a code block for proper rendering
     label = ('```%s\n%s\n```'):format(ft, label)
   end
   list_extend(contents, split(label, '\n', { plain = true }))
@@ -1223,7 +1212,7 @@ function M.preview_location(location, opts)
   local syntax = vim.bo[bufnr].syntax
   if syntax == '' then
     -- When no syntax is set, we use filetype as fallback. This might not result
-    -- in a valid syntax definition. See also ft detection in stylize_markdown.
+    -- in a valid syntax definition.
     -- An empty syntax is more common now with TreeSitter, since TS disables syntax.
     syntax = vim.bo[bufnr].filetype
   end
@@ -1240,36 +1229,65 @@ local function find_window_by_var(name, value)
   end
 end
 
---- Trims empty lines from input and pad top and bottom with empty lines
----
----@param contents table of lines to trim and pad
----@param opts table with optional fields
----             - pad_top    number of lines to pad contents at top (default 0)
----             - pad_bottom number of lines to pad contents at bottom (default 0)
----@return table table of trimmed and padded lines
-function M._trim(contents, opts)
-  validate({
-    contents = { contents, 't' },
-    opts = { opts, 't', true },
-  })
-  opts = opts or {}
-  contents = M.trim_empty_lines(contents)
-  if opts.pad_top then
-    for _ = 1, opts.pad_top do
-      table.insert(contents, 1, '')
-    end
-  end
-  if opts.pad_bottom then
-    for _ = 1, opts.pad_bottom do
-      table.insert(contents, '')
-    end
-  end
-  return contents
+---Returns true if the line is empty or only contains whitespace.
+---@param line string
+---@return boolean
+local function is_blank_line(line)
+  return line and line:match('^%s*$')
 end
 
---- Generates a table mapping markdown code block lang to vim syntax,
---- based on g:markdown_fenced_languages
----@return table table of lang -> syntax mappings
+---Returns true if the line corresponds to a Markdown thematic break.
+---@param line string
+---@return boolean
+local function is_separator_line(line)
+  return line and line:match('^ ? ? ?%-%-%-+%s*$')
+end
+
+---Replaces separator lines by the given divider and removing surrounding blank lines.
+---@param contents string[]
+---@param divider string
+---@return string[]
+local function replace_separators(contents, divider)
+  local trimmed = {}
+  local l = 1
+  while l <= #contents do
+    local line = contents[l]
+    if is_separator_line(line) then
+      if l > 1 and is_blank_line(contents[l - 1]) then
+        table.remove(trimmed)
+      end
+      table.insert(trimmed, divider)
+      if is_blank_line(contents[l + 1]) then
+        l = l + 1
+      end
+    else
+      table.insert(trimmed, line)
+    end
+    l = l + 1
+  end
+
+  return trimmed
+end
+
+---Collapses successive blank lines in the input table into a single one.
+---@param contents string[]
+---@return string[]
+local function collapse_blank_lines(contents)
+  local collapsed = {}
+  local l = 1
+  while l <= #contents do
+    local line = contents[l]
+    if is_blank_line(line) then
+      while is_blank_line(contents[l + 1]) do
+        l = l + 1
+      end
+    end
+    table.insert(collapsed, line)
+    l = l + 1
+  end
+  return collapsed
+end
+
 local function get_markdown_fences()
   local fences = {}
   for _, fence in pairs(vim.g.markdown_fenced_languages or {}) do
@@ -1297,8 +1315,6 @@ end
 ---  - wrap_at   character to wrap at for computing height
 ---  - max_width  maximal width of floating window
 ---  - max_height maximal height of floating window
----  - pad_top    number of lines to pad contents at top
----  - pad_bottom number of lines to pad contents at bottom
 ---  - separator insert separator after code block
 ---@return table stripped content
 function M.stylize_markdown(bufnr, contents, opts)
@@ -1335,7 +1351,7 @@ function M.stylize_markdown(bufnr, contents, opts)
   end
 
   -- Clean up
-  contents = M._trim(contents, opts)
+  contents = M.trim_empty_lines(contents)
 
   local stripped = {}
   local highlights = {}
@@ -1484,6 +1500,49 @@ function M.stylize_markdown(bufnr, contents, opts)
   return stripped
 end
 
+--- @class lsp.util.NormalizeMarkdownOptions
+--- @field width integer Thematic breaks are expanded to this size. Defaults to 80.
+
+--- Normalizes Markdown input to a canonical form.
+---
+--- The returned Markdown adheres to the GitHub Flavored Markdown (GFM)
+--- specification.
+---
+--- The following transformations are made:
+---
+---   1. Empty lines at the beginning or end of the content are removed
+---   2. Carriage returns ('\r') are removed
+---   3. Successive empty lines are collapsed into a single empty line
+---   4. Thematic breaks are expanded to the given width
+---
+---@private
+---@param contents string[]
+---@param opts? lsp.util.NormalizeMarkdownOptions
+---@return string[] table of lines containing normalized Markdown
+---@see https://github.github.com/gfm
+function M._normalize_markdown(contents, opts)
+  validate({
+    contents = { contents, 't' },
+    opts = { opts, 't', true },
+  })
+  opts = opts or {}
+
+  -- 1. Empty lines at the beginning or end of the content are removed
+  contents = M.trim_empty_lines(contents)
+
+  -- 2. Carriage returns are removed
+  contents = vim.split(table.concat(contents, '\n'):gsub('\r', ''), '\n')
+
+  -- 3. Successive empty lines are collapsed into a single empty line
+  contents = collapse_blank_lines(contents)
+
+  -- 4. Thematic breaks are expanded to the given width
+  local divider = string.rep('─', opts.width or 80)
+  contents = replace_separators(contents, divider)
+
+  return contents
+end
+
 --- Closes the preview window
 ---
 ---@param winnr integer window id of preview window
@@ -1620,8 +1679,6 @@ end
 ---             - wrap_at: (integer) character to wrap at for computing height when wrap is enabled
 ---             - max_width: (integer) maximal width of floating window
 ---             - max_height: (integer) maximal height of floating window
----             - pad_top: (integer) number of lines to pad contents at top
----             - pad_bottom: (integer) number of lines to pad contents at bottom
 ---             - focus_id: (string) if a popup with this id is opened, then focus it
 ---             - close_events: (table) list of events that closes the floating window
 ---             - focusable: (boolean, default true) Make float focusable
@@ -1629,8 +1686,7 @@ end
 ---                      is also `true`, focus an existing floating window with the same
 ---                      {focus_id}
 ---@return integer bufnr of newly created float window
----@return integer winid of newly created float window
----preview window
+---@return integer winid of newly created float window preview window
 function M.open_floating_preview(contents, syntax, opts)
   validate({
     contents = { contents, 't' },
@@ -1639,7 +1695,6 @@ function M.open_floating_preview(contents, syntax, opts)
   })
   opts = opts or {}
   opts.wrap = opts.wrap ~= false -- wrapping by default
-  opts.stylize_markdown = opts.stylize_markdown ~= false and vim.g.syntax_on ~= nil
   opts.focus = opts.focus ~= false
   opts.close_events = opts.close_events or { 'CursorMoved', 'CursorMovedI', 'InsertCharPre' }
 
@@ -1671,16 +1726,21 @@ function M.open_floating_preview(contents, syntax, opts)
     api.nvim_win_close(existing_float, true)
   end
 
+  -- Create the buffer
   local floating_bufnr = api.nvim_create_buf(false, true)
-  local do_stylize = syntax == 'markdown' and opts.stylize_markdown
 
-  -- Clean up input: trim empty lines from the end, pad
-  contents = M._trim(contents, opts)
-
+  -- Set up the contents, using treesitter for markdown
+  local do_stylize = syntax == 'markdown' and vim.g.syntax_on ~= nil
   if do_stylize then
-    -- applies the syntax and sets the lines to the buffer
-    contents = M.stylize_markdown(floating_bufnr, contents, opts)
+    local width = M._make_floating_popup_size(contents, opts)
+    contents = M._normalize_markdown(contents, { width = width })
+    vim.bo[floating_bufnr].filetype = 'markdown'
+    vim.treesitter.start(floating_bufnr)
+    api.nvim_buf_set_lines(floating_bufnr, 0, -1, false, contents)
   else
+    -- Clean up input: trim empty lines from the end, pad
+    contents = M.trim_empty_lines(contents)
+
     if syntax then
       vim.bo[floating_bufnr].syntax = syntax
     end
@@ -1697,9 +1757,9 @@ function M.open_floating_preview(contents, syntax, opts)
 
   local float_option = M.make_floating_popup_options(width, height, opts)
   local floating_winnr = api.nvim_open_win(floating_bufnr, false, float_option)
+
   if do_stylize then
     vim.wo[floating_winnr].conceallevel = 2
-    vim.wo[floating_winnr].concealcursor = 'n'
   end
   -- disable folding
   vim.wo[floating_winnr].foldenable = false
@@ -1708,6 +1768,7 @@ function M.open_floating_preview(contents, syntax, opts)
 
   vim.bo[floating_bufnr].modifiable = false
   vim.bo[floating_bufnr].bufhidden = 'wipe'
+
   api.nvim_buf_set_keymap(
     floating_bufnr,
     'n',

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -61,3 +61,11 @@
 ] @string.escape
 
 (inline) @spell
+
+;; Conceal backticks
+(fenced_code_block
+  (fenced_code_block_delimiter) @conceal
+  (#set! conceal ""))
+(fenced_code_block
+  (info_string (language) @conceal
+  (#set! conceal "")))

--- a/runtime/queries/markdown_inline/highlights.scm
+++ b/runtime/queries/markdown_inline/highlights.scm
@@ -92,3 +92,11 @@
     "]"
   ] @conceal
   (#set! conceal ""))
+
+;; Replace common HTML entities.
+((entity_reference) @conceal (#eq? @conceal "&nbsp;") (#set! conceal ""))
+((entity_reference) @conceal (#eq? @conceal "&lt;") (#set! conceal "<"))
+((entity_reference) @conceal (#eq? @conceal "&gt;") (#set! conceal ">"))
+((entity_reference) @conceal (#eq? @conceal "&amp;") (#set! conceal "&"))
+((entity_reference) @conceal (#eq? @conceal "&quot;") (#set! conceal "\""))
+((entity_reference) @conceal (#any-of? @conceal "&ensp;" "&emsp;") (#set! conceal " "))

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3032,7 +3032,7 @@ describe('LSP', function()
         }
         return vim.lsp.util.convert_signature_help_to_markdown_lines(signature_help, 'cs', {','})
       ]]
-      local expected = {'```cs', 'TestEntity.TestEntity()', '```', '<text>', 'some doc', '</text>'}
+      local expected = {'```cs', 'TestEntity.TestEntity()', '```', 'some doc'}
       eq(expected, result)
     end)
   end)


### PR DESCRIPTION
Closes #20857, #20246 (?)

This PR includes the following changes:
- A new private function `_normalize_markdown` has been added, which transforms the input contents as follows:
  1. Trim out empty lines before and after the content. For simplicity I'm also removing the `pad_top` and `pad_bottom` options (open to discussion about this).
  2. Remove carriage returns.
  3. Consecutive blank lines are collapsed into a single one.
  4. Separator Markdown lines (e.g. `---`) will be replaced by a horizontal divider spanning the entire floating window and blank lines before and after the separator are removed.

Note that this means that this function won't be performing any additional highlighting or configure the buffer.
- `open_floating_preview` will now display the input content as is OR use Treesitter for displaying a Markdown buffer if the response received by the LSP request indicated that the content had a `'markdown'` `MarkupKind`. If the server indicates that the `MarkupKind` is `'plaintext'`, we'll respect that and display the contents as is.

- `convert_input_to_markdown_lines` will now simply return the unprocessed input when it is `MarkupContent` with kind '`plaintext`' (previously it would wrap it around `<text>` tags and display it as Markdown).

- `trim_empty_lines` is now deprecated since its functionality can be replaced by `vim.split(..., { trimempty = true })`