### PR TITLE
docs: do not use deprecated functions

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1680,7 +1680,7 @@ vim.print({...})                                                 *vim.print()*
     "Pretty prints" the given arguments and returns them unmodified.
 
     Example: >lua
-        local hl_normal = vim.print(vim.api.nvim_get_hl_by_name('Normal', true))
+        local hl_normal = vim.print(vim.api.nvim_get_hl(0, { name = 'Normal' }))
 <
 
     Return: ~

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -888,7 +888,7 @@ end
 --- Example:
 ---
 --- ```lua
---- local hl_normal = vim.print(vim.api.nvim_get_hl_by_name('Normal', true))
+--- local hl_normal = vim.print(vim.api.nvim_get_hl(0, { name = 'Normal' }))
 --- ```
 ---
 --- @see |vim.inspect()|

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -425,6 +425,7 @@ function vim.api.nvim_buf_get_number(buffer) end
 --- @return integer
 function vim.api.nvim_buf_get_offset(buffer, index) end
 
+--- @deprecated
 --- @param buffer integer
 --- @param name string
 --- @return any
@@ -632,6 +633,7 @@ function vim.api.nvim_buf_set_mark(buffer, name, line, col, opts) end
 --- @param name string Buffer name
 function vim.api.nvim_buf_set_name(buffer, name) end
 
+--- @deprecated
 --- @param buffer integer
 --- @param name string
 --- @param value any
@@ -1283,10 +1285,12 @@ function vim.api.nvim_get_mode() end
 --- @return table<string,any>
 function vim.api.nvim_get_namespaces() end
 
+--- @deprecated
 --- @param name string
 --- @return any
 function vim.api.nvim_get_option(name) end
 
+--- @deprecated
 --- @param name string
 --- @return table<string,any>
 function vim.api.nvim_get_option_info(name) end
@@ -1912,6 +1916,7 @@ function vim.api.nvim_set_hl_ns_fast(ns_id) end
 ---               "callback" is equivalent to returning an empty string.
 function vim.api.nvim_set_keymap(mode, lhs, rhs, opts) end
 
+--- @deprecated
 --- @param name string
 --- @param value any
 function vim.api.nvim_set_option(name, value) end
@@ -2115,6 +2120,7 @@ function vim.api.nvim_win_get_height(window) end
 --- @return integer
 function vim.api.nvim_win_get_number(window) end
 
+--- @deprecated
 --- @param window integer
 --- @param name string
 --- @return any
@@ -2197,6 +2203,7 @@ function vim.api.nvim_win_set_height(window, height) end
 --- @param ns_id integer the namespace to use
 function vim.api.nvim_win_set_hl_ns(window, ns_id) end
 
+--- @deprecated
 --- @param window integer
 --- @param name string
 --- @param value any

--- a/runtime/lua/vim/_options.lua
+++ b/runtime/lua/vim/_options.lua
@@ -127,7 +127,7 @@ end
 
 --- @param name string
 local function get_options_info(name)
-  local info = api.nvim_get_option_info(name)
+  local info = api.nvim_get_option_info2(name, {})
   info.metatype = get_option_metatype(name, info)
   return info
 end

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -518,6 +518,7 @@ static int64_t convert_index(int64_t index)
 /// @return         Option Information
 Dictionary nvim_get_option_info(String name, Error *err)
   FUNC_API_SINCE(7)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   return get_vimoption(name, OPT_GLOBAL, curbuf, curwin, err);
 }
@@ -531,6 +532,7 @@ Dictionary nvim_get_option_info(String name, Error *err)
 /// @param[out] err Error details, if any
 void nvim_set_option(uint64_t channel_id, String name, Object value, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   set_option_to(channel_id, NULL, SREQ_GLOBAL, name, value, err);
 }
@@ -543,6 +545,7 @@ void nvim_set_option(uint64_t channel_id, String name, Object value, Error *err)
 /// @return         Option value (global)
 Object nvim_get_option(String name, Arena *arena, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   return get_option_from(NULL, SREQ_GLOBAL, name, err);
 }
@@ -556,6 +559,7 @@ Object nvim_get_option(String name, Arena *arena, Error *err)
 /// @return Option value
 Object nvim_buf_get_option(Buffer buffer, String name, Arena *arena, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
@@ -577,6 +581,7 @@ Object nvim_buf_get_option(Buffer buffer, String name, Arena *arena, Error *err)
 /// @param[out] err   Error details, if any
 void nvim_buf_set_option(uint64_t channel_id, Buffer buffer, String name, Object value, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   buf_T *buf = find_buffer_by_handle(buffer, err);
 
@@ -596,6 +601,7 @@ void nvim_buf_set_option(uint64_t channel_id, Buffer buffer, String name, Object
 /// @return Option value
 Object nvim_win_get_option(Window window, String name, Arena *arena, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   win_T *win = find_window_by_handle(window, err);
 
@@ -617,6 +623,7 @@ Object nvim_win_get_option(Window window, String name, Arena *arena, Error *err)
 /// @param[out] err Error details, if any
 void nvim_win_set_option(uint64_t channel_id, Window window, String name, Object value, Error *err)
   FUNC_API_SINCE(1)
+  FUNC_API_DEPRECATED_SINCE(11)
 {
   win_T *win = find_window_by_handle(window, err);
 


### PR DESCRIPTION
Updating examples, type annotations, and internal usages to make sure we're not using deprecated stuff.