### PR TITLE
fix(float): "Not enough room" error for 1-line float

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -22,6 +22,7 @@
 #include "nvim/move.h"
 #include "nvim/option.h"
 #include "nvim/option_defs.h"
+#include "nvim/option_vars.h"
 #include "nvim/optionstr.h"
 #include "nvim/pos_defs.h"
 #include "nvim/strings.h"
@@ -65,6 +66,12 @@ win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
     }
     wp = win_alloc(tp_last, false);
     win_init(wp, curwin, 0);
+    if (wp->w_p_wbr != NULL && fconfig.height == 1) {
+      if (wp->w_p_wbr != empty_string_option) {
+        free_string_option(wp->w_p_wbr);
+      }
+      wp->w_p_wbr = empty_string_option;
+    }
   } else {
     assert(!last);
     assert(!wp->w_floating);

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9845,6 +9845,35 @@ describe('float window', function()
         })
       end
     end)
+
+    it("does not set winbar when float only have one line #19464", function()
+      local res = exec_lua([[
+        local win = vim.api.nvim_get_current_win()
+        vim.wo[win].winbar = '%f'
+        local grp = vim.api.nvim_create_augroup('asdf', { clear = true })
+        vim.api.nvim_create_autocmd('WinEnter', {
+          group = grp,
+          pattern = '*',
+          desc = 'winbar crash?',
+          callback = function()
+            vim.wo[win].winbar = '%f'
+          end,
+        })
+
+        local buf = vim.api.nvim_create_buf(false, true)
+        local float_winid = vim.api.nvim_open_win(buf, true, {
+          relative = 'win',
+          win = win,
+          border = 'single',
+          col = 1,
+          row = 1,
+          height = 1,
+          width = 40,
+        })
+        return {vim.wo[win].winbar, vim.wo[float_winid].winbar}
+      ]])
+      eq({"%f", ""}, res)
+    end)
   end
 
   describe('with ext_multigrid', function()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9846,7 +9846,7 @@ describe('float window', function()
       end
     end)
 
-    it("does not set winbar when float only have one line #19464", function()
+    it("1-line float does not inherit'winbar' #19464", function()
       local res = exec_lua([[
         local win = vim.api.nvim_get_current_win()
         vim.wo[win].winbar = '%f'

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9846,7 +9846,7 @@ describe('float window', function()
       end
     end)
 
-    it("1-line float does not inherit'winbar' #19464", function()
+    it("1-line float does not inherit 'winbar' #19464", function()
       local res = exec_lua([[
         local win = vim.api.nvim_get_current_win()
         vim.wo[win].winbar = '%f'


### PR DESCRIPTION
When float height is 1 and before window has winbar set . reset it to empty on float win avoid trigger no room.


Fix #19464