### PR TITLE
docs: additional desc for nvim_win_set_cursor

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2973,6 +2973,10 @@ nvim_win_set_cursor({window}, {pos})                   *nvim_win_set_cursor()*
     Sets the (1,0)-indexed cursor position in the window. |api-indexing| This
     scrolls the window even if it is not the current one.
 
+    Alerts if row outside buffer and col greater than |v:maxcol| If col is
+    greater than the maximum col of the line and the |'virtualedit'| option is
+    not set, col will be moved to end of the line while no alert
+
     Parameters: ~
       • {window}  Window handle, or 0 for current window
       • {pos}     (row, col) tuple representing the new position

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2196,6 +2196,9 @@ function vim.api.nvim_win_set_config(window, config) end
 
 --- Sets the (1,0)-indexed cursor position in the window. `api-indexing` This
 --- scrolls the window even if it is not the current one.
+--- Alerts if row outside buffer and col greater than `v:maxcol` If col is
+--- greater than the maximum col of the line and the `virtualedit` option is
+--- not set, col will be moved to end of the line while no alert
 ---
 --- @param window integer Window handle, or 0 for current window
 --- @param pos integer[] (row, col) tuple representing the new position

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -92,6 +92,10 @@ ArrayOf(Integer, 2) nvim_win_get_cursor(Window window, Error *err)
 /// Sets the (1,0)-indexed cursor position in the window. |api-indexing|
 /// This scrolls the window even if it is not the current one.
 ///
+/// Alerts if row outside buffer and col greater than |v:maxcol|
+/// If col is greater than the maximum col of the line and the |'virtualedit'|
+/// option is not set, col will be moved to end of the line while no alert
+///
 /// @param window   Window handle, or 0 for current window
 /// @param pos      (row, col) tuple representing the new position
 /// @param[out] err Error details, if any


### PR DESCRIPTION
When I was using the function `vim.api.nvim_win_set_cursor`, I tried to set `row` and `col` to very large values. The former resulted in an expected error, but the latter did not, which made me feel strange because it was not mentioned in the documentation. This commit adds this.

This is my first time making a PR in such a large project. If there is anything wrong with what I have done, please point it out. 😄

After cloning the Neovim repository, I directly ran the `make doc` command, but encountered the following error:

```
Setting log level to ERROR
Traceback (most recent call last):
  File "/home/shellraining/Documents/learnsth/neovim/scripts/gen_[vimdoc.py](http://vimdoc.py/)", line 1399, in <module>
    main(Doxyfile, args)
  File "/home/shellraining/Documents/learnsth/neovim/scripts/gen_[vimdoc.py](http://vimdoc.py/)", line 1272, in main
    fail(f'no sections for target: {target} (look for errors near "Preprocessing" log lines above)')
  File "/home/shellraining/Documents/learnsth/neovim/scripts/gen_[vimdoc.py](http://vimdoc.py/)", line 388, in fail
    raise RuntimeError(s)
RuntimeError: no sections for target: lua (look for errors near "Preprocessing" log lines above)
ninja: build stopped: subcommand failed.
```

how can I solve this problem?