### PR TITLE
refactor(message): simplify msg_puts_display and use batched grid updates

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -8094,13 +8094,6 @@ void ex_execute(exarg_T *eap)
   }
 
   if (ret != FAIL && ga.ga_data != NULL) {
-    if (eap->cmdidx == CMD_echomsg || eap->cmdidx == CMD_echoerr) {
-      // Mark the already saved text as finishing the line, so that what
-      // follows is displayed on a new line when scrolling back at the
-      // more prompt.
-      msg_sb_eol();
-    }
-
     if (eap->cmdidx == CMD_echomsg) {
       msg_ext_set_kind("echomsg");
       msg(ga.ga_data, echo_attr);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1329,7 +1329,7 @@ static int command_line_execute(VimState *state, int key)
 
       if (!cmd_silent) {
         if (!ui_has(kUICmdline)) {
-          cmd_cursor_goto(msg_row, 0);
+          msg_cursor_goto(msg_row, 0);
         }
         ui_flush();
       }
@@ -3884,7 +3884,7 @@ void redrawcmd(void)
 
   // when 'incsearch' is set there may be no command line while redrawing
   if (ccline.cmdbuff == NULL) {
-    cmd_cursor_goto(cmdline_row, 0);
+    msg_cursor_goto(cmdline_row, 0);
     msg_clr_eos();
     return;
   }
@@ -3961,14 +3961,7 @@ void cursorcmd(void)
     }
   }
 
-  cmd_cursor_goto(msg_row, msg_col);
-}
-
-static void cmd_cursor_goto(int row, int col)
-{
-  ScreenGrid *grid = &msg_grid_adj;
-  grid_adjust(&grid, &row, &col);
-  ui_grid_cursor_goto(grid->handle, row, col);
+  msg_cursor_goto(msg_row, msg_col);
 }
 
 void gotocmdline(bool clr)
@@ -3985,7 +3978,7 @@ void gotocmdline(bool clr)
   if (clr) {  // clear the bottom line(s)
     msg_clr_eos();  // will reset clear_cmdline
   }
-  cmd_cursor_goto(cmdline_row, 0);
+  msg_cursor_goto(cmdline_row, 0);
 }
 
 // Check the word in front of the cursor for an abbreviation.

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -455,6 +455,22 @@ void grid_line_flush(void)
                    false, 0, false, invalid_row);
 }
 
+/// flush grid line but only if on a valid row
+///
+/// This is a stopgap until message.c has been refactored to behave
+void grid_line_flush_if_valid_row(void)
+{
+  if (grid_line_row < 0 || grid_line_row >= grid_line_grid->rows) {
+    if (rdb_flags & RDB_INVALID) {
+      abort();
+    } else {
+      grid_line_grid = NULL;
+      return;
+    }
+  }
+  grid_line_flush();
+}
+
 /// Fill the grid from "start_row" to "end_row" (exclusive), from "start_col"
 /// to "end_col" (exclusive) with character "c1" in first column followed by
 /// "c2" in the other columns.  Use attributes "attr".

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -259,8 +259,8 @@ describe('fileio', function()
     screen:expect([[
       {2:WARNING: The file has been changed since}|
       {2: reading it!!!}                          |
-      {3:Do you really want to write to it (y/n)^?}|
-                                              |
+      {3:Do you really want to write to it (y/n)?}|
+      ^                                        |
     ]])
 
     feed("n")

--- a/test/functional/legacy/digraph_spec.lua
+++ b/test/functional/legacy/digraph_spec.lua
@@ -22,7 +22,7 @@ describe('digraph', function()
       {0:~           }|
       {0:~           }|
       {0:~           }|
-      {2:-- INSERT -} |
+      {2:-- INSERT --}|
     ]])
     feed('1')
     screen:expect([[
@@ -31,7 +31,7 @@ describe('digraph', function()
       {0:~           }|
       {0:~           }|
       {0:~           }|
-      {2:-- INSERT -} |
+      {2:-- INSERT --}|
     ]])
     feed('2')
     screen:expect([[
@@ -40,7 +40,7 @@ describe('digraph', function()
       {0:~           }|
       {0:~           }|
       {0:~           }|
-      {2:-- INSERT -} |
+      {2:-- INSERT --}|
     ]])
   end)
 end)

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -43,7 +43,7 @@ describe('edit', function()
       {0:~           }|
       {0:~           }|
       {0:~           }|
-      {2:-- INSERT -} |
+      {2:-- INSERT --}|
     ]])
     feed('=')
     screen:expect([[

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -577,10 +577,10 @@ describe('Command-line coloring', function()
                                               |
       {EOB:~                                       }|
       {EOB:~                                       }|
+      {EOB:~                                       }|
       {MSEP:                                        }|
       :+                                      |
       {ERR:E5404: Chunk 1 end 3 not in range (1, 2]}|
-                                              |
       :++^                                     |
     ]])
   end)

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2439,14 +2439,14 @@ describe('builtin popupmenu', function()
           prefix      |
           bef{n: word  }  |
           tex{n: }^        |
-          {2:-- INSERT -} |
+          {2:-- INSERT --}|
         ]])
 
         -- can't draw the pum, but check we don't crash
         screen:try_resize(12,2)
         screen:expect([[
           {1:<<<}t^        |
-          {2:-- INSERT -} |
+          {2:-- INSERT --}|
         ]])
 
         -- but state is preserved, pum reappears

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -795,7 +795,7 @@ local function screen_tests(linegrid)
       screen:try_resize(1, 1)
       screen:expect([[
         resize^      |
-        {2:-- INSERT -} |
+        {2:-- INSERT --}|
       ]])
 
       feed('<esc>:ls')


### PR DESCRIPTION
msg_puts_display was more complex than necessary in nvim, as in nvim, it no longer talks directly with a terminal.

In particular we don't need to scroll the grid before emitting the last char. The TUI already takes care of things like that, for terminals where it matters. This improves the behavior in GUI and many terminals, where it actually is safe to write to the bottom right screen cell, as shown in updated tests.