### PR TITLE
fix(float): minimal style leaks into normal windows

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -599,7 +599,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     }
     buflist_setfpos(buf, win,
                     win->w_cursor.lnum == 1 ? 0 : win->w_cursor.lnum,
-                    win->w_cursor.col, true);
+                    win->w_cursor.col, win->w_config.style != kWinStyleMinimal);
   }
 
   bufref_T bufref;
@@ -3215,7 +3215,8 @@ void buflist_slash_adjust(void)
 /// Also save the local window option values.
 void buflist_altfpos(win_T *win)
 {
-  buflist_setfpos(curbuf, win, win->w_cursor.lnum, win->w_cursor.col, true);
+  buflist_setfpos(curbuf, win, win->w_cursor.lnum, win->w_cursor.col,
+                  win->w_config.style != kWinStyleMinimal);
 }
 
 /// Check that "ffname" is not the same file as current file.

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -407,13 +407,19 @@ describe('float window', function()
     assert_alive()
   end)
 
-  it("should re-apply 'style' when present", function()
+  it("should re-apply 'style' when present and not leak to normal windows", function()
+    local buf = api.nvim_create_buf(true, false)
     local float_opts = { style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
-    local float_win = api.nvim_open_win(0, true, float_opts)
+    local float_win = api.nvim_open_win(buf, true, float_opts)
     api.nvim_set_option_value('number', true, { win = float_win })
     float_opts.row = 2
     api.nvim_win_set_config(float_win, float_opts)
     eq(false, api.nvim_get_option_value('number', { win = float_win }))
+    -- closing the float should not leak minimal style options to normal windows
+    api.nvim_win_close(float_win, true)
+    api.nvim_set_option_value('number', true, { win = 0 })
+    command('bnext')
+    eq(true, api.nvim_get_option_value('number', { win = 0 }))
   end)
 
   it("should not re-apply 'style' when missing", function()


### PR DESCRIPTION
Problem: closing a minimal float saves its style-imposed options into
buffer's wininfo, which get picked up by normal windows on :bnext.

Solution: in win_free, clear wi_optset for float windows so their saved
options are not used as fallback by find_wininfo.

Fix #24973
