### PR TITLE
docs: use `abort()` for unreachable `default:` case in C

### DIFF
--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -846,7 +846,7 @@ Annotate non-trivial fall-through between cases.
 If not conditional on an enumerated value, switch statements should always
 have a `default` case (in the case of an enumerated value, the compiler will
 warn you if any values are not handled). If the default case should never
-execute, simply `assert`: >c
+execute, simply use `abort()`: >c
 
     switch (var) {
       case 0:
@@ -856,7 +856,7 @@ execute, simply `assert`: >c
         ...
         break;
       default:
-        assert(false);
+        abort();
     }
 
 Return Values ~


### PR DESCRIPTION
Problem: The style guide currently recommends having a `default:` case for switch statements that are not conditional on an enumerated value. Additionally, it recommends using `assert(false)` if `default:` is unreachable. This is problematic because `assert()` only runs on debug builds, which may lead to confusing breakages in release builds. Moreover, this suggestion is followed nowhere in the C code and `abort()` is used everywhere instead.

Solution: Suggest using `abort()` instead of `assert(false)`, that way the program always terminates if a logically unreachable case is reached.