### PR TITLE
fix(treesitter): add Query:captures_iterator()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -945,6 +945,23 @@ parse({lang}, {query})                          *vim.treesitter.query.parse()*
     Return: ~
         Query Parsed query
 
+                                                   *Query:captures_iterator()*
+Query:captures_iterator({node}, {source}, {start}, {stop})
+    Like |Query:iter_captures()| but returns an iterator that cannot be used
+    in for-loops but instead takes optional arguments to control each
+    invocation of the iterator.
+
+    Parameters: ~
+      • {node}    |TSNode| under which the search will occur
+      • {source}  (integer|string) Source buffer or string to extract text
+                  from
+      • {start}   (integer) Starting line for the search
+      • {stop}    (integer) Stopping line for the search (end-exclusive)
+
+    Return: ~
+        (fun(end_line: integer?): integer, TSNode, TSMetadata): capture id,
+        capture node, metadata
+
                                                        *Query:iter_captures()*
 Query:iter_captures({node}, {source}, {start}, {stop})
     Iterate over all captures from all matches inside {node}
@@ -976,8 +993,8 @@ Query:iter_captures({node}, {source}, {start}, {stop})
       • {stop}    (integer) Stopping line for the search (end-exclusive)
 
     Return: ~
-        (fun(end_line: integer|nil): integer, TSNode, TSMetadata): capture id,
-        capture node, metadata
+        (fun(): integer, TSNode, TSMetadata): capture id, capture node,
+        metadata
 
                                                         *Query:iter_matches()*
 Query:iter_matches({node}, {source}, {start}, {stop}, {opts})

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -237,7 +237,7 @@ local function on_line_impl(self, buf, line, is_spell_nav)
 
     if state.iter == nil or state.next_row < line then
       state.iter =
-        highlighter_query:query():iter_captures(root_node, self.bufnr, line, root_end_row + 1)
+        highlighter_query:query():captures_iterator(root_node, self.bufnr, line, root_end_row + 1)
     end
 
     while line >= state.next_row do

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -712,9 +712,26 @@ end
 ---@param start integer Starting line for the search
 ---@param stop integer Stopping line for the search (end-exclusive)
 ---
----@return (fun(end_line: integer|nil): integer, TSNode, TSMetadata):
+---@return (fun(): integer, TSNode, TSMetadata):
 ---        capture id, capture node, metadata
 function Query:iter_captures(node, source, start, stop)
+  local iter = self:captures_iterator(node, source, start, stop)
+  return function()
+    return iter()
+  end
+end
+
+--- Like |Query:iter_captures()| but returns an iterator that cannot be used in for-loops
+--- but instead takes optional arguments to control each invocation of the iterator.
+---
+---@param node TSNode under which the search will occur
+---@param source (integer|string) Source buffer or string to extract text from
+---@param start integer Starting line for the search
+---@param stop integer Stopping line for the search (end-exclusive)
+---
+---@return (fun(end_line: integer?): integer, TSNode, TSMetadata):
+---        capture id, capture node, metadata
+function Query:captures_iterator(node, source, start, stop)
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
   end

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -879,14 +879,7 @@ set(VIMDOC_FILES
 )
 
 glob_wrapper(API_SOURCES ${PROJECT_SOURCE_DIR}/src/nvim/api/*.c)
-glob_wrapper(LUA_SOURCES ${NVIM_RUNTIME_DIR}/lua/vim/*.lua)
-
-add_custom_command(
-  OUTPUT ${VIMDOC_FILES}
-  COMMAND ${PROJECT_SOURCE_DIR}/scripts/gen_vimdoc.py
-  DEPENDS ${API_SOURCES} ${LUA_SOURCES}
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-)
+glob_wrapper(LUA_SOURCES ${NVIM_RUNTIME_DIR}/lua/vim/**/*.lua)
 
 set(GEN_EVAL_FILES
   ${NVIM_RUNTIME_DIR}/lua/vim/_meta/vimfn.lua
@@ -895,6 +888,15 @@ set(GEN_EVAL_FILES
   ${NVIM_RUNTIME_DIR}/doc/builtin.txt
   ${NVIM_RUNTIME_DIR}/lua/vim/_meta/options.lua
   ${NVIM_RUNTIME_DIR}/doc/options.txt
+)
+
+list(REMOVE_ITEM LUA_SOURCES ${GEN_EVAL_FILES})
+
+add_custom_command(
+  OUTPUT ${VIMDOC_FILES}
+  COMMAND ${PROJECT_SOURCE_DIR}/scripts/gen_vimdoc.py
+  DEPENDS ${API_SOURCES} ${LUA_SOURCES}
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
 )
 
 add_custom_command(


### PR DESCRIPTION
07080f67f introduced changes to `iter_captures()` by adding arguments to
the created iterator to control each iteration step. However this breaks
usages of `iter_captures()` in for-loops since the arguments of
iterators should be the invariant state and control variable, see:
https://www.lua.org/pil/7.3.html.

This change fixes that by introducing a new function
`captures_iterator()` which by design cannot be used in for-loops, and
restores `iter_captures()` to return a stateless iterator (function with
no arguments).
