### PR TITLE
feat: include i3wm subconfigs in syntax highlighting

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1706,6 +1706,7 @@ local pattern = {
   ['.*%.html%.m4'] = 'htmlm4',
   ['.*/%.i3/config'] = 'i3config',
   ['.*/i3/config'] = 'i3config',
+  ['.*/i3/.*%.conf'] = 'i3config',
   ['.*/%.icewm/menu'] = 'icemenu',
   ['.*/etc/initng/.*/.*%.i'] = 'initng',
   ['JAM.*%..*'] = starsetf('jam'),


### PR DESCRIPTION
This PR includes the i3wm subconfigs files in runtime/lua/vim/filetype.lua so that they are syntax highlighted by neovim.

In version 4.20, [i3wm](https://i3wm.org/) added a new feature that allows users to divide their config files into smaller subconfigs and include them in the main config file using "include <filepath>" statement [(here's docs about it)](https://i3wm.org/docs/userguide.html#include).