### PR TITLE
fix(deps): bump libmpack from luarocks

### DIFF
--- a/cmake.deps/cmake/BuildLuarocks.cmake
+++ b/cmake.deps/cmake/BuildLuarocks.cmake
@@ -106,7 +106,7 @@ endif()
 
 # mpack
 add_custom_command(OUTPUT ${ROCKS_DIR}/mpack
-  COMMAND ${CMAKE_COMMAND} -E env "${PATH}" ${LUAROCKS_BINARY} build mpack 1.0.10-0 ${LUAROCKS_BUILDARGS}
+  COMMAND ${CMAKE_COMMAND} -E env "${PATH}" ${LUAROCKS_BINARY} build mpack 1.0.11-0 ${LUAROCKS_BUILDARGS}
   DEPENDS luarocks)
 add_custom_target(mpack ALL DEPENDS ${ROCKS_DIR}/mpack)
 


### PR DESCRIPTION
fixup for the backport 4f6e4c5447b25316e2defd4a04ca85115b34f71c
(which forgot that release-0.9 still uses luarocks)
