### PR TITLE
vim-patch:ba77bbb5c775,20f48d5b2ddb,cd39b69b0200

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -925,7 +925,7 @@ cosh({expr})                                                            *cosh()*
 			echo cosh(-0.5)
 <			-1.127626
 
-count({comp}, {expr} [, {ic} [, {start}]])                             *count()*
+count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E706*
 		Return the number of times an item with value {expr} appears
 		in |String|, |List| or |Dictionary| {comp}.
 
@@ -5116,6 +5116,7 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 		using a {n$} positional argument specifier. See |printf-$|.
 
 
+								*E1520*
 		The conversion specifiers and their meanings are:
 
 				*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -742,7 +742,7 @@ An example for subtracting (which isn't very useful): >
 On this text:
 	1 one ~
 	2 two ~
-	3 three FOLDED~
+	3 three FOLDED ~
 	4 four FOLDED ~
 	5 five FOLDED ~
 	6 six FOLDED ~

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -396,7 +396,7 @@ So to enable this only for ruby, set the following variable: >
 	:let g:ruby_exec = 1
 
 If both, the global `plugin_exec` and the `<filetype>_exec` specific variable
-are set, the filetpe specific variable should have precedent.
+are set, the filetype specific variable should have precedent.
 
 AWK							*ft-awk-plugin*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1966,7 +1966,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 				When omitted a context of six lines is used.
 				When using zero the context is actually one,
 				since folds require a line in between, also
-				for a deleted line.
+				for a deleted line. Set it to a very large
+				value (999999) to disable folding completely.
 				See |fold-diff|.
 
 		iblank		Ignore changes where lines are all blank.  Adds

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1065,7 +1065,7 @@ match ASCII characters, as indicated by the range.
 
 \(\)	A pattern enclosed by escaped parentheses.	*/\(* */\(\)* */\)*
 	E.g., "\(^a\)" matches 'a' at the start of a line.
-	There can only be ten of these.  You can use "\%(" to add more, but
+	There can only be nine of these.  You can use "\%(" to add more, but
 	not counting it as a sub-expression.
 	*E51* *E54* *E55* *E872* *E873*
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1591,7 +1591,8 @@ vim.go.dex = vim.go.diffexpr
 --- 			When omitted a context of six lines is used.
 --- 			When using zero the context is actually one,
 --- 			since folds require a line in between, also
---- 			for a deleted line.
+--- 			for a deleted line. Set it to a very large
+--- 			value (999999) to disable folding completely.
 --- 			See `fold-diff`.
 ---
 --- 	iblank		Ignore changes where lines are all blank.  Adds

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6099,6 +6099,7 @@ function vim.fn.prevnonblank(lnum) end
 --- using a {n$} positional argument specifier. See |printf-$|.
 ---
 ---
+---             *E1520*
 --- The conversion specifiers and their meanings are:
 ---
 ---     *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1542,6 +1542,7 @@ M.funcs = {
   count = {
     args = { 2, 4 },
     base = 1,
+    tags = { 'E706' },
     desc = [=[
       Return the number of times an item with value {expr} appears
       in |String|, |List| or |Dictionary| {comp}.
@@ -7381,6 +7382,7 @@ M.funcs = {
       using a {n$} positional argument specifier. See |printf-$|.
 
 
+      						*E1520*
       The conversion specifiers and their meanings are:
 
       		*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2067,7 +2067,8 @@ return {
         			When omitted a context of six lines is used.
         			When using zero the context is actually one,
         			since folds require a line in between, also
-        			for a deleted line.
+        			for a deleted line. Set it to a very large
+        			value (999999) to disable folding completely.
         			See |fold-diff|.
 
         	iblank		Ignore changes where lines are all blank.  Adds


### PR DESCRIPTION
#### vim-patch:ba77bbb5c775

runtime(doc): fix typos.

* Fix typo in document (Related: vim/vim#12516)
* Fix E1363 duplication
* Fix one more typo.

https://github.com/vim/vim/commit/ba77bbb5c775663a8b55871f753d7b1b570bb9ba

Co-authored-by: h_east <h.east.727@gmail.com>


#### vim-patch:20f48d5b2ddb

runtime(doc): mention how to disable folding in diff mode (vim/vim#13242)

https://github.com/vim/vim/commit/20f48d5b2ddb9fdc29e83f0da6f31f895eaeab47

Co-authored-by: dundargoc <33953936+dundargoc@users.noreply.github.com>


#### vim-patch:cd39b69b0200

runtime(doc): add missing error numbers in the help.  (vim/vim#13241)

https://github.com/vim/vim/commit/cd39b69b0200005622db7291bbacff95bd03a3d0

Co-authored-by: Yegappan Lakshmanan <4298407+yegappan@users.noreply.github.com>