### PR TITLE
fix(provider): update import neovim->pynvim

### DIFF
--- a/runtime/autoload/provider/pythonx.vim
+++ b/runtime/autoload/provider/pythonx.vim
@@ -8,7 +8,7 @@ let s:loaded_pythonx_provider = 1
 function! provider#pythonx#Require(host) abort
   " Python host arguments
   let prog = provider#python3#Prog()
-  let args = [prog, '-c', 'import sys; sys.path = [p for p in sys.path if p != ""]; import neovim; neovim.start_host()']
+  let args = [prog, '-c', 'import sys; sys.path = [p for p in sys.path if p != ""]; import pynvim; neovim.start_host()']
 
 
   " Collect registered Python plugins into args

--- a/runtime/lua/provider/health.lua
+++ b/runtime/lua/provider/health.lua
@@ -315,7 +315,7 @@ local function version_info(python)
   local nvim_path = vim.trim(system({
     python,
     '-c',
-    'import sys; sys.path = [p for p in sys.path if p != ""]; import neovim; print(neovim.__file__)',
+    'import sys; sys.path = [p for p in sys.path if p != ""]; import pynvim; print(neovim.__file__)',
   }))
   if shell_error() or is_blank(nvim_path) then
     return { python_version, 'unable to load neovim Python module', pypi_version, nvim_path }
@@ -408,14 +408,14 @@ local function python()
 
   if is_blank(pyname) then
     warn(
-      'No Python executable found that can `import neovim`. '
+      'No Python executable found that can `import pynvim`. '
         .. 'Using the first available executable for diagnostics.'
     )
   elseif vim.g[host_prog_var] then
     python_exe = pyname
   end
 
-  -- No Python executable could `import neovim`, or host_prog_var was used.
+  -- No Python executable could `import pynvim`, or host_prog_var was used.
   if not is_blank(pythonx_warnings) then
     warn(pythonx_warnings, {
       'See :help provider-python for more information.',


### PR DESCRIPTION
Related commit on master:

0c2ca48e5f from Marco Hinz 2018-11-17 `doc/python: 'neovim' module was renamed to 'pynvim'.`