### PR TITLE
vim-patch:9.0.{1893,1894}

### DIFF
--- a/test/old/testdir/check.vim
+++ b/test/old/testdir/check.vim
@@ -100,6 +100,14 @@ func CheckLinux()
   endif
 endfunc
 
+" Command to check for not running on a BSD system.
+command CheckNotBSD call CheckNotBSD()
+func CheckNotBSD()
+  if has('bsd')
+    throw 'Skipped: does not work on BSD'
+  endif
+endfunc
+
 " Command to check that making screendumps is supported.
 " Caller must source screendump.vim
 command CheckScreendump call CheckScreendump()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -290,6 +290,7 @@ endfunc
 
 func Test_strptime()
   CheckFunction strptime
+  CheckNotBSD
   CheckNotMSWindows
 
   if exists('$TZ')
@@ -305,6 +306,8 @@ func Test_strptime()
 
   call assert_fails('call strptime()', 'E119:')
   call assert_fails('call strptime("xxx")', 'E119:')
+  " This fails on BSD 14 and returns 
+  " -2209078800 instead of 0
   call assert_equal(0, strptime("%Y", ''))
   call assert_equal(0, strptime("%Y", "xxx"))
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -306,7 +306,7 @@ func Test_strptime()
 
   call assert_fails('call strptime()', 'E119:')
   call assert_fails('call strptime("xxx")', 'E119:')
-  " This fails on BSD 14 and returns 
+  " This fails on BSD 14 and returns
   " -2209078800 instead of 0
   call assert_equal(0, strptime("%Y", ''))
   call assert_equal(0, strptime("%Y", "xxx"))


### PR DESCRIPTION
#### vim-patch:9.0.1893: CI: strptime test fails on BSD14

Problem:  CI: strptime test fails on BSD14
Solution: Skip the test

https://github.com/vim/vim/commit/983d808674f998eaea12b302028de45f1c6857cd

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1894: CI: trailing whitespace in tests

Problem:  CI: trailing white space in tests
Solution: clean up the trailing white space

https://github.com/vim/vim/commit/e5f7cd0a60d0eeab84f7aeb35c13d3af7e50072e

Co-authored-by: Christian Brabandt <cb@256bit.org>