### PR TITLE
fix(treesitter): `language.add` - only register parser if it exists

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -82,9 +82,8 @@ function M.add(lang, opts)
     filetype = { filetype, { 'string', 'table' }, true },
   })
 
-  M.register(lang, filetype)
-
   if vim._ts_has_language(lang) then
+    M.register(lang, filetype)
     return
   end
 
@@ -102,6 +101,7 @@ function M.add(lang, opts)
   end
 
   vim._ts_add_language(path, lang, symbol_name)
+  M.register(lang, filetype)
 end
 
 --- @param x string|string[]


### PR DESCRIPTION
Fixes: #24531