### PR TITLE
vim-patch:8.2.2356,9.0.1633

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -949,8 +949,7 @@ int skip_expr(char **pp, evalarg_T *const evalarg)
 
 /// Convert "tv" to a string.
 ///
-/// @param convert  when true convert a List into a sequence of lines and convert
-///                 a Float to a String.
+/// @param convert  when true convert a List into a sequence of lines.
 ///
 /// @return  an allocated string.
 static char *typval2string(typval_T *tv, bool convert)
@@ -967,20 +966,14 @@ static char *typval2string(typval_T *tv, bool convert)
     ga_append(&ga, NUL);
     return (char *)ga.ga_data;
   }
-  if (convert && tv->v_type == VAR_FLOAT) {
-    char numbuf[NUMBUFLEN];
-    vim_snprintf(numbuf, NUMBUFLEN, "%g", tv->vval.v_float);
-    return xstrdup(numbuf);
-  }
   return xstrdup(tv_get_string(tv));
 }
 
 /// Top level evaluation function, returning a string.
 ///
-/// @param convert  when true convert a List into a sequence of lines and convert
-///                 a Float to a String.
+/// @param convert  when true convert a List into a sequence of lines.
 ///
-/// @return         pointer to allocated memory, or NULL for failure.
+/// @return  pointer to allocated memory, or NULL for failure.
 char *eval_to_string(char *arg, bool convert)
 {
   typval_T tv;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -947,6 +947,34 @@ int skip_expr(char **pp, evalarg_T *const evalarg)
   return res;
 }
 
+/// Convert "tv" to a string.
+///
+/// @param convert  when true convert a List into a sequence of lines and convert
+///                 a Float to a String.
+///
+/// @return  an allocated string.
+static char *typval2string(typval_T *tv, bool convert)
+{
+  if (convert && tv->v_type == VAR_LIST) {
+    garray_T ga;
+    ga_init(&ga, (int)sizeof(char), 80);
+    if (tv->vval.v_list != NULL) {
+      tv_list_join(&ga, tv->vval.v_list, "\n");
+      if (tv_list_len(tv->vval.v_list) > 0) {
+        ga_append(&ga, NL);
+      }
+    }
+    ga_append(&ga, NUL);
+    return (char *)ga.ga_data;
+  }
+  if (convert && tv->v_type == VAR_FLOAT) {
+    char numbuf[NUMBUFLEN];
+    vim_snprintf(numbuf, NUMBUFLEN, "%g", tv->vval.v_float);
+    return xstrdup(numbuf);
+  }
+  return xstrdup(tv_get_string(tv));
+}
+
 /// Top level evaluation function, returning a string.
 ///
 /// @param convert  when true convert a List into a sequence of lines and convert
@@ -957,28 +985,11 @@ char *eval_to_string(char *arg, bool convert)
 {
   typval_T tv;
   char *retval;
-  garray_T ga;
 
   if (eval0(arg, &tv, NULL, &EVALARG_EVALUATE) == FAIL) {
     retval = NULL;
   } else {
-    if (convert && tv.v_type == VAR_LIST) {
-      ga_init(&ga, (int)sizeof(char), 80);
-      if (tv.vval.v_list != NULL) {
-        tv_list_join(&ga, tv.vval.v_list, "\n");
-        if (tv_list_len(tv.vval.v_list) > 0) {
-          ga_append(&ga, NL);
-        }
-      }
-      ga_append(&ga, NUL);
-      retval = (char *)ga.ga_data;
-    } else if (convert && tv.v_type == VAR_FLOAT) {
-      char numbuf[NUMBUFLEN];
-      vim_snprintf(numbuf, NUMBUFLEN, "%g", tv.vval.v_float);
-      retval = xstrdup(numbuf);
-    } else {
-      retval = xstrdup(tv_get_string(&tv));
-    }
+    retval = typval2string(&tv, convert);
     tv_clear(&tv);
   }
   clear_evalarg(&EVALARG_EVALUATE, NULL);


### PR DESCRIPTION
#### vim-patch:8.2.2356: Vim9: ":put =expr" does not handle a list properly

Problem:    Vim9: ":put =expr" does not handle a list properly.
Solution:   Use the same logic as eval_to_string_eap().

https://github.com/vim/vim/commit/883cf97f109d2ff281cf77f7b2e3bb44aced7cb3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1633: duplicate code for converting float to string

Problem:    Duplicate code for converting float to string.
Solution:   Use tv_get_string(). (closes vim/vim#12521)

https://github.com/vim/vim/commit/19dfa276c37dcf657922c6f9b48cf2954191e8b6