### PR TITLE
vim-patch:8.2.3467: CursorHoldI event interferes with "CTRL-G U"

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -878,6 +878,10 @@ static int insert_handle_key(InsertState *s)
 
   case K_EVENT:       // some event
     state_handle_k_event();
+    // If CTRL-G U was used apply it to the next typed key.
+    if (dont_sync_undo == kTrue) {
+      dont_sync_undo = kNone;
+    }
     goto check_pum;
 
   case K_COMMAND:     // <Cmd>command<CR>

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -104,6 +104,22 @@ if has('timers')
     set updatetime&
   endfunc
 
+  func Test_cursorhold_insert_ctrl_g_U()
+    au CursorHoldI * :
+    set updatetime=20
+    new
+    call timer_start(100, { -> feedkeys("\<Left>foo\<Esc>", 't') })
+    call feedkeys("i()\<C-g>U", 'tx!')
+    sleep 200m
+    call assert_equal('(foo)', getline(1))
+    undo
+    call assert_equal('', getline(1))
+
+    bwipe!
+    au! CursorHoldI
+    set updatetime&
+  endfunc
+
   func Test_OptionSet_modeline()
     CheckFunction test_override
     call test_override('starting', 1)


### PR DESCRIPTION
#### vim-patch:8.2.3467: CursorHoldI event interferes with "CTRL-G U"

Problem:    CursorHoldI event interferes with "CTRL-G U". (Naohiro Ono)
Solution:   Restore the flag for "CTRL-G U" after triggering CursorHoldI.

https://github.com/vim/vim/commit/5a9357d0bff9059f547906d8d03b31bca7215af1

Co-authored-by: Bram Moolenaar <Bram@vim.org>
