### PR TITLE
refactor(grid): unused grid->line_wraps delenda est

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3172,9 +3172,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
 
         // Force a redraw of the first column of the next line.
         current_grid->attrs[current_grid->line_offset[current_row + 1]] = -1;
-
-        // Remember that the line wraps, used for modeless copy.
-        current_grid->line_wraps[current_row] = true;
       }
 
       wlv.boguscols = 0;

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -215,7 +215,6 @@ void screenclear(void)
   for (int i = 0; i < default_grid.rows; i++) {
     grid_clear_line(&default_grid, default_grid.line_offset[i],
                     default_grid.cols, true);
-    default_grid.line_wraps[i] = false;
   }
 
   ui_call_grid_clear(1);  // clear the display

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -52,10 +52,6 @@ enum {
 /// line_offset[n] is the offset from chars[], attrs[] and vcols[] for the start
 /// of line 'n'. These offsets are in general not linear, as full screen scrolling
 /// is implemented by rotating the offsets in the line_offset array.
-///
-/// line_wraps[] is an array of boolean flags indicating if the screen line
-/// wraps to the next line. It can only be true if a window occupies the entire
-/// screen width.
 typedef struct ScreenGrid ScreenGrid;
 struct ScreenGrid {
   handle_T handle;
@@ -64,7 +60,6 @@ struct ScreenGrid {
   sattr_T *attrs;
   colnr_T *vcols;
   size_t *line_offset;
-  char *line_wraps;
 
   // last column that was drawn (not cleared with the default background).
   // only used when "throttled" is set. Not allocated by grid_alloc!
@@ -120,7 +115,7 @@ struct ScreenGrid {
   bool comp_disabled;
 };
 
-#define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, false, \
+#define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, false, \
                            false, 0, 0, NULL, false, true, 0, \
                            0, 0, 0, 0, 0,  false }
 

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -413,9 +413,7 @@ static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlag
   assert(endcol <= chk_width);
   assert(row < chk_height);
 
-  if (!(grid && grid == &default_grid)) {
-    // TODO(bfredl): too conservative, need check
-    // grid->line_wraps if grid->Width == Width
+  if (!(grid && (grid == &default_grid || (grid->comp_col == 0 && grid->cols == Columns)))) {
     flags = flags & ~kLineFlagWrap;
   }
 


### PR DESCRIPTION
This is not used as part of the logic to actually implement TUI line wrapping. In vim (especially gvim) it is used to emulate terminal-style text selection. But in nvim we don't do that, and have no plans to reintroduce it.