### PR TITLE
feat(ui-ext): make 'mousehide' into proper ui_option

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -211,6 +211,7 @@ the editor.
 	- 'guifontwide'
 	- 'linespace'
 	- 'mousefocus'
+	- 'mousehide'
 	- 'mousemoveevent'
 	- 'pumblend'
 	- 'showtabline'

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -571,6 +571,7 @@ EXTERN char *p_mouse;           ///< 'mouse'
 EXTERN char *p_mousem;          ///< 'mousemodel'
 EXTERN int p_mousemev;          ///< 'mousemoveevent'
 EXTERN int p_mousef;            ///< 'mousefocus'
+EXTERN int p_mh;                ///< 'mousehide'
 EXTERN char *p_mousescroll;     ///< 'mousescroll'
 EXTERN OptInt p_mousescroll_vert INIT(= MOUSESCROLL_VERT_DFLT);
 EXTERN OptInt p_mousescroll_hor INIT(= MOUSESCROLL_HOR_DFLT);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5452,9 +5452,11 @@ return {
       ]=],
       enable_if = false,
       full_name = 'mousehide',
+      redraw = { 'ui_option' },
       scope = { 'global' },
       short_desc = N_('hide mouse pointer while typing'),
       type = 'bool',
+      varname = 'p_mh',
     },
     {
       abbreviation = 'mousem',

--- a/test/functional/ui/options_spec.lua
+++ b/test/functional/ui/options_spec.lua
@@ -19,6 +19,7 @@ describe('UI receives option updates', function()
       linespace=0,
       pumblend=0,
       mousefocus=false,
+      mousehide=true,
       mousemoveevent=false,
       showtabline=1,
       termguicolors=false,
@@ -129,6 +130,12 @@ describe('UI receives option updates', function()
 
     command("set mousefocus")
     expected.mousefocus = true
+    screen:expect(function()
+      eq(expected, screen.options)
+    end)
+
+    command("set nomousehide")
+    expected.mousehide = false
     screen:expect(function()
       eq(expected, screen.options)
     end)


### PR DESCRIPTION
Fixes #14955

Tested using 

```sh
nvim -u NORC
echo nvim_get_option("mousehide")
```

Tests; Passed functional test; `TEST_FILE=test/functional/ui/options_spec.lua make functionaltest`

This PR just adds an option to be visible, there is no actual implementation as per #14955. 