### PR TITLE
docs: small improvements to compl-autocomplete example

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1093,11 +1093,11 @@ To get basic "autocompletion" without installing a plugin, try this script: >lua
   vim.api.nvim_create_autocmd("InsertCharPre", {
     buffer = vim.api.nvim_get_current_buf(),
     callback = function()
-      if vim.fn.pumvisible() == 1 then
+      if vim.fn.pumvisible() == 1 or vim.fn.state("m") == "m" then
         return
       end
       local char = vim.v.char
-      if vim.tbl_contains(triggers, char) then
+      if vim.list_contains(triggers, char) then
         local key = vim.keycode("<C-x><C-n>")
         vim.api.nvim_feedkeys(key, "m", false)
       end


### PR DESCRIPTION
- Don't complete when there is pending input.
- Use vim.list_contains() instead of vim.tbl_contains().