### PR TITLE
refactor(grid): unify the two put-text-on-the-screen code paths

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -608,7 +608,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
 
     grid_line_fill(clen, Columns, fillchar, attr);
 
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   win_redraw_last_status(topframe);

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -771,20 +771,20 @@ static void win_redr_border(win_T *wp)
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[2], attrs[2]);
     }
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   for (int i = 0; i < irow; i++) {
     if (adj[3]) {
       grid_line_start(grid, i + adj[0]);
       grid_line_put_schar(0, chars[7], attrs[7]);
-      grid_line_flush(false);
+      grid_line_flush();
     }
     if (adj[1]) {
       int ic = (i == 0 && !adj[0] && chars[2]) ? 2 : 3;
       grid_line_start(grid, i + adj[0]);
       grid_line_put_schar(icol + adj[3], chars[ic], attrs[ic]);
-      grid_line_flush(false);
+      grid_line_flush();
     }
   }
 
@@ -807,7 +807,7 @@ static void win_redr_border(win_T *wp)
     if (adj[1]) {
       grid_line_put_schar(icol + adj[3], chars[4], attrs[4]);
     }
-    grid_line_flush(false);
+    grid_line_flush();
   }
 }
 
@@ -1098,7 +1098,7 @@ int showmode(void)
       && !(p_ch == 0 && !ui_has(kUIMessages))) {
     grid_line_start(&msg_grid_adj, Rows - 1);
     win_redr_ruler(ruler_win);
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   redraw_cmdline = false;
@@ -1370,25 +1370,25 @@ static void draw_sep_connectors_win(win_T *wp)
   bool bot_left = !(win_at_bottom || win_at_left);
   bool bot_right = !(win_at_bottom || win_at_right);
 
-  if (top_left || top_right) {
+  if (top_left) {
     grid_line_start(&default_grid, wp->w_winrow - 1);
-    if (top_left) {
-      grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_TOP_LEFT), hl);
-    }
-    if (top_right) {
-      grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_TOP_RIGHT), hl);
-    }
-    grid_line_flush(false);
+    grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_TOP_LEFT), hl);
+    grid_line_flush();
   }
-  if (bot_left || bot_right) {
+  if (top_right) {
+    grid_line_start(&default_grid, wp->w_winrow - 1);
+    grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_TOP_RIGHT), hl);
+    grid_line_flush();
+  }
+  if (bot_left) {
     grid_line_start(&default_grid, W_ENDROW(wp));
-    if (bot_left) {
-      grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_BOTTOM_LEFT), hl);
-    }
-    if (bot_right) {
-      grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_BOTTOM_RIGHT), hl);
-    }
-    grid_line_flush(false);
+    grid_line_put_schar(wp->w_wincol - 1, get_corner_sep_connector(wp, WC_BOTTOM_LEFT), hl);
+    grid_line_flush();
+  }
+  if (bot_right) {
+    grid_line_start(&default_grid, W_ENDROW(wp));
+    grid_line_put_schar(W_ENDCOL(wp), get_corner_sep_connector(wp, WC_BOTTOM_RIGHT), hl);
+    grid_line_flush();
   }
 }
 
@@ -2394,8 +2394,11 @@ static void win_update(win_T *wp, DecorProviders *providers)
       int symbol = wp->w_p_fcs_chars.lastline;
 
       // Last line isn't finished: Display "@@@" at the end.
-      grid_fill(&wp->w_grid, wp->w_grid.rows - 1, wp->w_grid.rows,
-                MAX(start_col, 0), wp->w_grid.cols, symbol, symbol, at_attr);
+      // TODO(bfredl): this display ">@@@" when ">" was a left-halve
+      // maybe "@@@@" is preferred when this happens.
+      grid_line_start(&wp->w_grid, wp->w_grid.rows - 1);
+      grid_line_fill(MAX(start_col, 0), wp->w_grid.cols, symbol, at_attr);
+      grid_line_flush();
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2087,7 +2087,7 @@ static void display_showcmd(void)
   // clear the rest of an old message by outputting up to SHOWCMD_COLS spaces
   grid_line_puts(sc_col + len, (char *)"          " + len, -1, HL_ATTR(HLF_MSG));
 
-  grid_line_flush(false);
+  grid_line_flush();
 }
 
 /// When "check" is false, prepare for commands that scroll the window.

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -655,7 +655,7 @@ void pum_redraw(void)
                        i >= thumb_pos && i < thumb_pos + thumb_height ? attr_thumb : attr_scroll);
       }
     }
-    grid_line_flush(false);
+    grid_line_flush();
     row++;
   }
 }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -171,7 +171,7 @@ void win_redr_status(win_T *wp)
       }
     }
 
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   // May need to draw the character below the vertical separator.
@@ -449,7 +449,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
   grid_line_fill(col, maxcol, fillchar, curattr);
 
   if (!draw_ruler) {
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   // Fill the tab_page_click_defs, w_status_click_defs or w_winbar_click_defs array for clicking
@@ -861,7 +861,7 @@ void draw_tabline(void)
       };
     }
 
-    grid_line_flush(false);
+    grid_line_flush();
   }
 
   // Reset the flag here again, in case evaluating 'tabline' causes it to be


### PR DESCRIPTION
The screen grid refactors will continue until morale improves. Jokes aside, this is quite a central installment in the series.

Before this refactor, there were two fundamentally distinct codepaths for getting some text on the screen:

- the win_line() -> grid_put_linebuf() -> ui_line() call chain used for buffer text, with `linebuf_char` as a temporary scratch buffer
- the grid_line_start/grid_line_puts/grid_line_flush() -> ui_line() path used for every thing else: statuslines, messages and the command line. Here the `grid->chars[]` array itself doubles as a scratch buffer.

With this refactor, the later family of functions still exist, however they now as well render to linebuf_char just like win_line() did, and grid_put_linebuf() is called in the end to calculate delta changes. This means we don't need any duplicate logic for delta calculations anymore.

Later down the line, it will be possible to share more logic operating on this scratch buffer, like doing 'rightleft' reversal and arabic shaping as a post-processing step.