### PR TITLE
fix(meta): make vim.json show up in LSP completions

### DIFF
--- a/runtime/lua/vim/_meta/json.lua
+++ b/runtime/lua/vim/_meta/json.lua
@@ -1,5 +1,8 @@
 ---@meta
 
+---@nodoc
+vim.json = {}
+
 -- luacheck: no unused args
 
 ---@defgroup vim.json


### PR DESCRIPTION
There doesn't seem to be a reason why this module isn't included.