### PR TITLE
vim-patch:2dfc22908e43

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1078,8 +1078,8 @@ will get the ACL info of the original file.
    The ACL info is also used to check if a file is read-only (when opening the
 file).
 
-				*xattr* *E1506* *E1507* *E1508* *E1509*
-xattr stands for Extended Attributes  It is an advanced way to save metadata
+					*xattr* *E1506* *E1508* *E1509*
+xattr stands for Extended Attributes.  It is an advanced way to save metadata
 alongside the file in the filesystem.  It depends on the actual filesystem
 being used and Vim supports it only on a Linux system.
    Vim attempts to preserve the extended attribute info when writing a file.


### PR DESCRIPTION
#### vim-patch:2dfc22908e43

runtime(doc): remove E1507 help tag, which is no longer used (vim/vim#13254)

https://github.com/vim/vim/commit/2dfc22908e432f63d200e1fc4f024645c87b8bf3