### PR TITLE
vim-patch:9.0.1990,27e12c7669e3

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5115,8 +5115,6 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 		precision, the argument(s) to be used must also be specified
 		using a {n$} positional argument specifier. See |printf-$|.
 
-
-								*E1520*
 		The conversion specifiers and their meanings are:
 
 				*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
@@ -5308,11 +5306,11 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 			%1$d at width %2$d is: %01$*2$.3$d
 
 							*E1507*
-		This internal error indicates that the logic to
-		parse a positional format error ran into a problem
-		that couldn't be otherwise reported. Please file a
-		bug against vim if you run into this, copying the
-		exact format string and parameters that were used.
+		This internal error indicates that the logic to parse a
+		positional format argument ran into a problem that couldn't be
+		otherwise reported.  Please file a bug against Vim if you run
+		into this, copying the exact format string and parameters that
+		were used.
 
 prompt_getprompt({buf})                                     *prompt_getprompt()*
 		Returns the effective prompt text for buffer {buf}.  {buf} can

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -5307,6 +5307,13 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 <			E1505: Invalid format specifier:
 			%1$d at width %2$d is: %01$*2$.3$d
 
+							*E1507*
+		This internal error indicates that the logic to
+		parse a positional format error ran into a problem
+		that couldn't be otherwise reported. Please file a
+		bug against vim if you run into this, copying the
+		exact format string and parameters that were used.
+
 prompt_getprompt({buf})                                     *prompt_getprompt()*
 		Returns the effective prompt text for buffer {buf}.  {buf} can
 		be a buffer name or number.  See |prompt-buffer|.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6098,8 +6098,6 @@ function vim.fn.prevnonblank(lnum) end
 --- precision, the argument(s) to be used must also be specified
 --- using a {n$} positional argument specifier. See |printf-$|.
 ---
----
----             *E1520*
 --- The conversion specifiers and their meanings are:
 ---
 ---     *printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
@@ -6291,11 +6289,11 @@ function vim.fn.prevnonblank(lnum) end
 ---   %1$d at width %2$d is: %01$*2$.3$d
 ---
 ---           *E1507*
---- This internal error indicates that the logic to
---- parse a positional format error ran into a problem
---- that couldn't be otherwise reported. Please file a
---- bug against vim if you run into this, copying the
---- exact format string and parameters that were used.
+--- This internal error indicates that the logic to parse a
+--- positional format argument ran into a problem that couldn't be
+--- otherwise reported.  Please file a bug against Vim if you run
+--- into this, copying the exact format string and parameters that
+--- were used.
 ---
 --- @param fmt any
 --- @param expr1? any

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6290,6 +6290,13 @@ function vim.fn.prevnonblank(lnum) end
 --- <  E1505: Invalid format specifier:
 ---   %1$d at width %2$d is: %01$*2$.3$d
 ---
+---           *E1507*
+--- This internal error indicates that the logic to
+--- parse a positional format error ran into a problem
+--- that couldn't be otherwise reported. Please file a
+--- bug against vim if you run into this, copying the
+--- exact format string and parameters that were used.
+---
 --- @param fmt any
 --- @param expr1? any
 --- @return any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7381,8 +7381,6 @@ M.funcs = {
       precision, the argument(s) to be used must also be specified
       using a {n$} positional argument specifier. See |printf-$|.
 
-
-      						*E1520*
       The conversion specifiers and their meanings are:
 
       		*printf-d* *printf-b* *printf-B* *printf-o* *printf-x* *printf-X*
@@ -7574,11 +7572,11 @@ M.funcs = {
       	%1$d at width %2$d is: %01$*2$.3$d
 
       					*E1507*
-      This internal error indicates that the logic to
-      parse a positional format error ran into a problem
-      that couldn't be otherwise reported. Please file a
-      bug against vim if you run into this, copying the
-      exact format string and parameters that were used.
+      This internal error indicates that the logic to parse a
+      positional format argument ran into a problem that couldn't be
+      otherwise reported.  Please file a bug against Vim if you run
+      into this, copying the exact format string and parameters that
+      were used.
 
     ]=],
     name = 'printf',

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7572,6 +7572,14 @@ M.funcs = {
       	echo printf("%1$d at width %2$d is: %01$*2$.3$d", 1, 2)
       <	E1505: Invalid format specifier:
       	%1$d at width %2$d is: %01$*2$.3$d
+
+      					*E1507*
+      This internal error indicates that the logic to
+      parse a positional format error ran into a problem
+      that couldn't be otherwise reported. Please file a
+      bug against vim if you run into this, copying the
+      exact format string and parameters that were used.
+
     ]=],
     name = 'printf',
     params = { { 'fmt', 'any' }, { 'expr1', 'any' } },

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -46,7 +46,7 @@ static const char e_positional_arg_num_type_inconsistent_str_str[]
 static const char e_invalid_format_specifier_str[]
   = N_("E1505: Invalid format specifier: %s");
 static const char e_aptypes_is_null_nr_str[]
-  = "E1520: Internal error: ap_types or ap_types[idx] is NULL: %d: %s";
+  = "E1507: Internal error: ap_types or ap_types[idx] is NULL: %d: %s";
 
 static const char typename_unknown[] = N_("unknown");
 static const char typename_int[] = N_("int");


### PR DESCRIPTION
#### vim-patch:9.0.1990: strange error number

Problem:  strange error number
Solution: change error number,
          add doc tag for E1507

closes: vim/vim#13270

https://github.com/vim/vim/commit/ea746f9e862092aef3d4e95c64d116759b9fabe0

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>


#### vim-patch:27e12c7669e3

runtime(doc): remove E1520 tag (vim/vim#13289)

https://github.com/vim/vim/commit/27e12c7669e36a8f60fefa9db9a08024efeb06e8