### PR TITLE
fix(ui): always use stl/stlnc fillchars when drawing statusline

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2465,8 +2465,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	and the value of that item:
 
 	  item		default		Used for ~
-	  stl		' ' or '^'	statusline of the current window
-	  stlnc		' ' or '='	statusline of the non-current windows
+	  stl		' '		statusline of the current window
+	  stlnc		' '		statusline of the non-current windows
 	  wbr		' '		window bar
 	  horiz		'─' or '-'	horizontal separators |:split|
 	  horizup	'┴' or '-'	upwards facing horizontal separator
@@ -2485,9 +2485,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  eob		'~'		empty lines at the end of a buffer
 	  lastline	'@'		'display' contains lastline/truncate
 
-	Any one that is omitted will fall back to the default.  For "stl" and
-	"stlnc" the space will be used when there is highlighting, '^' or '='
-	otherwise.
+	Any one that is omitted will fall back to the default.
 
 	Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
 	"verthoriz" are only used when 'laststatus' is 3, since only vertical

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5322,8 +5322,6 @@ SpellRare	Word that is recognized by the spellchecker as one that is
 StatusLine	Status line of current window.
 							*hl-StatusLineNC*
 StatusLineNC	Status lines of not-current windows.
-		Note: If this is equal to "StatusLine", Vim will use "^^^" in
-		the status line of the current window.
 							*hl-TabLine*
 TabLine		Tab pages line, not active tab page label.
 							*hl-TabLineFill*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -534,6 +534,10 @@ Vimscript compatibility:
   `shell_error` does not alias to |v:shell_error|
   `this_session` does not alias to |v:this_session|
 
+UI/Display:
+  'statusline' always uses the "stl" and "stlnc" fields of 'fillchars', even
+  if they are the same and |hl-StatusLine| and |hl-StatusLineNC| are equal.
+
 Working directory (Vim implemented some of these after Nvim):
 - |DirChanged| and |DirChangedPre| can be triggered when switching to another
   window or tab.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2181,8 +2181,8 @@ vim.bo.ft = vim.bo.filetype
 --- and the value of that item:
 ---
 ---   item		default		Used for ~
----   stl		' ' or '^'	statusline of the current window
----   stlnc		' ' or '='	statusline of the non-current windows
+---   stl		' '		statusline of the current window
+---   stlnc		' '		statusline of the non-current windows
 ---   wbr		' '		window bar
 ---   horiz		'─' or '-'	horizontal separators `:split`
 ---   horizup	'┴' or '-'	upwards facing horizontal separator
@@ -2201,9 +2201,7 @@ vim.bo.ft = vim.bo.filetype
 ---   eob		'~'		empty lines at the end of a buffer
 ---   lastline	'@'		'display' contains lastline/truncate
 ---
---- Any one that is omitted will fall back to the default.  For "stl" and
---- "stlnc" the space will be used when there is highlighting, '^' or '='
---- otherwise.
+--- Any one that is omitted will fall back to the default.
 ---
 --- Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
 --- "verthoriz" are only used when 'laststatus' is 3, since only vertical

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2790,8 +2790,8 @@ return {
         and the value of that item:
 
           item		default		Used for ~
-          stl		' ' or '^'	statusline of the current window
-          stlnc		' ' or '='	statusline of the non-current windows
+          stl		' '		statusline of the current window
+          stlnc		' '		statusline of the non-current windows
           wbr		' '		window bar
           horiz		'─' or '-'	horizontal separators |:split|
           horizup	'┴' or '-'	upwards facing horizontal separator
@@ -2810,9 +2810,7 @@ return {
           eob		'~'		empty lines at the end of a buffer
           lastline	'@'		'display' contains lastline/truncate
 
-        Any one that is omitted will fall back to the default.  For "stl" and
-        "stlnc" the space will be used when there is highlighting, '^' or '='
-        otherwise.
+        Any one that is omitted will fall back to the default.
 
         Note that "horiz", "horizup", "horizdown", "vertleft", "vertright" and
         "verthoriz" are only used when 'laststatus' is 3, since only vertical

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -637,18 +637,7 @@ int fillchar_status(int *attr, win_T *wp)
     *attr = win_hl_attr(wp, HLF_SNC);
     fill = wp->w_p_fcs_chars.stlnc;
   }
-  // Use fill when there is highlighting, and highlighting of current
-  // window differs, or the fillchars differ, or this is not the
-  // current window
-  if (*attr != 0 && ((win_hl_attr(wp, HLF_S) != win_hl_attr(wp, HLF_SNC)
-                      || !is_curwin || ONE_WINDOW)
-                     || (wp->w_p_fcs_chars.stl != wp->w_p_fcs_chars.stlnc))) {
-    return fill;
-  }
-  if (is_curwin) {
-    return '^';
-  }
-  return '=';
+  return fill;
 }
 
 /// Redraw the status line according to 'statusline' and take care of any

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -799,3 +799,21 @@ it("shows correct ruler in cmdline with no statusline", function()
                    3longlonglong  |
   ]]
 end)
+
+it('uses "stl" and "stlnc" fillchars even if they are the same #19803', function()
+  clear()
+  local screen = Screen.new(53, 4)
+  screen:attach()
+  screen:set_default_attr_ids({
+    [1] = {bold = true, foreground = Screen.colors.Blue},  -- NonText
+  })
+  command('hi clear StatusLine')
+  command('hi clear StatusLineNC')
+  command('vsplit')
+  screen:expect{grid=[[
+    ^                          │                          |
+    {1:~                         }│{1:~                         }|
+    [No Name]                  [No Name]                 |
+                                                         |
+  ]]}
+end)


### PR DESCRIPTION
Not technically a fix as the original behavior—to use `^` and `=` when `StatusLine` and `StatusLineNC` are the same—was intended, but as discussed in [this issue](https://github.com/neovim/neovim/issues/19803), it was agreed upon to modify this behavior to always use stl/stlnc.

Close #19803