### PR TITLE
fix(terminal): check terminal size at end of screen update

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1519,16 +1519,12 @@ static void win_update(win_T *wp, DecorProviders *providers)
     }
   }
 
-  // Force redraw when width of 'number' or 'relativenumber' column
-  // changes.
-  int nrwidth = (wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc) ? number_width(wp) : 0;
-  if (wp->w_nrwidth != nrwidth) {
+  const int nrwidth_before = wp->w_nrwidth;
+  int nrwidth_new = (wp->w_p_nu || wp->w_p_rnu || *wp->w_p_stc) ? number_width(wp) : 0;
+  // Force redraw when width of 'number' or 'relativenumber' column changes.
+  if (wp->w_nrwidth != nrwidth_new) {
     type = UPD_NOT_VALID;
-    wp->w_nrwidth = nrwidth;
-
-    if (buf->terminal) {
-      terminal_check_size(buf->terminal);
-    }
+    wp->w_nrwidth = nrwidth_new;
   } else if (buf->b_mod_set
              && buf->b_mod_xlines != 0
              && wp->w_redraw_top != 0) {
@@ -2496,6 +2492,10 @@ static void win_update(win_T *wp, DecorProviders *providers)
       }
       recursive = false;
     }
+  }
+
+  if (nrwidth_before != wp->w_nrwidth && buf->terminal) {
+    terminal_check_size(buf->terminal);
   }
 
   // restore got_int, unless CTRL-C was hit while redrawing

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -44,7 +44,7 @@ describe(':terminal window', function()
         {7:6 }                                                |
         {3:-- TERMINAL --}                                    |
       ]])
-      feed_data({'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'})
+      feed_data('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
       screen:expect([[
         {7:1 }tty ready                                       |
         {7:2 }rows: 6, cols: 48                               |
@@ -54,8 +54,6 @@ describe(':terminal window', function()
         {7:6 }                                                |
         {3:-- TERMINAL --}                                    |
       ]])
-
-      skip(is_os('win'), 'win: :terminal resize is unreliable #7007')
 
       -- numberwidth=9
       feed([[<C-\><C-N>]])
@@ -69,7 +67,7 @@ describe(':terminal window', function()
         {7:       6 }                                         |
         {3:-- TERMINAL --}                                    |
       ]])
-      feed_data({' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'})
+      feed_data(' abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
       screen:expect([[
         {7:       1 }tty ready                                |
         {7:       2 }rows: 6, cols: 48                        |
@@ -77,6 +75,41 @@ describe(':terminal window', function()
         {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
         {7:       5 } abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN|
         {7:       6 }OPQRSTUVWXYZ{1: }                            |
+        {3:-- TERMINAL --}                                    |
+      ]])
+    end)
+  end)
+
+  describe("with 'statuscolumn'", function()
+    it('wraps text', function()
+      command([[set number statuscolumn=++%l\ \ ]])
+      screen:expect([[
+        {7:++1  }tty ready                                    |
+        {7:++2  }rows: 6, cols: 45                            |
+        {7:++3  }{1: }                                            |
+        {7:++4  }                                             |
+        {7:++5  }                                             |
+        {7:++6  }                                             |
+        {3:-- TERMINAL --}                                    |
+      ]])
+      feed_data('\n\n\n\n\nabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      screen:expect([[
+        {7:++4  }                                             |
+        {7:++5  }                                             |
+        {7:++6  }                                             |
+        {7:++7  }                                             |
+        {7:++8  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS|
+        {7:++9  }TUVWXYZ{1: }                                     |
+        {3:-- TERMINAL --}                                    |
+      ]])
+      feed_data('\nabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+      screen:expect([[
+        {7:++7   }                                            |
+        {7:++8   }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
+        {7:++9   }STUVWXYZ                                    |
+        {7:++10  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
+        {7:++11  }STUVWXYZrows: 6, cols: 44                   |
+        {7:++12  }{1: }                                           |
         {3:-- TERMINAL --}                                    |
       ]])
     end)


### PR DESCRIPTION
Fix #25472
