### PR TITLE
fix(marktree): preserve ordering in `marktree_move`

### DIFF
--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -1178,6 +1178,9 @@ void marktree_move(MarkTree *b, MarkTreeIter *itr, int row, int col)
     }
 
     if (internal) {
+      if (key.pos.row == newpos.row && key.pos.col == newpos.col) {
+        return;
+      }
       key.pos = newpos;
       bool match;
       // tricky: could minimize movement in either direction better
@@ -1185,7 +1188,7 @@ void marktree_move(MarkTree *b, MarkTreeIter *itr, int row, int col)
       if (!match) {
         new_i++;
       }
-      if (new_i == itr->i || key_cmp(key, x->key[new_i]) == 0) {
+      if (new_i == itr->i) {
         x->key[itr->i].pos = newpos;
       } else if (new_i < itr->i) {
         memmove(&x->key[new_i + 1], &x->key[new_i], sizeof(MTKey) * (size_t)(itr->i - new_i));


### PR DESCRIPTION
`marktree_move` is making the tree out of order at:

https://github.com/neovim/neovim/blob/be10d65bfafe056025ffffa2c1131712b9a493a5/src/nvim/marktree.c#L1188

Because `key` is at the new position, and `x->key[new_i]` is also at the new position, this comparison spuriously returns true, which causes `x->key[i]` to be updated in-place even when it needs to be moved.

This causes crashes down the line, since the ordering of `MTNode.key` is an invariant that must be preserved.

Co-Authored-By: bfredl <bjorn.linse@gmail.com>
Fixes: #25157