### PR TITLE
vim-patch:9.0.2021: Coverity complains about change in charset

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -345,7 +345,7 @@ int win_lbr_chartabsize(chartabsize_T *cts, int *headp)
   // needs a break here
   if (wp->w_p_lbr && wp->w_p_wrap && wp->w_width_inner != 0) {
     char *t = cts->cts_line;
-    while (vim_isbreak((uint8_t)(*t))) {
+    while (vim_isbreak((uint8_t)t[0])) {
       t++;
     }
     vcol_start = (colnr_T)(t - cts->cts_line);


### PR DESCRIPTION
#### vim-patch:9.0.2021: Coverity complains about change in charset

Problem:  Coverity complains about change in charset (after v9.0.2017)
Solution: check pointer t at index 0

closes: vim/vim#13322

https://github.com/vim/vim/commit/cd6ee6935811ab223605a3f39a550d26a617867d

Co-authored-by: Christian Brabandt <cb@256bit.org>