### PR TITLE
vim-patch:9.0.1919: Wrong curswant when clicking on empty line or with vsplits

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1849,56 +1849,55 @@ static void mouse_check_grid(colnr_T *vcolp, int *flagsp)
   int click_grid = mouse_grid;
   int click_row = mouse_row;
   int click_col = mouse_col;
-  int max_row = Rows;
-  int max_col = Columns;
-  bool multigrid = ui_has(kUIMultigrid);
+
+  // XXX: this doesn't change click_grid if it is 1, even with multigrid
+  win_T *wp = mouse_find_win(&click_grid, &click_row, &click_col);
+  // Only use vcols[] after the window was redrawn.  Mainly matters
+  // for tests, a user would not click before redrawing.
+  if (wp == NULL || wp->w_redr_type != 0) {
+    return;
+  }
+  ScreenGrid *gp = &wp->w_grid;
+  int start_row = 0;
+  int start_col = 0;
+  grid_adjust(&gp, &start_row, &start_col);
+  if (gp->handle != click_grid) {
+    return;
+  }
+  click_row += start_row;
+  click_col += start_col;
+
   colnr_T col_from_screen = -1;
 
-  win_T *wp = mouse_find_win(&click_grid, &click_row, &click_col);
-  if (wp && multigrid) {
-    max_row = wp->w_grid_alloc.rows;
-    max_col = wp->w_grid_alloc.cols;
-  }
+  if (gp->chars != NULL
+      && click_row >= 0 && click_row < gp->rows
+      && click_col >= 0 && click_col < gp->cols) {
+    const size_t off = gp->line_offset[click_row] + (size_t)click_col;
+    col_from_screen = gp->vcols[off];
 
-  if (wp && mouse_row >= 0 && mouse_row < max_row
-      && mouse_col >= 0 && mouse_col < max_col) {
-    ScreenGrid *gp = multigrid ? &wp->w_grid_alloc : &default_grid;
-    int use_row = multigrid && mouse_grid == 0 ? click_row : mouse_row;
-    int use_col = multigrid && mouse_grid == 0 ? click_col : mouse_col;
-
-    if (gp->chars != NULL) {
-      const size_t off = gp->line_offset[use_row] + (size_t)use_col;
-
-      // Only use vcols[] after the window was redrawn.  Mainly matters
-      // for tests, a user would not click before redrawing.
-      if (wp->w_redr_type == 0) {
-        col_from_screen = gp->vcols[off];
-      }
-
-      if (col_from_screen == MAXCOL) {
-        // When clicking after end of line, still need to set correct curswant
-        size_t off_l = gp->line_offset[use_row];
-        if (gp->vcols[off_l] < MAXCOL) {
-          // Binary search to find last char in line
-          size_t off_r = off;
-          while (off_l < off_r) {
-            size_t off_m = (off_l + off_r + 1) / 2;
-            if (gp->vcols[off_m] < MAXCOL) {
-              off_l = off_m;
-            } else {
-              off_r = off_m - 1;
-            }
+    if (col_from_screen == MAXCOL) {
+      // When clicking after end of line, still need to set correct curswant
+      size_t off_l = gp->line_offset[click_row] + (size_t)start_col;
+      if (gp->vcols[off_l] < MAXCOL) {
+        // Binary search to find last char in line
+        size_t off_r = off;
+        while (off_l < off_r) {
+          size_t off_m = (off_l + off_r + 1) / 2;
+          if (gp->vcols[off_m] < MAXCOL) {
+            off_l = off_m;
+          } else {
+            off_r = off_m - 1;
           }
-          *vcolp = gp->vcols[off_r] + (int)(off - off_r);
-        } else {
-          // Shouldn't normally happen
-          *vcolp = MAXCOL;
         }
-      } else if (col_from_screen >= 0) {
-        // Use the virtual column from vcols[], it is accurate also after
-        // concealed characters.
-        *vcolp = col_from_screen;
+        *vcolp = gp->vcols[off_r] + (int)(off - off_r);
+      } else {
+        // Clicking on an empty line
+        *vcolp = click_col - start_col;
       }
+    } else if (col_from_screen >= 0) {
+      // Use the virtual column from vcols[], it is accurate also after
+      // concealed characters.
+      *vcolp = col_from_screen;
     }
   }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -8831,6 +8831,117 @@ describe('float window', function()
         meths.input_mouse('left', 'press', '', 0, 3, 15)
       end
       eq({0, 3, 1, 0, 10}, funcs.getcurpos())
+
+      command('setlocal foldcolumn=1')
+      feed('zfkgg')
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+                                                  |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:┌────────────────────┐}|
+          {5:│}{19: }{1:^                   }{5:│}|
+          {5:│}{19:+}{28:+--  2 lines: ·····}{5:│}|
+          {5:│}{2:~                   }{5:│}|
+          {5:└────────────────────┘}|
+        ]], float_pos={
+          [4] = {{id = 1001}, "NW", 1, 0, 5, true, 50};
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = {id = 1001}, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
+        }}
+      else
+        screen:expect{grid=[[
+               {5:┌────────────────────┐}             |
+          {0:~    }{5:│}{19: }{1:^                   }{5:│}{0:             }|
+          {0:~    }{5:│}{19:+}{28:+--  2 lines: ·····}{5:│}{0:             }|
+          {0:~    }{5:│}{2:~                   }{5:│}{0:             }|
+          {0:~    }{5:└────────────────────┘}{0:             }|
+          {0:~                                       }|
+                                                  |
+        ]]}
+      end
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 2, 1)
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+                                                  |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:┌────────────────────┐}|
+          {5:│}{19: }{1:^                   }{5:│}|
+          {5:│}{19:-}{1:                   }{5:│}|
+          {5:│}{19:│}{1:                   }{5:│}|
+          {5:└────────────────────┘}|
+        ]], float_pos={
+          [4] = {{id = 1001}, "NW", 1, 0, 5, true, 50};
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = {id = 1001}, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
+        }}
+      else
+        meths.input_mouse('left', 'press', '', 0, 2, 6)
+        screen:expect{grid=[[
+               {5:┌────────────────────┐}             |
+          {0:~    }{5:│}{19: }{1:^                   }{5:│}{0:             }|
+          {0:~    }{5:│}{19:-}{1:                   }{5:│}{0:             }|
+          {0:~    }{5:│}{19:│}{1:                   }{5:│}{0:             }|
+          {0:~    }{5:└────────────────────┘}{0:             }|
+          {0:~                                       }|
+                                                  |
+        ]]}
+      end
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 2, 2)
+      else
+        meths.input_mouse('left', 'press', '', 0, 2, 7)
+      end
+      eq({0, 2, 1, 0, 1}, funcs.getcurpos())
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 2, 3)
+      else
+        meths.input_mouse('left', 'press', '', 0, 2, 8)
+      end
+      eq({0, 2, 1, 0, 2}, funcs.getcurpos())
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 2, 11)
+      else
+        meths.input_mouse('left', 'press', '', 0, 2, 16)
+      end
+      eq({0, 2, 1, 0, 10}, funcs.getcurpos())
     end)
 
     it("'winblend' option", function()

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -8764,6 +8764,75 @@ describe('float window', function()
       end
     end)
 
+    it('left click sets correct curswant in float window with border', function()
+      local buf = meths.create_buf(false,false)
+      meths.buf_set_lines(buf, 0, -1, true, {'', '', ''})
+      meths.open_win(buf, false, {relative='editor', width=20, height=3, row=0, col=5, border='single'})
+      if multigrid then
+        screen:expect{grid=[[
+        ## grid 1
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [2:----------------------------------------]|
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+          {0:~                                       }|
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:┌────────────────────┐}|
+          {5:│}{1:                    }{5:│}|
+          {5:│}{1:                    }{5:│}|
+          {5:│}{1:                    }{5:│}|
+          {5:└────────────────────┘}|
+        ]], float_pos={
+          [4] = {{id = 1001}, "NW", 1, 0, 5, true, 50};
+        }, win_viewport={
+          [2] = {win = {id = 1000}, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = {id = 1001}, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
+        }}
+      else
+        screen:expect{grid=[[
+          ^     {5:┌────────────────────┐}             |
+          {0:~    }{5:│}{1:                    }{5:│}{0:             }|
+          {0:~    }{5:│}{1:                    }{5:│}{0:             }|
+          {0:~    }{5:│}{1:                    }{5:│}{0:             }|
+          {0:~    }{5:└────────────────────┘}{0:             }|
+          {0:~                                       }|
+                                                  |
+        ]]}
+      end
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 3, 1)
+      else
+        meths.input_mouse('left', 'press', '', 0, 3, 6)
+      end
+      eq({0, 3, 1, 0, 1}, funcs.getcurpos())
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 3, 2)
+      else
+        meths.input_mouse('left', 'press', '', 0, 3, 7)
+      end
+      eq({0, 3, 1, 0, 2}, funcs.getcurpos())
+
+      if multigrid then
+        meths.input_mouse('left', 'press', '', 4, 3, 10)
+      else
+        meths.input_mouse('left', 'press', '', 0, 3, 15)
+      end
+      eq({0, 3, 1, 0, 10}, funcs.getcurpos())
+    end)
+
     it("'winblend' option", function()
       screen:try_resize(50,9)
       screen:set_default_attr_ids({

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -6287,7 +6287,7 @@ describe('float window', function()
         end
 
         if multigrid then
-          meths.input_mouse('left', 'press', '', 1, 0, 0)
+          meths.input_mouse('left', 'press', '', 2, 0, 0)
           screen:expect{grid=[[
           ## grid 1
             [2:----------------------------------------]|
@@ -6366,7 +6366,7 @@ describe('float window', function()
         end
 
         if multigrid then
-          meths.input_mouse('left', 'press', '', 1, 0, 0)
+          meths.input_mouse('left', 'press', '', 2, 0, 0)
           screen:expect{grid=[[
           ## grid 1
             [2:----------------------------------------]|

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -1676,7 +1676,7 @@ describe('ui/mouse/input', function()
 
   end)
 
-  it('getmousepos works correctly', function()
+  it('getmousepos() works correctly', function()
     local winwidth = meths.get_option_value('winwidth', {})
     -- Set winwidth=1 so that window sizes don't change.
     meths.set_option_value('winwidth', 1, {})
@@ -1771,7 +1771,7 @@ describe('ui/mouse/input', function()
 
     -- Test that mouse position values are properly set for ordinary windows.
     -- Set the float to be unfocusable instead of closing, to additionally test
-    -- that getmousepos does not consider unfocusable floats. (see discussion
+    -- that getmousepos() does not consider unfocusable floats. (see discussion
     -- in PR #14937 for details).
     opts.focusable = false
     meths.win_set_config(float, opts)

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -2307,6 +2307,7 @@ describe('ext_multigrid', function()
       {1:~                                                                               }|
     ]]}
 
+    -- XXX: mouse_check_grid() doesn't work properly when clicking on grid 1
     meths.input_mouse('left', 'press', '', 1, 6, 20)
     -- TODO(bfredl): "batching" input_mouse is formally not supported yet.
     -- Normally it should work fine in async context when nvim is not blocked,

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4107,6 +4107,39 @@ func Test_normal_click_on_double_width_char()
   let &mouse = save_mouse
 endfunc
 
+func Test_normal_click_on_empty_line()
+  let save_mouse = &mouse
+  set mouse=a
+  botright new
+  call setline(1, ['', '', ''])
+  let row = win_screenpos(0)[0] + 2
+  20vsplit
+  redraw
+
+  call Ntest_setmouse(row, 1)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 1], getcurpos())
+  call Ntest_setmouse(row, 2)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 2], getcurpos())
+  call Ntest_setmouse(row, 10)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 10], getcurpos())
+
+  call Ntest_setmouse(row, 21 + 1)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 1], getcurpos())
+  call Ntest_setmouse(row, 21 + 2)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 2], getcurpos())
+  call Ntest_setmouse(row, 21 + 10)
+  call feedkeys("\<LeftMouse>", 'xt')
+  call assert_equal([0, 3, 1, 0, 10], getcurpos())
+
+  bwipe!
+  let &mouse = save_mouse
+endfunc
+
 func Test_normal33_g_cmd_nonblank()
   " Test that g<End> goes to the last non-blank char and g$ to the last
   " visible column

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -564,35 +564,38 @@ func Test_virtualedit_mouse()
   let save_mouse = &mouse
   set mouse=a
   set virtualedit=all
-  new
+  botright new
+  let row = win_screenpos(0)[0]
+  20vsplit
+  wincmd p
 
   call setline(1, ["text\tword"])
   redraw
-  call Ntest_setmouse(1, 4)
+  call Ntest_setmouse(row, 21 + 4)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 4, 0, 4], getcurpos())
-  call Ntest_setmouse(1, 5)
+  call Ntest_setmouse(row, 21 + 5)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 5, 0, 5], getcurpos())
-  call Ntest_setmouse(1, 6)
+  call Ntest_setmouse(row, 21 + 6)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 5, 1, 6], getcurpos())
-  call Ntest_setmouse(1, 7)
+  call Ntest_setmouse(row, 21 + 7)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 5, 2, 7], getcurpos())
-  call Ntest_setmouse(1, 8)
+  call Ntest_setmouse(row, 21 + 8)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 5, 3, 8], getcurpos())
-  call Ntest_setmouse(1, 9)
+  call Ntest_setmouse(row, 21 + 9)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 6, 0, 9], getcurpos())
-  call Ntest_setmouse(1, 12)
+  call Ntest_setmouse(row, 21 + 12)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 9, 0, 12], getcurpos())
-  call Ntest_setmouse(1, 13)
+  call Ntest_setmouse(row, 21 + 13)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 10, 0, 13], getcurpos())
-  call Ntest_setmouse(1, 15)
+  call Ntest_setmouse(row, 21 + 15)
   call feedkeys("\<LeftMouse>", "xt")
   call assert_equal([0, 1, 10, 2, 15], getcurpos())
 


### PR DESCRIPTION
#### vim-patch:9.0.1919: Wrong curswant when clicking on empty line or with vsplits

Problem:  Wrong curswant when clicking on empty line or with vsplits.
Solution: Don't check for ScreenCols[] before the start of the window
          and handle empty line properly.

closes: vim/vim#13132

https://github.com/vim/vim/commit/03cd697d635f1b0e7ffe21cf8244a8fb755f2ddb