### PR TITLE
build(deps): bump tree-sitter to HEAD - 46af27796

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -60,5 +60,5 @@ TREESITTER_BASH_URL https://github.com/tree-sitter/tree-sitter-bash/archive/4936
 TREESITTER_BASH_SHA256 99ebe9f2886efecc1a5e9e1360d804a1b49ad89976a66bb5c3871539cca5fb7e
 TREESITTER_MARKDOWN_URL https://github.com/MDeiml/tree-sitter-markdown/archive/v0.1.6.tar.gz
 TREESITTER_MARKDOWN_SHA256 34cbeadfbe07454a5040163d04b3118ef0ac427a5cba39089de7384992729088
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/a0d0b35c046681485fa19203cd121ce830968248.tar.gz
-TREESITTER_SHA256 02c0e9d0ba72978dafcd86e0eb0980e23fc378989b988d95861e0621da70ce65
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/46af27796a76c72d8466627d499f2bca4af958ee.tar.gz
+TREESITTER_SHA256 2e35fa4c4d66c34d04fdb4a3a6c3abe01a05dff571ed9553b15aabf25d870f69


### PR DESCRIPTION
fix for segmentation fault in `ts_node_parse_state`
