### PR TITLE
fix(float): don't trigger au event when enter is false

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -190,7 +190,8 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(float_config) *config, E
   }
   // autocmds in win_enter or win_set_buf below may close the window
   if (win_valid(wp) && buffer > 0) {
-    win_set_buf(wp, buf, fconfig.noautocmd, err);
+    Boolean noautocmd = !enter || fconfig.noautocmd;
+    win_set_buf(wp, buf, noautocmd, err);
   }
   if (!win_valid(wp)) {
     api_set_error(err, kErrorTypeException, "Window was closed immediately");


### PR DESCRIPTION
Problem:  when `enter` is false it's better not trigger `BufEnter` etc events.

Solution: `noautocmd` also check `enter` value.


Fix #15300