### PR TITLE
build: actually export symbols on mac

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -230,6 +230,11 @@ if(WIN32)
   endif()
 elseif(APPLE)
   target_link_libraries(nvim PRIVATE "-framework CoreServices")
+
+  # Actually export symbols - symbols may not be visible even though
+  # ENABLE_EXPORTS is set to true. See
+  # https://github.com/neovim/neovim/issues/25295
+  set_target_properties(nvim PROPERTIES LINK_FLAGS "-Wl,-export_dynamic")
 endif()
 
 if(UNIX)


### PR DESCRIPTION
If `-export_dynamic` is not passed to the linker, then Link Time
Optimization may inline and remove global functions even though
ENABLE_EXPORTS is set to true.

Closes https://github.com/neovim/neovim/issues/25295.
Closes https://github.com/kevinhwang91/nvim-ufo/issues/162.
Closes https://github.com/neovim/neovim/issues/25295.

Co-authored-by: Carlo Cabrera <30379873+carlocab@users.noreply.github.com>