### PR TITLE
docs: note that gettext must be installed to run macOS release

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -20,6 +20,8 @@ ${NVIM_VERSION}
 
 ### macOS
 
+`gettext` must be installed to run these releases.
+
 1. Download **nvim-macos.tar.gz**
 2. Run `xattr -c ./nvim-macos.tar.gz` (to avoid "unknown developer" warning)
 3. Extract: `tar xzvf nvim-macos.tar.gz`


### PR DESCRIPTION
closes #25580