### PR TITLE
vim-patch:9.0.1997: Some unused code in move.c and string.c

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1313,7 +1313,6 @@ bool scrolldown(long line_count, int byfold)
     }
     if (col > width2 && width2 > 0) {
       row += (int)col / width2;
-      col = col % width2;
     }
     if (row >= curwin->w_height_inner) {
       curwin->w_curswant = curwin->w_virtcol - (row - curwin->w_height_inner + 1) * width2;
@@ -1518,7 +1517,6 @@ void adjust_skipcol(void)
   }
   if (col > width2) {
     row += (int)col / width2;
-    col = col % width2;
   }
   if (row >= curwin->w_height_inner) {
     if (curwin->w_skipcol == 0) {

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1079,7 +1079,7 @@ static int parse_fmt_types(const char ***ap_types, int *num_posarg, const char *
           any_arg = 1;
           CHECK_POS_ARG;
         }
-      } else if (ascii_isdigit((int)(*(arg = p)))) {
+      } else if (ascii_isdigit((int)(*p))) {
         // size_t could be wider than unsigned int; make sure we treat
         // argument like common implementations do
         unsigned uj = (unsigned)(*p++ - '0');
@@ -1126,7 +1126,7 @@ static int parse_fmt_types(const char ***ap_types, int *num_posarg, const char *
             any_arg = 1;
             CHECK_POS_ARG;
           }
-        } else if (ascii_isdigit((int)(*(arg = p)))) {
+        } else if (ascii_isdigit((int)(*p))) {
           // size_t could be wider than unsigned int; make sure we
           // treat argument like common implementations do
           unsigned uj = (unsigned)(*p++ - '0');
@@ -1155,7 +1155,7 @@ static int parse_fmt_types(const char ***ap_types, int *num_posarg, const char *
         p++;
         if (length_modifier == 'l' && *p == 'l') {
           // double l = long long
-          length_modifier = 'L';
+          // length_modifier = 'L';
           p++;
         }
       }


### PR DESCRIPTION
Problem:  Some unused code in move.c and string.c
Solution: Remove it

closes: vim/vim#13288

https://github.com/vim/vim/commit/580c1fcb4ad85360cd3a361c3c8e37b534153d60

Co-authored-by: dundargoc <gocdundar@gmail.com>
