### PR TITLE
docs: fix typo, trailing space

### DIFF
--- a/runtime/doc/channel.txt
+++ b/runtime/doc/channel.txt
@@ -117,7 +117,7 @@ simple example, echoing some data through a cat-process:
     call chansend(id, "hello!")
 <
 
-Here is a example of setting a buffer to the result of grep, but only after
+Here is an example of setting a buffer to the result of grep, but only after
 all data has been processed:
 >vim
     function! s:OnEvent(id, data, event) dict

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -277,7 +277,6 @@ g:rust_keep_autopairs_default ~
 	Don't override auto-pairs default for the Rust filetype. The default
 	is 0.
 
-
 ==============================================================================
 COMMANDS                                                       *rust-commands*
 

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -276,7 +276,7 @@ g:rust_keep_autopairs_default ~
 
 	Don't override auto-pairs default for the Rust filetype. The default
 	is 0.
- 
+
 
 ==============================================================================
 COMMANDS                                                       *rust-commands*


### PR DESCRIPTION
Fixed:
`runtime/doc/channel.txt` -> typo
`runtime/doc/ft_rust.txt` -> trailing space