### PR TITLE
fix(nix): (aarch64-)darwin should build

### DIFF
--- a/contrib/flake.nix
+++ b/contrib/flake.nix
@@ -26,7 +26,7 @@
     in
     {
       overlay = final: prev: {
-
+        liblpeg-darwin = final.callPackage ./lpeg.nix { };
         neovim = (final.neovim-unwrapped.override {
           treesitter-parsers = pipe ../cmake.deps/deps.txt [
             readFile
@@ -39,7 +39,7 @@
                   lang = toLower (elemAt matches 0);
                   type = toLower (elemAt matches 1);
                   value = elemAt matches 2;
-                in
+                in 
                 acc // {
                   ${lang} = acc.${lang} or { } // {
                     ${type} = value;
@@ -64,6 +64,8 @@
           '';
           nativeBuildInputs = oa.nativeBuildInputs ++ [
             final.libiconv
+          ] ++ final.lib.optionals final.stdenv.isDarwin [
+            final.liblpeg-darwin
           ];
         });
 
@@ -77,7 +79,6 @@
           lua = final.luajit;
           inherit stdenv;
         }).overrideAttrs (oa: {
-
           dontStrip = true;
           NIX_CFLAGS_COMPILE = " -ggdb -Og";
 
@@ -93,7 +94,7 @@
         }).overrideAttrs (oa: {
           cmakeFlags = oa.cmakeFlags ++ [
             "-DLUACHECK_PRG=${luacheck}/bin/luacheck"
-            "-DENABLE_LTO=OFF"
+            "-DENABLE_LTO=OFF" 
           ] ++ final.lib.optionals final.stdenv.isLinux [
             # https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
             # https://clang.llvm.org/docs/AddressSanitizer.html#symbolizing-the-reports
@@ -131,7 +132,6 @@
 
         devShells = {
           default = pkgs.neovim-developer.overrideAttrs (oa: {
-
             buildInputs = with pkgs;
               oa.buildInputs ++ [
                 cmake

--- a/contrib/lpeg.nix
+++ b/contrib/lpeg.nix
@@ -1,0 +1,24 @@
+{
+  luajit,
+  luajitPackages,
+  stdenv,
+  fixDarwinDylibNames,
+}:
+stdenv.mkDerivation {
+  pname = "liblpeg";
+  inherit (luajitPackages.lpeg) version meta src;
+  buildInputs = [luajit];
+  buildPhase = ''
+    sed -i makefile -e "s/CC = gcc/CC = clang/"
+    sed -i makefile -e "s/-bundle/-dynamiclib/"
+
+    make macosx
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mv lpeg.so $out/lib/lpeg.dylib
+  '';
+
+  nativeBuildInputs = [fixDarwinDylibNames];
+}


### PR DESCRIPTION
A quick fix for now, some relevant discussions are in https://github.com/NixOS/nixpkgs/issues/229275 (thanks nifoc)

There was a fix to FindLpeg.cmake since https://github.com/neovim/neovim/issues/23395 to address the first part of this (to use imported liblpeg), but Nix + darwin users never had much love from the second part - discover liblpeg's location.

There's also subtle difference in `CMAKE_SHARED_LIBRARY_SUFFIX` https://gitlab.kitware.com/cmake/cmake/-/issues/21189.

> macOS distinguishes between shared libraries and loadable modules.  CMAKE_SHARED_LIBRARY_SUFFIX is set to .dylib for shared libraries.  CMAKE_SHARED_MODULE_SUFFIX is set to .so for loadable modules (e.g. dlopen).  See the [add_library](https://cmake.org/cmake/help/v3.18/command/add_library.html#normal-libraries) command's SHARED and MODULE options.

lpeg's make always exports `liblpeg.so` for darwin via gcc; clang builds to `.dylib`. I'm still not an expert with C/C++ build system yet, let alone the Mach-O differences that leads to this.

~~I'd imagine a sister PR where it changes `CMAKE_SHARED_LIBRARY_SUFFIX` onto `CMAKE_SHARED_MODULE_SUFFIX` for a consistent `.so` output. I'm not sure how much this would break for other platforms.~~

EDIT: This does not work since neovim uses `clang` as a compiler backend and expects `.dylib` on darwin anyways

```
% ❯ nix build .#                                  
warning: Git tree '/Users/<>/local_repos/neovim' is dirty
error: builder for '/nix/store/1fk5q3jgp074gdkb1qx951lb9h9bq8s8-neovim-unwrapped-dirty.drv' failed with exit cod
e 2;
       last 10 log lines:
       > [  0%] Building C object src/nvim/CMakeFiles/nlua0.dir/__/mpack/mpack_core.c.o
       > [  0%] Building C object src/nvim/CMakeFiles/nlua0.dir/__/nlua0.c.o
       > -- Using NVIM_VERSION: v0.10.0-dev
       > [  0%] Built target update_version_stamp
       > [  0%] Linking C shared module ../../lib/libnlua0.so
       > ld: can't link with bundle (MH_BUNDLE) only dylibs (MH_DYLIB) file '/nix/store/v1byly3yi0q45psbbi14v1qq
ak6v5rak-luajit-2.1.0-2022-10-04-env/lib/lua/5.1/lpeg.so' for architecture arm64
       > clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
       > make[2]: *** [src/nvim/CMakeFiles/nlua0.dir/build.make:178: lib/libnlua0.so] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:616: src/nvim/CMakeFiles/nlua0.dir/all] Error 2
       > make: *** [Makefile:156: all] Error 2
       For full logs, run 'nix log /nix/store/1fk5q3jgp074gdkb1qx951lb9h9bq8s8-neovim-unwrapped-dirty.drv'.

```

https://github.com/neovim/neovim/blob/c26b39a9aa56e834262753e08372240fde9dcdf1/cmake/FindLpeg.cmake#L1