### PR TITLE
vim-patch:9.0.1915: r_CTRL-C works differently in visual mode

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -196,6 +196,7 @@ gR			Enter Virtual Replace mode: Each character you type
 
 							*v_r*
 {Visual}r{char}		Replace all selected characters by {char}.
+			CTRL-C will be inserted literally.
 
 							*v_C*
 {Visual}["x]C		Delete the highlighted lines [into register x] and

--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -169,6 +169,7 @@ If you want to highlight exactly the same area as the last time, you can use
 CTRL-C			In Visual mode: Stop Visual mode.  When insert mode is
 			pending (the mode message shows
 			"-- (insert) VISUAL --"), it is also stopped.
+			On MS-Windows, you may need to press CTRL-Break.
 
 ==============================================================================
 3. Changing the Visual area				*visual-change*

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4513,7 +4513,7 @@ static void nv_replace(cmdarg_T *cap)
   // Visual mode "r"
   if (VIsual_active) {
     if (got_int) {
-      reset_VIsual();
+      got_int = false;
     }
     if (had_ctrl_v) {
       // Use a special (negative) number to make a difference between a

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1577,4 +1577,18 @@ func Test_visual_hl_with_showbreak()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_Visual_r_CTRL_C()
+  new
+  " visual r_cmd
+  call setline(1, ['   '])
+  call feedkeys("\<c-v>$r\<c-c>", 'tx')
+  call assert_equal([''], getline(1, 1))
+
+  " visual gr_cmd
+  call setline(1, ['   '])
+  call feedkeys("\<c-v>$gr\<c-c>", 'tx')
+  call assert_equal([''], getline(1, 1))
+  bw!
+endfu
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1915: r_CTRL-C works differently in visual mode

Problem:  r_CTRL-C works differently in visual mode
Solution: Make r_CTRL-C behave consistent in visual mode
          in terminal and Windows GUI

in visual mode, r CTRL-C behaves strange in Unix like environments. It
seems to end visual mode, but still is waiting for few more chars,
however it never seems to replace it by any characters and eventually
just returns back into normal mode.

In contrast in Windows GUI mode, r_CTRL-C replaces in the selected area
all characters by a literal CTRL-C.

Not sure why it behaves like this. It seems in the Windows GUI, got_int
is not set and therefore behaves as if any other normal character has
been pressed.

So remove the special casing of what happens when got_int is set and
make it always behave like in Windows GUI mode. Add a test to verify it
always behaves like replacing in the selected area each selected
character by a literal CTRL-C.

closes: vim/vim#13112

https://github.com/vim/vim/commit/476733f3d06876c7ac105e064108c973a57984d3

Co-authored-by: Christian Brabandt <cb@256bit.org>