### PR TITLE
fix(path): restore space separation in 'path'

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -57,8 +57,6 @@ The following changes may require adaptations in user config or plugins.
     • for `backspace=1` set `backspace=indent,eol`
     • for `backspace=2` set `backspace=indent,eol,start` (default behavior in Nvim)
     • for `backspace=3` set `backspace=indent,eol,nostop`
-  • paths in |'path'| and |'cdpath'| can no longer be separated with spaces
-    (but paths themselves may contain spaces now).
   • |'backupdir'| and |'directory'| will no longer remove a `>` at the start
     of the option.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4499,6 +4499,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	option may be relative or absolute.
 	- Use commas to separate directory names: >
 		:set path=.,/usr/local/include,/usr/include
+<	- Spaces can also be used to separate directory names.  To have a
+	  space in a directory name, precede it with an extra backslash, and
+	  escape the space: >
+		:set path=.,/dir/with\\\ space
 <	- To include a comma in a directory name precede it with an extra
 	  backslash: >
 		:set path=.,/dir/with\\,comma

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -658,7 +658,6 @@ Options:
   *'ballooneval'* *'beval'* *'noballooneval'* *'nobeval'*
   *'balloonexpr'* *'bexpr'*
   bioskey (MS-DOS)
-  'cdpath': paths can no longer be separated with spaces.
   conskey (MS-DOS)
   *'cp'* *'nocompatible'* *'nocp'* *'compatible'* (Nvim is always "nocompatible".)
   'cpoptions' (gjkHw<*- and all POSIX flags were removed)
@@ -723,7 +722,6 @@ Options:
     Use |g8| or |ga|.  See |mbyte-combining|.
   *'maxmem'* Nvim delegates memory-management to the OS.
   *'maxmemtot'* Nvim delegates memory-management to the OS.
-  'path': paths can no longer be separated with spaces.
   printoptions
   *'printdevice'*
   *'printencoding'*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4621,6 +4621,12 @@ vim.go.pm = vim.go.patchmode
 --- ```
 --- 	:set path=.,/usr/local/include,/usr/include
 --- ```
+--- - Spaces can also be used to separate directory names.  To have a
+---   space in a directory name, precede it with an extra backslash, and
+---   escape the space:
+--- ```
+--- 	:set path=.,/dir/with\\\ space
+--- ```
 --- - To include a comma in a directory name precede it with an extra
 ---   backslash:
 --- ```

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5926,6 +5926,10 @@ return {
         option may be relative or absolute.
         - Use commas to separate directory names: >
         	:set path=.,/usr/local/include,/usr/include
+        <	- Spaces can also be used to separate directory names.  To have a
+          space in a directory name, precede it with an extra backslash, and
+          escape the space: >
+        	:set path=.,/dir/with\\\ space
         <	- To include a comma in a directory name precede it with an extra
           backslash: >
         	:set path=.,/dir/with\\,comma

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -848,7 +848,7 @@ static void expand_path_option(char *curdir, garray_T *gap)
   char *buf = xmalloc(MAXPATHL);
 
   while (*path_option != NUL) {
-    copy_option_part(&path_option, buf, MAXPATHL, ",");
+    copy_option_part(&path_option, buf, MAXPATHL, " ,");
 
     if (buf[0] == '.' && (buf[1] == NUL || vim_ispathsep(buf[1]))) {
       // Relative to current buffer:


### PR DESCRIPTION
Removing this behavior causes more inconsistencies and bugs.

Partially reverts #24350
Related #25324