### PR TITLE
docs Update term.txt to recommend tic -x vs. tic

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -31,7 +31,7 @@ a non-superuser:
 >
   curl -LO https://invisible-island.net/datafiles/current/terminfo.src.gz
   gunzip terminfo.src.gz
-  tic terminfo.src
+  tic -x terminfo.src
 <
 								*$TERM*
 The $TERM environment variable must match the terminal you are using!


### PR DESCRIPTION
I have just installed a local terminfo to allow me to get undercurl supported on RHEL 7, using ncurses 5 over ssh using mintty.

The current instructions mean if `tic` hits extended codes it does not understand, which is a lot of them, it will discard them from the new terminfo.

By adding the flag `-x`, supported since 1999 (https://invisible-island.net/ncurses/NEWS.html#index-t990301), `tic` will try to include any new features automatically as custom user flags, including undercurl.