### PR TITLE
vim-patch:9.0.{1931,1934}

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3442,9 +3442,20 @@ func Test_closing_autocmd_window()
   END
   call CheckScriptFailure(lines, 'E814:')
   au! BufEnter
-  only!
   bwipe Xa.txt
   bwipe Xb.txt
+endfunc
+
+func Test_switch_window_in_autocmd_window()
+  edit Xa.txt
+  tabnew Xb.txt
+  autocmd BufEnter Xa.txt wincmd w
+  doautoall BufEnter
+  au! BufEnter
+  bwipe Xa.txt
+  call assert_false(bufexists('Xa.txt'))
+  bwipe Xb.txt
+  call assert_false(bufexists('Xb.txt'))
 endfunc
 
 func Test_bufwipeout_changes_window()

--- a/test/old/testdir/test_compiler.vim
+++ b/test/old/testdir/test_compiler.vim
@@ -7,10 +7,8 @@ func Test_compiler()
   CheckExecutable perl
   CheckFeature quickfix
 
-  " $LANG changes the output of Perl.
-  if $LANG != ''
-    unlet $LANG
-  endif
+  let save_LC_ALL = $LC_ALL
+  let $LC_ALL= "C"
 
   " %:S does not work properly with 'shellslash' set
   let save_shellslash = &shellslash
@@ -40,12 +38,13 @@ func Test_compiler()
   let &shellslash = save_shellslash
   call delete('Xfoo.pl')
   bw!
+  let $LC_ALL = save_LC_ALL
 endfunc
 
 func GetCompilerNames()
   return glob('$VIMRUNTIME/compiler/*.vim', 0, 1)
-       \ ->map({i, v -> substitute(v, '.*[\\/]\([a-zA-Z0-9_\-]*\).vim', '\1', '')})
-       \ ->sort()
+        \ ->map({i, v -> substitute(v, '.*[\\/]\([a-zA-Z0-9_\-]*\).vim', '\1', '')})
+        \ ->sort()
 endfunc
 
 func Test_compiler_without_arg()

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -41,9 +41,9 @@ func AssertHighlightGroups(lnum, startcol, expected, trans = 1, msg = "")
 
   for l:i in range(a:startcol, a:startcol + l:expectedGroups->len() - 1)
     let l:errors += synID(a:lnum, l:i, a:trans)
-         \ ->synIDattr("name")
-         \ ->assert_equal(l:expectedGroups[l:i - 1],
-         \    l:msg .. l:i)
+          \ ->synIDattr("name")
+          \ ->assert_equal(l:expectedGroups[l:i - 1],
+          \    l:msg .. l:i)
   endfor
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.1931: make test_compilers fails on ubuntu

Problem:  make test_compilers fails on ubuntu
Solution: set LC_ALL=C

fix: make test_compiler failed on xubuntu 22.04.3

Problem: 'make test_compiler' failed on Linux xubuntu 22.04.3 but
         succeeded on e.g. macOS. To reproduce:
```
$ ./configure --with-features=huge --enable-gui=no --enable-perlinterp=yes
$ make -j12
$ cd vim/src/testdir
$ make test_compiler
...snip...
Found errors in Test_compiler():
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[601]..function RunTheTest[54]..Test_compiler line 24: command did not fail: clist
command line..script /home/dope/sb/vim/src/testdir/runtest.vim[601]..function RunTheTest[54]..Test_compiler line 30: Pattern '\\n \\d\\+ Xfoo.pl:3: Global symbol "$foo" requires explicit package name' does not match '\n19 Xfoo.pl:3: Global symbol "$foo" requires explicit package name (did you forget to declare "my $foo"?)'
make: *** [Makefile:70: test_compiler] Error 1
```
Solution: set `LC_ALL` to "C" in `Test_compiler()`

closes: vim/vim#13173

https://github.com/vim/vim/commit/ca0ffc0d63727850c520a80929698e4c199b17f4

Co-authored-by: Dominique Pellé <dominique.pelle@tomtom.com>


#### vim-patch:9.0.1934: :bwipe fails after switching window from aucmd_win.

Problem:  :bwipe fails after switching window from aucmd_win.
Solution: Decrement b_nwindows after switching back to aucmd_win.

closes: vim/vim#13160

https://github.com/vim/vim/commit/46bdae036ac4121e305fc3ed4ef3f9fc928dcb25