### PR TITLE
NVIM_APPNAME supports relative paths

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -169,6 +169,8 @@ The following new APIs and features were added.
 • |vim.lsp.util.locations_to_items()| sets the `user_data` of each item to the
   original LSP `Location` or `LocationLink`.
 
+• |$NVIM_APPNAME| can be set to a relative path instead of only a name.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -1366,6 +1366,9 @@ The $XDG_CONFIG_HOME, $XDG_DATA_HOME, $XDG_RUNTIME_DIR, $XDG_STATE_HOME,
 $XDG_CACHE_HOME, $XDG_CONFIG_DIRS and $XDG_DATA_DIRS environment variables
 are used if defined, else default values (listed below) are used.
 
+Throughout the help pages these defaults are used as placeholders, e.g.
+"~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
+
 CONFIG DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_HOME*            Nvim: stdpath("config")
     Unix:         ~/.config                   ~/.config/nvim
@@ -1392,9 +1395,11 @@ CACHE DIRECTORY (DEFAULT) ~
     Windows:      ~/AppData/Local/Temp        ~/AppData/Local/Temp/nvim-data
 
 LOG FILE (DEFAULT) ~
-                  `$NVIM_LOG_FILE`              Nvim: stdpath("log")
+                  `$NVIM_LOG_FILE`              Nvim: stdpath("log")/log
     Unix:         ~/.local/state/nvim         ~/.local/state/nvim/log
     Windows:      ~/AppData/Local/nvim-data   ~/AppData/Local/nvim-data/log
+
+Note that stdpath("log") is currently an alias for stdpath("state").
 
 ADDITIONAL CONFIGS DIRECTORY (DEFAULT) ~
                   *$XDG_CONFIG_DIRS*            Nvim: stdpath("config_dirs")
@@ -1407,18 +1412,14 @@ ADDITIONAL DATA DIRECTORY (DEFAULT) ~
                   /usr/share                  /usr/share/nvim
     Windows:      Not applicable              Not applicable
 
-Note: Throughout the help pages these defaults are used as placeholders, e.g.
-"~/.config" is understood to mean "$XDG_CONFIG_HOME or ~/.config".
-
-Note: The log file directory is controlled by `$XDG_STATE_HOME`.
-
 NVIM_APPNAME					*$NVIM_APPNAME*
 The standard directories can be further configured by the `$NVIM_APPNAME`
 environment variable. This variable controls the sub-directory that Nvim will
 read from (and auto-create) in each of the base directories. For example,
 setting `$NVIM_APPNAME` to "foo" before starting will cause Nvim to look for
 configuration files in `$XDG_CONFIG_HOME/foo` instead of
-`$XDG_CONFIG_HOME/nvim`.
+`$XDG_CONFIG_HOME/nvim`. `$NVIM_APPNAME` must be a name, such as "foo", or a
+relative path, such as "foo/bar".
 
 One use-case for $NVIM_APPNAME is to "isolate" Nvim applications.
 Alternatively, for true isolation, on Linux you can use cgroups namespaces: >

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3279,11 +3279,17 @@ static void vim_mktempdir(void)
   char tmp[TEMP_FILE_PATH_MAXLEN];
   char path[TEMP_FILE_PATH_MAXLEN];
   char user[40] = { 0 };
+  char appname[40] = { 0 };
 
   (void)os_get_username(user, sizeof(user));
   // Usernames may contain slashes! #19240
   memchrsub(user, '/', '_', sizeof(user));
   memchrsub(user, '\\', '_', sizeof(user));
+
+  // Appname may be a relative path, replace slashes to make it name-like.
+  xstrlcpy(appname, get_appname(), sizeof(appname));
+  memchrsub(appname, '/', '%', sizeof(appname));
+  memchrsub(appname, '\\', '%', sizeof(appname));
 
   // Make sure the umask doesn't remove the executable bit.
   // "repl" has been reported to use "0177".
@@ -3298,7 +3304,6 @@ static void vim_mktempdir(void)
     // "/tmp/" exists, now try to create "/tmp/nvim.<user>/".
     add_pathsep(tmp);
 
-    const char *appname = get_appname();
     xstrlcat(tmp, appname, sizeof(tmp));
     xstrlcat(tmp, ".", sizeof(tmp));
     xstrlcat(tmp, user, sizeof(tmp));

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -251,7 +251,7 @@ int main(int argc, char **argv)
   argv0 = argv[0];
 
   if (!appname_is_valid()) {
-    os_errmsg("$NVIM_APPNAME is not a valid file name.\n");
+    os_errmsg("$NVIM_APPNAME must be a name or relative path.\n");
     exit(1);
   }
 

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -69,15 +69,23 @@ const char *get_appname(void)
   return env_val;
 }
 
-/// Ensure that APPNAME is valid. In particular, it cannot contain directory separators.
+/// Ensure that APPNAME is valid. Must be a name or relative path.
 bool appname_is_valid(void)
 {
   const char *appname = get_appname();
-  const size_t appname_len = strlen(appname);
-  for (size_t i = 0; i < appname_len; i++) {
-    if (appname[i] == PATHSEP) {
-      return false;
-    }
+  if (path_is_absolute(appname)
+      // TODO(justinmk): on Windows, path_is_absolute says "/" is NOT absolute. Should it?
+      || strequal(appname, "/")
+      || strequal(appname, "\\")
+      || strequal(appname, ".")
+      || strequal(appname, "..")
+#ifdef BACKSLASH_IN_FILENAME
+      || strstr(appname, "\\..") != NULL
+      || strstr(appname, "..\\") != NULL
+#endif
+      || strstr(appname, "/..") != NULL
+      || strstr(appname, "../") != NULL) {
+    return false;
   }
   return true;
 }

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -377,4 +377,14 @@ describe('tmpdir', function()
     rm_tmpdir()
     eq('E5431: tempdir disappeared (3 times)', meths.get_vvar('errmsg'))
   end)
+
+  it('$NVIM_APPNAME relative path', function()
+    clear({ env={
+      NVIM_APPNAME='a/b',
+      NVIM_LOG_FILE=testlog,
+      TMPDIR=os_tmpdir,
+    } })
+    matches([=[.*[/\\]a%%b%.[^/\\]+]=], funcs.tempname())
+  end)
+
 end)


### PR DESCRIPTION
This is a minimum viable product to allow paths in `NVIM_APPNAME`. It is enough to fix #23056 and close #24966

The current implementation means a user with multiple configs will end up with a lot of messy directories that may not be clear they relate to neovim (depending on what the appname they used once and then forgot about was).

Allowing the appname to include sub-directories would mean that they can choose to group all these together,
e.g.
```
NVIM_APPNAME="neovim-configs/first-config" nvim
NVIM_APPNAME="neovim-configs/second-config" nvim
```
It would also allow the user to clone someones dotfiles repo and then reach the config without moving it from the repo (this is a key part to how [dotfyle-cli](https://github.com/rorynesbitt/dotfyle-cli) works),
e.g.
```
git clone git@github.com:user/dotfiles ~/.config/user/dotfiles
NVIM_APPNAME="user/dotfiles/.config/nvim" nvim
```

I am looking for feedback about what else would need to be included in this for it to be merged.
I don't know c but I'm willing to do what I can if pointed in the right direction

From the relevant issue:
- ~updated stdpath logic in various places~
- [x] update to the docs
- [x] block the inclusion of `../` in the appname