### PR TITLE
lua: Add missing typing `field` to `TSNode` class

### DIFF
--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -29,6 +29,7 @@
 ---@field sexpr fun(self: TSNode): string
 ---@field equal fun(self: TSNode, other: TSNode): boolean
 ---@field iter_children fun(self: TSNode): fun(): TSNode, string
+---@field field fun(self: TSNode, name: string): TSNode[]
 local TSNode = {}
 
 ---@param query userdata


### PR DESCRIPTION
According `:h TSNode`, the class `TSNode` has a method `field`, but it has no annotation. This PR adds the missing annotation.