### PR TITLE
fix(netrw): patch navigation

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -702,6 +702,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
   endif
 
   " save registers
+  if has("clipboard") && g:netrw_clipboard
+"   call Decho("(netrw#Explore) save @* and @+",'~'.expand("<slnum>"))
+   sil! let keepregstar = @*
+   sil! let keepregplus = @+
+  endif
   sil! let keepregslash= @/
 
   " if   dosplit
@@ -925,6 +930,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
 "     call Decho("..case Nexplore with starpat=".starpat.": (indx=".indx.")",'~'.expand("<slnum>"))
      if !exists("w:netrw_explore_list") " sanity check
       NetrwKeepj call netrw#ErrorMsg(s:WARNING,"using Nexplore or <s-down> improperly; see help for netrw-starstar",40)
+      if has("clipboard") && g:netrw_clipboard
+"       call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+       if @* != keepregstar | sil! let @* = keepregstar | endif
+       if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
 "      call Dret("netrw#Explore")
       return
@@ -946,6 +956,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
 "     call Decho("case Pexplore with starpat=".starpat.": (indx=".indx.")",'~'.expand("<slnum>"))
      if !exists("w:netrw_explore_list") " sanity check
       NetrwKeepj call netrw#ErrorMsg(s:WARNING,"using Pexplore or <s-up> improperly; see help for netrw-starstar",41)
+      if has("clipboard") && g:netrw_clipboard
+"       call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+       if @* != keepregstar | sil! let @* = keepregstar | endif
+       if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
 "      call Dret("netrw#Explore")
       return
@@ -997,6 +1012,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
       catch /^Vim\%((\a\+)\)\=:E480/
        keepalt call netrw#ErrorMsg(s:WARNING,'no files matched pattern<'.pattern.'>',45)
        if &hls | let keepregslash= s:ExplorePatHls(pattern) | endif
+       if has("clipboard") && g:netrw_clipboard
+"        call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+        if @* != keepregstar | sil! let @* = keepregstar | endif
+        if @+ != keepregplus | sil! let @+ = keepregplus | endif
+       endif
        sil! let @/ = keepregslash
 "       call Dret("netrw#Explore : no files matched pattern")
        return
@@ -1029,6 +1049,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
 
      if w:netrw_explore_listlen == 0 || (w:netrw_explore_listlen == 1 && w:netrw_explore_list[0] =~ '\*\*\/')
       keepalt NetrwKeepj call netrw#ErrorMsg(s:WARNING,"no files matched",42)
+      if has("clipboard") && g:netrw_clipboard
+"       call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+        if @* != keepregstar | sil! let @* = keepregstar | endif
+        if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
 "      call Dret("netrw#Explore : no files matched")
       return
@@ -1072,6 +1097,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
 "    call Decho("..your vim does not have +path_extra",'~'.expand("<slnum>"))
     if !exists("g:netrw_quiet")
      keepalt NetrwKeepj call netrw#ErrorMsg(s:WARNING,"your vim needs the +path_extra feature for Exploring with **!",44)
+    endif
+    if has("clipboard") && g:netrw_clipboard
+"     call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+      if @* != keepregstar | sil! let @* = keepregstar | endif
+      if @+ != keepregplus | sil! let @+ = keepregplus | endif
     endif
     sil! let @/ = keepregslash
 "    call Dret("netrw#Explore : missing +path_extra")
@@ -1142,6 +1172,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
   " there's no danger of a late FocusGained event on initialization.
   " Consequently, set s:netrw_events to 2.
   let s:netrw_events= 2
+  if has("clipboard") && g:netrw_clipboard
+"   call Decho("(netrw#Explore) restore @* and @+",'~'.expand("<slnum>"))
+   if @* != keepregstar | sil! let @* = keepregstar | endif
+   if @+ != keepregplus | sil! let @+ = keepregplus | endif
+  endif
   sil! let @/ = keepregslash
 "  call Dret("netrw#Explore : @/<".@/.">")
 endfun
@@ -1679,8 +1714,13 @@ fun! s:NetrwOptionsSave(vt)
    let {a:vt}netrw_dirkeep  = getcwd()
 "   call Decho("saving to ".a:vt."netrw_dirkeep<".{a:vt}netrw_dirkeep.">",'~'.expand("<slnum>"))
   endif
+  if has("clipboard") && g:netrw_clipboard
+   sil! let {a:vt}netrw_starkeep = @*
+   sil! let {a:vt}netrw_pluskeep = @+
+  endif
   sil! let {a:vt}netrw_slashkeep= @/
 
+"  call Decho("(s:NetrwOptionsSave) lines=".&lines)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
 "  call Dret("s:NetrwOptionsSave : tab#".tabpagenr()." win#".winnr())
 endfun
@@ -1856,6 +1896,11 @@ fun! s:NetrwOptionsRestore(vt)
     call s:NetrwLcd(dirkeep)
     unlet {a:vt}netrw_dirkeep
    endif
+  endif
+  if has("clipboard") && g:netrw_clipboard
+"   call Decho("has clipboard",'~'.expand("<slnum>"))
+   call s:NetrwRestoreSetting(a:vt."netrw_starkeep","@*")
+   call s:NetrwRestoreSetting(a:vt."netrw_pluskeep","@+")
   endif
   call s:NetrwRestoreSetting(a:vt."netrw_slashkeep","@/")
 
@@ -9725,6 +9770,11 @@ fun! s:NetrwWideListing()
    let newcolstart = w:netrw_bannercnt + fpc
    let newcolend   = newcolstart + fpc - 1
 "   call Decho("bannercnt=".w:netrw_bannercnt." fpl=".w:netrw_fpl." fpc=".fpc." newcol[".newcolstart.",".newcolend."]",'~'.expand("<slnum>"))
+   if has("clipboard") && g:netrw_clipboard
+"    call Decho("(s:NetrwWideListing) save @* and @+",'~'.expand("<slnum>"))
+    sil! let keepregstar = @*
+    sil! let keepregplus = @+
+   endif
    while line("$") >= newcolstart
     if newcolend > line("$") | let newcolend= line("$") | endif
     let newcolqty= newcolend - newcolstart
@@ -9738,6 +9788,11 @@ fun! s:NetrwWideListing()
     exe "sil! NetrwKeepj ".newcolstart.','.newcolend.'d _'
     exe 'sil! NetrwKeepj '.w:netrw_bannercnt
    endwhile
+   if has("clipboard")
+"    call Decho("(s:NetrwWideListing) restore @* and @+",'~'.expand("<slnum>"))
+    if @* != keepregstar | sil! let @* = keepregstar | endif
+    if @+ != keepregplus | sil! let @+ = keepregplus | endif
+   endif
    exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/\s\+$//e'
    NetrwKeepj call histdel("/",-1)
    exe 'nno <buffer> <silent> w	:call search(''^.\\|\s\s\zs\S'',''W'')'."\<cr>"


### PR DESCRIPTION
# Problem

Navigation marks are not properly used after opening a file through `netrw`.

# Solution

Patched the `@*` and `@+` logic from Vim's `netrw`.

--- 

I wasn't able to find the exact commit that this was introduced that's why I didn't create this as a patch commit.

Fixes #24721.