### PR TITLE
vim-patch:9.0.1907: No support for liquidsoap filetypes

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -592,6 +592,7 @@ local extension = {
   ly = 'lilypond',
   ily = 'lilypond',
   liquid = 'liquid',
+  liq = 'liquidsoap',
   cl = 'lisp',
   L = 'lisp',
   lisp = 'lisp',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -362,6 +362,7 @@ func s:GetFilenameChecks() abort
     \ 'lilo': ['lilo.conf', 'lilo.conf-file'],
     \ 'lilypond': ['file.ly', 'file.ily'],
     \ 'limits': ['/etc/limits', '/etc/anylimits.conf', '/etc/anylimits.d/file.conf', '/etc/limits.conf', '/etc/limits.d/file.conf', '/etc/some-limits.conf', '/etc/some-limits.d/file.conf', 'any/etc/limits', 'any/etc/limits.conf', 'any/etc/limits.d/file.conf', 'any/etc/some-limits.conf', 'any/etc/some-limits.d/file.conf'],
+    \ 'liquidsoap': ['file.liq'],
     \ 'liquid': ['file.liquid'],
     \ 'lisp': ['file.lsp', 'file.lisp', 'file.asd', 'file.el', 'file.cl', '.emacs', '.sawfishrc', 'sbclrc', '.sbclrc'],
     \ 'lite': ['file.lite', 'file.lt'],


### PR DESCRIPTION
Problem:  No support for liquidsoap filetypes
Solution: Add liquidsoap filetype detection code

closes: vim/vim#13111

https://github.com/vim/vim/commit/6b5efcdd8e976d2ab2554b22c4220c5e88de4717

Co-authored-by: Romain Beauxis <toots@rastageeks.org>
