### PR TITLE
refactor(options)!: unify interfaces for setting options

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -71,6 +71,10 @@ The following changes may require adaptations in user config or plugins.
   defined by LSP, and hence previously parsed snippets might now be considered
   invalid input.
 
+• |OptionSet| autocommand args |v:option_new|, |v:option_old|,
+  |v:option_oldlocal|, |v:option_oldglobal| now have the type of the option
+  instead of always being strings.
+
 ==============================================================================
 NEW FEATURES                                                    *news-features*
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -379,6 +379,9 @@ UI/Display:
 Variables:
   |v:progpath| is always absolute ("full")
   |v:windowid| is always available (for use by external UIs)
+  |OptionSet| autocommand args |v:option_new|, |v:option_old|,
+  |v:option_oldlocal|, |v:option_oldglobal| have the type of the option
+  instead of always being strings.
 
 Vimscript:
   |:redir| nested in |execute()| works.

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -133,47 +133,6 @@ static buf_T *do_ft_buf(char *filetype, aco_save_T *aco, Error *err)
   return ftbuf;
 }
 
-/// Consume an OptVal and convert it to an API Object.
-static Object optval_as_object(OptVal o)
-{
-  switch (o.type) {
-  case kOptValTypeNil:
-    return NIL;
-  case kOptValTypeBoolean:
-    switch (o.data.boolean) {
-    case kFalse:
-    case kTrue:
-      return BOOLEAN_OBJ(o.data.boolean);
-    case kNone:
-      return NIL;
-    }
-    UNREACHABLE;
-  case kOptValTypeNumber:
-    return INTEGER_OBJ(o.data.number);
-  case kOptValTypeString:
-    return STRING_OBJ(o.data.string);
-  }
-  UNREACHABLE;
-}
-
-/// Consume an API Object and convert it to an OptVal.
-static OptVal object_as_optval(Object o, bool *error)
-{
-  switch (o.type) {
-  case kObjectTypeNil:
-    return NIL_OPTVAL;
-  case kObjectTypeBoolean:
-    return BOOLEAN_OPTVAL(o.data.boolean);
-  case kObjectTypeInteger:
-    return NUMBER_OPTVAL((OptInt)o.data.integer);
-  case kObjectTypeString:
-    return STRING_OPTVAL(o.data.string);
-  default:
-    *error = true;
-    return NIL_OPTVAL;
-  }
-}
-
 /// Gets the value of an option. The behavior of this function matches that of
 /// |:set|: the local value of an option is returned if it exists; otherwise,
 /// the global value is returned. Local values always correspond to the current

--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -140,7 +140,7 @@ void alist_expand(int *fnum_list, int fnum_len)
   // Don't use 'suffixes' here.  This should work like the shell did the
   // expansion.  Also, the vimrc file isn't read yet, thus the user
   // can't set the options.
-  p_su = empty_option;
+  p_su = empty_string_option;
   for (int i = 0; i < GARGCOUNT; i++) {
     old_arg_files[i] = xstrdup(GARGLIST[i].ae_fname);
   }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2237,7 +2237,7 @@ int pattern_match(const char *pat, const char *text, bool ic)
 
   // avoid 'l' flag in 'cpoptions'
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
   regmatch.regprog = vim_regcomp(pat, RE_MAGIC + RE_STRING);
   if (regmatch.regprog != NULL) {
     regmatch.rm_ic = ic;
@@ -8645,7 +8645,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char 
 
   // Make 'cpoptions' empty, so that the 'l' flag doesn't work here
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   ga_init(&ga, 1, 200);
 
@@ -8710,7 +8710,7 @@ char *do_string_sub(char *str, char *pat, char *sub, typval_T *expr, const char 
 
   char *ret = xstrdup(ga.ga_data == NULL ? str : ga.ga_data);
   ga_clear(&ga);
-  if (p_cpo == empty_option) {
+  if (p_cpo == empty_string_option) {
     p_cpo = save_cpo;
   } else {
     // Darn, evaluating {sub} expression or {expr} changed the value.

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7226,6 +7226,17 @@ void set_vim_var_dict(const VimVarIndex idx, dict_T *const val)
   tv_dict_set_keys_readonly(val);
 }
 
+/// Set v:variable to tv.
+///
+/// @param[in]  idx  Index of variable to set.
+/// @param[in,out]  val  Value to set to. Reference count will be incremented.
+///                      Also keys of the dictionary will be made read-only.
+void set_vim_var_tv(const VimVarIndex idx, typval_T *const tv)
+{
+  tv_clear(&vimvars[idx].vv_di.di_tv);
+  vimvars[idx].vv_di.di_tv = *tv;
+}
+
 /// Set the v:argv list.
 void set_argv_var(char **argv, int argc)
 {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -482,7 +482,7 @@ buf_T *tv_get_buf(typval_T *tv, int curtab_only)
   int save_magic = p_magic;
   p_magic = true;
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   buf_T *buf = buflist_findnr(buflist_findpat(name, name + strlen(name),
                                               true, false, curtab_only));
@@ -1733,7 +1733,7 @@ static void f_expand(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   char *p_csl_save = p_csl;
 
   // avoid using 'completeslash' here
-  p_csl = empty_option;
+  p_csl = empty_string_option;
 #endif
 
   rettv->v_type = VAR_STRING;
@@ -4516,7 +4516,7 @@ static void find_some_match(typval_T *const argvars, typval_T *const rettv,
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   rettv->vval.v_number = -1;
   switch (type) {
@@ -7108,7 +7108,7 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   // Set the time limit, if there is one.
   proftime_T tm = profile_setlimit(time_limit);
@@ -7234,7 +7234,7 @@ long do_searchpair(const char *spat, const char *mpat, const char *epat, int dir
 
   xfree(pat2);
   xfree(pat3);
-  if (p_cpo == empty_option) {
+  if (p_cpo == empty_string_option) {
     p_cpo = save_cpo;
   } else {
     // Darn, evaluating the {skip} expression changed the value.
@@ -7966,7 +7966,7 @@ static void f_split(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *save_cpo = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   const char *str = tv_get_string(&argvars[0]);
   const char *pat = NULL;

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -822,7 +822,7 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
       if (curval.type == kOptValTypeNumber) {
         newval = NUMBER_OPTVAL(new_n);
       } else {
-        newval = BOOLEAN_OPTVAL(new_n == 0 ? kFalse : (new_n >= 1 ? kTrue : kNone));
+        newval = BOOLEAN_OPTVAL(TRISTATE_FROM_INT(new_n));
       }
     } else if (!hidden && is_string
                && curval.data.string.data != NULL && newval.data.string.data != NULL) {  // string
@@ -1875,8 +1875,7 @@ static OptVal tv_to_optval(typval_T *tv, const char *option, uint32_t flags, boo
         semsg(_("E521: Number required: &%s = '%s'"), option, tv->vval.v_string);
       }
     }
-    value = (flags & P_NUM) ? NUMBER_OPTVAL((OptInt)n)
-                            : BOOLEAN_OPTVAL(n == 0 ? kFalse : (n >= 1 ? kTrue : kNone));
+    value = (flags & P_NUM) ? NUMBER_OPTVAL((OptInt)n) : BOOLEAN_OPTVAL(TRISTATE_FROM_INT(n));
   } else if ((flags & P_STRING) || is_tty_option(option)) {
     // Avoid setting string option to a boolean or a special value.
     if (tv->v_type != VAR_BOOL && tv->v_type != VAR_SPECIAL) {

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -20,6 +20,7 @@
 #include "nvim/eval/encode.h"
 #include "nvim/eval/funcs.h"
 #include "nvim/eval/typval.h"
+#include "nvim/eval/typval_defs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/eval/vars.h"
 #include "nvim/eval/window.h"
@@ -1894,6 +1895,45 @@ static OptVal tv_to_optval(typval_T *tv, const char *option, uint32_t flags, boo
     *error = err;
   }
   return value;
+}
+
+/// Convert an option value to typval.
+///
+/// @param[in]  value  Option value to convert.
+///
+/// @return  OptVal converted to typval.
+typval_T optval_as_tv(OptVal value)
+{
+  typval_T rettv = { .v_type = VAR_SPECIAL, .vval = { .v_special = kSpecialVarNull } };
+
+  switch (value.type) {
+  case kOptValTypeNil:
+    break;
+  case kOptValTypeBoolean:
+    switch (value.data.boolean) {
+    case kTrue:
+      rettv.v_type = VAR_BOOL;
+      rettv.vval.v_bool = kBoolVarTrue;
+      break;
+    case kFalse:
+      rettv.v_type = VAR_BOOL;
+      rettv.vval.v_bool = kBoolVarFalse;
+      break;
+    case kNone:
+      break;  // return v:null for None boolean value
+    }
+    break;
+  case kOptValTypeNumber:
+    rettv.v_type = VAR_NUMBER;
+    rettv.vval.v_number = value.data.number;
+    break;
+  case kOptValTypeString:
+    rettv.v_type = VAR_STRING;
+    rettv.vval.v_string = value.data.string.data;
+    break;
+  }
+
+  return rettv;
 }
 
 /// Set option "varname" to the value of "varp" for the current buffer/window.

--- a/src/nvim/eval/vars.h
+++ b/src/nvim/eval/vars.h
@@ -2,6 +2,7 @@
 #define NVIM_EVAL_VARS_H
 
 #include "nvim/ex_cmds_defs.h"
+#include "nvim/option_defs.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "eval/vars.h.generated.h"

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -1342,7 +1342,7 @@ void ex_catch(exarg_T *eap)
           *end = NUL;
         }
         save_cpo = p_cpo;
-        p_cpo = empty_option;
+        p_cpo = empty_string_option;
         // Disable error messages, it will make current exception
         // invalid
         emsg_off++;

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -789,10 +789,11 @@ EXTERN char *escape_chars INIT(= " \t\\\"|");  // need backslash in cmd line
 
 EXTERN bool keep_help_flag INIT(= false);  // doing :ta from help file
 
-// When a string option is NULL (which only happens in out-of-memory
-// situations), it is set to empty_option, to avoid having to check for NULL
-// everywhere.
-EXTERN char *empty_option INIT(= "");
+// When a string option is NULL (which only happens in out-of-memory situations), it is set to
+// empty_string_option, to avoid having to check for NULL everywhere.
+//
+// TODO(famiu): Remove this when refcounted strings are used for string options.
+EXTERN char *empty_string_option INIT(= "");
 
 EXTERN bool redir_off INIT(= false);        // no redirection for a moment
 EXTERN FILE *redir_fd INIT(= NULL);         // message redirection file

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1878,8 +1878,8 @@ void clear_showcmd(void)
       char *const saved_w_sbr = curwin->w_p_sbr;
 
       // Make 'sbr' empty for a moment to get the correct size.
-      p_sbr = empty_option;
-      curwin->w_p_sbr = empty_option;
+      p_sbr = empty_string_option;
+      curwin->w_p_sbr = empty_string_option;
       getvcols(curwin, &curwin->w_cursor, &VIsual, &leftcol, &rightcol);
       p_sbr = saved_sbr;
       curwin->w_p_sbr = saved_w_sbr;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5365,8 +5365,8 @@ void cursor_pos_info(dict_T *dict)
         char *const saved_w_sbr = curwin->w_p_sbr;
 
         // Make 'sbr' empty for a moment to get the correct size.
-        p_sbr = empty_option;
-        curwin->w_p_sbr = empty_option;
+        p_sbr = empty_string_option;
+        curwin->w_p_sbr = empty_string_option;
         oparg.is_VIsual = true;
         oparg.motion_type = kMTBlockWise;
         oparg.op_type = OP_NOP;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1173,8 +1173,7 @@ static void do_set_option_string(int opt_idx, int opt_flags, char **argp, int ne
   // options. Note: when setting 'syntax' or 'filetype' autocommands may
   // be triggered that can cause havoc.
   *errmsg = did_set_string_option(curbuf, curwin, opt_idx, (char **)varp, oldval,
-                                  errbuf, errbuflen,
-                                  opt_flags, op, value_checked);
+                                  errbuf, errbuflen, opt_flags, value_checked);
 
   secure = secure_saved;
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3683,25 +3683,17 @@ static const char *set_option(const int opt_idx, void *varp, OptVal value, int o
   }
   if (did_set_cb != NULL) {
     // TODO(famiu): make os_oldval and os_newval use OptVal.
-    optset_T did_set_cb_args = (value.type == kOptValTypeNumber)
-                                 ? (optset_T){ .os_varp = varp,
-                                               .os_flags = opt_flags,
-                                               .os_oldval.number = old_value.data.number,
-                                               .os_newval.number = value.data.number,
-                                               .os_doskip = false,
-                                               .os_errbuf = NULL,
-                                               .os_errbuflen = 0,
-                                               .os_buf = curbuf,
-                                               .os_win = curwin }
-                                 : (optset_T){ .os_varp = varp,
-                                               .os_flags = opt_flags,
-                                               .os_oldval.boolean = old_value.data.boolean,
-                                               .os_newval.boolean = value.data.boolean,
-                                               .os_doskip = false,
-                                               .os_errbuf = NULL,
-                                               .os_errbuflen = 0,
-                                               .os_buf = curbuf,
-                                               .os_win = curwin };
+    optset_T did_set_cb_args = {
+      .os_varp = varp,
+      .os_flags = opt_flags,
+      .os_oldval = old_value.data,
+      .os_newval = value.data,
+      .os_doskip = false,
+      .os_errbuf = NULL,
+      .os_errbuflen = 0,
+      .os_buf = curbuf,
+      .os_win = curwin
+    };
 
     errmsg = did_set_cb(&did_set_cb_args);
     doskip = did_set_cb_args.os_doskip;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -761,7 +761,7 @@ static char *stropt_get_default_val(int opt_idx, uint64_t flags)
   // already expanded, only required when an environment variable was set
   // later
   if (newval == NULL) {
-    newval = empty_option;
+    newval = empty_string_option;
   } else if (!(options[opt_idx].flags & P_NO_DEF_EXP)) {
     char *s = option_expand(opt_idx, newval);
     if (s == NULL) {
@@ -2294,7 +2294,7 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
         if (buf->b_p_vsts_nopaste) {
           xfree(buf->b_p_vsts_nopaste);
         }
-        buf->b_p_vsts_nopaste = buf->b_p_vsts && buf->b_p_vsts != empty_option
+        buf->b_p_vsts_nopaste = buf->b_p_vsts && buf->b_p_vsts != empty_string_option
                                     ? xstrdup(buf->b_p_vsts)
                                     : NULL;
       }
@@ -2313,7 +2313,7 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
       if (p_vsts_nopaste) {
         xfree(p_vsts_nopaste);
       }
-      p_vsts_nopaste = p_vsts && p_vsts != empty_option ? xstrdup(p_vsts) : NULL;
+      p_vsts_nopaste = p_vsts && p_vsts != empty_string_option ? xstrdup(p_vsts) : NULL;
     }
 
     // Always set the option values, also when 'paste' is set when it is
@@ -2328,7 +2328,7 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
       if (buf->b_p_vsts) {
         free_string_option(buf->b_p_vsts);
       }
-      buf->b_p_vsts = empty_option;
+      buf->b_p_vsts = empty_string_option;
       XFREE_CLEAR(buf->b_p_vsts_array);
     }
 
@@ -2349,7 +2349,7 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
     if (p_vsts) {
       free_string_option(p_vsts);
     }
-    p_vsts = empty_option;
+    p_vsts = empty_string_option;
   } else if (old_p_paste) {
     // Paste switched from on to off: Restore saved values.
 
@@ -2363,9 +2363,9 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
       if (buf->b_p_vsts) {
         free_string_option(buf->b_p_vsts);
       }
-      buf->b_p_vsts = buf->b_p_vsts_nopaste ? xstrdup(buf->b_p_vsts_nopaste) : empty_option;
+      buf->b_p_vsts = buf->b_p_vsts_nopaste ? xstrdup(buf->b_p_vsts_nopaste) : empty_string_option;
       xfree(buf->b_p_vsts_array);
-      if (buf->b_p_vsts && buf->b_p_vsts != empty_option) {
+      if (buf->b_p_vsts && buf->b_p_vsts != empty_string_option) {
         (void)tabstop_set(buf->b_p_vsts, &buf->b_p_vsts_array);
       } else {
         buf->b_p_vsts_array = NULL;
@@ -2389,7 +2389,7 @@ static const char *did_set_paste(optset_T *args FUNC_ATTR_UNUSED)
     if (p_vsts) {
       free_string_option(p_vsts);
     }
-    p_vsts = p_vsts_nopaste ? xstrdup(p_vsts_nopaste) : empty_option;
+    p_vsts = p_vsts_nopaste ? xstrdup(p_vsts_nopaste) : empty_string_option;
   }
 
   old_p_paste = p_paste;
@@ -4789,8 +4789,8 @@ void win_copy_options(win_T *wp_from, win_T *wp_to)
 
 static char *copy_option_val(const char *val)
 {
-  if (val == empty_option) {
-    return empty_option;  // no need to allocate memory
+  if (val == empty_string_option) {
+    return empty_string_option;  // no need to allocate memory
   }
   return xstrdup(val);
 }
@@ -4837,7 +4837,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_cocu = copy_option_val(from->wo_cocu);
   to->wo_cole = from->wo_cole;
   to->wo_fdc = copy_option_val(from->wo_fdc);
-  to->wo_fdc_save = from->wo_diff_saved ? xstrdup(from->wo_fdc_save) : empty_option;
+  to->wo_fdc_save = from->wo_diff_saved ? xstrdup(from->wo_fdc_save) : empty_string_option;
   to->wo_fen = from->wo_fen;
   to->wo_fen_save = from->wo_fen_save;
   to->wo_fdi = copy_option_val(from->wo_fdi);
@@ -4845,7 +4845,7 @@ void copy_winopt(winopt_T *from, winopt_T *to)
   to->wo_fdl = from->wo_fdl;
   to->wo_fdl_save = from->wo_fdl_save;
   to->wo_fdm = copy_option_val(from->wo_fdm);
-  to->wo_fdm_save = from->wo_diff_saved ? xstrdup(from->wo_fdm_save) : empty_option;
+  to->wo_fdm_save = from->wo_diff_saved ? xstrdup(from->wo_fdm_save) : empty_string_option;
   to->wo_fdn = from->wo_fdn;
   to->wo_fde = copy_option_val(from->wo_fde);
   to->wo_fdt = copy_option_val(from->wo_fdt);
@@ -4867,7 +4867,7 @@ void check_win_options(win_T *win)
   check_winopt(&win->w_allbuf_opt);
 }
 
-/// Check for NULL pointers in a winopt_T and replace them with empty_option.
+/// Check for NULL pointers in a winopt_T and replace them with empty_string_option.
 static void check_winopt(winopt_T *wop)
 {
   check_string_option(&wop->wo_fdc);
@@ -5020,8 +5020,8 @@ void buf_copy_options(buf_T *buf, int flags)
           buf->b_p_ff = xstrdup(p_ff);
           break;
         }
-        buf->b_p_bh = empty_option;
-        buf->b_p_bt = empty_option;
+        buf->b_p_bh = empty_string_option;
+        buf->b_p_bt = empty_string_option;
       } else {
         free_buf_options(buf, false);
       }
@@ -5082,7 +5082,7 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_sts_nopaste = p_sts_nopaste;
       buf->b_p_vsts = xstrdup(p_vsts);
       COPY_OPT_SCTX(buf, BV_VSTS);
-      if (p_vsts && p_vsts != empty_option) {
+      if (p_vsts && p_vsts != empty_string_option) {
         (void)tabstop_set(p_vsts, &buf->b_p_vsts_array);
       } else {
         buf->b_p_vsts_array = NULL;
@@ -5118,7 +5118,7 @@ void buf_copy_options(buf_T *buf, int flags)
       COPY_OPT_SCTX(buf, BV_LOP);
 
       // Don't copy 'filetype', it must be detected
-      buf->b_p_ft = empty_option;
+      buf->b_p_ft = empty_string_option;
       buf->b_p_pi = p_pi;
       COPY_OPT_SCTX(buf, BV_PI);
       buf->b_p_cinw = xstrdup(p_cinw);
@@ -5126,10 +5126,10 @@ void buf_copy_options(buf_T *buf, int flags)
       buf->b_p_lisp = p_lisp;
       COPY_OPT_SCTX(buf, BV_LISP);
       // Don't copy 'syntax', it must be set
-      buf->b_p_syn = empty_option;
+      buf->b_p_syn = empty_string_option;
       buf->b_p_smc = p_smc;
       COPY_OPT_SCTX(buf, BV_SMC);
-      buf->b_s.b_syn_isk = empty_option;
+      buf->b_s.b_syn_isk = empty_string_option;
       buf->b_s.b_p_spc = xstrdup(p_spc);
       COPY_OPT_SCTX(buf, BV_SPC);
       (void)compile_cap_prog(&buf->b_s);
@@ -5143,7 +5143,7 @@ void buf_copy_options(buf_T *buf, int flags)
       COPY_OPT_SCTX(buf, BV_INDE);
       buf->b_p_indk = xstrdup(p_indk);
       COPY_OPT_SCTX(buf, BV_INDK);
-      buf->b_p_fp = empty_option;
+      buf->b_p_fp = empty_string_option;
       buf->b_p_fex = xstrdup(p_fex);
       COPY_OPT_SCTX(buf, BV_FEX);
       buf->b_p_sua = xstrdup(p_sua);
@@ -5162,30 +5162,30 @@ void buf_copy_options(buf_T *buf, int flags)
       // are not copied, start using the global value
       buf->b_p_ar = -1;
       buf->b_p_ul = NO_LOCAL_UNDOLEVEL;
-      buf->b_p_bkc = empty_option;
+      buf->b_p_bkc = empty_string_option;
       buf->b_bkc_flags = 0;
-      buf->b_p_gp = empty_option;
-      buf->b_p_mp = empty_option;
-      buf->b_p_efm = empty_option;
-      buf->b_p_ep = empty_option;
-      buf->b_p_kp = empty_option;
-      buf->b_p_path = empty_option;
-      buf->b_p_tags = empty_option;
-      buf->b_p_tc = empty_option;
+      buf->b_p_gp = empty_string_option;
+      buf->b_p_mp = empty_string_option;
+      buf->b_p_efm = empty_string_option;
+      buf->b_p_ep = empty_string_option;
+      buf->b_p_kp = empty_string_option;
+      buf->b_p_path = empty_string_option;
+      buf->b_p_tags = empty_string_option;
+      buf->b_p_tc = empty_string_option;
       buf->b_tc_flags = 0;
-      buf->b_p_def = empty_option;
-      buf->b_p_inc = empty_option;
+      buf->b_p_def = empty_string_option;
+      buf->b_p_inc = empty_string_option;
       buf->b_p_inex = xstrdup(p_inex);
       COPY_OPT_SCTX(buf, BV_INEX);
-      buf->b_p_dict = empty_option;
-      buf->b_p_tsr = empty_option;
-      buf->b_p_tsrfu = empty_option;
+      buf->b_p_dict = empty_string_option;
+      buf->b_p_tsr = empty_string_option;
+      buf->b_p_tsrfu = empty_string_option;
       buf->b_p_qe = xstrdup(p_qe);
       COPY_OPT_SCTX(buf, BV_QE);
       buf->b_p_udf = p_udf;
       COPY_OPT_SCTX(buf, BV_UDF);
-      buf->b_p_lw = empty_option;
-      buf->b_p_menc = empty_option;
+      buf->b_p_lw = empty_string_option;
+      buf->b_p_menc = empty_string_option;
 
       // Don't copy the options set by ex_help(), use the saved values,
       // when going from a help buffer to a non-help buffer.
@@ -5193,7 +5193,7 @@ void buf_copy_options(buf_T *buf, int flags)
       // or to a help buffer.
       if (dont_do_help) {
         buf->b_p_isk = save_p_isk;
-        if (p_vts && p_vts != empty_option && !buf->b_p_vts_array) {
+        if (p_vts && p_vts != empty_string_option && !buf->b_p_vts_array) {
           (void)tabstop_set(p_vts, &buf->b_p_vts_array);
         } else {
           buf->b_p_vts_array = NULL;
@@ -5206,7 +5206,7 @@ void buf_copy_options(buf_T *buf, int flags)
         COPY_OPT_SCTX(buf, BV_TS);
         buf->b_p_vts = xstrdup(p_vts);
         COPY_OPT_SCTX(buf, BV_VTS);
-        if (p_vts && p_vts != empty_option && !buf->b_p_vts_array) {
+        if (p_vts && p_vts != empty_string_option && !buf->b_p_vts_array) {
           (void)tabstop_set(p_vts, &buf->b_p_vts_array);
         } else {
           buf->b_p_vts_array = NULL;
@@ -6082,7 +6082,7 @@ char *get_showbreak_value(win_T *const win)
     return p_sbr;
   }
   if (strcmp(win->w_p_sbr, "NONE") == 0) {
-    return empty_option;
+    return empty_string_option;
   }
   return win->w_p_sbr;
 }

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -17,16 +17,17 @@ typedef enum {
   kOptValTypeString,
 } OptValType;
 
+typedef union {
+  // boolean options are actually tri-states because they have a third "None" value.
+  TriState boolean;
+  OptInt number;
+  String string;
+} OptValData;
+
 /// Option value
 typedef struct {
   OptValType type;
-
-  union {
-    // boolean options are actually tri-states because they have a third "None" value.
-    TriState boolean;
-    OptInt number;
-    String string;
-  } data;
+  OptValData data;
 } OptVal;
 
 /// :set operator types
@@ -46,19 +47,10 @@ typedef struct {
   int os_idx;
   int os_flags;
 
-  /// old value of the option (can be a string, number or a boolean)
-  union {
-    const OptInt number;
-    const bool boolean;
-    const char *string;
-  } os_oldval;
-
-  /// new value of the option (can be a string, number or a boolean)
-  union {
-    const OptInt number;
-    const bool boolean;
-    const char *string;
-  } os_newval;
+  /// Old value of the option.
+  OptValData os_oldval;
+  /// New value of the option.
+  OptValData os_newval;
 
   /// When set by the called function: Stop processing the option further.
   /// Currently only used for boolean options.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -45,7 +45,6 @@ typedef struct {
   void *os_varp;
   int os_idx;
   int os_flags;
-  set_op_T os_op;
 
   /// old value of the option (can be a string, number or a boolean)
   union {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6824,6 +6824,7 @@ return {
     },
     {
       abbreviation = 'sd',
+      cb = 'did_set_shada',
       defaults = {
         if_true = "!,'100,<50,s10,h",
         doc = [[for

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2119,20 +2119,11 @@ int expand_set_sessionoptions(optexpand_T *args, int *numMatches, char ***matche
                                matches);
 }
 
-static const char *did_set_shada(vimoption_T **opt, int *opt_idx, bool *free_oldval, char *errbuf,
-                                 size_t errbuflen)
+const char *did_set_shada(optset_T *args)
 {
-  static int shada_idx = -1;
-  // TODO(ZyX-I): Remove this code in the future, alongside with &viminfo
-  //              option.
-  *opt_idx = (((*opt)->fullname[0] == 'v')
-              ? (shada_idx == -1 ? ((shada_idx = findoption("shada"))) : shada_idx)
-              : *opt_idx);
-  *opt = get_option(*opt_idx);
-  // Update free_oldval now that we have the opt_idx for 'shada', otherwise
-  // there would be a disconnect between the check for P_ALLOCED at the start
-  // of the function and the set of P_ALLOCED at the end of the function.
-  *free_oldval = ((*opt)->flags & P_ALLOCED);
+  char *errbuf = args->os_errbuf;
+  size_t errbuflen = args->os_errbuflen;
+
   for (char *s = p_shada; *s;) {
     // Check it's a valid character
     if (vim_strchr("!\"%'/:<@cfhnrs", (uint8_t)(*s)) == NULL) {
@@ -2784,8 +2775,6 @@ const char *did_set_string_option(buf_T *buf, win_T *win, int opt_idx, char **va
     // The 'isident', 'iskeyword', 'isprint' and 'isfname' options may
     // change the character table.  On failure, this needs to be restored.
     restore_chartab = args.os_restore_chartab;
-  } else if (varp == &p_shada) {                        // 'shada'
-    errmsg = did_set_shada(&opt, &opt_idx, &free_oldval, errbuf, errbuflen);
   }
 
   // If an error is detected, restore the previous value.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -442,7 +442,8 @@ void set_string_option_direct_in_buf(buf_T *buf, const char *name, int opt_idx, 
 ///
 /// @return NULL on success, an untranslated error message on error.
 const char *set_string_option(const int opt_idx, void *varp, const char *value, const int opt_flags,
-                              bool *value_checked, char *const errbuf, const size_t errbuflen)
+                              const bool new_value, bool *value_checked, char *const errbuf,
+                              const size_t errbuflen)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   vimoption_T *opt = get_option(opt_idx);
@@ -492,13 +493,12 @@ const char *set_string_option(const int opt_idx, void *varp, const char *value, 
   char *const saved_newval = xstrdup(*(char **)varp);
 
   const int secure_saved = secure;
+  const uint32_t *p = insecure_flag(curwin, opt_idx, opt_flags);
 
-  // When an option is set in the sandbox, from a modeline or in secure
-  // mode, then deal with side effects in secure mode.  Also when the
-  // value was set with the P_INSECURE flag and is not completely
-  // replaced.
-  if ((opt_flags & OPT_MODELINE)
-      || sandbox != 0) {
+  // When an option is set in the sandbox, from a modeline or in secure mode, then deal with side
+  // effects in secure mode. Also when the value was set with the P_INSECURE flag and is not
+  // completely replaced.
+  if ((opt_flags & OPT_MODELINE) || sandbox != 0 || (!new_value && (*p & P_INSECURE))) {
     secure = 1;
   }
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -503,8 +503,7 @@ const char *set_string_option(const int opt_idx, void *varp, const char *value, 
   }
 
   const char *const errmsg = did_set_string_option(curbuf, curwin, opt_idx, varp, oldval,
-                                                   errbuf, errbuflen,
-                                                   opt_flags, OP_NONE, value_checked);
+                                                   errbuf, errbuflen, opt_flags, value_checked);
 
   secure = secure_saved;
 
@@ -2741,7 +2740,7 @@ static void do_spelllang_source(win_T *win)
 ///
 /// @return  NULL for success, or an untranslated error message for an error
 const char *did_set_string_option(buf_T *buf, win_T *win, int opt_idx, char **varp, char *oldval,
-                                  char *errbuf, size_t errbuflen, int opt_flags, set_op_T op,
+                                  char *errbuf, size_t errbuflen, int opt_flags,
                                   bool *value_checked)
 {
   const char *errmsg = NULL;
@@ -2755,7 +2754,6 @@ const char *did_set_string_option(buf_T *buf, win_T *win, int opt_idx, char **va
     .os_varp = varp,
     .os_idx = opt_idx,
     .os_flags = opt_flags,
-    .os_op = op,
     .os_oldval.string = oldval,
     .os_newval.string = *varp,
     .os_value_checked = false,

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -441,14 +441,13 @@ void set_string_option_direct_in_buf(buf_T *buf, const char *name, int opt_idx, 
 ///                        #OPT_GLOBAL.
 ///
 /// @return NULL on success, an untranslated error message on error.
-const char *set_string_option(const int opt_idx, void *varp_arg, const char *value,
+const char *set_string_option(const int opt_idx, void *varp, const char *value,
                               const int opt_flags, bool *value_checked, char *const errbuf,
                               const size_t errbuflen)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   vimoption_T *opt = get_option(opt_idx);
 
-  void *varp = (char **)varp_arg;
   char *origval_l = NULL;
   char *origval_g = NULL;
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -441,9 +441,8 @@ void set_string_option_direct_in_buf(buf_T *buf, const char *name, int opt_idx, 
 ///                        #OPT_GLOBAL.
 ///
 /// @return NULL on success, an untranslated error message on error.
-const char *set_string_option(const int opt_idx, void *varp, const char *value,
-                              const int opt_flags, bool *value_checked, char *const errbuf,
-                              const size_t errbuflen)
+const char *set_string_option(const int opt_idx, void *varp, const char *value, const int opt_flags,
+                              bool *value_checked, char *const errbuf, const size_t errbuflen)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
   vimoption_T *opt = get_option(opt_idx);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -287,29 +287,28 @@ void check_buf_options(buf_T *buf)
 }
 
 /// Free the string allocated for an option.
-/// Checks for the string being empty_option. This may happen if we're out of
-/// memory, xstrdup() returned NULL, which was replaced by empty_option by
-/// check_options().
+/// Checks for the string being empty_string_option. This may happen if we're out of memory,
+/// xstrdup() returned NULL, which was replaced by empty_string_option by check_options().
 /// Does NOT check for P_ALLOCED flag!
 void free_string_option(char *p)
 {
-  if (p != empty_option) {
+  if (p != empty_string_option) {
     xfree(p);
   }
 }
 
 void clear_string_option(char **pp)
 {
-  if (*pp != empty_option) {
+  if (*pp != empty_string_option) {
     xfree(*pp);
   }
-  *pp = empty_option;
+  *pp = empty_string_option;
 }
 
 void check_string_option(char **pp)
 {
   if (*pp == NULL) {
-    *pp = empty_option;
+    *pp = empty_string_option;
   }
 }
 
@@ -385,7 +384,7 @@ void set_string_option_direct(const char *name, int opt_idx, const char *val, in
     // make the local value empty, so that the global value is used.
     if ((opt->indir & PV_BOTH) && both) {
       free_string_option(*varp);
-      *varp = empty_option;
+      *varp = empty_string_option;
     }
     if (set_sid != SID_NONE) {
       sctx_T script_ctx;
@@ -468,7 +467,7 @@ const char *set_string_option(const int opt_idx, void *varp, const char *value, 
 
     // A global-local string option might have an empty option as value to
     // indicate that the global value should be used.
-    if (((int)opt->indir & PV_BOTH) && origval_l == empty_option) {
+    if (((int)opt->indir & PV_BOTH) && origval_l == empty_string_option) {
       origval_l = origval_g;
     }
   }
@@ -482,7 +481,7 @@ const char *set_string_option(const int opt_idx, void *varp, const char *value, 
     origval = oldval;
   }
 
-  *(char **)varp = xstrdup(value != NULL ? value : empty_option);
+  *(char **)varp = xstrdup(value != NULL ? value : empty_string_option);
 
   char *const saved_origval = (origval != NULL) ? xstrdup(origval) : NULL;
   char *const saved_oldval_l = (origval_l != NULL) ? xstrdup(origval_l) : 0;
@@ -2814,7 +2813,7 @@ const char *did_set_string_option(buf_T *buf, win_T *win, int opt_idx, char **va
       // the local value and make it empty
       char *p = get_varp_scope(opt, OPT_LOCAL);
       free_string_option(*(char **)p);
-      *(char **)p = empty_option;
+      *(char **)p = empty_string_option;
     } else if (!(opt_flags & OPT_LOCAL) && opt_flags != OPT_GLOBAL) {
       // May set global value for local option.
       set_string_option_global(opt, varp);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -860,7 +860,7 @@ int expand_set_backspace(optexpand_T *args, int *numMatches, char ***matches)
 const char *did_set_backupcopy(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
-  const char *oldval = args->os_oldval.string;
+  const char *oldval = args->os_oldval.string.data;
   int opt_flags = args->os_flags;
   char *bkc = p_bkc;
   unsigned *flags = &bkc_flags;
@@ -1459,7 +1459,7 @@ const char *did_set_fileformat(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
   char **varp = (char **)args->os_varp;
-  const char *oldval = args->os_oldval.string;
+  const char *oldval = args->os_oldval.string.data;
   int opt_flags = args->os_flags;
   if (!MODIFIABLE(buf) && !(opt_flags & OPT_GLOBAL)) {
     return e_modifiable;
@@ -1512,7 +1512,7 @@ const char *did_set_filetype_or_syntax(optset_T *args)
     return e_invarg;
   }
 
-  args->os_value_changed = strcmp(args->os_oldval.string, *varp) != 0;
+  args->os_value_changed = strcmp(args->os_oldval.string.data, *varp) != 0;
 
   // Since we check the value, there is no need to set P_INSECURE,
   // even when the value comes from a modeline.
@@ -2103,7 +2103,7 @@ const char *did_set_sessionoptions(optset_T *args)
   }
   if ((ssop_flags & SSOP_CURDIR) && (ssop_flags & SSOP_SESDIR)) {
     // Don't allow both "sesdir" and "curdir".
-    const char *oldval = args->os_oldval.string;
+    const char *oldval = args->os_oldval.string.data;
     (void)opt_strings_flags(oldval, p_ssop_values, &ssop_flags, true);
     return e_invarg;
   }
@@ -2224,7 +2224,7 @@ const char *did_set_signcolumn(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
-  const char *oldval = args->os_oldval.string;
+  const char *oldval = args->os_oldval.string.data;
   if (check_signcolumn(*varp) != OK) {
     return e_invarg;
   }
@@ -2578,7 +2578,7 @@ const char *did_set_virtualedit(optset_T *args)
   } else {
     if (opt_strings_flags(ve, p_ve_values, flags, true) != OK) {
       return e_invarg;
-    } else if (strcmp(ve, args->os_oldval.string) != 0) {
+    } else if (strcmp(ve, args->os_oldval.string.data) != 0) {
       // Recompute cursor position in case the new 've' setting
       // changes something.
       validate_virtcol_win(win);
@@ -2753,8 +2753,8 @@ const char *did_set_string_option(buf_T *buf, win_T *win, int opt_idx, char **va
     .os_varp = varp,
     .os_idx = opt_idx,
     .os_flags = opt_flags,
-    .os_oldval.string = oldval,
-    .os_newval.string = *varp,
+    .os_oldval.string = cstr_as_string(oldval),
+    .os_newval.string = cstr_as_string(*varp),
     .os_value_checked = false,
     .os_value_changed = false,
     .os_restore_chartab = false,

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2596,7 +2596,7 @@ static int qf_open_new_file_win(qf_info_T *ll_ref)
   if (win_split(0, flags) == FAIL) {
     return FAIL;  // not enough room for window
   }
-  p_swb = empty_option;  // don't split again
+  p_swb = empty_string_option;  // don't split again
   swb_flags = 0;
   RESET_BINDING(curwin);
   if (ll_ref != NULL) {
@@ -3073,7 +3073,7 @@ theend:
     qfl->qf_ptr = qf_ptr;
     qfl->qf_index = qf_index;
   }
-  if (p_swb != old_swb && p_swb == empty_option) {
+  if (p_swb != old_swb && p_swb == empty_string_option) {
     // Restore old 'switchbuf' value, but not when an autocommand or
     // modeline has changed the value.
     p_swb = old_swb;
@@ -7201,7 +7201,7 @@ void ex_helpgrep(exarg_T *eap)
   // Make 'cpoptions' empty, the 'l' flag should not be used here.
   char *const save_cpo = p_cpo;
   const bool save_cpo_allocated = is_option_allocated("cpo");
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
 
   bool new_qi = false;
   if (is_loclist_cmd(eap->cmdidx)) {
@@ -7232,7 +7232,7 @@ void ex_helpgrep(exarg_T *eap)
     updated = true;
   }
 
-  if (p_cpo == empty_option) {
+  if (p_cpo == empty_string_option) {
     p_cpo = save_cpo;
   } else {
     // Darn, some plugin changed the value.  If it's still empty it was

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -729,7 +729,7 @@ static void syn_sync(win_T *wp, linenr_T start_lnum, synstate_T *last_valid)
 
 static void save_chartab(char *chartab)
 {
-  if (syn_block->b_syn_isk == empty_option) {
+  if (syn_block->b_syn_isk == empty_string_option) {
     return;
   }
 
@@ -739,7 +739,7 @@ static void save_chartab(char *chartab)
 
 static void restore_chartab(char *chartab)
 {
-  if (syn_win->w_s->b_syn_isk != empty_option) {
+  if (syn_win->w_s->b_syn_isk != empty_string_option) {
     memmove(syn_buf->b_chartab, chartab, (size_t)32);
   }
 }
@@ -2946,7 +2946,7 @@ static void syn_cmd_iskeyword(exarg_T *eap, int syncing)
   arg = skipwhite(arg);
   if (*arg == NUL) {
     msg_puts("\n");
-    if (curwin->w_s->b_syn_isk != empty_option) {
+    if (curwin->w_s->b_syn_isk != empty_string_option) {
       msg_puts("syntax iskeyword ");
       msg_outtrans(curwin->w_s->b_syn_isk, 0);
     } else {
@@ -4758,7 +4758,7 @@ static char *get_syn_pattern(char *arg, synpat_T *ci)
 
   // Make 'cpoptions' empty, to avoid the 'l' flag
   char *cpo_save = p_cpo;
-  p_cpo = empty_option;
+  p_cpo = empty_string_option;
   ci->sp_prog = vim_regcomp(ci->sp_pattern, RE_MAGIC);
   p_cpo = cpo_save;
 
@@ -4915,7 +4915,7 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
 
         // Make 'cpoptions' empty, to avoid the 'l' flag
         cpo_save = p_cpo;
-        p_cpo = empty_option;
+        p_cpo = empty_string_option;
         curwin->w_s->b_syn_linecont_prog =
           vim_regcomp(curwin->w_s->b_syn_linecont_pat, RE_MAGIC);
         p_cpo = cpo_save;
@@ -5298,7 +5298,7 @@ void ex_ownsyntax(exarg_T *eap)
     hash_init(&curwin->w_s->b_keywtab_ic);
     // TODO(vim): Keep the spell checking as it was.
     curwin->w_p_spell = false;  // No spell checking
-    // make sure option values are "empty_option" instead of NULL
+    // make sure option values are "empty_string_option" instead of NULL
     clear_string_option(&curwin->w_s->b_p_spc);
     clear_string_option(&curwin->w_s->b_p_spf);
     clear_string_option(&curwin->w_s->b_p_spl);

--- a/src/nvim/types.h
+++ b/src/nvim/types.h
@@ -42,6 +42,8 @@ typedef enum {
 #define TRISTATE_TO_BOOL(val, \
                          default) ((val) == kTrue ? true : ((val) == kFalse ? false : (default)))
 
+#define TRISTATE_FROM_INT(val) ((val) == 0 ? kFalse : ((val) >= 1 ? kTrue : kNone))
+
 typedef struct Decoration Decoration;
 
 #ifndef ORDER_BIG_ENDIAN

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -48,10 +48,10 @@ end
 local function expected_table(option, oldval, oldval_l, oldval_g, newval, scope, cmd, attr)
   return {
     option   = option,
-    oldval   = tostring(oldval),
-    oldval_l = tostring(oldval_l),
-    oldval_g = tostring(oldval_g),
-    newval   = tostring(newval),
+    oldval   = oldval,
+    oldval_l = oldval_l,
+    oldval_g = oldval_g,
+    newval   = newval,
     scope    = scope,
     cmd      = cmd,
     attr     = attr,
@@ -129,44 +129,44 @@ describe('au OptionSet', function()
 
     it('should be called in setting number option', function()
       command('set nu')
-      expected_combination({'number', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'number', false, false, false, true, 'global', 'set'})
 
       command('setlocal nonu')
-      expected_combination({'number', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'number', true, true, '', false, 'local', 'setlocal'})
 
       command('setglobal nonu')
-      expected_combination({'number', 1, '', 1, 0, 'global', 'setglobal'})
+      expected_combination({'number', true, '', true, false, 'global', 'setglobal'})
     end)
 
     it('should be called in setting autoindent option',function()
       command('setlocal ai')
-      expected_combination({'autoindent', 0, 0, '', 1, 'local', 'setlocal'})
+      expected_combination({'autoindent', false, false, '', true, 'local', 'setlocal'})
 
       command('setglobal ai')
-      expected_combination({'autoindent', 0, '', 0, 1, 'global', 'setglobal'})
+      expected_combination({'autoindent', false, '', false, true, 'global', 'setglobal'})
 
       command('set noai')
-      expected_combination({'autoindent', 1, 1, 1, 0, 'global', 'set'})
+      expected_combination({'autoindent', true, true, true, false, 'global', 'set'})
     end)
 
     it('should be called in inverting global autoindent option',function()
       command('set ai!')
-      expected_combination({'autoindent', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'autoindent', false, false, false, true, 'global', 'set'})
     end)
 
     it('should be called in being unset local autoindent option',function()
       command('setlocal ai')
-      expected_combination({'autoindent', 0, 0, '', 1, 'local', 'setlocal'})
+      expected_combination({'autoindent', false, false, '', true, 'local', 'setlocal'})
 
       command('setlocal ai<')
-      expected_combination({'autoindent', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'autoindent', true, true, '', false, 'local', 'setlocal'})
     end)
 
     it('should be called in setting global list and number option at the same time',function()
       command('set list nu')
       expected_combination(
-        {'list', 0, 0, 0, 1, 'global', 'set'},
-        {'number', 0, 0, 0, 1, 'global', 'set'}
+        {'list', false, false, false, true, 'global', 'set'},
+        {'number', false, false, false, true, 'global', 'set'}
       )
     end)
 
@@ -177,20 +177,20 @@ describe('au OptionSet', function()
 
     it('should be called in setting local acd', function()
       command('setlocal acd')
-      expected_combination({'autochdir', 0, 0, '', 1, 'local', 'setlocal'})
+      expected_combination({'autochdir', false, false, '', true, 'local', 'setlocal'})
     end)
 
     it('should be called in setting autoread', function()
       command('set noar')
-      expected_combination({'autoread', 1, 1, 1, 0, 'global', 'set'})
+      expected_combination({'autoread', true, true, true, false, 'global', 'set'})
 
       command('setlocal ar')
-      expected_combination({'autoread', 0, 0, '', 1, 'local', 'setlocal'})
+      expected_combination({'autoread', false, false, '', true, 'local', 'setlocal'})
     end)
 
     it('should be called in inverting global autoread', function()
       command('setglobal invar')
-      expected_combination({'autoread', 1, '', 1, 0, 'global', 'setglobal'})
+      expected_combination({'autoread', true, '', true, false, 'global', 'setglobal'})
     end)
 
     it('should be called in setting backspace option through :let', function()
@@ -208,7 +208,7 @@ describe('au OptionSet', function()
 
       it('should trigger using correct option name', function()
         command('call setbufvar(1, "&backup", 1)')
-        expected_combination({'backup', 0, 0, '', 1, 'local', 'setlocal'})
+        expected_combination({'backup', false, false, '', true, 'local', 'setlocal'})
       end)
 
       it('should trigger if the current buffer is different from the targeted buffer', function()
@@ -441,105 +441,105 @@ describe('au OptionSet', function()
       command('noa setglobal foldcolumn=8')
       command('noa setlocal foldcolumn=1')
       command('setglobal foldcolumn=2')
-      expected_combination({'foldcolumn', 8, '', 8, 2, 'global', 'setglobal'})
+      expected_combination({'foldcolumn', '8', '', '8', '2', 'global', 'setglobal'})
 
       command('noa setglobal foldcolumn=8')
       command('noa setlocal foldcolumn=1')
       command('setlocal foldcolumn=2')
-      expected_combination({'foldcolumn', 1, 1, '', 2, 'local', 'setlocal'})
+      expected_combination({'foldcolumn', '1', '1', '', '2', 'local', 'setlocal'})
 
       command('noa setglobal foldcolumn=8')
       command('noa setlocal foldcolumn=1')
       command('set foldcolumn=2')
-      expected_combination({'foldcolumn', 1, 1, 8, 2, 'global', 'set'})
+      expected_combination({'foldcolumn', '1', '1', '8', '2', 'global', 'set'})
 
       command('noa set foldcolumn=8')
       command('set foldcolumn=2')
-      expected_combination({'foldcolumn', 8, 8, 8, 2, 'global', 'set'})
+      expected_combination({'foldcolumn', '8', '8', '8', '2', 'global', 'set'})
     end)
 
     it('with boolean global option', function()
       command('noa setglobal nowrapscan')
       command('noa setlocal wrapscan') -- Sets the global(!) value
       command('setglobal nowrapscan')
-      expected_combination({'wrapscan', 1, '', 1, 0, 'global', 'setglobal'})
+      expected_combination({'wrapscan', true, '', true, false, 'global', 'setglobal'})
 
       command('noa setglobal nowrapscan')
       command('noa setlocal wrapscan') -- Sets the global(!) value
       command('setlocal nowrapscan')
-      expected_combination({'wrapscan', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'wrapscan', true, true, '', false, 'local', 'setlocal'})
 
       command('noa setglobal nowrapscan')
       command('noa setlocal wrapscan') -- Sets the global(!) value
       command('set nowrapscan')
-      expected_combination({'wrapscan', 1, 1, 1, 0, 'global', 'set'})
+      expected_combination({'wrapscan', true, true, true, false, 'global', 'set'})
 
       command('noa set nowrapscan')
       command('set wrapscan')
-      expected_combination({'wrapscan', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'wrapscan', false, false, false, true, 'global', 'set'})
     end)
 
     it('with boolean global-local (to buffer) option', function()
       command('noa setglobal noautoread')
       command('noa setlocal autoread')
       command('setglobal autoread')
-      expected_combination({'autoread', 0, '', 0, 1, 'global', 'setglobal'})
+      expected_combination({'autoread', false, '', false, true, 'global', 'setglobal'})
 
       command('noa setglobal noautoread')
       command('noa setlocal autoread')
       command('setlocal noautoread')
-      expected_combination({'autoread', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'autoread', true, true, '', false, 'local', 'setlocal'})
 
       command('noa setglobal noautoread')
       command('noa setlocal autoread')
       command('set autoread')
-      expected_combination({'autoread', 1, 1, 0, 1, 'global', 'set'})
+      expected_combination({'autoread', true, true, false, true, 'global', 'set'})
 
       command('noa set noautoread')
       command('set autoread')
-      expected_combination({'autoread', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'autoread', false, false, false, true, 'global', 'set'})
     end)
 
     it('with boolean local (to buffer) option', function()
       command('noa setglobal nocindent')
       command('noa setlocal cindent')
       command('setglobal cindent')
-      expected_combination({'cindent', 0, '', 0, 1, 'global', 'setglobal'})
+      expected_combination({'cindent', false, '', false, true, 'global', 'setglobal'})
 
       command('noa setglobal nocindent')
       command('noa setlocal cindent')
       command('setlocal nocindent')
-      expected_combination({'cindent', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'cindent', true, true, '', false, 'local', 'setlocal'})
 
       command('noa setglobal nocindent')
       command('noa setlocal cindent')
       command('set cindent')
-      expected_combination({'cindent', 1, 1, 0, 1, 'global', 'set'})
+      expected_combination({'cindent', true, true, false, true, 'global', 'set'})
 
       command('noa set nocindent')
       command('set cindent')
-      expected_combination({'cindent', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'cindent', false, false, false, true, 'global', 'set'})
     end)
 
     it('with boolean local (to window) option', function()
       command('noa setglobal nocursorcolumn')
       command('noa setlocal cursorcolumn')
       command('setglobal cursorcolumn')
-      expected_combination({'cursorcolumn', 0, '', 0, 1, 'global', 'setglobal'})
+      expected_combination({'cursorcolumn', false, '', false, true, 'global', 'setglobal'})
 
       command('noa setglobal nocursorcolumn')
       command('noa setlocal cursorcolumn')
       command('setlocal nocursorcolumn')
-      expected_combination({'cursorcolumn', 1, 1, '', 0, 'local', 'setlocal'})
+      expected_combination({'cursorcolumn', true, true, '', false, 'local', 'setlocal'})
 
       command('noa setglobal nocursorcolumn')
       command('noa setlocal cursorcolumn')
       command('set cursorcolumn')
-      expected_combination({'cursorcolumn', 1, 1, 0, 1, 'global', 'set'})
+      expected_combination({'cursorcolumn', true, true, false, true, 'global', 'set'})
 
       command('noa set nocursorcolumn')
       command('set cursorcolumn')
-      expected_combination({'cursorcolumn', 0, 0, 0, 1, 'global', 'set'})
+      expected_combination({'cursorcolumn', false, false, false, true, 'global', 'set'})
     end)
 
   end)
@@ -559,13 +559,13 @@ describe('au OptionSet', function()
       expected_empty()
 
       command('setlocal ro')
-      expected_combination({'readonly', 0, 0, '', 1, 'local', 'setlocal'})
+      expected_combination({'readonly', false, false, '', true, 'local', 'setlocal'})
 
       command('setglobal ro')
-      expected_combination({'readonly', 0, '', 0, 1, 'global', 'setglobal'})
+      expected_combination({'readonly', false, '', false, true, 'global', 'setglobal'})
 
       command('set noro')
-      expected_combination({'readonly', 1, 1, 1, 0, 'global', 'set'})
+      expected_combination({'readonly', true, true, true, false, 'global', 'set'})
     end)
 
     describe('being set by setbufvar()', function()
@@ -580,7 +580,7 @@ describe('au OptionSet', function()
         set_hook('backup')
 
         command('call setbufvar(1, "&backup", 1)')
-        expected_combination({'backup', 0, 0, '', 1, 'local', 'setlocal'})
+        expected_combination({'backup', false, false, '', true, 'local', 'setlocal'})
       end)
 
       it('should trigger if the current buffer is different from the targeted buffer', function()
@@ -590,7 +590,8 @@ describe('au OptionSet', function()
         local new_bufnr = buf.get_number(new_buffer)
 
         command('call setbufvar(' .. new_bufnr .. ', "&buftype", "nofile")')
-        expected_combination({'buftype', '', '', '', 'nofile', 'local', 'setlocal', {bufnr = new_bufnr}})
+        expected_combination({ 'buftype', '', '', '', 'nofile', 'local', 'setlocal',
+          { bufnr = new_bufnr } })
       end)
     end)
 
@@ -606,7 +607,7 @@ describe('au OptionSet', function()
         set_hook('backup')
 
         command('call setwinvar(1, "&backup", 1)')
-        expected_combination({'backup', 0, 0, '', 1, 'local', 'setlocal'})
+        expected_combination({'backup', false, false, '', true, 'local', 'setlocal'})
       end)
 
       it('should not trigger if the current window is different from the targeted window', function()
@@ -615,7 +616,7 @@ describe('au OptionSet', function()
         local new_winnr = get_new_window_number()
 
         command('call setwinvar(' .. new_winnr .. ', "&cursorcolumn", 1)')
-        -- expected_combination({'cursorcolumn', 0, 1, 'local', {winnr = new_winnr}})
+        -- expected_combination({'cursorcolumn', false, true, 'local', {winnr = new_winnr}})
         expected_empty()
       end)
     end)
@@ -626,7 +627,7 @@ describe('au OptionSet', function()
 
         nvim.set_option_value('autochdir', true, {scope='global'})
         eq(true, nvim.get_option_value('autochdir', {scope='global'}))
-        expected_combination({'autochdir', 0, '', 0, 1, 'global', 'setglobal'})
+        expected_combination({'autochdir', false, '', false, true, 'global', 'setglobal'})
       end)
 
       it('should trigger if a number option be set globally', function()


### PR DESCRIPTION
Problem: There is a separate function for setting an option for each type, which are currently `set_string_option`, `set_num_option`, `set_bool_option`, `do_set_option_value`, `do_set_num_option`, `do_set_bool_option`, `do_set_option_string`. This leads to a lot of unnecessary code duplication and also vastly reduces maintainability and extensibility.

Solution: Unify most ways of setting options to a single `set_option` function, cleaning up a lot of code duplication and greatly simplifying the options code, thus making it a lot more extensible and making it easier to add more option types. This PR unifies everything besides some functions used for string options (`set_string_option`, `did_set_string_option`, etc.). Unification of the code paths for setting string options and all other options will be done in a follow-up PR.

BREAKING CHANGE: This breaks the `OptionSet` autocommand, as the `v:` values associated with it (`v:option_new`, `v:option_old`, `v:option_oldlocal` and `v:option_oldglobal`) are now the same type as the option, instead of all option values being converted to strings.