### PR TITLE
vim-patch:9.0.1967: xattr errors not translated

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -66,9 +66,9 @@ static const char e_xattr_erange[]
 static const char e_xattr_enotsup[]
   = N_("E1507: Extended attributes are not supported by the filesystem");
 static const char e_xattr_e2big[]
-  = N_("E1508: size of the extended attribute value is larger than the maximum size allowed");
+  = N_("E1508: Size of the extended attribute value is larger than the maximum size allowed");
 static const char e_xattr_other[]
-  = N_("E1509: error occured when reading or writing extended attribute");
+  = N_("E1509: Error occured when reading or writing extended attribute");
 #endif
 
 struct iovec;
@@ -832,7 +832,7 @@ error_exit:
   xfree(val);
 
   if (errmsg != NULL) {
-    emsg(errmsg);
+    emsg(_(errmsg));
   }
 }
 #endif

--- a/test/old/testdir/test_writefile.vim
+++ b/test/old/testdir/test_writefile.vim
@@ -1011,7 +1011,6 @@ func Test_write_with_xattr_support()
 
   set backupcopy&
   bw!
-
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1967: xattr errors not translated

Problem:  xattr errors not translated
Solution: mark for translation, consistently capitalize
          first letter.

closes: vim/vim#13236

https://github.com/vim/vim/commit/7ece036d72cf639b05d3936183220bec7179bf63