### PR TITLE
chore(autocmd): Remove mention to removed 'key' option

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -785,8 +785,8 @@ OptionSet			After setting an option (except during
 				number options, ...) it is the old local
 				value.
 
-				OptionSet is not triggered on startup and for
-				the 'key' option for obvious reasons.
+				OptionSet is not triggered on startup for obvious
+				reasons.
 
 				Usage example: Check for the existence of the
 				directory in the 'backupdir' and 'undodir'


### PR DESCRIPTION
While reading the doc for `OptionSet` autocmd I've found the option `'key'`, and jumping to its documentation I end up in `vim_diff.txt` in the list of removed options:
https://github.com/neovim/neovim/blob/23c21e763074d401e8b36a91e6568bebc1655ce9/runtime/doc/vim_diff.txt#L654

So I think this mention can be removed.