### PR TITLE
vim-patch:9.0.2017: linebreak applies for leading whitespace

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -340,9 +340,17 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
     *headp = head;
   }
 
+  colnr_T vcol_start = 0;  // start from where to consider linebreak
   // If 'linebreak' set check at a blank before a non-blank if the line
   // needs a break here
-  if (wp->w_p_lbr
+  if (wp->w_p_lbr && wp->w_p_wrap && wp->w_width_inner != 0) {
+    char *t = cts->cts_line;
+    while (vim_isbreak((uint8_t)(*t))) {
+      t++;
+    }
+    vcol_start = (colnr_T)(t - cts->cts_line);
+  }
+  if (wp->w_p_lbr && vcol_start <= vcol
       && vim_isbreak((uint8_t)s[0])
       && !vim_isbreak((uint8_t)s[1])
       && wp->w_p_wrap

--- a/test/old/testdir/test_listlbr.vim
+++ b/test/old/testdir/test_listlbr.vim
@@ -373,4 +373,19 @@ func Test_ctrl_char_on_wrap_column()
   call s:close_windows()
 endfunc
 
+func Test_linebreak_no_break_after_whitespace_only()
+  call s:test_windows('setl ts=4 linebreak wrap')
+  call setline(1, "\tabcdefghijklmnopqrstuvwxyz" ..
+        \ "abcdefghijklmnopqrstuvwxyz")
+  let lines = s:screen_lines([1, 4], winwidth(0))
+  let expect = [
+\ "    abcdefghijklmnop",
+\ "qrstuvwxyzabcdefghij",
+\ "klmnopqrstuvwxyz    ",
+\ "~                   ",
+\ ]
+  call s:compare_lines(expect, lines)
+  call s:close_windows()
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.0.2017: linebreak applies for leading whitespace

Problem:  linebreak applies for leading whitespace
Solution: only apply linebreak, once we have found non-breakat chars in
          the line

closes: vim/vim#13243

https://github.com/vim/vim/commit/dd75fcfbdff1934c6e531b5a89ebc636318bf4a2

Co-authored-by: Christian Brabandt <cb@256bit.org>