### PR TITLE
fix(meta): cleanup lpeg meta

### DIFF
--- a/runtime/lua/vim/_meta/lpeg.lua
+++ b/runtime/lua/vim/_meta/lpeg.lua
@@ -42,7 +42,7 @@ local Pattern = {}
 --- @param pattern vim.lpeg.Pattern
 --- @param subject string
 --- @param init? integer
---- @return integer|vim.lpeg.Capture
+--- @return integer|vim.lpeg.Capture|nil
 function vim.lpeg.match(pattern, subject, init) end
 
 --- Matches the given `pattern` against the `subject` string. If the match succeeds, returns the
@@ -64,7 +64,7 @@ function vim.lpeg.match(pattern, subject, init) end
 ---
 --- @param subject string
 --- @param init? integer
---- @return integer|vim.lpeg.Capture
+--- @return integer|vim.lpeg.Capture|nil
 function Pattern:match(subject, init) end
 
 --- Returns the string `"pattern"` if the given value is a pattern, otherwise `nil`.

--- a/runtime/lua/vim/_meta/lpeg.lua
+++ b/runtime/lua/vim/_meta/lpeg.lua
@@ -7,7 +7,9 @@
 vim.lpeg = {}
 
 --- @class vim.lpeg.Pattern
+--- @operator unm: vim.lpeg.Pattern
 --- @operator add(vim.lpeg.Pattern): vim.lpeg.Pattern
+--- @operator sub(vim.lpeg.Pattern): vim.lpeg.Pattern
 --- @operator mul(vim.lpeg.Pattern): vim.lpeg.Pattern
 --- @operator mul(vim.lpeg.Capture): vim.lpeg.Pattern
 --- @operator div(string): vim.lpeg.Capture
@@ -15,17 +17,10 @@ vim.lpeg = {}
 --- @operator div(table): vim.lpeg.Capture
 --- @operator div(function): vim.lpeg.Capture
 --- @operator pow(number): vim.lpeg.Pattern
+--- @operator mod(function): nil
 local Pattern = {}
 
 --- @alias vim.lpeg.Capture vim.lpeg.Pattern
---- @operator add(vim.lpeg.Capture): vim.lpeg.Pattern
---- @operator mul(vim.lpeg.Capture): vim.lpeg.Pattern
---- @operator mul(vim.lpeg.Pattern): vim.lpeg.Pattern
---- @operator div(string): vim.lpeg.Capture
---- @operator div(number): vim.lpeg.Capture
---- @operator div(table): vim.lpeg.Capture
---- @operator div(function): vim.lpeg.Capture
---- @operator pow(number): vim.lpeg.Pattern
 
 --- Matches the given `pattern` against the `subject` string. If the match succeeds, returns the index in the
 --- subject of the first character after the match, or the captured values (if the pattern captured any value).


### PR DESCRIPTION
- Adding the operator annotation for `pattern1 - pattern2`, `-pattern` and `pattern % func`.
- Removing the redundant operator annotations from the `Capture` alias, since those are already defined in the `Pattern` type.
- Adding `|nil` to some return types.