### PR TITLE
build(lint): use stylua without add_glob_target

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -1,6 +1,7 @@
 /scripts
 /src
 /test
+/build
 /runtime/lua/vim/re.lua
 /runtime/lua/vim/_meta/options.lua
 /runtime/lua/coxpcall.lua

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,18 +230,11 @@ add_glob_target(
   TOUCH_STRATEGY SINGLE)
 add_dependencies(lintlua-luacheck lua-dev-deps)
 
-add_glob_target(
-  TARGET lintlua-stylua
-  COMMAND ${STYLUA_PRG}
-  FLAGS --color=always --check
-  GLOB_DIRS runtime/
-  GLOB_PAT *.lua
-  EXCLUDE
-    /runtime/lua/vim/re.lua
-    /runtime/lua/vim/_meta/.*
-    /runtime/lua/coxpcall.lua
-  TOUCH_STRATEGY SINGLE)
-
+# Don't use add_glob_target as .styluaignore won't be respected.
+# https://github.com/JohnnyMorganz/StyLua/issues/751
+add_custom_target(lintlua-stylua
+  COMMAND ${STYLUA_PRG} --color=always --check .
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
 add_custom_target(lintlua)
 add_dependencies(lintlua lintlua-luacheck lintlua-stylua)
 


### PR DESCRIPTION
add_glob_target is our custom method to figure out whether a work needs
to be done or not. This works as expected most of the time, but causes a
problem with stylua.

Stylua makes the decision that if a file is explicitly passed to be
formatted, then it will format the file even if the file is set to be
ignored in .styluaignore. This behavior breaks add_glob_target with
seemingly no easy workaround.
More information: https://github.com/JohnnyMorganz/StyLua/issues/751

Instead, what we can do is call stylua as you would in the command line.
This will make stylua work as expected. The downside is that we no
longer get a free "is this work necessary" detection, meaning that
stylua will be run each time `make lint` is called, regardless if it's
necessary or not. For longer lint tasks such as uncrustify and
clang-tidy this would be disastrous, but this is an acceptable tradeoff
since stylua is very quick.
