### PR TITLE
fix(float): improve error message when reconfig failed

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1023,6 +1023,17 @@ static void parse_border_style(Object style, WinConfig *fconfig, Error *err)
   }
 }
 
+static void generate_api_error(win_T *wp, const char *attribute, Error *err)
+{
+  if (wp->w_floating) {
+    api_set_error(err, kErrorTypeValidation,
+                  "Missing 'relative' field when reconfiguring floating window %d",
+                  wp->handle);
+  } else {
+    api_set_error(err, kErrorTypeValidation, "non-float cannot have '%s'", attribute);
+  }
+}
+
 static bool parse_float_config(win_T *wp, Dict(win_config) *config, WinConfig *fconfig, bool reconf,
                                Error *err)
 {
@@ -1083,7 +1094,7 @@ static bool parse_float_config(win_T *wp, Dict(win_config) *config, WinConfig *f
 
   if (HAS_KEY_X(config, row)) {
     if (!has_relative || is_split) {
-      api_set_error(err, kErrorTypeValidation, "non-float cannot have 'row'");
+      generate_api_error(wp, "row", err);
       return false;
     }
     fconfig->row = config->row;
@@ -1091,7 +1102,7 @@ static bool parse_float_config(win_T *wp, Dict(win_config) *config, WinConfig *f
 
   if (HAS_KEY_X(config, col)) {
     if (!has_relative || is_split) {
-      api_set_error(err, kErrorTypeValidation, "non-float cannot have 'col'");
+      generate_api_error(wp, "col", err);
       return false;
     }
     fconfig->col = config->col;
@@ -1099,7 +1110,7 @@ static bool parse_float_config(win_T *wp, Dict(win_config) *config, WinConfig *f
 
   if (HAS_KEY_X(config, bufpos)) {
     if (!has_relative || is_split) {
-      api_set_error(err, kErrorTypeValidation, "non-float cannot have 'bufpos'");
+      generate_api_error(wp, "bufpos", err);
       return false;
     } else {
       if (!parse_float_bufpos(config->bufpos, &fconfig->bufpos)) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -325,6 +325,34 @@ describe('float window', function()
     eq(12, pos[2])
   end)
 
+
+  it('opened and can reset config see issue #18368', function()
+    local res = exec_lua([[
+      local bufnr = vim.api.nvim_create_buf(false, true)
+
+      local opts = {
+        width = 10,
+        height = 10,
+        col = 5,
+        row = 5,
+        relative = 'editor',
+        style = 'minimal'
+      }
+
+      local win_id = vim.api.nvim_open_win(bufnr, true, opts)
+
+      vim.api.nvim_win_set_config(win_id, {
+	width = 3,
+	height = 3,
+	row = 10,
+	col = 10,
+      })
+      return vim.api.nvim_win_get_config(win_id)
+    ]])
+
+    eq({10, 10, 3, 3,'editor'}, {res.row, res.col, res.width, res.height, res.relative})
+  end)
+
   it('is not operated on by windo when non-focusable #15374', function()
     command([[
       let winids = []

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -325,32 +325,25 @@ describe('float window', function()
     eq(12, pos[2])
   end)
 
-
-  it('opened and can reset config see issue #18368', function()
-    local res = exec_lua([[
-      local bufnr = vim.api.nvim_create_buf(false, true)
-
-      local opts = {
-        width = 10,
-        height = 10,
-        col = 5,
-        row = 5,
-        relative = 'editor',
-        style = 'minimal'
-      }
-
-      local win_id = vim.api.nvim_open_win(bufnr, true, opts)
-
-      vim.api.nvim_win_set_config(win_id, {
-	width = 3,
-	height = 3,
-	row = 10,
-	col = 10,
-      })
-      return vim.api.nvim_win_get_config(win_id)
-    ]])
-
-    eq({10, 10, 3, 3,'editor'}, {res.row, res.col, res.width, res.height, res.relative})
+  it('error message when reconfig missing relative field', function()
+    local bufnr = api.nvim_create_buf(false, true)
+    local opts = {
+      width = 10,
+      height = 10,
+      col = 5,
+      row = 5,
+      relative = 'editor',
+      style = 'minimal',
+    }
+    local win_id = api.nvim_open_win(bufnr, true, opts)
+    eq(
+    "Missing 'relative' field when reconfiguring floating window 1001",
+    pcall_err(api.nvim_win_set_config, win_id, {
+      width = 3,
+      height = 3,
+      row = 10,
+      col = 10,
+    }))
   end)
 
   it('is not operated on by windo when non-focusable #15374', function()


### PR DESCRIPTION
Problem: current error message is less readable when reconfig a floating window failed.

Solution: improve error message when reconfig float window.



Fix #18368