### PR TITLE
fix(path): accept special characters on Windows

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -649,11 +649,13 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
       }
       s = p + 1;
     } else if (path_end >= path + wildoff
+#ifdef MSWIN
+               && vim_strchr("*?[~", (uint8_t)(*path_end)) != NULL
+#else
                && (vim_strchr("*?[{~$", (uint8_t)(*path_end)) != NULL
-#ifndef MSWIN
-                   || (!p_fic && (flags & EW_ICASE) && mb_isalpha(utf_ptr2char(path_end)))
+                   || (!p_fic && (flags & EW_ICASE) && mb_isalpha(utf_ptr2char(path_end))))
 #endif
-                   )) {  // NOLINT(whitespace/parens)
+               ) {  // NOLINT(whitespace/parens)
       e = p;
     }
     len = (size_t)(utfc_ptr2len(path_end));

--- a/test/functional/core/path_spec.lua
+++ b/test/functional/core/path_spec.lua
@@ -6,15 +6,18 @@ local command = helpers.command
 local insert = helpers.insert
 local feed = helpers.feed
 local is_os = helpers.is_os
+local mkdir = helpers.mkdir
+local rmdir = helpers.rmdir
+local write_file = helpers.write_file
+
+local function join_path(...)
+  local pathsep = (is_os('win') and '\\' or '/')
+  return table.concat({...}, pathsep)
+end
 
 describe('path collapse', function()
   local targetdir
   local expected_path
-
-  local function join_path(...)
-    local pathsep = (is_os('win') and '\\' or '/')
-    return table.concat({...}, pathsep)
-  end
 
   before_each(function()
     targetdir = join_path('test', 'functional', 'fixtures')
@@ -54,6 +57,27 @@ describe('path collapse', function()
     command('cd test')
     command('edit '..join_path('.', '..', targetdir, 'tty-test.c'))
     eq(expected_path, eval('expand("%:p")'))
+  end)
+end)
+
+describe('expand wildcard', function()
+  before_each(clear)
+
+  it('with special characters #24421', function()
+    local folders = is_os('win') and {
+      '{folder}',
+      'folder$name'
+    } or {
+      'folder-name',
+      'folder#name'
+    }
+    for _, folder in ipairs(folders) do
+      mkdir(folder)
+      local file = join_path(folder, 'file.txt')
+      write_file(file, '')
+      eq(file, eval('expand("'..folder..'/*")'))
+      rmdir(folder)
+    end
   end)
 end)
 


### PR DESCRIPTION
# Problem

When expanding wildcards some special characters on Windows are not being accounted.

# Solution

Considering `{` and `$` on the logic.

---

Fixes #24421.
Fixes #22661.

Vim resolves this by having two different methods `dos_expandpath` and `unix_expandpath`.

Should I add tests on `test/functional/vimscript/glob_spec.lua` for this?