### PR TITLE
vim-patch:9.0.2009: cmdline-completion for comma-separated options wrong

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -136,10 +136,26 @@ To include white space in a string option value it has to be preceded with a
 backslash.  To include a backslash you have to use two.  Effectively this
 means that the number of backslashes in an option value is halved (rounded
 down).
+In options 'path', 'cdpath', and 'tags', spaces have to be preceded with three
+backslashes instead becuase they can be separated by either commas or spaces.
+Comma-separated options like 'backupdir' and 'tags' will also require commas
+to be escaped with two backslashes, whereas this is not needed for
+non-comma-separated ones like 'makeprg'.
+When setting options using |:let| and |literal-string|, you need to use one
+fewer layer of backslash.
 A few examples: >
-   :set tags=tags\ /usr/tags	    results in "tags /usr/tags"
-   :set tags=tags\\,file	    results in "tags\,file"
-   :set tags=tags\\\ file	    results in "tags\ file"
+   :set makeprg=make\ file	    results in "make file"
+   :let &makeprg='make file'	    (same as above)
+   :set makeprg=make\\\ file	    results in "make\ file"
+   :set tags=tags\ /usr/tags	    results in "tags" and "/usr/tags"
+   :set tags=tags\\\ file	    results in "tags file"
+   :let &tags='tags\ file'	    (same as above)
+
+   :set makeprg=make,file	    results in "make,file"
+   :set makeprg=make\\,file	    results in "make\,file"
+   :set tags=tags,file		    results in "tags" and "file"
+   :set tags=tags\\,file	    results in "tags,file"
+   :let &tags='tags\,file'	    (same as above)
 
 The "|" character separates a ":set" command from a following command.  To
 include the "|" in the option value, use "\|" instead.  This example sets the
@@ -6426,8 +6442,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'tags' 'tag'		string	(default "./tags;,tags")
 			global or local to buffer |global-local|
 	Filenames for the tag command, separated by spaces or commas.  To
-	include a space or comma in a file name, precede it with a backslash
-	(see |option-backslash| about including spaces and backslashes).
+	include a space or comma in a file name, precede it with backslashes
+	(see |option-backslash| about including spaces/commas and backslashes).
 	When a file name starts with "./", the '.' is replaced with the path
 	of the current file.  But only when the 'd' flag is not included in
 	'cpoptions'.  Environment variables are expanded |:set_env|.  Also see

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6877,8 +6877,8 @@ vim.go.tagrelative = vim.o.tagrelative
 vim.go.tr = vim.go.tagrelative
 
 --- Filenames for the tag command, separated by spaces or commas.  To
---- include a space or comma in a file name, precede it with a backslash
---- (see `option-backslash` about including spaces and backslashes).
+--- include a space or comma in a file name, precede it with backslashes
+--- (see `option-backslash` about including spaces/commas and backslashes).
 --- When a file name starts with "./", the '.' is replaced with the path
 --- of the current file.  But only when the 'd' flag is not included in
 --- 'cpoptions'.  Environment variables are expanded `:set_env`.  Also see

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -156,8 +156,9 @@ static void wildescape(expand_T *xp, const char *str, int numfiles, char **files
     // and wildmatch characters, except '~'.
     for (int i = 0; i < numfiles; i++) {
       // for ":set path=" we need to escape spaces twice
-      if (xp->xp_backslash == XP_BS_THREE) {
-        p = vim_strsave_escaped(files[i], " ");
+      if (xp->xp_backslash & XP_BS_THREE) {
+        char *pat = (xp->xp_backslash & XP_BS_COMMA) ? " ," : " ";
+        p = vim_strsave_escaped(files[i], pat);
         xfree(files[i]);
         files[i] = p;
 #if defined(BACKSLASH_IN_FILENAME)
@@ -165,6 +166,14 @@ static void wildescape(expand_T *xp, const char *str, int numfiles, char **files
         xfree(files[i]);
         files[i] = p;
 #endif
+      } else if (xp->xp_backslash & XP_BS_COMMA) {
+        if (vim_strchr(files[i], ',') != NULL) {
+          p = vim_strsave_escaped(files[i], ",");
+          if (p != NULL) {
+            xfree(files[i]);
+            files[i] = p;
+          }
+        }
       }
 #ifdef BACKSLASH_IN_FILENAME
       p = vim_strsave_fnameescape(files[i], vse_what);
@@ -2440,15 +2449,23 @@ static int expand_files_and_dirs(expand_T *xp, char *pat, char ***matches, int *
     pat = xstrdup(pat);
     for (int i = 0; pat[i]; i++) {
       if (pat[i] == '\\') {
-        if (xp->xp_backslash == XP_BS_THREE
+        if (xp->xp_backslash & XP_BS_THREE
             && pat[i + 1] == '\\'
             && pat[i + 2] == '\\'
             && pat[i + 3] == ' ') {
           STRMOVE(pat + i, pat + i + 3);
-        }
-        if (xp->xp_backslash == XP_BS_ONE
-            && pat[i + 1] == ' ') {
+        } else if (xp->xp_backslash & XP_BS_ONE
+                   && pat[i + 1] == ' ') {
           STRMOVE(pat + i, pat + i + 1);
+        } else if ((xp->xp_backslash & XP_BS_COMMA)
+                   && pat[i + 1] == '\\'
+                   && pat[i + 2] == ',') {
+          STRMOVE(pat + i, pat + i + 2);
+#ifdef BACKSLASH_IN_FILENAME
+        } else if ((xp->xp_backslash & XP_BS_COMMA)
+                   && pat[i + 1] == ',') {
+          STRMOVE(pat + i, pat + i + 1);
+#endif
         }
       }
     }

--- a/src/nvim/cmdexpand_defs.h
+++ b/src/nvim/cmdexpand_defs.h
@@ -40,9 +40,10 @@ typedef struct expand {
 
 /// values for xp_backslash
 enum {
-  XP_BS_NONE  = 0,  ///< nothing special for backslashes
-  XP_BS_ONE   = 1,  ///< uses one backslash before a space
-  XP_BS_THREE = 2,  ///< uses three backslashes before a space
+  XP_BS_NONE  = 0,    ///< nothing special for backslashes
+  XP_BS_ONE   = 0x1,  ///< uses one backslash before a space
+  XP_BS_THREE = 0x2,  ///< uses three backslashes before a space
+  XP_BS_COMMA = 0x4,  ///< commas need to be escaped with a backslash
 };
 
 /// values for xp_context when doing command line completion

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5496,6 +5496,9 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
         xp->xp_backslash = XP_BS_ONE;
       }
     }
+    if (flags & P_COMMA) {
+      xp->xp_backslash |= XP_BS_COMMA;
+    }
   }
 
   // For an option that is a list of file names, or comma/colon-separated
@@ -5511,8 +5514,12 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
         while (s > xp->xp_pattern && *(s - 1) == '\\') {
           s--;
         }
-        if ((*p == ' ' && (xp->xp_backslash == XP_BS_THREE && (p - s) < 3))
-            || (*p == ',' && (flags & P_COMMA) && ((p - s) % 1) == 0)
+        if ((*p == ' ' && ((xp->xp_backslash & XP_BS_THREE) && (p - s) < 3))
+#if defined(BACKSLASH_IN_FILENAME)
+            || (*p == ',' && (flags & P_COMMA) && (p - s) < 1)
+#else
+            || (*p == ',' && (flags & P_COMMA) && (p - s) < 2)
+#endif
             || (*p == ':' && (flags & P_COLON))) {
           xp->xp_pattern = p + 1;
           break;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8679,8 +8679,8 @@ return {
       deny_duplicates = true,
       desc = [=[
         Filenames for the tag command, separated by spaces or commas.  To
-        include a space or comma in a file name, precede it with a backslash
-        (see |option-backslash| about including spaces and backslashes).
+        include a space or comma in a file name, precede it with backslashes
+        (see |option-backslash| about including spaces/commas and backslashes).
         When a file name starts with "./", the '.' is replaced with the path
         of the current file.  But only when the 'd' flag is not included in
         'cpoptions'.  Environment variables are expanded |:set_env|.  Also see

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -316,16 +316,60 @@ func Test_set_completion()
 
   " Expand directories.
   call feedkeys(":set cdpath=./\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('./samples/ ', @:)
-  call assert_notmatch('./small.vim ', @:)
+  call assert_match(' ./samples/ ', @:)
+  call assert_notmatch(' ./summarize.vim ', @:)
+  set cdpath&
 
   " Expand files and directories.
   call feedkeys(":set tags=./\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('./samples/ ./sautest/ ./screendump.vim ./script_util.vim ./setup.vim ./shared.vim', @:)
+  call assert_match(' ./samples/.* ./summarize.vim', @:)
 
   call feedkeys(":set tags=./\\\\ dif\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set tags=./\\ diff diffexpr diffopt', @:)
-  set tags&
+
+  " Expand files with spaces/commas in them. Make sure we delimit correctly.
+  "
+  " 'tags' allow for for spaces/commas to both act as delimiters, with actual
+  " spaces requiring double escape, and commas need a single escape.
+  " 'dictionary' is a normal comma-separated option where only commas act as
+  " delimiters, and both space/comma need one single escape.
+  " 'makeprg' is a non-comma-separated option. Commas don't need escape.
+  defer delete('Xfoo Xspace.txt')
+  defer delete('Xsp_dummy')
+  defer delete('Xbar,Xcomma.txt')
+  defer delete('Xcom_dummy')
+  call writefile([], 'Xfoo Xspace.txt')
+  call writefile([], 'Xsp_dummy')
+  call writefile([], 'Xbar,Xcomma.txt')
+  call writefile([], 'Xcom_dummy')
+
+  call feedkeys(':set tags=./Xfoo\ Xsp' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set tags=./Xfoo\ Xsp_dummy', @:)
+  call feedkeys(':set tags=./Xfoo\\\ Xsp' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set tags=./Xfoo\\\ Xspace.txt', @:)
+  call feedkeys(':set dictionary=./Xfoo\ Xsp' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set dictionary=./Xfoo\ Xspace.txt', @:)
+
+  call feedkeys(':set dictionary=./Xbar,Xcom' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set dictionary=./Xbar,Xcom_dummy', @:)
+  if has('win32')
+    " In Windows, '\,' is literal, see `:help filename-backslash`, so this
+    " means we treat it as one file name.
+    call feedkeys(':set dictionary=Xbar\,Xcom' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"set dictionary=Xbar\,Xcomma.txt', @:)
+  else
+    " In other platforms, '\,' simply escape to ',', and indicate a delimiter
+    " to split into a separate file name. You need '\\,' to escape the comma
+    " as part of the file name.
+    call feedkeys(':set dictionary=Xbar\,Xcom' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"set dictionary=Xbar\,Xcom_dummy', @:)
+
+    call feedkeys(':set dictionary=Xbar\\,Xcom' .. "\<C-A>\<C-B>\"\<CR>", 'tx')
+    call assert_equal('"set dictionary=Xbar\\,Xcomma.txt', @:)
+  endif
+  call feedkeys(":set makeprg=./Xbar,Xcom\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"set makeprg=./Xbar,Xcomma.txt', @:)
+  set tags& dictionary& makeprg&
 
   " Expanding the option names
   call feedkeys(":set \<Tab>\<C-B>\"\<CR>", 'xt')


### PR DESCRIPTION
#### vim-patch:9.0.2009: cmdline-completion for comma-separated options wrong

Problem:  cmdline-completion for comma-separated options wrong
Solution: Fix command-line expansions for options with filenames with
          commas

Fix command-line expansions for options with filenames with commas

Cmdline expansion for option values that take a comma-separated list
of file names is currently not handling file names with commas as the
commas are not escaped. For such options, the commas in file names need
to be escaped (to differentiate from a comma that delimit the list
items). The escaped comma is unescaped in `copy_option_part()` during
option parsing.

Fix as follows:
- Cmdline completion for option values with comma-separated file/folder
  names will not start a new match when seeing `\\,` and will instead
  consider it as one value.
- File/folder regex matching will strip the `\\` when seeing `\\,` to
  make sure it can match the correct files/folders.
- The expanded value will escape `,` with `\\,`, similar to how spaces
  are escaped to make sure the option value is correct on the cmdline.

This fix also takes into account the fact that Win32 Vim handles file
name escaping differently. Typing '\,' for a file name results in it
being handled literally but in other platforms '\,' is interpreted as a
simple ',' and commas need to be escaped using '\\,' instead.

Also, make sure this new logic only applies to comma-separated options
like 'path'. Non-list options like 'set makeprg=<Tab>' and regular ex
commands like `:edit <Tab>` do not require escaping and will continue to
work.

Also fix up documentation to be clearer. The original docs are slightly
misleading in how it discusses triple slashes for 'tags'.

closes: vim/vim#13303
related: vim/vim#13301

https://github.com/vim/vim/commit/54844857fd6933fa4f6678e47610c4b9c9f7a091

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>