### PR TITLE
fix(highlight): add `FloatFooter` to 'highlight_defs.h'

### DIFF
--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -123,6 +123,7 @@ typedef enum {
   HLF_WBRNC,      // Window bars of not-current windows
   HLF_CU,         // Cursor
   HLF_BTITLE,     // Float Border Title
+  HLF_BFOOTER,    // Float Border Footer
   HLF_COUNT,      // MUST be the last one
 } hlf_T;
 
@@ -192,6 +193,7 @@ EXTERN const char *hlf_names[] INIT(= {
   [HLF_WBRNC] = "WinBarNC",
   [HLF_CU] = "Cursor",
   [HLF_BTITLE] = "FloatTitle",
+  [HLF_BFOOTER] = "FloatFooter",
 });
 
 EXTERN int highlight_attr[HLF_COUNT + 1];     // Highl. attr for each context.

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -215,7 +215,7 @@ describe('ui/cursor', function()
           m.hl_id = 64
           m.attr = {background = Screen.colors.DarkGray}
       end
-      if m.id_lm then m.id_lm = 66 end
+      if m.id_lm then m.id_lm = 67 end
     end
 
     -- Assert the new expectation.


### PR DESCRIPTION
This is a followup to #24739 after #24888 is resolved.