### PR TITLE
refactor(options)!: graduate some more shortmess flags

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -539,10 +539,10 @@ set to "dos", otherwise it is set to "unix".  When 'fileformats' includes
 "mac".
 
 If the 'fileformat' option is set to "dos" on non-MS-Windows systems the
-message "[dos format]" is shown to remind you that something unusual is
-happening.  On MS-Windows systems you get the message "[unix format]" if
-'fileformat' is set to "unix".  On all systems but the Macintosh you get the
-message "[mac format]" if 'fileformat' is set to "mac".
+message "[dos]" is shown to remind you that something unusual is happening.  On
+MS-Windows systems you get the message "[unix]" if 'fileformat' is set to
+"unix".  On all systems you get the message "[mac]" if 'fileformat' is set to
+"mac".
 
 If the 'fileformats' option is empty and DOS format is used, but while reading
 a file some lines did not end in <CR><NL>, "[CR missing]" will be included in
@@ -1056,14 +1056,14 @@ lost the original file.
 
 						*DOS-format-write*
 If the 'fileformat' is "dos", <CR><NL> is used for <EOL>.  This is default
-for Windows. On other systems the message "[dos format]" is shown to
+for Windows. On other systems the message "[dos]" is shown to
 remind you that an unusual <EOL> was used.
 						*Unix-format-write*
 If the 'fileformat' is "unix", <NL> is used for <EOL>.  On Windows
-the message "[unix format]" is shown.
+the message "[unix]" is shown.
 						*Mac-format-write*
-If the 'fileformat' is "mac", <CR> is used for <EOL>.  On non-Mac systems the
-message "[mac format]" is shown.
+If the 'fileformat' is "mac", <CR> is used for <EOL>.  The
+message "[mac]" is shown.
 
 See also |file-formats| and the 'fileformat' and 'fileformats' options.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -247,8 +247,11 @@ The following deprecated functions or APIs were removed.
 
 • Support for legacy treesitter injection queries is removed.
 
-• 'shortmess' flags:
-  - |shm-f| is removed. Always uses "(3 of 5)", never "(file 3 of 5)"
+• Removed 'shortmess' flags:
+  - |shm-f|. Always uses "(3 of 5)", never "(file 3 of 5)"
+  - |shm-i|. Always use "[noeol]".
+  - |shm-x|. Always use "[dos]", "[unix]" and "[mac]"
+  - |shm-n|. Always use "[New]".
 
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5383,22 +5383,17 @@ A jump table for the options with a short description can be found at |Q_op|.
 	function to get the effective shiftwidth value.
 
 					*'shortmess'* *'shm'* *E1336*
-'shortmess' 'shm'	string	(default "ilnxtToOCF")
+'shortmess' 'shm'	string	(default "ltToOCF")
 			global
 	This option helps to avoid all the |hit-enter| prompts caused by file
 	messages, for example  with CTRL-G, and to avoid some other messages.
 	It is a list of flags:
 	 flag	meaning when present	~
-	  i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
 	  l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
 	  m	use "[+]" instead of "[Modified]"			*shm-m*
-	  n	use "[New]" instead of "[New File]"			*shm-n*
 	  r	use "[RO]" instead of "[readonly]"			*shm-r*
 	  w	use "[w]" instead of "written" for file write message	*shm-w*
 		and "[a]" instead of "appended" for ':w >> file' command
-	  x	use "[dos]" instead of "[dos format]", "[unix]"		*shm-x*
-		instead of "[unix format]" and "[mac]" instead of "[mac
-		format]"
 	  a	all of the above abbreviations				*shm-a*
 
 	  o	overwrite message for writing a file with subsequent	*shm-o*

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -40,7 +40,7 @@ blank window. This is what your screen will look like:
 	|~					|
 	|~					|
 	|~					|
-	|"file.txt" [New file]			|
+	|"file.txt" [New]			|
 	+---------------------------------------+
 		('#' is the cursor position.)
 <

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -731,7 +731,7 @@ Options:
     Everything is allowed in 'exrc' files since they must be explicitly marked
     trusted.
   *'shelltype'*
-  'shortmess' *shm-f* flag (always on, never show "file" in "(3 of 5)")
+  'shortmess' flags: *shm-f* *shm-n* *shm-x* *shm-i* (behave like always on)
   *'shortname'* *'sn'* *'noshortname'* *'nosn'*
   *'swapsync'* *'sws'*
   *'termencoding'* *'tenc'* (Vim 7.4.852 also removed this for Windows)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5666,16 +5666,11 @@ vim.bo.sw = vim.bo.shiftwidth
 --- messages, for example  with CTRL-G, and to avoid some other messages.
 --- It is a list of flags:
 ---  flag	meaning when present	~
----   i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
 ---   l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
 ---   m	use "[+]" instead of "[Modified]"			*shm-m*
----   n	use "[New]" instead of "[New File]"			*shm-n*
 ---   r	use "[RO]" instead of "[readonly]"			*shm-r*
 ---   w	use "[w]" instead of "written" for file write message	*shm-w*
 --- 	and "[a]" instead of "appended" for ':w >> file' command
----   x	use "[dos]" instead of "[dos format]", "[unix]"		*shm-x*
---- 	instead of "[unix format]" and "[mac]" instead of "[mac
---- 	format]"
 ---   a	all of the above abbreviations				*shm-a*
 ---
 ---   o	overwrite message for writing a file with subsequent	*shm-o*
@@ -5719,7 +5714,7 @@ vim.bo.sw = vim.bo.shiftwidth
 ---     shm=at	Abbreviation, and truncate message when necessary.
 ---
 --- @type string
-vim.o.shortmess = "ilnxtToOCF"
+vim.o.shortmess = "ltToOCF"
 vim.o.shm = vim.o.shortmess
 vim.go.shortmess = vim.o.shortmess
 vim.go.shm = vim.go.shortmess

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3182,7 +3182,7 @@ void fileinfo(int fullname, int shorthelp, int dont_truncate)
                    (curbuf->b_flags & BF_NOTEDITED) && !dontwrite
                    ? _("[Not edited]") : "",
                    (curbuf->b_flags & BF_NEW) && !dontwrite
-                   ? new_file_message() : "",
+                   ? _("[New]") : "",
                    (curbuf->b_flags & BF_READERR)
                    ? _("[Read errors]") : "",
                    curbuf->b_p_ro

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1766,11 +1766,11 @@ restore_backup:
       xstrlcat(IObuff, _("[Device]"), IOSIZE);
       insert_space = true;
     } else if (newfile) {
-      xstrlcat(IObuff, new_file_message(), IOSIZE);
+      xstrlcat(IObuff, _("[New]"), IOSIZE);
       insert_space = true;
     }
     if (no_eol) {
-      msg_add_eol();
+      xstrlcat(IObuff, _("[noeol]"), IOSIZE);
       insert_space = true;
     }
     // may add [unix/dos/mac]

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -459,7 +459,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
       }
       if (!silent) {
         if (dir_of_file_exists(fname)) {
-          filemess(curbuf, sfname, new_file_message(), 0);
+          filemess(curbuf, sfname, _("[New]"), 0);
         } else {
           filemess(curbuf, sfname, _("[New DIRECTORY]"), 0);
         }
@@ -1718,7 +1718,7 @@ failed:
         c = true;
       }
       if (read_no_eol_lnum) {
-        msg_add_eol();
+        xstrlcat(IObuff, _("[noeol]"), IOSIZE);
         c = true;
       }
       if (ff_error == EOL_DOS) {
@@ -2064,11 +2064,6 @@ static void check_marks_read(void)
   curbuf->b_marks_read = true;
 }
 
-char *new_file_message(void)
-{
-  return shortmess(SHM_NEW) ? _("[New]") : _("[New File]");
-}
-
 /// Set the name of the current buffer.  Use when the buffer doesn't have a
 /// name and a ":r" or ":w" command with a file name is used.
 int set_rw_fname(char *fname, char *sfname)
@@ -2142,17 +2137,17 @@ bool msg_add_fileformat(int eol_type)
 {
 #ifndef USE_CRNL
   if (eol_type == EOL_DOS) {
-    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[dos]") : _("[dos format]"), IOSIZE);
+    xstrlcat(IObuff, _("[dos]"), IOSIZE);
     return true;
   }
 #endif
   if (eol_type == EOL_MAC) {
-    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[mac]") : _("[mac format]"), IOSIZE);
+    xstrlcat(IObuff, _("[mac]"), IOSIZE);
     return true;
   }
 #ifdef USE_CRNL
   if (eol_type == EOL_UNIX) {
-    xstrlcat(IObuff, shortmess(SHM_TEXT) ? _("[unix]") : _("[unix format]"), IOSIZE);
+    xstrlcat(IObuff, _("[unix]"), IOSIZE);
     return true;
   }
 #endif
@@ -2179,12 +2174,6 @@ void msg_add_lines(int insert_space, long lnum, off_T nchars)
                  NGETTEXT("%" PRId64 " byte", "%" PRId64 " bytes", nchars),
                  (int64_t)nchars);
   }
-}
-
-/// Append message for missing line separator to IObuff.
-void msg_add_eol(void)
-{
-  xstrlcat(IObuff, shortmess(SHM_LAST) ? _("[noeol]") : _("[Incomplete last line]"), IOSIZE);
 }
 
 bool time_differs(const FileInfo *file_info, long mtime, long mtime_ns) FUNC_ATTR_CONST

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -240,11 +240,7 @@ typedef enum {
 enum {
   SHM_RO             = 'r',  ///< Readonly.
   SHM_MOD            = 'm',  ///< Modified.
-  SHM_FILE           = 'f',  ///< (file 1 of 2)
-  SHM_LAST           = 'i',  ///< Last line incomplete.
-  SHM_TEXT           = 'x',  ///< tx instead of textmode.
   SHM_LINES          = 'l',  ///< "L" instead of "lines".
-  SHM_NEW            = 'n',  ///< "[New]" instead of "[New file]".
   SHM_WRI            = 'w',  ///< "[w]" instead of "written".
   SHM_ABBREVIATIONS  = 'a',  ///< Use abbreviations from #SHM_ALL_ABBREVIATIONS.
   SHM_WRITE          = 'W',  ///< Don't use "written" at all.
@@ -260,11 +256,10 @@ enum {
   SHM_RECORDING      = 'q',  ///< Short recording message.
   SHM_FILEINFO       = 'F',  ///< No file info messages.
   SHM_SEARCHCOUNT    = 'S',  ///< No search stats: '[1/10]'
-  SHM_LEN            = 30,   ///< Max length of all flags together plus a NUL character.
 };
 /// Represented by 'a' flag.
 #define SHM_ALL_ABBREVIATIONS ((char[]) { \
-    SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW, SHM_WRI, \
+    SHM_RO, SHM_MOD, SHM_LINES, SHM_WRI, \
     0 })
 
 // characters for p_go:

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7239,22 +7239,17 @@ return {
     {
       abbreviation = 'shm',
       cb = 'did_set_shortmess',
-      defaults = { if_true = 'ilnxtToOCF' },
+      defaults = { if_true = 'ltToOCF' },
       desc = [=[
         This option helps to avoid all the |hit-enter| prompts caused by file
         messages, for example  with CTRL-G, and to avoid some other messages.
         It is a list of flags:
          flag	meaning when present	~
-          i	use "[noeol]" instead of "[Incomplete last line]"	*shm-i*
           l	use "999L, 888B" instead of "999 lines, 888 bytes"	*shm-l*
           m	use "[+]" instead of "[Modified]"			*shm-m*
-          n	use "[New]" instead of "[New File]"			*shm-n*
           r	use "[RO]" instead of "[readonly]"			*shm-r*
           w	use "[w]" instead of "written" for file write message	*shm-w*
         	and "[a]" instead of "appended" for ':w >> file' command
-          x	use "[dos]" instead of "[dos format]", "[unix]"		*shm-x*
-        	instead of "[unix format]" and "[mac]" instead of "[mac
-        	format]"
           a	all of the above abbreviations				*shm-a*
 
           o	overwrite message for writing a file with subsequent	*shm-o*

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -132,11 +132,12 @@ static char *(p_rdb_values[]) = { "compositor", "nothrottle", "invalid", "nodelt
 static char *(p_sloc_values[]) = { "last", "statusline", "tabline", NULL };
 
 /// All possible flags for 'shm'.
-static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_FILE, SHM_LAST, SHM_TEXT, SHM_LINES, SHM_NEW,
+/// the literal chars before 0 are removed flags. these are safely ignored
+static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_LINES,
                           SHM_WRI, SHM_ABBREVIATIONS, SHM_WRITE, SHM_TRUNC, SHM_TRUNCALL,
                           SHM_OVER, SHM_OVERALL, SHM_SEARCH, SHM_ATTENTION, SHM_INTRO,
                           SHM_COMPLETIONMENU, SHM_COMPLETIONSCAN, SHM_RECORDING, SHM_FILEINFO,
-                          SHM_SEARCHCOUNT, 0, };
+                          SHM_SEARCHCOUNT, 'n', 'f', 'x', 'i', 0, };
 
 /// After setting various option values: recompute variables that depend on
 /// option values.


### PR DESCRIPTION
A lot of updated places in the docs were already incorrect since long since they did not reflect the default behaviour.

"[dos format]" could've been argued being better for discoverability but that ship has already sailed as it is no longer displayed by default.

Also, getting rid of some noise makes it easier to discover and focus on the 'shortmess' flags which _are_ somewhat useful to customize behavior.