### PR TITLE
test(old): don't check for $CLANG_SANITIZER

### DIFF
--- a/test/old/testdir/test.sh
+++ b/test/old/testdir/test.sh
@@ -85,7 +85,5 @@ valgrind_check() {
 }
 
 check_sanitizer() {
-  if test -n "${CLANG_SANITIZER}"; then
-    check_logs "${1}" "*san.*" | cat
-  fi
+  check_logs "${1}" "*san.*"
 }


### PR DESCRIPTION
Functional tests don't check for an environment variable before printing
ASAN logs, so oldtests shouldn't either.
