### PR TITLE
vim-patch:dbf749bd5aae

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -1914,7 +1914,7 @@ endfun
 "                        Doing this means that netrw will not come up as having changed a
 "                        setting last when it really didn't actually change it.
 "
-"                        Used by s:NetrwOptionsRestore() to restore each netrw-senstive setting
+"                        Used by s:NetrwOptionsRestore() to restore each netrw-sensitive setting
 "                        keepvars are set up by s:NetrwOptionsSave
 fun! s:NetrwRestoreSetting(keepvar,setting)
 """  call Dfunc("s:NetrwRestoreSetting(a:keepvar<".a:keepvar."> a:setting<".a:setting.">)")
@@ -5515,7 +5515,7 @@ fun! netrw#BrowseX(fname,remote)
   " cleanup: remove temporary file,
   "          delete current buffer if success with handler,
   "          return to prior buffer (directory listing)
-  "          Feb 12, 2008: had to de-activiate removal of
+  "          Feb 12, 2008: had to de-activate removal of
   "          temporary file because it wasn't getting seen.
 "  if remote == 1 && fname != a:fname
 ""   call Decho("deleting temporary file<".fname.">",'~'.expand("<slnum>"))

--- a/runtime/autoload/phpcomplete.vim
+++ b/runtime/autoload/phpcomplete.vim
@@ -2924,7 +2924,7 @@ endfor
 " builtin class information
 let g:php_builtin_object_functions = {}
 
-" When completing for 'everyting imaginable' (no class context, not a
+" When completing for 'everything imaginable' (no class context, not a
 " variable) we need a list of built-in classes in a format of {'classname':''}
 " for performance reasons we precompile this too
 let g:php_builtin_classnames = {}

--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -25,7 +25,7 @@ function! rustfmt#DetectVersion()
     silent let s:rustfmt_help = system(g:rustfmt_command . " --help")
     let s:rustfmt_unstable_features = s:rustfmt_help =~# "--unstable-features"
 
-    " Build a comparable rustfmt version varible out of its `--version` output:
+    " Build a comparable rustfmt version variable out of its `--version` output:
     silent let l:rustfmt_version_full = system(g:rustfmt_command . " --version")
     let l:rustfmt_version_list = matchlist(l:rustfmt_version_full,
         \    '\vrustfmt ([0-9]+[.][0-9]+[.][0-9]+)')

--- a/runtime/colors/README.txt
+++ b/runtime/colors/README.txt
@@ -111,11 +111,11 @@ please check the following items:
 - Do not use hard coded escape sequences, these will not work in other
   terminals.  Always use #RRGGBB for the GUI.
 
-- When targetting 8-16 colors terminals, don't count on "darkblue" to be blue
+- When targeting 8-16 colors terminals, don't count on "darkblue" to be blue
   and dark, or on "2" to be even vaguely reddish.  Names are more portable
   than numbers, though.
 
-- When targetting 256 colors terminals, prefer colors 16-255 to colors 0-15
+- When targeting 256 colors terminals, prefer colors 16-255 to colors 0-15
   for the same reason.
 
 - Typographic attributes (bold, italic, underline, reverse, etc.) are not

--- a/runtime/indent/cdl.vim
+++ b/runtime/indent/cdl.vim
@@ -21,7 +21,7 @@ endif
 
 " find out if an "...=..." expression is an assignment (or a conditional)
 " it scans 'line' first, and then the previous lines
-fun! CdlAsignment(lnum, line)
+fun! CdlAssignment(lnum, line)
   let f = -1
   let lnum = a:lnum
   let line = a:line
@@ -90,7 +90,7 @@ fun! CdlGetIndent(lnum)
     end
   end
 
-  " remove members [a] of [b]:[c]... (inicio remainds valid)
+  " remove members [a] of [b]:[c]... (inicio remains valid)
   let line = substitute(line, '\c\(\[[^]]*]\(\s*of\s*\|:\)*\)\+', ' ', 'g')
   while 1
     " search for the next interesting element
@@ -111,7 +111,7 @@ fun! CdlGetIndent(lnum)
     else " c == '='
       " if it is an assignment increase indent
       if f == -1 " we don't know yet, find out
-	let f = CdlAsignment(lnum, strpart(line, 0, inicio))
+	let f = CdlAssignment(lnum, strpart(line, 0, inicio))
       end
       if f == 1 " formula increase it
 	let ind = ind + shiftwidth()
@@ -125,7 +125,7 @@ fun! CdlGetIndent(lnum)
     let ind = ind - shiftwidth()
   elseif match(thisline, '^\s*=') >= 0
     if f == -1 " we don't know yet if is an assignment, find out
-      let f = CdlAsignment(lnum, "")
+      let f = CdlAssignment(lnum, "")
     end
     if f == 1 " formula increase it
       let ind = ind + shiftwidth()

--- a/runtime/indent/erlang.vim
+++ b/runtime/indent/erlang.vim
@@ -1324,7 +1324,7 @@ function! s:ErlangCalcIndent2(lnum, stack)
           "   maybe A else
           "               LTI
           "
-          " Note about Emacs compabitility {{{
+          " Note about Emacs compatibility {{{
           "
           " It would be fine to indent the examples above the following way:
           "

--- a/runtime/indent/julia.vim
+++ b/runtime/indent/julia.vim
@@ -310,7 +310,7 @@ function IsFunctionArgPar(lnum, c)
 endfunction
 
 function JumpToMatch(lnum, last_closed_bracket)
-  " we use the % command to skip back (tries to ues matchit if possible,
+  " we use the % command to skip back (tries to use matchit if possible,
   " otherwise resorts to vim's default, which is buggy but better than
   " nothing)
   call cursor(a:lnum, a:last_closed_bracket)

--- a/runtime/indent/krl.vim
+++ b/runtime/indent/krl.vim
@@ -41,7 +41,7 @@ function GetKrlIndent() abort
   let currentLine = getline(v:lnum)
   if  currentLine =~? '\v^;(\s*(end)?fold>)@!' && !get(g:, 'krlCommentIndent', 0)
     " If current line has a ; in column 1 and is no fold, keep zero indent.
-    " This may be usefull if code is commented out at the first column.
+    " This may be useful if code is commented out at the first column.
     return 0
   endif
 
@@ -117,7 +117,7 @@ function s:KrlPreNoneBlank(lnum) abort
   let nPreNoneBlank = prevnonblank(a:lnum)
 
   while nPreNoneBlank > 0 && getline(nPreNoneBlank) =~? '\v^\s*(\&\w\+|;|continue>)'
-    " Previouse none blank line irrelevant. Look further aback.
+    " Previous none blank line irrelevant. Look further aback.
     let nPreNoneBlank = prevnonblank(nPreNoneBlank - 1)
   endwhile
 

--- a/runtime/indent/rapid.vim
+++ b/runtime/indent/rapid.vim
@@ -74,7 +74,7 @@ function s:GetRapidIndentIntern() abort
 
   if  l:currentLine =~ '^!' && !get(g:,'rapidCommentIndent',0)
     " If current line is ! line comment, do not change indent
-    " This may be usefull if code is commented out at the first column.
+    " This may be useful if code is commented out at the first column.
     return 0
   endif
 

--- a/runtime/indent/systemverilog.vim
+++ b/runtime/indent/systemverilog.vim
@@ -78,10 +78,10 @@ function SystemVerilogIndent()
   " Multiple-line comment count
   if curr_line =~ '^\s*/\*' && curr_line !~ '/\*.\{-}\*/'
     let s:multiple_comment += 1
-    if vverb | echom vverb_str "Start of multiple-line commnt" | endif
+    if vverb | echom vverb_str "Start of multiple-line comment" | endif
   elseif curr_line =~ '\*/\s*$' && curr_line !~ '/\*.\{-}\*/'
     let s:multiple_comment -= 1
-    if vverb | echom vverb_str "End of multiple-line commnt" | endif
+    if vverb | echom vverb_str "End of multiple-line comment" | endif
     return ind
   endif
   " Maintain indentation during commenting.

--- a/runtime/keymap/greek_utf-8.vim
+++ b/runtime/keymap/greek_utf-8.vim
@@ -34,7 +34,7 @@
 " without having to combine them with letters (usufull for grammarians
 " in particular) (especially for dasia and psiln we use ' for psili
 " (that is apostrophe) and ;' for dasia. This is done in order to
-" preserve the posibility to write a plain < or >.
+" preserve the possibility to write a plain < or >.
 
 " Ypogegrammeni is | following the character (the originally proposed
 " i after the character is problematic: can't write easily ai or vi) :

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -87,7 +87,7 @@ SynMenu AB.Assembly.PIC:pic
 SynMenu AB.Assembly.Turbo:tasm
 SynMenu AB.Assembly.VAX\ Macro\ Assembly:vmasm
 SynMenu AB.Assembly.Z-80:z8a
-SynMenu AB.Assembly.xa\ 6502\ cross\ assember:a65
+SynMenu AB.Assembly.xa\ 6502\ cross\ assembler:a65
 SynMenu AB.ASN\.1:asn
 SynMenu AB.Asterisk\ config:asterisk
 SynMenu AB.Asterisk\ voicemail\ config:asteriskvm
@@ -325,7 +325,7 @@ SynMenu HIJK.Kivy:kivy
 SynMenu HIJK.KixTart:kix
 
 SynMenu L.Lace:lace
-SynMenu L.LamdaProlog:lprolog
+SynMenu L.LambdaProlog:lprolog
 SynMenu L.Latte:latte
 SynMenu L.Ld\ script:ld
 SynMenu L.LDAP.LDIF:ldif

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1248,7 +1248,7 @@ func s:Run(args)
   call s:SendResumingCommand('-exec-run')
 endfunc
 
-" :Frame - go to a specfic frame in the stack
+" :Frame - go to a specific frame in the stack
 func s:Frame(arg)
   " Note: we explicit do not use mi's command
   " call s:SendCommand('-stack-select-frame "' . a:arg .'"')

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -78,7 +78,7 @@ an 50.10.440 &Syntax.AB.Assembly.PIC :cal SetSyn("pic")<CR>
 an 50.10.450 &Syntax.AB.Assembly.Turbo :cal SetSyn("tasm")<CR>
 an 50.10.460 &Syntax.AB.Assembly.VAX\ Macro\ Assembly :cal SetSyn("vmasm")<CR>
 an 50.10.470 &Syntax.AB.Assembly.Z-80 :cal SetSyn("z8a")<CR>
-an 50.10.480 &Syntax.AB.Assembly.xa\ 6502\ cross\ assember :cal SetSyn("a65")<CR>
+an 50.10.480 &Syntax.AB.Assembly.xa\ 6502\ cross\ assembler :cal SetSyn("a65")<CR>
 an 50.10.490 &Syntax.AB.ASN\.1 :cal SetSyn("asn")<CR>
 an 50.10.500 &Syntax.AB.Asterisk\ config :cal SetSyn("asterisk")<CR>
 an 50.10.510 &Syntax.AB.Asterisk\ voicemail\ config :cal SetSyn("asteriskvm")<CR>
@@ -308,7 +308,7 @@ an 50.50.710 &Syntax.HIJK.Kimwitu++ :cal SetSyn("kwt")<CR>
 an 50.50.720 &Syntax.HIJK.Kivy :cal SetSyn("kivy")<CR>
 an 50.50.730 &Syntax.HIJK.KixTart :cal SetSyn("kix")<CR>
 an 50.60.100 &Syntax.L.Lace :cal SetSyn("lace")<CR>
-an 50.60.110 &Syntax.L.LamdaProlog :cal SetSyn("lprolog")<CR>
+an 50.60.110 &Syntax.L.LambdaProlog :cal SetSyn("lprolog")<CR>
 an 50.60.120 &Syntax.L.Latte :cal SetSyn("latte")<CR>
 an 50.60.130 &Syntax.L.Ld\ script :cal SetSyn("ld")<CR>
 an 50.60.140 &Syntax.L.LDAP.LDIF :cal SetSyn("ldif")<CR>

--- a/runtime/syntax/abap.vim
+++ b/runtime/syntax/abap.vim
@@ -122,7 +122,7 @@ syn keyword abapStatement TABLES TIMES TRANSFER TRANSLATE TRY TYPE TYPES
 syn keyword abapStatement UNASSIGN ULINE UNPACK UPDATE
 syn keyword abapStatement WHEN WHILE WINDOW WRITE
 
-" More statemets
+" More statements
 syn keyword abapStatement LINES
 syn keyword abapStatement INTO GROUP BY HAVING ORDER BY SINGLE
 syn keyword abapStatement APPENDING CORRESPONDING FIELDS OF TABLE

--- a/runtime/syntax/asm68k.vim
+++ b/runtime/syntax/asm68k.vim
@@ -4,7 +4,7 @@
 " Last change:	2001 May 01
 "
 " This is incomplete.  In particular, support for 68020 and
-" up and 68851/68881 co-processors is partial or non-existant.
+" up and 68851/68881 co-processors is partial or non-existent.
 " Feel free to contribute...
 "
 

--- a/runtime/syntax/debcontrol.vim
+++ b/runtime/syntax/debcontrol.vim
@@ -22,7 +22,7 @@ syn iskeyword @,48-57,-
 " Everything that is not explicitly matched by the rules below
 syn match debcontrolElse "^.*$"
 
-" Common seperators
+" Common separators
 syn match debControlComma ",[ \t]*"
 syn match debControlSpace "[ \t]"
 

--- a/runtime/syntax/nix.vim
+++ b/runtime/syntax/nix.vim
@@ -99,7 +99,7 @@ syn match nixArgOperator '[a-zA-Z_][a-zA-Z0-9_'-]*\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{
 "
 " "\%(\s\|#.\{-\}\n\|\n\|/\*\_.\{-\}\*/\)*"
 "
-" It is also used throught the whole file and is marked with 'v's as well.
+" It is also used throughout the whole file and is marked with 'v's as well.
 "
 " Fortunately the matching rules for function arguments are much simpler than
 " for real attribute sets, because we can stop when we hit the first ellipsis or

--- a/runtime/syntax/ora.vim
+++ b/runtime/syntax/ora.vim
@@ -449,7 +449,7 @@ hi def link oraString	  String		"strings
 
 hi def link oraSpecial	  Special		"special characters
 hi def link oraError	  Error			"errors
-hi def link oraParenError	  oraError		"errors caused by mismatching parantheses
+hi def link oraParenError	  oraError		"errors caused by mismatching parentheses
 
 hi def link oraComment	  Comment		"comments
 

--- a/runtime/syntax/po.vim
+++ b/runtime/syntax/po.vim
@@ -42,7 +42,7 @@ syn match     poHeaderItem "\(Project-Id-Version\|Report-Msgid-Bugs-To\|POT-Crea
 syn match     poHeaderUndefined "\(PACKAGE VERSION\|YEAR-MO-DA HO:MI+ZONE\|FULL NAME <EMAIL@ADDRESS>\|LANGUAGE <LL@li.org>\|CHARSET\|ENCODING\|INTEGER\|EXPRESSION\)" contained
 syn match     poCopyrightUnset "SOME DESCRIPTIVE TITLE\|FIRST AUTHOR <EMAIL@ADDRESS>, YEAR\|Copyright (C) YEAR Free Software Foundation, Inc\|YEAR THE PACKAGE\'S COPYRIGHT HOLDER\|PACKAGE" contained
 
-" Translation comment block including: translator comment, automatic coments, flags and locations
+" Translation comment block including: translator comment, automatic comments, flags and locations
 syn match     poComment "^#.*$"
 syn keyword   poFlagFuzzy fuzzy contained
 syn match     poCommentTranslator "^# .*$" contains=poCopyrightUnset

--- a/runtime/syntax/ppd.vim
+++ b/runtime/syntax/ppd.vim
@@ -15,7 +15,7 @@ syn match	ppdDefine	"\*[a-zA-Z0-9\-_]\+:"
 syn match	ppdUI		"\*[a-zA-Z]*\(Open\|Close\)UI"
 syn match	ppdUIGroup	"\*[a-zA-Z]*\(Open\|Close\)Group"
 syn match	ppdGUIText	"/.*:"
-syn match	ppdContraints	"^*UIConstraints:"
+syn match	ppdConstraints	"^*UIConstraints:"
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
@@ -27,7 +27,7 @@ hi def link ppdUI			Function
 hi def link ppdUIGroup		Function
 hi def link ppdDef			String
 hi def link ppdGUIText		Type
-hi def link ppdContraints		Special
+hi def link ppdConstraints		Special
 
 
 let b:current_syntax = "ppd"

--- a/runtime/syntax/spup.vim
+++ b/runtime/syntax/spup.vim
@@ -29,7 +29,7 @@ set cpo&vim
 "let strict_subsections = 1
 
 " highlight types usually found in DECLARE section
-if !exists("hightlight_types")
+if !exists("highlight_types")
     let highlight_types = 1
 endif
 

--- a/runtime/syntax/tsscl.vim
+++ b/runtime/syntax/tsscl.vim
@@ -22,7 +22,7 @@ syn case ignore
 
 "
 "
-" Begin syntax definitions for tss geomtery file.
+" Begin syntax definitions for tss geometry file.
 "
 
 " Load TSS geometry syntax file

--- a/runtime/syntax/zsh.vim
+++ b/runtime/syntax/zsh.vim
@@ -88,7 +88,7 @@ syn match   zshOperator         '||\|&&\|;\|&!\='
 syn match   zshRedir            '\d\=\(<<<\|<&\s*[0-9p-]\=\|<>\?\)'
                                 " >, >>, and variants.
 syn match   zshRedir            '\d\=\(>&\s*[0-9p-]\=\|&>>\?\|>>\?&\?\)[|!]\='
-                                " | and |&, but only if it's not preceeded or
+                                " | and |&, but only if it's not preceded or
                                 " followed by a | to avoid matching ||.
 syn match   zshRedir            '|\@1<!|&\=|\@!'
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5825,7 +5825,7 @@ int ExpandSettingSubtract(expand_T *xp, regmatch_T *regmatch, int *numMatches, c
     if (*xp->xp_pattern != NUL) {
       // Don't suggest anything if cmdline is non-empty. Vim's set-=
       // behavior requires consecutive strings and it's usually
-      // unintuitive to users if ther try to subtract multiple flags at
+      // unintuitive to users if they try to subtract multiple flags at
       // once.
       return FAIL;
     }

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -66,7 +66,7 @@ static const char e_xattr_erange[]
 static const char e_xattr_e2big[]
   = N_("E1508: Size of the extended attribute value is larger than the maximum size allowed");
 static const char e_xattr_other[]
-  = N_("E1509: Error occured when reading or writing extended attribute");
+  = N_("E1509: Error occurred when reading or writing extended attribute");
 #endif
 
 struct iovec;


### PR DESCRIPTION
#### vim-patch:dbf749bd5aae

runtime: Fix more typos (vim/vim#13354)

* Fix more typos

* Fix typos in ignored runtime/ directory

https://github.com/vim/vim/commit/dbf749bd5aaef6ea2d28bce081349785d174d96a

Co-authored-by: Viktor Szépe <viktor@szepe.net>