### PR TITLE
docs(term): use tic -x for better compatibility with old ncurses

### DIFF
--- a/runtime/doc/term.txt
+++ b/runtime/doc/term.txt
@@ -31,7 +31,7 @@ a non-superuser:
 >
   curl -LO https://invisible-island.net/datafiles/current/terminfo.src.gz
   gunzip terminfo.src.gz
-  tic terminfo.src
+  tic -x terminfo.src
 <
 								*$TERM*
 The $TERM environment variable must match the terminal you are using!


### PR DESCRIPTION
Use `tic -x` instead of `tic` to include any unknown capabilities in a modern `terminfo.src` as user-defined ones, instead of dropping them. Modern ncurses behavior with `tic -x` will not change.