### PR TITLE
refactor(treesitter)!: add `language.load()` and soft-deprecate `language.add()`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -143,7 +143,9 @@ LSP FUNCTIONS
 - *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()|
 
 TREESITTER FUNCTIONS
-- *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|
+- *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.load()|
+						instead.
+- *vim.treesitter.language.add()*		Use |vim.treesitter.language.load()|
 						instead.
 - *vim.treesitter.get_node_at_pos()*		Use |vim.treesitter.get_node()|
 						instead.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -138,6 +138,7 @@ The following new APIs and features were added.
   • Added `vim.treesitter.preview_query()`, for live editing of treesitter
     queries.
   • Improved error messages for query parsing.
+  • |vim.treesitter.language.load()| replaces |vim.treesitter.language.add()|.
 
 • |vim.ui.open()| opens URIs using the system default handler (macOS `open`,
   Windows `explorer`, Linux `xdg-open`, etc.)
@@ -265,6 +266,9 @@ release.
   - |vim.lsp.util.get_progress_messages()|	Use |vim.lsp.status()| instead.
   - |vim.lsp.get_active_clients()|		Use |vim.lsp.get_clients()| instead.
   - |vim.lsp.for_each_buffer_client()|		Use |vim.lsp.get_clients()| instead.
+
+• vim.treesitter functions:
+  • |vim.treesitter.language.add()|		Use |vim.treesitter.language.load()| instead.
 
 • `vim.loop` has been renamed to `vim.uv`.
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -27,7 +27,8 @@ the same language are found, the first one is used. (This typically implies
 the priority "user config > plugins > bundled".
 A parser can also be loaded manually using a full path: >lua
 
-    vim.treesitter.language.add('python', { path = "/path/to/python.so" })
+    vim.treesitter.language.load('python', { path = "/path/to/python.so" })
+    vim.treesitter.language.register('python', 'python')
 <
 ==============================================================================
 TREESITTER TREES                                             *treesitter-tree*
@@ -772,21 +773,6 @@ stop({bufnr})                                          *vim.treesitter.stop()*
 ==============================================================================
 Lua module: vim.treesitter.language                  *lua-treesitter-language*
 
-add({lang}, {opts})                            *vim.treesitter.language.add()*
-    Load parser with name {lang}
-
-    Parsers are searched in the `parser` runtime directory, or the provided
-    {path}
-
-    Parameters: ~
-      • {lang}  (string) Name of the parser (alphanumerical and `_` only)
-      • {opts}  (table|nil) Options:
-                • filetype (string|string[]) Default filetype the parser
-                  should be associated with. Defaults to {lang}.
-                • path (string|nil) Optional path the parser is located at
-                • symbol_name (string|nil) Internal symbol name for the
-                  language to load
-
 get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
     Get the filetypes associated with the parser named {lang}.
 
@@ -814,6 +800,21 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
 
     Return: ~
         (table)
+
+load({lang}, {opts})                          *vim.treesitter.language.load()*
+    Load parser with name {lang}. To associate a parser with a filetype, use
+    |vim.treesitter.language.register()|.
+
+    Parsers are searched in the `parser` runtime directory, or the provided
+    {opts.path}
+
+    Parameters: ~
+      • {lang}  (string) Name of the parser (alphanumerical and `_` only)
+      • {opts}  (table|nil) Options:
+                • path (string|nil) (optional) Non-default path to load the
+                  parser from
+                • symbol_name (string|nil) Internal symbol name for the
+                  language to load
 
 register({lang}, {filetype})              *vim.treesitter.language.register()*
     Register a parser named {lang} to be used for {filetype}(s).

--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -10,7 +10,7 @@ function M.check()
 
   for _, parser in pairs(parsers) do
     local parsername = vim.fn.fnamemodify(parser, ':t:r')
-    local is_loadable, err_or_nil = pcall(ts.language.add, parsername)
+    local is_loadable, err_or_nil = pcall(ts.language.load, parsername)
 
     if not is_loadable then
       health.error(

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -52,37 +52,30 @@ function M.require_language(lang, path, silent, symbol_name)
   return true
 end
 
----@class treesitter.RequireLangOpts
+---@class treesitter.LoadLangOpts
 ---@field path? string
----@field silent? boolean
----@field filetype? string|string[]
 ---@field symbol_name? string
 
---- Load parser with name {lang}
+--- Load parser with name {lang}.
+--- To associate a parser with a filetype, use |vim.treesitter.language.register()|.
 ---
---- Parsers are searched in the `parser` runtime directory, or the provided {path}
+--- Parsers are searched in the `parser` runtime directory, or the provided {opts.path}
 ---
 ---@param lang string Name of the parser (alphanumerical and `_` only)
 ---@param opts (table|nil) Options:
----                        - filetype (string|string[]) Default filetype the parser should be associated with.
----                          Defaults to {lang}.
----                        - path (string|nil) Optional path the parser is located at
+---                        - path (string|nil) (optional) Non-default path to load the parser from
 ---                        - symbol_name (string|nil) Internal symbol name for the language to load
-function M.add(lang, opts)
-  ---@cast opts treesitter.RequireLangOpts
+function M.load(lang, opts)
+  ---@cast opts treesitter.LoadLangOpts
   opts = opts or {}
   local path = opts.path
-  local filetype = opts.filetype or lang
   local symbol_name = opts.symbol_name
 
   vim.validate({
     lang = { lang, 'string' },
     path = { path, 'string', true },
     symbol_name = { symbol_name, 'string', true },
-    filetype = { filetype, { 'string', 'table' }, true },
   })
-
-  M.register(lang, filetype)
 
   if vim._ts_has_language(lang) then
     return
@@ -102,6 +95,14 @@ function M.add(lang, opts)
   end
 
   vim._ts_add_language(path, lang, symbol_name)
+end
+
+---@deprecated in favor of `M.load()`
+function M.add(lang, opts)
+  local filetype = (opts or {}).filetype or lang
+  vim.validate({ filetype = { filetype, { 'string', 'table' }, true } })
+  M.register(lang, filetype)
+  M.load(lang, opts)
 end
 
 --- @param x string|string[]
@@ -136,7 +137,7 @@ end
 ---@param lang string Language
 ---@return table
 function M.inspect(lang)
-  M.add(lang)
+  M.load(lang)
   return vim._ts_inspect_language(lang)
 end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -109,7 +109,7 @@ LanguageTree.__index = LanguageTree
 ---@param parent_lang? string Parent language name of this tree
 ---@return LanguageTree parser object
 function LanguageTree.new(source, lang, opts, parent_lang)
-  language.add(lang)
+  language.load(lang)
   ---@type LanguageTreeOpts
   opts = opts or {}
 
@@ -371,7 +371,7 @@ function LanguageTree:_add_injections()
 
   local query_time, injections_by_lang = tcall(self._get_injections, self)
   for lang, injection_ranges in pairs(injections_by_lang) do
-    local has_lang = pcall(language.add, lang)
+    local has_lang = pcall(language.load, lang)
 
     -- Child language trees should just be ignored if not found, since
     -- they can depend on the text of a node. Intermediate strings

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -263,7 +263,7 @@ end
 ---
 ---@return Query Parsed query
 function M.parse(lang, query)
-  language.add(lang)
+  language.load(lang)
   local cached = query_parse_cache[lang][query]
   if cached then
     return cached

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -660,7 +660,7 @@ local function parse_buf(fname, parser_path)
     vim.cmd('sbuffer '..tostring(fname))          -- Buffer number.
   end
   if parser_path then
-    vim.treesitter.language.add('vimdoc', { path = parser_path })
+    vim.treesitter.language.load('vimdoc', { path = parser_path })
   end
   local lang_tree = vim.treesitter.get_parser(buf)
   return lang_tree, buf

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -18,22 +18,22 @@ describe('treesitter language API', function()
 
     -- actual message depends on platform
     matches("Failed to load parser for language 'borklang': uv_dlopen: .+",
-       pcall_err(exec_lua, "parser = vim.treesitter.language.add('borklang', { path = 'borkbork.so' })"))
+       pcall_err(exec_lua, "parser = vim.treesitter.language.load('borklang', { path = 'borkbork.so' })"))
 
-    eq(false, exec_lua("return pcall(vim.treesitter.language.add, 'borklang')"))
+    eq(false, exec_lua("return pcall(vim.treesitter.language.load, 'borklang')"))
 
-    eq(false, exec_lua("return pcall(vim.treesitter.language.add, 'borklang', { path = 'borkbork.so' })"))
+    eq(false, exec_lua("return pcall(vim.treesitter.language.load, 'borklang', { path = 'borkbork.so' })"))
 
     eq(".../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
        pcall_err(exec_lua, "parser = vim.treesitter.language.inspect('borklang')"))
 
     matches("Failed to load parser: uv_dlsym: .+",
-       pcall_err(exec_lua, 'vim.treesitter.language.add("c", { symbol_name = "borklang" })'))
+       pcall_err(exec_lua, 'vim.treesitter.language.load("c", { symbol_name = "borklang" })'))
   end)
 
   it('shows error for invalid language name', function()
     eq(".../language.lua:0: '/foo/' is not a valid language name",
-      pcall_err(exec_lua, 'vim.treesitter.language.add("/foo/")'))
+      pcall_err(exec_lua, 'vim.treesitter.language.load("/foo/")'))
   end)
 
   it('inspects language', function()


### PR DESCRIPTION
`language.add()` also calls `language.register()` which violates the single responsibility principle and functional purity, and abets issues like #24531.

Although some of these issues are user error, what if someone does want `get_lang(ft) != ft` even when a parser named `ft` is available, or for any other legitimate reason wishes to load without registering?

In fact, several current usages are not even to load the parser, but to check whether it exists, so the registration side-effect is especially unnecessary.

This patch also "breaks" callers of `language.add()` to do `language.load()` without `language.register()`, but for those cases: https://xkcd.com/1172/

Closes: #24531