### PR TITLE
feat: handle "file:/" and "file:///" for 'gf' command

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1396,7 +1396,10 @@ char *find_file_in_path_option(char *ptr, size_t len, int options, int first, ch
     // filename on the first call.
     if (first == true) {
       if (path_with_url(*file_to_find)) {
-        file_name = xstrdup(*file_to_find);
+        file_name =
+          strncmp(*file_to_find, "file:/", 6) == 0 ?
+          xstrdup(handle_file_path_prefix(*file_to_find)) :
+          xstrdup(*file_to_find);
         goto theend;
       }
 


### PR DESCRIPTION
Fixes #24032

Somehow, `file://` is a wrong one?  https://en.wikipedia.org/wiki/File_URI_scheme#How_many_slashes?


Changelog:
* Added more test cases and also have windows example. 
* Not handling `file://` as it is based on a host. 
* Handling hexcode on Windows; %A3 -> `;`