### PR TITLE
vim-patch:9.0.2035: [security] use-after-free with wildmenu

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6920,6 +6920,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The character is not recognized when used inside a macro.  See
 	'wildcharm' for that.
 	Some keys will not work, such as CTRL-C, <CR> and Enter.
+	<Esc> can be used, but hitting it twice in a row will still exit
+	command-line as a failsafe measure.
 	Although 'wc' is a number option, you can set it to a special key: >
 		:set wc=<Tab>
 <

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7466,6 +7466,8 @@ vim.go.ww = vim.go.whichwrap
 --- The character is not recognized when used inside a macro.  See
 --- 'wildcharm' for that.
 --- Some keys will not work, such as CTRL-C, <CR> and Enter.
+--- <Esc> can be used, but hitting it twice in a row will still exit
+--- command-line as a failsafe measure.
 --- Although 'wc' is a number option, you can set it to a special key:
 --- ```
 --- 	:set wc=<Tab>

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2677,6 +2677,19 @@ static const char *did_set_updatecount(optset_T *args)
   return NULL;
 }
 
+/// Process the new 'wildchar' / 'wildcharm' option value.
+static const char *did_set_wildchar(optset_T *args)
+{
+  OptInt c = *(OptInt *)args->os_varp;
+
+  // Don't allow key values that wouldn't work as wildchar.
+  if (c == Ctrl_C || c == '\n' || c == '\r' || c == K_KENTER) {
+    return e_invarg;
+  }
+
+  return NULL;
+}
+
 /// Process the new 'winblend' option value.
 static const char *did_set_winblend(optset_T *args)
 {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9473,6 +9473,7 @@ return {
     },
     {
       abbreviation = 'wc',
+      cb = 'did_set_wildchar',
       defaults = {
         if_true = imacros('TAB'),
         doc = '<Tab>',
@@ -9484,6 +9485,8 @@ return {
         The character is not recognized when used inside a macro.  See
         'wildcharm' for that.
         Some keys will not work, such as CTRL-C, <CR> and Enter.
+        <Esc> can be used, but hitting it twice in a row will still exit
+        command-line as a failsafe measure.
         Although 'wc' is a number option, you can set it to a special key: >
         	:set wc=<Tab>
         <
@@ -9496,6 +9499,7 @@ return {
     },
     {
       abbreviation = 'wcm',
+      cb = 'did_set_wildchar',
       defaults = { if_true = 0 },
       desc = [=[
         'wildcharm' works exactly like 'wildchar', except that it is

--- a/test/functional/options/cursorbind_spec.lua
+++ b/test/functional/options/cursorbind_spec.lua
@@ -8,6 +8,7 @@ local feed = helpers.feed
 before_each(clear)
 
 describe("'cursorbind'", function()
+  -- oldtest: Test_cursorline_cursorbind_horizontal_scroll()
   it("behaves consistently whether 'cursorline' is set or not vim-patch:8.2.4795", function()
     local screen = Screen.new(60, 8)
     screen:set_default_attr_ids({

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -17,6 +17,85 @@ describe("'wildmenu'", function()
     screen:attach()
   end)
 
+  -- oldtest: Test_wildmenu_screendump()
+  it('works', function()
+    screen:set_default_attr_ids({
+      [0] = {bold = true, foreground = Screen.colors.Blue};  -- NonText
+      [1] = {foreground = Screen.colors.Black, background = Screen.colors.Yellow};  -- WildMenu
+      [2] = {bold = true, reverse = true};  -- StatusLine
+    })
+    -- Test simple wildmenu
+    feed(':sign <Tab>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {1:define}{2:  jump  list  >    }|
+      :sign define^             |
+    ]]}
+
+    feed('<Tab>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {2:define  }{1:jump}{2:  list  >    }|
+      :sign jump^               |
+    ]]}
+
+    feed('<Tab>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {2:define  jump  }{1:list}{2:  >    }|
+      :sign list^               |
+    ]]}
+
+    -- Looped back to the original value
+    feed('<Tab><Tab><Tab><Tab>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {2:define  jump  list  >    }|
+      :sign ^                   |
+    ]]}
+
+    -- Test that the wild menu is cleared properly
+    feed('<Space>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {0:~                        }|
+      :sign  ^                  |
+    ]]}
+
+    -- Test that a different wildchar still works
+    feed('<Esc>')
+    command('set wildchar=<Esc>')
+    feed(':sign <Esc>')
+    screen:expect{grid=[[
+                               |
+      {0:~                        }|
+      {0:~                        }|
+      {1:define}{2:  jump  list  >    }|
+      :sign define^             |
+    ]]}
+
+    -- Double-<Esc> is a hard-coded method to escape while wildchar=<Esc>. Make
+    -- sure clean up is properly done in edge case like this.
+    feed('<Esc>')
+    screen:expect{grid=[[
+      ^                         |
+      {0:~                        }|
+      {0:~                        }|
+      {0:~                        }|
+                               |
+    ]]}
+  end)
+
   it('C-E to cancel wildmenu completion restore original input', function()
     feed(':sign <tab>')
     screen:expect([[

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -177,8 +177,9 @@ func Test_wildmenu_screendump()
   let lines =<< trim [SCRIPT]
     set wildmenu hlsearch
   [SCRIPT]
-  call writefile(lines, 'XTest_wildmenu')
+  call writefile(lines, 'XTest_wildmenu', 'D')
 
+  " Test simple wildmenu
   let buf = RunVimInTerminal('-S XTest_wildmenu', {'rows': 8})
   call term_sendkeys(buf, ":vim\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_1', {})
@@ -189,13 +190,26 @@ func Test_wildmenu_screendump()
   call term_sendkeys(buf, "\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_3', {})
 
-  call term_sendkeys(buf, "\<Tab>")
+  " Looped back to the original value
+  call term_sendkeys(buf, "\<Tab>\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_4', {})
+
+  " Test that the wild menu is cleared properly
+  call term_sendkeys(buf, " ")
+  call VerifyScreenDump(buf, 'Test_wildmenu_5', {})
+
+  " Test that a different wildchar still works
+  call term_sendkeys(buf, "\<Esc>:set wildchar=<Esc>\<CR>")
+  call term_sendkeys(buf, ":vim\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_1', {})
+
+  " Double-<Esc> is a hard-coded method to escape while wildchar=<Esc>. Make
+  " sure clean up is properly done in edge case like this.
   call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_6', {})
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('XTest_wildmenu')
 endfunc
 
 func Test_redraw_in_autocmd()
@@ -2789,7 +2803,7 @@ func Test_wildmenu_pum_from_terminal()
   let cmds = ['set wildmenu wildoptions=pum']
   let pcmd = python .. ' -c "import sys; sys.stdout.write(sys.stdin.read())"'
   call add(cmds, "call term_start('" .. pcmd .. "')")
-  call writefile(cmds, 'Xtest')
+  call writefile(cmds, 'Xtest', 'D')
   let buf = RunVimInTerminal('-S Xtest', #{rows: 10})
   call term_sendkeys(buf, "\r\r\r")
   call term_wait(buf)
@@ -2798,13 +2812,13 @@ func Test_wildmenu_pum_from_terminal()
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_term_01', {})
   call term_wait(buf)
   call StopVimInTerminal(buf)
-  call delete('Xtest')
 endfunc
 
-func Test_wildmenu_pum_clear_entries()
+func Test_wildmenu_pum_odd_wildchar()
   CheckRunVimInTerminal
 
-  " This was using freed memory.  Run in a terminal to get the pum to update.
+  " Test odd wildchar interactions with pum. Make sure they behave properly
+  " and don't lead to memory corruption due to improperly cleaned up memory.
   let lines =<< trim END
     set wildoptions=pum
     set wildchar=<C-E>
@@ -2812,10 +2826,35 @@ func Test_wildmenu_pum_clear_entries()
   call writefile(lines, 'XwildmenuTest', 'D')
   let buf = RunVimInTerminal('-S XwildmenuTest', #{rows: 10})
 
-  call term_sendkeys(buf, ":\<C-E>\<C-E>")
-  call VerifyScreenDump(buf, 'Test_wildmenu_pum_clear_entries_1', {})
+  call term_sendkeys(buf, ":\<C-E>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_1', {})
 
-  set wildoptions& wildchar&
+  " <C-E> being a wildchar takes priority over its original functionality
+  call term_sendkeys(buf, "\<C-E>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_2', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_3', {})
+
+  " Escape key can be wildchar too. Double-<Esc> is hard-coded to escape
+  " command-line, and we need to make sure to clean up properly.
+  call term_sendkeys(buf, ":set wildchar=<Esc>\<CR>")
+  call term_sendkeys(buf, ":\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_1', {})
+
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_3', {})
+
+  " <C-\> can also be wildchar. <C-\><C-N> however will still escape cmdline
+  " and we again need to make sure we clean up properly.
+  call term_sendkeys(buf, ":set wildchar=<C-\\>\<CR>")
+  call term_sendkeys(buf, ":\<C-\>\<C-\>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_1', {})
+
+  call term_sendkeys(buf, "\<C-N>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_odd_wildchar_3', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 " Test for completion after a :substitute command followed by a pipe (|)

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -232,6 +232,11 @@ func Test_keymap_valid()
   call assert_fails(":set kmp=trunc\x00name", "trunc")
 endfunc
 
+func Test_wildchar_valid()
+  call assert_fails("set wildchar=<CR>", "E474:")
+  call assert_fails("set wildcharm=<C-C>", "E474:")
+endfunc
+
 func Check_dir_option(name)
   " Check that it's possible to set the option.
   exe 'set ' . a:name . '=/usr/share/dict/words'


### PR DESCRIPTION
#### vim-patch:9.0.2035: [security] use-after-free with wildmenu

Problem:  [security] use-after-free with wildmenu
Solution: properly clean up the wildmenu when exiting

Fix wildchar/wildmenu/pum memory corruption with special wildchar's

Currently, using `wildchar=<Esc>` or `wildchar=<C-\>` can lead to a
memory corruption if using wildmenu+pum, or wrong states if only using
wildmenu. This is due to the code only using one single place inside the
cmdline process loop to perform wild menu clean up (by checking
`end_wildmenu`) but there are other odd situations where the loop could
have exited and we need a post-loop clean up just to be sure. If the
clean up was not done you would have a stale popup menu referring to
invalid memory, or if not using popup menu, incorrect status line (if
`laststatus=0`).

For example, if you hit `<Esc>` two times when it's wildchar, there's a
hard-coded behavior to exit command-line as a failsafe for user, and if
you hit `<C-\><C-\><C-N>` it will also exit command-line, but the clean
up code would not have hit because of specialized `<C-\>` handling.

Fix Ctrl-E / Ctrl-Y to not cancel/accept wildmenu if they are also
used for 'wildchar'/'wildcharm'. Currently they don't behave properly,
and also have potentially memory unsafe behavior as the logic is
currently not accounting for this situation and try to do both.
(Previous patch that addressed this: vim/vim#11677)

Also, correctly document Escape key behavior (double-hit it to escape)
in wildchar docs as it's previously undocumented.

In addition, block known invalid chars to be set in `wildchar` option,
such as Ctrl-C and `<CR>`. This is just to make it clear to the user
they shouldn't be set, and is not required for this bug fix.

closes: vim/vim#13361

https://github.com/vim/vim/commit/8f4fb007e4d472b09ff6bed9ffa485e0c3093699

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>