### PR TITLE
[Backport release-0.9] fix(treesitter): language.add - only register parser if it exists

### DIFF
--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -77,9 +77,8 @@ function M.add(lang, opts)
     filetype = { filetype, { 'string', 'table' }, true },
   })
 
-  M.register(lang, filetype)
-
   if vim._ts_has_language(lang) then
+    M.register(lang, filetype)
     return
   end
 
@@ -97,6 +96,7 @@ function M.add(lang, opts)
   end
 
   vim._ts_add_language(path, lang, symbol_name)
+  M.register(lang, filetype)
 end
 
 --- @private


### PR DESCRIPTION
Backport of #25151.

Fixes: #24531