### PR TITLE
vim-patch:9.0.{1962,1963}: extended attributes

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -12,7 +12,7 @@ done
 os=$(uname -s)
 if [[ $os == Linux ]]; then
   sudo apt-get update
-  sudo apt-get install -y build-essential cmake curl gettext ninja-build unzip
+  sudo apt-get install -y attr build-essential cmake curl gettext libattr1-dev ninja-build unzip
   if [[ -n $TEST ]]; then
     sudo apt-get install -y locales-all cpanminus
   fi

--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -36,11 +36,13 @@ check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)
 # Headers
 check_include_files(langinfo.h HAVE_LANGINFO_H)
 check_include_files(strings.h HAVE_STRINGS_H)
-check_include_files(attr/xattr.h HAVE_XATTR)
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
 check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)
 check_include_files(sys/sdt.h HAVE_SYS_SDT_H)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  check_include_files(sys/xattr.h HAVE_XATTR)
+endif()
 
 # Functions
 check_function_exists(fseeko HAVE_FSEEKO)

--- a/cmake.config/CMakeLists.txt
+++ b/cmake.config/CMakeLists.txt
@@ -36,6 +36,7 @@ check_symbol_exists(_NSGetEnviron crt_externs.h HAVE__NSGETENVIRON)
 # Headers
 check_include_files(langinfo.h HAVE_LANGINFO_H)
 check_include_files(strings.h HAVE_STRINGS_H)
+check_include_files(attr/xattr.h HAVE_XATTR)
 check_include_files(sys/utsname.h HAVE_SYS_UTSNAME_H)
 check_include_files(termios.h HAVE_TERMIOS_H)
 check_include_files(sys/uio.h HAVE_SYS_UIO_H)

--- a/cmake.config/config.h.in
+++ b/cmake.config/config.h.in
@@ -27,6 +27,7 @@
 #cmakedefine HAVE_STRINGS_H
 #cmakedefine HAVE_STRNCASECMP
 #cmakedefine HAVE_STRPTIME
+#cmakedefine HAVE_XATTR
 #cmakedefine HAVE_SYS_SDT_H
 #cmakedefine HAVE_SYS_UTSNAME_H
 #cmakedefine HAVE_SYS_WAIT_H

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1078,6 +1078,13 @@ will get the ACL info of the original file.
    The ACL info is also used to check if a file is read-only (when opening the
 file).
 
+				*xattr* *E1506* *E1507* *E1508* *E1509*
+xattr stands for Extended Attributes  It is an advanced way to save metadata
+alongside the file in the filesystem.  It depends on the actual filesystem
+being used and Vim supports it only on a Linux system.
+   Vim attempts to preserve the extended attribute info when writing a file.
+The backup file will get the extended attribute of the original file.
+
 						*read-only-share*
 When MS-Windows shares a drive on the network it can be marked as read-only.
 This means that even if the file read-only attribute is absent, and the ACL

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3171,6 +3171,9 @@ static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     "windows",
     "winaltkeys",
     "writebackup",
+#ifdef HAVE_XATTR
+    "xattr",
+#endif
     "nvim",
   };
 

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -18,6 +18,8 @@
 # include <shlobj.h>
 #endif
 
+#include "auto/config.h"
+
 #if defined(HAVE_ACL)
 # ifdef HAVE_SYS_ACL_H
 #  include <sys/acl.h>
@@ -27,7 +29,11 @@
 # endif
 #endif
 
-#include "auto/config.h"
+#ifdef HAVE_XATTR
+# include <attr/xattr.h>
+# define XATTR_VAL_LEN 1024
+#endif
+
 #include "nvim/ascii.h"
 #include "nvim/gettext.h"
 #include "nvim/globals.h"
@@ -53,6 +59,17 @@
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fs.c.generated.h"
+#endif
+
+#ifdef HAVE_XATTR
+static const char e_xattr_erange[]
+  = N_("E1506: Buffer too small to copy xattr value or key");
+static const char e_xattr_enotsup[]
+  = N_("E1507: Extended attributes are not supported by the filesystem");
+static const char e_xattr_e2big[]
+  = N_("E1508: size of the extended attribute value is larger than the maximum size allowed");
+static const char e_xattr_other[]
+  = N_("E1509: error occured when reading or writing extended attribute");
 #endif
 
 struct iovec;
@@ -742,6 +759,84 @@ int os_setperm(const char *const name, int perm)
   RUN_UV_FS_FUNC(r, uv_fs_chmod, name, perm, NULL);
   return (r == kLibuvSuccess ? OK : FAIL);
 }
+
+#ifdef HAVE_XATTR
+/// Copy extended attributes from_file to to_file
+void os_copy_xattr(const char *from_file, const char *to_file)
+{
+  if (from_file == NULL) {
+    return;
+  }
+
+  // get the length of the extended attributes
+  ssize_t size = listxattr((char *)from_file, NULL, 0);
+  // not supported or no attributes to copy
+  if (errno == ENOTSUP || size <= 0) {
+    return;
+  }
+  char *xattr_buf = xmalloc((size_t)size);
+  size = listxattr(from_file, xattr_buf, (size_t)size);
+  ssize_t tsize = size;
+
+  errno = 0;
+
+  ssize_t max_vallen = 0;
+  char *val = NULL;
+  const char *errmsg = NULL;
+
+  for (int round = 0; round < 2; round++) {
+    char *key = xattr_buf;
+    if (round == 1) {
+      size = tsize;
+    }
+
+    while (size > 0) {
+      ssize_t vallen = getxattr(from_file, key, val, round ? (size_t)max_vallen : 0);
+      // only set the attribute in the second round
+      if (vallen >= 0 && round
+          && setxattr(to_file, key, val, (size_t)vallen, 0) == 0) {
+        //
+      } else if (errno) {
+        switch (errno) {
+        case E2BIG:
+          errmsg = e_xattr_e2big;
+          goto error_exit;
+        case ENOTSUP:
+          errmsg = e_xattr_enotsup;
+          goto error_exit;
+        case ERANGE:
+          errmsg = e_xattr_erange;
+          goto error_exit;
+        default:
+          errmsg = e_xattr_other;
+          goto error_exit;
+        }
+      }
+
+      if (round == 0 && vallen > max_vallen) {
+        max_vallen = vallen;
+      }
+
+      // add one for terminating null
+      ssize_t keylen = (ssize_t)strlen(key) + 1;
+      size -= keylen;
+      key += keylen;
+    }
+    if (round) {
+      break;
+    }
+
+    val = xmalloc((size_t)max_vallen + 1);
+  }
+error_exit:
+  xfree(xattr_buf);
+  xfree(val);
+
+  if (errmsg != NULL) {
+    emsg(errmsg);
+  }
+}
+#endif
 
 // Return a pointer to the ACL of file "fname" in allocated memory.
 // Return NULL if the ACL is not available for whatever reason.

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -30,7 +30,7 @@
 #endif
 
 #ifdef HAVE_XATTR
-# include <attr/xattr.h>
+# include <sys/xattr.h>
 # define XATTR_VAL_LEN 1024
 #endif
 

--- a/test/old/testdir/test_writefile.vim
+++ b/test/old/testdir/test_writefile.vim
@@ -992,6 +992,7 @@ endfunc
 
 func Test_write_with_xattr_support()
   CheckLinux
+  CheckFeature xattr
   CheckExecutable setfattr
 
   let contents = ["file with xattrs", "line two"]

--- a/test/old/testdir/test_writefile.vim
+++ b/test/old/testdir/test_writefile.vim
@@ -990,4 +990,27 @@ func Test_wq_quitpre_autocommand()
   call delete('Xsomefile')
 endfunc
 
+func Test_write_with_xattr_support()
+  CheckLinux
+  CheckExecutable setfattr
+
+  let contents = ["file with xattrs", "line two"]
+  call writefile(contents, 'Xwattr.txt', 'D')
+  " write a couple of xattr
+  call system('setfattr -n user.cookie -v chocolate Xwattr.txt')
+  call system('setfattr -n user.frieda -v bar Xwattr.txt')
+  call system('setfattr -n user.empty Xwattr.txt')
+
+  set backupcopy=no writebackup& backup&
+  sp Xwattr.txt
+  w
+  $r! getfattr -d %
+  let expected = ['file with xattrs', 'line two', '# file: Xwattr.txt', 'user.cookie="chocolate"', 'user.empty=""', 'user.frieda="bar"', '']
+  call assert_equal(expected, getline(1,'$'))
+
+  set backupcopy&
+  bw!
+
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1962: No support for writing extended attributes

Problem:  No support for writing extended attributes
Solution: Add extended attribute support for linux

It's been a long standing issue, that if you write a file with extended
attributes and backupcopy is set to no, the file will loose the extended
attributes.

So this patch adds support for retrieving the extended attributes and
copying it to the new file. It currently only works on linux, mainly
because I don't know the different APIs for other systems (BSD, MacOSX and
Solaris).  On linux, this should be supported since Kernel 2.4 or
something, so this should be pretty safe to use now.

Enable the extended attribute support with normal builds.

I also added it explicitly to the :version output as well as make it
able to check using `:echo has("xattr")`, to have users easily check
that this is available.

In contrast to the similar support for SELINUX and SMACK support (which
also internally uses extended attributes), I have made this a FEAT_XATTR
define, instead of the similar HAVE_XATTR.

Add a test and change CI to include relevant packages so that CI can
test that extended attributes are correctly written.

closes: vim/vim#13203

https://github.com/vim/vim/commit/e085dfda5d8dde064b0332464040959479696d1c

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1963: Configure script may not detect xattr

Problem:  Configure script may not detect xattr correctly
Solution: include sys/xattr instead of attr/xattr,
          make Test_write_with_xattr_support() test
          xattr feature correctly

This also applies to the Smack security feature, so change the include
and configure script for it as well.

closes: vim/vim#13229

https://github.com/vim/vim/commit/6de4e58cf27a3bb6e81653ca63b77e29d1bb46f2