### PR TITLE
vim-patch:9.0.1918

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -210,6 +210,7 @@ local extension = {
   astro = 'astro',
   atl = 'atlas',
   as = 'atlas',
+  zed = 'authzed',
   ahk = 'autohotkey',
   au3 = 'autoit',
   ave = 'ave',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -97,6 +97,7 @@ func s:GetFilenameChecks() abort
     \ 'asterisk': ['asterisk/file.conf', 'asterisk/file.conf-file', 'some-asterisk/file.conf', 'some-asterisk/file.conf-file'],
     \ 'astro': ['file.astro'],
     \ 'atlas': ['file.atl', 'file.as'],
+    \ 'authzed': ['file.zed'],
     \ 'autohotkey': ['file.ahk'],
     \ 'autoit': ['file.au3'],
     \ 'automake': ['GNUmakefile.am', 'makefile.am', 'Makefile.am'],


### PR DESCRIPTION
patch 9.0.1918: No filetype detection for Authzed filetypes

Problem:  No filetype detection for Authzed filetypes
Solution: Detect the *.zed file extension as authzed filetype

closes: vim/vim#13129

https://github.com/vim/vim/commit/5790a54166793554d16f6a85d8824632860b8b37

Co-authored-by: Matt Polzin <mpolzin@workwithopal.com>
