### PR TITLE
refactor(grid): get rid of unbatched grid_puts and grid_putchar

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3330,5 +3330,6 @@ static void win_put_linebuf(win_T *wp, int row, int coloff, int endcol, int clea
     }
   }
 
+  grid_adjust(&grid, &row, &coloff);
   grid_put_linebuf(grid, row, coloff, 0, endcol, clear_width, wp->w_p_rl, bg_attr, wrap, false);
 }

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2382,26 +2382,20 @@ static void win_update(win_T *wp, DecorProviders *providers)
       wp->w_botline = lnum;
       wp->w_filler_rows = wp->w_grid.rows - srow;
     } else if (dy_flags & DY_TRUNCATE) {      // 'display' has "truncate"
-      int scr_row = wp->w_grid.rows - 1;
-      int symbol = wp->w_p_fcs_chars.lastline;
-      char fillbuf[12];  // 2 characters of 6 bytes
-      int charlen = utf_char2bytes(symbol, &fillbuf[0]);
-      utf_char2bytes(symbol, &fillbuf[charlen]);
-
       // Last line isn't finished: Display "@@@" in the last screen line.
-      grid_puts(&wp->w_grid, fillbuf, MIN(wp->w_grid.cols, 2) * charlen, scr_row, 0, at_attr);
-      grid_fill(&wp->w_grid, scr_row, scr_row + 1, 2, wp->w_grid.cols, symbol, ' ', at_attr);
+      grid_line_start(&wp->w_grid, wp->w_grid.rows - 1);
+      grid_line_fill(0, MIN(wp->w_grid.cols, 3), wp->w_p_fcs_chars.lastline, at_attr);
+      grid_line_fill(3, wp->w_grid.cols, ' ', at_attr);
+      grid_line_flush();
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;
     } else if (dy_flags & DY_LASTLINE) {      // 'display' has "lastline"
-      int start_col = wp->w_grid.cols - 3;
-      int symbol = wp->w_p_fcs_chars.lastline;
-
       // Last line isn't finished: Display "@@@" at the end.
       // TODO(bfredl): this display ">@@@" when ">" was a left-halve
       // maybe "@@@@" is preferred when this happens.
       grid_line_start(&wp->w_grid, wp->w_grid.rows - 1);
-      grid_line_fill(MAX(start_col, 0), wp->w_grid.cols, symbol, at_attr);
+      grid_line_fill(MAX(wp->w_grid.cols - 3, 0), wp->w_grid.cols,
+                     wp->w_p_fcs_chars.lastline, at_attr);
       grid_line_flush();
       set_empty_rows(wp, srow);
       wp->w_botline = lnum;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1412,11 +1412,11 @@ static void ins_ctrl_v(void)
 // Put a character directly onto the screen.  It's not stored in a buffer.
 // Used while handling CTRL-K, CTRL-V, etc. in Insert mode.
 static int pc_status;
-#define PC_STATUS_UNSET 0       // pc_bytes was not set
-#define PC_STATUS_RIGHT 1       // right half of double-wide char
-#define PC_STATUS_LEFT  2       // left half of double-wide char
-#define PC_STATUS_SET   3       // pc_bytes was filled
-static char pc_bytes[MB_MAXBYTES + 1];  // saved bytes
+#define PC_STATUS_UNSET 0  // nothing was put on screen
+#define PC_STATUS_RIGHT 1  // right half of double-wide char
+#define PC_STATUS_LEFT  2  // left half of double-wide char
+#define PC_STATUS_SET   3  // pc_schar was filled
+static schar_T pc_schar;   // saved char
 static int pc_attr;
 static int pc_row;
 static int pc_col;
@@ -1433,31 +1433,34 @@ void edit_putchar(int c, bool highlight)
       attr = 0;
     }
     pc_row = curwin->w_wrow;
-    pc_col = 0;
     pc_status = PC_STATUS_UNSET;
+    grid_line_start(&curwin->w_grid, pc_row);
     if (curwin->w_p_rl) {
-      pc_col += curwin->w_grid.cols - 1 - curwin->w_wcol;
-      const int fix_col = grid_fix_col(&curwin->w_grid, pc_col, pc_row);
+      pc_col = curwin->w_grid.cols - 1 - curwin->w_wcol;
 
-      if (fix_col != pc_col) {
-        grid_putchar(&curwin->w_grid, ' ', pc_row, fix_col, attr);
+      if (grid_line_getchar(pc_col, NULL) == NUL) {
+        grid_line_put_schar(pc_col - 1, schar_from_ascii(' '), attr);
         curwin->w_wcol--;
         pc_status = PC_STATUS_RIGHT;
       }
     } else {
-      pc_col += curwin->w_wcol;
-      if (grid_lefthalve(&curwin->w_grid, pc_row, pc_col)) {
+      pc_col = curwin->w_wcol;
+
+      if (grid_line_getchar(pc_col + 1, NULL) == NUL) {
+        // pc_col is the left half of a double-width char
         pc_status = PC_STATUS_LEFT;
       }
     }
 
     // save the character to be able to put it back
     if (pc_status == PC_STATUS_UNSET) {
-      // TODO(bfredl): save the schar_T instead
-      grid_getbytes(&curwin->w_grid, pc_row, pc_col, pc_bytes, &pc_attr);
+      pc_schar = grid_line_getchar(pc_col, &pc_attr);
       pc_status = PC_STATUS_SET;
     }
-    grid_putchar(&curwin->w_grid, c, pc_row, pc_col, attr);
+
+    char buf[MB_MAXBYTES + 1];
+    grid_line_puts(pc_col, buf, utf_char2bytes(c, buf), attr);
+    grid_line_flush();
   }
 }
 
@@ -1537,7 +1540,10 @@ void edit_unputchar(void)
     if (pc_status == PC_STATUS_RIGHT || pc_status == PC_STATUS_LEFT) {
       redrawWinline(curwin, curwin->w_cursor.lnum);
     } else {
-      grid_puts(&curwin->w_grid, pc_bytes, -1, pc_row, pc_col, pc_attr);
+      // TODO(bfredl): this could be smarter and also handle the dubyawidth case
+      grid_line_start(&curwin->w_grid, pc_row);
+      grid_line_put_schar(pc_col, pc_schar, pc_attr);
+      grid_line_flush();
     }
   }
 }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6885,7 +6885,7 @@ static void f_screenchar(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     c = -1;
   } else {
     char buf[MB_MAXBYTES + 1];
-    grid_getbytes(grid, row, col, buf, NULL);
+    schar_get(buf, grid_getchar(grid, row, col, NULL));
     c = utf_ptr2char(buf);
   }
   rettv->vval.v_number = c;
@@ -6906,7 +6906,7 @@ static void f_screenchars(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   char buf[MB_MAXBYTES + 1];
-  grid_getbytes(grid, row, col, buf, NULL);
+  schar_get(buf, grid_getchar(grid, row, col, NULL));
   int pcc[MAX_MCO];
   int c = utfc_ptr2char(buf, pcc);
   int composing_len = 0;
@@ -6951,7 +6951,7 @@ static void f_screenstring(typval_T *argvars, typval_T *rettv, EvalFuncData fptr
   }
 
   char buf[MB_MAXBYTES + 1];
-  grid_getbytes(grid, row, col, buf, NULL);
+  schar_get(buf, grid_getchar(grid, row, col, NULL));
   rettv->vval.v_string = xstrdup(buf);
 }
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2959,15 +2959,15 @@ void os_msg(const char *str)
 
 void msg_moremsg(int full)
 {
-  int attr;
-  char *s = _("-- More --");
-
-  attr = hl_combine_attr(HL_ATTR(HLF_MSG), HL_ATTR(HLF_M));
-  grid_puts(&msg_grid_adj, s, -1, Rows - 1, 0, attr);
+  int attr = hl_combine_attr(HL_ATTR(HLF_MSG), HL_ATTR(HLF_M));
+  grid_line_start(&msg_grid_adj, Rows - 1);
+  int len = grid_line_puts(0, _("-- More --"), -1, attr);
   if (full) {
-    grid_puts(&msg_grid_adj, _(" SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "), -1,
-              Rows - 1, vim_strsize(s), attr);
+    len += grid_line_puts(len, _(" SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "),
+                          -1, attr);
   }
+  grid_line_cursor_goto(len);
+  grid_line_flush();
 }
 
 /// Repeat the message for the current mode: MODE_ASKMORE, MODE_EXTERNCMD,

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -182,7 +182,9 @@ void win_redr_status(win_T *wp)
       attr = win_hl_attr(wp, HLF_C);
       fillchar = wp->w_p_fcs_chars.vert;
     }
-    grid_putchar(&default_grid, fillchar, W_ENDROW(wp), W_ENDCOL(wp), attr);
+    grid_line_start(&default_grid, W_ENDROW(wp));
+    grid_line_put_schar(W_ENDCOL(wp), schar_from_char(fillchar), attr);
+    grid_line_flush();
   }
   busy = false;
 }

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -532,7 +532,7 @@ void ui_comp_raw_line(Integer grid, Integer row, Integer startcol, Integer endco
     compose_debug(row, row + 1, startcol, clearcol, dbghl_composed, true);
     compose_line(row, startcol, clearcol, flags);
   } else {
-    compose_debug(row, row + 1, startcol, endcol, dbghl_normal, false);
+    compose_debug(row, row + 1, startcol, endcol, dbghl_normal, endcol >= clearcol);
     compose_debug(row, row + 1, endcol, clearcol, dbghl_clear, true);
 #ifndef NDEBUG
     for (int i = 0; i < endcol - startcol; i++) {

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2827,7 +2827,7 @@ void intro_message(int colon)
       }
 
       if (*mesg != NUL) {
-        do_intro_line(row, mesg, 0);
+        do_intro_line((int)row, mesg, 0);
       }
       row++;
 
@@ -2838,14 +2838,13 @@ void intro_message(int colon)
   }
 }
 
-static void do_intro_line(long row, char *mesg, int attr)
+static void do_intro_line(int row, char *mesg, int attr)
 {
   char *p;
   int l;
-  int clen;
 
   // Center the message horizontally.
-  long col = vim_strsize(mesg);
+  int col = vim_strsize(mesg);
 
   col = (Columns - col) / 2;
 
@@ -2853,21 +2852,18 @@ static void do_intro_line(long row, char *mesg, int attr)
     col = 0;
   }
 
+  grid_line_start(&default_grid, row);
   // Split up in parts to highlight <> items differently.
   for (p = mesg; *p != NUL; p += l) {
-    clen = 0;
-
     for (l = 0;
          p[l] != NUL && (l == 0 || (p[l] != '<' && p[l - 1] != '>'));
          l++) {
-      clen += ptr2cells(p + l);
       l += utfc_ptr2len(p + l) - 1;
     }
     assert(row <= INT_MAX && col <= INT_MAX);
-    grid_puts(&default_grid, p, l, (int)row, (int)col,
-              *p == '<' ? HL_ATTR(HLF_8) : attr);
-    col += clen;
+    col += grid_line_puts(col, p, l, *p == '<' ? HL_ATTR(HLF_8) : attr);
   }
+  grid_line_flush();
 }
 
 /// ":intro": clear screen, display intro screen and wait for return.

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1366,7 +1366,7 @@ describe('ui/ext_messages', function()
 
     feed(":intro<cr>")
     screen:expect{grid=[[
-                                                                                      |
+      ^                                                                                |
                                                                                       |
                                                                                       |
                                                                                       |


### PR DESCRIPTION
This finalizes the long running refactor from the old TUI-focused grid implementation where text-drawing cursor was not separated from the visible cursor.

Still, the pattern of setting cursor position togheter with updating a line was convenient. So introduce grid_line_cursor_goto() to still allow this pattern but now being explicit about it.

Only having batched drawing functions makes code involving drawing a bit longer. but it is better to be explicit, and this highlights cases where multiple small redraws can be grouped togheter. This was the case for most of the changed places (messages, lastline, and :intro)