### PR TITLE
vim-patch:596ad66d1ddb

### DIFF
--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -121,7 +121,7 @@ Vim would never have become what it is now, without the help of these people!
 	Eric Fischer		Mac port, 'cindent', and other improvements
 	Benji Fisher		Answering lots of user questions
 	Bill Foster		Athena GUI port (later removed)
-	Google			Lets me work on Vim one day a week
+	Google			Let Bram work on Vim one day a week
 	Loic Grenie		xvim (ideas for multi windows version)
 	Sven Guckes		Vim promoter and previous WWW page maintainer
 	Darren Hiebert		Exuberant ctags

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -240,7 +240,7 @@ The options local to a window are remembered for each buffer.  This also
 happens when the buffer is not loaded, but they are lost when the buffer is
 wiped out |:bwipe|.
 
-Special local window options			*special-local-window-option*
+Special local window options			*local-noglobal*
 
 The following local window options won't be copied over when new windows are
 created, thus they behave slightly differently:
@@ -251,7 +251,7 @@ created, thus they behave slightly differently:
 	'winfixheight'	specific to existing window
 	'winfixwidth'	specific to existing window
 
-Special local buffer options			*special-local-buffer-option*
+Special local buffer options
 
 The following local buffer options won't be copied over when new buffers are
 created, thus they behave slightly differently:
@@ -1095,7 +1095,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'bufhidden'* *'bh'*
 'bufhidden' 'bh'	string	(default "")
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	This option specifies what happens when a buffer is no longer
 	displayed in a window:
 	  <empty>	follow the global 'hidden' option
@@ -1127,7 +1127,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'buftype'* *'bt'* *E382*
 'buftype' 'bt'		string	(default "")
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	The value of this option specifies the type of a buffer:
 	  <empty>	normal buffer
 	  acwrite	buffer will always be written with |BufWriteCmd|s
@@ -2433,7 +2433,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'filetype'* *'ft'*
 'filetype' 'ft'		string	(default "")
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	When this option is set, the FileType autocommand event is triggered.
 	All autocommands that match with the value of this option will be
 	executed.  Thus the value of 'filetype' is used in place of the file
@@ -4109,7 +4109,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'modified'* *'mod'* *'nomodified'* *'nomod'*
 'modified' 'mod'	boolean	(default off)
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	When on, the buffer is considered to be modified.  This option is set
 	when:
 	1. A change was made to the text since it was last written.  Using the
@@ -4558,7 +4558,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 		*'previewwindow'* *'pvw'* *'nopreviewwindow'* *'nopvw'* *E590*
 'previewwindow' 'pvw'	boolean	(default off)
-			local to window  |special-local-window-option|
+			local to window  |local-noglobal|
 	Identifies the preview window.  Only one window can have this option
 	set.  It's normally not set directly, but by using one of the commands
 	|:ptag|, |:pedit|, etc.
@@ -4628,7 +4628,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 				*'readonly'* *'ro'* *'noreadonly'* *'noro'*
 'readonly' 'ro'		boolean	(default off)
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	If on, writes fail unless you use a '!'.  Protects you from
 	accidentally overwriting a file.  Default on when Vim is started
 	in read-only mode ("vim -R") or when the executable is called "view".
@@ -4890,7 +4890,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'scroll'* *'scr'*
 'scroll' 'scr'		number	(default half the window height)
-			local to window  |special-local-window-option|
+			local to window  |local-noglobal|
 	Number of lines to scroll with CTRL-U and CTRL-D commands.  Will be
 	set to half the number of lines in the window when the window size
 	changes.  This may happen when enabling the |status-line| or
@@ -6240,7 +6240,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'syntax'* *'syn'*
 'syntax' 'syn'		string	(default "")
-			local to buffer  |special-local-buffer-option|
+			local to buffer  |local-noglobal|
 	When this option is set, the syntax with this name is loaded, unless
 	syntax highlighting has been switched off with ":syntax off".
 	Otherwise this option does not always reflect the current syntax (the
@@ -7107,7 +7107,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			*'winfixheight'* *'wfh'* *'nowinfixheight'* *'nowfh'*
 'winfixheight' 'wfh'	boolean	(default off)
-			local to window  |special-local-window-option|
+			local to window  |local-noglobal|
 	Keep the window height when windows are opened or closed and
 	'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
 	|preview-window| and |quickfix-window|.
@@ -7115,7 +7115,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 			*'winfixwidth'* *'wfw'* *'nowinfixwidth'* *'nowfw'*
 'winfixwidth' 'wfw'	boolean	(default off)
-			local to window  |special-local-window-option|
+			local to window  |local-noglobal|
 	Keep the window width when windows are opened or closed and
 	'equalalways' is set.  Also for |CTRL-W_=|.
 	The width may be changed anyway when running out of room.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2125,11 +2125,11 @@ should set a variable in your vimrc file: >
 	:let lpc_syntax_for_c = 1
 
 If it doesn't work properly for some particular C or LPC files, use a
-modeline.  For a LPC file:
+modeline.  For a LPC file: >
 
 	// vim:set ft=lpc:
 
-For a C file that is recognized as LPC:
+For a C file that is recognized as LPC: >
 
 	// vim:set ft=c:
 
@@ -2161,7 +2161,7 @@ LUA						*lua.vim* *ft-lua-syntax*
 The Lua syntax file can be used for versions 4.0, 5.0, 5.1 and 5.2 (5.2 is
 the default). You can select one of these versions using the global variables
 lua_version and lua_subversion. For example, to activate Lua
-5.1 syntax highlighting, set the variables like this:
+5.1 syntax highlighting, set the variables like this: >
 
 	:let lua_version = 5
 	:let lua_subversion = 1

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -552,26 +552,19 @@ end
 local function scope_more_doc(o)
   if
     vim.list_contains({
-      'previewwindow',
-      'scroll',
-      'winfixheight',
-      'winfixwidth',
-    }, o.full_name)
-  then
-    return '  |special-local-window-option|'
-  end
-
-  if
-    vim.list_contains({
       'bufhidden',
       'buftype',
       'filetype',
       'modified',
+      'previewwindow',
       'readonly',
+      'scroll',
       'syntax',
+      'winfixheight',
+      'winfixwidth',
     }, o.full_name)
   then
-    return '  |special-local-buffer-option|'
+    return '  |local-noglobal|'
   end
 
   return ''


### PR DESCRIPTION
#### vim-patch:596ad66d1ddb

runtime(doc): documentation updates

This is a collection of various improvements to the help pages

closes vim/vim#12790

https://github.com/vim/vim/commit/596ad66d1ddb742ef349e98eb06b8e4052f68f51

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Houl <anwoku@yahoo.de>
Co-authored-by: Doug Kearns <dougkearns@gmail.com>
Co-authored-by: Adri Verhoef <a3@a3.xs4all.nl>