### PR TITLE
vim-patch:9.0.2033: gcc overflow-warning for f_resolve

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6098,13 +6098,13 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         }
 
         // Ensure that the result will have a trailing path separator
-        // if the argument has one. */
+        // if the argument has one.
         if (remain == NULL && has_trailing_pathsep) {
           add_pathsep(buf);
         }
 
         // Separate the first path component in the link value and
-        // concatenate the remainders. */
+        // concatenate the remainders.
         q = (char *)path_next_component(vim_ispathsep(*buf) ? buf + 1 : buf);
         if (*q != NUL) {
           cpy = remain;
@@ -6118,7 +6118,7 @@ static void f_resolve(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         q = path_tail(p);
         if (q > p && *q == NUL) {
           // Ignore trailing path separator.
-          q[-1] = NUL;
+          p[q - p - 1] = NUL;
           q = path_tail(p);
         }
         if (q > p && !path_is_absolute(buf)) {


### PR DESCRIPTION
#### vim-patch:9.0.2033: gcc overflow-warning for f_resolve

Problem:  gcc overflow-warning for f_resolve
Solution: use pointer p instead of pointer q[-1]

Suppress the following warning:
```
filepath.c: In function ‘f_resolve’:
filepath.c:2162:27: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2162 |                     q[-1] = NUL;
```

Closes: vim/vim#13352
closes: vim/vim#13353

https://github.com/vim/vim/commit/215c3261a25f7a99e8711a3b3c6158119c6aea9e

Co-authored-by: Ken Takata <kentkt@csc.jp>