### PR TITLE
fix(float): add fixed option

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3172,6 +3172,8 @@ nvim_open_win({buffer}, {enter}, {*config})                  *nvim_open_win()*
                   • noautocmd: If true then no buffer-related autocommand
                     events such as |BufEnter|, |BufLeave| or |BufWinEnter| may
                     fire from calling this function.
+                  • fixed: If true when anchor is NW or SW, the float window
+                    would be kept fixed even if the window would be truncated.
 
     Return: ~
         Window handle, or 0 on error

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1585,6 +1585,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---               • noautocmd: If true then no buffer-related autocommand
 ---                 events such as `BufEnter`, `BufLeave` or `BufWinEnter` may
 ---                 fire from calling this function.
+---               • fixed: If true when anchor is NW or SW, the float window
+---                 would be kept fixed even if the window would be truncated.
 --- @return integer
 function vim.api.nvim_open_win(buffer, enter, config) end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -112,6 +112,7 @@ error('Cannot require a meta file')
 --- @field footer_pos? string
 --- @field style? string
 --- @field noautocmd? boolean
+--- @field fixed? boolean
 
 --- @class vim.api.keyset.get_autocmds
 --- @field event? any

--- a/src/nvim/api/keysets.h
+++ b/src/nvim/api/keysets.h
@@ -112,6 +112,7 @@ typedef struct {
   String footer_pos;
   String style;
   Boolean noautocmd;
+  Boolean fixed;
 } Dict(float_config);
 
 typedef struct {

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -160,6 +160,8 @@
 ///   - noautocmd: If true then no buffer-related autocommand events such as
 ///                  |BufEnter|, |BufLeave| or |BufWinEnter| may fire from
 ///                  calling this function.
+///   - fixed: If true when anchor is NW or SW, the float window
+///            would be kept fixed even if the window would be truncated.
 ///
 /// @param[out] err Error details, if any
 ///
@@ -839,6 +841,10 @@ static bool parse_float_config(Dict(float_config) *config, FloatConfig *fconfig,
       return false;
     }
     fconfig->noautocmd = config->noautocmd;
+  }
+
+  if (HAS_KEY_X(config, fixed)) {
+    fconfig->fixed = config->fixed;
   }
 
   return true;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -966,6 +966,7 @@ typedef struct {
   VirtText footer_chunks;
   int footer_width;
   bool noautocmd;
+  bool fixed;
 } FloatConfig;
 
 #define FLOAT_CONFIG_INIT ((FloatConfig){ .height = 0, .width = 0, \
@@ -975,7 +976,8 @@ typedef struct {
                                           .focusable = true, \
                                           .zindex = kZIndexFloatDefault, \
                                           .style = kWinStyleUnused, \
-                                          .noautocmd = false })
+                                          .noautocmd = false, \
+                                          .fixed = false })
 
 // Structure to store last cursor position and topline.  Used by check_lnums()
 // and reset_lnums().

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -1010,6 +1010,10 @@ void ui_ext_win_position(win_T *wp, bool validate)
       comp_col += grid->comp_col;
       comp_row = MAX(MIN(comp_row, Rows - wp->w_height_outer - (p_ch > 0 ? 1 : 0)), 0);
       comp_col = MAX(MIN(comp_col, Columns - wp->w_width_outer), 0);
+      int right_extra = Columns - (int)c.col - wp->w_width - (c.border_chars[2][0] != 0);
+      if (!(c.anchor & kFloatAnchorEast) && c.fixed && right_extra < 0) {
+        comp_col = (int)c.col;
+      }
       wp->w_winrow = comp_row;
       wp->w_wincol = comp_col;
       ui_comp_put_grid(&wp->w_grid_alloc, comp_row, comp_col,

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -899,6 +899,89 @@ describe('float window', function()
       end
     end)
 
+    it('window position fixed', function()
+      local buf = meths.create_buf(false,false)
+      command("set nowrap")
+      local win = meths.open_win(buf, false, {
+        relative='editor', width=20, height=2, row=2, col=30, anchor = 'NW', fixed = true})
+      local expected_pos = {
+          [4]={{id=1001}, 'NW', 1, 2, 30, true},
+      }
+
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {1:                    }|
+          {2:~                   }|
+        ]], float_pos=expected_pos}
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~                             }{1:          }|
+          {0:~                             }{2:~         }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+          ]])
+      end
+
+      meths.win_set_config(win, {
+        relative='editor', width=20, height=2, row=2, col=30, anchor = 'NW', fixed = false})
+
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {1:                    }|
+          {2:~                   }|
+        ]], float_pos=expected_pos}
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~                   }{1:                    }|
+          {0:~                   }{2:~                   }|
+          {0:~                                       }|
+          {0:~                                       }|
+                                                  |
+          ]])
+      end
+    end)
+
     it('draws correctly with redrawdebug=compositor', function()
       -- NB: we do not test that it produces the "correct" debug info
       -- (as it is intermediate only, and is allowed to change by internal


### PR DESCRIPTION
Problem: We don't have an option (like vim's 'fixed') to truncate float screen when screen width overflows the screen.

Solution: Add `fixed` in `nvim_open_win`.

Fix https://github.com/neovim/neovim/issues/10811