### PR TITLE
vim-patch:9.0.2024: no filetype detection for Debian sources

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1628,6 +1628,7 @@ local pattern = {
   ['.*/debian/copyright'] = 'debcopyright',
   ['.*/etc/apt/sources%.list%.d/.*%.list'] = 'debsources',
   ['.*/etc/apt/sources%.list'] = 'debsources',
+  ['.*/etc/apt/sources%.list%.d/.*%.sources'] = 'deb822sources',
   ['.*%.directory'] = 'desktop',
   ['.*%.desktop'] = 'desktop',
   ['dictd.*%.conf'] = 'dictdconf',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -184,6 +184,7 @@ func s:GetFilenameChecks() abort
     \ 'debcontrol': ['/debian/control', 'any/debian/control'],
     \ 'debcopyright': ['/debian/copyright', 'any/debian/copyright'],
     \ 'debsources': ['/etc/apt/sources.list', '/etc/apt/sources.list.d/file.list', 'any/etc/apt/sources.list', 'any/etc/apt/sources.list.d/file.list'],
+    \ 'deb822sources': ['/etc/apt/sources.list.d/file.sources', 'any/etc/apt/sources.list.d/file.sources'],
     \ 'def': ['file.def'],
     \ 'denyhosts': ['denyhosts.conf'],
     \ 'desc': ['file.desc'],


### PR DESCRIPTION
Problem:  no filetype detection for Debian sources
Solution: Add new deb822sources filetype

closes: vim/vim#13320

https://github.com/vim/vim/commit/bd734c3bead9e167eb6875f62cc06fab2379c422

Co-authored-by: James McCoy <jamessan@jamessan.com>
