### PR TITLE
vim-patch:54e1f56cf2a5

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -39,8 +39,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-if (exists("b:is_bash") && (b:is_bash == 1)) ||
-      \ (exists("b:is_sh") && (b:is_sh == 1))
+if (exists("b:is_bash") && (b:is_bash == 1))
   if !has("gui_running") && executable("less")
     command! -buffer -nargs=1 Help silent exe '!bash -c "{ help "<args>" 2>/dev/null || man "<args>"; } | LESS= less"' | redraw!
   elseif has('terminal')


### PR DESCRIPTION
runtime(sh): only invoke bash help in ftplugin if it has been detected to be bash (vim/vim#13171)

https://github.com/vim/vim/commit/54e1f56cf2a5f74ee11baba170afff867e5d9f99

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
