### PR TITLE
fix(tui): don't overwrite an assertion faliure message on exit

### DIFF
--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -167,4 +167,7 @@ void msg_history_show(Array entries)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void msg_history_clear(void)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
+
+void error_exit(Integer status)
+  FUNC_API_SINCE(12);
 #endif  // NVIM_API_UI_EVENTS_IN_H

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -423,6 +423,7 @@ static void exit_event(void **argv)
 
   if (!exiting) {
     if (ui_client_channel_id) {
+      ui_client_exit_status = status;
       os_exit(status);
     } else {
       assert(status == 0);  // Called from rpc_close(), which passes 0 as status.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4591,7 +4591,9 @@ static void ex_cquit(exarg_T *eap)
   FUNC_ATTR_NORETURN
 {
   // this does not always pass on the exit code to the Manx compiler. why?
-  getout(eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE);
+  int status = eap->addr_count > 0 ? (int)eap->line2 : EXIT_FAILURE;
+  ui_call_error_exit(status);
+  getout(status);
 }
 
 /// Do preparations for "qall" and "wqall".

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -23,6 +23,9 @@ EXTERN sattr_T *grid_line_buf_attr INIT(= NULL);
 // ID of the ui client channel. If zero, the client is not running.
 EXTERN uint64_t ui_client_channel_id INIT(= 0);
 
+// exit status from embedded nvim process
+EXTERN int ui_client_exit_status INIT(= 0);
+
 // TODO(bfredl): the current structure for how tui and ui_client.c communicate is a bit awkward.
 // This will be restructured as part of The UI Devirtualization Project.
 


### PR DESCRIPTION
Fix #21608

If nvim exited with nonzero status this is for one of the two reasons:
- `:cquit` was invoked. This is used by users and plugins to communicate a result, like a nonzero status will fail a `git commit` operation
- There was an internal error or deadly signal. in this case an error message was likely written to stderr or to the screen.

In the latter case, the error message was often hidden by the TUI exiting altscreen mode, which erases all visible terminal text.

This change prevents this in the latter case, while still cleaning up the terminal properly when `:cquit` was deliberatily invoked. Other cleanup like exiting mouse mode and raw mode is still done.