### PR TITLE
vim-patch:9.0.2008: test: undofile left behind

### DIFF
--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -868,6 +868,7 @@ func Test_undo_after_write()
 
   call StopVimInTerminal(buf)
   call delete('Xtestfile.txt')
+  call delete('.Xtestfile.txt.un~')
 endfunc
 
 func Test_undo_range_normal()


### PR DESCRIPTION
#### vim-patch:9.0.2008: test: undofile left behind

Problem:  test: undofile left behind
Solution: cleanup undofile

fix: tmp file not deleted when running make test_undo

Temporary file `.Xtestfile.txt.un~` was left running `make test_undo`
and vim was configured with:
```
./configure --with-features=normal --enable-gui=no --enable-terminal
```

closes: vim/vim#13304

https://github.com/vim/vim/commit/b07b9dc4dafe2aad5ee752a51f06acacae210fef

Co-authored-by: Dominique Pellé <dominique.pelle@tomtom.com>