### PR TITLE
[Backport release-0.9] fix(languagetree): remove double recursion in LanguageTree:parse

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -312,9 +312,9 @@ function LanguageTree:parse()
     query_time = query_time,
   })
 
-  self:for_each_child(function(child)
+  for _, child in pairs(self._children) do
     child:parse()
-  end)
+  end
 
   self._valid = true
 


### PR DESCRIPTION
Backport of #25109.

`LanguageTree:parse` is recursive, and calls
`LanguageTree:for_each_child`, which is also recursive.

That means that, starting from the third level (child of child of root), nodes will be parsed twice.

Which then means that if the tree is N layers deep, there will be ~2^N parses even if the branching factor is 1.

Fixes: #25104