### PR TITLE
docs:(term.txt): recommend `tic -x` for better compatibility with older ncurses using local terminfo

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -31,7 +31,7 @@ a non-superuser:
 >
   curl -LO https://invisible-island.net/datafiles/current/terminfo.src.gz
   gunzip terminfo.src.gz
-  tic terminfo.src
+  tic -x terminfo.src
 <
 								*$TERM*
 The $TERM environment variable must match the terminal you are using!


### PR DESCRIPTION
Recommend `tic -x` instead of `tic` in docs instructions on compiling a local terminfo to support modern terminals. `-x` enables older ncurses to accommodate unknown capabilities as user-defined ones vs. build failing. Modern ncurses `tic` is unaffected.