### PR TITLE
Backport to release-0.9

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1689,7 +1689,9 @@ static void write_msg(String message, bool to_err, bool writeln)
   if (c == NL) { \
     kv_push(line_buf, NUL); \
     msg(line_buf.items); \
-    msg_didout = true; \
+    if (msg_silent == 0) { \
+      msg_didout = true; \
+    } \
     kv_drop(line_buf, kv_size(line_buf)); \
     kv_resize(line_buf, LINE_BUFFER_MIN_SIZE); \
   } else if (c == NUL) { \

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1319,7 +1319,9 @@ void do_shell(char *cmd, int flags)
   // 1" command to the terminal.
   ui_cursor_goto(msg_row, msg_col);
   (void)call_shell(cmd, (ShellOpts)flags, NULL);
-  msg_didout = true;
+  if (msg_silent == 0) {
+    msg_didout = true;
+  }
   did_check_timestamps = false;
   need_check_timestamps = true;
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -944,7 +944,9 @@ static void nlua_print_event(void **argv)
       break;
     }
     msg(str + start);
-    msg_didout = true;  // Make blank lines work properly
+    if (msg_silent == 0) {
+      msg_didout = true;  // Make blank lines work properly
+    }
   }
   if (len && str[len - 1] == NUL) {  // Last was newline
     msg("");

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1030,6 +1030,53 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
     -- luacheck: pop
   end)
 
+  it('no empty line after :silent #12099', function()
+    exec([[
+      func T1()
+        silent !echo
+        echo "message T1"
+      endfunc
+      func T2()
+        silent lua print("lua message")
+        echo "message T2"
+      endfunc
+      func T3()
+        silent call nvim_out_write("api message\n")
+        echo "message T3"
+      endfunc
+    ]])
+    feed(':call T1()<CR>')
+    screen:expect{grid=[[
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      message T1                                                  |
+    ]]}
+    feed(':call T2()<CR>')
+    screen:expect{grid=[[
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      message T2                                                  |
+    ]]}
+    feed(':call T3()<CR>')
+    screen:expect{grid=[[
+      ^                                                            |
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      {1:~                                                           }|
+      message T3                                                  |
+    ]]}
+  end)
+
   it('supports ruler with laststatus=0', function()
     command("set ruler laststatus=0")
     screen:expect{grid=[[


### PR DESCRIPTION
Problem:
  The next command after `silent !{cmd}` or `silent lua print('str')`
  prints an empty line before printing a message, because these commands
  set `msg_didout = true` despite not printing any messages.

Solution:
  Set `msg_didout = true` only if `msg_silent == 0`