### PR TITLE
vim-patch:8.2.4173: cannot use an import in 'foldexpr'

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1241,6 +1241,8 @@ struct window_S {
   // this window, w_allbuf_opt is for all buffers in this window.
   winopt_T w_onebuf_opt;
   winopt_T w_allbuf_opt;
+  // transform a pointer to a "onebuf" option into a "allbuf" option
+#define GLOBAL_WO(p)    ((char *)(p) + sizeof(winopt_T))
 
   // A few options have local flags for P_INSECURE.
   uint32_t w_p_stl_flags;           // flags for 'statusline'
@@ -1255,9 +1257,6 @@ struct window_S {
   bool w_briopt_sbr;                // sbr in 'briopt'
   int w_briopt_list;                // additional indent for lists
   int w_briopt_vcol;                // indent for specific column
-
-  // transform a pointer to a "onebuf" option into a "allbuf" option
-#define GLOBAL_WO(p)    ((char *)(p) + sizeof(winopt_T))
 
   long w_scbind_pos;
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1271,8 +1271,11 @@ void *call_func_retlist(const char *func, int argc, typval_T *argv)
 /// it in "*cp".  Doesn't give error messages.
 int eval_foldexpr(win_T *wp, int *cp)
 {
+  const sctx_T saved_sctx = current_sctx;
   const bool use_sandbox = was_set_insecurely(wp, "foldexpr", OPT_LOCAL);
+
   char *arg = wp->w_p_fde;
+  current_sctx = wp->w_p_script_ctx[WV_FDE].script_ctx;
 
   emsg_off++;
   if (use_sandbox) {
@@ -1309,6 +1312,7 @@ int eval_foldexpr(win_T *wp, int *cp)
   }
   textlock--;
   clear_evalarg(&EVALARG_EVALUATE, NULL);
+  current_sctx = saved_sctx;
 
   return (int)retval;
 }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1967,6 +1967,10 @@ void set_option_sctx_idx(int opt_idx, int opt_flags, sctx_T script_ctx)
       curbuf->b_p_script_ctx[indir & PV_MASK] = last_set;
     } else if (indir & PV_WIN) {
       curwin->w_p_script_ctx[indir & PV_MASK] = last_set;
+      if (both) {
+        // also setting the "all buffers" value
+        curwin->w_allbuf_opt.wo_script_ctx[indir & PV_MASK] = last_set;
+      }
     }
   }
 }


### PR DESCRIPTION
#### vim-patch:8.2.4173: cannot use an import in 'foldexpr'

Problem:    Cannot use an import in 'foldexpr'.
Solution:   Set the script context to where 'foldexpr' was set.
            Fix that the script context was not set for all buffers.

https://github.com/vim/vim/commit/e70dd11ef41f69bd5e94f630194e6b3c4f3f2102

Co-authored-by: Bram Moolenaar <Bram@vim.org>