### PR TITLE
test(old): don't set options to default before every test

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -45,7 +45,7 @@ Defaults					            *nvim-defaults*
 - 'directory' defaults to ~/.local/state/nvim/swap// (|xdg|), auto-created
 - 'display' defaults to "lastline"
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
-- 'fillchars' defaults (in effect) to "vert:│,fold:·,sep:│"
+- 'fillchars' defaults (in effect) to "vert:│,fold:·,foldsep:│"
 - 'formatoptions' defaults to "tcqj"
 - 'fsync' is disabled
 - 'hidden' is enabled

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -4,7 +4,6 @@ if exists('s:did_load')
   set commentstring=/*%s*/
   set complete=.,w,b,u,t,i
   set define=^\\s*#\\s*define
-  set directory&
   set directory^=.
   set display=
   set fillchars=vert:\|,foldsep:\|,fold:-
@@ -21,13 +20,10 @@ if exists('s:did_load')
   set shortmess=filnxtToOS
   set sidescroll=0
   set tags=./tags,tags
-  set undodir&
   set undodir^=.
   set wildoptions=
   set startofline
-  set sessionoptions&
   set sessionoptions+=options
-  set viewoptions&
   set viewoptions+=options
   set switchbuf=
   if g:testname !~ 'test_mapping.vim$'
@@ -58,7 +54,6 @@ endfunc
 
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
-
 
 " Make sure 'runtimepath' and 'packpath' does not include $HOME.
 set rtp=$VIM/vimfiles,$VIMRUNTIME,$VIM/vimfiles/after

--- a/test/old/testdir/test_listchars.vim
+++ b/test/old/testdir/test_listchars.vim
@@ -506,7 +506,7 @@ func Test_listchars_composing()
   set list
 
   set listchars=eol:$,space:_,nbsp:=
-  
+
   let nbsp1 = nr2char(0xa0)
   let nbsp2 = nr2char(0x202f)
   call append(0, [
@@ -533,22 +533,22 @@ endfunc
 func Test_listchars_window_local()
   %bw!
   set list listchars&
-  let l:default_listchars = &listchars  " Accommodate Nvim default
+  let nvim_default = &listchars  " Accommodate Nvim default
   new
   " set a local value for 'listchars'
   setlocal listchars=tab:+-,eol:#
   call s:CheckListCharsValue('tab:+-,eol:#')
   " When local value is reset, global value should be used
   setlocal listchars=
-  call s:CheckListCharsValue(l:default_listchars)  " Accommodate Nvim default
+  call s:CheckListCharsValue(nvim_default)
   " Use 'setlocal <' to copy global value
   setlocal listchars=space:.,extends:>
   setlocal listchars<
-  call s:CheckListCharsValue(l:default_listchars)  " Accommodate Nvim default
+  call s:CheckListCharsValue(nvim_default)
   " Use 'set <' to copy global value
   setlocal listchars=space:.,extends:>
   set listchars<
-  call s:CheckListCharsValue(l:default_listchars)  " Accommodate Nvim default
+  call s:CheckListCharsValue(nvim_default)
   " Changing global setting should not change the local setting
   setlocal listchars=space:.,extends:>
   setglobal listchars=tab:+-,eol:#
@@ -558,7 +558,7 @@ func Test_listchars_window_local()
   call s:CheckListCharsValue('space:.,extends:>')
   " clearing local value in one window should not change the other window
   set listchars&
-  call s:CheckListCharsValue(l:default_listchars)  " Accommodate Nvim default
+  call s:CheckListCharsValue(nvim_default)
   close
   call s:CheckListCharsValue('space:.,extends:>')
 


### PR DESCRIPTION
Oldtests clean up after themselves, and the options that need operators
to align with Vim all deny duplicates, so there is no need to set them
to default.

Also make the variable name that test_listchars.vim uses to align with
Vim more obvious.
