### PR TITLE
vim-patch:8.2.4497: wrong color for half of wide character next to pum scrollbar

### DIFF
--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1788,6 +1788,30 @@ describe('builtin popupmenu', function()
           {2:-- }{5:match 1 of 3}                 |
         ]])
       end)
+
+      -- oldtest: Test_scrollbar_on_wide_char()
+      it('scrollbar overwrites half of double-width char below properly', function()
+        screen:try_resize(32, 10)
+        exec([[
+          call setline(1, ['a', '            啊啊啊',
+                              \ '             哦哦哦',
+                              \ '              呃呃呃'])
+          call setline(5, range(10)->map({i, v -> 'aa' .. v .. 'bb'}))
+        ]])
+        feed('A<C-X><C-N>')
+        screen:expect([[
+          aa0bb^                           |
+          {s:aa0bb          }{c: }啊              |
+          {n:aa1bb          }{c: } 哦             |
+          {n:aa2bb          }{c: }呃呃            |
+          {n:aa3bb          }{c: }                |
+          {n:aa4bb          }{c: }                |
+          {n:aa5bb          }{c: }                |
+          {n:aa6bb          }{s: }                |
+          {n:aa7bb          }{s: }                |
+          {2:-- }{5:match 1 of 10}                |
+        ]])
+      end)
     end
 
     it('with vsplits', function()

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -530,10 +530,8 @@ func Test_ins_completeslash()
   CheckMSWindows
 
   call mkdir('Xdir')
-
   let orig_shellslash = &shellslash
   set cpt&
-
   new
 
   set noshellslash
@@ -653,6 +651,24 @@ func Test_pum_with_preview_win()
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
   call delete('Xpreviewscript')
+endfunc
+
+func Test_scrollbar_on_wide_char()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, ['a', '            啊啊啊',
+                        \ '             哦哦哦',
+                        \ '              呃呃呃'])
+    call setline(5, range(10)->map({i, v -> 'aa' .. v .. 'bb'}))
+  END
+  call writefile(lines, 'Xwidescript')
+  let buf = RunVimInTerminal('-S Xwidescript', #{rows: 10})
+  call term_sendkeys(buf, "A\<C-N>")
+  call VerifyScreenDump(buf, 'Test_scrollbar_on_wide_char', {})
+
+  call StopVimInTerminal(buf)
+  call delete('Xwidescript')
 endfunc
 
 " Test for inserting the tag search pattern in insert mode


### PR DESCRIPTION
#### vim-patch:8.2.4497: wrong color for half of wide character next to pum scrollbar

Problem:    Wrong color for half of wide character next to pum scrollbar.
Solution:   Redraw the screen cell with the right color.

https://github.com/vim/vim/commit/35d8c2010ea6ee5c9bcfa6a8285648172b92ed83

Co-authored-by: Bram Moolenaar <Bram@vim.org>