### PR TITLE
refactor: the long goodbye 2

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1766,10 +1766,10 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     patcmd.data = data;
 
     // set v:cmdarg (only when there is a matching pattern)
-    save_cmdbang = (long)get_vim_var_nr(VV_CMDBANG);
+    save_cmdbang = get_vim_var_nr(VV_CMDBANG);
     if (eap != NULL) {
       save_cmdarg = set_cmdarg(eap, NULL);
-      set_vim_var_nr(VV_CMDBANG, (long)eap->forceit);
+      set_vim_var_nr(VV_CMDBANG, eap->forceit);
     } else {
       save_cmdarg = NULL;  // avoid gcc warning
     }

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -274,8 +274,8 @@ typedef struct qf_info_S qf_info_T;
 typedef struct {
   proftime_T total;             // total time used
   proftime_T slowest;           // time of slowest call
-  long count;                   // nr of times used
-  long match;                   // nr of times matched
+  int count;                    // nr of times used
+  int match;                    // nr of times matched
 } syn_time_T;
 
 // These are items normally related to a buffer.  But when using ":ownsyntax"
@@ -440,10 +440,10 @@ struct file_buffer {
   disptick_T b_mod_tick_decor;  // last display tick decoration providers
                                 // where invoked
 
-  long b_mtime;                 // last change time of original file
-  long b_mtime_ns;              // nanoseconds of last change time
-  long b_mtime_read;            // last change time when reading
-  long b_mtime_read_ns;         // nanoseconds of last read time
+  int64_t b_mtime;              // last change time of original file
+  int64_t b_mtime_ns;           // nanoseconds of last change time
+  int64_t b_mtime_read;         // last change time when reading
+  int64_t b_mtime_read_ns;      // nanoseconds of last read time
   uint64_t b_orig_size;         // size of original file in bytes
   int b_orig_mode;              // mode of original file
   time_t b_last_used;           // time when the buffer was last used; used
@@ -1268,7 +1268,7 @@ struct window_S {
   int w_briopt_list;                // additional indent for lists
   int w_briopt_vcol;                // indent for specific column
 
-  long w_scbind_pos;
+  int w_scbind_pos;
 
   ScopeDictDictItem w_winvar;  ///< Variable for "w:" dictionary.
   dict_T *w_vars;  ///< Dictionary with w: variables.

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -339,7 +339,7 @@ static int buf_write_bytes(struct bw_info *ip)
     // Only checking conversion, which is OK if we get here.
     return OK;
   }
-  int wlen = (int)write_eintr(ip->bw_fd, buf, (size_t)len);
+  int wlen = write_eintr(ip->bw_fd, buf, (size_t)len);
   return (wlen < len) ? FAIL : OK;
 }
 
@@ -619,14 +619,14 @@ static void emit_err(Error_T *e)
 
 #if defined(UNIX)
 
-static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwriting, long *perm,
+static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwriting, int *perm,
                            bool *device, bool *newfile, Error_T *err)
 {
   *perm = -1;
   if (!os_fileinfo(fname, file_info_old)) {
     *newfile = true;
   } else {
-    *perm = (long)file_info_old->stat.st_mode;
+    *perm = (int)file_info_old->stat.st_mode;
     if (!S_ISREG(file_info_old->stat.st_mode)) {             // not a file
       if (S_ISDIR(file_info_old->stat.st_mode)) {
         *err = set_err_num("E502", _("is a directory"));
@@ -648,7 +648,7 @@ static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwritin
 
 #else
 
-static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwriting, long *perm,
+static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwriting, int *perm,
                            bool *device, bool *newfile, Error_T *err)
 {
   // Check for a writable device name.
@@ -688,7 +688,7 @@ static int get_fileinfo_os(char *fname, FileInfo *file_info_old, bool overwritin
 /// @param[out] newfile
 /// @param[out] readonly
 static int get_fileinfo(buf_T *buf, char *fname, bool overwriting, bool forceit,
-                        FileInfo *file_info_old, long *perm, bool *device, bool *newfile,
+                        FileInfo *file_info_old, int *perm, bool *device, bool *newfile,
                         bool *readonly, Error_T *err)
 {
   if (get_fileinfo_os(fname, file_info_old, overwriting, perm, device, newfile, err) == FAIL) {
@@ -723,7 +723,7 @@ static int get_fileinfo(buf_T *buf, char *fname, bool overwriting, bool forceit,
 }
 
 static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_old, vim_acl_T acl,
-                                 long perm, unsigned bkc, bool file_readonly, bool forceit,
+                                 int perm, unsigned bkc, bool file_readonly, bool forceit,
                                  int *backup_copyp, char **backupp, Error_T *err)
 {
   FileInfo file_info;
@@ -755,7 +755,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
         }
       }
       int fd = os_open(IObuff,
-                       O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, (int)perm);
+                       O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
       if (fd < 0) {           // can't write in directory
         *backup_copyp = true;
       } else {
@@ -764,7 +764,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
         if (!os_fileinfo(IObuff, &file_info)
             || file_info.stat.st_uid != file_info_old->stat.st_uid
             || file_info.stat.st_gid != file_info_old->stat.st_gid
-            || (long)file_info.stat.st_mode != perm) {
+            || (int)file_info.stat.st_mode != perm) {
           *backup_copyp = true;
         }
 #endif
@@ -911,7 +911,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
         //
         if (file_info_new.stat.st_gid != file_info_old->stat.st_gid
             && os_chown(*backupp, (uv_uid_t)-1, (uv_gid_t)file_info_old->stat.st_gid) != 0) {
-          os_setperm(*backupp, ((int)perm & 0707) | (((int)perm & 07) << 3));
+          os_setperm(*backupp, (perm & 0707) | ((perm & 07) << 3));
         }
 # ifdef HAVE_XATTR
         os_copy_xattr(fname, *backupp);
@@ -1193,7 +1193,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   }
 
   Error_T err = { 0 };
-  long perm;             // file permissions
+  int perm;              // file permissions
   bool newfile = false;  // true if file doesn't exist yet
   bool device = false;   // writing to a device
   bool file_readonly = false;  // overwritten file is read-only
@@ -1255,7 +1255,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
       && file_info_old.stat.st_uid == getuid()
       && vim_strchr(p_cpo, CPO_FWRITE) == NULL) {
     perm |= 0200;
-    (void)os_setperm(fname, (int)perm);
+    (void)os_setperm(fname, perm);
     made_writable = true;
   }
 #endif
@@ -1658,7 +1658,7 @@ restore_backup:
           || file_info.stat.st_gid != file_info_old.stat.st_gid) {
         os_fchown(fd, (uv_uid_t)file_info_old.stat.st_uid, (uv_gid_t)file_info_old.stat.st_gid);
         if (perm >= 0) {  // Set permission again, may have changed.
-          (void)os_setperm(wfname, (int)perm);
+          (void)os_setperm(wfname, perm);
         }
       }
       buf_set_file_id(buf);
@@ -1679,7 +1679,7 @@ restore_backup:
     }
 #endif
     if (perm >= 0) {  // Set perm. of new file same as old file.
-      (void)os_setperm(wfname, (int)perm);
+      (void)os_setperm(wfname, perm);
     }
     // Probably need to set the ACL before changing the user (can't set the
     // ACL on a file the user doesn't own).

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -831,7 +831,7 @@ int del_chars(int count, int fixpos)
 {
   int bytes = 0;
   char *p = get_cursor_pos_ptr();
-  for (long i = 0; i < count && *p != NUL; i++) {
+  for (int i = 0; i < count && *p != NUL; i++) {
     int l = utfc_ptr2len(p);
     bytes += l;
     p += l;
@@ -1829,7 +1829,7 @@ int open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
         if (flags & OPENLINE_MARKFIX) {
           mark_col_adjust(curwin->w_cursor.lnum,
                           curwin->w_cursor.col + less_cols_off,
-                          1L, (long)-less_cols, 0);
+                          1L, -less_cols, 0);
         }
         // Always move extmarks - Here we move only the line where the
         // cursor is, the previous mark_adjust takes care of the lines after

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1647,11 +1647,11 @@ static void win_update(win_T *wp, DecorProviders *providers)
   // When only displaying the lines at the top, set top_end.  Used when
   // window has scrolled down for msg_scrolled.
   if (type == UPD_REDRAW_TOP) {
-    long j = 0;
+    int j = 0;
     for (int i = 0; i < wp->w_lines_valid; i++) {
       j += wp->w_lines[i].wl_size;
       if (j >= wp->w_upd_rows) {
-        top_end = (int)j;
+        top_end = j;
         break;
       }
     }
@@ -1684,7 +1684,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
                    || (wp->w_topline == wp->w_lines[0].wl_lnum
                        && wp->w_topfill > wp->w_old_topfill))) {
       // New topline is above old topline: May scroll down.
-      long j;
+      int j;
       if (hasAnyFolding(wp)) {
         linenr_T ln;
 
@@ -1744,7 +1744,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
       // needs updating.
 
       // try to find wp->w_topline in wp->w_lines[].wl_lnum
-      long j = -1;
+      int j = -1;
       int row = 0;
       for (int i = 0; i < wp->w_lines_valid; i++) {
         if (wp->w_lines[i].wl_valid
@@ -2151,7 +2151,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
           int new_rows = 0;
           // Able to count old number of rows: Count new window
           // rows, and may insert/delete lines
-          long j = idx;
+          int j = idx;
           for (l = lnum; l < mod_bot; l++) {
             if (hasFoldingWin(wp, l, NULL, &l, true, NULL)) {
               new_rows++;
@@ -2212,14 +2212,14 @@ static void win_update(win_T *wp, DecorProviders *providers)
               while (true) {
                 // stop at last valid entry in w_lines[]
                 if (i >= wp->w_lines_valid) {
-                  wp->w_lines_valid = (int)j;
+                  wp->w_lines_valid = j;
                   break;
                 }
                 wp->w_lines[j] = wp->w_lines[i];
                 // stop at a line that won't fit
                 if (x + (int)wp->w_lines[j].wl_size
                     > wp->w_grid.rows) {
-                  wp->w_lines_valid = (int)j + 1;
+                  wp->w_lines_valid = j + 1;
                   break;
                 }
                 x += wp->w_lines[j++].wl_size;
@@ -2407,7 +2407,7 @@ static void win_update(win_T *wp, DecorProviders *providers)
   } else {
     if (eof) {  // we hit the end of the file
       wp->w_botline = buf->b_ml.ml_line_count + 1;
-      long j = win_get_fill(wp, wp->w_botline);
+      int j = win_get_fill(wp, wp->w_botline);
       if (j > 0 && !wp->w_botfill && row < wp->w_grid.rows) {
         // Display filler text below last line. win_line() will check
         // for ml_line_count+1 and only draw filler lines

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1645,7 +1645,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
         lp->ll_n1 = 0;
       } else {
         // Is number or string.
-        lp->ll_n1 = (long)tv_get_number(&var1);
+        lp->ll_n1 = (int)tv_get_number(&var1);
       }
       tv_clear(&var1);
 
@@ -1655,7 +1655,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
         return NULL;
       }
       if (lp->ll_range && !lp->ll_empty2) {
-        lp->ll_n2 = (long)tv_get_number(&var2);
+        lp->ll_n2 = (int)tv_get_number(&var2);
         tv_clear(&var2);
         if (tv_blob_check_range(bloblen, lp->ll_n1, lp->ll_n2, quiet) == FAIL) {
           return NULL;
@@ -1670,7 +1670,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
         lp->ll_n1 = 0;
       } else {
         // Is number or string.
-        lp->ll_n1 = (long)tv_get_number(&var1);
+        lp->ll_n1 = (int)tv_get_number(&var1);
       }
       tv_clear(&var1);
 
@@ -1687,7 +1687,7 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
       // When no index given: "lp->ll_empty2" is true.
       // Otherwise "lp->ll_n2" is set to the second index.
       if (lp->ll_range && !lp->ll_empty2) {
-        lp->ll_n2 = (long)tv_get_number(&var2);  // Is number or string.
+        lp->ll_n2 = (int)tv_get_number(&var2);  // Is number or string.
         tv_clear(&var2);
         if (tv_list_check_range_index_two(lp->ll_list,
                                           &lp->ll_n1, lp->ll_li,
@@ -1746,7 +1746,7 @@ void set_var_lval(lval_T *lp, char *endp, typval_T *rettv, int copy, const bool 
         bool error = false;
         const char val = (char)tv_get_number_chk(rettv, &error);
         if (!error) {
-          tv_blob_set_append(lp->ll_blob, (int)lp->ll_n1, (uint8_t)val);
+          tv_blob_set_append(lp->ll_blob, lp->ll_n1, (uint8_t)val);
         }
       }
     } else if (op != NULL && *op != '=') {
@@ -5914,7 +5914,7 @@ void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv, bool retlist
   char **argv = tv_to_argv(&argvars[0], NULL, &executable);
   if (!argv) {
     if (!executable) {
-      set_vim_var_nr(VV_SHELL_ERROR, (long)-1);
+      set_vim_var_nr(VV_SHELL_ERROR, -1);
     }
     xfree(input);
     return;  // Already did emsg.
@@ -5944,7 +5944,7 @@ void get_system_output_as_rettv(typval_T *argvars, typval_T *rettv, bool retlist
 
   xfree(input);
 
-  set_vim_var_nr(VV_SHELL_ERROR, (long)status);
+  set_vim_var_nr(VV_SHELL_ERROR, status);
 
   if (res == NULL) {
     if (retlist) {
@@ -6231,7 +6231,7 @@ void timer_due_cb(TimeWatcher *tw, void *data)
   timer_decref(timer);
 }
 
-uint64_t timer_start(const long timeout, const int repeat_count, const Callback *const callback)
+uint64_t timer_start(const int64_t timeout, const int repeat_count, const Callback *const callback)
 {
   timer_T *timer = xmalloc(sizeof *timer);
   timer->refcount = 1;
@@ -7122,7 +7122,7 @@ void set_vim_var_char(int c)
 /// Set v:count to "count" and v:count1 to "count1".
 ///
 /// @param set_prevcount  if true, first set v:prevcount from v:count.
-void set_vcount(long count, long count1, int set_prevcount)
+void set_vcount(int64_t count, int64_t count1, bool set_prevcount)
 {
   if (set_prevcount) {
     vimvars[VV_PREVCOUNT].vv_nr = vimvars[VV_COUNT].vv_nr;

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -53,11 +53,11 @@ typedef struct lval_S {
   list_T *ll_list;    ///< The list or NULL.
   bool ll_range;      ///< true when a [i:j] range was used.
   bool ll_empty2;     ///< Second index is empty: [i:].
-  long ll_n1;         ///< First index for list.
-  long ll_n2;         ///< Second index for list range.
+  int ll_n1;          ///< First index for list.
+  int ll_n2;          ///< Second index for list range.
   dict_T *ll_dict;    ///< The Dictionary or NULL.
   dictitem_T *ll_di;  ///< The dictitem or NULL.
-  char *ll_newkey;  ///< New key for Dict in allocated memory or NULL.
+  char *ll_newkey;    ///< New key for Dict in allocated memory or NULL.
   blob_T *ll_blob;    ///< The Blob or NULL.
 } lval_T;
 
@@ -225,7 +225,7 @@ typedef struct {
   int repeat_count;
   int refcount;
   int emsg_count;  ///< Errors in a repeating timer.
-  long timeout;
+  int64_t timeout;
   bool stopped;
   bool paused;
   Callback callback;

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -152,9 +152,9 @@ static int conv_error(const char *const msg, const MPConvStack *const mpstack,
                        ? 0
                        : (v.data.l.li == NULL
                           ? tv_list_len(v.data.l.list) - 1
-                          : (int)tv_list_idx_of_item(v.data.l.list,
-                                                     TV_LIST_ITEM_PREV(v.data.l.list,
-                                                                       v.data.l.li))));
+                          : tv_list_idx_of_item(v.data.l.list,
+                                                TV_LIST_ITEM_PREV(v.data.l.list,
+                                                                  v.data.l.li))));
       const listitem_T *const li = (v.data.l.li == NULL
                                     ? tv_list_last(v.data.l.list)
                                     : TV_LIST_ITEM_PREV(v.data.l.list,

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -526,7 +526,7 @@ buf_T *get_buf_arg(typval_T *arg)
 /// "byte2line(byte)" function
 static void f_byte2line(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  long boff = (long)tv_get_number(&argvars[0]) - 1;
+  int boff = (int)tv_get_number(&argvars[0]) - 1;
   if (boff < 0) {
     rettv->vval.v_number = -1;
   } else {
@@ -8708,8 +8708,7 @@ static void f_timer_start(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (!callback_from_typval(&callback, &argvars[1])) {
     return;
   }
-  rettv->vval.v_number = (varnumber_T)timer_start((const long)tv_get_number(&argvars[0]), repeat,
-                                                  &callback);
+  rettv->vval.v_number = (varnumber_T)timer_start(tv_get_number(&argvars[0]), repeat, &callback);
 }
 
 /// "timer_stop(timerid)" function

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -620,7 +620,7 @@ tv_list_copy_error:
 
 /// Get the list item in "l" with index "n1".  "n1" is adjusted if needed.
 /// Return NULL if there is no such item.
-listitem_T *tv_list_check_range_index_one(list_T *const l, long *const n1, const bool quiet)
+listitem_T *tv_list_check_range_index_one(list_T *const l, int *const n1, const bool quiet)
 {
   listitem_T *li = tv_list_find_index(l, n1);
   if (li == NULL) {
@@ -636,11 +636,11 @@ listitem_T *tv_list_check_range_index_one(list_T *const l, long *const n1, const
 /// If "n1" or "n2" is negative it is changed to the positive index.
 /// "li1" is the item for item "n1".
 /// Return OK or FAIL.
-int tv_list_check_range_index_two(list_T *const l, long *const n1, const listitem_T *const li1,
-                                  long *const n2, const bool quiet)
+int tv_list_check_range_index_two(list_T *const l, int *const n1, const listitem_T *const li1,
+                                  int *const n2, const bool quiet)
 {
   if (*n2 < 0) {
-    listitem_T *ni = tv_list_find(l, (int)(*n2));
+    listitem_T *ni = tv_list_find(l, *n2);
     if (ni == NULL) {
       if (!quiet) {
         semsg(_(e_list_index_out_of_range_nr), (int64_t)(*n2));
@@ -670,11 +670,10 @@ int tv_list_check_range_index_two(list_T *const l, long *const n1, const listite
 /// "op" is the operator, normally "=" but can be "+=" and the like.
 /// "varname" is used for error messages.
 /// Returns OK or FAIL.
-int tv_list_assign_range(list_T *const dest, list_T *const src, const long idx1_arg,
-                         const long idx2, const bool empty_idx2, const char *const op,
-                         const char *const varname)
+int tv_list_assign_range(list_T *const dest, list_T *const src, const int idx1_arg, const int idx2,
+                         const bool empty_idx2, const char *const op, const char *const varname)
 {
-  long idx1 = idx1_arg;
+  int idx1 = idx1_arg;
   listitem_T *const first_li = tv_list_find_index(dest, &idx1);
   listitem_T *src_li;
 
@@ -1634,14 +1633,14 @@ const char *tv_list_find_str(list_T *const l, const int n)
 
 /// Like tv_list_find() but when a negative index is used that is not found use
 /// zero and set "idx" to zero.  Used for first index of a range.
-static listitem_T *tv_list_find_index(list_T *const l, long *const idx)
+static listitem_T *tv_list_find_index(list_T *const l, int *const idx)
   FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  listitem_T *li = tv_list_find(l, (int)(*idx));
+  listitem_T *li = tv_list_find(l, *idx);
   if (li == NULL) {
     if (*idx < 0) {
       *idx = 0;
-      li = tv_list_find(l, (int)(*idx));
+      li = tv_list_find(l, *idx);
     }
   }
   return li;
@@ -1653,7 +1652,7 @@ static listitem_T *tv_list_find_index(list_T *const l, long *const idx)
 /// @param[in]  item  Item to search for.
 ///
 /// @return Index of an item or -1 if item is not in the list.
-long tv_list_idx_of_item(const list_T *const l, const listitem_T *const item)
+int tv_list_idx_of_item(const list_T *const l, const listitem_T *const item)
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_PURE
 {
   if (l == NULL) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3521,8 +3521,8 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
        && (cmdpreview_ns <= 0 || preview_lines.lines_needed <= (linenr_T)p_cwh
            || lnum <= curwin->w_botline);
        lnum++) {
-    int nmatch = (int)vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
-                                        (colnr_T)0, NULL, NULL);
+    int nmatch = vim_regexec_multi(&regmatch, curwin, curbuf, lnum,
+                                   (colnr_T)0, NULL, NULL);
     if (nmatch) {
       colnr_T copycol;
       colnr_T matchcol;
@@ -4087,9 +4087,9 @@ skip:
         // need to replace the line first (using \zs after \n).
         if (lastone
             || nmatch_tl > 0
-            || (nmatch = (int)vim_regexec_multi(&regmatch, curwin,
-                                                curbuf, sub_firstlnum,
-                                                matchcol, NULL, NULL)) == 0
+            || (nmatch = vim_regexec_multi(&regmatch, curwin,
+                                           curbuf, sub_firstlnum,
+                                           matchcol, NULL, NULL)) == 0
             || regmatch.startpos[0].lnum > 0) {
           if (new_start != NULL) {
             // Copy the rest of the line, that didn't match.
@@ -4149,8 +4149,8 @@ skip:
             copycol = 0;
           }
           if (nmatch == -1 && !lastone) {
-            nmatch = (int)vim_regexec_multi(&regmatch, curwin, curbuf,
-                                            sub_firstlnum, matchcol, NULL, NULL);
+            nmatch = vim_regexec_multi(&regmatch, curwin, curbuf,
+                                       sub_firstlnum, matchcol, NULL, NULL);
           }
 
           // 5. break if there isn't another match in this line
@@ -4446,7 +4446,7 @@ void ex_global(exarg_T *eap)
 
   if (global_busy) {
     lnum = curwin->w_cursor.lnum;
-    match = (int)vim_regexec_multi(&regmatch, curwin, curbuf, lnum, 0, NULL, NULL);
+    match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum, 0, NULL, NULL);
     if ((type == 'g' && match) || (type == 'v' && !match)) {
       global_exe_one(cmd, lnum);
     }
@@ -4455,7 +4455,7 @@ void ex_global(exarg_T *eap)
     // pass 1: set marks for each (not) matching line
     for (lnum = eap->line1; lnum <= eap->line2 && !got_int; lnum++) {
       // a match on this line?
-      match = (int)vim_regexec_multi(&regmatch, curwin, curbuf, lnum, 0, NULL, NULL);
+      match = vim_regexec_multi(&regmatch, curwin, curbuf, lnum, 0, NULL, NULL);
       if (regmatch.regprog == NULL) {
         break;  // re-compiling regprog failed
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1630,7 +1630,7 @@ static int execute_cmd0(int *retv, exarg_T *eap, const char **errormsg, bool pre
     // Call the function to execute the builtin command or the preview callback.
     eap->errmsg = NULL;
     if (preview) {
-      *retv = (cmdnames[eap->cmdidx].cmd_preview_func)(eap, (int)cmdpreview_get_ns(),
+      *retv = (cmdnames[eap->cmdidx].cmd_preview_func)(eap, cmdpreview_get_ns(),
                                                        cmdpreview_get_bufnr());
     } else {
       (cmdnames[eap->cmdidx].cmd_func)(eap);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2208,7 +2208,7 @@ handle_T cmdpreview_get_bufnr(void)
   return cmdpreview_bufnr;
 }
 
-long cmdpreview_get_ns(void)
+int cmdpreview_get_ns(void)
 {
   return cmdpreview_ns;
 }

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -615,7 +615,7 @@ void extmark_splice(buf_T *buf, int start_row, colnr_T start_col, int old_row, c
                     bcount_t old_byte, int new_row, colnr_T new_col, bcount_t new_byte,
                     ExtmarkOp undo)
 {
-  long offset = ml_find_line_or_offset(buf, start_row + 1, NULL, true);
+  int offset = ml_find_line_or_offset(buf, start_row + 1, NULL, true);
 
   // On empty buffers, when editing the first line, the line is buffered,
   // causing offset to be < 0. While the buffer is not actually empty, the

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -363,7 +363,7 @@ int foldmethodIsDiff(win_T *wp)
 // closeFold() {{{2
 /// Close fold for current window at position "pos".
 /// Repeat "count" times.
-void closeFold(pos_T pos, long count)
+void closeFold(pos_T pos, int count)
 {
   setFoldRepeat(pos, count, false);
 }
@@ -417,7 +417,7 @@ void opFoldRange(pos_T firstpos, pos_T lastpos, int opening, int recurse, int ha
 // openFold() {{{2
 /// Open fold for current window at position "pos".
 /// Repeat "count" times.
-void openFold(pos_T pos, long count)
+void openFold(pos_T pos, int count)
 {
   setFoldRepeat(pos, count, true);
 }
@@ -847,7 +847,7 @@ void foldUpdateAll(win_T *win)
 /// @return FAIL if not moved.
 ///
 /// @param dir  FORWARD or BACKWARD
-int foldMoveTo(const bool updown, const int dir, const long count)
+int foldMoveTo(const bool updown, const int dir, const int count)
 {
   int retval = FAIL;
   linenr_T lnum;
@@ -856,7 +856,7 @@ int foldMoveTo(const bool updown, const int dir, const long count)
   checkupdate(curwin);
 
   // Repeat "count" times.
-  for (long n = 0; n < count; n++) {
+  for (int n = 0; n < count; n++) {
     // Find nested folds.  Stop when a fold is closed.  The deepest fold
     // that moves the cursor is used.
     linenr_T lnum_off = 0;
@@ -1136,7 +1136,7 @@ static void checkupdate(win_T *wp)
 // setFoldRepeat() {{{2
 /// Open or close fold for current window at position `pos`.
 /// Repeat "count" times.
-static void setFoldRepeat(pos_T pos, long count, int do_open)
+static void setFoldRepeat(pos_T pos, int count, int do_open)
 {
   for (int n = 0; n < count; n++) {
     int done = DONE_NOTHING;
@@ -1816,11 +1816,11 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
     }
   }
   if (text == NULL) {
-    long count = lnume - lnum + 1;
+    int count = lnume - lnum + 1;
 
     vim_snprintf(buf, FOLD_TEXT_LEN,
-                 NGETTEXT("+--%3ld line folded",
-                          "+--%3ld lines folded ", count),
+                 NGETTEXT("+--%3d line folded",
+                          "+--%3d lines folded ", count),
                  count);
     text = buf;
   }
@@ -3304,8 +3304,8 @@ void f_foldtext(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         }
       }
     }
-    long count = foldend - foldstart + 1;
-    char *txt = NGETTEXT("+-%s%3ld line: ", "+-%s%3ld lines: ", count);
+    int count = foldend - foldstart + 1;
+    char *txt = NGETTEXT("+-%s%3d line: ", "+-%s%3d lines: ", count);
     size_t len = strlen(txt)
                  + strlen(dashes)  // for %s
                  + 20              // for %3ld

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -108,7 +108,7 @@ static pos_T *ind_find_start_CORS(linenr_T *is_raw)
 static pos_T *find_start_rawstring(int ind_maxcomment)  // XXX
 {
   pos_T *pos;
-  long cur_maxcomment = ind_maxcomment;
+  int cur_maxcomment = ind_maxcomment;
 
   while (true) {
     pos = findmatchlimit(NULL, 'R', FM_BACKWARD, cur_maxcomment);
@@ -1508,10 +1508,10 @@ static pos_T *find_match_paren_after_brace(int ind_maxparen)
 // looking a few lines further.
 static int corr_ind_maxparen(pos_T *startpos)
 {
-  long n = (long)startpos->lnum - (long)curwin->w_cursor.lnum;
+  int n = startpos->lnum - curwin->w_cursor.lnum;
 
   if (n > 0 && n < curbuf->b_ind_maxparen / 2) {
-    return curbuf->b_ind_maxparen - (int)n;
+    return curbuf->b_ind_maxparen - n;
   }
   return curbuf->b_ind_maxparen;
 }

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -144,9 +144,9 @@ static int count_n_matched_chars(const char **sp, const size_t n, bool iwhite)
   return matched_chars;
 }
 
-void fastforward_buf_to_lnum(const char **s, long lnum)
+void fastforward_buf_to_lnum(const char **s, linenr_T lnum)
 {
-  for (long i = 0; i < lnum - 1; i++) {
+  for (int i = 0; i < lnum - 1; i++) {
     *s = strchr(*s, '\n');
     if (!*s) {
       return;

--- a/src/nvim/linematch.h
+++ b/src/nvim/linematch.h
@@ -3,6 +3,8 @@
 
 #include <stddef.h>
 
+#include "nvim/pos.h"
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "linematch.h.generated.h"
 #endif

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -694,7 +694,7 @@ static int parser_get_timeout(lua_State *L)
     return 0;
   }
 
-  lua_pushinteger(L, (long)ts_parser_timeout_micros(*p));
+  lua_pushinteger(L, (lua_Integer)ts_parser_timeout_micros(*p));
   return 1;
 }
 

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -71,8 +71,8 @@ static void get_linematch_results(lua_State *lstate, mmfile_t *ma, mmfile_t *mb,
   const char *diff_begin[2] = { ma->ptr, mb->ptr };
   int diff_length[2] = { (int)count_a, (int)count_b };
 
-  fastforward_buf_to_lnum(&diff_begin[0], start_a + 1);
-  fastforward_buf_to_lnum(&diff_begin[1], start_b + 1);
+  fastforward_buf_to_lnum(&diff_begin[0], (linenr_T)start_a + 1);
+  fastforward_buf_to_lnum(&diff_begin[1], (linenr_T)start_b + 1);
 
   int *decisions = NULL;
   size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions, iwhite);
@@ -125,7 +125,7 @@ static int write_string(void *priv, mmbuffer_t *mb, int nbuf)
 }
 
 // hunk_func callback used when opts.hunk_lines = true
-static int hunk_locations_cb(long start_a, long count_a, long start_b, long count_b, void *cb_data)
+static int hunk_locations_cb(int start_a, int count_a, int start_b, int count_b, void *cb_data)
 {
   hunkpriv_t *priv = (hunkpriv_t *)cb_data;
   lua_State *lstate = priv->lstate;
@@ -140,7 +140,7 @@ static int hunk_locations_cb(long start_a, long count_a, long start_b, long coun
 }
 
 // hunk_func callback used when opts.on_hunk is given
-static int call_on_hunk_cb(long start_a, long count_a, long start_b, long count_b, void *cb_data)
+static int call_on_hunk_cb(int start_a, int count_a, int start_b, int count_b, void *cb_data)
 {
   // Mimic extra offsets done by xdiff, see:
   // src/xdiff/xemit.c:284

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2074,7 +2074,7 @@ void f_hasmapto(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 ///
 /// @return  A Dictionary.
 static Dictionary mapblock_fill_dict(const mapblock_T *const mp, const char *lhsrawalt,
-                                     const long buffer_value, const bool compatible)
+                                     const int buffer_value, const bool compatible)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   Dictionary dict = ARRAY_DICT_INIT;
@@ -2694,7 +2694,7 @@ ArrayOf(Dictionary) keymap_array(String mode, buf_T *buf)
   int int_mode = get_map_mode(&p, 0);
 
   // Determine the desired buffer value
-  long buffer_value = (buf == NULL) ? 0 : buf->handle;
+  int buffer_value = (buf == NULL) ? 0 : buf->handle;
 
   for (int i = 0; i < MAX_MAPHASH; i++) {
     for (const mapblock_T *current_maphash = get_maphash(i, buf);

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1315,7 +1315,7 @@ void mark_adjust_buf(buf_T *buf, linenr_T line1, linenr_T line2, linenr_T amount
 // position.
 // "spaces_removed" is the number of spaces that were removed, matters when the
 // cursor is inside them.
-void mark_col_adjust(linenr_T lnum, colnr_T mincol, linenr_T lnum_amount, long col_amount,
+void mark_col_adjust(linenr_T lnum, colnr_T mincol, linenr_T lnum_amount, colnr_T col_amount,
                      int spaces_removed)
 {
   int fnum = curbuf->b_fnum;

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -419,7 +419,7 @@ static void next_search_hl(win_T *win, match_T *search_hl, match_T *shl, linenr_
   FUNC_ATTR_NONNULL_ARG(2)
 {
   colnr_T matchcol;
-  long nmatched = 0;
+  int nmatched = 0;
   const int called_emsg_before = called_emsg;
 
   // for :{range}s/pat only highlight inside the range

--- a/src/nvim/memline_defs.h
+++ b/src/nvim/memline_defs.h
@@ -17,7 +17,7 @@ typedef struct info_pointer {
 
 typedef struct ml_chunksize {
   int mlcs_numlines;
-  long mlcs_totalsize;
+  int mlcs_totalsize;
 } chunksize_T;
 
 // Flags when calling ml_updatechunk()

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -78,7 +78,7 @@ void ex_menu(exarg_T *eap)
   char *arg;
   char *p;
   int i;
-  long pri_tab[MENUDEPTH + 1];
+  int pri_tab[MENUDEPTH + 1];
   TriState enable = kNone;        // kTrue for "menu enable",
                                   // kFalse for "menu disable
   vimmenu_T menuarg;
@@ -129,7 +129,7 @@ void ex_menu(exarg_T *eap)
   }
   if (ascii_iswhite(*p)) {
     for (i = 0; i < MENUDEPTH && !ascii_iswhite(*arg); i++) {
-      pri_tab[i] = getdigits_long(&arg, false, 0);
+      pri_tab[i] = getdigits_int(&arg, false, 0);
       if (pri_tab[i] == 0) {
         pri_tab[i] = 500;
       }
@@ -265,7 +265,7 @@ theend:
 /// @param[out]  menuarg menu entry
 /// @param[] pri_tab priority table
 /// @param[in] call_data Right hand side command
-static int add_menu_path(const char *const menu_path, vimmenu_T *menuarg, const long *const pri_tab,
+static int add_menu_path(const char *const menu_path, vimmenu_T *menuarg, const int *const pri_tab,
                          const char *const call_data)
 {
   char *path_name;
@@ -366,7 +366,7 @@ static int add_menu_path(const char *const menu_path, vimmenu_T *menuarg, const 
         menu->en_name = NULL;
         menu->en_dname = NULL;
       }
-      menu->priority = (int)pri_tab[pri_idx];
+      menu->priority = pri_tab[pri_idx];
       menu->parent = parent;
 
       // Add after menu that has lower priority.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -567,10 +567,10 @@ static char *get_emsg_lnum(void)
   if (SOURCING_NAME != NULL
       && (other_sourcing_name() || SOURCING_LNUM != last_sourcing_lnum)
       && SOURCING_LNUM != 0) {
-    const char *const p = _("line %4ld:");
+    const char *const p = _("line %4" PRIdLINENR ":");
     const size_t buf_len = 20 + strlen(p);
     char *const buf = xmalloc(buf_len);
-    snprintf(buf, buf_len, p, (long)SOURCING_LNUM);
+    snprintf(buf, buf_len, p, SOURCING_LNUM);
     return buf;
   }
   return NULL;
@@ -693,8 +693,8 @@ bool emsg_multiline(const char *s, bool multiline)
 
       // Log (silent) errors as debug messages.
       if (SOURCING_NAME != NULL && SOURCING_LNUM != 0) {
-        DLOG("(:silent) %s (%s (line %ld))",
-             s, SOURCING_NAME, (long)SOURCING_LNUM);
+        DLOG("(:silent) %s (%s (line %" PRIdLINENR "))",
+             s, SOURCING_NAME, SOURCING_LNUM);
       } else {
         DLOG("(:silent) %s", s);
       }
@@ -704,7 +704,7 @@ bool emsg_multiline(const char *s, bool multiline)
 
     // Log editor errors as INFO.
     if (SOURCING_NAME != NULL && SOURCING_LNUM != 0) {
-      ILOG("%s (%s (line %ld))", s, SOURCING_NAME, (long)SOURCING_LNUM);
+      ILOG("%s (%s (line %" PRIdLINENR "))", s, SOURCING_NAME, SOURCING_LNUM);
     } else {
       ILOG("%s", s);
     }
@@ -1357,7 +1357,7 @@ bool messaging(void)
 
 void msgmore(int n)
 {
-  long pn;
+  int pn;
 
   if (global_busy           // no messages now, wait until global is finished
       || !messaging()) {      // 'lazyredraw' set, don't do messages now
@@ -1380,11 +1380,11 @@ void msgmore(int n)
   if (pn > p_report) {
     if (n > 0) {
       vim_snprintf(msg_buf, MSG_BUF_LEN,
-                   NGETTEXT("%ld more line", "%ld more lines", pn),
+                   NGETTEXT("%d more line", "%d more lines", pn),
                    pn);
     } else {
       vim_snprintf(msg_buf, MSG_BUF_LEN,
-                   NGETTEXT("%ld line less", "%ld fewer lines", pn),
+                   NGETTEXT("%d line less", "%d fewer lines", pn),
                    pn);
     }
     if (got_int) {

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -340,9 +340,7 @@ void update_topline(win_T *wp)
     assert(wp->w_buffer != 0);
     if (wp->w_botline <= wp->w_buffer->b_ml.ml_line_count) {
       if (wp->w_cursor.lnum < wp->w_botline) {
-        if (((long)wp->w_cursor.lnum
-             >= (long)wp->w_botline - *so_ptr
-             || hasAnyFolding(wp))) {
+        if ((wp->w_cursor.lnum >= wp->w_botline - *so_ptr || hasAnyFolding(wp))) {
           lineoff_T loff;
 
           // Cursor is (a few lines) above botline, check if there are
@@ -1188,7 +1186,7 @@ void f_virtcol2col(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 ///
 /// @param line_count number of lines to scroll
 /// @param byfold if true, count a closed fold as one line
-bool scrolldown(long line_count, int byfold)
+bool scrolldown(linenr_T line_count, int byfold)
 {
   int done = 0;                // total # of physical lines done
   int width1 = 0;
@@ -1203,7 +1201,7 @@ bool scrolldown(long line_count, int byfold)
   // Make sure w_topline is at the first of a sequence of folded lines.
   (void)hasFolding(curwin->w_topline, &curwin->w_topline, NULL);
   validate_cursor();            // w_wrow needs to be valid
-  for (long todo = line_count; todo > 0; todo--) {
+  for (int todo = line_count; todo > 0; todo--) {
     if (curwin->w_topfill < win_get_fill(curwin, curwin->w_topline)
         && curwin->w_topfill < curwin->w_height_inner - 1) {
       curwin->w_topfill++;
@@ -1301,11 +1299,11 @@ bool scrolldown(long line_count, int byfold)
 
   if (curwin->w_cursor.lnum == curwin->w_topline && do_sms) {
     int so = get_scrolloff_value(curwin);
-    long scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
+    colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
 
     // make sure the cursor is in the visible text
     validate_virtcol();
-    long col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;
+    colnr_T col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;
     int row = 0;
     if (col >= width1) {
       col -= width1;
@@ -1347,7 +1345,7 @@ bool scrollup(linenr_T line_count, int byfold)
     // 'smoothscroll': increase "w_skipcol" until it goes over the end of
     // the line, then advance to the next line.
     // folding: count each sequence of folded lines as one logical line.
-    for (long todo = line_count; todo > 0; todo--) {
+    for (int todo = line_count; todo > 0; todo--) {
       if (curwin->w_topfill > 0) {
         curwin->w_topfill--;
       } else {
@@ -1429,7 +1427,7 @@ bool scrollup(linenr_T line_count, int byfold)
     int width2 = width1 + col_off2;
     int extra2 = col_off - col_off2;
     int so = get_scrolloff_value(curwin);
-    long scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
+    colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
     int space_cols = (curwin->w_height_inner - 1) * width2;
 
     // If we have non-zero scrolloff, just ignore the marker as we are
@@ -1480,7 +1478,7 @@ void adjust_skipcol(void)
   }
   int width2 = width1 + curwin_col_off2();
   int so = get_scrolloff_value(curwin);
-  long scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
+  colnr_T scrolloff_cols = so == 0 ? 0 : width1 + (so - 1) * width2;
   bool scrolled = false;
 
   validate_cheight();
@@ -1510,7 +1508,7 @@ void adjust_skipcol(void)
     redraw_later(curwin, UPD_NOT_VALID);
     return;  // don't scroll in the other direction now
   }
-  long col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;
+  colnr_T col = curwin->w_virtcol - curwin->w_skipcol + scrolloff_cols;
   int row = 0;
   if (col >= width1) {
     col -= width1;
@@ -2319,9 +2317,9 @@ void cursor_correct(void)
 /// and update the screen.
 ///
 /// @return  FAIL for failure, OK otherwise.
-int onepage(Direction dir, long count)
+int onepage(Direction dir, int count)
 {
-  long n;
+  int n;
   int retval = OK;
   lineoff_T loff;
   linenr_T old_topline = curwin->w_topline;
@@ -2562,7 +2560,7 @@ static void get_scroll_overlap(lineoff_T *lp, int dir)
 // Scroll 'scroll' lines up or down.
 void halfpage(bool flag, linenr_T Prenum)
 {
-  long scrolled = 0;
+  int scrolled = 0;
   int i;
 
   if (Prenum) {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -1496,7 +1496,7 @@ static int normal_check(VimState *state)
 /// Set v:prevcount only when "set_prevcount" is true.
 static void set_vcount_ca(cmdarg_T *cap, bool *set_prevcount)
 {
-  long count = cap->count0;
+  int64_t count = cap->count0;
 
   // multiply with cap->opcount the same way as above
   if (cap->opcount != 0) {
@@ -1856,7 +1856,7 @@ void clear_showcmd(void)
 
   if (VIsual_active && !char_avail()) {
     int cursor_bot = lt(VIsual, curwin->w_cursor);
-    long lines;
+    int lines;
     colnr_T leftcol, rightcol;
     linenr_T top, bot;
 
@@ -2115,8 +2115,7 @@ void do_check_scrollbind(bool check)
           && (curwin->w_topline != old_topline
               || curwin->w_topfill != old_topfill
               || curwin->w_leftcol != old_leftcol)) {
-        check_scrollbind(curwin->w_topline - old_topline,
-                         (long)(curwin->w_leftcol - old_leftcol));
+        check_scrollbind(curwin->w_topline - old_topline, curwin->w_leftcol - old_leftcol);
       }
     } else if (vim_strchr(p_sbo, 'j')) {  // jump flag set in 'scrollopt'
       // When switching between windows, make sure that the relative
@@ -2142,7 +2141,7 @@ void do_check_scrollbind(bool check)
 /// Synchronize any windows that have "scrollbind" set, based on the
 /// number of rows by which the current window has changed
 /// (1998-11-02 16:21:01  R. Edward Ralston <eralston@computer.org>)
-void check_scrollbind(linenr_T topline_diff, long leftcol_diff)
+void check_scrollbind(linenr_T topline_diff, int leftcol_diff)
 {
   bool want_ver;
   bool want_hor;
@@ -2468,7 +2467,7 @@ bool find_decl(char *ptr, size_t len, bool locally, bool thisblock, int flags_ar
 /// 'dist' must be positive.
 ///
 /// @return  true if able to move cursor, false otherwise.
-static bool nv_screengo(oparg_T *oap, int dir, long dist)
+static bool nv_screengo(oparg_T *oap, int dir, int dist)
 {
   int linelen = (int)linetabsize(curwin, curwin->w_cursor.lnum);
   bool retval = true;
@@ -2784,7 +2783,7 @@ static void nv_zet(cmdarg_T *cap)
 {
   colnr_T col;
   int nchar = cap->nchar;
-  long old_fdl = (long)curwin->w_p_fdl;
+  int old_fdl = (int)curwin->w_p_fdl;
   int old_fen = curwin->w_p_fen;
 
   int siso = get_sidescrolloff_value(curwin);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2202,7 +2202,7 @@ bool swapchar(int op_type, pos_T *pos)
 }
 
 /// Insert and append operators for Visual mode.
-void op_insert(oparg_T *oap, long count1)
+void op_insert(oparg_T *oap, int count1)
 {
   int pre_textlen = 0;
   char *firstline;
@@ -2491,7 +2491,7 @@ int op_change(oparg_T *oap)
 
     ins_len = (int)strlen(firstline) - pre_textlen;
     if (ins_len > 0) {
-      long offset;
+      int offset;
       char *newp;
       char *oldp;
       // Subsequent calls to ml_get() flush the firstline data - take a
@@ -2932,7 +2932,7 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
   pos_T old_pos;
   char *insert_string = NULL;
   bool allocated = false;
-  long cnt;
+  int cnt;
   const pos_T orig_start = curbuf->b_op_start;
   const pos_T orig_end = curbuf->b_op_end;
   unsigned cur_ve_flags = get_ve_flags();
@@ -3334,7 +3334,7 @@ void do_put(int regname, yankreg_T *reg, int dir, int count, int flags)
       ptr += bd.startspaces;
 
       // insert the new text
-      for (long j = 0; j < count; j++) {
+      for (int j = 0; j < count; j++) {
         memmove(ptr, y_array[i], (size_t)yanklen);
         ptr += yanklen;
 
@@ -5339,7 +5339,7 @@ void cursor_pos_info(dict_T *dict)
     linenr_T lnum;
     int eol_size;
     varnumber_T last_check = 100000L;
-    long line_count_selected = 0;
+    int line_count_selected = 0;
     if (get_fileformat(curbuf) == EOL_DOS) {
       eol_size = 2;
     } else {
@@ -5398,7 +5398,7 @@ void cursor_pos_info(dict_T *dict)
       if (l_VIsual_active
           && lnum >= min_pos.lnum && lnum <= max_pos.lnum) {
         char *s = NULL;
-        long len = 0L;
+        int len = 0L;
 
         switch (l_VIsual_mode) {
         case Ctrl_V:
@@ -5406,7 +5406,7 @@ void cursor_pos_info(dict_T *dict)
           block_prep(&oparg, &bd, lnum, false);
           virtual_op = kNone;
           s = bd.textstart;
-          len = (long)bd.textlen;
+          len = bd.textlen;
           break;
         case 'V':
           s = ml_get(lnum);
@@ -5429,7 +5429,7 @@ void cursor_pos_info(dict_T *dict)
           if (lnum == curbuf->b_ml.ml_line_count
               && !curbuf->b_p_eol
               && (curbuf->b_p_bin || !curbuf->b_p_fixeol)
-              && (long)strlen(s) < len) {
+              && (int)strlen(s) < len) {
             byte_count_cursor -= eol_size;
           }
         }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -131,7 +131,7 @@ typedef struct qf_list_S {
   bool qf_multiline;
   bool qf_multiignore;
   bool qf_multiscan;
-  long qf_changedtick;
+  int qf_changedtick;
 } qf_list_T;
 
 /// Quickfix/Location list stack definition
@@ -234,7 +234,7 @@ typedef struct {
 
 /// :vimgrep command arguments
 typedef struct vgr_args_S {
-  long tomatch;          ///< maximum number of matches to find
+  int tomatch;          ///< maximum number of matches to find
   char *spat;          ///< search pattern
   int flags;             ///< search modifier
   char **fnames;       ///< list of files to search
@@ -2756,7 +2756,7 @@ static int qf_jump_edit_buffer(qf_info_T *qi, qfline_T *qf_ptr, int forceit, int
                                int *opened_window)
 {
   qf_list_T *qfl = qf_get_curlist(qi);
-  long old_changetick = qfl->qf_changedtick;
+  int old_changetick = qfl->qf_changedtick;
   int old_qf_curlist = qi->qf_curlist;
   qfltype_T qfl_type = qfl->qfl_type;
   int retval = OK;
@@ -2836,7 +2836,7 @@ static void qf_jump_goto_line(linenr_T qf_lnum, int qf_col, char qf_viscol, char
     // Move the cursor to the first line in the buffer
     pos_T save_cursor = curwin->w_cursor;
     curwin->w_cursor.lnum = 0;
-    if (!do_search(NULL, '/', '/', qf_pattern, (long)1, SEARCH_KEEP, NULL)) {
+    if (!do_search(NULL, '/', '/', qf_pattern, 1, SEARCH_KEEP, NULL)) {
       curwin->w_cursor = save_cursor;
     }
   }
@@ -2891,7 +2891,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
 static int qf_jump_open_window(qf_info_T *qi, qfline_T *qf_ptr, bool newwin, int *opened_window)
 {
   qf_list_T *qfl = qf_get_curlist(qi);
-  long old_changetick = qfl->qf_changedtick;
+  int old_changetick = qfl->qf_changedtick;
   int old_qf_curlist = qi->qf_curlist;
   qfltype_T qfl_type = qfl->qfl_type;
 
@@ -4051,7 +4051,7 @@ static int qf_buf_add_line(qf_list_T *qfl, buf_T *buf, linenr_T lnum, const qfli
 
 // Call the 'quickfixtextfunc' function to get the list of lines to display in
 // the quickfix window for the entries 'start_idx' to 'end_idx'.
-static list_T *call_qftf_func(qf_list_T *qfl, int qf_winid, long start_idx, long end_idx)
+static list_T *call_qftf_func(qf_list_T *qfl, int qf_winid, int start_idx, int end_idx)
 {
   Callback *cb = &qftf_cb;
   list_T *qftf_list = NULL;
@@ -4142,7 +4142,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
       lnum = buf->b_ml.ml_line_count;
     }
 
-    list_T *qftf_list = call_qftf_func(qfl, qf_winid, lnum + 1, (long)qfl->qf_count);
+    list_T *qftf_list = call_qftf_func(qfl, qf_winid, lnum + 1, qfl->qf_count);
     listitem_T *qftf_li = tv_list_first(qftf_list);
 
     int prev_bufnr = -1;
@@ -5227,7 +5227,7 @@ static bool vgr_qflist_valid(win_T *wp, qf_info_T *qi, unsigned qfid, char *titl
 /// Search for a pattern in all the lines in a buffer and add the matching lines
 /// to a quickfix list.
 static bool vgr_match_buflines(qf_list_T *qfl, char *fname, buf_T *buf, char *spat,
-                               regmmatch_T *regmatch, long *tomatch, int duplicate_name, int flags)
+                               regmmatch_T *regmatch, int *tomatch, int duplicate_name, int flags)
   FUNC_ATTR_NONNULL_ARG(1, 3, 4, 5, 6)
 {
   bool found_match = false;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -893,11 +893,11 @@ static int64_t getoctchrs(void)
 // If the first character is '-', then the range is reversed.
 // Should end with 'end'.  If minval is missing, zero is default, if maxval is
 // missing, a very big number is the default.
-static int read_limits(long *minval, long *maxval)
+static int read_limits(int *minval, int *maxval)
 {
   int reverse = false;
   char *first_char;
-  long tmp;
+  int tmp;
 
   if (*regparse == '-') {
     // Starts with '-', so reverse the range later.
@@ -905,10 +905,10 @@ static int read_limits(long *minval, long *maxval)
     reverse = true;
   }
   first_char = regparse;
-  *minval = getdigits_long(&regparse, false, 0);
+  *minval = getdigits_int(&regparse, false, 0);
   if (*regparse == ',') {           // There is a comma.
     if (ascii_isdigit(*++regparse)) {
-      *maxval = getdigits_long(&regparse, false, MAX_LIMIT);
+      *maxval = getdigits_int(&regparse, false, MAX_LIMIT);
     } else {
       *maxval = MAX_LIMIT;
     }
@@ -2515,8 +2515,8 @@ bool vim_regexec_nl(regmatch_T *rmp, const char *line, colnr_T col)
 ///
 /// @return  zero if there is no match.  Return number of lines contained in the
 ///          match otherwise.
-long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
-                       proftime_T *tm, int *timed_out)
+int vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
+                      proftime_T *tm, int *timed_out)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   regexec_T rex_save;
@@ -2535,7 +2535,7 @@ long vim_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, 
   }
   rex_in_use = true;
 
-  long result = rmp->regprog->engine->regexec_multi(rmp, win, buf, lnum, col, tm, timed_out);
+  int result = rmp->regprog->engine->regexec_multi(rmp, win, buf, lnum, col, tm, timed_out);
   rmp->regprog->re_in_use = false;
 
   // NFA engine aborted because it's very slow, use backtracking engine instead.

--- a/src/nvim/regexp_bt.c
+++ b/src/nvim/regexp_bt.c
@@ -2466,8 +2466,8 @@ static uint8_t *regpiece(int *flagp)
   int op;
   uint8_t *next;
   int flags;
-  long minval;
-  long maxval;
+  int minval;
+  int maxval;
 
   ret = regatom(&flags);
   if (ret == NULL) {
@@ -4869,7 +4869,7 @@ static bool regmatch(uint8_t *scan, proftime_T *tm, int *timed_out)
 /// @param timed_out  flag set on timeout or NULL
 ///
 /// @return  0 for failure, or number of lines contained in the match.
-static long regtry(bt_regprog_T *prog, colnr_T col, proftime_T *tm, int *timed_out)
+static int regtry(bt_regprog_T *prog, colnr_T col, proftime_T *tm, int *timed_out)
 {
   rex.input = rex.line + col;
   rex.need_clear_subexpr = true;
@@ -4939,12 +4939,12 @@ static long regtry(bt_regprog_T *prog, colnr_T col, proftime_T *tm, int *timed_o
 /// @param timed_out  flag set on timeout or NULL
 ///
 /// @return  0 for failure, or number of lines contained in the match.
-static long bt_regexec_both(uint8_t *line, colnr_T startcol, proftime_T *tm, int *timed_out)
+static int bt_regexec_both(uint8_t *line, colnr_T startcol, proftime_T *tm, int *timed_out)
 {
   bt_regprog_T *prog;
   uint8_t *s;
   colnr_T col = startcol;
-  long retval = 0L;
+  int retval = 0;
 
   // Create "regstack" and "backpos" if they are not allocated yet.
   // We allocate *_INITIAL amount of bytes first and then set the grow size
@@ -5175,8 +5175,8 @@ static int bt_regexec_nl(regmatch_T *rmp, uint8_t *line, colnr_T col, bool line_
 ///
 /// @return zero if there is no match and number of lines contained in the match
 ///         otherwise.
-static long bt_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
-                             proftime_T *tm, int *timed_out)
+static int bt_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
+                            proftime_T *tm, int *timed_out)
 {
   init_regexec_multi(rmp, win, buf, lnum);
   return bt_regexec_both(NULL, col, tm, timed_out);

--- a/src/nvim/regexp_defs.h
+++ b/src/nvim/regexp_defs.h
@@ -169,7 +169,7 @@ struct regengine {
   /// bt_regexec_nl or nfa_regexec_nl
   int (*regexec_nl)(regmatch_T *, uint8_t *, colnr_T, bool);
   /// bt_regexec_mult or nfa_regexec_mult
-  long (*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T, proftime_T *, int *);
+  int (*regexec_multi)(regmmatch_T *, win_T *, buf_T *, linenr_T, colnr_T, proftime_T *, int *);
   // uint8_t *expr;
 };
 

--- a/src/nvim/regexp_nfa.c
+++ b/src/nvim/regexp_nfa.c
@@ -2541,7 +2541,7 @@ static int nfa_regpiece(void)
   int i;
   int op;
   int ret;
-  long minval, maxval;
+  int minval, maxval;
   bool greedy = true;  // Braces are prefixed with '-' ?
   parse_state_T old_state;
   parse_state_T new_state;
@@ -5792,7 +5792,7 @@ static int skip_to_start(int c, colnr_T *colp)
 // Check for a match with match_text.
 // Called after skip_to_start() has found regstart.
 // Returns zero for no match, 1 for a match.
-static long find_match_text(colnr_T *startcol, int regstart, uint8_t *match_text)
+static int find_match_text(colnr_T *startcol, int regstart, uint8_t *match_text)
 {
 #define PTR2LEN(x) utf_ptr2len(x)
 
@@ -7207,7 +7207,7 @@ theend:
 /// @param timed_out  flag set on timeout or NULL
 ///
 /// @return  <= 0 for failure, number of lines contained in the match otherwise.
-static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm, int *timed_out)
+static int nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm, int *timed_out)
 {
   int i;
   regsubs_T subs, m;
@@ -7334,10 +7334,10 @@ static long nfa_regtry(nfa_regprog_T *prog, colnr_T col, proftime_T *tm, int *ti
 ///
 /// @return <= 0 if there is no match and number of lines contained in the
 /// match otherwise.
-static long nfa_regexec_both(uint8_t *line, colnr_T startcol, proftime_T *tm, int *timed_out)
+static int nfa_regexec_both(uint8_t *line, colnr_T startcol, proftime_T *tm, int *timed_out)
 {
   nfa_regprog_T *prog;
-  long retval = 0L;
+  int retval = 0;
   colnr_T col = startcol;
 
   if (REG_MULTI) {
@@ -7631,8 +7631,8 @@ static int nfa_regexec_nl(regmatch_T *rmp, uint8_t *line, colnr_T col, bool line
 ///
 /// @par
 /// FIXME if this behavior is not compatible.
-static long nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
-                              proftime_T *tm, int *timed_out)
+static int nfa_regexec_multi(regmmatch_T *rmp, win_T *win, buf_T *buf, linenr_T lnum, colnr_T col,
+                             proftime_T *tm, int *timed_out)
 {
   init_regexec_multi(rmp, win, buf, lnum);
   return nfa_regexec_both(NULL, col, tm, timed_out);

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2554,9 +2554,9 @@ static int is_zero_width(char *pattern, int move, pos_T *cur, Direction directio
     // start and end are in the same position.
     do {
       regmatch.startpos[0].col++;
-      nmatched = (int)vim_regexec_multi(&regmatch, curwin, curbuf,
-                                        pos.lnum, regmatch.startpos[0].col,
-                                        NULL, NULL);
+      nmatched = vim_regexec_multi(&regmatch, curwin, curbuf,
+                                   pos.lnum, regmatch.startpos[0].col,
+                                   NULL, NULL);
       if (nmatched != 0) {
         break;
       }

--- a/src/nvim/spell_defs.h
+++ b/src/nvim/spell_defs.h
@@ -120,7 +120,7 @@ struct slang_S {
   bool sl_add;              // true if it's a .add file.
 
   uint8_t *sl_fbyts;        // case-folded word bytes
-  long sl_fbyts_len;        // length of sl_fbyts
+  int sl_fbyts_len;         // length of sl_fbyts
   idx_T *sl_fidxs;          // case-folded word indexes
   uint8_t *sl_kbyts;        // keep-case word bytes
   idx_T *sl_kidxs;          // keep-case word indexes

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -1678,7 +1678,7 @@ static int *mb_str2wide(const char *s)
 /// @param prefixcnt  when "prefixtree" is true: prefix count
 ///
 /// @return  zero when OK, SP_ value for an error.
-static int spell_read_tree(FILE *fd, uint8_t **bytsp, long *bytsp_len, idx_T **idxsp,
+static int spell_read_tree(FILE *fd, uint8_t **bytsp, int *bytsp_len, idx_T **idxsp,
                            bool prefixtree, int prefixcnt)
   FUNC_ATTR_NONNULL_ARG(1, 2, 4)
 {
@@ -4214,7 +4214,7 @@ static int node_compress(spellinfo_T *spin, wordnode_T *node, hashtab_T *ht, int
   wordnode_T *child;
   hash_T hash;
   hashitem_T *hi;
-  long len = 0;
+  int len = 0;
   unsigned nr, n;
   int compressed = 0;
 
@@ -4262,7 +4262,7 @@ static int node_compress(spellinfo_T *spin, wordnode_T *node, hashtab_T *ht, int
       }
     }
   }
-  *tot += (int)len + 1;      // add one for the node that stores the length
+  *tot += len + 1;      // add one for the node that stores the length
 
   // Make a hash key for the node and its siblings, so that we can quickly
   // find a lookalike node.  This must be done after compressing the sibling

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -5646,11 +5646,11 @@ static void syntime_report(void)
       p = GA_APPEND_VIA_PTR(time_entry_T, &ga);
       p->total = spp->sp_time.total;
       total_total = profile_add(total_total, spp->sp_time.total);
-      p->count = (int)spp->sp_time.count;
-      p->match = (int)spp->sp_time.match;
-      total_count += (int)spp->sp_time.count;
+      p->count = spp->sp_time.count;
+      p->match = spp->sp_time.match;
+      total_count += spp->sp_time.count;
       p->slowest = spp->sp_time.slowest;
-      proftime_T tm = profile_divide(spp->sp_time.total, (int)spp->sp_time.count);
+      proftime_T tm = profile_divide(spp->sp_time.total, spp->sp_time.count);
       p->average = tm;
       p->id = spp->sp_syn.id;
       p->pattern = spp->sp_pattern;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -714,7 +714,7 @@ static bool is_filter_char(int c)
   return !!(tpf_flags & flag);
 }
 
-void terminal_paste(long count, char **y_array, size_t y_size)
+void terminal_paste(int count, char **y_array, size_t y_size)
 {
   if (y_size == 0) {
     return;
@@ -1584,7 +1584,7 @@ static void refresh_terminal(Terminal *term)
     }
     return;
   }
-  long ml_before = buf->b_ml.ml_line_count;
+  linenr_T ml_before = buf->b_ml.ml_line_count;
 
   // refresh_ functions assume the terminal buffer is current
   aco_save_T aco;
@@ -1594,7 +1594,7 @@ static void refresh_terminal(Terminal *term)
   refresh_screen(term, buf);
   aucmd_restbuf(&aco);
 
-  long ml_added = buf->b_ml.ml_line_count - ml_before;
+  int ml_added = buf->b_ml.ml_line_count - ml_before;
   adjust_topline(term, buf, ml_added);
 }
 
@@ -1754,7 +1754,7 @@ static void refresh_screen(Terminal *term, buf_T *buf)
   term->invalid_end = -1;
 }
 
-static void adjust_topline(Terminal *term, buf_T *buf, long added)
+static void adjust_topline(Terminal *term, buf_T *buf, int added)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
     if (wp->w_buffer == buf) {

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -1108,15 +1108,13 @@ void format_lines(linenr_T line_count, bool avoid_fex)
         }
         if (next_leader_len > 0) {
           (void)del_bytes(next_leader_len, false, false);
-          mark_col_adjust(curwin->w_cursor.lnum, (colnr_T)0, 0L,
-                          (long)-next_leader_len, 0);
+          mark_col_adjust(curwin->w_cursor.lnum, 0, 0, -next_leader_len, 0);
         } else if (second_indent > 0) {   // the "leader" for FO_Q_SECOND
           int indent = (int)getwhitecols_curline();
 
           if (indent > 0) {
             (void)del_bytes(indent, false, false);
-            mark_col_adjust(curwin->w_cursor.lnum,
-                            (colnr_T)0, 0L, (long)-indent, 0);
+            mark_col_adjust(curwin->w_cursor.lnum, 0, 0, -indent, 0);
           }
         }
         curwin->w_cursor.lnum--;

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -733,7 +733,7 @@ int current_sent(oparg_T *oap, int count, bool include)
   bool start_blank;
   int c;
   bool at_start_sent;
-  long ncount;
+  int ncount;
 
   start_pos = curwin->w_cursor;
   pos = start_pos;
@@ -838,7 +838,7 @@ extend:
     }
   }
   if (ncount > 0) {
-    findsent_forward((int)ncount, true);
+    findsent_forward(ncount, true);
   } else {
     decl(&curwin->w_cursor);
   }
@@ -1142,7 +1142,7 @@ int current_tagblock(oparg_T *oap, int count_arg, bool include)
 again:
   // Search backwards for unclosed "<aaa>".
   // Put this position in start_pos.
-  for (long n = 0; n < count; n++) {
+  for (int n = 0; n < count; n++) {
     if (do_searchpair("<[^ \t>/!]\\+\\%(\\_s\\_[^>]\\{-}[^/]>\\|$\\|\\_s\\=>\\)",
                       "",
                       "</[^>]*>", BACKWARD, NULL, 0,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -287,7 +287,7 @@ static void terminfo_start(TUIData *tui)
   const char *colorterm = os_getenv("COLORTERM");
   const char *termprg = os_getenv("TERM_PROGRAM");
   const char *vte_version_env = os_getenv("VTE_VERSION");
-  long vtev = vte_version_env ? strtol(vte_version_env, NULL, 10) : 0;
+  int vtev = vte_version_env ? (int)strtol(vte_version_env, NULL, 10) : 0;
   bool iterm_env = termprg && strstr(termprg, "iTerm.app");
   bool nsterm = (termprg && strstr(termprg, "Apple_Terminal"))
                 || terminfo_is_term_family(term, "nsterm");
@@ -295,7 +295,7 @@ static void terminfo_start(TUIData *tui)
                  || os_getenv("KONSOLE_PROFILE_NAME")
                  || os_getenv("KONSOLE_DBUS_SESSION");
   const char *konsolev_env = os_getenv("KONSOLE_VERSION");
-  long konsolev = konsolev_env ? strtol(konsolev_env, NULL, 10)
+  int konsolev = konsolev_env ? (int)strtol(konsolev_env, NULL, 10)
                                : (konsole ? 1 : 0);
 
   patch_terminfo_bugs(tui, term, colorterm, vtev, konsolev, iterm_env, nsterm);
@@ -1456,7 +1456,7 @@ void tui_option_set(TUIData *tui, String name, Object value)
   } else if (strequal(name.data, "ttimeout")) {
     tui->input.ttimeout = value.data.boolean;
   } else if (strequal(name.data, "ttimeoutlen")) {
-    tui->input.ttimeoutlen = (long)value.data.integer;
+    tui->input.ttimeoutlen = (OptInt)value.data.integer;
   } else if (strequal(name.data, "verbose")) {
     tui->verbose = value.data.integer;
   }
@@ -1689,7 +1689,7 @@ static int unibi_find_ext_bool(unibi_term *ut, const char *name)
 /// Several entries in terminfo are known to be deficient or outright wrong;
 /// and several terminal emulators falsely announce incorrect terminal types.
 static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colorterm,
-                                long vte_version, long konsolev, bool iterm_env, bool nsterm)
+                                int vte_version, int konsolev, bool iterm_env, bool nsterm)
 {
   unibi_term *ut = tui->ut;
   const char *xterm_version = os_getenv("XTERM_VERSION");
@@ -2019,7 +2019,7 @@ static void patch_terminfo_bugs(TUIData *tui, const char *term, const char *colo
 
 /// This adds stuff that is not in standard terminfo as extended unibilium
 /// capabilities.
-static void augment_terminfo(TUIData *tui, const char *term, long vte_version, long konsolev,
+static void augment_terminfo(TUIData *tui, const char *term, int vte_version, int konsolev,
                              bool iterm_env, bool nsterm)
 {
   unibi_term *ut = tui->ut;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -147,7 +147,7 @@ static const char e_write_error_in_undo_file_str[]
   = N_("E829: Write error in undo file: %s");
 
 // used in undo_end() to report number of added and deleted lines
-static long u_newcount, u_oldcount;
+static int u_newcount, u_oldcount;
 
 // When 'u' flag included in 'cpoptions', we behave like vi.  Need to remember
 // the action that "u" should do.
@@ -507,7 +507,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, int re
     if (size == 1) {
       uep = u_get_headentry(buf);
       prev_uep = NULL;
-      for (long i = 0; i < 10; i++) {
+      for (int i = 0; i < 10; i++) {
         if (uep == NULL) {
           break;
         }
@@ -589,7 +589,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, int re
   if (size > 0) {
     uep->ue_array = xmalloc(sizeof(char *) * (size_t)size);
     linenr_T lnum;
-    long i;
+    int i;
     for (i = 0, lnum = top + 1; i < size; i++) {
       fast_breakcheck();
       if (got_int) {
@@ -2312,7 +2312,7 @@ static void u_undoredo(int undo, bool do_buf_event)
         // Use the first line that actually changed.  Avoids that
         // undoing auto-formatting puts the cursor in the previous
         // line.
-        long i;
+        int i;
         for (i = 0; i < newsize && i < oldsize; i++) {
           if (strcmp(uep->ue_array[i], ml_get(top + 1 + (linenr_T)i)) != 0) {
             break;
@@ -2334,7 +2334,7 @@ static void u_undoredo(int undo, bool do_buf_event)
     if (oldsize > 0) {
       newarray = xmalloc(sizeof(char *) * (size_t)oldsize);
       // delete backwards, it goes faster in most cases
-      long i;
+      int i;
       linenr_T lnum;
       for (lnum = bot - 1, i = oldsize; --i >= 0; lnum--) {
         // what can we do when we run out of memory?
@@ -2352,7 +2352,7 @@ static void u_undoredo(int undo, bool do_buf_event)
 
     // insert the lines in u_array between top and bot
     if (newsize) {
-      long i;
+      int i;
       linenr_T lnum;
       for (lnum = top, i = 0; i < newsize; i++, lnum++) {
         // If the file is empty, there is an empty line 1 that we
@@ -2420,13 +2420,13 @@ static void u_undoredo(int undo, bool do_buf_event)
   // Adjust Extmarks
   ExtmarkUndoObject undo_info;
   if (undo) {
-    for (long i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
+    for (int i = (int)kv_size(curhead->uh_extmark) - 1; i > -1; i--) {
       undo_info = kv_A(curhead->uh_extmark, i);
       extmark_apply_undo(undo_info, undo);
     }
     // redo
   } else {
-    for (long i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
+    for (int i = 0; i < (int)kv_size(curhead->uh_extmark); i++) {
       undo_info = kv_A(curhead->uh_extmark, i);
       extmark_apply_undo(undo_info, undo);
     }
@@ -2457,7 +2457,7 @@ static void u_undoredo(int undo, bool do_buf_event)
   }
 
   // restore marks from before undo/redo
-  for (long i = 0; i < NMARKS; i++) {
+  for (int i = 0; i < NMARKS; i++) {
     if (curhead->uh_namedm[i].mark.lnum != 0) {
       free_fmark(curbuf->b_namedm[i]);
       curbuf->b_namedm[i] = curhead->uh_namedm[i];
@@ -2962,7 +2962,7 @@ static void u_freeentries(buf_T *buf, u_header_T *uhp, u_header_T **uhpp)
 }
 
 /// free entry 'uep' and 'n' lines in uep->ue_array[]
-static void u_freeentry(u_entry_T *uep, long n)
+static void u_freeentry(u_entry_T *uep, int n)
 {
   while (n > 0) {
     xfree(uep->ue_array[--n]);

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -37,19 +37,19 @@ struct u_header {
   // the undo file in u_read_undo()
   union {
     u_header_T *ptr;            // pointer to next undo header in list
-    long seq;
+    int seq;
   } uh_next;
   union {
     u_header_T *ptr;            // pointer to previous header in list
-    long seq;
+    int seq;
   } uh_prev;
   union {
     u_header_T *ptr;            // pointer to next header for alt. redo
-    long seq;
+    int seq;
   } uh_alt_next;
   union {
     u_header_T *ptr;            // pointer to previous header for alt. redo
-    long seq;
+    int seq;
   } uh_alt_prev;
   int uh_seq;                   // sequence number, higher == newer undo
   int uh_walk;                  // used by undo_time()

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -706,7 +706,7 @@ int parse_compl_arg(const char *value, int vallen, int *complp, uint32_t *argt, 
   return OK;
 }
 
-static int uc_scan_attr(char *attr, size_t len, uint32_t *argt, long *def, int *flags, int *complp,
+static int uc_scan_attr(char *attr, size_t len, uint32_t *argt, int *def, int *flags, int *complp,
                         char **compl_arg, cmd_addr_T *addr_type_arg)
   FUNC_ATTR_NONNULL_ALL
 {
@@ -773,7 +773,7 @@ two_count:
           return FAIL;
         }
 
-        *def = getdigits_long(&p, true, 0);
+        *def = getdigits_int(&p, true, 0);
         *argt |= EX_ZEROR;
 
         if (p != val + vallen || vallen == 0) {
@@ -799,7 +799,7 @@ invalid_count:
           goto two_count;
         }
 
-        *def = getdigits_long(&p, true, 0);
+        *def = getdigits_int(&p, true, 0);
 
         if (p != val + vallen) {
           goto invalid_count;
@@ -975,7 +975,7 @@ void ex_command(exarg_T *eap)
 {
   char *end;
   uint32_t argt = 0;
-  long def = -1;
+  int def = -1;
   int flags = 0;
   int context = EXPAND_NOTHING;
   char *compl_arg = NULL;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2773,7 +2773,7 @@ void intro_message(int colon)
   size_t lines_size = ARRAY_SIZE(lines);
   assert(lines_size <= LONG_MAX);
 
-  long blanklines = Rows - ((long)lines_size - 1L);
+  int blanklines = Rows - ((int)lines_size - 1);
 
   // Don't overwrite a statusline.  Depends on 'cmdheight'.
   if (p_ls > 1) {
@@ -2790,7 +2790,7 @@ void intro_message(int colon)
   sponsor = ((sponsor & 2) == 0) - ((sponsor & 4) == 0);
 
   // start displaying the message lines after half of the blank lines
-  long row = blanklines / 2;
+  int row = blanklines / 2;
 
   if (((row >= 2) && (Columns >= 50)) || colon) {
     for (int i = 0; i < (int)ARRAY_SIZE(lines); i++) {
@@ -2827,7 +2827,7 @@ void intro_message(int colon)
       }
 
       if (*mesg != NUL) {
-        do_intro_line((int)row, mesg, 0);
+        do_intro_line(row, mesg, 0);
       }
       row++;
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6615,8 +6615,8 @@ void scroll_to_fraction(win_T *wp, int prev_height)
     if (lnum < 1) {             // can happen when starting up
       lnum = 1;
     }
-    wp->w_wrow = (int)((long)wp->w_fraction * (long)height - 1L) / FRACTION_MULT;
-    int line_size = plines_win_col(wp, lnum, (long)(wp->w_cursor.col)) - 1;
+    wp->w_wrow = (int)(wp->w_fraction * height - 1L) / FRACTION_MULT;
+    int line_size = plines_win_col(wp, lnum, wp->w_cursor.col) - 1;
     int sline = wp->w_wrow - line_size;
 
     if (sline >= 0) {
@@ -6894,7 +6894,7 @@ char *grab_file_name(int count, linenr_T *file_lnum)
     if (file_lnum != NULL && ptr[len] == ':' && isdigit((uint8_t)ptr[len + 1])) {
       char *p = ptr + len + 1;
 
-      *file_lnum = (linenr_T)getdigits_long(&p, false, 0);
+      *file_lnum = getdigits_int32(&p, false, 0);
     }
     return find_file_name_in_path(ptr, len, options, count, curbuf->b_ffname);
   }

--- a/src/xdiff/xdiff.h
+++ b/src/xdiff/xdiff.h
@@ -102,8 +102,8 @@ typedef struct s_xdemitcb {
 
 typedef long (*find_func_t)(const char *line, long line_len, char *buffer, long buffer_size, void *priv);
 
-typedef int (*xdl_emit_hunk_consume_func_t)(long start_a, long count_a,
-					    long start_b, long count_b,
+typedef int (*xdl_emit_hunk_consume_func_t)(int start_a, int count_a,
+					    int start_b, int count_b,
 					    void *cb_data);
 
 typedef struct s_xdemitconf {


### PR DESCRIPTION
long is 32 bits on windows, while it is 64 bits on other architectures.
This makes the type suboptimal for a codebase meant to be
cross-platform. Replace it with more appropriate integer types.
