### PR TITLE
refactor(options)!: graduate shortmess+=f flag

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -247,6 +247,9 @@ The following deprecated functions or APIs were removed.
 
 • Support for legacy treesitter injection queries is removed.
 
+• 'shortmess' flags:
+  - |shm-f| is removed. Always uses "(3 of 5)", never "(file 3 of 5)"
+
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5391,7 +5391,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	messages, for example  with CTRL-G, and to avoid some other messages.
 	It is a list of flags:
 	 flag	meaning when present	~
-	  f	use "(3 of 5)" instead of "(file 3 of 5)"		*shm-f*
 	  i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
 	  l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
 	  m	use "[+]" instead of "[Modified]"			*shm-m*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -727,6 +727,7 @@ Options:
     Everything is allowed in 'exrc' files since they must be explicitly marked
     trusted.
   *'shelltype'*
+  'shortmess' *shm-f* flag (always on, never show "file" in "(3 of 5)")
   *'shortname'* *'sn'* *'noshortname'* *'nosn'*
   *'swapsync'* *'sws'*
   *'termencoding'* *'tenc'* (Vim 7.4.852 also removed this for Windows)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5668,7 +5668,6 @@ vim.bo.sw = vim.bo.shiftwidth
 --- messages, for example  with CTRL-G, and to avoid some other messages.
 --- It is a list of flags:
 ---  flag	meaning when present	~
----   f	use "(3 of 5)" instead of "(file 3 of 5)"		*shm-f*
 ---   i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
 ---   l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
 ---   m	use "[+]" instead of "[Modified]"			*shm-m*

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3221,7 +3221,7 @@ void fileinfo(int fullname, int shorthelp, int dont_truncate)
               (int)curwin->w_cursor.col + 1, (int)curwin->w_virtcol + 1);
   }
 
-  (void)append_arg_number(curwin, buffer, IOSIZE, !shortmess(SHM_FILE));
+  (void)append_arg_number(curwin, buffer, IOSIZE);
 
   if (dont_truncate) {
     // Temporarily set msg_scroll to avoid the message being truncated.
@@ -3372,7 +3372,7 @@ void maketitle(void)
         *buf_p = NUL;
       }
 
-      append_arg_number(curwin, buf_p, (int)(SPACE_FOR_ARGNR - (size_t)(buf_p - buf)), false);
+      append_arg_number(curwin, buf_p, (int)(SPACE_FOR_ARGNR - (size_t)(buf_p - buf)));
 
       xstrlcat(buf_p, " - NVIM", (sizeof(buf) - (size_t)(buf_p - buf)));
 
@@ -3509,15 +3509,14 @@ void get_rel_pos(win_T *wp, char *buf, int buflen)
   }
 }
 
-/// Append (file 2 of 8) to "buf[buflen]", if editing more than one file.
+/// Append (2 of 8) to "buf[buflen]", if editing more than one file.
 ///
 /// @param          wp        window whose buffers to check
 /// @param[in,out]  buf       string buffer to add the text to
 /// @param          buflen    length of the string buffer
-/// @param          add_file  if true, add "file" before the arg number
 ///
 /// @return  true if it was appended.
-bool append_arg_number(win_T *wp, char *buf, int buflen, bool add_file)
+bool append_arg_number(win_T *wp, char *buf, int buflen)
   FUNC_ATTR_NONNULL_ALL
 {
   // Nothing to do
@@ -3525,17 +3524,7 @@ bool append_arg_number(win_T *wp, char *buf, int buflen, bool add_file)
     return false;
   }
 
-  const char *msg;
-  switch ((wp->w_arg_idx_invalid ? 1 : 0) + (add_file ? 2 : 0)) {
-  case 0:
-    msg = _(" (%d of %d)"); break;
-  case 1:
-    msg = _(" ((%d) of %d)"); break;
-  case 2:
-    msg = _(" (file %d of %d)"); break;
-  case 3:
-    msg = _(" (file (%d) of %d)"); break;
-  }
+  const char *msg = wp->w_arg_idx_invalid ? _(" ((%d) of %d)") : _(" (%d of %d)");
 
   char *p = buf + strlen(buf);  // go to the end of the buffer
   vim_snprintf(p, (size_t)(buflen - (p - buf)), msg, wp->w_arg_idx + 1, ARGCOUNT);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7247,7 +7247,6 @@ return {
         messages, for example  with CTRL-G, and to avoid some other messages.
         It is a list of flags:
          flag	meaning when present	~
-          f	use "(3 of 5)" instead of "(file 3 of 5)"		*shm-f*
           i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
           l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
           m	use "[+]" instead of "[Modified]"			*shm-m*

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1583,7 +1583,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, char *opt_n
 
       // Note: The call will only return true if it actually
       //       appended data to the `buf_tmp` buffer.
-      if (append_arg_number(wp, buf_tmp, (int)sizeof(buf_tmp), false)) {
+      if (append_arg_number(wp, buf_tmp, (int)sizeof(buf_tmp))) {
         str = buf_tmp;
       }
       break;


### PR DESCRIPTION
Not everything needs to be crazy overconfigurable.

Also fixes a warning in latest clang which doesn't approve of the funky math switch statement.