### PR TITLE
fix(virt-text): prevent overlap of right-aligned virtual text

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -261,12 +261,17 @@ static void draw_virt_text(win_T *wp, buf_T *buf, int col_off, int *end_col, int
     }
     if (item->draw_col == -1) {
       if (item->decor.virt_text_pos == kVTRightAlign) {
-        if (wp->w_p_rl) {
-          right_pos += item->decor.virt_text_width;
+        int available_space = right_pos - state->eol_col;
+        if (item->decor.virt_text_width > available_space) {
+          item->draw_col = state->eol_col;
         } else {
-          right_pos -= item->decor.virt_text_width;
+          if (wp->w_p_rl) {
+            right_pos += item->decor.virt_text_width;
+          } else {
+            right_pos -= item->decor.virt_text_width;
+          }
+          item->draw_col = right_pos;
         }
-        item->draw_col = right_pos;
       } else if (item->decor.virt_text_pos == kVTEndOfLine && do_eol) {
         item->draw_col = state->eol_col;
       } else if (item->decor.virt_text_pos == kVTWinCol) {


### PR DESCRIPTION
This PR builds upon the work done in PR #24724, it addresses an issue where right-aligned virtual text could overlap with, and consequently delete, existing text on a line. The changes in this PR modify the `draw_virt_text` function to calculate the available space for drawing right-aligned virtual text. If the virtual text is too long to fit within the available space, it now starts drawing immediately after the existing text, effectively truncating the virtual text to prevent overlap.

Changes:
- Modified `draw_virt_text` function to check available space for right-aligned virtual text.
- Adjusted `item->draw_col` to start drawing virtual text after existing text if it's too long.
