### PR TITLE
vim-patch:9.0.2039: completion shows current word after completion restart

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3635,7 +3635,7 @@ static int ins_compl_next(bool allow_get_expansion, int count, bool insert_match
   }
 
   if (allow_get_expansion && insert_match
-      && (!(compl_get_longest || compl_restarting) || compl_used_match)) {
+      && (!compl_get_longest || compl_used_match)) {
     // Delete old text to be replaced
     ins_compl_delete();
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -864,7 +864,7 @@ func Test_complete_add_onechar()
   setlocal complete=.
   call setline(1, ['workhorse', 'workload'])
   normal Go
-  exe "normal aWOR\<C-P>\<bs>\<bs>\<bs>\<bs>\<bs>\<bs>\<C-L>r\<C-L>\<C-L>"
+  exe "normal aWOR\<C-P>\<bs>\<bs>\<bs>\<bs>\<bs>\<bs>\<C-L>\<C-L>\<C-L>"
   call assert_equal('workh', getline(3))
   set ignorecase& backspace&
   close!
@@ -2278,6 +2278,17 @@ endfunc
 func GetCompleteInfo()
   let g:compl_info = complete_info()
   return ''
+endfunc
+
+func Test_completion_restart()
+  new
+  set complete=. completeopt=menuone backspace=2
+  call setline(1, 'workhorse workhorse')
+  exe "normal $a\<C-N>\<BS>\<BS>\<C-R>=GetCompleteInfo()\<CR>"
+  call assert_equal(1, len(g:compl_info['items']))
+  call assert_equal('workhorse', g:compl_info['items'][0]['word'])
+  set complete& completeopt& backspace&
+  bwipe!
 endfunc
 
 func Test_complete_info_index()


### PR DESCRIPTION
#### vim-patch:9.0.2039: completion shows current word after completion restart

Problem:  completion shows current word after completion restart
Solution: remove the word being completed after completion restart

The word being completed is shown in a completion list after completion
restart, because it isn't removed from the current buffer before
searching for matches.

Also adjust `Test_complete_add_onechar` to match the new behavior.

closes: vim/vim#13349

https://github.com/vim/vim/commit/2e3cd52fa02b1a208c97992b1bca3b04f7be66d4

Co-authored-by: nwounkn <nwounkn@gmail.com>