### PR TITLE
bugfix: syntax/gemtext: headers and preformatted text

### DIFF
--- a/runtime/syntax/gemtext.vim
+++ b/runtime/syntax/gemtext.vim
@@ -1,18 +1,18 @@
 " Vim syntax file
 " Language:             Gemtext markup language
 " Maintainer:           Suneel Freimuth <suneelfreimuth1@gmail.com>
-" Latest Revision:      2020-11-21
+" Latest Revision:      2023-09-23
 " Filenames:            *.gmi
 
 if exists('b:current_syntax')
     finish
 endif
 
-syntax match  Heading  /^#\{1,3}.\+$/
+syntax match  Heading  /^#\{1,3}[ \t].*$/
 syntax match  List     /^\* /
 syntax match  LinkURL  /^=>\s*\S\+/
 syntax match  Quote    /^>.\+/
-syntax region Preformatted start=/^```/ end=/```/
+syntax region Preformatted start=/^```/ end=/^```/
 
 highlight default link Heading  Special
 highlight default link List     Statement


### PR DESCRIPTION
- headers kan have no more than three levels
- both start and end marker for preformatted text should be at the start of the line