### PR TITLE
vim-patch:9.0.1975: xattr: permission-denied errors on write

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -63,8 +63,6 @@
 #ifdef HAVE_XATTR
 static const char e_xattr_erange[]
   = N_("E1506: Buffer too small to copy xattr value or key");
-static const char e_xattr_enotsup[]
-  = N_("E1507: Extended attributes are not supported by the filesystem");
 static const char e_xattr_e2big[]
   = N_("E1508: Size of the extended attribute value is larger than the maximum size allowed");
 static const char e_xattr_other[]
@@ -800,9 +798,9 @@ void os_copy_xattr(const char *from_file, const char *to_file)
         case E2BIG:
           errmsg = e_xattr_e2big;
           goto error_exit;
-        case ENOTSUP:
-          errmsg = e_xattr_enotsup;
-          goto error_exit;
+        case EACCES:
+        case EPERM:
+          break;
         case ERANGE:
           errmsg = e_xattr_erange;
           goto error_exit;


### PR DESCRIPTION
#### vim-patch:9.0.1975: xattr: permission-denied errors on write

Problem:  xattr: permission-denied errors on write
Solution: ignore those errors

https://github.com/vim/vim/commit/993b17569b5acffe2d8941d1709a55da4e439755

N/A patches:
vim-patch:9.0.1965: wrong auto/configure script
vim-patch:9.0.1966: configure prints stray 6 when checking libruby

Co-authored-by: Gene C <arch@sapience.com>