### PR TITLE
fix(job-control): fix use after free

### DIFF
--- a/src/nvim/os/pty_process_win.c
+++ b/src/nvim/os/pty_process_win.c
@@ -256,9 +256,9 @@ static int build_cmd_line(char **argv, wchar_t **cmd_line, bool is_cmdexe)
   QUEUE_FOREACH(q, &args_q, {
     ArgNode *arg_node = QUEUE_DATA(q, ArgNode, node);
     xstrlcat(utf8_cmd_line, arg_node->arg, utf8_cmd_line_len);
+    QUEUE_REMOVE(q);
     xfree(arg_node->arg);
     xfree(arg_node);
-    QUEUE_REMOVE(q);
     if (!QUEUE_EMPTY(&args_q)) {
       xstrlcat(utf8_cmd_line, " ", utf8_cmd_line_len);
     }


### PR DESCRIPTION
Fixes a use after free issue that was causing a lot of crashes when running debug builds on Windows. `xfree()` would fill the freed memory in debug builds, causing the `QUEUE_REMOVE` to fail because the node pointers were gone.

This fixes a lot of crashing tests in debug builds. Bringing up a terminal in debug builds also no longer causes an immediate crash.
