### PR TITLE
vim-patch:9.0.1983: scrolling inactive window not possible with cursorbind

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -32,6 +32,7 @@
 #include "nvim/grid.h"
 #include "nvim/highlight.h"
 #include "nvim/macros.h"
+#include "nvim/mark.h"
 #include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/message.h"
@@ -2684,6 +2685,15 @@ void halfpage(bool flag, linenr_T Prenum)
 
 void do_check_cursorbind(void)
 {
+  static win_T *prev_curwin = NULL;
+  static pos_T prev_cursor = { 0, 0, 0 };
+
+  if (curwin == prev_curwin && equalpos(curwin->w_cursor, prev_cursor)) {
+    return;
+  }
+  prev_curwin = curwin;
+  prev_cursor = curwin->w_cursor;
+
   linenr_T line    = curwin->w_cursor.lnum;
   colnr_T col      = curwin->w_cursor.col;
   colnr_T coladd   = curwin->w_cursor.coladd;

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -50,6 +50,9 @@ tlunmenu *
 " roughly equivalent to test_setmouse() in Vim
 func Ntest_setmouse(row, col)
   call nvim_input_mouse('move', '', '', 0, a:row - 1, a:col - 1)
+  if state('m') == ''
+    call getchar(0)
+  endif
 endfunc
 
 " Prevent Nvim log from writing to stderr.

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1,4 +1,4 @@
-" Test for reset 'scroll' and 'smoothscroll'
+" Test for 'scroll', 'scrolloff', 'smoothscroll', etc.
 
 source check.vim
 source screendump.vim
@@ -39,20 +39,74 @@ func Test_reset_scroll()
 endfunc
 
 func Test_scolloff_even_line_count()
-   new
-   resize 6
-   setlocal scrolloff=3
-   call setline(1, range(20))
-   normal 2j
-   call assert_equal(1, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(1, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(2, getwininfo(win_getid())[0].topline)
-   normal j
-   call assert_equal(3, getwininfo(win_getid())[0].topline)
+  new
+  resize 6
+  setlocal scrolloff=3
+  call setline(1, range(20))
+  normal 2j
+  call assert_equal(1, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(1, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(2, getwininfo(win_getid())[0].topline)
+  normal j
+  call assert_equal(3, getwininfo(win_getid())[0].topline)
 
-   bwipe!
+  bwipe!
+endfunc
+
+func Test_mouse_scroll_inactive_with_cursorbind()
+  for scb in [0, 1]
+    for so in [0, 1, 2]
+      let msg = $'scb={scb} so={so}'
+
+      new | only
+      let w1 = win_getid()
+      setlocal cursorbind
+      let &l:scb = scb
+      let &l:so = so
+      call setline(1, range(101, 109))
+      rightbelow vnew
+      let w2 = win_getid()
+      setlocal cursorbind
+      let &l:scb = scb
+      let &l:so = so
+      call setline(1, range(101, 109))
+
+      normal! $
+      call assert_equal(3, col('.', w1), msg)
+      call assert_equal(3, col('.', w2), msg)
+      call Ntest_setmouse(1, 1)
+      call feedkeys("\<ScrollWheelDown>", 'xt')
+      call assert_equal(4, line('w0', w1), msg)
+      call assert_equal(4 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelDown>", 'xt')
+      call assert_equal(7, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelUp>", 'xt')
+      call assert_equal(4, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call feedkeys("\<ScrollWheelUp>", 'xt')
+      call assert_equal(1, line('w0', w1), msg)
+      call assert_equal(7 + so, line('.', w1), msg)
+      call assert_equal(1, line('w0', w2), msg)
+      call assert_equal(1, line('.', w2), msg)
+      normal! 0
+      call assert_equal(1, line('.', w1), msg)
+      call assert_equal(1, col('.', w1), msg)
+      call assert_equal(1, line('.', w2), msg)
+      call assert_equal(1, col('.', w2), msg)
+
+      bwipe!
+      bwipe!
+    endfor
+  endfor
 endfunc
 
 func Test_CtrlE_CtrlY_stop_at_end()


### PR DESCRIPTION
#### vim-patch:9.0.1983: scrolling inactive window not possible with cursorbind

Problem:  Scrolling non-current window using mouse is inconsistent
          depending on 'scrollbind'/'scrolloff' and different from GUI
          vertical scrollbar when 'cursorbind' is set.
Solution: Don't move cursor in non-current windows for 'cursorbind' if
          cursor in the current window didn't move.

closes: vim/vim#13219

https://github.com/vim/vim/commit/8e5f26ec6a1446aabffa7a0a7819a7462372a5b8