### PR TITLE
vim-patch:9.0.2041: trim(): hard to use default mask

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8291,15 +8291,18 @@ tr({src}, {fromstr}, {tostr})                                             *tr()*
 trim({text} [, {mask} [, {dir}]])                                       *trim()*
 		Return {text} as a String where any character in {mask} is
 		removed from the beginning and/or end of {text}.
-		If {mask} is not given, {mask} is all characters up to 0x20,
-		which includes Tab, space, NL and CR, plus the non-breaking
-		space character 0xa0.
+
+		If {mask} is not given, or is an empty string, {mask} is all
+		characters up to 0x20, which includes Tab, space, NL and CR,
+		plus the non-breaking space character 0xa0.
+
 		The optional {dir} argument specifies where to remove the
 		characters:
 			0	remove from the beginning and end of {text}
 			1	remove only at the beginning of {text}
 			2	remove only at the end of {text}
 		When omitted both ends are trimmed.
+
 		This function deals with multibyte characters properly.
 		Returns an empty string on error.
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -9845,15 +9845,18 @@ function vim.fn.tr(src, fromstr, tostr) end
 
 --- Return {text} as a String where any character in {mask} is
 --- removed from the beginning and/or end of {text}.
---- If {mask} is not given, {mask} is all characters up to 0x20,
---- which includes Tab, space, NL and CR, plus the non-breaking
---- space character 0xa0.
+---
+--- If {mask} is not given, or is an empty string, {mask} is all
+--- characters up to 0x20, which includes Tab, space, NL and CR,
+--- plus the non-breaking space character 0xa0.
+---
 --- The optional {dir} argument specifies where to remove the
 --- characters:
 ---   0  remove from the beginning and end of {text}
 ---   1  remove only at the beginning of {text}
 ---   2  remove only at the end of {text}
 --- When omitted both ends are trimmed.
+---
 --- This function deals with multibyte characters properly.
 --- Returns an empty string on error.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -11805,15 +11805,18 @@ M.funcs = {
     desc = [=[
       Return {text} as a String where any character in {mask} is
       removed from the beginning and/or end of {text}.
-      If {mask} is not given, {mask} is all characters up to 0x20,
-      which includes Tab, space, NL and CR, plus the non-breaking
-      space character 0xa0.
+
+      If {mask} is not given, or is an empty string, {mask} is all
+      characters up to 0x20, which includes Tab, space, NL and CR,
+      plus the non-breaking space character 0xa0.
+
       The optional {dir} argument specifies where to remove the
       characters:
       	0	remove from the beginning and end of {text}
       	1	remove only at the beginning of {text}
       	2	remove only at the end of {text}
       When omitted both ends are trimmed.
+
       This function deals with multibyte characters properly.
       Returns an empty string on error.
 

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -2926,6 +2926,10 @@ void f_trim(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   if (argvars[1].v_type == VAR_STRING) {
     mask = tv_get_string_buf_chk(&argvars[1], buf2);
+    if (*mask == NUL) {
+      mask = NULL;
+    }
+
     if (argvars[2].v_type != VAR_UNKNOWN) {
       bool error = false;
       // leading or trailing characters to trim

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2099,6 +2099,10 @@ func Test_trim()
   let chars = join(map(range(1, 0x20) + [0xa0], {n -> n->nr2char()}), '')
   call assert_equal("x", trim(chars . "x" . chars))
 
+  call assert_equal("x", trim(chars . "x" . chars, '', 0))
+  call assert_equal("x" . chars, trim(chars . "x" . chars, '', 1))
+  call assert_equal(chars . "x", trim(chars . "x" . chars, '', 2))
+
   call assert_fails('let c=trim([])', 'E730:')
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.2041: trim(): hard to use default mask

Problem:  trim(): hard to use default mask (partly revert v9.0.2040)
Solution: use default mask when it is empty

The default 'mask' value is pretty complex, as it includes many
characters.  Yet, if one needs to specify the trimming direction, the
third argument, 'trim()' currently requires the 'mask' value to be
provided explicitly.

Currently, an empty 'mask' will make 'trim()' call return 'text' value
that is passed in unmodified.  It is unlikely that someone is using it,
so the chances of scripts being broken by this change are low.

Also, this reverts commit 9.0.2040 (which uses v:none for the default
and requires to use an empty string instead).

closes: vim/vim#13358

https://github.com/vim/vim/commit/8079917447e7436dccc2e4cd4a4a56ae0a4712f2

vim-patch:9.0.2040: trim(): hard to use default mask

Problem:  trim(): hard to use default mask
Solution: Use default 'mask' when it is v:none

The default 'mask' value is pretty complex, as it includes many
characters.  Yet, if one needs to specify the trimming direction, the
third argument, 'trim()' currently requires the 'mask' value to be
provided explicitly.

'v:none' is already used to mean "use the default argument value" in
user defined functions.  See |none-function_argument| in help.

closes: vim/vim#13363

https://github.com/vim/vim/commit/6e6386716f9494ae86027c6d34f657fd03dfec42

Co-authored-by: Illia Bobyr <illia.bobyr@gmail.com>