### PR TITLE
refactor: remove 'shortmess' save/restore panic for ex commands

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2689,7 +2689,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
 
     // Obey the 'O' flag in 'cpoptions': overwrite any previous file
     // message.
-    if (shortmess(SHM_OVERALL) && !exiting && p_verbose == 0) {
+    if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
       msg_scroll = false;
     }
     if (!msg_scroll) {          // wait a bit when overwriting an error msg

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -105,7 +105,7 @@ void filemess(buf_T *buf, char *name, char *s, int attr)
   // For further ones overwrite the previous one, reset msg_scroll before
   // calling filemess().
   msg_scroll_save = msg_scroll;
-  if (shortmess(SHM_OVERALL) && !exiting && p_verbose == 0) {
+  if (shortmess(SHM_OVERALL) && !msg_listdo_overwrite && !exiting && p_verbose == 0) {
     msg_scroll = false;
   }
   if (!msg_scroll) {    // wait a bit when overwriting an error msg
@@ -316,7 +316,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     }
   }
 
-  if ((shortmess(SHM_OVER) || curbuf->b_help) && p_verbose == 0) {
+  if (((shortmess(SHM_OVER) && !msg_listdo_overwrite) || curbuf->b_help) && p_verbose == 0) {
     msg_scroll = false;         // overwrite previous file message
   } else {
     msg_scroll = true;          // don't overwrite previous file message

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -68,6 +68,8 @@ EXTERN int msg_scrolled_at_flush INIT(= 0);
 
 EXTERN int msg_grid_scroll_discount INIT(= 0);
 
+EXTERN int msg_listdo_overwrite INIT(= 0);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "message.h.generated.h"
 #endif

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -69,8 +69,6 @@ static const char e_backupext_and_patchmode_are_equal[]
   = N_("E589: 'backupext' and 'patchmode' are equal");
 static const char e_showbreak_contains_unprintable_or_wide_character[]
   = N_("E595: 'showbreak' contains unprintable or wide character");
-static const char e_internal_error_shortmess_too_long[]
-  = N_("E1336: Internal error: shortmess too long");
 
 static char *(p_ambw_values[]) = { "single", "double", NULL };
 static char *(p_bg_values[]) = { "light", "dark", NULL };
@@ -2267,36 +2265,6 @@ static int opt_strings_flags(const char *val, char **values, unsigned *flagp, bo
 int check_ff_value(char *p)
 {
   return check_opt_strings(p, p_ff_values, false);
-}
-
-static char shm_buf[SHM_LEN];
-static int set_shm_recursive = 0;
-
-/// Save the actual shortmess Flags and clear them temporarily to avoid that
-/// file messages overwrites any output from the following commands.
-///
-/// Caller must make sure to first call save_clear_shm_value() and then
-/// restore_shm_value() exactly the same number of times.
-void save_clear_shm_value(void)
-{
-  if (strlen(p_shm) >= SHM_LEN) {
-    iemsg(e_internal_error_shortmess_too_long);
-    return;
-  }
-
-  if (++set_shm_recursive == 1) {
-    STRCPY(shm_buf, p_shm);
-    set_option_value_give_err("shm", STATIC_CSTR_AS_OPTVAL(""), 0);
-  }
-}
-
-/// Restore the shortmess Flags set from the save_clear_shm_value() function.
-void restore_shm_value(void)
-{
-  if (--set_shm_recursive == 0) {
-    set_option_value_give_err("shm", CSTR_AS_OPTVAL(shm_buf), 0);
-    memset(shm_buf, 0, SHM_LEN);
-  }
 }
 
 static const char e_conflicts_with_value_of_listchars[]

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -3671,7 +3671,7 @@ endfunc
 func SetupVimTest_shm()
   let g:bwe = []
   let g:brp = []
-  set shortmess+=F
+  set shortmess-=l
   messages clear
 
   let dirname='XVimTestSHM'


### PR DESCRIPTION
This was only used to avoid the effect of SHM_OVERALL. This can easily
be handled in isolation, instead of clearing out all of 'shortmess' which
has unwanted side effects and mystifies what really is going on.