### PR TITLE
fix: allow multiline message for echoerr

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8106,7 +8106,7 @@ void ex_execute(exarg_T *eap)
       // We don't want to abort following commands, restore did_emsg.
       int save_did_emsg = did_emsg;
       msg_ext_set_kind("echoerr");
-      emsg(ga.ga_data);
+      emsg_multiline(ga.ga_data, true);
       if (!force_abort) {
         did_emsg = save_did_emsg;
       }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -333,6 +333,36 @@ describe('ui/ext_messages', function()
     ]]}
   end)
 
+  it(':echoerr multiline', function()
+    exec_lua([[vim.g.multi = table.concat({ "bork", "fail" }, "\n")]])
+    feed(':echoerr g:multi<cr>')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={{
+      content = {{ "bork\nfail", 2 }},
+      kind = "echoerr"
+    }}}
+
+    feed(':messages<cr>')
+    screen:expect{grid=[[
+      ^                         |
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+      {1:~                        }|
+    ]], messages={{
+      content = {{ "Press ENTER or type command to continue", 4 }},
+      kind = "return_prompt"
+    }}, msg_history={{
+      content = {{ "bork\nfail", 2 }},
+      kind = "echoerr"
+    }}}
+  end)
+
   it('shortmess-=S', function()
     command('set shortmess-=S')
     feed('iline 1\nline 2<esc>')


### PR DESCRIPTION
### PROBLEM

Currently `:echoerr` prints multi-line strings in a single line
as `:echom` does (Note: `:echon` can print multi-line strings well).
This makes stacktrace printed via echoerr difficult to read.

Related to #25350

Example code:

    try
      lua error("lua stacktrace")
    catch
      echoerr v:exception
    endtry

Output:

    Error detected while processing a.vim[5]..a.vim:
    line    4:
    Vim(lua):E5108: Error executing lua [string ":lua"]:1: lua stacktrace^@stack traceback:^@^I[C]: in function 'error'^@^I[string ":lua"]:1: in main chunk

### SOLUTION

Allow echoerr to print multiline messages (e.g., lua exceptions),
because this command is usually used to print stacktraces.

Output after the fix:

    Error detected while processing a.vim[5]..a.vim:
    line    4:
    Vim(lua):E5108: Error executing lua [string ":lua"]:1: lua stacktrace
    stack traceback:
            [C]: in function 'error'
            [string ":lua"]:1: in main chunk
