### PR TITLE
refactor(treesitter): rename query previewer to query editor

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -135,7 +135,7 @@ The following new APIs and features were added.
     `vim.treesitter.language.register`.
   • The `#set!` directive now supports `injection.self` and `injection.parent` for injecting either the current node's language
     or the parent LanguageTree's language, respectively.
-  • Added `vim.treesitter.preview_query()`, for live editing of treesitter
+  • Added `vim.treesitter.query.edit()`, for live editing of treesitter
     queries.
   • Improved error messages for query parsing.
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -553,6 +553,9 @@ edit_query()                                     *vim.treesitter.edit_query()*
 
     Can also be shown with `:EditQuery`.                          *:EditQuery*
 
+    Note that the editor opens a scratch buffer, and so queries aren't
+    persisted on disk.
+
 foldexpr({lnum})                                   *vim.treesitter.foldexpr()*
     Returns the fold level for {lnum} in the current buffer. Can be set
     directly to 'foldexpr': >lua

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -548,6 +548,11 @@ library.
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*
 
+edit_query()                                     *vim.treesitter.edit_query()*
+    Open a window for live editing of a treesitter query.
+
+    Can also be shown with `:EditQuery`.                          *:EditQuery*
+
 foldexpr({lnum})                                   *vim.treesitter.foldexpr()*
     Returns the fold level for {lnum} in the current buffer. Can be set
     directly to 'foldexpr': >lua
@@ -676,8 +681,8 @@ inspect_tree({opts})                           *vim.treesitter.inspect_tree()*
 
     While in the window, press "a" to toggle display of anonymous nodes, "I"
     to toggle the display of the source language of each node, "o" to toggle
-    the query previewer, and press <Enter> to jump to the node under the
-    cursor in the source buffer.
+    the query editor, and press <Enter> to jump to the node under the cursor
+    in the source buffer.
 
     Can also be shown with `:InspectTree`.                      *:InspectTree*
 
@@ -729,11 +734,6 @@ node_contains({node}, {range})                *vim.treesitter.node_contains()*
 
     Return: ~
         (boolean) True if the {node} contains the {range}
-
-preview_query()                               *vim.treesitter.preview_query()*
-    Open a window for live editing of a treesitter query.
-
-    Can also be shown with `:PreviewQuery`.                    *:PreviewQuery*
 
 start({bufnr}, {lang})                                *vim.treesitter.start()*
     Starts treesitter highlighting for a buffer

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -548,14 +548,6 @@ library.
 ==============================================================================
 Lua module: vim.treesitter                               *lua-treesitter-core*
 
-edit_query()                                     *vim.treesitter.edit_query()*
-    Open a window for live editing of a treesitter query.
-
-    Can also be shown with `:EditQuery`.                          *:EditQuery*
-
-    Note that the editor opens a scratch buffer, and so queries aren't
-    persisted on disk.
-
 foldexpr({lnum})                                   *vim.treesitter.foldexpr()*
     Returns the fold level for {lnum} in the current buffer. Can be set
     directly to 'foldexpr': >lua
@@ -860,6 +852,14 @@ add_predicate({name}, {handler}, {force})
                    • see |vim.treesitter.query.add_directive()| for argument
                      meanings
       • {force}    (boolean|nil)
+
+edit()                                           *vim.treesitter.query.edit()*
+    Open a window for live editing of a treesitter query.
+
+    Can also be shown with `:EditQuery`.                          *:EditQuery*
+
+    Note that the editor opens a scratch buffer, and so queries aren't
+    persisted on disk.
 
 get({lang}, {query_name})                         *vim.treesitter.query.get()*
     Returns the runtime query {query_name} for {lang}.

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -495,15 +495,6 @@ function M.inspect_tree(opts)
   require('vim.treesitter.dev').inspect_tree(opts)
 end
 
---- Open a window for live editing of a treesitter query.
----
---- Can also be shown with `:EditQuery`. *:EditQuery*
----
---- Note that the editor opens a scratch buffer, and so queries aren't persisted on disk.
-function M.edit_query()
-  require('vim.treesitter.dev').edit_query()
-end
-
 --- Returns the fold level for {lnum} in the current buffer. Can be set directly to 'foldexpr':
 ---
 --- ```lua

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -498,6 +498,8 @@ end
 --- Open a window for live editing of a treesitter query.
 ---
 --- Can also be shown with `:EditQuery`. *:EditQuery*
+---
+--- Note that the editor opens a scratch buffer, and so queries aren't persisted on disk.
 function M.edit_query()
   require('vim.treesitter.dev').edit_query()
 end

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -473,7 +473,7 @@ end
 --- Open a window that displays a textual representation of the nodes in the language tree.
 ---
 --- While in the window, press "a" to toggle display of anonymous nodes, "I" to toggle the
---- display of the source language of each node, "o" to toggle the query previewer, and press
+--- display of the source language of each node, "o" to toggle the query editor, and press
 --- <Enter> to jump to the node under the cursor in the source buffer.
 ---
 --- Can also be shown with `:InspectTree`. *:InspectTree*
@@ -497,9 +497,9 @@ end
 
 --- Open a window for live editing of a treesitter query.
 ---
---- Can also be shown with `:PreviewQuery`. *:PreviewQuery*
-function M.preview_query()
-  require('vim.treesitter.dev').preview_query()
+--- Can also be shown with `:EditQuery`. *:EditQuery*
+function M.edit_query()
+  require('vim.treesitter.dev').edit_query()
 end
 
 --- Returns the fold level for {lnum} in the current buffer. Can be set directly to 'foldexpr':

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -835,4 +835,13 @@ function M.omnifunc(findstart, base)
   return require('vim.treesitter._query_linter').omnifunc(findstart, base)
 end
 
+--- Open a window for live editing of a treesitter query.
+---
+--- Can also be shown with `:EditQuery`. *:EditQuery*
+---
+--- Note that the editor opens a scratch buffer, and so queries aren't persisted on disk.
+function M.edit()
+  require('vim.treesitter.dev').edit_query()
+end
+
 return M

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -19,6 +19,6 @@ vim.api.nvim_create_user_command('InspectTree', function(cmd)
   end
 end, { desc = 'Inspect treesitter language tree for buffer', count = true })
 
-vim.api.nvim_create_user_command('PreviewQuery', function()
-  vim.treesitter.preview_query()
-end, { desc = 'Preview treesitter query' })
+vim.api.nvim_create_user_command('EditQuery', function()
+  vim.treesitter.edit_query()
+end, { desc = 'Edit treesitter query' })

--- a/runtime/plugin/nvim.lua
+++ b/runtime/plugin/nvim.lua
@@ -20,5 +20,5 @@ vim.api.nvim_create_user_command('InspectTree', function(cmd)
 end, { desc = 'Inspect treesitter language tree for buffer', count = true })
 
 vim.api.nvim_create_user_command('EditQuery', function()
-  vim.treesitter.edit_query()
+  vim.treesitter.query.edit()
 end, { desc = 'Edit treesitter query' })


### PR DESCRIPTION
As agreed in https://github.com/neovim/neovim/pull/24703#discussion_r1321719133.