### PR TITLE
docs: replace `screen.c` for `undo.c` in `src/nvim/README.md`

### DIFF
--- a/src/nvim/README.md
+++ b/src/nvim/README.md
@@ -1,8 +1,7 @@
 Nvim core
 =========
 
-Module-specific details are documented at the top of each module (`terminal.c`,
-`screen.c`, …).
+Module-specific details are documented at the top of each module (`terminal.c`, `undo.c`, …).
 
 See `:help dev` for guidelines.
 


### PR DESCRIPTION
`src/nvim/screen.c` does not exist now. So I replaced `screen.c` for `undo.c` in `src/nvim/README.md`
The reason I chose `undo.c` is that there is module-specific details are documented at the top of the file.