### PR TITLE
vim-patch:9.0.1938: multispace wrong when scrolling horizontally

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1539,6 +1539,25 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
       cts.cts_vcol += charsize;
       prev_ptr = cts.cts_ptr;
       MB_PTR_ADV(cts.cts_ptr);
+      if (wp->w_p_list) {
+        in_multispace = *prev_ptr == ' ' && (*cts.cts_ptr == ' '
+                                             || (prev_ptr > line && prev_ptr[-1] == ' '));
+        if (!in_multispace) {
+          multispace_pos = 0;
+        } else if (cts.cts_ptr >= line + leadcol
+                   && wp->w_p_lcs_chars.multispace != NULL) {
+          multispace_pos++;
+          if (wp->w_p_lcs_chars.multispace[multispace_pos] == NUL) {
+            multispace_pos = 0;
+          }
+        } else if (cts.cts_ptr < line + leadcol
+                   && wp->w_p_lcs_chars.leadmultispace != NULL) {
+          multispace_pos++;
+          if (wp->w_p_lcs_chars.leadmultispace[multispace_pos] == NUL) {
+            multispace_pos = 0;
+          }
+        }
+      }
     }
     wlv.vcol = cts.cts_vcol;
     ptr = cts.cts_ptr;
@@ -2367,9 +2386,12 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, bool number_onl
           }
         }
 
-        in_multispace = c == ' ' && ((ptr > line + 1 && ptr[-2] == ' ') || *ptr == ' ');
-        if (!in_multispace) {
-          multispace_pos = 0;
+        if (wp->w_p_list) {
+          in_multispace = c == ' ' && (*ptr == ' '
+                                       || (prev_ptr > line && prev_ptr[-1] == ' '));
+          if (!in_multispace) {
+            multispace_pos = 0;
+          }
         }
 
         // 'list': Change char 160 to 'nbsp' and space to 'space'.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1907,10 +1907,13 @@ void msg_prt_line(const char *s, int list)
       continue;
     } else {
       attr = 0;
-      c = (unsigned char)(*s++);
-      in_multispace = c == ' ' && ((col > 0 && s[-2] == ' ') || *s == ' ');
-      if (!in_multispace) {
-        multispace_pos = 0;
+      c = (uint8_t)(*s++);
+      if (list) {
+        in_multispace = c == ' ' && (*s == ' '
+                                     || (col > 0 && s[-2] == ' '));
+        if (!in_multispace) {
+          multispace_pos = 0;
+        }
       }
       if (c == TAB && (!list || curwin->w_p_lcs_chars.tab1)) {
         // tab amount depends on current column
@@ -1950,7 +1953,7 @@ void msg_prt_line(const char *s, int list)
         // the same in plain text.
         attr = HL_ATTR(HLF_0);
       } else if (c == ' ') {
-        if (list && lead != NULL && s <= lead && in_multispace
+        if (lead != NULL && s <= lead && in_multispace
             && curwin->w_p_lcs_chars.leadmultispace != NULL) {
           c = curwin->w_p_lcs_chars.leadmultispace[multispace_pos++];
           if (curwin->w_p_lcs_chars.leadmultispace[multispace_pos] == NUL) {
@@ -1963,7 +1966,7 @@ void msg_prt_line(const char *s, int list)
         } else if (trail != NULL && s > trail) {
           c = curwin->w_p_lcs_chars.trail;
           attr = HL_ATTR(HLF_0);
-        } else if (list && in_multispace
+        } else if (in_multispace
                    && curwin->w_p_lcs_chars.multispace != NULL) {
           c = curwin->w_p_lcs_chars.multispace[multispace_pos++];
           if (curwin->w_p_lcs_chars.multispace[multispace_pos] == NUL) {


### PR DESCRIPTION
#### vim-patch:9.0.1938: multispace wrong when scrolling horizontally

Problem:  multispace wrong when scrolling horizontally
Solution: Update position in "multispace" or "leadmultispace" also in
          skipped chars. Reorder conditions to be more consistent.

closes: vim/vim#13147

https://github.com/vim/vim/commit/abc808112ee5df58a9f612f2bb5a65389c2c14e1