### PR TITLE
refactor(lsp): deprecate util methods

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -142,6 +142,8 @@ LSP FUNCTIONS
 - *vim.lsp.get_active_clients()*		Use |vim.lsp.get_clients()|
 - *vim.lsp.for_each_buffer_client()*		Use |vim.lsp.get_clients()|
 - *vim.lsp.util.trim_empty_lines()*		Use |vim.split()| with `trimempty` instead.
+- *vim.lsp.util.try_trim_markdown_code_blocks()*
+- *vim.lsp.util.set_lines()*
 
 TREESITTER FUNCTIONS
 - *vim.treesitter.language.require_language()*	Use |vim.treesitter.language.add()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1955,20 +1955,6 @@ rename({old_fname}, {new_fname}, {opts})               *vim.lsp.util.rename()*
     Parameters: ~
       • {opts}  (table)
 
-set_lines({lines}, {A}, {B}, {new_lines})           *vim.lsp.util.set_lines()*
-    Replaces text in a range with new text.
-
-    CAUTION: Changes in-place!
-
-    Parameters: ~
-      • {lines}      (table) Original list of strings
-      • {A}          (table) Start position; a 2-tuple of {line,col} numbers
-      • {B}          (table) End position; a 2-tuple of {line,col} numbers
-      • {new_lines}  (table) list of strings to replace the original
-
-    Return: ~
-        (table) The modified {lines} object
-
                                                 *vim.lsp.util.show_document()*
 show_document({location}, {offset_encoding}, {opts})
     Shows document and optionally jumps to the location.
@@ -2032,19 +2018,6 @@ text_document_completion_list_to_complete_items({result}, {prefix})
 
     See also: ~
       • complete-items
-
-                                *vim.lsp.util.try_trim_markdown_code_blocks()*
-try_trim_markdown_code_blocks({lines})
-    Accepts markdown lines and tries to reduce them to a filetype if they
-    comprise just a single code block.
-
-    CAUTION: Modifies the input in-place!
-
-    Parameters: ~
-      • {lines}  (table) list of lines
-
-    Return: ~
-        (string) filetype or "markdown" if it was unchanged.
 
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -279,6 +279,8 @@ release.
   - |vim.lsp.get_active_clients()|		Use |vim.lsp.get_clients()| instead.
   - |vim.lsp.for_each_buffer_client()|		Use |vim.lsp.get_clients()| instead.
   - |vim.lsp.util.trim_empty_lines()|		Use |vim.split()| with `trimempty` instead.
+  - |vim.lsp.util.try_trim_markdown_code_blocks()|
+  - |vim.lsp.util.set_lines()|
 
 • `vim.loop` has been renamed to `vim.uv`.
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -168,10 +168,12 @@ end
 
 local _str_utfindex_enc = M._str_utfindex_enc
 local _str_byteindex_enc = M._str_byteindex_enc
+
 --- Replaces text in a range with new text.
 ---
 --- CAUTION: Changes in-place!
 ---
+---@deprecated
 ---@param lines (table) Original list of strings
 ---@param A (table) Start position; a 2-tuple of {line,col} numbers
 ---@param B (table) End position; a 2-tuple of {line,col} numbers
@@ -320,9 +322,7 @@ local function get_line(bufnr, row)
 end
 
 --- Position is a https://microsoft.github.io/language-server-protocol/specifications/specification-current/#position
---- Returns a zero-indexed column, since set_lines() does the conversion to
 ---@param offset_encoding string|nil utf-8|utf-16|utf-32
---- 1-indexed
 ---@return integer
 local function get_line_byte_from_position(bufnr, position, offset_encoding)
   -- LSP's line and characters are 0-indexed
@@ -1991,6 +1991,7 @@ end
 ---
 --- CAUTION: Modifies the input in-place!
 ---
+---@deprecated
 ---@param lines table list of lines
 ---@return string filetype or "markdown" if it was unchanged.
 function M.try_trim_markdown_code_blocks(lines)


### PR DESCRIPTION
Let the culling of `vim.lsp.util` begin.

Part of #25272. 