### PR TITLE
feat(treesitter): Allow setting custom hl group through metadata

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -478,6 +478,14 @@ attribute: >query
     ((super_important_node) @superimportant (#set! "priority" 105))
 <
 
+                                               *treesitter-highlight-hl_group*
+By default, highlight group for a capture is taken from the capture name.
+It is also possible to provide a custom highlight group by setting "hl_group"
+metadata attribute: >query
+
+    ((comment) @comment (#set! hl_group "CustomComment"))
+<
+
 ==============================================================================
 TREESITTER LANGUAGE INJECTIONS                *treesitter-language-injections*
 <

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -263,6 +263,10 @@ local function on_line_impl(self, buf, line, is_spell_nav)
         -- Give nospell a higher priority so it always overrides spell captures.
         local spell_pri_offset = capture_name == 'nospell' and 1 or 0
 
+        if metadata and metadata.hl_group then
+          hl = metadata.hl_group
+        end
+
         if hl and end_row >= line and (not is_spell_nav or spell ~= nil) then
           local priority = (tonumber(metadata.priority) or vim.highlight.priorities.treesitter)
             + spell_pri_offset

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -753,6 +753,67 @@ describe('treesitter highlighting (C)', function()
     ]]}
   end)
 
+  it("supports hl_group attribute", function()
+    insert(hl_text_c)
+
+    exec_lua [=[
+      local parser = vim.treesitter.get_parser(0, "c")
+      test_hl = vim.treesitter.highlighter.new(parser, {queries = {c = [[
+        ("static" @keyword)
+      ]]}})
+    ]=]
+
+    screen:expect{grid=[[
+      /// Schedule Lua callback on main loop's event queue             |
+      {4:static} int nlua_schedule(lua_State *const lstate)                |
+      {                                                                |
+        if (lua_type(lstate, 1) != LUA_TFUNCTION                       |
+            || lstate != lstate) {                                     |
+          lua_pushliteral(lstate, "vim.schedule: expected function");  |
+          return lua_error(lstate);                                    |
+        }                                                              |
+                                                                       |
+        LuaRef cb = nlua_ref(lstate, 1);                               |
+                                                                       |
+        multiqueue_put(main_loop.events, nlua_schedule_event,          |
+                       1, (void *)(ptrdiff_t)cb);                      |
+        return 0;                                                      |
+      ^}                                                                |
+      {1:~                                                                }|
+      {1:~                                                                }|
+                                                                       |
+    ]]}
+
+    command [[ hi link CustomHLGroup String ]]
+    exec_lua [=[
+      local parser = vim.treesitter.get_parser(0, "c")
+      test_hl = vim.treesitter.highlighter.new(parser, {queries = {c = [[
+        ("static" @keyword (set! hl_group "CustomHLGroup"))
+      ]]}})
+    ]=]
+
+    screen:expect{grid=[[
+      /// Schedule Lua callback on main loop's event queue             |
+      {5:static} int nlua_schedule(lua_State *const lstate)                |
+      {                                                                |
+        if (lua_type(lstate, 1) != LUA_TFUNCTION                       |
+            || lstate != lstate) {                                     |
+          lua_pushliteral(lstate, "vim.schedule: expected function");  |
+          return lua_error(lstate);                                    |
+        }                                                              |
+                                                                       |
+        LuaRef cb = nlua_ref(lstate, 1);                               |
+                                                                       |
+        multiqueue_put(main_loop.events, nlua_schedule_event,          |
+                       1, (void *)(ptrdiff_t)cb);                      |
+        return 0;                                                      |
+      ^}                                                                |
+      {1:~                                                                }|
+      {1:~                                                                }|
+                                                                       |
+    ]]}
+  end)
+
   it("@foo.bar groups has the correct fallback behavior", function()
     local get_hl = function(name) return meths.get_hl_by_name(name,1).foreground end
     meths.set_hl(0, "@foo", {fg = 1})


### PR DESCRIPTION
Add an ability to provide a custom highlight group for a tree-sitter capture through metadata, in a similar fashion to conceal and priority.
Feature as presented in the docs doesn't add much value since capture name can be set to match he hl group name, but it gives an ability to dynamically define hl groups via custom directives. Here's a trivial example:

To highlight a defined list of strings with the provided color that is defined through variable, we can now do something like this:

```query
; highlights.scm for lua
(string (string_content) @my_string (#set-custom-colors! @my_string))
```

```lua
local my_colors = {
  yes = "#00FF00",
  no = "#FF0000",
  maybe = "#FFFF00"

}

for name, color in pairs(my_colors) do
  vim.cmd(string.format('hi MyColor%s guifg=%s', name:lower(), color))
end

vim.treesitter.query.add_directive("set-custom-colors!", function(match, _, source, pred, metadata)
  local node = match[pred[2]]
  if node then
    local text = vim.treesitter.get_node_text(node, source)
    if my_colors[text:lower()] then
      metadata.hl_group = string.format('MyColor%s', text:lower())
    end
  end
end)
```

Example result:
![screenshot_2023_10_03_23_43_12](https://github.com/neovim/neovim/assets/1782860/eb9df442-a5a1-49bd-82ea-33b39b680d6d)


Creating draft PR for now. Once and if confirmed, I'll make it ready for review.
