### PR TITLE
fix(highlight): winhl receive wrong argument

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1915,6 +1915,9 @@ bool parse_winhl_opt(win_T *wp)
     char *commap = xstrchrnul(hi, ',');
     size_t len = (size_t)(commap - hi);
     int hl_id = len ? syn_check_group(hi, len) : -1;
+    if (hl_id == 0) {
+      return false;
+    }
     int hl_id_link = nlen ? syn_check_group(p, nlen) : 0;
 
     HlAttrs attrs = HLATTRS_INIT;

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -8,6 +8,7 @@ local feed_command, eq = helpers.feed_command, helpers.eq
 local curbufmeths = helpers.curbufmeths
 local funcs = helpers.funcs
 local meths = helpers.meths
+local exec_lua = helpers.exec_lua
 
 describe('colorscheme compatibility', function()
   before_each(function()
@@ -2640,5 +2641,18 @@ describe('highlight namespaces', function()
       {8:~                        }|
                                |
     ]]}
+  end)
+
+  it('winhl does not accept invalid value #24586', function()
+    local res = exec_lua([[
+      local curwin = vim.api.nvim_get_current_win()
+      vim.api.nvim_command("set winhl=Normal:Visual")
+      local _, msg = pcall(vim.api.nvim_command,"set winhl='Normal:Wrong'")
+      return { msg, vim.wo[curwin].winhl }
+    ]])
+    eq({
+     "Vim(set):E5248: Invalid character in group name",
+     "Normal:Visual",
+    },res)
   end)
 end)


### PR DESCRIPTION
Problem: winhl receive and set the wrong format value even if nvim through an error

Solution: validate winhl value.

Fix #24586