### PR TITLE
ci: enable clang-analyzer warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,20 @@ jobs:
         name: uncrustify
         run: cmake --build build --target lintc-uncrustify
 
+  clang-analyzer:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./.github/scripts/install_deps.sh
+      - uses: ./.github/actions/cache
+      - name: Build third-party deps
+        run: |
+          cmake -S cmake.deps -B .deps -G Ninja
+          cmake --build .deps
+          cmake -B build -G Ninja
+      - run: cmake --build build --target clang-analyzer
+
   posix:
     name: ${{ matrix.runner }} ${{ matrix.flavor }} (cc=${{ matrix.cc }})
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ functionaltest-lua: | nvim
 	$(BUILD_TOOL) -C build functionaltest
 
 FORMAT=formatc formatlua format
-LINT=lintlua lintsh lintc clang-tidy lintcommit lint
+LINT=lintlua lintsh lintc clang-tidy clang-analyzer lintcommit lint
 TEST=functionaltest unittest
 generated-sources benchmark $(FORMAT) $(LINT) $(TEST) doc: | build/.ran-cmake
 	$(CMAKE_PRG) --build build --target $@

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -821,10 +821,32 @@ add_glob_target(
   FILES ${NVIM_SOURCES} ${NVIM_HEADERS}
   FLAGS --quiet
   EXCLUDE ${EXCLUDE_CLANG_TIDY})
+
+# These are the same warnings as https://neovim.io/doc/reports/clang/. The
+# checks we ignore are meant to be removed eventually, but we can only do so
+# after we properly fix the problems without breaking CI.
+add_glob_target(
+  TARGET clang-analyzer
+  COMMAND ${CLANG_TIDY_PRG}
+  FILES ${NVIM_SOURCES} ${NVIM_HEADERS}
+  FLAGS --quiet
+  --checks='
+  -*,
+  clang-analyzer-*,
+  -clang-analyzer-core.NonNullParamChecker,
+  -clang-analyzer-core.NullDereference,
+  -clang-analyzer-core.UndefinedBinaryOperatorResult,
+  -clang-analyzer-core.uninitialized.Assign,
+  -clang-analyzer-optin.performance.Padding,
+  -clang-analyzer-security.insecureAPI.strcpy,
+  '
+  EXCLUDE ${EXCLUDE_CLANG_TIDY})
+
 add_custom_target(copy_compile_commands
   COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/compile_commands.json ${PROJECT_SOURCE_DIR}/compile_commands.json)
 add_dependencies(copy_compile_commands nvim)
 add_dependencies(clang-tidy copy_compile_commands)
+add_dependencies(clang-analyzer copy_compile_commands)
 
 if(CI_BUILD)
   set(LINT_OUTPUT_FORMAT gh_action)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5641,7 +5641,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
 
-  const char *prompt = "";
+  const char *prompt;
   const char *defstr = "";
   typval_T *cancelreturn = NULL;
   typval_T cancelreturn_strarg2 = TV_INITIAL_VALUE;


### PR DESCRIPTION
This adds the checks in https://neovim.io/doc/reports/clang/ when using
clang-tidy. The strategy is to enable all clang-analyzer checks, and
disable only the checks for the warnings that exist currently. This
allows us to eliminate each warning type without blocking ongoing work,
but also without adding bugs for already eliminated warnings.

The plan is to eventually eliminate https://neovim.io/doc/reports/clang/
by completely integrating it into the clang-tidy check.

Also add make and cmake targets `clang-analyzer` to run this check.