### PR TITLE
vim-patch:9.0.1995: Invalid memory access with empty 'foldexpr'

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1299,7 +1299,7 @@ int eval_foldexpr(win_T *wp, int *cp)
       // If the result is a string, check if there is a non-digit before
       // the number.
       char *s = tv.vval.v_string;
-      if (!ascii_isdigit(*s) && *s != '-') {
+      if (*s != NUL && !ascii_isdigit(*s) && *s != '-') {
         *cp = (uint8_t)(*s++);
       }
       retval = atol(s);

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1569,4 +1569,13 @@ func Test_foldcolumn_linebreak_control_char()
   bwipe!
 endfunc
 
+" This used to cause invalid memory access
+func Test_foldexpr_return_empty_string()
+  new
+  setlocal foldexpr='' foldmethod=expr
+  redraw
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.1995: Invalid memory access with empty 'foldexpr'

Problem:  Invalid memory access when 'foldexpr' returns empty string.
Solution: Check for NUL.

closes: vim/vim#13293

https://github.com/vim/vim/commit/a991ce9c083bb8c02b1b1ec34ed35728197050f3