### PR TITLE
vim-patch:9.0.2030: no max callback recursion limit

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4024,6 +4024,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Increasing this limit above 200 also changes the maximum for Ex
 	command recursion, see |E169|.
 	See also |:function|.
+	Also used for maximum depth of callback functions.
 
 					*'maxmapdepth'* *'mmd'* *E223*
 'maxmapdepth' 'mmd'	number	(default 1000)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4035,6 +4035,7 @@ vim.go.mat = vim.go.matchtime
 --- Increasing this limit above 200 also changes the maximum for Ex
 --- command recursion, see `E169`.
 --- See also `:function`.
+--- Also used for maximum depth of callback functions.
 ---
 --- @type integer
 vim.o.maxfuncdepth = 100

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -6064,6 +6064,11 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
                    typval_T *const rettv)
   FUNC_ATTR_NONNULL_ALL
 {
+  if (callback_depth > p_mfd) {
+    emsg(_(e_command_too_recursive));
+    return false;
+  }
+
   partial_T *partial;
   char *name;
   Array args = ARRAY_DICT_INIT;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5154,6 +5154,7 @@ return {
         Increasing this limit above 200 also changes the maximum for Ex
         command recursion, see |E169|.
         See also |:function|.
+        Also used for maximum depth of callback functions.
       ]=],
       full_name = 'maxfuncdepth',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:9.0.2030: no max callback recursion limit

Problem:  no max callback recursion limit
Solution: bail out, if max call recursion for callback functions
          has been reached.

This checks the 'maxfuncdepth' setting and throws E169 when a callback
function recursively calls itself.

closes: vim/vim#13339

https://github.com/vim/vim/commit/47510f3d6598a1218958c03ed11337a43b73f48d

Co-authored-by: Christian Brabandt <cb@256bit.org>