### PR TITLE
fix(provider): fix python3 provider cannot detect python3.12

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -26,7 +26,7 @@ endfunction
 
 function! s:get_python_candidates(major_version) abort
   return {
-        \ 3: ['python3', 'python3.10', 'python3.9', 'python3.8', 'python3.7', 'python']
+        \ 3: ['python3', 'python3.12', 'python3.11', 'python3.10', 'python3.9', 'python3.8', 'python3.7', 'python']
         \ }[a:major_version]
 endfunction
 
@@ -61,12 +61,11 @@ endfunction
 
 " Returns array: [prog_exitcode, prog_version]
 function! s:import_module(prog, module) abort
-  let prog_version = system([a:prog, '-c' , printf(
-        \ 'import sys; ' .
+  let prog_version = system([a:prog, '-W', 'ignore', '-c', printf(
+        \ 'import sys, importlib; ' .
         \ 'sys.path = [p for p in sys.path if p != ""]; ' .
         \ 'sys.stdout.write(str(sys.version_info[0]) + "." + str(sys.version_info[1])); ' .
-        \ 'import pkgutil; ' .
-        \ 'exit(2*int(pkgutil.get_loader("%s") is None))',
+        \ 'sys.exit(2 * int(importlib.util.find_spec("%s") is None))',
         \ a:module)])
   return [v:shell_error, prog_version]
 endfunction


### PR DESCRIPTION
PROBLEM: The builtin python3 provider cannot auto-detect python3.12
when g:python3_host_prog is not set. As a result, when python3 on $PATH
is currently python 3.12, neovim will fail to load python3 provider
and result in `has("python3") == 0`, e.g.,
"Failed to load python3 host. You can try to see what happened by ..."

ROOT CAUSE: the `system()` call from `provider#pythonx#DetectByModule`
does not ignore python warnings, and `pkgutil.get_loader` will print
a warning message in the very first line:
```
<string>:1: DeprecationWarning: 'pkgutil.get_loader' is deprecated and
slated for removal in Python 3.14; use importlib.util.find_spec() instead
```

SOLUTION:
- Use `importlib.util.find_spec` instead (python >= 3.4)
- Use `-W ignore` option to prevent any potential warning messages

WORKAROUND (for *old* neovim versions):

```lua
-- Put this in your init.lua before any has("python3") call
vim.g.python3_host_prog = "python3"
```
```vim
" Put this in your init.vim before any has("python3") call
let g:python3_host_prog = "python3"
```