### PR TITLE
fix(lsp): handle non-displayable characters in floating preview

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1647,7 +1647,8 @@ function M._make_floating_popup_size(contents, opts)
     width = 0
     for i, line in ipairs(contents) do
       -- TODO(ashkan) use nvim_strdisplaywidth if/when that is introduced.
-      line_widths[i] = vim.fn.strdisplaywidth(line)
+      local ok, line_width = pcall(vim.fn.strdisplaywidth, line)
+      line_widths[i] = ok and line_width or line:len()
       width = math.max(line_widths[i], width)
     end
   end
@@ -1676,7 +1677,8 @@ function M._make_floating_popup_size(contents, opts)
       height = 0
       if vim.tbl_isempty(line_widths) then
         for _, line in ipairs(contents) do
-          local line_width = vim.fn.strdisplaywidth(line)
+          local ok, line_width = pcall(vim.fn.strdisplaywidth, line)
+          line_width = ok and line_width or line:len()
           height = height + math.ceil(line_width / wrap_at)
         end
       else

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3069,6 +3069,15 @@ describe('LSP', function()
     it('calculates size correctly with wrapping', function()
       eq({15,5}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents,{width = 15, wrap_at = 14})} ]])
     end)
+
+    it('does not error when there are nondisplayable chars', function()
+      exec_lua([[ contents = {
+        '\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09',
+        '\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19',
+        '\x20\x21\x22\x23\x24\x25\x26\x27\x28\x29',
+      } ]])
+      eq({20,3}, exec_lua[[ return {vim.lsp.util._make_floating_popup_size(contents)} ]])
+    end)
   end)
 
   describe('lsp.util.trim.trim_empty_lines', function()


### PR DESCRIPTION
Scenario:
```lua
local payload = '\x93\x02\xa6\x72\x65\x64\x72\x61\x77\x91\x92\xa9\x67\x72\x69\x64\x5f\x6c\x69\x6e\x65\x95\x02\x00\x00\x90\xc2'
```

Hover over `payload` will cause an error. Prefer inexact hover window dimensions over erroring out.