### PR TITLE
Add Liquidsoap filetype

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -591,6 +591,7 @@ local extension = {
   ll = 'lifelines',
   ly = 'lilypond',
   ily = 'lilypond',
+  liq = 'liquidsoap',
   liquid = 'liquid',
   cl = 'lisp',
   L = 'lisp',


### PR DESCRIPTION
This PR adds proper filetype detection for liquidsoap script files.

Liquidsoap is scripting language for creating media streams and more. It's got about [1.5k](https://github.com/search?type=code&q=NOT+is%3Afork+path%3A*.liq) script files on github.

Thanks for your consideration!