### PR TITLE
fix(api): avoid immediate TextChanged with nvim_create_buf

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -941,6 +941,12 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
     goto fail;
   }
 
+  // Set last_changedtick to avoid triggering a TextChanged autocommand right
+  // after it was added.
+  buf->b_last_changedtick = buf_get_changedtick(buf);
+  buf->b_last_changedtick_i = buf_get_changedtick(buf);
+  buf->b_last_changedtick_pum = buf_get_changedtick(buf);
+
   // Only strictly needed for scratch, but could just as well be consistent
   // and do this now. buffer is created NOW, not when it latter first happen
   // to reach a window or aucmd_prepbuf() ..

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2869,6 +2869,18 @@ describe('API', function()
       eq(false, eval('g:fired'))
     end)
 
+    it('TextChanged and TextChangedI do not trigger without changes', function()
+      local buf = meths.create_buf(true, false)
+      command([[let g:changed = '']])
+      meths.create_autocmd({'TextChanged', 'TextChangedI'}, {
+        buffer = buf,
+        command = 'let g:changed ..= mode()',
+      })
+      meths.set_current_buf(buf)
+      feed('i')
+      eq('', meths.get_var('changed'))
+    end)
+
     it('scratch-buffer', function()
       eq({id=2}, meths.create_buf(false, true))
       eq({id=3}, meths.create_buf(true, true))


### PR DESCRIPTION
Fix #25490
