### PR TITLE
fix(lsp): filetype matching to documentSelector in dynamic capabilities

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1073,7 +1073,7 @@ function lsp.start_client(config)
     end
 
     --- @param method string
-    --- @param opts? {bufnr?: number}
+    --- @param opts? {bufnr: integer?}
     client.supports_method = function(method, opts)
       opts = opts or {}
       local required_capability = lsp._request_name_to_capability[method]

--- a/runtime/lua/vim/lsp/_dynamic.lua
+++ b/runtime/lua/vim/lsp/_dynamic.lua
@@ -55,7 +55,7 @@ function M:unregister(unregisterations)
 end
 
 --- @param method string
---- @param opts? {bufnr?: number}
+--- @param opts? {bufnr: integer?}
 --- @return lsp.Registration? (table|nil) the registration if found
 --- @private
 function M:get(method, opts)
@@ -76,7 +76,7 @@ function M:get(method, opts)
 end
 
 --- @param method string
---- @param opts? {bufnr?: number}
+--- @param opts? {bufnr: integer?}
 --- @private
 function M:supports(method, opts)
   return self:get(method, opts) ~= nil

--- a/runtime/lua/vim/lsp/_dynamic.lua
+++ b/runtime/lua/vim/lsp/_dynamic.lua
@@ -69,7 +69,7 @@ function M:get(method, opts)
     if not documentSelector then
       return reg
     end
-    if M.match(opts.bufnr, documentSelector) then
+    if self:match(opts.bufnr, documentSelector) then
       return reg
     end
   end
@@ -85,13 +85,17 @@ end
 --- @param bufnr number
 --- @param documentSelector lsp.DocumentSelector
 --- @private
-function M.match(bufnr, documentSelector)
-  local ft = vim.bo[bufnr].filetype
+function M:match(bufnr, documentSelector)
+  local client = vim.lsp.get_client_by_id(self.client_id)
+  if not client then
+    return false
+  end
+  local language = client.config.get_language_id(bufnr, vim.bo[bufnr].filetype)
   local uri = vim.uri_from_bufnr(bufnr)
   local fname = vim.uri_to_fname(uri)
   for _, filter in ipairs(documentSelector) do
     local matches = true
-    if filter.language and ft ~= filter.language then
+    if filter.language and language ~= filter.language then
       matches = false
     end
     if matches and filter.scheme and not vim.startswith(uri, filter.scheme .. ':') then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3936,12 +3936,15 @@ describe('LSP', function()
 
   describe('#dynamic vim.lsp._dynamic', function()
     it('supports dynamic registration', function()
+      ---@type string
       local root_dir = helpers.tmpname()
       os.remove(root_dir)
       mkdir(root_dir)
       local tmpfile = root_dir .. '/dynamic.foo'
       local file = io.open(tmpfile, 'w')
-      file:close()
+      if file then
+        file:close()
+      end
 
       exec_lua(create_server_definition)
       local result = exec_lua([[
@@ -3952,6 +3955,9 @@ describe('LSP', function()
           name = 'dynamic-test',
           cmd = server.cmd,
           root_dir = root_dir,
+          get_language_id = function()
+            return "dummy-lang"
+          end,
           capabilities = {
             textDocument = {
               formatting = {
@@ -3985,6 +3991,13 @@ describe('LSP', function()
             {
               id = 'range-formatting',
               method = 'textDocument/rangeFormatting',
+              registerOptions = {
+              documentSelector = {
+                  {
+                    language = "dummy-lang"
+                  },
+                }
+              }
             },
           },
         }, { client_id = client_id })
@@ -4002,7 +4015,11 @@ describe('LSP', function()
         local function check(method, fname)
           local bufnr = fname and vim.fn.bufadd(fname) or nil
           local client = vim.lsp.get_client_by_id(client_id)
-          result[#result + 1] = {method = method, fname = fname, supported = client.supports_method(method, {bufnr = bufnr})}
+          result[#result + 1] = {
+            method = method,
+            fname = fname,
+            supported = client.supports_method(method, {bufnr = bufnr})
+          }
         end
 
 


### PR DESCRIPTION
The filetype option may contain multiple file type names (dot-separated).
We now allow the document selector to match any of those names.