### PR TITLE
feat: support line('v$'), fix visual star for linewise selection

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6621,9 +6621,28 @@ pos_T *var2fpos(const typval_T *const tv, const bool dollar_lnum, int *const ret
     // cursor
     pos = curwin->w_cursor;
   } else if (name[0] == 'v' && name[1] == NUL) {
-    // Visual start
+    // "v": Visual start.
     if (VIsual_active) {
       pos = VIsual;
+      if (VIsual_mode == 'V') {
+        pos.col = MAXCOL;
+      }
+    } else {
+      pos = curwin->w_cursor;
+    }
+  } else if (name[0] == 'v' && name[1] == '$') {
+    // "v$": Visual end.
+    if (VIsual_active) {
+      // See usage of getvcols() in cursor_pos_info(), v_swap_corners().
+
+      // TODO(justinmk): getvvcol()? See getvcols().
+      // colnr_T from1;
+      // colnr_T to1;
+      // getvvcol(curwin, pos1, &from1, NULL, &to1);
+
+      pos.lnum = curwin->w_cursor.lnum;
+      pos.col = (VIsual_mode == 'V') ? MAXCOL : curwin->w_cursor.col;
+      // pos.coladd = (VIsual_mode == 'V') ? MAXCOL : curwin->w_cursor.coladd;
     } else {
       pos = curwin->w_cursor;
     }

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5900,10 +5900,13 @@ M.funcs = {
       	    display isn't updated, e.g. in silent Ex mode)
           w$	    last line visible in current window (this is one
       	    less than "w0" if no lines are visible)
-          v	    In Visual mode: the start of the Visual area (the
-      	    cursor is the end).  When not in Visual mode
-      	    returns the cursor position.  Differs from |'<| in
-      	    that it's updated right away.
+          v	    In Visual mode: start of the Visual area, that is, the
+            corner opposite the cursor position.  Updated immediately, unlike
+            |'<|. When not in Visual mode returns the cursor position.
+          v$	    In Visual mode: end of the Visual area, equivalent to
+            cursor position except in |blockwise-visual| mode.  Updated
+            immediately, unlike |'<|. When not in Visual mode returns the
+            cursor position.
       Note that a mark in another file can be used.  The line number
       then applies to another buffer.
       To get the column number use |col()|.  To get both use

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -86,7 +86,7 @@ static inline bool ltoreq(pos_T a, pos_T b)
 static inline void clearpos(pos_T *a)
   REAL_FATTR_ALWAYS_INLINE;
 
-/// Return true if position a is before (less than) position b.
+/// Returns true if position `a` is before (less than) position `b`.
 static inline bool lt(pos_T a, pos_T b)
 {
   if (a.lnum != b.lnum) {
@@ -98,13 +98,13 @@ static inline bool lt(pos_T a, pos_T b)
   }
 }
 
-/// Return true if position a and b are equal.
+/// Returns true if position `a` and `b` are equal.
 static inline bool equalpos(pos_T a, pos_T b)
 {
   return (a.lnum == b.lnum) && (a.col == b.col) && (a.coladd == b.coladd);
 }
 
-/// Return true if position a is less than or equal to b.
+/// Returns true if position `a` is less than or equal to `b`.
 static inline bool ltoreq(pos_T a, pos_T b)
 {
   return lt(a, b) || equalpos(a, b);

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2322,7 +2322,7 @@ describe('lua stdlib', function()
   end)
 
   describe('vim.region', function()
-    it('charwise', function()
+    it('charwise-visual "v"', function()
       insert(dedent( [[
       text tααt tααt text
       text tαxt txtα tex
@@ -2330,7 +2330,20 @@ describe('lua stdlib', function()
       ]]))
       eq({5,15}, exec_lua[[ return vim.region(0,{1,5},{1,14},'v',true)[1] ]])
     end)
-    it('blockwise', function()
+    it('linewise-visual "V"', function()
+      insert(dedent( [[
+      text tααt tααt text
+      text tαxt txtα tex
+      text tαxt tαxt
+      ]]))
+      feed('gg0lvjjllV')
+      local expected = {
+        { 0, -1 },
+        { 0, eval('v:maxcol') },
+      }
+      eq(expected, exec_lua[[ local r = vim.region(0, 'v', 'v$', 'V', vim.o.selection == 'inclusive'); return {r[1], r[2]}; ]])
+    end)
+    it('blockwise-visual "^v"', function()
       insert([[αα]])
       eq({0,5}, exec_lua[[ return vim.region(0,{0,0},{0,4},'3',true)[0] ]])
     end)

--- a/test/functional/vimscript/getpos_line_spec.lua
+++ b/test/functional/vimscript/getpos_line_spec.lua
@@ -1,0 +1,57 @@
+-- Tests for line(), getpos(), getcurpos(), getcharpos().
+
+local helpers = require('test.functional.helpers')(after_each)
+local eval = helpers.eval
+local getpos = helpers.funcs.getpos
+local insert = helpers.insert
+local clear = helpers.clear
+local eq = helpers.eq
+local feed = helpers.feed
+
+describe('getpos() function', function()
+  before_each(function()
+    clear()
+    insert([[
+    First line of text
+    Second line of text
+    Third line of text
+    Fourth line of text]])
+  end)
+
+  it('getpos("v"), getpos("v$")', function()
+    local maxcol = eval('v:maxcol')
+    feed('gg0')
+
+    -- "v" (charwise-visual)
+    feed('ljv3ljl')
+    eq({0, 2, 2, 0}, getpos('v'))   -- Visual start.
+    eq({0, 3, 6, 0}, getpos('.'))   -- Cursor position.
+    eq({0, 3, 6, 0}, getpos('v$'))  -- Visual end.
+
+    -- "V" (linewise-visual)
+    feed('V')
+    eq({0, 2, maxcol, 0}, getpos('v'))
+    eq({0, 3, maxcol, 0}, getpos('v$'))
+    feed('o')
+    eq({0, 3, maxcol, 0}, getpos('v'))
+    eq({0, 2, maxcol, 0}, getpos('v$'))
+    feed('o')
+
+    -- "^v" (blockwise-visual)
+    feed('\22')
+    local v_pos = getpos('v')   -- Visual start.
+    local v_end = getpos('v$')  -- Visual end.
+    eq({0, 2, 2, 0}, v_pos)
+    eq({0, 3, 6, 0}, v_end)
+    -- "o" changes the result: "start" and "end" are swapped.
+    feed('o')
+    eq(v_end, getpos('v'))
+    eq(v_pos, getpos('v$'))
+    -- "O" changes the result of getpos('v').
+    feed('O')
+    eq({0, 3, 2, 0}, getpos('v'))
+    eq({0, 2, 6, 0}, getpos('v$'))
+  end)
+
+end)
+


### PR DESCRIPTION
# Problem:
- [visual star](https://github.com/neovim/neovim/pull/21677) (`:help v_star-default`) does not handle linewise-visual mode ("V").
- `vim.region()` clobbers `v:maxcol` result of `getpos()`.
- `getpos('v')` result is misleading for linewise-visual ("V") selection, which means callers need special handling of "V".

# Solution:
- Return `v:maxcol` for `getpos('v')` column during linewise-visual mode.
- Introduce `line('v$')` / `getpos('v$')`. It's equivalent to cursor position except during linewise-visual mode.

# TODO:
- tests for vim.region()

# Related

- https://github.com/neovim/neovim/issues/18155