### PR TITLE
vim-patch:8.2.3064: Vim9: in script cannot set item in uninitialized list

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1467,14 +1467,22 @@ char *get_lval(char *const name, typval_T *const rettv, lval_T *const lp, const 
       }
       return NULL;
     }
-    if (!(lp->ll_tv->v_type == VAR_LIST && lp->ll_tv->vval.v_list != NULL)
-        && !(lp->ll_tv->v_type == VAR_DICT && lp->ll_tv->vval.v_dict != NULL)
-        && !(lp->ll_tv->v_type == VAR_BLOB && lp->ll_tv->vval.v_blob != NULL)) {
+    if (lp->ll_tv->v_type != VAR_LIST
+        && lp->ll_tv->v_type != VAR_DICT
+        && lp->ll_tv->v_type != VAR_BLOB) {
       if (!quiet) {
         emsg(_("E689: Can only index a List, Dictionary or Blob"));
       }
       return NULL;
     }
+
+    // a NULL list/blob works like an empty list/blob, allocate one now.
+    if (lp->ll_tv->v_type == VAR_LIST && lp->ll_tv->vval.v_list == NULL) {
+      tv_list_alloc_ret(lp->ll_tv, kListLenUnknown);
+    } else if (lp->ll_tv->v_type == VAR_BLOB && lp->ll_tv->vval.v_blob == NULL) {
+      tv_blob_alloc_ret(lp->ll_tv);
+    }
+
     if (lp->ll_range) {
       if (!quiet) {
         emsg(_("E708: [:] must come last"));

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -625,7 +625,7 @@ listitem_T *tv_list_check_range_index_one(list_T *const l, int *const n1, const 
   listitem_T *li = tv_list_find_index(l, n1);
   if (li == NULL) {
     if (!quiet) {
-      semsg(_(e_list_index_out_of_range_nr), (int64_t)n1);
+      semsg(_(e_list_index_out_of_range_nr), (int64_t)(*n1));
     }
     return NULL;
   }

--- a/test/functional/vimscript/null_spec.lua
+++ b/test/functional/vimscript/null_spec.lua
@@ -53,17 +53,13 @@ describe('NULL', function()
     end)
   end
   describe('list', function()
-    -- Incorrect behaviour
-    -- FIXME Should error out with different message
-    null_test('makes :unlet act as if it is not a list', ':unlet L[0]',
-              'Vim(unlet):E689: Can only index a List, Dictionary or Blob')
-
     -- Subjectable behaviour
-
     null_expr_test('is equal to empty list', 'L == []', 0, 1)
     null_expr_test('is equal to empty list (reverse order)', '[] == L', 0, 1)
 
     -- Correct behaviour
+    null_test('can be :unlet item with error message for empty list', ':unlet L[0]',
+              'Vim(unlet):E684: List index out of range: 0')
     null_expr_test('can be indexed with error message for empty list', 'L[0]',
                    'E684: List index out of range: 0', nil)
     null_expr_test('can be splice-indexed', 'L[:]', 0, {})


### PR DESCRIPTION
#### vim-patch:8.2.3064: Vim9: in script cannot set item in uninitialized list

Problem:    Vim9: in script cannot set item in uninitialized list.
Solution:   When a list is NULL allocate an empty one.

https://github.com/vim/vim/commit/e65081d1b591f16dc6e380a830d87565c5eb7b03

Co-authored-by: Bram Moolenaar <Bram@vim.org>