### PR TITLE
fix(languagetree): apply `resolve_lang` to `metadata['injection.language']`

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -731,7 +731,8 @@ local has_parser = function(lang)
     or #vim.api.nvim_get_runtime_file('parser/' .. lang .. '.*', false) > 0
 end
 
---- Return parser name for language (if exists) or filetype (if registered and exists)
+--- Return parser name for language (if exists) or filetype (if registered and exists).
+--- Also attempts with the input lower-cased.
 ---
 ---@param alias string language or filetype name
 ---@return string? # resolved parser name
@@ -740,7 +741,16 @@ local function resolve_lang(alias)
     return alias
   end
 
+  if has_parser(alias:lower()) then
+    return alias:lower()
+  end
+
   local lang = vim.treesitter.language.get_lang(alias)
+  if lang and has_parser(lang) then
+    return lang
+  end
+
+  lang = vim.treesitter.language.get_lang(alias:lower())
   if lang and has_parser(lang) then
     return lang
   end
@@ -755,9 +765,10 @@ end
 function LanguageTree:_get_injection(match, metadata)
   local ranges = {} ---@type Range6[]
   local combined = metadata['injection.combined'] ~= nil
+  local injection_lang = metadata['injection.language'] --[[@as string?]]
   local lang = metadata['injection.self'] ~= nil and self:lang()
     or metadata['injection.parent'] ~= nil and self._parent_lang
-    or metadata['injection.language'] --[[@as string?]]
+    or (injection_lang and resolve_lang(injection_lang))
   local include_children = metadata['injection.include-children'] ~= nil
 
   for id, node in pairs(match) do
@@ -765,7 +776,7 @@ function LanguageTree:_get_injection(match, metadata)
     -- Lang should override any other language tag
     if name == 'injection.language' then
       local text = vim.treesitter.get_node_text(node, self._source, { metadata = metadata[id] })
-      lang = resolve_lang(text) or resolve_lang(text:lower())
+      lang = resolve_lang(text)
     elseif name == 'injection.content' then
       ranges = get_node_ranges(node, self._source, metadata[id], include_children)
     end


### PR DESCRIPTION
`resolve_lang` is applied to `@injection.language` when it's supplied as a capture:

https://github.com/neovim/neovim/blob/f5953edbac14febce9d4f8a3c35bdec1eae26fbe/runtime/lua/vim/treesitter/languagetree.lua#L766-L768

If we want to support `metadata['injection.language']` (as per #22518 and [tree-sitter upstream](https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection)) then the behavior should be consistent.

Fixes: nvim-treesitter/nvim-treesitter#4918
Fixes: MDeiml/tree-sitter-markdown#106