### PR TITLE
fix: performance regression in treesitter highlighter

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -136,7 +136,7 @@ function TSHighlighter.new(tree, opts)
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
 
-  self.tree:parse()
+  self.tree:parse(true)
 
   return self
 end
@@ -313,22 +313,31 @@ function TSHighlighter._on_spell_nav(_, _, buf, srow, _, erow, _)
 end
 
 ---@private
+---@param buf integer
+function TSHighlighter._on_buf(_, buf)
+  local self = TSHighlighter.active[buf]
+  if self then
+    self.tree:parse(true)
+  end
+end
+
+---@private
 ---@param _win integer
 ---@param buf integer
----@param topline integer
----@param botline integer
-function TSHighlighter._on_win(_, _win, buf, topline, botline)
+---@param _topline integer
+function TSHighlighter._on_win(_, _win, buf, _topline)
   local self = TSHighlighter.active[buf]
   if not self then
     return false
   end
-  self.tree:parse({ topline, botline })
+
   self:reset_highlight_state()
   self.redraw_count = self.redraw_count + 1
   return true
 end
 
 api.nvim_set_decoration_provider(ns, {
+  on_buf = TSHighlighter._on_buf,
   on_win = TSHighlighter._on_win,
   on_line = TSHighlighter._on_line,
   _on_spell_nav = TSHighlighter._on_spell_nav,


### PR DESCRIPTION
fixes #25074
minimal partial revert of #24647

EDIT: It turns out the following change also removes the regression - that is; intercepting regions is actually *better*:
```diff
diff --git a/runtime/lua/vim/treesitter/languagetree.lua b/runtime/lua/vim/treesitter/languagetree.lua
index e81778b26..99218a2d3 100644
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -323,7 +323,7 @@ local function intercepts_region(region, range)
     end
   end
 
-  return false
+  return true
 end
 
 --- @private
```

Materially, that means we *want* to go into this loop:
```lua
    if not self._valid[i] and intercepts_region(ranges, range) then
      self._parser:set_included_ranges(ranges)
      local parse_time, tree, tree_changes =
        tcall(self._parser.parse, self._parser, self._trees[i], self._source, true)

      -- Pass ranges if this is an initial parse
      local cb_changes = self._trees[i] and tree_changes or tree:included_ranges(true)

      self:_do_callback('changedtree', cb_changes, tree)
      self._trees[i] = tree
      vim.list_extend(changes, tree_changes)

      total_parse_time = total_parse_time + parse_time
      no_regions_parsed = no_regions_parsed + 1
      self._valid[i] = true
    end
```
