### PR TITLE
vim-patch:2bbd0d30eebd

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -81,9 +81,11 @@ CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 		modifier into the key.
 
 							*c_<Left>* *c_Left*
-<Left>		cursor left
+<Left>		cursor left.  See 'wildmenu' for behavior during wildmenu
+		completion mode.
 							*c_<Right>* *c_Right*
-<Right>		cursor right
+<Right>		cursor right.  See 'wildmenu' for behavior during wildmenu
+		completion mode.
 							*c_<S-Left>*
 <S-Left> or <C-Left>					*c_<C-Left>*
 		cursor one WORD left
@@ -93,7 +95,8 @@ CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 CTRL-B or <Home>				*c_CTRL-B* *c_<Home>* *c_Home*
 		cursor to beginning of command-line
 CTRL-E or <End>					*c_CTRL-E* *c_<End>* *c_End*
-		cursor to end of command-line
+		cursor to end of command-line.  See 'wildmenu' for behavior
+		during wildmenu completion mode.
 
 							*c_<LeftMouse>*
 <LeftMouse>	Move the cursor to the position of the mouse click.
@@ -226,6 +229,7 @@ CTRL-\ e {expr}						*c_CTRL-\_e*
 CTRL-Y		When there is a modeless selection, copy the selection into
 		the clipboard.
 		If there is no selection CTRL-Y is inserted as a character.
+		See 'wildmenu' for behavior during wildmenu completion mode.
 
 							*c_CTRL-Z*
 CTRL-Z		Trigger 'wildmode'. Same as 'wildcharm', but always available.
@@ -248,10 +252,12 @@ CTRL-C		quit command-line without executing
 
 							*c_<Up>* *c_Up*
 <Up>		recall older command-line from history, whose beginning
-		matches the current command-line (see below).
+		matches the current command-line (see below).  See 'wildmenu'
+		for behavior during wildmenu completion mode.
 							*c_<Down>* *c_Down*
 <Down>		recall more recent command-line from history, whose beginning
-		matches the current command-line (see below).
+		matches the current command-line (see below).  See 'wildmenu'
+		for behavior during wildmenu completion mode.
 
 							*c_<S-Up>* *c_<PageUp>*
 <S-Up> or <PageUp>
@@ -439,10 +445,15 @@ When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,
 you can use <S-Tab> or CTRL-P to go straight back to what you typed.
 
-The 'wildignorecase' option can be set to ignore case in filenames.
-
 The 'wildmenu' option can be set to show the matches just above the command
 line.
+
+The 'wildoptions' option provides additional configuration to use a popup menu
+for 'wildmenu', and to use fuzzy matching.
+
+The 'wildignorecase' option can be set to ignore case in filenames.  For
+completing other texts (e.g. command names), the 'ignorecase' option is used
+instead (fuzzy matching always ignores case, however).
 
 If you like tcsh's autolist completion, you can use this mapping:
 	:cnoremap X <C-L><C-D>

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1096,6 +1096,22 @@ tag		command		action in Command-line editing mode	~
 |c_<Insert>|	<Insert>	toggle insert/overstrike mode
 |c_<LeftMouse>|	<LeftMouse>	cursor at mouse click
 
+commands in wildmenu mode (see 'wildmenu')
+
+		<Up>		move up to parent
+		<Down>		move down to submenu
+		<Left>		select the previous match
+		<Right>		select the next match
+		<CR>		move into submenu when doing menu completion
+		CTRL-E		stop completion and go back to original text
+		CTRL-Y		accept selected match and stop completion
+		other		stop completion and insert the typed character
+
+commands in wildmenu mode with 'wildoptions' set to "pum"
+
+		<PageUp>	select a match several entries back
+		<PageDown>	select a match several entries forward
+
 ==============================================================================
 5. Terminal mode				*terminal-mode-index*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3255,8 +3255,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			*'ignorecase'* *'ic'* *'noignorecase'* *'noic'*
 'ignorecase' 'ic'	boolean	(default off)
 			global
-	Ignore case in search patterns, completion, and when searching the tags file.
-	See also 'smartcase' and 'tagcase'.
+	Ignore case in search patterns, |cmdline-completion|, when
+	searching in the tags file, and |expr-==|.
 	Can be overruled by using "\c" or "\C" in the pattern, see
 	|/ignorecase|.
 
@@ -6975,18 +6975,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 	a completion.
 
 	While the menu is active these keys have special meanings:
-
-	CTRL-Y		- accept the currently selected match and stop
-			  completion.
-	CTRL-E		- end completion, go back to what was there before
-			  selecting a match.
+	CTRL-P		- go to the previous entry
+	CTRL-N		- go to the next entry
 	<Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
+	<PageUp>	- select a match several entries back
+	<PageDown>	- select a match several entries further
+	<Up>		- in filename/menu name completion: move up into
+			  parent directory or parent menu.
 	<Down>		- in filename/menu name completion: move into a
 			  subdirectory or submenu.
 	<CR>		- in menu completion, when the cursor is just after a
 			  dot: move into a submenu.
-	<Up>		- in filename/menu name completion: move up into
-			  parent directory or parent menu.
+	CTRL-E		- end completion, go back to what was there before
+			  selecting a match.
+	CTRL-Y		- accept the currently selected match and stop
+			  completion.
 
 	If you want <Left> and <Right> to move the cursor instead of selecting
 	a different match, use this: >

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3087,8 +3087,8 @@ vim.go.icon = vim.o.icon
 vim.o.iconstring = ""
 vim.go.iconstring = vim.o.iconstring
 
---- Ignore case in search patterns, completion, and when searching the tags file.
---- See also 'smartcase' and 'tagcase'.
+--- Ignore case in search patterns, `cmdline-completion`, when
+--- searching in the tags file, and `expr-==`.
 --- Can be overruled by using "\c" or "\C" in the pattern, see
 --- `/ignorecase`.
 ---
@@ -7539,18 +7539,21 @@ vim.go.wic = vim.go.wildignorecase
 --- a completion.
 ---
 --- While the menu is active these keys have special meanings:
----
---- CTRL-Y		- accept the currently selected match and stop
---- 		  completion.
---- CTRL-E		- end completion, go back to what was there before
---- 		  selecting a match.
+--- CTRL-P		- go to the previous entry
+--- CTRL-N		- go to the next entry
 --- <Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
+--- <PageUp>	- select a match several entries back
+--- <PageDown>	- select a match several entries further
+--- <Up>		- in filename/menu name completion: move up into
+--- 		  parent directory or parent menu.
 --- <Down>		- in filename/menu name completion: move into a
 --- 		  subdirectory or submenu.
 --- <CR>		- in menu completion, when the cursor is just after a
 --- 		  dot: move into a submenu.
---- <Up>		- in filename/menu name completion: move up into
---- 		  parent directory or parent menu.
+--- CTRL-E		- end completion, go back to what was there before
+--- 		  selecting a match.
+--- CTRL-Y		- accept the currently selected match and stop
+--- 		  completion.
 ---
 --- If you want <Left> and <Right> to move the cursor instead of selecting
 --- a different match, use this:

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3970,8 +3970,8 @@ return {
       cb = 'did_set_ignorecase',
       defaults = { if_true = false },
       desc = [=[
-        Ignore case in search patterns, completion, and when searching the tags file.
-        See also 'smartcase' and 'tagcase'.
+        Ignore case in search patterns, |cmdline-completion|, when
+        searching in the tags file, and |expr-==|.
         Can be overruled by using "\c" or "\C" in the pattern, see
         |/ignorecase|.
       ]=],
@@ -9568,18 +9568,21 @@ return {
         a completion.
 
         While the menu is active these keys have special meanings:
-
-        CTRL-Y		- accept the currently selected match and stop
-        		  completion.
-        CTRL-E		- end completion, go back to what was there before
-        		  selecting a match.
+        CTRL-P		- go to the previous entry
+        CTRL-N		- go to the next entry
         <Left> <Right>	- select previous/next match (like CTRL-P/CTRL-N)
+        <PageUp>	- select a match several entries back
+        <PageDown>	- select a match several entries further
+        <Up>		- in filename/menu name completion: move up into
+        		  parent directory or parent menu.
         <Down>		- in filename/menu name completion: move into a
         		  subdirectory or submenu.
         <CR>		- in menu completion, when the cursor is just after a
         		  dot: move into a submenu.
-        <Up>		- in filename/menu name completion: move up into
-        		  parent directory or parent menu.
+        CTRL-E		- end completion, go back to what was there before
+        		  selecting a match.
+        CTRL-Y		- accept the currently selected match and stop
+        		  completion.
 
         If you want <Left> and <Right> to move the cursor instead of selecting
         a different match, use this: >


### PR DESCRIPTION
#### vim-patch:2bbd0d30eebd

runtime(doc): Improve command-line completion docs (vim/vim#13331)

* Improve command-line completion docs

Add more details about 'ignorecase' and its effect on cmdline
completion.

Make sure keys used in wildmenu are properly documented and linked in the
keys' documentation entries, and in `:h index` for proper
cross-referencing, as wildmenu popup is slightly different from
insert-mode popup menu.

* Fix docs typos

https://github.com/vim/vim/commit/2bbd0d30eebdea66c0da3895e83d999ed6ad83fb

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>