### PR TITLE
fix(unittests): ignore __s128 and __u128 types in ffi

### DIFF
--- a/test/unit/helpers.lua
+++ b/test/unit/helpers.lua
@@ -137,6 +137,8 @@ local function filter_complex_blocks(body)
     if not (string.find(line, "(^)", 1, true) ~= nil
             or string.find(line, "_ISwupper", 1, true)
             or string.find(line, "_Float")
+            or string.find(line, "__s128")
+            or string.find(line, "__u128")
             or string.find(line, "msgpack_zone_push_finalizer")
             or string.find(line, "msgpack_unpacker_reserve_buffer")
             or string.find(line, "value_init_")


### PR DESCRIPTION
Linux added these types to their userspace headers in [6.5], which causes unit tests to fail like

```
-------- Running tests from test/unit/api/private_helpers_spec.lua
RUN       vim_to_object converts true: 17.00 ms ERR
test/unit/helpers.lua:748: test/unit/helpers.lua:732: (string) '
test/unit/helpers.lua:264: ';' expected near '__s128' at line 194'
exit code: 256

stack traceback:
	test/unit/helpers.lua:748: in function 'itp_parent'
	test/unit/helpers.lua:784: in function <test/unit/helpers.lua:774>
```

Since we don't use these types, they can be ignored to avoid LuaJIT's C parser choking on them.

[6.5]: https://github.com/torvalds/linux/commit/224d80c584d3016cb8d83d1c33914fdd3508aa8c