### PR TITLE
fix(jumplist): Ctrl+o, Ctrl+i behave unintuitively when deleting buffers

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -405,7 +405,7 @@ buf_found:
 
   // Open the changed buffer in the current window.
   if (buf != curbuf) {
-    set_curbuf(buf, unload ? DOBUF_UNLOAD : DOBUF_GOTO);
+    set_curbuf(buf, unload ? DOBUF_UNLOAD : DOBUF_GOTO, true);
   }
 
 theend:


### PR DESCRIPTION
Closes #25365.

These changes fix the weird behavior described in #25365, by applying two simple changes:
- remove all entries of a buffer from the jump list when deleting it
- not adding a new entry to the jump list if the next buffer to be displayed was also found in the jump list

This makes the jump list behave exactly as you would expect when deleting buffers