### PR TITLE
refactor(grid): properly namespace and separate stateful grid functions

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -601,10 +601,10 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
     ScreenGrid *grid = (wild_menu_showing == WM_SCROLLED)
                         ? &msg_grid_adj : &default_grid;
 
-    grid_puts(grid, buf, row, 0, attr);
+    grid_puts(grid, buf, -1, row, 0, attr);
     if (selstart != NULL && highlight) {
       *selend = NUL;
-      grid_puts(grid, selstart, row, selstart_col, HL_ATTR(HLF_WM));
+      grid_puts(grid, selstart, -1, row, selstart_col, HL_ATTR(HLF_WM));
     }
 
     grid_fill(grid, row, row + 1, clen, Columns,

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -709,7 +709,7 @@ void end_search_hl(void)
   screen_search_hl.rm.regprog = NULL;
 }
 
-static void win_redr_bordertext(win_T *wp, ScreenGrid *grid, VirtText vt, int row, int col)
+static void win_redr_bordertext(win_T *wp, VirtText vt, int col)
 {
   for (size_t i = 0; i < kv_size(vt);) {
     int attr = 0;
@@ -717,9 +717,7 @@ static void win_redr_bordertext(win_T *wp, ScreenGrid *grid, VirtText vt, int ro
     if (text == NULL) {
       break;
     }
-    int cell = (int)mb_string2cells(text);
-    grid_puts(grid, text, row, col, attr);
-    col += cell;
+    col += grid_line_puts(col, text, -1, attr);
   }
 }
 
@@ -756,60 +754,60 @@ static void win_redr_border(win_T *wp)
   int irow = wp->w_height_inner + wp->w_winbar_height, icol = wp->w_width_inner;
 
   if (adj[0]) {
-    grid_puts_line_start(grid, 0);
+    grid_line_start(grid, 0);
     if (adj[3]) {
-      grid_put_schar(grid, 0, 0, chars[0], attrs[0]);
+      grid_line_put_schar(0, chars[0], attrs[0]);
     }
 
     for (int i = 0; i < icol; i++) {
-      grid_put_schar(grid, 0, i + adj[3], chars[1], attrs[1]);
+      grid_line_put_schar(i + adj[3], chars[1], attrs[1]);
     }
 
     if (wp->w_float_config.title) {
       int title_col = win_get_bordertext_col(icol, wp->w_float_config.title_width,
                                              wp->w_float_config.title_pos);
-      win_redr_bordertext(wp, grid, wp->w_float_config.title_chunks, 0, title_col);
+      win_redr_bordertext(wp, wp->w_float_config.title_chunks, title_col);
     }
     if (adj[1]) {
-      grid_put_schar(grid, 0, icol + adj[3], chars[2], attrs[2]);
+      grid_line_put_schar(icol + adj[3], chars[2], attrs[2]);
     }
-    grid_puts_line_flush(false);
+    grid_line_flush(false);
   }
 
   for (int i = 0; i < irow; i++) {
     if (adj[3]) {
-      grid_puts_line_start(grid, i + adj[0]);
-      grid_put_schar(grid, i + adj[0], 0, chars[7], attrs[7]);
-      grid_puts_line_flush(false);
+      grid_line_start(grid, i + adj[0]);
+      grid_line_put_schar(0, chars[7], attrs[7]);
+      grid_line_flush(false);
     }
     if (adj[1]) {
       int ic = (i == 0 && !adj[0] && chars[2]) ? 2 : 3;
-      grid_puts_line_start(grid, i + adj[0]);
-      grid_put_schar(grid, i + adj[0], icol + adj[3], chars[ic], attrs[ic]);
-      grid_puts_line_flush(false);
+      grid_line_start(grid, i + adj[0]);
+      grid_line_put_schar(icol + adj[3], chars[ic], attrs[ic]);
+      grid_line_flush(false);
     }
   }
 
   if (adj[2]) {
-    grid_puts_line_start(grid, irow + adj[0]);
+    grid_line_start(grid, irow + adj[0]);
     if (adj[3]) {
-      grid_put_schar(grid, irow + adj[0], 0, chars[6], attrs[6]);
+      grid_line_put_schar(0, chars[6], attrs[6]);
     }
 
     for (int i = 0; i < icol; i++) {
       int ic = (i == 0 && !adj[3] && chars[6]) ? 6 : 5;
-      grid_put_schar(grid, irow + adj[0], i + adj[3], chars[ic], attrs[ic]);
+      grid_line_put_schar(i + adj[3], chars[ic], attrs[ic]);
     }
 
     if (wp->w_float_config.footer) {
       int footer_col = win_get_bordertext_col(icol, wp->w_float_config.footer_width,
                                               wp->w_float_config.footer_pos);
-      win_redr_bordertext(wp, grid, wp->w_float_config.footer_chunks, grid->rows - 1, footer_col);
+      win_redr_bordertext(wp, wp->w_float_config.footer_chunks, footer_col);
     }
     if (adj[1]) {
-      grid_put_schar(grid, irow + adj[0], icol + adj[3], chars[4], attrs[4]);
+      grid_line_put_schar(icol + adj[3], chars[4], attrs[4]);
     }
-    grid_puts_line_flush(false);
+    grid_line_flush(false);
   }
 }
 
@@ -932,7 +930,9 @@ int showmode(void)
                      || (State & MODE_INSERT)
                      || restart_edit != NUL
                      || VIsual_active));
-  if (do_mode || reg_recording != 0) {
+
+  bool can_show_mode = (p_ch != 0 || ui_has(kUIMessages));
+  if ((do_mode || reg_recording != 0) && can_show_mode) {
     int sub_attr;
     if (skip_showmode()) {
       return 0;  // show mode later
@@ -1307,23 +1307,25 @@ static void draw_hsep_win(win_T *wp)
 }
 
 /// Get the separator connector for specified window corner of window "wp"
-static int get_corner_sep_connector(win_T *wp, WindowCorner corner)
+static schar_T get_corner_sep_connector(win_T *wp, WindowCorner corner)
 {
   // It's impossible for windows to be connected neither vertically nor horizontally
   // So if they're not vertically connected, assume they're horizontally connected
+  int c;
   if (vsep_connected(wp, corner)) {
     if (hsep_connected(wp, corner)) {
-      return wp->w_p_fcs_chars.verthoriz;
+      c = wp->w_p_fcs_chars.verthoriz;
     } else if (corner == WC_TOP_LEFT || corner == WC_BOTTOM_LEFT) {
-      return wp->w_p_fcs_chars.vertright;
+      c = wp->w_p_fcs_chars.vertright;
     } else {
-      return wp->w_p_fcs_chars.vertleft;
+      c = wp->w_p_fcs_chars.vertleft;
     }
   } else if (corner == WC_TOP_LEFT || corner == WC_TOP_RIGHT) {
-    return wp->w_p_fcs_chars.horizdown;
+    c = wp->w_p_fcs_chars.horizdown;
   } else {
-    return wp->w_p_fcs_chars.horizup;
+    c = wp->w_p_fcs_chars.horizup;
   }
+  return schar_from_char(c);
 }
 
 /// Draw separator connecting characters on the corners of window "wp"
@@ -1366,28 +1368,24 @@ static void draw_sep_connectors_win(win_T *wp)
   bool bot_right = !(win_at_bottom || win_at_right);
 
   if (top_left || top_right) {
-    grid_puts_line_start(&default_grid, wp->w_winrow - 1);
+    grid_line_start(&default_grid, wp->w_winrow - 1);
     if (top_left) {
-      grid_putchar(&default_grid, get_corner_sep_connector(wp, WC_TOP_LEFT),
-                   wp->w_winrow - 1, wp->w_wincol - 1, hl);
+      grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_TOP_LEFT), hl);
     }
     if (top_right) {
-      grid_putchar(&default_grid, get_corner_sep_connector(wp, WC_TOP_RIGHT),
-                   wp->w_winrow - 1, W_ENDCOL(wp), hl);
+      grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_TOP_RIGHT), hl);
     }
-    grid_puts_line_flush(false);
+    grid_line_flush(false);
   }
   if (bot_left || bot_right) {
-    grid_puts_line_start(&default_grid, W_ENDROW(wp));
+    grid_line_start(&default_grid, W_ENDROW(wp));
     if (bot_left) {
-      grid_putchar(&default_grid, get_corner_sep_connector(wp, WC_BOTTOM_LEFT),
-                   W_ENDROW(wp), wp->w_wincol - 1, hl);
+      grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_BOTTOM_LEFT), hl);
     }
     if (bot_right) {
-      grid_putchar(&default_grid, get_corner_sep_connector(wp, WC_BOTTOM_RIGHT),
-                   W_ENDROW(wp), W_ENDCOL(wp), hl);
+      grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_BOTTOM_RIGHT), hl);
     }
-    grid_puts_line_flush(false);
+    grid_line_flush(false);
   }
 }
 
@@ -2384,7 +2382,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
       utf_char2bytes(symbol, &fillbuf[charlen]);
 
       // Last line isn't finished: Display "@@@" in the last screen line.
-      grid_puts_len(&wp->w_grid, fillbuf, MIN(wp->w_grid.cols, 2) * charlen, scr_row, 0, at_attr);
+      grid_puts(&wp->w_grid, fillbuf, MIN(wp->w_grid.cols, 2) * charlen, scr_row, 0, at_attr);
       grid_fill(&wp->w_grid, scr_row, scr_row + 1, 2, wp->w_grid.cols, symbol, ' ', at_attr);
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1449,6 +1449,7 @@ void edit_putchar(int c, bool highlight)
 
     // save the character to be able to put it back
     if (pc_status == PC_STATUS_UNSET) {
+      // TODO(bfredl): save the schar_T instead
       grid_getbytes(&curwin->w_grid, pc_row, pc_col, pc_bytes, &pc_attr);
       pc_status = PC_STATUS_SET;
     }
@@ -1532,7 +1533,7 @@ void edit_unputchar(void)
     if (pc_status == PC_STATUS_RIGHT || pc_status == PC_STATUS_LEFT) {
       redrawWinline(curwin, curwin->w_cursor.lnum);
     } else {
-      grid_puts(&curwin->w_grid, pc_bytes, pc_row, pc_col, pc_attr);
+      grid_puts(&curwin->w_grid, pc_bytes, -1, pc_row, pc_col, pc_attr);
     }
   }
 }
@@ -3485,7 +3486,8 @@ static bool ins_esc(long *count, int cmdchar, bool nomove)
   // Otherwise remove the mode message.
   if (reg_recording != 0 || restart_edit != NUL) {
     showmode();
-  } else if (p_smd && (got_int || !skip_showmode())) {
+  } else if (p_smd && (got_int || !skip_showmode())
+             && !(p_ch == 0 && !ui_has(kUIMessages))) {
     msg("");
   }
   // Exit Insert mode

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2004,7 +2004,7 @@ static const char *screen_puts_mbyte(const char *s, int l, int attr)
     return s;
   }
 
-  grid_puts_len(&msg_grid_adj, s, l, msg_row, msg_col, attr);
+  grid_puts(&msg_grid_adj, s, l, msg_row, msg_col, attr);
   if (cmdmsg_rl) {
     msg_col -= cw;
     if (msg_col == 0) {
@@ -2705,7 +2705,7 @@ static void t_puts(int *t_col, const char *t_s, const char *s, int attr)
   attr = hl_combine_attr(HL_ATTR(HLF_MSG), attr);
   // Output postponed text.
   msg_didout = true;  // Remember that line is not empty.
-  grid_puts_len(&msg_grid_adj, t_s, (int)(s - t_s), msg_row, msg_col, attr);
+  grid_puts(&msg_grid_adj, t_s, (int)(s - t_s), msg_row, msg_col, attr);
   msg_col += *t_col;
   *t_col = 0;
   // If the string starts with a composing character don't increment the
@@ -3091,9 +3091,9 @@ void msg_moremsg(int full)
   char *s = _("-- More --");
 
   attr = hl_combine_attr(HL_ATTR(HLF_MSG), HL_ATTR(HLF_M));
-  grid_puts(&msg_grid_adj, s, Rows - 1, 0, attr);
+  grid_puts(&msg_grid_adj, s, -1, Rows - 1, 0, attr);
   if (full) {
-    grid_puts(&msg_grid_adj, _(" SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "),
+    grid_puts(&msg_grid_adj, _(" SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "), -1,
               Rows - 1, vim_strsize(s), attr);
   }
 }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2078,18 +2078,16 @@ static void display_showcmd(void)
 
   msg_grid_validate();
   int showcmd_row = Rows - 1;
-  grid_puts_line_start(&msg_grid_adj, showcmd_row);
+  grid_line_start(&msg_grid_adj, showcmd_row);
 
   if (!showcmd_is_clear) {
-    grid_puts(&msg_grid_adj, showcmd_buf, showcmd_row, sc_col,
-              HL_ATTR(HLF_MSG));
+    grid_line_puts(sc_col, showcmd_buf, -1, HL_ATTR(HLF_MSG));
   }
 
   // clear the rest of an old message by outputting up to SHOWCMD_COLS spaces
-  grid_puts(&msg_grid_adj, (char *)"          " + len, showcmd_row,
-            sc_col + len, HL_ATTR(HLF_MSG));
+  grid_line_puts(sc_col + len, (char *)"          " + len, -1, HL_ATTR(HLF_MSG));
 
-  grid_puts_line_flush(false);
+  grid_line_flush(false);
 }
 
 /// When "check" is false, prepare for commands that scroll the window.

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -507,14 +507,14 @@ void pum_redraw(void)
     const int *const attrs = (idx == pum_selected) ? attrsSel : attrsNorm;
     int attr = attrs[0];  // start with "word" highlight
 
-    grid_puts_line_start(&pum_grid, row);
+    grid_line_start(&pum_grid, row);
 
     // prepend a space if there is room
     if (extra_space) {
       if (pum_rl) {
-        grid_putchar(&pum_grid, ' ', row, col_off + 1, attr);
+        grid_line_puts(col_off + 1, " ", 1, attr);
       } else {
-        grid_putchar(&pum_grid, ' ', row, col_off - 1, attr);
+        grid_line_puts(col_off - 1, " ", 1, attr);
       }
     }
 
@@ -580,13 +580,13 @@ void pum_redraw(void)
                   size++;
                 }
               }
-              grid_puts_len(&pum_grid, rt, (int)strlen(rt), row, grid_col - size + 1, attr);
+              grid_line_puts(grid_col - size + 1, rt, -1, attr);
               xfree(rt_start);
               xfree(st);
               grid_col -= width;
             } else {
-              // use grid_puts_len() to truncate the text
-              grid_puts(&pum_grid, st, row, grid_col, attr);
+              // use grid_line_puts() to truncate the text
+              grid_line_puts(grid_col, st, -1, attr);
               xfree(st);
               grid_col += width;
             }
@@ -597,11 +597,10 @@ void pum_redraw(void)
 
             // Display two spaces for a Tab.
             if (pum_rl) {
-              grid_puts_len(&pum_grid, "  ", 2, row, grid_col - 1,
-                            attr);
+              grid_line_puts(grid_col - 1, "  ", 2, attr);
               grid_col -= 2;
             } else {
-              grid_puts_len(&pum_grid, "  ", 2, row, grid_col, attr);
+              grid_line_puts(grid_col, "  ", 2, attr);
               grid_col += 2;
             }
             totwidth += 2;
@@ -632,37 +631,31 @@ void pum_redraw(void)
       }
 
       if (pum_rl) {
-        grid_fill(&pum_grid, row, row + 1, col_off - pum_base_width - n + 1,
-                  grid_col + 1, ' ', ' ', attr);
+        grid_line_fill(col_off - pum_base_width - n + 1, grid_col + 1, ' ', attr);
         grid_col = col_off - pum_base_width - n + 1;
       } else {
-        grid_fill(&pum_grid, row, row + 1, grid_col,
-                  col_off + pum_base_width + n, ' ', ' ', attr);
+        grid_line_fill(grid_col, col_off + pum_base_width + n, ' ', attr);
         grid_col = col_off + pum_base_width + n;
       }
       totwidth = pum_base_width + n;
     }
 
     if (pum_rl) {
-      grid_fill(&pum_grid, row, row + 1, col_off - pum_width + 1, grid_col + 1,
-                ' ', ' ', attr);
+      grid_line_fill(col_off - pum_width + 1, grid_col + 1, ' ', attr);
     } else {
-      grid_fill(&pum_grid, row, row + 1, grid_col, col_off + pum_width, ' ', ' ',
-                attr);
+      grid_line_fill(grid_col, col_off + pum_width, ' ', attr);
     }
 
     if (pum_scrollbar > 0) {
       if (pum_rl) {
-        grid_putchar(&pum_grid, ' ', row, col_off - pum_width,
-                     i >= thumb_pos && i < thumb_pos + thumb_height
-                     ? attr_thumb : attr_scroll);
+        grid_line_puts(col_off - pum_width, " ", 1,
+                       i >= thumb_pos && i < thumb_pos + thumb_height ? attr_thumb : attr_scroll);
       } else {
-        grid_putchar(&pum_grid, ' ', row, col_off + pum_width,
-                     i >= thumb_pos && i < thumb_pos + thumb_height
-                     ? attr_thumb : attr_scroll);
+        grid_line_puts(col_off + pum_width, " ", 1,
+                       i >= thumb_pos && i < thumb_pos + thumb_height ? attr_thumb : attr_scroll);
       }
     }
-    grid_puts_line_flush(false);
+    grid_line_flush(false);
     row++;
   }
 }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -153,13 +153,13 @@ void win_redr_status(win_T *wp)
 
     row = is_stl_global ? (Rows - (int)p_ch - 1) : W_ENDROW(wp);
     col = is_stl_global ? 0 : wp->w_wincol;
-    int width = grid_puts(&default_grid, p, row, col, attr);
+    int width = grid_puts(&default_grid, p, -1, row, col, attr);
     grid_fill(&default_grid, row, row + 1, width + col,
               this_ru_col + col, fillchar, fillchar, attr);
 
     if (get_keymap_str(wp, "<%s>", NameBuff, MAXPATHL)
         && this_ru_col - len > (int)(strlen(NameBuff) + 1)) {
-      grid_puts(&default_grid, NameBuff, row,
+      grid_puts(&default_grid, NameBuff, -1, row,
                 (int)((size_t)this_ru_col - strlen(NameBuff) - 1), attr);
     }
 
@@ -170,8 +170,8 @@ void win_redr_status(win_T *wp)
       const int sc_width = MIN(10, this_ru_col - len - 2);
 
       if (sc_width > 0) {
-        grid_puts_len(&default_grid, showcmd_buf, sc_width, row,
-                      wp->w_wincol + this_ru_col - sc_width - 1, attr);
+        grid_puts(&default_grid, showcmd_buf, sc_width, row,
+                  wp->w_wincol + this_ru_col - sc_width - 1, attr);
       }
     }
   }
@@ -419,7 +419,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   int start_col = col;
 
   // Draw each snippet with the specified highlighting.
-  grid_puts_line_start(grid, row);
+  grid_line_start(grid, row);
 
   int curattr = attr;
   char *p = buf;
@@ -427,7 +427,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
     int textlen = (int)(hltab[n].start - p);
     // Make all characters printable.
     size_t tsize = transstr_buf(p, textlen, transbuf, sizeof transbuf, true);
-    col += grid_puts_len(grid, transbuf, (int)tsize, row, col, curattr);
+    col += grid_line_puts(col, transbuf, (int)tsize, curattr);
     p = hltab[n].start;
 
     if (hltab[n].userhl == 0) {
@@ -442,13 +442,13 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   }
   // Make sure to use an empty string instead of p, if p is beyond buf + len.
   size_t tsize = transstr_buf(p >= buf + len ? "" : p, -1, transbuf, sizeof transbuf, true);
-  col += grid_puts_len(grid, transbuf, (int)tsize, row, col, curattr);
+  col += grid_line_puts(col, transbuf, (int)tsize, curattr);
   int maxcol = start_col + maxwidth;
 
   // fill up with "fillchar"
-  grid_fill(grid, row, row + 1, col, maxcol, fillchar, fillchar, curattr);
+  grid_line_fill(col, maxcol, fillchar, curattr);
 
-  grid_puts_line_flush(false);
+  grid_line_flush(false);
 
   // Fill the tab_page_click_defs, w_status_click_defs or w_winbar_click_defs array for clicking
   // in the tab page line, status line or window bar
@@ -618,7 +618,7 @@ void win_redr_ruler(win_T *wp)
     }
 
     ScreenGrid *grid = part_of_status ? &default_grid : &msg_grid_adj;
-    grid_puts(grid, buffer, row, this_ru_col + off, attr);
+    grid_puts(grid, buffer, -1, row, this_ru_col + off, attr);
     grid_fill(grid, row, row + 1,
               this_ru_col + off + (int)strlen(buffer), off + width, fillchar,
               fillchar, attr);
@@ -810,12 +810,12 @@ void draw_tabline(void)
           if (col + len >= Columns - 3) {
             break;
           }
-          grid_puts_len(&default_grid, NameBuff, len, 0, col,
-                        hl_combine_attr(attr, win_hl_attr(cwp, HLF_T)));
+          grid_puts(&default_grid, NameBuff, len, 0, col,
+                    hl_combine_attr(attr, win_hl_attr(cwp, HLF_T)));
           col += len;
         }
         if (modified) {
-          grid_puts_len(&default_grid, "+", 1, 0, col++, attr);
+          grid_puts(&default_grid, "+", 1, 0, col++, attr);
         }
         grid_putchar(&default_grid, ' ', 0, col++, attr);
       }
@@ -835,7 +835,7 @@ void draw_tabline(void)
           len = Columns - col - 1;
         }
 
-        grid_puts_len(&default_grid, p, (int)strlen(p), 0, col, attr);
+        grid_puts(&default_grid, p, (int)strlen(p), 0, col, attr);
         col += len;
       }
       grid_putchar(&default_grid, ' ', 0, col++, attr);
@@ -864,8 +864,8 @@ void draw_tabline(void)
       const int sc_width = MIN(10, (int)Columns - col - (tabcount > 1) * 3);
 
       if (sc_width > 0) {
-        grid_puts_len(&default_grid, showcmd_buf, sc_width, 0,
-                      Columns - sc_width - (tabcount > 1) * 2, attr_nosel);
+        grid_puts(&default_grid, showcmd_buf, sc_width, 0,
+                  Columns - sc_width - (tabcount > 1) * 2, attr_nosel);
       }
     }
 

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2837,12 +2837,6 @@ void intro_message(int colon)
       }
     }
   }
-
-  // Make the wait-return message appear just below the text.
-  if (colon) {
-    assert(row <= INT_MAX);
-    msg_row = (int)row;
-  }
 }
 
 static void do_intro_line(long row, char *mesg, int attr)
@@ -2871,8 +2865,8 @@ static void do_intro_line(long row, char *mesg, int attr)
       l += utfc_ptr2len(p + l) - 1;
     }
     assert(row <= INT_MAX && col <= INT_MAX);
-    grid_puts_len(&default_grid, p, l, (int)row, (int)col,
-                  *p == '<' ? HL_ATTR(HLF_8) : attr);
+    grid_puts(&default_grid, p, l, (int)row, (int)col,
+              *p == '<' ? HL_ATTR(HLF_8) : attr);
     col += clen;
   }
 }


### PR DESCRIPTION
This is a step in an ongoing refactor where the "grid_puts" and "grid_put_linebuf" code paths will share more of the implementation (in particular for delta calculation, doublewidth and 'arabicshape' handling). But it also makes sense by its own as a cleanup, and is thus committed separately.

Before this change many of the low level grid functions grid_puts, grid_fill etc could both be used in a standalone fashion but also as part of a batched line update which would be finally transmitted as a single grid_line call (via ui_line() ). This was initially useful to quickly refactor pre-existing vim code to use batched logic safely.

However, this pattern is not really helpful for maintainable and newly written code, where the "grid" and "row" arguments are just needlessly repeated. This simplifies these calls to just use grid and row as specified in the initial grid_line_start(grid, row) call.

This also makes the intent clear whether any grid_puts() call is actually part of a batch or not, which is better in the long run when more things get refactored to use effective (properly batched) updates.