### PR TITLE
fix(marktree): off-by-one error in `marktree_move`

### DIFF
--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1191,8 +1191,8 @@ void marktree_move(MarkTree *b, MarkTreeIter *itr, int row, int col)
         memmove(&x->key[new_i + 1], &x->key[new_i], sizeof(MTKey) * (size_t)(itr->i - new_i));
         x->key[new_i] = key;
       } else if (new_i > itr->i) {
-        memmove(&x->key[itr->i], &x->key[itr->i + 1], sizeof(MTKey) * (size_t)(new_i - itr->i));
-        x->key[new_i] = key;
+        memmove(&x->key[itr->i], &x->key[itr->i + 1], sizeof(MTKey) * (size_t)(new_i - itr->i - 1));
+        x->key[new_i - 1] = key;
       }
       return;
     }

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -208,6 +208,23 @@ describe('API/extmarks', function()
     eq({}, get_extmarks(ns2, {0, 0}, {-1, -1}))
   end)
 
+  it('can undo with extmarks (#25147)', function()
+    feed('itest<esc>')
+    set_extmark(ns, 1, 0, 0)
+    set_extmark(ns, 2, 1, 0)
+    eq({ { 1, 0, 0 }, { 2, 1, 0 } }, get_extmarks(ns, {0, 0}, {-1, -1}))
+    feed('dd')
+    eq({ { 1, 1, 0 }, { 2, 1, 0 } }, get_extmarks(ns, {0, 0}, {-1, -1}))
+    curbufmeths.clear_namespace(ns, 0, -1)
+    eq({}, get_extmarks(ns, {0, 0}, {-1, -1}))
+    set_extmark(ns, 1, 0, 0, { right_gravity = false })
+    set_extmark(ns, 2, 1, 0, { right_gravity = false })
+    eq({ { 1, 0, 0 }, { 2, 1, 0 } }, get_extmarks(ns, {0, 0}, {-1, -1}))
+    feed('u')
+    eq({ { 1, 0, 0 }, { 2, 1, 0 } }, get_extmarks(ns, {0, 0}, {-1, -1}))
+    curbufmeths.clear_namespace(ns, 0, -1)
+  end)
+
   it('querying for information and ranges', function()
     --marks = {1, 2, 3}
     --positions = {{0, 0,}, {0, 2}, {0, 3}}


### PR DESCRIPTION
If you would insert element X at position j, then if you are moving that
same element X from position i < j, you should move it to position j -
1, because you are losing an element.
    
This error caused a gap to be left in the array, so that it looked like
[x, null, y] instead of [x, y], where len = 2. This triggered #25147.
    
Fixes: #25147