### PR TITLE
refactor(cpoptions): remove 'p'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1720,9 +1720,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 			when it didn't exist when editing it.  This is a
 			protection against a file unexpectedly created by
 			someone else.  Vi didn't complain about this.
-								*cpo-p*
-		p	Vi compatible Lisp indenting.  When not present, a
-			slightly better algorithm is used.
 								*cpo-P*
 		P	When included, a ":write" command that appends to a
 			file will set the file name for the current buffer, if

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -675,7 +675,7 @@ Options:
   bioskey (MS-DOS)
   conskey (MS-DOS)
   *'cp'* *'nocompatible'* *'nocp'* *'compatible'* (Nvim is always "nocompatible".)
-  'cpoptions' (gjkHw<*- and all POSIX flags were removed)
+  'cpoptions' (gjpkHw<*- and all POSIX flags were removed)
   *'cryptmethod'* *'cm'* *'key'* (Vim encryption implementation)
   cscopepathcomp
   cscopeprg

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1296,9 +1296,6 @@ vim.bo.ci = vim.bo.copyindent
 --- 		when it didn't exist when editing it.  This is a
 --- 		protection against a file unexpectedly created by
 --- 		someone else.  Vi didn't complain about this.
---- 							*cpo-p*
---- 	p	Vi compatible Lisp indenting.  When not present, a
---- 		slightly better algorithm is used.
 --- 							*cpo-P*
 --- 	P	When included, a ":write" command that appends to a
 --- 		file will set the file name for the current buffer, if

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -151,7 +151,6 @@
 #define CPO_NUMCOL      'n'     // 'number' column also used for text
 #define CPO_LINEOFF     'o'
 #define CPO_OVERNEW     'O'     // silently overwrite new file
-#define CPO_LISP        'p'     // 'lisp' indenting
 #define CPO_FNAMEAPP    'P'     // set file name for ":w >>file"
 #define CPO_JOINCOL     'q'     // with "3J" use column after first join
 #define CPO_REDO        'r'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1709,9 +1709,6 @@ return {
         		when it didn't exist when editing it.  This is a
         		protection against a file unexpectedly created by
         		someone else.  Vi didn't complain about this.
-        							*cpo-p*
-        	p	Vi compatible Lisp indenting.  When not present, a
-        		slightly better algorithm is used.
         							*cpo-P*
         	P	When included, a ":write" command that appends to a
         		file will set the file name for the current buffer, if

--- a/test/old/testdir/test_lispindent.vim
+++ b/test/old/testdir/test_lispindent.vim
@@ -50,6 +50,7 @@ func Test_lisp_indent()
 
   set lisp
   set lispwords&
+  throw 'Skipped: cpo+=p not supported'
   let save_copt = &cpoptions
   set cpoptions+=p
   normal 1G=G


### PR DESCRIPTION
Deleting a cpo flag a day keeps the doctor away

We don't need two different ways to indent LISP code