### PR TITLE
vim-patch:7687238e1b0d

### DIFF
--- a/runtime/ftplugin/csh.vim
+++ b/runtime/ftplugin/csh.vim
@@ -3,9 +3,11 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Johannes Zellner <johannes@zellner.org>
-" Last Change:		2021 Oct 15
+" Last Change:		2023 Oct 09
 
-if exists("b:did_ftplugin") | finish | endif
+if exists("b:did_ftplugin")
+  finish
+endif
 let b:did_ftplugin = 1
 
 let s:save_cpo = &cpo
@@ -18,7 +20,7 @@ setlocal formatoptions+=crql
 
 let b:undo_ftplugin = "setlocal com< cms< fo<"
 
-" Csh:  thanks to Johannes Zellner
+" Csh: thanks to Johannes Zellner
 " - Both foreach and end must appear alone on separate lines.
 " - The words else and endif must appear at the beginning of input lines;
 "   the if must appear alone on its input line or after an else.
@@ -38,13 +40,14 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\   s:line_start .. 'case\s\+:' .. s:line_start .. 'default\>:\<breaksw\>:' ..
 	\   s:line_start .. 'endsw\>'
   unlet s:line_start
-  let b:undo_ftplugin ..= " | unlet b:match_words"
+  let b:undo_ftplugin ..= " | unlet! b:match_words"
 endif
 
 if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
-  let  b:browsefilter="csh Scripts (*.csh)\t*.csh\n" ..
-	\	      "All Files (*.*)\t*.*\n"
-  let b:undo_ftplugin ..= " | unlet b:browsefilter"
+  let b:browsefilter = "csh Scripts (*.csh)\t*.csh\n" ..
+	\	       "All Files (*.*)\t*.*\n"
+  let b:csh_set_browsefilter = 1
+  let b:undo_ftplugin ..= " | unlet! b:browsefilter b:csh_set_browsefilter"
 endif
 
 let &cpo = s:save_cpo

--- a/runtime/ftplugin/tcsh.vim
+++ b/runtime/ftplugin/tcsh.vim
@@ -2,9 +2,11 @@
 " Language:		tcsh
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Change:		2021 Oct 15
+" Last Change:		2023 Oct 09
 
-if exists("b:did_ftplugin") | finish | endif
+if exists("b:did_ftplugin")
+  finish
+endif
 
 let s:save_cpo = &cpo
 set cpo-=C
@@ -12,24 +14,26 @@ set cpo-=C
 " Define some defaults in case the included ftplugins don't set them.
 let s:undo_ftplugin = ""
 let s:browsefilter = "csh Files (*.csh)\t*.csh\n" ..
-	    \	     "All Files (*.*)\t*.*\n"
+      \		     "All Files (*.*)\t*.*\n"
 
 runtime! ftplugin/csh.vim ftplugin/csh_*.vim ftplugin/csh/*.vim
 let b:did_ftplugin = 1
 
 " Override our defaults if these were set by an included ftplugin.
 if exists("b:undo_ftplugin")
-    let s:undo_ftplugin = b:undo_ftplugin
+  let s:undo_ftplugin = b:undo_ftplugin
 endif
 if exists("b:browsefilter")
-    let s:browsefilter = b:browsefilter
+  let s:browsefilter = b:browsefilter
 endif
 
-if (has("gui_win32") || has("gui_gtk"))
-    let  b:browsefilter="tcsh Scripts (*.tcsh)\t*.tcsh\n" .. s:browsefilter
+if (has("gui_win32") || has("gui_gtk")) &&
+      \ (!exists("b:browsefilter") || exists("b:csh_set_browsefilter"))
+  let b:browsefilter = "tcsh Scripts (*.tcsh)\t*.tcsh\n" .. s:browsefilter
+  let s:undo_ftplugin = "unlet! b:browsefilter | " .. s:undo_ftplugin
 endif
 
-let b:undo_ftplugin = "unlet! b:browsefilter | " .. s:undo_ftplugin
+let b:undo_ftplugin = s:undo_ftplugin
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
runtime(tcsh): Update ftplugin (vim/vim#13327)

Fix b:browsefilter deletion error when calling b:undo_ftplugin.

Fixes vim/vim#13167

https://github.com/vim/vim/commit/7687238e1b0d2f26ba57e1bdf76f782eaa43af3a

Co-authored-by: dkearns <dougkearns@gmail.com>
