### PR TITLE
refactor: allow not having a `default` case for enum

### DIFF
--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -859,6 +859,33 @@ execute, simply use `abort()`: >c
         abort();
     }
 
+Switch statements that are conditional on an enumerated value should not have
+a `default` case if it is exhaustive. Explicit case labels are preferred over
+`default`, even if it leads to multiple case labels for the same code. For
+example, instead of: >c
+
+    case A:
+      ...
+    case B:
+      ...
+    case C:
+      ...
+    default:
+      ...
+
+You should use: >c
+
+    case A:
+      ...
+    case B:
+      ...
+    case C:
+      ...
+    case D:
+    case E:
+    case F:
+      ...
+
 Return Values ~
 
 Do not needlessly surround the `return` expression with parentheses.

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -90,7 +90,7 @@ if(MSVC)
   target_compile_options(main_lib INTERFACE -W3)
 
   # Disable warnings that give too many false positives.
-  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003)
+  target_compile_options(main_lib INTERFACE -wd4311 -wd4146 -wd4003 -wd4715)
   target_compile_definitions(main_lib INTERFACE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
 
   target_sources(main_lib INTERFACE ${CMAKE_CURRENT_LIST_DIR}/os/nvim.manifest)

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -294,7 +294,7 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Error *err)
         case kCallbackPartial:
           PUT(autocmd_info, "callback", CSTR_AS_OBJ(callback_to_string(cb)));
           break;
-        default:
+        case kCallbackNone:
           abort();
         }
       } else {

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -146,16 +146,14 @@ static Object optval_as_object(OptVal o)
       return BOOLEAN_OBJ(o.data.boolean);
     case kNone:
       return NIL;
-    default:
-      abort();
     }
+    UNREACHABLE;
   case kOptValTypeNumber:
     return INTEGER_OBJ(o.data.number);
   case kOptValTypeString:
     return STRING_OBJ(o.data.string);
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 /// Consume an API Object and convert it to an OptVal.

--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -363,9 +363,6 @@ bool object_to_vim(Object obj, typval_T *tv, Error *err)
     tv->vval.v_string = xstrdup(name);
     break;
   }
-
-  default:
-    abort();
   }
 
   return true;

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -610,9 +610,6 @@ void api_free_object(Object value)
   case kObjectTypeLuaRef:
     api_free_luaref(value.data.luaref);
     break;
-
-  default:
-    abort();
   }
 }
 
@@ -800,10 +797,8 @@ Object copy_object(Object obj, Arena *arena)
 
   case kObjectTypeLuaRef:
     return LUAREF_OBJ(api_new_luaref(obj.data.luaref));
-
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 void api_set_error(Error *err, ErrorType errType, const char *format, ...)
@@ -884,9 +879,8 @@ char *api_typename(ObjectType t)
     return "Window";
   case kObjectTypeTabpage:
     return "Tabpage";
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 HlMessage parse_hl_msg(Array chunks, Error *err)

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -279,8 +279,6 @@ Dictionary config_put_bordertext(Dictionary config, FloatConfig *fconfig,
     field_name = "footer";
     field_pos_name = "footer_pos";
     break;
-  default:
-    abort();
   }
 
   Array bordertext = virt_text_to_array(vt, true);

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -168,9 +168,6 @@ bool channel_close(uint64_t id, ChannelPart part, const char **error)
       channel_decref(chan);
     }
     break;
-
-  default:
-    abort();
   }
 
   return true;
@@ -917,9 +914,6 @@ Dictionary channel_info(uint64_t id)
   case kChannelStreamSocket:
     stream_desc = "socket";
     break;
-
-  default:
-    abort();
   }
   PUT(info, "stream", CSTR_TO_OBJ(stream_desc));
 

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -738,9 +738,8 @@ int win_get_bordertext_col(int total_col, int text_width, AlignTextPos align)
     return (total_col - text_width) / 2 + 1;
   case kAlignRight:
     return total_col - text_width + 1;
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 static void win_redr_border(win_T *wp)

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6088,9 +6088,6 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
   case kCallbackNone:
     return false;
     break;
-
-  default:
-    abort();
   }
 
   funcexe_T funcexe = FUNCEXE_INIT;
@@ -6120,7 +6117,7 @@ bool set_ref_in_callback(Callback *callback, int copyID, ht_stack_T **ht_stack,
     return set_ref_in_item(&tv, copyID, ht_stack, list_stack);
     break;
 
-  default:
+  case kCallbackLua:
     abort();
   }
   return false;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -4990,9 +4990,10 @@ static int msgpackparse_convert_item(const msgpack_object data, const msgpack_un
     tv_list_append_owned_tv(ret_list, tv);
     return OK;
   }
-  default:
+  case MSGPACK_UNPACK_EXTRA_BYTES:
     abort();
   }
+  UNREACHABLE;
 }
 
 static void msgpackparse_unpack_list(const list_T *const list, list_T *const ret_list)

--- a/src/nvim/event/process.c
+++ b/src/nvim/event/process.c
@@ -78,8 +78,6 @@ int process_spawn(Process *proc, bool in, bool out, bool err)
   case kProcessTypePty:
     status = pty_process_spawn((PtyProcess *)proc);
     break;
-  default:
-    abort();
   }
 
   if (status) {
@@ -239,8 +237,6 @@ void process_stop(Process *proc) FUNC_ATTR_NONNULL_ALL
     process_close_streams(proc);
     pty_process_close_master((PtyProcess *)proc);
     break;
-  default:
-    abort();
   }
 
   // (Re)start timer to verify that stopped process(es) died.
@@ -340,8 +336,6 @@ static void process_close(Process *proc)
   case kProcessTypePty:
     pty_process_close((PtyProcess *)proc);
     break;
-  default:
-    abort();
   }
 }
 

--- a/src/nvim/macros.h
+++ b/src/nvim/macros.h
@@ -154,6 +154,14 @@
 # define FALLTHROUGH
 #endif
 
+#if defined(__clang__) || defined(__GNUC__)
+# define UNREACHABLE __builtin_unreachable()
+#elif defined(_MSVC_VER)
+# define UNREACHABLE __assume(false)
+#else
+# define UNREACHABLE
+#endif
+
 // -V:STRUCT_CAST:641
 
 /// Change type of structure pointers: cast `struct a *` to `struct b *`

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -173,9 +173,6 @@ static void api_parse_enter(mpack_parser_t *parser, mpack_node_t *node)
     node->data[0].p = result;
     break;
   }
-
-  default:
-    abort();
   }
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3461,9 +3461,8 @@ OptVal optval_copy(OptVal o)
     return o;
   case kOptValTypeString:
     return STRING_OPTVAL(copy_string(o.data.string, NULL));
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 // Match type of OptVal with the type of the target option. Returns true if the types match and
@@ -3482,9 +3481,8 @@ static bool optval_match_type(OptVal o, int opt_idx)
     return flags & P_NUM;
   case kOptValTypeString:
     return flags & P_STRING;
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 // Return C-string representation of OptVal. Caller must free the returned C-string.
@@ -3505,9 +3503,8 @@ static char *optval_to_cstr(OptVal o)
     snprintf(buf, o.data.string.size + 3, "\"%s\"", o.data.string.data);
     return buf;
   }
-  default:
-    abort();
   }
+  UNREACHABLE;
 }
 
 // Get an allocated string containing a list of valid types for an option.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1135,8 +1135,6 @@ void tui_set_mode(TUIData *tui, ModeShape mode)
 
   int shape;
   switch (c.shape) {
-  default:
-    abort(); break;
   case SHAPE_BLOCK:
     shape = 1; break;
   case SHAPE_HOR:


### PR DESCRIPTION
Problem: The style guide states that all switch statements that are not conditional on an enum must have a `default` case, but does not give any explicit guideline for switch statements that are conditional on enums. As a result, a `default` case is added in many enum switch statements, even when the switch statement is exhaustive. This is not ideal because it removes the ability to have compiler errors to easily detect unchanged switch statements when a new possible value for an enum is added.

Solution: Add explicit guidelines for switch statements that are conditional on an enum, clarifying that a `default` case is not necessary if the switch statement is exhaustive. Also refactor pre-existing code with unnecessary `default` cases.