### PR TITLE
fix(runtime): add commentstring for D ftplugin

### DIFF
--- a/runtime/ftplugin/d.lua
+++ b/runtime/ftplugin/d.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '/*%s*/'


### PR DESCRIPTION
Problem: No commentstring is set for D buffers after removing the default C-style commentstring

Same solution than neovim#23039