### PR TITLE
vim-patch:9.0.1964: xattr support fails to build on MacOS X

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -31,7 +31,6 @@
 
 #ifdef HAVE_XATTR
 # include <sys/xattr.h>
-# define XATTR_VAL_LEN 1024
 #endif
 
 #include "nvim/ascii.h"


### PR DESCRIPTION
#### vim-patch:9.0.1964: xattr support fails to build on MacOS X

Problem:  xattr support fails to build on MacOS X
Solution: Disable xattr support for MacOS X

MacOS X uses the same headers and functions sys/xattr.h but the function
signatures for xattr support are much different, so building fails.

So let's for now disable xattr support there.

closes: vim/vim#13230
closes: vim/vim#13232

https://github.com/vim/vim/commit/a4dfbfed89e26a766e30cca62c18e710eec81c3f

Co-authored-by: Christian Brabandt <cb@256bit.org>