### PR TITLE
docs: add info on standard $XDG environment variables

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1408,7 +1408,7 @@ ADDITIONAL DATA DIRECTORY (DEFAULT) ~
     Windows:      Not applicable              Not applicable
 
 Note: Throughout the help pages these defaults are used as placeholders, e.g.
-"~/.config" is understood to mean "`$XDG_CONFIG_HOME` or ~/.config".
+"~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
 
 Note: The log file directory is controlled by `$XDG_STATE_HOME`.
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1363,14 +1363,13 @@ paths.
 The "base" (root) directories conform to the XDG Base Directory Specification.
 https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 The $XDG_CONFIG_HOME, $XDG_DATA_HOME, $XDG_RUNTIME_DIR, $XDG_STATE_HOME,
-$XDG_CACHE_HOME, $XDG_CONFIG_DIRS and $XDG_DATA_DIRS environment variables 
+$XDG_CACHE_HOME, $XDG_CONFIG_DIRS and $XDG_DATA_DIRS environment variables
 are used if defined, else default values (listed below) are used.
 
 CONFIG DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_HOME*            Nvim: stdpath("config")
     Unix:         ~/.config                   ~/.config/nvim
     Windows:      ~/AppData/Local             ~/AppData/Local/nvim
-
 DATA DIRECTORY (DEFAULT) ~
                   *$XDG_DATA_HOME*              Nvim: stdpath("data")
     Unix:         ~/.local/share              ~/.local/share/nvim

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1388,29 +1388,29 @@ STATE DIRECTORY (DEFAULT) ~
 
 CACHE DIRECTORY (DEFAULT) ~
                   *$XDG_CACHE_HOME*             Nvim: stdpath("cache")
-    Unix:         ~/.cache	              ~/.cache/nvim
+    Unix:         ~/.cache                    ~/.cache/nvim
     Windows:      ~/AppData/Local/Temp        ~/AppData/Local/Temp/nvim-data
 
 LOG FILE (DEFAULT) ~
-                  *$NVIM_LOG_FILE*	      Nvim: stdpath("log")
-    Unix:         ~/.local/state/nvim	      ~/.local/state/nvim/log
+                  `$NVIM_LOG_FILE`              Nvim: stdpath("log")
+    Unix:         ~/.local/state/nvim         ~/.local/state/nvim/log
     Windows:      ~/AppData/Local/nvim-data   ~/AppData/Local/nvim-data/log
 
 ADDITIONAL CONFIGS DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_DIRS*            Nvim: stdpath("config_dirs")
-    Unix:         /etc/xdg/		      /etc/xdg/nvim
-    Windows:      Not applicable	      Not applicable
+    Unix:         /etc/xdg/                   /etc/xdg/nvim
+    Windows:      Not applicable              Not applicable
 
 ADDITIONAL DATA DIRECTORY (DEFAULT) ~
                   *$XDG_DATA_DIRS*              Nvim: stdpath("data_dirs")
-    Unix:         /usr/local/share	      /usr/local/share/nvim
-		  /usr/share                  /usr/share/nvim
-    Windows:      Not applicable	      Not applicable
+    Unix:         /usr/local/share            /usr/local/share/nvim
+                  /usr/share                  /usr/share/nvim
+    Windows:      Not applicable              Not applicable
 
 Note: Throughout the help pages these defaults are used as placeholders, e.g.
-"~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
+"~/.config" is understood to mean "`$XDG_CONFIG_HOME` or ~/.config".
 
-Note: The log file directory is controlled by $XDG_STATE_HOME.
+Note: The log file directory is controlled by `$XDG_STATE_HOME`.
 
 NVIM_APPNAME					*$NVIM_APPNAME*
 The standard directories can be further configured by the `$NVIM_APPNAME`
@@ -1431,7 +1431,7 @@ LOG FILE					*log* *$NVIM_LOG_FILE* *E5430*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
-By default, the file is located at stdpath("log")/log ($XDG_STATE_HOME/nvim/log)
+By default, the file is located at stdpath("log")/log (`$XDG_STATE_HOME`/nvim/log)
 unless that path is inaccessible or if `$NVIM_LOG_FILE` was set before |startup|.
 
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1370,6 +1370,7 @@ CONFIG DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_HOME*            Nvim: stdpath("config")
     Unix:         ~/.config                   ~/.config/nvim
     Windows:      ~/AppData/Local             ~/AppData/Local/nvim
+
 DATA DIRECTORY (DEFAULT) ~
                   *$XDG_DATA_HOME*              Nvim: stdpath("data")
     Unix:         ~/.local/share              ~/.local/share/nvim

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1431,7 +1431,7 @@ LOG FILE					*log* *$NVIM_LOG_FILE* *E5430*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
-By default, the file is located at stdpath("log")/log (`$XDG_STATE_HOME`/nvim/log)
+By default, the file is located at stdpath("log")/log ($XDG_STATE_HOME/nvim/log)
 unless that path is inaccessible or if `$NVIM_LOG_FILE` was set before |startup|.
 
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1432,7 +1432,7 @@ Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
 By default, the file is located at stdpath("log")/log ($XDG_STATE_HOME/nvim/log)
-unless that path is inaccessible or if `$NVIM_LOG_FILE` was set before |startup|.
+unless that path is inaccessible or if $NVIM_LOG_FILE was set before |startup|.
 
 
  vim:noet:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1362,9 +1362,9 @@ paths.
 						*base-directories* *xdg*
 The "base" (root) directories conform to the XDG Base Directory Specification.
 https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-The $XDG_CONFIG_HOME, $XDG_DATA_HOME, $XDG_RUNTIME_DIR, and $XDG_STATE_HOME
-environment variables are used if defined, else default values (listed below)
-are used.
+The $XDG_CONFIG_HOME, $XDG_DATA_HOME, $XDG_RUNTIME_DIR, $XDG_STATE_HOME,
+$XDG_CACHE_HOME, $XDG_CONFIG_DIRS and $XDG_DATA_DIRS environment variables 
+are used if defined, else default values (listed below) are used.
 
 CONFIG DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_HOME*            Nvim: stdpath("config")
@@ -1386,8 +1386,31 @@ STATE DIRECTORY (DEFAULT) ~
     Unix:         ~/.local/state              ~/.local/state/nvim
     Windows:      ~/AppData/Local             ~/AppData/Local/nvim-data
 
+CACHE DIRECTORY (DEFAULT) ~
+                  *$XDG_CACHE_HOME*             Nvim: stdpath("cache")
+    Unix:         ~/.cache	              ~/.cache/nvim
+    Windows:      ~/AppData/Local/Temp        ~/AppData/Local/Temp/nvim-data
+
+LOG FILE (DEFAULT) ~
+                  *$NVIM_LOG_FILE*	      Nvim: stdpath("log")
+    Unix:         ~/.local/state/nvim	      ~/.local/state/nvim/log
+    Windows:      ~/AppData/Local/nvim-data   ~/AppData/Local/nvim-data/log
+
+ADDITIONAL CONFIGS DIRECTORY (DEFAULT) ~
+                  *$XDG_CONFIG_DIRS*            Nvim: stdpath("config_dirs")
+    Unix:         /etc/xdg/		      /etc/xdg/nvim
+    Windows:      Not applicable	      Not applicable
+
+ADDITIONAL DATA DIRECTORY (DEFAULT) ~
+                  *$XDG_DATA_DIRS*              Nvim: stdpath("data_dirs")
+    Unix:         /usr/local/share	      /usr/local/share/nvim
+		  /usr/share                  /usr/share/nvim
+    Windows:      Not applicable	      Not applicable
+
 Note: Throughout the help pages these defaults are used as placeholders, e.g.
 "~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
+
+Note: The log file directory is controlled by $XDG_STATE_HOME.
 
 NVIM_APPNAME					*$NVIM_APPNAME*
 The standard directories can be further configured by the `$NVIM_APPNAME`
@@ -1408,8 +1431,8 @@ LOG FILE					*log* *$NVIM_LOG_FILE* *E5430*
 Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
-By default, the file is located at stdpath("log")/log unless that path
-is inaccessible or if $NVIM_LOG_FILE was set before |startup|.
+By default, the file is located at stdpath("log")/log ($XDG_STATE_HOME/nvim/log)
+unless that path is inaccessible or if $NVIM_LOG_FILE was set before |startup|.
 
 
  vim:noet:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1432,7 +1432,7 @@ Besides 'debug' and 'verbose', Nvim keeps a general log file for internal
 debugging, plugins and RPC clients. >
 	:echo $NVIM_LOG_FILE
 By default, the file is located at stdpath("log")/log ($XDG_STATE_HOME/nvim/log)
-unless that path is inaccessible or if $NVIM_LOG_FILE was set before |startup|.
+unless that path is inaccessible or if `$NVIM_LOG_FILE` was set before |startup|.
 
 
  vim:noet:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Added documentation on rest of $XDG environment variables available in stdpath(): #25205 
