### PR TITLE
fix(docs): Miscellaneous doc and type fixes

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2552,7 +2552,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	    "auto":       resize to the minimum amount of folds to display.
 	    "auto:[1-9]": resize to accommodate multiple folds up to the
 			  selected level
-	    0:            to disable foldcolumn
+	    "0":          to disable foldcolumn
 	    "[1-9]":      to display a fixed number of columns
 	See |folding|.
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1,4 +1,4 @@
---- @meta
+--- @meta _
 -- THIS FILE IS GENERATED
 -- DO NOT EDIT
 error('Cannot require a meta file')

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -1,4 +1,4 @@
---- @meta
+--- @meta _
 -- THIS FILE IS GENERATED
 -- DO NOT EDIT
 error('Cannot require a meta file')

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1,4 +1,4 @@
---- @meta
+--- @meta _
 -- THIS FILE IS GENERATED
 -- DO NOT EDIT
 error('Cannot require a meta file')

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2276,7 +2276,7 @@ vim.go.fcl = vim.go.foldclose
 ---     "auto":       resize to the minimum amount of folds to display.
 ---     "auto:[1-9]": resize to accommodate multiple folds up to the
 --- 		  selected level
----     0:            to disable foldcolumn
+---     "0":          to disable foldcolumn
 ---     "[1-9]":      to display a fixed number of columns
 --- See `folding`.
 ---

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1,4 +1,4 @@
---- @meta
+--- @meta _
 -- THIS FILE IS GENERATED
 -- DO NOT EDIT
 error('Cannot require a meta file')

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8055,7 +8055,7 @@ function vim.fn.shellescape(string, special) end
 --- will be assumed.
 ---
 --- @param col? integer
---- @return any
+--- @return integer
 function vim.fn.shiftwidth(col) end
 
 --- @param name string

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -19,14 +19,14 @@ local DEP_API_DOC  = 'runtime/doc/api.mpack'
 --- @field since integer
 
 local LUA_META_HEADER = {
-  '--- @meta',
+  '--- @meta _',
   '-- THIS FILE IS GENERATED',
   '-- DO NOT EDIT',
   "error('Cannot require a meta file')",
 }
 
 local LUA_API_META_HEADER = {
-  '--- @meta',
+  '--- @meta _',
   '-- THIS FILE IS GENERATED',
   '-- DO NOT EDIT',
   "error('Cannot require a meta file')",
@@ -35,7 +35,7 @@ local LUA_API_META_HEADER = {
 }
 
 local LUA_OPTION_META_HEADER = {
-  '--- @meta',
+  '--- @meta _',
   '-- THIS FILE IS GENERATED',
   '-- DO NOT EDIT',
   "error('Cannot require a meta file')",

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9636,6 +9636,7 @@ M.funcs = {
     name = 'shiftwidth',
     params = { { 'col', 'integer' } },
     signature = 'shiftwidth([{col}])',
+    returns = 'integer',
   },
   sign_define = {
     args = { 1, 2 },

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2932,7 +2932,7 @@ return {
             "auto":       resize to the minimum amount of folds to display.
             "auto:[1-9]": resize to accommodate multiple folds up to the
         		  selected level
-            0:            to disable foldcolumn
+            "0":          to disable foldcolumn
             "[1-9]":      to display a fixed number of columns
         See |folding|.
       ]=],


### PR DESCRIPTION
This PR:
- Adds `@meta _` to the type files that should not be required (the [LuaLS docs](https://github.com/LuaLS/lua-language-server/wiki/Annotations#meta) say that "giving the name _ will make it unable to be required"). Still keeping the `error(...)` since it has a more accurate message.
- <s>Changes the return type of `nvim_buf_get_extmark_by_id` from `int[]` to array/table, since if `opts.details` is set then the last entry will be a dict. Unfortunately it seems like the type generator script cannot narrow the type down to `(int|table)[]`.</s> Removing this for now since this would require deprecating `nvim_buf_get_extmark_by_id` and it involves a larger change.
- Changes the return type of `shiftwidth` to `integer`.
- Fixes #25516.