### PR TITLE
vim-patch:9.0.1981: not being able to scroll up in diff mode

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2455,11 +2455,11 @@ int onepage(Direction dir, long count)
           if (curwin->w_topfill == loff.fill) {
             curwin->w_topline--;
             curwin->w_topfill = 0;
+            curwin->w_valid &= ~(VALID_WROW|VALID_CROW);
           }
           comp_botline(curwin);
           curwin->w_cursor.lnum = curwin->w_botline - 1;
-          curwin->w_valid &=
-            ~(VALID_WCOL | VALID_CHEIGHT | VALID_WROW | VALID_CROW);
+          curwin->w_valid &= ~(VALID_WCOL|VALID_CHEIGHT|VALID_WROW|VALID_CROW);
         } else {
           curwin->w_topline = loff.lnum;
           curwin->w_topfill = loff.fill;

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -1616,6 +1616,42 @@ func Test_diff_scroll_wrap_on()
   call assert_equal(1, winsaveview().topline)
   normal! j
   call assert_equal(2, winsaveview().topline)
+
+  bwipe!
+  bwipe!
+endfunc
+
+func Test_diff_scroll_many_filler()
+  20new
+  vnew
+  call setline(1, ['^^^', '^^^', '$$$', '$$$'])
+  diffthis
+  setlocal scrolloff=0
+  wincmd p
+  call setline(1, ['^^^', '^^^'] + repeat(['###'], 41) + ['$$$', '$$$'])
+  diffthis
+  setlocal scrolloff=0
+  wincmd p
+  redraw
+
+  " Note: need a redraw after each scroll, otherwise the test always passes.
+  normal! G
+  redraw
+  call assert_equal(3, winsaveview().topline)
+  call assert_equal(18, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(3, winsaveview().topline)
+  call assert_equal(19, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(2, winsaveview().topline)
+  call assert_equal(0, winsaveview().topfill)
+  exe "normal! \<C-B>"
+  redraw
+  call assert_equal(1, winsaveview().topline)
+  call assert_equal(0, winsaveview().topfill)
+
   bwipe!
   bwipe!
 endfunc


### PR DESCRIPTION
Fix #25479

#### vim-patch:9.0.1981: not being able to scroll up in diff mode

Problem:  Cannot scroll up in diff mode with many filler lines and zero
          'scrolloff'.
Solution: Invalidate w_cline_row before calling comp_botline().

closes: vim/vim#13256

https://github.com/vim/vim/commit/0583491277dea9d14e000051c26405b90d839072