### PR TITLE
fix(runtime) - use bufhidden unload for Man

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -415,7 +415,7 @@ end
 local function set_options(pager)
   vim.bo.swapfile = false
   vim.bo.buftype = 'nofile'
-  vim.bo.bufhidden = 'hide'
+  vim.bo.bufhidden = 'unload'
   vim.bo.modified = false
   vim.bo.readonly = true
   vim.bo.modifiable = false

--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -10,7 +10,7 @@ vim.api.nvim_create_user_command('Man', function(params)
   else
     local ok, err = pcall(man.open_page, params.count, params.smods, params.fargs)
     vim.api.nvim_set_option_value('bufhidden', 'unload', {
-      scope = 'local'
+      scope = 'local',
     })
     if not ok then
       vim.notify(man.errormsg or err, vim.log.levels.ERROR)

--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -9,6 +9,9 @@ vim.api.nvim_create_user_command('Man', function(params)
     man.init_pager()
   else
     local ok, err = pcall(man.open_page, params.count, params.smods, params.fargs)
+    vim.api.nvim_set_option_value('bufhidden', 'unload', {
+      scope = 'local'
+    })
     if not ok then
       vim.notify(man.errormsg or err, vim.log.levels.ERROR)
     end

--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -9,9 +9,6 @@ vim.api.nvim_create_user_command('Man', function(params)
     man.init_pager()
   else
     local ok, err = pcall(man.open_page, params.count, params.smods, params.fargs)
-    vim.api.nvim_set_option_value('bufhidden', 'unload', {
-      scope = 'local',
-    })
     if not ok then
       vim.notify(man.errormsg or err, vim.log.levels.ERROR)
     end


### PR DESCRIPTION
This fixes a resizing issue when opening the man pages in vertical, closing and then opening horizontally and vice versa

fixes: #25457

## Short video:

https://github.com/neovim/neovim/assets/29375815/1f4d5c06-3359-48a5-b825-906bf9d30f92

