### PR TITLE
docs: remove "f" from default 'shortmess' value

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -820,12 +820,10 @@ by the shell before executing the find program.
 When there is an argument list you can see which file you are editing in the
 title of the window (if there is one and 'title' is on) and with the file
 message you get with the "CTRL-G" command.  You will see something like
-	(file 4 of 11)
-If 'shortmess' contains 'f' it will be
 	(4 of 11)
 If you are not really editing the file at the current position in the argument
 list it will be
-	(file (4) of 11)
+	((4) of 11)
 This means that you are position 4 in the argument list, but not editing the
 fourth file in the argument list.  This happens when you do ":e file".
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5383,7 +5383,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 					*'shortmess'* *'shm'* *E1336*
-'shortmess' 'shm'	string	(default "filnxtToOCF")
+'shortmess' 'shm'	string	(default "ilnxtToOCF")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5719,7 +5719,7 @@ vim.bo.sw = vim.bo.shiftwidth
 ---     shm=at	Abbreviation, and truncate message when necessary.
 ---
 --- @type string
-vim.o.shortmess = "filnxtToOCF"
+vim.o.shortmess = "ilnxtToOCF"
 vim.o.shm = vim.o.shortmess
 vim.go.shortmess = vim.o.shortmess
 vim.go.shm = vim.go.shortmess

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7239,7 +7239,7 @@ return {
     {
       abbreviation = 'shm',
       cb = 'did_set_shortmess',
-      defaults = { if_true = 'filnxtToOCF' },
+      defaults = { if_true = 'ilnxtToOCF' },
       desc = [=[
         This option helps to avoid all the |hit-enter| prompts caused by file
         messages, for example  with CTRL-G, and to avoid some other messages.


### PR DESCRIPTION
The "f" flag was removed in f7da4722570617bd8927e7aa533fa9a608c45bba.
The value of the "f" flag is no longer listed in the 'shortmess'
description and it cannot be disabled, so having it in the default value
is pointless and confusing.
