### PR TITLE
feat(lua): patch ipairs/pairs to check metatables for __ipairs/__pairs

### DIFF
--- a/runtime/doc/luaref.txt
+++ b/runtime/doc/luaref.txt
@@ -3610,8 +3610,11 @@ getmetatable({object})                                  *getmetatable()*
         object.
 
 ipairs({t})                                             *ipairs()*
-        Returns three values: an |iterator| function, the table {t}, and 0, so
-        that the construction
+        If {t} has a metamethod `__ipairs`, calls it with the argument {t} and
+        returns the first three results from the call.
+
+        Otherwise, returns three values: an |iterator| function, the table
+        {t}, and 0, so that the construction
 
                `for i,v in ipairs(t) do`  `body`  `end`
 
@@ -3662,8 +3665,11 @@ next({table} [, {index}])                               *next()*
         modify existing fields. In particular, you may clear existing fields.
 
 pairs({t})                                              *pairs()*
-        Returns three values: the |next()| function, the table {t}, and `nil`,
-        so that the construction
+        If {t} has a metamethod `__pairs`, calls it with the argument {t} and
+        returns the first three results from the call.
+
+        Otherwise, returns three values: the |next()| function, the table {t},
+        and `nil`, so that the construction
 
                `for k,v in pairs(t) do`  `body`  `end`
 
@@ -3689,9 +3695,15 @@ rawequal({v1}, {v2})                                    *rawequal()*
         Checks whether {v1} is equal to {v2}, without invoking any metamethod.
         Returns a boolean.
 
+rawipairs({t})                                          *rawipairs()*
+        Non-metamethod aware version of |ipairs|.
+
 rawget({table}, {index})                                *rawget()*
         Gets the real value of `table[index]`, without invoking any
         metamethod. {table} must be a table; {index} may be any value.
+
+rawpairs({t})                                           *rawpairs()*
+        Non-metamethod aware version of |pairs|.
 
 rawset({table}, {index}, {value})                       *rawset()*
         Sets the real value of `table[index]` to {value}, without invoking any

--- a/runtime/lua/vim/_init_packages.lua
+++ b/runtime/lua/vim/_init_packages.lua
@@ -1,3 +1,19 @@
+-- Replace ipairs/pairs with functions that call a tables metatable
+-- __ipairs or __pairs function if present. Original ipairs/pairs
+-- are saved at _G.rawipairs _G.rawpairs, in the style of rawget, etc.
+-- Backport from Lua 5.2
+for raw_name, iter_name in pairs({rawpairs = "pairs", rawipairs = "ipairs"}) do
+  _G[raw_name] = _G[iter_name]
+  _G[iter_name] = function(t)
+    local mt = getmetatable(t)
+    local mt_iter = mt and mt["__" .. iter_name]
+    if mt_iter then
+      return mt_iter(t)
+    else
+      return _G[raw_name](t)
+    end
+  end
+end
 local pathtrails = {}
 vim._so_trails = {}
 for s in (package.cpath .. ';'):gmatch('[^;]*;') do

--- a/test/unit/lua_5_2_backport_spec.lua
+++ b/test/unit/lua_5_2_backport_spec.lua
@@ -1,0 +1,67 @@
+local helpers = require("test.unit.helpers")(after_each)
+local eq = helpers.eq
+
+describe('pairs and ipairs metatable support', function()
+  local function collect_iter(t, iter)
+    local acc = {}
+    for k, v in iter(t) do
+      acc[k] = v
+    end
+    return acc
+  end
+
+  local seq = {10, 20, 30}
+  local assoc = {dog = "grey", house = "blue", bike = "red"}
+  local mixed = {10, 20, dog = "grey"}
+
+  it('behaves normally without any metatable', function()
+    eq({10, 20, 30}, collect_iter(seq, ipairs))
+    eq({}, collect_iter(assoc, ipairs))
+    eq({10, 20}, collect_iter(mixed, ipairs))
+
+    eq({10, 20, 30}, collect_iter(seq, pairs))
+    eq({dog = "grey", house = "blue", bike = "red"}, collect_iter(assoc, pairs))
+    eq({10, 20, dog = "grey"}, collect_iter(mixed, pairs))
+  end)
+
+  it('can override ipairs and pairs', function()
+    -- builds a custom __ipairs/__pairs function that doubles the value of each element.
+    local function make_double_iter(iter_next_fn, initial_value)
+      local function double(val)
+        if type(val) == "number" then
+          return val * 2
+        else
+          return val .. val
+        end
+      end
+      return function(t)
+        local function custom_next(invariant, state)
+          local next_key = iter_next_fn(invariant, state)
+          if next_key and invariant[next_key] then
+            return next_key, double(invariant[next_key])
+          else
+            return nil
+          end
+        end
+        return custom_next, t, initial_value
+      end
+    end
+
+    local mt = {
+      __ipairs = make_double_iter(function(_table, index) return index + 1 end, 0),
+      __pairs = make_double_iter(next, nil)
+    }
+
+    setmetatable(seq, mt)
+    setmetatable(assoc, mt)
+    setmetatable(mixed, mt)
+
+    eq({20, 40, 60}, collect_iter(seq, ipairs))
+    eq({}, collect_iter(assoc, ipairs))
+    eq({20, 40}, collect_iter(mixed, ipairs))
+
+    eq({20, 40, 60}, collect_iter(seq, pairs))
+    eq({dog = "greygrey", bike = "redred", house = "blueblue"}, collect_iter(assoc, pairs))
+    eq({20, 40, dog = "greygrey"}, collect_iter(mixed, pairs))
+  end)
+end)


### PR DESCRIPTION
This is a backport of a Lua 5.2+ feature which allows for the replacement of `ipairs` and `pairs` default behaviour via a tables metatable.

`_G.ipairs` and `_G.pairs` are replaced with new functions that check a tables metatable for corresponding `__ipairs` and `__pairs` keys.

The original `ipairs` and `pairs` functions remain at `_G.rawipairs` and `_G.rawpairs`, in the style of `rawget`, etc.

This allows for some more flexibility for user data structures at a pretty small maintenance cost. `_init_packages.lua` seemed the best "bootstraping" location to put this.

I could not see any [previous discussion](https://github.com/search?q=repo%3Aneovim%2Fneovim+__pairs+OR+__ipairs&type=commits) around this idea, (ignore the code results, it seems to be searching all projects...), but I am not sure what the teams feelings are about patching the lua stdlib like this -- slippery slope? I also have a PR ready for `table.pack`... but that's it I swear!

(I didn't update news.txt because it felt presumptive -- I dont really expect this to be merged I guess, but perhaps I should have since CI is complaining.)