### PR TITLE
vim-patch:790f9a890cee,960822a11f70

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7742,6 +7742,7 @@ strutf16len({string} [, {countcc}])                              *strutf16len()*
 		    echo strutf16len('😊')		" returns 2
 		    echo strutf16len('ą́')		" returns 1
 		    echo strutf16len('ą́', v:true)	" returns 3
+<
 
 strwidth({string})                                                  *strwidth()*
 		The result is a Number, which is the number of display cells

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -467,8 +467,8 @@ rust.vim Debugging ~
 		register.
 
 :RustInfoToFile [filename]                                   *:RustInfoToFile*
-		Saves debugging info of the Vim Rust plugin to the the given
-		file, overwritting it.
+		Saves debugging info of the Vim Rust plugin to the given file,
+		overwriting it.
 
 ==============================================================================
 MAPPINGS                                                       *rust-mappings*

--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -482,7 +482,7 @@ The function will be called with the list of arguments so far, and a second
 argument that is the name of the pty.
 							*gdb-version*
 Only debuggers fully compatible with gdb will work.  Vim uses the GDB/MI
-interface.  The "new-ui" command  requires gdb version 7.12 or later.  if you
+interface.  The "new-ui" command requires gdb version 7.12 or later.  If you
 get this error:
 	Undefined command: "new-ui". Try "help".~
 Then your gdb is too old.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -9192,6 +9192,7 @@ function vim.fn.strtrans(string) end
 ---     echo strutf16len('😊')    " returns 2
 ---     echo strutf16len('ą́')    " returns 1
 ---     echo strutf16len('ą́', v:true)  " returns 3
+--- <
 ---
 --- @param string string
 --- @param countcc? 0|1

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10973,7 +10973,7 @@ M.funcs = {
           echo strutf16len('😊')		" returns 2
           echo strutf16len('ą́')		" returns 1
           echo strutf16len('ą́', v:true)	" returns 3
-
+      <
     ]=],
     name = 'strutf16len',
     params = { { 'string', 'string' }, { 'countcc', '0|1' } },


### PR DESCRIPTION
#### vim-patch:790f9a890cee

runtime(doc): Add a missing '<' to the help of strutf16len() (vim/vim#13168)

https://github.com/vim/vim/commit/790f9a890ceeb9539776265cba0f026fb2c96790

Co-authored-by: a5ob7r <12132068+a5ob7r@users.noreply.github.com>


#### vim-patch:960822a11f70

runtime(doc): grammar fixes in doc (vim/vim#13164)

https://github.com/vim/vim/commit/960822a11f70d2ed7e78b42fb6b75a9f8839ec9f

Co-authored-by: Dominique Pellé <dominique.pelle@gmail.com>