### PR TITLE
docs: rename dev-lua-doc to dev-doc-lua to match CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -350,7 +350,7 @@ as context, use the `-W` argument as well.
 [complexity:low]: https://github.com/neovim/neovim/issues?q=is%3Aopen+is%3Aissue+label%3Acomplexity%3Alow
 [conventional_commits]: https://www.conventionalcommits.org
 [dev-doc-guide]: https://neovim.io/doc/user/develop.html#dev-doc
-[dev-doc-lua]: https://neovim.io/doc/user/develop.html#dev-lua-doc
+[dev-doc-lua]: https://neovim.io/doc/user/develop.html#dev-doc-lua
 [LuaLS]: https://github.com/LuaLS/lua-language-server/wiki/Annotations
 [gcc-warnings]: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 [gh]: https://cli.github.com/

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -227,7 +227,7 @@ in src/nvim/api/win_config.c like this: >
 
 
 Lua docstrings ~
-							*dev-lua-doc*
+							*dev-doc-lua*
 Lua documentation lives in the source code, as docstrings on the function
 definitions.  The |lua-vim| :help is generated from the docstrings.
 


### PR DESCRIPTION
CONTRIBUTING.md recommends reading `:help dev-doc-lua`, which does not exist but `dev-lua-doc` does.

Since the existing `dev-lua-doc` section comes after `dev-doc` and before `dev-lua`, it seemed to make more sense to namespace the section under `dev-doc-*` instead of `dev-lua-*`.

`dev-lua-doc` had no references in the codebase.