### PR TITLE
Update jump list when deleting buffers

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1178,6 +1178,31 @@ static int empty_curbuf(int close_others, int forceit, int action)
   return retval;
 }
 
+/// Remove every jump list entry referring to a given buffer.
+/// This function will also adjust the current jump list index.
+void remove_buffer_from_jumplist(buf_T *deleted_buffer) {
+  // Remove all jump list entries that match the deleted buffer.
+  for (int i = curwin->w_jumplistlen - 1; i >= 0; i--) {
+    buf_T *tested_buffer = buflist_findnr(curwin->w_jumplist[i].fmark.fnum);
+
+    if (tested_buffer == deleted_buffer) {
+      // Found an entry that we want to delete.
+      curwin->w_jumplistlen -= 1;
+
+      // If the current jump list index behind the entry we want to
+      // delete, move it back by one.
+      if (curwin->w_jumplistidx > i && curwin->w_jumplistidx > 0) {
+        curwin->w_jumplistidx -= 1;
+      }
+
+      // Actually remove the entry from the jump list.
+      for (int d = i; d < curwin->w_jumplistlen; d++) {
+        curwin->w_jumplist[d] = curwin->w_jumplist[d + 1];
+      }
+    }
+  }
+}
+
 /// Implementation of the commands for the buffer list.
 ///
 /// action == DOBUF_GOTO     go to specified buffer
@@ -1200,6 +1225,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
 {
   buf_T *buf;
   buf_T *bp;
+  bool update_jumplist = true;
   int unload = (action == DOBUF_UNLOAD || action == DOBUF_DEL
                 || action == DOBUF_WIPE);
 
@@ -1357,7 +1383,11 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
 
     // If the buffer to be deleted is not the current one, delete it here.
     if (buf != curbuf) {
+      // Remove the buffer to be deleted from the jump list.
+      remove_buffer_from_jumplist(buf);
+
       close_windows(buf, false);
+
       if (buf != curbuf && bufref_valid(&bufref) && buf->b_nwindows <= 0) {
         close_buffer(NULL, buf, action, false, false);
       }
@@ -1377,20 +1407,25 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
     if (au_new_curbuf.br_buf != NULL && bufref_valid(&au_new_curbuf)) {
       buf = au_new_curbuf.br_buf;
     } else if (curwin->w_jumplistlen > 0) {
-      int jumpidx;
+      // Remove the current buffer from the jump list.
+      remove_buffer_from_jumplist(curbuf);
 
-      jumpidx = curwin->w_jumplistidx - 1;
-      if (jumpidx < 0) {
-        jumpidx = curwin->w_jumplistlen - 1;
+      // If the index is the same as the length, the current position was not yet added to the jump
+      // list. So we can safely go back to the last entry and search from there.
+      if (curwin->w_jumplistidx == curwin->w_jumplistlen) {
+        curwin->w_jumplistidx = curwin->w_jumplistlen - 1;
       }
 
+      int jumpidx = curwin->w_jumplistidx;
+
       forward = jumpidx;
-      while (jumpidx != curwin->w_jumplistidx) {
+      do {
         buf = buflist_findnr(curwin->w_jumplist[jumpidx].fmark.fnum);
+
         if (buf != NULL) {
-          // Skip current and unlisted bufs.  Also skip a quickfix
+          // Skip unlisted bufs.  Also skip a quickfix
           // buffer, it might be deleted soon.
-          if (buf == curbuf || !buf->b_p_bl || bt_quickfix(buf)) {
+          if (!buf->b_p_bl || bt_quickfix(buf)) {
             buf = NULL;
           } else if (buf->b_ml.ml_mfp == NULL) {
             // skip unloaded buf, but may keep it for later
@@ -1401,6 +1436,8 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
           }
         }
         if (buf != NULL) {         // found a valid buffer: stop searching
+          curwin->w_jumplistidx = jumpidx;
+          update_jumplist = false;
           break;
         }
         // advance to older entry in jump list
@@ -1413,7 +1450,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
         if (jumpidx == forward) {               // List exhausted for sure
           break;
         }
-      }
+      } while (jumpidx != curwin->w_jumplistidx);
     }
 
     if (buf == NULL) {          // No previous buffer, Try 2'nd approach
@@ -1508,7 +1545,7 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
   }
 
   // Go to the other buffer.
-  set_curbuf(buf, action);
+  set_curbuf(buf, action, update_jumplist);
 
   if (action == DOBUF_SPLIT) {
     RESET_BINDING(curwin);      // reset 'scrollbind' and 'cursorbind'
@@ -1530,14 +1567,17 @@ int do_buffer(int action, int start, int dir, int count, int forceit)
 ///                DOBUF_UNLOAD     unload it
 ///                DOBUF_DEL        delete it
 ///                DOBUF_WIPE       wipe it out
-void set_curbuf(buf_T *buf, int action)
+void set_curbuf(buf_T *buf, int action, bool update_jumplist)
 {
   buf_T *prevbuf;
   int unload = (action == DOBUF_UNLOAD || action == DOBUF_DEL
                 || action == DOBUF_WIPE);
   OptInt old_tw = curbuf->b_p_tw;
 
-  setpcmark();
+  if (update_jumplist) {
+    setpcmark();
+  }
+
   if ((cmdmod.cmod_flags & CMOD_KEEPALT) == 0) {
     curwin->w_alt_fnum = curbuf->b_fnum;     // remember alternate file
   }
@@ -3694,7 +3734,7 @@ void ex_buffer_all(exarg_T *eap)
 
       // Open the buffer in this window.
       swap_exists_action = SEA_DIALOG;
-      set_curbuf(buf, DOBUF_GOTO);
+      set_curbuf(buf, DOBUF_GOTO, false);
       if (!bufref_valid(&bufref)) {
         // Autocommands deleted the buffer.
         swap_exists_action = SEA_NONE;

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -408,7 +408,7 @@ buf_found:
 
   // Open the changed buffer in the current window.
   if (buf != curbuf) {
-    set_curbuf(buf, unload ? DOBUF_UNLOAD : DOBUF_GOTO);
+    set_curbuf(buf, unload ? DOBUF_UNLOAD : DOBUF_GOTO, true);
   }
 
 theend:


### PR DESCRIPTION
Closes #25365.

These changes fix the weird behavior described in #25365, by applying two simple changes:
- remove all entries of a buffer from the jump list when deleting it
- not adding a new entry to the jump list if the next buffer to be displayed was also found in the jump list

This makes the jump list behave exactly as you would expect when deleting buffers