### PR TITLE
fix(languagetree): remove double recursion in LanguageTree:parse

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -444,9 +444,9 @@ function LanguageTree:parse(range)
     range = range,
   })
 
-  self:for_each_child(function(child)
+  for _, child in pairs(self._children) do
     child:parse(range)
-  end)
+  end
 
   return self._trees
 end


### PR DESCRIPTION
`LanguageTree:parse` is recursive, and calls
`LanguageTree:for_each_child`, which is also recursive.

That means that, starting from the third level (child of child of root), nodes will be parsed twice.

Which then means that if the tree is N layers deep, there will be ~2^N parses even if the branching factor is 1.

Now, why was the tree deepening with each character inserted? And why did this only regress in #24647? And why doesn't `:parse` ever get short-circuited by `:is_valid` (I think I have a guess for this one - `:parse_regions` never gets called)? These are mysteries for another time, maybe they also go away with this fix, maybe they don't.

Fixes: #25104