### PR TITLE
fix(coverity): dead code

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6952,9 +6952,7 @@ char *file_name_in_line(char *line, int col, int options, int count, char *rel_f
   while (ptr > line) {
     if ((len = (size_t)(utf_head_off(line, ptr - 1))) > 0) {
       ptr -= len + 1;
-    } else if (vim_isfilec((uint8_t)ptr[-1])
-               || (len >= 2 && path_has_drive_letter(ptr - 2))
-               || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
+    } else if (vim_isfilec((uint8_t)ptr[-1]) || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
       ptr--;
     } else {
       break;


### PR DESCRIPTION
Followup to https://github.com/neovim/neovim/pull/25236 

    *** CID 466056:  Control flow issues  (DEADCODE)
    /src/nvim/window.c: 6951 in file_name_in_line()
    6945       // Search backward for first char of the file name.
    6946       // Go one char back to ":" before "//", or to the drive letter before ":\" (even if ":"
    6947       // is not in 'isfname').
    6948       while (ptr > line) {
    6949         if ((len = (size_t)(utf_head_off(line, ptr - 1))) > 0) {
    6950           ptr -= len + 1;
    >>>     CID 466056:  Control flow issues  (DEADCODE)
    >>>     Execution cannot reach the expression "path_has_drive_letter(ptr - 2)" inside this statement: "if (vim_isfilec((uint8_t)pt...".
    6951         } else if (vim_isfilec((uint8_t)ptr[-1])
    6952                    || (len >= 2 && path_has_drive_letter(ptr - 2))
    6953                    || ((options & FNAME_HYP) && path_is_url(ptr - 1))) {
    6954           ptr--;
    6955         } else {
    6956           break;


## Todo

- revisit `path_has_drive_letter`