### PR TITLE
fix(languagetree): don't treat unparsed nodes as occupying full range

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -650,8 +650,8 @@ function LanguageTree:included_regions()
     return self._regions
   end
 
-  if not self._has_regions or next(self._trees) == nil then
-    -- treesitter.c will default empty ranges to { -1, -1, -1, -1, -1, -1}
+  if not self._has_regions then
+    -- treesitter.c will default empty ranges to { -1, -1, -1, -1, -1, -1} (the full range)
     return { {} }
   end
 


### PR DESCRIPTION
This is incorrect in the following scenario:
1. The language tree is Lua > Vim > Lua.
2. An edit simultaneously wipes out the `_regions` of all nodes, while taking the Vim injection off-screen.
3. The Vim injection is not re-parsed, so the child Lua `_regions` is still `nil`.
4. The child Lua is assumed, incorrectly, to occupy the whole document.
5. This causes the injections to be parsed again, resulting in Lua > Vim > Lua > Vim.
6. Now, by the same process, Vim ends up with its range assumed over the whole document. Now the parse is broken and results in broken highlighting and poor performance.

It should be fine to instead treat an unparsed node as occupying nothing (i.e. effectively non-existent). Since, either:
- The parent was just parsed, hence defining `_regions`
- The parent was not just parsed, in which case this node doesn't need to be parsed either.

Additionally, the name `has_regions` is confusing; it seems to simply mean the opposite of "root" or "full_document". However, we do not touch it in this PR.

Fixes: #25252