### PR TITLE
docs(lua): reference to missing regex:match()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -674,7 +674,7 @@ vim.regex:match_line({bufnr}, {line_idx}, {start}, {end_})
 vim.regex:match_str({str})                                 *regex:match_str()*
     Match the string against the regex. If the string should match the regex
     precisely, surround the regex with `^` and `$` . If there was a match, the byte indices for the beginning and end of the
-    match are returned. When there is no match, `nil` is returned. Because any integer is "truthy", `regex:match()` can be directly used as a condition in an if-statement.
+    match are returned. When there is no match, `nil` is returned. Because any integer is "truthy", `regex:match_str()` can be directly used as a condition in an if-statement.
 
     Parameters: ~
       • {str}  (string)

--- a/runtime/lua/vim/_meta/regex.lua
+++ b/runtime/lua/vim/_meta/regex.lua
@@ -21,7 +21,7 @@ local regex = {} -- luacheck: no unused
 --- precisely, surround the regex with `^` and `$`. If there was a match, the
 --- byte indices for the beginning and end of the match are returned. When
 --- there is no match, `nil` is returned. Because any integer is "truthy",
---- `regex:match()` can be directly used as a condition in an if-statement.
+--- `regex:match_str()` can be directly used as a condition in an if-statement.
 --- @param str string
 function regex:match_str(str) end
 


### PR DESCRIPTION
The documentation of vim.regex references a match() method on regex objects which does not exist. What was meant is probably regex:match_str()